### PR TITLE
[HiSparse] Support IndexCache shared layer IO overlap

### DIFF
--- a/python/sglang/jit_kernel/csrc/hisparse.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse.cuh
@@ -164,6 +164,9 @@ __global__ void load_cache_to_device_buffer_kernel(
     void* __restrict__ device_buffer_k,
     void* __restrict__ device_buffer_v,
     int32_t* __restrict__ top_k_device_locs,
+    int32_t* __restrict__ miss_tokens_out,
+    int32_t* __restrict__ miss_slots_out,
+    int32_t* __restrict__ miss_counts_out,
     const ReqPoolIndicesT* __restrict__ req_pool_indices,
     const SeqLensT* __restrict__ seq_lens,
     int16_t* __restrict__ lru_slots,
@@ -173,6 +176,8 @@ __global__ void load_cache_to_device_buffer_kernel(
     int64_t lru_slot_stride_0,
     int64_t top_k_tokens_stride,
     int64_t top_k_device_locs_stride,
+    int64_t miss_tokens_stride,
+    int64_t miss_slots_stride,
     int64_t page_size,
     int64_t item_size_bytes) {
   static_assert(!IsDsv4Layout || IsMLA, "DSv4 page-padded layout is K-only (MLA).");
@@ -205,6 +210,9 @@ __global__ void load_cache_to_device_buffer_kernel(
 
   // Fast path: short sequences have all tokens in the device buffer in order.
   if (seq_len <= HOT_BUFFER_SIZE) {
+    if (tid == 0 && miss_counts_out != nullptr) {
+      miss_counts_out[bid] = 0;
+    }
     const int count = (seq_len < NUM_TOP_K) ? static_cast<int>(seq_len) : NUM_TOP_K;
     for (int i = tid; i < count; i += BLOCK_SIZE) {
       int32_t token_pos = req_top_k_tokens[i];
@@ -402,11 +410,18 @@ __global__ void load_cache_to_device_buffer_kernel(
       s_top_k_tokens[miss_offset] = my_token;
       req_top_k_device_locs[my_token_idx] = req_device_buffer_locs[evict_slot];
       req_device_buffer_tokens[evict_slot] = my_token;
+      if (miss_tokens_out != nullptr) {
+        miss_tokens_out[bid * miss_tokens_stride + miss_offset] = my_token;
+        miss_slots_out[bid * miss_slots_stride + miss_offset] = static_cast<int32_t>(evict_slot);
+      }
     }
   }
   __syncthreads();
 
   total_misses = NUM_TOP_K - s_total_hits - s_newest_hit;
+  if (tid == 0 && miss_counts_out != nullptr) {
+    miss_counts_out[bid] = total_misses;
+  }
   // Write back LRU order: evictables at front (LRU), hits at back (MRU).
   {
     const int total_evictable = HOT_BUFFER_SIZE - s_total_hits;
@@ -443,6 +458,96 @@ __global__ void load_cache_to_device_buffer_kernel(
           /*src_index=*/static_cast<int32_t>(src_loc));
     } else {
       // Generic path: device + host both linear, stride = item_size_bytes.
+      const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
+      auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
+      transfer_item_warp(lane_id, src_k, dst_k, item_size_bytes);
+
+      if constexpr (!IsMLA) {
+        const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes;
+        auto dst_v = static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes;
+        transfer_item_warp(lane_id, src_v, dst_v, item_size_bytes);
+      }
+    }
+  }
+}
+
+template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, bool IsMLA, bool IsDsv4Layout, typename ReqPoolIndicesT>
+__global__ void load_cache_to_device_buffer_io_only_kernel(
+    const int32_t* __restrict__ source_top_k_device_locs,
+    int32_t* __restrict__ target_top_k_device_locs,
+    const int32_t* __restrict__ miss_tokens,
+    const int32_t* __restrict__ miss_slots,
+    const int32_t* __restrict__ miss_counts,
+    const int32_t* __restrict__ source_device_buffer_tokens,
+    int32_t* __restrict__ target_device_buffer_tokens,
+    const int16_t* __restrict__ source_lru_slots,
+    int16_t* __restrict__ target_lru_slots,
+    const int64_t* __restrict__ host_cache_locs,
+    const int32_t* __restrict__ device_buffer_locs,
+    const void* __restrict__ host_cache_k,
+    const void* __restrict__ host_cache_v,
+    void* __restrict__ device_buffer_k,
+    void* __restrict__ device_buffer_v,
+    const ReqPoolIndicesT* __restrict__ req_pool_indices,
+    const int32_t* __restrict__ num_real_reqs,
+    int64_t source_top_k_stride,
+    int64_t target_top_k_stride,
+    int64_t miss_tokens_stride,
+    int64_t miss_slots_stride,
+    int64_t token_stride_0,
+    int64_t lru_slot_stride_0,
+    int64_t host_stride,
+    int64_t buffer_stride_0,
+    int64_t item_size_bytes) {
+  static_assert(!IsDsv4Layout || IsMLA, "DSv4 page-padded layout is K-only (MLA).");
+  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+
+  const int bid = blockIdx.x;
+  if (bid >= num_real_reqs[0]) return;
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / WARP_SIZE;
+  const int lane_id = tid % WARP_SIZE;
+  const int64_t rid = req_pool_indices[bid];
+
+  const int64_t token_offset = rid * token_stride_0;
+  const int64_t lru_offset = rid * lru_slot_stride_0;
+  const int64_t buffer_offset = rid * buffer_stride_0;
+  const int64_t host_offset = rid * host_stride;
+
+  for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
+    target_top_k_device_locs[bid * target_top_k_stride + i] = source_top_k_device_locs[bid * source_top_k_stride + i];
+  }
+
+  // Full and Shared layers consume the same top-k sequence. Mirror the Full
+  // layer's hot-buffer metadata so future Shared-layer IO-only prefetches can
+  // keep using Full-layer miss decisions without recomputing top-k diffs.
+  for (int i = tid; i < HOT_BUFFER_SIZE + 1; i += BLOCK_SIZE) {
+    target_device_buffer_tokens[token_offset + i] = source_device_buffer_tokens[token_offset + i];
+  }
+  for (int i = tid; i < HOT_BUFFER_SIZE; i += BLOCK_SIZE) {
+    target_lru_slots[lru_offset + i] = source_lru_slots[lru_offset + i];
+  }
+
+  const int total_misses = miss_counts[bid];
+  const int64_t miss_token_offset = bid * miss_tokens_stride;
+  const int64_t miss_slot_offset = bid * miss_slots_stride;
+  const int64_t* req_host_cache_locs = host_cache_locs + host_offset;
+  const int32_t* req_device_buffer_locs = device_buffer_locs + buffer_offset;
+
+  for (int miss_idx = warp_id; miss_idx < total_misses; miss_idx += NUM_WARPS) {
+    const int32_t miss_token = miss_tokens[miss_token_offset + miss_idx];
+    const int32_t evict_slot = miss_slots[miss_slot_offset + miss_idx];
+    const int64_t src_loc = req_host_cache_locs[miss_token];
+    const int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
+
+    if constexpr (IsDsv4Layout) {
+      device::hisparse::transfer_item(
+          /*dst_cache=*/device_buffer_k,
+          /*src_cache=*/const_cast<void*>(host_cache_k),
+          /*dst_index=*/static_cast<int32_t>(dst_loc),
+          /*src_index=*/static_cast<int32_t>(src_loc));
+    } else {
       const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
       auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
       transfer_item_warp(lane_id, src_k, dst_k, item_size_bytes);
@@ -501,6 +606,9 @@ void load_cache_to_device_buffer(
         device_buffer_k.data_ptr(),
         (IsMLA || device_buffer_v.ndim() == 0) ? (void*)nullptr : device_buffer_v.data_ptr(),
         static_cast<int32_t*>(top_k_device_locs.data_ptr()),
+        nullptr,
+        nullptr,
+        nullptr,
         req_pool_indices_ptr,
         seq_lens_ptr,
         static_cast<int16_t*>(lru_slots.data_ptr()),
@@ -510,6 +618,8 @@ void load_cache_to_device_buffer(
         lru_slot_stride_0,
         top_k_tokens_stride,
         top_k_device_locs_stride,
+        0,
+        0,
         page_size,
         item_size_bytes);
   };
@@ -566,6 +676,217 @@ void load_cache_to_device_buffer(
             int32_t,
             int32_t>,
         static_cast<const int32_t*>(seq_lens.data_ptr()),
+        static_cast<const int32_t*>(req_pool_indices.data_ptr()));
+  }
+}
+
+template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, bool IsMLA, bool IsDsv4Layout>
+void load_cache_to_device_buffer_with_miss(
+    tvm::ffi::TensorView top_k_tokens,
+    tvm::ffi::TensorView device_buffer_tokens,
+    tvm::ffi::TensorView host_cache_locs,
+    tvm::ffi::TensorView device_buffer_locs,
+    tvm::ffi::TensorView host_cache_k,
+    tvm::ffi::TensorView host_cache_v,
+    tvm::ffi::TensorView device_buffer_k,
+    tvm::ffi::TensorView device_buffer_v,
+    tvm::ffi::TensorView top_k_device_locs,
+    tvm::ffi::TensorView miss_tokens,
+    tvm::ffi::TensorView miss_slots,
+    tvm::ffi::TensorView miss_counts,
+    tvm::ffi::TensorView req_pool_indices,
+    tvm::ffi::TensorView seq_lens,
+    tvm::ffi::TensorView lru_slots,
+    tvm::ffi::TensorView num_real_reqs,
+    int64_t page_size,
+    int64_t item_size_bytes) {
+  using namespace host;
+
+  const int64_t bs = top_k_tokens.shape()[0];
+  const int64_t host_stride = host_cache_locs.shape()[1];
+  const int64_t buffer_stride_0 = device_buffer_tokens.strides()[0];
+  const int64_t lru_slot_stride_0 = lru_slots.strides()[0];
+  const int64_t top_k_tokens_stride = top_k_tokens.strides()[0];
+  const int64_t top_k_device_locs_stride = top_k_device_locs.strides()[0];
+  const int64_t miss_tokens_stride = miss_tokens.strides()[0];
+  const int64_t miss_slots_stride = miss_slots.strides()[0];
+  const auto device = LaunchKernel::resolve_device(top_k_tokens.device());
+
+  auto launch = [&](auto kernel_fn, const auto* seq_lens_ptr, const auto* req_pool_indices_ptr) {
+    constexpr size_t smem_bytes = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>::BYTES;
+    if constexpr (smem_bytes > 48u * 1024u) {
+      cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
+    }
+    LaunchKernel(bs, BLOCK_SIZE, device, smem_bytes)(
+        kernel_fn,
+        static_cast<const int32_t*>(top_k_tokens.data_ptr()),
+        static_cast<int32_t*>(device_buffer_tokens.data_ptr()),
+        static_cast<const int64_t*>(host_cache_locs.data_ptr()),
+        static_cast<const int32_t*>(device_buffer_locs.data_ptr()),
+        host_cache_k.data_ptr(),
+        (IsMLA || host_cache_v.ndim() == 0) ? (const void*)nullptr : host_cache_v.data_ptr(),
+        device_buffer_k.data_ptr(),
+        (IsMLA || device_buffer_v.ndim() == 0) ? (void*)nullptr : device_buffer_v.data_ptr(),
+        static_cast<int32_t*>(top_k_device_locs.data_ptr()),
+        static_cast<int32_t*>(miss_tokens.data_ptr()),
+        static_cast<int32_t*>(miss_slots.data_ptr()),
+        static_cast<int32_t*>(miss_counts.data_ptr()),
+        req_pool_indices_ptr,
+        seq_lens_ptr,
+        static_cast<int16_t*>(lru_slots.data_ptr()),
+        static_cast<const int32_t*>(num_real_reqs.data_ptr()),
+        buffer_stride_0,
+        host_stride,
+        lru_slot_stride_0,
+        top_k_tokens_stride,
+        top_k_device_locs_stride,
+        miss_tokens_stride,
+        miss_slots_stride,
+        page_size,
+        item_size_bytes);
+  };
+
+  const auto seq_dtype = seq_lens.dtype();
+  const auto rpi_dtype = req_pool_indices.dtype();
+  const bool seq_is_i64 = (seq_dtype.code == kDLInt && seq_dtype.bits == 64);
+  const bool rpi_is_i64 = (rpi_dtype.code == kDLInt && rpi_dtype.bits == 64);
+
+  if (seq_is_i64 && rpi_is_i64) {
+    launch(
+        load_cache_to_device_buffer_kernel<
+            BLOCK_SIZE,
+            NUM_TOP_K,
+            HOT_BUFFER_SIZE,
+            IsMLA,
+            IsDsv4Layout,
+            int64_t,
+            int64_t>,
+        static_cast<const int64_t*>(seq_lens.data_ptr()),
+        static_cast<const int64_t*>(req_pool_indices.data_ptr()));
+  } else if (seq_is_i64 && !rpi_is_i64) {
+    launch(
+        load_cache_to_device_buffer_kernel<
+            BLOCK_SIZE,
+            NUM_TOP_K,
+            HOT_BUFFER_SIZE,
+            IsMLA,
+            IsDsv4Layout,
+            int64_t,
+            int32_t>,
+        static_cast<const int64_t*>(seq_lens.data_ptr()),
+        static_cast<const int32_t*>(req_pool_indices.data_ptr()));
+  } else if (!seq_is_i64 && rpi_is_i64) {
+    launch(
+        load_cache_to_device_buffer_kernel<
+            BLOCK_SIZE,
+            NUM_TOP_K,
+            HOT_BUFFER_SIZE,
+            IsMLA,
+            IsDsv4Layout,
+            int32_t,
+            int64_t>,
+        static_cast<const int32_t*>(seq_lens.data_ptr()),
+        static_cast<const int64_t*>(req_pool_indices.data_ptr()));
+  } else {
+    launch(
+        load_cache_to_device_buffer_kernel<
+            BLOCK_SIZE,
+            NUM_TOP_K,
+            HOT_BUFFER_SIZE,
+            IsMLA,
+            IsDsv4Layout,
+            int32_t,
+            int32_t>,
+        static_cast<const int32_t*>(seq_lens.data_ptr()),
+        static_cast<const int32_t*>(req_pool_indices.data_ptr()));
+  }
+}
+
+template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, bool IsMLA, bool IsDsv4Layout>
+void load_cache_to_device_buffer_io_only(
+    tvm::ffi::TensorView source_top_k_device_locs,
+    tvm::ffi::TensorView target_top_k_device_locs,
+    tvm::ffi::TensorView miss_tokens,
+    tvm::ffi::TensorView miss_slots,
+    tvm::ffi::TensorView miss_counts,
+    tvm::ffi::TensorView source_device_buffer_tokens,
+    tvm::ffi::TensorView target_device_buffer_tokens,
+    tvm::ffi::TensorView source_lru_slots,
+    tvm::ffi::TensorView target_lru_slots,
+    tvm::ffi::TensorView host_cache_locs,
+    tvm::ffi::TensorView device_buffer_locs,
+    tvm::ffi::TensorView host_cache_k,
+    tvm::ffi::TensorView host_cache_v,
+    tvm::ffi::TensorView device_buffer_k,
+    tvm::ffi::TensorView device_buffer_v,
+    tvm::ffi::TensorView req_pool_indices,
+    tvm::ffi::TensorView num_real_reqs,
+    int64_t item_size_bytes) {
+  using namespace host;
+
+  const int64_t bs = source_top_k_device_locs.shape()[0];
+  const int64_t source_top_k_stride = source_top_k_device_locs.strides()[0];
+  const int64_t target_top_k_stride = target_top_k_device_locs.strides()[0];
+  const int64_t miss_tokens_stride = miss_tokens.strides()[0];
+  const int64_t miss_slots_stride = miss_slots.strides()[0];
+  const int64_t token_stride_0 = source_device_buffer_tokens.strides()[0];
+  const int64_t lru_slot_stride_0 = source_lru_slots.strides()[0];
+  const int64_t host_stride = host_cache_locs.shape()[1];
+  const int64_t buffer_stride_0 = device_buffer_locs.strides()[0];
+  const auto device = LaunchKernel::resolve_device(source_top_k_device_locs.device());
+
+  auto launch = [&](auto kernel_fn, const auto* req_pool_indices_ptr) {
+    LaunchKernel(bs, BLOCK_SIZE, device)(
+        kernel_fn,
+        static_cast<const int32_t*>(source_top_k_device_locs.data_ptr()),
+        static_cast<int32_t*>(target_top_k_device_locs.data_ptr()),
+        static_cast<const int32_t*>(miss_tokens.data_ptr()),
+        static_cast<const int32_t*>(miss_slots.data_ptr()),
+        static_cast<const int32_t*>(miss_counts.data_ptr()),
+        static_cast<const int32_t*>(source_device_buffer_tokens.data_ptr()),
+        static_cast<int32_t*>(target_device_buffer_tokens.data_ptr()),
+        static_cast<const int16_t*>(source_lru_slots.data_ptr()),
+        static_cast<int16_t*>(target_lru_slots.data_ptr()),
+        static_cast<const int64_t*>(host_cache_locs.data_ptr()),
+        static_cast<const int32_t*>(device_buffer_locs.data_ptr()),
+        host_cache_k.data_ptr(),
+        (IsMLA || host_cache_v.ndim() == 0) ? (const void*)nullptr : host_cache_v.data_ptr(),
+        device_buffer_k.data_ptr(),
+        (IsMLA || device_buffer_v.ndim() == 0) ? (void*)nullptr : device_buffer_v.data_ptr(),
+        req_pool_indices_ptr,
+        static_cast<const int32_t*>(num_real_reqs.data_ptr()),
+        source_top_k_stride,
+        target_top_k_stride,
+        miss_tokens_stride,
+        miss_slots_stride,
+        token_stride_0,
+        lru_slot_stride_0,
+        host_stride,
+        buffer_stride_0,
+        item_size_bytes);
+  };
+
+  const auto rpi_dtype = req_pool_indices.dtype();
+  const bool rpi_is_i64 = (rpi_dtype.code == kDLInt && rpi_dtype.bits == 64);
+  if (rpi_is_i64) {
+    launch(
+        load_cache_to_device_buffer_io_only_kernel<
+            BLOCK_SIZE,
+            NUM_TOP_K,
+            HOT_BUFFER_SIZE,
+            IsMLA,
+            IsDsv4Layout,
+            int64_t>,
+        static_cast<const int64_t*>(req_pool_indices.data_ptr()));
+  } else {
+    launch(
+        load_cache_to_device_buffer_io_only_kernel<
+            BLOCK_SIZE,
+            NUM_TOP_K,
+            HOT_BUFFER_SIZE,
+            IsMLA,
+            IsDsv4Layout,
+            int32_t>,
         static_cast<const int32_t*>(req_pool_indices.data_ptr()));
   }
 }

--- a/python/sglang/jit_kernel/hisparse.py
+++ b/python/sglang/jit_kernel/hisparse.py
@@ -35,7 +35,15 @@ def _jit_sparse_module(
             (
                 "load_cache_to_device_buffer",
                 f"load_cache_to_device_buffer<{template_args}>",
-            )
+            ),
+            (
+                "load_cache_to_device_buffer_with_miss",
+                f"load_cache_to_device_buffer_with_miss<{template_args}>",
+            ),
+            (
+                "load_cache_to_device_buffer_io_only",
+                f"load_cache_to_device_buffer_io_only<{template_args}>",
+            ),
         ],
     )
 
@@ -183,6 +191,130 @@ def load_cache_to_device_buffer_mla(
         block_size=block_size,
         num_real_reqs=num_real_reqs,
     )
+
+
+def load_cache_to_device_buffer_mla_with_miss(
+    top_k_tokens: torch.Tensor,
+    device_buffer_tokens: torch.Tensor,
+    host_cache_locs: torch.Tensor,
+    device_buffer_locs: torch.Tensor,
+    host_cache: torch.Tensor,
+    device_buffer: torch.Tensor,
+    top_k_device_locs: torch.Tensor,
+    miss_tokens: torch.Tensor,
+    miss_slots: torch.Tensor,
+    miss_counts: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    lru_slots: torch.Tensor,
+    item_size_bytes: int,
+    num_top_k: int,
+    hot_buffer_size: int,
+    page_size: int = 1,
+    block_size: int = 256,
+    num_real_reqs: torch.Tensor | None = None,
+) -> None:
+    """MLA HiSparse swap-in that also exports miss tokens and evicted slots."""
+    assert (
+        hot_buffer_size >= num_top_k
+    ), f"hot_buffer_size ({hot_buffer_size}) must be >= num_top_k ({num_top_k})"
+
+    module = _jit_sparse_module(
+        item_size_bytes,
+        block_size,
+        num_top_k,
+        hot_buffer_size,
+        is_mla=True,
+        is_dsv4_layout=False,
+    )
+    empty = torch.empty(0)
+    if num_real_reqs is None:
+        num_real_reqs = torch.tensor(
+            [top_k_tokens.size(0)], dtype=torch.int32, device=top_k_tokens.device
+        )
+
+    with _get_tvm_ffi_use_torch_stream()():
+        module.load_cache_to_device_buffer_with_miss(
+            top_k_tokens,
+            device_buffer_tokens,
+            host_cache_locs,
+            device_buffer_locs,
+            host_cache,
+            empty,
+            device_buffer,
+            empty,
+            top_k_device_locs,
+            miss_tokens,
+            miss_slots,
+            miss_counts,
+            req_pool_indices,
+            seq_lens,
+            lru_slots,
+            num_real_reqs,
+            page_size,
+            item_size_bytes,
+        )
+
+
+def load_cache_to_device_buffer_mla_io_only(
+    source_top_k_device_locs: torch.Tensor,
+    target_top_k_device_locs: torch.Tensor,
+    miss_tokens: torch.Tensor,
+    miss_slots: torch.Tensor,
+    miss_counts: torch.Tensor,
+    source_device_buffer_tokens: torch.Tensor,
+    target_device_buffer_tokens: torch.Tensor,
+    source_lru_slots: torch.Tensor,
+    target_lru_slots: torch.Tensor,
+    host_cache_locs: torch.Tensor,
+    device_buffer_locs: torch.Tensor,
+    host_cache: torch.Tensor,
+    device_buffer: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    item_size_bytes: int,
+    num_top_k: int,
+    hot_buffer_size: int,
+    block_size: int = 256,
+    num_real_reqs: torch.Tensor | None = None,
+) -> None:
+    """Shared-layer IndexCache prefetch: mirror metadata and copy Full misses."""
+    module = _jit_sparse_module(
+        item_size_bytes,
+        block_size,
+        num_top_k,
+        hot_buffer_size,
+        is_mla=True,
+        is_dsv4_layout=False,
+    )
+    empty = torch.empty(0)
+    if num_real_reqs is None:
+        num_real_reqs = torch.tensor(
+            [source_top_k_device_locs.size(0)],
+            dtype=torch.int32,
+            device=source_top_k_device_locs.device,
+        )
+
+    with _get_tvm_ffi_use_torch_stream()():
+        module.load_cache_to_device_buffer_io_only(
+            source_top_k_device_locs,
+            target_top_k_device_locs,
+            miss_tokens,
+            miss_slots,
+            miss_counts,
+            source_device_buffer_tokens,
+            target_device_buffer_tokens,
+            source_lru_slots,
+            target_lru_slots,
+            host_cache_locs,
+            device_buffer_locs,
+            host_cache,
+            empty,
+            device_buffer,
+            empty,
+            req_pool_indices,
+            num_real_reqs,
+            item_size_bytes,
+        )
 
 
 def load_cache_to_device_buffer_dsv4_mla(

--- a/python/sglang/jit_kernel/hisparse.py
+++ b/python/sglang/jit_kernel/hisparse.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 import torch
@@ -55,6 +56,17 @@ def _jit_dsv4_transfer_module(block_size: int) -> Module:
     )
 
 
+@functools.cache
+def _get_tvm_ffi_use_torch_stream():
+    """Make TVM-FFI launches follow torch current stream/cuda graph capture."""
+    try:
+        import tvm_ffi
+
+        return tvm_ffi.use_torch_stream
+    except (ImportError, AttributeError):
+        return nullcontext
+
+
 def transfer_cache_dsv4_mla(
     src_ptrs: torch.Tensor,
     dst_ptrs: torch.Tensor,
@@ -64,12 +76,13 @@ def transfer_cache_dsv4_mla(
 ) -> None:
     """Transfer DSv4 C4 tokens between page-padded C4 buffers."""
     module = _jit_dsv4_transfer_module(block_size)
-    module.transfer_cache_dsv4_mla(
-        src_ptrs,
-        dst_ptrs,
-        src_indices,
-        dst_indices,
-    )
+    with _get_tvm_ffi_use_torch_stream()():
+        module.transfer_cache_dsv4_mla(
+            src_ptrs,
+            dst_ptrs,
+            src_indices,
+            dst_indices,
+        )
 
 
 def _load_cache_to_device_buffer_mla(
@@ -112,23 +125,24 @@ def _load_cache_to_device_buffer_mla(
             [top_k_tokens.size(0)], dtype=torch.int32, device=top_k_tokens.device
         )
 
-    module.load_cache_to_device_buffer(
-        top_k_tokens,
-        device_buffer_tokens,
-        host_cache_locs,
-        device_buffer_locs,
-        host_cache,
-        empty,
-        device_buffer,
-        empty,
-        top_k_device_locs,
-        req_pool_indices,
-        seq_lens,
-        lru_slots,
-        num_real_reqs,
-        page_size,
-        item_size_bytes,
-    )
+    with _get_tvm_ffi_use_torch_stream()():
+        module.load_cache_to_device_buffer(
+            top_k_tokens,
+            device_buffer_tokens,
+            host_cache_locs,
+            device_buffer_locs,
+            host_cache,
+            empty,
+            device_buffer,
+            empty,
+            top_k_device_locs,
+            req_pool_indices,
+            seq_lens,
+            lru_slots,
+            num_real_reqs,
+            page_size,
+            item_size_bytes,
+        )
 
 
 def load_cache_to_device_buffer_mla(

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1644,6 +1644,12 @@ class DeepseekSparseAttnBackend(
                 topk_indices,
                 layer.layer_id,
             )
+            self.hisparse_coordinator.prefetch_indexcache_shared_layers(
+                forward_batch.req_pool_indices,
+                forward_batch.seq_lens,
+                topk_indices,
+                layer.layer_id,
+            )
         elif envs.SGLANG_DSA_FUSE_TOPK.get():
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
         else:

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -1,7 +1,7 @@
 # to be combined with the sparse coordinator class and sparse algorithm family
 
 import logging
-from typing import List, NamedTuple, Union
+from typing import Dict, List, NamedTuple, Optional, Tuple, Union
 
 import torch
 
@@ -28,6 +28,64 @@ from sglang.jit_kernel.hisparse import (
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 
 logger = logging.getLogger(__name__)
+
+
+def _cfg_get(config, name: str, default=None):
+    if isinstance(config, dict):
+        return config.get(name, default)
+    return getattr(config, name, default)
+
+
+def build_indexcache_prefetch_layers_after(
+    config,
+    *,
+    start_layer: int,
+    layer_num: int,
+) -> Dict[int, Tuple[int, ...]]:
+    """Return Full-layer -> consecutive Shared layers served by its top-k.
+
+    This mirrors DeepseekV2AttentionMLA.skip_topk/next_skip_topk semantics:
+    Shared layers reuse the nearest preceding Full layer's top-k indices.
+    """
+    if layer_num <= 1:
+        return {}
+
+    index_topk_pattern = _cfg_get(config, "index_topk_pattern", None)
+    index_topk_freq = int(_cfg_get(config, "index_topk_freq", 1) or 1)
+    index_skip_topk_offset = _cfg_get(config, "index_skip_topk_offset", None)
+
+    if index_topk_pattern is None and index_topk_freq <= 1:
+        return {}
+
+    end_layer = start_layer + layer_num
+    num_hidden_layers = int(_cfg_get(config, "num_hidden_layers", end_layer))
+
+    def is_shared_layer(layer_id: int) -> bool:
+        if layer_id < 0 or layer_id >= num_hidden_layers:
+            return False
+        if index_topk_pattern is not None:
+            if layer_id >= len(index_topk_pattern):
+                return False
+            return str(index_topk_pattern[layer_id]).upper().startswith("S")
+        if index_skip_topk_offset is not None:
+            offset = int(index_skip_topk_offset)
+            if offset <= 0:
+                return False
+            return max(layer_id - offset + 1, 0) % index_topk_freq != 0
+        return max(layer_id - 1, 0) % index_topk_freq != 0
+
+    layers_after: Dict[int, Tuple[int, ...]] = {}
+    for layer_id in range(start_layer, end_layer):
+        if is_shared_layer(layer_id):
+            continue
+        shared_layers = []
+        next_layer = layer_id + 1
+        while next_layer < end_layer and is_shared_layer(next_layer):
+            shared_layers.append(next_layer)
+            next_layer += 1
+        if shared_layers:
+            layers_after[layer_id] = tuple(shared_layers)
+    return layers_after
 
 
 class HiSparseAct(NamedTuple):
@@ -177,6 +235,9 @@ class HiSparseCoordinator:
         self.raw_indices_buffer = torch.full(
             (max_num_req_slots, self.top_k), -1, dtype=torch.int32, device=device
         )
+        # DSA IndexCache prefetch uses this as throwaway page-table output.
+        # DSv4 uses it for raw indices, but IndexCache prefetch is disabled there.
+        self.indexcache_prefetch_top_k_device_locs_buffer = self.raw_indices_buffer
         # Scalar tensor: number of real (non-padded) requests in the batch.
         # Updated before each graph replay so padded blocks early-return.
         self.num_real_reqs = torch.zeros(1, dtype=torch.int32, device=device)
@@ -185,8 +246,58 @@ class HiSparseCoordinator:
         # staging already backed up all prefill tokens.  Cleared after one step.
         self._skip_first_backup = [False] * max_num_req_slots
 
+        # IndexCache + HiSparse: a Full layer already knows the top-k token ids
+        # used by the following Shared layers.  Fire those Shared-layer swap-ins
+        # on a side stream so their host->device KV loads overlap current-layer
+        # attention/MLP work.  The Shared layer still runs swap_in on the main
+        # stream to materialize its page table, but it should see device hits.
+        self.indexcache_prefetch_stream = device_module.Stream()
+        self._indexcache_prefetch_events = [
+            device_module.Event() for _ in range(layer_num)
+        ]
+        self._indexcache_prefetch_pending = [False] * layer_num
+        self._indexcache_prefetch_layers_after: Dict[int, Tuple[int, ...]] = {}
+        self._indexcache_prefetch_enabled = False
+
     def set_decode_producer_stream(self, stream) -> None:
         self.decode_producer_stream = stream
+
+    def configure_indexcache_prefetch(self, config) -> None:
+        """Build the Full-layer -> Shared-layers prefetch plan from DSA config."""
+        self._indexcache_prefetch_layers_after.clear()
+        self._indexcache_prefetch_enabled = False
+
+        if self.is_dsv4_hisparse:
+            return
+
+        layer_num = self.mem_pool_device.layer_num
+        if layer_num <= 1:
+            return
+
+        start_layer = getattr(self.mem_pool_device, "start_layer", 0)
+        self._indexcache_prefetch_layers_after = build_indexcache_prefetch_layers_after(
+            config,
+            start_layer=start_layer,
+            layer_num=layer_num,
+        )
+
+        self._indexcache_prefetch_enabled = bool(self._indexcache_prefetch_layers_after)
+        if self._indexcache_prefetch_enabled:
+            logger.info(
+                "HiSparse IndexCache prefetch enabled for %d Full layers",
+                len(self._indexcache_prefetch_layers_after),
+            )
+
+    def _local_layer_index(self, layer_id: int) -> Optional[int]:
+        if self.is_dsv4_hisparse and 0 <= layer_id < self.mem_pool_device.layer_num:
+            return layer_id
+        start_layer = getattr(self.mem_pool_device, "start_layer", 0)
+        if start_layer == 0 and 0 <= layer_id < self.mem_pool_device.layer_num:
+            return layer_id
+        local_layer_id = layer_id - start_layer
+        if 0 <= local_layer_id < self.mem_pool_device.layer_num:
+            return local_layer_id
+        return None
 
     def get_token_stats(self) -> HiSparseTokenStats:
         device_allocator = self.token_to_kv_pool_allocator.hisparse_attn_allocator
@@ -604,6 +715,72 @@ class HiSparseCoordinator:
         self._backup_done_event.wait(device_module.current_stream())
         self._has_pending_backup = False
 
+    def _record_tensor_on_indexcache_prefetch_stream(
+        self, tensor: torch.Tensor
+    ) -> None:
+        if tensor.is_cuda:
+            tensor.record_stream(self.indexcache_prefetch_stream)
+
+    def wait_for_indexcache_prefetch(self, layer_id: int) -> None:
+        layer_idx = self._local_layer_index(layer_id)
+        if layer_idx is None or not self._indexcache_prefetch_pending[layer_idx]:
+            return
+        self._indexcache_prefetch_events[layer_idx].wait(device_module.current_stream())
+        self._indexcache_prefetch_pending[layer_idx] = False
+
+    def wait_for_pending_indexcache_prefetch(self) -> None:
+        if not any(self._indexcache_prefetch_pending):
+            return
+        device_module.current_stream().wait_stream(self.indexcache_prefetch_stream)
+        for i in range(len(self._indexcache_prefetch_pending)):
+            self._indexcache_prefetch_pending[i] = False
+
+    def prefetch_indexcache_shared_layers(
+        self,
+        req_pool_indices: torch.Tensor,
+        compressed_seq_lens: torch.Tensor,
+        top_k_result: Optional[torch.Tensor],
+        layer_id: int,
+    ) -> None:
+        """Prefetch HiSparse KV for Shared layers served by this Full layer."""
+        if (
+            not self._indexcache_prefetch_enabled
+            or top_k_result is None
+            or layer_id not in self._indexcache_prefetch_layers_after
+        ):
+            return
+
+        target_layers = self._indexcache_prefetch_layers_after[layer_id]
+        if not target_layers:
+            return
+
+        num_reqs = req_pool_indices.size(0)
+        scratch = self.indexcache_prefetch_top_k_device_locs_buffer[:num_reqs]
+
+        current_stream = device_module.current_stream()
+        self.indexcache_prefetch_stream.wait_stream(current_stream)
+        with device_module.stream(self.indexcache_prefetch_stream):
+            for target_layer_id in target_layers:
+                layer_idx = self._local_layer_index(target_layer_id)
+                if layer_idx is None:
+                    continue
+                self._swap_in_selected_pages_to_buffer(
+                    req_pool_indices=req_pool_indices,
+                    compressed_seq_lens=compressed_seq_lens,
+                    top_k_result=top_k_result,
+                    layer_id=target_layer_id,
+                    top_k_indices=scratch,
+                    clear_output=False,
+                )
+                self._indexcache_prefetch_events[layer_idx].record(
+                    self.indexcache_prefetch_stream
+                )
+                self._indexcache_prefetch_pending[layer_idx] = True
+
+        self._record_tensor_on_indexcache_prefetch_stream(req_pool_indices)
+        self._record_tensor_on_indexcache_prefetch_stream(compressed_seq_lens)
+        self._record_tensor_on_indexcache_prefetch_stream(top_k_result)
+
     def naive_load_topk(
         self,
         req_pool_indices: torch.Tensor,
@@ -738,6 +915,7 @@ class HiSparseCoordinator:
         # release resources only after the execution of a potential overlapped batch
         if self.decode_producer_stream is not None:
             device_module.current_stream().wait_stream(self.decode_producer_stream)
+        self.wait_for_pending_indexcache_prefetch()
         self.wait_for_pending_backup()
 
         # Use kv_allocated_len (not seqlen): under speculative decoding the
@@ -790,10 +968,38 @@ class HiSparseCoordinator:
         layer_id: int,
     ) -> torch.Tensor:
         """Swap selected top-k tokens into device memory and return their indices."""
+        self.wait_for_indexcache_prefetch(layer_id)
         num_reqs = req_pool_indices.size(0)
-
         top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
-        top_k_indices.fill_(-1)
+        return self._swap_in_selected_pages_to_buffer(
+            req_pool_indices=req_pool_indices,
+            compressed_seq_lens=compressed_seq_lens,
+            top_k_result=top_k_result,
+            layer_id=layer_id,
+            top_k_indices=top_k_indices,
+            clear_output=True,
+        )
+
+    def _swap_in_selected_pages_to_buffer(
+        self,
+        req_pool_indices: torch.Tensor,
+        compressed_seq_lens: torch.Tensor,
+        top_k_result: torch.Tensor,
+        layer_id: int,
+        top_k_indices: torch.Tensor,
+        clear_output: bool,
+    ) -> torch.Tensor:
+        layer_idx = self._local_layer_index(layer_id)
+        if layer_idx is None:
+            start_layer = getattr(self.mem_pool_device, "start_layer", 0)
+            end_layer = start_layer + self.mem_pool_device.layer_num
+            raise ValueError(
+                f"HiSparse layer_id {layer_id} is outside local layer range "
+                f"[{start_layer}, {end_layer})"
+            )
+
+        if clear_output:
+            top_k_indices.fill_(-1)
 
         # todo, adjustable for performance
         block_size = 1024
@@ -804,15 +1010,15 @@ class HiSparseCoordinator:
         )
         swap_in_fn(
             top_k_tokens=top_k_result,
-            device_buffer_tokens=self.req_device_buffer_tokens[layer_id],
+            device_buffer_tokens=self.req_device_buffer_tokens[layer_idx],
             host_cache_locs=self.req_to_host_pool,
-            device_buffer_locs=self.req_device_buffer_token_locs[layer_id],
-            host_cache=self.mem_pool_host.kv_buffer[layer_id],
-            device_buffer=self.mem_pool_device.kv_buffer[layer_id],
+            device_buffer_locs=self.req_device_buffer_token_locs[layer_idx],
+            host_cache=self.mem_pool_host.kv_buffer[layer_idx],
+            device_buffer=self.mem_pool_device.kv_buffer[layer_idx],
             top_k_device_locs=top_k_indices,
             req_pool_indices=req_pool_indices,
             seq_lens=compressed_seq_lens,
-            lru_slots=self.lru_slots[layer_id],
+            lru_slots=self.lru_slots[layer_idx],
             item_size_bytes=self.item_size_bytes,
             num_top_k=self.top_k,
             hot_buffer_size=self.device_buffer_size,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -24,6 +24,8 @@ device_module = get_device_module()
 from sglang.jit_kernel.hisparse import (
     load_cache_to_device_buffer_dsv4_mla,
     load_cache_to_device_buffer_mla,
+    load_cache_to_device_buffer_mla_io_only,
+    load_cache_to_device_buffer_mla_with_miss,
 )
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 
@@ -114,6 +116,7 @@ class HiSparseCoordinator:
         device: str,
         tp_group,
         host_to_device_ratio: int = 2,
+        max_prefetch_num_reqs: Optional[int] = None,
     ):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
@@ -164,6 +167,10 @@ class HiSparseCoordinator:
         self.page_size = self.mem_pool_device.page_size
 
         max_num_req_slots = req_to_token_pool.req_to_token.shape[0]
+        max_prefetch_num_reqs = max_prefetch_num_reqs or max_num_req_slots
+        self.max_prefetch_num_reqs = max(
+            1, min(max_num_req_slots, max_prefetch_num_reqs)
+        )
         max_context_len = req_to_token_pool.max_context_len
         max_compressed_context_len = (
             max_context_len + self.compress_ratio - 1
@@ -235,9 +242,16 @@ class HiSparseCoordinator:
         self.raw_indices_buffer = torch.full(
             (max_num_req_slots, self.top_k), -1, dtype=torch.int32, device=device
         )
-        # DSA IndexCache prefetch uses this as throwaway page-table output.
-        # DSv4 uses it for raw indices, but IndexCache prefetch is disabled there.
-        self.indexcache_prefetch_top_k_device_locs_buffer = self.raw_indices_buffer
+        self.indexcache_prefetch_top_k_device_locs_buffers: Optional[torch.Tensor] = (
+            None
+        )
+        self.indexcache_prefetch_miss_tokens_buffer: Optional[torch.Tensor] = None
+        self.indexcache_prefetch_miss_slots_buffer: Optional[torch.Tensor] = None
+        self.indexcache_prefetch_miss_counts_buffer: Optional[torch.Tensor] = None
+        self._indexcache_prefetch_source_top_k_device_locs: Optional[torch.Tensor] = (
+            None
+        )
+        self._indexcache_prefetch_source_layer_idx: Optional[int] = None
         # Scalar tensor: number of real (non-padded) requests in the batch.
         # Updated before each graph replay so padded blocks early-return.
         self.num_real_reqs = torch.zeros(1, dtype=torch.int32, device=device)
@@ -246,16 +260,17 @@ class HiSparseCoordinator:
         # staging already backed up all prefill tokens.  Cleared after one step.
         self._skip_first_backup = [False] * max_num_req_slots
 
-        # IndexCache + HiSparse: a Full layer already knows the top-k token ids
-        # used by the following Shared layers.  Fire those Shared-layer swap-ins
-        # on a side stream so their host->device KV loads overlap current-layer
-        # attention/MLP work.  The Shared layer still runs swap_in on the main
-        # stream to materialize its page table, but it should see device hits.
+        # IndexCache + HiSparse: a Full layer's top-k token ids are reused by
+        # following Shared layers. Fire those Shared-layer swap-ins on a side
+        # stream and keep their page tables, so Shared layers can consume the
+        # prefetched result without running swap-in again.
         self.indexcache_prefetch_stream = device_module.Stream()
+        self.indexcache_prefetch_streams = [self.indexcache_prefetch_stream]
         self._indexcache_prefetch_events = [
             device_module.Event() for _ in range(layer_num)
         ]
         self._indexcache_prefetch_pending = [False] * layer_num
+        self._indexcache_prefetch_buffer_slots = [-1] * layer_num
         self._indexcache_prefetch_layers_after: Dict[int, Tuple[int, ...]] = {}
         self._indexcache_prefetch_enabled = False
 
@@ -266,6 +281,16 @@ class HiSparseCoordinator:
         """Build the Full-layer -> Shared-layers prefetch plan from DSA config."""
         self._indexcache_prefetch_layers_after.clear()
         self._indexcache_prefetch_enabled = False
+        self.indexcache_prefetch_top_k_device_locs_buffers = None
+        self.indexcache_prefetch_miss_tokens_buffer = None
+        self.indexcache_prefetch_miss_slots_buffer = None
+        self.indexcache_prefetch_miss_counts_buffer = None
+        self._indexcache_prefetch_source_top_k_device_locs = None
+        self._indexcache_prefetch_source_layer_idx = None
+        self.indexcache_prefetch_streams = [self.indexcache_prefetch_stream]
+        for i in range(len(self._indexcache_prefetch_pending)):
+            self._indexcache_prefetch_pending[i] = False
+            self._indexcache_prefetch_buffer_slots[i] = -1
 
         if self.is_dsv4_hisparse:
             return
@@ -283,9 +308,38 @@ class HiSparseCoordinator:
 
         self._indexcache_prefetch_enabled = bool(self._indexcache_prefetch_layers_after)
         if self._indexcache_prefetch_enabled:
+            max_prefetch_targets = max(
+                len(targets)
+                for targets in self._indexcache_prefetch_layers_after.values()
+            )
+            self.indexcache_prefetch_top_k_device_locs_buffers = torch.full(
+                (max_prefetch_targets, self.max_prefetch_num_reqs, self.top_k),
+                -1,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self.indexcache_prefetch_miss_tokens_buffer = torch.empty(
+                (self.max_prefetch_num_reqs, self.top_k),
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self.indexcache_prefetch_miss_slots_buffer = torch.empty(
+                (self.max_prefetch_num_reqs, self.top_k),
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self.indexcache_prefetch_miss_counts_buffer = torch.empty(
+                (self.max_prefetch_num_reqs,), dtype=torch.int32, device=self.device
+            )
+            self.indexcache_prefetch_streams = [
+                device_module.Stream() for _ in range(max_prefetch_targets)
+            ]
             logger.info(
-                "HiSparse IndexCache prefetch enabled for %d Full layers",
+                "HiSparse IndexCache prefetch enabled for %d Full layers, "
+                "%d target buffers, max_prefetch_num_reqs=%d",
                 len(self._indexcache_prefetch_layers_after),
+                max_prefetch_targets,
+                self.max_prefetch_num_reqs,
             )
 
     def _local_layer_index(self, layer_id: int) -> Optional[int]:
@@ -719,21 +773,39 @@ class HiSparseCoordinator:
         self, tensor: torch.Tensor
     ) -> None:
         if tensor.is_cuda:
-            tensor.record_stream(self.indexcache_prefetch_stream)
+            for stream in self.indexcache_prefetch_streams:
+                tensor.record_stream(stream)
 
-    def wait_for_indexcache_prefetch(self, layer_id: int) -> None:
+    def wait_for_indexcache_prefetch(
+        self, layer_id: int, num_reqs: Optional[int] = None
+    ) -> Optional[torch.Tensor]:
         layer_idx = self._local_layer_index(layer_id)
         if layer_idx is None or not self._indexcache_prefetch_pending[layer_idx]:
-            return
+            return None
         self._indexcache_prefetch_events[layer_idx].wait(device_module.current_stream())
         self._indexcache_prefetch_pending[layer_idx] = False
+        buffer_slot = self._indexcache_prefetch_buffer_slots[layer_idx]
+        self._indexcache_prefetch_buffer_slots[layer_idx] = -1
+        if (
+            buffer_slot >= 0
+            and self.indexcache_prefetch_top_k_device_locs_buffers is not None
+        ):
+            if num_reqs is None:
+                num_reqs = self.max_prefetch_num_reqs
+            return self.indexcache_prefetch_top_k_device_locs_buffers[
+                buffer_slot, :num_reqs
+            ]
+        return None
 
     def wait_for_pending_indexcache_prefetch(self) -> None:
         if not any(self._indexcache_prefetch_pending):
             return
-        device_module.current_stream().wait_stream(self.indexcache_prefetch_stream)
+        current_stream = device_module.current_stream()
+        for stream in self.indexcache_prefetch_streams:
+            current_stream.wait_stream(stream)
         for i in range(len(self._indexcache_prefetch_pending)):
             self._indexcache_prefetch_pending[i] = False
+            self._indexcache_prefetch_buffer_slots[i] = -1
 
     def prefetch_indexcache_shared_layers(
         self,
@@ -755,31 +827,103 @@ class HiSparseCoordinator:
             return
 
         num_reqs = req_pool_indices.size(0)
-        scratch = self.indexcache_prefetch_top_k_device_locs_buffer[:num_reqs]
+        if (
+            self.indexcache_prefetch_top_k_device_locs_buffers is None
+            or num_reqs > self.max_prefetch_num_reqs
+        ):
+            return
+        source_layer_idx = self._local_layer_index(layer_id)
+        can_use_io_only = (
+            source_layer_idx is not None
+            and self._indexcache_prefetch_source_layer_idx == source_layer_idx
+            and self._indexcache_prefetch_source_top_k_device_locs is not None
+            and self.indexcache_prefetch_miss_tokens_buffer is not None
+            and self.indexcache_prefetch_miss_slots_buffer is not None
+            and self.indexcache_prefetch_miss_counts_buffer is not None
+            and not self.is_dsv4_hisparse
+        )
 
         current_stream = device_module.current_stream()
-        self.indexcache_prefetch_stream.wait_stream(current_stream)
-        with device_module.stream(self.indexcache_prefetch_stream):
-            for target_layer_id in target_layers:
+        for buffer_slot, target_layer_id in enumerate(target_layers):
+            prefetch_stream = self.indexcache_prefetch_streams[
+                min(buffer_slot, len(self.indexcache_prefetch_streams) - 1)
+            ]
+            prefetch_stream.wait_stream(current_stream)
+            with device_module.stream(prefetch_stream):
                 layer_idx = self._local_layer_index(target_layer_id)
                 if layer_idx is None:
                     continue
-                self._swap_in_selected_pages_to_buffer(
-                    req_pool_indices=req_pool_indices,
-                    compressed_seq_lens=compressed_seq_lens,
-                    top_k_result=top_k_result,
-                    layer_id=target_layer_id,
-                    top_k_indices=scratch,
-                    clear_output=False,
-                )
-                self._indexcache_prefetch_events[layer_idx].record(
-                    self.indexcache_prefetch_stream
-                )
+                top_k_indices = self.indexcache_prefetch_top_k_device_locs_buffers[
+                    buffer_slot, :num_reqs
+                ]
+                if can_use_io_only:
+                    load_cache_to_device_buffer_mla_io_only(
+                        source_top_k_device_locs=(
+                            self._indexcache_prefetch_source_top_k_device_locs[
+                                :num_reqs
+                            ]
+                        ),
+                        target_top_k_device_locs=top_k_indices,
+                        miss_tokens=self.indexcache_prefetch_miss_tokens_buffer[
+                            :num_reqs
+                        ],
+                        miss_slots=self.indexcache_prefetch_miss_slots_buffer[
+                            :num_reqs
+                        ],
+                        miss_counts=self.indexcache_prefetch_miss_counts_buffer[
+                            :num_reqs
+                        ],
+                        source_device_buffer_tokens=self.req_device_buffer_tokens[
+                            source_layer_idx
+                        ],
+                        target_device_buffer_tokens=self.req_device_buffer_tokens[
+                            layer_idx
+                        ],
+                        source_lru_slots=self.lru_slots[source_layer_idx],
+                        target_lru_slots=self.lru_slots[layer_idx],
+                        host_cache_locs=self.req_to_host_pool,
+                        device_buffer_locs=self.req_device_buffer_token_locs[layer_idx],
+                        host_cache=self.mem_pool_host.kv_buffer[layer_idx],
+                        device_buffer=self.mem_pool_device.kv_buffer[layer_idx],
+                        req_pool_indices=req_pool_indices,
+                        item_size_bytes=self.item_size_bytes,
+                        num_top_k=self.top_k,
+                        hot_buffer_size=self.device_buffer_size,
+                        block_size=1024,
+                        num_real_reqs=self.num_real_reqs,
+                    )
+                else:
+                    self._swap_in_selected_pages_to_buffer(
+                        req_pool_indices=req_pool_indices,
+                        compressed_seq_lens=compressed_seq_lens,
+                        top_k_result=top_k_result,
+                        layer_id=target_layer_id,
+                        top_k_indices=top_k_indices,
+                        clear_output=True,
+                    )
+                self._indexcache_prefetch_events[layer_idx].record(prefetch_stream)
                 self._indexcache_prefetch_pending[layer_idx] = True
+                self._indexcache_prefetch_buffer_slots[layer_idx] = buffer_slot
 
         self._record_tensor_on_indexcache_prefetch_stream(req_pool_indices)
         self._record_tensor_on_indexcache_prefetch_stream(compressed_seq_lens)
         self._record_tensor_on_indexcache_prefetch_stream(top_k_result)
+        if self._indexcache_prefetch_source_top_k_device_locs is not None:
+            self._record_tensor_on_indexcache_prefetch_stream(
+                self._indexcache_prefetch_source_top_k_device_locs
+            )
+        if self.indexcache_prefetch_miss_tokens_buffer is not None:
+            self._record_tensor_on_indexcache_prefetch_stream(
+                self.indexcache_prefetch_miss_tokens_buffer
+            )
+        if self.indexcache_prefetch_miss_slots_buffer is not None:
+            self._record_tensor_on_indexcache_prefetch_stream(
+                self.indexcache_prefetch_miss_slots_buffer
+            )
+        if self.indexcache_prefetch_miss_counts_buffer is not None:
+            self._record_tensor_on_indexcache_prefetch_stream(
+                self.indexcache_prefetch_miss_counts_buffer
+            )
 
     def naive_load_topk(
         self,
@@ -968,9 +1112,28 @@ class HiSparseCoordinator:
         layer_id: int,
     ) -> torch.Tensor:
         """Swap selected top-k tokens into device memory and return their indices."""
-        self.wait_for_indexcache_prefetch(layer_id)
         num_reqs = req_pool_indices.size(0)
+        prefetched_top_k_indices = self.wait_for_indexcache_prefetch(layer_id, num_reqs)
+        if prefetched_top_k_indices is not None:
+            return prefetched_top_k_indices
         top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
+        capture_miss_for_indexcache = (
+            self._indexcache_prefetch_enabled
+            and layer_id in self._indexcache_prefetch_layers_after
+            and self.indexcache_prefetch_miss_tokens_buffer is not None
+            and self.indexcache_prefetch_miss_slots_buffer is not None
+            and self.indexcache_prefetch_miss_counts_buffer is not None
+            and num_reqs <= self.max_prefetch_num_reqs
+            and not self.is_dsv4_hisparse
+        )
+        if capture_miss_for_indexcache:
+            self._indexcache_prefetch_source_top_k_device_locs = top_k_indices
+            self._indexcache_prefetch_source_layer_idx = self._local_layer_index(
+                layer_id
+            )
+        else:
+            self._indexcache_prefetch_source_top_k_device_locs = None
+            self._indexcache_prefetch_source_layer_idx = None
         return self._swap_in_selected_pages_to_buffer(
             req_pool_indices=req_pool_indices,
             compressed_seq_lens=compressed_seq_lens,
@@ -978,6 +1141,21 @@ class HiSparseCoordinator:
             layer_id=layer_id,
             top_k_indices=top_k_indices,
             clear_output=True,
+            miss_tokens=(
+                self.indexcache_prefetch_miss_tokens_buffer[:num_reqs]
+                if capture_miss_for_indexcache
+                else None
+            ),
+            miss_slots=(
+                self.indexcache_prefetch_miss_slots_buffer[:num_reqs]
+                if capture_miss_for_indexcache
+                else None
+            ),
+            miss_counts=(
+                self.indexcache_prefetch_miss_counts_buffer[:num_reqs]
+                if capture_miss_for_indexcache
+                else None
+            ),
         )
 
     def _swap_in_selected_pages_to_buffer(
@@ -988,6 +1166,9 @@ class HiSparseCoordinator:
         layer_id: int,
         top_k_indices: torch.Tensor,
         clear_output: bool,
+        miss_tokens: Optional[torch.Tensor] = None,
+        miss_slots: Optional[torch.Tensor] = None,
+        miss_counts: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         layer_idx = self._local_layer_index(layer_id)
         if layer_idx is None:
@@ -1003,12 +1184,7 @@ class HiSparseCoordinator:
 
         # todo, adjustable for performance
         block_size = 1024
-        swap_in_fn = (
-            load_cache_to_device_buffer_dsv4_mla
-            if self.is_dsv4_hisparse
-            else load_cache_to_device_buffer_mla
-        )
-        swap_in_fn(
+        common_kwargs = dict(
             top_k_tokens=top_k_result,
             device_buffer_tokens=self.req_device_buffer_tokens[layer_idx],
             host_cache_locs=self.req_to_host_pool,
@@ -1026,4 +1202,23 @@ class HiSparseCoordinator:
             block_size=block_size,
             num_real_reqs=self.num_real_reqs,
         )
+        if (
+            miss_tokens is not None
+            and miss_slots is not None
+            and miss_counts is not None
+            and not self.is_dsv4_hisparse
+        ):
+            load_cache_to_device_buffer_mla_with_miss(
+                **common_kwargs,
+                miss_tokens=miss_tokens,
+                miss_slots=miss_slots,
+                miss_counts=miss_counts,
+            )
+        else:
+            swap_in_fn = (
+                load_cache_to_device_buffer_dsv4_mla
+                if self.is_dsv4_hisparse
+                else load_cache_to_device_buffer_mla
+            )
+            swap_in_fn(**common_kwargs)
         return top_k_indices

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -872,6 +872,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 ),
                 host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
             )
+            self.hisparse_coordinator.configure_indexcache_prefetch(
+                self.model_config.hf_text_config
+            )
 
         self.init_routed_experts_capturer()
         self.init_indexer_capturer()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -859,6 +859,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             hisparse_top_k = getattr(
                 self.model_config.hf_text_config, "index_topk", hisparse_cfg.top_k
             )
+            max_prefetch_num_reqs = self.max_running_requests
+            decode_cuda_graph_config = self.server_args.cuda_graph_config.decode
+            if decode_cuda_graph_config.max_bs is not None:
+                max_prefetch_num_reqs = max(
+                    max_prefetch_num_reqs, decode_cuda_graph_config.max_bs
+                )
             self.hisparse_coordinator = HiSparseCoordinator(
                 req_to_token_pool=self.req_to_token_pool,
                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
@@ -871,10 +877,24 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     else self.tp_group.cpu_group
                 ),
                 host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
+                max_prefetch_num_reqs=max_prefetch_num_reqs,
             )
-            self.hisparse_coordinator.configure_indexcache_prefetch(
-                self.model_config.hf_text_config
+            indexcache_config = self.model_config.hf_text_config
+            hf_config = self.model_config.hf_config
+            text_config_has_indexcache = (
+                getattr(indexcache_config, "index_topk_pattern", None) is not None
+                or int(getattr(indexcache_config, "index_topk_freq", 1) or 1) > 1
+                or getattr(indexcache_config, "index_skip_topk_offset", None)
+                is not None
             )
+            hf_config_has_indexcache = (
+                getattr(hf_config, "index_topk_pattern", None) is not None
+                or int(getattr(hf_config, "index_topk_freq", 1) or 1) > 1
+                or getattr(hf_config, "index_skip_topk_offset", None) is not None
+            )
+            if not text_config_has_indexcache and hf_config_has_indexcache:
+                indexcache_config = hf_config
+            self.hisparse_coordinator.configure_indexcache_prefetch(indexcache_config)
 
         self.init_routed_experts_capturer()
         self.init_indexer_capturer()

--- a/test/registered/unit/managers/test_hisparse_indexcache.py
+++ b/test/registered/unit/managers/test_hisparse_indexcache.py
@@ -118,6 +118,13 @@ class TestHiSparseIndexCacheUnit(unittest.TestCase):
             self.coordinator._indexcache_prefetch_layers_after,
             {0: (1,)},
         )
+        self.assertIsNotNone(
+            self.coordinator.indexcache_prefetch_top_k_device_locs_buffers
+        )
+        self.assertEqual(
+            tuple(self.coordinator.indexcache_prefetch_top_k_device_locs_buffers.shape),
+            (1, self.coordinator.max_prefetch_num_reqs, TOP_K),
+        )
 
     def test_indexcache_prefetch_shared_layer_swap_in(self):
         """Full layer can preload KV for its following Shared layer."""
@@ -139,12 +146,25 @@ class TestHiSparseIndexCacheUnit(unittest.TestCase):
         batch = tokens.unsqueeze(0)
         rpi, sls = self._make_batch_tensors([req], [fill_len])
         self.coordinator.num_real_reqs[0] = rpi.shape[0]
+        prefetch_buffers = (
+            self.coordinator.indexcache_prefetch_top_k_device_locs_buffers
+        )
+        self.assertIsNotNone(prefetch_buffers)
 
-        self.coordinator.prefetch_indexcache_shared_layers(rpi, sls, batch, layer_id=0)
+        self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=0)
+        self.coordinator.prefetch_indexcache_shared_layers(
+            rpi,
+            sls,
+            batch,
+            layer_id=0,
+        )
         locs = self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=1)
         torch.cuda.synchronize()
 
         self.assertFalse(self.coordinator._indexcache_prefetch_pending[1])
+        self.assertEqual(
+            locs.data_ptr(), prefetch_buffers[0, : rpi.shape[0]].data_ptr()
+        )
         self._assert_kv_correct(
             locs[0], tokens, layer_id=1, count=TOP_K, msg="IndexCache prefetch: "
         )
@@ -213,10 +233,18 @@ class TestHiSparseIndexCacheUnit(unittest.TestCase):
         batch = tokens.unsqueeze(0)
         rpi, sls = self._make_batch_tensors([req], [fill_len])
         self.coordinator.num_real_reqs[0] = rpi.shape[0]
+        prefetch_buffers = (
+            self.coordinator.indexcache_prefetch_top_k_device_locs_buffers
+        )
+        self.assertIsNotNone(prefetch_buffers)
 
         def graph_body():
+            self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=0)
             self.coordinator.prefetch_indexcache_shared_layers(
-                rpi, sls, batch, layer_id=0
+                rpi,
+                sls,
+                batch,
+                layer_id=0,
             )
             return self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=1)
 
@@ -233,6 +261,9 @@ class TestHiSparseIndexCacheUnit(unittest.TestCase):
 
         self.assertFalse(self.coordinator._indexcache_prefetch_pending[1])
         self.assertTrue(torch.all(locs[0, :TOP_K] >= 0))
+        self.assertEqual(
+            locs.data_ptr(), prefetch_buffers[0, : rpi.shape[0]].data_ptr()
+        )
         self._assert_kv_correct(
             locs[0],
             tokens,
@@ -303,14 +334,21 @@ class TestHiSparseIndexCacheUnit(unittest.TestCase):
             synthetic_current_layer_compute()
 
         def no_overlap_body():
+            self._reset_layer_hot_cache_tags_for_reqs(reqs, layer_id=0)
             self._reset_layer_hot_cache_tags_for_reqs(reqs, layer_id=1)
+            self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=0)
             synthetic_current_layer_compute()
             return self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=1)
 
         def overlap_body():
+            self._reset_layer_hot_cache_tags_for_reqs(reqs, layer_id=0)
             self._reset_layer_hot_cache_tags_for_reqs(reqs, layer_id=1)
+            self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=0)
             self.coordinator.prefetch_indexcache_shared_layers(
-                rpi, sls, batch, layer_id=0
+                rpi,
+                sls,
+                batch,
+                layer_id=0,
             )
             synthetic_current_layer_compute()
             return self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=1)
@@ -324,21 +362,21 @@ class TestHiSparseIndexCacheUnit(unittest.TestCase):
             no_hisparse_graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(no_hisparse_graph):
                 no_hisparse_body()
+            no_hisparse_ms = self._measure_cuda_graph_ms(no_hisparse_graph, iters=iters)
 
             no_overlap_graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(no_overlap_graph):
                 no_overlap_locs = no_overlap_body()
+            no_overlap_ms = self._measure_cuda_graph_ms(no_overlap_graph, iters=iters)
+            torch.cuda.synchronize()
+            self.assertTrue(torch.all(no_overlap_locs[:, :TOP_K] >= 0))
 
             overlap_graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(overlap_graph):
                 overlap_locs = overlap_body()
-
-            no_hisparse_ms = self._measure_cuda_graph_ms(no_hisparse_graph, iters=iters)
-            no_overlap_ms = self._measure_cuda_graph_ms(no_overlap_graph, iters=iters)
             overlap_ms = self._measure_cuda_graph_ms(overlap_graph, iters=iters)
             torch.cuda.synchronize()
 
-            self.assertTrue(torch.all(no_overlap_locs[:, :TOP_K] >= 0))
             self.assertTrue(torch.all(overlap_locs[:, :TOP_K] >= 0))
 
             speedup = no_overlap_ms / overlap_ms if overlap_ms > 0 else float("inf")

--- a/test/registered/unit/managers/test_hisparse_indexcache.py
+++ b/test/registered/unit/managers/test_hisparse_indexcache.py
@@ -1,0 +1,378 @@
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.managers.hisparse_coordinator import (
+    build_indexcache_prefetch_layers_after,
+)
+from sglang.srt.utils import is_cuda
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+
+_UNIT_PATH = Path(__file__).with_name("test_hisparse_unit.py")
+_spec = importlib.util.spec_from_file_location("test_hisparse_unit_fixture", _UNIT_PATH)
+_unit = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_unit)
+
+DEVICE_BUFFER_SIZE = _unit.DEVICE_BUFFER_SIZE
+LAYER_NUM = _unit.LAYER_NUM
+MAX_NUM_REQS = _unit.MAX_NUM_REQS
+SIZE = _unit.SIZE
+TOP_K = _unit.TOP_K
+_make_req = _unit._make_req
+
+
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "0").lower() in ("1", "true", "yes", "on")
+
+
+class TestHiSparseIndexCachePrefetchPlan(unittest.TestCase):
+    def test_disabled_without_indexcache(self):
+        cfg = SimpleNamespace(num_hidden_layers=4)
+
+        self.assertEqual(
+            build_indexcache_prefetch_layers_after(cfg, start_layer=0, layer_num=4),
+            {},
+        )
+
+    def test_pattern_groups_consecutive_shared_layers(self):
+        cfg = SimpleNamespace(
+            num_hidden_layers=6,
+            index_topk_pattern=["F", "S", "S", "F", "S", "F"],
+        )
+
+        self.assertEqual(
+            build_indexcache_prefetch_layers_after(cfg, start_layer=0, layer_num=6),
+            {0: (1, 2), 3: (4,)},
+        )
+
+    def test_freq_matches_existing_skip_topk_semantics(self):
+        cfg = SimpleNamespace(num_hidden_layers=6, index_topk_freq=2)
+
+        self.assertEqual(
+            build_indexcache_prefetch_layers_after(cfg, start_layer=0, layer_num=6),
+            {1: (2,), 3: (4,)},
+        )
+
+    def test_offset_matches_existing_skip_topk_semantics(self):
+        cfg = SimpleNamespace(
+            num_hidden_layers=8,
+            index_topk_freq=3,
+            index_skip_topk_offset=2,
+        )
+
+        self.assertEqual(
+            build_indexcache_prefetch_layers_after(cfg, start_layer=0, layer_num=8),
+            {1: (2, 3), 4: (5, 6)},
+        )
+
+    def test_pipeline_local_range_keeps_global_layer_ids(self):
+        cfg = SimpleNamespace(
+            num_hidden_layers=8,
+            index_topk_pattern=["F", "S", "F", "S", "S", "F", "S", "F"],
+        )
+
+        self.assertEqual(
+            build_indexcache_prefetch_layers_after(cfg, start_layer=2, layer_num=4),
+            {2: (3, 4)},
+        )
+
+
+class TestHiSparseIndexCacheUnit(unittest.TestCase):
+    setUpClass = classmethod(_unit.TestHiSparseUnit.setUpClass.__func__)
+    tearDownClass = classmethod(_unit.TestHiSparseUnit.tearDownClass.__func__)
+    setUp = _unit.TestHiSparseUnit.setUp
+
+    _alloc_req_slot = _unit.TestHiSparseUnit._alloc_req_slot
+    _free_req_slot = _unit.TestHiSparseUnit._free_req_slot
+    _alloc_kv = _unit.TestHiSparseUnit._alloc_kv
+    _kv_pattern = staticmethod(_unit.TestHiSparseUnit._kv_pattern)
+    _populate_host_pool = _unit.TestHiSparseUnit._populate_host_pool
+    _build_topk_tokens = _unit.TestHiSparseUnit._build_topk_tokens
+    _make_batch_tensors = _unit.TestHiSparseUnit._make_batch_tensors
+    _assert_kv_correct = _unit.TestHiSparseUnit._assert_kv_correct
+    _cleanup_req = _unit.TestHiSparseUnit._cleanup_req
+    _get_initial_sizes = _unit.TestHiSparseUnit._get_initial_sizes
+    _assert_sizes_restored = _unit.TestHiSparseUnit._assert_sizes_restored
+    _reset_layer_hot_cache_tags = _unit.TestHiSparseUnit._reset_layer_hot_cache_tags
+    _reset_layer_hot_cache_tags_for_reqs = (
+        _unit.TestHiSparseUnit._reset_layer_hot_cache_tags_for_reqs
+    )
+    _measure_cuda_graph_ms = staticmethod(_unit.TestHiSparseUnit._measure_cuda_graph_ms)
+
+    def test_indexcache_prefetch_plan_pattern(self):
+        """Explicit IndexCache pattern marks layer 1 as sharing layer 0 top-k."""
+        cfg = SimpleNamespace(
+            num_hidden_layers=LAYER_NUM, index_topk_pattern=["F", "S"]
+        )
+        self.coordinator.configure_indexcache_prefetch(cfg)
+
+        self.assertTrue(self.coordinator._indexcache_prefetch_enabled)
+        self.assertEqual(
+            self.coordinator._indexcache_prefetch_layers_after,
+            {0: (1,)},
+        )
+
+    def test_indexcache_prefetch_shared_layer_swap_in(self):
+        """Full layer can preload KV for its following Shared layer."""
+        initial = self._get_initial_sizes()
+        cfg = SimpleNamespace(
+            num_hidden_layers=LAYER_NUM, index_topk_pattern=["F", "S"]
+        )
+        self.coordinator.configure_indexcache_prefetch(cfg)
+
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size * 2
+        req = _make_req("indexcache-prefetch", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+        self._populate_host_pool(req, fill_len)
+        self.coordinator.admit_request_direct(req)
+
+        tokens = self._build_topk_tokens(fill_len - 1)
+        batch = tokens.unsqueeze(0)
+        rpi, sls = self._make_batch_tensors([req], [fill_len])
+        self.coordinator.num_real_reqs[0] = rpi.shape[0]
+
+        self.coordinator.prefetch_indexcache_shared_layers(rpi, sls, batch, layer_id=0)
+        locs = self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=1)
+        torch.cuda.synchronize()
+
+        self.assertFalse(self.coordinator._indexcache_prefetch_pending[1])
+        self._assert_kv_correct(
+            locs[0], tokens, layer_id=1, count=TOP_K, msg="IndexCache prefetch: "
+        )
+
+        self._cleanup_req(req, kv_loc, logical_only=True)
+        self._assert_sizes_restored(initial, "indexcache_prefetch")
+
+    def test_cuda_graph_swap_in_selected_pages_long_seq(self):
+        """HiSparse swap-in is captured and replayed by CUDA graph."""
+        if not is_cuda():
+            self.skipTest("CUDA graph test only supports CUDA.")
+
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size * 2
+        req = _make_req("cuda-graph-swap", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+        self._populate_host_pool(req, fill_len)
+        self.coordinator.admit_request_direct(req)
+
+        tokens = self._build_topk_tokens(fill_len - 1)
+        batch = tokens.unsqueeze(0)
+        rpi, sls = self._make_batch_tensors([req], [fill_len])
+        self.coordinator.num_real_reqs[0] = rpi.shape[0]
+
+        self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=1)
+        torch.cuda.synchronize()
+        self._reset_layer_hot_cache_tags(req, layer_id=1)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            locs = self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=1)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.all(locs[0, :TOP_K] >= 0))
+        self._assert_kv_correct(
+            locs[0], tokens, layer_id=1, count=TOP_K, msg="CUDA graph swap: "
+        )
+
+        self._cleanup_req(req, kv_loc, logical_only=True)
+        self._assert_sizes_restored(initial, "cuda_graph_swap")
+
+    def test_cuda_graph_indexcache_prefetch_shared_layer_swap_in(self):
+        """IndexCache prefetch side-stream work is part of the CUDA graph DAG."""
+        if not is_cuda():
+            self.skipTest("CUDA graph test only supports CUDA.")
+
+        initial = self._get_initial_sizes()
+        cfg = SimpleNamespace(
+            num_hidden_layers=LAYER_NUM, index_topk_pattern=["F", "S"]
+        )
+        self.coordinator.configure_indexcache_prefetch(cfg)
+
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size * 2
+        req = _make_req("cuda-graph-indexcache-prefetch", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+        self._populate_host_pool(req, fill_len)
+        self.coordinator.admit_request_direct(req)
+
+        tokens = self._build_topk_tokens(fill_len - 1)
+        batch = tokens.unsqueeze(0)
+        rpi, sls = self._make_batch_tensors([req], [fill_len])
+        self.coordinator.num_real_reqs[0] = rpi.shape[0]
+
+        def graph_body():
+            self.coordinator.prefetch_indexcache_shared_layers(
+                rpi, sls, batch, layer_id=0
+            )
+            return self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=1)
+
+        graph_body()
+        torch.cuda.synchronize()
+        self._reset_layer_hot_cache_tags(req, layer_id=1)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            locs = graph_body()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertFalse(self.coordinator._indexcache_prefetch_pending[1])
+        self.assertTrue(torch.all(locs[0, :TOP_K] >= 0))
+        self._assert_kv_correct(
+            locs[0],
+            tokens,
+            layer_id=1,
+            count=TOP_K,
+            msg="CUDA graph IndexCache prefetch: ",
+        )
+
+        self._cleanup_req(req, kv_loc, logical_only=True)
+        self._assert_sizes_restored(initial, "cuda_graph_indexcache_prefetch")
+
+    def test_cuda_graph_indexcache_prefetch_overlap_perf(self):
+        """Opt-in CUDA graph microbenchmark for three HiSparse overlap modes."""
+        if not is_cuda():
+            self.skipTest("CUDA graph test only supports CUDA.")
+        if not _env_flag("SGLANG_RUN_HISPARSE_CUDA_GRAPH_OVERLAP_PERF"):
+            self.skipTest(
+                "Set SGLANG_RUN_HISPARSE_CUDA_GRAPH_OVERLAP_PERF=1 to run "
+                "the CUDA graph overlap microbenchmark."
+            )
+        if not hasattr(torch.cuda, "_sleep"):
+            self.skipTest("torch.cuda._sleep is required for synthetic compute.")
+
+        initial = self._get_initial_sizes()
+        cfg = SimpleNamespace(
+            num_hidden_layers=LAYER_NUM, index_topk_pattern=["F", "S"]
+        )
+        self.coordinator.configure_indexcache_prefetch(cfg)
+
+        num_reqs = int(os.getenv("SGLANG_HISPARSE_OVERLAP_PERF_NUM_REQS", "3"))
+        num_reqs = max(1, min(num_reqs, MAX_NUM_REQS))
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size * 2
+        if fill_len * num_reqs > SIZE:
+            self.skipTest(
+                f"Fixture SIZE={SIZE} is too small for num_reqs={num_reqs}, "
+                f"fill_len={fill_len}."
+            )
+
+        reqs = [
+            _make_req(f"overlap-perf-{i}", list(range(fill_len)))
+            for i in range(num_reqs)
+        ]
+        kv_locs = []
+        for req in reqs:
+            self._alloc_req_slot(req)
+            kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+            kv_locs.append(kv_loc)
+            self._populate_host_pool(req, fill_len)
+            self.coordinator.admit_request_direct(req)
+
+        row = torch.arange(TOP_K, dtype=torch.int32, device="cuda")
+        batch = row.unsqueeze(0).repeat(num_reqs, 1).contiguous()
+        rpi, sls = self._make_batch_tensors(reqs, [fill_len] * num_reqs)
+        self.coordinator.num_real_reqs[0] = rpi.shape[0]
+
+        sleep_cycles = int(
+            os.getenv("SGLANG_HISPARSE_OVERLAP_PERF_SLEEP_CYCLES", "200000")
+        )
+        iters = int(os.getenv("SGLANG_HISPARSE_OVERLAP_PERF_ITERS", "50"))
+        min_speedup = float(
+            os.getenv("SGLANG_HISPARSE_OVERLAP_PERF_MIN_SPEEDUP", "1.10")
+        )
+
+        def synthetic_current_layer_compute():
+            torch.cuda._sleep(sleep_cycles)
+
+        def no_hisparse_body():
+            synthetic_current_layer_compute()
+
+        def no_overlap_body():
+            self._reset_layer_hot_cache_tags_for_reqs(reqs, layer_id=1)
+            synthetic_current_layer_compute()
+            return self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=1)
+
+        def overlap_body():
+            self._reset_layer_hot_cache_tags_for_reqs(reqs, layer_id=1)
+            self.coordinator.prefetch_indexcache_shared_layers(
+                rpi, sls, batch, layer_id=0
+            )
+            synthetic_current_layer_compute()
+            return self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id=1)
+
+        try:
+            no_hisparse_body()
+            no_overlap_body()
+            overlap_body()
+            torch.cuda.synchronize()
+
+            no_hisparse_graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(no_hisparse_graph):
+                no_hisparse_body()
+
+            no_overlap_graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(no_overlap_graph):
+                no_overlap_locs = no_overlap_body()
+
+            overlap_graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(overlap_graph):
+                overlap_locs = overlap_body()
+
+            no_hisparse_ms = self._measure_cuda_graph_ms(no_hisparse_graph, iters=iters)
+            no_overlap_ms = self._measure_cuda_graph_ms(no_overlap_graph, iters=iters)
+            overlap_ms = self._measure_cuda_graph_ms(overlap_graph, iters=iters)
+            torch.cuda.synchronize()
+
+            self.assertTrue(torch.all(no_overlap_locs[:, :TOP_K] >= 0))
+            self.assertTrue(torch.all(overlap_locs[:, :TOP_K] >= 0))
+
+            speedup = no_overlap_ms / overlap_ms if overlap_ms > 0 else float("inf")
+            no_overlap_overhead = (
+                no_overlap_ms / no_hisparse_ms if no_hisparse_ms > 0 else float("inf")
+            )
+            overlap_overhead = (
+                overlap_ms / no_hisparse_ms if no_hisparse_ms > 0 else float("inf")
+            )
+            print(
+                "cuda_graph_indexcache_overlap_perf: "
+                f"no_hisparse={no_hisparse_ms:.4f} ms, "
+                f"hisparse_no_overlap={no_overlap_ms:.4f} ms, "
+                f"hisparse_overlap={overlap_ms:.4f} ms, "
+                f"overlap_speedup={speedup:.3f}x, "
+                f"no_overlap_overhead={no_overlap_overhead:.3f}x, "
+                f"overlap_overhead={overlap_overhead:.3f}x, "
+                f"sleep_cycles={sleep_cycles}, "
+                f"num_reqs={num_reqs}, iters={iters}"
+            )
+            self.assertGreater(
+                speedup,
+                min_speedup,
+                "CUDA graph IndexCache overlap microbenchmark did not show enough "
+                f"speedup: no_overlap={no_overlap_ms:.4f} ms, "
+                f"overlap={overlap_ms:.4f} ms, speedup={speedup:.3f}x, "
+                f"min_speedup={min_speedup:.3f}x, sleep_cycles={sleep_cycles}, "
+                f"num_reqs={num_reqs}, iters={iters}",
+            )
+        finally:
+            for req, kv_loc in zip(reqs, kv_locs):
+                self._cleanup_req(req, kv_loc, logical_only=True)
+        self._assert_sizes_restored(initial, "cuda_graph_indexcache_overlap_perf")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -158,6 +158,7 @@ class TestHiSparseUnit(unittest.TestCase):
         Without this, a mid-test assertion failure skips cleanup and leaks
         resources, causing unrelated failures in later tests.
         """
+        self.coordinator.wait_for_pending_indexcache_prefetch()
         self.allocator.clear()
         self.req_to_token_pool.clear()
         self.coordinator.mem_pool_host.clear()
@@ -171,6 +172,10 @@ class TestHiSparseUnit(unittest.TestCase):
         self.coordinator.lru_slots[:] = self.coordinator._lru_init.view(1, 1, -1)
         self.coordinator.ack_staging_queue.clear()
         self.coordinator._has_pending_backup = False
+        self.coordinator._indexcache_prefetch_layers_after.clear()
+        self.coordinator._indexcache_prefetch_enabled = False
+        for i in range(len(self.coordinator._indexcache_prefetch_pending)):
+            self.coordinator._indexcache_prefetch_pending[i] = False
         for i in range(len(self.coordinator._skip_first_backup)):
             self.coordinator._skip_first_backup[i] = False
 
@@ -338,6 +343,54 @@ class TestHiSparseUnit(unittest.TestCase):
         """
         self.coordinator.num_real_reqs[0] = rpi.shape[0]
         return self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id)
+
+    def _reset_layer_hot_cache_tags(self, req, layer_id: int):
+        """Restore a cold logical cache state while keeping allocated slot locs.
+
+        The physical device-buffer slot table is created by admit_request_direct
+        and must remain valid; only token tags and LRU order model cache hits.
+        """
+        layer_idx = self.coordinator._local_layer_index(layer_id)
+        self.assertIsNotNone(layer_idx)
+        self.coordinator.req_device_buffer_tokens[layer_idx, req.req_pool_idx, :].fill_(
+            -1
+        )
+        self.coordinator.lru_slots[layer_idx, req.req_pool_idx, :].copy_(
+            self.coordinator._lru_init
+        )
+        self.coordinator.top_k_device_locs_buffer.fill_(-1)
+        self.coordinator.raw_indices_buffer.fill_(-1)
+        for i in range(len(self.coordinator._indexcache_prefetch_pending)):
+            self.coordinator._indexcache_prefetch_pending[i] = False
+
+    def _reset_layer_hot_cache_tags_for_reqs(self, reqs, layer_id: int):
+        """Graph-capturable reset for multiple request hot-cache tag rows."""
+        layer_idx = self.coordinator._local_layer_index(layer_id)
+        self.assertIsNotNone(layer_idx)
+        for req in reqs:
+            self.coordinator.req_device_buffer_tokens[
+                layer_idx, req.req_pool_idx, :
+            ].fill_(-1)
+            self.coordinator.lru_slots[layer_idx, req.req_pool_idx, :].copy_(
+                self.coordinator._lru_init
+            )
+        self.coordinator.top_k_device_locs_buffer[: len(reqs)].fill_(-1)
+        self.coordinator.raw_indices_buffer[: len(reqs)].fill_(-1)
+
+    @staticmethod
+    def _measure_cuda_graph_ms(graph: torch.cuda.CUDAGraph, *, iters: int) -> float:
+        for _ in range(5):
+            graph.replay()
+        torch.cuda.synchronize()
+
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            graph.replay()
+        end.record()
+        end.synchronize()
+        return start.elapsed_time(end) / iters
 
     def _cleanup_req(self, req, kv_loc, *, logical_only=False):
         """request_finished -> free KV -> free req slot."""

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -176,6 +176,9 @@ class TestHiSparseUnit(unittest.TestCase):
         self.coordinator._indexcache_prefetch_enabled = False
         for i in range(len(self.coordinator._indexcache_prefetch_pending)):
             self.coordinator._indexcache_prefetch_pending[i] = False
+        if hasattr(self.coordinator, "_indexcache_prefetch_buffer_slots"):
+            for i in range(len(self.coordinator._indexcache_prefetch_buffer_slots)):
+                self.coordinator._indexcache_prefetch_buffer_slots[i] = -1
         for i in range(len(self.coordinator._skip_first_backup)):
             self.coordinator._skip_first_backup[i] = False
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
IndexCache currently enables top-k sharing across multiple layers. Upon retrieving the top-k indices from IndexCache, a side CUDA stream prefetches the HiSparse KV pages required for subsequent shared layers. When execution reaches a shared layer, it only needs to wait for the corresponding event, allowing the vast majority of host-to-device I/O to be overlapped with the current layer's attention or MLP computations.

```
main stream:  Full layer topk ---- current layer attention/MLP ---- Shared layer use KV
                        \                                     /
side stream:             -- Shared layers HiSparse prefetch --
```

Calculated based on the post-1000-token tail ITL, using no-HiSparse as the baseline:

| Configuration       | post-1000 mean ITL | Overhead relative to no-HiSparse |
|---------------------|--------------------|----------------------------------|
| no-HiSparse         | 18.15 ms           | baseline                         |
| HiSparse no-overlap | 25.32 ms           | +7.17 ms                         |
| HiSparse overlap    | 21.33 ms           | +3.18 ms                         |
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27814926951](https://github.com/sgl-project/sglang/actions/runs/27814926951)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27814926948](https://github.com/sgl-project/sglang/actions/runs/27814926948)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->