### PR TITLE
[NPU] Quantize bfloat16 hidden_states before npu_grouped_matmul in W4…

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
@@ -975,6 +975,11 @@ class NPUW4A8Int8DynamicMoEMethod(_NPUFusedMoEMethodBase):
     ):
         from sgl_kernel_npu.activation.swiglu_quant import swiglu_quant
 
+        if hidden_states.dtype == torch.bfloat16:
+            hidden_states, hidden_states_scale = torch.ops.npu.npu_dynamic_quant(
+                hidden_states
+            )
+
         hidden_states = torch.ops.npu.npu_grouped_matmul(
             x=[hidden_states],
             weight=[layer.w13_weight],


### PR DESCRIPTION
## Summary
  - Fix RuntimeError in `npu_grouped_matmul` when `hidden_states` is bfloat16 in
  `NPUW4A8Int8DynamicMoEMethod.apply_without_routing_weights`
  - When `hidden_states` is bfloat16, `hidden_states_scale` is `None`, causing `per_token_scale=[None]` to be passed to
  `npu_grouped_matmul`, which fails with a pybind11 cast error: `Unable to cast Python instance of type <class 'list'>
  to C++ type '?'`
  - Apply `npu_dynamic_quant` to bfloat16 inputs before the grouped matmul call to produce a proper scale tensor

  ## Test plan
  - [ ] Run GLM-5.1 inference with NPU W4A8 quantization and verify no RuntimeError
  - [ ] Verify output accuracy is not affected













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27687829783](https://github.com/sgl-project/sglang/actions/runs/27687829783)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27687829615](https://github.com/sgl-project/sglang/actions/runs/27687829615)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->