### PR TITLE
fix: propagate topk_indices across PP stages for DSA skip_topk layers

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2474,7 +2474,12 @@ class DeepseekV2Model(nn.Module):
             elif self.first_k_dense_replace < normal_start_layer:
                 normal_end_layer = normal_start_layer = 0
         aux_hidden_states = []
-        topk_indices = None
+        topk_indices = (
+            pp_proxy_tensors["topk_indices"]
+            if pp_proxy_tensors is not None
+            and "topk_indices" in pp_proxy_tensors.tensors
+            else None
+        )
         for i in range(normal_start_layer, normal_end_layer):
             # NOTE: torch dynamo does not support graph break in context manager
             ctx = (
@@ -2518,12 +2523,13 @@ class DeepseekV2Model(nn.Module):
             )
 
         if not self.pp_group.is_last_rank:
-            return PPProxyTensors(
-                {
-                    "hidden_states": hidden_states,
-                    "residual": residual,
-                }
-            )
+            proxy = {
+                "hidden_states": hidden_states,
+                "residual": residual,
+            }
+            if topk_indices is not None:
+                proxy["topk_indices"] = topk_indices
+            return PPProxyTensors(proxy)
         else:
             if not forward_batch.forward_mode.is_idle():
                 if residual is None:


### PR DESCRIPTION
## Motivation

Fixes #28537

DSA models with `pp_size > 1` and `index_topk_freq > 1` crash on non-first PP stages because `topk_indices` is not passed between PP stages. When the first layer on PP1 is a `skip_topk` layer, `prev_topk_indices` is `None`, leading to `page_table_1 = None` → `AttributeError` in `_forward_flashmla_kv`.

## Changes

Two lines in `deepseek_v2.py` `DeepseekV2Model.forward()`:

1. **Send**: add `topk_indices` to `PPProxyTensors` when forwarding to the next PP stage (only when non-None, i.e., the next layer is `skip_topk`)
2. **Recv**: initialize the layer loop's `topk_indices` from received `PPProxyTensors` instead of hardcoded `None`

No changes to the PP communication layer — `send_tensor_dict`/`recv_tensor_dict` already handle arbitrary key-value dicts.

## Test plan

- [ ] Verify GLM-5.2-FP8 with `pp_size=2` no longer crashes on PP1
- [ ] Verify DeepSeek V3 with `pp_size > 1` and `index_topk_freq > 1`
- [ ] Verify `pp_size=1` is unaffected (no regression)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27702745807](https://github.com/sgl-project/sglang/actions/runs/27702745807)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27702745534](https://github.com/sgl-project/sglang/actions/runs/27702745534)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->