### PR TITLE
Fix HiCache page_first write-back crash for DSA sidecar pools

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -400,7 +400,9 @@ class HybridCacheController(BaseHiCacheController):
         if self.io_backend == "kernel" and self.mem_pool_host.layout == "page_first":
             host_indices = op.host_indices
             device_indices = op.device_indices
-            resolved_pool_transfers = op.pool_transfers
+            # Sidecar pools (e.g. DSA indexer) still use kernels that require
+            # CUDA indices, so we must move pool_transfers indices to device.
+            resolved_pool_transfers = self._move_pool_transfers(op.pool_transfers)
         else:
             host_indices, device_indices, resolved_pool_transfers = (
                 self.move_hybrid_indices(op)
@@ -612,16 +614,19 @@ class HybridCacheController(BaseHiCacheController):
             kv_hit_pages * self.page_size,
         )
 
-    def move_hybrid_indices(
-        self, operation: CacheOperation
-    ) -> tuple[torch.Tensor, torch.Tensor, Optional[list[PoolTransfer]]]:
-        host_indices, device_indices = self.move_indices(
-            operation.host_indices, operation.device_indices
-        )
+    def _move_pool_transfers(
+        self, pool_transfers: Optional[list[PoolTransfer]]
+    ) -> Optional[list[PoolTransfer]]:
+        """Move pool_transfers indices to the appropriate device.
+
+        This is factored out of ``move_hybrid_indices`` so that
+        ``start_writing`` can move sidecar indices independently when the
+        anchor KV pool keeps its indices on CPU (e.g. page_first JIT path).
+        """
         resolved_pool_transfers = None
-        if operation.pool_transfers:
+        if pool_transfers:
             resolved_pool_transfers = []
-            for transfer in operation.pool_transfers:
+            for transfer in pool_transfers:
                 transfer_host_indices, transfer_device_indices = self.move_indices(
                     transfer.host_indices, transfer.device_indices
                 )
@@ -638,6 +643,15 @@ class HybridCacheController(BaseHiCacheController):
                         indices_from_pool=transfer.indices_from_pool,
                     )
                 )
+        return resolved_pool_transfers
+
+    def move_hybrid_indices(
+        self, operation: CacheOperation
+    ) -> tuple[torch.Tensor, torch.Tensor, Optional[list[PoolTransfer]]]:
+        host_indices, device_indices = self.move_indices(
+            operation.host_indices, operation.device_indices
+        )
+        resolved_pool_transfers = self._move_pool_transfers(operation.pool_transfers)
         return host_indices, device_indices, resolved_pool_transfers
 
     def _page_transfer(self, operation):


### PR DESCRIPTION
## Motivation

When `io_backend="kernel"` and `layout="page_first"`, `start_writing()` skips
`move_hybrid_indices()` because the anchor KV pool's JIT kernel accepts CPU
destination indices. However, sidecar pool transfers (e.g. DSA indexer pool)
are also left unmoved, and their CUDA kernel
(`transfer_kv_all_layer_mla_lf_pf`) still requires CUDA indices, causing:

```
RuntimeError: Destination indices must be a CUDA tensor
```

This regression was introduced in the commit that added the `page_first`
CPU-indices optimization path. It affects any DSA model (GLM-5.1, GLM-5.2,
DeepSeek V3.2, etc.) with HiCache enabled and a storage backend that triggers
`page_first` layout (e.g. Mooncake).

Fixes #24817

## Modifications

- Extract pool_transfers move logic from `move_hybrid_indices` into a new
  `_move_pool_transfers` helper method.
- In `start_writing`'s `page_first` branch, call `_move_pool_transfers` to
  ensure sidecar pool indices are moved to CUDA, while anchor KV indices
  remain on CPU as intended.
- `move_hybrid_indices` now reuses `_move_pool_transfers`, no behavior change
  for existing code paths.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27707349817](https://github.com/sgl-project/sglang/actions/runs/27707349817)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27707347932](https://github.com/sgl-project/sglang/actions/runs/27707347932)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->