### PR TITLE
[diffusion] Tune LTX2.3 auto parallelism

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
@@ -200,6 +200,7 @@ class LTX2PipelineConfig(PipelineConfig):
         return ModelDeploymentConfig(
             auto_disable_component_offload_min_available_memory_gb=70,
             auto_disable_component_offload_components=("dit",),
+            auto_cfg_parallel_degree_by_num_gpus=((4, 1),),
         )
 
     def prepare_latent_shape(self, batch, batch_size, num_frames):

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
@@ -25,3 +25,6 @@ class ModelDeploymentConfig:
     fsdp_auto_requires_cfg: bool = True
     fsdp_auto_requires_default_parallelism: bool = True
     auto_enable_cfg_parallel: bool = True
+    # Per-GPU-count auto CFG degree override. A degree of 1 keeps CFG parallel
+    # disabled and leaves the remaining GPUs available for sequence parallelism.
+    auto_cfg_parallel_degree_by_num_gpus: tuple[tuple[int, int], ...] = ()

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -819,12 +819,47 @@ class ServerArgs(DisaggServerArgsMixin):
         # because non-CFG models (e.g. FLUX) crash when CFG parallel splits ranks.
         if cfg_unspecified:
             deployment_config = self.pipeline_config.get_model_deployment_config()
-            self._adjust_auto_cfg_parallelism(
-                deployment_config,
-                sp_unspecified=sp_unspecified,
-                ulysses_unspecified=ulysses_unspecified,
-                ring_unspecified=ring_unspecified,
-            )
+            auto_cfg_parallel_degree = None
+            for (
+                num_gpus,
+                cfg_degree,
+            ) in deployment_config.auto_cfg_parallel_degree_by_num_gpus:
+                if num_gpus == self.num_gpus:
+                    auto_cfg_parallel_degree = cfg_degree
+                    break
+            if auto_cfg_parallel_degree is None:
+                auto_cfg_parallel_degree = 2
+            if auto_cfg_parallel_degree < 1:
+                self.enable_cfg_parallel = False
+            else:
+                cfg_group_size = self.dp_size * self.tp_size * auto_cfg_parallel_degree
+                if (
+                    self.performance_mode != "manual"
+                    and deployment_config.auto_enable_cfg_parallel
+                    and self.num_gpus >= 2
+                    and self.num_gpus % cfg_group_size == 0
+                    and sp_unspecified
+                    and ulysses_unspecified
+                    and ring_unspecified
+                    and self._model_default_uses_cfg()
+                ):
+                    self.cfg_parallel_degree = auto_cfg_parallel_degree
+                    self.enable_cfg_parallel = auto_cfg_parallel_degree > 1
+                    if self.enable_cfg_parallel:
+                        logger.info(
+                            "Automatically enabled CFG parallel at degree %d for %d GPUs. "
+                            "Use --sp-degree / --ulysses-degree to use sequence "
+                            "parallelism instead.",
+                            self.cfg_parallel_degree,
+                            self.num_gpus,
+                        )
+                    else:
+                        logger.info(
+                            "Automatically disabled CFG parallel for %d GPUs based on model deployment config.",
+                            self.num_gpus,
+                        )
+                else:
+                    self.enable_cfg_parallel = False
 
         # Resolve cfg_parallel_degree to a concrete int now that enable_cfg_parallel is settled.
         if self.cfg_parallel_degree is None:
@@ -860,73 +895,6 @@ class ServerArgs(DisaggServerArgsMixin):
         if self.ring_degree is None:
             self.ring_degree = 1
             logger.debug(f"Ring degree not set, using default value {self.ring_degree}")
-
-    def _adjust_auto_cfg_parallelism(
-        self,
-        deployment_config,
-        *,
-        sp_unspecified: bool,
-        ulysses_unspecified: bool,
-        ring_unspecified: bool,
-    ) -> None:
-        cfg_parallel_degree = self._get_auto_cfg_parallel_degree(deployment_config)
-        if not self._can_apply_auto_cfg_parallelism(
-            deployment_config,
-            cfg_parallel_degree,
-            sp_unspecified=sp_unspecified,
-            ulysses_unspecified=ulysses_unspecified,
-            ring_unspecified=ring_unspecified,
-        ):
-            self.enable_cfg_parallel = False
-            return
-
-        self.cfg_parallel_degree = cfg_parallel_degree
-        self.enable_cfg_parallel = cfg_parallel_degree > 1
-        if self.enable_cfg_parallel:
-            logger.info(
-                "Automatically enabled CFG parallel at degree %d for %d GPUs. "
-                "Use --sp-degree / --ulysses-degree to use sequence parallelism instead.",
-                self.cfg_parallel_degree,
-                self.num_gpus,
-            )
-        else:
-            logger.info(
-                "Automatically kept CFG parallel disabled for %d GPUs based on model deployment config.",
-                self.num_gpus,
-            )
-
-    def _get_auto_cfg_parallel_degree(self, deployment_config) -> int:
-        for (
-            num_gpus,
-            cfg_degree,
-        ) in deployment_config.auto_cfg_parallel_degree_by_num_gpus:
-            if num_gpus == self.num_gpus:
-                return cfg_degree
-        return 2
-
-    def _can_apply_auto_cfg_parallelism(
-        self,
-        deployment_config,
-        cfg_parallel_degree: int,
-        *,
-        sp_unspecified: bool,
-        ulysses_unspecified: bool,
-        ring_unspecified: bool,
-    ) -> bool:
-        if cfg_parallel_degree < 1:
-            return False
-
-        cfg_group_size = self.dp_size * self.tp_size * cfg_parallel_degree
-        return (
-            self.performance_mode != "manual"
-            and deployment_config.auto_enable_cfg_parallel
-            and self.num_gpus >= 2
-            and self.num_gpus % cfg_group_size == 0
-            and sp_unspecified
-            and ulysses_unspecified
-            and ring_unspecified
-            and self._model_default_uses_cfg()
-        )
 
     def _model_default_uses_cfg(self) -> bool:
         """

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -819,47 +819,12 @@ class ServerArgs(DisaggServerArgsMixin):
         # because non-CFG models (e.g. FLUX) crash when CFG parallel splits ranks.
         if cfg_unspecified:
             deployment_config = self.pipeline_config.get_model_deployment_config()
-            auto_cfg_parallel_degree = None
-            for (
-                num_gpus,
-                cfg_degree,
-            ) in deployment_config.auto_cfg_parallel_degree_by_num_gpus:
-                if num_gpus == self.num_gpus:
-                    auto_cfg_parallel_degree = cfg_degree
-                    break
-            if auto_cfg_parallel_degree is None:
-                auto_cfg_parallel_degree = 2
-            if auto_cfg_parallel_degree < 1:
-                self.enable_cfg_parallel = False
-            else:
-                cfg_group_size = self.dp_size * self.tp_size * auto_cfg_parallel_degree
-                if (
-                    self.performance_mode != "manual"
-                    and deployment_config.auto_enable_cfg_parallel
-                    and self.num_gpus >= 2
-                    and self.num_gpus % cfg_group_size == 0
-                    and sp_unspecified
-                    and ulysses_unspecified
-                    and ring_unspecified
-                    and self._model_default_uses_cfg()
-                ):
-                    self.cfg_parallel_degree = auto_cfg_parallel_degree
-                    self.enable_cfg_parallel = auto_cfg_parallel_degree > 1
-                    if self.enable_cfg_parallel:
-                        logger.info(
-                            "Automatically enabled CFG parallel at degree %d for %d GPUs. "
-                            "Use --sp-degree / --ulysses-degree to use sequence "
-                            "parallelism instead.",
-                            self.cfg_parallel_degree,
-                            self.num_gpus,
-                        )
-                    else:
-                        logger.info(
-                            "Automatically disabled CFG parallel for %d GPUs based on model deployment config.",
-                            self.num_gpus,
-                        )
-                else:
-                    self.enable_cfg_parallel = False
+            self._adjust_auto_cfg_parallelism(
+                deployment_config,
+                sp_unspecified=sp_unspecified,
+                ulysses_unspecified=ulysses_unspecified,
+                ring_unspecified=ring_unspecified,
+            )
 
         # Resolve cfg_parallel_degree to a concrete int now that enable_cfg_parallel is settled.
         if self.cfg_parallel_degree is None:
@@ -895,6 +860,73 @@ class ServerArgs(DisaggServerArgsMixin):
         if self.ring_degree is None:
             self.ring_degree = 1
             logger.debug(f"Ring degree not set, using default value {self.ring_degree}")
+
+    def _adjust_auto_cfg_parallelism(
+        self,
+        deployment_config,
+        *,
+        sp_unspecified: bool,
+        ulysses_unspecified: bool,
+        ring_unspecified: bool,
+    ) -> None:
+        cfg_parallel_degree = self._get_auto_cfg_parallel_degree(deployment_config)
+        if not self._can_apply_auto_cfg_parallelism(
+            deployment_config,
+            cfg_parallel_degree,
+            sp_unspecified=sp_unspecified,
+            ulysses_unspecified=ulysses_unspecified,
+            ring_unspecified=ring_unspecified,
+        ):
+            self.enable_cfg_parallel = False
+            return
+
+        self.cfg_parallel_degree = cfg_parallel_degree
+        self.enable_cfg_parallel = cfg_parallel_degree > 1
+        if self.enable_cfg_parallel:
+            logger.info(
+                "Automatically enabled CFG parallel at degree %d for %d GPUs. "
+                "Use --sp-degree / --ulysses-degree to use sequence parallelism instead.",
+                self.cfg_parallel_degree,
+                self.num_gpus,
+            )
+        else:
+            logger.info(
+                "Automatically kept CFG parallel disabled for %d GPUs based on model deployment config.",
+                self.num_gpus,
+            )
+
+    def _get_auto_cfg_parallel_degree(self, deployment_config) -> int:
+        for (
+            num_gpus,
+            cfg_degree,
+        ) in deployment_config.auto_cfg_parallel_degree_by_num_gpus:
+            if num_gpus == self.num_gpus:
+                return cfg_degree
+        return 2
+
+    def _can_apply_auto_cfg_parallelism(
+        self,
+        deployment_config,
+        cfg_parallel_degree: int,
+        *,
+        sp_unspecified: bool,
+        ulysses_unspecified: bool,
+        ring_unspecified: bool,
+    ) -> bool:
+        if cfg_parallel_degree < 1:
+            return False
+
+        cfg_group_size = self.dp_size * self.tp_size * cfg_parallel_degree
+        return (
+            self.performance_mode != "manual"
+            and deployment_config.auto_enable_cfg_parallel
+            and self.num_gpus >= 2
+            and self.num_gpus % cfg_group_size == 0
+            and sp_unspecified
+            and ulysses_unspecified
+            and ring_unspecified
+            and self._model_default_uses_cfg()
+        )
 
     def _model_default_uses_cfg(self) -> bool:
         """

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -819,26 +819,47 @@ class ServerArgs(DisaggServerArgsMixin):
         # because non-CFG models (e.g. FLUX) crash when CFG parallel splits ranks.
         if cfg_unspecified:
             deployment_config = self.pipeline_config.get_model_deployment_config()
-            cfg_group_size = self.dp_size * self.tp_size * 2
-            if (
-                self.performance_mode != "manual"
-                and deployment_config.auto_enable_cfg_parallel
-                and self.num_gpus >= 2
-                and self.num_gpus % cfg_group_size == 0
-                and sp_unspecified
-                and ulysses_unspecified
-                and ring_unspecified
-                and self._model_default_uses_cfg()
-            ):
-                self.enable_cfg_parallel = True
-                logger.info(
-                    "Automatically enabled CFG parallel for %d GPUs. "
-                    "Use --sp-degree / --ulysses-degree to use sequence "
-                    "parallelism instead.",
-                    self.num_gpus,
-                )
-            else:
+            auto_cfg_parallel_degree = None
+            for (
+                num_gpus,
+                cfg_degree,
+            ) in deployment_config.auto_cfg_parallel_degree_by_num_gpus:
+                if num_gpus == self.num_gpus:
+                    auto_cfg_parallel_degree = cfg_degree
+                    break
+            if auto_cfg_parallel_degree is None:
+                auto_cfg_parallel_degree = 2
+            if auto_cfg_parallel_degree < 1:
                 self.enable_cfg_parallel = False
+            else:
+                cfg_group_size = self.dp_size * self.tp_size * auto_cfg_parallel_degree
+                if (
+                    self.performance_mode != "manual"
+                    and deployment_config.auto_enable_cfg_parallel
+                    and self.num_gpus >= 2
+                    and self.num_gpus % cfg_group_size == 0
+                    and sp_unspecified
+                    and ulysses_unspecified
+                    and ring_unspecified
+                    and self._model_default_uses_cfg()
+                ):
+                    self.cfg_parallel_degree = auto_cfg_parallel_degree
+                    self.enable_cfg_parallel = auto_cfg_parallel_degree > 1
+                    if self.enable_cfg_parallel:
+                        logger.info(
+                            "Automatically enabled CFG parallel at degree %d for %d GPUs. "
+                            "Use --sp-degree / --ulysses-degree to use sequence "
+                            "parallelism instead.",
+                            self.cfg_parallel_degree,
+                            self.num_gpus,
+                        )
+                    else:
+                        logger.info(
+                            "Automatically disabled CFG parallel for %d GPUs based on model deployment config.",
+                            self.num_gpus,
+                        )
+                else:
+                    self.enable_cfg_parallel = False
 
         # Resolve cfg_parallel_degree to a concrete int now that enable_cfg_parallel is settled.
         if self.cfg_parallel_degree is None:

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -816,6 +816,7 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertEqual(
             ltx_deployment.auto_disable_component_offload_components, ("dit",)
         )
+        self.assertEqual(ltx_deployment.auto_cfg_parallel_degree_by_num_gpus, ((4, 1),))
 
         self.assertEqual(sana_wm_deployment.fsdp_auto_min_available_memory_gb, 60)
         self.assertTrue(sana_wm_deployment.auto_dit_layerwise_offload)
@@ -1194,6 +1195,54 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertEqual(args.ltx2_two_stage_device_mode, "resident")
         self.assertEqual(args.layerwise_offload_components, ["text_encoder"])
+
+    def test_ltx23_auto_four_gpu_uses_full_sequence_parallel(self):
+        with patch.object(ServerArgs, "_model_default_uses_cfg", return_value=True):
+            args = self._from_dict_with_pipeline_config(
+                LTX2PipelineConfig(),
+                kwargs={
+                    "model_path": "Lightricks/LTX-2.3",
+                    "num_gpus": 4,
+                    "performance_mode": "auto",
+                },
+            )
+
+        self.assertFalse(args.enable_cfg_parallel)
+        self.assertEqual(args.cfg_parallel_degree, 1)
+        self.assertEqual(args.sp_degree, 4)
+        self.assertEqual(args.ulysses_degree, 4)
+
+    def test_ltx23_auto_eight_gpu_keeps_cfg_plus_sequence_parallel(self):
+        with patch.object(ServerArgs, "_model_default_uses_cfg", return_value=True):
+            args = self._from_dict_with_pipeline_config(
+                LTX2PipelineConfig(),
+                kwargs={
+                    "model_path": "Lightricks/LTX-2.3",
+                    "num_gpus": 8,
+                    "performance_mode": "auto",
+                },
+            )
+
+        self.assertTrue(args.enable_cfg_parallel)
+        self.assertEqual(args.cfg_parallel_degree, 2)
+        self.assertEqual(args.sp_degree, 4)
+        self.assertEqual(args.ulysses_degree, 4)
+
+    def test_ltx23_auto_four_gpu_preserves_explicit_cfg_parallel_degree(self):
+        args = self._from_dict_with_pipeline_config(
+            LTX2PipelineConfig(),
+            kwargs={
+                "model_path": "Lightricks/LTX-2.3",
+                "num_gpus": 4,
+                "performance_mode": "auto",
+                "cfg_parallel_degree": 2,
+            },
+        )
+
+        self.assertTrue(args.enable_cfg_parallel)
+        self.assertEqual(args.cfg_parallel_degree, 2)
+        self.assertEqual(args.sp_degree, 2)
+        self.assertEqual(args.ulysses_degree, 2)
 
     def test_auto_multi_gpu_qwen_replaces_text_encoder_offload_with_cfg(self):
         args = self._from_dict_with_pipeline_config(


### PR DESCRIPTION
## Summary

- add a model deployment hint for per-GPU-count auto CFG parallel degree overrides
- use the hint when resolving auto CFG parallelism before assigning remaining GPUs to sequence parallelism
- set LTX2.3 4-GPU auto mode to leave CFG parallel disabled, so auto resolves to full SP4
- keep 8-GPU auto behavior unchanged and cover both paths with unit tests

## Validation

- `pre-commit run --files python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py python/sglang/multimodal_gen/runtime/server_args.py python/sglang/multimodal_gen/test/unit/test_server_args.py`

Draft while remote LTX2.3 benchmark validation is still pending.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28213261238](https://github.com/sgl-project/sglang/actions/runs/28213261238)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28213261160](https://github.com/sgl-project/sglang/actions/runs/28213261160)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->