### PR TITLE
refactor: centralize speculative weight-update fan-out in the scheduler

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1461,8 +1461,9 @@ class UpdateWeightsFromDistributedReqInput(BaseReq):
     weight_version: Optional[str] = None
     # Optional format specification for loading
     load_format: Optional[str] = None
-    # Optional: Determine whether to disable updating the draft model
-    disable_draft_model: Optional[bool] = None
+    # Which model runners to update: "target" (target model only), "draft" (draft
+    # worker(s) only), or "both" (default).
+    selector: Literal["target", "draft", "both"] = "both"
     # Whether to call torch.cuda.empty_cache() during flush
     torch_empty_cache: bool = False
 
@@ -1490,8 +1491,9 @@ class UpdateWeightsFromTensorReqInput(BaseReq):
     abort_all_requests: bool = False
     # Optional: Update weight version along with weights
     weight_version: Optional[str] = None
-    # Optional: Determine whether to disable updating the draft model
-    disable_draft_model: Optional[bool] = None
+    # Which model runners to update: "target" (target model only), "draft" (draft
+    # worker(s) only), or "both" (default).
+    selector: Literal["target", "draft", "both"] = "both"
     # Whether to call torch.cuda.empty_cache() during flush
     torch_empty_cache: bool = False
 

--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -123,23 +123,29 @@ class SchedulerUpdateWeightsMixin:
     ) -> Tuple[bool, str]:
         """Update the online model parameter, fanning out to the selected runners."""
         self._quiesce_for_weight_update()
-        runners = [runner for _, runner in self.get_model_runners(recv_req.selector)]
-        # The target runner owns the distributed update group: it receives the
-        # broadcast once and loads the weights into every selected runner.
-        success, message = (
-            self.tp_worker.model_runner.update_weights_from_distributed_to_model_runners(
-                runners,
+        # The target (main) model owns this process's connection to the training
+        # engine, so it receives the broadcast once; the received weights are then
+        # loaded into each selected runner locally.
+        try:
+            weights = self.tp_worker.model_runner.receive_weights_from_distributed(
                 recv_req.names,
                 recv_req.dtypes,
                 recv_req.shapes,
                 recv_req.group_name,
                 recv_req.load_format,
             )
-        )
+            for _, runner in self.get_model_runners(recv_req.selector):
+                runner.load_weights(weights)
+            success, message = True, "Succeeded to update parameter online."
+        except Exception as e:
+            success = False
+            message = (
+                f"Failed to update parameter online: {e}. The full weights of the "
+                "ModelRunner are partially updated. Please discard the whole weights."
+            )
+            logger.error(message)
         if success:
             self.flush_cache_after_weight_update(recv_req)
-        else:
-            logger.error(message)
         torch.distributed.barrier(group=self.tp_cpu_group)
         return UpdateWeightsFromDistributedReqOutput(success, message)
 

--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import traceback
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, List, Set, Tuple
 
 import torch
 
@@ -37,14 +37,41 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
 )
+from sglang.srt.utils import MultiprocessingSerializer
+from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler
+    from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
 
 
+def _parse_runner_selector(selector: str) -> Set[str]:
+    """Map a {target, draft, both} weight-op selector to the set of roles it covers."""
+    if selector == "both":
+        return {"target", "draft"}
+    if selector in ("target", "draft"):
+        return {selector}
+    raise ValueError(
+        f"invalid selector {selector!r}; expected 'target', 'draft', or 'both'"
+    )
+
+
 class SchedulerUpdateWeightsMixin:
+    def get_model_runners(
+        self: Scheduler, selector: str = "both"
+    ) -> List[Tuple[str, "ModelRunner"]]:
+        """Resolve a {target, draft} selector to (role, ModelRunner) pairs, target first.
+        role is "" for the target runner; draft roles come from iter_draft_runners()."""
+        parsed = _parse_runner_selector(selector)
+        runners: List[Tuple[str, "ModelRunner"]] = []
+        if "target" in parsed:
+            runners.append(("", self.tp_worker.model_runner))
+        if "draft" in parsed and self.draft_worker is not None:
+            runners += self.draft_worker.iter_draft_runners()
+        return runners
+
     def flush_cache_after_weight_update(self: Scheduler, recv_req) -> None:
         if recv_req.flush_cache:
             flush_cache_success = self.flush_cache(
@@ -91,16 +118,24 @@ class SchedulerUpdateWeightsMixin:
         return DestroyWeightsUpdateGroupReqOutput(success, message)
 
     def update_weights_from_distributed(
-        self,
+        self: Scheduler,
         recv_req: UpdateWeightsFromDistributedReqInput,
     ) -> Tuple[bool, str]:
-        """Update the online model parameter."""
+        """Update the online model parameter, fanning out to the selected runners."""
         self._quiesce_for_weight_update()
-        if recv_req.disable_draft_model:
-            worker = self.tp_worker
-        else:
-            worker = self.draft_worker or self.tp_worker
-        success, message = worker.update_weights_from_distributed(recv_req)
+        runners = [runner for _, runner in self.get_model_runners(recv_req.selector)]
+        # The target runner owns the distributed update group: it receives the
+        # broadcast once and loads the weights into every selected runner.
+        success, message = (
+            self.tp_worker.model_runner.update_weights_from_distributed_to_model_runners(
+                runners,
+                recv_req.names,
+                recv_req.dtypes,
+                recv_req.shapes,
+                recv_req.group_name,
+                recv_req.load_format,
+            )
+        )
         if success:
             self.flush_cache_after_weight_update(recv_req)
         else:
@@ -111,13 +146,21 @@ class SchedulerUpdateWeightsMixin:
     def update_weights_from_tensor(
         self: Scheduler, recv_req: UpdateWeightsFromTensorReqInput
     ):
-        """Update the online model parameter from tensors."""
+        """Update the online model parameter from tensors, fanning out to the
+        selected runners."""
         self._quiesce_for_weight_update()
-        if recv_req.disable_draft_model:
-            worker = self.tp_worker
-        else:
-            worker = self.draft_worker or self.tp_worker
-        success, message = worker.update_weights_from_tensor(recv_req)
+        monkey_patch_torch_reductions()
+        named_tensors = MultiprocessingSerializer.deserialize(
+            recv_req.serialized_named_tensors[self.tp_rank]
+        )
+        success, message = True, "Success"
+        for _, runner in self.get_model_runners(recv_req.selector):
+            success, message = runner.update_weights_from_tensor(
+                named_tensors=named_tensors,
+                load_format=recv_req.load_format,
+            )
+            if not success:
+                break
         if success:
             self.flush_cache_after_weight_update(recv_req)
         else:

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -428,6 +428,14 @@ class TpModelWorker(BaseTpWorker):
     def model_runner(self) -> "ModelRunner":
         return self._model_runner
 
+    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+        # The target worker shares this class (is_draft_worker=False) and returns [].
+        if not self.is_draft_worker:
+            return []
+        if self.model_runner_list:
+            return [(f"draft_step_{i}", r) for i, r in enumerate(self.model_runner_list)]
+        return [("draft", self.model_runner)]
+
     def register_hicache_layer_transfer_counter(self, counter: LayerDoneCounter):
         self.hicache_layer_transfer_counter = counter
 

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -34,9 +34,7 @@ from sglang.srt.managers.io_struct import (
     SendWeightsToRemoteInstanceReqInput,
     UnloadLoRAAdapterReqInput,
     UpdateWeightFromDiskReqInput,
-    UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromIPCReqInput,
-    UpdateWeightsFromTensorReqInput,
 )
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch, ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
@@ -142,29 +140,6 @@ class BaseTpWorker(ABC):
             recv_req.master_address,
             recv_req.ports,
             recv_req.group_name,
-        )
-        return success, message
-
-    def update_weights_from_distributed(
-        self, recv_req: UpdateWeightsFromDistributedReqInput
-    ):
-        success, message = self.model_runner.update_weights_from_distributed(
-            recv_req.names,
-            recv_req.dtypes,
-            recv_req.shapes,
-            recv_req.group_name,
-            recv_req.load_format,
-        )
-        return success, message
-
-    def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
-
-        monkey_patch_torch_reductions()
-        success, message = self.model_runner.update_weights_from_tensor(
-            named_tensors=MultiprocessingSerializer.deserialize(
-                recv_req.serialized_named_tensors[self.tp_rank]
-            ),
-            load_format=recv_req.load_format,
         )
         return success, message
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2040,62 +2040,16 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger.error(message)
             return False, message
 
-    def update_weights_from_distributed(
-        self,
-        names,
-        dtypes,
-        shapes,
-        group_name,
-        load_format: Optional[str] = None,
-    ):
-        """
-        Update specific parameter in the model weights online
-        through `_model_update_group` process group.
+    def load_weights(self, weights) -> None:
+        """Load an in-memory list of (name, tensor) weights into this runner's model."""
+        self.model.load_weights(weights)
 
-        Args:
-            name: the name of the parameter to be updated.
-            dtype: the data type of the parameter to be updated.
-            shape: the shape of the parameter to be updated.
-        """
-
-        return self.update_weights_from_distributed_to_model_runners(
-            [self], names, dtypes, shapes, group_name, load_format
-        )
-
-    def update_weights_from_distributed_to_model_runners(
-        self,
-        model_runners,
-        names,
-        dtypes,
-        shapes,
-        group_name,
-        load_format: Optional[str] = None,
-    ):
-        assert group_name in self._model_update_group, (
-            f"Group {group_name} not in {list(self._model_update_group.keys())}. "
-            "Please call `init_weights_update_group` first."
-        )
-
-        try:
-            weights = self._receive_weights_from_distributed(
-                names, dtypes, shapes, group_name, load_format
-            )
-            for model_runner in model_runners:
-                model_runner.model.load_weights(weights)
-            return True, "Succeeded to update parameter online."
-
-        except Exception as e:
-            error_msg = (
-                f"Failed to update parameter online: {e}. "
-                f"The full weights of the ModelRunner are partially updated. "
-                f"Please discard the whole weights."
-            )
-            logger.error(error_msg)
-            return False, error_msg
-
-    def _receive_weights_from_distributed(
+    def receive_weights_from_distributed(
         self, names, dtypes, shapes, group_name, load_format: Optional[str] = None
     ):
+        """Receive one weight broadcast from the training engine over this runner's
+        `_model_update_group`. Only the runner that joined the group (the target /
+        main model) can receive; the caller loads the result into each runner."""
         if load_format == "flattened_bucket":
             return self._receive_bucketed_weights_from_distributed(
                 names, dtypes, shapes, group_name

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -1,12 +1,11 @@
 import logging
 import math
 from copy import deepcopy
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 
 from sglang.srt.distributed import get_tp_group
-from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch, ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -31,6 +30,10 @@ from sglang.srt.speculative.dflash_utils import (
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
 from sglang.srt.utils import is_cuda
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
 
 logger = logging.getLogger(__name__)
 
@@ -344,22 +347,17 @@ class DFlashWorker:
         # Delegate anything not implemented yet to the target worker.
         return getattr(self.target_worker, name)
 
-    def update_weights_from_distributed(
-        self, recv_req: UpdateWeightsFromDistributedReqInput
-    ):
-        # Spelled out instead of falling through `__getattr__` so the gap is
-        # visible: this only updates the target. The DFlash draft model
-        # (`self.draft_model_runner`) is NOT refreshed and goes stale after a
-        # distributed weight update.
-        # TODO(dflash): fan out to the draft runner like EAGLEWorker does.
-        return self.target_worker.update_weights_from_distributed(recv_req)
-
     def clear_cache_pool(self):
         # The target worker owns the shared KV allocator/cache. For the compact
         # sliding-window path, the draft req->token view is rebuilt from committed
         # target state before each draft forward, so there is nothing persistent
         # to flush here.
         pass
+
+    def iter_draft_runners(self) -> list[tuple[str, "ModelRunner"]]:
+        # Explicit so DFlash's __getattr__ doesn't delegate this to the target
+        # (whose model_runner is aliased here) and miss the real draft.
+        return [("draft", self.draft_model_runner)]
 
     def _gather_req_to_token_masked(
         self,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -16,10 +16,6 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_backend_context,
 )
 from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
-from sglang.srt.managers.io_struct import (
-    UpdateWeightsFromDistributedReqInput,
-    UpdateWeightsFromTensorReqInput,
-)
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -71,7 +67,6 @@ from sglang.srt.speculative.spec_utils import (
     select_top_k_tokens,
 )
 from sglang.srt.utils import (
-    MultiprocessingSerializer,
     empty_context,
     get_available_gpu_memory,
     is_cuda,
@@ -80,7 +75,6 @@ from sglang.srt.utils import (
     log_info_on_rank0,
     next_power_of_2,
 )
-from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
 
 _is_npu = is_npu()
 _is_musa = is_musa()
@@ -1285,36 +1279,6 @@ class EAGLEWorker(TpModelWorker):
         probs = torch.softmax(logits_output.next_token_logits, dim=-1)
         draft_input.topk_p, draft_input.topk_index = fast_topk(probs, self.topk, dim=-1)
         draft_input.hidden_states = logits_output.hidden_states
-
-    def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
-        monkey_patch_torch_reductions()
-        named_tensors = MultiprocessingSerializer.deserialize(
-            recv_req.serialized_named_tensors[self.tp_rank]
-        )
-        success, message = self.model_runner.update_weights_from_tensor(
-            named_tensors=named_tensors,
-            load_format=recv_req.load_format,
-        )
-        if not success:
-            return success, message
-
-        success, message = self.target_worker.model_runner.update_weights_from_tensor(
-            named_tensors=named_tensors,
-            load_format=recv_req.load_format,
-        )
-        return success, message
-
-    def update_weights_from_distributed(
-        self, recv_req: UpdateWeightsFromDistributedReqInput
-    ):
-        return self.target_worker.model_runner.update_weights_from_distributed_to_model_runners(
-            [self.model_runner, self.target_worker.model_runner],
-            recv_req.names,
-            recv_req.dtypes,
-            recv_req.shapes,
-            recv_req.group_name,
-            recv_req.load_format,
-        )
 
 
 @torch.compile(dynamic=True, disable=(_is_npu or _is_musa))

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1,7 +1,7 @@
 import contextlib
 import logging
 import time
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
 
@@ -13,9 +13,7 @@ from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_npu_graph_runner i
     EAGLEDraftNpuGraphRunner,
 )
 from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
-from sglang.srt.layers.attention.trtllm_mla_backend import (
-    TRTLLMMLABackend,
-)
+from sglang.srt.layers.attention.trtllm_mla_backend import TRTLLMMLABackend
 from sglang.srt.layers.dp_attention import get_attention_tp_group
 from sglang.srt.layers.moe.utils import (
     speculative_moe_a2a_backend_context,
@@ -24,9 +22,7 @@ from sglang.srt.layers.moe.utils import (
 from sglang.srt.layers.utils.logprob import compute_spec_v2_logprobs
 from sglang.srt.managers.io_struct import (
     UpdateWeightFromDiskReqInput,
-    UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromIPCReqInput,
-    UpdateWeightsFromTensorReqInput,
 )
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
@@ -63,7 +59,6 @@ from sglang.srt.speculative.spec_utils import (
     select_top_k_tokens,
 )
 from sglang.srt.utils.common import (
-    MultiprocessingSerializer,
     empty_context,
     fast_topk,
     get_available_gpu_memory,
@@ -74,12 +69,15 @@ from sglang.srt.utils.common import (
     log_info_on_rank0,
     next_power_of_2,
 )
-from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
 
 _is_npu = is_npu()
 _is_cuda = is_cuda()
 _is_musa = is_musa()
 _is_hip = is_hip()
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
 
 logger = logging.getLogger(__name__)
 
@@ -742,6 +740,9 @@ class EAGLEWorkerV2(BaseSpecWorker):
         # allocator and kv cache pool are shared with target worker, which are cleared in scheduler
         pass
 
+    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+        return [("draft", self.draft_worker.draft_runner)]
+
     def forward_batch_generation(self, model_worker_batch: ModelWorkerBatch):
         if (
             model_worker_batch.forward_mode.is_extend()
@@ -1246,36 +1247,3 @@ class EAGLEWorkerV2(BaseSpecWorker):
         if not success:
             return success, message
         return True, "Succeeded to update model weights."
-
-    def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
-        monkey_patch_torch_reductions()
-        named_tensors = MultiprocessingSerializer.deserialize(
-            recv_req.serialized_named_tensors[self.tp_rank]
-        )
-        success, message = self.draft_worker.draft_runner.update_weights_from_tensor(
-            named_tensors=named_tensors,
-            load_format=recv_req.load_format,
-        )
-        if not success:
-            return success, message
-
-        success, message = self.target_worker.model_runner.update_weights_from_tensor(
-            named_tensors=named_tensors,
-            load_format=recv_req.load_format,
-        )
-        return success, message
-
-    def update_weights_from_distributed(
-        self, recv_req: UpdateWeightsFromDistributedReqInput
-    ):
-        return self.target_worker.model_runner.update_weights_from_distributed_to_model_runners(
-            [
-                self.draft_worker.draft_runner,
-                self.target_worker.model_runner,
-            ],
-            recv_req.names,
-            recv_req.dtypes,
-            recv_req.shapes,
-            recv_req.group_name,
-            recv_req.load_format,
-        )

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -31,7 +31,6 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_backend_context,
 )
 from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
-from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -196,18 +195,6 @@ class FrozenKVMTPWorker(TpModelWorker):
 
     def clear_cache_pool(self):
         pass
-
-    def update_weights_from_distributed(
-        self, recv_req: UpdateWeightsFromDistributedReqInput
-    ):
-        return self.target_worker.model_runner.update_weights_from_distributed_to_model_runners(
-            [self.draft_model_runner, self.target_worker.model_runner],
-            recv_req.names,
-            recv_req.dtypes,
-            recv_req.shapes,
-            recv_req.group_name,
-            recv_req.load_format,
-        )
 
     def _resolve_draft_backend_type(self) -> str:
         return (

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -25,7 +25,6 @@ from sglang.srt.layers.dp_attention import get_attention_tp_group
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.moe.utils import speculative_moe_backend_context
 from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
-from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -844,18 +843,3 @@ class MultiLayerEagleWorker(TpModelWorker):
         batch.req_pool_indices = req_pool_indices_backup
         batch.return_logprob = return_logprob_backup
         return next_draft_input
-
-    def update_weights_from_distributed(
-        self, recv_req: UpdateWeightsFromDistributedReqInput
-    ):
-        draft_model_runners = [
-            self.mtp_model_runner(i) for i in range(self.speculative_num_steps)
-        ]
-        return self.target_worker.model_runner.update_weights_from_distributed_to_model_runners(
-            draft_model_runners + [self.target_worker.model_runner],
-            recv_req.names,
-            recv_req.dtypes,
-            recv_req.shapes,
-            recv_req.group_name,
-            recv_req.load_format,
-        )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -23,16 +23,12 @@ from sglang.srt.layers.moe.utils import speculative_moe_backend_context
 from sglang.srt.layers.utils.logprob import compute_spec_v2_logprobs
 from sglang.srt.managers.io_struct import (
     UpdateWeightFromDiskReqInput,
-    UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromIPCReqInput,
 )
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
-from sglang.srt.model_executor.forward_batch_info import (
-    CaptureHiddenMode,
-    ForwardBatch,
-)
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWorker
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
@@ -657,6 +653,12 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         # allocator and kv cache pool are shared with target worker, which are cleared in scheduler
         pass
 
+    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+        return [
+            (f"draft_step_{i}", r)
+            for i, r in enumerate(self.draft_worker.draft_runner_list)
+        ]
+
     def forward_batch_generation(self, model_worker_batch: ModelWorkerBatch):
         if (
             model_worker_batch.forward_mode.is_extend()
@@ -834,15 +836,3 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             if not success:
                 return success, message
         return True, "Succeeded to update model weights."
-
-    def update_weights_from_distributed(
-        self, recv_req: UpdateWeightsFromDistributedReqInput
-    ):
-        return self.target_worker.model_runner.update_weights_from_distributed_to_model_runners(
-            self.draft_worker.draft_runner_list + [self.target_worker.model_runner],
-            recv_req.names,
-            recv_req.dtypes,
-            recv_req.shapes,
-            recv_req.group_name,
-            recv_req.load_format,
-        )

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -1,12 +1,11 @@
 import logging
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import numpy as np
 import torch
 from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
 
 from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
-from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -18,6 +17,10 @@ from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
 from sglang.srt.speculative.ngram_info import NgramVerifyInput
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import generate_token_bitmask
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
 
 logger = logging.getLogger(__name__)
 
@@ -84,19 +87,9 @@ class NGRAMWorker:
     def clear_cache_pool(self):
         self.ngram_corpus.reset()
 
-    def update_weights_from_tensor(self, recv_req):
-        # NGRAM has no draft weights of its own — the n-gram corpus is a CPU
-        # lookup structure built from request token streams — and its
-        # `model_runner` is shared with the target worker. The scheduler
-        # mixin dispatches via `self.draft_worker or self.tp_worker`, so
-        # without this method any caller of `update_weights_from_tensor`
-        # under `--speculative-algorithm NGRAM` raises AttributeError.
-        return self.target_worker.update_weights_from_tensor(recv_req)
-
-    def update_weights_from_distributed(
-        self, recv_req: UpdateWeightsFromDistributedReqInput
-    ):
-        return self.target_worker.update_weights_from_distributed(recv_req)
+    def iter_draft_runners(self) -> list[tuple[str, "ModelRunner"]]:
+        # NGRAM shares the target's model_runner — no independent draft.
+        return []
 
     def add_external_corpus(self, corpus_id: str, token_chunks: list[list[int]]) -> int:
         return self.ngram_corpus.load_external_corpus_named(corpus_id, token_chunks)

--- a/test/srt/test_distributed_weight_update_spec_worker.py
+++ b/test/srt/test_distributed_weight_update_spec_worker.py
@@ -5,7 +5,6 @@ from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
 from sglang.srt.managers.scheduler_update_weights_mixin import (
     SchedulerUpdateWeightsMixin,
 )
-from sglang.srt.model_executor.model_runner import ModelRunner
 
 
 class _TestScheduler(SchedulerUpdateWeightsMixin):
@@ -33,16 +32,14 @@ def _scheduler(tp_worker, draft_worker):
     return scheduler
 
 
-def test_scheduler_distributed_update_fans_out_to_target_and_draft():
-    # Default selector ("both"): the scheduler resolves the runner list via
-    # get_model_runners; the target runner owns the update group, receives the
-    # broadcast once, and loads it into both the target and the draft runner.
+def test_scheduler_distributed_update_receives_once_on_target_loads_into_each():
+    # Default selector ("both"): only the target (main model) owns the update group,
+    # so it receives the broadcast once; that single weights object is then loaded
+    # into every selected runner — receive once on the target, load into each.
+    weights = object()
     target_runner = Mock()
-    target_runner.update_weights_from_distributed_to_model_runners.return_value = (
-        True,
-        "updated",
-    )
-    draft_runner = object()
+    target_runner.receive_weights_from_distributed.return_value = weights
+    draft_runner = Mock()
     scheduler = _scheduler(
         tp_worker=SimpleNamespace(model_runner=target_runner),
         draft_worker=SimpleNamespace(
@@ -58,25 +55,25 @@ def test_scheduler_distributed_update_fans_out_to_target_and_draft():
         )
 
     assert output.success is True
-    target_runner.update_weights_from_distributed_to_model_runners.assert_called_once_with(
-        [target_runner, draft_runner],
+    target_runner.receive_weights_from_distributed.assert_called_once_with(
         ["model.layers.0.weight"],
         ["float32"],
         [[1]],
         "weight_update_group",
         None,
     )
+    # The single received weights object is loaded into every selected runner.
+    target_runner.load_weights.assert_called_once_with(weights)
+    draft_runner.load_weights.assert_called_once_with(weights)
     assert barrier.call_count == 2
 
 
 def test_scheduler_distributed_update_target_only_selector_skips_draft():
-    # selector="target" resolves to the target runner alone; the draft worker is
-    # never enumerated.
+    # selector="target": the target still receives once, but the draft worker is
+    # never enumerated and no draft runner is loaded.
+    weights = object()
     target_runner = Mock()
-    target_runner.update_weights_from_distributed_to_model_runners.return_value = (
-        True,
-        "updated",
-    )
+    target_runner.receive_weights_from_distributed.return_value = weights
     draft_worker = Mock()
     scheduler = _scheduler(
         tp_worker=SimpleNamespace(model_runner=target_runner),
@@ -91,37 +88,6 @@ def test_scheduler_distributed_update_target_only_selector_skips_draft():
         )
 
     assert output.success is True
-    target_runner.update_weights_from_distributed_to_model_runners.assert_called_once_with(
-        [target_runner],
-        ["model.layers.0.weight"],
-        ["float32"],
-        [[1]],
-        "weight_update_group",
-        None,
-    )
+    target_runner.receive_weights_from_distributed.assert_called_once()
+    target_runner.load_weights.assert_called_once_with(weights)
     draft_worker.iter_draft_runners.assert_not_called()
-
-
-def test_model_runner_loads_one_distributed_receive_into_multiple_runners():
-    weights = [("model.layers.0.weight", object())]
-    source_runner = SimpleNamespace(
-        _model_update_group={"weight_update_group": object()},
-        _receive_weights_from_distributed=Mock(return_value=weights),
-    )
-    draft_runner = SimpleNamespace(model=Mock())
-    target_runner = SimpleNamespace(model=Mock())
-
-    success, message = ModelRunner.update_weights_from_distributed_to_model_runners(
-        source_runner,
-        [draft_runner, target_runner],
-        ["model.layers.0.weight"],
-        ["float32"],
-        [[1]],
-        "weight_update_group",
-    )
-
-    assert success is True
-    assert message == "Succeeded to update parameter online."
-    source_runner._receive_weights_from_distributed.assert_called_once()
-    draft_runner.model.load_weights.assert_called_once_with(weights)
-    target_runner.model.load_weights.assert_called_once_with(weights)

--- a/test/srt/test_distributed_weight_update_spec_worker.py
+++ b/test/srt/test_distributed_weight_update_spec_worker.py
@@ -6,34 +6,48 @@ from sglang.srt.managers.scheduler_update_weights_mixin import (
     SchedulerUpdateWeightsMixin,
 )
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.speculative.eagle_worker_v2 import EAGLEWorkerV2
-from sglang.srt.speculative.multi_layer_eagle_worker_v2 import MultiLayerEagleWorkerV2
 
 
 class _TestScheduler(SchedulerUpdateWeightsMixin):
     pass
 
 
-def _distributed_req():
+def _distributed_req(selector="both"):
     return UpdateWeightsFromDistributedReqInput(
         names=["model.layers.0.weight"],
         dtypes=["float32"],
         shapes=[[1]],
         group_name="weight_update_group",
         flush_cache=False,
+        selector=selector,
     )
 
 
-def test_scheduler_routes_distributed_weight_update_to_spec_worker():
+def _scheduler(tp_worker, draft_worker):
     scheduler = _TestScheduler()
     scheduler.enable_overlap = False
     scheduler.schedule_stream = Mock()
     scheduler.tp_cpu_group = object()
-    scheduler.tp_worker = Mock()
-    scheduler.draft_worker = Mock()
-    scheduler.draft_worker.update_weights_from_distributed.return_value = (
+    scheduler.tp_worker = tp_worker
+    scheduler.draft_worker = draft_worker
+    return scheduler
+
+
+def test_scheduler_distributed_update_fans_out_to_target_and_draft():
+    # Default selector ("both"): the scheduler resolves the runner list via
+    # get_model_runners; the target runner owns the update group, receives the
+    # broadcast once, and loads it into both the target and the draft runner.
+    target_runner = Mock()
+    target_runner.update_weights_from_distributed_to_model_runners.return_value = (
         True,
         "updated",
+    )
+    draft_runner = object()
+    scheduler = _scheduler(
+        tp_worker=SimpleNamespace(model_runner=target_runner),
+        draft_worker=SimpleNamespace(
+            iter_draft_runners=lambda: [("draft", draft_runner)]
+        ),
     )
 
     with patch(
@@ -44,9 +58,48 @@ def test_scheduler_routes_distributed_weight_update_to_spec_worker():
         )
 
     assert output.success is True
-    scheduler.draft_worker.update_weights_from_distributed.assert_called_once()
-    scheduler.tp_worker.update_weights_from_distributed.assert_not_called()
+    target_runner.update_weights_from_distributed_to_model_runners.assert_called_once_with(
+        [target_runner, draft_runner],
+        ["model.layers.0.weight"],
+        ["float32"],
+        [[1]],
+        "weight_update_group",
+        None,
+    )
     assert barrier.call_count == 2
+
+
+def test_scheduler_distributed_update_target_only_selector_skips_draft():
+    # selector="target" resolves to the target runner alone; the draft worker is
+    # never enumerated.
+    target_runner = Mock()
+    target_runner.update_weights_from_distributed_to_model_runners.return_value = (
+        True,
+        "updated",
+    )
+    draft_worker = Mock()
+    scheduler = _scheduler(
+        tp_worker=SimpleNamespace(model_runner=target_runner),
+        draft_worker=draft_worker,
+    )
+
+    with patch(
+        "sglang.srt.managers.scheduler_update_weights_mixin.torch.distributed.barrier"
+    ):
+        output = SchedulerUpdateWeightsMixin.update_weights_from_distributed(
+            scheduler, _distributed_req(selector="target")
+        )
+
+    assert output.success is True
+    target_runner.update_weights_from_distributed_to_model_runners.assert_called_once_with(
+        [target_runner],
+        ["model.layers.0.weight"],
+        ["float32"],
+        [[1]],
+        "weight_update_group",
+        None,
+    )
+    draft_worker.iter_draft_runners.assert_not_called()
 
 
 def test_model_runner_loads_one_distributed_receive_into_multiple_runners():
@@ -72,55 +125,3 @@ def test_model_runner_loads_one_distributed_receive_into_multiple_runners():
     source_runner._receive_weights_from_distributed.assert_called_once()
     draft_runner.model.load_weights.assert_called_once_with(weights)
     target_runner.model.load_weights.assert_called_once_with(weights)
-
-
-def test_eagle_v2_distributed_update_loads_draft_and_target_from_target_group():
-    req = _distributed_req()
-    target_runner = Mock()
-    target_runner.update_weights_from_distributed_to_model_runners.return_value = (
-        True,
-        "updated",
-    )
-    draft_runner = object()
-    worker = object.__new__(EAGLEWorkerV2)
-    worker._target_worker = SimpleNamespace(model_runner=target_runner)
-    worker._draft_worker = SimpleNamespace(draft_runner=draft_runner)
-
-    success, message = worker.update_weights_from_distributed(req)
-
-    assert success is True
-    assert message == "updated"
-    target_runner.update_weights_from_distributed_to_model_runners.assert_called_once_with(
-        [draft_runner, target_runner],
-        req.names,
-        req.dtypes,
-        req.shapes,
-        req.group_name,
-        req.load_format,
-    )
-
-
-def test_multi_layer_eagle_v2_distributed_update_loads_all_drafts_and_target():
-    req = _distributed_req()
-    target_runner = Mock()
-    target_runner.update_weights_from_distributed_to_model_runners.return_value = (
-        True,
-        "updated",
-    )
-    draft_runners = [object(), object()]
-    worker = object.__new__(MultiLayerEagleWorkerV2)
-    worker._target_worker = SimpleNamespace(model_runner=target_runner)
-    worker._draft_worker = SimpleNamespace(draft_runner_list=draft_runners)
-
-    success, message = worker.update_weights_from_distributed(req)
-
-    assert success is True
-    assert message == "updated"
-    target_runner.update_weights_from_distributed_to_model_runners.assert_called_once_with(
-        draft_runners + [target_runner],
-        req.names,
-        req.dtypes,
-        req.shapes,
-        req.group_name,
-        req.load_format,
-    )


### PR DESCRIPTION
## Summary
Centralize speculative weight-update fan-out in the scheduler via `get_model_runners`.

## Motivation
`update_weights_from_distributed` / `update_weights_from_tensor` dispatched to `self.draft_worker or self.tp_worker`, and each of the 7 speculative workers re-implemented forwarding that hard-coded which runners to update — duplicating the runner-set knowledge `iter_draft_runners()` already encodes (introduced in #27749). The online weight-update behavior for the target and draft runners is unchanged; only where runner selection lives changes.

## Before / After
- **Before:** each speculative worker (`eagle_worker`, `eagle_worker_v2`, `multi_layer_eagle_worker`, `multi_layer_eagle_worker_v2`, `frozen_kv_mtp_worker`, `ngram_worker`, `dflash_worker`) built its own `[draft..., target]` runner list for `update_weights_from_distributed_to_model_runners`.
- **After:** `update_weights_from_distributed` / `_from_tensor` in `SchedulerUpdateWeightsMixin` resolve the runner list once via `get_model_runners(selector)`.
- **Distributed load:** `model_runner.update_weights_from_distributed_to_model_runners` receives the broadcast once for all selected runners.
- **Tensor load:** the mixin deserializes `serialized_named_tensors[self.tp_rank]` once for all selected runners.
- **What moved where:** runner selection moved out of the 7 workers into the scheduler mixin.
- **Deleted:** the per-worker `update_weights_from_distributed` / `update_weights_from_tensor` methods.
- **Worker surface:** speculative workers now expose only `iter_draft_runners()`.
- **API:** `disable_draft_model` on the two `UpdateWeights*ReqInput` structs becomes the unified `{target, draft}` `selector` (default both).

## Behavior Preservation
- **Scheduler fan-out:** `test_distributed_weight_update_spec_worker.py` asserts one distributed receive loads into target plus draft.
- **Selector scope:** the same test asserts a `target`-only selector skips the draft worker.
- **Checker unchanged:** the weight-checker suites (`test_check_weights_draft_fanout.py`, `test_weight_checker.py`) still pass.
- **Behavior change:** DFlash's draft runner is now refreshed on a distributed update.

## Verification
- **Unit suite:** 102 tests pass (fanout 31, `_cuda` 5, distributed-spec-worker 3, weight-checker 63).
- **Lint:** `ruff --select F401,F821`, `black --check`, `isort --check` clean on the touched files.

## Review Focus
- Scrutinize `update_weights_from_tensor` in `scheduler_update_weights_mixin.py` for the once-only deserialize across selected runners.
- Scrutinize the `disable_draft_model` to `selector` swap on the request structs.
- Verify `get_model_runners` keeps the target first so the target owns the distributed update group.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->