### PR TITLE
[HiCache] Fix write-back crash on non-JIT backends (ROCm): gate page_first CPU dst-indices on can_use_jit

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -727,13 +727,20 @@ class HiCacheController:
 
         op = CacheOperation.merge_ops(self.write_queue)
         # Keeping host (destination) indices on CPU only works with the staged JIT
-        # write-back kernel (CUDA-only). The AOT fallback used when can_use_jit is
-        # False (e.g. ROCm) calls transfer_kv_all_layer_*_lf_pf, which requires GPU
-        # destination indices (TORCH_CHECK is_cuda), so gate this on can_use_jit.
+        # write-back kernel. The AOT fallback used on non-JIT backends (e.g. ROCm)
+        # calls transfer_kv_all_layer_*_lf_pf, which requires GPU destination indices
+        # (TORCH_CHECK is_cuda), so gate this on the write-back JIT predicate.
+        # Prefer can_use_write_back_jit (the accurate per-pool field standardized in
+        # #28434); fall back to can_use_jit until that lands. Both are already gated
+        # on _is_cuda, so no separate is_cuda check is needed.
         if (
             self.io_backend == "kernel"
             and self.mem_pool_host.layout == "page_first"
-            and getattr(self.mem_pool_host, "can_use_jit", False)
+            and getattr(
+                self.mem_pool_host,
+                "can_use_write_back_jit",
+                getattr(self.mem_pool_host, "can_use_jit", False),
+            )
         ):
             host_indices, device_indices = op.host_indices, op.device_indices
         else:

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -726,10 +726,15 @@ class HiCacheController:
             return
 
         op = CacheOperation.merge_ops(self.write_queue)
-        # For now, kernel write-back keeps host indices on CPU only for page_first.
-        # More layouts can use this path once their write-back kernels accept CPU
-        # destination indices.
-        if self.io_backend == "kernel" and self.mem_pool_host.layout == "page_first":
+        # Keeping host (destination) indices on CPU only works with the staged JIT
+        # write-back kernel (CUDA-only). The AOT fallback used when can_use_jit is
+        # False (e.g. ROCm) calls transfer_kv_all_layer_*_lf_pf, which requires GPU
+        # destination indices (TORCH_CHECK is_cuda), so gate this on can_use_jit.
+        if (
+            self.io_backend == "kernel"
+            and self.mem_pool_host.layout == "page_first"
+            and getattr(self.mem_pool_host, "can_use_jit", False)
+        ):
             host_indices, device_indices = op.host_indices, op.device_indices
         else:
             host_indices, device_indices = self.move_indices(

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -395,13 +395,20 @@ class HybridCacheController(BaseHiCacheController):
             return
         op = CacheOperation.merge_ops(self.write_queue)
         # Keeping host (destination) indices on CPU only works with the staged JIT
-        # write-back kernel (CUDA-only). The AOT fallback used when can_use_jit is
-        # False (e.g. ROCm) calls transfer_kv_all_layer_*_lf_pf, which requires GPU
-        # destination indices (TORCH_CHECK is_cuda), so gate this on can_use_jit.
+        # write-back kernel. The AOT fallback used on non-JIT backends (e.g. ROCm)
+        # calls transfer_kv_all_layer_*_lf_pf, which requires GPU destination indices
+        # (TORCH_CHECK is_cuda), so gate this on the write-back JIT predicate.
+        # Prefer can_use_write_back_jit (the accurate per-pool field standardized in
+        # #28434); fall back to can_use_jit until that lands. Both are already gated
+        # on _is_cuda, so no separate is_cuda check is needed.
         if (
             self.io_backend == "kernel"
             and self.mem_pool_host.layout == "page_first"
-            and getattr(self.mem_pool_host, "can_use_jit", False)
+            and getattr(
+                self.mem_pool_host,
+                "can_use_write_back_jit",
+                getattr(self.mem_pool_host, "can_use_jit", False),
+            )
         ):
             host_indices = op.host_indices
             device_indices = op.device_indices

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -394,10 +394,15 @@ class HybridCacheController(BaseHiCacheController):
         if not self.write_queue:
             return
         op = CacheOperation.merge_ops(self.write_queue)
-        # For now, kernel write-back keeps host indices on CPU only for page_first.
-        # More layouts can use this path once their write-back kernels accept CPU
-        # destination indices.
-        if self.io_backend == "kernel" and self.mem_pool_host.layout == "page_first":
+        # Keeping host (destination) indices on CPU only works with the staged JIT
+        # write-back kernel (CUDA-only). The AOT fallback used when can_use_jit is
+        # False (e.g. ROCm) calls transfer_kv_all_layer_*_lf_pf, which requires GPU
+        # destination indices (TORCH_CHECK is_cuda), so gate this on can_use_jit.
+        if (
+            self.io_backend == "kernel"
+            and self.mem_pool_host.layout == "page_first"
+            and getattr(self.mem_pool_host, "can_use_jit", False)
+        ):
             host_indices = op.host_indices
             device_indices = op.device_indices
             resolved_pool_transfers = op.pool_transfers


### PR DESCRIPTION
## Summary

Fixes a HiCache write-back crash on non-JIT backends (ROCm / MI325):

```
RuntimeError: Destination indices must be a CUDA tensor
```

### Root cause

#21631 ("Refactoring HiCache Write-Back Kernel") made two changes that interact badly on non-CUDA backends:

1. In `start_writing` (both `HiCacheController` and `HybridCacheController`), kernel write-back now **keeps host (destination) indices on CPU** for the `page_first` layout — relying on the new staged JIT write-back kernel (`transfer_hicache_all_layer_staged_lf_pf`), which accepts CPU destination indices.
2. It flipped the default `hicache_mem_layout` from `layer_first` → `page_first`.

On backends where `can_use_jit` is `False` (`can_use_jit = _is_cuda and ...`, and `_is_cuda` is `False` on ROCm), write-back falls back to the AOT kernel `transfer_kv_all_layer_lf_pf` / `transfer_kv_all_layer_mla_lf_pf`, which asserts `dst_indices.is_cuda()` (`sgl-kernel/csrc/kvcacheio/transfer.cu`). Because the host indices were left on CPU, the assert fires and the scheduler crashes.

This regressed AMD CI on `main` (first failing run 2026-06-16; passing immediately before #21631 merged). Affected tests include `test/registered/hicache/test_hicache_variants.py`, `test_hicache_storage.py`, and `test_hicache_storage_file_backend.py`.

### Fix

Gate the "keep host indices on CPU" optimization on `can_use_jit`, so non-JIT backends fall back to `move_indices` (which moves host indices to the GPU) before invoking the AOT write-back kernel. Applied to both controllers. No behavior change on CUDA (where `can_use_jit` is `True`).

```python
if (
    self.io_backend == "kernel"
    and self.mem_pool_host.layout == "page_first"
    and getattr(self.mem_pool_host, "can_use_jit", False)
):
    # staged JIT kernel: CPU destination indices OK
else:
    ... = self.move_indices(...)  # AOT/non-JIT: host indices -> GPU
```

### Test plan

- [ ] AMD `stage-b-test-1-gpu-small-amd` / `stage-b-test-2-gpu-large-amd`: `test_hicache_variants.py`, `test_hicache_storage.py`, `test_hicache_storage_file_backend.py` pass (no "Destination indices must be a CUDA tensor").
- [ ] CUDA HiCache unchanged (JIT path still keeps host indices on CPU).

cc #21631 author (@huangtingwei9988)





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27791922505](https://github.com/sgl-project/sglang/actions/runs/27791922505)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27792065984](https://github.com/sgl-project/sglang/actions/runs/27792065984)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->