### PR TITLE
Add JonnyKong to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -202,6 +202,13 @@
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
+    "JonnyKong": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 60,
+        "reason": "custom override"
+    },
     "JustinTong0323": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
Adds `JonnyKong` to `.github/CI_PERMISSIONS.json` in sorted position (between `Johnsonms` and `JustinTong0323`).

```json
"JonnyKong": {
    "can_tag_run_ci_label": true,
    "can_rerun_failed_ci": true,
    "can_rerun_stage": true,
    "cooldown_interval_minutes": 60,
    "reason": "custom override"
}
```









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27711333483](https://github.com/sgl-project/sglang/actions/runs/27711333483)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27711333321](https://github.com/sgl-project/sglang/actions/runs/27711333321)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->