### PR TITLE
Fix MXFP8 FlashInfer CUTLASS scale selection

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -790,10 +790,9 @@ class Fp8LinearMethod(LinearMethodBase):
             )
 
         if self.use_mxfp8:
-            if (
-                get_fp8_gemm_runner_backend().is_flashinfer_cutlass()
-                or get_fp8_gemm_runner_backend().is_flashinfer_trtllm()
-            ):
+            if get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
+                weight_scale = layer.weight_scale_inv_swizzled
+            elif get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
                 weight_scale = layer.weight_scale_inv_shuffled
             else:
                 weight_scale = layer.weight_scale_inv


### PR DESCRIPTION
## Summary

Fixes the #28459 mixup by making FlashInfer CUTLASS MXFP8 use its swizzled scale instead of the TRT-LLM shuffled one























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27714701901](https://github.com/sgl-project/sglang/actions/runs/27714701901)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27714845423](https://github.com/sgl-project/sglang/actions/runs/27714845423)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->