### PR TITLE
[AMD]: CI add NIXL PD disaggregation tests

### DIFF
--- a/.github/workflows/pr-test-amd-nixl-build.yml
+++ b/.github/workflows/pr-test-amd-nixl-build.yml
@@ -1,0 +1,62 @@
+name: PR Test NIXL Build (AMD)
+# Build-tests the optional ENABLE_NIXL=1 stage in docker/rocm.Dockerfile and
+# verifies the resulting image can import nixl with UCX present + plugins
+# discoverable. Build-only (no serving), so no multi-GPU runner is required.
+# Covers BOTH the un-suffixed ROCm 7.0 default base and the rocm720 (7.2) base,
+# since UCX --with-rocm links against /opt/rocm and behavior can drift by minor.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docker/rocm.Dockerfile'
+      - '.github/workflows/pr-test-amd-nixl-build.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  nixl-build-import:
+    if: github.event.pull_request.draft == false
+    runs-on: amd-docker-scale
+    strategy:
+      fail-fast: false
+      matrix:
+        # gfx950        -> ROCm 7.0 base (un-suffixed default path)
+        # gfx950-rocm720 -> ROCm 7.2 base (functionally validated flavor)
+        gpu_arch: ['gfx950', 'gfx950-rocm720']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build image with ENABLE_NIXL=1
+        run: |
+          docker build . -f docker/rocm.Dockerfile \
+            --build-arg SGL_BRANCH=${{ github.ref_name }} \
+            --build-arg GPU_ARCH=${{ matrix.gpu_arch }} \
+            --build-arg ENABLE_NIXL=1 \
+            --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com \
+            -t sglang-nixl-test:${{ matrix.gpu_arch }} \
+            --no-cache
+
+      - name: Verify nixl import + UCX + plugins
+        run: |
+          docker run --rm \
+            -e LD_LIBRARY_PATH=/opt/ucx/lib:/opt/rocm/lib \
+            sglang-nixl-test:${{ matrix.gpu_arch }} \
+            bash -lc '
+              set -eux
+              # nixl python package importable (built as nixl_rocm, symlinked to nixl)
+              python -c "import nixl; print(\"nixl OK:\", nixl.__file__)"
+              # UCX runtime present and built with ROCm transport
+              test -d /opt/ucx/lib
+              ucx_info -v
+              ucx_info -d | grep -iq rocm
+              # NIXL UCX plugin discoverable
+              python - <<PY
+              from nixl._api import nixl_agent, nixl_agent_config
+              a = nixl_agent("ci-smoke", nixl_agent_config(backends=["UCX"]))
+              print("nixl UCX backend init OK")
+              PY
+            '

--- a/test/registered/amd/disaggregation/test_nixl_transfer_engine_e2e.py
+++ b/test/registered/amd/disaggregation/test_nixl_transfer_engine_e2e.py
@@ -1,0 +1,209 @@
+import os
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_pd_server,
+    try_cached_model,
+)
+
+register_amd_ci(est_time=900, suite="stage-b-test-large-8-gpu-mi35x-disaggregation-amd")
+
+
+class NixlTransferEngineBase(PDDisaggregationServerBase):
+    """PD-over-NIXL e2e on ROCm. NIXL (upstream ai-dynamo/nixl + UCX --with-rocm)
+    is an opt-in image stage built with `--build-arg ENABLE_NIXL=1`; when the
+    image was built without it, `import nixl` fails and the test skips rather
+    than failing the suite."""
+
+    port_delta = 0
+    prefill_tp = 1
+    decode_tp = 1
+    decode_base_gpu_id = 1
+    required_gpus = 2
+
+    model_default = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+    model_env_var = "SGLANG_NIXL_E2E_TEST_MODEL"
+    extra_prefill_args: list = []
+    extra_decode_args: list = []
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import torch
+
+            if not torch.cuda.is_available():
+                raise unittest.SkipTest("torch.cuda is not available.")
+            if torch.cuda.device_count() < cls.required_gpus:
+                raise unittest.SkipTest(
+                    f"NIXL PD smoke test requires >= {cls.required_gpus} visible GPUs."
+                )
+        except unittest.SkipTest:
+            raise
+        except Exception as e:
+            raise unittest.SkipTest(f"torch is not available/usable: {e}")
+
+        try:
+            import nixl  # noqa: F401
+        except Exception as e:
+            raise unittest.SkipTest(
+                "nixl not importable; image built without --build-arg ENABLE_NIXL=1 "
+                f"({e})."
+            )
+
+        super().setUpClass()
+
+        cls._old_use_aiter = os.environ.get("SGLANG_USE_AITER")
+        os.environ["SGLANG_USE_AITER"] = "1"
+
+        # The shared fixture defaults to Mooncake in CI; pin NIXL explicitly here.
+        cls.transfer_backend = ["--disaggregation-transfer-backend", "nixl"]
+
+        rdma_env = os.environ.get("SGLANG_TEST_RDMA_DEVICE")
+        if rdma_env:
+            cls.rdma_devices = ["--disaggregation-ib-device", rdma_env]
+            print(f"Found RDMA devices in env: {rdma_env}")
+        else:
+            print("SGLANG_TEST_RDMA_DEVICE is not set! Running without RDMA.")
+            cls.rdma_devices = []
+
+        cls._shift_ports()
+        cls.model = try_cached_model(
+            os.environ.get(cls.model_env_var, cls.model_default)
+        )
+
+        cls.start_prefill()
+        cls.start_decode()
+
+        cls.wait_server_ready(
+            cls.prefill_url + "/health",
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            process=cls.process_prefill,
+        )
+        cls.wait_server_ready(
+            cls.decode_url + "/health",
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            process=cls.process_decode,
+        )
+        cls.launch_lb()
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "_old_use_aiter", None) is None:
+            os.environ.pop("SGLANG_USE_AITER", None)
+        else:
+            os.environ["SGLANG_USE_AITER"] = cls._old_use_aiter
+        super().tearDownClass()
+
+    @classmethod
+    def _shift_ports(cls):
+        if cls.port_delta == 0:
+            return
+
+        cls.lb_port = str(int(cls.lb_port) + cls.port_delta)
+        cls.prefill_port = str(int(cls.prefill_port) + cls.port_delta)
+        cls.decode_port = str(int(cls.decode_port) + cls.port_delta)
+        cls.bootstrap_port = str(int(cls.bootstrap_port) + cls.port_delta)
+        cls.prefill_url = f"http://{cls.base_host}:{cls.prefill_port}"
+        cls.decode_url = f"http://{cls.base_host}:{cls.decode_port}"
+        cls.lb_url = f"http://{cls.base_host}:{cls.lb_port}"
+        cls.base_url = cls.lb_url
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "prefill",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            str(cls.prefill_tp),
+            "--attention-backend",
+            "aiter",
+        ] + list(cls.extra_prefill_args)
+        prefill_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "decode",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            str(cls.decode_tp),
+            "--base-gpu-id",
+            str(cls.decode_base_gpu_id),
+            "--attention-backend",
+            "aiter",
+            "--mem-fraction-static",
+            "0.8",
+        ] + list(cls.extra_decode_args)
+        decode_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+        )
+
+    def _assert_generate_smoke(self):
+        resp = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": "Hello",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+            },
+            timeout=120,
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        out = resp.json()
+        self.assertIn("text", out)
+        self.assertIsInstance(out["text"], str)
+        self.assertGreater(len(out["text"]), 0)
+
+
+class TestNixlTransferEngineE2E(NixlTransferEngineBase):
+    def test_generate_smoke(self):
+        self._assert_generate_smoke()
+
+
+class TestNixlTransferEngineAccuracy(NixlTransferEngineBase):
+    port_delta = 10
+    model_default = DEFAULT_MODEL_NAME_FOR_TEST
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host=f"http://{self.base_host}",
+            port=int(self.lb_port),
+        )
+        metrics = run_eval_few_shot_gsm8k(args)
+        print(f"Evaluation metrics: {metrics}")
+        self.assertGreater(metrics["accuracy"], 0.70)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 ## Motivation

  Add CI coverage for PD disaggregation over the optional NIXL (ai-dynamo/nixl + UCX `--with-rocm`) backend on ROCm. The backend itself is added
  by a separate Dockerfile PR; this PR adds only the tests.

  ## Modifications

  - Register a PD-over-NIXL e2e test in the AMD suite `stage-b-test-large-8-gpu-mi35x-disaggregation-amd` (smoke + GSM8K accuracy). Modeled on the
   existing MORI transfer-engine test; pins `--disaggregation-transfer-backend nixl` and skips gracefully when the image was built without
  `--build-arg ENABLE_NIXL=1`.
  - Add a PR build-test workflow that builds `docker/rocm.Dockerfile` with `ENABLE_NIXL=1` on both the ROCm 7.0 (gfx950) and 7.2 (gfx950-rocm720)
  bases and asserts nixl imports with UCX present and plugins discoverable.


## Accuracy Tests

N/A

## Speed Tests and Profiling

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27715749389](https://github.com/sgl-project/sglang/actions/runs/27715749389)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27715749424](https://github.com/sgl-project/sglang/actions/runs/27715749424)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->