### PR TITLE
fix: speculative draft worker clobbering target attention backend

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -38,6 +38,10 @@ class AttentionBackend(ABC):
     those must migrate to ``init_forward_metadata_out_graph(fb, in_capture)``.
     """
 
+    # Resolved per-mode backend names, stamped by ModelRunner.init_attention_backend
+    prefill_attention_backend_str: Optional[str] = None
+    decode_attention_backend_str: Optional[str] = None
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Eager entry point. Default = ``_out_graph(fb) + _in_graph(fb)``.
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2415,6 +2415,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         else:
             self.attn_backend = self._get_attention_backend()
 
+        # Record resolved per-mode backends on the backend for model dispatch.
+        self.attn_backend.prefill_attention_backend_str = (
+            self.prefill_attention_backend_str
+        )
+        self.attn_backend.decode_attention_backend_str = (
+            self.decode_attention_backend_str
+        )
+
     def _get_attention_backend(self, init_new_workspace: bool = False):
         """Init attention kernel backend."""
         draft_attn_backend = self.server_args.speculative_draft_attention_backend
@@ -2422,6 +2430,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger.warning(
                 f"Overriding draft attention backend to {draft_attn_backend}."
             )
+            # Single backend for all draft modes (no prefill/decode split).
+            self.prefill_attention_backend_str = draft_attn_backend
+            self.decode_attention_backend_str = draft_attn_backend
             return self._get_attention_backend_from_str(
                 draft_attn_backend,
                 init_new_workspace=init_new_workspace,
@@ -2463,10 +2474,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 init_new_workspace=init_new_workspace,
             )
 
-        (
-            get_global_server_args().prefill_attention_backend,
-            get_global_server_args().decode_attention_backend,
-        ) = (self.prefill_attention_backend_str, self.decode_attention_backend_str)
         return attn_backend
 
     def _get_attention_backend_from_str(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -140,6 +140,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.models.deepseek_common.attention_backend_handler import (
     AttentionBackendRegistry,
@@ -1737,20 +1738,28 @@ class DeepseekV2AttentionMLA(
     def dispatch_attn_forward_method(
         self, forward_batch: ForwardBatch
     ) -> AttnForwardMethod:
-        # Determine attention backend used by current forward batch
+        # Determine attention backend name for current forward batch: prefer the
+        # name stamped per-runner on the backend object, else resolve from server args.
+        backend = get_attn_backend()
+        server_args = get_global_server_args()
+        default_prefill_str, default_decode_str = server_args.get_attention_backends()
+        prefill_backend_str = (
+            backend.prefill_attention_backend_str or default_prefill_str
+        )
+        decode_backend_str = backend.decode_attention_backend_str or default_decode_str
         if forward_batch.forward_mode.is_decode_or_idle():
-            attention_backend = get_global_server_args().decode_attention_backend
+            attention_backend = decode_backend_str
         elif (
             forward_batch.forward_mode.is_target_verify()
             or forward_batch.forward_mode.is_draft_extend_v2()
         ):
             # Use the specified backend for speculative operations (both verify and draft extend)
-            if get_global_server_args().speculative_attention_mode == "decode":
-                attention_backend = get_global_server_args().decode_attention_backend
+            if server_args.speculative_attention_mode == "decode":
+                attention_backend = decode_backend_str
             else:  # default to prefill
-                attention_backend = get_global_server_args().prefill_attention_backend
+                attention_backend = prefill_backend_str
         else:
-            attention_backend = get_global_server_args().prefill_attention_backend
+            attention_backend = prefill_backend_str
         self.current_attention_backend = attention_backend
 
         handler = AttentionBackendRegistry.get_handler(attention_backend)


### PR DESCRIPTION
## Summary

Fix #28528 

## Root cause
### The bug

`ModelRunner._get_attention_backend()` wrote its resolved backend into the global server_args for dispatch seeing it. This is anti-pattern because it relies on correct initialization order for multiple runners in spec dec. In this buggy case,
1. Target runner init: writes the global `prefill_backend = trtllm_mla`
2. DFLASH draft runner init: overwrites the global with its own `prefill_backend = flashinfer`


### The trigger
[DeepSeek attention dispatch ](https://github.com/sgl-project/sglang/blob/3e97c9239f5ccf9a7df084c081b04609d172d752/python/sglang/srt/models/deepseek_v2.py#L1737-L1757) decides MLA-absorbed vs materialized by looking up the attention backend, and it read that from a shared global: `get_global_server_args().prefill_attention_backend`

At serving time target's prefill dispatch to flashinfer (the draft's backend). The flashinfer has a `chunked_prefix_cache_threshold` gate which dispatch the absorbed inputs to materialized kernel when prefix shorter than 8192. So it crashed with
```
AssertionError: Unsupported head dimensions: query=576, key=576, value=512. Supported: (192, 192, 128) for DeepSeek-R1, (128, 128, 128), or (256, 256, 256) for GLM-5
```

More importantly, if draft backend is specified by `--speculative-draft-attention-backend`, [it does not override the global server args](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/model_executor/model_runner.py#L2420-L2428) so it is free from this bug but causing inconsistency.


## Fix
Stop passing the resolved backend through the mutable global. Instead, each runner records its own resolution and the dispatch reads it per-forward:

  1. model_runner.py : `init_attention_backend` stamps the resolved prefill/decode_attention_backend_str onto the runner's own backend object (and the draft branch records its single backend for both modes).
  2. deepseek_v2.py: the dispatch reads the strings off the active forward's backend (get_attn_backend())












































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27728036970](https://github.com/sgl-project/sglang/actions/runs/27728036970)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27728036858](https://github.com/sgl-project/sglang/actions/runs/27728036858)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->