### PR TITLE
Revert deepseek_weight_loader.py changes from #25141

### DIFF
--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -261,10 +261,9 @@ class DeepseekV2WeightLoaderMixin:
                         if self.fuse_qkv_a_proj and (
                             "q_a_proj" in name or "kv_a_proj_with_mqa" in name
                         ):
-                            # Clone: `loaded_weight` may be a view into an IPC
-                            # bucket that gets reused by the next chunk, and
-                            # the RunAI streamer also relies on cloning.
-                            cached_a_proj[name] = loaded_weight.detach().clone()
+                            cached_a_proj[name] = _clone_if_runai_streamed_tensor(
+                                loaded_weight
+                            )
                             q_a_proj_name = (
                                 name
                                 if "q_a_proj" in name


### PR DESCRIPTION
## Summary
- The deepseek_weight_loader.py changes in #25141 (persistent \`cached_a_proj\` + unconditional \`.detach().clone()\`) were a workaround for \`q_a_proj\` and \`kv_a_proj_with_mqa\` landing in different chunks during chunked weight updates. The fusion to \`fused_qkv_a_proj_with_mqa\` only fires when both halves are visible in the same \`load_weights\` call, so without persistence, a split chunk produced partially-fused weights.
- The proper fix is on the sender side: pair the two halves before chunking so they always arrive in the same \`load_weights\` call. Done in [radixark/miles#1361](https://github.com/radixark/miles/pull/1361), mirroring the approach slime adopted in [THUDM/slime#1753](https://github.com/THUDM/slime/pull/1753).
- With sender-side pairing in place, \`cached_a_proj\` only needs to live for one \`load_weights\` call, matching the original upstream behavior. This PR reverts the loader back to that form.

## Why revert on \`sglang-miles\` and not main
- #25141 was merged onto \`sglang-miles\`, not main. This is the smallest possible un-doing — keeps the K2.5 LoRA work (mem_pool / triton kernels / load-from-tensors RPC) and only removes the deepseek-loader workaround that's no longer needed.
- The remaining files from #25141 will be carved into focused PRs against main separately.

## Test plan
- [ ] Sender-side pairing (radixark/miles#1361) must land before this PR is exercised end-to-end.
- [ ] Run K2.5 LoRA on \`sglang-miles\` + the miles pairing fix and confirm \`train/train_rollout_logprob_abs_diff\` stays bounded (~0.03) across steps.
- [ ] Existing non-MLA / non-chunked-update behavior is unchanged because the diff exactly restores the pre-#25141 state of this file.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28424125993](https://github.com/sgl-project/sglang/actions/runs/28424125993)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28424125889](https://github.com/sgl-project/sglang/actions/runs/28424125889)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->