### PR TITLE
[LoRA] Per-rank serialization for load_lora_adapter_from_tensors

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1125,15 +1125,16 @@ class Engine(EngineScoreMixin, EngineBase):
         load_format: Optional[str] = None,
     ):
         if load_format == "flattened_bucket":
-            serialized_tensors = tensors
+            serialized_named_tensors = list(tensors)
         else:
-            serialized_tensors = MultiprocessingSerializer.serialize(
-                tensors, output_str=True
-            )
+            serialized_named_tensors = [
+                MultiprocessingSerializer.serialize(tensors, output_str=True)
+                for _ in range(self.server_args.tp_size)
+            ]
         lora_req = LoadLoRAAdapterFromTensorsReqInput(
             lora_name=lora_name,
             config_dict=config_dict,
-            serialized_tensors=serialized_tensors,
+            serialized_named_tensors=serialized_named_tensors,
             load_format=load_format,
         )
         return self.loop.run_until_complete(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1958,7 +1958,7 @@ class UnloadLoRAAdapterReqInput(BaseReq):
 class LoadLoRAAdapterFromTensorsReqInput(BaseReq):
     lora_name: str
     config_dict: Dict[str, Any]
-    serialized_tensors: str
+    serialized_named_tensors: List[Union[str, bytes]]
     pinned: bool = False
     added_tokens_config: Optional[Dict[str, Any]] = None
     lora_id: Optional[str] = None

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -558,11 +558,9 @@ class TokenizerControlMixin:
                     "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
                 )
 
-            # TODO (lifuhuang): Remove this after we verify that dynamic lora loading works
-            # with dp_size > 1.
             assert (
-                self.server_args.dp_size == 1
-            ), "dp_size must be 1 for dynamic lora loading"
+                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
             logger.info(
                 "Start load Lora adapter. Lora name=%s, path=%s",
                 obj.lora_name,
@@ -637,8 +635,8 @@ class TokenizerControlMixin:
                 )
 
             assert (
-                self.server_args.dp_size == 1
-            ), "dp_size must be 1 for dynamic lora loading"
+                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
             logger.info(
                 "Start load Lora adapter from tensors. Lora name=%s",
                 obj.lora_name,
@@ -710,11 +708,9 @@ class TokenizerControlMixin:
                 obj.lora_name is not None
             ), "lora_name must be provided to unload LoRA adapter"
 
-            # TODO (lifuhuang): Remove this after we verify that dynamic lora loading works
-            # with dp_size > 1.
             assert (
-                self.server_args.dp_size == 1
-            ), "dp_size must be 1 for dynamic lora loading"
+                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
             logger.info(
                 "Start unload Lora adapter. Lora name=%s",
                 obj.lora_name,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -188,19 +188,23 @@ class BaseTpWorker(ABC):
     def load_lora_adapter_from_tensors(
         self, recv_req: LoadLoRAAdapterFromTensorsReqInput
     ):
-        # The LoRA code handles TP sharding internally using slice_lora_a_weights
-        # and slice_lora_b_weights methods (see lora/layers.py:46-49, mem_pool.py:437-440).
+        # TP sharding for LoRA happens inside the lora module (see
+        # lora/layers.py:46-49 and mem_pool.py:437-440). Each TP rank
+        # deserializes its own producer's bytes — same convention as
+        # ``update_weights_from_tensor`` above. One producer per one
+        # consumer means the CUDA-IPC ref counter on the producer's
+        # bucket drops cleanly each cycle.
+        monkey_patch_torch_reductions()
+        serialized = recv_req.serialized_named_tensors[self.tp_rank]
         if recv_req.load_format == "flattened_bucket":
-            flattened_data = MultiprocessingSerializer.deserialize(
-                recv_req.serialized_tensors
-            )
+            flattened_data = MultiprocessingSerializer.deserialize(serialized)
             bucket = FlattenedTensorBucket(
                 flattened_tensor=flattened_data["flattened_tensor"],
                 metadata=flattened_data["metadata"],
             )
             tensors = dict(bucket.reconstruct_tensors())
         else:
-            tensors = MultiprocessingSerializer.deserialize(recv_req.serialized_tensors)
+            tensors = MultiprocessingSerializer.deserialize(serialized)
         result = self.model_runner.load_lora_adapter_from_tensors(
             recv_req.to_ref(),
             tensors,


### PR DESCRIPTION
## Summary
- Mirrors the per-rank CUDA-IPC convention that \`update_weights_from_tensor\` already uses for base weights. Each TP rank deserializes its own producer's bucket, so the producer's IPC ref counter drops cleanly each chunk.
- \`LoadLoRAAdapterFromTensorsReqInput.serialized_tensors: str\` becomes \`serialized_named_tensors: List[Union[str, bytes]]\` (one entry per TP rank).
- \`Engine.load_lora_adapter_from_tensors\` produces a length-\`tp_size\` list (one entry per rank) when not in \`flattened_bucket\` mode, and passes the producer's per-rank list through verbatim otherwise.
- \`BaseTpWorker.load_lora_adapter_from_tensors\` picks \`serialized_named_tensors[self.tp_rank]\` and deserializes only that.
- \`TokenizerControlMixin\` relaxes the \`dp_size == 1\` assertion on dynamic LoRA loading to also allow \`enable_dp_attention\`, matching the existing path for adapter unload.

## Context
Carved out of #25141 (which was merged on \`sglang-miles\` to unblock Kimi K2.5 LoRA). This is the smallest, most self-contained piece — it's a pure RPC shape change with no functional dependency on the other parts of #25141.

## Test plan
- [ ] Existing LoRA-load-from-tensors tests still pass (the non-flattened-bucket path goes from \"serialize once, broadcast\" to \"serialize once per rank with identical bytes\", which is equivalent in effect).
- [ ] Chunked LoRA load from RL training paths (used in sglang-miles) — each rank receives its own producer's bucket.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27721355650](https://github.com/sgl-project/sglang/actions/runs/27721355650)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27721354564](https://github.com/sgl-project/sglang/actions/runs/27721354564)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->