### PR TITLE
[Fix] Reuse an already-running server in bench_one_batch_server instead of forking an orphan

### DIFF
--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -402,10 +402,8 @@ def launch_server_process(launch_server_func: Callable, server_args: ServerArgs)
     # occupied port, where it would orphan, compete for the GPU, and OOM.
     if server_is_up(base_url, timeout=5):
         print(
-            f"WARNING: a server is already running at {base_url}; reusing it. "
-            f"--model and all server-launch args are ignored; the benchmark "
-            f"runs against the config that server was started with. "
-            f"Pass --base-url {base_url} to silence this warning."
+            f"WARNING: reusing the server already running at {base_url} "
+            f"(--model and server-launch args ignored). Pass --base-url to silence."
         )
         return None, base_url
 

--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -381,7 +381,36 @@ def launch_server_internal(launch_server_func: Callable, server_args: ServerArgs
         kill_process_tree(os.getpid(), include_parent=False)
 
 
+def server_is_up(base_url: str, timeout: float = DEFAULT_TIMEOUT) -> bool:
+    """Return True if a server answers /v1/models with 200 at base_url."""
+    try:
+        headers = {
+            "Content-Type": "application/json; charset=utf-8",
+        }
+        response = requests.get(
+            f"{base_url}/v1/models", headers=headers, timeout=timeout
+        )
+        return response.status_code == 200
+    except requests.RequestException:
+        return False
+
+
 def launch_server_process(launch_server_func: Callable, server_args: ServerArgs):
+    base_url = f"http://{server_args.host}:{server_args.port}"
+
+    # Reuse an already-running server instead of forking a second one onto the
+    # same host:port. Forking onto an occupied port spawns an orphan server that
+    # competes for the GPU, OOMs, and (via SIGQUIT) can take down the whole
+    # benchmark -- a race whose outcome depends on how long the run lasts. Probe
+    # first with a short timeout so the common "no server yet" case stays fast.
+    if server_is_up(base_url, timeout=5):
+        print(
+            f"WARNING: a server is already running at {base_url}; reusing it "
+            f"(--host/--port/--model and other server args are ignored). "
+            f"Pass --base-url {base_url} to silence this warning."
+        )
+        return None, base_url
+
     proc = multiprocessing.Process(
         target=launch_server_internal,
         args=(
@@ -390,22 +419,23 @@ def launch_server_process(launch_server_func: Callable, server_args: ServerArgs)
         ),
     )
     proc.start()
-    base_url = f"http://{server_args.host}:{server_args.port}"
 
     start_time = time.time()
     while time.time() - start_time < DEFAULT_TIMEOUT:
-        try:
-            headers = {
-                "Content-Type": "application/json; charset=utf-8",
-            }
-            response = requests.get(
-                f"{base_url}/v1/models", headers=headers, timeout=DEFAULT_TIMEOUT
+        # Fail fast if the server died during startup (e.g. OOM) instead of
+        # polling a port nobody will ever bind until the full timeout elapses.
+        if not proc.is_alive():
+            raise RuntimeError(
+                f"Server process exited during startup (exit code "
+                f"{proc.exitcode}); see the traceback above for the cause."
             )
-            if response.status_code == 200:
-                return proc, base_url
-        except requests.RequestException:
-            pass
+        if server_is_up(base_url):
+            return proc, base_url
         time.sleep(10)
+
+    # Timed out: kill the half-started server so it does not linger as an orphan
+    # competing for the GPU after we give up on it.
+    kill_process_tree(proc.pid)
     raise TimeoutError("Server failed to start within the timeout period.")
 
 

--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -399,10 +399,7 @@ def launch_server_process(launch_server_func: Callable, server_args: ServerArgs)
     base_url = f"http://{server_args.host}:{server_args.port}"
 
     # Reuse an already-running server instead of forking a second one onto the
-    # same host:port. Forking onto an occupied port spawns an orphan server that
-    # competes for the GPU, OOMs, and (via SIGQUIT) can take down the whole
-    # benchmark -- a race whose outcome depends on how long the run lasts. Probe
-    # first with a short timeout so the common "no server yet" case stays fast.
+    # occupied port, where it would orphan, compete for the GPU, and OOM.
     if server_is_up(base_url, timeout=5):
         print(
             f"WARNING: a server is already running at {base_url}; reusing it "
@@ -422,8 +419,7 @@ def launch_server_process(launch_server_func: Callable, server_args: ServerArgs)
 
     start_time = time.time()
     while time.time() - start_time < DEFAULT_TIMEOUT:
-        # Fail fast if the server died during startup (e.g. OOM) instead of
-        # polling a port nobody will ever bind until the full timeout elapses.
+        # Fail fast if the server died during startup (e.g. OOM).
         if not proc.is_alive():
             raise RuntimeError(
                 f"Server process exited during startup (exit code "
@@ -433,8 +429,7 @@ def launch_server_process(launch_server_func: Callable, server_args: ServerArgs)
             return proc, base_url
         time.sleep(10)
 
-    # Timed out: kill the half-started server so it does not linger as an orphan
-    # competing for the GPU after we give up on it.
+    # Timed out: kill the half-started server so it does not linger as an orphan.
     kill_process_tree(proc.pid)
     raise TimeoutError("Server failed to start within the timeout period.")
 

--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -402,8 +402,9 @@ def launch_server_process(launch_server_func: Callable, server_args: ServerArgs)
     # occupied port, where it would orphan, compete for the GPU, and OOM.
     if server_is_up(base_url, timeout=5):
         print(
-            f"WARNING: a server is already running at {base_url}; reusing it "
-            f"(--host/--port/--model and other server args are ignored). "
+            f"WARNING: a server is already running at {base_url}; reusing it. "
+            f"--model and all server-launch args are ignored; the benchmark "
+            f"runs against the config that server was started with. "
             f"Pass --base-url {base_url} to silence this warning."
         )
         return None, base_url


### PR DESCRIPTION
When `bench_one_batch_server` is run without `--base-url` against a host:port that already has a server, it still forks a second server onto the occupied port. The readiness poll is satisfied by the pre-existing server, so the benchmark proceeds, but the forked child keeps loading the model in the background, OOMs (GPU already full), and its SIGQUIT kills the whole benchmark. Whether this manifests depends on a race between benchmark duration and child startup.

Fix: probe the target host:port before forking; if a server already answers, reuse it (with a warning) instead of launching. Also fail fast if the forked server dies during startup, and kill it on timeout so it does not linger as an orphan.









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27722012644](https://github.com/sgl-project/sglang/actions/runs/27722012644)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27722012499](https://github.com/sgl-project/sglang/actions/runs/27722012499)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->