### PR TITLE
[LoRA] Sentinel-pad token->lora mapping for DP-attention foreign tokens

### DIFF
--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -384,6 +384,13 @@ def _compute_moe_lora_info(
             (num_tokens,), dtype=torch.int32, device=seg_indptr.device
         )
 
+    # Sentinel-fill so any positions not covered by a segment (foreign tokens
+    # gathered under DP-attention live past ``seg_indptr[-1]``) read as -1
+    # rather than as garbage from the prior batch's mapping. The CUDA-kernel
+    # path overwrites only the in-segment slots; the Python fallback below
+    # uses a padded ``weight_indices`` lookup so the same -1 lands there.
+    token_lora_mapping.fill_(-1)
+
     if adapter_enabled is not None:
         assert (
             len(lora_ranks) <= adapter_enabled.shape[0]
@@ -424,10 +431,7 @@ def _compute_moe_lora_info(
         adapter_enabled.scatter_(
             0, weight_indices.long(), (active_ranks > 0).to(torch.int32)
         )
-    if num_tokens == 0:
-        return adapter_enabled, token_lora_mapping
-    if not has_segments:
-        token_lora_mapping.fill_(-1)
+    if num_tokens == 0 or not has_segments:
         return adapter_enabled, token_lora_mapping
 
     token_positions = torch.arange(
@@ -440,8 +444,15 @@ def _compute_moe_lora_info(
         torch.searchsorted(seg_indptr.to(torch.int32), token_positions, right=True) - 1
     )
 
+    # Pad weight_indices with a -1 sentinel so foreign tokens (whose
+    # req_indices land at len(weight_indices)) read -1 instead of going
+    # out of bounds. Matches the kernel-path semantics established above.
+    weight_indices_int32 = weight_indices.to(torch.int32)
+    weight_indices_padded = torch.cat(
+        [weight_indices_int32, weight_indices_int32.new_full((1,), -1)]
+    )
     token_lora_mapping = torch.index_select(
-        weight_indices.to(torch.int32), 0, req_indices, out=token_lora_mapping
+        weight_indices_padded, 0, req_indices, out=token_lora_mapping
     )
 
     return adapter_enabled, token_lora_mapping


### PR DESCRIPTION
## Summary
Under DP-attention, the gathered forward batch contains both local and foreign tokens, but \`seg_indptr\` / \`weight_indices\` cover only the local requests. \`_compute_moe_lora_info\` in \`backend/base_backend.py\` currently does one of two wrong things at the foreign positions:

- **CUDA-kernel path**: \`token_lora_mapping\` is \`torch.empty(...)\`, so foreign-position slots stay uninitialized when the kernel only writes to positions within segments. The MoE LoRA hook then dispatches on garbage.
- **Python fallback path**: \`torch.searchsorted(seg_indptr, ..., right=True) - 1\` returns \`num_segments\` for foreign positions, which makes \`torch.index_select(weight_indices, 0, req_indices, ...)\` index one past the end of \`weight_indices\`.

This PR fixes both paths with the same -1-sentinel convention:

1. Pre-fill \`token_lora_mapping\` with \`-1\` before either path runs, so un-segmented slots stay \`-1\` after the kernel returns.
2. In the Python fallback, \`torch.cat\` a \`-1\` entry onto \`weight_indices\` and use that padded tensor for the \`index_select\`, so the same \`-1\` lands at the foreign positions.

Foreign-token LoRA outputs are discarded by the DP-attention scatter anyway, so mapping them to \`-1\` (\"no LoRA\") is the correct local behaviour — it just stops the kernel from acting on uninitialised data / out-of-bounds reads.

## Context
Carved out of #25141. The sglang-miles version of this fix lives in a helper called \`_compute_token_lora_mapping\` in \`lora_moe_runners.py\`; on \`main\` the equivalent work is done in \`_compute_moe_lora_info\` here, so this PR ports the same idea to the on-main code path.

## Test plan
- [ ] Existing non-DP-attention LoRA tests — behaviour unchanged (the pre-fill is a no-op when the kernel/fallback overwrite every slot, which is the normal case).
- [ ] DP-attention + MoE LoRA: confirm the kernel and Python paths both place \`-1\` at foreign positions.
- [ ] Empty / no-segment edge cases — covered by the simplified \`num_tokens == 0 or not has_segments\` return-early (the prior explicit \`fill_(-1)\` for the no-segments case is subsumed by the earlier pre-fill).













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27722492929](https://github.com/sgl-project/sglang/actions/runs/27722492929)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27851913609](https://github.com/sgl-project/sglang/actions/runs/27851913609)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->