### PR TITLE
[Kimi K2.5] Fuse deferred MoE finalize into next-layer AR + residual + RMSNorm

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -567,7 +567,28 @@ class LayerCommunicator:
                 and hasattr(hidden_states, "_sglang_needs_allreduce_fusion")
                 and hidden_states._sglang_needs_allreduce_fusion
             ):
-                if (
+                moe_finalize_bundle = getattr(
+                    hidden_states, "_sglang_moe_finalize_bundle", None
+                )
+                if moe_finalize_bundle is not None and hasattr(
+                    self.input_layernorm, "forward_with_moe_finalize_allreduce_fusion"
+                ):
+                    # Fuse the deferred MoE finalize into the AR + residual +
+                    # RMSNorm. residual_out (kept for Eagle3 capture) is the
+                    # post-all-reduce, pre-norm residual. ``hidden_states`` here
+                    # is the un-finalized gemm2_out carried from the prev layer.
+                    hidden_states, residual = (
+                        self.input_layernorm.forward_with_moe_finalize_allreduce_fusion(
+                            gemm2_out=hidden_states,
+                            residual=residual,
+                            expanded_idx_to_permuted_idx=moe_finalize_bundle.expanded_idx_to_permuted_idx,
+                            expert_scale_factor=moe_finalize_bundle.expert_scale_factor,
+                            shared_expert_output=moe_finalize_bundle.shared_output,
+                            top_k=moe_finalize_bundle.top_k,
+                            use_attn_tp_group=False,
+                        )
+                    )
+                elif (
                     apply_aiter_all_reduce_fusion(hidden_states)
                     or apply_flashinfer_allreduce_fusion(hidden_states.shape[0])
                 ) and hasattr(self.input_layernorm, "forward_with_allreduce_fusion"):

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -817,6 +817,148 @@ def flashinfer_allreduce_residual_rmsnorm(
     return norm_out, residual_out
 
 
+def fake_flashinfer_moe_finalize_allreduce_residual_rmsnorm(
+    gemm2_out: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    expert_scale_factor: torch.Tensor,
+    shared_expert_output: Optional[torch.Tensor] = None,
+    eps: float = 1e-6,
+    max_token_num: int = 16384,
+    use_oneshot: Optional[bool] = None,
+    use_attn_tp_group: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    residual_out = torch.empty_like(residual)
+    norm_out = torch.empty_like(residual)
+    return norm_out, residual_out
+
+
+@register_custom_op(
+    mutates_args=["gemm2_out", "residual", "weight"],
+    fake_impl=fake_flashinfer_moe_finalize_allreduce_residual_rmsnorm,
+)
+def flashinfer_moe_finalize_allreduce_residual_rmsnorm(
+    gemm2_out: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    expert_scale_factor: torch.Tensor,
+    shared_expert_output: Optional[torch.Tensor] = None,
+    eps: float = 1e-6,
+    max_token_num: int = 2048,
+    use_oneshot: Optional[bool] = None,
+    use_attn_tp_group: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fused MoE finalize + all-reduce + residual add + RMSNorm.
+
+    Uses FlashInfer's ``kMoEFinalizeARResidualRMSNorm`` pattern, which combines
+    the per-rank expert outputs (weighted by ``expert_scale_factor`` and scattered
+    via ``expanded_idx_to_permuted_idx``), adds the shared-expert output, runs the
+    all-reduce across the MoE TP group, adds the residual and applies RMSNorm --
+    all in a single kernel. This lets the deferred MoE finalize be folded into the
+    next layer's input-RMSNorm AR fusion, while the post-all-reduce ``residual_out``
+    stays available for Eagle3 aux capture.
+
+    Args:
+        gemm2_out: Un-finalized expert outputs (the kernel's ``allreduce_in``),
+            shape [num_permuted_tokens, hidden_dim].
+        residual: Residual stream, shape [num_tokens, hidden_dim].
+        weight: RMSNorm weight (rms_gamma).
+        expanded_idx_to_permuted_idx: Map from (token, top_k slot) to the row in
+            ``gemm2_out`` (int32).
+        expert_scale_factor: Per-(token, expert) combine weights.
+        shared_expert_output: Optional shared-expert output [num_tokens, hidden_dim].
+        eps: RMSNorm epsilon.
+        max_token_num: Maximum token number for the workspace.
+        use_oneshot: Whether to use oneshot mode.
+        use_attn_tp_group: If True, use the attention TP group; otherwise the MoE
+            TP group (the all-reduce group the MoE output lives on).
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: (norm_output, residual_output), or
+        (None, None) if the fused kernel is unavailable and the caller should fall
+        back to a separate finalize + AR + RMSNorm.
+    """
+    if not is_flashinfer_available() or _flashinfer_comm is None:
+        return None, None
+
+    moe_finalize_pattern = getattr(
+        _flashinfer_comm.AllReduceFusionPattern,
+        "kMoEFinalizeARResidualRMSNorm",
+        None,
+    )
+    if moe_finalize_pattern is None:
+        logger.debug(
+            "FlashInfer build lacks kMoEFinalizeARResidualRMSNorm, "
+            "falling back to separate finalize + allreduce fusion"
+        )
+        return None, None
+
+    if use_attn_tp_group:
+        world_size = get_attn_tensor_model_parallel_world_size()
+    else:
+        if get_moe_expert_parallel_world_size() > 1:
+            world_size = get_moe_expert_parallel_world_size()
+        else:
+            world_size = get_moe_tensor_parallel_world_size()
+
+    if world_size <= 1:
+        return None, None
+
+    assert residual.shape[0] <= max_token_num
+    if (
+        not gemm2_out.is_contiguous()
+        or not residual.is_contiguous()
+        or not weight.is_contiguous()
+        or not expanded_idx_to_permuted_idx.is_contiguous()
+        or not expert_scale_factor.is_contiguous()
+        or (
+            shared_expert_output is not None
+            and not shared_expert_output.is_contiguous()
+        )
+    ):
+        logger.debug("Non-contiguous tensors, skipping FlashInfer MoE finalize fusion")
+        return None, None
+
+    if not ensure_workspace_initialized(
+        max_token_num=max_token_num,
+        hidden_dim=residual.shape[-1],
+        use_fp32_lamport=(residual.dtype == torch.float32),
+        dtype=residual.dtype,
+        token_num=residual.shape[0],
+        use_oneshot=use_oneshot,
+        use_attn_tp_group=use_attn_tp_group,
+    ):
+        logger.debug("FlashInfer workspace not available")
+        return None, None
+
+    workspace_manager = _get_workspace_manager(use_attn_tp_group)
+    if workspace_manager.workspace is None:
+        return None, None
+
+    residual_out = torch.empty_like(residual)
+    norm_out = torch.empty_like(residual)
+
+    _flashinfer_comm.allreduce_fusion(
+        input=gemm2_out,
+        workspace=workspace_manager.workspace,
+        pattern=moe_finalize_pattern,
+        launch_with_pdl=True,
+        residual_out=residual_out,
+        norm_out=norm_out,
+        residual_in=residual,
+        rms_gamma=weight,
+        rms_eps=eps,
+        use_oneshot=use_oneshot,
+        expanded_idx_to_permuted_idx=expanded_idx_to_permuted_idx,
+        expert_scale_factor=expert_scale_factor,
+        shared_expert_output=shared_expert_output,
+    )
+
+    return norm_out, residual_out
+
+
 def pre_initialize_workspaces(
     max_token_num: int,
     hidden_dim: int,

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -19,6 +19,7 @@ from sglang.srt.distributed import (
     get_tp_group,
 )
 from sglang.srt.distributed.parallel_state import in_the_same_node_as
+from sglang.srt.environ import envs
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     ceil_align,
@@ -41,6 +42,9 @@ _flashinfer_create_workspace_supports_group = False
 _flashinfer_create_workspace_supports_comm_backend = False
 _flashinfer_allreduce_supports_trigger_completion = False
 _mnnvl_non_blackwell_fallback_logged = False
+# Mirrors flashinfer.comm.trtllm_ar.MAX_COMM_SIZE (MAX_INT32 rounded down to 2MB):
+# the largest one-shot lamport comm the MoE-finalize fusion kernel accepts.
+_FLASHINFER_MAX_COMM_SIZE = 2147483647 & ~((1 << 21) - 1)
 
 
 def _mnnvl_supported(is_multi_node: bool) -> bool:
@@ -62,17 +66,28 @@ def _resolve_backend(backend: str, is_multi_node: bool = False) -> str:
     if backend == "auto":
         # Prefer mnnvl wherever it is supported (any Blackwell system, or SM90
         # single-node); fall back to trtllm otherwise.
-        return "mnnvl" if _mnnvl_supported(is_multi_node) else "trtllm"
-
-    if backend == "mnnvl" and not _mnnvl_supported(is_multi_node):
+        resolved = "mnnvl" if _mnnvl_supported(is_multi_node) else "trtllm"
+    elif backend == "mnnvl" and not _mnnvl_supported(is_multi_node):
         if not _mnnvl_non_blackwell_fallback_logged:
             logger.info(
                 "FlashInfer allreduce fusion: forcing trtllm backend "
                 "(mnnvl requires a Blackwell system, or SM90 single-node)."
             )
             _mnnvl_non_blackwell_fallback_logged = True
-        return "trtllm"
-    return backend
+        resolved = "trtllm"
+    else:
+        resolved = backend
+
+    # The deferred MoE finalize fusion (kMoEFinalizeARResidualRMSNorm, pattern 7)
+    # is only implemented by the trtllm backend; mnnvl rejects it. When deferred
+    # finalize is enabled the finalize is folded into the AR + residual + RMSNorm
+    # fusion, so the shared workspace must be trtllm (which also serves the plain
+    # kARResidualRMSNorm pattern used by the non-finalize fusion path). Note this
+    # ties the whole fusion to trtllm's intra-node lamport all-reduce, so deferred
+    # finalize fusion is single-(NVLink-)node only -- see _mnnvl_supported.
+    if resolved == "mnnvl" and envs.SGLANG_ENABLE_MOE_DEFERRED_FINALIZE.get():
+        resolved = "trtllm"
+    return resolved
 
 
 def resolve_flashinfer_allreduce_fusion_backend(server_args) -> Optional[str]:
@@ -906,7 +921,25 @@ def flashinfer_moe_finalize_allreduce_residual_rmsnorm(
     if world_size <= 1:
         return None, None
 
-    assert residual.shape[0] <= max_token_num
+    # The MoE-finalize pattern all-reduces the *permuted* expert output
+    # (``gemm2_out``), whose row count is dominated by per-expert tile padding and
+    # is many times larger than the token count. FlashInfer sizes the lamport comm
+    # buffer from ``allreduce_in.numel()``, so the workspace must cover
+    # ``gemm2_out.shape[0]`` rows, not ``residual.shape[0]``.
+    comm_token_num = gemm2_out.shape[0]
+    # FlashInfer's MoE-finalize kernel derives ``top_k`` from
+    # ``expanded_idx_to_permuted_idx.size(-1)`` and indexes both the index map and
+    # ``expert_scale_factor`` as ``[token, slot]``. The deferred-finalize path hands
+    # us a *flat* ``[token_num * top_k]`` index tensor, which would make the kernel
+    # treat ``top_k == token_num * top_k`` and read far past the end of every per-
+    # token row (illegal access). Restore the ``[token_num, top_k]`` shape the kernel
+    # expects (``expert_scale_factor`` is already 2D, but normalize defensively).
+    num_token = residual.shape[0]
+    top_k = expanded_idx_to_permuted_idx.numel() // max(num_token, 1)
+    expanded_idx_to_permuted_idx = expanded_idx_to_permuted_idx.reshape(
+        num_token, top_k
+    )
+    expert_scale_factor = expert_scale_factor.reshape(num_token, top_k)
     if (
         not gemm2_out.is_contiguous()
         or not residual.is_contiguous()
@@ -921,20 +954,38 @@ def flashinfer_moe_finalize_allreduce_residual_rmsnorm(
         logger.debug("Non-contiguous tensors, skipping FlashInfer MoE finalize fusion")
         return None, None
 
-    if not ensure_workspace_initialized(
-        max_token_num=max_token_num,
-        hidden_dim=residual.shape[-1],
-        use_fp32_lamport=(residual.dtype == torch.float32),
-        dtype=residual.dtype,
-        token_num=residual.shape[0],
-        use_oneshot=use_oneshot,
-        use_attn_tp_group=use_attn_tp_group,
-    ):
-        logger.debug("FlashInfer workspace not available")
+    # FlashInfer's MoE-finalize fusion is one-shot only and rejects comms whose
+    # lamport size exceeds MAX_COMM_SIZE. Mirror that bound here and fall back for
+    # large (e.g. prefill) shapes instead of letting the kernel raise.
+    required_comm_size = comm_token_num * residual.shape[-1] * 2 * world_size
+    if required_comm_size > _FLASHINFER_MAX_COMM_SIZE:
+        logger.debug(
+            "MoE finalize fusion comm size %d exceeds MAX_COMM_SIZE; falling back",
+            required_comm_size,
+        )
         return None, None
 
+    # Never grow the workspace here: this op runs inside captured CUDA graphs, and
+    # reallocating the symmetric workspace would invalidate graph-captured pointers.
+    # The workspace is pre-sized for the deferred-finalize comm in
+    # pre_initialize_workspaces(); if it is too small for this shape (e.g. an
+    # un-captured large prefill), fall back to the separate finalize + AR fusion.
     workspace_manager = _get_workspace_manager(use_attn_tp_group)
-    if workspace_manager.workspace is None:
+    if (
+        not workspace_manager.initialized
+        or workspace_manager.workspace is None
+        or not workspace_manager.is_buffer_size_sufficient(
+            token_num=comm_token_num,
+            hidden_dim=residual.shape[-1],
+            dtype=residual.dtype,
+            use_oneshot=use_oneshot,
+        )
+    ):
+        logger.debug(
+            "FlashInfer workspace insufficient for MoE finalize fusion "
+            "(need %d permuted rows); falling back",
+            comm_token_num,
+        )
         return None, None
 
     residual_out = torch.empty_like(residual)
@@ -964,21 +1015,31 @@ def pre_initialize_workspaces(
     hidden_dim: int,
     dtype: torch.dtype,
     use_oneshot: Optional[bool] = None,
+    moe_finalize_max_token_num: Optional[int] = None,
 ):
     """Pre-initialize flashinfer workspaces before CUDA graph capture.
 
     This must be called before graph capture to avoid collective operations
     (broadcasts, barriers) inside the graph capture context, which can
     deadlock with custom_all_reduce.register_graph_buffers.
+
+    ``moe_finalize_max_token_num`` sizes the MoE-TP workspace for the deferred
+    MoE-finalize AR fusion, whose ``allreduce_in`` is the *permuted* expert
+    output (``num_local_experts`` tile padding + ``num_tokens * top_k`` rows) and
+    is far larger than the token count. It must be sized up front because the
+    fused op runs inside captured CUDA graphs and must never grow the workspace.
     """
     if _flashinfer_allreduce_unavailable or _flashinfer_comm is None:
         return
 
-    # Initialize MoE workspace
+    # Initialize MoE workspace (sized for the permuted MoE-finalize comm when the
+    # deferred-finalize fusion is enabled).
+    moe_max_token_num = max(max_token_num, moe_finalize_max_token_num or 0)
     ensure_workspace_initialized(
-        max_token_num=max_token_num,
+        max_token_num=moe_max_token_num,
         hidden_dim=hidden_dim,
         dtype=dtype,
+        token_num=moe_max_token_num,
         use_oneshot=use_oneshot,
         use_attn_tp_group=False,
     )

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -202,6 +202,60 @@ def _forward_with_allreduce_fusion(
     return norm_module.forward(x, residual, post_residual_addition)
 
 
+def _forward_with_moe_finalize_allreduce_fusion(
+    norm_module,
+    gemm2_out: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    expert_scale_factor: torch.Tensor,
+    shared_expert_output: Optional[torch.Tensor],
+    top_k: int,
+    use_attn_tp_group: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fuse MoE finalize + all-reduce + residual + RMSNorm.
+
+    Returns (norm_out, residual_out). ``residual_out`` is the post-all-reduce,
+    pre-norm residual that Eagle3 aux capture reads. Falls back to a separate
+    finalize kernel followed by the standard AR+RMSNorm fusion when the fused
+    MoE-finalize kernel is unavailable.
+    """
+    from sglang.srt.layers.flashinfer_comm_fusion import (
+        flashinfer_moe_finalize_allreduce_residual_rmsnorm,
+    )
+
+    norm_out, residual_out = flashinfer_moe_finalize_allreduce_residual_rmsnorm(
+        gemm2_out=gemm2_out,
+        residual=residual,
+        weight=weight,
+        expanded_idx_to_permuted_idx=expanded_idx_to_permuted_idx,
+        expert_scale_factor=expert_scale_factor,
+        shared_expert_output=shared_expert_output,
+        eps=norm_module.variance_epsilon,
+        max_token_num=max(residual.shape[0], 2048),
+        use_attn_tp_group=use_attn_tp_group,
+    )
+    if norm_out is not None:
+        return norm_out, residual_out
+
+    # Fallback: run the finalize kernel separately, then the standard
+    # all-reduce + residual + RMSNorm fusion (still emits a fresh residual_out).
+    from sglang.jit_kernel.moe_finalize_fuse_shared import moe_finalize_fuse_shared
+    from sglang.jit_kernel.utils import is_arch_support_pdl
+
+    finalized = moe_finalize_fuse_shared(
+        gemm2_out,
+        expanded_idx_to_permuted_idx,
+        expert_scale_factor,
+        shared_expert_output,
+        top_k,
+        enable_pdl=is_arch_support_pdl(),
+    )
+    return _forward_with_allreduce_fusion(
+        norm_module, finalized, residual, None, weight, use_attn_tp_group
+    )
+
+
 class RMSNorm(MultiPlatformOp):
     def __init__(
         self,
@@ -560,6 +614,29 @@ class RMSNorm(MultiPlatformOp):
         """Forward with allreduce fusion, prioritizing flashinfer fused operations."""
         return _forward_with_allreduce_fusion(
             self, x, residual, post_residual_addition, self.weight, use_attn_tp_group
+        )
+
+    def forward_with_moe_finalize_allreduce_fusion(
+        self,
+        gemm2_out: torch.Tensor,
+        residual: torch.Tensor,
+        expanded_idx_to_permuted_idx: torch.Tensor,
+        expert_scale_factor: torch.Tensor,
+        shared_expert_output: Optional[torch.Tensor],
+        top_k: int,
+        use_attn_tp_group: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Fuse the deferred MoE finalize into this layer's AR + residual + RMSNorm."""
+        return _forward_with_moe_finalize_allreduce_fusion(
+            self,
+            gemm2_out,
+            residual,
+            self.weight,
+            expanded_idx_to_permuted_idx,
+            expert_scale_factor,
+            shared_expert_output,
+            top_k,
+            use_attn_tp_group,
         )
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextvars
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generator, cast
+from typing import TYPE_CHECKING, Generator, Optional, cast
 
 import torch
 from torch.nn import Module
@@ -55,6 +55,23 @@ class FlashInferTrtllmDeferredFinalizeOutput:
     gemm2_out: torch.Tensor
     expert_weights: torch.Tensor
     expanded_idx_to_permuted_idx: torch.Tensor
+    top_k: int
+
+
+@dataclass
+class FlashInferTrtllmMoeFinalizeFusionBundle:
+    """Carries a deferred MoE finalize across the layer boundary so the next
+    layer's input-RMSNorm can fuse finalize + all-reduce + residual + RMSNorm
+    (flashinfer ``kMoEFinalizeARResidualRMSNorm``).
+
+    The associated ``gemm2_out`` (the kernel's ``allreduce_in``) is carried as the
+    layer's ``hidden_states`` tensor; this bundle is attached to it via the
+    ``_sglang_moe_finalize_bundle`` attribute.
+    """
+
+    expanded_idx_to_permuted_idx: torch.Tensor
+    expert_scale_factor: torch.Tensor
+    shared_output: Optional[torch.Tensor]
     top_k: int
 
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -327,6 +327,21 @@ logger = logging.getLogger(__name__)
 _UNSET: Any = object()
 
 
+def _calculate_tile_tokens_dim(
+    num_tokens: int, num_experts: int, top_k: int, max_tile: int = 128
+) -> int:
+    """Perfect-balance estimate of trtllm-gen's per-CTA token tile (mirrors
+    flashinfer.utils.calculate_tile_tokens_dim). Used only to size the deferred
+    MoE-finalize workspace; an under-estimate just makes the fused op fall back.
+    """
+    num_tokens_per_expert = (num_tokens * top_k) // max(num_experts, 1)
+    num_tokens_per_expert = int(num_tokens_per_expert * 1.3)
+    tile = 1
+    while tile < max(num_tokens_per_expert, 1):
+        tile <<= 1
+    return min(max(tile, 8), max_tile)
+
+
 def resolve_language_model(model: nn.Module) -> nn.Module:
     model_cls_name = model.__class__.__name__
     if model_cls_name == "Qwen3OmniMoeForConditionalGeneration":
@@ -2515,7 +2530,77 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             max_token_num=FUSE_ALLREDUCE_MAX_BATCH_SIZE,
             hidden_dim=self.model_config.hidden_size,
             dtype=self.dtype,
+            moe_finalize_max_token_num=self._compute_moe_finalize_workspace_tokens(
+                FUSE_ALLREDUCE_MAX_BATCH_SIZE
+            ),
         )
+
+    def _compute_moe_finalize_workspace_tokens(
+        self, max_batch_size: int
+    ) -> Optional[int]:
+        """Upper-bound permuted-row count for the deferred MoE-finalize AR fusion.
+
+        The fused kernel all-reduces the *permuted* expert output (``gemm2_out``),
+        whose rows are bounded by ``num_local_experts * tile + num_tokens * top_k``
+        with the trtllm-gen tile capped at 128. This workspace must be sized up
+        front because the fused op runs inside captured CUDA graphs and must never
+        grow the symmetric workspace. Returns ``None`` when deferred finalize is
+        disabled or no deferred-capable MoE layer is present.
+        """
+        from sglang.srt.environ import envs
+
+        if not envs.SGLANG_ENABLE_MOE_DEFERRED_FINALIZE.get():
+            return None
+
+        from sglang.srt.layers.flashinfer_comm_fusion import (
+            _FLASHINFER_MAX_COMM_SIZE,
+        )
+        from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+
+        num_local_experts = 0
+        num_experts = 0
+        top_k = 0
+        moe_world_size = 1
+        for module in self.model.modules():
+            if isinstance(module, FusedMoE) and getattr(
+                module, "supports_deferred_finalize", False
+            ):
+                num_local_experts = max(
+                    num_local_experts, int(module.num_local_experts)
+                )
+                num_experts = max(num_experts, int(module.num_experts))
+                top_k = max(top_k, int(module.top_k))
+                ws = (
+                    module.moe_ep_size if module.moe_ep_size > 1 else module.moe_tp_size
+                )
+                moe_world_size = max(moe_world_size, int(ws))
+
+        if num_local_experts == 0 or top_k == 0:
+            return None
+
+        # Largest token count routed through a captured decode/verify graph (the
+        # only shapes that use the fused path; larger prefill falls back).
+        spec = self.server_args.speculative_num_draft_tokens or 1
+        cg = self.server_args.cuda_graph_config
+        decode_max_bs = (cg.decode.max_bs if cg is not None else 0) or max_batch_size
+        max_decode_tokens = max(decode_max_bs * spec, 1)
+
+        # trtllm-gen pads the permuted expert buffer to roughly
+        # ``num_local_experts * tile + num_tokens * top_k`` where ``tile`` is the
+        # per-CTA token tile. We over-estimate the tile (2x the perfect-balance
+        # estimate, floor 16) so the workspace reliably covers the real shape; if
+        # it ever underflows the fused op simply falls back (no correctness risk).
+        tile = _calculate_tile_tokens_dim(max_decode_tokens, num_experts, top_k)
+        eff_tile = max(2 * tile, 16)
+        bound = (
+            num_local_experts * eff_tile + max_decode_tokens * top_k + num_local_experts
+        )
+
+        # The lamport comm (rows * hidden * 2 bytes * world_size) cannot exceed
+        # MAX_COMM_SIZE; larger shapes fall back, so sizing beyond it is wasteful.
+        hidden = self.model_config.hidden_size
+        max_safe_rows = _FLASHINFER_MAX_COMM_SIZE // max(hidden * 2 * moe_world_size, 1)
+        return max(min(bound, max_safe_rows), 1)
 
     def _should_run_flashinfer_autotune(self) -> bool:
         """Check if flashinfer autotune should be run."""

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -927,6 +927,26 @@ class DeepseekV2MoE(nn.Module):
 
         current_stream.wait_stream(self.alt_stream)
 
+        if deferred_finalize and should_allreduce_fusion:
+            # Defer the finalize across the layer boundary: the next layer's
+            # input-RMSNorm fuses finalize + all-reduce + residual + RMSNorm
+            # (flashinfer kMoEFinalizeARResidualRMSNorm) and keeps residual_out
+            # for Eagle3 capture. Carry the un-finalized gemm2_out as the layer's
+            # hidden_states with the finalize inputs attached.
+            from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+                FlashInferTrtllmMoeFinalizeFusionBundle,
+            )
+
+            deferred_output = final_hidden_states
+            carried = deferred_output.gemm2_out
+            carried._sglang_moe_finalize_bundle = FlashInferTrtllmMoeFinalizeFusionBundle(
+                expanded_idx_to_permuted_idx=deferred_output.expanded_idx_to_permuted_idx,
+                expert_scale_factor=deferred_output.expert_weights,
+                shared_output=shared_output,
+                top_k=deferred_output.top_k,
+            )
+            return carried
+
         if deferred_finalize:
             from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
                 finalize_flashinfer_trtllm_deferred_output,


### PR DESCRIPTION
## Summary
Fuse the deferred MoE finalize into the next layer's input-RMSNorm via flashinfer `kMoEFinalizeARResidualRMSNorm` (pattern 7): weighted expert combine + shared-expert add + all-reduce + residual + RMSNorm in one kernel, while keeping `residual_out` available for Eagle3 aux capture. Gated by `SGLANG_ENABLE_MOE_DEFERRED_FINALIZE`. Builds on #28343.

## Key modifications
- **deepseek_v2.py**: when deferred finalize + AR fusion are active, carry the un-finalized permuted `gemm2_out` across the layer boundary with a finalize-inputs bundle attached.
- **communicator.py / layernorm.py**: input-RMSNorm consumes the bundle through new `RMSNorm.forward_with_moe_finalize_allreduce_fusion` (falls back to separate finalize + AR+RMSNorm fusion if unavailable).
- **flashinfer_trtllm.py**: `FlashInferTrtllmMoeFinalizeFusionBundle` to package deferred outputs.
- **flashinfer_comm_fusion.py**: new fused custom op; reshape `expanded_idx_to_permuted_idx`/`expert_scale_factor` to `[token, top_k]` (kernel derives `top_k` from `size(-1)` — flat index caused OOB); force trtllm backend (pattern 7 is trtllm-only); lamport workspace sizing + `MAX_COMM_SIZE`/capacity fallbacks.
- **model_runner.py**: pre-size the MoE-TP workspace for the permuted buffer before CUDA-graph capture (never grow inside captured graphs).

Note: pattern 7 is trtllm-only, so the fusion is intra-node (single NVLink domain).

## HumanEval (164, K2.5-NVFP4 + EAGLE3, attn_tp8_moe_tp8)
| Metric | Fused | Baseline |
|---|---|---|
| Accept length | **3.02** | 3.03 |
| Successful | 164/164 | 164/164 |

Accept length is unchanged within noise — `residual_out` is correctly preserved for Eagle3 (a broken residual would collapse acceptance toward ~1.0).

## Numerics & speed vs the separate-finalize fallback
Compared the fused kernel against the fallback path (deferred finalize + `kARResidualRMSNorm`, which **also emits `residual_out`**):

- **Correctness**: no structural/indexing bug. 8-rank kernel equivalence vs fp32 truth — residual/norm mean rel-error **3.4% / 3.8%** (fused) vs **1.9% / 1.9%** (fallback): the fused kernel carries ~2× the bf16 rounding error (it accumulates the expert combine inside the bf16 AR pipeline; `fp32_acc` doesn't reach that step). Negligible on real data — HumanEval accept length **3.02 fused == 3.02 fallback**; only OOD random-token GSP shows a small dip (2.18 vs 2.23).
- **Speed** (graph-captured decode, 8×B200, per MoE layer): fused is **slower at every batch size** — bs=1 `15.5 vs 14.4 µs` (+1.0), bs=16 `38.4 vs 26.4 µs` (+12.0). Confirmed the kernel's `allreduce_in` is the padded permuted `gemm2_out` (verified runtime rows **256 → 6272**, i.e. 64–128× the token count); this is trtllm's `do_finalize=False` output that the index map gathers from — the intended input, **not a mis-sized/bugged input**. The cross-rank AR is over the **finalized T rows** though (timing is invariant to the permuted-buffer size; AR-only is ~12–22 µs, latency-bound), so the slowdown is **not** AR bandwidth — it's the fused kernel's in-kernel finalize being ~2–4× the cost of the standalone finalize kernel (4–6 µs).

**Takeaway**: under CUDA-graph decode the cheaper fallback is faster, more accurate, and already preserves `residual_out`, so it is preferred there; the fused kernel only wins when launch-bound (eager).

Made with [Cursor](https://cursor.com)




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27725890409](https://github.com/sgl-project/sglang/actions/runs/27725890409)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27725890323](https://github.com/sgl-project/sglang/actions/runs/27725890323)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

