### PR TITLE
[misc] Unify bench seed default to 42 and rename --profile-filename-prefix to --profile-prefix

### DIFF
--- a/python/sglang/bench_offline_throughput.py
+++ b/python/sglang/bench_offline_throughput.py
@@ -48,7 +48,7 @@ class BenchArgs:
     gsp_system_prompt_len: int = 2048
     gsp_question_len: int = 128
     gsp_output_len: int = 256
-    seed: int = 1
+    seed: int = 42
     disable_ignore_eos: bool = False
     extra_request_body: Optional[str] = None
     apply_chat_template: bool = False
@@ -144,7 +144,7 @@ class BenchArgs:
             default=BenchArgs.gsp_output_len,
             help="Target length in tokens for outputs in generated-shared-prefix dataset",
         )
-        parser.add_argument("--seed", type=int, default=1, help="The random seed.")
+        parser.add_argument("--seed", type=int, default=42, help="The random seed.")
         parser.add_argument(
             "--disable-ignore-eos",
             action="store_true",

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -206,7 +206,7 @@ class BenchArgs:
     profile_record_shapes: bool = False
     profile_activities: Tuple[str] = ("CPU", "GPU")
     profile_stage: str = "all"
-    profile_filename_prefix: str = "profile"
+    profile_prefix: str = "profile"
     profile_start_step: Optional[int] = None
     profile_steps: Optional[int] = None
 
@@ -258,11 +258,13 @@ class BenchArgs:
             help="Which stage to profile: all, prefill, or decode only.",
         )
         parser.add_argument(
-            "--profile-filename-prefix",
+            "--profile-prefix",
+            "--profile-filename-prefix",  # deprecated alias, kept for back-compat
+            dest="profile_prefix",
             type=str,
-            default=BenchArgs.profile_filename_prefix,
+            default=BenchArgs.profile_prefix,
             help="Prefix of the profiling file names. The full profiling result file(s) be "
-            '"[profile_filename_prefix]_batch[batch_size]_input[input_len]_output[output_len].trace.json.gz"',
+            '"[profile_prefix]_batch[batch_size]_input[input_len]_output[output_len].trace.json.gz"',
         )
         parser.add_argument(
             "--profile-start-step",
@@ -612,10 +614,10 @@ def _get_torch_profiler_output_dir():
 
 
 def _create_torch_profiler_filename(
-    profile_filename_prefix, batch_size, input_len, output_len, stage
+    profile_prefix, batch_size, input_len, output_len, stage
 ):
     output_dir = _get_torch_profiler_output_dir()
-    filename = f"{profile_filename_prefix}_batch{batch_size}_input{input_len}_output{output_len}_{stage}.trace.json.gz"
+    filename = f"{profile_prefix}_batch{batch_size}_input{input_len}_output{output_len}_{stage}.trace.json.gz"
     return os.path.join(output_dir, filename)
 
 
@@ -701,7 +703,7 @@ def latency_test_run_once(
     profile,
     profile_record_shapes,
     profile_activities,
-    profile_filename_prefix,
+    profile_prefix,
     profile_stage,
     tp_rank,
     profile_start_step=None,
@@ -730,7 +732,7 @@ def latency_test_run_once(
     trace_filename_prefill = None
     if enable_profile_prefill:
         trace_filename_prefill = _create_torch_profiler_filename(
-            profile_filename_prefix, batch_size, input_len, output_len, "prefill"
+            profile_prefix, batch_size, input_len, output_len, "prefill"
         )
         profiler = start_profile(
             profile_activities,
@@ -777,7 +779,7 @@ def latency_test_run_once(
         # Start profiler at the specified step
         if enable_profile_decode and i == profile_start:
             trace_filename_decode = _create_torch_profiler_filename(
-                profile_filename_prefix, batch_size, input_len, output_len, "decode"
+                profile_prefix, batch_size, input_len, output_len, "decode"
             )
             profiler = start_profile(
                 profile_activities,
@@ -875,7 +877,7 @@ def latency_test(
         profile=False,
         profile_record_shapes=False,
         profile_activities=("CPU", "GPU"),
-        profile_filename_prefix="",
+        profile_prefix="",
         profile_stage="all",
         tp_rank=tp_rank,
         profile_start_step=None,
@@ -926,7 +928,7 @@ def latency_test(
             bench_args.profile if tp_rank == 0 else None,
             bench_args.profile_record_shapes if tp_rank == 0 else None,
             bench_args.profile_activities,
-            bench_args.profile_filename_prefix,
+            bench_args.profile_prefix,
             bench_args.profile_stage,
             tp_rank,
             bench_args.profile_start_step,

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2374,7 +2374,7 @@ if __name__ == "__main__":
         help="Collect and display cache hit statistics after the benchmark. "
         "Supported with sglang backends (native, oai, oai-chat).",
     )
-    parser.add_argument("--seed", type=int, default=1, help="The random seed.")
+    parser.add_argument("--seed", type=int, default=42, help="The random seed.")
     parser.add_argument(
         "--disable-ignore-eos",
         action="store_true",


### PR DESCRIPTION
Mechanical consistency cleanup across the bench scripts:

- Unify the default `--seed` to 42 in `bench_serving` and `bench_offline_throughput` (was 1), matching `bench_one_batch_server`.
- Rename `bench_one_batch`'s `--profile-filename-prefix` to `--profile-prefix` to match `bench_one_batch_server`. The old flag is kept as a deprecated alias, so existing callers keep working.

No behavior change beyond the seed default; pure rename + alias otherwise.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27726287794](https://github.com/sgl-project/sglang/actions/runs/27726287794)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27726287615](https://github.com/sgl-project/sglang/actions/runs/27726287615)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->