### PR TITLE
[misc] Trim dead code in trtllm_mha page-table backend; reuse eager page-table buffer

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/trtllm_mha_page_table.py
+++ b/python/sglang/srt/layers/attention/triton_ops/trtllm_mha_page_table.py
@@ -18,7 +18,9 @@ import torch
 import triton
 import triton.language as tl
 
-# Tokens covered per CTA along the page-block (grid axis-1) dimension.
+# Tokens covered per CTA along the page-block (grid axis-1) dimension. Must be a
+# multiple of every supported page_size so a page-block spans an exact token span
+# (see build_trtllm_mha_page_table's assert); true for all power-of-two page sizes.
 _MHA_KV_INDEX_BLOCK_TOKENS = 4096
 # Triton kernels can only read module globals that are tl.constexpr instances.
 _MHA_KV_INDEX_BLOCK_TOKENS_TL = tl.constexpr(_MHA_KV_INDEX_BLOCK_TOKENS)
@@ -55,6 +57,11 @@ def create_trtllm_mha_kv_indices_triton(
     from ``req_to_token`` and converts it to a block id (``slot // PAGE_SIZE``).
     Programs past the request's page count are guarded out, so the work (and the
     DRAM traffic) is bounded by the device-side ``seq_lens`` — no host max needed.
+
+    The SWA lookup assumes every read slot is a valid (``>= 0``) full-pool index;
+    it does not handle the ``-1`` sentinel that ``translate_loc_from_full_to_swa``
+    maps via negative indexing (raw pointer arithmetic would read out of bounds).
+    Page-boundary reads stay within ``seq_len``, so slots are always valid here.
     """
     PAGES_PER_BLOCK: tl.constexpr = _MHA_KV_INDEX_BLOCK_TOKENS_TL // PAGE_SIZE
     pid_req = tl.program_id(0)
@@ -109,6 +116,9 @@ def build_trtllm_mha_page_table(
     assert has_swa == (
         swa_page_table is not None
     ), "full_to_swa and swa_page_table must be provided together"
+    assert (
+        _MHA_KV_INDEX_BLOCK_TOKENS % page_size == 0
+    ), f"page_size={page_size} must divide _MHA_KV_INDEX_BLOCK_TOKENS={_MHA_KV_INDEX_BLOCK_TOKENS}"
     bs, num_pages = page_table.shape
     create_trtllm_mha_kv_indices_triton[
         (bs, get_num_mha_kv_index_blocks(num_pages, page_size))

--- a/python/sglang/srt/layers/attention/triton_ops/trtllm_mha_page_table.py
+++ b/python/sglang/srt/layers/attention/triton_ops/trtllm_mha_page_table.py
@@ -18,9 +18,8 @@ import torch
 import triton
 import triton.language as tl
 
-# Tokens covered per CTA along the page-block (grid axis-1) dimension. Must be a
-# multiple of every supported page_size so a page-block spans an exact token span
-# (see build_trtllm_mha_page_table's assert); true for all power-of-two page sizes.
+# Tokens covered per CTA along the page-block (grid axis-1) dimension.
+# Must be a multiple of page_size (asserted in build_trtllm_mha_page_table).
 _MHA_KV_INDEX_BLOCK_TOKENS = 4096
 # Triton kernels can only read module globals that are tl.constexpr instances.
 _MHA_KV_INDEX_BLOCK_TOKENS_TL = tl.constexpr(_MHA_KV_INDEX_BLOCK_TOKENS)
@@ -58,10 +57,9 @@ def create_trtllm_mha_kv_indices_triton(
     Programs past the request's page count are guarded out, so the work (and the
     DRAM traffic) is bounded by the device-side ``seq_lens`` — no host max needed.
 
-    The SWA lookup assumes every read slot is a valid (``>= 0``) full-pool index;
-    it does not handle the ``-1`` sentinel that ``translate_loc_from_full_to_swa``
-    maps via negative indexing (raw pointer arithmetic would read out of bounds).
-    Page-boundary reads stay within ``seq_len``, so slots are always valid here.
+    The SWA lookup assumes valid (``>= 0``) slots, unlike
+    ``translate_loc_from_full_to_swa``'s ``-1`` sentinel handling; page-boundary
+    reads stay within ``seq_len``, so slots are always valid here.
     """
     PAGES_PER_BLOCK: tl.constexpr = _MHA_KV_INDEX_BLOCK_TOKENS_TL // PAGE_SIZE
     pid_req = tl.program_id(0)

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -54,8 +54,6 @@ class TRTLLMMHAMetadata:
     cache_seqlens_int32: torch.Tensor = None
     # Maximum sequence length for query
     max_seq_len_q: int = 1
-    # Maximum sequence length for key
-    max_seq_len_k: int = 0
     # Cumulative sequence lengths for `query
     cu_seqlens_q: torch.Tensor = None
     # Cumulative sequence lengths for key
@@ -149,6 +147,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None
 
+        # Reusable eager-path page-table buffers, grown on demand (the cuda-graph
+        # path uses its own pre-allocated buffers). Avoids a per-forward alloc.
+        self._eager_page_table: Optional[torch.Tensor] = None
+        self._eager_swa_page_table: Optional[torch.Tensor] = None
+
         # Init backend (XQA or TRTLLM-GEN)
         # We need to specify q_type and out_type for different backend
         # XQA: (q_type must be bf16)
@@ -217,6 +220,35 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ),
         )
 
+    def _get_eager_page_tables(
+        self, batch_size: int, device: torch.device
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Reusable [bs, max_num_pages] eager page-table buffer(s), grown on demand.
+
+        The device-side build overwrites every used column per request, so the
+        buffer is safe to reuse across eager forwards without clearing. Sized to
+        the static ``max_num_pages`` upper bound (sync-free), like the cuda-graph
+        buffers, and returned as a ``[:batch_size]`` view.
+        """
+        has_swa = self._swa_kv_pool is not None
+        if (
+            self._eager_page_table is None
+            or self._eager_page_table.shape[0] < batch_size
+        ):
+            self._eager_page_table = torch.empty(
+                (batch_size, self.max_num_pages), dtype=torch.int32, device=device
+            )
+            self._eager_swa_page_table = (
+                torch.empty(
+                    (batch_size, self.max_num_pages), dtype=torch.int32, device=device
+                )
+                if has_swa
+                else None
+            )
+        page_table = self._eager_page_table[:batch_size]
+        swa_page_table = self._eager_swa_page_table[:batch_size] if has_swa else None
+        return page_table, swa_page_table
+
     def _get_layer_cache_loc(
         self,
         layer: RadixAttention,
@@ -257,7 +289,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         kv_indices_buf: Optional[torch.Tensor] = None,
     ):
         """Initialize CUDA graph state for TRTLLM MHA."""
-        max_num_pages = (self.max_context_len + self.page_size - 1) // self.page_size
+        max_num_pages = self.max_num_pages
         self.decode_cuda_graph_metadata = {
             "cache_seqlens": torch.zeros(max_bs, dtype=torch.int32, device=self.device),
             "page_table": torch.zeros(
@@ -454,9 +486,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         """
         seq_lens = seq_lens[:bs]
         req_pool_indices = req_pool_indices[:bs]
-        # max_seq_len_k is the page-table width upper bound; the device-side build
-        # (_fill_page_table_device) sizes to the static max_num_pages and bounds
-        # the actual writes by cache_seqlens, so no runtime host max is needed.
+        # The device-side build (_fill_page_table_device) sizes the page table to
+        # the static max_num_pages and bounds the actual writes by cache_seqlens,
+        # so no runtime host max is needed.
         metadata = None
         if forward_mode.is_decode_or_idle():
             if spec_info is not None:
@@ -474,7 +506,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata = self.decode_cuda_graph_metadata[bs]
                 metadata.cache_seqlens_int32.copy_(seq_lens)
 
-            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
@@ -485,7 +516,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             # Here we only support topk = 1 for now.
             metadata = self.target_verify_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens + metadata.max_seq_len_q)
-            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
@@ -495,39 +525,24 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         elif forward_mode.is_draft_extend_v2():
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)
-            metadata.max_seq_len_k = self.max_context_len
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
-            if forward_mode.is_draft_extend_v2():
-                num_tokens_per_bs = spec_info.num_tokens_per_req
-                if num_tokens_per_bs <= 0:
-                    # Capture uses a synthetic EagleDraftExtendInput; infer the
-                    # fixed V2 stride from the capture buffer when it is unset.
-                    num_tokens_per_bs = int(
-                        spec_info.num_accept_tokens[:bs].max().item()
-                    )
-                metadata.max_seq_len_q = num_tokens_per_bs
-                metadata.cu_seqlens_q[1:].copy_(
-                    torch.arange(
-                        num_tokens_per_bs,
-                        bs * num_tokens_per_bs + 1,
-                        num_tokens_per_bs,
-                        dtype=torch.int32,
-                        device=metadata.cu_seqlens_q.device,
-                    )
+            num_tokens_per_bs = spec_info.num_tokens_per_req
+            if num_tokens_per_bs <= 0:
+                # Capture uses a synthetic EagleDraftExtendInput; infer the
+                # fixed V2 stride from the capture buffer when it is unset.
+                num_tokens_per_bs = int(spec_info.num_accept_tokens[:bs].max().item())
+            metadata.max_seq_len_q = num_tokens_per_bs
+            metadata.cu_seqlens_q[1:].copy_(
+                torch.arange(
+                    num_tokens_per_bs,
+                    bs * num_tokens_per_bs + 1,
+                    num_tokens_per_bs,
+                    dtype=torch.int32,
+                    device=metadata.cu_seqlens_q.device,
                 )
-            else:
-                extend_lens = spec_info.num_accept_tokens[:bs]
-                if spec_info.num_accept_tokens_cpu:
-                    metadata.max_seq_len_q = max(spec_info.num_accept_tokens_cpu)
-                else:
-                    metadata.max_seq_len_q = 1
-
-                metadata.cu_seqlens_q[1:].copy_(
-                    torch.cumsum(extend_lens, dim=0, dtype=torch.int32)
-                )
-
+            )
             self._fill_page_table_device(
                 metadata, req_pool_indices, metadata.cache_seqlens_int32
             )
@@ -692,17 +707,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else:
                 metadata.cu_seqlens_q = metadata.cu_seqlens_k
 
-        metadata.max_seq_len_k = self.max_context_len
-        has_swa = self._swa_kv_pool is not None
-        metadata.page_table = torch.empty(
-            (batch_size, self.max_num_pages), dtype=torch.int32, device=device
-        )
-        metadata.swa_page_table = (
-            torch.empty(
-                (batch_size, self.max_num_pages), dtype=torch.int32, device=device
-            )
-            if has_swa
-            else None
+        metadata.page_table, metadata.swa_page_table = self._get_eager_page_tables(
+            batch_size, device
         )
         self._fill_page_table_device(
             metadata, forward_batch.req_pool_indices, metadata.cache_seqlens_int32

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -147,10 +147,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None
 
-        # Reusable eager-path page-table buffers, grown on demand.
-        self._eager_page_table: Optional[torch.Tensor] = None
-        self._eager_swa_page_table: Optional[torch.Tensor] = None
-
         # Init backend (XQA or TRTLLM-GEN)
         # We need to specify q_type and out_type for different backend
         # XQA: (q_type must be bf16)
@@ -218,33 +214,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 self._swa_kv_pool.full_to_swa_index_mapping if has_swa else None
             ),
         )
-
-    def _get_eager_page_tables(
-        self, batch_size: int, device: torch.device
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-        """Reusable [bs, max_num_pages] eager page-table buffer(s), grown on demand.
-
-        Safe to reuse without clearing: the device build overwrites every used
-        column per request.
-        """
-        has_swa = self._swa_kv_pool is not None
-        if (
-            self._eager_page_table is None
-            or self._eager_page_table.shape[0] < batch_size
-        ):
-            self._eager_page_table = torch.empty(
-                (batch_size, self.max_num_pages), dtype=torch.int32, device=device
-            )
-            self._eager_swa_page_table = (
-                torch.empty(
-                    (batch_size, self.max_num_pages), dtype=torch.int32, device=device
-                )
-                if has_swa
-                else None
-            )
-        page_table = self._eager_page_table[:batch_size]
-        swa_page_table = self._eager_swa_page_table[:batch_size] if has_swa else None
-        return page_table, swa_page_table
 
     def _get_layer_cache_loc(
         self,
@@ -704,8 +673,16 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else:
                 metadata.cu_seqlens_q = metadata.cu_seqlens_k
 
-        metadata.page_table, metadata.swa_page_table = self._get_eager_page_tables(
-            batch_size, device
+        has_swa = self._swa_kv_pool is not None
+        metadata.page_table = torch.empty(
+            (batch_size, self.max_num_pages), dtype=torch.int32, device=device
+        )
+        metadata.swa_page_table = (
+            torch.empty(
+                (batch_size, self.max_num_pages), dtype=torch.int32, device=device
+            )
+            if has_swa
+            else None
         )
         self._fill_page_table_device(
             metadata, forward_batch.req_pool_indices, metadata.cache_seqlens_int32

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -147,8 +147,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None
 
-        # Reusable eager-path page-table buffers, grown on demand (the cuda-graph
-        # path uses its own pre-allocated buffers). Avoids a per-forward alloc.
+        # Reusable eager-path page-table buffers, grown on demand.
         self._eager_page_table: Optional[torch.Tensor] = None
         self._eager_swa_page_table: Optional[torch.Tensor] = None
 
@@ -225,10 +224,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Reusable [bs, max_num_pages] eager page-table buffer(s), grown on demand.
 
-        The device-side build overwrites every used column per request, so the
-        buffer is safe to reuse across eager forwards without clearing. Sized to
-        the static ``max_num_pages`` upper bound (sync-free), like the cuda-graph
-        buffers, and returned as a ``[:batch_size]`` view.
+        Safe to reuse without clearing: the device build overwrites every used
+        column per request.
         """
         has_swa = self._swa_kv_pool is not None
         if (
@@ -486,9 +483,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         """
         seq_lens = seq_lens[:bs]
         req_pool_indices = req_pool_indices[:bs]
-        # The device-side build (_fill_page_table_device) sizes the page table to
-        # the static max_num_pages and bounds the actual writes by cache_seqlens,
-        # so no runtime host max is needed.
+        # Page table is built on-device (_fill_page_table_device), no host max.
         metadata = None
         if forward_mode.is_decode_or_idle():
             if spec_info is not None:

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -483,7 +483,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         """
         seq_lens = seq_lens[:bs]
         req_pool_indices = req_pool_indices[:bs]
-        # Page table is built on-device (_fill_page_table_device), no host max.
+        # The device-side build (_fill_page_table_device) sizes to the static
+        # max_num_pages and bounds the actual writes by cache_seqlens, so no
+        # runtime host max is needed.
         metadata = None
         if forward_mode.is_decode_or_idle():
             if spec_info is not None:

--- a/test/registered/attention/test_trtllm_mha_page_table.py
+++ b/test/registered/attention/test_trtllm_mha_page_table.py
@@ -28,7 +28,6 @@ def _build_page_table_reference(
     req_pool_indices: torch.Tensor,
     cache_seqlens: torch.Tensor,
     page_size: int,
-    max_num_pages: int,
     full_to_swa: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
     """Reference impl: host-side strided gather, then // page_size.
@@ -113,7 +112,6 @@ class TestTrtllmMhaPageTable(CustomTestCase):
             req_pool_indices,
             cache_seqlens,
             page_size,
-            max_num_pages,
             full_to_swa=full_to_swa,
         )
 
@@ -133,7 +131,7 @@ class TestTrtllmMhaPageTable(CustomTestCase):
 
     def test_matches_reference_gather(self):
         for max_ctx in (2048, 4096, 131072):
-            for page_size in (1, 32, 64, 128):
+            for page_size in (1, 32, 64, 128, 256):
                 for bs in (1, 7, 32):
                     self._run_case(max_ctx, page_size, num_reqs=max(64, bs), bs=bs)
 


### PR DESCRIPTION
Stacks on #28106. Follow-up cleanup on the trtllm_mha device-side page-table backend:

- Remove the now-dead `TRTLLMMHAMetadata.max_seq_len_k` (no reader; flashinfer is fed `max_context_len` directly).
- Drop an unreachable `else` branch under `is_draft_extend_v2()` in the cuda-graph path.
- Dedup `max_num_pages` (reuse `self.max_num_pages`).
- Reuse a grown-on-demand eager page-table buffer instead of allocating per forward.
- Assert `page_size` divides the page-block token span; document the SWA `-1` sentinel assumption; cover `page_size=256` in the unit test.













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27727604697](https://github.com/sgl-project/sglang/actions/runs/27727604697)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27727604572](https://github.com/sgl-project/sglang/actions/runs/27727604572)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->