### PR TITLE
Guard image decode against oversized (decompression-bomb) images

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -654,6 +654,13 @@ class Envs:
     # VLM
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)
     SGLANG_IMAGE_MAX_PIXELS = EnvInt(16384 * 28 * 28)
+    # Reject images larger than this many pixels before decoding them. PIL's
+    # Image.open only reads the header, so the size is known before the expensive
+    # full decode + downscale. Without this guard a decompression-bomb-sized image
+    # (e.g. a high-DPI rasterized PDF page) is fully decoded, which can take
+    # minutes. Matches PIL's default decompression-bomb threshold. Set to 0 to
+    # disable the check.
+    SGLANG_IMAGE_MAX_DECODE_PIXELS = EnvInt(89_478_485)
     SGLANG_RESIZE_RESAMPLE = EnvStr("")
     SGLANG_MM_BUFFER_SIZE_MB = EnvInt(0)
     SGLANG_MM_PRECOMPUTE_HASH = EnvBool(False)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -904,6 +904,24 @@ def is_jpeg_with_cuda(image_bytes: bytes = b"", gpu_image_decode: bool = True) -
     return False
 
 
+def _check_image_pixels(width: int, height: int) -> None:
+    """Reject images whose pixel count exceeds the configured limit.
+
+    A decompression-bomb-sized image (e.g. a high-DPI rasterized PDF page) can
+    take minutes to fully decode and downscale. PIL's Image.open only reads the
+    header, so the size is known before the expensive decode -- checking here lets
+    us fail fast with a clear error instead of grinding through the decode.
+    """
+    max_pixels = envs.SGLANG_IMAGE_MAX_DECODE_PIXELS.get()
+    num_pixels = width * height
+    if max_pixels > 0 and num_pixels > max_pixels:
+        raise ValueError(
+            f"Image is too large to decode: {width}x{height} = {num_pixels} pixels "
+            f"exceeds the limit of {max_pixels} pixels. Raise "
+            f"SGLANG_IMAGE_MAX_DECODE_PIXELS to allow larger images."
+        )
+
+
 def _load_image(
     image_bytes: bytes = b"",
     image_file: str = "",
@@ -925,7 +943,9 @@ def _load_image(
             logger.warning(
                 f"Failed to decode JPEG on GPU, falling back to CPU. Error: {e}"
             )
-    return Image.open(BytesIO(image_bytes))
+    image = Image.open(BytesIO(image_bytes))
+    _check_image_pixels(image.width, image.height)
+    return image
 
 
 def load_image(

--- a/test/registered/unit/utils/test_load_image_guard.py
+++ b/test/registered/unit/utils/test_load_image_guard.py
@@ -1,0 +1,46 @@
+import unittest
+from io import BytesIO
+
+from PIL import Image
+
+from sglang.srt.environ import envs
+from sglang.srt.utils.common import load_image
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cpu_ci(est_time=5, suite="base-b-test-cpu")
+
+
+def _png_bytes(width: int, height: int) -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", (width, height)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+class TestLoadImageDecodeGuard(CustomTestCase):
+    """`load_image` must reject decompression-bomb-sized images before the
+    expensive full decode, using SGLANG_IMAGE_MAX_DECODE_PIXELS as the limit.
+    """
+
+    def test_image_within_limit_loads(self):
+        image_bytes = _png_bytes(64, 64)
+        with envs.SGLANG_IMAGE_MAX_DECODE_PIXELS.override(1_000_000):
+            image, _ = load_image(image_bytes)
+        self.assertEqual((image.width, image.height), (64, 64))
+
+    def test_image_over_limit_raises(self):
+        image_bytes = _png_bytes(64, 64)  # 4096 pixels
+        with envs.SGLANG_IMAGE_MAX_DECODE_PIXELS.override(100):
+            with self.assertRaises(ValueError):
+                load_image(image_bytes)
+
+    def test_limit_disabled_with_zero(self):
+        image_bytes = _png_bytes(64, 64)
+        with envs.SGLANG_IMAGE_MAX_DECODE_PIXELS.override(0):
+            image, _ = load_image(image_bytes)
+        self.assertEqual((image.width, image.height), (64, 64))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Closes #28587.

`_load_image` (`python/sglang/srt/utils/common.py`) decodes images via `Image.open(BytesIO(...))` with **no pixel-count guard**. The per-model cap (`SGLANG_IMAGE_MAX_PIXELS`, used by `smart_resize` in `qwen_vl.py`) is only applied **after** PIL has fully decoded the image. So an oversized image — e.g. a 300-DPI rasterized PDF page, or a 12000×12000 PNG (144 M px) — is fully decoded into memory (≈ 432 MB RGB buffer) and only then downscaled.

Effect on a single Qwen3-VL request with such an image:
- a CPU core pinned at ~100% for a long time (the reported case took ~1m50s),
- RSS grows by ~1 GB per request.

With `--max-running-requests 256`, concurrent oversized-image requests scale memory linearly and can OOM the server **before any GPU inference** — a pre-inference DoS vector. vLLM short-circuits the same input via PIL's `DecompressionBombWarning`.

Note: #27451 truncated the *exception message* for malformed inputs to 100 chars, which fixed the raw-base64-in-logs / log-flood symptom for the **malformed** path. It does **not** help here: a *valid* oversized image never raises, so the decode cost and memory growth remain. See the issue for the full breakdown.

## Modification

- Add `_check_image_pixels(width, height)` in `utils/common.py`. `Image.open` only reads the header, so width/height are known **before** the expensive decode (`.convert()` / `.load()`). The check rejects images whose pixel count exceeds the limit with a clear `ValueError`, before any pixels are decoded.
- Add `SGLANG_IMAGE_MAX_DECODE_PIXELS` (`environ.py`), default `89_478_485` (PIL's default decompression-bomb threshold); set `0` to disable.
- Add a CPU unit test (`test/registered/unit/utils/test_load_image_guard.py`) covering within-limit, over-limit, and disabled cases.

This intentionally only guards the PIL decode path (the bomb vector). Malformed inputs that fail `Image.open` outright are already handled by #27451.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-tests).
- [x] Update documentation / environment-variable reference as needed.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27730377137](https://github.com/sgl-project/sglang/actions/runs/27730377137)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27730376966](https://github.com/sgl-project/sglang/actions/runs/27730376966)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->