### PR TITLE
[Docs] DeepSeek-V4 cookbook: drop --disable-flashinfer-autotune from GB300 Flash low-latency

### DIFF
--- a/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4-benchmarks.jsx
@@ -140,6 +140,13 @@ export const benchmarks = [
   // ====================================================================
   {
     match: { hw: "gb300", variant: "flash", quant: "fp4", strategy: "low-latency", nodes: "single" },
+    sglang_version: "0.5.13.post1",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 463, tpot_ms: 4.19, tokens_per_sec_per_gpu: 35 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 436, tpot_ms: 8.93, tokens_per_sec_per_gpu: 336 },
+    ],
   },
   {
     match: { hw: "gb300", variant: "flash", quant: "fp4", strategy: "balanced", nodes: "single" },

--- a/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -743,7 +743,6 @@ sgl-eval run aime25 \\
         "--speculative-eagle-topk 1",
         "--speculative-num-draft-tokens 4",
         "--chunked-prefill-size 4096",
-        "--disable-flashinfer-autotune",
         "--swa-full-tokens-ratio 0.1",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",


### PR DESCRIPTION
## What

- Remove `--disable-flashinfer-autotune` from the **GB300 / Flash / Low-Latency** serve command in the DeepSeek-V4 cookbook.
- Fill in the previously-empty GB300 Flash low-latency benchmark cell.

## Benchmark

Measured on sglang **v0.5.13.post1**, 4× GB300 single-node, `tp=4`, `random` dataset `isl=8192 / osl=1024`:

| concurrency | median TTFT (ms) | median TPOT (ms) | tokens/sec/GPU |
| --- | ---: | ---: | ---: |
| 1  | 463 | 4.19 | 35  |
| 16 | 436 | 8.93 | 336 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27730869236](https://github.com/sgl-project/sglang/actions/runs/27730869236)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27730869125](https://github.com/sgl-project/sglang/actions/runs/27730869125)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->