### PR TITLE
ci: run nightly image comparisons on 2 GPUs

### DIFF
--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -42,10 +42,10 @@
             "width": 1024,
             "height": 1024,
             "seed": 42,
-            "num_gpus": 1,
+            "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup",
+                    "serve_args": "--warmup --tp-size 2",
                     "extra_env": {}
                 }
             }
@@ -59,10 +59,10 @@
             "width": 1024,
             "height": 1024,
             "seed": 42,
-            "num_gpus": 1,
+            "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup",
+                    "serve_args": "--warmup --tp-size 2",
                     "extra_env": {}
                 }
             }
@@ -75,10 +75,10 @@
             "width": 1024,
             "height": 1024,
             "seed": 42,
-            "num_gpus": 1,
+            "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup",
+                    "serve_args": "--warmup --tp-size 2",
                     "extra_env": {}
                 }
             }

--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -10,10 +10,10 @@
             "width": 1024,
             "height": 1024,
             "seed": 42,
-            "num_gpus": 1,
+            "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --dit-layerwise-offload false",
+                    "serve_args": "--warmup --dit-layerwise-offload false --tp-size 2",
                     "extra_env": {}
                 }
             }
@@ -26,10 +26,10 @@
             "width": 1024,
             "height": 1024,
             "seed": 42,
-            "num_gpus": 1,
+            "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --dit-layerwise-offload false",
+                    "serve_args": "--warmup --dit-layerwise-offload false --tp-size 2",
                     "extra_env": {}
                 }
             }


### PR DESCRIPTION
## Summary
- Run nightly diffusion comparison image cases with `num_gpus=2`
- Add explicit `--tp-size 2` to the SGLang nightly image serve args
- Applies to FLUX, Qwen-Image, Qwen-Image-Edit, and Z-Image image cases

## Testing
- `pre-commit run --files scripts/ci/utils/diffusion/comparison_configs.json`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27731828053](https://github.com/sgl-project/sglang/actions/runs/27731828053)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27731827929](https://github.com/sgl-project/sglang/actions/runs/27731827929)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->