### PR TITLE
[router] cache_aware_zmq: load-aware selection from engine LoadSnapshot

### DIFF
--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -117,6 +117,7 @@ async fn main() -> Result<()> {
             kv_index.tree(),
             Arc::clone(&tokenizers),
             Arc::clone(&block_size_oracle),
+            kv_index.engine_load(),
         )
         .context("build policy registry")?,
     );

--- a/experimental/sgl-router/src/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/src/policies/cache_aware_zmq.rs
@@ -12,6 +12,11 @@
 //! Given `workers` (already filtered to healthy + matching pool by the
 //! caller) and a `SelectionContext` carrying the JSON request body:
 //!
+//! Every load comparison below uses [`WorkerLoads::load_of`]: the
+//! engine-reported queue depth (`num_running + num_waiting`) where a fresh
+//! [`super::engine_load::EngineLoadTable`] snapshot exists, otherwise the
+//! router-side in-flight counter `Worker::active_load()`.
+//!
 //! 1. **Load-imbalance fast-path.** If `max_load - min_load >
 //!    balance_abs_threshold` AND `max_load > min_load *
 //!    balance_rel_threshold`, skip the cache lookup and pick the
@@ -28,8 +33,7 @@
 //!    for the longest matching prefix. If `match_rate > cache_threshold`,
 //!    pick the lowest-load worker whose `url` appears in the match result.
 //!    Otherwise, fall through.
-//! 4. **Min-load fallback.** Pick the lowest-load worker by
-//!    `Worker::active_load()`.
+//! 4. **Min-load fallback.** Pick the lowest-load worker.
 //!
 //! The implementation never returns `None` for a non-empty `workers` slice;
 //! a misconfigured tree or tokenizer degrades to round-robin-with-load
@@ -38,6 +42,7 @@
 use crate::config::CacheAwareConfig;
 
 use crate::discovery::ModelId;
+use crate::policies::engine_load::EngineLoadTable;
 use crate::policies::kv_events::{
     compute_block_hashes, compute_block_hashes_bigram, BlockSizeOracle, HashTree,
 };
@@ -45,7 +50,9 @@ use crate::policies::{Policy, SelectionContext};
 use crate::server::metrics::MetricsRegistry;
 use crate::tokenizer::{adapter, TokenizerRegistry};
 use crate::workers::Worker;
+use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
+use std::time::Instant;
 
 /// Selection policy that scores candidates by tree-overlap with the
 /// request's prefix and falls back to load-based picking when the tree
@@ -64,6 +71,12 @@ pub struct CacheAwareZmqPolicy {
     /// degrades to min-load — the router cannot hash a prompt without
     /// a block size that matches what the worker publishes.
     block_size_oracle: Arc<BlockSizeOracle>,
+    /// Engine-reported per-worker load (running + waiting), shared with the
+    /// `KvEventIndex` load subscriber. Read once per selection; a worker with
+    /// a fresh snapshot uses it in place of the router-side in-flight counter
+    /// (`Worker::active_load`), falling back to that counter when the snapshot
+    /// is stale or absent (cold start / worker predates load publishing).
+    engine_load: Arc<EngineLoadTable>,
     /// Optional metrics sink. Set via [`Self::with_metrics`] by the policy
     /// factory for the production policy; `None` in unit tests and
     /// non-cache-aware call sites. When set, each cache-aware selection
@@ -83,18 +96,64 @@ impl std::fmt::Debug for CacheAwareZmqPolicy {
     }
 }
 
+/// Snapshot of the load-imbalance check, carried out of
+/// [`CacheAwareZmqPolicy::balance_check`] so the caller can log the
+/// numbers behind a rebalance decision.
+struct BalanceCheck {
+    min_load: usize,
+    max_load: usize,
+    abs_diff: usize,
+    imbalanced: bool,
+}
+
+/// Per-selection load lookup. Built once per `select` from a single
+/// [`EngineLoadTable::snapshot_fresh`] pass: a worker with a fresh
+/// engine-reported snapshot uses its queue depth (`num_running +
+/// num_waiting`); otherwise it falls back to the router-side in-flight
+/// counter (`Worker::active_load`). Holding the snapshot keeps every
+/// per-worker `load_of` an O(1) map lookup.
+struct WorkerLoads {
+    fresh: HashMap<String, usize>,
+}
+
+impl WorkerLoads {
+    /// Build the per-selection snapshot from one `snapshot_fresh` pass. The
+    /// single construction chokepoint guarantees every comparison in a given
+    /// `select` sees one consistent view of load.
+    fn from_engine(table: &EngineLoadTable, now: Instant) -> Self {
+        Self {
+            fresh: table.snapshot_fresh(now),
+        }
+    }
+
+    fn load_of(&self, w: &Worker) -> usize {
+        self.fresh
+            .get(w.url.as_str())
+            .copied()
+            .unwrap_or_else(|| w.active_load())
+    }
+
+    /// Number of workers whose load came from the engine (vs the router-side
+    /// fallback). Used only to annotate the rebalance log.
+    fn engine_worker_count(&self) -> usize {
+        self.fresh.len()
+    }
+}
+
 impl CacheAwareZmqPolicy {
     pub fn new(
         config: CacheAwareConfig,
         tree: Arc<HashTree>,
         tokenizers: Arc<TokenizerRegistry>,
         block_size_oracle: Arc<BlockSizeOracle>,
+        engine_load: Arc<EngineLoadTable>,
     ) -> Self {
         Self {
             config,
             tree,
             tokenizers,
             block_size_oracle,
+            engine_load,
             metrics: OnceLock::new(),
         }
     }
@@ -108,28 +167,37 @@ impl CacheAwareZmqPolicy {
         self
     }
 
-    /// Lowest-load worker — ties broken by stable iteration order (which
-    /// is the order the registry returned, i.e. dashmap-undefined). For
-    /// production traffic the ties are rare; tests pin the load skew.
-    fn pick_min_load(workers: &[Arc<Worker>]) -> Option<Arc<Worker>> {
+    /// Lowest-load worker by the per-selection load lookup — ties broken by
+    /// stable iteration order (the order the registry returned, i.e.
+    /// dashmap-undefined). For production traffic the ties are rare; tests
+    /// pin the load skew.
+    fn pick_min_load(workers: &[Arc<Worker>], loads: &WorkerLoads) -> Option<Arc<Worker>> {
         workers
             .iter()
-            .min_by_key(|w| w.active_load())
+            .min_by_key(|w| loads.load_of(w))
             .map(Arc::clone)
     }
 
-    /// Detect load imbalance. Returns `true` when the spread between max
+    /// Detect load imbalance. Returns the min/max load snapshot together
+    /// with the `imbalanced` verdict — `true` when the spread between max
     /// and min load is large enough that cache-aware routing would dump
-    /// even more on the hot worker.
-    fn is_imbalanced(&self, workers: &[Arc<Worker>]) -> bool {
+    /// even more on the hot worker. The caller logs these numbers so every
+    /// rebalance decision is visible in the logs.
+    fn balance_check(&self, workers: &[Arc<Worker>], loads: &WorkerLoads) -> BalanceCheck {
         let (min_load, max_load) = workers.iter().fold((usize::MAX, 0usize), |(mn, mx), w| {
-            let l = w.active_load();
+            let l = loads.load_of(w);
             (mn.min(l), mx.max(l))
         });
         let min_load = if min_load == usize::MAX { 0 } else { min_load };
         let abs_diff = max_load.saturating_sub(min_load);
         let rel_threshold = (min_load as f32 * self.config.balance_rel_threshold) as usize;
-        abs_diff > self.config.balance_abs_threshold && max_load > rel_threshold
+        let imbalanced = abs_diff > self.config.balance_abs_threshold && max_load > rel_threshold;
+        BalanceCheck {
+            min_load,
+            max_load,
+            abs_diff,
+            imbalanced,
+        }
     }
 
     /// Byte-slice convenience wrapper over [`Self::extract_prompt_text_from_value`].
@@ -249,20 +317,57 @@ impl Policy for CacheAwareZmqPolicy {
             return None;
         }
 
+        // Per-selection load lookup: engine-reported queue depth where fresh,
+        // else the router-side in-flight counter. One snapshot pass serves
+        // every comparison below (imbalance check, min-load fallback,
+        // matched-set tiebreak).
+        let loads = WorkerLoads::from_engine(&self.engine_load, Instant::now());
+
         // 1. Load-imbalance fast-path: even the best cache hit gets
-        //    dropped in favour of evening out load.
-        if self.is_imbalanced(workers) {
-            return Self::pick_min_load(workers);
+        //    dropped in favour of evening out load. Logged on every
+        //    request (debug) so the input to the decision is auditable;
+        //    the actual rebalance is logged at info when it fires.
+        let balance = self.balance_check(workers, &loads);
+        tracing::debug!(
+            model = %ctx.model(),
+            min_load = balance.min_load,
+            max_load = balance.max_load,
+            abs_diff = balance.abs_diff,
+            balance_abs_threshold = self.config.balance_abs_threshold,
+            balance_rel_threshold = self.config.balance_rel_threshold,
+            imbalanced = balance.imbalanced,
+            engine_load_workers = loads.engine_worker_count(),
+            engine_load_expected = self.engine_load.expected_count(),
+            "cache-aware-zmq: load-balance check considered",
+        );
+        if balance.imbalanced {
+            let chosen = Self::pick_min_load(workers, &loads);
+            if let Some(w) = &chosen {
+                tracing::info!(
+                    model = %ctx.model(),
+                    worker = %w.url,
+                    worker_load = loads.load_of(w),
+                    min_load = balance.min_load,
+                    max_load = balance.max_load,
+                    abs_diff = balance.abs_diff,
+                    balance_abs_threshold = self.config.balance_abs_threshold,
+                    balance_rel_threshold = self.config.balance_rel_threshold,
+                    engine_load_workers = loads.engine_worker_count(),
+                    engine_load_expected = self.engine_load.expected_count(),
+                    "cache-aware-zmq: load imbalance detected — bypassing cache, routing to min-load worker",
+                );
+            }
+            return chosen;
         }
 
         // 2. Tokenize the request (chat-template-aware for chat traffic on
         //    models that ship a template; raw prompt text otherwise).
         let body = match ctx.request_body() {
             Some(b) if !b.is_empty() => b,
-            _ => return Self::pick_min_load(workers),
+            _ => return Self::pick_min_load(workers, &loads),
         };
         let Some(tokens) = self.tokens_for_request(ctx.model(), body) else {
-            return Self::pick_min_load(workers);
+            return Self::pick_min_load(workers, &loads);
         };
 
         // 3. Hash + match.
@@ -275,7 +380,7 @@ impl Policy for CacheAwareZmqPolicy {
                 model = %ctx.model(),
                 "cache-aware-zmq: block size unknown (no worker page_size yet), falling back to min-load",
             );
-            return Self::pick_min_load(workers);
+            return Self::pick_min_load(workers, &loads);
         };
         // EAGLE-family workers hash KV blocks over token bigrams; the query
         // hashes must match the worker's stored hashes or the tree lookup
@@ -288,7 +393,7 @@ impl Policy for CacheAwareZmqPolicy {
             compute_block_hashes(&tokens, block_size as usize)
         };
         if block_hashes.is_empty() {
-            return Self::pick_min_load(workers);
+            return Self::pick_min_load(workers, &loads);
         }
         let matched = self.tree.match_prefix(None, &block_hashes);
         let match_rate = matched.matched_blocks as f32 / block_hashes.len() as f32;
@@ -316,7 +421,7 @@ impl Policy for CacheAwareZmqPolicy {
                 cache_threshold = self.config.cache_threshold,
                 "cache-aware-zmq: overlap below threshold, falling back to min-load",
             );
-            return Self::pick_min_load(workers);
+            return Self::pick_min_load(workers, &loads);
         }
         // Among workers in the matched set, pick the lowest-load one.
         let matched_urls: std::collections::HashSet<&str> =
@@ -324,9 +429,9 @@ impl Policy for CacheAwareZmqPolicy {
         let best_matched: Option<Arc<Worker>> = workers
             .iter()
             .filter(|w| matched_urls.contains(w.url.as_str()))
-            .min_by_key(|w| w.active_load())
+            .min_by_key(|w| loads.load_of(w))
             .map(Arc::clone);
-        let chosen = best_matched.or_else(|| Self::pick_min_load(workers));
+        let chosen = best_matched.or_else(|| Self::pick_min_load(workers, &loads));
         if let Some(w) = &chosen {
             tracing::debug!(
                 model = %ctx.model(),
@@ -348,8 +453,10 @@ mod tests {
     use super::*;
     use crate::config::CacheAwareConfig;
     use crate::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
+    use crate::policies::engine_load::LoadStat;
     use crate::policies::kv_events::tree::KvWorkerId;
     use crate::policies::kv_events::HashTree;
+    use std::time::Duration;
 
     fn cfg_default() -> CacheAwareConfig {
         CacheAwareConfig {
@@ -377,6 +484,39 @@ mod tests {
             model_ids: vec![ModelId(model_id.into())],
             bootstrap_port: None,
         }))
+    }
+
+    /// Build a policy with a fresh (empty) engine-load table, so selection
+    /// reads the router-side `active_load` counter — matching the
+    /// pre-load-aware behaviour these tests assert.
+    fn new_policy(
+        config: CacheAwareConfig,
+        tree: Arc<HashTree>,
+        tokenizers: Arc<TokenizerRegistry>,
+        oracle: Arc<BlockSizeOracle>,
+    ) -> CacheAwareZmqPolicy {
+        CacheAwareZmqPolicy::new(config, tree, tokenizers, oracle, EngineLoadTable::new())
+    }
+
+    /// Build a policy with an explicit engine-load table, for tests that
+    /// exercise engine-reported load overriding the router-side counter.
+    fn new_policy_with_load(
+        config: CacheAwareConfig,
+        tree: Arc<HashTree>,
+        tokenizers: Arc<TokenizerRegistry>,
+        oracle: Arc<BlockSizeOracle>,
+        engine_load: Arc<EngineLoadTable>,
+    ) -> CacheAwareZmqPolicy {
+        CacheAwareZmqPolicy::new(config, tree, tokenizers, oracle, engine_load)
+    }
+
+    fn load_stat(running: u64, waiting: u64) -> LoadStat {
+        LoadStat {
+            num_running_reqs: running,
+            num_waiting_reqs: waiting,
+            num_tokens: 0,
+            max_total_num_tokens: 0,
+        }
     }
 
     fn tokenizer_registry_with_tiny() -> Arc<TokenizerRegistry> {
@@ -409,7 +549,7 @@ mod tests {
     #[test]
     fn empty_workers_returns_none() {
         let tree = Arc::new(HashTree::new());
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             cfg_default(),
             tree,
             tokenizer_registry_with_tiny(),
@@ -424,7 +564,7 @@ mod tests {
     #[test]
     fn empty_tree_falls_back_to_min_load() {
         let tree = Arc::new(HashTree::new());
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             cfg_default(),
             tree,
             tokenizer_registry_with_tiny(),
@@ -465,7 +605,7 @@ mod tests {
         );
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0, // any match counts
                 balance_abs_threshold: 32,
@@ -502,7 +642,7 @@ mod tests {
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
 
         let metrics = MetricsRegistry::new();
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -547,7 +687,7 @@ mod tests {
         assert!(!hashes.is_empty());
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -598,7 +738,7 @@ mod tests {
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
 
         let metrics = MetricsRegistry::new();
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 1.0, // match_rate <= 1.0 always -> always fall back
                 balance_abs_threshold: 32,
@@ -681,7 +821,7 @@ mod tests {
             oracle.try_set(block_size).unwrap();
             oracle.set_bigram(true);
             let metrics = MetricsRegistry::new();
-            let policy = CacheAwareZmqPolicy::new(
+            let policy = new_policy(
                 CacheAwareConfig {
                     cache_threshold: 0.0,
                     balance_abs_threshold: 32,
@@ -720,7 +860,7 @@ mod tests {
             let oracle = BlockSizeOracle::new();
             oracle.try_set(block_size).unwrap();
             let metrics = MetricsRegistry::new();
-            let policy = CacheAwareZmqPolicy::new(
+            let policy = new_policy(
                 CacheAwareConfig {
                     cache_threshold: 0.0,
                     balance_abs_threshold: 32,
@@ -778,7 +918,7 @@ mod tests {
             &templated_hashes,
         );
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -850,7 +990,7 @@ mod tests {
 
         let tree = Arc::new(HashTree::new());
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -888,7 +1028,7 @@ mod tests {
         );
         let tree = Arc::new(HashTree::new());
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -991,7 +1131,7 @@ mod tests {
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
         tree.insert(&KvWorkerId::new("http://w1:30000".into(), 0), None, &hashes);
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -1026,7 +1166,7 @@ mod tests {
         let hashes = compute_block_hashes(&ids, block_size as usize);
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0, // would normally always match
                 balance_abs_threshold: 5,
@@ -1051,14 +1191,151 @@ mod tests {
         assert_eq!(chosen.url, "http://w1:30000", "imbalance must dominate");
     }
 
+    /// Fresh engine-reported load drives the imbalance + min-load decision
+    /// instead of the router-side in-flight counter. Both workers hold the
+    /// prefix and have zero router-side load, so without engine load the
+    /// tiebreak would pick w0 (stable order). Engine load says w0 is hot
+    /// (50) and w1 is light (1) → the imbalance branch routes to w1.
+    #[test]
+    fn engine_load_overrides_active_load() {
+        let tree = Arc::new(HashTree::new());
+        let registry = tokenizer_registry_with_tiny();
+        let text = "hello world hello world hello world";
+        let tok = registry.get("tiny").unwrap();
+        let ids = adapter::encode(&tok, text).unwrap();
+        let hashes = compute_block_hashes(&ids, 4);
+        tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
+        tree.insert(&KvWorkerId::new("http://w1:30000".into(), 0), None, &hashes);
+
+        let engine_load = EngineLoadTable::new();
+        let now = Instant::now();
+        engine_load.set("http://w0:30000", 0, load_stat(50, 0), now);
+        engine_load.set("http://w1:30000", 0, load_stat(1, 0), now);
+
+        let policy = new_policy_with_load(
+            CacheAwareConfig {
+                cache_threshold: 0.0,
+                balance_abs_threshold: 5,
+                balance_rel_threshold: 2.0,
+            },
+            tree,
+            registry,
+            oracle_for_tests(4),
+            engine_load,
+        );
+        // Router-side counters are both 0 — only engine load is skewed.
+        let w0 = worker("http://w0:30000", "tiny");
+        let w1 = worker("http://w1:30000", "tiny");
+        let workers = vec![Arc::clone(&w0), Arc::clone(&w1)];
+        let model = ModelId("tiny".into());
+        let body = serde_json::to_vec(&serde_json::json!({"prompt": text})).unwrap();
+        let ctx = SelectionContext::new(&model, Some(&body));
+        let chosen = policy.select(&workers, &ctx).expect("must pick");
+        assert_eq!(
+            chosen.url, "http://w1:30000",
+            "engine-reported load must drive selection",
+        );
+    }
+
+    /// When load is balanced enough that the imbalance branch does NOT fire,
+    /// the matched-set tiebreak still uses engine load: both workers hold the
+    /// prefix, engine load says w1 is lighter → w1 wins. (Guards against a
+    /// regression that reverted the tiebreak to `active_load()`.)
+    #[test]
+    fn matched_set_tiebreak_uses_engine_load() {
+        let tree = Arc::new(HashTree::new());
+        let registry = tokenizer_registry_with_tiny();
+        let text = "hello world hello world hello world";
+        let tok = registry.get("tiny").unwrap();
+        let ids = adapter::encode(&tok, text).unwrap();
+        let hashes = compute_block_hashes(&ids, 4);
+        tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
+        tree.insert(&KvWorkerId::new("http://w1:30000".into(), 0), None, &hashes);
+
+        let engine_load = EngineLoadTable::new();
+        let now = Instant::now();
+        engine_load.set("http://w0:30000", 0, load_stat(10, 0), now);
+        engine_load.set("http://w1:30000", 0, load_stat(2, 0), now);
+
+        let policy = new_policy_with_load(
+            CacheAwareConfig {
+                cache_threshold: 0.0,
+                // High thresholds so the imbalance fast-path never fires (10 vs
+                // 2) and selection reaches the matched-set tiebreak.
+                balance_abs_threshold: 100,
+                balance_rel_threshold: 100.0,
+            },
+            tree,
+            registry,
+            oracle_for_tests(4),
+            engine_load,
+        );
+        let w0 = worker("http://w0:30000", "tiny");
+        let w1 = worker("http://w1:30000", "tiny");
+        let workers = vec![Arc::clone(&w0), Arc::clone(&w1)];
+        let model = ModelId("tiny".into());
+        let body = serde_json::to_vec(&serde_json::json!({"prompt": text})).unwrap();
+        let ctx = SelectionContext::new(&model, Some(&body));
+        let chosen = policy.select(&workers, &ctx).expect("must pick");
+        assert_eq!(
+            chosen.url, "http://w1:30000",
+            "matched-set tiebreak must use engine load",
+        );
+    }
+
+    /// A stale engine snapshot is ignored: selection falls back to the
+    /// router-side `active_load` counter. w0's (stale) engine load is high,
+    /// but w1 carries a router-side guard, so fallback picks w0.
+    #[test]
+    fn stale_engine_load_falls_back_to_active_load() {
+        let tree = Arc::new(HashTree::new());
+        let registry = tokenizer_registry_with_tiny();
+        let text = "hello world hello world hello world";
+        let tok = registry.get("tiny").unwrap();
+        let ids = adapter::encode(&tok, text).unwrap();
+        let hashes = compute_block_hashes(&ids, 4);
+        tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
+        tree.insert(&KvWorkerId::new("http://w1:30000".into(), 0), None, &hashes);
+
+        // Past the default freshness window; an hour ago is comfortably stale.
+        let engine_load = EngineLoadTable::new();
+        let stale = Instant::now() - Duration::from_secs(3600);
+        engine_load.set("http://w0:30000", 0, load_stat(50, 0), stale);
+
+        let policy = new_policy_with_load(
+            CacheAwareConfig {
+                cache_threshold: 0.0,
+                balance_abs_threshold: 32,
+                balance_rel_threshold: 1.1,
+            },
+            tree,
+            registry,
+            oracle_for_tests(4),
+            engine_load,
+        );
+        let w0 = worker("http://w0:30000", "tiny");
+        let w1 = worker("http://w1:30000", "tiny");
+        // Router-side: w1 has one in-flight request, w0 has none. With the
+        // stale engine load ignored, the tiebreak picks w0 (load 0 < 1).
+        let _g = w1.load_guard();
+        let workers = vec![Arc::clone(&w0), Arc::clone(&w1)];
+        let model = ModelId("tiny".into());
+        let body = serde_json::to_vec(&serde_json::json!({"prompt": text})).unwrap();
+        let ctx = SelectionContext::new(&model, Some(&body));
+        let chosen = policy.select(&workers, &ctx).expect("must pick");
+        assert_eq!(
+            chosen.url, "http://w0:30000",
+            "stale engine load must be ignored in favour of active_load",
+        );
+    }
+
     /// Tokenizer is missing for the requested model → fall back to
     /// min-load (no panic, no error).
     #[test]
     fn missing_tokenizer_falls_back_to_min_load() {
         let tree = Arc::new(HashTree::new());
         let empty_registry = Arc::new(TokenizerRegistry::default());
-        let policy =
-            CacheAwareZmqPolicy::new(cfg_default(), tree, empty_registry, oracle_for_tests(4));
+        let policy = new_policy(cfg_default(), tree, empty_registry, oracle_for_tests(4));
         let w0 = worker("http://w0:30000", "tiny");
         let w1 = worker("http://w1:30000", "tiny");
         let _g = w0.load_guard();
@@ -1075,7 +1352,7 @@ mod tests {
     #[test]
     fn missing_request_body_falls_back_to_min_load() {
         let tree = Arc::new(HashTree::new());
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             cfg_default(),
             tree,
             tokenizer_registry_with_tiny(),
@@ -1096,7 +1373,7 @@ mod tests {
     #[test]
     fn body_without_prompt_field_falls_back_to_min_load() {
         let tree = Arc::new(HashTree::new());
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             cfg_default(),
             tree,
             tokenizer_registry_with_tiny(),
@@ -1120,7 +1397,7 @@ mod tests {
     #[test]
     fn empty_text_falls_back_to_min_load() {
         let tree = Arc::new(HashTree::new());
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             cfg_default(),
             tree,
             tokenizer_registry_with_tiny(),
@@ -1151,7 +1428,7 @@ mod tests {
             &[999, 998, 997],
         );
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.99,
                 balance_abs_threshold: 32,
@@ -1227,7 +1504,7 @@ mod tests {
         let kw0 = KvWorkerId::new("http://w0:30000".into(), 0);
         tree.insert(&kw0, None, &hashes);
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,

--- a/experimental/sgl-router/src/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/src/policies/cache_aware_zmq.rs
@@ -13,6 +13,11 @@
 //! caller) and a `SelectionContext` carrying the JSON request body and the
 //! ingress-precomputed routing tokens:
 //!
+//! Every load comparison below uses [`WorkerLoads::load_of`]: the
+//! engine-reported queue depth (`num_running + num_waiting`) where a fresh
+//! [`super::engine_load::EngineLoadTable`] snapshot exists, otherwise the
+//! router-side in-flight counter `Worker::active_load()`.
+//!
 //! 1. **Load-imbalance fast-path.** If `max_load - min_load >
 //!    balance_abs_threshold` AND `max_load > min_load *
 //!    balance_rel_threshold`, skip the cache lookup and pick the
@@ -28,8 +33,7 @@
 //!    for the longest matching prefix. If `match_rate > cache_threshold`,
 //!    pick the lowest-load worker whose `url` appears in the match result.
 //!    Otherwise, fall through.
-//! 4. **Min-load fallback.** Pick the lowest-load worker by
-//!    `Worker::active_load()`.
+//! 4. **Min-load fallback.** Pick the lowest-load worker.
 //!
 //! The implementation never returns `None` for a non-empty `workers` slice;
 //! a misconfigured tree or tokenizer degrades to round-robin-with-load
@@ -37,6 +41,7 @@
 
 use crate::config::CacheAwareConfig;
 
+use crate::policies::engine_load::EngineLoadTable;
 use crate::policies::kv_events::{
     compute_block_hashes, compute_block_hashes_bigram, BlockSizeOracle, HashTree,
 };
@@ -44,7 +49,9 @@ use crate::policies::{request_tokens_for, Policy, SelectionContext};
 use crate::server::metrics::MetricsRegistry;
 use crate::tokenizer::TokenizerRegistry;
 use crate::workers::Worker;
+use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
+use std::time::Instant;
 
 /// Selection policy that scores candidates by tree-overlap with the
 /// request's prefix and falls back to load-based picking when the tree
@@ -63,6 +70,12 @@ pub struct CacheAwareZmqPolicy {
     /// degrades to min-load — the router cannot hash a prompt without
     /// a block size that matches what the worker publishes.
     block_size_oracle: Arc<BlockSizeOracle>,
+    /// Engine-reported per-worker load (running + waiting), shared with the
+    /// `KvEventIndex` load subscriber. Read once per selection; a worker with
+    /// a fresh snapshot uses it in place of the router-side in-flight counter
+    /// (`Worker::active_load`), falling back to that counter when the snapshot
+    /// is stale or absent (cold start / worker predates load publishing).
+    engine_load: Arc<EngineLoadTable>,
     /// Optional metrics sink. Set via [`Self::with_metrics`] by the policy
     /// factory for the production policy; `None` in unit tests and
     /// non-cache-aware call sites. When set, each cache-aware selection
@@ -82,18 +95,64 @@ impl std::fmt::Debug for CacheAwareZmqPolicy {
     }
 }
 
+/// Snapshot of the load-imbalance check, carried out of
+/// [`CacheAwareZmqPolicy::balance_check`] so the caller can log the
+/// numbers behind a rebalance decision.
+struct BalanceCheck {
+    min_load: usize,
+    max_load: usize,
+    abs_diff: usize,
+    imbalanced: bool,
+}
+
+/// Per-selection load lookup. Built once per `select` from a single
+/// [`EngineLoadTable::snapshot_fresh`] pass: a worker with a fresh
+/// engine-reported snapshot uses its queue depth (`num_running +
+/// num_waiting`); otherwise it falls back to the router-side in-flight
+/// counter (`Worker::active_load`). Holding the snapshot keeps every
+/// per-worker `load_of` an O(1) map lookup.
+struct WorkerLoads {
+    fresh: HashMap<String, usize>,
+}
+
+impl WorkerLoads {
+    /// Build the per-selection snapshot from one `snapshot_fresh` pass. The
+    /// single construction chokepoint guarantees every comparison in a given
+    /// `select` sees one consistent view of load.
+    fn from_engine(table: &EngineLoadTable, now: Instant) -> Self {
+        Self {
+            fresh: table.snapshot_fresh(now),
+        }
+    }
+
+    fn load_of(&self, w: &Worker) -> usize {
+        self.fresh
+            .get(w.url.as_str())
+            .copied()
+            .unwrap_or_else(|| w.active_load())
+    }
+
+    /// Number of workers whose load came from the engine (vs the router-side
+    /// fallback). Used only to annotate the rebalance log.
+    fn engine_worker_count(&self) -> usize {
+        self.fresh.len()
+    }
+}
+
 impl CacheAwareZmqPolicy {
     pub fn new(
         config: CacheAwareConfig,
         tree: Arc<HashTree>,
         tokenizers: Arc<TokenizerRegistry>,
         block_size_oracle: Arc<BlockSizeOracle>,
+        engine_load: Arc<EngineLoadTable>,
     ) -> Self {
         Self {
             config,
             tree,
             tokenizers,
             block_size_oracle,
+            engine_load,
             metrics: OnceLock::new(),
         }
     }
@@ -107,28 +166,37 @@ impl CacheAwareZmqPolicy {
         self
     }
 
-    /// Lowest-load worker — ties broken by stable iteration order (which
-    /// is the order the registry returned, i.e. dashmap-undefined). For
-    /// production traffic the ties are rare; tests pin the load skew.
-    fn pick_min_load(workers: &[Arc<Worker>]) -> Option<Arc<Worker>> {
+    /// Lowest-load worker by the per-selection load lookup — ties broken by
+    /// stable iteration order (the order the registry returned, i.e.
+    /// dashmap-undefined). For production traffic the ties are rare; tests
+    /// pin the load skew.
+    fn pick_min_load(workers: &[Arc<Worker>], loads: &WorkerLoads) -> Option<Arc<Worker>> {
         workers
             .iter()
-            .min_by_key(|w| w.active_load())
+            .min_by_key(|w| loads.load_of(w))
             .map(Arc::clone)
     }
 
-    /// Detect load imbalance. Returns `true` when the spread between max
+    /// Detect load imbalance. Returns the min/max load snapshot together
+    /// with the `imbalanced` verdict — `true` when the spread between max
     /// and min load is large enough that cache-aware routing would dump
-    /// even more on the hot worker.
-    fn is_imbalanced(&self, workers: &[Arc<Worker>]) -> bool {
+    /// even more on the hot worker. The caller logs these numbers so every
+    /// rebalance decision is visible in the logs.
+    fn balance_check(&self, workers: &[Arc<Worker>], loads: &WorkerLoads) -> BalanceCheck {
         let (min_load, max_load) = workers.iter().fold((usize::MAX, 0usize), |(mn, mx), w| {
-            let l = w.active_load();
+            let l = loads.load_of(w);
             (mn.min(l), mx.max(l))
         });
         let min_load = if min_load == usize::MAX { 0 } else { min_load };
         let abs_diff = max_load.saturating_sub(min_load);
         let rel_threshold = (min_load as f32 * self.config.balance_rel_threshold) as usize;
-        abs_diff > self.config.balance_abs_threshold && max_load > rel_threshold
+        let imbalanced = abs_diff > self.config.balance_abs_threshold && max_load > rel_threshold;
+        BalanceCheck {
+            min_load,
+            max_load,
+            abs_diff,
+            imbalanced,
+        }
     }
 }
 
@@ -138,10 +206,47 @@ impl Policy for CacheAwareZmqPolicy {
             return None;
         }
 
+        // Per-selection load lookup: engine-reported queue depth where fresh,
+        // else the router-side in-flight counter. One snapshot pass serves
+        // every comparison below (imbalance check, min-load fallback,
+        // matched-set tiebreak).
+        let loads = WorkerLoads::from_engine(&self.engine_load, Instant::now());
+
         // 1. Load-imbalance fast-path: even the best cache hit gets
-        //    dropped in favour of evening out load.
-        if self.is_imbalanced(workers) {
-            return Self::pick_min_load(workers);
+        //    dropped in favour of evening out load. Logged on every
+        //    request (debug) so the input to the decision is auditable;
+        //    the actual rebalance is logged at info when it fires.
+        let balance = self.balance_check(workers, &loads);
+        tracing::debug!(
+            model = %ctx.model(),
+            min_load = balance.min_load,
+            max_load = balance.max_load,
+            abs_diff = balance.abs_diff,
+            balance_abs_threshold = self.config.balance_abs_threshold,
+            balance_rel_threshold = self.config.balance_rel_threshold,
+            imbalanced = balance.imbalanced,
+            engine_load_workers = loads.engine_worker_count(),
+            engine_load_expected = self.engine_load.expected_count(),
+            "cache-aware-zmq: load-balance check considered",
+        );
+        if balance.imbalanced {
+            let chosen = Self::pick_min_load(workers, &loads);
+            if let Some(w) = &chosen {
+                tracing::info!(
+                    model = %ctx.model(),
+                    worker = %w.url,
+                    worker_load = loads.load_of(w),
+                    min_load = balance.min_load,
+                    max_load = balance.max_load,
+                    abs_diff = balance.abs_diff,
+                    balance_abs_threshold = self.config.balance_abs_threshold,
+                    balance_rel_threshold = self.config.balance_rel_threshold,
+                    engine_load_workers = loads.engine_worker_count(),
+                    engine_load_expected = self.engine_load.expected_count(),
+                    "cache-aware-zmq: load imbalance detected — bypassing cache, routing to min-load worker",
+                );
+            }
+            return chosen;
         }
 
         // 2. Routing tokens. Prefer the ids computed once at ingress; fall
@@ -154,13 +259,13 @@ impl Policy for CacheAwareZmqPolicy {
             _ => {
                 let body = match ctx.request_body() {
                     Some(b) if !b.is_empty() => b,
-                    _ => return Self::pick_min_load(workers),
+                    _ => return Self::pick_min_load(workers, &loads),
                 };
                 let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
-                    return Self::pick_min_load(workers);
+                    return Self::pick_min_load(workers, &loads);
                 };
                 let Some(rt) = request_tokens_for(&self.tokenizers, ctx.model(), &value) else {
-                    return Self::pick_min_load(workers);
+                    return Self::pick_min_load(workers, &loads);
                 };
                 fallback_ids = rt.ids;
                 &fallback_ids
@@ -177,7 +282,7 @@ impl Policy for CacheAwareZmqPolicy {
                 model = %ctx.model(),
                 "cache-aware-zmq: block size unknown (no worker page_size yet), falling back to min-load",
             );
-            return Self::pick_min_load(workers);
+            return Self::pick_min_load(workers, &loads);
         };
         // EAGLE-family workers hash KV blocks over token bigrams; the query
         // hashes must match the worker's stored hashes or the tree lookup
@@ -190,7 +295,7 @@ impl Policy for CacheAwareZmqPolicy {
             compute_block_hashes(tokens, block_size as usize)
         };
         if block_hashes.is_empty() {
-            return Self::pick_min_load(workers);
+            return Self::pick_min_load(workers, &loads);
         }
         let matched = self.tree.match_prefix(None, &block_hashes);
         let match_rate = matched.matched_blocks as f32 / block_hashes.len() as f32;
@@ -218,7 +323,7 @@ impl Policy for CacheAwareZmqPolicy {
                 cache_threshold = self.config.cache_threshold,
                 "cache-aware-zmq: overlap below threshold, falling back to min-load",
             );
-            return Self::pick_min_load(workers);
+            return Self::pick_min_load(workers, &loads);
         }
         // Among workers in the matched set, pick the lowest-load one.
         let matched_urls: std::collections::HashSet<&str> =
@@ -226,9 +331,9 @@ impl Policy for CacheAwareZmqPolicy {
         let best_matched: Option<Arc<Worker>> = workers
             .iter()
             .filter(|w| matched_urls.contains(w.url.as_str()))
-            .min_by_key(|w| w.active_load())
+            .min_by_key(|w| loads.load_of(w))
             .map(Arc::clone);
-        let chosen = best_matched.or_else(|| Self::pick_min_load(workers));
+        let chosen = best_matched.or_else(|| Self::pick_min_load(workers, &loads));
         if let Some(w) = &chosen {
             tracing::debug!(
                 model = %ctx.model(),
@@ -254,9 +359,11 @@ mod tests {
     use super::*;
     use crate::config::CacheAwareConfig;
     use crate::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
+    use crate::policies::engine_load::LoadSnapshot;
     use crate::policies::kv_events::tree::KvWorkerId;
     use crate::policies::kv_events::HashTree;
     use crate::tokenizer::adapter;
+    use std::time::Duration;
 
     fn cfg_default() -> CacheAwareConfig {
         CacheAwareConfig {
@@ -284,6 +391,39 @@ mod tests {
             model_ids: vec![ModelId(model_id.into())],
             bootstrap_port: None,
         }))
+    }
+
+    /// Build a policy with a fresh (empty) engine-load table, so selection
+    /// reads the router-side `active_load` counter — matching the
+    /// pre-load-aware behaviour these tests assert.
+    fn new_policy(
+        config: CacheAwareConfig,
+        tree: Arc<HashTree>,
+        tokenizers: Arc<TokenizerRegistry>,
+        oracle: Arc<BlockSizeOracle>,
+    ) -> CacheAwareZmqPolicy {
+        CacheAwareZmqPolicy::new(config, tree, tokenizers, oracle, EngineLoadTable::new())
+    }
+
+    /// Build a policy with an explicit engine-load table, for tests that
+    /// exercise engine-reported load overriding the router-side counter.
+    fn new_policy_with_load(
+        config: CacheAwareConfig,
+        tree: Arc<HashTree>,
+        tokenizers: Arc<TokenizerRegistry>,
+        oracle: Arc<BlockSizeOracle>,
+        engine_load: Arc<EngineLoadTable>,
+    ) -> CacheAwareZmqPolicy {
+        CacheAwareZmqPolicy::new(config, tree, tokenizers, oracle, engine_load)
+    }
+
+    fn load_snap(running: u64, waiting: u64) -> LoadSnapshot {
+        LoadSnapshot {
+            num_running_reqs: running,
+            num_waiting_reqs: waiting,
+            num_used_tokens: 0,
+            max_total_num_tokens: 0,
+        }
     }
 
     fn tokenizer_registry_with_tiny() -> Arc<TokenizerRegistry> {
@@ -316,7 +456,7 @@ mod tests {
     #[test]
     fn empty_workers_returns_none() {
         let tree = Arc::new(HashTree::new());
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             cfg_default(),
             tree,
             tokenizer_registry_with_tiny(),
@@ -331,7 +471,7 @@ mod tests {
     #[test]
     fn empty_tree_falls_back_to_min_load() {
         let tree = Arc::new(HashTree::new());
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             cfg_default(),
             tree,
             tokenizer_registry_with_tiny(),
@@ -372,7 +512,7 @@ mod tests {
         );
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0, // any match counts
                 balance_abs_threshold: 32,
@@ -409,7 +549,7 @@ mod tests {
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
 
         let metrics = MetricsRegistry::new();
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -454,7 +594,7 @@ mod tests {
         assert!(!hashes.is_empty());
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -505,7 +645,7 @@ mod tests {
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
 
         let metrics = MetricsRegistry::new();
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 1.0, // match_rate <= 1.0 always -> always fall back
                 balance_abs_threshold: 32,
@@ -588,7 +728,7 @@ mod tests {
             oracle.try_set(block_size).unwrap();
             oracle.set_bigram(true);
             let metrics = MetricsRegistry::new();
-            let policy = CacheAwareZmqPolicy::new(
+            let policy = new_policy(
                 CacheAwareConfig {
                     cache_threshold: 0.0,
                     balance_abs_threshold: 32,
@@ -627,7 +767,7 @@ mod tests {
             let oracle = BlockSizeOracle::new();
             oracle.try_set(block_size).unwrap();
             let metrics = MetricsRegistry::new();
-            let policy = CacheAwareZmqPolicy::new(
+            let policy = new_policy(
                 CacheAwareConfig {
                     cache_threshold: 0.0,
                     balance_abs_threshold: 32,
@@ -685,7 +825,7 @@ mod tests {
             &templated_hashes,
         );
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -757,7 +897,7 @@ mod tests {
 
         let tree = Arc::new(HashTree::new());
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -795,7 +935,7 @@ mod tests {
         );
         let tree = Arc::new(HashTree::new());
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -898,7 +1038,7 @@ mod tests {
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
         tree.insert(&KvWorkerId::new("http://w1:30000".into(), 0), None, &hashes);
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -933,7 +1073,7 @@ mod tests {
         let hashes = compute_block_hashes(&ids, block_size as usize);
         tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0, // would normally always match
                 balance_abs_threshold: 5,
@@ -958,14 +1098,151 @@ mod tests {
         assert_eq!(chosen.url, "http://w1:30000", "imbalance must dominate");
     }
 
+    /// Fresh engine-reported load drives the imbalance + min-load decision
+    /// instead of the router-side in-flight counter. Both workers hold the
+    /// prefix and have zero router-side load, so without engine load the
+    /// tiebreak would pick w0 (stable order). Engine load says w0 is hot
+    /// (50) and w1 is light (1) → the imbalance branch routes to w1.
+    #[test]
+    fn engine_load_overrides_active_load() {
+        let tree = Arc::new(HashTree::new());
+        let registry = tokenizer_registry_with_tiny();
+        let text = "hello world hello world hello world";
+        let tok = registry.get("tiny").unwrap();
+        let ids = adapter::encode(&tok, text).unwrap();
+        let hashes = compute_block_hashes(&ids, 4);
+        tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
+        tree.insert(&KvWorkerId::new("http://w1:30000".into(), 0), None, &hashes);
+
+        let engine_load = EngineLoadTable::new();
+        let now = Instant::now();
+        engine_load.set("http://w0:30000", 0, load_snap(50, 0), now);
+        engine_load.set("http://w1:30000", 0, load_snap(1, 0), now);
+
+        let policy = new_policy_with_load(
+            CacheAwareConfig {
+                cache_threshold: 0.0,
+                balance_abs_threshold: 5,
+                balance_rel_threshold: 2.0,
+            },
+            tree,
+            registry,
+            oracle_for_tests(4),
+            engine_load,
+        );
+        // Router-side counters are both 0 — only engine load is skewed.
+        let w0 = worker("http://w0:30000", "tiny");
+        let w1 = worker("http://w1:30000", "tiny");
+        let workers = vec![Arc::clone(&w0), Arc::clone(&w1)];
+        let model = ModelId("tiny".into());
+        let body = serde_json::to_vec(&serde_json::json!({"prompt": text})).unwrap();
+        let ctx = SelectionContext::new(&model, Some(&body));
+        let chosen = policy.select(&workers, &ctx).expect("must pick");
+        assert_eq!(
+            chosen.url, "http://w1:30000",
+            "engine-reported load must drive selection",
+        );
+    }
+
+    /// When load is balanced enough that the imbalance branch does NOT fire,
+    /// the matched-set tiebreak still uses engine load: both workers hold the
+    /// prefix, engine load says w1 is lighter → w1 wins. (Guards against a
+    /// regression that reverted the tiebreak to `active_load()`.)
+    #[test]
+    fn matched_set_tiebreak_uses_engine_load() {
+        let tree = Arc::new(HashTree::new());
+        let registry = tokenizer_registry_with_tiny();
+        let text = "hello world hello world hello world";
+        let tok = registry.get("tiny").unwrap();
+        let ids = adapter::encode(&tok, text).unwrap();
+        let hashes = compute_block_hashes(&ids, 4);
+        tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
+        tree.insert(&KvWorkerId::new("http://w1:30000".into(), 0), None, &hashes);
+
+        let engine_load = EngineLoadTable::new();
+        let now = Instant::now();
+        engine_load.set("http://w0:30000", 0, load_snap(10, 0), now);
+        engine_load.set("http://w1:30000", 0, load_snap(2, 0), now);
+
+        let policy = new_policy_with_load(
+            CacheAwareConfig {
+                cache_threshold: 0.0,
+                // High thresholds so the imbalance fast-path never fires (10 vs
+                // 2) and selection reaches the matched-set tiebreak.
+                balance_abs_threshold: 100,
+                balance_rel_threshold: 100.0,
+            },
+            tree,
+            registry,
+            oracle_for_tests(4),
+            engine_load,
+        );
+        let w0 = worker("http://w0:30000", "tiny");
+        let w1 = worker("http://w1:30000", "tiny");
+        let workers = vec![Arc::clone(&w0), Arc::clone(&w1)];
+        let model = ModelId("tiny".into());
+        let body = serde_json::to_vec(&serde_json::json!({"prompt": text})).unwrap();
+        let ctx = SelectionContext::new(&model, Some(&body));
+        let chosen = policy.select(&workers, &ctx).expect("must pick");
+        assert_eq!(
+            chosen.url, "http://w1:30000",
+            "matched-set tiebreak must use engine load",
+        );
+    }
+
+    /// A stale engine snapshot is ignored: selection falls back to the
+    /// router-side `active_load` counter. w0's (stale) engine load is high,
+    /// but w1 carries a router-side guard, so fallback picks w0.
+    #[test]
+    fn stale_engine_load_falls_back_to_active_load() {
+        let tree = Arc::new(HashTree::new());
+        let registry = tokenizer_registry_with_tiny();
+        let text = "hello world hello world hello world";
+        let tok = registry.get("tiny").unwrap();
+        let ids = adapter::encode(&tok, text).unwrap();
+        let hashes = compute_block_hashes(&ids, 4);
+        tree.insert(&KvWorkerId::new("http://w0:30000".into(), 0), None, &hashes);
+        tree.insert(&KvWorkerId::new("http://w1:30000".into(), 0), None, &hashes);
+
+        // Past the default freshness window; an hour ago is comfortably stale.
+        let engine_load = EngineLoadTable::new();
+        let stale = Instant::now() - Duration::from_secs(3600);
+        engine_load.set("http://w0:30000", 0, load_snap(50, 0), stale);
+
+        let policy = new_policy_with_load(
+            CacheAwareConfig {
+                cache_threshold: 0.0,
+                balance_abs_threshold: 32,
+                balance_rel_threshold: 1.1,
+            },
+            tree,
+            registry,
+            oracle_for_tests(4),
+            engine_load,
+        );
+        let w0 = worker("http://w0:30000", "tiny");
+        let w1 = worker("http://w1:30000", "tiny");
+        // Router-side: w1 has one in-flight request, w0 has none. With the
+        // stale engine load ignored, the tiebreak picks w0 (load 0 < 1).
+        let _g = w1.load_guard();
+        let workers = vec![Arc::clone(&w0), Arc::clone(&w1)];
+        let model = ModelId("tiny".into());
+        let body = serde_json::to_vec(&serde_json::json!({"prompt": text})).unwrap();
+        let ctx = SelectionContext::new(&model, Some(&body));
+        let chosen = policy.select(&workers, &ctx).expect("must pick");
+        assert_eq!(
+            chosen.url, "http://w0:30000",
+            "stale engine load must be ignored in favour of active_load",
+        );
+    }
+
     /// Tokenizer is missing for the requested model → fall back to
     /// min-load (no panic, no error).
     #[test]
     fn missing_tokenizer_falls_back_to_min_load() {
         let tree = Arc::new(HashTree::new());
         let empty_registry = Arc::new(TokenizerRegistry::default());
-        let policy =
-            CacheAwareZmqPolicy::new(cfg_default(), tree, empty_registry, oracle_for_tests(4));
+        let policy = new_policy(cfg_default(), tree, empty_registry, oracle_for_tests(4));
         let w0 = worker("http://w0:30000", "tiny");
         let w1 = worker("http://w1:30000", "tiny");
         let _g = w0.load_guard();
@@ -982,7 +1259,7 @@ mod tests {
     #[test]
     fn missing_request_body_falls_back_to_min_load() {
         let tree = Arc::new(HashTree::new());
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             cfg_default(),
             tree,
             tokenizer_registry_with_tiny(),
@@ -1003,7 +1280,7 @@ mod tests {
     #[test]
     fn body_without_prompt_field_falls_back_to_min_load() {
         let tree = Arc::new(HashTree::new());
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             cfg_default(),
             tree,
             tokenizer_registry_with_tiny(),
@@ -1027,7 +1304,7 @@ mod tests {
     #[test]
     fn empty_text_falls_back_to_min_load() {
         let tree = Arc::new(HashTree::new());
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             cfg_default(),
             tree,
             tokenizer_registry_with_tiny(),
@@ -1058,7 +1335,7 @@ mod tests {
             &[999, 998, 997],
         );
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.99,
                 balance_abs_threshold: 32,
@@ -1141,7 +1418,7 @@ mod tests {
         let kw0 = KvWorkerId::new("http://w0:30000".into(), 0);
         tree.insert(&kw0, None, &hashes);
 
-        let policy = CacheAwareZmqPolicy::new(
+        let policy = new_policy(
             CacheAwareConfig {
                 cache_threshold: 0.0,
                 balance_abs_threshold: 32,
@@ -1247,6 +1524,7 @@ mod tests {
             tree,
             registry,
             oracle_for_tests(4),
+            EngineLoadTable::new(),
         );
         let w0 = worker("http://w0:30000", "tiny");
         let w1 = worker("http://w1:30000", "tiny");

--- a/experimental/sgl-router/src/policies/engine_load.rs
+++ b/experimental/sgl-router/src/policies/engine_load.rs
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Engine-reported runtime load, fed by the load subscriber.
+//!
+//! Workers publish a [`LoadStat`] gauge on their dedicated load socket (see
+//! `python/sglang/srt/managers/scheduler_components/load_publisher.py`). The
+//! load subscriber routes those into this table, keyed per
+//! `(worker_url, dp_rank)`; the
+//! cache-aware-zmq policy reads the freshest aggregate per worker as a
+//! truthful load signal, falling back to the router-side in-flight counter
+//! when no fresh snapshot exists (cold start, stale publisher, or a worker
+//! that predates load publishing).
+//!
+//! Load is a *gauge*, not a delta: last value wins, no sequence/replay
+//! semantics. Entries older than [`EngineLoadTable::freshness`] are ignored.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::{DashMap, DashSet};
+use serde::de::{self, Deserializer, IgnoredAny, SeqAccess, Visitor};
+use serde::Deserialize;
+
+/// Per-scheduler runtime load snapshot. Mirrors the Python `LoadStat` in
+/// `managers/scheduler_components/load_publisher.py`, published on the
+/// worker's dedicated load socket (separate from KV-cache events).
+///
+/// Wire shape (msgspec `tag=True` + `array_like`):
+/// `["LoadStat", num_running_reqs, num_waiting_reqs, num_tokens,
+/// max_total_num_tokens, attn_dp_rank?]`. We read the four counts and ignore
+/// any trailing fields (`attn_dp_rank` — the router keys load by the
+/// subscriber's socket rank, not the payload).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoadStat {
+    /// Requests currently running on the engine.
+    pub num_running_reqs: u64,
+    /// Requests queued waiting to run.
+    pub num_waiting_reqs: u64,
+    /// KV tokens currently in use.
+    pub num_tokens: u64,
+    /// KV-cache token capacity; 0 when unknown.
+    pub max_total_num_tokens: u64,
+}
+
+impl<'de> Deserialize<'de> for LoadStat {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct LoadStatVisitor;
+
+        impl<'de> Visitor<'de> for LoadStatVisitor {
+            type Value = LoadStat;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a tagged msgpack array [\"LoadStat\", ...fields]")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<LoadStat, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let tag: String = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::missing_field("event tag"))?;
+                if tag != "LoadStat" {
+                    return Err(de::Error::custom(format!(
+                        "expected \"LoadStat\" tag, got {tag:?}"
+                    )));
+                }
+                // Counts are always emitted (no Python defaults), but default
+                // missing fields to 0 and drain trailing fields (attn_dp_rank,
+                // future additions) for forward-compatibility.
+                let num_running_reqs: u64 = seq.next_element()?.unwrap_or(0);
+                let num_waiting_reqs: u64 = seq.next_element()?.unwrap_or(0);
+                let num_tokens: u64 = seq.next_element()?.unwrap_or(0);
+                let max_total_num_tokens: u64 = seq.next_element()?.unwrap_or(0);
+                while seq.next_element::<IgnoredAny>()?.is_some() {}
+                Ok(LoadStat {
+                    num_running_reqs,
+                    num_waiting_reqs,
+                    num_tokens,
+                    max_total_num_tokens,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(LoadStatVisitor)
+    }
+}
+
+/// Decode a single load frame's msgpack payload into a [`LoadStat`].
+pub fn decode_load_stat(payload: &[u8]) -> Result<LoadStat, rmp_serde::decode::Error> {
+    rmp_serde::from_slice(payload)
+}
+
+/// A per-rank load snapshot older than this is treated as stale, so a silent
+/// or slow publisher degrades to the router-side load signal rather than
+/// pinning a worker at its last reported value.
+const DEFAULT_FRESHNESS: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone)]
+struct LoadEntry {
+    load: LoadStat,
+    at: Instant,
+}
+
+/// Per-`(worker_url, dp_rank)` engine-reported load. Written by the load
+/// subscriber pump, read by the cache-aware-zmq policy. Shared out of
+/// [`super::kv_events::index::KvEventIndex`] the same way the hash tree is.
+#[derive(Debug)]
+pub struct EngineLoadTable {
+    by_rank: DashMap<(String, u32), LoadEntry>,
+    /// Worker URLs that advertised a load topic and so are *expected* to
+    /// publish load. Lets the router distinguish "load-aware routing active"
+    /// from "silently degraded to the in-flight counter" (expected but no
+    /// fresh snapshot) — see [`Self::expected_count`].
+    expected: DashSet<String>,
+    freshness: Duration,
+}
+
+impl EngineLoadTable {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            by_rank: DashMap::new(),
+            expected: DashSet::new(),
+            freshness: DEFAULT_FRESHNESS,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn with_freshness(freshness: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            by_rank: DashMap::new(),
+            expected: DashSet::new(),
+            freshness,
+        })
+    }
+
+    /// Record the latest load for one `(worker_url, dp_rank)`.
+    pub fn set(&self, url: &str, dp_rank: u32, load: LoadStat, at: Instant) {
+        self.by_rank
+            .insert((url.to_string(), dp_rank), LoadEntry { load, at });
+    }
+
+    /// Mark a worker as expected to publish load (it advertised a load topic).
+    pub fn mark_expected(&self, url: &str) {
+        self.expected.insert(url.to_string());
+    }
+
+    /// Number of workers expected to publish load. Compared against the size
+    /// of [`Self::snapshot_fresh`] to surface a dead/misconfigured publisher
+    /// (expected > 0 but no fresh snapshots) in logs.
+    pub fn expected_count(&self) -> usize {
+        self.expected.len()
+    }
+
+    /// One pass over the table returning, per worker URL, the summed queue
+    /// depth (`num_running_reqs + num_waiting_reqs`) across that worker's
+    /// ranks — **but only for workers whose every known rank is fresh**. A
+    /// worker with any stale rank is omitted, so the caller falls back to its
+    /// own load signal. (Summing only the fresh ranks would make a worker
+    /// whose other ranks went silent look misleadingly idle and draw *more*
+    /// traffic.) Computed once per selection so per-worker lookups are O(1).
+    pub fn snapshot_fresh(&self, now: Instant) -> HashMap<String, usize> {
+        // url -> (summed depth across all ranks, all-ranks-fresh).
+        let mut acc: HashMap<String, (usize, bool)> = HashMap::new();
+        for entry in self.by_rank.iter() {
+            let fresh = now.duration_since(entry.value().at) <= self.freshness;
+            let l = &entry.value().load;
+            let depth = (l.num_running_reqs.saturating_add(l.num_waiting_reqs)) as usize;
+            let slot = acc.entry(entry.key().0.clone()).or_insert((0, true));
+            slot.0 = slot.0.saturating_add(depth);
+            slot.1 = slot.1 && fresh;
+        }
+        acc.into_iter()
+            .filter_map(|(url, (depth, all_fresh))| all_fresh.then_some((url, depth)))
+            .collect()
+    }
+
+    /// Drop every rank entry (and the expected mark) for a worker. Called on
+    /// worker removal so a re-added worker does not leave stale load behind.
+    pub fn forget_worker(&self, url: &str) {
+        self.by_rank.retain(|k, _| k.0 != url);
+        self.expected.remove(url);
+    }
+
+    #[cfg(test)]
+    pub fn entry_count(&self) -> usize {
+        self.by_rank.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load(running: u64, waiting: u64) -> LoadStat {
+        LoadStat {
+            num_running_reqs: running,
+            num_waiting_reqs: waiting,
+            num_tokens: 0,
+            max_total_num_tokens: 0,
+        }
+    }
+
+    #[test]
+    fn sums_queue_depth_across_ranks() {
+        let t = EngineLoadTable::new();
+        let now = Instant::now();
+        t.set("http://w:30000", 0, load(5, 1), now);
+        t.set("http://w:30000", 1, load(3, 2), now);
+        let fresh = t.snapshot_fresh(now);
+        // (5+1) + (3+2) = 11
+        assert_eq!(fresh.get("http://w:30000").copied(), Some(11));
+    }
+
+    #[test]
+    fn stale_entries_are_dropped_from_snapshot() {
+        let t = EngineLoadTable::with_freshness(Duration::from_millis(10));
+        let old = Instant::now();
+        t.set("http://w:30000", 0, load(9, 9), old);
+        // A read far in the future sees the entry as stale -> worker absent.
+        let later = old + Duration::from_secs(60);
+        assert!(t.snapshot_fresh(later).get("http://w:30000").is_none());
+    }
+
+    #[test]
+    fn forget_worker_clears_all_ranks() {
+        let t = EngineLoadTable::new();
+        let now = Instant::now();
+        t.set("http://w:30000", 0, load(1, 0), now);
+        t.set("http://w:30000", 1, load(1, 0), now);
+        t.set("http://other:30000", 0, load(1, 0), now);
+        t.forget_worker("http://w:30000");
+        assert_eq!(t.entry_count(), 1);
+        assert!(t.snapshot_fresh(now).get("http://w:30000").is_none());
+        assert!(t.snapshot_fresh(now).get("http://other:30000").is_some());
+    }
+
+    /// A worker with any stale rank is omitted entirely (not summed over only
+    /// its fresh ranks), so a partially-silent worker falls back to the
+    /// router-side counter instead of looking misleadingly idle.
+    #[test]
+    fn partial_freshness_excludes_worker() {
+        let t = EngineLoadTable::with_freshness(Duration::from_secs(5));
+        let now = Instant::now();
+        let stale = now - Duration::from_secs(3600);
+        t.set("http://w:30000", 0, load(5, 1), now); // fresh
+        t.set("http://w:30000", 1, load(9, 9), stale); // stale
+        assert!(
+            t.snapshot_fresh(now).get("http://w:30000").is_none(),
+            "any stale rank must drop the whole worker from the snapshot"
+        );
+    }
+
+    #[test]
+    fn expected_count_tracks_marked_workers_and_forget() {
+        let t = EngineLoadTable::new();
+        assert_eq!(t.expected_count(), 0);
+        t.mark_expected("http://w:30000");
+        t.mark_expected("http://w:30000"); // idempotent
+        t.mark_expected("http://other:30000");
+        assert_eq!(t.expected_count(), 2);
+        t.forget_worker("http://w:30000");
+        assert_eq!(t.expected_count(), 1);
+    }
+}

--- a/experimental/sgl-router/src/policies/engine_load.rs
+++ b/experimental/sgl-router/src/policies/engine_load.rs
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Engine-reported runtime load, fed by the load subscriber.
+//!
+//! Workers publish a [`LoadSnapshot`] gauge on their dedicated load socket
+//! (see `python/sglang/srt/managers/load_snapshot.py`). The load subscriber
+//! routes those into this table, keyed per `(worker_url, dp_rank)`; the
+//! cache-aware-zmq policy sums each worker's ranks into a truthful load
+//! signal, falling back to the router-side in-flight counter for any worker
+//! whose picture is incomplete (cold start, a stale or silent rank, or a
+//! worker that predates load publishing) — see [`EngineLoadTable::snapshot_fresh`].
+//!
+//! Load is a *gauge*, not a delta: last value wins, no sequence/replay
+//! semantics. Entries older than [`EngineLoadTable::freshness`] are ignored.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use serde::Deserialize;
+
+/// Per-scheduler runtime load snapshot. Mirrors the Python `LoadSnapshot` in
+/// `managers/load_snapshot.py` — the same struct that backs `/v1/loads` and
+/// DP balancing, republished on the worker's dedicated load socket.
+///
+/// Wire shape is a msgpack **map** keyed by field name, declared
+/// `omit_defaults=True` on the Python side, so any field may be absent and
+/// every one defaults to zero here. The snapshot carries considerably more
+/// (memory, speculative, LoRA, disaggregation and queue sub-structs) and serde
+/// ignores what is not declared, which is what keeps this forward-compatible as
+/// the engine grows. Of the four declared, routing reads only
+/// `num_running_reqs` + `num_waiting_reqs`; the two token counts are decoded
+/// but not yet consumed.
+///
+/// Because absent and zero are indistinguishable on the wire, a producer-side
+/// field rename would report every worker as idle rather than failing — the
+/// wire-shape test on the Python side is what guards that.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(default)]
+pub struct LoadSnapshot {
+    /// Requests currently running on the engine.
+    pub num_running_reqs: u64,
+    /// Requests queued waiting to run.
+    pub num_waiting_reqs: u64,
+    /// KV tokens currently in use.
+    pub num_used_tokens: u64,
+    /// KV-cache token capacity; 0 when unknown.
+    pub max_total_num_tokens: u64,
+}
+
+/// Decode a single load frame's msgpack payload into a [`LoadSnapshot`].
+pub fn decode_load_snapshot(payload: &[u8]) -> Result<LoadSnapshot, rmp_serde::decode::Error> {
+    rmp_serde::from_slice(payload)
+}
+
+/// A per-rank load snapshot older than this is treated as stale, so a silent
+/// or slow publisher degrades to the router-side load signal rather than
+/// pinning a worker at its last reported value.
+const DEFAULT_FRESHNESS: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone)]
+struct LoadEntry {
+    load: LoadSnapshot,
+    at: Instant,
+}
+
+/// Per-`(worker_url, dp_rank)` engine-reported load. Written by the load
+/// subscriber pump, read by the cache-aware-zmq policy. Shared out of
+/// [`super::kv_events::index::KvEventIndex`] the same way the hash tree is.
+#[derive(Debug)]
+pub struct EngineLoadTable {
+    by_rank: DashMap<(String, u32), LoadEntry>,
+    /// Worker URLs that advertised a load topic, mapped to how many ranks each
+    /// is expected to publish. Serves two purposes: distinguishing "load-aware
+    /// routing active" from "silently degraded to the in-flight counter"
+    /// (see [`Self::expected_count`]), and giving [`Self::snapshot_fresh`] the
+    /// denominator it needs to notice a rank that has never published at all.
+    expected: DashMap<String, u32>,
+    freshness: Duration,
+}
+
+impl EngineLoadTable {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            by_rank: DashMap::new(),
+            expected: DashMap::new(),
+            freshness: DEFAULT_FRESHNESS,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn with_freshness(freshness: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            by_rank: DashMap::new(),
+            expected: DashMap::new(),
+            freshness,
+        })
+    }
+
+    /// Record the latest load for one `(worker_url, dp_rank)`.
+    pub fn set(&self, url: &str, dp_rank: u32, load: LoadSnapshot, at: Instant) {
+        self.by_rank
+            .insert((url.to_string(), dp_rank), LoadEntry { load, at });
+    }
+
+    /// Mark a worker as expected to publish load on `dp_size` ranks (it
+    /// advertised a load topic).
+    pub fn mark_expected(&self, url: &str, dp_size: u32) {
+        self.expected.insert(url.to_string(), dp_size);
+    }
+
+    /// Number of workers expected to publish load. Compared against the size
+    /// of [`Self::snapshot_fresh`] to surface a dead/misconfigured publisher
+    /// (expected > 0 but no fresh snapshots) in logs.
+    pub fn expected_count(&self) -> usize {
+        self.expected.len()
+    }
+
+    /// One pass over the table returning, per worker URL, the summed queue
+    /// depth (`num_running_reqs + num_waiting_reqs`) across that worker's
+    /// ranks — **but only for workers reporting a full, fresh complement of
+    /// ranks**. Any worker with a stale rank, or with fewer entries than the
+    /// rank count it advertised, is omitted so the caller falls back to its own
+    /// load signal. Computed once per selection so per-worker lookups are O(1).
+    ///
+    /// WHY the completeness half matters as much as the freshness half: a
+    /// partial sum under-reports depth, which makes a worker look idle and
+    /// draws *more* traffic to it. Freshness alone cannot catch a rank that has
+    /// never published — an entry that does not exist cannot be judged stale —
+    /// so a rank whose publisher failed to bind at startup would otherwise
+    /// bias selection toward the broken worker indefinitely.
+    pub fn snapshot_fresh(&self, now: Instant) -> HashMap<String, usize> {
+        // url -> (summed depth, all-ranks-fresh, ranks seen).
+        let mut acc: HashMap<String, (usize, bool, u32)> = HashMap::new();
+        for entry in self.by_rank.iter() {
+            let fresh = now.duration_since(entry.value().at) <= self.freshness;
+            let l = &entry.value().load;
+            let depth = (l.num_running_reqs.saturating_add(l.num_waiting_reqs)) as usize;
+            let slot = acc.entry(entry.key().0.clone()).or_insert((0, true, 0));
+            slot.0 = slot.0.saturating_add(depth);
+            slot.1 = slot.1 && fresh;
+            slot.2 += 1;
+        }
+        acc.into_iter()
+            .filter_map(|(url, (depth, all_fresh, seen))| {
+                // A worker absent from `expected` published without advertising
+                // a load topic; trust what it sent rather than inventing a
+                // denominator for it.
+                let complete = self
+                    .expected
+                    .get(&url)
+                    .is_none_or(|expected| seen >= *expected);
+                (all_fresh && complete).then_some((url, depth))
+            })
+            .collect()
+    }
+
+    /// Drop every rank entry (and the expected mark) for a worker. Called on
+    /// worker removal so a re-added worker does not leave stale load behind.
+    pub fn forget_worker(&self, url: &str) {
+        self.by_rank.retain(|k, _| k.0 != url);
+        self.expected.remove(url);
+    }
+
+    #[cfg(test)]
+    pub fn entry_count(&self) -> usize {
+        self.by_rank.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load(running: u64, waiting: u64) -> LoadSnapshot {
+        LoadSnapshot {
+            num_running_reqs: running,
+            num_waiting_reqs: waiting,
+            num_used_tokens: 0,
+            max_total_num_tokens: 0,
+        }
+    }
+
+    #[test]
+    fn sums_queue_depth_across_ranks() {
+        let t = EngineLoadTable::new();
+        let now = Instant::now();
+        t.set("http://w:30000", 0, load(5, 1), now);
+        t.set("http://w:30000", 1, load(3, 2), now);
+        let fresh = t.snapshot_fresh(now);
+        // (5+1) + (3+2) = 11
+        assert_eq!(fresh.get("http://w:30000").copied(), Some(11));
+    }
+
+    #[test]
+    fn stale_entries_are_dropped_from_snapshot() {
+        let t = EngineLoadTable::with_freshness(Duration::from_millis(10));
+        let old = Instant::now();
+        t.set("http://w:30000", 0, load(9, 9), old);
+        // A read far in the future sees the entry as stale -> worker absent.
+        let later = old + Duration::from_secs(60);
+        assert!(!t.snapshot_fresh(later).contains_key("http://w:30000"));
+    }
+
+    #[test]
+    fn forget_worker_clears_all_ranks() {
+        let t = EngineLoadTable::new();
+        let now = Instant::now();
+        t.set("http://w:30000", 0, load(1, 0), now);
+        t.set("http://w:30000", 1, load(1, 0), now);
+        t.set("http://other:30000", 0, load(1, 0), now);
+        t.forget_worker("http://w:30000");
+        assert_eq!(t.entry_count(), 1);
+        assert!(!t.snapshot_fresh(now).contains_key("http://w:30000"));
+        assert!(t.snapshot_fresh(now).contains_key("http://other:30000"));
+    }
+
+    /// A worker with any stale rank is omitted entirely (not summed over only
+    /// its fresh ranks), so a partially-silent worker falls back to the
+    /// router-side counter instead of looking misleadingly idle.
+    #[test]
+    fn partial_freshness_excludes_worker() {
+        let t = EngineLoadTable::with_freshness(Duration::from_secs(5));
+        let now = Instant::now();
+        let stale = now - Duration::from_secs(3600);
+        t.set("http://w:30000", 0, load(5, 1), now); // fresh
+        t.set("http://w:30000", 1, load(9, 9), stale); // stale
+        assert!(
+            !t.snapshot_fresh(now).contains_key("http://w:30000"),
+            "any stale rank must drop the whole worker from the snapshot"
+        );
+    }
+
+    #[test]
+    fn expected_count_tracks_marked_workers_and_forget() {
+        let t = EngineLoadTable::new();
+        assert_eq!(t.expected_count(), 0);
+        t.mark_expected("http://w:30000", 1);
+        t.mark_expected("http://w:30000", 1); // idempotent
+        t.mark_expected("http://other:30000", 1);
+        assert_eq!(t.expected_count(), 2);
+        t.forget_worker("http://w:30000");
+        assert_eq!(t.expected_count(), 1);
+    }
+
+    /// A rank that never published cannot be judged stale, so freshness alone
+    /// would report a partial sum — making the worker look idle and drawing
+    /// *more* traffic to it. This is the startup-bind-failure case.
+    #[test]
+    fn worker_missing_a_rank_entirely_is_excluded() {
+        let t = EngineLoadTable::new();
+        let now = Instant::now();
+        t.mark_expected("http://w:30000", 4);
+        for rank in 0..3 {
+            t.set("http://w:30000", rank, load(5, 5), now);
+        }
+
+        assert!(
+            !t.snapshot_fresh(now).contains_key("http://w:30000"),
+            "3 of 4 ranks reporting must not be treated as a complete picture"
+        );
+
+        t.set("http://w:30000", 3, load(5, 5), now);
+        assert_eq!(
+            t.snapshot_fresh(now).get("http://w:30000").copied(),
+            Some(40),
+            "the full complement sums normally"
+        );
+    }
+
+    /// A worker that never advertised a load topic has no expected rank count,
+    /// so whatever it publishes is taken at face value rather than measured
+    /// against an invented denominator.
+    #[test]
+    fn unmarked_worker_is_trusted_without_a_denominator() {
+        let t = EngineLoadTable::new();
+        let now = Instant::now();
+        t.set("http://w:30000", 0, load(2, 3), now);
+        assert_eq!(
+            t.snapshot_fresh(now).get("http://w:30000").copied(),
+            Some(5)
+        );
+    }
+}

--- a/experimental/sgl-router/src/policies/factory.rs
+++ b/experimental/sgl-router/src/policies/factory.rs
@@ -5,6 +5,7 @@ use crate::config::{Config, ModelConfig, PolicyKind};
 use crate::discovery::ModelId;
 use crate::policies::{
     cache_aware_zmq::CacheAwareZmqPolicy,
+    engine_load::EngineLoadTable,
     kv_events::{BlockSizeOracle, HashTree},
     load_based::LoadBasedPolicy,
     power_of_two::PowerOfTwoChoicesPolicy,
@@ -58,6 +59,7 @@ pub fn build_policy(
     tree: Arc<HashTree>,
     tokenizers: Arc<TokenizerRegistry>,
     block_size_oracle: Arc<BlockSizeOracle>,
+    engine_load: Arc<EngineLoadTable>,
 ) -> Arc<dyn Policy> {
     match model.policy {
         PolicyKind::RoundRobin => Arc::new(RoundRobinPolicy::new()),
@@ -71,6 +73,7 @@ pub fn build_policy(
                 tree,
                 tokenizers,
                 block_size_oracle,
+                engine_load,
             ))
         }
         PolicyKind::Sticky => build_sticky(model),
@@ -98,6 +101,7 @@ pub fn build_policy_kind_only(kind: PolicyKind) -> Arc<dyn Policy> {
                 Arc::new(HashTree::new()),
                 Arc::new(TokenizerRegistry::default()),
                 BlockSizeOracle::new(),
+                EngineLoadTable::new(),
             ))
         }
         PolicyKind::Sticky => {
@@ -116,6 +120,7 @@ pub fn build_registry(
     tree: Arc<HashTree>,
     tokenizers: Arc<TokenizerRegistry>,
     block_size_oracle: Arc<BlockSizeOracle>,
+    engine_load: Arc<EngineLoadTable>,
 ) -> Result<PolicyRegistry> {
     let reg = PolicyRegistry::default();
     let m = &cfg.model;
@@ -126,6 +131,7 @@ pub fn build_registry(
             Arc::clone(&tree),
             Arc::clone(&tokenizers),
             Arc::clone(&block_size_oracle),
+            Arc::clone(&engine_load),
         ),
     );
     Ok(reg)
@@ -145,6 +151,7 @@ pub fn build_registry_with_defaults(cfg: &Config) -> Result<PolicyRegistry> {
         Arc::new(HashTree::new()),
         Arc::new(TokenizerRegistry::default()),
         BlockSizeOracle::new(),
+        EngineLoadTable::new(),
     )
 }
 
@@ -197,7 +204,14 @@ mod tests {
         let cfg = cfg_with_model("qwen", PolicyKind::RoundRobin);
         let tree = Arc::new(HashTree::new());
         let tokenizers = Arc::new(TokenizerRegistry::default());
-        let reg = build_registry(&cfg, tree, tokenizers, BlockSizeOracle::new()).unwrap();
+        let reg = build_registry(
+            &cfg,
+            tree,
+            tokenizers,
+            BlockSizeOracle::new(),
+            EngineLoadTable::new(),
+        )
+        .unwrap();
         assert!(reg.get(&ModelId("qwen".into())).is_some());
         assert!(reg.get(&ModelId("missing".into())).is_none());
     }
@@ -207,7 +221,14 @@ mod tests {
         let cfg = cfg_with_model("modelA", PolicyKind::CacheAwareZmq);
         let tree = Arc::new(HashTree::new());
         let tokenizers = Arc::new(TokenizerRegistry::default());
-        let reg = build_registry(&cfg, tree, tokenizers, BlockSizeOracle::new()).unwrap();
+        let reg = build_registry(
+            &cfg,
+            tree,
+            tokenizers,
+            BlockSizeOracle::new(),
+            EngineLoadTable::new(),
+        )
+        .unwrap();
         let p = reg.get(&ModelId("modelA".into())).unwrap();
         // Down-cast probe via Debug — cheaper than carrying a type-tag
         // on the trait. Pinning the debug repr is fine because the field
@@ -224,7 +245,14 @@ mod tests {
         let cfg = cfg_with_model("modelA", PolicyKind::LoadBased);
         let tree = Arc::new(HashTree::new());
         let tokenizers = Arc::new(TokenizerRegistry::default());
-        let reg = build_registry(&cfg, tree, tokenizers, BlockSizeOracle::new()).unwrap();
+        let reg = build_registry(
+            &cfg,
+            tree,
+            tokenizers,
+            BlockSizeOracle::new(),
+            EngineLoadTable::new(),
+        )
+        .unwrap();
         let p = reg.get(&ModelId("modelA".into())).unwrap();
         let dbg = format!("{p:?}");
         assert!(
@@ -238,7 +266,14 @@ mod tests {
         let cfg = cfg_with_model("modelA", PolicyKind::Sticky);
         let tree = Arc::new(HashTree::new());
         let tokenizers = Arc::new(TokenizerRegistry::default());
-        let reg = build_registry(&cfg, tree, tokenizers, BlockSizeOracle::new()).unwrap();
+        let reg = build_registry(
+            &cfg,
+            tree,
+            tokenizers,
+            BlockSizeOracle::new(),
+            EngineLoadTable::new(),
+        )
+        .unwrap();
         let p = reg.get(&ModelId("modelA".into())).unwrap();
         let dbg = format!("{p:?}");
         assert!(

--- a/experimental/sgl-router/src/policies/kv_events/discovery.rs
+++ b/experimental/sgl-router/src/policies/kv_events/discovery.rs
@@ -39,6 +39,11 @@ pub struct EventConfig {
     pub port_base: u16,
     /// ZMQ topic prefix the gateway should SUBSCRIBE to.
     pub topic: String,
+    /// Base port of the worker's dedicated load-snapshot socket range
+    /// (per-rank load port = `load_port_base + dp_rank`). `None` when the
+    /// worker predates load publishing — the load subscriber is then skipped
+    /// and selection falls back to the router-side in-flight counter.
+    pub load_port_base: Option<u16>,
     /// Worker-reported `page_size`. Callers MUST compare against their
     /// own configured `block_size`; a mismatch produces silent
     /// miscompute since [`super::hash::compute_block_hashes`] is keyed
@@ -127,6 +132,7 @@ pub async fn fetch_event_config(
         host,
         port_base: block.endpoint_port_base,
         topic: block.topic,
+        load_port_base: block.load_endpoint_port_base,
         block_size: block.block_size,
         dp_size: block.dp_size,
         is_bigram,
@@ -252,6 +258,10 @@ struct KvEventsBlock {
     endpoint_port_base: u16,
     #[serde(default)]
     topic: String,
+    /// Base port of the dedicated load-snapshot socket range. Absent on
+    /// workers that predate load publishing (`None` ⇒ no load subscriber).
+    #[serde(default)]
+    load_endpoint_port_base: Option<u16>,
     block_size: u32,
     dp_size: u32,
 }
@@ -306,6 +316,7 @@ mod tests {
                 "endpoint_host": "*",
                 "endpoint_port_base": 5557,
                 "topic": "kv",
+                "load_endpoint_port_base": 5559,
                 "block_size": 64,
                 "dp_size": 2,
             }
@@ -318,6 +329,7 @@ mod tests {
                 host: "127.0.0.1".to_string(),
                 port_base: 5557,
                 topic: "kv".to_string(),
+                load_port_base: Some(5559),
                 block_size: 64,
                 dp_size: 2,
                 is_bigram: false,

--- a/experimental/sgl-router/src/policies/kv_events/index.rs
+++ b/experimental/sgl-router/src/policies/kv_events/index.rs
@@ -7,10 +7,11 @@
 //! always operate together in production:
 //!
 //! - [`HashTree`] — the cache-aware routing index keyed by SGLang block hash.
-//! - [`KvEventSubscriberRegistry`] — one ZMQ SUB connection per `(worker_url,
-//!   dp_rank)`.
-//! - A pump task that drains [`WorkerEvent`]s from the subscriber and applies
-//!   them to the tree.
+//! - [`EngineLoadTable`] — engine-reported per-worker load.
+//! - Two [`KvEventSubscriberRegistry`]s — one per `(worker_url, dp_rank)` on
+//!   the cache topic, one on the load topic.
+//! - A pump task that drains [`WorkerEvent`]s and applies KV batches to the
+//!   tree and `Load` snapshots to the engine-load table.
 //!
 //! `add_worker` / `remove_worker` are driven from the worker manager on every
 //! `DiscoveryEvent::Added` / `DiscoveryEvent::Removed`.
@@ -26,7 +27,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 use tokio::sync::mpsc;
@@ -36,9 +37,10 @@ use tracing::{debug, info, warn};
 
 use super::block_size_oracle::BlockSizeOracle;
 use super::discovery::{fetch_event_config, EventConfig};
-use super::subscriber::{KvEventSubscriberRegistry, WorkerEvent};
+use super::subscriber::{KvEventSubscriberRegistry, SubKind, WorkerEvent};
 use super::tree::{HashTree, KvWorkerId};
 use super::wire::KvCacheEvent;
+use crate::policies::engine_load::EngineLoadTable;
 
 /// Channel buffer between the subscriber registry and the pump task.
 ///
@@ -66,6 +68,14 @@ struct WorkerEntry {
 pub struct KvEventIndex {
     tree: Arc<HashTree>,
     subscribers: Arc<KvEventSubscriberRegistry>,
+    /// Second registry subscribing to the load topic (one per worker rank),
+    /// feeding `LoadStat` snapshots into `engine_load`. Shares the pump
+    /// channel with `subscribers`; keyed independently so KV and load
+    /// subscribers for the same worker don't collide.
+    load_subscribers: Arc<KvEventSubscriberRegistry>,
+    /// Engine-reported per-worker load, written by the pump from
+    /// `WorkerEvent::Load` and read by the cache-aware-zmq policy.
+    engine_load: Arc<EngineLoadTable>,
     pump: Mutex<Option<JoinHandle<()>>>,
     pump_cancel: CancellationToken,
     workers: Mutex<HashMap<String, WorkerEntry>>,
@@ -117,12 +127,15 @@ impl KvEventIndex {
     ) -> Arc<Self> {
         let tree = Arc::new(HashTree::new());
         let (tx, rx) = mpsc::channel::<WorkerEvent>(EVENT_CHANNEL_BUFFER);
-        let subscribers = Arc::new(KvEventSubscriberRegistry::new(tx));
+        let subscribers = Arc::new(KvEventSubscriberRegistry::new(tx.clone()));
+        let load_subscribers = Arc::new(KvEventSubscriberRegistry::with_kind(tx, SubKind::Load));
+        let engine_load = EngineLoadTable::new();
         let cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>> = Arc::new(Mutex::new(HashMap::new()));
         let live_workers: Arc<Mutex<HashSet<KvWorkerId>>> = Arc::new(Mutex::new(HashSet::new()));
         let pump_cancel = CancellationToken::new();
         let pump = tokio::spawn(pump_loop(
             tree.clone(),
+            engine_load.clone(),
             cursors.clone(),
             live_workers.clone(),
             pump_cancel.clone(),
@@ -131,6 +144,8 @@ impl KvEventIndex {
         Arc::new(Self {
             tree,
             subscribers,
+            load_subscribers,
+            engine_load,
             pump: Mutex::new(Some(pump)),
             pump_cancel,
             workers: Mutex::new(HashMap::new()),
@@ -154,6 +169,15 @@ impl KvEventIndex {
     /// returned handle as read-only.
     pub fn tree(&self) -> Arc<HashTree> {
         self.tree.clone()
+    }
+
+    /// Shared accessor for the engine-load table. The `CacheAwareZmqPolicy`
+    /// (via [`crate::policies::factory`]) holds the same `Arc` and only reads
+    /// it at selection time. Load *values* are written solely by the pump
+    /// (from `LoadStat` events); `add_worker` / `remove_worker` here manage
+    /// the expected set and per-worker eviction.
+    pub fn engine_load(&self) -> Arc<EngineLoadTable> {
+        Arc::clone(&self.engine_load)
     }
 
     /// Register a worker. If `preresolved` is `Some`, the caller has
@@ -250,6 +274,14 @@ impl KvEventIndex {
             },
         );
         self.subscribers.add_worker(worker_url, &cfg).await;
+        // Load subscribers (one per rank on the dedicated load port). A no-op
+        // when the worker advertises no load port (older engine). Workers that
+        // do advertise one are marked expected, so the router can tell a dead
+        // load publisher apart from one that was never configured.
+        if cfg.load_port_base.is_some() {
+            self.engine_load.mark_expected(worker_url);
+        }
+        self.load_subscribers.add_worker(worker_url, &cfg).await;
     }
 
     /// Tear down a worker's subscribers and clear it from the tree.
@@ -278,12 +310,14 @@ impl KvEventIndex {
                 live.remove(id);
             }
         }
-        // 2. Cancel and join the per-rank subscriber tasks. No further
-        //    events for these ranks will be queued after this returns.
+        // 2. Cancel and join the per-rank subscriber tasks (KV + load). No
+        //    further events for these ranks will be queued after this returns.
         self.subscribers.remove_worker(worker_url).await;
-        // 3. Drop each rank's tree state and cursor. Any event already in
-        //    the mpsc buffer at this point will be filtered by the
-        //    live-set check inside the pump.
+        self.load_subscribers.remove_worker(worker_url).await;
+        // 3. Drop each rank's tree state and cursor, and the worker's engine
+        //    load. Any event already in the mpsc buffer at this point will be
+        //    filtered by the live-set check inside the pump.
+        self.engine_load.forget_worker(worker_url);
         let mut cursors = self.cursors.lock();
         for id in &ids {
             self.tree.clear_worker(id);
@@ -305,6 +339,7 @@ impl KvEventIndex {
     /// events are discarded and the task exits promptly.
     pub async fn shutdown(&self) {
         self.subscribers.shutdown().await;
+        self.load_subscribers.shutdown().await;
         self.pump_cancel.cancel();
         let handle = self.pump.lock().take();
         if let Some(h) = handle {
@@ -320,12 +355,14 @@ impl KvEventIndex {
     }
 }
 
-/// Drain `WorkerEvent`s and apply each batch to the tree. Out-of-order
-/// (seq ≤ last_applied) and stale (worker not in `live_workers`) batches
-/// are skipped. `PublisherReset` events clear the cursor so a publisher
+/// Drain `WorkerEvent`s: apply KV `Batch`es to the tree and `Load` snapshots
+/// to the engine-load table. Out-of-order (seq ≤ last_applied) and stale
+/// (worker not in `live_workers`) KV batches are skipped; `Load` is a gauge
+/// with no seq. `PublisherReset` events clear the cursor so a publisher
 /// restarting from seq=1 (after sending END_SEQ) is not filtered.
 async fn pump_loop(
     tree: Arc<HashTree>,
+    engine_load: Arc<EngineLoadTable>,
     cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>>,
     live_workers: Arc<Mutex<HashSet<KvWorkerId>>>,
     cancel: CancellationToken,
@@ -361,6 +398,11 @@ async fn pump_loop(
         }
 
         match ev {
+            WorkerEvent::Load { worker, load } => {
+                // Gauge: last value wins, no sequence/dedup. The live-worker
+                // filter above already dropped load from detached workers.
+                engine_load.set(&worker.url, worker.dp_rank, load, Instant::now());
+            }
             WorkerEvent::PublisherReset { worker } => {
                 if cursors.lock().remove(&worker).is_some() {
                     info!(
@@ -404,6 +446,7 @@ async fn pump_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::policies::engine_load::LoadStat;
     use crate::policies::kv_events::wire::{BlockRemoved, BlockStored, KvEventBatch};
 
     fn worker_id(url: &str, rank: u32) -> KvWorkerId {
@@ -425,6 +468,7 @@ mod tests {
     /// can destructure just the bits they need.
     struct PumpHarness {
         tree: Arc<HashTree>,
+        engine_load: Arc<EngineLoadTable>,
         cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>>,
         #[allow(dead_code)]
         live_set: Arc<Mutex<HashSet<KvWorkerId>>>,
@@ -438,6 +482,7 @@ mod tests {
     /// the given workers pre-marked live.
     fn spawn_pump(live: &[KvWorkerId]) -> PumpHarness {
         let tree = Arc::new(HashTree::new());
+        let engine_load = EngineLoadTable::new();
         let cursors = Arc::new(Mutex::new(HashMap::new()));
         let live_set: Arc<Mutex<HashSet<KvWorkerId>>> =
             Arc::new(Mutex::new(live.iter().cloned().collect()));
@@ -445,6 +490,7 @@ mod tests {
         let (tx, rx) = mpsc::channel(4);
         let pump = tokio::spawn(pump_loop(
             tree.clone(),
+            engine_load.clone(),
             cursors.clone(),
             live_set.clone(),
             cancel.clone(),
@@ -452,6 +498,7 @@ mod tests {
         ));
         PumpHarness {
             tree,
+            engine_load,
             cursors,
             live_set,
             cancel,
@@ -490,6 +537,34 @@ mod tests {
         let m = tree.match_prefix(None, &[10, 20, 30]);
         assert_eq!(m.matched_blocks, 3);
         assert!(m.workers.contains(&id), "tree must hold the worker");
+    }
+
+    /// A `WorkerEvent::Load` lands in the engine-load table (gauge, no
+    /// cursor) keyed by the worker URL, and does not touch the tree.
+    #[tokio::test]
+    async fn pump_applies_load_to_engine_load_table() {
+        let id = worker_id("http://w1", 0);
+        let h = spawn_pump(std::slice::from_ref(&id));
+        let (tree, engine_load, tx, pump) = (h.tree, h.engine_load, h.tx, h.pump);
+
+        tx.send(WorkerEvent::Load {
+            worker: id.clone(),
+            load: LoadStat {
+                num_running_reqs: 8,
+                num_waiting_reqs: 4,
+                num_tokens: 0,
+                max_total_num_tokens: 0,
+            },
+        })
+        .await
+        .unwrap();
+        drop(tx);
+        pump.await.unwrap();
+
+        let fresh = engine_load.snapshot_fresh(Instant::now());
+        assert_eq!(fresh.get("http://w1").copied(), Some(12)); // 8 + 4
+                                                               // Load events must not pollute the cache tree.
+        assert_eq!(tree.node_count(), 0);
     }
 
     /// Out-of-order seq is filtered: a batch with seq <= last_applied is
@@ -649,6 +724,7 @@ mod tests {
             host: "127.0.0.1".into(),
             port_base: 30100,
             topic: String::new(),
+            load_port_base: None,
             block_size: 128,
             dp_size: 1,
             is_bigram: false,
@@ -678,6 +754,7 @@ mod tests {
             host: "127.0.0.1".into(),
             port_base: 30200,
             topic: String::new(),
+            load_port_base: None,
             block_size: 64,
             dp_size: 0,
             is_bigram: false,
@@ -699,6 +776,7 @@ mod tests {
             host: "127.0.0.1".into(),
             port_base: 30300,
             topic: String::new(),
+            load_port_base: None,
             block_size: 64,
             dp_size: 0,
             is_bigram: true,
@@ -708,6 +786,53 @@ mod tests {
             index.block_size_oracle().is_bigram(),
             "add_worker must seed the bigram flag from EventConfig"
         );
+        index.shutdown().await;
+    }
+
+    /// `remove_worker` clears the worker's engine load and its expected mark,
+    /// so a re-added worker does not inherit stale load. The worker advertises
+    /// a load port (no publisher there; the subscriber just retries in the
+    /// background and is cancelled on remove).
+    #[tokio::test]
+    async fn remove_worker_clears_engine_load() {
+        let index = KvEventIndex::new();
+        let url = "http://127.0.0.1:59123";
+        let cfg = EventConfig {
+            host: "127.0.0.1".into(),
+            port_base: 59123,
+            topic: String::new(),
+            load_port_base: Some(59223),
+            block_size: 64,
+            dp_size: 1,
+            is_bigram: false,
+        };
+        index.add_worker(url, Some(cfg)).await;
+        assert_eq!(index.engine_load().expected_count(), 1);
+
+        let now = Instant::now();
+        index.engine_load().set(
+            url,
+            0,
+            LoadStat {
+                num_running_reqs: 3,
+                num_waiting_reqs: 1,
+                num_tokens: 0,
+                max_total_num_tokens: 0,
+            },
+            now,
+        );
+        assert!(index.engine_load().snapshot_fresh(now).contains_key(url));
+
+        index.remove_worker(url).await;
+        assert!(
+            index
+                .engine_load()
+                .snapshot_fresh(Instant::now())
+                .get(url)
+                .is_none(),
+            "remove_worker must clear engine load"
+        );
+        assert_eq!(index.engine_load().expected_count(), 0);
         index.shutdown().await;
     }
 }

--- a/experimental/sgl-router/src/policies/kv_events/index.rs
+++ b/experimental/sgl-router/src/policies/kv_events/index.rs
@@ -7,10 +7,11 @@
 //! always operate together in production:
 //!
 //! - [`HashTree`] — the cache-aware routing index keyed by SGLang block hash.
-//! - [`KvEventSubscriberRegistry`] — one ZMQ SUB connection per `(worker_url,
-//!   dp_rank)`.
-//! - A pump task that drains [`WorkerEvent`]s from the subscriber and applies
-//!   them to the tree.
+//! - [`EngineLoadTable`] — engine-reported per-worker load.
+//! - Two [`KvEventSubscriberRegistry`]s — one per `(worker_url, dp_rank)` on
+//!   the cache topic, one on the load topic.
+//! - A pump task that drains [`WorkerEvent`]s and applies KV batches to the
+//!   tree and `Load` snapshots to the engine-load table.
 //!
 //! `add_worker` / `remove_worker` are driven from the worker manager on every
 //! `DiscoveryEvent::Added` / `DiscoveryEvent::Removed`.
@@ -26,7 +27,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 use tokio::sync::mpsc;
@@ -36,9 +37,10 @@ use tracing::{debug, info, warn};
 
 use super::block_size_oracle::BlockSizeOracle;
 use super::discovery::{fetch_event_config, EventConfig};
-use super::subscriber::{KvEventSubscriberRegistry, WorkerEvent};
+use super::subscriber::{KvEventSubscriberRegistry, SubKind, WorkerEvent};
 use super::tree::{HashTree, KvWorkerId};
 use super::wire::KvCacheEvent;
+use crate::policies::engine_load::EngineLoadTable;
 
 /// Channel buffer between the subscriber registry and the pump task.
 ///
@@ -66,6 +68,14 @@ struct WorkerEntry {
 pub struct KvEventIndex {
     tree: Arc<HashTree>,
     subscribers: Arc<KvEventSubscriberRegistry>,
+    /// Second registry subscribing to the load topic (one per worker rank),
+    /// feeding `LoadSnapshot` snapshots into `engine_load`. Shares the pump
+    /// channel with `subscribers`; keyed independently so KV and load
+    /// subscribers for the same worker don't collide.
+    load_subscribers: Arc<KvEventSubscriberRegistry>,
+    /// Engine-reported per-worker load, written by the pump from
+    /// `WorkerEvent::Load` and read by the cache-aware-zmq policy.
+    engine_load: Arc<EngineLoadTable>,
     pump: Mutex<Option<JoinHandle<()>>>,
     pump_cancel: CancellationToken,
     workers: Mutex<HashMap<String, WorkerEntry>>,
@@ -117,12 +127,15 @@ impl KvEventIndex {
     ) -> Arc<Self> {
         let tree = Arc::new(HashTree::new());
         let (tx, rx) = mpsc::channel::<WorkerEvent>(EVENT_CHANNEL_BUFFER);
-        let subscribers = Arc::new(KvEventSubscriberRegistry::new(tx));
+        let subscribers = Arc::new(KvEventSubscriberRegistry::new(tx.clone()));
+        let load_subscribers = Arc::new(KvEventSubscriberRegistry::with_kind(tx, SubKind::Load));
+        let engine_load = EngineLoadTable::new();
         let cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>> = Arc::new(Mutex::new(HashMap::new()));
         let live_workers: Arc<Mutex<HashSet<KvWorkerId>>> = Arc::new(Mutex::new(HashSet::new()));
         let pump_cancel = CancellationToken::new();
         let pump = tokio::spawn(pump_loop(
             tree.clone(),
+            engine_load.clone(),
             cursors.clone(),
             live_workers.clone(),
             pump_cancel.clone(),
@@ -131,6 +144,8 @@ impl KvEventIndex {
         Arc::new(Self {
             tree,
             subscribers,
+            load_subscribers,
+            engine_load,
             pump: Mutex::new(Some(pump)),
             pump_cancel,
             workers: Mutex::new(HashMap::new()),
@@ -154,6 +169,15 @@ impl KvEventIndex {
     /// returned handle as read-only.
     pub fn tree(&self) -> Arc<HashTree> {
         self.tree.clone()
+    }
+
+    /// Shared accessor for the engine-load table. The `CacheAwareZmqPolicy`
+    /// (via [`crate::policies::factory`]) holds the same `Arc` and only reads
+    /// it at selection time. Load *values* are written solely by the pump
+    /// (from `LoadSnapshot` events); `add_worker` / `remove_worker` here manage
+    /// the expected set and per-worker eviction.
+    pub fn engine_load(&self) -> Arc<EngineLoadTable> {
+        Arc::clone(&self.engine_load)
     }
 
     /// Register a worker. If `preresolved` is `Some`, the caller has
@@ -250,6 +274,14 @@ impl KvEventIndex {
             },
         );
         self.subscribers.add_worker(worker_url, &cfg).await;
+        // Load subscribers (one per rank on the dedicated load port). A no-op
+        // when the worker advertises no load port (older engine). Workers that
+        // do advertise one are marked expected, so the router can tell a dead
+        // load publisher apart from one that was never configured.
+        if cfg.load_port_base.is_some() {
+            self.engine_load.mark_expected(worker_url, cfg.dp_size);
+        }
+        self.load_subscribers.add_worker(worker_url, &cfg).await;
     }
 
     /// Tear down a worker's subscribers and clear it from the tree.
@@ -278,12 +310,14 @@ impl KvEventIndex {
                 live.remove(id);
             }
         }
-        // 2. Cancel and join the per-rank subscriber tasks. No further
-        //    events for these ranks will be queued after this returns.
+        // 2. Cancel and join the per-rank subscriber tasks (KV + load). No
+        //    further events for these ranks will be queued after this returns.
         self.subscribers.remove_worker(worker_url).await;
-        // 3. Drop each rank's tree state and cursor. Any event already in
-        //    the mpsc buffer at this point will be filtered by the
-        //    live-set check inside the pump.
+        self.load_subscribers.remove_worker(worker_url).await;
+        // 3. Drop each rank's tree state and cursor, and the worker's engine
+        //    load. Any event already in the mpsc buffer at this point will be
+        //    filtered by the live-set check inside the pump.
+        self.engine_load.forget_worker(worker_url);
         let mut cursors = self.cursors.lock();
         for id in &ids {
             self.tree.clear_worker(id);
@@ -305,6 +339,7 @@ impl KvEventIndex {
     /// events are discarded and the task exits promptly.
     pub async fn shutdown(&self) {
         self.subscribers.shutdown().await;
+        self.load_subscribers.shutdown().await;
         self.pump_cancel.cancel();
         let handle = self.pump.lock().take();
         if let Some(h) = handle {
@@ -320,12 +355,14 @@ impl KvEventIndex {
     }
 }
 
-/// Drain `WorkerEvent`s and apply each batch to the tree. Out-of-order
-/// (seq ≤ last_applied) and stale (worker not in `live_workers`) batches
-/// are skipped. `PublisherReset` events clear the cursor so a publisher
+/// Drain `WorkerEvent`s: apply KV `Batch`es to the tree and `Load` snapshots
+/// to the engine-load table. Out-of-order (seq ≤ last_applied) and stale
+/// (worker not in `live_workers`) KV batches are skipped; `Load` is a gauge
+/// with no seq. `PublisherReset` events clear the cursor so a publisher
 /// restarting from seq=1 (after sending END_SEQ) is not filtered.
 async fn pump_loop(
     tree: Arc<HashTree>,
+    engine_load: Arc<EngineLoadTable>,
     cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>>,
     live_workers: Arc<Mutex<HashSet<KvWorkerId>>>,
     cancel: CancellationToken,
@@ -361,6 +398,11 @@ async fn pump_loop(
         }
 
         match ev {
+            WorkerEvent::Load { worker, load } => {
+                // Gauge: last value wins, no sequence/dedup. The live-worker
+                // filter above already dropped load from detached workers.
+                engine_load.set(&worker.url, worker.dp_rank, load, Instant::now());
+            }
             WorkerEvent::PublisherReset { worker } => {
                 if cursors.lock().remove(&worker).is_some() {
                     info!(
@@ -404,6 +446,7 @@ async fn pump_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::policies::engine_load::LoadSnapshot;
     use crate::policies::kv_events::wire::{BlockRemoved, BlockStored, KvEventBatch};
 
     fn worker_id(url: &str, rank: u32) -> KvWorkerId {
@@ -425,6 +468,7 @@ mod tests {
     /// can destructure just the bits they need.
     struct PumpHarness {
         tree: Arc<HashTree>,
+        engine_load: Arc<EngineLoadTable>,
         cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>>,
         #[allow(dead_code)]
         live_set: Arc<Mutex<HashSet<KvWorkerId>>>,
@@ -438,6 +482,7 @@ mod tests {
     /// the given workers pre-marked live.
     fn spawn_pump(live: &[KvWorkerId]) -> PumpHarness {
         let tree = Arc::new(HashTree::new());
+        let engine_load = EngineLoadTable::new();
         let cursors = Arc::new(Mutex::new(HashMap::new()));
         let live_set: Arc<Mutex<HashSet<KvWorkerId>>> =
             Arc::new(Mutex::new(live.iter().cloned().collect()));
@@ -445,6 +490,7 @@ mod tests {
         let (tx, rx) = mpsc::channel(4);
         let pump = tokio::spawn(pump_loop(
             tree.clone(),
+            engine_load.clone(),
             cursors.clone(),
             live_set.clone(),
             cancel.clone(),
@@ -452,6 +498,7 @@ mod tests {
         ));
         PumpHarness {
             tree,
+            engine_load,
             cursors,
             live_set,
             cancel,
@@ -490,6 +537,34 @@ mod tests {
         let m = tree.match_prefix(None, &[10, 20, 30]);
         assert_eq!(m.matched_blocks, 3);
         assert!(m.workers.contains(&id), "tree must hold the worker");
+    }
+
+    /// A `WorkerEvent::Load` lands in the engine-load table (gauge, no
+    /// cursor) keyed by the worker URL, and does not touch the tree.
+    #[tokio::test]
+    async fn pump_applies_load_to_engine_load_table() {
+        let id = worker_id("http://w1", 0);
+        let h = spawn_pump(std::slice::from_ref(&id));
+        let (tree, engine_load, tx, pump) = (h.tree, h.engine_load, h.tx, h.pump);
+
+        tx.send(WorkerEvent::Load {
+            worker: id.clone(),
+            load: LoadSnapshot {
+                num_running_reqs: 8,
+                num_waiting_reqs: 4,
+                num_used_tokens: 0,
+                max_total_num_tokens: 0,
+            },
+        })
+        .await
+        .unwrap();
+        drop(tx);
+        pump.await.unwrap();
+
+        let fresh = engine_load.snapshot_fresh(Instant::now());
+        assert_eq!(fresh.get("http://w1").copied(), Some(12)); // 8 + 4
+                                                               // Load events must not pollute the cache tree.
+        assert_eq!(tree.node_count(), 0);
     }
 
     /// Out-of-order seq is filtered: a batch with seq <= last_applied is
@@ -649,6 +724,7 @@ mod tests {
             host: "127.0.0.1".into(),
             port_base: 30100,
             topic: String::new(),
+            load_port_base: None,
             block_size: 128,
             dp_size: 1,
             is_bigram: false,
@@ -678,6 +754,7 @@ mod tests {
             host: "127.0.0.1".into(),
             port_base: 30200,
             topic: String::new(),
+            load_port_base: None,
             block_size: 64,
             dp_size: 0,
             is_bigram: false,
@@ -699,6 +776,7 @@ mod tests {
             host: "127.0.0.1".into(),
             port_base: 30300,
             topic: String::new(),
+            load_port_base: None,
             block_size: 64,
             dp_size: 0,
             is_bigram: true,
@@ -708,6 +786,52 @@ mod tests {
             index.block_size_oracle().is_bigram(),
             "add_worker must seed the bigram flag from EventConfig"
         );
+        index.shutdown().await;
+    }
+
+    /// `remove_worker` clears the worker's engine load and its expected mark,
+    /// so a re-added worker does not inherit stale load. The worker advertises
+    /// a load port (no publisher there; the subscriber just retries in the
+    /// background and is cancelled on remove).
+    #[tokio::test]
+    async fn remove_worker_clears_engine_load() {
+        let index = KvEventIndex::new();
+        let url = "http://127.0.0.1:59123";
+        let cfg = EventConfig {
+            host: "127.0.0.1".into(),
+            port_base: 59123,
+            topic: String::new(),
+            load_port_base: Some(59223),
+            block_size: 64,
+            dp_size: 1,
+            is_bigram: false,
+        };
+        index.add_worker(url, Some(cfg)).await;
+        assert_eq!(index.engine_load().expected_count(), 1);
+
+        let now = Instant::now();
+        index.engine_load().set(
+            url,
+            0,
+            LoadSnapshot {
+                num_running_reqs: 3,
+                num_waiting_reqs: 1,
+                num_used_tokens: 0,
+                max_total_num_tokens: 0,
+            },
+            now,
+        );
+        assert!(index.engine_load().snapshot_fresh(now).contains_key(url));
+
+        index.remove_worker(url).await;
+        assert!(
+            !index
+                .engine_load()
+                .snapshot_fresh(Instant::now())
+                .contains_key(url),
+            "remove_worker must clear engine load"
+        );
+        assert_eq!(index.engine_load().expected_count(), 0);
         index.shutdown().await;
     }
 }

--- a/experimental/sgl-router/src/policies/kv_events/mod.rs
+++ b/experimental/sgl-router/src/policies/kv_events/mod.rs
@@ -1,7 +1,8 @@
 //! ZMQ-based KV-cache event indexer for cache-aware routing.
 //!
 //! Decodes the msgpack wire format emitted by SGLang's `ZmqEventPublisher`
-//! (see `python/sglang/srt/disaggregation/kv_events.py`) and maintains the
+//! (`python/sglang/srt/utils/event_publisher.py`; KV event types in
+//! `python/sglang/srt/disaggregation/kv_events.py`) and maintains the
 //! router-side index used for cache-aware request routing.
 //!
 //! # Submodules
@@ -27,7 +28,7 @@ pub(crate) use discovery::classify_bigram;
 pub use discovery::{fetch_event_config, EventConfig};
 pub use hash::{compute_block_hashes, compute_block_hashes_bigram, sha256_to_i64};
 pub use index::KvEventIndex;
-pub use subscriber::{KvEventSubscriberRegistry, WorkerEvent};
+pub use subscriber::{KvEventSubscriberRegistry, SubKind, WorkerEvent};
 pub use tree::{HashTree, KvWorkerId, MatchResult};
 pub use wire::{
     decode_event_batch, BlockRemoved, BlockStored, DecodeError, KvCacheEvent, KvEventBatch,

--- a/experimental/sgl-router/src/policies/kv_events/mod.rs
+++ b/experimental/sgl-router/src/policies/kv_events/mod.rs
@@ -1,7 +1,7 @@
 //! ZMQ-based KV-cache event indexer for cache-aware routing.
 //!
 //! Decodes the msgpack wire format emitted by SGLang's `ZmqEventPublisher`
-//! (see `python/sglang/srt/disaggregation/kv_events.py`) and maintains the
+//! (`python/sglang/srt/disaggregation/kv_events.py`) and maintains the
 //! router-side index used for cache-aware request routing.
 //!
 //! # Submodules
@@ -27,7 +27,7 @@ pub(crate) use discovery::classify_bigram;
 pub use discovery::{fetch_event_config, EventConfig};
 pub use hash::{compute_block_hashes, compute_block_hashes_bigram, sha256_to_i64};
 pub use index::KvEventIndex;
-pub use subscriber::{KvEventSubscriberRegistry, WorkerEvent};
+pub use subscriber::{KvEventSubscriberRegistry, SubKind, WorkerEvent};
 pub use tree::{HashTree, KvWorkerId, MatchResult};
 pub use wire::{
     decode_event_batch, BlockRemoved, BlockStored, DecodeError, KvCacheEvent, KvEventBatch,

--- a/experimental/sgl-router/src/policies/kv_events/subscriber.rs
+++ b/experimental/sgl-router/src/policies/kv_events/subscriber.rs
@@ -1,12 +1,14 @@
 //! Per-worker, per-DP-rank ZMQ subscriber for SGLang's `ZmqEventPublisher`.
 //!
-//! This module owns the I/O plumbing between SGLang workers (which publish
-//! KV-cache events on a PUB socket — see
-//! `python/sglang/srt/disaggregation/kv_events.py`) and the in-memory hash
-//! tree consumed by [`super::index::KvEventIndex`]. Each `(worker_url,
-//! dp_rank)` pair gets its own SUB socket on its own tokio task, decodes
-//! msgpack batches via [`super::wire`], and forwards [`WorkerEvent`]s to
-//! a shared mpsc channel.
+//! This module owns the I/O plumbing between SGLang workers (which publish on
+//! a PUB socket via `python/sglang/srt/utils/event_publisher.py` —
+//! KV-cache events from `disaggregation/kv_events.py`, load gauges from
+//! `managers/scheduler_components/load_publisher.py`) and the in-memory state
+//! consumed by [`super::index::KvEventIndex`]. Each `(worker_url, dp_rank)`
+//! pair gets its own SUB socket on its own tokio task, decodes msgpack frames
+//! by [`SubKind`] (KV batches via [`super::wire`], load via
+//! [`crate::policies::engine_load`]), and forwards [`WorkerEvent`]s to a
+//! shared mpsc channel.
 //!
 //! # Wire format (3-frame multipart)
 //!
@@ -70,6 +72,7 @@ use zeromq::{Socket, SocketRecv, SubSocket, ZmqMessage};
 use super::discovery::EventConfig;
 use super::tree::KvWorkerId;
 use super::wire::{decode_event_batch, KvEventBatch};
+use crate::policies::engine_load::{decode_load_stat, LoadStat};
 
 /// Maximum number of consecutive `recv()` errors before the subscriber
 /// gives up and exits its task. ZMQ's internal reconnect handles transient
@@ -92,7 +95,25 @@ const CONNECT_BACKOFF_CAP: Duration = Duration::from_secs(2);
 /// signal is handled correctly.
 const END_SEQ_SENTINEL: i64 = -1;
 
+/// Which topic a subscriber task listens on, and therefore what kind of
+/// [`WorkerEvent`] it produces. KV-cache events feed the hash tree (with
+/// sequence-ordered dedup); load snapshots feed the engine-load table (a
+/// gauge — no sequence semantics).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubKind {
+    /// Cache-delta topic (`BlockStored` / `BlockRemoved` / `AllBlocksCleared`).
+    Kv,
+    /// Load-snapshot topic (`LoadStat`).
+    Load,
+}
+
 /// Message forwarded from a per-worker subscriber task to the pump.
+///
+/// The variants partition by subscriber [`SubKind`]: `Batch` and
+/// `PublisherReset` come only from a `SubKind::Kv` subscriber and carry the
+/// cache stream's sequence/replay semantics; `Load` comes only from a
+/// `SubKind::Load` subscriber and is a seqless gauge. A given subscriber
+/// never emits both families.
 #[derive(Debug)]
 pub enum WorkerEvent {
     /// A normal decoded event batch.
@@ -104,6 +125,14 @@ pub enum WorkerEvent {
         seq: i64,
         /// Decoded batch payload.
         batch: KvEventBatch,
+    },
+    /// A runtime load snapshot from the load topic. Carries no sequence
+    /// number: load is a gauge, applied last-value-wins with no dedup.
+    Load {
+        /// Identity of the SGLang worker (DP rank) that produced this load.
+        worker: KvWorkerId,
+        /// Latest load snapshot for this `(worker, dp_rank)`.
+        load: LoadStat,
     },
     /// The publisher emitted its `END_SEQ` (-1) sentinel, signalling
     /// shutdown. A re-connecting publisher will restart its sequence
@@ -117,6 +146,7 @@ impl WorkerEvent {
     pub fn worker(&self) -> &KvWorkerId {
         match self {
             Self::Batch { worker, .. } => worker,
+            Self::Load { worker, .. } => worker,
             Self::PublisherReset { worker } => worker,
         }
     }
@@ -142,19 +172,32 @@ struct Inner {
 
 /// Owns one ZMQ SUB connection per `(worker_url, dp_rank)`. Forwards
 /// decoded batches to a tokio mpsc channel supplied at construction time.
+///
+/// A registry is single-kind: a [`SubKind::Kv`] registry subscribes to the
+/// cache topic and emits [`WorkerEvent::Batch`]; a [`SubKind::Load`] registry
+/// subscribes to the load topic and emits [`WorkerEvent::Load`]. The index
+/// runs one of each, both feeding the same pump channel, so KV and load
+/// subscribers for the same worker never collide in the handle map.
 pub struct KvEventSubscriberRegistry {
     inner: Arc<Inner>,
+    kind: SubKind,
 }
 
 impl KvEventSubscriberRegistry {
-    /// Build an empty registry. `tx` is where decoded events flow out;
-    /// the channel buffer capacity is the caller's choice.
+    /// Build an empty KV-cache registry. `tx` is where decoded events flow
+    /// out; the channel buffer capacity is the caller's choice.
     pub fn new(tx: mpsc::Sender<WorkerEvent>) -> Self {
+        Self::with_kind(tx, SubKind::Kv)
+    }
+
+    /// Build an empty registry of the given kind.
+    pub fn with_kind(tx: mpsc::Sender<WorkerEvent>, kind: SubKind) -> Self {
         Self {
             inner: Arc::new(Inner {
                 tx,
                 handles: Mutex::new(HashMap::new()),
             }),
+            kind,
         }
     }
 
@@ -174,6 +217,24 @@ impl KvEventSubscriberRegistry {
     /// If `cfg.port_base + dp_rank` overflows `u16`, that rank is skipped
     /// with a `warn!` log and the remaining ranks proceed.
     pub async fn add_worker(&self, worker_url: &str, cfg: &EventConfig) {
+        // (port_base, topic) depend on this registry's kind. KV uses the cache
+        // socket + configured topic; Load uses the dedicated load socket (own
+        // port range) and subscribe-all (that socket carries only load). A Load
+        // registry whose worker advertises no load port (older engine) opens no
+        // sockets at all.
+        let (port_base, topic) = match self.kind {
+            SubKind::Kv => (cfg.port_base, cfg.topic.clone()),
+            SubKind::Load => match cfg.load_port_base {
+                Some(p) => (p, String::new()),
+                None => {
+                    debug!(
+                        worker_url = %worker_url,
+                        "kv-events: worker advertises no load port; skipping load subscribers"
+                    );
+                    return;
+                }
+            },
+        };
         let mut handles = self.inner.handles.lock().await;
         for dp_rank in 0..cfg.dp_size {
             let id = KvWorkerId {
@@ -188,13 +249,14 @@ impl KvEventSubscriberRegistry {
                 );
                 continue;
             }
-            let port = match u16::try_from(cfg.port_base as u32 + dp_rank) {
+            let port = match u16::try_from(port_base as u32 + dp_rank) {
                 Ok(p) => p,
                 Err(_) => {
                     warn!(
                         worker_url = %worker_url,
                         dp_rank,
-                        port_base = cfg.port_base,
+                        port_base,
+                        kind = ?self.kind,
                         "ZMQ event port overflows u16; skipping this rank"
                     );
                     continue;
@@ -205,7 +267,8 @@ impl KvEventSubscriberRegistry {
             let join = spawn_subscriber_task(
                 id.clone(),
                 endpoint,
-                cfg.topic.clone(),
+                topic.clone(),
+                self.kind,
                 self.inner.tx.clone(),
                 cancel.clone(),
             );
@@ -286,11 +349,12 @@ fn spawn_subscriber_task(
     id: KvWorkerId,
     endpoint: String,
     topic: String,
+    kind: SubKind,
     tx: mpsc::Sender<WorkerEvent>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        run_subscriber(id, endpoint, topic, tx, cancel).await;
+        run_subscriber(id, endpoint, topic, kind, tx, cancel).await;
     })
 }
 
@@ -305,6 +369,7 @@ async fn run_subscriber(
     id: KvWorkerId,
     endpoint: String,
     topic: String,
+    kind: SubKind,
     tx: mpsc::Sender<WorkerEvent>,
     cancel: CancellationToken,
 ) {
@@ -313,6 +378,7 @@ async fn run_subscriber(
         dp_rank = id.dp_rank,
         endpoint = %endpoint,
         topic = %topic,
+        kind = ?kind,
         "starting kv-event subscriber"
     );
 
@@ -337,7 +403,7 @@ async fn run_subscriber(
                 match res {
                     Ok(msg) => {
                         errors_in_a_row = 0;
-                        if let Some(event) = decode_message(&id, msg) {
+                        if let Some(event) = decode_message(&id, msg, kind) {
                             if tx.send(event).await.is_err() {
                                 // The pump (or the entire index) is gone.
                                 // This is unexpected mid-stream; warn so
@@ -462,8 +528,9 @@ async fn connect_with_backoff(
 
 /// Validate, parse, and decode a single 3-frame multipart ZMQ message.
 /// Returns `None` (with logging) for any non-event input (bad frame
-/// count, sentinel sequence, or msgpack decode error).
-fn decode_message(id: &KvWorkerId, msg: ZmqMessage) -> Option<WorkerEvent> {
+/// count, sentinel sequence, or msgpack decode error). `kind` selects
+/// whether to emit a KV [`WorkerEvent::Batch`] or a [`WorkerEvent::Load`].
+fn decode_message(id: &KvWorkerId, msg: ZmqMessage, kind: SubKind) -> Option<WorkerEvent> {
     if msg.len() != 3 {
         warn!(
             worker_url = %id.url,
@@ -498,41 +565,77 @@ fn decode_message(id: &KvWorkerId, msg: ZmqMessage) -> Option<WorkerEvent> {
     let seq = i64::from_be_bytes(seq_bytes);
 
     if seq == END_SEQ_SENTINEL {
-        info!(
-            worker_url = %id.url,
-            dp_rank = id.dp_rank,
-            "publisher signalled shutdown (END_SEQ); forwarding cursor reset"
-        );
-        return Some(WorkerEvent::PublisherReset { worker: id.clone() });
+        match kind {
+            SubKind::Kv => {
+                info!(
+                    worker_url = %id.url,
+                    dp_rank = id.dp_rank,
+                    "publisher signalled shutdown (END_SEQ); forwarding cursor reset"
+                );
+                return Some(WorkerEvent::PublisherReset { worker: id.clone() });
+            }
+            // Load has no cursor / replay state to reset — just drop.
+            SubKind::Load => return None,
+        }
     }
 
-    let batch = match decode_event_batch(payload.as_ref()) {
-        Ok(b) => b,
-        Err(e) => {
-            warn!(
+    // Decode by kind: the cache topic carries `KvEventBatch`es, the load
+    // topic carries bare `LoadStat` snapshots — two independent wire formats
+    // on two independent sockets.
+    match kind {
+        SubKind::Kv => {
+            let batch = match decode_event_batch(payload.as_ref()) {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!(
+                        worker_url = %id.url,
+                        dp_rank = id.dp_rank,
+                        seq,
+                        error = %e,
+                        "failed to decode KV event batch payload; dropping"
+                    );
+                    return None;
+                }
+            };
+            trace!(
                 worker_url = %id.url,
                 dp_rank = id.dp_rank,
                 seq,
-                error = %e,
-                "failed to decode KV event batch payload; dropping"
+                n_events = batch.events.len(),
+                "decoded KV event batch"
             );
-            return None;
+            Some(WorkerEvent::Batch {
+                worker: id.clone(),
+                seq,
+                batch,
+            })
         }
-    };
-
-    trace!(
-        worker_url = %id.url,
-        dp_rank = id.dp_rank,
-        seq,
-        n_events = batch.events.len(),
-        "decoded KV event batch"
-    );
-
-    Some(WorkerEvent::Batch {
-        worker: id.clone(),
-        seq,
-        batch,
-    })
+        SubKind::Load => {
+            let load = match decode_load_stat(payload.as_ref()) {
+                Ok(l) => l,
+                Err(e) => {
+                    warn!(
+                        worker_url = %id.url,
+                        dp_rank = id.dp_rank,
+                        seq,
+                        error = %e,
+                        "failed to decode load snapshot payload; dropping"
+                    );
+                    return None;
+                }
+            };
+            trace!(
+                worker_url = %id.url,
+                dp_rank = id.dp_rank,
+                seq,
+                "decoded load snapshot"
+            );
+            Some(WorkerEvent::Load {
+                worker: id.clone(),
+                load,
+            })
+        }
+    }
 }
 
 /// Pull the host out of a routing URL like `http://10.0.0.1:30000` or
@@ -591,6 +694,7 @@ mod tests {
                 host: extract_host(worker_url).unwrap_or_else(|| "127.0.0.1".to_string()),
                 port_base,
                 topic: String::new(),
+                load_port_base: None,
                 block_size: 64,
                 dp_size,
                 is_bigram: false,
@@ -615,6 +719,29 @@ mod tests {
                 }
                 None => mp::write_nil(&mut buf).unwrap(),
             }
+            buf
+        }
+
+        /// Encode a LoadStat batch `[ts, [["LoadStat", running, waiting,
+        /// num_tokens, max_total]], dp_rank?]` in msgspec's array layout.
+        /// Encode a bare LoadStat msgpack array `["LoadStat", running, waiting,
+        /// num_tokens, max_total, attn_dp_rank]` — the payload on the load
+        /// socket (no EventBatch envelope).
+        pub fn encode_load_stat(
+            running: u64,
+            waiting: u64,
+            num_tokens: u64,
+            max_total: u64,
+            attn_dp_rank: u32,
+        ) -> Vec<u8> {
+            let mut buf = Vec::new();
+            mp::write_array_len(&mut buf, 6).unwrap();
+            mp::write_str(&mut buf, "LoadStat").unwrap();
+            mp::write_uint(&mut buf, running).unwrap();
+            mp::write_uint(&mut buf, waiting).unwrap();
+            mp::write_uint(&mut buf, num_tokens).unwrap();
+            mp::write_uint(&mut buf, max_total).unwrap();
+            mp::write_uint(&mut buf, attn_dp_rank as u64).unwrap();
             buf
         }
 
@@ -644,6 +771,9 @@ mod tests {
         pub fn expect_batch(ev: WorkerEvent) -> (KvWorkerId, i64, KvEventBatch) {
             match ev {
                 WorkerEvent::Batch { worker, seq, batch } => (worker, seq, batch),
+                WorkerEvent::Load { worker, .. } => {
+                    panic!("expected Batch, got Load for {worker:?}")
+                }
                 WorkerEvent::PublisherReset { worker } => {
                     panic!("expected Batch, got PublisherReset for {worker:?}")
                 }
@@ -1252,32 +1382,61 @@ mod tests {
 
         // Wrong frame count.
         let one_frame = ZmqMessage::from(Bytes::from_static(b"only"));
-        assert!(decode_message(&id, one_frame).is_none());
+        assert!(decode_message(&id, one_frame, SubKind::Kv).is_none());
 
         // Sentinel seq = -1 now surfaces as PublisherReset (not None) so
         // the downstream pump can clear its cursor before a reconnecting
         // publisher restarts from seq=1.
         let sentinel = helpers::build_multipart(-1, b"ignored".to_vec());
-        let reset = decode_message(&id, sentinel).expect("END_SEQ forwards");
+        let reset = decode_message(&id, sentinel, SubKind::Kv).expect("END_SEQ forwards");
         assert!(matches!(reset, WorkerEvent::PublisherReset { .. }));
 
         // Bad seq frame length.
         let mut bad_seq = ZmqMessage::from(Bytes::new());
         bad_seq.push_back(Bytes::from_static(b"abc")); // 3 bytes, not 8
         bad_seq.push_back(Bytes::from_static(b""));
-        assert!(decode_message(&id, bad_seq).is_none());
+        assert!(decode_message(&id, bad_seq, SubKind::Kv).is_none());
 
         // Bad payload.
         let bad_payload = helpers::build_multipart(1, vec![0xff, 0xfe]);
-        assert!(decode_message(&id, bad_payload).is_none());
+        assert!(decode_message(&id, bad_payload, SubKind::Kv).is_none());
 
         // Happy path.
         let payload = helpers::encode_all_blocks_cleared_batch(0.0, None);
         let good = helpers::build_multipart(7, payload);
-        let event = decode_message(&id, good).expect("should decode");
+        let event = decode_message(&id, good, SubKind::Kv).expect("should decode");
         let (worker, seq, _batch) = helpers::expect_batch(event);
         assert_eq!(seq, 7);
         assert_eq!(worker, id);
+    }
+
+    /// A `SubKind::Load` subscriber decodes a bare LoadStat frame into
+    /// `WorkerEvent::Load`, and drops the END_SEQ sentinel (no cursor state).
+    #[test]
+    fn decode_message_load_kind() {
+        let id = KvWorkerId {
+            url: "http://x".to_string(),
+            dp_rank: 1,
+        };
+
+        // END_SEQ is dropped for the load topic.
+        let sentinel = helpers::build_multipart(-1, b"ignored".to_vec());
+        assert!(decode_message(&id, sentinel, SubKind::Load).is_none());
+
+        // A bare LoadStat frame becomes WorkerEvent::Load.
+        let payload = helpers::encode_load_stat(5, 2, 100, 1000, 1);
+        let msg = helpers::build_multipart(3, payload);
+        let event = decode_message(&id, msg, SubKind::Load).expect("should decode load");
+        match event {
+            WorkerEvent::Load { worker, load } => {
+                assert_eq!(worker, id);
+                assert_eq!(load.num_running_reqs, 5);
+                assert_eq!(load.num_waiting_reqs, 2);
+                assert_eq!(load.num_tokens, 100);
+                assert_eq!(load.max_total_num_tokens, 1000);
+            }
+            other => panic!("expected Load, got {other:?}"),
+        }
     }
 
     /// Restart-resume contract: after a worker is removed and then re-added

--- a/experimental/sgl-router/src/policies/kv_events/subscriber.rs
+++ b/experimental/sgl-router/src/policies/kv_events/subscriber.rs
@@ -1,12 +1,14 @@
 //! Per-worker, per-DP-rank ZMQ subscriber for SGLang's `ZmqEventPublisher`.
 //!
-//! This module owns the I/O plumbing between SGLang workers (which publish
-//! KV-cache events on a PUB socket — see
-//! `python/sglang/srt/disaggregation/kv_events.py`) and the in-memory hash
-//! tree consumed by [`super::index::KvEventIndex`]. Each `(worker_url,
-//! dp_rank)` pair gets its own SUB socket on its own tokio task, decodes
-//! msgpack batches via [`super::wire`], and forwards [`WorkerEvent`]s to
-//! a shared mpsc channel.
+//! This module owns the I/O plumbing between SGLang workers (which publish on
+//! PUB sockets — KV-cache events from
+//! `python/sglang/srt/disaggregation/kv_events.py`, load gauges from
+//! `python/sglang/srt/managers/load_snapshot.py`) and the in-memory state
+//! consumed by [`super::index::KvEventIndex`]. Each `(worker_url, dp_rank)`
+//! pair gets its own SUB socket on its own tokio task, decodes msgpack frames
+//! by [`SubKind`] (KV batches via [`super::wire`], load via
+//! [`crate::policies::engine_load`]), and forwards [`WorkerEvent`]s to a
+//! shared mpsc channel.
 //!
 //! # Wire format (3-frame multipart)
 //!
@@ -70,6 +72,7 @@ use zeromq::{Socket, SocketRecv, SubSocket, ZmqMessage};
 use super::discovery::EventConfig;
 use super::tree::KvWorkerId;
 use super::wire::{decode_event_batch, KvEventBatch};
+use crate::policies::engine_load::{decode_load_snapshot, LoadSnapshot};
 
 /// Maximum number of consecutive `recv()` errors before the subscriber
 /// gives up and exits its task. ZMQ's internal reconnect handles transient
@@ -92,7 +95,25 @@ const CONNECT_BACKOFF_CAP: Duration = Duration::from_secs(2);
 /// signal is handled correctly.
 const END_SEQ_SENTINEL: i64 = -1;
 
+/// Which topic a subscriber task listens on, and therefore what kind of
+/// [`WorkerEvent`] it produces. KV-cache events feed the hash tree (with
+/// sequence-ordered dedup); load snapshots feed the engine-load table (a
+/// gauge — no sequence semantics).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubKind {
+    /// Cache-delta topic (`BlockStored` / `BlockRemoved` / `AllBlocksCleared`).
+    Kv,
+    /// Load-snapshot topic (`LoadSnapshot`).
+    Load,
+}
+
 /// Message forwarded from a per-worker subscriber task to the pump.
+///
+/// The variants partition by subscriber [`SubKind`]: `Batch` and
+/// `PublisherReset` come only from a `SubKind::Kv` subscriber and carry the
+/// cache stream's sequence/replay semantics; `Load` comes only from a
+/// `SubKind::Load` subscriber and is a seqless gauge. A given subscriber
+/// never emits both families.
 #[derive(Debug)]
 pub enum WorkerEvent {
     /// A normal decoded event batch.
@@ -104,6 +125,14 @@ pub enum WorkerEvent {
         seq: i64,
         /// Decoded batch payload.
         batch: KvEventBatch,
+    },
+    /// A runtime load snapshot from the load topic. Carries no sequence
+    /// number: load is a gauge, applied last-value-wins with no dedup.
+    Load {
+        /// Identity of the SGLang worker (DP rank) that produced this load.
+        worker: KvWorkerId,
+        /// Latest load snapshot for this `(worker, dp_rank)`.
+        load: LoadSnapshot,
     },
     /// The publisher emitted its `END_SEQ` (-1) sentinel, signalling
     /// shutdown. A re-connecting publisher will restart its sequence
@@ -117,6 +146,7 @@ impl WorkerEvent {
     pub fn worker(&self) -> &KvWorkerId {
         match self {
             Self::Batch { worker, .. } => worker,
+            Self::Load { worker, .. } => worker,
             Self::PublisherReset { worker } => worker,
         }
     }
@@ -142,19 +172,32 @@ struct Inner {
 
 /// Owns one ZMQ SUB connection per `(worker_url, dp_rank)`. Forwards
 /// decoded batches to a tokio mpsc channel supplied at construction time.
+///
+/// A registry is single-kind: a [`SubKind::Kv`] registry subscribes to the
+/// cache topic and emits [`WorkerEvent::Batch`]; a [`SubKind::Load`] registry
+/// subscribes to the load topic and emits [`WorkerEvent::Load`]. The index
+/// runs one of each, both feeding the same pump channel, so KV and load
+/// subscribers for the same worker never collide in the handle map.
 pub struct KvEventSubscriberRegistry {
     inner: Arc<Inner>,
+    kind: SubKind,
 }
 
 impl KvEventSubscriberRegistry {
-    /// Build an empty registry. `tx` is where decoded events flow out;
-    /// the channel buffer capacity is the caller's choice.
+    /// Build an empty KV-cache registry. `tx` is where decoded events flow
+    /// out; the channel buffer capacity is the caller's choice.
     pub fn new(tx: mpsc::Sender<WorkerEvent>) -> Self {
+        Self::with_kind(tx, SubKind::Kv)
+    }
+
+    /// Build an empty registry of the given kind.
+    pub fn with_kind(tx: mpsc::Sender<WorkerEvent>, kind: SubKind) -> Self {
         Self {
             inner: Arc::new(Inner {
                 tx,
                 handles: Mutex::new(HashMap::new()),
             }),
+            kind,
         }
     }
 
@@ -174,6 +217,24 @@ impl KvEventSubscriberRegistry {
     /// If `cfg.port_base + dp_rank` overflows `u16`, that rank is skipped
     /// with a `warn!` log and the remaining ranks proceed.
     pub async fn add_worker(&self, worker_url: &str, cfg: &EventConfig) {
+        // (port_base, topic) depend on this registry's kind. KV uses the cache
+        // socket + configured topic; Load uses the dedicated load socket (own
+        // port range) and subscribe-all (that socket carries only load). A Load
+        // registry whose worker advertises no load port (older engine) opens no
+        // sockets at all.
+        let (port_base, topic) = match self.kind {
+            SubKind::Kv => (cfg.port_base, cfg.topic.clone()),
+            SubKind::Load => match cfg.load_port_base {
+                Some(p) => (p, String::new()),
+                None => {
+                    debug!(
+                        worker_url = %worker_url,
+                        "kv-events: worker advertises no load port; skipping load subscribers"
+                    );
+                    return;
+                }
+            },
+        };
         let mut handles = self.inner.handles.lock().await;
         for dp_rank in 0..cfg.dp_size {
             let id = KvWorkerId {
@@ -188,13 +249,14 @@ impl KvEventSubscriberRegistry {
                 );
                 continue;
             }
-            let port = match u16::try_from(cfg.port_base as u32 + dp_rank) {
+            let port = match u16::try_from(port_base as u32 + dp_rank) {
                 Ok(p) => p,
                 Err(_) => {
                     warn!(
                         worker_url = %worker_url,
                         dp_rank,
-                        port_base = cfg.port_base,
+                        port_base,
+                        kind = ?self.kind,
                         "ZMQ event port overflows u16; skipping this rank"
                     );
                     continue;
@@ -205,7 +267,8 @@ impl KvEventSubscriberRegistry {
             let join = spawn_subscriber_task(
                 id.clone(),
                 endpoint,
-                cfg.topic.clone(),
+                topic.clone(),
+                self.kind,
                 self.inner.tx.clone(),
                 cancel.clone(),
             );
@@ -286,11 +349,12 @@ fn spawn_subscriber_task(
     id: KvWorkerId,
     endpoint: String,
     topic: String,
+    kind: SubKind,
     tx: mpsc::Sender<WorkerEvent>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        run_subscriber(id, endpoint, topic, tx, cancel).await;
+        run_subscriber(id, endpoint, topic, kind, tx, cancel).await;
     })
 }
 
@@ -305,6 +369,7 @@ async fn run_subscriber(
     id: KvWorkerId,
     endpoint: String,
     topic: String,
+    kind: SubKind,
     tx: mpsc::Sender<WorkerEvent>,
     cancel: CancellationToken,
 ) {
@@ -313,6 +378,7 @@ async fn run_subscriber(
         dp_rank = id.dp_rank,
         endpoint = %endpoint,
         topic = %topic,
+        kind = ?kind,
         "starting kv-event subscriber"
     );
 
@@ -337,7 +403,7 @@ async fn run_subscriber(
                 match res {
                     Ok(msg) => {
                         errors_in_a_row = 0;
-                        if let Some(event) = decode_message(&id, msg) {
+                        if let Some(event) = decode_message(&id, msg, kind) {
                             if tx.send(event).await.is_err() {
                                 // The pump (or the entire index) is gone.
                                 // This is unexpected mid-stream; warn so
@@ -462,8 +528,9 @@ async fn connect_with_backoff(
 
 /// Validate, parse, and decode a single 3-frame multipart ZMQ message.
 /// Returns `None` (with logging) for any non-event input (bad frame
-/// count, sentinel sequence, or msgpack decode error).
-fn decode_message(id: &KvWorkerId, msg: ZmqMessage) -> Option<WorkerEvent> {
+/// count, sentinel sequence, or msgpack decode error). `kind` selects
+/// whether to emit a KV [`WorkerEvent::Batch`] or a [`WorkerEvent::Load`].
+fn decode_message(id: &KvWorkerId, msg: ZmqMessage, kind: SubKind) -> Option<WorkerEvent> {
     if msg.len() != 3 {
         warn!(
             worker_url = %id.url,
@@ -498,41 +565,77 @@ fn decode_message(id: &KvWorkerId, msg: ZmqMessage) -> Option<WorkerEvent> {
     let seq = i64::from_be_bytes(seq_bytes);
 
     if seq == END_SEQ_SENTINEL {
-        info!(
-            worker_url = %id.url,
-            dp_rank = id.dp_rank,
-            "publisher signalled shutdown (END_SEQ); forwarding cursor reset"
-        );
-        return Some(WorkerEvent::PublisherReset { worker: id.clone() });
+        match kind {
+            SubKind::Kv => {
+                info!(
+                    worker_url = %id.url,
+                    dp_rank = id.dp_rank,
+                    "publisher signalled shutdown (END_SEQ); forwarding cursor reset"
+                );
+                return Some(WorkerEvent::PublisherReset { worker: id.clone() });
+            }
+            // Load has no cursor / replay state to reset — just drop.
+            SubKind::Load => return None,
+        }
     }
 
-    let batch = match decode_event_batch(payload.as_ref()) {
-        Ok(b) => b,
-        Err(e) => {
-            warn!(
+    // Decode by kind: the cache topic carries `KvEventBatch`es, the load
+    // topic carries bare `LoadSnapshot` snapshots — two independent wire formats
+    // on two independent sockets.
+    match kind {
+        SubKind::Kv => {
+            let batch = match decode_event_batch(payload.as_ref()) {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!(
+                        worker_url = %id.url,
+                        dp_rank = id.dp_rank,
+                        seq,
+                        error = %e,
+                        "failed to decode KV event batch payload; dropping"
+                    );
+                    return None;
+                }
+            };
+            trace!(
                 worker_url = %id.url,
                 dp_rank = id.dp_rank,
                 seq,
-                error = %e,
-                "failed to decode KV event batch payload; dropping"
+                n_events = batch.events.len(),
+                "decoded KV event batch"
             );
-            return None;
+            Some(WorkerEvent::Batch {
+                worker: id.clone(),
+                seq,
+                batch,
+            })
         }
-    };
-
-    trace!(
-        worker_url = %id.url,
-        dp_rank = id.dp_rank,
-        seq,
-        n_events = batch.events.len(),
-        "decoded KV event batch"
-    );
-
-    Some(WorkerEvent::Batch {
-        worker: id.clone(),
-        seq,
-        batch,
-    })
+        SubKind::Load => {
+            let load = match decode_load_snapshot(payload.as_ref()) {
+                Ok(l) => l,
+                Err(e) => {
+                    warn!(
+                        worker_url = %id.url,
+                        dp_rank = id.dp_rank,
+                        seq,
+                        error = %e,
+                        "failed to decode load snapshot payload; dropping"
+                    );
+                    return None;
+                }
+            };
+            trace!(
+                worker_url = %id.url,
+                dp_rank = id.dp_rank,
+                seq,
+                "decoded load snapshot"
+            );
+            Some(WorkerEvent::Load {
+                worker: id.clone(),
+                load,
+            })
+        }
+    }
 }
 
 /// Pull the host out of a routing URL like `http://10.0.0.1:30000` or
@@ -591,6 +694,7 @@ mod tests {
                 host: extract_host(worker_url).unwrap_or_else(|| "127.0.0.1".to_string()),
                 port_base,
                 topic: String::new(),
+                load_port_base: None,
                 block_size: 64,
                 dp_size,
                 is_bigram: false,
@@ -615,6 +719,46 @@ mod tests {
                 }
                 None => mp::write_nil(&mut buf).unwrap(),
             }
+            buf
+        }
+
+        /// Encode a bare `LoadSnapshot` payload as the engine does: a msgpack
+        /// **map** keyed by field name, which is what `omit_defaults=True`
+        /// without `array_like` produces. Only the fields the router reads are
+        /// written; the real engine also emits `dp_rank`, `timestamp` and
+        /// several sub-structs, and the decoder must ignore them.
+        pub fn encode_load_snapshot(
+            running: u64,
+            waiting: u64,
+            num_used_tokens: u64,
+            max_total: u64,
+        ) -> Vec<u8> {
+            let mut buf = Vec::new();
+            mp::write_map_len(&mut buf, 4).unwrap();
+            mp::write_str(&mut buf, "num_running_reqs").unwrap();
+            mp::write_uint(&mut buf, running).unwrap();
+            mp::write_str(&mut buf, "num_waiting_reqs").unwrap();
+            mp::write_uint(&mut buf, waiting).unwrap();
+            mp::write_str(&mut buf, "num_used_tokens").unwrap();
+            mp::write_uint(&mut buf, num_used_tokens).unwrap();
+            mp::write_str(&mut buf, "max_total_num_tokens").unwrap();
+            mp::write_uint(&mut buf, max_total).unwrap();
+            buf
+        }
+
+        /// A snapshot carrying fields the router does not model, to pin that an
+        /// engine adding to `LoadSnapshot` cannot break decoding.
+        pub fn encode_load_snapshot_with_extra_fields(running: u64, waiting: u64) -> Vec<u8> {
+            let mut buf = Vec::new();
+            mp::write_map_len(&mut buf, 4).unwrap();
+            mp::write_str(&mut buf, "dp_rank").unwrap();
+            mp::write_uint(&mut buf, 0).unwrap();
+            mp::write_str(&mut buf, "num_running_reqs").unwrap();
+            mp::write_uint(&mut buf, running).unwrap();
+            mp::write_str(&mut buf, "num_waiting_reqs").unwrap();
+            mp::write_uint(&mut buf, waiting).unwrap();
+            mp::write_str(&mut buf, "gen_throughput").unwrap();
+            mp::write_f64(&mut buf, 12.5).unwrap();
             buf
         }
 
@@ -644,6 +788,9 @@ mod tests {
         pub fn expect_batch(ev: WorkerEvent) -> (KvWorkerId, i64, KvEventBatch) {
             match ev {
                 WorkerEvent::Batch { worker, seq, batch } => (worker, seq, batch),
+                WorkerEvent::Load { worker, .. } => {
+                    panic!("expected Batch, got Load for {worker:?}")
+                }
                 WorkerEvent::PublisherReset { worker } => {
                     panic!("expected Batch, got PublisherReset for {worker:?}")
                 }
@@ -1252,32 +1399,87 @@ mod tests {
 
         // Wrong frame count.
         let one_frame = ZmqMessage::from(Bytes::from_static(b"only"));
-        assert!(decode_message(&id, one_frame).is_none());
+        assert!(decode_message(&id, one_frame, SubKind::Kv).is_none());
 
         // Sentinel seq = -1 now surfaces as PublisherReset (not None) so
         // the downstream pump can clear its cursor before a reconnecting
         // publisher restarts from seq=1.
         let sentinel = helpers::build_multipart(-1, b"ignored".to_vec());
-        let reset = decode_message(&id, sentinel).expect("END_SEQ forwards");
+        let reset = decode_message(&id, sentinel, SubKind::Kv).expect("END_SEQ forwards");
         assert!(matches!(reset, WorkerEvent::PublisherReset { .. }));
 
         // Bad seq frame length.
         let mut bad_seq = ZmqMessage::from(Bytes::new());
         bad_seq.push_back(Bytes::from_static(b"abc")); // 3 bytes, not 8
         bad_seq.push_back(Bytes::from_static(b""));
-        assert!(decode_message(&id, bad_seq).is_none());
+        assert!(decode_message(&id, bad_seq, SubKind::Kv).is_none());
 
         // Bad payload.
         let bad_payload = helpers::build_multipart(1, vec![0xff, 0xfe]);
-        assert!(decode_message(&id, bad_payload).is_none());
+        assert!(decode_message(&id, bad_payload, SubKind::Kv).is_none());
 
         // Happy path.
         let payload = helpers::encode_all_blocks_cleared_batch(0.0, None);
         let good = helpers::build_multipart(7, payload);
-        let event = decode_message(&id, good).expect("should decode");
+        let event = decode_message(&id, good, SubKind::Kv).expect("should decode");
         let (worker, seq, _batch) = helpers::expect_batch(event);
         assert_eq!(seq, 7);
         assert_eq!(worker, id);
+    }
+
+    /// A `SubKind::Load` subscriber decodes a bare LoadSnapshot frame into
+    /// `WorkerEvent::Load`, and drops the END_SEQ sentinel (no cursor state).
+    #[test]
+    fn decode_message_load_kind() {
+        let id = KvWorkerId {
+            url: "http://x".to_string(),
+            dp_rank: 1,
+        };
+
+        // END_SEQ is dropped for the load topic.
+        let sentinel = helpers::build_multipart(-1, b"ignored".to_vec());
+        assert!(decode_message(&id, sentinel, SubKind::Load).is_none());
+
+        // A bare LoadSnapshot frame becomes WorkerEvent::Load.
+        let payload = helpers::encode_load_snapshot(5, 2, 100, 1000);
+        let msg = helpers::build_multipart(3, payload);
+        let event = decode_message(&id, msg, SubKind::Load).expect("should decode load");
+        match event {
+            WorkerEvent::Load { worker, load } => {
+                assert_eq!(worker, id);
+                assert_eq!(load.num_running_reqs, 5);
+                assert_eq!(load.num_waiting_reqs, 2);
+                assert_eq!(load.num_used_tokens, 100);
+                assert_eq!(load.max_total_num_tokens, 1000);
+            }
+            other => panic!("expected Load, got {other:?}"),
+        }
+    }
+
+    /// The engine publishes the same `LoadSnapshot` that backs `/v1/loads`, so
+    /// it carries many fields the router does not model and will grow more.
+    /// Unknown keys must be ignored and absent ones must default, or every
+    /// engine-side addition becomes a router-side decode failure.
+    #[test]
+    fn decode_message_load_ignores_unknown_and_missing_fields() {
+        let id = KvWorkerId {
+            url: "http://x".to_string(),
+            dp_rank: 0,
+        };
+
+        let payload = helpers::encode_load_snapshot_with_extra_fields(4, 6);
+        let msg = helpers::build_multipart(1, payload);
+        let event = decode_message(&id, msg, SubKind::Load).expect("should decode load");
+        match event {
+            WorkerEvent::Load { load, .. } => {
+                assert_eq!(load.num_running_reqs, 4);
+                assert_eq!(load.num_waiting_reqs, 6);
+                // Absent from the payload => zero, not a decode error.
+                assert_eq!(load.num_used_tokens, 0);
+                assert_eq!(load.max_total_num_tokens, 0);
+            }
+            other => panic!("expected Load, got {other:?}"),
+        }
     }
 
     /// Restart-resume contract: after a worker is removed and then re-added

--- a/experimental/sgl-router/src/policies/kv_events/wire.rs
+++ b/experimental/sgl-router/src/policies/kv_events/wire.rs
@@ -1,13 +1,13 @@
 //! Wire-format types for SGLang's KV cache event stream.
 //!
 //! SGLang's `ZmqEventPublisher` (Python:
-//! `python/sglang/srt/disaggregation/kv_events.py`) encodes batches with
+//! `python/sglang/srt/utils/event_publisher.py`) encodes batches with
 //! `msgspec.msgpack`. Two struct families are involved:
 //!
-//! * `EventBatch` (the outer payload) — declared with
-//!   `array_like=True, omit_defaults=True, gc=False` (no tag).
-//! * `KVCacheEvent` (each inner event variant) — additionally declared
-//!   with `tag=True`.
+//! * `EventBatch` (the outer payload, in `utils/event_publisher.py`) —
+//!   declared with `array_like=True, omit_defaults=True, gc=False` (no tag).
+//! * `KVCacheEvent` (each inner event variant, in
+//!   `disaggregation/kv_events.py`) — additionally declared with `tag=True`.
 //!
 //! The combined effect on the wire:
 //!

--- a/experimental/sgl-router/src/policies/mod.rs
+++ b/experimental/sgl-router/src/policies/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod active_load;
 pub mod cache_aware_zmq;
+pub mod engine_load;
 pub mod factory;
 pub mod kv_events;
 pub mod load_based;

--- a/experimental/sgl-router/src/workers/introspect.rs
+++ b/experimental/sgl-router/src/workers/introspect.rs
@@ -300,6 +300,7 @@ pub(crate) fn resolve_event_config(
         host,
         port_base: block.endpoint_port_base,
         topic: block.topic,
+        load_port_base: block.load_endpoint_port_base,
         block_size: block.block_size,
         dp_size: block.dp_size,
         is_bigram,
@@ -346,6 +347,10 @@ pub(crate) struct KvEventsBlock {
     pub endpoint_port_base: u16,
     #[serde(default)]
     pub topic: String,
+    /// Base port of the dedicated load-snapshot socket range. Absent on
+    /// workers that predate load publishing (`None` ⇒ no load subscriber).
+    #[serde(default)]
+    pub load_endpoint_port_base: Option<u16>,
     pub block_size: u32,
     pub dp_size: u32,
 }

--- a/experimental/sgl-router/src/workers/introspect.rs
+++ b/experimental/sgl-router/src/workers/introspect.rs
@@ -300,6 +300,7 @@ pub(crate) fn resolve_event_config(
         host,
         port_base: block.endpoint_port_base,
         topic: block.topic,
+        load_port_base: block.load_endpoint_port_base,
         block_size: block.block_size,
         dp_size: block.dp_size,
         is_bigram,
@@ -346,6 +347,10 @@ pub(crate) struct KvEventsBlock {
     pub endpoint_port_base: u16,
     #[serde(default)]
     pub topic: String,
+    /// Base port of the dedicated load-snapshot socket range. Absent on
+    /// workers that predate load publishing (`None` ⇒ no load subscriber).
+    #[serde(default)]
+    pub load_endpoint_port_base: Option<u16>,
     pub block_size: u32,
     pub dp_size: u32,
 }
@@ -460,6 +465,58 @@ mod tests {
         assert_eq!(cfg.topic, "kv");
         assert_eq!(cfg.block_size, 64);
         assert_eq!(cfg.dp_size, 2);
+    }
+
+    /// This is the primary `/server_info` path, so the load port has to be
+    /// threaded here — not only in the discovery.rs fallback. If it were
+    /// dropped, every worker would look like it predates load publishing, the
+    /// load subscribers would open zero sockets, and nothing would fail.
+    #[tokio::test]
+    async fn fetch_threads_load_endpoint_port_base() {
+        let (url, _shutdown) = spawn_fake_worker(json!({
+            "served_model_name": "m",
+            "kv_events": {
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "",
+                "block_size": 64,
+                "dp_size": 2,
+                "load_endpoint_port_base": 5559,
+            }
+        }))
+        .await;
+        let cfg = fast_introspector()
+            .fetch(&url)
+            .await
+            .event_config
+            .expect("kv_events present");
+        assert_eq!(cfg.load_port_base, Some(5559));
+    }
+
+    /// An engine predating load publishing omits the key entirely. That must
+    /// leave cache-aware routing fully working rather than failing the block.
+    #[tokio::test]
+    async fn fetch_load_port_absent_does_not_break_kv_events() {
+        let (url, _shutdown) = spawn_fake_worker(json!({
+            "served_model_name": "m",
+            "kv_events": {
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "",
+                "block_size": 64,
+                "dp_size": 1,
+            }
+        }))
+        .await;
+        let cfg = fast_introspector()
+            .fetch(&url)
+            .await
+            .event_config
+            .expect("kv_events must still parse without the load key");
+        assert_eq!(cfg.load_port_base, None);
+        assert_eq!(cfg.port_base, 5557);
     }
 
     #[tokio::test]

--- a/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
@@ -113,6 +113,7 @@ async fn zmq_indexer_routes_to_publishing_worker_e2e() {
         kv_index.tree(),
         Arc::clone(&tokenizers),
         block_size_oracle,
+        kv_index.engine_load(),
     );
 
     // 5. Register two workers. They share `127.0.0.1` so both
@@ -123,6 +124,9 @@ async fn zmq_indexer_routes_to_publishing_worker_e2e() {
     let preresolved = EventConfig {
         host: "127.0.0.1".to_string(),
         port_base: port,
+        // These exercise KV events only; None means "worker publishes no
+        // load", so the load subscriber is skipped.
+        load_port_base: None,
         topic: String::new(),
         block_size,
         dp_size: 1,

--- a/experimental/sgl-router/tests/component/policies/kv_events_two_subscribers.rs
+++ b/experimental/sgl-router/tests/component/policies/kv_events_two_subscribers.rs
@@ -38,6 +38,9 @@ async fn two_independent_subscribers_converge_to_same_tree_state() {
     let cfg = EventConfig {
         host: "127.0.0.1".into(),
         port_base: port,
+        // These exercise KV events only; None means "worker publishes no
+        // load", so the load subscriber is skipped.
+        load_port_base: None,
         topic: String::new(),
         block_size,
         dp_size: 1,
@@ -171,6 +174,9 @@ async fn two_subscribers_merge_events_from_two_publishers() {
     let cfg_x = EventConfig {
         host: "127.0.0.1".into(),
         port_base: port_x,
+        // These exercise KV events only; None means "worker publishes no
+        // load", so the load subscriber is skipped.
+        load_port_base: None,
         topic: String::new(),
         block_size,
         dp_size: 1,
@@ -179,6 +185,9 @@ async fn two_subscribers_merge_events_from_two_publishers() {
     let cfg_y = EventConfig {
         host: "127.0.0.1".into(),
         port_base: port_y,
+        // These exercise KV events only; None means "worker publishes no
+        // load", so the load subscriber is skipped.
+        load_port_base: None,
         topic: String::new(),
         block_size,
         dp_size: 1,

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -25,6 +25,7 @@ use sgl_router::config::{
     PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
+use sgl_router::policies::engine_load::EngineLoadTable;
 use sgl_router::policies::factory::build_registry;
 use sgl_router::policies::kv_events::{BlockSizeOracle, HashTree};
 use sgl_router::proxy::Proxy;
@@ -86,6 +87,7 @@ fn build_ctx(url: String) -> Arc<AppContext> {
             Arc::new(HashTree::new()),
             Arc::clone(&tokenizers),
             BlockSizeOracle::new(),
+            EngineLoadTable::new(),
         )
         .unwrap(),
     );


### PR DESCRIPTION
## Motivation

The `cache_aware_zmq` policy prices workers by a router-side in-flight counter. That counter reflects what this router dispatched, not what the engine has queued: it cannot see traffic from other router replicas or from direct clients, and for streaming responses it stays held for the full response rather than for the time the request occupies the scheduler.

With #28599 the engine publishes its `LoadSnapshot` on a dedicated socket. This subscribes to it and routes on real queue depth, keeping the in-flight counter as the fallback for any worker whose reported picture is missing or incomplete.

Depends on #28599 for the publisher and the `/server_info` advertisement.

## Modifications

**Discovery.** Workers advertise `load_endpoint_port_base` in `/server_info`'s `kv_events` block. It is `Option<u16>`: an engine that does not publish load simply omits it, and such a worker opens no load sockets and keeps using the router-side signal. Both the introspector and the discovery fallback thread the field.

**Subscription.** A `SubKind::Load` registry opens one SUB per advertised DP rank on `load_port_base + dp_rank`, subscribe-all, sharing the existing pump channel. It is a separate registry from the KV one, each with its own handle map, so the two never collide despite sharing the `(url, dp_rank)` key.

**Decoding.** The payload is the engine's `LoadSnapshot`, a msgpack map keyed by field name. Every field defaults to zero — the Python side is `omit_defaults` — and unknown keys are ignored, because the snapshot carries considerably more than this policy reads (memory, speculative, LoRA, disaggregation and queue sub-structs) and will keep growing. Tolerating both is what stops an engine-side addition from becoming a router-side decode failure.

**A worker is trusted only when its picture is complete and fresh.** `EngineLoadTable::snapshot_fresh` sums a worker's ranks and omits the worker entirely if any rank is stale *or* if fewer ranks have reported than the worker advertised. Freshness alone is not sufficient: an entry that does not exist cannot be judged stale, so a rank whose publisher failed to bind at startup would leave that worker reporting a partial sum indefinitely — looking idle and drawing *more* traffic precisely because it is broken. Workers are recorded with the rank count they advertised, which gives the read path its denominator; a worker that never advertised a load topic has no denominator and is taken at face value.

**Selection.** `WorkerLoads` is built once per `select()` so every comparison in one decision sees a consistent view, and `load_of` returns engine-reported depth where a fresh snapshot exists and `Worker::active_load()` otherwise. Both the imbalance fast-path and the matched-set tiebreak go through it.

### Degradation

Every failure path lands on the prior behavior rather than an error:

- no advertised load port → no load sockets opened;
- an undecodable frame → logged and dropped, the subscriber survives;
- entries older than the freshness window, or an incomplete rank set → the worker is omitted from the table;
- worker removal clears its entries so a re-added worker cannot inherit stale load.

### Known gap

`load_of` can mix measurement bases within a single selection: engine queue depth for workers with a complete fresh snapshot, and the router-side in-flight counter for the rest. Those quantities are not interchangeable, so a fleet where only some workers report load can produce a fabricated spread in the imbalance check. Making the choice all-or-nothing per selection is a follow-up.

## Accuracy Tests

Not applicable — routing policy only, no change to model execution or output.

## Speed Tests and Profiling

No benchmark run. `snapshot_fresh` is computed once per selection so per-worker lookups are O(1); it does allocate per worker on the routing path, which is a candidate for `Arc<str>` keys if it shows up in profiles.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Tests cover the wire contract and each degradation path: decoding a load frame into `WorkerEvent::Load`; ignoring unknown fields and defaulting absent ones; rank sums, staleness, partial freshness, and a worker missing a rank entirely; engine load overriding `active_load`, the matched-set tiebreak using it, and stale load falling back; clearing a removed worker; and the `/server_info` introspection path both with and without the load port advertised.
