### PR TITLE
[Fix] Return streaming logprobs when reasoning/tool parser is active

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -435,9 +435,14 @@ class OpenAIServingChat(OpenAIServingBase):
                 )
                 remaining_logprobs = None
 
-        # Flush logprobs still unattached this step: tool-call parser consumed
-        # the delta (its chunks take no logprobs param), or delta was empty.
-        if remaining_logprobs is not None:
+        # Flush logprobs still unattached this step — only when a parser is
+        # active, since _process_tool_call_stream may consume the delta and emit
+        # no content chunk. On the plain path an empty-delta step has no chunk
+        # to attach to either way, and a standalone empty-delta logprobs chunk
+        # is not a shape clients expect.
+        if remaining_logprobs is not None and (
+            self.reasoning_parser or self.tool_call_parser
+        ):
             usage = None
             if continuous_usage_stats:
                 usage = UsageProcessor.calculate_token_usage(

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -435,15 +435,24 @@ class OpenAIServingChat(OpenAIServingBase):
                 )
                 remaining_logprobs = None
 
-        # Flush logprobs unattached this step (e.g. the tool-call parser
-        # consumed the delta, so the content branch never ran).
+        # Flush logprobs still unattached this step: tool-call parser consumed
+        # the delta (its chunks take no logprobs param), or delta was empty.
         if remaining_logprobs is not None:
+            usage = None
+            if continuous_usage_stats:
+                usage = UsageProcessor.calculate_token_usage(
+                    prompt_tokens=prompt_tokens.get(index, 0),
+                    reasoning_tokens=reasoning_tokens.get(index, 0),
+                    completion_tokens=completion_tokens.get(index, 0),
+                ).model_dump()
+
             yield build_sse_content(
                 chunk_id=content["meta_info"]["id"],
                 created=int(time.time()),
                 model=request.model,
                 index=index,
                 logprobs=remaining_logprobs,
+                usage=usage,
             )
 
     def _validate_request(self, request: ChatCompletionRequest) -> Optional[str]:

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -360,6 +360,14 @@ class OpenAIServingChat(OpenAIServingBase):
             delta = content["text"][offset:]
             stream_offsets[index] = len(content["text"])
 
+        # choice_logprobs covers every token generated in this step. Attach it
+        # to the first chunk we emit this step — reasoning, tool-call, or
+        # regular content — so logprobs are never dropped when a reasoning or
+        # tool parser is active (the branches below would otherwise omit them),
+        # and never duplicated across the multiple chunks one step can produce.
+        # Anything left unattached is flushed on a trailing chunk at the end.
+        remaining_logprobs = choice_logprobs
+
         # Handle reasoning content
         if self.reasoning_parser and request.separate_reasoning:
             reasoning_text, delta = self._process_reasoning_stream(
@@ -380,8 +388,10 @@ class OpenAIServingChat(OpenAIServingBase):
                     model=request.model,
                     index=index,
                     reasoning_content=reasoning_text,
+                    logprobs=remaining_logprobs,
                     usage=usage,
                 )
+                remaining_logprobs = None
 
         # Handle tool calls
         if request.tool_choice != "none" and request.tools and self.tool_call_parser:
@@ -423,9 +433,24 @@ class OpenAIServingChat(OpenAIServingBase):
                     model=request.model,
                     index=index,
                     content=delta,
-                    logprobs=choice_logprobs,
+                    logprobs=remaining_logprobs,
                     usage=usage,
                 )
+                remaining_logprobs = None
+
+        # Flush any logprobs not yet attached to a chunk this step. This happens
+        # when the tool-call parser consumed the delta (or is still buffering
+        # tool-call arguments), so the regular-content branch above never ran.
+        # A standalone logprobs chunk keeps parity with vLLM, which still
+        # returns logprobs while tool calls / reasoning are being streamed.
+        if remaining_logprobs is not None:
+            yield build_sse_content(
+                chunk_id=content["meta_info"]["id"],
+                created=int(time.time()),
+                model=request.model,
+                index=index,
+                logprobs=remaining_logprobs,
+            )
 
     def _validate_request(self, request: ChatCompletionRequest) -> Optional[str]:
         """Validate that the input is valid."""

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -360,12 +360,9 @@ class OpenAIServingChat(OpenAIServingBase):
             delta = content["text"][offset:]
             stream_offsets[index] = len(content["text"])
 
-        # choice_logprobs covers every token generated in this step. Attach it
-        # to the first chunk we emit this step — reasoning, tool-call, or
-        # regular content — so logprobs are never dropped when a reasoning or
-        # tool parser is active (the branches below would otherwise omit them),
-        # and never duplicated across the multiple chunks one step can produce.
-        # Anything left unattached is flushed on a trailing chunk at the end.
+        # Attach logprobs to the first chunk emitted this step (reasoning,
+        # tool-call, or content) so they aren't dropped when a parser is active
+        # nor duplicated across chunks; flush any leftover at the end.
         remaining_logprobs = choice_logprobs
 
         # Handle reasoning content
@@ -438,11 +435,8 @@ class OpenAIServingChat(OpenAIServingBase):
                 )
                 remaining_logprobs = None
 
-        # Flush any logprobs not yet attached to a chunk this step. This happens
-        # when the tool-call parser consumed the delta (or is still buffering
-        # tool-call arguments), so the regular-content branch above never ran.
-        # A standalone logprobs chunk keeps parity with vLLM, which still
-        # returns logprobs while tool calls / reasoning are being streamed.
+        # Flush logprobs unattached this step (e.g. the tool-call parser
+        # consumed the delta, so the content branch never ran).
         if remaining_logprobs is not None:
             yield build_sse_content(
                 chunk_id=content["meta_info"]["id"],

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1448,6 +1448,193 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(len(chunks), 2)
         self.assertIn("error", chunks[0])
 
+    def _run_chat_stream(self, adapted_request, req):
+        async def run_stream():
+            chunks = []
+            async for chunk in self.chat._generate_chat_stream(
+                adapted_request, req, self.fastapi_request
+            ):
+                chunks.append(chunk)
+            return chunks
+
+        return get_or_create_event_loop().run_until_complete(run_stream())
+
+    def _parse_chunks(self, chunks):
+        parsed = []
+        for c in chunks:
+            if c.startswith("data: ") and c != "data: [DONE]\n\n":
+                parsed.append(json.loads(c[len("data: ") :]))
+        return parsed
+
+    async def _collect_stream_content(self, content, choice_logprobs, req):
+        chunks = []
+        async for chunk in self.chat._generate_stream_content(
+            content=content,
+            index=0,
+            request=req,
+            stream_offsets={},
+            reasoning_parser_dict={},
+            parser_dict={},
+            has_tool_calls={},
+            choice_logprobs=choice_logprobs,
+            finish_reason_type="stop",
+            continuous_usage_stats=False,
+            prompt_tokens={0: 5},
+            reasoning_tokens={0: 0},
+            completion_tokens={0: 1},
+        ):
+            chunks.append(chunk)
+        return chunks
+
+    def test_streaming_logprobs_attached_with_reasoning_parser(self):
+        """Logprobs must ride on the reasoning chunk when a reasoning parser is active."""
+        self.chat.reasoning_parser = "qwen3"
+
+        content = {
+            "text": "thinking...",
+            "meta_info": {
+                "id": "chatcmpl-reasoning",
+                "prompt_tokens": 5,
+                "completion_tokens": 2,
+                "cached_tokens": 0,
+                "finish_reason": {"type": "stop", "matched": None},
+                "output_token_logprobs": [(0.1, 1, "think"), (0.2, 2, "ing")],
+                "output_top_logprobs": [],
+                "output_token_logprobs_length": 2,
+            },
+            "index": 0,
+        }
+        choice_logprobs = self.chat._process_streaming_logprobs(
+            content, 0, 2
+        ).model_dump()
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            logprobs=True,
+            separate_reasoning=True,
+        )
+
+        with patch.object(self.chat, "_process_reasoning_stream") as proc_mock:
+            proc_mock.return_value = ("Let me think", "")
+            chunks = get_or_create_event_loop().run_until_complete(
+                self._collect_stream_content(content, choice_logprobs, req)
+            )
+
+        parsed = self._parse_chunks(chunks)
+        reasoning_chunks = [
+            c
+            for c in parsed
+            if c["choices"][0]["delta"].get("reasoning_content") is not None
+        ]
+        self.assertTrue(
+            reasoning_chunks, "reasoning_parser did not emit a reasoning_content chunk"
+        )
+        logprob_chunks = [
+            c for c in parsed if c["choices"][0].get("logprobs") is not None
+        ]
+        self.assertTrue(
+            logprob_chunks,
+            "logprobs dropped: no chunk carried logprobs with reasoning_parser active",
+        )
+
+    def test_streaming_logprobs_flushed_when_tool_parser_buffers_delta(self):
+        """Logprobs must be flushed on a standalone chunk when the tool parser emits no content delta."""
+        self.chat.tool_call_parser = "hermes"
+
+        content = {
+            "text": "(<",
+            "meta_info": {
+                "id": "chatcmpl-tool",
+                "prompt_tokens": 5,
+                "completion_tokens": 1,
+                "cached_tokens": 0,
+                "finish_reason": {"type": "stop", "matched": None},
+                "output_token_logprobs": [(0.3, 9, "(<")],
+                "output_top_logprobs": [],
+                "output_token_logprobs_length": 1,
+            },
+            "index": 0,
+        }
+        choice_logprobs = self.chat._process_streaming_logprobs(
+            content, 0, 1
+        ).model_dump()
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            stream=True,
+            logprobs=True,
+        )
+
+        async def _empty_tool_stream(*args, **kwargs):
+            return
+            yield  # make it an async generator
+
+        with patch.object(self.chat, "_process_tool_call_stream", _empty_tool_stream):
+            chunks = get_or_create_event_loop().run_until_complete(
+                self._collect_stream_content(content, choice_logprobs, req)
+            )
+
+        parsed = self._parse_chunks(chunks)
+        logprob_chunks = [
+            c for c in parsed if c["choices"][0].get("logprobs") is not None
+        ]
+        self.assertTrue(
+            logprob_chunks,
+            "logprobs dropped: no flush chunk carried logprobs when tool parser buffered the delta",
+        )
+
+    def test_streaming_logprobs_flushed_on_empty_delta_step(self):
+        """Logprobs for an empty-delta step (no parser) are flushed, not dropped."""
+
+        async def _mock_generate():
+            yield {
+                "text": "",
+                "meta_info": {
+                    "id": "chatcmpl-empty",
+                    "prompt_tokens": 5,
+                    "completion_tokens": 1,
+                    "cached_tokens": 0,
+                    "finish_reason": {"type": "stop", "matched": None},
+                    "output_token_logprobs": [(0.5, 7, "")],
+                    "output_top_logprobs": [],
+                    "output_token_logprobs_length": 1,
+                },
+                "index": 0,
+            }
+
+        self.tm.generate_request.return_value = _mock_generate()
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            logprobs=True,
+        )
+
+        with patch(
+            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+        ) as conv_mock:
+            conv_ins = Mock()
+            conv_ins.get_prompt.return_value = "Test prompt"
+            conv_mock.return_value = conv_ins
+            adapted_request, _ = self.chat._convert_to_internal_request(
+                req, self.fastapi_request
+            )
+            chunks = self._run_chat_stream(adapted_request, req)
+
+        parsed = self._parse_chunks(chunks)
+        logprob_chunks = [
+            c for c in parsed if c["choices"][0].get("logprobs") is not None
+        ]
+        self.assertTrue(
+            logprob_chunks,
+            "logprobs dropped: empty-delta step should flush logprobs on a standalone chunk",
+        )
+
     def test_non_streaming_cached_tokens_details_emits_sglext(self):
         """Test that non-streaming chat responses emit cached token details in sglext."""
 

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1587,8 +1587,12 @@ class ServingChatTestCase(unittest.TestCase):
             "logprobs dropped: no flush chunk carried logprobs when tool parser buffered the delta",
         )
 
-    def test_streaming_logprobs_flushed_on_empty_delta_step(self):
-        """Logprobs for an empty-delta step (no parser) are flushed, not dropped."""
+    def test_streaming_logprobs_not_flushed_on_empty_delta_step_without_parser(self):
+        """With no parser active, an empty-delta step must not emit a standalone
+        empty-delta logprobs chunk — clients expect each chunk to carry real
+        content/reasoning/tool_calls or a finish_reason."""
+        self.chat.reasoning_parser = None
+        self.chat.tool_call_parser = None
 
         async def _mock_generate():
             yield {
@@ -1627,12 +1631,18 @@ class ServingChatTestCase(unittest.TestCase):
             chunks = self._run_chat_stream(adapted_request, req)
 
         parsed = self._parse_chunks(chunks)
-        logprob_chunks = [
-            c for c in parsed if c["choices"][0].get("logprobs") is not None
+        empty_logprob_chunks = [
+            c
+            for c in parsed
+            if c["choices"][0].get("logprobs") is not None
+            and not c["choices"][0]["delta"].get("content")
+            and not c["choices"][0]["delta"].get("reasoning_content")
+            and not c["choices"][0]["delta"].get("tool_calls")
+            and not c["choices"][0].get("finish_reason")
         ]
-        self.assertTrue(
-            logprob_chunks,
-            "logprobs dropped: empty-delta step should flush logprobs on a standalone chunk",
+        self.assertFalse(
+            empty_logprob_chunks,
+            "empty-delta logprobs chunk emitted without a parser; would break client chunk-shape assumptions",
         )
 
     def test_non_streaming_cached_tokens_details_emits_sglext(self):


### PR DESCRIPTION
## Motivation

Fixes #28456. In the OpenAI chat completions **streaming** path, log probabilities disappear entirely once a `--reasoning-parser` or `--tool-call-parser` is enabled. The reporter saw logprobs with plain content but lost them as soon as reasoning or tool parsing was active, expecting parity with vLLM.

Root cause: in `_generate_stream_content`, `choice_logprobs` was only attached in the regular-content `else` branch. When reasoning or tool calls are active, output flows through those branches instead, which never carried logprobs — so they were silently dropped.

(The non-streaming path is unaffected — `_process_response_logprobs` already attaches logprobs regardless of parser.)

## Modifications

`python/sglang/srt/entrypoints/openai/serving_chat.py`, `_generate_stream_content`:

- Introduce a consume-once `remaining_logprobs` token initialized to the step's `choice_logprobs`.
- Attach it to the **first** chunk emitted that step — reasoning, tool-call, or regular content — then clear it. This prevents both dropping (when reasoning/tool branches run) and duplicating (a single step can emit reasoning + content chunks).
- Flush any still-unattached logprobs on a trailing standalone chunk, covering the case where the tool-call parser consumed/buffered the delta and no content chunk was emitted.

No schema change is required — `StreamChoice` / `build_sse_content` already support a `logprobs` field.

### Notes / known limitations

- `choice_logprobs` covers all tokens generated in a step (computed from `output_token_logprobs` before reasoning/tool parsing splits the text), so logprobs are bundled per-step rather than split token-exactly across reasoning-vs-content boundaries. Clients accumulating `choices[].logprobs.content` across chunks (incl. the official `openai` SDK) still get the complete, correctly-ordered sequence. Token-exact per-segment alignment would require threading the logprob cursor through the parsers — a larger change.
- Tool-call argument logprobs are delivered on a standalone chunk rather than piggybacked on the `tool_calls` delta, to avoid invasive changes to `_process_tool_call_stream`.

## Reproducer

Self-contained unit-style reproducer that drives `_generate_stream_content` directly with a mocked `TokenizerManager`. No GPU / model download required. Two scenarios cover the two flows that lose logprobs on `main`:

1. **`reasoning`** — `reasoning_parser="deepseek-r1"`, mid-thinking chunk (no `</think>` yet) so only a `reasoning_content` chunk is yielded. On `main` that chunk has `logprobs: null`; with the fix it carries the step's logprobs.
2. **`tool-buffered`** — `tool_call_parser="qwen25"`, partial opener (`<tool_call>`) that the parser buffers and emits **no** content delta for. On `main` zero chunks are yielded → logprobs lost; with the fix a trailing flush chunk carries the logprobs.

Full script: https://gist.github.com/kpham-sgl/2210c2d967f78e052ce96c538510e6b5

### Run

```bash
curl -sL https://gist.githubusercontent.com/kpham-sgl/2210c2d967f78e052ce96c538510e6b5/raw/repro_28601.py -o repro_28601.py
python repro_28601.py
echo "exit=$?"
```

### Before fix (on `main` @ `fac11f3b`) — exits **1**

```
[reasoning] yielded 1 chunk(s); logprob-bearing: 0
  chunk[0]: data: {"id":"chatcmpl-test-reasoning",...,"choices":[{"index":0,"delta":{"reasoning_content":"Let me think about this."},"logprobs":null,"finish_reason":null,"matched_stop":null}]}
FAIL reasoning: BUG: logprobs missing from all chunks when reasoning_parser is active

[tool-buffered] yielded 0 chunk(s); logprob-bearing: 0
FAIL tool-buffered: BUG: logprobs missing when tool_call_parser buffers the delta

2 scenario(s) failed.
exit=1
```

### After fix (this PR) — exits **0**

```
[reasoning] yielded 1 chunk(s); logprob-bearing: 1
  chunk[0]: data: {"id":"chatcmpl-test-reasoning",...,"choices":[{"index":0,"delta":{"reasoning_content":"Let me think about this."},"logprobs":{"content":[{"token":"ans","logprob":-0.5,"bytes":null,"top_logprobs":[]}]},"finish_reason":null,"matched_stop":null}]}
PASS reasoning

[tool-buffered] yielded 1 chunk(s); logprob-bearing: 1
  chunk[0]: data: {"id":"chatcmpl-test-tool",...,"choices":[{"index":0,"delta":{"reasoning_content":null},"logprobs":{"content":[{"token":"ans","logprob":-0.5,"bytes":null,"top_logprobs":[]}]},"finish_reason":null,"matched_stop":null}]}
PASS tool-buffered

All scenarios passed.
exit=0
```

## Accuracy Tests

N/A — does not change model outputs, only which streaming chunk carries the already-computed logprobs.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).

[Claude Code](https://claude.com/claude-code)






























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27953702789](https://github.com/sgl-project/sglang/actions/runs/27953702789)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27953702600](https://github.com/sgl-project/sglang/actions/runs/27953702600)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
