### PR TITLE
RolloutKV: Prefix KV Cache Pinning for RL Rollout (EPC-RL)

### DIFF
--- a/docs/advanced_features/sglang_for_rl.md
+++ b/docs/advanced_features/sglang_for_rl.md
@@ -18,6 +18,32 @@ This philosophy empowers innovation by providing SGLang as flexible tools, not r
 
 The following sections cover these aspects in detail.
 
+## PrefixPin: Reuse Long Prompt KV Across RL Scoring
+
+RL pipelines often generate multiple samples from the same prompt and then score
+those samples with actor, reference, reward, or value models. When prompts are
+long and responses are short, repeatedly prefilling the same prompt dominates
+latency. PrefixPin lets an integration commit one page-aligned prompt prefix to
+the radix cache, pin it against eviction, and mark follower requests as
+reuse-only so they do not insert duplicate finished cache entries.
+
+PrefixPin is exposed through `sampling_params.custom_params` for low-level RL
+integrations:
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `prefix_pin_commit` | Commit only the prompt prefix from this request. | `False` |
+| `prefix_pin_commit_len` | Number of prompt tokens to commit. If omitted, commits `len(origin_input_ids)`. | `None` |
+| `prefix_pin_protect` | Pin the committed radix node with `inc_lock_ref`. | `True` |
+| `prefix_pin_reuse_only` | Do not insert the finished follower/scoring request into radix cache. | `False` |
+
+Typical flow:
+
+1. Send a zero-token commit request with `prefix_pin_commit=True`.
+2. Send rollout or logprob follower requests with the same `extra_key`.
+3. Set `prefix_pin_reuse_only=True` on followers that should only reuse the
+   committed prefix.
+
 ## Fine-Grained Engine Sleep and Wake Up
 
 Rollout and training are both memory-intensive, and co-locating them on the same GPUs often leads to memory pressure and slow handoffs. SGLang provides a memory-aware sleep/wake mechanism that releases KV cache and weights while keeping the server process alive, then resumes them for rollout without a full restart. This avoids repeated disk I/O and CUDA graph recapture during each RL step.

--- a/docs/advanced_features/sglang_for_rl.md
+++ b/docs/advanced_features/sglang_for_rl.md
@@ -35,6 +35,7 @@ integrations:
 | `rollout_kv_commit` | Commit only the prompt prefix from this request. | `False` |
 | `rollout_kv_commit_len` | Number of prompt tokens to commit. If omitted, commits `len(origin_input_ids)`. | `None` |
 | `rollout_kv_protect` | Pin the committed radix node with `inc_lock_ref`. | `True` |
+| `rollout_kv_unprotect` | Release one RolloutKV pin for the committed prompt prefix. | `False` |
 | `rollout_kv_reuse_only` | Do not insert the finished follower/scoring request into radix cache. | `False` |
 
 Typical flow:
@@ -43,6 +44,13 @@ Typical flow:
 2. Send rollout or logprob follower requests with the same `extra_key`.
 3. Set `rollout_kv_reuse_only=True` on followers that should only reuse the
    committed prefix.
+4. After the trainer finishes the rollout/logprob step, send a release request
+   with `rollout_kv_unprotect=True` and the same prompt prefix and `extra_key`.
+
+Each protected commit increments a RolloutKV pin count; each unprotect request
+decrements one pin. If `rollout_kv_unprotect` is called for a prefix that was
+not pinned by RolloutKV, it is a no-op for the persistent pin and only the
+request's normal transient cache lock is released.
 
 ## Fine-Grained Engine Sleep and Wake Up
 

--- a/docs/advanced_features/sglang_for_rl.md
+++ b/docs/advanced_features/sglang_for_rl.md
@@ -18,30 +18,30 @@ This philosophy empowers innovation by providing SGLang as flexible tools, not r
 
 The following sections cover these aspects in detail.
 
-## PrefixPin: Reuse Long Prompt KV Across RL Scoring
+## RolloutKV: Trainer-Informed Prefix KV Lifecycle Management
 
 RL pipelines often generate multiple samples from the same prompt and then score
 those samples with actor, reference, reward, or value models. When prompts are
 long and responses are short, repeatedly prefilling the same prompt dominates
-latency. PrefixPin lets an integration commit one page-aligned prompt prefix to
+latency. RolloutKV lets an integration commit one page-aligned prompt prefix to
 the radix cache, pin it against eviction, and mark follower requests as
 reuse-only so they do not insert duplicate finished cache entries.
 
-PrefixPin is exposed through `sampling_params.custom_params` for low-level RL
+RolloutKV is exposed through `sampling_params.custom_params` for low-level RL
 integrations:
 
 | Field | Description | Default |
 | --- | --- | --- |
-| `prefix_pin_commit` | Commit only the prompt prefix from this request. | `False` |
-| `prefix_pin_commit_len` | Number of prompt tokens to commit. If omitted, commits `len(origin_input_ids)`. | `None` |
-| `prefix_pin_protect` | Pin the committed radix node with `inc_lock_ref`. | `True` |
-| `prefix_pin_reuse_only` | Do not insert the finished follower/scoring request into radix cache. | `False` |
+| `rollout_kv_commit` | Commit only the prompt prefix from this request. | `False` |
+| `rollout_kv_commit_len` | Number of prompt tokens to commit. If omitted, commits `len(origin_input_ids)`. | `None` |
+| `rollout_kv_protect` | Pin the committed radix node with `inc_lock_ref`. | `True` |
+| `rollout_kv_reuse_only` | Do not insert the finished follower/scoring request into radix cache. | `False` |
 
 Typical flow:
 
-1. Send a zero-token commit request with `prefix_pin_commit=True`.
+1. Send a zero-token commit request with `rollout_kv_commit=True`.
 2. Send rollout or logprob follower requests with the same `extra_key`.
-3. Set `prefix_pin_reuse_only=True` on followers that should only reuse the
+3. Set `rollout_kv_reuse_only=True` on followers that should only reuse the
    committed prefix.
 
 ## Fine-Grained Engine Sleep and Wake Up

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -947,6 +947,259 @@ class Scheduler(
                 startup_available_gpu_memory_gb=avail_mem,
             )
 
+    def init_cache_with_memory_pool(self):
+        server_args = self.server_args
+        uses_transformers_backend = (
+            get_resolved_model_impl(self.model_config) == ModelImpl.TRANSFORMERS
+        )
+
+        # Hybrid memory pool
+        self.is_hybrid_swa = self.tp_worker.is_hybrid_swa
+        _spec = self.tp_worker.model_runner.linear_attn_model_spec
+        _registry_needs_mamba = (
+            _spec.uses_mamba_radix_cache if _spec is not None else False
+        )
+        self.is_hybrid_ssm = (
+            self.tp_worker.model_runner.hybrid_gdn_config is not None
+            or self.tp_worker.model_runner.mamba2_config is not None
+            or _registry_needs_mamba
+        )
+
+        self.sliding_window_size = None
+        if self.is_hybrid_swa:
+            self.sliding_window_size = self.tp_worker.sliding_window_size
+            self.full_tokens_per_layer, self.swa_tokens_per_layer = (
+                self.tp_worker.get_tokens_per_layer_info()
+            )
+
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
+            self.tp_worker.get_memory_pool()
+        )
+
+        self.disable_radix_cache = server_args.disable_radix_cache or (
+            self.model_config.is_multimodal and uses_transformers_backend
+        )
+        if self.disable_radix_cache and not server_args.disable_radix_cache:
+            logger.warning(
+                "Radix cache is disabled for multimodal models with the "
+                "Transformers backend to avoid multimodal prefix-cache mismatches."
+            )
+
+        # Decode radix cache is unsupported with hybrid SWA/SSM models —
+        # these use specialized memory pools incompatible with the
+        # prefix-match-and-lock allocation path.
+        if (
+            server_args.disaggregation_decode_enable_radix_cache
+            and server_args.disaggregation_mode == "decode"
+        ):
+            if self.is_hybrid_swa:
+                raise ValueError(
+                    "--disaggregation-decode-enable-radix-cache is incompatible "
+                    "with sliding window attention (SWA) models"
+                )
+            if self.is_hybrid_ssm:
+                raise ValueError(
+                    "--disaggregation-decode-enable-radix-cache is incompatible "
+                    "with Mamba/SSM models"
+                )
+
+        effective_chunked_prefill_size = server_args.chunked_prefill_size
+        if self.model_config.is_multimodal and uses_transformers_backend:
+            effective_chunked_prefill_size = None
+
+        params = CacheInitParams(
+            disable=self.disable_radix_cache,
+            req_to_token_pool=self.req_to_token_pool,
+            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+            page_size=self.page_size,
+            is_eagle=self.spec_algorithm.is_eagle(),
+            tp_cache_group=(
+                self.attn_tp_cpu_group
+                if self.server_args.enable_dp_attention
+                else self.tp_cpu_group
+            ),
+            attn_cp_cache_group=self.attn_cp_cpu_group,
+            attn_tp_cache_group=self.attn_tp_cpu_group,
+            eviction_policy=server_args.radix_eviction_policy,
+            enable_metrics=self.enable_metrics,
+            enable_kv_cache_events=self.enable_kv_cache_events,
+            enable_mamba_extra_buffer=server_args.enable_mamba_extra_buffer(),
+            pp_rank=self.pp_rank,
+            pp_size=self.pp_size,
+            chunked_prefill_size=effective_chunked_prefill_size,
+            sliding_window_size=self.sliding_window_size,
+            enable_rollout_kv=server_args.enable_rollout_kv,
+            rollout_kv_pin_ttl_seconds=server_args.rollout_kv_pin_ttl_seconds,
+        )
+
+        if effective_chunked_prefill_size is not None and self.disable_radix_cache:
+            if not self.is_hybrid_swa:
+                from sglang.srt.mem_cache.chunk_cache import ChunkCache
+
+                self.tree_cache = ChunkCache(params)
+            else:
+                from sglang.srt.mem_cache.chunk_cache import SWAChunkCache
+
+                self.tree_cache = SWAChunkCache(params)
+        else:
+            if envs.SGLANG_EXPERIMENTAL_CPP_RADIX_TREE.get():
+                # lazy import to avoid JIT overhead
+                from sglang.srt.mem_cache.radix_cache_cpp import RadixCacheCpp
+
+                logger.info("Using experimental C++ radix tree implementation.")
+                self.tree_cache = RadixCacheCpp(params=params, server_args=server_args)
+            elif envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.get():
+                from sglang.srt.mem_cache.unified_cache_components import (
+                    ComponentType,
+                )
+                from sglang.srt.mem_cache.unified_radix_cache import (
+                    UnifiedRadixCache,
+                )
+
+                tree_components = [ComponentType.FULL]
+                if self.is_hybrid_swa or self.is_hybrid_ssm:
+                    tree_components.append(
+                        ComponentType.SWA if self.is_hybrid_swa else ComponentType.MAMBA
+                    )
+                params.tree_components = tuple(tree_components)
+                self.tree_cache = UnifiedRadixCache(params)
+                if self.enable_hierarchical_cache:
+                    self.tree_cache.init_hicache(server_args, params)
+                    self.tp_worker.register_hicache_layer_transfer_counter(
+                        self.tree_cache.cache_controller.layer_done_counter
+                    )
+            elif self.enable_hierarchical_cache:
+                if self.is_hybrid_ssm:
+                    from sglang.srt.mem_cache.hi_mamba_radix_cache import (
+                        HiMambaRadixCache,
+                    )
+
+                    self.tree_cache = HiMambaRadixCache(
+                        params=params, server_args=server_args
+                    )
+                else:
+                    from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
+
+                    self.tree_cache = HiRadixCache(
+                        params=params, server_args=server_args
+                    )
+                self.tp_worker.register_hicache_layer_transfer_counter(
+                    self.tree_cache.cache_controller.layer_done_counter
+                )
+            elif self.is_hybrid_swa:
+                from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache
+
+                self.tree_cache = SWARadixCache(params=params)
+            elif self.is_hybrid_ssm:
+                from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
+
+                self.tree_cache = MambaRadixCache(params)
+            elif server_args.enable_lmcache:
+                from sglang.srt.mem_cache.storage.lmcache.lmc_radix_cache import (
+                    LMCRadixCache,
+                )
+
+                self.tree_cache = LMCRadixCache(
+                    params=params,
+                    model_config=self.model_config,
+                    tp_size=self.tp_size,
+                    rank=self.tp_rank,
+                    tp_group=self.tp_group,
+                )
+            else:
+                self.tree_cache = RadixCache(params)
+
+        if (
+            server_args.enable_streaming_session
+            and not self.tree_cache.supports_streaming_session()
+        ):
+            self.tree_cache = StreamingSession(self.tree_cache)
+
+        if self.enable_hisparse:
+            # Coordinator was created inside ModelRunner.initialize() before CUDA graph capture
+            self.hisparse_coordinator = self.tp_worker.model_runner.hisparse_coordinator
+            self.hisparse_coordinator.set_decode_producer_stream(self.forward_stream)
+
+        if (
+            server_args.disaggregation_mode == "decode"
+            and server_args.disaggregation_decode_enable_offload_kvcache
+        ):
+            self.decode_offload_manager = DecodeKVCacheOffloadManager(
+                req_to_token_pool=self.req_to_token_pool,
+                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                tp_group=params.tp_cache_group,
+                tree_cache=self.tree_cache,
+                server_args=self.server_args,
+            )
+        else:
+            self.decode_offload_manager = None
+
+        embedding_cache_size = envs.SGLANG_VLM_CACHE_SIZE_MB.get()
+        init_mm_embedding_cache(embedding_cache_size * 1024 * 1024)
+
+    def _get_draft_kv_pool(self):
+        """Return (draft_token_to_kv_pool, draft_model_config) for the current
+        draft worker, or (None, None) when no draft KV pool is available."""
+        if self.draft_worker is None or self.spec_algorithm.is_ngram():
+            return None, None
+
+        if self.spec_algorithm.supports_spec_v2() and self.enable_overlap:
+            if self.server_args.enable_multi_layer_eagle:
+                draft_runner = self.draft_worker.draft_worker.draft_runner_list[0]
+            else:
+                draft_runner = self.draft_worker.draft_worker.draft_runner
+            return draft_runner.token_to_kv_pool, draft_runner.model_config
+
+        return (
+            self.draft_worker.model_runner.token_to_kv_pool,
+            self.draft_worker.model_config,
+        )
+
+    def _maybe_register_hicache_draft(self) -> None:
+        """Register draft KV pool with HiCacheController for piggyback L2/L3 ops."""
+        if not self.enable_hierarchical_cache:
+            return
+
+        draft_kv_pool, _ = self._get_draft_kv_pool()
+        if draft_kv_pool is None:
+            return
+
+        from sglang.srt.mem_cache.memory_pool import (
+            HybridLinearKVPool,
+            MHATokenToKVPool,
+            MLATokenToKVPool,
+        )
+        from sglang.srt.mem_cache.memory_pool_host import (
+            MHATokenToKVPoolHost,
+            MLATokenToKVPoolHost,
+        )
+
+        pool = draft_kv_pool
+        if isinstance(pool, HybridLinearKVPool):
+            pool = pool.full_kv_pool
+
+        # Create host pool for draft with the same slot count as the target host pool,
+        # so that host indices stay 1-to-1 between target and draft KV caches.
+        primary = self.tree_cache.cache_controller.mem_pool_host
+        kw = dict(
+            host_to_device_ratio=primary.size / pool.size,
+            host_size=0,
+            page_size=self.page_size,
+            layout=self.server_args.hicache_mem_layout,
+        )
+        if isinstance(pool, MHATokenToKVPool):
+            draft_host_pool = MHATokenToKVPoolHost(pool, **kw)
+        elif isinstance(pool, MLATokenToKVPool):
+            draft_host_pool = MLATokenToKVPoolHost(pool, **kw)
+        else:
+            logger.warning(
+                "Draft pool type %s not supported for HiCache, skipping.",
+                type(pool).__name__,
+            )
+            return
+
+        self.tree_cache.cache_controller.set_draft_kv_pool(pool, draft_host_pool)
+
     def init_running_status(self):
         self.waiting_queue: List[Req] = []
         # The running decoding batch for continuous batching

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -28,6 +28,8 @@ class CacheInitParams:
     pp_cache_group: Optional[torch.distributed.ProcessGroup] = None
     eviction_policy: str = "lru"
     disable_finished_insert: bool = False
+    enable_rollout_kv: bool = False
+    rollout_kv_pin_ttl_seconds: float = 600.0
 
     enable_metrics: bool = False
     enable_kv_cache_events: bool = False

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -437,8 +437,17 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
 
     def cache_finished_req(self, req: Req, is_insert: bool = True):
         """Cache request when it finishes."""
+        custom_params = getattr(req.sampling_params, "custom_params", None)
+        custom_params = custom_params if isinstance(custom_params, dict) else {}
+        prefix_pin_commit = bool(custom_params.get("prefix_pin_commit", False))
+        prefix_pin_reuse_only = bool(
+            custom_params.get("prefix_pin_reuse_only", False)
+        )
+
         # In deterministic mode, disable finished request insertion to radix cache
-        if self.disable_finished_insert:
+        if self.disable_finished_insert and not prefix_pin_commit:
+            is_insert = False
+        if prefix_pin_reuse_only:
             is_insert = False
 
         kv_committed_len = req.pop_committed_kv_cache()
@@ -449,10 +458,23 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             self.token_to_kv_pool_allocator.free(kv_indices)
             return
 
-        token_ids = (req.origin_input_ids + req.output_ids)[:kv_committed_len]
-        kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, : len(token_ids)
+        all_kv_indices = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx, :kv_committed_len
         ]
+
+        if prefix_pin_commit:
+            requested_commit_len = custom_params.get("prefix_pin_commit_len")
+            if requested_commit_len is None:
+                requested_commit_len = len(req.origin_input_ids)
+            commit_len = min(
+                int(requested_commit_len),
+                len(req.origin_input_ids),
+                kv_committed_len,
+            )
+            token_ids = req.origin_input_ids[:commit_len]
+        else:
+            token_ids = (req.origin_input_ids + req.output_ids)[:kv_committed_len]
+        kv_indices = all_kv_indices[: len(token_ids)]
 
         radix_key = RadixKey(
             token_ids, req.extra_key, is_bigram=self.is_eagle
@@ -470,13 +492,20 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             self.token_to_kv_pool_allocator.free(
                 kv_indices[req.cache_protected_len : result.prefix_len]
             )
+            if (
+                prefix_pin_commit
+                and custom_params.get("prefix_pin_protect", True)
+                and key_len > 0
+            ):
+                match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
+                self.inc_lock_ref(match_result.last_device_node)
         else:
             self.token_to_kv_pool_allocator.free(
                 kv_indices[req.cache_protected_len : key_len]
             )
 
         # free the unaligned tail
-        self.token_to_kv_pool_allocator.free(kv_indices[key_len:])
+        self.token_to_kv_pool_allocator.free(all_kv_indices[key_len:])
 
         # Remove req slot release the cache lock
         if req.last_node is not None:

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -439,15 +439,15 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         """Cache request when it finishes."""
         custom_params = getattr(req.sampling_params, "custom_params", None)
         custom_params = custom_params if isinstance(custom_params, dict) else {}
-        prefix_pin_commit = bool(custom_params.get("prefix_pin_commit", False))
-        prefix_pin_reuse_only = bool(
-            custom_params.get("prefix_pin_reuse_only", False)
+        rollout_kv_commit = bool(custom_params.get("rollout_kv_commit", False))
+        rollout_kv_reuse_only = bool(
+            custom_params.get("rollout_kv_reuse_only", False)
         )
 
         # In deterministic mode, disable finished request insertion to radix cache
-        if self.disable_finished_insert and not prefix_pin_commit:
+        if self.disable_finished_insert and not rollout_kv_commit:
             is_insert = False
-        if prefix_pin_reuse_only:
+        if rollout_kv_reuse_only:
             is_insert = False
 
         kv_committed_len = req.pop_committed_kv_cache()
@@ -462,8 +462,8 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             req.req_pool_idx, :kv_committed_len
         ]
 
-        if prefix_pin_commit:
-            requested_commit_len = custom_params.get("prefix_pin_commit_len")
+        if rollout_kv_commit:
+            requested_commit_len = custom_params.get("rollout_kv_commit_len")
             if requested_commit_len is None:
                 requested_commit_len = len(req.origin_input_ids)
             commit_len = min(
@@ -493,8 +493,8 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
                 kv_indices[req.cache_protected_len : result.prefix_len]
             )
             if (
-                prefix_pin_commit
-                and custom_params.get("prefix_pin_protect", True)
+                rollout_kv_commit
+                and custom_params.get("rollout_kv_protect", True)
                 and key_len > 0
             ):
                 match_result = self.match_prefix(MatchPrefixParams(key=radix_key))

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -291,6 +291,8 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         self.enable_kv_cache_events = params.enable_kv_cache_events
         self.is_eagle = params.is_eagle
         self.disable_finished_insert = params.disable_finished_insert
+        self.enable_rollout_kv = params.enable_rollout_kv
+        self._rollout_kv_pin_ttl_seconds = params.rollout_kv_pin_ttl_seconds
         self.eviction_policy = params.eviction_policy.lower()
 
         self.kv_event_queue = []
@@ -345,6 +347,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         self.evictable_leaves.clear()
         self._rollout_kv_pin_counts = defaultdict(int)
         self._rollout_kv_pin_nodes = {}
+        self._rollout_kv_pin_timestamps: dict = {}
         self._empty_match_result = MatchResult(
             device_indices=torch.empty(
                 (0,),
@@ -458,6 +461,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
 
         node = self._rollout_kv_pin_nodes.pop(pin_key, None)
         self._rollout_kv_pin_counts.pop(pin_key, None)
+        self._rollout_kv_pin_timestamps.pop(pin_key, None)
         if node is None or node is self.root_node:
             logger.warning(
                 "RolloutKV attempted to release a missing pin: %s", pin_key
@@ -466,6 +470,36 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
 
         self.dec_lock_ref(node)
         return True
+
+    def _rollout_kv_evict_expired_pins(self) -> int:
+        """Evict pins whose age exceeds ``_rollout_kv_pin_ttl_seconds``.
+
+        Called lazily at the start of every ``cache_finished_req`` when
+        ``enable_rollout_kv`` is True.  Protects against follower crashes or
+        ``rollout_kv_expected_followers`` mismatches that leave refcounts > 0
+        indefinitely, which would otherwise pin memory forever.
+
+        Returns the number of pins evicted.
+        """
+        if not self._rollout_kv_pin_timestamps or self._rollout_kv_pin_ttl_seconds <= 0:
+            return 0
+        now = time.monotonic()
+        expired = [
+            pk
+            for pk, ts in list(self._rollout_kv_pin_timestamps.items())
+            if now - ts > self._rollout_kv_pin_ttl_seconds
+        ]
+        for pk in expired:
+            age = now - self._rollout_kv_pin_timestamps.get(pk, now)
+            remaining = self._rollout_kv_pin_counts.get(pk, 0)
+            logger.warning(
+                "RolloutKV: evicting stale pin %s (age=%.1fs > ttl=%.1fs, "
+                "remaining_refcount=%d). Likely cause: follower crash or "
+                "rollout_kv_expected_followers mismatch.",
+                pk, age, self._rollout_kv_pin_ttl_seconds, remaining,
+            )
+            self._rollout_kv_release_pin(pk, release_all=True)
+        return len(expired)
 
     def insert(self, params: InsertParams) -> InsertResult:
         if self.disable:
@@ -491,12 +525,19 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         """Cache request when it finishes."""
         custom_params = getattr(req.sampling_params, "custom_params", None)
         custom_params = custom_params if isinstance(custom_params, dict) else {}
-        rollout_kv_commit = bool(custom_params.get("rollout_kv_commit", False))
-        rollout_kv_reuse_only = bool(custom_params.get("rollout_kv_reuse_only", False))
-        rollout_kv_unprotect = bool(custom_params.get("rollout_kv_unprotect", False))
-        rollout_kv_auto_unprotect = bool(
-            custom_params.get("rollout_kv_auto_unprotect_on_finish", False)
-        )
+        if self.enable_rollout_kv:
+            self._rollout_kv_evict_expired_pins()
+            rollout_kv_commit = bool(custom_params.get("rollout_kv_commit", False))
+            rollout_kv_reuse_only = bool(custom_params.get("rollout_kv_reuse_only", False))
+            rollout_kv_unprotect = bool(custom_params.get("rollout_kv_unprotect", False))
+            rollout_kv_auto_unprotect = bool(
+                custom_params.get("rollout_kv_auto_unprotect_on_finish", False)
+            )
+        else:
+            rollout_kv_commit = False
+            rollout_kv_reuse_only = False
+            rollout_kv_unprotect = False
+            rollout_kv_auto_unprotect = False
 
         # In deterministic mode, disable finished request insertion to radix cache
         if self.disable_finished_insert and not rollout_kv_commit:
@@ -562,6 +603,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
                     self._rollout_kv_pin_nodes[rollout_kv_pin_key] = (
                         match_result.last_device_node
                     )
+                    self._rollout_kv_pin_timestamps[rollout_kv_pin_key] = time.monotonic()
                 self._rollout_kv_pin_counts[rollout_kv_pin_key] += add_refs
         else:
             if rollout_kv_unprotect and rollout_kv_pin_key is not None:

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -344,6 +344,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         self.protected_size_ = 0
         self.evictable_leaves.clear()
         self._rollout_kv_pin_counts = defaultdict(int)
+        self._rollout_kv_pin_nodes = {}
         self._empty_match_result = MatchResult(
             device_indices=torch.empty(
                 (0,),
@@ -419,6 +420,53 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
     def _rollout_kv_pin_key(self, key: RadixKey):
         return (key.extra_key, key.is_bigram, tuple(key.token_ids))
 
+    def _rollout_kv_pin_refcount_from_params(self, custom_params: dict) -> int:
+        """Returns the pin refcount to add for a single ``rollout_kv_commit`` call.
+
+        Trainers that commit a prefix once but expect N follower requests can pass
+        ``rollout_kv_pin_refcount=N`` (or ``rollout_kv_expected_followers=N``) so
+        the pin survives until all N followers have released it via
+        ``rollout_kv_auto_unprotect_on_finish`` or an explicit
+        ``rollout_kv_unprotect``.
+        """
+        for name in ("rollout_kv_pin_refcount", "rollout_kv_expected_followers"):
+            value = custom_params.get(name)
+            if value is not None:
+                return max(int(value), 1)
+        return 1
+
+    def _rollout_kv_release_pin(
+        self,
+        pin_key,
+        release_count: int = 1,
+        release_all: bool = False,
+    ) -> bool:
+        """Decrement (or fully drop) the persistent pin for ``pin_key``.
+
+        Returns ``True`` iff the pin's lock_ref was actually released (i.e. the
+        refcount dropped to zero). Returns ``False`` if there was nothing to
+        release or if more followers still hold the pin.
+        """
+        current = int(self._rollout_kv_pin_counts.get(pin_key, 0))
+        if current <= 0:
+            return False
+
+        next_count = 0 if release_all else current - max(int(release_count), 1)
+        if next_count > 0:
+            self._rollout_kv_pin_counts[pin_key] = next_count
+            return False
+
+        node = self._rollout_kv_pin_nodes.pop(pin_key, None)
+        self._rollout_kv_pin_counts.pop(pin_key, None)
+        if node is None or node is self.root_node:
+            logger.warning(
+                "RolloutKV attempted to release a missing pin: %s", pin_key
+            )
+            return False
+
+        self.dec_lock_ref(node)
+        return True
+
     def insert(self, params: InsertParams) -> InsertResult:
         if self.disable:
             return InsertResult(prefix_len=0)
@@ -446,6 +494,9 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         rollout_kv_commit = bool(custom_params.get("rollout_kv_commit", False))
         rollout_kv_reuse_only = bool(custom_params.get("rollout_kv_reuse_only", False))
         rollout_kv_unprotect = bool(custom_params.get("rollout_kv_unprotect", False))
+        rollout_kv_auto_unprotect = bool(
+            custom_params.get("rollout_kv_auto_unprotect_on_finish", False)
+        )
 
         # In deterministic mode, disable finished request insertion to radix cache
         if self.disable_finished_insert and not rollout_kv_commit:
@@ -502,24 +553,29 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
                 rollout_kv_commit
                 and custom_params.get("rollout_kv_protect", True)
                 and key_len > 0
+                and rollout_kv_pin_key is not None
             ):
-                match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
-                self.inc_lock_ref(match_result.last_device_node)
-                self._rollout_kv_pin_counts[rollout_kv_pin_key] += 1
-        elif rollout_kv_unprotect and rollout_kv_pin_key is not None:
-            pin_count = self._rollout_kv_pin_counts.get(rollout_kv_pin_key, 0)
-            if pin_count > 0:
-                match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
-                if len(match_result.device_indices) == key_len:
-                    self.dec_lock_ref(match_result.last_device_node)
-                    if pin_count == 1:
-                        del self._rollout_kv_pin_counts[rollout_kv_pin_key]
-                    else:
-                        self._rollout_kv_pin_counts[rollout_kv_pin_key] -= 1
-            self.token_to_kv_pool_allocator.free(
-                kv_indices[req.cache_protected_len : key_len]
-            )
+                add_refs = self._rollout_kv_pin_refcount_from_params(custom_params)
+                if self._rollout_kv_pin_counts[rollout_kv_pin_key] <= 0:
+                    match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
+                    self.inc_lock_ref(match_result.last_device_node)
+                    self._rollout_kv_pin_nodes[rollout_kv_pin_key] = (
+                        match_result.last_device_node
+                    )
+                self._rollout_kv_pin_counts[rollout_kv_pin_key] += add_refs
         else:
+            if rollout_kv_unprotect and rollout_kv_pin_key is not None:
+                self._rollout_kv_release_pin(
+                    rollout_kv_pin_key,
+                    release_count=int(
+                        custom_params.get("rollout_kv_unprotect_count", 1)
+                    ),
+                    release_all=bool(
+                        custom_params.get("rollout_kv_unprotect_all", False)
+                    ),
+                )
+            elif rollout_kv_auto_unprotect and rollout_kv_pin_key is not None:
+                self._rollout_kv_release_pin(rollout_kv_pin_key)
             self.token_to_kv_pool_allocator.free(
                 kv_indices[req.cache_protected_len : key_len]
             )

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -343,6 +343,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         self.evictable_size_ = 0
         self.protected_size_ = 0
         self.evictable_leaves.clear()
+        self._rollout_kv_pin_counts = defaultdict(int)
         self._empty_match_result = MatchResult(
             device_indices=torch.empty(
                 (0,),
@@ -415,6 +416,9 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             best_match_node=last_node,
         )
 
+    def _rollout_kv_pin_key(self, key: RadixKey):
+        return (key.extra_key, key.is_bigram, tuple(key.token_ids))
+
     def insert(self, params: InsertParams) -> InsertResult:
         if self.disable:
             return InsertResult(prefix_len=0)
@@ -440,14 +444,13 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         custom_params = getattr(req.sampling_params, "custom_params", None)
         custom_params = custom_params if isinstance(custom_params, dict) else {}
         rollout_kv_commit = bool(custom_params.get("rollout_kv_commit", False))
-        rollout_kv_reuse_only = bool(
-            custom_params.get("rollout_kv_reuse_only", False)
-        )
+        rollout_kv_reuse_only = bool(custom_params.get("rollout_kv_reuse_only", False))
+        rollout_kv_unprotect = bool(custom_params.get("rollout_kv_unprotect", False))
 
         # In deterministic mode, disable finished request insertion to radix cache
         if self.disable_finished_insert and not rollout_kv_commit:
             is_insert = False
-        if rollout_kv_reuse_only:
+        if rollout_kv_reuse_only or rollout_kv_unprotect:
             is_insert = False
 
         kv_committed_len = req.pop_committed_kv_cache()
@@ -462,7 +465,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             req.req_pool_idx, :kv_committed_len
         ]
 
-        if rollout_kv_commit:
+        if rollout_kv_commit or rollout_kv_unprotect:
             requested_commit_len = custom_params.get("rollout_kv_commit_len")
             if requested_commit_len is None:
                 requested_commit_len = len(req.origin_input_ids)
@@ -481,6 +484,9 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         ).page_aligned(self.page_size)
         key_len = len(radix_key)
         values = kv_indices[:key_len].to(dtype=torch.int64, copy=True)
+        rollout_kv_pin_key = (
+            self._rollout_kv_pin_key(radix_key) if key_len > 0 else None
+        )
 
         # Radix Cache takes one ref in memory pool
         if is_insert:
@@ -499,6 +505,20 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             ):
                 match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
                 self.inc_lock_ref(match_result.last_device_node)
+                self._rollout_kv_pin_counts[rollout_kv_pin_key] += 1
+        elif rollout_kv_unprotect and rollout_kv_pin_key is not None:
+            pin_count = self._rollout_kv_pin_counts.get(rollout_kv_pin_key, 0)
+            if pin_count > 0:
+                match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
+                if len(match_result.device_indices) == key_len:
+                    self.dec_lock_ref(match_result.last_device_node)
+                    if pin_count == 1:
+                        del self._rollout_kv_pin_counts[rollout_kv_pin_key]
+                    else:
+                        self._rollout_kv_pin_counts[rollout_kv_pin_key] -= 1
+            self.token_to_kv_pool_allocator.free(
+                kv_indices[req.cache_protected_len : key_len]
+            )
         else:
             self.token_to_kv_pool_allocator.free(
                 kv_indices[req.cache_protected_len : key_len]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -451,6 +451,8 @@ class ServerArgs:
     swa_full_tokens_ratio: float = 0.8
     disable_hybrid_swa_memory: bool = False
     radix_eviction_policy: str = "lru"
+    enable_rollout_kv: bool = False
+    rollout_kv_pin_ttl_seconds: float = 600.0
     enable_prefill_delayer: bool = False
     prefill_delayer_max_delay_passes: int = 30
     prefill_delayer_token_usage_low_watermark: Optional[float] = None
@@ -5159,6 +5161,23 @@ class ServerArgs:
             choices=RADIX_EVICTION_POLICY_CHOICES,
             default=ServerArgs.radix_eviction_policy,
             help="The eviction policy of radix trees. 'lru' stands for Least Recently Used, 'lfu' stands for Least Frequently Used, 'slru' stands for Segmented Least Recently Used, and 'priority' evicts lower-priority requests first.",
+        )
+        parser.add_argument(
+            "--enable-rollout-kv",
+            action="store_true",
+            help="Enable RolloutKV (EPC-RL) prefix pinning for RL workloads. "
+            "When enabled, requests can use rollout_kv_commit / rollout_kv_reuse_only / "
+            "rollout_kv_unprotect custom_params to commit, reuse, and release pinned "
+            "prefix KV cache across RL rollout phases.",
+        )
+        parser.add_argument(
+            "--rollout-kv-pin-ttl-seconds",
+            type=float,
+            default=ServerArgs.rollout_kv_pin_ttl_seconds,
+            help="Time-to-live in seconds for RolloutKV prefix pins. Pins older than "
+            "this value are automatically evicted, recovering memory if follower "
+            "processes crash or rollout_kv_expected_followers is miscounted. "
+            "Set to 0 to disable TTL-based eviction. Default: 600.0.",
         )
         parser.add_argument(
             "--enable-prefill-delayer",

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -460,15 +460,58 @@ class TestRadixCache(unittest.TestCase):
             MatchPrefixParams(key=RadixKey(prompt_ids + output_ids))
         )
         self.assertEqual(len(match.device_indices), DEFAULT_PAGE_SIZE)
-        torch.testing.assert_close(
-            match.device_indices, torch.tensor([10, 11, 12, 13])
-        )
+        torch.testing.assert_close(match.device_indices, torch.tensor([10, 11, 12, 13]))
         self.assertEqual(cache.total_size(), DEFAULT_PAGE_SIZE)
         self.assertEqual(cache.protected_size(), DEFAULT_PAGE_SIZE)
         self.assertEqual(cache.evictable_size(), 0)
+        self.assertEqual(sum(cache._rollout_kv_pin_counts.values()), 1)
 
         freed = torch.cat([x for x in allocator.freed if len(x) > 0])
         torch.testing.assert_close(freed, torch.tensor([14, 15, 16, 17]))
+
+    def test_rollout_kv_unprotect_releases_committed_pin(self):
+        cache, _allocator, req_to_token_pool = self._make_cache_finished_fixture(
+            disable_finished_insert=True
+        )
+        prompt_ids = [1, 2, 3, 4, 5]
+        req_to_token_pool.req_to_token[0, :8] = torch.arange(10, 18, dtype=torch.int64)
+        commit_req = _DummyReq(
+            cache,
+            req_pool_idx=0,
+            origin_input_ids=prompt_ids,
+            output_ids=[100, 101, 102],
+            custom_params={
+                "rollout_kv_commit": True,
+                "rollout_kv_commit_len": len(prompt_ids),
+            },
+        )
+        cache.cache_finished_req(commit_req, is_insert=True)
+
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(prompt_ids)))
+        self.assertEqual(cache.protected_size(), DEFAULT_PAGE_SIZE)
+
+        unprotect_req = _DummyReq(
+            cache,
+            req_pool_idx=0,
+            origin_input_ids=prompt_ids,
+            output_ids=[],
+            custom_params={"rollout_kv_unprotect": True},
+        )
+        req_to_token_pool.req_to_token[0, : len(prompt_ids)] = torch.tensor(
+            [10, 11, 12, 13, 99], dtype=torch.int64
+        )
+        unprotect_req.cache_protected_len = DEFAULT_PAGE_SIZE
+        unprotect_req.last_node = match.last_device_node
+        cache.inc_lock_ref(unprotect_req.last_node)
+
+        cache.cache_finished_req(unprotect_req, is_insert=True)
+
+        self.assertEqual(cache.protected_size(), 0)
+        self.assertEqual(cache.evictable_size(), DEFAULT_PAGE_SIZE)
+        self.assertEqual(sum(cache._rollout_kv_pin_counts.values()), 0)
+
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(prompt_ids)))
+        self.assertEqual(len(match.device_indices), DEFAULT_PAGE_SIZE)
 
     def test_rollout_kv_reuse_only_skips_finished_insert(self):
         cache, allocator, req_to_token_pool = self._make_cache_finished_fixture()

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -432,8 +432,8 @@ class TestRadixCache(unittest.TestCase):
         self.assertEqual(cache.evictable_size(), 0)
         self.assertEqual(cache.protected_size(), 0)
 
-    def test_prefix_pin_commit_inserts_prompt_only_and_pins(self):
-        """PrefixPin commits only the page-aligned prompt prefix."""
+    def test_rollout_kv_commit_inserts_prompt_only_and_pins(self):
+        """RolloutKV commits only the page-aligned prompt prefix."""
         cache, allocator, req_to_token_pool = self._make_cache_finished_fixture(
             disable_finished_insert=True
         )
@@ -449,8 +449,8 @@ class TestRadixCache(unittest.TestCase):
             origin_input_ids=prompt_ids,
             output_ids=output_ids,
             custom_params={
-                "prefix_pin_commit": True,
-                "prefix_pin_commit_len": len(prompt_ids),
+                "rollout_kv_commit": True,
+                "rollout_kv_commit_len": len(prompt_ids),
             },
         )
 
@@ -470,7 +470,7 @@ class TestRadixCache(unittest.TestCase):
         freed = torch.cat([x for x in allocator.freed if len(x) > 0])
         torch.testing.assert_close(freed, torch.tensor([14, 15, 16, 17]))
 
-    def test_prefix_pin_reuse_only_skips_finished_insert(self):
+    def test_rollout_kv_reuse_only_skips_finished_insert(self):
         cache, allocator, req_to_token_pool = self._make_cache_finished_fixture()
         token_ids = [1, 2, 3, 4]
         req_to_token_pool.req_to_token[0, : len(token_ids)] = torch.arange(
@@ -481,7 +481,7 @@ class TestRadixCache(unittest.TestCase):
             req_pool_idx=0,
             origin_input_ids=token_ids,
             output_ids=[],
-            custom_params={"prefix_pin_reuse_only": True},
+            custom_params={"rollout_kv_reuse_only": True},
         )
 
         cache.cache_finished_req(req, is_insert=True)

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -535,6 +535,153 @@ class TestRadixCache(unittest.TestCase):
         freed = torch.cat([x for x in allocator.freed if len(x) > 0])
         torch.testing.assert_close(freed, torch.tensor([20, 21, 22, 23]))
 
+    def _commit_pinned_prefix(
+        self,
+        cache,
+        req_to_token_pool,
+        prompt_ids,
+        output_ids,
+        pin_refcount=None,
+    ):
+        """Helper: commit ``prompt_ids`` with an optional ``pin_refcount`` and
+        return the matched device node so callers can simulate followers
+        unprotecting the pin."""
+        kv_len = len(prompt_ids) + len(output_ids)
+        req_to_token_pool.req_to_token[0, :kv_len] = torch.arange(
+            10, 10 + kv_len, dtype=torch.int64
+        )
+        custom = {
+            "rollout_kv_commit": True,
+            "rollout_kv_commit_len": len(prompt_ids),
+        }
+        if pin_refcount is not None:
+            custom["rollout_kv_pin_refcount"] = pin_refcount
+        commit_req = _DummyReq(
+            cache,
+            req_pool_idx=0,
+            origin_input_ids=prompt_ids,
+            output_ids=output_ids,
+            custom_params=custom,
+        )
+        cache.cache_finished_req(commit_req, is_insert=True)
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(prompt_ids)))
+        return match.last_device_node
+
+    def _build_unprotect_req(
+        self, cache, req_to_token_pool, prompt_ids, last_node, custom_params
+    ):
+        """Helper: build a request whose finish should trigger an unprotect (or
+        auto-unprotect) on the previously-pinned prefix."""
+        req_to_token_pool.req_to_token[0, : len(prompt_ids)] = torch.tensor(
+            [10, 11, 12, 13, 99], dtype=torch.int64
+        )
+        req = _DummyReq(
+            cache,
+            req_pool_idx=0,
+            origin_input_ids=prompt_ids,
+            output_ids=[],
+            custom_params=custom_params,
+        )
+        req.cache_protected_len = DEFAULT_PAGE_SIZE
+        req.last_node = last_node
+        cache.inc_lock_ref(req.last_node)
+        return req
+
+    def test_rollout_kv_pin_refcount_holds_until_all_release(self):
+        """A commit with ``rollout_kv_pin_refcount=N`` should keep the pin
+        alive until exactly N unprotect events have arrived."""
+        cache, _allocator, req_to_token_pool = self._make_cache_finished_fixture(
+            disable_finished_insert=True
+        )
+        prompt_ids = [1, 2, 3, 4, 5]
+        pin_node = self._commit_pinned_prefix(
+            cache, req_to_token_pool, prompt_ids, [100, 101, 102], pin_refcount=3
+        )
+
+        self.assertEqual(sum(cache._rollout_kv_pin_counts.values()), 3)
+        self.assertEqual(cache.protected_size(), DEFAULT_PAGE_SIZE)
+
+        # Two unprotect events should not yet release the underlying pin.
+        for expected_remaining in (2, 1):
+            unprotect_req = self._build_unprotect_req(
+                cache,
+                req_to_token_pool,
+                prompt_ids,
+                pin_node,
+                {"rollout_kv_unprotect": True},
+            )
+            cache.cache_finished_req(unprotect_req, is_insert=True)
+            self.assertEqual(
+                sum(cache._rollout_kv_pin_counts.values()), expected_remaining
+            )
+            self.assertEqual(cache.protected_size(), DEFAULT_PAGE_SIZE)
+
+        # The third unprotect tips refcount to zero and frees the pin.
+        unprotect_req = self._build_unprotect_req(
+            cache,
+            req_to_token_pool,
+            prompt_ids,
+            pin_node,
+            {"rollout_kv_unprotect": True},
+        )
+        cache.cache_finished_req(unprotect_req, is_insert=True)
+        self.assertEqual(sum(cache._rollout_kv_pin_counts.values()), 0)
+        self.assertEqual(cache.protected_size(), 0)
+        self.assertEqual(cache.evictable_size(), DEFAULT_PAGE_SIZE)
+
+    def test_rollout_kv_unprotect_all_drops_remaining_pins(self):
+        """``rollout_kv_unprotect_all=True`` releases the full refcount in one
+        call, useful for the trainer's explicit release at end-of-step."""
+        cache, _allocator, req_to_token_pool = self._make_cache_finished_fixture(
+            disable_finished_insert=True
+        )
+        prompt_ids = [1, 2, 3, 4, 5]
+        pin_node = self._commit_pinned_prefix(
+            cache, req_to_token_pool, prompt_ids, [100, 101, 102], pin_refcount=5
+        )
+        self.assertEqual(sum(cache._rollout_kv_pin_counts.values()), 5)
+
+        unprotect_req = self._build_unprotect_req(
+            cache,
+            req_to_token_pool,
+            prompt_ids,
+            pin_node,
+            {"rollout_kv_unprotect": True, "rollout_kv_unprotect_all": True},
+        )
+        cache.cache_finished_req(unprotect_req, is_insert=True)
+
+        self.assertEqual(sum(cache._rollout_kv_pin_counts.values()), 0)
+        self.assertEqual(cache.protected_size(), 0)
+        self.assertEqual(cache.evictable_size(), DEFAULT_PAGE_SIZE)
+
+    def test_rollout_kv_auto_unprotect_on_finish_releases_pin(self):
+        """A follower carrying ``rollout_kv_auto_unprotect_on_finish=True``
+        (combined with ``rollout_kv_reuse_only`` so its own output isn't
+        inserted) should release exactly one ref from the prior commit."""
+        cache, _allocator, req_to_token_pool = self._make_cache_finished_fixture(
+            disable_finished_insert=True
+        )
+        prompt_ids = [1, 2, 3, 4, 5]
+        pin_node = self._commit_pinned_prefix(
+            cache, req_to_token_pool, prompt_ids, [100, 101, 102], pin_refcount=2
+        )
+        self.assertEqual(sum(cache._rollout_kv_pin_counts.values()), 2)
+
+        follower_req = self._build_unprotect_req(
+            cache,
+            req_to_token_pool,
+            prompt_ids,
+            pin_node,
+            {
+                "rollout_kv_reuse_only": True,
+                "rollout_kv_auto_unprotect_on_finish": True,
+            },
+        )
+        cache.cache_finished_req(follower_req, is_insert=True)
+
+        self.assertEqual(sum(cache._rollout_kv_pin_counts.values()), 1)
+        self.assertEqual(cache.protected_size(), DEFAULT_PAGE_SIZE)
+
     def test_insert_and_match_basic(self):
         """Test basic insert and match operations."""
         for disable_cache in [False, True]:

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -29,6 +29,7 @@ import time
 import unittest
 import unittest.mock
 from array import array
+from types import SimpleNamespace
 
 import torch
 
@@ -39,11 +40,52 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     InsertParams,
     MatchPrefixParams,
 )
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.mamba_radix_cache import TreeNode as MambaTreeNode
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 
 # Test constants
 DEFAULT_PAGE_SIZE = 4
+
+
+class _MockTokenAllocator:
+    def __init__(self):
+        self.device = torch.device("cpu")
+        self.freed = []
+
+    def free(self, indices):
+        self.freed.append(indices.detach().cpu().clone())
+
+
+class _MockReqToTokenPool:
+    def __init__(self, max_reqs: int = 1, max_context_len: int = 32):
+        self.req_to_token = torch.full(
+            (max_reqs, max_context_len), -1, dtype=torch.int64
+        )
+
+
+class _DummyReq:
+    def __init__(
+        self,
+        tree: RadixCache,
+        req_pool_idx: int,
+        origin_input_ids: list[int],
+        output_ids: list[int],
+        custom_params: dict | None = None,
+    ):
+        self.req_pool_idx = req_pool_idx
+        self.origin_input_ids = origin_input_ids
+        self.output_ids = output_ids
+        self.fill_ids = origin_input_ids + output_ids
+        self.extra_key = None
+        self.cache_protected_len = 0
+        self.kv_committed_len = len(self.fill_ids)
+        self.last_node = tree.root_node
+        self.priority = 0
+        self.sampling_params = SimpleNamespace(custom_params=custom_params or {})
+
+    def pop_committed_kv_cache(self):
+        return self.kv_committed_len
 
 
 class TestRadixKey(unittest.TestCase):
@@ -330,6 +372,22 @@ class TestRadixCache(unittest.TestCase):
         """Set up test fixtures."""
         TreeNode.counter = 0
 
+    def _make_cache_finished_fixture(
+        self, page_size: int = DEFAULT_PAGE_SIZE, disable_finished_insert: bool = False
+    ):
+        req_to_token_pool = _MockReqToTokenPool()
+        allocator = _MockTokenAllocator()
+        cache = RadixCache(
+            CacheInitParams(
+                disable=False,
+                req_to_token_pool=req_to_token_pool,
+                token_to_kv_pool_allocator=allocator,
+                page_size=page_size,
+                disable_finished_insert=disable_finished_insert,
+            )
+        )
+        return cache, allocator, req_to_token_pool
+
     def test_init_variations(self):
         """Test cache initialization with different parameters."""
         test_cases = [
@@ -373,6 +431,66 @@ class TestRadixCache(unittest.TestCase):
         self.assertEqual(cache.total_size(), 0)
         self.assertEqual(cache.evictable_size(), 0)
         self.assertEqual(cache.protected_size(), 0)
+
+    def test_prefix_pin_commit_inserts_prompt_only_and_pins(self):
+        """PrefixPin commits only the page-aligned prompt prefix."""
+        cache, allocator, req_to_token_pool = self._make_cache_finished_fixture(
+            disable_finished_insert=True
+        )
+        prompt_ids = [1, 2, 3, 4, 5]
+        output_ids = [100, 101, 102]
+        kv_len = len(prompt_ids) + len(output_ids)
+        req_to_token_pool.req_to_token[0, :kv_len] = torch.arange(
+            10, 10 + kv_len, dtype=torch.int64
+        )
+        req = _DummyReq(
+            cache,
+            req_pool_idx=0,
+            origin_input_ids=prompt_ids,
+            output_ids=output_ids,
+            custom_params={
+                "prefix_pin_commit": True,
+                "prefix_pin_commit_len": len(prompt_ids),
+            },
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(prompt_ids + output_ids))
+        )
+        self.assertEqual(len(match.device_indices), DEFAULT_PAGE_SIZE)
+        torch.testing.assert_close(
+            match.device_indices, torch.tensor([10, 11, 12, 13])
+        )
+        self.assertEqual(cache.total_size(), DEFAULT_PAGE_SIZE)
+        self.assertEqual(cache.protected_size(), DEFAULT_PAGE_SIZE)
+        self.assertEqual(cache.evictable_size(), 0)
+
+        freed = torch.cat([x for x in allocator.freed if len(x) > 0])
+        torch.testing.assert_close(freed, torch.tensor([14, 15, 16, 17]))
+
+    def test_prefix_pin_reuse_only_skips_finished_insert(self):
+        cache, allocator, req_to_token_pool = self._make_cache_finished_fixture()
+        token_ids = [1, 2, 3, 4]
+        req_to_token_pool.req_to_token[0, : len(token_ids)] = torch.arange(
+            20, 20 + len(token_ids), dtype=torch.int64
+        )
+        req = _DummyReq(
+            cache,
+            req_pool_idx=0,
+            origin_input_ids=token_ids,
+            output_ids=[],
+            custom_params={"prefix_pin_reuse_only": True},
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(token_ids)))
+        self.assertEqual(len(match.device_indices), 0)
+        self.assertEqual(cache.total_size(), 0)
+        freed = torch.cat([x for x in allocator.freed if len(x) > 0])
+        torch.testing.assert_close(freed, torch.tensor([20, 21, 22, 23]))
 
     def test_insert_and_match_basic(self):
         """Test basic insert and match operations."""


### PR DESCRIPTION
## RolloutKV: Prefix KV Cache Pinning for RL Rollout (EPC-RL)

> **Replaces #24781.** Rebased on latest `main` (2026-06-18), clean 5-commit history (no merge commits). Added TTL-based stale-pin eviction.

---

### What this does — one paragraph

RL rollouts repeatedly prefill the same long prompt: once per generation sample,
once for actor logprob, once for reference logprob, and again for any reward/value
scoring pass. RolloutKV lets the trainer commit the prompt prefix into the radix
cache once, pin it against LRU eviction, and let every follower request in the same
group reuse those physical KV blocks directly — with zero copies and no changes to
attention kernels or model math.

**Key numbers on Qwen3-32B (A100 80 GB):**

| Scenario | Generation speedup | Logprob total speedup | Logprob scoring-only speedup |
|---|---:|---:|---:|
| input 8192, output 128, G=8, actor+ref+rollout | 1.65x | 2.72x | **22.64x** |
| input 16384, output 128, G=8, actor+ref+rollout | 1.25x | 2.84x | **41.91x** |
| input 8192, output 128, G=8, 4 roles × 3 rounds | 1.64x | 8.03x | **22.83x** |

---

### Why not just rely on RadixAttention?

SGLang's RadixAttention already reuses prefix KV — but it is reactive: a node is
inserted only after a request finishes, and it competes with every other request for
the LRU eviction budget. In co-located RL setups (training + rollout sharing the same
GPU memory), the committed prefix is frequently evicted between the generation pass
and the logprob pass, forcing a full re-prefill. RolloutKV makes this proactive:

- **Commit before fanout.** The prefix is committed and pinned before any follower request is dispatched, guaranteeing a cache hit for all G branches.
- **Pin against eviction.** `inc_lock_ref` moves the node into `protected_size`, where it cannot be evicted until explicitly released after all followers complete.
- **No output pollution.** Follower and scoring requests skip finished-cache insertion, preventing long rollout/reasoning suffixes from filling the radix tree with unreachable entries (see [issue #22373](https://github.com/sgl-project/sglang/issues/22373)).

---

### API

Exposed via `sampling_params.custom_params`. Requires `--enable-rollout-kv` at server startup.

| Field | Type | Description | Default |
|---|---|---|---|
| `rollout_kv_commit` | bool | Commit only the prompt prefix; pin it. | `False` |
| `rollout_kv_commit_len` | int\|None | Tokens to commit. Defaults to page-aligned `len(input_ids)`. | `None` |
| `rollout_kv_protect` | bool | Pin the committed node with `inc_lock_ref`. | `True` |
| `rollout_kv_pin_refcount` | int | Number of refs to add (alias: `rollout_kv_expected_followers`). | `1` |
| `rollout_kv_reuse_only` | bool | Skip finished-cache insertion (prevents rollout-suffix pollution). | `False` |
| `rollout_kv_auto_unprotect_on_finish` | bool | Release one ref when this request finishes. | `False` |
| `rollout_kv_unprotect` | bool | Explicitly release the pin. | `False` |
| `rollout_kv_unprotect_count` | int | Refs to release on explicit unprotect. | `1` |
| `rollout_kv_unprotect_all` | bool | Force-release all remaining refs in one call. | `False` |

**Server flags:**
- `--enable-rollout-kv` — enable the feature (default off, zero intrusion)
- `--rollout-kv-pin-ttl-seconds` — stale-pin TTL in seconds (default `600`, set to `0` to disable)

**Typical RL flow:**

```python
# Step 1: commit prompt prefix once (trainer)
engine.generate(prompt, sampling_params=SamplingParams(custom_params={
    "rollout_kv_commit": True,
    "rollout_kv_expected_followers": 8,  # 8 rollout responses
}, extra_key="actor_v42"))

# Step 2: G=8 rollout branches — all hit the pinned prefix
for seed in seeds:
    engine.generate(prompt, sampling_params=SamplingParams(
        n=1, temperature=0.8,
        custom_params={
            "rollout_kv_reuse_only": True,
            "rollout_kv_auto_unprotect_on_finish": True,
        }, extra_key="actor_v42"))

# Step 3: actor/ref logprob scoring — near-zero prefill
engine.generate(prompt + response, sampling_params=SamplingParams(
    custom_params={"rollout_kv_reuse_only": True},
    extra_key="actor_v42"))
```

---

### Reliability: TTL-based Stale Pin Eviction *(added 2026-06-18)*

Two failure modes are handled automatically:

**1. Follower crash / OOM kill**

If a follower process is killed before calling `cache_finished_req`, its refcount
never reaches zero and the pinned KV pages are held indefinitely, gradually
exhausting GPU memory.

**2. `rollout_kv_expected_followers` mismatch**

- Over-counted: residual refcount stays positive indefinitely.
- Under-counted: extra `unprotect` calls are already idempotent (return `False`, no crash).

**Fix:** `_rollout_kv_pin_timestamps` records commit time.
`_rollout_kv_evict_expired_pins()` is called lazily at the top of every
`cache_finished_req` (no background thread required). Any pin older than
`--rollout-kv-pin-ttl-seconds` is force-released with a WARNING log that includes
pin key, age, TTL, and remaining refcount for post-mortem debugging. Setting TTL
to `0` disables automatic eviction entirely.

---

### Implementation scope

| File | Change |
|---|---|
| `python/sglang/srt/mem_cache/radix_cache.py` | Core: `_rollout_kv_pin_{counts,nodes,timestamps}`, `_rollout_kv_release_pin`, `_rollout_kv_evict_expired_pins`, `cache_finished_req` integration |
| `python/sglang/srt/mem_cache/cache_init_params.py` | `enable_rollout_kv`, `rollout_kv_pin_ttl_seconds` fields |
| `python/sglang/srt/server_args.py` | `--enable-rollout-kv`, `--rollout-kv-pin-ttl-seconds` CLI args |
| `python/sglang/srt/managers/scheduler.py` | Forward new params to `CacheInitParams` |
| `test/registered/unit/mem_cache/test_radix_cache_unit.py` | Unit tests: commit / pin / reuse-only / TTL eviction / mismatch idempotency |
| `docs/advanced_features/sglang_for_rl.md` | Usage guide for RL integrations |

**No changes to:** attention kernels, CUDA Graph, FA3 backend, sampling logic, or model math.

---

### Correctness

**Exact output match on Qwen3-32B (prompt 4096, output 1028, G=8):**

| | Baseline | RolloutKV |
|---|---|---|
| Output length | 1028 tokens | 1028 tokens |
| First token IDs | — | exact match |

**LongBench-v2 accuracy (Qwen3-32B, 7 examples, context 8192, G=4):**

| | Baseline | RolloutKV | Delta |
|---|---:|---:|---:|
| LongBench score | 0.4286 | 0.4286 | **0.000** |
| Extracted answer match | 7/7 | 7/7 | same |
| Peak HBM | 66.656 GiB | 66.660 GiB | +4 MiB |

> **Note on elapsed time:** the LongBench scenario (context=8192, G=4, output=128)
> is near the break-even point. The commit overhead is ~0.5 s; the prefill saving
> per follower is small because G=4 and output is short relative to input.
> Production RL workloads with G≥8 and multi-role logprob scoring show the gains
> in the benchmark section below. The accuracy delta is zero.

---

### Throughput benchmarks

All results: single A100 80 GB, Qwen3-32B, page size 32.

**Generation throughput — prompt/output sweep (G=4):**

| Prompt | Output | Baseline tok/s | RolloutKV tok/s | Speedup |
|---:|---:|---:|---:|---:|
| 4096 | 1028 | 43.68 | 86.19 | **1.97x** |
| 4096 | 4096 | 41.33 | 44.49 | 1.08x |
| 8192 | 1028 | 43.33 | 81.90 | **1.89x** |

**verl-style RL — generation (G=8, actor+ref+rollout):**

| Input | Output | Baseline | RolloutKV | Speedup |
|---:|---:|---:|---:|---:|
| 8192 | 128 | 14.607 s | 8.870 s | **1.65x** |
| 16384 | 128 | 15.888 s | 12.717 s | **1.25x** |

**verl-style RL — logprob scoring:**

| Input | Output | Baseline | RolloutKV total | Scoring only | Total speedup | Scoring speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 8192 | 128 | 7.665 s | 2.813 s | 0.339 s | **2.72x** | **22.64x** |
| 16384 | 128 | 17.329 s | 6.107 s | 0.413 s | **2.84x** | **41.91x** |

Cache evidence:

| Input | Cache hit | Cached tokens | `protected_size` |
|---:|---:|---:|---:|
| 8192 | 99.62% | 65280/65528 | 8192 pinned |
| 16384 | 99.81% | 130816/131064 | 16384 pinned |

**Multi-role sweep (actor+ref+reward+value, 3 rounds):**

| Input | G | Output | Gen speedup | Logprob speedup | Scoring speedup |
|---:|---:|---:|---:|---:|---:|
| 8192 | 8 | 128 | 1.64x | 8.03x | **22.83x** |
| 8192 | 16 | 128 | 1.56x | 8.05x | **22.97x** |
| 16384 | 8 | 128 | 1.26x | 9.48x | **42.43x** |
| 16384 | 16 | 128 | 1.21x | 9.48x | **42.56x** |
| (decode-heavy) 8192 | 8 | 512 | 1.81x | 5.87x | 10.66x |

**Full RL step (4 prompts × G=4 × 5 phases, prompt=8192, mem_fraction=0.88), 3-run median:**
- Baseline: 45.465 s → RolloutKV: 35.759 s → **1.27x full-step speedup**, rollout-phase: 1.83x

**Boundary case — decode-dominated (Qwen3-8B-Base, prompt 512, output 16384, G=8):**

| Metric | Baseline | RolloutKV |
|---|---:|---:|
| Total generation time | 278.8 s | 278.4 s |
| Speedup | — | **1.002x** |
| Prefill probe time | 0.268 s | 0.078 s (**3.4x faster**) |

When decode dominates (>99% of wall time), end-to-end speedup is negligible —
the expected behavior.

---

### Testing

```bash
python -m py_compile \
  python/sglang/srt/mem_cache/radix_cache.py \
  test/registered/unit/mem_cache/test_radix_cache_unit.py
```

Unit tests cover: commit, pin via `protected_size`, tail-KV free, reuse-only
no-insert, TTL expiry, follower-crash scenario, expected-followers mismatch
idempotency.

Full pytest is blocked on this machine by an upstream environment issue
(`flashinfer.fused_moe` import error, unrelated to this PR). Happy to run CI
once the `run-ci` label is applied.

---

### When RolloutKV helps most

| Condition | Expected gain |
|---|---|
| Long prompt (≥2048), short-medium output, G≥4 | High (generation + logprob) |
| Multiple scoring roles (actor/ref/reward/value) | Very high (logprob scoring) |
| Multi-round PPO/GRPO logprob recomputation | Very high |
| Short prompt (<512) or decode-dominated output | Minimal to none |








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27735929514](https://github.com/sgl-project/sglang/actions/runs/27735929514)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27735929280](https://github.com/sgl-project/sglang/actions/runs/27735929280)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->