### PR TITLE
Fix bench serving base-url-only runs

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -48,7 +48,7 @@ from sglang.benchmark.utils import (
     set_ulimit,
 )
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
-from sglang.srt.utils.network import NetworkAddress, resolve_base_url
+from sglang.srt.utils.network import resolve_base_url, resolve_host_port
 
 _ROUTING_KEY_HEADER = "X-SMG-Routing-Key"
 
@@ -1941,19 +1941,14 @@ def run_benchmark(args_: argparse.Namespace):
         }.get(args.backend, 30000)
 
     # Base URL the client sends to: --base-url if given, else http://host:port
-    # (IPv6-correct). NetworkAddress is only needed for gserver's host:port form.
+    # (IPv6-correct). gserver uses the scheme-less host:port form instead.
     base_url = resolve_base_url(args.base_url, args.host, args.port)
-    _na = (
-        NetworkAddress(args.host, args.port)
-        if args.backend == "gserver" and not args.base_url
-        else None
-    )
 
     model_url = f"{base_url}/v1/models"
 
     if args.backend == "gserver":
         # gRPC server takes a bare host:port, not an http URL.
-        api_url = args.base_url if args.base_url else _na.to_host_port_str()
+        api_url = resolve_host_port(args.base_url, args.host, args.port)
         args.model = args.model or "default"
     else:
         api_url = f"{base_url}{_BACKEND_API_PATHS[args.backend]}"

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1941,9 +1941,13 @@ def run_benchmark(args_: argparse.Namespace):
         }.get(args.backend, 30000)
 
     # Base URL the client sends to: --base-url if given, else http://host:port
-    # (IPv6-correct). NetworkAddress is also kept for gserver's host:port form.
+    # (IPv6-correct). NetworkAddress is only needed for gserver's host:port form.
     base_url = resolve_base_url(args.base_url, args.host, args.port)
-    _na = NetworkAddress(args.host, args.port)
+    _na = (
+        NetworkAddress(args.host, args.port)
+        if args.backend == "gserver" and not args.base_url
+        else None
+    )
 
     model_url = f"{base_url}/v1/models"
 

--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -551,3 +551,12 @@ def resolve_base_url(base_url: str, host: str, port: int) -> str:
     if base_url:
         return base_url
     return NetworkAddress(host, port).to_url()
+
+
+def resolve_host_port(base_url: str, host: str, port: int) -> str:
+    """Like :func:`resolve_base_url` but returns the scheme-less ``host:port``
+    form (for gRPC-style endpoints): ``base_url`` if set, else ``host:port``
+    (IPv6-correct via :class:`NetworkAddress`)."""
+    if base_url:
+        return base_url
+    return NetworkAddress(host, port).to_host_port_str()


### PR DESCRIPTION
## Summary

Fixes the #28598 regression where `bench_serving` crashed for `--base-url`-only runs by avoiding `NetworkAddress(None, port)` unless the gserver host:port fallback needs it

https://github.com/sgl-project/sglang/actions/runs/27738332069/job/82059895721
https://github.com/sgl-project/sglang/actions/runs/27738332069/job/82059895725

cc @hnyls2002 





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27743395444](https://github.com/sgl-project/sglang/actions/runs/27743395444)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27743395275](https://github.com/sgl-project/sglang/actions/runs/27743395275)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->