### PR TITLE
[DeepSeek V4 Flash] Add SM89 FP8 indexer fallback

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -291,6 +291,15 @@ PD-Disagg recipes on H200 may require `docker run --privileged --ulimit memlock=
 can discover the IB HCAs; without IB exposure mooncake silently falls back to
 TCP, which can lead to garbled KV transfer on large checkpoints.
 
+**Ada (L20 / SM89) note**
+
+On NVIDIA L20 (SM89), SGLang supports the converted
+[`sgl-project/DeepSeek-V4-Flash-FP8`](https://huggingface.co/sgl-project/DeepSeek-V4-Flash-FP8)
+checkpoint through the default DeepSeek-V4 FP8 indexer path. The SM89 route uses
+a Triton paged-MQA logits fallback and avoids Hopper/Blackwell-only kernels such
+as FlashMLA, DeepGEMM indexer metadata, and `topk_v2` cluster kernels. Hopper and
+Blackwell routes keep their existing optimized kernels.
+
 **RTX PRO 6000 (SM120 / Blackwell Desktop) note**
 
 RTX PRO 6000 (96 GB) runs **Flash only** — V4-Pro doesn't fit on 8× 96 GB. It uses the

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -69,7 +69,7 @@ from sglang.srt.speculative.ragged_verify import (
     resolve_ragged_verify_layout,
 )
 from sglang.srt.utils import ceil_align, is_cuda, is_xpu
-from sglang.srt.utils.common import is_sm120_supported
+from sglang.srt.utils.common import is_sm89_supported, is_sm120_supported
 
 if TYPE_CHECKING:
     from sgl_kernel.flash_mla import FlashMLASchedMeta
@@ -81,6 +81,8 @@ if TYPE_CHECKING:
 _is_sm120 = is_sm120_supported()
 _is_cuda = is_cuda()
 _is_xpu = is_xpu()
+_is_sm89 = is_sm89_supported()
+_use_flashmla_fallback_path = _is_sm120 or _is_sm89
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +134,7 @@ def _pad_last_dim(x: T, multiples_of: int = PAGE_INDEX_ALIGNED_SIZE) -> T:
 
 
 def _create_flashmla_metadata():
-    if _is_sm120 or _is_xpu:
+    if _use_flashmla_fallback_path or _is_xpu:
         return None
     import sgl_kernel.flash_mla as flash_mla
 
@@ -1686,7 +1688,7 @@ class DeepseekV4AttnBackend(
                     attn_sink=attn_sink,
                 )
 
-            if _is_sm120:
+            if _use_flashmla_fallback_path:
                 from sglang.kernels.ops.attention.flash_mla_sm120 import (
                     flash_mla_with_kvcache_sm120,
                 )

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -31,7 +31,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
 from sglang.srt.utils import add_prefix, is_cuda, is_hip, is_xpu
-from sglang.srt.utils.common import is_sm120_supported
+from sglang.srt.utils.common import is_sm89_supported, is_sm120_supported
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -629,6 +629,10 @@ class C4IndexerBackendMixin:
             # TODO: switch from triton to SYCL when OOM is resolved
 
             fn = fp8_paged_mqa_logits_triton
+        elif is_sm89_supported():
+            from sglang.srt.layers.attention.dsv4.triton_paged_mqa_logits import (
+                fp8_paged_mqa_logits_triton_sm89 as fn,
+            )
         else:
             from deep_gemm import fp8_paged_mqa_logits as fn
 
@@ -722,7 +726,11 @@ class C4IndexerBackendMixin:
                 indexer_metadata.c4_page_size,
                 raw_indices,
             )
-        elif envs.SGLANG_OPT_USE_TOPK_V2.get() and raw_indices is None:
+        elif (
+            envs.SGLANG_OPT_USE_TOPK_V2.get()
+            and raw_indices is None
+            and not is_sm89_supported()
+        ):
             topk_transform_512_v2(
                 logits,
                 c4_seq_lens,

--- a/python/sglang/srt/layers/attention/dsv4/metadata.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata.py
@@ -8,6 +8,7 @@ import torch
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import is_hip, is_xpu
+from sglang.srt.utils.common import is_sm89_supported
 
 if TYPE_CHECKING:
     pass
@@ -124,6 +125,7 @@ class PagedIndexerMetadata:
             envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
             or is_xpu()
             or envs.SGLANG_OPT_USE_AITER_INDEXER.get()
+            or is_sm89_supported()
         ):
             self.deep_gemm_metadata = None
         else:
@@ -151,7 +153,7 @@ class PagedIndexerMetadata:
 
         from sglang.jit_kernel.dsv4 import plan_topk_v2
 
-        if envs.SGLANG_OPT_USE_TOPK_V2.get():
+        if envs.SGLANG_OPT_USE_TOPK_V2.get() and not is_sm89_supported():
             self.topk_metadata = plan_topk_v2(self.c4_seq_lens)
         else:
             self.topk_metadata = torch.empty((0,))

--- a/python/sglang/srt/layers/attention/dsv4/triton_paged_mqa_logits.py
+++ b/python/sglang/srt/layers/attention/dsv4/triton_paged_mqa_logits.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+_HEAD_DIM = 128
+_NUM_HEADS = 64
+_BLOCK_SIZE = 64
+
+FP8_DTYPE = torch.float8_e4m3fn
+
+
+@triton.jit
+def _paged_dot_relu_kernel(
+    kv_val_ptr,
+    kv_srow,
+    kv_sdim,
+    kv_sc_ptr,
+    q_ptr,
+    q_sb,
+    q_snh,
+    q_shd,
+    w_ptr,
+    w_sb,
+    pt_ptr,
+    pt_sb,
+    sl_ptr,
+    out_ptr,
+    out_sb,
+    max_seq_len,
+    NH: tl.constexpr,
+    HD: tl.constexpr,
+    BS: tl.constexpr,
+):
+    pid_b = tl.program_id(0)
+    pid_pg = tl.program_id(1)
+
+    seq_len = tl.load(sl_ptr + pid_b)
+    kv_start = pid_pg * BS
+    if kv_start >= seq_len:
+        return
+
+    page_id = tl.load(pt_ptr + pid_b * pt_sb + pid_pg)
+    if page_id < 0:
+        return
+
+    p_offs = tl.arange(0, BS)
+    kv_offs = kv_start + p_offs
+    valid = (kv_offs < seq_len) & (kv_offs < max_seq_len)
+
+    row_offs = page_id * BS + p_offs
+    d_offs = tl.arange(0, HD)
+    kv_2d = row_offs[:, None] * kv_srow + d_offs[None, :] * kv_sdim
+    kv_fp8 = tl.load(kv_val_ptr + kv_2d, mask=valid[:, None], other=0.0)
+    kv_f32 = kv_fp8.to(tl.float32)
+
+    kv_scale = tl.load(kv_sc_ptr + row_offs, mask=valid, other=0.0)
+
+    h_offs = tl.arange(0, NH)
+    q_2d = h_offs[:, None] * q_snh + d_offs[None, :] * q_shd
+    q = tl.load(q_ptr + pid_b * q_sb + q_2d)
+    w = tl.load(w_ptr + pid_b * w_sb + h_offs)
+
+    dot = tl.dot(
+        kv_f32.to(tl.float16), tl.trans(q.to(tl.float16)), out_dtype=tl.float32
+    )
+    score = tl.sum(tl.maximum(dot, 0.0) * w[None, :], axis=1) * kv_scale
+
+    tl.store(out_ptr + pid_b * out_sb + kv_offs, score, mask=valid)
+
+
+def fp8_paged_mqa_logits_triton_sm89(
+    q_fp8: torch.Tensor,
+    kvcache_fp8: torch.Tensor,
+    weight: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    deep_gemm_metadata,
+    max_seq_len: int,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    _ = deep_gemm_metadata
+    _ = clean_logits
+
+    if seq_lens.dim() > 1:
+        seq_lens = seq_lens.squeeze(-1)
+
+    batch_size, _, num_heads, head_dim = q_fp8.shape
+    block_size = kvcache_fp8.shape[1]
+    assert head_dim == _HEAD_DIM
+    assert num_heads == _NUM_HEADS
+    assert block_size == _BLOCK_SIZE
+    assert kvcache_fp8.shape[1:] == (block_size, 1, head_dim + 4)
+    assert weight.shape == (batch_size, num_heads)
+    assert seq_lens.shape == (batch_size,)
+    assert page_table.shape[0] == batch_size
+
+    total_pages = kvcache_fp8.shape[0]
+    total_dim = block_size * (head_dim + 4)
+    scale_offset = block_size * head_dim
+
+    kvcache_flat = kvcache_fp8.view(total_pages, total_dim)
+    kv_val_u8 = kvcache_flat[:, :scale_offset].contiguous()
+    kv_val_fp8 = kv_val_u8.view(dtype=FP8_DTYPE).reshape(
+        total_pages * block_size, head_dim
+    )
+    kv_sc_u8 = kvcache_flat[:, scale_offset:].contiguous()
+    kv_sc_f32 = kv_sc_u8.view(dtype=torch.float32).reshape(total_pages * block_size)
+
+    q_f32 = q_fp8[:, 0].to(torch.float32)
+    logits = torch.full(
+        (batch_size, max_seq_len),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+
+    max_pages = triton.cdiv(max_seq_len, block_size)
+    _paged_dot_relu_kernel[(batch_size, max_pages)](
+        kv_val_fp8,
+        kv_val_fp8.stride(0),
+        kv_val_fp8.stride(1),
+        kv_sc_f32,
+        q_f32,
+        q_f32.stride(0),
+        q_f32.stride(1),
+        q_f32.stride(2),
+        weight,
+        weight.stride(0),
+        page_table,
+        page_table.stride(0),
+        seq_lens.to(torch.int32),
+        logits,
+        logits.stride(0),
+        max_seq_len,
+        NH=num_heads,
+        HD=head_dim,
+        BS=block_size,
+        num_warps=4,
+        num_stages=4,
+    )
+    return logits

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -80,6 +80,7 @@ from sglang.srt.utils.common import (
     is_no_spec_infer_or_topk_one,
     is_npu,
     is_remote_url,
+    is_sm89_supported,
     is_sm90_supported,
     is_sm100_supported,
     is_sm120_supported,
@@ -96,6 +97,16 @@ from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.utils import is_in_ci
 
 logger = logging.getLogger(__name__)
+
+
+def apply_deepseek_v4_sm89_defaults() -> None:
+    # Ada/L20 lacks the Hopper/Blackwell-only DeepGEMM and topk_v2 paths used by
+    # DeepSeek-V4's FP8 indexer and MHC prenorm fast paths.
+    envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
+    envs.SGLANG_OPT_USE_TOPK_V2.set(False)
+    envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.set(False)
+    envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
+
 
 # Define constants
 DEFAULT_UVICORN_ACCESS_LOG_EXCLUDE_PREFIXES = ()
@@ -4401,7 +4412,9 @@ class ServerArgs:
             )
 
             run_post_process_pass(self, _deepseek_v4_sm120_moe)
-            if is_sm120_supported():
+            if is_sm89_supported():
+                apply_deepseek_v4_sm89_defaults()
+            elif is_sm120_supported():
                 # SM120 lacks tcgen05/TMEM: disable features that depend on
                 # DeepGEMM or require >99KB SMEM (topk_v2).
                 envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -293,6 +293,11 @@ is_sm80_supported = lru_cache(maxsize=1)(
         _check_cuda_device_version, device_capability_majors=[8], cuda_version=(11, 0)
     )
 )
+is_sm89_supported = lru_cache(maxsize=1)(
+    lambda: is_cuda()
+    and torch.cuda.get_device_capability() == (8, 9)
+    and tuple(map(int, torch.version.cuda.split(".")[:2])) >= (11, 0)
+)
 is_sm90_supported = lru_cache(maxsize=1)(
     partial(
         _check_cuda_device_version, device_capability_majors=[9], cuda_version=(12, 3)

--- a/test/manual/dsv4/test_sm89_paged_mqa_logits.py
+++ b/test/manual/dsv4/test_sm89_paged_mqa_logits.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import sys
+
+import torch
+import torch.nn.functional as F
+
+
+def _is_sm89() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() == (8, 9)
+
+
+def _run_case(batch_size: int, max_seq_len: int, seq_len: int) -> None:
+    from sglang.srt.layers.attention.dsv4.triton_paged_mqa_logits import (
+        FP8_DTYPE,
+        fp8_paged_mqa_logits_triton_sm89,
+    )
+
+    num_heads, head_dim, block_size = 64, 128, 64
+    max_pages = (max_seq_len + block_size - 1) // block_size
+    total_pages = batch_size * max_pages
+    total_dim = block_size * (head_dim + 4)
+    scale_offset = block_size * head_dim
+    device = "cuda"
+
+    raw = torch.zeros(total_pages, total_dim, dtype=torch.uint8, device=device)
+    kv_source = (
+        torch.randn(total_pages, block_size, head_dim, device=device) * 0.1
+    ).to(FP8_DTYPE)
+    scales = (
+        torch.rand(total_pages, block_size, dtype=torch.float32, device=device) * 0.2
+        + 0.9
+    )
+    raw[:, :scale_offset] = kv_source.reshape(total_pages, block_size * head_dim).view(
+        torch.uint8
+    )
+    raw[:, scale_offset:] = (
+        scales.reshape(total_pages, block_size)
+        .view(torch.uint8)
+        .reshape(total_pages, block_size * 4)
+    )
+    kvcache = raw.view(total_pages, block_size, 1, head_dim + 4)
+
+    page_table = torch.arange(total_pages, dtype=torch.int32, device=device).view(
+        batch_size, max_pages
+    )
+    q = (torch.randn(batch_size, 1, num_heads, head_dim, device=device) * 0.1).to(
+        FP8_DTYPE
+    )
+    weight = torch.randn(batch_size, num_heads, dtype=torch.float32, device=device)
+    seq_lens = torch.full((batch_size,), seq_len, dtype=torch.int32, device=device)
+
+    got = fp8_paged_mqa_logits_triton_sm89(
+        q,
+        kvcache,
+        weight,
+        seq_lens,
+        page_table,
+        deep_gemm_metadata=None,
+        max_seq_len=max_seq_len,
+        clean_logits=False,
+    )
+    torch.cuda.synchronize()
+
+    flat = kvcache.view(total_pages, total_dim)
+    gathered = flat[page_table]
+    kv_val = (
+        gathered[..., :scale_offset]
+        .contiguous()
+        .view(FP8_DTYPE)
+        .to(torch.float32)
+        .reshape(batch_size, max_pages * block_size, head_dim)
+    )
+    kv_sc = (
+        gathered[..., scale_offset:]
+        .contiguous()
+        .view(torch.float32)
+        .reshape(batch_size, max_pages * block_size)
+    )
+    q_f32 = q[:, 0].to(torch.float32)
+    ref = torch.bmm(kv_val, q_f32.transpose(1, 2))
+    ref = F.relu(ref)
+    ref = ref * weight.unsqueeze(1)
+    ref = ref.sum(dim=2) * kv_sc
+    ref_logits = torch.full(
+        (batch_size, max_seq_len),
+        float("-inf"),
+        dtype=torch.float32,
+        device=device,
+    )
+    valid_len = min(seq_len, max_seq_len)
+    ref_logits[:, :valid_len] = ref[:, :valid_len]
+
+    finite = torch.isfinite(ref_logits)
+    max_diff = (got[finite] - ref_logits[finite]).abs().max().item()
+    tail_ok = True
+    if valid_len < max_seq_len:
+        tail_ok = torch.isneginf(got[:, valid_len:]).all().item()
+
+    print(
+        f"case batch={batch_size} max_seq={max_seq_len} seq={seq_len} "
+        f"max_diff={max_diff:.6f} tail_ok={tail_ok}"
+    )
+    assert max_diff < 2e-2
+    assert tail_ok
+
+
+def main() -> int:
+    if not _is_sm89():
+        print("[skip] SM89/L20 CUDA device is required.")
+        return 0
+
+    torch.manual_seed(0)
+    for batch_size, max_seq_len, seq_len in (
+        (2, 256, 192),
+        (4, 512, 448),
+        (16, 1024, 960),
+    ):
+        _run_case(batch_size, max_seq_len, seq_len)
+    print("SM89 paged MQA logits correctness OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/registered/attention/unittests/dsv4/test_deepseek_v4_sm89.py
+++ b/test/registered/attention/unittests/dsv4/test_deepseek_v4_sm89.py
@@ -54,6 +54,33 @@ def test_common_sm89_helper_is_strict():
         assert not is_sm89_supported()
 
 
+def test_sm89_deepseek_v4_defaults_disable_hopper_only_fast_paths():
+    from sglang.srt.environ import envs
+    from sglang.srt.server_args import apply_deepseek_v4_sm89_defaults
+
+    fields = [
+        envs.SGLANG_OPT_FP8_WO_A_GEMM,
+        envs.SGLANG_OPT_USE_TOPK_V2,
+        envs.SGLANG_OPT_USE_TILELANG_MHC_PRE,
+        envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM,
+        envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH,
+    ]
+    for field in fields:
+        field.clear()
+
+    try:
+        apply_deepseek_v4_sm89_defaults()
+
+        assert not envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
+        assert not envs.SGLANG_OPT_USE_TOPK_V2.get()
+        assert not envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get()
+        assert not envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get()
+        assert not envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
+    finally:
+        for field in fields:
+            field.clear()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/test/registered/attention/unittests/dsv4/test_deepseek_v4_sm89.py
+++ b/test/registered/attention/unittests/dsv4/test_deepseek_v4_sm89.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+
+def test_sm89_kernel_imports():
+    from sglang.srt.layers.attention.dsv4.triton_paged_mqa_logits import (
+        fp8_paged_mqa_logits_triton_sm89,
+    )
+
+    assert callable(fp8_paged_mqa_logits_triton_sm89)
+
+
+def test_common_sm89_helper_is_strict():
+    from sglang.srt.utils.common import is_cuda, is_sm89_supported
+
+    is_sm89_supported.cache_clear()
+    is_cuda.cache_clear()
+    with patch.object(torch.cuda, "is_available", return_value=True), patch.object(
+        torch.cuda, "get_device_capability", return_value=(8, 9)
+    ):
+        assert is_sm89_supported()
+
+    is_sm89_supported.cache_clear()
+    is_cuda.cache_clear()
+    with patch.object(torch.cuda, "is_available", return_value=True), patch.object(
+        torch.cuda, "get_device_capability", return_value=(8, 6)
+    ):
+        assert not is_sm89_supported()
+
+    is_sm89_supported.cache_clear()
+    is_cuda.cache_clear()
+    with patch.object(torch.cuda, "is_available", return_value=True), patch.object(
+        torch.cuda, "get_device_capability", return_value=(9, 0)
+    ):
+        assert not is_sm89_supported()
+
+    is_sm89_supported.cache_clear()
+    is_cuda.cache_clear()
+    with patch.object(torch.cuda, "is_available", return_value=True), patch.object(
+        torch.cuda, "get_device_capability", return_value=(12, 0)
+    ):
+        assert not is_sm89_supported()
+
+    is_sm89_supported.cache_clear()
+    is_cuda.cache_clear()
+    with patch.object(torch.cuda, "is_available", return_value=False):
+        assert not is_sm89_supported()
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

This PR adds SM89/Ada (NVIDIA L20) support for running DeepSeek-V4-Flash-FP8 in SGLang.

Current DeepSeek-V4-Flash-FP8 paths can route SM89 into kernels or metadata paths that rely on SM90+ capabilities, including FlashMLA / DeepGEMM metadata / `topk_v2` cluster-kernel paths. For local L20 deployment, these had to be avoided with deployment-only patches and environment-variable workarounds. This PR upstreams the SM89 path as explicit source-level capability gating instead.

This is intended to implement the SM89 item in the DeepSeek V4 roadmap's "Other SM versions (community may implement them if needed)" section: #23602.

Model used for local validation: https://huggingface.co/sgl-project/DeepSeek-V4-Flash-FP8

## Key Changes

- Add explicit SM89 `(8, 9)` capability detection.
- Route DeepSeek-V4-Flash-FP8 on SM89 away from SM90-only FlashMLA / DeepGEMM metadata / `topk_v2` paths.
- Add an SM89 Triton FP8 paged MQA logits fallback for the DeepSeek-V4 indexer.
- Disable Hopper/Blackwell-only DeepGEMM/TileLang MHC prenorm fast paths by default on SM89.
- Add CI-safe helper/import tests and a manual L20 correctness test for the Triton fallback.
- Document the SM89/L20 route in the DeepSeek-V4 cookbook.

## Scope

This PR is intentionally scoped to SM89/L20 support for DeepSeek-V4-Flash-FP8.

Existing non-SM89 paths are intended to remain unchanged:

- SM90 / Hopper
- SM100 / SM120
- AMD / HIP
- FP4 indexer
- TileLang and AITER indexer paths

## Local Validation

Hardware / model setup:

- Hardware: 8x NVIDIA L20, SM89
- Parallelism: TP=8
- Model: `sgl-project/DeepSeek-V4-Flash-FP8`
- Base image used for source-mounted validation: `lmsysorg/sglang:v0.5.13`
- Source-mounted runtime for the latest validation used `sglang-kernel==0.4.4`, matching the rebased upstream dependency requirement.

Validation results:

- Import smoke for the SM89 helper/path passed.
- Registered pytest passed:
  - `python3 -m pytest test/registered/attention/unittests/dsv4/test_deepseek_v4_sm89.py -q`
  - Result: `3 passed`
- Changed-files pre-commit passed.
- Manual Triton paged MQA logits correctness passed on L20:
  - `python3 test/manual/dsv4/test_sm89_paged_mqa_logits.py`
  - 3 cases passed with max diff `0.000000`
- Full local service validation on 8xL20 passed:
  - source-mounted PR branch reached `/v1/models`
  - no legacy MHC workaround env vars were required for `SGLANG_OPT_USE_TILELANG_MHC_PRE=0` / `SGLANG_OPT_DEEPGEMM_HC_PRENORM=0`
  - short chat completion passed
  - long-context request with `max_tokens=4096` passed

## Speed Tests and Profiling

The SM89 Triton FP8 paged MQA logits fallback uses the locally tuned launch config:

- `num_warps=4`
- `num_stages=4`

Fixed-shape single-request serving results are posted in https://github.com/sgl-project/sglang/pull/28620#issuecomment-4842519239.

Summary of the latest 8xL20 comparison using `ignore_eos=true`, TP=8, `--attention-backend triton`, `--mem-fraction-static 0.85`, `--context-length 32768`, `--cuda-graph-max-bs 8`, and `--max-running-requests 8`:

| Setup | Case | Prompt tokens | Completion tokens | Elapsed sec | Client completion tok/s | Finish |
|---|---:|---:|---:|---:|---:|---|
| baseline patched v0.5.13 | `short-256x256` | 516 | 256 | 6.39 | 40.08 | length |
| baseline patched v0.5.13 | `mid-512x512` | 1028 | 512 | 12.53 | 40.86 | length |
| baseline patched v0.5.13 | `long-4096x1024` | 8196 | 1024 | 25.22 | 40.61 | length |
| rebased PR branch | `short-256x256` | 516 | 256 | 8.83 | 29.00 | length |
| rebased PR branch | `mid-512x512` | 1028 | 512 | 14.15 | 36.19 | length |
| rebased PR branch | `long-4096x1024` | 8196 | 1024 | 50.71 | 20.19 | length |

The PR branch is slower than the internal patched baseline on the long 4096x1024 case, but it is no longer in the 3-4 tok/s range reported earlier and now starts successfully from the rebased PR source without the MHC/DeepGEMM env workaround. I will keep this PR scoped as SM89/L20 compatibility enablement unless maintainers prefer follow-up performance tuning in the same PR.

## Trying this before merge

There is no official public Docker image for this PR yet.

For pre-merge testing, the recommended options are:

1. build an image from this PR branch, or
2. mount this PR branch's `python/` source over a recent SGLang image with a compatible `sglang-kernel` version.

The local image used for validation was an internal v0.5.13-based test image, not an official or public release image.

## Checklist

- [x] Format code with pre-commit
  - `pre-commit run --files docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx`: passed
  - `SKIP=rustfmt-sgl-model-gateway,rustfmt-sgl-router RUFF_CACHE_DIR=/tmp/sglang-ruff-cache pre-commit run --all-files`: passed
  - Note: an unskipped local `pre-commit run --all-files` cannot complete on this machine because `rustup`/`cargo` are not installed; this PR does not modify Rust files.
- [x] Add tests
  - `test/registered/attention/unittests/dsv4/test_deepseek_v4_sm89.py`
  - `test/manual/dsv4/test_sm89_paged_mqa_logits.py`
- [x] Provide local correctness / validation results
  - registered pytest: `3 passed`
  - changed-files pre-commit: passed
  - manual Triton paged MQA logits correctness on L20: 3 cases, max diff `0.000000`
  - 8xL20 service startup and long-context request passed
  - fixed-shape serving benchmark posted in the PR discussion
- [x] Documentation update
  - `docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx`
- [x] Follow SGLang code style guidance
  - SM89 path is explicitly gated by CUDA capability `(8, 9)`
  - existing non-SM89 paths are kept unchanged
- [ ] Full upstream CI
  - Waiting for an authorized maintainer to trigger CI with `run-ci` / `run-ci-extra`.

## Review and Merge Process

1. Get feedback / approval from DeepSeek-V4 code owners and maintainers.
2. Trigger full CI via an authorized maintainer.
   - Common commands: `/tag-and-rerun-ci` or `/tag-and-rerun-ci extra`.
3. Address any CI or review findings.
4. Merge after green CI and required approval.

## CI Status

Current Base/Extra failures are from the PR gate because the PR is missing the required `run-ci` label. The real test jobs have not run yet. Once an authorized maintainer triggers CI with `/tag-and-rerun-ci` or `/tag-and-rerun-ci extra`, I will address any resulting failures.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29494954106](https://github.com/sgl-project/sglang/actions/runs/29494954106)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29494952206](https://github.com/sgl-project/sglang/actions/runs/29494952206)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->