### PR TITLE
[diffusion] optimize LTX2.3 CFG/SP paths

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/ltx_2.py
@@ -162,6 +162,7 @@ class LTX2ArchConfig(DiTArchConfig):
     # SGLang-specific parameters
     patch_size: tuple[int, int, int] = (1, 2, 2)
     text_len: int = 512
+    enable_packed_qkv_input_a2a: bool = False
 
     def __post_init__(self):
         super().__post_init__()

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
@@ -715,6 +715,9 @@ class LTX2PipelineConfig(PipelineConfig):
 class LTX23PipelineConfig(LTX2PipelineConfig):
     """Configuration overrides for LTX-2.3."""
 
+    def __post_init__(self):
+        self.dit_config.arch_config.enable_packed_qkv_input_a2a = True
+
 
 @dataclasses.dataclass
 class LTX2I2VPipelineConfig(LTX2PipelineConfig):

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
@@ -715,9 +715,6 @@ class LTX2PipelineConfig(PipelineConfig):
 class LTX23PipelineConfig(LTX2PipelineConfig):
     """Configuration overrides for LTX-2.3."""
 
-    def __post_init__(self):
-        self.dit_config.arch_config.enable_packed_qkv_input_a2a = True
-
 
 @dataclasses.dataclass
 class LTX2I2VPipelineConfig(LTX2PipelineConfig):

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
@@ -200,6 +200,7 @@ class LTX2PipelineConfig(PipelineConfig):
         return ModelDeploymentConfig(
             auto_disable_component_offload_min_available_memory_gb=70,
             auto_disable_component_offload_components=("dit",),
+            auto_cfg_parallel_degree_by_num_gpus=((4, 1), (8, 1)),
         )
 
     def prepare_latent_shape(self, batch, batch_size, num_frames):

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
@@ -25,6 +25,11 @@ class ModelDeploymentConfig:
     fsdp_auto_requires_cfg: bool = True
     fsdp_auto_requires_default_parallelism: bool = True
     auto_enable_cfg_parallel: bool = True
-    # Per-GPU-count auto CFG degree override. A degree of 1 keeps CFG parallel
-    # disabled and leaves the remaining GPUs available for sequence parallelism.
+    # degree 1 keeps CFG parallel disabled and leaves GPUs available for SP
     auto_cfg_parallel_degree_by_num_gpus: tuple[tuple[int, int], ...] = ()
+
+    def get_auto_cfg_parallel_degree(self, num_gpus: int) -> int:
+        for candidate_num_gpus, cfg_degree in self.auto_cfg_parallel_degree_by_num_gpus:
+            if candidate_num_gpus == num_gpus:
+                return cfg_degree
+        return 2

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
@@ -25,3 +25,6 @@ class ModelDeploymentConfig:
     fsdp_auto_requires_cfg: bool = True
     fsdp_auto_requires_default_parallelism: bool = True
     auto_enable_cfg_parallel: bool = True
+    # Per-GPU-count auto CFG degree override. A degree of 1 keeps CFG parallel
+    # disabled and leaves the remaining GPUs available for sequence parallelism.
+    auto_cfg_parallel_degree_by_num_gpus: tuple[tuple[int, int], ...] = ()

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -409,6 +409,7 @@ class USPAttention(nn.Module):
         prefix: str = "",
         dropout_rate: float = 0.0,
         skip_sequence_parallel: bool = False,
+        enable_packed_qkv_input_a2a: bool = False,
         **extra_impl_args,
     ) -> None:
         """
@@ -464,6 +465,7 @@ class USPAttention(nn.Module):
         self.dropout_p = dropout_rate
 
         self.skip_sequence_parallel = skip_sequence_parallel
+        self.enable_packed_qkv_input_a2a = bool(enable_packed_qkv_input_a2a)
 
     def _get_usp_a2a_stream(self):
         if USPAttention._usp_a2a_stream is None:
@@ -765,9 +767,21 @@ class USPAttention(nn.Module):
         # Ulysses-style All-to-All for sequence/head sharding
         if sp_size > 1:
             # -> [B, S, H_local, D]
-            q = _usp_input_all_to_all(q, head_dim=2)
-            k = _usp_input_all_to_all(k, head_dim=2)
-            v = _usp_input_all_to_all(v, head_dim=2)
+            if self.enable_packed_qkv_input_a2a and q.device.type == "cuda":
+                q, k, v = async_a2a_communicate(
+                    [q, k, v],
+                    sp_size,
+                    get_sp_group().ulysses_group,
+                    self._get_usp_a2a_stream(),
+                    local_seq_2_local_head=True,
+                )
+                q = q.contiguous()
+                k = k.contiguous()
+                v = v.contiguous()
+            else:
+                q = _usp_input_all_to_all(q, head_dim=2)
+                k = _usp_input_all_to_all(k, head_dim=2)
+                v = _usp_input_all_to_all(v, head_dim=2)
 
         # Ring Attention within subgroups or local attention
         if get_ring_parallel_world_size() > 1:

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -765,21 +765,9 @@ class USPAttention(nn.Module):
         # Ulysses-style All-to-All for sequence/head sharding
         if sp_size > 1:
             # -> [B, S, H_local, D]
-            if q.device.type == "cuda":
-                q, k, v = async_a2a_communicate(
-                    [q, k, v],
-                    sp_size,
-                    get_sp_group().ulysses_group,
-                    self._get_usp_a2a_stream(),
-                    local_seq_2_local_head=True,
-                )
-                q = q.contiguous()
-                k = k.contiguous()
-                v = v.contiguous()
-            else:
-                q = _usp_input_all_to_all(q, head_dim=2)
-                k = _usp_input_all_to_all(k, head_dim=2)
-                v = _usp_input_all_to_all(v, head_dim=2)
+            q = _usp_input_all_to_all(q, head_dim=2)
+            k = _usp_input_all_to_all(k, head_dim=2)
+            v = _usp_input_all_to_all(v, head_dim=2)
 
         # Ring Attention within subgroups or local attention
         if get_ring_parallel_world_size() > 1:

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -765,9 +765,21 @@ class USPAttention(nn.Module):
         # Ulysses-style All-to-All for sequence/head sharding
         if sp_size > 1:
             # -> [B, S, H_local, D]
-            q = _usp_input_all_to_all(q, head_dim=2)
-            k = _usp_input_all_to_all(k, head_dim=2)
-            v = _usp_input_all_to_all(v, head_dim=2)
+            if q.device.type == "cuda":
+                q, k, v = async_a2a_communicate(
+                    [q, k, v],
+                    sp_size,
+                    get_sp_group().ulysses_group,
+                    self._get_usp_a2a_stream(),
+                    local_seq_2_local_head=True,
+                )
+                q = q.contiguous()
+                k = k.contiguous()
+                v = v.contiguous()
+            else:
+                q = _usp_input_all_to_all(q, head_dim=2)
+                k = _usp_input_all_to_all(k, head_dim=2)
+                v = _usp_input_all_to_all(v, head_dim=2)
 
         # Ring Attention within subgroups or local attention
         if get_ring_parallel_world_size() > 1:

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -531,6 +531,7 @@ class LTX2Attention(nn.Module):
         qk_norm: bool = True,
         use_local_attention: bool = False,
         apply_gated_attention: bool = False,
+        enable_packed_qkv_input_a2a: bool = False,
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
         prefix: str = "",
         quant_config: QuantizationConfig | None = None,
@@ -546,6 +547,7 @@ class LTX2Attention(nn.Module):
         self.qk_norm = bool(qk_norm)
         self.use_local_attention = bool(use_local_attention)
         self.apply_gated_attention = bool(apply_gated_attention)
+        self.enable_packed_qkv_input_a2a = bool(enable_packed_qkv_input_a2a)
         self.prefix = prefix
 
         tp_size = get_tp_world_size()
@@ -633,6 +635,7 @@ class LTX2Attention(nn.Module):
                 causal=False,
                 supported_attention_backends=supported_attention_backends,
                 prefix=f"{prefix}.attn",
+                enable_packed_qkv_input_a2a=self.enable_packed_qkv_input_a2a,
                 # official LTX2 torch_sdpa uses cuDNN; cuda setup disables it
                 allow_cudnn_sdp=True,
             )
@@ -832,6 +835,7 @@ class LTX2TransformerBlock(nn.Module):
         cross_attention_adaln: bool = False,
         use_local_av_cross_attention: bool = False,
         force_sdpa_v2a_cross_attention: bool = False,
+        enable_packed_qkv_input_a2a: bool = False,
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
         prefix: str = "",
         quant_config: QuantizationConfig | None = None,
@@ -851,6 +855,7 @@ class LTX2TransformerBlock(nn.Module):
             norm_eps=norm_eps,
             qk_norm=qk_norm,
             apply_gated_attention=apply_gated_attention,
+            enable_packed_qkv_input_a2a=enable_packed_qkv_input_a2a,
             supported_attention_backends=supported_attention_backends,
             prefix=f"{prefix}.attn1",
             quant_config=quant_config,
@@ -862,6 +867,7 @@ class LTX2TransformerBlock(nn.Module):
             norm_eps=norm_eps,
             qk_norm=qk_norm,
             apply_gated_attention=apply_gated_attention,
+            enable_packed_qkv_input_a2a=enable_packed_qkv_input_a2a,
             supported_attention_backends=supported_attention_backends,
             prefix=f"{prefix}.audio_attn1",
             quant_config=quant_config,
@@ -907,6 +913,7 @@ class LTX2TransformerBlock(nn.Module):
             qk_norm=qk_norm,
             use_local_attention=use_local_av_cross_attention,
             apply_gated_attention=apply_gated_attention,
+            enable_packed_qkv_input_a2a=enable_packed_qkv_input_a2a,
             supported_attention_backends=supported_attention_backends,
             prefix=f"{prefix}.audio_to_video_attn",
             quant_config=quant_config,
@@ -920,6 +927,7 @@ class LTX2TransformerBlock(nn.Module):
             qk_norm=qk_norm,
             use_local_attention=use_local_av_cross_attention,
             apply_gated_attention=apply_gated_attention,
+            enable_packed_qkv_input_a2a=enable_packed_qkv_input_a2a,
             supported_attention_backends=(
                 {AttentionBackendEnum.TORCH_SDPA}
                 if force_sdpa_v2a_cross_attention
@@ -1526,6 +1534,7 @@ class LTX2VideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
                     force_sdpa_v2a_cross_attention=bool(
                         getattr(arch, "force_sdpa_v2a_cross_attention", False)
                     ),
+                    enable_packed_qkv_input_a2a=arch.enable_packed_qkv_input_a2a,
                     supported_attention_backends=self._supported_attention_backends,
                     prefix=config.prefix,
                     quant_config=quant_config,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
@@ -72,6 +72,7 @@ class ParallelExecutor(PipelineExecutor):
                     local_batch_fields = stage.cfg_parallel_local_batch_fields(
                         batch, server_args
                     )
+                    # filter local batch fields from batch
                     if rank == 0 and local_batch_fields:
                         local_field_values = {
                             name: getattr(batch, name) for name in local_batch_fields
@@ -80,6 +81,7 @@ class ParallelExecutor(PipelineExecutor):
                             setattr(batch, name, None)
                     else:
                         local_field_values = {}
+
                     obj_list = [batch] if rank == 0 else []
                     try:
                         # `dist.broadcast(src=...)` expects a global rank for process groups.
@@ -91,6 +93,7 @@ class ParallelExecutor(PipelineExecutor):
                         )
                     finally:
                         if rank == 0:
+                            # resume local batch fields on rank 0
                             for name, value in local_field_values.items():
                                 setattr(batch, name, value)
                     if rank != 0:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
@@ -68,16 +68,35 @@ class ParallelExecutor(PipelineExecutor):
                     torch.distributed.barrier()
 
                 elif paradigm == StageParallelismType.CFG_PARALLEL:
-                    obj_list = [batch] if rank == 0 else []
-                    # `dist.broadcast(src=...)` expects a global rank for process groups.
-                    broadcasted_list = broadcast_pyobj(
-                        obj_list,
-                        rank=get_world_rank(),
-                        dist_group=cfg_group.cpu_group,
-                        src=cfg_group.ranks[0],
+                    local_batch = batch
+                    local_batch_fields = stage.cfg_parallel_local_batch_fields(
+                        batch, server_args
                     )
+                    if rank == 0 and local_batch_fields:
+                        local_field_values = {
+                            name: getattr(batch, name) for name in local_batch_fields
+                        }
+                        for name in local_batch_fields:
+                            setattr(batch, name, None)
+                    else:
+                        local_field_values = {}
+                    obj_list = [batch] if rank == 0 else []
+                    try:
+                        # `dist.broadcast(src=...)` expects a global rank for process groups.
+                        broadcasted_list = broadcast_pyobj(
+                            obj_list,
+                            rank=get_world_rank(),
+                            dist_group=cfg_group.cpu_group,
+                            src=cfg_group.ranks[0],
+                        )
+                    finally:
+                        if rank == 0:
+                            for name, value in local_field_values.items():
+                                setattr(batch, name, value)
                     if rank != 0:
                         batch = broadcasted_list[0]
+                        for name in local_batch_fields:
+                            setattr(batch, name, getattr(local_batch, name))
                     batch = self._run_stage_with_executor_hooks(
                         stage,
                         stage_index,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py
@@ -275,6 +275,7 @@ class PipelineStage(StageDedupMixin, ABC):
     def cfg_parallel_local_batch_fields(
         self, batch: Req, server_args: ServerArgs
     ) -> tuple[str, ...]:
+        """the name of fields which already have a local version on each GPU in CFG-Parallel, no need to broadcast"""
         return ()
 
     def verify_output(self, batch: Req, server_args: ServerArgs) -> VerificationResult:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py
@@ -272,6 +272,11 @@ class PipelineStage(StageDedupMixin, ABC):
         #     return StageParallelismType.MAIN_RANK_ONLY
         return StageParallelismType.REPLICATED
 
+    def cfg_parallel_local_batch_fields(
+        self, batch: Req, server_args: ServerArgs
+    ) -> tuple[str, ...]:
+        return ()
+
     def verify_output(self, batch: Req, server_args: ServerArgs) -> VerificationResult:
         """
         Verify the output for the stage.

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/decoding_av.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/decoding_av.py
@@ -164,10 +164,13 @@ class LTX2AVDecodingStage(DecodingStage):
                     audio_vae_dtype, server_args.disable_autocast
                 )
                 should_cast_audio_vae = not audio_vae_autocast_enabled
-                with torch.no_grad(), torch.autocast(
-                    device_type=current_platform.device_type,
-                    dtype=audio_vae_dtype,
-                    enabled=audio_vae_autocast_enabled,
+                with (
+                    torch.no_grad(),
+                    torch.autocast(
+                        device_type=current_platform.device_type,
+                        dtype=audio_vae_dtype,
+                        enabled=audio_vae_autocast_enabled,
+                    ),
                 ):
                     # Decode latents to spectrogram
                     with temporary_module_dtype(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/denoising.py
@@ -167,6 +167,13 @@ class LTX2DenoisingStage(DenoisingStage):
             return StageParallelismType.CFG_PARALLEL
         return StageParallelismType.REPLICATED
 
+    def cfg_parallel_local_batch_fields(
+        self, batch: Req, server_args: ServerArgs
+    ) -> tuple[str, ...]:
+        if is_ltx23_native_variant(server_args.pipeline_config.vae_config.arch_config):
+            return ("latents", "audio_latents")
+        return ()
+
     @staticmethod
     def _combine_cfg_parallel_av(
         video: torch.Tensor,

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -821,21 +821,13 @@ class ServerArgs(DisaggServerArgsMixin):
         # because non-CFG models (e.g. FLUX) crash when CFG parallel splits ranks.
         if cfg_unspecified:
             deployment_config = self.pipeline_config.get_model_deployment_config()
-            auto_cfg_parallel_degree = None
-            for num_gpus, cfg_degree in (
-                deployment_config.auto_cfg_parallel_degree_by_num_gpus
-            ):
-                if num_gpus == self.num_gpus:
-                    auto_cfg_parallel_degree = cfg_degree
-                    break
-            if auto_cfg_parallel_degree is None:
-                auto_cfg_parallel_degree = 2
+            auto_cfg_parallel_degree = deployment_config.get_auto_cfg_parallel_degree(
+                self.num_gpus
+            )
             if auto_cfg_parallel_degree < 1:
                 self.enable_cfg_parallel = False
             else:
-                cfg_group_size = (
-                    self.dp_size * self.tp_size * auto_cfg_parallel_degree
-                )
+                cfg_group_size = self.dp_size * self.tp_size * auto_cfg_parallel_degree
                 if (
                     self.performance_mode != "manual"
                     and deployment_config.auto_enable_cfg_parallel

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -821,48 +821,12 @@ class ServerArgs(DisaggServerArgsMixin):
         # because non-CFG models (e.g. FLUX) crash when CFG parallel splits ranks.
         if cfg_unspecified:
             deployment_config = self.pipeline_config.get_model_deployment_config()
-            auto_cfg_parallel_degree = None
-            for num_gpus, cfg_degree in (
-                deployment_config.auto_cfg_parallel_degree_by_num_gpus
-            ):
-                if num_gpus == self.num_gpus:
-                    auto_cfg_parallel_degree = cfg_degree
-                    break
-            if auto_cfg_parallel_degree is None:
-                auto_cfg_parallel_degree = 2
-            if auto_cfg_parallel_degree < 1:
-                self.enable_cfg_parallel = False
-            else:
-                cfg_group_size = (
-                    self.dp_size * self.tp_size * auto_cfg_parallel_degree
-                )
-                if (
-                    self.performance_mode != "manual"
-                    and deployment_config.auto_enable_cfg_parallel
-                    and self.num_gpus >= 2
-                    and self.num_gpus % cfg_group_size == 0
-                    and sp_unspecified
-                    and ulysses_unspecified
-                    and ring_unspecified
-                    and self._model_default_uses_cfg()
-                ):
-                    self.cfg_parallel_degree = auto_cfg_parallel_degree
-                    self.enable_cfg_parallel = auto_cfg_parallel_degree > 1
-                    if self.enable_cfg_parallel:
-                        logger.info(
-                            "Automatically enabled CFG parallel at degree %d for %d GPUs. "
-                            "Use --sp-degree / --ulysses-degree to use sequence "
-                            "parallelism instead.",
-                            self.cfg_parallel_degree,
-                            self.num_gpus,
-                        )
-                    else:
-                        logger.info(
-                            "Automatically disabled CFG parallel for %d GPUs based on model deployment config.",
-                            self.num_gpus,
-                        )
-                else:
-                    self.enable_cfg_parallel = False
+            self._adjust_auto_cfg_parallelism(
+                deployment_config,
+                sp_unspecified=sp_unspecified,
+                ulysses_unspecified=ulysses_unspecified,
+                ring_unspecified=ring_unspecified,
+            )
 
         # Resolve cfg_parallel_degree to a concrete int now that enable_cfg_parallel is settled.
         if self.cfg_parallel_degree is None:
@@ -898,6 +862,73 @@ class ServerArgs(DisaggServerArgsMixin):
         if self.ring_degree is None:
             self.ring_degree = 1
             logger.debug(f"Ring degree not set, using default value {self.ring_degree}")
+
+    def _adjust_auto_cfg_parallelism(
+        self,
+        deployment_config,
+        *,
+        sp_unspecified: bool,
+        ulysses_unspecified: bool,
+        ring_unspecified: bool,
+    ) -> None:
+        cfg_parallel_degree = self._get_auto_cfg_parallel_degree(deployment_config)
+        if not self._can_apply_auto_cfg_parallelism(
+            deployment_config,
+            cfg_parallel_degree,
+            sp_unspecified=sp_unspecified,
+            ulysses_unspecified=ulysses_unspecified,
+            ring_unspecified=ring_unspecified,
+        ):
+            self.enable_cfg_parallel = False
+            return
+
+        self.cfg_parallel_degree = cfg_parallel_degree
+        self.enable_cfg_parallel = cfg_parallel_degree > 1
+        if self.enable_cfg_parallel:
+            logger.info(
+                "Automatically enabled CFG parallel at degree %d for %d GPUs. "
+                "Use --sp-degree / --ulysses-degree to use sequence parallelism instead.",
+                self.cfg_parallel_degree,
+                self.num_gpus,
+            )
+        else:
+            logger.info(
+                "Automatically kept CFG parallel disabled for %d GPUs based on model deployment config.",
+                self.num_gpus,
+            )
+
+    def _get_auto_cfg_parallel_degree(self, deployment_config) -> int:
+        for (
+            num_gpus,
+            cfg_degree,
+        ) in deployment_config.auto_cfg_parallel_degree_by_num_gpus:
+            if num_gpus == self.num_gpus:
+                return cfg_degree
+        return 2
+
+    def _can_apply_auto_cfg_parallelism(
+        self,
+        deployment_config,
+        cfg_parallel_degree: int,
+        *,
+        sp_unspecified: bool,
+        ulysses_unspecified: bool,
+        ring_unspecified: bool,
+    ) -> bool:
+        if cfg_parallel_degree < 1:
+            return False
+
+        cfg_group_size = self.dp_size * self.tp_size * cfg_parallel_degree
+        return (
+            self.performance_mode != "manual"
+            and deployment_config.auto_enable_cfg_parallel
+            and self.num_gpus >= 2
+            and self.num_gpus % cfg_group_size == 0
+            and sp_unspecified
+            and ulysses_unspecified
+            and ring_unspecified
+            and self._model_default_uses_cfg()
+        )
 
     def _model_default_uses_cfg(self) -> bool:
         """

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -821,12 +821,48 @@ class ServerArgs(DisaggServerArgsMixin):
         # because non-CFG models (e.g. FLUX) crash when CFG parallel splits ranks.
         if cfg_unspecified:
             deployment_config = self.pipeline_config.get_model_deployment_config()
-            self._adjust_auto_cfg_parallelism(
-                deployment_config,
-                sp_unspecified=sp_unspecified,
-                ulysses_unspecified=ulysses_unspecified,
-                ring_unspecified=ring_unspecified,
-            )
+            auto_cfg_parallel_degree = None
+            for num_gpus, cfg_degree in (
+                deployment_config.auto_cfg_parallel_degree_by_num_gpus
+            ):
+                if num_gpus == self.num_gpus:
+                    auto_cfg_parallel_degree = cfg_degree
+                    break
+            if auto_cfg_parallel_degree is None:
+                auto_cfg_parallel_degree = 2
+            if auto_cfg_parallel_degree < 1:
+                self.enable_cfg_parallel = False
+            else:
+                cfg_group_size = (
+                    self.dp_size * self.tp_size * auto_cfg_parallel_degree
+                )
+                if (
+                    self.performance_mode != "manual"
+                    and deployment_config.auto_enable_cfg_parallel
+                    and self.num_gpus >= 2
+                    and self.num_gpus % cfg_group_size == 0
+                    and sp_unspecified
+                    and ulysses_unspecified
+                    and ring_unspecified
+                    and self._model_default_uses_cfg()
+                ):
+                    self.cfg_parallel_degree = auto_cfg_parallel_degree
+                    self.enable_cfg_parallel = auto_cfg_parallel_degree > 1
+                    if self.enable_cfg_parallel:
+                        logger.info(
+                            "Automatically enabled CFG parallel at degree %d for %d GPUs. "
+                            "Use --sp-degree / --ulysses-degree to use sequence "
+                            "parallelism instead.",
+                            self.cfg_parallel_degree,
+                            self.num_gpus,
+                        )
+                    else:
+                        logger.info(
+                            "Automatically disabled CFG parallel for %d GPUs based on model deployment config.",
+                            self.num_gpus,
+                        )
+                else:
+                    self.enable_cfg_parallel = False
 
         # Resolve cfg_parallel_degree to a concrete int now that enable_cfg_parallel is settled.
         if self.cfg_parallel_degree is None:
@@ -862,73 +898,6 @@ class ServerArgs(DisaggServerArgsMixin):
         if self.ring_degree is None:
             self.ring_degree = 1
             logger.debug(f"Ring degree not set, using default value {self.ring_degree}")
-
-    def _adjust_auto_cfg_parallelism(
-        self,
-        deployment_config,
-        *,
-        sp_unspecified: bool,
-        ulysses_unspecified: bool,
-        ring_unspecified: bool,
-    ) -> None:
-        cfg_parallel_degree = self._get_auto_cfg_parallel_degree(deployment_config)
-        if not self._can_apply_auto_cfg_parallelism(
-            deployment_config,
-            cfg_parallel_degree,
-            sp_unspecified=sp_unspecified,
-            ulysses_unspecified=ulysses_unspecified,
-            ring_unspecified=ring_unspecified,
-        ):
-            self.enable_cfg_parallel = False
-            return
-
-        self.cfg_parallel_degree = cfg_parallel_degree
-        self.enable_cfg_parallel = cfg_parallel_degree > 1
-        if self.enable_cfg_parallel:
-            logger.info(
-                "Automatically enabled CFG parallel at degree %d for %d GPUs. "
-                "Use --sp-degree / --ulysses-degree to use sequence parallelism instead.",
-                self.cfg_parallel_degree,
-                self.num_gpus,
-            )
-        else:
-            logger.info(
-                "Automatically kept CFG parallel disabled for %d GPUs based on model deployment config.",
-                self.num_gpus,
-            )
-
-    def _get_auto_cfg_parallel_degree(self, deployment_config) -> int:
-        for (
-            num_gpus,
-            cfg_degree,
-        ) in deployment_config.auto_cfg_parallel_degree_by_num_gpus:
-            if num_gpus == self.num_gpus:
-                return cfg_degree
-        return 2
-
-    def _can_apply_auto_cfg_parallelism(
-        self,
-        deployment_config,
-        cfg_parallel_degree: int,
-        *,
-        sp_unspecified: bool,
-        ulysses_unspecified: bool,
-        ring_unspecified: bool,
-    ) -> bool:
-        if cfg_parallel_degree < 1:
-            return False
-
-        cfg_group_size = self.dp_size * self.tp_size * cfg_parallel_degree
-        return (
-            self.performance_mode != "manual"
-            and deployment_config.auto_enable_cfg_parallel
-            and self.num_gpus >= 2
-            and self.num_gpus % cfg_group_size == 0
-            and sp_unspecified
-            and ulysses_unspecified
-            and ring_unspecified
-            and self._model_default_uses_cfg()
-        )
 
     def _model_default_uses_cfg(self) -> bool:
         """

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -821,26 +821,48 @@ class ServerArgs(DisaggServerArgsMixin):
         # because non-CFG models (e.g. FLUX) crash when CFG parallel splits ranks.
         if cfg_unspecified:
             deployment_config = self.pipeline_config.get_model_deployment_config()
-            cfg_group_size = self.dp_size * self.tp_size * 2
-            if (
-                self.performance_mode != "manual"
-                and deployment_config.auto_enable_cfg_parallel
-                and self.num_gpus >= 2
-                and self.num_gpus % cfg_group_size == 0
-                and sp_unspecified
-                and ulysses_unspecified
-                and ring_unspecified
-                and self._model_default_uses_cfg()
+            auto_cfg_parallel_degree = None
+            for num_gpus, cfg_degree in (
+                deployment_config.auto_cfg_parallel_degree_by_num_gpus
             ):
-                self.enable_cfg_parallel = True
-                logger.info(
-                    "Automatically enabled CFG parallel for %d GPUs. "
-                    "Use --sp-degree / --ulysses-degree to use sequence "
-                    "parallelism instead.",
-                    self.num_gpus,
-                )
-            else:
+                if num_gpus == self.num_gpus:
+                    auto_cfg_parallel_degree = cfg_degree
+                    break
+            if auto_cfg_parallel_degree is None:
+                auto_cfg_parallel_degree = 2
+            if auto_cfg_parallel_degree < 1:
                 self.enable_cfg_parallel = False
+            else:
+                cfg_group_size = (
+                    self.dp_size * self.tp_size * auto_cfg_parallel_degree
+                )
+                if (
+                    self.performance_mode != "manual"
+                    and deployment_config.auto_enable_cfg_parallel
+                    and self.num_gpus >= 2
+                    and self.num_gpus % cfg_group_size == 0
+                    and sp_unspecified
+                    and ulysses_unspecified
+                    and ring_unspecified
+                    and self._model_default_uses_cfg()
+                ):
+                    self.cfg_parallel_degree = auto_cfg_parallel_degree
+                    self.enable_cfg_parallel = auto_cfg_parallel_degree > 1
+                    if self.enable_cfg_parallel:
+                        logger.info(
+                            "Automatically enabled CFG parallel at degree %d for %d GPUs. "
+                            "Use --sp-degree / --ulysses-degree to use sequence "
+                            "parallelism instead.",
+                            self.cfg_parallel_degree,
+                            self.num_gpus,
+                        )
+                    else:
+                        logger.info(
+                            "Automatically disabled CFG parallel for %d GPUs based on model deployment config.",
+                            self.num_gpus,
+                        )
+                else:
+                    self.enable_cfg_parallel = False
 
         # Resolve cfg_parallel_degree to a concrete int now that enable_cfg_parallel is settled.
         if self.cfg_parallel_degree is None:

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -816,6 +816,9 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertEqual(
             ltx_deployment.auto_disable_component_offload_components, ("dit",)
         )
+        self.assertEqual(
+            ltx_deployment.auto_cfg_parallel_degree_by_num_gpus, ((4, 1), (8, 1))
+        )
 
         self.assertEqual(sana_wm_deployment.fsdp_auto_min_available_memory_gb, 60)
         self.assertTrue(sana_wm_deployment.auto_dit_layerwise_offload)
@@ -845,6 +848,24 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertFalse(args.enable_cfg_parallel)
+
+    def test_auto_ltx23_large_gpu_counts_prefer_sp_over_cfg_parallel(self):
+        for num_gpus in (4, 8):
+            with self.subTest(num_gpus=num_gpus):
+                args = self._from_dict_with_pipeline_config(
+                    LTX2PipelineConfig(),
+                    kwargs={
+                        "model_path": "Lightricks/LTX-2.3",
+                        "num_gpus": num_gpus,
+                        "performance_mode": "auto",
+                    },
+                )
+
+                self.assertFalse(args.enable_cfg_parallel)
+                self.assertEqual(args.cfg_parallel_degree, 1)
+                self.assertEqual(args.sp_degree, num_gpus)
+                self.assertEqual(args.ulysses_degree, num_gpus)
+                self.assertEqual(args.ring_degree, 1)
 
     def test_manual_mode_preserves_unset_performance_args(self):
         args = self._from_dict_with_pipeline_config(

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -15,7 +15,10 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
     PipelineConfig,
 )
-from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import LTX2PipelineConfig
+from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import (
+    LTX2PipelineConfig,
+    LTX23PipelineConfig,
+)
 from sglang.multimodal_gen.configs.pipeline_configs.mova import MOVAPipelineConfig
 from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import (
     QwenImagePipelineConfig,
@@ -795,6 +798,7 @@ class TestOffloadDefaults(unittest.TestCase):
         mova_deployment = MOVAPipelineConfig().get_model_deployment_config()
         zimage_deployment = ZImagePipelineConfig().get_model_deployment_config()
         ltx_deployment = LTX2PipelineConfig().get_model_deployment_config()
+        ltx23_config = LTX23PipelineConfig()
         sana_wm_deployment = SanaWMPipelineConfig().get_model_deployment_config()
 
         self.assertIsNone(qwen_deployment.fsdp_auto_min_available_memory_gb)
@@ -822,6 +826,10 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertEqual(ltx_deployment.get_auto_cfg_parallel_degree(4), 1)
         self.assertEqual(ltx_deployment.get_auto_cfg_parallel_degree(8), 1)
         self.assertEqual(ltx_deployment.get_auto_cfg_parallel_degree(2), 2)
+        self.assertFalse(
+            LTX2PipelineConfig().dit_config.arch_config.enable_packed_qkv_input_a2a
+        )
+        self.assertTrue(ltx23_config.dit_config.arch_config.enable_packed_qkv_input_a2a)
 
         self.assertEqual(sana_wm_deployment.fsdp_auto_min_available_memory_gb, 60)
         self.assertTrue(sana_wm_deployment.auto_dit_layerwise_offload)

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -816,9 +816,6 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertEqual(
             ltx_deployment.auto_disable_component_offload_components, ("dit",)
         )
-        self.assertEqual(
-            ltx_deployment.auto_cfg_parallel_degree_by_num_gpus, ((4, 1), (8, 1))
-        )
 
         self.assertEqual(sana_wm_deployment.fsdp_auto_min_available_memory_gb, 60)
         self.assertTrue(sana_wm_deployment.auto_dit_layerwise_offload)
@@ -848,24 +845,6 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertFalse(args.enable_cfg_parallel)
-
-    def test_auto_ltx23_large_gpu_counts_prefer_sp_over_cfg_parallel(self):
-        for num_gpus in (4, 8):
-            with self.subTest(num_gpus=num_gpus):
-                args = self._from_dict_with_pipeline_config(
-                    LTX2PipelineConfig(),
-                    kwargs={
-                        "model_path": "Lightricks/LTX-2.3",
-                        "num_gpus": num_gpus,
-                        "performance_mode": "auto",
-                    },
-                )
-
-                self.assertFalse(args.enable_cfg_parallel)
-                self.assertEqual(args.cfg_parallel_degree, 1)
-                self.assertEqual(args.sp_degree, num_gpus)
-                self.assertEqual(args.ulysses_degree, num_gpus)
-                self.assertEqual(args.ring_degree, 1)
 
     def test_manual_mode_preserves_unset_performance_args(self):
         args = self._from_dict_with_pipeline_config(

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -829,7 +829,9 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertFalse(
             LTX2PipelineConfig().dit_config.arch_config.enable_packed_qkv_input_a2a
         )
-        self.assertTrue(ltx23_config.dit_config.arch_config.enable_packed_qkv_input_a2a)
+        self.assertFalse(
+            ltx23_config.dit_config.arch_config.enable_packed_qkv_input_a2a
+        )
 
         self.assertEqual(sana_wm_deployment.fsdp_auto_min_available_memory_gb, 60)
         self.assertTrue(sana_wm_deployment.auto_dit_layerwise_offload)

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -816,6 +816,12 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertEqual(
             ltx_deployment.auto_disable_component_offload_components, ("dit",)
         )
+        self.assertEqual(
+            ltx_deployment.auto_cfg_parallel_degree_by_num_gpus, ((4, 1), (8, 1))
+        )
+        self.assertEqual(ltx_deployment.get_auto_cfg_parallel_degree(4), 1)
+        self.assertEqual(ltx_deployment.get_auto_cfg_parallel_degree(8), 1)
+        self.assertEqual(ltx_deployment.get_auto_cfg_parallel_degree(2), 2)
 
         self.assertEqual(sana_wm_deployment.fsdp_auto_min_available_memory_gb, 60)
         self.assertTrue(sana_wm_deployment.auto_dit_layerwise_offload)
@@ -845,6 +851,24 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertFalse(args.enable_cfg_parallel)
+
+    def test_auto_ltx23_large_gpu_counts_prefer_sp_over_cfg_parallel(self):
+        for num_gpus in (4, 8):
+            with self.subTest(num_gpus=num_gpus):
+                args = self._from_dict_with_pipeline_config(
+                    LTX2PipelineConfig(),
+                    kwargs={
+                        "model_path": "Lightricks/LTX-2.3",
+                        "num_gpus": num_gpus,
+                        "performance_mode": "auto",
+                    },
+                )
+
+                self.assertFalse(args.enable_cfg_parallel)
+                self.assertEqual(args.cfg_parallel_degree, 1)
+                self.assertEqual(args.sp_degree, num_gpus)
+                self.assertEqual(args.ulysses_degree, num_gpus)
+                self.assertEqual(args.ring_degree, 1)
 
     def test_manual_mode_preserves_unset_performance_args(self):
         args = self._from_dict_with_pipeline_config(


### PR DESCRIPTION
## Summary

This PR keeps the LTX2.3 changes that have real pipeline support:

- keeps packed video/audio latents local across CFG-parallel batch broadcast, avoiding Python object broadcast of rank0 CUDA tensors for those fields
- changes LTX2 auto parallelism policy so 4-GPU and 8-GPU auto modes use pure SP instead of auto CFG parallel by default
- keeps packed QKV input A2A as an explicit `USPAttention` instance opt-in, but leaves it disabled for LTX2.3 after the end-to-end rerun below

The packed QKV input A2A path is deliberately not a global default. Cross-model validation showed it is workload-sensitive, and the latest LTX2.3 end-to-end paired run does not show a reliable speedup, so this PR keeps the implementation available but does not opt LTX2.3 into it by default.

## Measured Benefit

### Real LTX2.3 pipeline, 8xB200

Workload: `Lightricks/LTX-2.3`, 768x512, 121 frames, 8 denoise steps, no warmup, no output save, FA transformer backend.

Step 0 includes first-use/CUTLASS/JIT overhead, so `mean step 1-7` is the cleaner steady-state denoise metric.

| Config | Denoise total | Step 0 | Mean step 1-7 | Peak reserved | Relative result |
|---|---:|---:|---:|---:|---:|
| `cfg2+sp4` | 33.92s | 23.94s | 1.296s | 59.46GB | baseline |
| `sp8` | 30.71s | 22.30s | 1.057s | 59.46GB | 1.10x denoise total / 1.23x steady-state step |

This is the direct evidence for changing 8-GPU LTX2.3 auto mode from `cfg2+sp4` to pure `sp8`.

### Packed QKV input A2A microbench

Workload: batch=2, real LTX2.3 token shapes. This measures only the Q/K/V input all-to-all path inside USP attention, not full end-to-end pipeline speedup.

| GPU | Frames | Old QKV input A2A | Packed async QKV input A2A | Output A2A | Input A2A speedup |
|---|---:|---:|---:|---:|---:|
| 8xB300 | 121f | 0.3207ms | 0.2640ms | 0.1009ms | 1.22x |
| 8xB300 | 249f | 0.5739ms | 0.4537ms | 0.1819ms | 1.27x |
| 8xB200 | 121f | 0.2428ms | 0.2297ms | 0.0743ms | 1.06x |
| 8xB200 | 249f | 0.4098ms | 0.3346ms | 0.1304ms | 1.22x |

The local A2A path can improve in isolation, especially for larger shapes and B300, but this is not enough to justify default enablement without end-to-end benefit.

### Packed QKV input A2A e2e pipeline A/B, 8xH100

Workload: `Lightricks/LTX-2.3`, 768x512, 121 frames, 8 denoise steps, no output save, FA transformer backend, `num_gpus=8`, `performance_mode=auto` resolving to pure `sp8` on this PR head.

Each sample launches a fresh CLI process. Model load is outside `total_duration_ms`, but denoise step 0 still includes first-use overhead. The steady-state metric therefore excludes step 0. One warmup off/on pair was excluded, followed by 10 measured off/on pairs.

Paired delta below is `packed_on - packed_off`.

| Metric | Mean delta | Median delta | packed on faster |
|---|---:|---:|---:|
| total duration | +82.67ms | +219.36ms | 4 / 10 |
| denoise stage | +131.61ms | +100.67ms | 4 / 10 |
| denoise step 0 | +109.37ms | +21.14ms | 4 / 10 |
| steady denoise step 1-7 mean | +4.93ms/step | +2.98ms/step | 4 / 10 |

This e2e result is neutral to slightly slower, not a pipeline speedup. The local input-A2A microbench benefit does not translate into this LTX2.3 H100x8 workload, so LTX2.3 no longer enables the packed QKV input A2A path by default in this PR.

### CFG-local packed latents

The local-latent hook is not claimed as an isolated latency speedup yet. Its measured validation is correctness/path cleanup: in an 8xB300 distributed smoke, each CFG rank preserved its own local CUDA `latents` / `audio_latents` after CFG batch broadcast instead of receiving rank0 tensor fields through `broadcast_pyobj`.

## Why

For LTX2.3 native packed latents, latent prep already creates video/audio latents on each local GPU. CFG-parallel denoise then broadcasts the rank0 batch object and moves the broadcasted tensors back to local device. The new stage hook lets model-specific stages keep selected tensor fields local while still broadcasting the rest of the request metadata.

The 8xB200 real-pipeline result showed pure SP8 beating cfg2+sp4 for the 121f LTX2.3 workload, so LTX2.3 auto now prefers pure SP on 8 GPUs as well as 4 GPUs. Explicit CLI settings still override this.

Packed QKV input A2A is an attention implementation choice, not a server-wide deployment policy. The switch therefore lives on `USPAttention` instances. It remains default-off because the latest e2e run shows no reliable benefit for LTX2.3.

## Validation

- `git diff --check`
- `pre-commit run --files python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py`
- previous `pre-commit run --files python/sglang/multimodal_gen/configs/models/dits/ltx_2.py python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py python/sglang/multimodal_gen/runtime/layers/attention/layer.py python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py python/sglang/multimodal_gen/test/unit/test_server_args.py`
- 8xB300 distributed CFG-local-field smoke: each rank preserved its own local CUDA `latents` / `audio_latents` after CFG batch broadcast
- 4xB300 real LTX2.3 smoke: `cfg2+sp2`, 768x512x121, 2 denoise steps, passed
- 8xB200 real LTX2.3 smoke: `cfg2+sp4`, 768x512x121, 2 denoise steps, passed
- 8xB200 real LTX2.3 comparison table above
- 8xB300/B200 packed QKV input A2A microbench table above
- 8xH100 LTX2.3 packed QKV input A2A e2e A/B table above, paired n=10
- 8xB200 parser validation after the policy change:
  - auto 4 GPU -> cfg disabled, SP4
  - auto 8 GPU -> cfg disabled, SP8
  - explicit `cfg2+sp4` and explicit `sp8` remain honored

## Follow-up

Packed QKV input A2A should stay per-model gated and default-off. Additional models should opt in only with their own end-to-end evidence.

8xB300 full real-pipeline testing is still blocked by a node/platform issue: after a cold-load failure, several GPUs had large unaccounted memory with no visible compute process and GPU reset was unsupported.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28285296551](https://github.com/sgl-project/sglang/actions/runs/28285296551)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28285296487](https://github.com/sgl-project/sglang/actions/runs/28285296487)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
