### PR TITLE
[bench] fix: respect explicit base url

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1941,15 +1941,18 @@ def run_benchmark(args_: argparse.Namespace):
         }.get(args.backend, 30000)
 
     # Base URL the client sends to: --base-url if given, else http://host:port
-    # (IPv6-correct). NetworkAddress is also kept for gserver's host:port form.
+    # (IPv6-correct).
     base_url = resolve_base_url(args.base_url, args.host, args.port)
-    _na = NetworkAddress(args.host, args.port)
 
     model_url = f"{base_url}/v1/models"
 
     if args.backend == "gserver":
         # gRPC server takes a bare host:port, not an http URL.
-        api_url = args.base_url if args.base_url else _na.to_host_port_str()
+        api_url = (
+            args.base_url
+            if args.base_url
+            else NetworkAddress(args.host, args.port).to_host_port_str()
+        )
         args.model = args.model or "default"
     else:
         api_url = f"{base_url}{_BACKEND_API_PATHS[args.backend]}"


### PR DESCRIPTION
### Summary

Fix two benchmark CI startup issues:

- `bench_serving` now respects an explicit `--base-url` without requiring `--host`.
- DeepGEMM availability probing now treats dynamic library load failures as unavailable optional acceleration instead of crashing server startup.

### Problem

`run_benchmark` resolved `base_url` from `--base-url`, but still eagerly constructed `NetworkAddress(args.host, args.port)`. Some benchmark call sites provide `base_url` directly and leave `host` unset, which made URL setup fail before the benchmark could run.

The linked CI also failed during server startup while importing optional DeepGEMM: the `deep_gemm` package was importable, but its native module failed to load `libnvrtc.so.13`, raising `RuntimeError` rather than `ImportError`.

CI failure context: https://github.com/sgl-project/sglang/actions/runs/27739708721/job/82064108922?pr=27273

### Fix

Only construct `NetworkAddress` for the `gserver` fallback path that actually needs a bare `host:port` value. Other backends use the resolved HTTP base URL directly.

For DeepGEMM, catch native load failures in the optional availability probe and disable JIT DeepGEMM when the package cannot be loaded successfully.

### Validation

- Pre-commit hooks during `git commit` passed.
- Verified the DeepGEMM availability probe no longer crashes locally and returns `ENABLE_JIT_DEEPGEMM=False` when `deep_gemm` cannot load `libnvrtc.so.13`.
- Attempted `PYTHONPATH=python pytest test/registered/tokenizer/test_multi_tokenizer.py`; local full run is blocked by environment drift: local `sglang-kernel==0.4.3` is older than the required `0.4.4`, and downloading the 615MB 0.4.4 wheel from available indexes was too slow to complete in this session.