### PR TITLE
[Bugfix] Fix Intern-S1 FP8 expert count lookup

### DIFF
--- a/python/sglang/srt/models/interns1.py
+++ b/python/sglang/srt/models/interns1.py
@@ -211,7 +211,7 @@ class InternS1ForConditionalGeneration(nn.Module):
                 ckpt_gate_proj_name="gate_proj",
                 ckpt_down_proj_name="down_proj",
                 ckpt_up_proj_name="up_proj",
-                num_experts=self.config.num_experts,
+                num_experts=self.config.text_config.num_experts,
             )
 
         params_dict = dict(self.named_parameters())


### PR DESCRIPTION
## Summary

Fix Intern-S1 FP8 MoE weight loading by reading `num_experts` from `self.config.text_config`, where Intern-S1 stores the text model MoE config.

## Root cause

`InternS1Config` does not expose `num_experts` at the top level. The FP8 MoE weight-loader path passed `self.config.num_experts` into `maybe_dequant_moe_weight_scale`, so `internlm/Intern-S1-FP8` failed during `load_weights` before the server became ready.

## Validation

Validated on Verda B300, 8x NVIDIA B300 SXM6 AC, container `sglang_bbuf_b300`.

Command used for both before and after:

```bash
python3 -m sglang.launch_server \
  --model-path internlm/Intern-S1-FP8 \
  --host 127.0.0.1 \
  --port <port> \
  --skip-server-warmup \
  --tp-size 8 \
  --ep 2 \
  --trust-remote-code \
  --attention-backend flashinfer \
  --tokenizer-path internlm/Intern-S1
```

Before, on `origin/main` repro commit `b7ae7149e8`, model loading failed with `AttributeError: 'InternS1Config' object has no attribute 'num_experts'`.

![Intern-S1 main failure](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/screenshots/interns1_main_before.png)

After this patch, the same model served successfully and completed a `/v1/completions` request.

![Intern-S1 patched success](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/screenshots/interns1_patched_after.png)

Raw logs:

- [before log](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/interns1_main_before.log)
- [before json](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/interns1_main_before.json)
- [after log](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/interns1_patched_after.log)
- [after json](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/interns1_patched_after.json)

## Cleanup

After validation, I removed the downloaded `internlm/Intern-S1-FP8` and `internlm/Intern-S1` Hugging Face cache entries. HF hub cache went from `232G + 5.1M` to `396K`, and all 8 B300 GPUs returned to `0` memory used.

![B300 cleanup](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/screenshots/cleanup_after_validation.png)

[cleanup log](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/cleanup_after_validation.log)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27744320992](https://github.com/sgl-project/sglang/actions/runs/27744320992)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #27746479323](https://github.com/sgl-project/sglang/actions/runs/27746479323)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->