### PR TITLE
[Bugfix] Add activation fallback for unaligned hidden sizes

### DIFF
--- a/python/sglang/jit_kernel/activation.py
+++ b/python/sglang/jit_kernel/activation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 import torch
+import torch.nn.functional as F
 
 from sglang.jit_kernel.utils import (
     cache_once,
@@ -54,6 +55,51 @@ SUPPORTED_ACTIVATIONS = {"silu", "gelu", "gelu_tanh"}
 SUPPORTED_UNARY_ACTIVATIONS = {"relu2"}
 
 
+def _activation_vec_size(input: torch.Tensor) -> int:
+    vec_bytes = (
+        32
+        if input.is_cuda and not is_hip_runtime() and get_jit_cuda_arch().major >= 10
+        else 16
+    )
+    return max(1, vec_bytes // input.element_size())
+
+
+def _supports_activation_jit(input: torch.Tensor) -> bool:
+    hidden_size = input.shape[-1] // 2
+    return hidden_size % _activation_vec_size(input) == 0
+
+
+def _run_activation_torch(
+    op_name: str,
+    input: torch.Tensor,
+    out: torch.Tensor,
+    expert_ids: Optional[torch.Tensor],
+    expert_step: int,
+) -> torch.Tensor:
+    hidden_size = input.shape[-1] // 2
+    gate = input[..., :hidden_size].float()
+    up = input[..., hidden_size:]
+    if op_name == "silu":
+        activated = F.silu(gate)
+    elif op_name == "gelu":
+        activated = F.gelu(gate, approximate="none")
+    else:
+        activated = F.gelu(gate, approximate="tanh")
+
+    result = activated.to(dtype=input.dtype) * up
+    if expert_ids is None:
+        out.copy_(result)
+    else:
+        result_2d = result.view(-1, hidden_size)
+        out_2d = out.view(-1, hidden_size)
+        keep = torch.repeat_interleave(expert_ids != -1, expert_step)[
+            : result_2d.shape[0]
+        ]
+        keep = keep.to(device=out_2d.device)
+        out_2d[keep] = result_2d[keep]
+    return out
+
+
 @register_custom_op(mutates_args=["out"])
 def _run_activation_inplace(
     op_name: str, input: torch.Tensor, out: torch.Tensor
@@ -98,6 +144,8 @@ def run_activation(
     hidden_size = input.shape[-1] // 2
     if out is None:
         out = input.new_empty(*input.shape[:-1], hidden_size)
+    if not _supports_activation_jit(input):
+        return _run_activation_torch(op_name, input, out, expert_ids, expert_step)
     if expert_ids is None:
         _run_activation_inplace(op_name, input, out)
     else:

--- a/test/registered/jit/test_activation.py
+++ b/test/registered/jit/test_activation.py
@@ -22,6 +22,7 @@ DTYPES = [torch.float16, torch.bfloat16, torch.float32]
 SHAPES = get_ci_test_range(
     full_range=[
         (7, 16),
+        (11, 30),
         (83, 1024),
         (3, 5, 16),
         (2, 3, 512),
@@ -29,7 +30,7 @@ SHAPES = get_ci_test_range(
         *[(2**x, 2048) for x in range(0, 15, 2)],
         *[(2**x, 65536) for x in range(0, 5, 2)],
     ],
-    ci_range=[(7, 16), (2, 3, 512)],
+    ci_range=[(7, 16), (11, 30), (2, 3, 512)],
 )
 
 
@@ -81,8 +82,8 @@ def test_activation_out_param(
 
 
 FILTER_SHAPES = get_ci_test_range(
-    full_range=[(83, 1024), (256, 2048), (1024, 4096)],
-    ci_range=[(83, 1024)],
+    full_range=[(17, 30), (83, 1024), (256, 2048), (1024, 4096)],
+    ci_range=[(17, 30), (83, 1024)],
 )
 EXPERT_STEPS = [1, 16]
 


### PR DESCRIPTION
## Summary

Add a torch fallback for gated JIT activations when the hidden size is not divisible by the kernel vector width, and add regression coverage for non-vector-aligned shapes.

## Root cause

The JIT gated activation kernel requires `hidden_size % vec_size == 0`. On Blackwell, the kernel uses a 32-byte vector width, so shapes such as `(11, 30)` have `hidden_size=15` and fail before producing output. These shapes can still be computed correctly with the torch reference path.

## Fix

- Detect whether the input hidden size is supported by the JIT activation kernel.
- Fall back to torch for unsupported gated activation shapes.
- Preserve `expert_ids == -1` filtered rows by leaving the corresponding output rows untouched.
- Add CI-range regression shapes `(11, 30)` and `(17, 30)`.

## Validation

Validated on Verda B300, 8x NVIDIA B300 SXM6 AC, container `sglang_bbuf_b300`.

Before, on `origin/main` repro commit `b7ae7149e8`, `run_activation(op, x, None)` with `x.shape=(11, 30)` failed with `hidden size must be divisible by vector size`.

![activation main failure](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/screenshots/activation_main_before.png)

After this patch, direct repro cases passed for `silu`, `gelu`, `gelu_tanh`, and the CI-range activation test passed:

```bash
SGLANG_IS_IN_CI=true python3 -m pytest -q test/registered/jit/test_activation.py --tb=short
```

Result: `109 passed, 5 warnings in 9.23s`.

![activation patched success](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/screenshots/activation_patched_after.png)

Raw logs:

- [before log](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/activation_main_before.log)
- [before json](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/activation_main_before.json)
- [after log](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/activation_patched_after.log)
- [after json](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/activation_patched_after.json)
- [pytest log](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/activation_pytest.log)

## Cleanup

The activation validation did not download model weights. After the full PR validation run, I also removed the Intern-S1 model cache used by the other PR validation; HF hub cache is `396K` and all 8 B300 GPUs are back to `0` memory used.

![B300 cleanup](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/screenshots/cleanup_after_validation.png)

[cleanup log](https://raw.githubusercontent.com/BBuf/sglang/validation-artifacts-20260618-b300-prs/pr-validation/logs/cleanup_after_validation.log)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27745509672](https://github.com/sgl-project/sglang/actions/runs/27745509672)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27745509468](https://github.com/sgl-project/sglang/actions/runs/27745509468)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->