### PR TITLE
[Docker] Fix cu12 dev image build: pin torch reinstall + JIT-fallback for missing x86 cubins

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -244,7 +244,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
            pip list --format=freeze | awk -F'==' '/-cu13(==|$)/ {print $1}' \
                | xargs -r python3 -m pip uninstall -y && \
            python3 -m pip install --index-url https://download.pytorch.org/whl/cu${CUINDEX} \
-               torch torchvision torchaudio --force-reinstall; \
+               torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --force-reinstall; \
            python3 -m pip install https://github.com/sgl-project/whl/releases/download/v${SGL_DEEP_GEMM_VERSION}/sgl_deep_gemm-${SGL_DEEP_GEMM_VERSION}+cu129-py3-none-manylinux2014_$(uname -m).whl --force-reinstall; \
        fi \
     && cd /sgl-workspace \
@@ -655,6 +655,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
                  success=1 && break; \
                  echo "sgl-kernel cubin download failed, retrying in 30s..." && sleep 30; \
              done; \
+             # x86: if no prebuilt sgl-flash-attn3 variant matches this torch+CUDA \
+             # combo (e.g. cu129 publishes no torch>=2.10 cubin), fall back to \
+             # runtime JIT instead of failing the build, mirroring the aarch64 branch. \
+             if [ "$success" != "1" ]; then \
+                 echo "WARNING: no matching sgl-flash-attn3 cubin variant for this torch+CUDA; kernels will be JIT-compiled at runtime"; \
+                 success=1; \
+             fi; \
          fi; \
          [ "$success" = "1" ] ) \
     && mkdir -p /root/.cache/huggingface /root/.cache/sglang \


### PR DESCRIPTION
## Problem

The nightly **Build and Push Development Docker Images** workflow fails on the x86 `build-and-publish / build-x86` job at **Build and push AMD64 image (CUDA 12)** ([example run](https://github.com/sgl-project/sglang/actions/runs/27727050537/job/82025624777)). arm64 and (would-be) cu13 are unaffected.

Fatal error in the `framework_final` editable-install step:

```
kernels download python
Cannot find a build variant for this system in kernels-community/sgl-flash-attn3
Available variants: torch29/210/211-cu128, torch29-cu129, torch29/210/211-cu130
→ retried 3x, exit 1
```

## Root cause (two compounding issues)

1. **Unpinned torch reinstall floated to torch 2.12.** In `docker/Dockerfile`, the cu12-only fixup does:
   ```dockerfile
   pip install --index-url .../cu${CUINDEX} torch torchvision torchaudio --force-reinstall
   ```
   With no version, it grabbed `torch-2.12.1+cu129` once 2.12 landed on the PyTorch cu129 index — diverging from the `torch==2.11.0` the `.[all]` install (and the cu13 path) use. This is the regression trigger; it's an upstream torch release leaking in, not a code change.

2. **cu129 has a cubin hole.** `kernels-community/sgl-flash-attn3` publishes **no** variant for `torch>=2.10` on cu129 (only `torch29-cu129`); `torch211` exists only for cu128/cu130, and there is no `torch212` variant at all. So even pinned to 2.11, the cu129 image cannot find a prebuilt cubin.

## Fix

1. **Pin** the cu12 torch reinstall to `torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0` (matches the rest of the build). Stops the silent 2.12 float.
2. **Make the x86 `kernels download` non-fatal**: still attempt the download (so prebuilt cubins are used when available), but fall back to **runtime JIT** when no variant matches — exactly what the aarch64 branch already does. This decouples the release build from upstream's cubin publish matrix.

Net effect on cu12 x86: ships without prebuilt `sgl-flash-attn3` cubins (JIT-compiled on first use, a few seconds once) — same behavior arm64 already ships. cu13 x86 is unchanged (its `torch211-cu130` cubin still downloads).

Note: the pinned versions mirror the `.[all]`/cu13 path and should be bumped together with any future torch upgrade.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27744927393](https://github.com/sgl-project/sglang/actions/runs/27744927393)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27744934341](https://github.com/sgl-project/sglang/actions/runs/27744934341)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->