### PR TITLE
fix(gateway): parse /v1/loads per-rank format for PowerOfTwo

### DIFF
--- a/sgl-model-gateway/src/core/worker_manager.rs
+++ b/sgl-model-gateway/src/core/worker_manager.rs
@@ -220,14 +220,12 @@ impl WorkerManager {
                 Ok(json) => json
                     .get("loads")
                     .and_then(|l| l.as_array())
-                    .filter(|loads| !loads.is_empty())
-                    .map(|loads| {
-                        loads
-                            .iter()
-                            .filter_map(|load| {
-                                load.get("num_total_tokens").and_then(|v| v.as_i64())
-                            })
-                            .sum::<i64>() as isize
+                    .and_then(|loads| {
+                        let mut parsed = loads.iter().filter_map(|load| {
+                            load.get("num_total_tokens").and_then(|v| v.as_i64())
+                        });
+                        let first = parsed.next()?;
+                        Some((first + parsed.sum::<i64>()) as isize)
                     })
                     .unwrap_or(-1),
                 _ => -1,

--- a/sgl-model-gateway/src/core/worker_manager.rs
+++ b/sgl-model-gateway/src/core/worker_manager.rs
@@ -218,10 +218,17 @@ impl WorkerManager {
         match req.send().await {
             Ok(r) if r.status().is_success() => match r.json::<Value>().await {
                 Ok(json) => json
-                    .get("aggregate")
-                    .and_then(|a| a.get("total_tokens"))
-                    .and_then(|v| v.as_i64())
-                    .map(|n| n as isize)
+                    .get("loads")
+                    .and_then(|l| l.as_array())
+                    .filter(|loads| !loads.is_empty())
+                    .map(|loads| {
+                        loads
+                            .iter()
+                            .filter_map(|load| {
+                                load.get("num_total_tokens").and_then(|v| v.as_i64())
+                            })
+                            .sum::<i64>() as isize
+                    })
                     .unwrap_or(-1),
                 _ => -1,
             },
@@ -358,22 +365,25 @@ impl LoadMonitor {
 
             let mut loads = HashMap::new();
             for load_info in result.loads {
-                loads.insert(load_info.worker, load_info.load);
+                if load_info.load >= 0 {
+                    loads.insert(load_info.worker, load_info.load);
+                }
             }
 
-            if !loads.is_empty() {
+            if loads.is_empty() {
+                warn!("No valid loads fetched from workers");
+            } else {
                 debug!(
                     "Fetched loads from {} workers, updating {} PowerOfTwo policies",
                     loads.len(),
                     power_of_two_policies.len()
                 );
-                for policy in &power_of_two_policies {
-                    policy.update_loads(&loads);
-                }
-                let _ = tx.send(loads);
-            } else {
-                warn!("No loads fetched from workers");
             }
+
+            for policy in &power_of_two_policies {
+                policy.update_loads(&loads);
+            }
+            let _ = tx.send(loads);
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
`/v1/loads` dropped the top-level `aggregate` object and now returns a per-DP-rank `loads` array. 
`parse_load_response()` still read `aggregate.total_tokens`, so every worker reported `-1` and PowerOfTwo could no longer balance on token load.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Parse the new format: sum `num_total_tokens` across `loads[]` (same value the old aggregate held). Empty/missing `loads` still returns `-1`.
- Skip workers reporting a negative load instead of caching it. `-1` made a broken worker look least-loaded, so now the policy falls back to request counts.
- Always publish the load snapshot so stale per-worker loads are cleared.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
- `cargo build` is clean and the existing `power_of_two` tests pass.
- Verified `parse_load_response()` against a stub `/v1/loads` server (new format, empty, legacy `aggregate`, non-2xx, connection error all behave correctly).

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [X] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27748683576](https://github.com/sgl-project/sglang/actions/runs/27748683576)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27748683509](https://github.com/sgl-project/sglang/actions/runs/27748683509)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->