### PR TITLE
[codex] Fix DSA indexer in prefill piecewise CUDA graph

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -99,6 +99,35 @@ if TYPE_CHECKING:
 DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
 
 
+def _uses_dsa_attention_backend(forward_batch: ForwardBatch) -> bool:
+    attn_backend = get_attn_backend()
+    server_args = get_global_server_args()
+    prefill_backend, decode_backend = server_args.get_attention_backends()
+    prefill_backend = (
+        getattr(attn_backend, "prefill_attention_backend_str", None)
+        or prefill_backend
+    )
+    decode_backend = (
+        getattr(attn_backend, "decode_attention_backend_str", None) or decode_backend
+    )
+
+    if forward_batch.forward_mode.is_decode_or_idle():
+        backend_name = decode_backend
+    elif (
+        forward_batch.forward_mode.is_target_verify()
+        or forward_batch.forward_mode.is_draft_extend_v2()
+    ):
+        backend_name = (
+            decode_backend
+            if server_args.speculative_attention_mode == "decode"
+            else prefill_backend
+        )
+    else:
+        backend_name = prefill_backend
+
+    return backend_name in ("dsa", "nsa")
+
+
 if _is_cuda:
     from sglang.srt.compilation.compilation_config import register_split_op
     from sglang.srt.utils.custom_op import register_custom_op
@@ -120,6 +149,10 @@ if _is_cuda:
         forward_batch = get_tc_piecewise_forward_context().forward_batch
         indexer = get_tc_piecewise_forward_context().dsa_indexers[layer_id]
         metadata = get_attn_backend().get_indexer_metadata(layer_id, forward_batch)
+        assert metadata is not None, (
+            "DSA piecewise CUDA graph requires indexer metadata from the DSA "
+            "attention backend"
+        )
 
         # slice off padding from piecewise CUDA graph
         extend_num_tokens = forward_batch.extend_num_tokens
@@ -1574,6 +1607,9 @@ class Indexer(MultiPlatformOp):
                     assert (
                         not enable_dual_stream
                     ), "Internal error: piecewise CUDA graph should not be enabled with dual stream"
+
+                    if not _uses_dsa_attention_backend(forward_batch):
+                        return None
 
                     topk_result = torch.full(
                         (q_fp8.shape[0], self.index_topk),

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -104,8 +104,7 @@ def _uses_dsa_attention_backend(forward_batch: ForwardBatch) -> bool:
     server_args = get_global_server_args()
     prefill_backend, decode_backend = server_args.get_attention_backends()
     prefill_backend = (
-        getattr(attn_backend, "prefill_attention_backend_str", None)
-        or prefill_backend
+        getattr(attn_backend, "prefill_attention_backend_str", None) or prefill_backend
     )
     decode_backend = (
         getattr(attn_backend, "decode_attention_backend_str", None) or decode_backend


### PR DESCRIPTION
## Summary

- Skip the DSA indexer in TC piecewise prefill CUDA graph when the resolved attention backend is not `dsa`/`nsa`, matching the eager path that returns `None` when indexer metadata is unavailable.
- Add a clearer assertion if the true DSA piecewise path is entered without indexer metadata.

## Root Cause

`GLM-5-NVFP4` can be launched with the DSA model architecture but an explicit non-DSA attention backend, e.g. `--attention-backend flashinfer`. In eager mode, `Indexer.forward_cuda` asks the active attention backend for indexer metadata and returns `None` when that backend does not provide it.

The TC piecewise CUDA graph path skipped that eager metadata check to avoid Dynamo guards and always entered the split op. The split op then received `metadata=None` from the non-DSA backend and crashed in `_get_topk_ragged` at `metadata.get_page_table_64()`.

## Reproduction Before Fix

Base failure was reproduced on B300 with main commit `105e095e00`; `python/sglang/srt/layers/attention/dsa/dsa_indexer.py` is unchanged between that commit and current base `bb9d31f22d`.

```bash
python3 -m sglang.launch_server \
  --model-path nvidia/GLM-5-NVFP4 \
  --host 127.0.0.1 --port 32003 \
  --skip-server-warmup \
  --tp-size 4 \
  --attention-backend flashinfer \
  --enforce-disable-flashinfer-allreduce-fusion \
  --moe-runner-backend flashinfer_cutlass \
  --cuda-graph-backend-decode disabled \
  --disable-flashinfer-autotune
```

Failure excerpt:

```text
Capture piecewise CUDA graph begin
Piecewise CUDA Graph failed with error: 'NoneType' object has no attribute 'get_page_table_64'
block_tables = metadata.get_page_table_64()
AttributeError: 'NoneType' object has no attribute 'get_page_table_64'
```

## Validation After Fix

Validated on 4x B300 using current base `bb9d31f22d` plus this patch with the same launch command above. The server completed piecewise prefill CUDA graph capture without adding `--cuda-graph-backend-prefill disabled`:

```text
Capture piecewise CUDA graph end. Time elapsed: 172.86 s.
Capture piecewise CUDA graph end. Time elapsed: 173.13 s.
Capture piecewise CUDA graph end. Time elapsed: 173.64 s.
Capture piecewise CUDA graph end. Time elapsed: 173.81 s.
The server is fired up and ready to roll!
```

Smoke request:

```bash
curl http://127.0.0.1:32005/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"nvidia/GLM-5-NVFP4","prompt":"Hello, my name is","max_tokens":16,"temperature":0}'
```

Result:

```text
POST /v1/completions HTTP/1.1" 200 OK
completion_tokens: 16
```

Additional local checks:

```bash
git diff --check
python3 -m compileall -q python/sglang/srt/layers/attention/dsa/dsa_indexer.py
python3 -m ruff check --select F821,F822,F823,E999 python/sglang/srt/layers/attention/dsa/dsa_indexer.py
```

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27755005141](https://github.com/sgl-project/sglang/actions/runs/27755005141)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27755113700](https://github.com/sgl-project/sglang/actions/runs/27755113700)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->