### PR TITLE
disaggregation: Fix FakeKVSender queue accumulation

### DIFF
--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -13,6 +13,7 @@ from sglang.srt.disaggregation.base.conn import (
     KVTransferMetric,
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -48,16 +49,38 @@ class FakeKVSender(BaseKVSender):
         self.kv_mgr = mgr
         self.has_sent = False
         self.conclude_state: Optional[KVPoll] = None
+        self.poll_count = 0  # Track number of times polled before send()
+        # Threshold for auto-aborting leaked requests (health checks, connection validation)
+        # while avoiding premature abortion during multi-GPU bootstrap sync.
+        self._auto_abort_threshold = (
+            envs.SGLANG_DISAGGREGATION_FAKE_AUTO_ABORT_THRESHOLD.get()
+        )
 
     def poll(self) -> KVPoll:
         if self.conclude_state is not None:
             return self.conclude_state
+
         if not self.has_sent:
-            # Assume handshake completed instantly
+            self.poll_count += 1
+
+            # During normal operation, a request transitions from bootstrap to prefill
+            # within a few polls. If poll_count exceeds threshold, it's a leaked
+            # request (health check, aborted) that will never call send().
+            # Auto-abort to Failed to prevent queue accumulation.
+            if self.poll_count >= self._auto_abort_threshold:
+                logger.warning(
+                    f"FakeKVSender auto-aborting after {self.poll_count} polls without send() - "
+                    "likely a leaked request (health check or aborted)"
+                )
+                self.conclude_state = KVPoll.Failed
+                return KVPoll.Failed
+
+            # First poll and subsequent polls (< threshold): return WaitingForInput
+            # to allow multi-GPU bootstrap synchronization without premature abortion
             return KVPoll.WaitingForInput
 
-        # Assume transfer completed instantly
-        logger.debug("FakeKVSender poll success")
+        # Assume transfer completed instantly after send()
+        logger.debug("FakeKVSender poll success after send()")
         self.conclude_state = KVPoll.Success
         return KVPoll.Success
 
@@ -79,7 +102,10 @@ class FakeKVSender(BaseKVSender):
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
     ):
+        # Note: send() after auto-abort (poll_count >= threshold) is a no-op
+        # since conclude_state=Failed takes precedence in poll()
         self.has_sent = True
+        self.poll_count = 0  # Reset counter after send
         logger.debug(
             f"FakeKVSender send with kv_indices: {kv_indices}, state_indices: {state_indices}"
         )

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import List, Optional
 
 import numpy as np
@@ -13,6 +14,7 @@ from sglang.srt.disaggregation.base.conn import (
     KVTransferMetric,
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -46,13 +48,26 @@ class FakeKVSender(BaseKVSender):
         req_has_disagg_prefill_dp_rank: bool = False,
     ):
         self.kv_mgr = mgr
+        self.bootstrap_room = bootstrap_room
+        # Set by any chunk, not only the last one: nothing is transferred, so a
+        # chunk that never comes cannot change the outcome.
         self.has_sent = False
         self.conclude_state: Optional[KVPoll] = None
+        # Read here rather than off kv_mgr: a FAKE_BOOTSTRAP_HOST req on a real
+        # backend pairs this sender with that backend's KVManager, which carries
+        # no waiting_timeout in prefill mode.
+        self.waiting_timeout = envs.SGLANG_DISAGGREGATION_WAITING_TIMEOUT.get()
+        self.inited = False
+        self.waiting_since: Optional[float] = None
 
     def poll(self) -> KVPoll:
         if self.conclude_state is not None:
             return self.conclude_state
+
         if not self.has_sent:
+            timeout_result = self._check_waiting_timeout()
+            if timeout_result is not None:
+                return timeout_result
             # Assume handshake completed instantly
             return KVPoll.WaitingForInput
 
@@ -61,18 +76,47 @@ class FakeKVSender(BaseKVSender):
         self.conclude_state = KVPoll.Success
         return KVPoll.Success
 
+    def _check_waiting_timeout(self) -> Optional[KVPoll]:
+        # A send() that never comes must not pin the prefill inflight queue forever.
+        # No deadline before init(): the request is still in the bootstrap queue.
+        if not self.inited:
+            return None
+        if self.waiting_since is None:
+            # Clock starts at the first poll after init(), not at init() itself:
+            # the scheduler stops polling while a request queues and computes
+            # prefill. Monotonic, so an NTP step cannot fail a healthy request.
+            self.waiting_since = time.monotonic()
+            return None
+        elapsed = time.monotonic() - self.waiting_since
+        if elapsed < self.waiting_timeout:
+            return None
+        logger.warning_once(
+            "Some FakeKVSender requests fail to receive a KV chunk after bootstrapping. "
+            "If a greater mean TTFT is acceptable, you can 'export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=600' (10 minutes) to relax the timeout condition. "
+        )
+        logger.debug(
+            f"FakeKVSender for room {self.bootstrap_room} timed out after {elapsed:.1f}s "
+            "in KVPoll.WaitingForInput; no KV chunk was ever sent."
+        )
+        self.conclude_state = KVPoll.Failed
+        return KVPoll.Failed
+
     def get_transfer_metric(self) -> KVTransferMetric:
         return KVTransferMetric()
 
     def init(
         self,
-        kv_indices: list[int],
+        num_kv_indices: int,
         aux_index: Optional[int] = None,
     ):
+        self.inited = True
         logger.debug(
-            f"FakeKVSender init with kv_indices: {kv_indices}, aux_index: {aux_index}"
+            f"FakeKVSender init with num_kv_indices: {num_kv_indices}, aux_index: {aux_index}"
         )
-        pass
+
+    def should_send_kv_chunk(self, num_pages: int, last_chunk: bool) -> bool:
+        # A zero-page last chunk must still send: poll() only concludes after send().
+        return num_pages > 0 or last_chunk
 
     def send(
         self,
@@ -112,6 +156,9 @@ class FakeKVReceiver(BaseKVReceiver):
         if not self.bootstrap_done:
             return KVPoll.Bootstrapping
         if not self.has_sent_metadata:
+            # No deadline needed here, unlike FakeKVSender: send_metadata() is
+            # unconditional once the decode side preallocates, and waiting for
+            # KV space is not a stalled transfer.
             return KVPoll.WaitingForInput
         logger.debug("FakeKVReceiver poll success")
         self.conclude_state = KVPoll.Success

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -382,6 +382,12 @@ class Envs:
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
+    # FakeKVSender auto-abort threshold: number of poll() calls without send()
+    # before auto-aborting to Failed. Prevents memory leaks from leaked requests
+    # (health checks, connection validation) while avoiding premature abortion
+    # during multi-GPU bootstrap sync. Default 100 polls ≈ 0.1-10s depending on
+    # scheduler loop frequency.
+    SGLANG_DISAGGREGATION_FAKE_AUTO_ABORT_THRESHOLD = EnvInt(100)
 
     # Scheduler: others:
     # in seconds. Set if you observe high memory accumulation over a long serving period.

--- a/test/registered/unit/disaggregation/test_fake_kv_sender.py
+++ b/test/registered/unit/disaggregation/test_fake_kv_sender.py
@@ -1,0 +1,168 @@
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.fake.conn import FakeKVSender
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestFakeKVSender(unittest.TestCase):
+    """Test FakeKVSender queue accumulation fix and lifecycle behavior."""
+
+    def setUp(self):
+        """Create a FakeKVSender instance for testing."""
+        self.mgr = MagicMock()
+        self.sender = FakeKVSender(
+            mgr=self.mgr,
+            bootstrap_addr="fake_addr:1234",
+            bootstrap_room=42,
+            dest_tp_ranks=[0],
+            pp_rank=0,
+        )
+
+    def test_first_poll_returns_waiting_for_input(self):
+        """First poll should return WaitingForInput for proper handshake."""
+        result = self.sender.poll()
+        self.assertEqual(result, KVPoll.WaitingForInput)
+        self.assertEqual(self.sender.poll_count, 1)
+
+    def test_multiple_polls_without_send_return_waiting_for_input(self):
+        """Polls 2-99 should return WaitingForInput without auto-completing."""
+        for i in range(1, 99):
+            result = self.sender.poll()
+            self.assertEqual(result, KVPoll.WaitingForInput)
+            self.assertEqual(self.sender.poll_count, i)
+
+    def test_auto_abort_after_threshold(self):
+        """After 100 polls without send(), should auto-abort to Failed."""
+        # Poll 99 times (still WaitingForInput)
+        for i in range(99):
+            result = self.sender.poll()
+            self.assertEqual(result, KVPoll.WaitingForInput)
+
+        # 100th poll should auto-abort
+        result = self.sender.poll()
+        self.assertEqual(result, KVPoll.Failed)
+        self.assertEqual(self.sender.poll_count, 100)
+        self.assertEqual(self.sender.conclude_state, KVPoll.Failed)
+
+        # Subsequent polls should return cached Failed
+        result = self.sender.poll()
+        self.assertEqual(result, KVPoll.Failed)
+
+    def test_normal_send_flow(self):
+        """Normal flow: poll -> send -> poll should work correctly."""
+        # First poll returns WaitingForInput
+        result = self.sender.poll()
+        self.assertEqual(result, KVPoll.WaitingForInput)
+
+        # Send KV data
+        kv_indices = np.array([0, 1, 2], dtype=np.int32)
+        self.sender.send(kv_indices)
+        self.assertTrue(self.sender.has_sent)
+        self.assertEqual(self.sender.poll_count, 0)  # Reset after send
+
+        # Next poll should return Success
+        result = self.sender.poll()
+        self.assertEqual(result, KVPoll.Success)
+        self.assertEqual(self.sender.conclude_state, KVPoll.Success)
+
+        # Subsequent polls return cached Success
+        result = self.sender.poll()
+        self.assertEqual(result, KVPoll.Success)
+
+    def test_send_resets_poll_count(self):
+        """send() should reset poll_count to prevent carry-over."""
+        # Poll multiple times
+        for _ in range(5):
+            self.sender.poll()
+        self.assertEqual(self.sender.poll_count, 5)
+
+        # Send should reset counter
+        kv_indices = np.array([0], dtype=np.int32)
+        self.sender.send(kv_indices)
+        self.assertEqual(self.sender.poll_count, 0)
+
+    def test_send_without_poll(self):
+        """send() can be called without prior polling."""
+        kv_indices = np.array([0, 1], dtype=np.int32)
+        self.sender.send(kv_indices)
+        self.assertTrue(self.sender.has_sent)
+        self.assertEqual(self.sender.poll_count, 0)
+
+        # Next poll should return Success
+        result = self.sender.poll()
+        self.assertEqual(result, KVPoll.Success)
+
+    def test_conclude_state_caching(self):
+        """Once conclude_state is set, it should be returned immediately."""
+        # Trigger auto-abort
+        for _ in range(100):
+            self.sender.poll()
+
+        self.assertEqual(self.sender.conclude_state, KVPoll.Failed)
+
+        # All subsequent polls should return cached state without incrementing poll_count
+        for _ in range(10):
+            result = self.sender.poll()
+            self.assertEqual(result, KVPoll.Failed)
+            self.assertEqual(self.sender.poll_count, 100)  # Unchanged
+
+    def test_abort_sets_failed_state(self):
+        """abort() should set conclude_state to Failed."""
+        self.sender.abort()
+        self.assertEqual(self.sender.conclude_state, KVPoll.Failed)
+
+        # Subsequent polls should return Failed
+        result = self.sender.poll()
+        self.assertEqual(result, KVPoll.Failed)
+
+    def test_init_method(self):
+        """init() should execute without errors."""
+        self.sender.init(kv_indices=[0, 1, 2], aux_index=5)
+        # Should not raise any exceptions
+
+    def test_get_transfer_metric(self):
+        """get_transfer_metric() should return empty metric."""
+        metric = self.sender.get_transfer_metric()
+        self.assertIsNone(metric.transfer_latency_s)
+        self.assertIsNone(metric.alloc_latency_s)
+        self.assertIsNone(metric.transfer_total_bytes)
+
+    def test_failure_exception(self):
+        """failure_exception() should raise exception."""
+        with self.assertRaises(Exception) as ctx:
+            self.sender.failure_exception()
+        self.assertIn("Fake KVSender Exception", str(ctx.exception))
+
+    def test_configurable_threshold(self):
+        """Threshold should be configurable via environment variable."""
+        # Test with custom threshold of 50
+        with envs.SGLANG_DISAGGREGATION_FAKE_AUTO_ABORT_THRESHOLD.override(50):
+            custom_sender = FakeKVSender(
+                mgr=self.mgr,
+                bootstrap_addr="fake_addr:1234",
+                bootstrap_room=42,
+                dest_tp_ranks=[0],
+                pp_rank=0,
+            )
+            self.assertEqual(custom_sender._auto_abort_threshold, 50)
+
+            # Poll 49 times - should still return WaitingForInput
+            for i in range(49):
+                result = custom_sender.poll()
+                self.assertEqual(result, KVPoll.WaitingForInput)
+
+            # 50th poll should auto-abort
+            result = custom_sender.poll()
+            self.assertEqual(result, KVPoll.Failed)
+            self.assertEqual(custom_sender.poll_count, 50)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_fake_kv_sender.py
+++ b/test/registered/unit/disaggregation/test_fake_kv_sender.py
@@ -1,0 +1,162 @@
+import time
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll
+from sglang.srt.disaggregation.fake.conn import FakeKVManager, FakeKVSender
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestFakeKVSender(unittest.TestCase):
+    """A FakeKVSender whose send() never comes must not pin the prefill
+    inflight queue forever, and a healthy request must never be failed early."""
+
+    def setUp(self):
+        self.mgr = self._make_mgr()
+        self.sender = self._make_sender()
+
+    def _make_mgr(self) -> FakeKVManager:
+        return FakeKVManager(
+            args=KVArgs(),
+            disaggregation_mode=DisaggregationMode.PREFILL,
+            server_args=MagicMock(),
+        )
+
+    def _make_sender(self, mgr=None) -> FakeKVSender:
+        return FakeKVSender(
+            mgr=self.mgr if mgr is None else mgr,
+            bootstrap_addr="fake_addr:1234",
+            bootstrap_room=42,
+            dest_tp_ranks=[0],
+            pp_rank=0,
+        )
+
+    def _expire_deadline(self, sender: FakeKVSender, by: float = 1.0) -> None:
+        """Push the armed deadline `by` seconds past the timeout."""
+        sender.waiting_since -= sender.waiting_timeout + by
+
+    def test_polls_before_send_stay_waiting_for_input(self):
+        """Repeated polling must not conclude on its own: the scheduler polls a
+        waiting request once per loop iteration, and those are healthy requests."""
+        self.sender.init(3, 5)
+        for _ in range(1000):
+            self.assertEqual(self.sender.poll(), KVPoll.WaitingForInput)
+        self.assertIsNone(self.sender.conclude_state)
+
+    def test_normal_send_flow(self):
+        self.sender.init(3, 5)
+        self.assertEqual(self.sender.poll(), KVPoll.WaitingForInput)
+
+        self.sender.send(np.array([0, 1, 2], dtype=np.int32))
+        self.assertTrue(self.sender.has_sent)
+
+        self.assertEqual(self.sender.poll(), KVPoll.Success)
+        self.assertEqual(self.sender.conclude_state, KVPoll.Success)
+        # Cached afterwards.
+        self.assertEqual(self.sender.poll(), KVPoll.Success)
+
+    def test_zero_page_last_chunk_still_sends(self):
+        """A zero-page last chunk must not be gated out: skipping it leaves the
+        sender in WaitingForInput forever and pins the prefill inflight queue."""
+        self.assertTrue(self.sender.should_send_kv_chunk(0, last_chunk=True))
+        self.assertFalse(self.sender.should_send_kv_chunk(0, last_chunk=False))
+        self.assertTrue(self.sender.should_send_kv_chunk(3, last_chunk=False))
+
+    def test_fully_cached_request_concludes(self):
+        """Regression: a request whose last chunk carries no pages still reaches
+        a terminal poll state instead of accumulating in the inflight queue."""
+        self.sender.init(0, 0)
+        page_indices = np.array([], dtype=np.int32)
+        # Mirrors the send_kv_chunk gate in SchedulerDisaggregationPrefillMixin.
+        if self.sender.should_send_kv_chunk(len(page_indices), True):
+            self.sender.send(page_indices)
+        self.assertEqual(self.sender.poll(), KVPoll.Success)
+
+    def test_send_without_init_or_poll(self):
+        self.sender.send(np.array([0, 1], dtype=np.int32))
+        self.assertEqual(self.sender.poll(), KVPoll.Success)
+
+    def test_waiting_timeout_fails_a_stuck_sender(self):
+        self.sender.init(1, 0)
+        self.assertEqual(self.sender.poll(), KVPoll.WaitingForInput)
+
+        self._expire_deadline(self.sender)
+        self.assertEqual(self.sender.poll(), KVPoll.Failed)
+        self.assertEqual(self.sender.conclude_state, KVPoll.Failed)
+        # Terminal: stays Failed even if send() arrives late.
+        self.sender.send(np.array([0], dtype=np.int32))
+        self.assertEqual(self.sender.poll(), KVPoll.Failed)
+
+    def test_poll_does_not_read_the_timeout_off_the_manager(self):
+        """Regression: a FAKE_BOOTSTRAP_HOST req on a real transfer backend pairs
+        FakeKVSender with that backend's KVManager, which defines no
+        waiting_timeout in prefill mode. Reading the knob off the manager raised
+        AttributeError in the scheduler loop on the first poll after init()."""
+
+        class ManagerWithoutWaitingTimeout:
+            pass
+
+        sender = self._make_sender(mgr=ManagerWithoutWaitingTimeout())
+        sender.init(1, 0)
+        self.assertEqual(sender.poll(), KVPoll.WaitingForInput)
+
+        self._expire_deadline(sender)
+        self.assertEqual(sender.poll(), KVPoll.Failed)
+
+    def test_queue_and_prefill_time_is_not_charged_to_the_deadline(self):
+        """The scheduler stops polling between init() and the last chunk, so the
+        deadline starts at the first poll. Arming it at init() instead would fail
+        a healthy request that merely queued for longer than the timeout."""
+        self.sender.init(1, 0)
+        self.assertIsNone(self.sender.waiting_since)
+
+        after_init = time.monotonic()
+        self.assertEqual(self.sender.poll(), KVPoll.WaitingForInput)
+        self.assertGreaterEqual(self.sender.waiting_since, after_init)
+
+    def test_no_timeout_before_init(self):
+        """A sender still in the bootstrap queue has no deadline, matching the
+        real backends, which cover that window with the bootstrap timeout."""
+        self.assertFalse(self.sender.inited)
+        for _ in range(100):
+            self.assertEqual(self.sender.poll(), KVPoll.WaitingForInput)
+        self.assertIsNone(self.sender.waiting_since)
+
+    def test_timeout_is_configurable(self):
+        """The knob is read once, when the sender is built."""
+        with envs.SGLANG_DISAGGREGATION_WAITING_TIMEOUT.override(600):
+            sender = self._make_sender()
+        self.assertEqual(sender.waiting_timeout, 600)
+
+        sender.init(1, 0)
+        self.assertEqual(sender.poll(), KVPoll.WaitingForInput)
+        sender.waiting_since -= 599
+        self.assertEqual(sender.poll(), KVPoll.WaitingForInput)
+        sender.waiting_since -= 2
+        self.assertEqual(sender.poll(), KVPoll.Failed)
+
+    def test_abort_sets_failed_state(self):
+        self.sender.abort()
+        self.assertEqual(self.sender.conclude_state, KVPoll.Failed)
+        self.assertEqual(self.sender.poll(), KVPoll.Failed)
+
+    def test_get_transfer_metric(self):
+        metric = self.sender.get_transfer_metric()
+        self.assertIsNone(metric.transfer_latency_s)
+        self.assertIsNone(metric.alloc_latency_s)
+        self.assertIsNone(metric.transfer_total_bytes)
+
+    def test_failure_exception(self):
+        with self.assertRaises(Exception) as ctx:
+            self.sender.failure_exception()
+        self.assertIn("Fake KVSender Exception", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 ## Motivation
 FakeKVSender.poll() only leaves KVPoll.WaitingForInput once send() has been
  called, and two paths could leave send() uncalled forever. Such a request stays on
  disagg_prefill_inflight_queue for the lifetime of the process and its KV cache lock
  is never released. To be precise about scope: this prevents stuck fake-bootstrap
  requests from accumulating and pinning KV/tree-cache resources; it does not reduce
  normal peak memory usage. Healthy requests allocate and release exactly as before.

  This is not limited to --disaggregation-transfer-backend fake: every
  FAKE_BOOTSTRAP_HOST request is served by FakeKVSender regardless of the
  configured backend, so startup warmup, /health_generate, compile_deep_gemm
  and the benchmark scripts all go through this path on a real NIXL/Mooncake
  deployment.

## Modifications

  - Override `should_send_kv_chunk()` as `num_pages > 0 or last_chunk`, matching
    `CommonKVSender`, instead of inheriting `BaseKVSender`'s `num_pages > 0`. A
    fully cached request whose last chunk carries zero pages was gated out of
    `send_kv_chunk()` entirely and could never conclude.
  - Conclude a stuck sender as `KVPoll.Failed` after a waiting timeout, so the
    scheduler aborts it and unlocks the tree cache. Same knob as the real
    backends, `SGLANG_DISAGGREGATION_WAITING_TIMEOUT` (default 300s), but read by
    the sender rather than off `kv_mgr` — a `FAKE_BOOTSTRAP_HOST` request on a real
    backend pairs `FakeKVSender` with that backend's `KVManager`, which defines
    `waiting_timeout` only in decode mode. The clock starts at the first poll after
    `init()`, not at `init()` itself, because nothing polls the sender while the
    request queues and computes prefill; a sender still in the bootstrap queue has
    no deadline at all.
  - Rename `FakeKVSender.init()`'s first parameter to `num_kv_indices`, matching
    `BaseKVSender.init()` and the caller, which passes a page count.

  Healthy requests are unaffected: repeated polls before `send()` keep returning
  `WaitingForInput`, and `poll()` after `send()` still concludes `Success`
  instantly.

  ## Accuracy Tests

  Not applicable — no change to kernels or model forward code.

  ## Speed Tests and Profiling

  Not applicable. The timeout only fires on a request that would otherwise never
  conclude; it adds one `time.monotonic()` per poll of an unsent sender.

  ## Tests

  - `test/registered/unit/disaggregation/test_fake_kv_sender.py` (new, 13 cases,
    `base-a-test-cpu`): the zero-page last chunk, the timeout and its env
    override, the manager-independent knob, the arming point, and the
    normal/abort/metric paths. The two regression cases were verified to fail
    against the pre-fix `fake/conn.py`.
  - `pytest test/registered/unit/disaggregation/` — 351 passed.
  - Prefill server on a real backend, the path this actually regressed on:
    `python -m sglang.launch_server --model-path Qwen/Qwen3-0.6B
    --disaggregation-mode prefill --disaggregation-transfer-backend nixl` reaches
    `End of disaggregation warmup` and serves.




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35182796813](https://github.com/sgl-project/sglang/actions/runs/35182796813)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35182796329](https://github.com/sgl-project/sglang/actions/runs/35182796329)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35182796517](https://github.com/sgl-project/sglang/actions/runs/35182796517)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->