### PR TITLE
[HiCache] Shard file backend into hash-prefix subdirs to avoid single-dir ENOSPC at scale

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -349,15 +349,11 @@ class HiCacheFile(HiCacheStorage):
             os.makedirs(self.file_path)
             logger.info(f"Created HiCacheFile storage directory at {self.file_path}")
 
-        # All LRU / size accounting and disk eviction lives in the evictor so
-        # this backend stays a thin raw-bytes store. Imported lazily: the storage
-        # package __init__ pulls in the backend factory, which imports this
-        # module, so a top-level import here would be circular.
+        # Lazy import: storage/__init__ pulls in the backend factory which imports
+        # this module, so a top-level import would be circular.
         from sglang.srt.mem_cache.storage.file.lru_file_evictor import LRUFileEvictor
 
-        # The evictor unlinks pages and so must resolve the same sharded paths
-        # the backend writes to. Inject the bucket helper rather than have the
-        # evictor import this module back (which would be circular).
+        # Inject _shard_subdir so the evictor resolves the same sharded paths.
         self._evictor = LRUFileEvictor(
             self.file_path,
             self.config_suffix,
@@ -371,18 +367,12 @@ class HiCacheFile(HiCacheStorage):
     def _shard_subdir(filename: str) -> str:
         """Map a ``.bin`` filename to its 2-level hash-prefix subdir ``<ab>/<cd>``.
 
-        Pages are fanned into ``<ab>/<cd>/<name>.bin`` so no single directory
-        accumulates millions of entries. A flat layout exhausts the ext4
-        directory index ("htree") at scale (~7.5M files), after which writes
-        fail with ENOSPC even though free bytes and inodes remain. Sharding caps
-        per-directory entries and also turns batched existence checks from one
-        ``O(total_files)`` scandir into ``O(keys)`` stats. The bucket is derived
-        purely from the leading hex of the filename (the content-hash prefix),
-        so get/set/exists and the evictor all resolve the same path -- the
-        evictor receives this exact helper (as ``shard_dir_fn``) to stay in sync.
+        A flat layout exhausts the ext4 directory index ("htree") at scale
+        (~7.5M files) and writes start failing with ENOSPC despite free
+        bytes/inodes. Sharding by the filename's content-hash prefix caps
+        per-directory entries; ``>= 4`` chars give 256x256 buckets, shorter
+        names fall back to a flat bucket.
         """
-        # First 4 hex chars give 256x256 buckets; short/atypical names fall
-        # back to a single flat bucket.
         if len(filename) >= 4:
             return os.path.join(filename[:2], filename[2:4])
         return ""
@@ -461,9 +451,8 @@ class HiCacheFile(HiCacheStorage):
                 return False
             reserved = True
 
-            # Create the hash-prefix subdir before writing the temp file; tmp
-            # and final live in the same shard dir so os.replace stays an atomic
-            # same-filesystem rename.
+            # tmp and final live in the same shard dir, so os.replace stays an
+            # atomic same-filesystem rename.
             os.makedirs(os.path.dirname(tensor_path), exist_ok=True)
             tmp_path = (
                 f"{tensor_path}.tmp."
@@ -512,10 +501,8 @@ class HiCacheFile(HiCacheStorage):
             for key in keys:
                 target_files.add(f"{self._get_component_key(key, transfer.name)}.bin")
 
-        # Probe each target file in its hash-prefix shard directly: a per-target
-        # os.path.exists is O(len(target_files)) and shard-correct, versus
-        # scanning the whole flat file_path -- O(total_files) per call, i.e. a
-        # full cache-dir walk per request once millions of pages accumulate.
+        # Per-target os.path.exists in the shard is O(keys), versus an os.scandir
+        # of the whole flat dir (O(total files)) on every call.
         existing_files = set()
         for fname in target_files:
             if os.path.exists(self._sharded_path(fname)):
@@ -634,13 +621,9 @@ class HiCacheFile(HiCacheStorage):
 
     def clear(self) -> bool:
         try:
-            # Files live in hash-prefix subdirs, so walk recursively rather than
-            # a single-level listdir. Walk bottom-up (topdown=False) so an empty
-            # shard subdir can be removed right after its pages are unlinked,
-            # otherwise eviction/clear would leak up to 256*256 empty dirs.
-            # Only unlink cache pages (*.bin) -- never non-.bin metadata such as
-            # a migration sentinel; a shard dir that still holds such a file
-            # fails rmdir and is kept. The root file_path itself is never removed.
+            # Walk shard subdirs bottom-up so emptied dirs can be reaped right
+            # after their pages are unlinked. Only *.bin is removed; a shard
+            # holding non-.bin files fails rmdir and is kept, as is file_path.
             for root, _dirs, files in os.walk(self.file_path, topdown=False):
                 for filename in files:
                     if not filename.endswith(".bin"):

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -350,9 +350,9 @@ class HiCacheFile(HiCacheStorage):
             logger.info(f"Created HiCacheFile storage directory at {self.file_path}")
 
         # All LRU / size accounting and disk eviction lives in the evictor so
-        # this backend stays a thin raw-bytes store. Imported lazily: the storage
-        # package __init__ pulls in the backend factory, which imports this
-        # module, so a top-level import here would be circular.
+        # this backend stays a thin raw-bytes store. Imported lazily because
+        # lru_file_evictor imports HiCacheFile at module level for the shared
+        # shard-path helper; a top-level import here would be circular.
         from sglang.srt.mem_cache.storage.file.lru_file_evictor import LRUFileEvictor
 
         self._evictor = LRUFileEvictor(
@@ -363,21 +363,22 @@ class HiCacheFile(HiCacheStorage):
             extra_config=storage_config.extra_config,
         )
 
-    # LOCAL PATCH (dsv4-l3-shard): fan .bin files into 2-level hash-prefix
-    # subdirs (<ab>/<cd>/<name>.bin) so a single directory never accumulates
-    # millions of entries. Upstream HiCacheFile (incl. latest main) writes all
-    # files flat under file_path -> at ~7.5M files the ext4 directory index
-    # ("htree") is exhausted and writes fail with ENOSPC even though bytes AND
-    # inodes remain free. Sharding caps per-directory entries and also turns the
-    # batch-existence check from one O(total_files) scandir into O(keys) stats.
-    # The shard is derived purely from the leading hex of the .bin FILENAME
-    # (== content-hash prefix), so get/set/exists/evictor all agree. MUST stay
-    # byte-identical to LRUFileEvictor._sharded_path (separate module; no shared
-    # import to avoid the storage-package circular import).
     @staticmethod
     def _shard_subdir(filename: str) -> str:
-        # filename starts with the 64-char hex content hash; first 4 hex chars
-        # give 256x256 buckets. Short/atypical names fall back to a flat bucket.
+        """Map a ``.bin`` filename to its 2-level hash-prefix subdir ``<ab>/<cd>``.
+
+        Pages are fanned into ``<ab>/<cd>/<name>.bin`` so no single directory
+        accumulates millions of entries. A flat layout exhausts the ext4
+        directory index ("htree") at scale (~7.5M files), after which writes
+        fail with ENOSPC even though free bytes and inodes remain. Sharding caps
+        per-directory entries and also turns batched existence checks from one
+        ``O(total_files)`` scandir into ``O(keys)`` stats. The bucket is derived
+        purely from the leading hex of the filename (the content-hash prefix),
+        so get/set/exists and the evictor all resolve the same path -- the
+        evictor imports this exact helper to stay in sync.
+        """
+        # First 4 hex chars give 256x256 buckets; short/atypical names fall
+        # back to a single flat bucket.
         if len(filename) >= 4:
             return os.path.join(filename[:2], filename[2:4])
         return ""
@@ -405,9 +406,7 @@ class HiCacheFile(HiCacheStorage):
         target_sizes: Optional[Any] = None,
     ) -> torch.Tensor | None:
         suffixed = self._get_suffixed_key(key)
-        tensor_path = self._sharded_path(
-            f"{suffixed}.bin"
-        )  # LOCAL PATCH (dsv4-l3-shard)
+        tensor_path = self._sharded_path(f"{suffixed}.bin")
         try:
             expected = target_location.numel() * target_location.element_size()
             with open(tensor_path, "rb", buffering=0) as f:
@@ -441,9 +440,7 @@ class HiCacheFile(HiCacheStorage):
         target_sizes: Optional[Any] = None,
     ) -> bool:
         suffixed = self._get_suffixed_key(key)
-        tensor_path = self._sharded_path(
-            f"{suffixed}.bin"
-        )  # LOCAL PATCH (dsv4-l3-shard)
+        tensor_path = self._sharded_path(f"{suffixed}.bin")
 
         # Fast path: same key already on disk. Refresh recency and skip rewrite.
         if os.path.exists(tensor_path):
@@ -460,9 +457,9 @@ class HiCacheFile(HiCacheStorage):
                 return False
             reserved = True
 
-            # LOCAL PATCH (dsv4-l3-shard): ensure the hash-prefix subdir exists
-            # before writing the temp file (tmp + final live in the same shard
-            # dir so os.replace stays an atomic same-filesystem rename).
+            # Create the hash-prefix subdir before writing the temp file; tmp
+            # and final live in the same shard dir so os.replace stays an atomic
+            # same-filesystem rename.
             os.makedirs(os.path.dirname(tensor_path), exist_ok=True)
             tmp_path = (
                 f"{tensor_path}.tmp."
@@ -498,7 +495,7 @@ class HiCacheFile(HiCacheStorage):
 
     def exists(self, key: str) -> bool:
         key = self._get_suffixed_key(key)
-        tensor_path = self._sharded_path(f"{key}.bin")  # LOCAL PATCH (dsv4-l3-shard)
+        tensor_path = self._sharded_path(f"{key}.bin")
         return os.path.exists(tensor_path)
 
     def _collect_existing_component_keys(
@@ -511,11 +508,10 @@ class HiCacheFile(HiCacheStorage):
             for key in keys:
                 target_files.add(f"{self._get_component_key(key, transfer.name)}.bin")
 
-        # LOCAL PATCH (dsv4-l3-shard): probe each target file in its hash-prefix
-        # shard directly. Upstream scandir'd the entire flat file_path on every
-        # batch_exists call -- O(total_files) per lookup, which with millions of
-        # cached pages is a per-request scan over the whole cache dir. Per-target
-        # os.path.exists is O(len(target_files)) and shard-correct.
+        # Probe each target file in its hash-prefix shard directly: a per-target
+        # os.path.exists is O(len(target_files)) and shard-correct, versus
+        # scanning the whole flat file_path -- O(total_files) per call, i.e. a
+        # full cache-dir walk per request once millions of pages accumulate.
         existing_files = set()
         for fname in target_files:
             if os.path.exists(self._sharded_path(fname)):
@@ -634,19 +630,25 @@ class HiCacheFile(HiCacheStorage):
 
     def clear(self) -> bool:
         try:
-            # LOCAL PATCH (dsv4-l3-shard): files live in hash-prefix subdirs now,
-            # so walk recursively instead of a single-level listdir. Only unlink
-            # cache pages (*.bin) -- NEVER non-.bin metadata such as the init
-            # container's `.sharded-v1` migration sentinel: deleting it would make
-            # the next pod start re-run the flat->sharded migration and wipe the
-            # live L3 tier.
-            for root, _dirs, files in os.walk(self.file_path):
+            # Files live in hash-prefix subdirs, so walk recursively rather than
+            # a single-level listdir. Walk bottom-up (topdown=False) so an empty
+            # shard subdir can be removed right after its pages are unlinked,
+            # otherwise eviction/clear would leak up to 256*256 empty dirs.
+            # Only unlink cache pages (*.bin) -- never non-.bin metadata such as
+            # a migration sentinel; a shard dir that still holds such a file
+            # fails rmdir and is kept. The root file_path itself is never removed.
+            for root, _dirs, files in os.walk(self.file_path, topdown=False):
                 for filename in files:
                     if not filename.endswith(".bin"):
                         continue
                     fp = os.path.join(root, filename)
                     if os.path.isfile(fp):
                         os.remove(fp)
+                if root != self.file_path:
+                    try:
+                        os.rmdir(root)
+                    except OSError:
+                        pass  # not empty (other pages / sentinel) -> keep it
             self._evictor.clear()
             logger.info("Cleared all entries in HiCacheFile storage.")
             return True

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -350,16 +350,20 @@ class HiCacheFile(HiCacheStorage):
             logger.info(f"Created HiCacheFile storage directory at {self.file_path}")
 
         # All LRU / size accounting and disk eviction lives in the evictor so
-        # this backend stays a thin raw-bytes store. Imported lazily because
-        # lru_file_evictor imports HiCacheFile at module level for the shared
-        # shard-path helper; a top-level import here would be circular.
+        # this backend stays a thin raw-bytes store. Imported lazily: the storage
+        # package __init__ pulls in the backend factory, which imports this
+        # module, so a top-level import here would be circular.
         from sglang.srt.mem_cache.storage.file.lru_file_evictor import LRUFileEvictor
 
+        # The evictor unlinks pages and so must resolve the same sharded paths
+        # the backend writes to. Inject the bucket helper rather than have the
+        # evictor import this module back (which would be circular).
         self._evictor = LRUFileEvictor(
             self.file_path,
             self.config_suffix,
             tp_rank=tp_rank,
             is_mla_model=is_mla_model,
+            shard_dir_fn=self._shard_subdir,
             extra_config=storage_config.extra_config,
         )
 
@@ -375,7 +379,7 @@ class HiCacheFile(HiCacheStorage):
         ``O(total_files)`` scandir into ``O(keys)`` stats. The bucket is derived
         purely from the leading hex of the filename (the content-hash prefix),
         so get/set/exists and the evictor all resolve the same path -- the
-        evictor imports this exact helper to stay in sync.
+        evictor receives this exact helper (as ``shard_dir_fn``) to stay in sync.
         """
         # First 4 hex chars give 256x256 buckets; short/atypical names fall
         # back to a single flat bucket.

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -363,6 +363,28 @@ class HiCacheFile(HiCacheStorage):
             extra_config=storage_config.extra_config,
         )
 
+    # LOCAL PATCH (dsv4-l3-shard): fan .bin files into 2-level hash-prefix
+    # subdirs (<ab>/<cd>/<name>.bin) so a single directory never accumulates
+    # millions of entries. Upstream HiCacheFile (incl. latest main) writes all
+    # files flat under file_path -> at ~7.5M files the ext4 directory index
+    # ("htree") is exhausted and writes fail with ENOSPC even though bytes AND
+    # inodes remain free. Sharding caps per-directory entries and also turns the
+    # batch-existence check from one O(total_files) scandir into O(keys) stats.
+    # The shard is derived purely from the leading hex of the .bin FILENAME
+    # (== content-hash prefix), so get/set/exists/evictor all agree. MUST stay
+    # byte-identical to LRUFileEvictor._sharded_path (separate module; no shared
+    # import to avoid the storage-package circular import).
+    @staticmethod
+    def _shard_subdir(filename: str) -> str:
+        # filename starts with the 64-char hex content hash; first 4 hex chars
+        # give 256x256 buckets. Short/atypical names fall back to a flat bucket.
+        if len(filename) >= 4:
+            return os.path.join(filename[:2], filename[2:4])
+        return ""
+
+    def _sharded_path(self, filename: str) -> str:
+        return os.path.join(self.file_path, self._shard_subdir(filename), filename)
+
     def _get_suffixed_key(self, key: str) -> str:
         return key + self.config_suffix
 
@@ -374,8 +396,8 @@ class HiCacheFile(HiCacheStorage):
     def _get_component_path(
         self, key: str, component_name: Optional[str] = None
     ) -> str:
-        return os.path.join(
-            self.file_path, f"{self._get_component_key(key, component_name)}.bin"
+        return self._sharded_path(
+            f"{self._get_component_key(key, component_name)}.bin"
         )
 
     def get(
@@ -385,7 +407,7 @@ class HiCacheFile(HiCacheStorage):
         target_sizes: Optional[Any] = None,
     ) -> torch.Tensor | None:
         suffixed = self._get_suffixed_key(key)
-        tensor_path = os.path.join(self.file_path, f"{suffixed}.bin")
+        tensor_path = self._sharded_path(f"{suffixed}.bin")  # LOCAL PATCH (dsv4-l3-shard)
         try:
             expected = target_location.numel() * target_location.element_size()
             with open(tensor_path, "rb", buffering=0) as f:
@@ -419,7 +441,7 @@ class HiCacheFile(HiCacheStorage):
         target_sizes: Optional[Any] = None,
     ) -> bool:
         suffixed = self._get_suffixed_key(key)
-        tensor_path = os.path.join(self.file_path, f"{suffixed}.bin")
+        tensor_path = self._sharded_path(f"{suffixed}.bin")  # LOCAL PATCH (dsv4-l3-shard)
 
         # Fast path: same key already on disk. Refresh recency and skip rewrite.
         if os.path.exists(tensor_path):
@@ -436,6 +458,10 @@ class HiCacheFile(HiCacheStorage):
                 return False
             reserved = True
 
+            # LOCAL PATCH (dsv4-l3-shard): ensure the hash-prefix subdir exists
+            # before writing the temp file (tmp + final live in the same shard
+            # dir so os.replace stays an atomic same-filesystem rename).
+            os.makedirs(os.path.dirname(tensor_path), exist_ok=True)
             tmp_path = (
                 f"{tensor_path}.tmp."
                 f"{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex}"
@@ -470,7 +496,7 @@ class HiCacheFile(HiCacheStorage):
 
     def exists(self, key: str) -> bool:
         key = self._get_suffixed_key(key)
-        tensor_path = os.path.join(self.file_path, f"{key}.bin")
+        tensor_path = self._sharded_path(f"{key}.bin")  # LOCAL PATCH (dsv4-l3-shard)
         return os.path.exists(tensor_path)
 
     def _collect_existing_component_keys(
@@ -483,11 +509,15 @@ class HiCacheFile(HiCacheStorage):
             for key in keys:
                 target_files.add(f"{self._get_component_key(key, transfer.name)}.bin")
 
+        # LOCAL PATCH (dsv4-l3-shard): probe each target file in its hash-prefix
+        # shard directly. Upstream scandir'd the entire flat file_path on every
+        # batch_exists call -- O(total_files) per lookup, which with millions of
+        # cached pages is a per-request scan over the whole cache dir. Per-target
+        # os.path.exists is O(len(target_files)) and shard-correct.
         existing_files = set()
-        with os.scandir(self.file_path) as entries:
-            for entry in entries:
-                if entry.is_file() and entry.name in target_files:
-                    existing_files.add(entry.name)
+        for fname in target_files:
+            if os.path.exists(self._sharded_path(fname)):
+                existing_files.add(fname)
         return existing_files
 
     def batch_exists_v2(
@@ -602,10 +632,19 @@ class HiCacheFile(HiCacheStorage):
 
     def clear(self) -> bool:
         try:
-            for filename in os.listdir(self.file_path):
-                file_path = os.path.join(self.file_path, filename)
-                if os.path.isfile(file_path):
-                    os.remove(file_path)
+            # LOCAL PATCH (dsv4-l3-shard): files live in hash-prefix subdirs now,
+            # so walk recursively instead of a single-level listdir. Only unlink
+            # cache pages (*.bin) -- NEVER non-.bin metadata such as the init
+            # container's `.sharded-v1` migration sentinel: deleting it would make
+            # the next pod start re-run the flat->sharded migration and wipe the
+            # live L3 tier.
+            for root, _dirs, files in os.walk(self.file_path):
+                for filename in files:
+                    if not filename.endswith(".bin"):
+                        continue
+                    fp = os.path.join(root, filename)
+                    if os.path.isfile(fp):
+                        os.remove(fp)
             self._evictor.clear()
             logger.info("Cleared all entries in HiCacheFile storage.")
             return True

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -396,9 +396,7 @@ class HiCacheFile(HiCacheStorage):
     def _get_component_path(
         self, key: str, component_name: Optional[str] = None
     ) -> str:
-        return self._sharded_path(
-            f"{self._get_component_key(key, component_name)}.bin"
-        )
+        return self._sharded_path(f"{self._get_component_key(key, component_name)}.bin")
 
     def get(
         self,
@@ -407,7 +405,9 @@ class HiCacheFile(HiCacheStorage):
         target_sizes: Optional[Any] = None,
     ) -> torch.Tensor | None:
         suffixed = self._get_suffixed_key(key)
-        tensor_path = self._sharded_path(f"{suffixed}.bin")  # LOCAL PATCH (dsv4-l3-shard)
+        tensor_path = self._sharded_path(
+            f"{suffixed}.bin"
+        )  # LOCAL PATCH (dsv4-l3-shard)
         try:
             expected = target_location.numel() * target_location.element_size()
             with open(tensor_path, "rb", buffering=0) as f:
@@ -441,7 +441,9 @@ class HiCacheFile(HiCacheStorage):
         target_sizes: Optional[Any] = None,
     ) -> bool:
         suffixed = self._get_suffixed_key(key)
-        tensor_path = self._sharded_path(f"{suffixed}.bin")  # LOCAL PATCH (dsv4-l3-shard)
+        tensor_path = self._sharded_path(
+            f"{suffixed}.bin"
+        )  # LOCAL PATCH (dsv4-l3-shard)
 
         # Fast path: same key already on disk. Refresh recency and skip rewrite.
         if os.path.exists(tensor_path):

--- a/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
+++ b/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
@@ -76,11 +76,8 @@ class LRUFileEvictor:
         self.file_path = file_path
         self.config_suffix = config_suffix
         self._tp_rank = tp_rank
-        # Maps a ``.bin`` filename to its relative hash-prefix shard subdir.
-        # Injected by HiCacheFile (its ``_shard_subdir``) so the evictor resolves
-        # the exact same on-disk paths the backend writes to, without importing
-        # the backend here -- HiCacheFile imports this evictor lazily, so a
-        # module-level back-import would be circular.
+        # Injected by HiCacheFile so the evictor resolves the same sharded paths;
+        # avoids a back-import (the backend imports this evictor lazily).
         self._shard_dir_fn = shard_dir_fn
 
         # MLA ranks share the same physical files, so centralize LRU bookkeeping
@@ -302,10 +299,8 @@ class LRUFileEvictor:
 
     def _scan_existing_files(self) -> None:
         """Seed LRU index from disk on startup (oldest mtime first)."""
-        # Files live in hash-prefix subdirs, so walk recursively rather than a
-        # single-level listdir. The LRU key stays the bare stem (filename without
-        # .bin); only discovery and the unlink path are shard-aware, never the
-        # index keys. os.walk on a missing dir yields nothing.
+        # Walk shard subdirs (the LRU key stays the bare stem; only discovery
+        # and unlink are shard-aware, not the index keys).
         entries = []
         for root, _dirs, files in os.walk(self.file_path):
             for fn in files:

--- a/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
+++ b/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
@@ -36,6 +36,24 @@ from sglang.srt.utils.common import human_readable_int
 logger = logging.getLogger(__name__)
 
 
+# LOCAL PATCH (dsv4-l3-shard): the HiCacheFile backend now fans .bin files into
+# 2-level hash-prefix subdirs (<ab>/<cd>/<name>.bin) instead of one flat dir, to
+# avoid ext4 directory-index ("htree") ENOSPC at millions of files. The evictor
+# must discover (scan) and unlink files at those sharded paths. This rule MUST
+# stay byte-identical to HiCacheFile._shard_subdir / _sharded_path in
+# hicache_storage.py (kept duplicated rather than imported: the storage package
+# __init__ pulls in the backend factory which imports this module -> a shared
+# import would be circular).
+def _shard_subdir(filename: str) -> str:
+    if len(filename) >= 4:
+        return os.path.join(filename[:2], filename[2:4])
+    return ""
+
+
+def _sharded_path(file_path: str, filename: str) -> str:
+    return os.path.join(file_path, _shard_subdir(filename), filename)
+
+
 def _parse_size_to_bytes(value: Any) -> int:
     """Parse a size to bytes via human_readable_int (e.g. '200G', '1Gi', '1048576').
     None / empty / '0' disables; an invalid value also disables (with a warning)."""
@@ -295,24 +313,25 @@ class LRUFileEvictor:
 
     def _scan_existing_files(self) -> None:
         """Seed LRU index from disk on startup (oldest mtime first)."""
-        try:
-            names = os.listdir(self.file_path)
-        except FileNotFoundError:
-            return
+        # LOCAL PATCH (dsv4-l3-shard): files live in hash-prefix subdirs now, so
+        # walk recursively instead of a single-level listdir. The LRU key stays
+        # the bare stem (filename without .bin); only discovery + the unlink path
+        # change, never the index keys. os.walk on a missing dir yields nothing.
         entries = []
-        for fn in names:
-            if not fn.endswith(".bin"):
-                continue
-            stem = fn[:-4]
-            # Only files belonging to this rank/model.
-            if not stem.endswith(self.config_suffix):
-                continue
-            fp = os.path.join(self.file_path, fn)
-            try:
-                st = os.stat(fp)
-            except OSError:
-                continue
-            entries.append((st.st_mtime, stem, st.st_size))
+        for root, _dirs, files in os.walk(self.file_path):
+            for fn in files:
+                if not fn.endswith(".bin"):
+                    continue
+                stem = fn[:-4]
+                # Only files belonging to this rank/model.
+                if not stem.endswith(self.config_suffix):
+                    continue
+                fp = os.path.join(root, fn)
+                try:
+                    st = os.stat(fp)
+                except OSError:
+                    continue
+                entries.append((st.st_mtime, stem, st.st_size))
         entries.sort(key=lambda e: e[0])  # oldest first
         for _, stem, size in entries:
             self._lru[stem] = size
@@ -338,7 +357,7 @@ class LRUFileEvictor:
             # Keep in-flight reservations; their file isn't committed yet.
             self._lru[evict_stem] = evict_size
             return "skipped", 0
-        tensor_path = os.path.join(self.file_path, f"{evict_stem}.bin")
+        tensor_path = _sharded_path(self.file_path, f"{evict_stem}.bin")  # LOCAL PATCH (dsv4-l3-shard)
         try:
             os.remove(tensor_path)
             freed = evict_size

--- a/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
+++ b/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
@@ -31,27 +31,21 @@ from collections import OrderedDict
 from typing import Any, Optional, Set, Tuple
 
 from sglang.srt.environ import envs
+from sglang.srt.mem_cache.hicache_storage import HiCacheFile
 from sglang.srt.utils.common import human_readable_int
 
 logger = logging.getLogger(__name__)
 
 
-# LOCAL PATCH (dsv4-l3-shard): the HiCacheFile backend now fans .bin files into
-# 2-level hash-prefix subdirs (<ab>/<cd>/<name>.bin) instead of one flat dir, to
-# avoid ext4 directory-index ("htree") ENOSPC at millions of files. The evictor
-# must discover (scan) and unlink files at those sharded paths. This rule MUST
-# stay byte-identical to HiCacheFile._shard_subdir / _sharded_path in
-# hicache_storage.py (kept duplicated rather than imported: the storage package
-# __init__ pulls in the backend factory which imports this module -> a shared
-# import would be circular).
-def _shard_subdir(filename: str) -> str:
-    if len(filename) >= 4:
-        return os.path.join(filename[:2], filename[2:4])
-    return ""
-
-
 def _sharded_path(file_path: str, filename: str) -> str:
-    return os.path.join(file_path, _shard_subdir(filename), filename)
+    """Resolve a ``.bin`` filename to its sharded path under ``file_path``.
+
+    Reuses ``HiCacheFile._shard_subdir`` rather than re-deriving the bucket so
+    the evictor's scan/unlink paths can never desynchronize from the paths the
+    backend writes to. (``HiCacheFile`` imports the evictor lazily inside its
+    ``__init__``, so this module-level import is not circular.)
+    """
+    return os.path.join(file_path, HiCacheFile._shard_subdir(filename), filename)
 
 
 def _parse_size_to_bytes(value: Any) -> int:
@@ -313,10 +307,10 @@ class LRUFileEvictor:
 
     def _scan_existing_files(self) -> None:
         """Seed LRU index from disk on startup (oldest mtime first)."""
-        # LOCAL PATCH (dsv4-l3-shard): files live in hash-prefix subdirs now, so
-        # walk recursively instead of a single-level listdir. The LRU key stays
-        # the bare stem (filename without .bin); only discovery + the unlink path
-        # change, never the index keys. os.walk on a missing dir yields nothing.
+        # Files live in hash-prefix subdirs, so walk recursively rather than a
+        # single-level listdir. The LRU key stays the bare stem (filename without
+        # .bin); only discovery and the unlink path are shard-aware, never the
+        # index keys. os.walk on a missing dir yields nothing.
         entries = []
         for root, _dirs, files in os.walk(self.file_path):
             for fn in files:
@@ -336,6 +330,25 @@ class LRUFileEvictor:
         for _, stem, size in entries:
             self._lru[stem] = size
             self._total_bytes += size
+
+    def _rmdir_empty_shard(self, tensor_path: str) -> None:
+        """Remove now-empty hash-prefix subdirs after unlinking a victim.
+
+        ``rmdir`` only succeeds on an empty directory, so a shard still holding
+        other pages is left intact; the backend recreates the dir (``makedirs``
+        with ``exist_ok``) before its next write. Without this, per-file eviction
+        would slowly leak up to 256*256 empty directories.
+        """
+        shard_dir = os.path.dirname(tensor_path)
+        if shard_dir == self.file_path:
+            return  # unsharded fallback bucket; nothing to prune
+        try:
+            os.rmdir(shard_dir)  # inner <cd> level
+            parent = os.path.dirname(shard_dir)
+            if parent != self.file_path:
+                os.rmdir(parent)  # outer <ab> level
+        except OSError:
+            pass  # dir still holds other pages -> keep it
 
     def _evict_one_lru_locked(self) -> Tuple[str, int]:
         """Evict the single oldest evictable LRU entry. Caller holds _lock.
@@ -357,12 +370,11 @@ class LRUFileEvictor:
             # Keep in-flight reservations; their file isn't committed yet.
             self._lru[evict_stem] = evict_size
             return "skipped", 0
-        tensor_path = _sharded_path(
-            self.file_path, f"{evict_stem}.bin"
-        )  # LOCAL PATCH (dsv4-l3-shard)
+        tensor_path = _sharded_path(self.file_path, f"{evict_stem}.bin")
         try:
             os.remove(tensor_path)
             freed = evict_size
+            self._rmdir_empty_shard(tensor_path)
         except FileNotFoundError:
             freed = 0  # file already gone; still drop the stale index entry
         except OSError as e:

--- a/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
+++ b/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
@@ -28,24 +28,12 @@ import logging
 import os
 import threading
 from collections import OrderedDict
-from typing import Any, Optional, Set, Tuple
+from typing import Any, Callable, Optional, Set, Tuple
 
 from sglang.srt.environ import envs
-from sglang.srt.mem_cache.hicache_storage import HiCacheFile
 from sglang.srt.utils.common import human_readable_int
 
 logger = logging.getLogger(__name__)
-
-
-def _sharded_path(file_path: str, filename: str) -> str:
-    """Resolve a ``.bin`` filename to its sharded path under ``file_path``.
-
-    Reuses ``HiCacheFile._shard_subdir`` rather than re-deriving the bucket so
-    the evictor's scan/unlink paths can never desynchronize from the paths the
-    backend writes to. (``HiCacheFile`` imports the evictor lazily inside its
-    ``__init__``, so this module-level import is not circular.)
-    """
-    return os.path.join(file_path, HiCacheFile._shard_subdir(filename), filename)
 
 
 def _parse_size_to_bytes(value: Any) -> int:
@@ -82,11 +70,18 @@ class LRUFileEvictor:
         *,
         tp_rank: int,
         is_mla_model: bool,
+        shard_dir_fn: Callable[[str], str],
         extra_config: Optional[dict] = None,
     ) -> None:
         self.file_path = file_path
         self.config_suffix = config_suffix
         self._tp_rank = tp_rank
+        # Maps a ``.bin`` filename to its relative hash-prefix shard subdir.
+        # Injected by HiCacheFile (its ``_shard_subdir``) so the evictor resolves
+        # the exact same on-disk paths the backend writes to, without importing
+        # the backend here -- HiCacheFile imports this evictor lazily, so a
+        # module-level back-import would be circular.
+        self._shard_dir_fn = shard_dir_fn
 
         # MLA ranks share the same physical files, so centralize LRU bookkeeping
         # on rank 0; non-MLA ranks each own their own files via the suffix.
@@ -331,6 +326,15 @@ class LRUFileEvictor:
             self._lru[stem] = size
             self._total_bytes += size
 
+    def _sharded_path(self, filename: str) -> str:
+        """Resolve a ``.bin`` filename to its full sharded path under file_path.
+
+        Delegates the bucket layout to the backend-supplied ``shard_dir_fn`` so
+        the evictor's scan/unlink paths can never desynchronize from where the
+        backend writes.
+        """
+        return os.path.join(self.file_path, self._shard_dir_fn(filename), filename)
+
     def _rmdir_empty_shard(self, tensor_path: str) -> None:
         """Remove now-empty hash-prefix subdirs after unlinking a victim.
 
@@ -370,7 +374,7 @@ class LRUFileEvictor:
             # Keep in-flight reservations; their file isn't committed yet.
             self._lru[evict_stem] = evict_size
             return "skipped", 0
-        tensor_path = _sharded_path(self.file_path, f"{evict_stem}.bin")
+        tensor_path = self._sharded_path(f"{evict_stem}.bin")
         try:
             os.remove(tensor_path)
             freed = evict_size

--- a/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
+++ b/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
@@ -357,7 +357,9 @@ class LRUFileEvictor:
             # Keep in-flight reservations; their file isn't committed yet.
             self._lru[evict_stem] = evict_size
             return "skipped", 0
-        tensor_path = _sharded_path(self.file_path, f"{evict_stem}.bin")  # LOCAL PATCH (dsv4-l3-shard)
+        tensor_path = _sharded_path(
+            self.file_path, f"{evict_stem}.bin"
+        )  # LOCAL PATCH (dsv4-l3-shard)
         try:
             os.remove(tensor_path)
             freed = evict_size

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -435,15 +435,11 @@ class TestPreReservationConcurrency(HiCacheFileLRUTestBase):
         self.assertLessEqual(b._evictor._total_bytes, 100)
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
-
-
 # ---------------------------------------------------------------------------
-# Hash-prefix sharding tests (dsv4-l3-shard): files fan into <ab>/<cd>/ subdirs
-# so a single directory never accumulates millions of entries (ext4 htree limit).
-# Covers all four patched paths: write layout, get/exists roundtrip, clear (only
-# .bin removed), and the evictor (os.walk discovery + sharded unlink).
+# Hash-prefix sharding tests: files fan into <ab>/<cd>/ subdirs so a single
+# directory never accumulates millions of entries (ext4 htree limit). Covers the
+# write layout, get/exists roundtrip, clear (only .bin removed, empty shard dirs
+# reaped), and the evictor (os.walk discovery + sharded unlink + empty-dir reap).
 # ---------------------------------------------------------------------------
 class TestFileSharding(HiCacheFileLRUTestBase):
     @staticmethod
@@ -504,6 +500,16 @@ class TestFileSharding(HiCacheFileLRUTestBase):
         self.assertTrue(
             os.path.exists(marker), "clear() must not delete non-.bin files"
         )
+        # Empty shard subdirs are reaped (only the root + its marker remain),
+        # so clear() can't leave up to 256*256 empty dirs behind.
+        leftover_dirs = [
+            os.path.relpath(os.path.join(dp, d), be.file_path)
+            for dp, dirs, _ in os.walk(be.file_path)
+            for d in dirs
+        ]
+        self.assertEqual(
+            leftover_dirs, [], f"empty shard dirs not reaped: {leftover_dirs}"
+        )
 
     def test_evictor_discovers_sharded_files_on_restart(self):
         # Write with one backend, then construct a fresh backend over the same
@@ -534,3 +540,15 @@ class TestFileSharding(HiCacheFileLRUTestBase):
         # on disk (victims were physically unlinked, not orphaned).
         on_disk = set(self._all_bins(be.file_path))
         self.assertEqual(len(on_disk), len(be._evictor._lru))
+        # Eviction also reaps the shard dirs it empties: no fully-empty subdir
+        # should linger under the root.
+        empty = [
+            os.path.relpath(dp, be.file_path)
+            for dp, dirs, files in os.walk(be.file_path)
+            if dp != be.file_path and not dirs and not files
+        ]
+        self.assertEqual(empty, [], f"empty shard dirs left after eviction: {empty}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -501,7 +501,9 @@ class TestFileSharding(HiCacheFileLRUTestBase):
 
         self.assertTrue(be.clear())
         self.assertEqual(self._all_bins(be.file_path), [])
-        self.assertTrue(os.path.exists(marker), "clear() must not delete non-.bin files")
+        self.assertTrue(
+            os.path.exists(marker), "clear() must not delete non-.bin files"
+        )
 
     def test_evictor_discovers_sharded_files_on_restart(self):
         # Write with one backend, then construct a fresh backend over the same
@@ -514,7 +516,9 @@ class TestFileSharding(HiCacheFileLRUTestBase):
 
         be2 = self.make_backend(max_size="1Gi", subdir="restart")
         self.assertEqual(
-            len(be2._evictor._lru), n, "evictor must rediscover sharded files on restart"
+            len(be2._evictor._lru),
+            n,
+            "evictor must rediscover sharded files on restart",
         )
 
     def test_evictor_unlinks_sharded_victims_under_cap(self):

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -437,3 +437,96 @@ class TestPreReservationConcurrency(HiCacheFileLRUTestBase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+# ---------------------------------------------------------------------------
+# Hash-prefix sharding tests (dsv4-l3-shard): files fan into <ab>/<cd>/ subdirs
+# so a single directory never accumulates millions of entries (ext4 htree limit).
+# Covers all four patched paths: write layout, get/exists roundtrip, clear (only
+# .bin removed), and the evictor (os.walk discovery + sharded unlink).
+# ---------------------------------------------------------------------------
+class TestFileSharding(HiCacheFileLRUTestBase):
+    @staticmethod
+    def _hexkey(i: int) -> str:
+        # 64-char hex content-hash-like key (what the radix cache passes).
+        return f"{i:064x}"
+
+    def _all_bins(self, root):
+        out = []
+        for dp, _dirs, files in os.walk(root):
+            for f in files:
+                if f.endswith(".bin"):
+                    out.append(os.path.relpath(os.path.join(dp, f), root))
+        return out
+
+    def test_writes_land_in_two_level_shard_dirs(self):
+        be = self.make_backend()
+        keys = [self._hexkey(i) for i in range(25)]
+        for k in keys:
+            self.assertTrue(be.set(k, value=_t(16, 1)))
+
+        # No .bin directly under the root (flat layout would hit the dir limit).
+        flat = [f for f in os.listdir(be.file_path) if f.endswith(".bin")]
+        self.assertEqual(flat, [], f"no .bin should sit flat at root, got {flat}")
+
+        # Every .bin lives at <ab>/<cd>/<name>.bin (depth 3 from root) and the
+        # shard dirs match the leading hex of the filename.
+        bins = self._all_bins(be.file_path)
+        self.assertEqual(len(bins), len(keys))
+        for rel in bins:
+            parts = rel.split(os.sep)
+            self.assertEqual(len(parts), 3, f"expected <ab>/<cd>/<file>: {rel}")
+            ab, cd, name = parts
+            self.assertEqual((ab, cd), (name[:2], name[2:4]))
+
+    def test_roundtrip_get_and_exists(self):
+        be = self.make_backend()
+        k = self._hexkey(7)
+        self.assertTrue(be.set(k, value=_t(32, 5)))
+        self.assertTrue(be.exists(k))
+        out = be.get(k, _t(32))
+        self.assertIsNotNone(out)
+        self.assertTrue(torch.equal(out, _t(32, 5)))
+        self.assertFalse(be.exists(self._hexkey(999)))
+
+    def test_clear_removes_bin_but_keeps_non_bin_files(self):
+        be = self.make_backend()
+        be.set(self._hexkey(1), value=_t(16, 1))
+        be.set(self._hexkey(2), value=_t(16, 2))
+        # A non-.bin marker at the root (e.g. an external migration sentinel)
+        # must survive clear(), which should only drop cache pages.
+        marker = os.path.join(be.file_path, ".keep_marker")
+        with open(marker, "w") as fh:
+            fh.write("x")
+
+        self.assertTrue(be.clear())
+        self.assertEqual(self._all_bins(be.file_path), [])
+        self.assertTrue(os.path.exists(marker), "clear() must not delete non-.bin files")
+
+    def test_evictor_discovers_sharded_files_on_restart(self):
+        # Write with one backend, then construct a fresh backend over the same
+        # dir: _scan_existing_files must walk the shard subdirs (not a flat
+        # listdir) to rebuild the LRU index.
+        be = self.make_backend(max_size="1Gi", subdir="restart")
+        n = 12
+        for i in range(n):
+            be.set(self._hexkey(i), value=_t(64, i % 7))
+
+        be2 = self.make_backend(max_size="1Gi", subdir="restart")
+        self.assertEqual(
+            len(be2._evictor._lru), n, "evictor must rediscover sharded files on restart"
+        )
+
+    def test_evictor_unlinks_sharded_victims_under_cap(self):
+        # Tiny cap forces eviction; the evictor must unlink files at their
+        # sharded paths (a flat-path unlink would silently leave orphans).
+        be = self.make_backend(max_size="512", eviction_ratio=0.9, subdir="cap")
+        for i in range(20):
+            be.set(self._hexkey(i), value=_t(64, i % 7))
+
+        # Accounting stayed within the cap (eviction actually ran)...
+        self.assertLessEqual(be._evictor._total_bytes, 512)
+        # ...and every byte the evictor still tracks corresponds to a real file
+        # on disk (victims were physically unlinked, not orphaned).
+        on_disk = set(self._all_bins(be.file_path))
+        self.assertEqual(len(on_disk), len(be._evictor._lru))


### PR DESCRIPTION
## Motivation

The `file` storage backend (`HiCacheFile`) stores every cached page as a `.bin` file directly under **one flat directory**. On a long-running single-replica deployment this directory reached **~7.5M files** and writes started failing with `ENOSPC` even though the filesystem had **~24 TB and ~456M inodes free** — the ext4 per-directory index (htree) limit. This silently disables the L3 restart-survival tier (~8.3k failed writes/hour in our logs): evicted/restarted sessions then miss the prefix cache and pay a full re-prefill. Additionally, `batch_exists` does a full `os.scandir(self.file_path)` **per call** (O(total cached files)).

Fixes #28653.

## Modifications

- **`hicache_storage.py`** — fan `.bin` files into 2-level hash-prefix subdirs `<ab>/<cd>/<name>.bin` (leading hex of the filename) across `get` / `set` / `exists` / `_get_component_path` / `clear`; create the shard dir on write (`os.makedirs(..., exist_ok=True)`, so tmp + final stay in the same dir and `os.replace` remains an atomic same-filesystem rename). Replace the per-call full-dir `os.scandir` in `_collect_existing_component_keys` with per-key `os.path.exists` (**O(keys)** instead of O(total files)). `clear()` now walks bottom-up, unlinks only `*.bin`, and reaps emptied shard subdirs while leaving any non-cache files intact.
- **`lru_file_evictor.py`** — discover files via `os.walk` in `_scan_existing_files`, unlink victims at their sharded path in `_evict_one_lru_locked`, and reap the now-empty shard dirs after each eviction. The shard-path helper is imported from `HiCacheFile._shard_subdir` (single source of truth) rather than duplicated; this is not circular because the backend imports the evictor lazily inside `__init__`.
- **Tests** — add `TestFileSharding` to `test_hicache_file_lru_unit.py`: sharded write layout, get/exists roundtrip, `clear` removes only `.bin`, evictor rediscovery on restart (os.walk), evictor unlinks sharded victims under a byte cap, and empty shard dirs are reaped by both `clear()` and eviction.

**Backward compatibility:** pre-existing flat files are simply not found by the new read path (graceful miss → re-fetch), so an upgrade degrades to a cold cache rather than breaking. Operators can wipe/migrate the storage dir on upgrade.

## Accuracy Test

Path-only change — cached bytes are identical, so model output is unchanged. The new `TestFileSharding` unit tests pass and the existing LRU/eviction tests in `test_hicache_file_lru_unit.py` are unaffected. Validated on a live DeepSeek-V4 deployment: `No space left` errors **8.3k/hr → 0**, all new files land sharded (depth-3, 0 flat), prefix restore confirmed.

## Benchmarking and Profiling

`_collect_existing_component_keys` goes from O(total cached files) per call (full-dir `scandir`) to O(requested keys) (`os.path.exists` per key). At ~7.5M files the prior scan was a per-request bottleneck on the prefix-match read path.

## Checklist

- [x] Format the code according to the project's pre-commit conventions.
- [x] Add unit tests (`TestFileSharding` in `test_hicache_file_lru_unit.py`).
- [x] Backward compatibility considered (graceful cold-miss on pre-existing flat files; no on-disk migration required).























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28248971242](https://github.com/sgl-project/sglang/actions/runs/28248971242)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28248971007](https://github.com/sgl-project/sglang/actions/runs/28248971007)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
