### PR TITLE
fix(openai): avoid IndexError when continue_final_message empties messages

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -725,7 +725,9 @@ class OpenAIServingChat(OpenAIServingBase):
                 messages, request
             )
 
-            if messages[0]["role"] != "system":
+            # messages can be empty here when continue_final_message strips a lone
+            # trailing assistant message, so guard before indexing messages[0].
+            if not messages or messages[0]["role"] != "system":
                 # insert an empty system prompt to help render tool system prompt
                 messages.insert(0, {"role": "system", "content": ""})
             if request.tools:

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -673,6 +673,24 @@ class ServingChatTestCase(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "must be a JSON object"):
                     self.chat._process_messages(req, is_multimodal=False)
 
+    def test_dsv_encoders_handle_continue_final_message_only_assistant(self):
+        """continue_final_message may strip the only message; do not IndexError."""
+        self.template_manager.chat_template_name = None
+        self.template_manager.jinja_template_content_format = "string"
+
+        for chat_encoding_spec in ("dsv4", "dsv32"):
+            with self.subTest(chat_encoding_spec=chat_encoding_spec):
+                self.chat.chat_encoding_spec = chat_encoding_spec
+                req = ChatCompletionRequest(
+                    model="x",
+                    messages=[{"role": "assistant", "content": "partial answer"}],
+                    continue_final_message=True,
+                )
+
+                # The lone assistant message is removed by continue_final_message,
+                # so the encoder must tolerate the now-empty message list.
+                self.chat._process_messages(req, is_multimodal=False)
+
     def test_dsv_encoders_accept_object_tool_call_arguments_string(self):
         """DeepSeek encoders accept object-shaped OpenAI JSON string arguments."""
         self.template_manager.chat_template_name = None


### PR DESCRIPTION
## Problem

In `_apply_jinja_template`, the DeepSeek encoding branch (`chat_encoding_spec` in `dsv4`/`dsv32`) runs:

```python
messages, assistant_prefix = self._handle_last_assistant_message(messages, request)

if messages[0]["role"] != "system":
    messages.insert(0, {"role": "system", "content": ""})
if request.tools:
    messages[0]["tools"] = [...]
```

When `continue_final_message=True` and the request contains only a single trailing assistant message, `_handle_last_assistant_message` does `messages = messages[:-1]`, leaving an empty list. `messages[0]` then raises `IndexError: list index out of range`.

`_validate_request` only rejects an originally-empty `messages`, so this empties *after* validation and isn't caught.

## Fix

Guard the system-prompt insertion against an empty list:

```python
if not messages or messages[0]["role"] != "system":
    messages.insert(0, {"role": "system", "content": ""})
```

An empty list now gets the empty system prompt inserted, so the subsequent `request.tools` indexing is safe too.

## Test

Added `test_dsv_encoders_handle_continue_final_message_only_assistant` to `test/registered/unit/entrypoints/openai/test_serving_chat.py` (CPU unit test), covering both `dsv4` and `dsv32`: a lone assistant message with `continue_final_message=True` is processed without raising.

I could not run the suite locally (this dev box is Windows and `sglang.srt.utils.common` imports the Unix-only `resource` module, so the package fails to import). I verified `python -m py_compile` on both files and reproduced the fix logic in isolation (the stripped list is empty → the old guard raises `IndexError`, the new guard inserts the system message). Relying on CI for the full unit test run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35634734872](https://github.com/sgl-project/sglang/actions/runs/35634734872)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35634734229](https://github.com/sgl-project/sglang/actions/runs/35634734229)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35634734530](https://github.com/sgl-project/sglang/actions/runs/35634734530)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->