### PR TITLE
[AMD] Fuse shared-expert sigmoid + bf16->fp32 cast into the MoE append kernel (3 kernels -> 1)

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
@@ -1244,10 +1244,12 @@ def _fused_append_shared_experts_with_weights_kernel(
     out_ids_ptr,
     out_weights_ptr,
     N_BASE,
+    scale,
     K: tl.constexpr,
     S: tl.constexpr,
     BLOCK_K: tl.constexpr,
     BLOCK_S: tl.constexpr,
+    APPLY_SIGMOID: tl.constexpr,
 ):
     pid = tl.program_id(0)
 
@@ -1266,22 +1268,43 @@ def _fused_append_shared_experts_with_weights_kernel(
     mask_s = offs_s < S
     shared_ids = tl.cast(N_BASE + offs_s, ids.dtype)
     shared_ws = tl.load(shared_weights_ptr + pid * S + offs_s, mask=mask_s)
+    if APPLY_SIGMOID:
+        # Fuse sigmoid(shared_gate) + dtype upcast (+ optional 1/ep_size scale)
+        # in-register so the raw bf16 logits stream straight into the fp32
+        # output, eliminating the standalone sigmoid and bf16->fp32 copy kernels.
+        shared_ws = tl.sigmoid(shared_ws.to(tl.float32)) * scale
 
     tl.store(out_ids_ptr + out_row_ptr + K + offs_s, shared_ids, mask=mask_s)
     tl.store(out_weights_ptr + out_row_ptr + K + offs_s, shared_ws, mask=mask_s)
 
 
 def fused_append_shared_experts_with_weights(
-    topk_ids, topk_weights, shared_weights, num_fused_shared_experts, N=None
+    topk_ids,
+    topk_weights,
+    shared_weights,
+    num_fused_shared_experts,
+    N=None,
+    apply_sigmoid=False,
+    scale=1.0,
 ):
-    """Like fused_append_shared_experts but accepts per-token shared weights tensor."""
+    """Like fused_append_shared_experts but accepts per-token shared weights tensor.
+
+    When ``apply_sigmoid`` is True, ``shared_weights`` are treated as raw gate
+    logits: the kernel applies ``sigmoid`` (in fp32) and the optional ``scale``
+    in-register, so the caller can skip the separate ``sigmoid`` activation and
+    the bf16->fp32 cast. When False the legacy behavior is preserved exactly.
+    """
     assert N is not None, "N (shared expert base id) must be provided"
     m, k = topk_ids.shape
     s = int(num_fused_shared_experts)
     if s <= 0:
         return topk_ids, topk_weights
 
-    shared_weights_2d = shared_weights.to(topk_weights.dtype)
+    # When fusing sigmoid in-kernel, keep the raw logits dtype (the kernel emits
+    # fp32 directly); otherwise match the output weight dtype as before.
+    shared_weights_2d = (
+        shared_weights if apply_sigmoid else shared_weights.to(topk_weights.dtype)
+    )
     if shared_weights_2d.ndim == 1:
         shared_weights_2d = shared_weights_2d.unsqueeze(-1)
     if shared_weights_2d.shape[1] < s:
@@ -1303,10 +1326,12 @@ def fused_append_shared_experts_with_weights(
         out_ids,
         out_weights,
         N_BASE=N,
+        scale=scale,
         K=k,
         S=s,
         BLOCK_K=block_k,
         BLOCK_S=block_s,
+        APPLY_SIGMOID=apply_sigmoid,
         num_warps=1,
     )
     return out_ids, out_weights

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -351,13 +351,17 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
 
     def _get_shared_expert_weights(
         self, hidden_states: torch.Tensor
-    ) -> Optional[torch.Tensor]:
-        """Return sigmoid(shared_expert_gate) for fused shared expert weights."""
+    ) -> Optional[Tuple[torch.Tensor, float]]:
+        """Return raw shared_expert_gate logits and the 1/ep_size scale.
+
+        The sigmoid activation and the scale are applied (in fp32) inside the
+        fused append kernel, so this returns the raw gate logits rather than
+        ``sigmoid(logits)`` to avoid a standalone activation kernel + cast.
+        """
         if not self.enable_shared_expert_fusion or self.shared_expert_gate is None:
             return None
         shared_out = self.shared_expert_gate(hidden_states)
         shared_logits = shared_out[0] if isinstance(shared_out, tuple) else shared_out
-        w = F.sigmoid(shared_logits)
         # This block runs only on the AMD AITER shared_expert_fusion path
         # Allreduce-EP path: the fused shared expert occupies a single global
         # slot loaded onto every EP rank (see FusedMoE.__init__: num_shared_slots
@@ -366,10 +370,11 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         # post-experts all_reduce sums it ep_size times. Pre-scale the per-token
         # routing weight by 1/ep_size to cancel this, mirroring DeepSeek-V2's
         # fused_shared_experts_scaling_factor pattern.
+        scale = 1.0
         moe_ep_size = get_parallel().moe_ep_size
         if moe_ep_size > 1 and not is_deepep_class_backend():
-            w = w / float(moe_ep_size)
-        return w
+            scale = 1.0 / float(moe_ep_size)
+        return shared_logits, scale
 
     def _append_shared_to_topk_output(
         self,
@@ -379,9 +384,10 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         """Append shared expert ids and weights to topk output before fused MoE."""
         if not self.enable_shared_expert_fusion:
             return topk_output
-        shared_weights = self._get_shared_expert_weights(hidden_states)
-        if shared_weights is None:
+        shared = self._get_shared_expert_weights(hidden_states)
+        if shared is None:
             return topk_output
+        shared_logits, shared_scale = shared
 
         from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_kernels import (
             fused_append_shared_experts_with_weights,
@@ -390,9 +396,11 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         fused_topk_ids, fused_topk_weights = fused_append_shared_experts_with_weights(
             topk_output.topk_ids,
             topk_output.topk_weights,
-            shared_weights,
+            shared_logits,
             self.num_fused_shared_experts,
             N=self.num_experts,
+            apply_sigmoid=True,
+            scale=shared_scale,
         )
         return StandardTopKOutput(
             topk_weights=fused_topk_weights,

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -352,17 +352,17 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
     def _get_shared_expert_weights(
         self, hidden_states: torch.Tensor
     ) -> Optional[Tuple[torch.Tensor, float]]:
-        """Return raw shared_expert_gate logits and the 1/ep_size scale.
+        """Return the shared_expert_gate weights and the 1/ep_size scale.
 
-        The sigmoid activation and the scale are applied (in fp32) inside the
-        fused append kernel, so this returns the raw gate logits rather than
-        ``sigmoid(logits)`` to avoid a standalone activation kernel + cast.
+        On the AMD AITER path the sigmoid activation and the scale are applied
+        (in fp32) inside the fused append kernel, so this returns the raw gate
+        logits to avoid a standalone activation kernel + cast. On the CUDA path
+        the legacy eager ``sigmoid(logits) * scale`` is returned unchanged.
         """
         if not self.enable_shared_expert_fusion or self.shared_expert_gate is None:
             return None
         shared_out = self.shared_expert_gate(hidden_states)
         shared_logits = shared_out[0] if isinstance(shared_out, tuple) else shared_out
-        # This block runs only on the AMD AITER shared_expert_fusion path
         # Allreduce-EP path: the fused shared expert occupies a single global
         # slot loaded onto every EP rank (see FusedMoE.__init__: num_shared_slots
         # == num_fused_shared_experts when not is_deepep_class_backend()). Every
@@ -374,6 +374,10 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         moe_ep_size = get_parallel().moe_ep_size
         if moe_ep_size > 1 and not is_deepep_class_backend():
             scale = 1.0 / float(moe_ep_size)
+        # Only AITER fuses sigmoid + cast in-kernel; on CUDA keep the legacy
+        # eager activation so the NVIDIA path behavior is unchanged.
+        if not _use_aiter:
+            return F.sigmoid(shared_logits) * scale, 1.0
         return shared_logits, scale
 
     def _append_shared_to_topk_output(
@@ -387,19 +391,21 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         shared = self._get_shared_expert_weights(hidden_states)
         if shared is None:
             return topk_output
-        shared_logits, shared_scale = shared
+        shared_weights, shared_scale = shared
 
         from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_kernels import (
             fused_append_shared_experts_with_weights,
         )
 
+        # AITER returns raw logits + scale for in-kernel sigmoid fusion; CUDA
+        # returns pre-activated weights (scale already folded in) → no fusion.
         fused_topk_ids, fused_topk_weights = fused_append_shared_experts_with_weights(
             topk_output.topk_ids,
             topk_output.topk_weights,
-            shared_logits,
+            shared_weights,
             self.num_fused_shared_experts,
             N=self.num_experts,
-            apply_sigmoid=True,
+            apply_sigmoid=_use_aiter,
             scale=shared_scale,
         )
         return StandardTopKOutput(


### PR DESCRIPTION
## Motivation

On the AITER shared-expert-fusion path (`Qwen2MoeSparseMoeBlock._append_shared_to_topk_output`), preparing the fused shared-expert routing weight launched **three** GPU kernels per MoE layer per decode step:

1. `sigmoid_kernel_cuda` — `w = F.sigmoid(shared_logits)` in `_get_shared_expert_weights` (~5.5 us)
2. `bfloat16tofloat32_copy_kernel_cuda` — `shared_weights.to(topk_weights.dtype)` inside the append wrapper (~4.5 us)
3. `_fused_append_shared_experts_with_weights_kernel` — the append itself (~4.2 us)

These are tiny, bandwidth/launch-bound elementwise ops on small tensors. The sigmoid and the bf16→fp32 cast are pure glue feeding the append kernel, so they can be folded into the append kernel's prologue. This collapses 3 kernels into 1 and removes two global round-trips per MoE layer.

## Modifications

- `python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py`
  - `_fused_append_shared_experts_with_weights_kernel`: added a `scale` runtime arg and an `APPLY_SIGMOID: tl.constexpr`. When set, the shared-weight load computes `sigmoid(logits.to(fp32)) * scale` in-register, emitting fp32 straight into the output.
  - `fused_append_shared_experts_with_weights(...)`: added `apply_sigmoid=False, scale=1.0`. When `apply_sigmoid=True`, raw bf16 gate logits are streamed in directly (host-side `.to(fp32)` cast skipped); the legacy path is byte-for-byte unchanged when the flag is off.
- `python/sglang/srt/models/qwen2_moe.py`
  - `_get_shared_expert_weights`: returns the **raw** gate logits plus a `1/ep_size` scale instead of `sigmoid(logits) / ep_size` (the activation and scale are now applied inside the kernel).
  - `_append_shared_to_topk_output`: passes `apply_sigmoid=True, scale=...` to the append wrapper.

Net effect: `sigmoid` + bf16→fp32 cast are fused into the existing append kernel — **3 kernels → 1**, ~10 us/layer of glue removed, at ~0 added cost to the append kernel.

## Accuracy Tests

GSM8K (200 questions, parallel 2000, greedy), Qwen3.5-397B-A17B-MXFP4, tp=2, AITER backend, MI35x. Run-to-run variance is large here (greedy + continuous-batching nondeterminism), so multiple samples were taken:

Mean difference 0.013 ≪ per-run σ ≈ 0.045 → within noise, no regression. Offline kernel equivalence test: routed weights bit-identical, expert ids exact, shared-expert column differs by ~4e-4 (the fused path computes sigmoid in fp32 vs the old bf16, i.e. strictly more precise).

## Benchmarking and Profiling

torch profiler trace (decode), same config. ATen kernels retain the `_cuda` suffix in their symbol names on ROCm/HIP builds.

| Kernel | Before | After | Notes |
|---|---|---|---|
| `sigmoid_kernel_cuda` (`<8, …sigmoid…>`) | ~5.5 us / layer | **0 occurrences** | eliminated |
| `bfloat16tofloat32_copy_kernel_cuda` (per-layer) | ~4.5 us / layer | **eliminated** | (13 unrelated residual one-offs remain) |
| `_fused_append_shared_experts_with_weights_kernel` | ~4.2 us | 780× @ **3.79 us** | now does sigmoid + cast in-register |

The append kernel fires 780× in the profiling run; with the fusion there are **zero** standalone `sigmoid_kernel_cuda` instances feeding it. Per-invocation saving ≈ **~10 us** (5.5 + 4.5), folded into the existing append kernel. This is decode glue (<0.1% of ITL), so end-to-end throughput impact is within benchmark noise by construction.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27967780275](https://github.com/sgl-project/sglang/actions/runs/27967780275)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27967778273](https://github.com/sgl-project/sglang/actions/runs/27967778273)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->