### PR TITLE
docs(minimax-m3): add MMMU-Pro accuracy to B200 benchmark card

### DIFF
--- a/docs_new/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
@@ -41,7 +41,7 @@ export const benchmarks = [
       { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64, num_prompts: 128 },
         ttft_ms: 1580, tpot_ms: 24.1, tokens_per_sec_per_gpu: 265 },
     ],
-    accuracy: { gpqa_pct: 89.1, gsm8k_pct: 96.5 }, // 2026-06-15, sgl-eval --thinking, recommended sampling (temp 1.0/top_p 0.95), tp8. GSM8K full 1319 = 96.51% (greedy 96.89%). GPQA Diamond 198, n-repeats 4 = pass@1[avg-of-4] 89.14% +/-1.73% (pass@4 95.45%, majority@4 93.52%).
+    accuracy: { gpqa_pct: 89.1, gsm8k_pct: 96.5, mmmu_pro_pct: 72.7 }, // 2026-06-15, sgl-eval --thinking, recommended sampling (temp 1.0/top_p 0.95), tp8. GSM8K full 1319 = 96.51% (greedy 96.89%). GPQA Diamond 198, n-repeats 4 = pass@1[avg-of-4] 89.14% +/-1.73% (pass@4 95.45%, majority@4 93.52%). MMMU-Pro 2026-06-18, sgl-eval "standard (10 options)" test split, full 1730, single-shot 72.66% (thinking, temp 1.0/top_p 0.95).
   },
   {
     // Hopper H200: bf16 build (MXFP8 is Blackwell-only) at tp8, built-in Triton

--- a/docs_new/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
+++ b/docs_new/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
@@ -71,6 +71,13 @@ sgl-eval run gpqa \\
   --model {{MODEL_NAME}} \\
   --temperature 1.0 --top-p 0.95 \\
   --thinking --n-repeats 4 --max-tokens 40960`,
+      mmmu_pro_pct:
+`pip install git+https://github.com/sgl-project/sgl-eval
+sgl-eval run mmmu_pro \\
+  --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1 \\
+  --model {{MODEL_NAME}} \\
+  --temperature 1.0 --top-p 0.95 \\
+  --thinking`,
     },
     numPromptsByConc: { 24: 24, 64: 128 },
   },
@@ -78,6 +85,7 @@ sgl-eval run gpqa \\
   accuracyLabels: [
     ["gpqa_pct", "GPQA Diamond", "%"],
     ["gsm8k_pct", "GSM8K", "%"],
+    ["mmmu_pro_pct", "MMMU-Pro", "%"],
   ],
 
   dockerImages: {


### PR DESCRIPTION
## Motivation

The MiniMax-M3 cookbook benchmark card lists GPQA Diamond and GSM8K on the B200 row but not MMMU-Pro (the 10-choice multimodal eval). This adds it.

## Modifications

- `minimax-m3-benchmarks.jsx`: B200 cell gains `mmmu_pro_pct: 72.7`.
- `minimax-m3.jsx`: register the `mmmu_pro_pct` accuracy label and the `sgl-eval run mmmu_pro` reproduce command (the MMMU-Pro loader + media infra ship in sgl-eval [#19](https://github.com/sgl-project/sgl-eval/pull/19)).

## Accuracy Tests

MMMU-Pro "standard (10 options)" test split, full 1730 questions, single-shot **72.66%**, sgl-eval `--thinking` with M3's recommended sampling (temp 1.0 / top_p 0.95). Measured on B200 (MXFP8, MSA fast path) on PR #27944.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27779492704](https://github.com/sgl-project/sglang/actions/runs/27779492704)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27779528292](https://github.com/sgl-project/sglang/actions/runs/27779528292)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->