### PR TITLE
fix(runner): size eager static buffers for prefill budget and MLP-sync autotune

### DIFF
--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -43,6 +43,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     set_tc_piecewise_forward_context,
 )
 from sglang.srt.utils import is_hip, require_mlp_tp_gather
+from sglang.srt.utils.common import ceil_align, require_mlp_sync
 
 logger = logging.getLogger(__name__)
 
@@ -94,12 +95,21 @@ class EagerRunner(BaseRunner):
             # Frozen-KV MTP expands the draft batch by topk on the bs axis
             # (expand_for_topk_draft) before the eager fallback.
             max_bs *= sa.speculative_eagle_topk
+        # Mirror prepare_mlp_sync_batch padding so the registry holds what load_batch copies.
+        if require_mlp_sync(sa):
+            from sglang.srt.layers.utils.cp_utils import get_cp_padding_align_size
+
+            max_bs = ceil_align(max_bs, self.attn_tp_size)
+            max_bs = ceil_align(max_bs, get_cp_padding_align_size())
         prefill_ceiling = (
-            sa.chunked_prefill_size
+            sa.max_prefill_buffer_tokens()
             if sa.chunked_prefill_size and sa.chunked_prefill_size > 0
             else mr.max_total_num_tokens
         )
         max_num_token = max(prefill_ceiling, max_bs * num_tokens_per_bs)
+        if require_mlp_sync(sa):
+            max_num_token = ceil_align(max_num_token, self.attn_tp_size)
+            max_num_token = ceil_align(max_num_token, get_cp_padding_align_size())
         self._eager_max_bs = max_bs
         self._eager_num_tokens_per_bs = num_tokens_per_bs
         is_encoder_decoder = mr.model_config.is_encoder_decoder

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -22,6 +22,7 @@ import importlib
 import importlib.util
 import json
 import logging
+import math
 import os
 import random
 import socket
@@ -3672,6 +3673,21 @@ class ServerArgs:
         decode_max_bs = (cg_config.decode.max_bs if cg_config is not None else 0) or 0
         decode_tokens = decode_max_bs * num_tokens_per_bs
         return max(prefill_tokens, decode_tokens)
+
+    def max_prefill_buffer_tokens(self) -> int:
+        """Prefill-buffer ceiling: chunked_prefill_size, except PP dynamic
+        chunking can grow chunks toward max_prefill_tokens and probe at 1.25x."""
+        chunked = (
+            self.chunked_prefill_size
+            if self.chunked_prefill_size and self.chunked_prefill_size > 0
+            else 0
+        )
+        tokens = chunked
+        if self.enable_dynamic_chunking and self.pp_size > 1 and chunked:
+            tokens = max(
+                tokens, self.max_prefill_tokens or 0, math.ceil(chunked * 1.25)
+            )
+        return tokens
 
     def _validate_cutedsl_a2a_token_budget(self):
         """Fail fast if the FlashInfer A2A dispatcher workspace cannot cover the


### PR DESCRIPTION
## Problem

The eager runner's static buffers were under-sized on two independent axes.

### 1. Token axis — the profiler hang
The prefill buffer was sized to `chunked_prefill_size`. That is the correct cap for normal chunked prefill (`PrefillAdder` admits against the remaining chunk budget), but under PP `--enable-dynamic-chunking`:
- the runtime predictor can grow a chunk toward `max_prefill_tokens`, and
- the latency profiler probes prefill at `chunked_prefill_size * 1.25`.

Both overflow the buffer — most visibly the hang at `Profiling prefill latency for dynamic chunking`.

### 2. Batch axis — autotune / load_batch at an unaligned shape
The FlashInfer autotune dummy forward runs at the eager bs ceiling `max_running_requests`, but under MLP sync the scheduler pads real batches in `prepare_mlp_sync_batch` (ceil-align to `attn_tp_size`, then to `get_cp_padding_align_size()`), and `_dummy_run` no longer re-pads. So the registry can be smaller than the padded batch `load_batch` copies in, and autotune would tune at a shape the scheduler never produces.

## Fix

- Add `ServerArgs.max_prefill_buffer_tokens()` as the single source of truth for the prefill-buffer ceiling: `chunked_prefill_size`, raised to `max(max_prefill_tokens, ceil(chunked_prefill_size * 1.25))` **only** under PP dynamic chunking (so non-dynamic configs are not over-sized). The eager runner reads it.
- Mirror the full `prepare_mlp_sync_batch` padding on the eager bs ceiling (`ceil_align` to `attn_tp_size`, then to the CP padding size) under MLP sync.

Both keep the sizing policy in server args / the runner's own ceiling rather than re-padding inside `_dummy_run`. Stacked on #28388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)













































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27846578585](https://github.com/sgl-project/sglang/actions/runs/27846578585)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27846578487](https://github.com/sgl-project/sglang/actions/runs/27846578487)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->