### PR TITLE
[AMD][CI] Use non-gated Qwen3-8B for MI35x disaggregation tests

### DIFF
--- a/test/registered/amd/disaggregation/test_disaggregation_basic.py
+++ b/test/registered/amd/disaggregation/test_disaggregation_basic.py
@@ -13,7 +13,6 @@ from sglang.test.server_fixtures.disaggregation_fixture import (
     PDDisaggregationServerBase,
 )
 from sglang.test.test_utils import (
-    DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     popen_launch_pd_server,
 )
@@ -36,7 +35,7 @@ class TestDisaggregationAccuracy(PDDisaggregationServerBase):
             print("SGLANG_TEST_RDMA_DEVICE is not set! Running without RDMA.")
             cls.rdma_devices = []
 
-        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        cls.model = "Qwen/Qwen3-8B"
         # DEFAULT_MODEL_NAME_FOR_TEST
 
         # Non blocking start servers
@@ -235,7 +234,7 @@ class TestDisaggregationMooncakeFailure(PDDisaggregationServerBase):
         # set DISAGGREGATION_TEST_FAILURE_PROB to simulate failure
         os.environ["DISAGGREGATION_TEST_FAILURE_PROB"] = "0.05"
 
-        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        cls.model = "Qwen/Qwen3-8B"
 
         # Non blocking start servers
         cls.start_prefill()
@@ -347,7 +346,7 @@ class TestDisaggregationSimulatedRetract(PDDisaggregationServerBase):
             cls.rdma_devices = []
 
         os.environ["SGLANG_TEST_RETRACT"] = "true"
-        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        cls.model = "Qwen/Qwen3-8B"
 
         # Non blocking start servers
         cls.start_prefill()

--- a/test/registered/amd/disaggregation/test_disaggregation_pp.py
+++ b/test/registered/amd/disaggregation/test_disaggregation_pp.py
@@ -9,7 +9,6 @@ from sglang.test.server_fixtures.disaggregation_fixture import (
     PDDisaggregationServerBase,
 )
 from sglang.test.test_utils import (
-    DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     popen_launch_pd_server,
     try_cached_model,
@@ -33,7 +32,7 @@ class TestDisaggregationPrefillPPAccuracy(PDDisaggregationServerBase):
             print("SGLANG_TEST_RDMA_DEVICE is not set! Running without RDMA.")
             cls.rdma_devices = []
 
-        cls.model = try_cached_model(DEFAULT_MODEL_NAME_FOR_TEST)
+        cls.model = try_cached_model("Qwen/Qwen3-8B")
 
         # Non blocking start servers
         cls.start_prefill()
@@ -126,7 +125,7 @@ class TestDisaggregationPrefillPPDynamicChunkAccuracy(PDDisaggregationServerBase
             print("SGLANG_TEST_RDMA_DEVICE is not set! Running without RDMA.")
             cls.rdma_devices = []
 
-        cls.model = try_cached_model(DEFAULT_MODEL_NAME_FOR_TEST)
+        cls.model = try_cached_model("Qwen/Qwen3-8B")
 
         # Non blocking start servers
         cls.start_prefill()
@@ -220,7 +219,7 @@ class TestDisaggregationDecodePPAccuracy(PDDisaggregationServerBase):
             print("SGLANG_TEST_RDMA_DEVICE is not set! Running without RDMA.")
             cls.rdma_devices = []
 
-        cls.model = try_cached_model(DEFAULT_MODEL_NAME_FOR_TEST)
+        cls.model = try_cached_model("Qwen/Qwen3-8B")
 
         # Non blocking start servers
         cls.start_prefill()


### PR DESCRIPTION
## Motivation

The MI35x PD disaggregation suite (`stage-b-test-large-8-gpu-mi35x-disaggregation-amd`) loads the **gated** model `meta-llama/Llama-3.1-8B-Instruct`, which requires an authenticated HuggingFace token at runtime. On self-hosted AMD runners without a valid token this fails (server cannot download the model -> exit 255), making the suite non-self-contained.

## Change

Switch the `pp` and `basic` disaggregation tests to the **non-gated** `Qwen/Qwen3-8B` (same 8B class), and drop the now-unused `DEFAULT_MODEL_NAME_FOR_TEST` import. No token or pre-cached model needed.

Note: `test_mori_transfer_engine_e2e.py` still uses the small gated model and is intentionally left unchanged in this PR.

## Test

Verified locally on MI35x (mia1-p01-g20):
```
test_disaggregation_basic.py ... 6 passed in 398.48s
```







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27789555310](https://github.com/sgl-project/sglang/actions/runs/27789555310)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27789555098](https://github.com/sgl-project/sglang/actions/runs/27789555098)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->