### PR TITLE
[DFlash] Support grammar constrained decoding support for DFlash

### DIFF
--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -227,6 +227,122 @@ def apply_dflash_verify_logits_adjustments(
         get_logits_3d().add_(logit_bias[:, None, :])
 
 
+def _dflash_vocab_mask_allows_token(
+    vocab_mask_row: torch.Tensor,
+    token_id: int,
+    vocab_size: int,
+) -> bool:
+    if token_id < 0 or token_id >= vocab_size:
+        return False
+
+    # Outlines uses dense bool masks where True means "masked out".
+    if vocab_mask_row.dtype == torch.bool and vocab_mask_row.numel() >= vocab_size:
+        return not bool(vocab_mask_row[token_id].item())
+
+    # xgrammar / llguidance use packed 32-token bitsets where a set bit is allowed.
+    word_idx = token_id // 32
+    if word_idx >= vocab_mask_row.numel():
+        return False
+    word = int(vocab_mask_row[word_idx].item())
+    return (word & (1 << (token_id & 31))) != 0
+
+
+def reset_dflash_vocab_mask_to_all_allowed(
+    vocab_mask: torch.Tensor,
+    vocab_size: int,
+) -> None:
+    if vocab_mask.dtype == torch.bool and vocab_mask.shape[-1] >= vocab_size:
+        vocab_mask.zero_()
+    else:
+        vocab_mask.fill_(-1)
+
+
+def generate_dflash_linear_vocab_mask(
+    *,
+    reqs: List[Req],
+    draft_token_tail_cpu: torch.Tensor,
+    vocab_size: int,
+    vocab_mask_buf: Optional[torch.Tensor] = None,
+) -> tuple[Optional[torch.Tensor], Optional[Any]]:
+    """Generate per-position grammar masks for a linear DFlash verify block.
+
+    `draft_token_tail_cpu` contains `candidates[:, 1:]`, the speculative tokens
+    after the already-accepted current token. Row j in the returned mask maps to
+    verify-logit position j:
+
+    - j == 0: grammar state before accepting any draft token in this block.
+    - j > 0: grammar state after accepting draft_token_tail_cpu[:, :j].
+
+    The helper only probes request grammars temporarily. Result processing later
+    advances live grammar state with the accepted token list.
+    """
+
+    if draft_token_tail_cpu.ndim != 2:
+        raise ValueError(
+            "draft_token_tail_cpu must be 2D, "
+            f"got shape={tuple(draft_token_tail_cpu.shape)}."
+        )
+    if len(reqs) != draft_token_tail_cpu.shape[0]:
+        raise ValueError(
+            "req count must match draft_token_tail_cpu batch size, "
+            f"got len(reqs)={len(reqs)}, bs={draft_token_tail_cpu.shape[0]}."
+        )
+    if vocab_size <= 0:
+        raise ValueError(f"vocab_size must be positive, got {vocab_size}.")
+
+    bs, tail_len = draft_token_tail_cpu.shape
+    block_size = tail_len + 1
+    max_rows = bs * block_size
+    vocab_mask = vocab_mask_buf
+    if vocab_mask is not None:
+        if vocab_mask.shape[0] < max_rows:
+            raise ValueError(
+                "preallocated DFLASH vocab mask is too small: "
+                f"need {max_rows} rows, got {vocab_mask.shape[0]}."
+            )
+        vocab_mask = vocab_mask[:max_rows]
+        reset_dflash_vocab_mask_to_all_allowed(vocab_mask, vocab_size)
+    grammar_for_apply = None
+
+    for i, req in enumerate(reqs):
+        grammar = req.grammar
+        if grammar is None:
+            continue
+
+        if vocab_mask is None:
+            vocab_mask = grammar.allocate_vocab_mask(
+                vocab_size=vocab_size,
+                batch_size=max_rows,
+                device="cpu",
+            )
+            reset_dflash_vocab_mask_to_all_allowed(vocab_mask, vocab_size)
+        grammar_for_apply = grammar
+
+        row_offset = i * block_size
+        accepted_for_probe = 0
+        draft_tail = draft_token_tail_cpu[i].tolist()
+        try:
+            for pos in range(block_size):
+                if pos > 0:
+                    token_id = int(draft_tail[pos - 1])
+                    prev_row = vocab_mask[row_offset + pos - 1]
+                    if not _dflash_vocab_mask_allows_token(
+                        prev_row, token_id, vocab_size
+                    ):
+                        break
+                    grammar.accept_token(token_id)
+                    accepted_for_probe += 1
+
+                if grammar.is_terminated():
+                    break
+                grammar.fill_vocab_mask(vocab_mask, row_offset + pos)
+        finally:
+            if accepted_for_probe:
+                grammar.rollback(accepted_for_probe)
+
+    return vocab_mask, grammar_for_apply
+
+
 def _get_or_create_chain_verify_buffers(
     *,
     bs: int,
@@ -810,16 +926,5 @@ def validate_dflash_request(req: Req, enable_overlap: bool) -> Optional[str]:
 
     if enable_overlap and req.return_hidden_states:
         return "DFLASH speculative decoding does not support return_hidden_states yet."
-
-    if (
-        req.sampling_params.json_schema is not None
-        or req.sampling_params.regex is not None
-        or req.sampling_params.ebnf is not None
-        or req.sampling_params.structural_tag is not None
-    ):
-        return (
-            "DFLASH speculative decoding does not support "
-            "grammar-constrained decoding yet."
-        )
 
     return None

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1,6 +1,7 @@
 import logging
 import math
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import List, Optional
 
 import torch
@@ -22,12 +23,16 @@ from sglang.srt.server_args import (
 )
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
-from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
+from sglang.srt.speculative.dflash_info_v2 import (
+    DFlashDraftInputV2,
+    _get_overlap_plan_stream,
+)
 from sglang.srt.speculative.dflash_utils import (
     apply_dflash_verify_logits_adjustments,
     can_dflash_use_fused_qkv_proj,
     compute_dflash_correct_drafts_and_bonus,
     compute_dflash_sampling_correct_drafts_and_bonus,
+    generate_dflash_linear_vocab_mask,
     is_dflash_sampling_verify_available,
     parse_dflash_draft_config,
 )
@@ -41,6 +46,7 @@ from sglang.srt.speculative.triton_ops.dflash_prepare_block import (
     _prepare_dflash_draft_block_unchecked,
 )
 from sglang.srt.utils import get_available_gpu_memory, is_cuda, is_hip, is_npu
+from sglang.srt.utils.common import is_pin_memory_available
 
 _is_npu = is_npu()
 
@@ -48,6 +54,28 @@ _is_npu = is_npu()
 logger = logging.getLogger(__name__)
 
 _FusedKVMaterializeHelper = None
+_DFLASH_GRAMMAR_MASK_RING_SIZE = 3
+
+
+@dataclass
+class _DFlashGrammarMaskSlot:
+    cpu_buf: Optional[torch.Tensor] = None
+    cpu_cap: int = 0
+    gpu_buf: Optional[torch.Tensor] = None
+    gpu_cap: int = 0
+    gpu_device: Optional[torch.device] = None
+    cache_key: Optional[tuple] = None
+    pin_memory: Optional[bool] = None
+    h2d_done: Optional[object] = None
+    apply_done: Optional[object] = None
+
+
+@dataclass
+class _DFlashPreparedGrammarMask:
+    vocab_mask: torch.Tensor
+    grammar: object
+    ready: Optional[object]
+    slot: Optional[_DFlashGrammarMaskSlot]
 
 
 def _get_fused_kv_materialize_helper():
@@ -253,6 +281,14 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._bonus_id_bufs: List[torch.Tensor] = []
         self._out_tokens_bufs: List[torch.Tensor] = []
         self._new_seq_lens_bufs: List[torch.Tensor] = []
+        self._grammar_draft_tail_cpu_buf: Optional[torch.Tensor] = None
+        self._grammar_draft_tail_cpu_cap: int = 0
+        self._grammar_draft_tail_cols: int = -1
+        self._grammar_draft_tail_pin_memory: Optional[bool] = None
+        self._grammar_vocab_mask_slots = [
+            _DFlashGrammarMaskSlot() for _ in range(_DFLASH_GRAMMAR_MASK_RING_SIZE)
+        ]
+        self._grammar_vocab_mask_slot: int = 0
 
     @property
     def target_worker(self) -> TpModelWorker:
@@ -417,6 +453,290 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._draft_seq_lens_cpu_buf = torch.empty(
             (new_cap,), dtype=torch.int32, device="cpu"
         )
+
+    def _ensure_grammar_draft_tail_cpu_buffer(
+        self, bs: int, block_size: int
+    ) -> torch.Tensor:
+        cols = max(int(block_size) - 1, 0)
+        pin_memory = is_pin_memory_available(self.device)
+        if (
+            self._grammar_draft_tail_cpu_buf is not None
+            and self._grammar_draft_tail_cpu_cap >= int(bs)
+            and self._grammar_draft_tail_cols == cols
+            and self._grammar_draft_tail_pin_memory == pin_memory
+        ):
+            return self._grammar_draft_tail_cpu_buf[:bs]
+
+        new_cap = max(
+            int(bs),
+            (
+                self._grammar_draft_tail_cpu_cap * 2
+                if self._grammar_draft_tail_cpu_cap > 0
+                else int(bs)
+            ),
+        )
+        self._grammar_draft_tail_cpu_buf = torch.empty(
+            (new_cap, cols),
+            dtype=torch.int64,
+            device="cpu",
+            pin_memory=pin_memory,
+        )
+        self._grammar_draft_tail_cpu_cap = new_cap
+        self._grammar_draft_tail_cols = cols
+        self._grammar_draft_tail_pin_memory = pin_memory
+        return self._grammar_draft_tail_cpu_buf[:bs]
+
+    @staticmethod
+    def _grammar_vocab_mask_key(grammar, vocab_size: int) -> tuple:
+        inner_grammar = getattr(grammar, "grammar", None)
+        return (
+            type(grammar),
+            type(inner_grammar) if inner_grammar is not None else None,
+            int(vocab_size),
+        )
+
+    @staticmethod
+    def _event_is_done(event) -> bool:
+        return event is None or bool(event.query())
+
+    @staticmethod
+    def _clear_done_event(event):
+        return None if event is None or bool(event.query()) else event
+
+    def _next_grammar_vocab_mask_slot(self) -> _DFlashGrammarMaskSlot:
+        slot_count = len(self._grammar_vocab_mask_slots)
+        start = self._grammar_vocab_mask_slot
+        for offset in range(slot_count):
+            idx = (start + offset) % slot_count
+            slot = self._grammar_vocab_mask_slots[idx]
+            if self._event_is_done(slot.h2d_done):
+                slot.h2d_done = None
+                slot.apply_done = self._clear_done_event(slot.apply_done)
+                self._grammar_vocab_mask_slot = (idx + 1) % slot_count
+                return slot
+
+        slot = self._grammar_vocab_mask_slots[start]
+        slot.h2d_done.synchronize()
+        slot.h2d_done = None
+        slot.apply_done = self._clear_done_event(slot.apply_done)
+        self._grammar_vocab_mask_slot = (start + 1) % slot_count
+        return slot
+
+    def _ensure_grammar_vocab_mask_slot(
+        self,
+        *,
+        grammar,
+        vocab_size: int,
+        bs: int,
+        block_size: int,
+    ) -> Optional[_DFlashGrammarMaskSlot]:
+        rows = int(bs) * int(block_size)
+        pin_memory = is_pin_memory_available(self.device)
+        key = self._grammar_vocab_mask_key(grammar, vocab_size)
+        slot = self._next_grammar_vocab_mask_slot()
+
+        if (
+            slot.cpu_buf is not None
+            and slot.cpu_cap >= rows
+            and slot.cache_key == key
+            and slot.pin_memory == pin_memory
+        ):
+            return slot
+
+        if slot.apply_done is not None:
+            slot.apply_done.synchronize()
+            slot.apply_done = None
+
+        new_cap = max(
+            rows,
+            (slot.cpu_cap * 2 if slot.cpu_cap > 0 and slot.cache_key == key else rows),
+        )
+        vocab_mask = grammar.allocate_vocab_mask(
+            vocab_size=vocab_size,
+            batch_size=new_cap,
+            device="cpu",
+        )
+        if vocab_mask is None:
+            return None
+        if pin_memory and not vocab_mask.is_pinned():
+            vocab_mask = vocab_mask.pin_memory()
+
+        slot.cpu_buf = vocab_mask
+        slot.cpu_cap = int(vocab_mask.shape[0])
+        slot.gpu_buf = None
+        slot.gpu_cap = 0
+        slot.gpu_device = None
+        slot.cache_key = key
+        slot.pin_memory = pin_memory
+        return slot
+
+    def _copy_grammar_vocab_mask_to_device(
+        self,
+        *,
+        slot: _DFlashGrammarMaskSlot,
+        cpu_vocab_mask: torch.Tensor,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, Optional[object]]:
+        rows = int(cpu_vocab_mask.shape[0])
+        need_new_gpu_buf = (
+            slot.gpu_buf is None
+            or slot.gpu_cap < rows
+            or slot.gpu_buf.dtype != cpu_vocab_mask.dtype
+            or slot.gpu_buf.shape[1:] != cpu_vocab_mask.shape[1:]
+            or slot.gpu_device != device
+        )
+        if need_new_gpu_buf:
+            if slot.apply_done is not None:
+                slot.apply_done.synchronize()
+                slot.apply_done = None
+            slot.gpu_buf = torch.empty(
+                (slot.cpu_cap, *cpu_vocab_mask.shape[1:]),
+                dtype=cpu_vocab_mask.dtype,
+                device=device,
+            )
+            slot.gpu_cap = int(slot.gpu_buf.shape[0])
+            slot.gpu_device = device
+
+        gpu_vocab_mask = slot.gpu_buf[:rows]
+        copy_stream, copy_stream_ctx = _get_overlap_plan_stream(device)
+        current_stream = torch.get_device_module(device).current_stream()
+        if copy_stream is not None:
+            with copy_stream_ctx:
+                if slot.apply_done is not None:
+                    copy_stream.wait_event(slot.apply_done)
+                    slot.apply_done = None
+                gpu_vocab_mask.copy_(cpu_vocab_mask, non_blocking=True)
+                ready = torch.get_device_module(device).Event()
+                ready.record()
+                slot.h2d_done = ready
+            return gpu_vocab_mask, ready
+
+        if slot.apply_done is not None:
+            current_stream.wait_event(slot.apply_done)
+            slot.apply_done = None
+        gpu_vocab_mask.copy_(cpu_vocab_mask, non_blocking=True)
+        ready = torch.get_device_module(device).Event()
+        ready.record()
+        slot.h2d_done = ready
+        return gpu_vocab_mask, None
+
+    def _copy_grammar_draft_tail_to_cpu(
+        self,
+        *,
+        draft_tokens: torch.Tensor,
+        bs: int,
+        block_size: int,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, Optional[object]]:
+        draft_tail_cpu = self._ensure_grammar_draft_tail_cpu_buffer(bs, block_size)
+        if block_size <= 1:
+            return draft_tail_cpu, None
+
+        copy_stream, copy_stream_ctx = _get_overlap_plan_stream(device)
+        if copy_stream is not None:
+            current_stream = torch.get_device_module(device).current_stream()
+            with copy_stream_ctx:
+                copy_stream.wait_stream(current_stream)
+                draft_tail_cpu.copy_(draft_tokens[:, 1:], non_blocking=True)
+                copy_done = torch.get_device_module(device).Event()
+                copy_done.record()
+            return draft_tail_cpu, copy_done
+
+        draft_tail_cpu.copy_(draft_tokens[:, 1:], non_blocking=True)
+        copy_done = torch.get_device_module(device).Event()
+        copy_done.record()
+        return draft_tail_cpu, copy_done
+
+    def _prepare_grammar_vocab_mask(
+        self,
+        *,
+        model_worker_batch: ScheduleBatch,
+        sampling_info,
+        draft_tail_cpu: Optional[torch.Tensor],
+        draft_tail_copy_done,
+        bs: int,
+        block_size: int,
+        logits_device: torch.device,
+    ) -> Optional[_DFlashPreparedGrammarMask]:
+        if draft_tail_copy_done is not None:
+            draft_tail_copy_done.synchronize()
+        if draft_tail_cpu is None:
+            raise RuntimeError(
+                "DFLASH grammar decoding expected draft-tail CPU buffer."
+            )
+
+        vocab_size = (
+            int(sampling_info.vocab_size)
+            if sampling_info is not None
+            else int(self.target_worker.model_runner.model_config.vocab_size)
+        )
+        first_grammar = next(
+            (req.grammar for req in model_worker_batch.reqs if req.grammar),
+            None,
+        )
+        slot = (
+            self._ensure_grammar_vocab_mask_slot(
+                grammar=first_grammar,
+                vocab_size=vocab_size,
+                bs=bs,
+                block_size=block_size,
+            )
+            if first_grammar is not None
+            else None
+        )
+        vocab_mask_buf = (
+            slot.cpu_buf[: bs * block_size]
+            if slot is not None and slot.cpu_buf is not None
+            else None
+        )
+        vocab_mask, grammar = generate_dflash_linear_vocab_mask(
+            reqs=model_worker_batch.reqs,
+            draft_token_tail_cpu=draft_tail_cpu,
+            vocab_size=vocab_size,
+            vocab_mask_buf=vocab_mask_buf,
+        )
+        if vocab_mask is None:
+            return None
+        if grammar is None:
+            raise RuntimeError("DFLASH grammar mask generation returned no grammar.")
+
+        ready = None
+        if slot is not None and vocab_mask.device.type == "cpu":
+            vocab_mask, ready = self._copy_grammar_vocab_mask_to_device(
+                slot=slot,
+                cpu_vocab_mask=vocab_mask,
+                device=logits_device,
+            )
+        else:
+            vocab_mask = grammar.move_vocab_mask(vocab_mask, logits_device)
+
+        return _DFlashPreparedGrammarMask(
+            vocab_mask=vocab_mask,
+            grammar=grammar,
+            ready=ready,
+            slot=slot,
+        )
+
+    @staticmethod
+    def _apply_prepared_grammar_vocab_mask(
+        prepared_mask: Optional[_DFlashPreparedGrammarMask],
+        logits: torch.Tensor,
+    ) -> None:
+        if prepared_mask is None:
+            return
+
+        if prepared_mask.ready is not None:
+            torch.get_device_module(logits.device).current_stream().wait_event(
+                prepared_mask.ready
+            )
+        prepared_mask.grammar.apply_vocab_mask(
+            logits=logits,
+            vocab_mask=prepared_mask.vocab_mask,
+        )
+        if prepared_mask.slot is not None:
+            apply_done = torch.get_device_module(logits.device).Event()
+            apply_done.record()
+            prepared_mask.slot.apply_done = apply_done
 
     def __getattr__(self, name):
         # Delegate anything not implemented yet to the target worker. Guard
@@ -1494,6 +1814,18 @@ class DFlashWorkerV2(BaseSpecWorker):
         draft_tokens[:, 0].copy_(block_ids[:, 0])
         draft_tokens[:, 1:].copy_(draft_next)
 
+        grammar_draft_tail_cpu = None
+        grammar_tail_copy_done = None
+        if model_worker_batch.has_grammar:
+            grammar_draft_tail_cpu, grammar_tail_copy_done = (
+                self._copy_grammar_draft_tail_to_cpu(
+                    draft_tokens=draft_tokens,
+                    bs=bs,
+                    block_size=block_size,
+                    device=device,
+                )
+            )
+
         # --- 2) Target verify.
         # TARGET_VERIFY uses standard causal masking; custom masks are unnecessary here.
         custom_mask = None
@@ -1541,12 +1873,32 @@ class DFlashWorkerV2(BaseSpecWorker):
         logits_output = target_out.logits_output
         can_run_cuda_graph = target_out.can_run_cuda_graph
 
+        prepared_grammar_mask = None
+        if model_worker_batch.has_grammar:
+            prepared_grammar_mask = self._prepare_grammar_vocab_mask(
+                model_worker_batch=model_worker_batch,
+                sampling_info=sampling_info,
+                draft_tail_cpu=grammar_draft_tail_cpu,
+                draft_tail_copy_done=grammar_tail_copy_done,
+                bs=bs,
+                block_size=block_size,
+                logits_device=logits_output.next_token_logits.device,
+            )
+            if sampling_info is not None:
+                # Regular grammar masks have one row per request. DFlash verify
+                # needs one row per verify-block position.
+                sampling_info.vocab_mask = None
+
         if sampling_info is not None:
             apply_dflash_verify_logits_adjustments(
                 next_token_logits=logits_output.next_token_logits,
                 sampling_info=sampling_info,
                 draft_token_num=int(self.block_size),
             )
+        self._apply_prepared_grammar_vocab_mask(
+            prepared_grammar_mask,
+            logits_output.next_token_logits,
+        )
 
         candidates = draft_tokens
         new_seq_lens = None

--- a/test/registered/spec/dflash/test_dflash.py
+++ b/test/registered/spec/dflash/test_dflash.py
@@ -1,6 +1,9 @@
+import random
+import time
 import unittest
 
 import openai
+import requests
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import is_hip, kill_process_tree
@@ -11,6 +14,7 @@ from sglang.test.kits.radix_cache_server_kit import (
     gen_radix_tree,
     run_radix_attention_test,
 )
+from sglang.test.kits.spec_server_kits import SpecFeatureKit
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_DFLASH,
     DEFAULT_TARGET_MODEL_DFLASH,
@@ -22,6 +26,14 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=302, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=302, stage="stage-b", runner_config="1-gpu-small-amd")
+
+PROMPTS = [
+    "Today is a sunny day and I like",
+    "Write a short travel tip for Hawaii.",
+    "Summarize what makes a good product launch.",
+    "Who are you?",
+    "Where are you from?",
+]
 
 
 class TestDFlashServerBase(CustomTestCase, MatchedStopMixin, GSM8KMixin):
@@ -124,13 +136,44 @@ class TestDFlashServerBase(CustomTestCase, MatchedStopMixin, GSM8KMixin):
         self.assertEqual(outputs[0], outputs[1])
         assert self.process.poll() is None
 
+    def send_request(self):
+        time.sleep(random.uniform(0, 2))
+        for prompt in PROMPTS:
+            response = requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": prompt,
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 256,
+                    },
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+
+    def send_requests_abort(self):
+        for prompt in PROMPTS:
+            try:
+                time.sleep(random.uniform(0, 2))
+                requests.post(
+                    self.base_url + "/generate",
+                    json={
+                        "text": prompt,
+                        "sampling_params": {
+                            "temperature": 0,
+                            "max_new_tokens": 256,
+                        },
+                    },
+                    timeout=1,
+                )
+            except Exception as e:
+                print(e)
+
 
 class TestDFlashServerPage256(TestDFlashServerBase):
     page_size = 256
 
     def test_radix_attention(self):
-        import requests
-
         nodes = gen_radix_tree(num_nodes=50)
         data = {
             "input_ids": [node["input_ids"] for node in nodes],
@@ -152,7 +195,7 @@ class TestDFlashServerNoCudaGraph(TestDFlashServerBase):
     other_launch_args = ["--disable-cuda-graph"]
 
 
-class TestDFlashServerSpecV2(TestDFlashServerBase):
+class TestDFlashServerSpecV2(TestDFlashServerBase, SpecFeatureKit):
     disable_overlap = False
 
     def test_radix_attention(self):


### PR DESCRIPTION
- Enables grammar-constrained decoding during DFlash speculative verification.
- Adds reusable DFlash grammar mask handling for JSON/grammar token filtering.
- Covers DFlash spec-v2 constrained decoding through the existing spec feature kit.

Server command:
```
SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1 venv/bin/python -m sglang.launch_server \
    --model-path Qwen/Qwen3-8B \
    --host 127.0.0.1 --port 20554 \
    --trust-remote-code \
    --attention-backend trtllm_mha \
    --tp-size 1 \
    --dtype bfloat16 \
    --max-running-requests 32 \
    --cuda-graph-max-bs 32 \
    --mamba-scheduler-strategy no_buffer \
    --enforce-piecewise-cuda-graph \
    --speculative-algorithm DFLASH \
    --speculative-draft-model-path z-lab/Qwen3-8B-DFlash-b16 \
    --speculative-draft-attention-backend fa4 \
    --grammar-backend xgrammar
```

Question:
```
Janet's ducks lay 16 eggs per day. She eats 3 for breakfast and uses 4 to bake muffins. She sells the rest for $2 per egg. How much money does she make every day?
```

Unconstrained request:
```
sampling_params = {
    "temperature": 0.0,
    "top_p": 1.0,
    "top_k": 1,
    "max_new_tokens": 1024
}
```

Unconstrained output:
```
... Janet makes \boxed{18} dollars every day.
```

Grammar-constrained request:
```
sampling_params = {
    "temperature": 0.0,
    "top_p": 1.0,
    "top_k": 1,
    "max_new_tokens": 1024,
    "json_schema": "{\"type\":\"object\",\"properties\":{\"reasoning\":{\"type\":\"string\"},\"answer\":{\"type\":\"integer\"}},\"required\":
    [\"reasoning\",\"answer\"],\"additionalProperties\":false}"
}
```

Grammar-constrained output:
```
{
    "reasoning": "Janet's ducks lay 16 eggs per day. She uses 3 eggs for breakfast and 4 eggs for muffins, so she uses 3 + 4 = 7 eggs. The remaining eggs
    are 16 - 7 = 9 eggs. She sells these 9 eggs at $2 per egg, so the total money made is 9 * 2 = $18.",
    "answer": 18
}
```










<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27791182071](https://github.com/sgl-project/sglang/actions/runs/27791182071)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27791181896](https://github.com/sgl-project/sglang/actions/runs/27791181896)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #27791182028](https://github.com/sgl-project/sglang/actions/runs/27791182028)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->