### PR TITLE
docs: add --trust-remote-code to Laguna cookbook configs

### DIFF
--- a/docs_new/cookbook/autoregressive/Poolside/Laguna-XS.2.mdx
+++ b/docs_new/cookbook/autoregressive/Poolside/Laguna-XS.2.mdx
@@ -82,6 +82,7 @@ import { LagunaXS2Deployment } from '/src/snippets/autoregressive/laguna-xs2-dep
 
 ### 3.2 Configuration Tips
 
+- **Trust remote code** (`--trust-remote-code`): Laguna-XS.2 ships custom modeling/config code on the Hugging Face Hub, so this flag is required for the server to load the model.
 - **Quantization**: NVFP4 requires Blackwell (B200 / B300); BF16 and FP8 run on either H200 or B200. FP8's first launch triggers a multi-session DeepGEMM JIT pre-compile (~10-20 min); pre-warm with `python3 -m sglang.compile_deep_gemm --model poolside/Laguna-XS.2-FP8` to avoid that cost on every restart.
 - **Reasoning parser** (`--reasoning-parser poolside_v1`): Splits `<think>...</think>` segments into `reasoning_content` so `content` holds only the final answer. Disable only if you want the raw `<think>` tags in `content`.
 - **Tool call parser** (`--tool-call-parser poolside_v1`): Required for OpenAI-compatible tool-call streaming. Disable only for chat-only deployments.

--- a/docs_new/src/snippets/autoregressive/laguna-xs2-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/laguna-xs2-deployment.jsx
@@ -121,7 +121,8 @@ export const LagunaXS2Deployment = () => {
     const lines = [
       'sglang serve \\',
       `  --model-path ${modelId} \\`,
-      `  --tp ${tp}`
+      `  --tp ${tp} \\`,
+      '  --trust-remote-code'
     ];
 
     if (dpAttention === 'enabled') {


### PR DESCRIPTION
## Motivation

`poolside/Laguna-XS.2` (and its FP8 / NVFP4 variants) ship custom modeling and config code on the Hugging Face Hub. Without `--trust-remote-code`, the SGLang server fails to load the model. The Laguna-XS.2 cookbook page's deployment command generator did not emit this flag, so the copy-pasteable commands would fail out of the box.

## Modifications

- `docs_new/src/snippets/autoregressive/laguna-xs2-deployment.jsx`: add `--trust-remote-code` to the generated launch command (applies to all quantization variants).
- `docs_new/cookbook/autoregressive/Poolside/Laguna-XS.2.mdx`: add a Configuration Tip documenting why the flag is required.

## Checklist

- [x] Docs-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27792293973](https://github.com/sgl-project/sglang/actions/runs/27792293973)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27792293790](https://github.com/sgl-project/sglang/actions/runs/27792293790)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->