### PR TITLE
[Fix] deepseekv32 detector: tolerate partial non-string param values raising MalformedJSON (stream tear-down)

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -366,6 +366,17 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
+            # Fail-safe: never surface raw DSML markup as user-visible content.
+            # While the buffer still holds tool-call markup, returning it as
+            # normal_text would both leak the markers AND -- because _buffer is
+            # retained across increments -- re-emit the whole buffer on every
+            # subsequent chunk, ballooning the response to the output-token cap.
+            # Emit nothing and keep buffering so a still-arriving invoke can
+            # complete on a later chunk.
+            if self.has_tool_call(current_text) or any(
+                marker in current_text for marker in dsml_markers
+            ):
+                return StreamingParseResult(normal_text="")
             return StreamingParseResult(normal_text=current_text)
 
     def structure_info(self) -> _GetInfoFunc:

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -179,7 +179,14 @@ class DeepSeekV32Detector(BaseFormatDetector):
                         parameters[param_name] = _partial_json_loads(
                             param_value, Allow.ALL
                         )[0]
-                    except json.JSONDecodeError:
+                    except (json.JSONDecodeError, ValueError):
+                        # partial_json_parser raises its own MalformedJSON
+                        # (a ValueError, but NOT a stdlib json.JSONDecodeError)
+                        # on a not-yet-valid partial value, e.g. code-exec
+                        # arguments whose streamed prefix is bare text like
+                        # `python3 -c "...`. Fall back to the raw string,
+                        # matching the complete-value branch above, instead of
+                        # letting the exception tear down the stream.
                         parameters[param_name] = param_value.strip()
 
         return json.dumps(parameters, ensure_ascii=False)

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1692,6 +1692,47 @@ class TestDeepSeekV32Detector(unittest.TestCase):
         grammar = xgr.Grammar.from_structural_tag(structural_tag)
         self.assertIsInstance(grammar, xgr.Grammar)
 
+    def test_streaming_partial_non_string_param_does_not_throw(self):
+        """Regression: a partial non-string parameter value whose streamed
+        prefix is bare text (e.g. agentic code-exec `python3 -c "..."`) makes
+        partial_json_parser raise MalformedJSON -- a ValueError that is NOT a
+        stdlib json.JSONDecodeError. The detector must tolerate it (fall back
+        to the raw string) rather than let it escape, which would dump the raw
+        DSML buffer into normal_text and wedge the stream.
+        """
+        run_tool = Tool(
+            type="function",
+            function=Function(
+                name="run",
+                parameters={
+                    "type": "object",
+                    "properties": {"code": {"type": "object"}},
+                },
+            ),
+        )
+        detector = DeepSeekV32Detector()
+        # `string="false"` selects the JSON-typed parameter path; the value
+        # streams in as bare (not-yet-valid-JSON) text before any closer.
+        chunks = [
+            '<｜DSML｜function_calls>\n<｜DSML｜invoke name="run">\n',
+            '<｜DSML｜parameter name="code" string="false">python3 -c "',
+            "import json",
+        ]
+        names = {}
+        for chunk in chunks:
+            # Must not raise, and must never leak DSML markers as user content.
+            result = detector.parse_streaming_increment(chunk, [run_tool])
+            self.assertNotIn(
+                "｜DSML｜",
+                result.normal_text,
+                "raw DSML markers leaked into normal_text",
+            )
+            for call in result.calls:
+                if call.name:
+                    names[call.tool_index] = call.name
+        # The tool name is still recovered despite the malformed partial value.
+        self.assertEqual(names, {0: "run"})
+
     def test_self_closing_zero_arg_invoke(self):
         """V32 inherits the same regex; verify self-closing parses to empty
         params here too (V32 model rarely emits this shape, but the parser

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1770,6 +1770,56 @@ class TestDeepSeekV32Detector(unittest.TestCase):
         self.assertEqual(result.normal_text, "")
         self.assertIn("｜DSML｜", detector._buffer)
 
+    def test_streaming_array_recipe_partial_value_chunked_1_7_64(self):
+        """Regression (V4-Flash, array-valued args): a non-string parameter
+        carrying a spreadsheet-edit ``operations: [...]`` recipe streams in as a
+        not-yet-valid-JSON prefix (the model emits Python-style single quotes),
+        so partial_json_parser raises MalformedJSON -- a ValueError that is NOT
+        a stdlib json.JSONDecodeError. Replaying the whole tool call at chunk
+        sizes 1, 7 and 64 must never raise, never leak DSML markers into
+        normal_text, and must still recover the tool name. Leaks on the
+        unpatched detector at every chunk size; clean after the fix.
+        """
+        apply_tool = Tool(
+            type="function",
+            function=Function(
+                name="apply_edits",
+                parameters={
+                    "type": "object",
+                    "properties": {"operations": {"type": "array"}},
+                },
+            ),
+        )
+        payload = (
+            "<｜DSML｜function_calls>\n"
+            '<｜DSML｜invoke name="apply_edits">\n'
+            '<｜DSML｜parameter name="operations" string="false">'
+            "[{'set': 'A1', 'value': 42}, {'set': 'B2', 'value': 7}]"
+            "</｜DSML｜parameter>\n"
+            "</｜DSML｜invoke>\n"
+            "</｜DSML｜function_calls>"
+        )
+        for chunk_size in (1, 7, 64):
+            detector = DeepSeekV32Detector()
+            names = {}
+            for i in range(0, len(payload), chunk_size):
+                result = detector.parse_streaming_increment(
+                    payload[i : i + chunk_size], [apply_tool]
+                )
+                self.assertNotIn(
+                    "｜DSML｜",
+                    result.normal_text,
+                    f"raw DSML markers leaked into normal_text at chunk_size={chunk_size}",
+                )
+                for call in result.calls:
+                    if call.name:
+                        names[call.tool_index] = call.name
+            self.assertEqual(
+                names,
+                {0: "apply_edits"},
+                f"tool name not recovered at chunk_size={chunk_size}",
+            )
+
     def test_self_closing_zero_arg_invoke(self):
         """V32 inherits the same regex; verify self-closing parses to empty
         params here too (V32 model rarely emits this shape, but the parser

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1733,6 +1733,43 @@ class TestDeepSeekV32Detector(unittest.TestCase):
         # The tool name is still recovered despite the malformed partial value.
         self.assertEqual(names, {0: "run"})
 
+    def test_streaming_increment_error_does_not_leak_dsml_markup(self):
+        """Fail-safe for the outer handler: if anything inside
+        parse_streaming_increment raises while the buffer still holds tool-call
+        markup, the detector must NOT dump the raw DSML buffer into normal_text.
+        Doing so leaks the markers into user content AND -- because _buffer is
+        retained across increments -- re-emits the whole buffer on every
+        subsequent chunk, ballooning the response to the output-token cap
+        (observed downstream with tool_calls empty / finish_reason=stop). It
+        must emit empty normal_text and keep buffering instead.
+        """
+        run_tool = Tool(
+            type="function",
+            function=Function(
+                name="run",
+                parameters={
+                    "type": "object",
+                    "properties": {"code": {"type": "object"}},
+                },
+            ),
+        )
+        detector = DeepSeekV32Detector()
+        # Force an unexpected failure inside the try block while the buffer
+        # holds DSML markup, exercising the outer except fail-safe directly
+        # (independent of which specific payload triggers it).
+        detector._parse_parameters_from_xml = lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        )
+        result = detector.parse_streaming_increment(
+            '<｜DSML｜function_calls>\n<｜DSML｜invoke name="run">\n'
+            '<｜DSML｜parameter name="code" string="false">{"ops":[',
+            [run_tool],
+        )
+        # No raw markup leaked, and the markup is kept buffered (not dropped)
+        # so a still-arriving invoke can complete on a later chunk.
+        self.assertEqual(result.normal_text, "")
+        self.assertIn("｜DSML｜", detector._buffer)
+
     def test_self_closing_zero_arg_invoke(self):
         """V32 inherits the same regex; verify self-closing parses to empty
         params here too (V32 model rarely emits this shape, but the parser


### PR DESCRIPTION
## Motivation

The DeepSeek-V3.2 / V4 function-call detector tears down streaming responses on certain tool-call payloads. We hit this in production on agentic code-exec traffic (e.g. a tool argument like `python3 -c "..."`), where the frontend logged a steady trickle of:

```
ERROR deepseekv32_detector.parse_streaming_increment: Error in parse_streaming_increment: ...
WARN  Stream closed unexpectedly; issuing cancellation
```

Each error torn an in-flight stream → incomplete response.

**Root cause:** in `DeepSeekV32Detector._parse_parameters_from_xml`, the *partial*-value branch catches only `except json.JSONDecodeError`. But `partial_json_parser` raises its own `MalformedJSON`, which is a `ValueError` and does **not** subclass the stdlib `json.JSONDecodeError`. So when a non-string-typed parameter's streamed prefix is not yet valid JSON (bare text such as `python3 -c "...` before any closing tag), the exception escapes the narrow `except` and propagates to the outer `except Exception` handler in `parse_streaming_increment`, which:

1. returns `normal_text=current_text` — dumping the **raw DSML buffer** (internal tool-call markers) into user-visible content, and
2. never clears `self._buffer` — so the same exception re-fires on every subsequent chunk, wedging/tearing the stream.

Note the sibling *complete*-value branch a few lines above already catches `(json.JSONDecodeError, ValueError)`; this is just an asymmetry between the two branches.

## Modifications

- `python/sglang/srt/function_call/deepseekv32_detector.py`: broaden the partial-value `except` to `(json.JSONDecodeError, ValueError)`, matching the complete-value branch, so a not-yet-valid partial value falls back to the raw string instead of crashing the stream.
- `test/registered/unit/function_call/test_function_call_parser.py`: add `TestDeepSeekV32Detector.test_streaming_partial_non_string_param_does_not_throw` — feeds the bare-text partial value across chunks and asserts no raise, no `｜DSML｜` leak into `normal_text`, and that the tool name is still recovered. The test fails before the fix and passes after.

This also affects DeepSeek-V4, whose detector inherits this method.

## Accuracy Tests

N/A — no change to model/kernel forward code. Pure parser robustness fix on the streaming-detect path.

## Speed Tests and Profiling

N/A — no hot-path or kernel change.

## Checklist

- [x] Add unit tests (regression test included; red before / green after).
- [x] Follow the SGLang code style guidance.









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27950909001](https://github.com/sgl-project/sglang/actions/runs/27950909001)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27950908843](https://github.com/sgl-project/sglang/actions/runs/27950908843)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->