### PR TITLE
[MoE] dedup triton_kernels backend quant-arg asserts and fill weight dtype guard

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/triton_kernels_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/triton_kernels_moe.py
@@ -19,6 +19,7 @@ from triton_kernels.matmul_ogs import (
 )
 from triton_kernels.numerics import InFlexData
 from triton_kernels.swiglu import swiglu_fn
+from triton_kernels.tensor import FP4
 
 from sglang.srt.utils import is_cuda
 
@@ -30,6 +31,26 @@ else:
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.moe_runner import MoeRunnerConfig
     from sglang.srt.layers.moe.topk import TopKOutput
+
+
+def _assert_unsupported_quant_args(
+    use_fp8_w8a8: bool,
+    per_channel_quant: bool,
+    expert_map: Optional[torch.Tensor],
+    w1_scale: Optional[torch.Tensor],
+    w2_scale: Optional[torch.Tensor],
+    a1_scale: Optional[torch.Tensor],
+    a2_scale: Optional[torch.Tensor],
+    block_shape: Optional[list[int]],
+) -> None:
+    assert use_fp8_w8a8 is False, "use_fp8_w8a8 is not supported"
+    assert per_channel_quant is False, "per_channel_quant is not supported"
+    assert expert_map is None, "expert_map is not supported"
+    assert w1_scale is None, "w1_scale is not supported"
+    assert w2_scale is None, "w2_scale is not supported"
+    assert a1_scale is None, "a1_scale is not supported"
+    assert a2_scale is None, "a2_scale is not supported"
+    assert block_shape is None, "block_shape is not supported"
 
 
 def quantize(w, dtype, dev, **opt):
@@ -105,14 +126,16 @@ def triton_kernel_fused_experts(
     block_shape: Optional[list[int]] = None,
 ) -> torch.Tensor:
 
-    assert use_fp8_w8a8 is False, "use_fp8_w8a8 is not supported"
-    assert per_channel_quant is False, "per_channel_quant is not supported"
-    assert expert_map is None, "expert_map is not supported"
-    assert w1_scale is None, "w1_scale is not supported"
-    assert w2_scale is None, "w2_scale is not supported"
-    assert a1_scale is None, "a1_scale is not supported"
-    assert a2_scale is None, "a2_scale is not supported"
-    assert block_shape is None, "block_shape is not supported"
+    _assert_unsupported_quant_args(
+        use_fp8_w8a8,
+        per_channel_quant,
+        expert_map,
+        w1_scale,
+        w2_scale,
+        a1_scale,
+        a2_scale,
+        block_shape,
+    )
 
     # type check
     assert hidden_states.dtype == torch.bfloat16, "hidden_states must be bfloat16"
@@ -253,21 +276,24 @@ def triton_kernel_fused_experts_with_bias(
     gemm1_alpha: Optional[float] = None,
     gemm1_clamp_limit: Optional[float] = None,
 ) -> torch.Tensor:
-    assert use_fp8_w8a8 is False, "use_fp8_w8a8 is not supported"
-    assert per_channel_quant is False, "per_channel_quant is not supported"
-    assert expert_map is None, "expert_map is not supported"
-    assert w1_scale is None, "w1_scale is not supported"
-    assert w2_scale is None, "w2_scale is not supported"
-    assert a1_scale is None, "a1_scale is not supported"
-    assert a2_scale is None, "a2_scale is not supported"
-    assert block_shape is None, "block_shape is not supported"
+    _assert_unsupported_quant_args(
+        use_fp8_w8a8,
+        per_channel_quant,
+        expert_map,
+        w1_scale,
+        w2_scale,
+        a1_scale,
+        a2_scale,
+        block_shape,
+    )
 
     # type check
     assert hidden_states.dtype == torch.bfloat16, "hidden_states must be bfloat16"
     for w in (w1, w2):
-        # TODO assert bf16 or mxfp4
-        # assert (w.dtype == torch.bfloat16) or check-is-mxfp4, f"w must be bfloat16 or mxfp4 {w1.dtype=}"
-        pass
+        assert w.dtype in (
+            torch.bfloat16,
+            FP4,
+        ), f"w must be bfloat16 or mxfp4 (FP4), got {w.dtype}"
 
     # Shape check
     assert hidden_states.ndim == 2, "hidden_states must be 2D"


### PR DESCRIPTION
## Motivation

The `triton_kernel` MoE backend (`python/sglang/srt/layers/moe/fused_moe_triton/triton_kernels_moe.py`) duplicated the same eight unsupported-arg asserts in both `triton_kernel_fused_experts` and `triton_kernel_fused_experts_with_bias`, and left the with-bias per-weight dtype check as a no-op `TODO`/`pass`.

## Modifications

- Extract the eight shared quant-arg asserts (`use_fp8_w8a8`, `per_channel_quant`, `expert_map`, `w1_scale`/`w2_scale`, `a1_scale`/`a2_scale`, `block_shape`) into `_assert_unsupported_quant_args`, called from both expert paths.
- Implement the existing with-bias weight dtype `TODO`: assert each of `w1`/`w2` is `torch.bfloat16` or `FP4`. Behavior-preserving for valid inputs (the weight loaders always produce bf16 or FP4).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27971667581](https://github.com/sgl-project/sglang/actions/runs/27971667581)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27971667383](https://github.com/sgl-project/sglang/actions/runs/27971667383)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->