### PR TITLE
[diffusion] Continuous batching v0

### DIFF
--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -1324,6 +1324,7 @@
                   "docs/sglang-diffusion/attention_backends",
                   "docs/sglang-diffusion/ring_sp_performance",
                   "docs/sglang-diffusion/dynamic_batching",
+                  "docs/sglang-diffusion/continuous_batching",
                   {
                     "group": "Caching Acceleration",
                     "root": "docs/sglang-diffusion/caching-acceleration",

--- a/docs_new/docs/sglang-diffusion/continuous_batching.mdx
+++ b/docs_new/docs/sglang-diffusion/continuous_batching.mdx
@@ -1,0 +1,48 @@
+---
+title: "Continuous Batching"
+description: "Batch compatible active SGLang-Diffusion denoising steps during serving."
+tag: "preserve"
+mode: wide
+---
+
+Continuous batching is an opt-in SGLang-Diffusion serving mode that batches compatible denoising steps from active requests. Unlike [dynamic batching](./dynamic_batching), new requests can join while other requests are already denoising, and completed requests can leave without waiting for the original batch to finish.
+
+Use it for concurrent prompt-only image-generation traffic where requests have compatible denoising-step inputs. Keep dynamic batching or singleton serving for unsupported tasks, image-conditioned requests, or highly mixed traffic that cannot share denoising steps.
+
+## Enable
+
+```bash Command
+sglang serve \
+  --model-path Qwen/Qwen-Image-2512 \
+  --backend sglang \
+  --port 30010 \
+  --batching-mode continuous \
+  --batching-max-size 4 \
+  --batching-delay-ms 5 \
+  --enable-batching-metrics
+```
+
+For request formats, see the [OpenAI-Compatible API](./api/openai_api).
+
+## Compatibility
+
+Continuous batching currently supports native SGLang prompt-only image-generation pipelines that expose a standard denoising stage. Pipelines that route through a progressive-resolution denoising router use the full-resolution standard denoising stage for continuous batching.
+
+Current limitations:
+
+- Native SGLang backend only. Continuous batching is not supported with `--backend diffusers`.
+- Prompt-only requests only. Image-conditioned requests, edits, I2V, TI2V, and other non-text-only tasks are rejected at request admission.
+- Rollout requests, TeaCache, Cache-DiT, startup LoRA adapters, raw-frame streaming responses, disaggregated serving, DiT CPU offload, and DiT layerwise offload are not currently supported.
+- Requests are packed only when their denoising-step inputs are compatible. Requests with incompatible shapes or metadata run separately.
+
+## Metrics
+
+Use `--enable-batching-metrics` to inspect realized denoising-step batches:
+
+```text
+Continuous batching scheduler enabled (max_active=4, max_delay=5.00ms)
+Continuous denoising step batch: size=4/4
+Batch stats (last 5 dispatches): avg_size=4.00, merged_rate=100.0%, full_rate=100.0%, utilization=100.0%, top_rejects=none
+```
+
+These logs show the active step batch size, queue wait, realized utilization, and fallback/rejection reasons.

--- a/docs_new/docs/sglang-diffusion/continuous_batching.mdx
+++ b/docs_new/docs/sglang-diffusion/continuous_batching.mdx
@@ -32,8 +32,29 @@ Current limitations:
 
 - Native SGLang backend only. Continuous batching is not supported with `--backend diffusers`.
 - Prompt-only requests only. Image-conditioned requests, edits, I2V, TI2V, and other non-text-only tasks are rejected at request admission.
-- Rollout requests, TeaCache, Cache-DiT, startup LoRA adapters, raw-frame streaming responses, disaggregated serving, DiT CPU offload, and DiT layerwise offload are not currently supported.
+- Rollout requests, Cache-DiT, startup LoRA adapters, raw-frame streaming responses, disaggregated serving, DiT CPU offload, and DiT layerwise offload are not currently supported.
 - Requests are packed only when their denoising-step inputs are compatible. Requests with incompatible shapes or metadata run separately.
+- Packed step groups advance exclusively through the vectorized FlowMatch-Euler solver. Requests whose scheduler cannot be vectorized (for example FlowUniPC or stochastic sampling) run their denoising steps unpacked; there is no per-request `scheduler.step()` fallback inside a packed group. Rate-limited log lines report why a request runs unpacked.
+
+## TeaCache
+
+TeaCache requests are admitted into the continuous loop. Each request keeps its own cache snapshot per DiT phase, so dual-transformer pipelines (for example Wan2.2 experts) never share cached residuals across experts, and snapshots survive drain/resume through `--cb-drain-export-dir`.
+
+By default TeaCache requests run unpacked. On models that support row-level plans (Wan), `--cb-packed-teacache true` lets TeaCache requests join packed step groups: each step, rows whose cache decision is a hit skip the transformer blocks through a gather/scatter around the block loop while the remaining rows compute. Set `--cb-allow-step-caches false` to reject TeaCache requests entirely.
+
+## Tuning
+
+| Flag | Default | Effect |
+| --- | --- | --- |
+| `--cb-schedule-policy` | `largest` | Step-group selection: `largest`, `srpt`, or `rotate`. |
+| `--cb-fold-cfg-branches` | `true` | Fold CFG cond/uncond into one packed forward. |
+| `--cb-batch-bucket-sizes` | unset | Comma-separated packed-row buckets for stable forward shapes. |
+| `--cb-async-stages` | `true` | Run text-encode and VAE-decode on dedicated side-stream workers. |
+| `--cb-stage-queue-depth` | `8` | Bounded queue depth per stage worker; full queues apply backpressure. |
+| `--cb-allow-step-caches` | `true` | Allow TeaCache requests in the continuous loop. |
+| `--cb-packed-teacache` | `false` | Experimental: pack TeaCache requests with per-row hit/miss on supported models. |
+| `--cb-varlen-packing` | `false` | Experimental: pack different resolutions along the sequence dimension. |
+| `--cb-drain-export-dir` | unset | Directory to drain/resume in-flight request state across restarts. |
 
 ## Metrics
 

--- a/docs_new/docs/sglang-diffusion/dynamic_batching.mdx
+++ b/docs_new/docs/sglang-diffusion/dynamic_batching.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Inference Batching"
-description: "Batch compatible native SGLang-Diffusion requests during serving."
+title: "Dynamic Batching"
+description: "Batch compatible queued native SGLang-Diffusion requests during serving."
 tag: "preserve"
 mode: wide
 ---
@@ -38,31 +38,6 @@ Use `--batching-config /path/to/batching_config.json` to load JSON rules when a 
   ]
 }
 ```
-
-## Continuous batching
-
-Continuous batching is an opt-in SGLang-Diffusion serving mode that batches compatible denoising steps from active requests. Unlike dynamic batching, new requests can join while other requests are already denoising, and completed requests can leave without waiting for the original batch to finish.
-
-```bash Command
-sglang serve \
-  --model-path Qwen/Qwen-Image-2512 \
-  --backend sglang \
-  --port 30010 \
-  --batching-mode continuous \
-  --batching-max-size 4 \
-  --batching-delay-ms 5 \
-  --enable-batching-metrics
-```
-
-Continuous batching currently supports native SGLang prompt-only image-generation pipelines that expose a standard denoising stage. Pipelines that route through a progressive-resolution denoising router use the full-resolution standard denoising stage for continuous batching.
-
-Current limitations:
-
-- Native SGLang backend only. Continuous batching is not supported with `--backend diffusers`.
-- Prompt-only requests only. Image-conditioned requests, edits, I2V, TI2V, and other non-text-only tasks are rejected at request admission.
-- Rollout requests, TeaCache, Cache-DiT, startup LoRA adapters, raw-frame streaming responses, disaggregated serving, DiT CPU offload, and DiT layerwise offload are not currently supported.
-- Requests are packed only when their denoising-step inputs are compatible. Requests with incompatible shapes or metadata run separately.
-- The benchmark coverage for this mode currently uses `Qwen/Qwen-Image-2512`.
 
 ## Compatibility
 

--- a/docs_new/docs/sglang-diffusion/dynamic_batching.mdx
+++ b/docs_new/docs/sglang-diffusion/dynamic_batching.mdx
@@ -39,6 +39,31 @@ Use `--batching-config /path/to/batching_config.json` to load JSON rules when a 
 }
 ```
 
+## Continuous batching
+
+Continuous batching is an opt-in SGLang-Diffusion serving mode that batches compatible denoising steps from active requests. Unlike dynamic batching, new requests can join while other requests are already denoising, and completed requests can leave without waiting for the original batch to finish.
+
+```bash Command
+sglang serve \
+  --model-path Qwen/Qwen-Image-2512 \
+  --backend sglang \
+  --port 30010 \
+  --batching-mode continuous \
+  --batching-max-size 4 \
+  --batching-delay-ms 5 \
+  --enable-batching-metrics
+```
+
+Continuous batching currently supports native SGLang prompt-only image-generation pipelines that expose a standard denoising stage. Pipelines that route through a progressive-resolution denoising router use the full-resolution standard denoising stage for continuous batching.
+
+Current limitations:
+
+- Native SGLang backend only. Continuous batching is not supported with `--backend diffusers`.
+- Prompt-only requests only. Image-conditioned requests, edits, I2V, TI2V, and other non-text-only tasks are rejected at request admission.
+- Rollout requests, TeaCache, Cache-DiT, startup LoRA adapters, raw-frame streaming responses, disaggregated serving, DiT CPU offload, and DiT layerwise offload are not currently supported.
+- Requests are packed only when their denoising-step inputs are compatible. Requests with incompatible shapes or metadata run separately.
+- The benchmark coverage for this mode currently uses `Qwen/Qwen-Image-2512`.
+
 ## Compatibility
 
 An initial implementation of dynamic batching for T2I and T2V models can be found in [#18764](https://github.com/sgl-project/sglang/pull/18764). The current compatibility grid is below and will be updated as more coverage is added. See [Supported Models and Optimization Compatibility](./compatibility_matrix) for common model IDs and optimization support.

--- a/python/sglang/jit_kernel/diffusion/cutedsl/scale_residual_norm_scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/cutedsl/scale_residual_norm_scale_shift.py
@@ -233,6 +233,14 @@ def validate_scale_shift(t: torch.Tensor, B: int, S: int, D: int):
         raise ValueError(f"Validate failed: not contiguous on dim D.")
 
 
+def normalize_packed_scale_shift(t: torch.Tensor, B: int, S: int, D: int):
+    if t.ndim == 2 and B == 1 and t.shape[0] != 1 and t.shape[1] == D:
+        F = t.shape[0]
+        if S % F == 0:
+            return t.view(1, F, 1, D)
+    return t
+
+
 def validate_gate(t: Union[torch.Tensor, int], B: int, S: int, D: int):
     if not isinstance(t, torch.Tensor):
         return
@@ -275,6 +283,8 @@ def fused_norm_scale_shift(
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
     # Tensor Validation
     BSD = x.shape
+    scale = normalize_packed_scale_shift(scale, *BSD)
+    shift = normalize_packed_scale_shift(shift, *BSD)
     validate_x(x, *BSD)
     validate_weight_bias(weight, BSD[-1])
     validate_weight_bias(bias, BSD[-1])
@@ -360,6 +370,10 @@ def fused_scale_residual_norm_scale_shift(
         return native_out
     # Tensor Validation
     BSD = x.shape
+    if gate is not None:
+        gate = normalize_packed_scale_shift(gate, *BSD)
+    scale = normalize_packed_scale_shift(scale, *BSD)
+    shift = normalize_packed_scale_shift(shift, *BSD)
     validate_x(x, *BSD)
     validate_x(residual, *BSD)
     validate_gate(gate, *BSD)

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -199,6 +199,10 @@ class PipelineConfig:
     """The base configuration class for a generation pipeline."""
 
     continuous_batching_supported_tasks: ClassVar[tuple[ModelTaskType, ...]] = ()
+    # True when cond/uncond can run as one batched forward (batch 2B).
+    supports_cfg_batch_folding: ClassVar[bool] = False
+    # True when different resolutions can pack along the sequence dim (varlen).
+    supports_varlen_step_packing: ClassVar[bool] = False
 
     task_type: ModelTaskType = ModelTaskType.I2I
     skip_input_image_preprocess: bool = False

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -7,7 +7,7 @@ import os
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field, fields
 from enum import Enum, auto
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
 import PIL
@@ -197,6 +197,8 @@ def maybe_unpad_latents(latents, batch):
 @dataclass
 class PipelineConfig:
     """The base configuration class for a generation pipeline."""
+
+    continuous_batching_supported_tasks: ClassVar[tuple[ModelTaskType, ...]] = ()
 
     task_type: ModelTaskType = ModelTaskType.I2I
     skip_input_image_preprocess: bool = False
@@ -398,7 +400,7 @@ class PipelineConfig:
         return False
 
     def supports_continuous_batching(self):
-        return False
+        return self.task_type in self.continuous_batching_supported_tasks
 
     def estimate_request_cost(self, batch) -> float:
         """Return the relative cost used for batching admission caps.

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -397,6 +397,9 @@ class PipelineConfig:
         """Return whether dynamic batches should run as grouped Req lists."""
         return False
 
+    def supports_continuous_batching(self):
+        return False
+
     def estimate_request_cost(self, batch) -> float:
         """Return the relative cost used for batching admission caps.
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ernie_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ernie_image.py
@@ -54,6 +54,8 @@ def _unpatchify_latents(latents: torch.Tensor) -> torch.Tensor:
 class ErnieImagePipelineConfig(ImagePipelineConfig):
     """Configuration for the ErnieImage text-to-image pipeline."""
 
+    continuous_batching_supported_tasks = (ModelTaskType.T2I,)
+
     should_use_guidance: bool = False
     task_type: ModelTaskType = ModelTaskType.T2I
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
@@ -497,6 +497,10 @@ class Flux2PipelineConfig(FluxPipelineConfig):
         """
         return True
 
+    def supports_continuous_batching(self):
+        """Allow continuous batching for Flux2 text-only requests."""
+        return True
+
     def tokenize_prompt(self, prompts: list[str], tokenizer, tok_kwargs) -> dict:
         messages = build_flux2_text_messages(prompts)
         effective_max_length = tok_kwargs.pop("max_length", 512)

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
@@ -122,6 +122,9 @@ class FluxPipelineConfig(ImagePipelineConfig):
     def get_text_encoder_pooler_output(self, outputs, encoder_index):
         return outputs.pooler_output
 
+    def supports_continuous_batching(self):
+        return True
+
     def prepare_sigmas(self, sigmas, num_inference_steps):
         return self._prepare_sigmas(sigmas, num_inference_steps)
 
@@ -448,6 +451,9 @@ class Flux2PipelineConfig(FluxPipelineConfig):
     embedded_cfg_scale: float = 4.0
 
     task_type: ModelTaskType = ModelTaskType.TI2I
+
+    def supports_continuous_batching(self):
+        return False
 
     vae_precision: str = "bf16"
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
@@ -37,6 +37,8 @@ def t5_postprocess_text(outputs: BaseEncoderOutput, _text_inputs) -> torch.Tenso
 class FluxPipelineConfig(ImagePipelineConfig):
     """Configuration for the FLUX pipeline."""
 
+    continuous_batching_supported_tasks = (ModelTaskType.T2I,)
+
     embedded_cfg_scale: float = 3.5
 
     task_type: ModelTaskType = ModelTaskType.T2I
@@ -121,9 +123,6 @@ class FluxPipelineConfig(ImagePipelineConfig):
 
     def get_text_encoder_pooler_output(self, outputs, encoder_index):
         return outputs.pooler_output
-
-    def supports_continuous_batching(self):
-        return True
 
     def prepare_sigmas(self, sigmas, num_inference_steps):
         return self._prepare_sigmas(sigmas, num_inference_steps)
@@ -451,9 +450,6 @@ class Flux2PipelineConfig(FluxPipelineConfig):
     embedded_cfg_scale: float = 4.0
 
     task_type: ModelTaskType = ModelTaskType.TI2I
-
-    def supports_continuous_batching(self):
-        return False
 
     vae_precision: str = "bf16"
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/glm_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/glm_image.py
@@ -19,6 +19,9 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
 class GlmImagePipelineConfig(SpatialImagePipelineConfig):
     """Configuration for the GlmImage pipeline."""
 
+    def supports_continuous_batching(self):
+        return True
+
     vae_precision: str = "bf16"
 
     should_use_guidance: bool = False

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ideogram.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ideogram.py
@@ -278,6 +278,8 @@ LATENT_SCALE = (
 
 @dataclass
 class Ideogram4PipelineConfig(ImagePipelineConfig):
+    continuous_batching_supported_tasks = (ModelTaskType.T2I,)
+
     task_type: ModelTaskType = ModelTaskType.T2I
     should_use_guidance: bool = False
     vae_precision: str = "bf16"

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
@@ -142,6 +142,11 @@ class QwenImagePipelineConfig(QwenImageRolloutPipelineMixin, ImagePipelineConfig
     """Configuration for the QwenImage pipeline."""
 
     continuous_batching_supported_tasks = (ModelTaskType.T2I,)
+    # Qwen-Image does not branch on is_cfg_negative, so cond/uncond can fold.
+    supports_cfg_batch_folding = True
+    # The DiT accepts per-row image masks and per-token rope positions, so
+    # different resolutions can share one packed forward.
+    supports_varlen_step_packing = True
 
     should_use_guidance: bool = False
     task_type: ModelTaskType = ModelTaskType.T2I

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
@@ -141,6 +141,8 @@ def _pack_latents(latents, batch_size, num_channels_latents, height, width):
 class QwenImagePipelineConfig(QwenImageRolloutPipelineMixin, ImagePipelineConfig):
     """Configuration for the QwenImage pipeline."""
 
+    continuous_batching_supported_tasks = (ModelTaskType.T2I,)
+
     should_use_guidance: bool = False
     task_type: ModelTaskType = ModelTaskType.T2I
 
@@ -362,9 +364,6 @@ class QwenImagePipelineConfig(QwenImageRolloutPipelineMixin, ImagePipelineConfig
         Single-request execution uses the full padded length. Batched execution
         uses stored per-request lengths and masks from text encoding.
         """
-        if batch_size == 1:
-            return [text_seq_len], None
-
         txt_seq_lens = self.require_text_seq_lens(
             batch, encoder_index, negative=negative, expected_batch_size=batch_size
         )
@@ -402,7 +401,7 @@ class QwenImagePipelineConfig(QwenImageRolloutPipelineMixin, ImagePipelineConfig
         `txt_seq_lens`: position j is valid for row i when
         `j < txt_seq_lens[i]`.
         """
-        if all(seq_len == text_seq_len for seq_len in txt_seq_lens):
+        if batch_size != 1 and all(seq_len == text_seq_len for seq_len in txt_seq_lens):
             return None
 
         masks_by_encoder = (

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/sana.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/sana.py
@@ -41,6 +41,7 @@ def sana_postprocess_text(outputs: BaseEncoderOutput, _text_inputs) -> torch.Ten
 
 @dataclass
 class SanaPipelineConfig(SpatialImagePipelineConfig):
+    continuous_batching_supported_tasks = (ModelTaskType.T2I,)
 
     task_type: ModelTaskType = ModelTaskType.T2I
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/stablediffusion3.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/stablediffusion3.py
@@ -100,6 +100,8 @@ class StableDiffusion3PipelineConfig(SpatialImagePipelineConfig):
     tokenizer kwargs, instead of stage-level tokenizer overrides.
     """
 
+    continuous_batching_supported_tasks = (ModelTaskType.T2I,)
+
     task_type: ModelTaskType = ModelTaskType.T2I
 
     dit_config: DiTConfig = field(default_factory=StableDiffusion3TransformerConfig)

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -62,6 +62,8 @@ class WanI2VCommonConfig(PipelineConfig):
 class WanT2V480PConfig(PipelineConfig):
     """Base configuration for Wan T2V 1.3B pipeline architecture."""
 
+    continuous_batching_supported_tasks = (ModelTaskType.T2V,)
+
     task_type: ModelTaskType = ModelTaskType.T2V
     # WanConfig-specific parameters with defaults
     # DiT
@@ -91,6 +93,11 @@ class WanT2V480PConfig(PipelineConfig):
     def __post_init__(self):
         self.vae_config.load_encoder = False
         self.vae_config.load_decoder = True
+
+    def supports_continuous_batching(self):
+        return (
+            super().supports_continuous_batching() and self.dmd_denoising_steps is None
+        )
 
     def get_model_deployment_config(self) -> ModelDeploymentConfig:
         return ModelDeploymentConfig(

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
@@ -63,6 +63,8 @@ class TransformersModelConfig(EncoderConfig):
 
 @dataclass
 class ZImagePipelineConfig(ZImageRolloutPipelineMixin, ImagePipelineConfig):
+    continuous_batching_supported_tasks = (ModelTaskType.T2I,)
+
     should_use_guidance: bool = False
     task_type: ModelTaskType = ModelTaskType.T2I
     dit_config: DiTConfig = field(default_factory=ZImageDitConfig)

--- a/python/sglang/multimodal_gen/runtime/cache/teacache.py
+++ b/python/sglang/multimodal_gen/runtime/cache/teacache.py
@@ -17,7 +17,7 @@ References:
   https://arxiv.org/abs/2411.14324
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -27,6 +27,315 @@ from sglang.multimodal_gen.configs.models import DiTConfig
 
 if TYPE_CHECKING:
     from sglang.multimodal_gen.configs.sample.teacache import TeaCacheParams
+
+
+# Scalar attributes shared by every TeaCache-capable model.
+TEACACHE_SCALAR_FIELDS: tuple[str, ...] = (
+    "cnt",
+    "enable_teacache",
+    "is_cfg_negative",
+    "accumulated_rel_l1_distance",
+    "accumulated_rel_l1_distance_negative",
+)
+# Tensor attributes (positive and CFG-negative caches).
+TEACACHE_TENSOR_FIELDS: tuple[str, ...] = (
+    "previous_modulated_input",
+    "previous_residual",
+    "previous_modulated_input_negative",
+    "previous_residual_negative",
+)
+# Negative-branch fields exist on the model only when it supports CFG caches.
+_TEACACHE_NEGATIVE_FIELDS: frozenset[str] = frozenset(
+    name
+    for name in TEACACHE_SCALAR_FIELDS + TEACACHE_TENSOR_FIELDS
+    if name.endswith("_negative")
+)
+
+
+def compute_l1_decision(
+    modulated_inp: torch.Tensor,
+    previous_modulated_input: torch.Tensor | None,
+    accumulated_rel_l1_distance: float,
+    coefficients: list[float],
+    teacache_thresh: float,
+) -> tuple[float, bool]:
+    """Pure L1-distance cache decision shared by attr- and state-based callers.
+
+    Returns ``(new_accumulated_distance, should_calc)``.
+    """
+    if previous_modulated_input is None:
+        return 0.0, True
+
+    diff = modulated_inp - previous_modulated_input
+    rel_l1 = (diff.abs().mean() / previous_modulated_input.abs().mean()).cpu().item()
+    rescale_func = np.poly1d(coefficients)
+    accumulated = accumulated_rel_l1_distance + rescale_func(rel_l1)
+
+    if accumulated >= teacache_thresh:
+        # Threshold exceeded: force compute and reset accumulator.
+        return 0.0, True
+    # Cache hit: keep accumulated distance.
+    return accumulated, False
+
+
+@dataclass
+class TeaCacheRequestState:
+    """Explicit, per-request snapshot of TeaCache state.
+
+    This is the canonical interchange format between a shared DiT model and
+    per-request bookkeeping (continuous batching, drain/resume, packed
+    row plans). Field names intentionally mirror the model attributes managed
+    by :class:`TeaCacheMixin`.
+    """
+
+    cnt: int = 0
+    enable_teacache: bool = True
+    is_cfg_negative: bool = False
+    accumulated_rel_l1_distance: float = 0.0
+    accumulated_rel_l1_distance_negative: float = 0.0
+    previous_modulated_input: torch.Tensor | None = None
+    previous_residual: torch.Tensor | None = None
+    previous_modulated_input_negative: torch.Tensor | None = None
+    previous_residual_negative: torch.Tensor | None = None
+
+    @classmethod
+    def capture_from(cls, model: Any) -> "TeaCacheRequestState":
+        """Capture the model's current TeaCache attributes into a snapshot."""
+        state = cls()
+        for name in TEACACHE_SCALAR_FIELDS + TEACACHE_TENSOR_FIELDS:
+            if hasattr(model, name):
+                setattr(state, name, getattr(model, name))
+        return state
+
+    def install_to(self, model: Any) -> None:
+        """Install this snapshot onto the model's TeaCache attributes."""
+        supports_cfg_cache = bool(getattr(model, "_supports_cfg_cache", False))
+        for name in TEACACHE_SCALAR_FIELDS + TEACACHE_TENSOR_FIELDS:
+            if name in _TEACACHE_NEGATIVE_FIELDS and not supports_cfg_cache:
+                continue
+            setattr(model, name, getattr(self, name))
+
+    def reset(self) -> None:
+        """Reset to a fresh generation-start state (mirrors the mixin reset)."""
+        self.cnt = 0
+        self.enable_teacache = True
+        self.is_cfg_negative = False
+        self.accumulated_rel_l1_distance = 0.0
+        self.accumulated_rel_l1_distance_negative = 0.0
+        self.previous_modulated_input = None
+        self.previous_residual = None
+        self.previous_modulated_input_negative = None
+        self.previous_residual_negative = None
+
+    def for_next_phase(self) -> "TeaCacheRequestState":
+        """Seed the state for a new transformer phase (e.g. Wan2.2 experts).
+
+        The forward-pass counter carries across the boundary so skip windows
+        keep their meaning over the whole schedule, but cached tensors never
+        cross models: each expert must rebuild its own baselines.
+        """
+        return TeaCacheRequestState(
+            cnt=self.cnt,
+            enable_teacache=self.enable_teacache,
+            is_cfg_negative=self.is_cfg_negative,
+        )
+
+    def clone(self) -> "TeaCacheRequestState":
+        return TeaCacheRequestState(
+            **{item.name: getattr(self, item.name) for item in fields(self)}
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize for drain/resume; tensors move to CPU."""
+        payload: dict[str, Any] = {}
+        for item in fields(self):
+            value = getattr(self, item.name)
+            if isinstance(value, torch.Tensor):
+                value = value.detach().to("cpu")
+            payload[item.name] = value
+        return payload
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: dict[str, Any],
+        device: torch.device | str | None = None,
+    ) -> "TeaCacheRequestState":
+        state = cls()
+        valid = {item.name for item in fields(cls)}
+        for name, value in payload.items():
+            if name not in valid:
+                continue
+            if isinstance(value, torch.Tensor) and device is not None:
+                value = value.to(device=device)
+            setattr(state, name, value)
+        return state
+
+
+def resolve_teacache_phase_state(
+    phase_states: dict[str, "TeaCacheRequestState | None"],
+    phase: str,
+    *,
+    create: bool = False,
+) -> "TeaCacheRequestState | None":
+    """Return (and lazily seed) the per-phase snapshot for one request.
+
+    Entering a phase for the first time seeds from the most recent other
+    phase via :meth:`TeaCacheRequestState.for_next_phase`, carrying the
+    forward counter but never cached tensors across experts. When ``create``
+    is True a missing snapshot is materialized as a fresh state so callers
+    can mutate it in place (packed row plans).
+    """
+    if phase in phase_states:
+        state = phase_states[phase]
+        if state is None and create:
+            state = TeaCacheRequestState()
+            phase_states[phase] = state
+        return state
+    seed: TeaCacheRequestState | None = None
+    for previous_phase, previous_state in phase_states.items():
+        if previous_phase == phase or previous_state is None:
+            continue
+        for_next_phase = getattr(previous_state, "for_next_phase", None)
+        if callable(for_next_phase):
+            seed = for_next_phase()
+    if seed is None and create:
+        seed = TeaCacheRequestState()
+    phase_states[phase] = seed
+    return seed
+
+
+@dataclass
+class TeaCachePackedMember:
+    """Per-request TeaCache bookkeeping for one member of a packed step batch.
+
+    ``state is None`` means TeaCache is disabled for this member: its rows are
+    always computed and no state is updated.
+    """
+
+    row_slice: slice
+    state: TeaCacheRequestState | None = None
+    step_index: int = 0
+    num_inference_steps: int = 0
+    do_cfg: bool = False
+    teacache_params: Any = None
+
+    @property
+    def enabled(self) -> bool:
+        return (
+            self.state is not None
+            and self.state.enable_teacache
+            and self.teacache_params is not None
+        )
+
+    def maybe_reset_for_first_step(self, is_cfg_negative: bool) -> None:
+        """Mirror the mixin reset at the first positive-branch step."""
+        if self.state is None:
+            return
+        if self.step_index == 0 and not self.state.is_cfg_negative:
+            enable = self.state.enable_teacache
+            self.state.reset()
+            self.state.enable_teacache = enable
+        self.state.is_cfg_negative = is_cfg_negative
+
+    def decide(self, modulated_inp: torch.Tensor, is_cfg_negative: bool) -> bool:
+        """Return True when this member's rows must run the model forward.
+
+        Mirrors ``TeaCacheMixin._compute_teacache_decision`` semantics on the
+        member's own state instead of shared model attributes.
+        """
+        if not self.enabled:
+            return True
+        state = self.state
+        self.maybe_reset_for_first_step(is_cfg_negative)
+
+        params = self.teacache_params
+        start_skipping, end_skipping = params.get_skip_boundaries(
+            self.num_inference_steps, self.do_cfg
+        )
+        is_boundary_step = state.cnt < start_skipping or state.cnt >= end_skipping
+
+        if is_boundary_step:
+            new_accum, should_calc = 0.0, True
+        else:
+            if is_cfg_negative:
+                prev_inp = state.previous_modulated_input_negative
+                accumulated = state.accumulated_rel_l1_distance_negative
+            else:
+                prev_inp = state.previous_modulated_input
+                accumulated = state.accumulated_rel_l1_distance
+            new_accum, should_calc = compute_l1_decision(
+                modulated_inp=modulated_inp,
+                previous_modulated_input=prev_inp,
+                accumulated_rel_l1_distance=accumulated,
+                coefficients=params.get_coefficients(),
+                teacache_thresh=params.teacache_thresh,
+            )
+
+        if is_cfg_negative:
+            state.previous_modulated_input_negative = modulated_inp.clone()
+            state.accumulated_rel_l1_distance_negative = new_accum
+        else:
+            state.previous_modulated_input = modulated_inp.clone()
+            state.accumulated_rel_l1_distance = new_accum
+        return should_calc
+
+    def stash_residual(self, residual: torch.Tensor, is_cfg_negative: bool) -> None:
+        if self.state is None:
+            return
+        if is_cfg_negative:
+            self.state.previous_residual_negative = residual
+        else:
+            self.state.previous_residual = residual
+
+    def cached_residual(self, is_cfg_negative: bool) -> torch.Tensor | None:
+        if self.state is None:
+            return None
+        if is_cfg_negative:
+            return self.state.previous_residual_negative
+        return self.state.previous_residual
+
+    def advance(self) -> None:
+        """Count one model forward for this member (mirrors ``self.cnt += 1``)."""
+        if self.state is not None:
+            self.state.cnt += 1
+
+
+@dataclass
+class TeaCachePackedPlan:
+    """Row-level TeaCache plan for one packed forward.
+
+    Models that set ``supports_packed_teacache = True`` read this plan from
+    the forward context and gather/scatter compute rows around their block
+    loop so cache-hit rows skip the transformer blocks entirely.
+    """
+
+    members: list[TeaCachePackedMember] = field(default_factory=list)
+
+    @property
+    def any_enabled(self) -> bool:
+        return any(member.enabled for member in self.members)
+
+    def partition(
+        self,
+        modulated_inp: torch.Tensor,
+        is_cfg_negative: bool,
+    ) -> tuple[list[TeaCachePackedMember], list[TeaCachePackedMember]]:
+        """Split members into (compute, skip) using per-member decisions.
+
+        ``modulated_inp`` is indexed with each member's ``row_slice``; rows
+        beyond the members' coverage (e.g. bucket padding) are always computed
+        by the caller.
+        """
+        compute: list[TeaCachePackedMember] = []
+        skip: list[TeaCachePackedMember] = []
+        for member in self.members:
+            member_inp = modulated_inp[member.row_slice]
+            if member.decide(member_inp, is_cfg_negative):
+                compute.append(member)
+            else:
+                skip.append(member)
+        return compute, skip
 
 
 @dataclass
@@ -168,6 +477,17 @@ class TeaCacheMixin:
             self.previous_residual_negative = None
             self.accumulated_rel_l1_distance_negative = 0.0
 
+    def capture_teacache_state(self) -> TeaCacheRequestState:
+        """Explicit cache-state interface: snapshot the model's TeaCache state."""
+        return TeaCacheRequestState.capture_from(self)
+
+    def install_teacache_state(self, state: TeaCacheRequestState | None) -> None:
+        """Explicit cache-state interface: install (or reset when None)."""
+        if state is None:
+            self.reset_teacache_state()
+        else:
+            state.install_to(self)
+
     def _compute_l1_and_decide(
         self,
         modulated_inp: torch.Tensor,
@@ -190,30 +510,18 @@ class TeaCacheMixin:
             if self.is_cfg_negative
             else self.previous_modulated_input
         )
-
-        # Defensive check: if previous input is not set, force calculation
-        if prev_modulated_inp is None:
-            return 0.0, True
-
-        # Compute relative L1 distance
-        diff = modulated_inp - prev_modulated_inp
-        rel_l1 = (diff.abs().mean() / prev_modulated_inp.abs().mean()).cpu().item()
-
-        # Apply polynomial rescaling
-        rescale_func = np.poly1d(coefficients)
-
         accumulated_rel_l1_distance = (
             self.accumulated_rel_l1_distance_negative
             if self.is_cfg_negative
             else self.accumulated_rel_l1_distance
         )
-        accumulated_rel_l1_distance = accumulated_rel_l1_distance + rescale_func(rel_l1)
-
-        if accumulated_rel_l1_distance >= teacache_thresh:
-            # Threshold exceeded: force compute and reset accumulator
-            return 0.0, True
-        # Cache hit: keep accumulated distance
-        return accumulated_rel_l1_distance, False
+        return compute_l1_decision(
+            modulated_inp=modulated_inp,
+            previous_modulated_input=prev_modulated_inp,
+            accumulated_rel_l1_distance=accumulated_rel_l1_distance,
+            coefficients=coefficients,
+            teacache_thresh=teacache_thresh,
+        )
 
     def _compute_teacache_decision(
         self,

--- a/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
+++ b/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
@@ -48,6 +48,9 @@ class DenoisingBatchKey:
     attention_backend: str | None
     attention_metadata_type: str | None
     attention_metadata_signature: Any
+    enable_sequence_shard: bool | None
+    did_sp_shard_latents: bool
+    sp_video_start_frame: int
     tp_size: int
     sp_degree: int
     ulysses_degree: int
@@ -334,6 +337,9 @@ def build_denoising_batch_key(
             type(attn_metadata).__name__ if attn_metadata is not None else None
         ),
         attention_metadata_signature=_to_hashable_signature(attn_metadata),
+        enable_sequence_shard=getattr(req, "enable_sequence_shard", None),
+        did_sp_shard_latents=bool(getattr(req, "did_sp_shard_latents", False)),
+        sp_video_start_frame=int(getattr(req, "sp_video_start_frame", 0) or 0),
         tp_size=int(getattr(server_args, "tp_size", 1) or 1),
         sp_degree=int(getattr(server_args, "sp_degree", 1) or 1),
         ulysses_degree=int(getattr(server_args, "ulysses_degree", 1) or 1),

--- a/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
+++ b/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field, fields, is_dataclass
 from typing import TYPE_CHECKING, Any
 
 from sglang.multimodal_gen import envs
-from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType
 from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
@@ -149,11 +148,6 @@ def validate_continuous_batching_config(server_args: Any) -> None:
             "use --backend sglang"
         )
 
-    if pipeline_config.task_type != ModelTaskType.T2I:
-        raise ContinuousBatchingError(
-            "continuous batching currently only supports text-to-image pipelines"
-        )
-
     disagg_role = getattr(server_args, "disagg_role", RoleType.MONOLITHIC)
     disagg_role_value = getattr(disagg_role, "value", disagg_role)
     if disagg_role_value != RoleType.MONOLITHIC.value:
@@ -196,12 +190,6 @@ def validate_continuous_batching_request(req: Req, server_args: Any) -> None:
     if not isinstance(req, Req):
         raise ContinuousBatchingError(
             f"continuous batching only handles generation Req objects, got {type(req)}"
-        )
-
-    pipeline_config = server_args.pipeline_config
-    if pipeline_config.task_type != ModelTaskType.T2I:
-        raise ContinuousBatchingError(
-            "continuous batching currently only supports text-to-image pipelines"
         )
 
     if not isinstance(getattr(req, "prompt", None), str):

--- a/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
+++ b/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
@@ -13,8 +13,6 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 
-_SUPPORTED_CONTINUOUS_ATTENTION_BACKENDS = {"fa", "fa2", "torch_sdpa"}
-
 if TYPE_CHECKING:
     from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
         OutputBatch,
@@ -153,7 +151,7 @@ def validate_continuous_batching_config(server_args: Any) -> None:
 
     if pipeline_config.task_type != ModelTaskType.T2I:
         raise ContinuousBatchingError(
-            "continuous batching v1 only supports text-to-image pipelines"
+            "continuous batching currently only supports text-to-image pipelines"
         )
 
     disagg_role = getattr(server_args, "disagg_role", RoleType.MONOLITHIC)
@@ -170,12 +168,12 @@ def validate_continuous_batching_config(server_args: Any) -> None:
 
     if envs.SGLANG_CACHE_DIT_ENABLED or getattr(server_args, "cache_dit_config", None):
         raise ContinuousBatchingError(
-            "continuous batching does not support Cache-DiT in v1"
+            "continuous batching currently does not support Cache-DiT"
         )
 
     if getattr(server_args, "lora_path", None):
         raise ContinuousBatchingError(
-            "continuous batching does not support startup LoRA adapters in v1"
+            "continuous batching currently does not support startup LoRA adapters"
         )
 
     if getattr(server_args, "dit_cpu_offload", False):
@@ -191,25 +189,6 @@ def validate_continuous_batching_config(server_args: Any) -> None:
             "--dit-layerwise-offload/DiT layerwise offload components"
         )
 
-    attention_backend = getattr(server_args, "attention_backend", None)
-    if attention_backend not in {None, "", *_SUPPORTED_CONTINUOUS_ATTENTION_BACKENDS}:
-        raise ContinuousBatchingError(
-            f"continuous batching does not support attention backend {attention_backend!r}"
-        )
-
-    component_backends = (
-        getattr(server_args, "component_attention_backends", None) or {}
-    )
-    if isinstance(component_backends, dict):
-        for component_name, backend in component_backends.items():
-            if "transformer" not in str(component_name):
-                continue
-            if backend not in _SUPPORTED_CONTINUOUS_ATTENTION_BACKENDS:
-                raise ContinuousBatchingError(
-                    "continuous batching does not support attention backend "
-                    f"{backend!r} for component {component_name!r}"
-                )
-
 
 def validate_continuous_batching_request(req: Req, server_args: Any) -> None:
     from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
@@ -222,32 +201,32 @@ def validate_continuous_batching_request(req: Req, server_args: Any) -> None:
     pipeline_config = server_args.pipeline_config
     if pipeline_config.task_type != ModelTaskType.T2I:
         raise ContinuousBatchingError(
-            "continuous batching v1 only supports text-to-image pipelines"
+            "continuous batching currently only supports text-to-image pipelines"
         )
 
     if not isinstance(getattr(req, "prompt", None), str):
         raise ContinuousBatchingError(
-            "continuous batching v1 only supports a single text prompt per request"
+            "continuous batching currently only supports a single text prompt per request"
         )
 
     if req.image_path is not None:
         raise ContinuousBatchingError(
-            "continuous batching v1 does not support image-conditioned requests"
+            "continuous batching currently does not support image-conditioned requests"
         )
 
     if getattr(req, "rollout", False):
         raise ContinuousBatchingError(
-            "continuous batching v1 does not support rollout requests"
+            "continuous batching currently does not support rollout requests"
         )
 
     if getattr(req, "enable_teacache", False):
         raise ContinuousBatchingError(
-            "continuous batching v1 does not support TeaCache requests"
+            "continuous batching currently does not support TeaCache requests"
         )
 
     if getattr(req, "return_raw_frames", False):
         raise ContinuousBatchingError(
-            "continuous batching v1 does not support raw-frame streaming responses"
+            "continuous batching currently does not support raw-frame streaming responses"
         )
 
 
@@ -325,6 +304,7 @@ def build_denoising_batch_key(
     denoising_stage: Any,
     server_args: Any,
 ) -> DenoisingBatchKey:
+    """Build the compatibility key used to group denoising steps."""
     req = state.req
     ctx = state.denoising_context
     step = state.current_step
@@ -377,6 +357,8 @@ def build_denoising_batch_key(
 
 
 class ContinuousDenoisingCoordinator:
+    """Coordinates request-local denoising state for continuous batching."""
+
     def __init__(
         self,
         *,
@@ -390,7 +372,7 @@ class ContinuousDenoisingCoordinator:
         self.pipeline = worker.pipeline
         self.denoising_stage = self.pipeline.get_denoising_stage()
 
-    def prepare_request_for_denoising_steps(
+    def prepare_request_state(
         self,
         *,
         identity: bytes | None,
@@ -444,7 +426,7 @@ class ContinuousDenoisingCoordinator:
         )
         return True
 
-    def select_compatible_requests_for_next_step(
+    def select_next_step_batch(
         self,
         active_states: list[DenoisingRequestState],
     ) -> list[DenoisingRequestState]:
@@ -477,6 +459,7 @@ class ContinuousDenoisingCoordinator:
         self,
         states: list[DenoisingRequestState],
     ) -> list[DenoisingRequestState]:
+        """Run one denoising step for selected requests and finish completed ones."""
         if not states:
             return []
 
@@ -540,6 +523,7 @@ class ContinuousDenoisingCoordinator:
         state.set_error_output(error)
 
     def _cleanup_denoising_context(self, ctx: DenoisingContext) -> None:
+        """Clean denoising resources without masking the original failure."""
         try:
             self.denoising_stage.cleanup_denoising_context(ctx)
         except Exception:

--- a/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
+++ b/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
@@ -90,7 +90,9 @@ class DenoisingRequestState:
     attn_metadata_is_static: bool = False
     # Deep-copied raw request for mid-flight export/import.
     raw_req_snapshot: Req | None = None
-    # Per-request TeaCache state snapshot.
+    # Per-request TeaCache snapshots keyed by model phase
+    # ("transformer" / "transformer_2") so dual-DiT pipelines never share
+    # cached residuals across experts.
     teacache_state: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
@@ -132,7 +134,19 @@ _TEACACHE_PREFIX_ATTRS = ("previous_", "accumulated_rel_l1")
 
 
 class TeaCacheStateIsolator:
-    """Capture/restore per-request TeaCache state on a shared DiT model."""
+    """Capture/restore per-request TeaCache state on a shared DiT model.
+
+    Models exposing the explicit cache-state interface
+    (``capture_teacache_state`` / ``install_teacache_state``) use typed
+    :class:`TeaCacheRequestState` snapshots; other models fall back to a
+    legacy attribute scan.
+    """
+
+    @staticmethod
+    def _has_explicit_interface(model: Any) -> bool:
+        return callable(getattr(model, "capture_teacache_state", None)) and callable(
+            getattr(model, "install_teacache_state", None)
+        )
 
     @staticmethod
     def state_attrs(model: Any) -> tuple[str, ...]:
@@ -145,11 +159,16 @@ class TeaCacheStateIsolator:
         return tuple(names)
 
     @classmethod
-    def capture(cls, model: Any) -> dict[str, Any]:
+    def capture(cls, model: Any) -> Any:
+        if cls._has_explicit_interface(model):
+            return model.capture_teacache_state()
         return {name: getattr(model, name) for name in cls.state_attrs(model)}
 
     @classmethod
-    def install(cls, model: Any, snapshot: dict[str, Any] | None) -> None:
+    def install(cls, model: Any, snapshot: Any | None) -> None:
+        if cls._has_explicit_interface(model):
+            model.install_teacache_state(snapshot)
+            return
         if snapshot is not None:
             for name, value in snapshot.items():
                 setattr(model, name, value)
@@ -560,13 +579,33 @@ class ContinuousDenoisingCoordinator:
         return "transformer"
 
     def _request_is_packable(self, state: DenoisingRequestState) -> bool:
-        if state.req.enable_teacache:
-            # TeaCache is per-request and must run unpacked.
+        from sglang.multimodal_gen.runtime.pipelines_core.batched_solver import (
+            scheduler_is_batchable,
+        )
+
+        if state.req.enable_teacache and not self._teacache_can_run_packed(state):
+            # TeaCache without a row-aware model must run unpacked.
             return False
         if not state.attn_metadata_is_static:
             # Sparse/video backends have step-dependent metadata; keep separate.
             return False
+        if not scheduler_is_batchable(state.denoising_context.scheduler, diagnose=True):
+            # Packed groups step only through the vectorized solver (no
+            # per-request scheduler.step fallback), so non-batchable
+            # schedulers run unpacked.
+            return False
         return True
+
+    def _teacache_can_run_packed(self, state: DenoisingRequestState) -> bool:
+        """TeaCache rows may pack when the model supports per-row plans."""
+        if not (
+            self.allow_step_caches
+            and bool(getattr(self.server_args, "cb_packed_teacache", False))
+        ):
+            return False
+        step = state.current_step
+        model = getattr(step, "current_model", None) if step is not None else None
+        return bool(getattr(model, "supports_packed_teacache", False))
 
     def prepare_next_denoising_step(self, state: DenoisingRequestState) -> bool:
         if state.step_index >= state.num_timesteps:
@@ -652,9 +691,28 @@ class ContinuousDenoisingCoordinator:
             return selected[:1]
         return selected
 
+    def _teacache_phase_states(self, state: DenoisingRequestState) -> dict[str, Any]:
+        if state.teacache_state is None:
+            state.teacache_state = {}
+        return state.teacache_state
+
+    def _teacache_state_for_phase(
+        self, state: DenoisingRequestState, phase: str
+    ) -> Any | None:
+        """Snapshot for this phase; entering a new phase seeds from the last.
+
+        The forward counter carries across the expert boundary but cached
+        tensors never do, so one expert's residuals can never patch the other.
+        """
+        from sglang.multimodal_gen.runtime.cache.teacache import (
+            resolve_teacache_phase_state,
+        )
+
+        return resolve_teacache_phase_state(self._teacache_phase_states(state), phase)
+
     def _swap_in_teacache_state(
         self, state: DenoisingRequestState
-    ) -> tuple[Any, dict[str, Any]] | None:
+    ) -> tuple[Any, Any, str] | None:
         """Install this request's TeaCache state on the active model."""
         if not (self.allow_step_caches and state.req.enable_teacache):
             return None
@@ -662,19 +720,22 @@ class ContinuousDenoisingCoordinator:
         model = getattr(step, "current_model", None) if step is not None else None
         if model is None or not TeaCacheStateIsolator.model_has_teacache(model):
             return None
+        phase = self._model_phase(state)
         previous = TeaCacheStateIsolator.capture(model)
-        TeaCacheStateIsolator.install(model, state.teacache_state)
-        return model, previous
+        TeaCacheStateIsolator.install(
+            model, self._teacache_state_for_phase(state, phase)
+        )
+        return model, previous, phase
 
     def _swap_out_teacache_state(
         self,
         state: DenoisingRequestState,
-        swap: tuple[Any, dict[str, Any]] | None,
+        swap: tuple[Any, Any, str] | None,
     ) -> None:
         if swap is None:
             return
-        model, previous = swap
-        state.teacache_state = TeaCacheStateIsolator.capture(model)
+        model, previous, phase = swap
+        self._teacache_phase_states(state)[phase] = TeaCacheStateIsolator.capture(model)
         TeaCacheStateIsolator.install(model, previous)
 
     def run_selected_steps_and_advance_requests(
@@ -750,6 +811,35 @@ class ContinuousDenoisingCoordinator:
             "response_group_id": state.response_group_id,
             "response_index": state.response_index,
             "response_group_size": state.response_group_size,
+            "teacache_state": self._export_teacache_states(state),
+        }
+
+    @staticmethod
+    def _export_teacache_states(
+        state: DenoisingRequestState,
+    ) -> dict[str, dict[str, Any]] | None:
+        """CPU-serialize per-phase TeaCache snapshots for drain/resume."""
+        if not state.teacache_state:
+            return None
+        payloads: dict[str, dict[str, Any]] = {}
+        for phase, snapshot in state.teacache_state.items():
+            to_payload = getattr(snapshot, "to_payload", None)
+            if callable(to_payload):
+                payloads[phase] = to_payload()
+        return payloads or None
+
+    @staticmethod
+    def _import_teacache_states(
+        payloads: dict[str, dict[str, Any]] | None,
+        device: Any,
+    ) -> dict[str, Any] | None:
+        if not payloads:
+            return None
+        from sglang.multimodal_gen.runtime.cache.teacache import TeaCacheRequestState
+
+        return {
+            phase: TeaCacheRequestState.from_payload(payload, device=device)
+            for phase, payload in payloads.items()
         }
 
     def import_request_state(
@@ -775,6 +865,10 @@ class ContinuousDenoisingCoordinator:
         scheduler_step_index = payload.get("scheduler_step_index")
         if scheduler_step_index is not None:
             ctx.scheduler._step_index = int(scheduler_step_index)
+        state.teacache_state = self._import_teacache_states(
+            payload.get("teacache_state"),
+            ctx.latents.device,
+        )
         if not self.prepare_next_denoising_step(state):
             raise ContinuousBatchingError(
                 f"imported request {state.request_id} has no remaining steps"

--- a/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
+++ b/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import copy
+import os
 import time
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import TYPE_CHECKING, Any
@@ -58,6 +60,9 @@ class DenoisingBatchKey:
     cfg_parallel_degree: int
     enable_cfg_parallel: bool
     target_dtype: str
+    # True when the request may share a forward with other resolutions via
+    # sequence packing; the latent/raw shapes are then resolution-free.
+    varlen_packed: bool = False
 
 
 @dataclass(slots=True)
@@ -66,7 +71,7 @@ class DenoisingRequestState:
     identity: bytes | None
     denoising_context: DenoisingContext
     request_id: str = ""
-    step_batch_key: DenoisingBatchKey | None = None
+    step_batch_key: Any = None
     step_index: int = 0
     current_step: DenoisingStepState | None = None
     output_batch: OutputBatch | None = None
@@ -77,6 +82,16 @@ class DenoisingRequestState:
     created_time_s: float = field(default_factory=time.monotonic)
     completed_time_s: float | None = None
     queue_wait_ms: float = 0.0
+    # Step-invariant compatibility key computed at admission.
+    static_batch_key: DenoisingBatchKey | None = None
+    packable: bool = True
+    # Cached step-invariant attention metadata.
+    static_attn_metadata: Any = None
+    attn_metadata_is_static: bool = False
+    # Deep-copied raw request for mid-flight export/import.
+    raw_req_snapshot: Req | None = None
+    # Per-request TeaCache state snapshot.
+    teacache_state: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         if not self.request_id:
@@ -98,6 +113,10 @@ class DenoisingRequestState:
             extra["timesteps_cpu"] = timesteps_cpu
         return int(timesteps_cpu.shape[0])
 
+    @property
+    def remaining_steps(self) -> int:
+        return max(0, self.num_timesteps - self.step_index)
+
     def set_error_output(self, error: str) -> None:
         from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
             OutputBatch,
@@ -106,6 +125,42 @@ class DenoisingRequestState:
         self.error = error
         self.output_batch = OutputBatch(error=error)
         self.completed_time_s = time.monotonic()
+
+
+_TEACACHE_SCALAR_ATTRS = ("cnt", "enable_teacache", "is_cfg_negative")
+_TEACACHE_PREFIX_ATTRS = ("previous_", "accumulated_rel_l1")
+
+
+class TeaCacheStateIsolator:
+    """Capture/restore per-request TeaCache state on a shared DiT model."""
+
+    @staticmethod
+    def state_attrs(model: Any) -> tuple[str, ...]:
+        names = []
+        for name in vars(model):
+            if name in _TEACACHE_SCALAR_ATTRS or name.startswith(
+                _TEACACHE_PREFIX_ATTRS
+            ):
+                names.append(name)
+        return tuple(names)
+
+    @classmethod
+    def capture(cls, model: Any) -> dict[str, Any]:
+        return {name: getattr(model, name) for name in cls.state_attrs(model)}
+
+    @classmethod
+    def install(cls, model: Any, snapshot: dict[str, Any] | None) -> None:
+        if snapshot is not None:
+            for name, value in snapshot.items():
+                setattr(model, name, value)
+        else:
+            reset = getattr(model, "reset_teacache_state", None)
+            if callable(reset):
+                reset()
+
+    @staticmethod
+    def model_has_teacache(model: Any) -> bool:
+        return callable(getattr(model, "reset_teacache_state", None))
 
 
 @dataclass(slots=True)
@@ -210,9 +265,12 @@ def validate_continuous_batching_request(req: Req, server_args: Any) -> None:
             "continuous batching currently does not support rollout requests"
         )
 
-    if getattr(req, "enable_teacache", False):
+    if getattr(req, "enable_teacache", False) and not getattr(
+        server_args, "cb_allow_step_caches", True
+    ):
         raise ContinuousBatchingError(
-            "continuous batching currently does not support TeaCache requests"
+            "continuous batching TeaCache support is disabled "
+            "(--cb-allow-step-caches false)"
         )
 
     if getattr(req, "return_raw_frames", False):
@@ -290,12 +348,30 @@ def _to_hashable_signature(value: Any) -> Any:
     return convert(value)
 
 
+def _request_is_varlen_packable(state: DenoisingRequestState, server_args: Any) -> bool:
+    """Whether this request may pack with other resolutions (varlen)."""
+    if not getattr(server_args, "cb_varlen_packing", False):
+        return False
+    if not getattr(server_args.pipeline_config, "supports_varlen_step_packing", False):
+        return False
+    for attr in ("sp_degree", "ulysses_degree", "ring_degree"):
+        if int(getattr(server_args, attr, 1) or 1) != 1:
+            return False
+    step = state.current_step
+    model = getattr(step, "current_model", None) if step is not None else None
+    if not getattr(model, "supports_varlen_step_packing", False):
+        return False
+    if getattr(model, "zero_cond_t", False):
+        return False
+    return state.denoising_context.latents.ndim == 3
+
+
 def build_denoising_batch_key(
     state: DenoisingRequestState,
     denoising_stage: Any,
     server_args: Any,
 ) -> DenoisingBatchKey:
-    """Build the compatibility key used to group denoising steps."""
+    """Build the step-invariant compatibility key for one request."""
     req = state.req
     ctx = state.denoising_context
     step = state.current_step
@@ -309,17 +385,18 @@ def build_denoising_batch_key(
     raw_latent_shape = _shape_suffix_from_sequence(
         getattr(req, "raw_latent_shape", None)
     )
+    latent_shape = _shape_suffix_of(ctx.latents) or ()
+    varlen_packed = _request_is_varlen_packable(state, server_args)
+    if varlen_packed:
+        # Drop the sequence dim so different resolutions share one group.
+        latent_shape = latent_shape[-1:]
+        raw_latent_shape = None
 
     return DenoisingBatchKey(
         pipeline_config_type=type(server_args.pipeline_config).__name__,
-        model_phase=(
-            "transformer_2"
-            if getattr(step, "current_model", None)
-            is getattr(denoising_stage, "transformer_2", None)
-            else "transformer"
-        ),
+        model_phase="",
         current_model_type=type(getattr(step, "current_model", None)).__name__,
-        latent_shape=_shape_suffix_of(ctx.latents) or (),
+        latent_shape=latent_shape,
         latent_dtype=_dtype_of(ctx.latents),
         latent_device=_device_of(ctx.latents),
         timestep_shape=_shape_of(step.t_device) or (),
@@ -347,11 +424,23 @@ def build_denoising_batch_key(
         cfg_parallel_degree=int(getattr(server_args, "cfg_parallel_degree", 1) or 1),
         enable_cfg_parallel=bool(getattr(server_args, "enable_cfg_parallel", False)),
         target_dtype=str(getattr(ctx, "target_dtype", "")),
+        varlen_packed=varlen_packed,
     )
 
 
+# Backends whose metadata does not depend on step content.
+_STEP_INVARIANT_ATTN_BACKENDS = frozenset({"FA"})
+
+
+def _attn_metadata_is_step_invariant(denoising_stage: Any) -> bool:
+    backend_name = _attention_backend_name(denoising_stage)
+    if backend_name is None:
+        return True
+    return backend_name in _STEP_INVARIANT_ATTN_BACKENDS
+
+
 class ContinuousDenoisingCoordinator:
-    """Coordinates request-local denoising state for continuous batching."""
+    """Coordinates continuous denoising for a set of in-flight requests."""
 
     def __init__(
         self,
@@ -365,6 +454,19 @@ class ContinuousDenoisingCoordinator:
         self.batching_max_size = max(1, int(batching_max_size))
         self.pipeline = worker.pipeline
         self.denoising_stage = self.pipeline.get_denoising_stage()
+        self.schedule_policy = str(
+            getattr(server_args, "cb_schedule_policy", "largest") or "largest"
+        )
+        self.allow_step_caches = bool(
+            getattr(server_args, "cb_allow_step_caches", True)
+        )
+        # Reused while membership and model phase stay the same.
+        self._packed_group: Any = None
+        # Avoid shape ping-pong between mixed compatibility groups.
+        self._last_selected_key: Any = None
+        self._attn_metadata_static = _attn_metadata_is_step_invariant(
+            self.denoising_stage
+        )
 
     def prepare_request_state(
         self,
@@ -376,8 +478,29 @@ class ContinuousDenoisingCoordinator:
         response_group_size: int = 1,
     ) -> DenoisingRequestState:
         validate_continuous_batching_request(req, self.server_args)
+        raw_req_snapshot = self._snapshot_raw_request(req)
 
         prepared_req = self.pipeline.run_stages_before_denoising(req, self.server_args)
+        return self.prepare_request_state_from_prepared(
+            identity=identity,
+            prepared_req=prepared_req,
+            raw_req_snapshot=raw_req_snapshot,
+            response_group_id=response_group_id,
+            response_index=response_index,
+            response_group_size=response_group_size,
+        )
+
+    def prepare_request_state_from_prepared(
+        self,
+        *,
+        identity: bytes | None,
+        prepared_req: Req,
+        raw_req_snapshot: Req | None = None,
+        response_group_id: str | None = None,
+        response_index: int = 0,
+        response_group_size: int = 1,
+    ) -> DenoisingRequestState:
+        """Build state from a request whose pre-denoise stages already ran."""
         ctx = self.denoising_stage.prepare_denoising_context(
             prepared_req,
             self.server_args,
@@ -392,15 +515,58 @@ class ContinuousDenoisingCoordinator:
                 response_group_id=response_group_id,
                 response_index=response_index,
                 response_group_size=response_group_size,
+                raw_req_snapshot=raw_req_snapshot,
             )
             if not self.prepare_next_denoising_step(state):
                 raise ContinuousBatchingError(
                     "continuous batching requires at least one denoising timestep"
                 )
+            state.static_batch_key = build_denoising_batch_key(
+                state,
+                self.denoising_stage,
+                self.server_args,
+            )
+            state.step_batch_key = (
+                state.static_batch_key,
+                self._model_phase(state),
+            )
+            state.attn_metadata_is_static = self._attn_metadata_static or (
+                state.current_step is not None
+                and state.current_step.attn_metadata is None
+            )
+            if state.attn_metadata_is_static and state.current_step is not None:
+                state.static_attn_metadata = state.current_step.attn_metadata
+            state.packable = self._request_is_packable(state)
             return state
         except Exception:
             self._cleanup_denoising_context(ctx)
             raise
+
+    @staticmethod
+    def _snapshot_raw_request(req: Req) -> Req | None:
+        """Deep-copy the raw request for mid-flight export/import."""
+        try:
+            return copy.deepcopy(req)
+        except Exception:
+            return None
+
+    def _model_phase(self, state: DenoisingRequestState) -> str:
+        step = state.current_step
+        if step is None:
+            return ""
+        transformer_2 = getattr(self.denoising_stage, "transformer_2", None)
+        if transformer_2 is not None and step.current_model is transformer_2:
+            return "transformer_2"
+        return "transformer"
+
+    def _request_is_packable(self, state: DenoisingRequestState) -> bool:
+        if state.req.enable_teacache:
+            # TeaCache is per-request and must run unpacked.
+            return False
+        if not state.attn_metadata_is_static:
+            # Sparse/video backends have step-dependent metadata; keep separate.
+            return False
+        return True
 
     def prepare_next_denoising_step(self, state: DenoisingRequestState) -> bool:
         if state.step_index >= state.num_timesteps:
@@ -412,42 +578,104 @@ class ContinuousDenoisingCoordinator:
             state.req,
             self.server_args,
             state.step_index,
+            attn_metadata_override=(
+                state.static_attn_metadata
+                if state.attn_metadata_is_static and state.step_index > 0
+                else None
+            ),
+            use_attn_metadata_override=(
+                state.attn_metadata_is_static and state.step_index > 0
+            ),
         )
-        state.step_batch_key = build_denoising_batch_key(
-            state,
-            self.denoising_stage,
-            self.server_args,
-        )
+        if state.static_batch_key is not None:
+            state.step_batch_key = (
+                state.static_batch_key,
+                self._model_phase(state),
+            )
         return True
 
-    def select_next_step_batch(
+    def _group_incomplete_states(
         self,
         active_states: list[DenoisingRequestState],
-    ) -> list[DenoisingRequestState]:
-        first_key = None
+    ) -> dict[Any, list[DenoisingRequestState]]:
+        groups: dict[Any, list[DenoisingRequestState]] = {}
         for state in active_states:
             if state.is_complete:
                 continue
             if state.current_step is None:
                 self.prepare_next_denoising_step(state)
-            first_key = state.step_batch_key
-            break
-        if first_key is None:
+            if state.current_step is None:
+                continue
+            groups.setdefault(state.step_batch_key, []).append(state)
+        return groups
+
+    def select_next_step_batch(
+        self,
+        active_states: list[DenoisingRequestState],
+    ) -> list[DenoisingRequestState]:
+        """Select the next compatible group to step.
+
+        Policies: rotate (round-robin), largest (sticky largest group),
+        srpt (shortest remaining steps first).
+        """
+        groups = self._group_incomplete_states(active_states)
+        if not groups:
             return []
 
-        selected = [
-            state
-            for state in active_states
-            if not state.is_complete and state.step_batch_key == first_key
-        ]
-        selected = selected[: self.batching_max_size]
-        can_pack_selected = self.denoising_stage.can_run_steps_in_one_forward_pass(
-            selected,
-            self.server_args,
-        )
-        if len(selected) > 1 and not can_pack_selected:
+        policy = self.schedule_policy
+        if policy == "rotate":
+            for state in active_states:
+                if not state.is_complete and state.current_step is not None:
+                    selected_key = state.step_batch_key
+                    break
+            else:
+                return []
+        elif policy == "srpt":
+            selected_key = min(
+                groups,
+                key=lambda key: (
+                    min(state.remaining_steps for state in groups[key]),
+                    -len(groups[key]),
+                ),
+            )
+        else:  # largest (default), with stickiness
+            selected_key = max(groups, key=lambda key: len(groups[key]))
+            sticky_key = self._last_selected_key
+            if sticky_key in groups and len(groups[sticky_key]) >= len(
+                groups[selected_key]
+            ):
+                selected_key = sticky_key
+        self._last_selected_key = selected_key
+
+        selected = groups[selected_key][: self.batching_max_size]
+        if len(selected) > 1 and not all(state.packable for state in selected):
             return selected[:1]
         return selected
+
+    def _swap_in_teacache_state(
+        self, state: DenoisingRequestState
+    ) -> tuple[Any, dict[str, Any]] | None:
+        """Install this request's TeaCache state on the active model."""
+        if not (self.allow_step_caches and state.req.enable_teacache):
+            return None
+        step = state.current_step
+        model = getattr(step, "current_model", None) if step is not None else None
+        if model is None or not TeaCacheStateIsolator.model_has_teacache(model):
+            return None
+        previous = TeaCacheStateIsolator.capture(model)
+        TeaCacheStateIsolator.install(model, state.teacache_state)
+        return model, previous
+
+    def _swap_out_teacache_state(
+        self,
+        state: DenoisingRequestState,
+        swap: tuple[Any, dict[str, Any]] | None,
+    ) -> None:
+        if swap is None:
+            return
+        model, previous = swap
+        state.teacache_state = TeaCacheStateIsolator.capture(model)
+        TeaCacheStateIsolator.install(model, previous)
 
     def run_selected_steps_and_advance_requests(
         self,
@@ -457,32 +685,157 @@ class ContinuousDenoisingCoordinator:
         if not states:
             return []
 
-        self.denoising_stage.run_denoising_steps_for_requests(
-            states,
-            self.server_args,
-        )
+        teacache_swap = None
+        if len(states) == 1:
+            teacache_swap = self._swap_in_teacache_state(states[0])
+        try:
+            self._packed_group = self.denoising_stage.run_denoising_steps_for_requests(
+                states,
+                self.server_args,
+                packed_group=self._packed_group,
+            )
+        finally:
+            if teacache_swap is not None:
+                self._swap_out_teacache_state(states[0], teacache_swap)
 
         completed: list[DenoisingRequestState] = []
         for state in states:
             state.step_index += 1
             if state.step_index >= state.num_timesteps:
-                try:
-                    self._finish_request_and_build_output(state)
-                except Exception as e:
-                    logger.error(
-                        "Error completing continuous batching request %s: %s",
-                        state.request_id,
-                        e,
-                        exc_info=True,
-                    )
-                    self._cleanup_denoising_context(state.denoising_context)
-                    state.set_error_output(
-                        f"continuous batching completion failed: {e}"
-                    )
+                # Detach finished latents from the shared packed buffer.
+                latents = state.denoising_context.latents
+                if latents is not None and latents._base is not None:
+                    state.denoising_context.latents = latents.clone()
+                self._packed_group = None
                 completed.append(state)
             else:
                 self.prepare_next_denoising_step(state)
         return completed
+
+    def finalize_completed_request(
+        self, state: DenoisingRequestState
+    ) -> DenoisingRequestState:
+        """Run post-denoise stages and build output for a finished request."""
+        try:
+            self._finish_request_and_build_output(state)
+        except Exception as e:
+            logger.error(
+                "Error completing continuous batching request %s: %s",
+                state.request_id,
+                e,
+                exc_info=True,
+            )
+            self._cleanup_denoising_context(state.denoising_context)
+            state.set_error_output(f"continuous batching completion failed: {e}")
+        return state
+
+    def export_request_state(self, state: DenoisingRequestState) -> dict[str, Any]:
+        """Serialize a mid-flight request for migration or drain-resume."""
+        if state.raw_req_snapshot is None:
+            raise ContinuousBatchingError(
+                f"request {state.request_id} has no exportable snapshot"
+            )
+        ctx = state.denoising_context
+        if "generator" in (ctx.extra_step_kwargs or {}):
+            raise ContinuousBatchingError(
+                "stochastic schedulers are not exportable mid-flight"
+            )
+        return {
+            "version": 1,
+            "request_id": state.request_id,
+            "raw_req": state.raw_req_snapshot,
+            "latents": ctx.latents.detach().to("cpu"),
+            "step_index": int(state.step_index),
+            "scheduler_step_index": getattr(ctx.scheduler, "_step_index", None),
+            "response_group_id": state.response_group_id,
+            "response_index": state.response_index,
+            "response_group_size": state.response_group_size,
+        }
+
+    def import_request_state(
+        self,
+        payload: dict[str, Any],
+        *,
+        identity: bytes | None,
+    ) -> DenoisingRequestState:
+        """Resume an exported mid-flight request on this worker."""
+        state = self.prepare_request_state(
+            identity=identity,
+            req=payload["raw_req"],
+            response_group_id=payload.get("response_group_id"),
+            response_index=int(payload.get("response_index", 0)),
+            response_group_size=int(payload.get("response_group_size", 1)),
+        )
+        ctx = state.denoising_context
+        latents = payload["latents"].to(
+            device=ctx.latents.device, dtype=ctx.latents.dtype
+        )
+        ctx.latents = latents
+        state.step_index = int(payload["step_index"])
+        scheduler_step_index = payload.get("scheduler_step_index")
+        if scheduler_step_index is not None:
+            ctx.scheduler._step_index = int(scheduler_step_index)
+        if not self.prepare_next_denoising_step(state):
+            raise ContinuousBatchingError(
+                f"imported request {state.request_id} has no remaining steps"
+            )
+        return state
+
+    def export_states_to_dir(
+        self,
+        states: list[DenoisingRequestState],
+        export_dir: str,
+    ) -> list[str]:
+        """Drain in-flight requests to disk for later resume."""
+        import torch
+
+        os.makedirs(export_dir, exist_ok=True)
+        exported = []
+        for state in states:
+            if state.is_complete:
+                continue
+            try:
+                payload = self.export_request_state(state)
+            except ContinuousBatchingError as e:
+                logger.warning(
+                    "Skipping drain export for request %s: %s",
+                    state.request_id,
+                    e,
+                )
+                continue
+            path = os.path.join(export_dir, f"{state.request_id}.cbstate.pt")
+            torch.save(payload, path)
+            exported.append(path)
+        return exported
+
+    def import_states_from_dir(
+        self,
+        export_dir: str,
+    ) -> list[DenoisingRequestState]:
+        """Resume drained requests from disk."""
+        import torch
+
+        if not export_dir or not os.path.isdir(export_dir):
+            return []
+        resumed = []
+        for name in sorted(os.listdir(export_dir)):
+            if not name.endswith(".cbstate.pt"):
+                continue
+            path = os.path.join(export_dir, name)
+            try:
+                payload = torch.load(path, map_location="cpu", weights_only=False)
+                state = self.import_request_state(payload, identity=None)
+            except Exception as e:
+                logger.error(
+                    "Failed to resume drained request from %s: %s",
+                    path,
+                    e,
+                    exc_info=True,
+                )
+                continue
+            os.remove(path)
+            resumed.append(state)
+        return resumed
 
     def _finish_denoising_context(self, state: DenoisingRequestState) -> None:
         from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
@@ -517,7 +870,7 @@ class ContinuousDenoisingCoordinator:
         state.set_error_output(error)
 
     def _cleanup_denoising_context(self, ctx: DenoisingContext) -> None:
-        """Clean denoising resources without masking the original failure."""
+        """Clean denoising resources; ignore cleanup errors."""
         try:
             self.denoising_stage.cleanup_denoising_context(ctx)
         except Exception:

--- a/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
+++ b/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
@@ -8,15 +8,21 @@ from typing import TYPE_CHECKING, Any
 from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType
 from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
-from sglang.multimodal_gen.runtime.pipelines_core.diffusion_scheduler_utils import (
-    clone_scheduler_runtime,
-)
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+_SUPPORTED_CONTINUOUS_ATTENTION_BACKENDS = {"fa", "fa2", "torch_sdpa"}
 
 if TYPE_CHECKING:
     from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
         OutputBatch,
         Req,
+    )
+    from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import (
+        DenoisingContext,
+        DenoisingStepState,
     )
 
 
@@ -24,7 +30,7 @@ class ContinuousBatchingError(ValueError):
     pass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DenoisingBatchKey:
     pipeline_config_type: str
     model_phase: str
@@ -54,16 +60,16 @@ class DenoisingBatchKey:
     target_dtype: str
 
 
-@dataclass
+@dataclass(slots=True)
 class DenoisingRequestState:
-    req: "Req"
+    req: Req
     identity: bytes | None
-    denoising_context: Any
+    denoising_context: DenoisingContext
     request_id: str = ""
-    denoising_batch_key: DenoisingBatchKey | None = None
+    step_batch_key: DenoisingBatchKey | None = None
     step_index: int = 0
-    current_step: Any | None = None
-    output_batch: "OutputBatch | None" = None
+    current_step: DenoisingStepState | None = None
+    output_batch: OutputBatch | None = None
     error: str | None = None
     response_group_id: str | None = None
     response_index: int = 0
@@ -102,10 +108,10 @@ class DenoisingRequestState:
         self.completed_time_s = time.monotonic()
 
 
-@dataclass
+@dataclass(slots=True)
 class ContinuousResponseGroup:
     identity: bytes | None
-    reqs: list["Req"]
+    reqs: list[Req]
     outputs: list[Any | None] = field(init=False)
     is_warmup: bool = field(init=False)
 
@@ -135,6 +141,14 @@ def validate_continuous_batching_config(server_args: Any) -> None:
         raise ContinuousBatchingError(
             "continuous batching is only supported by pipelines that explicitly "
             "opt in via supports_continuous_batching()"
+        )
+
+    backend = getattr(server_args, "backend", None)
+    backend_value = str(getattr(backend, "value", backend)).lower()
+    if backend_value == "diffusers":
+        raise ContinuousBatchingError(
+            "continuous batching requires the native composed pipeline backend; "
+            "use --backend sglang"
         )
 
     if pipeline_config.task_type != ModelTaskType.T2I:
@@ -169,14 +183,16 @@ def validate_continuous_batching_config(server_args: Any) -> None:
             "continuous batching requires a GPU-resident DiT; disable --dit-cpu-offload"
         )
 
-    if getattr(server_args, "dit_layerwise_offload", False):
+    if getattr(server_args, "dit_layerwise_offload", False) or getattr(
+        server_args, "is_dit_layerwise_offload_selected", False
+    ):
         raise ContinuousBatchingError(
-            "continuous batching requires a GPU-resident DiT; disable --dit-layerwise-offload"
+            "continuous batching requires a GPU-resident DiT; disable "
+            "--dit-layerwise-offload/DiT layerwise offload components"
         )
 
-    allowed_attention_backends = {"fa", "fa2", "torch_sdpa"}
     attention_backend = getattr(server_args, "attention_backend", None)
-    if attention_backend not in {None, "", *allowed_attention_backends}:
+    if attention_backend not in {None, "", *_SUPPORTED_CONTINUOUS_ATTENTION_BACKENDS}:
         raise ContinuousBatchingError(
             f"continuous batching does not support attention backend {attention_backend!r}"
         )
@@ -188,14 +204,14 @@ def validate_continuous_batching_config(server_args: Any) -> None:
         for component_name, backend in component_backends.items():
             if "transformer" not in str(component_name):
                 continue
-            if backend not in allowed_attention_backends:
+            if backend not in _SUPPORTED_CONTINUOUS_ATTENTION_BACKENDS:
                 raise ContinuousBatchingError(
                     "continuous batching does not support attention backend "
                     f"{backend!r} for component {component_name!r}"
                 )
 
 
-def validate_continuous_batching_request(req: "Req", server_args: Any) -> None:
+def validate_continuous_batching_request(req: Req, server_args: Any) -> None:
     from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 
     if not isinstance(req, Req):
@@ -229,6 +245,11 @@ def validate_continuous_batching_request(req: "Req", server_args: Any) -> None:
             "continuous batching v1 does not support TeaCache requests"
         )
 
+    if getattr(req, "return_raw_frames", False):
+        raise ContinuousBatchingError(
+            "continuous batching v1 does not support raw-frame streaming responses"
+        )
+
 
 def _shape_of(value: Any) -> tuple[int, ...] | None:
     shape = getattr(value, "shape", None)
@@ -241,6 +262,13 @@ def _shape_suffix_of(value: Any) -> tuple[int, ...] | None:
     shape = _shape_of(value)
     if shape is None:
         return None
+    return shape[1:]
+
+
+def _shape_suffix_from_sequence(value: Any) -> tuple[int, ...] | None:
+    if value is None:
+        return None
+    shape = tuple(int(dim) for dim in value)
     return shape[1:]
 
 
@@ -258,10 +286,8 @@ def _attention_backend_name(stage: Any) -> str | None:
     backend = getattr(stage, "attn_backend", None)
     if backend is None:
         return None
-    try:
-        enum_value = backend.get_enum()
-    except Exception:
-        enum_value = None
+    get_enum = getattr(backend, "get_enum", None)
+    enum_value = get_enum() if callable(get_enum) else None
     if isinstance(enum_value, AttentionBackendEnum):
         return enum_value.name
     return type(backend).__name__
@@ -270,27 +296,28 @@ def _attention_backend_name(stage: Any) -> str | None:
 def _to_hashable_signature(value: Any) -> Any:
     import torch
 
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, torch.Tensor):
-        return ("tensor", tuple(value.shape), str(value.dtype), str(value.device))
-    if is_dataclass(value):
-        return (
-            type(value).__name__,
-            tuple(
-                (item.name, _to_hashable_signature(getattr(value, item.name)))
-                for item in fields(value)
-            ),
-        )
-    if isinstance(value, dict):
-        return tuple(
-            sorted(
-                (str(key), _to_hashable_signature(item)) for key, item in value.items()
+    def convert(item: Any) -> Any:
+        if item is None or isinstance(item, (str, int, float, bool)):
+            return item
+        if isinstance(item, torch.Tensor):
+            return ("tensor", tuple(item.shape), str(item.dtype), str(item.device))
+        if is_dataclass(item):
+            return (
+                type(item).__name__,
+                tuple(
+                    (field.name, convert(getattr(item, field.name)))
+                    for field in fields(item)
+                ),
             )
-        )
-    if isinstance(value, (list, tuple)):
-        return tuple(_to_hashable_signature(item) for item in value)
-    return type(value).__name__
+        if isinstance(item, dict):
+            return tuple(
+                sorted((str(key), convert(value)) for key, value in item.items())
+            )
+        if isinstance(item, (list, tuple)):
+            return tuple(convert(value) for value in item)
+        return type(item).__name__
+
+    return convert(value)
 
 
 def build_denoising_batch_key(
@@ -304,19 +331,13 @@ def build_denoising_batch_key(
     if step is None:
         raise ValueError("state.current_step must be prepared before key building")
 
-    import torch
-
     scheduler = ctx.scheduler
     cfg_policy = ctx.cfg_policy
     branches = tuple(branch.name for branch in getattr(cfg_policy, "branches", ()))
     attn_metadata = getattr(step, "attn_metadata", None)
-    raw_latent_shape = getattr(req, "raw_latent_shape", None)
-    if isinstance(raw_latent_shape, torch.Size):
-        raw_latent_shape = tuple(int(dim) for dim in raw_latent_shape)
-    elif raw_latent_shape is not None:
-        raw_latent_shape = tuple(int(dim) for dim in raw_latent_shape)
-    if raw_latent_shape is not None:
-        raw_latent_shape = raw_latent_shape[1:]
+    raw_latent_shape = _shape_suffix_from_sequence(
+        getattr(req, "raw_latent_shape", None)
+    )
 
     return DenoisingBatchKey(
         pipeline_config_type=type(server_args.pipeline_config).__name__,
@@ -355,7 +376,7 @@ def build_denoising_batch_key(
     )
 
 
-class ContinuousDenoisingScheduler:
+class ContinuousDenoisingCoordinator:
     def __init__(
         self,
         *,
@@ -373,7 +394,7 @@ class ContinuousDenoisingScheduler:
         self,
         *,
         identity: bytes | None,
-        req: "Req",
+        req: Req,
         response_group_id: str | None = None,
         response_index: int = 0,
         response_group_size: int = 1,
@@ -381,8 +402,6 @@ class ContinuousDenoisingScheduler:
         validate_continuous_batching_request(req, self.server_args)
 
         prepared_req = self.pipeline.run_stages_before_denoising(req, self.server_args)
-        if prepared_req.scheduler is not None:
-            prepared_req.scheduler = clone_scheduler_runtime(prepared_req.scheduler)
         ctx = self.denoising_stage.prepare_denoising_context(
             prepared_req,
             self.server_args,
@@ -398,16 +417,19 @@ class ContinuousDenoisingScheduler:
                 response_index=response_index,
                 response_group_size=response_group_size,
             )
-            self.prepare_next_denoising_step(state)
+            if not self.prepare_next_denoising_step(state):
+                raise ContinuousBatchingError(
+                    "continuous batching requires at least one denoising timestep"
+                )
             return state
         except Exception:
-            self.denoising_stage.close_denoising_progress(ctx)
+            self._cleanup_denoising_context(ctx)
             raise
 
     def prepare_next_denoising_step(self, state: DenoisingRequestState) -> bool:
         if state.step_index >= state.num_timesteps:
             state.current_step = None
-            state.denoising_batch_key = None
+            state.step_batch_key = None
             return False
         state.current_step = self.denoising_stage.prepare_denoising_step_state(
             state.denoising_context,
@@ -415,7 +437,7 @@ class ContinuousDenoisingScheduler:
             self.server_args,
             state.step_index,
         )
-        state.denoising_batch_key = build_denoising_batch_key(
+        state.step_batch_key = build_denoising_batch_key(
             state,
             self.denoising_stage,
             self.server_args,
@@ -432,7 +454,7 @@ class ContinuousDenoisingScheduler:
                 continue
             if state.current_step is None:
                 self.prepare_next_denoising_step(state)
-            first_key = state.denoising_batch_key
+            first_key = state.step_batch_key
             break
         if first_key is None:
             return []
@@ -440,7 +462,7 @@ class ContinuousDenoisingScheduler:
         selected = [
             state
             for state in active_states
-            if not state.is_complete and state.denoising_batch_key == first_key
+            if not state.is_complete and state.step_batch_key == first_key
         ]
         selected = selected[: self.batching_max_size]
         can_pack_selected = self.denoising_stage.can_run_steps_in_one_forward_pass(
@@ -454,8 +476,6 @@ class ContinuousDenoisingScheduler:
     def run_selected_steps_and_advance_requests(
         self,
         states: list[DenoisingRequestState],
-        *,
-        build_output: bool = True,
     ) -> list[DenoisingRequestState]:
         if not states:
             return []
@@ -469,16 +489,25 @@ class ContinuousDenoisingScheduler:
         for state in states:
             state.step_index += 1
             if state.step_index >= state.num_timesteps:
-                if build_output:
-                    self.finish_request_and_build_output(state)
-                else:
-                    self.finish_request(state)
+                try:
+                    self._finish_request_and_build_output(state)
+                except Exception as e:
+                    logger.error(
+                        "Error completing continuous batching request %s: %s",
+                        state.request_id,
+                        e,
+                        exc_info=True,
+                    )
+                    self._cleanup_denoising_context(state.denoising_context)
+                    state.set_error_output(
+                        f"continuous batching completion failed: {e}"
+                    )
                 completed.append(state)
             else:
                 self.prepare_next_denoising_step(state)
         return completed
 
-    def finish_request(self, state: DenoisingRequestState) -> None:
+    def _finish_denoising_context(self, state: DenoisingRequestState) -> None:
         from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
             OutputBatch,
         )
@@ -491,27 +520,38 @@ class ContinuousDenoisingScheduler:
         state.output_batch = OutputBatch()
         state.completed_time_s = time.monotonic()
 
-    def finish_request_and_build_output(self, state: DenoisingRequestState) -> None:
+    def _finish_request_and_build_output(self, state: DenoisingRequestState) -> None:
         from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
             OutputBatch,
         )
 
-        self.finish_request(state)
+        self._finish_denoising_context(state)
         result = self.pipeline.run_stages_after_denoising(state.req, self.server_args)
         output_batch = self.worker._to_output_batch(result)
         if not isinstance(output_batch, OutputBatch):
-            output_batch = OutputBatch(error=f"Unexpected output: {type(result)}")
+            output_batch = OutputBatch(
+                error=f"Unexpected output batch: {type(output_batch).__name__}"
+            )
         self._prepare_output_for_return(state, output_batch)
         state.output_batch = output_batch
 
     def fail_request(self, state: DenoisingRequestState, error: str) -> None:
-        self.denoising_stage.close_denoising_progress(state.denoising_context)
+        self._cleanup_denoising_context(state.denoising_context)
         state.set_error_output(error)
+
+    def _cleanup_denoising_context(self, ctx: DenoisingContext) -> None:
+        try:
+            self.denoising_stage.cleanup_denoising_context(ctx)
+        except Exception:
+            logger.debug(
+                "Ignoring continuous batching cleanup failure",
+                exc_info=True,
+            )
 
     def _prepare_output_for_return(
         self,
         state: DenoisingRequestState,
-        output_batch: "OutputBatch",
+        output_batch: OutputBatch,
     ) -> None:
         import torch
 

--- a/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
+++ b/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
@@ -1,0 +1,533 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field, fields, is_dataclass
+from typing import TYPE_CHECKING, Any
+
+from sglang.multimodal_gen import envs
+from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType
+from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
+from sglang.multimodal_gen.runtime.pipelines_core.diffusion_scheduler_utils import (
+    clone_scheduler_runtime,
+)
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+
+if TYPE_CHECKING:
+    from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
+        OutputBatch,
+        Req,
+    )
+
+
+class ContinuousBatchingError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class DenoisingBatchKey:
+    pipeline_config_type: str
+    model_phase: str
+    current_model_type: str
+    latent_shape: tuple[int, ...]
+    latent_dtype: str
+    latent_device: str
+    timestep_shape: tuple[int, ...]
+    timestep_dtype: str
+    timestep_device: str
+    raw_latent_shape: tuple[int, ...] | None
+    image_latent_shape: tuple[int, ...] | None
+    cfg_branch_count: int
+    cfg_branch_names: tuple[str, ...]
+    do_classifier_free_guidance: bool
+    scheduler_type: str
+    scheduler_order: int | None
+    attention_backend: str | None
+    attention_metadata_type: str | None
+    attention_metadata_signature: Any
+    tp_size: int
+    sp_degree: int
+    ulysses_degree: int
+    ring_degree: int
+    cfg_parallel_degree: int
+    enable_cfg_parallel: bool
+    target_dtype: str
+
+
+@dataclass
+class DenoisingRequestState:
+    req: "Req"
+    identity: bytes | None
+    denoising_context: Any
+    request_id: str = ""
+    denoising_batch_key: DenoisingBatchKey | None = None
+    step_index: int = 0
+    current_step: Any | None = None
+    output_batch: "OutputBatch | None" = None
+    error: str | None = None
+    response_group_id: str | None = None
+    response_index: int = 0
+    response_group_size: int = 1
+    created_time_s: float = field(default_factory=time.monotonic)
+    completed_time_s: float | None = None
+    queue_wait_ms: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not self.request_id:
+            self.request_id = str(getattr(self.req, "request_id", ""))
+
+    @property
+    def is_complete(self) -> bool:
+        return self.output_batch is not None or self.error is not None
+
+    @property
+    def num_timesteps(self) -> int:
+        extra = getattr(self.denoising_context, "extra", None)
+        if extra is None:
+            extra = {}
+            self.denoising_context.extra = extra
+        timesteps_cpu = extra.get("timesteps_cpu")
+        if timesteps_cpu is None:
+            timesteps_cpu = self.denoising_context.timesteps.cpu()
+            extra["timesteps_cpu"] = timesteps_cpu
+        return int(timesteps_cpu.shape[0])
+
+    def set_error_output(self, error: str) -> None:
+        from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
+            OutputBatch,
+        )
+
+        self.error = error
+        self.output_batch = OutputBatch(error=error)
+        self.completed_time_s = time.monotonic()
+
+
+@dataclass
+class ContinuousResponseGroup:
+    identity: bytes | None
+    reqs: list["Req"]
+    outputs: list[Any | None] = field(init=False)
+    is_warmup: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.outputs = [None] * len(self.reqs)
+        self.is_warmup = any(req.is_warmup for req in self.reqs)
+
+    def set_member_output(self, index: int, output_batch: Any) -> None:
+        if index < 0 or index >= len(self.outputs):
+            raise IndexError(f"response group index {index} out of range")
+        self.outputs[index] = output_batch
+
+    @property
+    def has_all_outputs(self) -> bool:
+        return all(output is not None for output in self.outputs)
+
+    def merge_outputs(self, worker: Any) -> Any:
+        if not self.has_all_outputs:
+            raise RuntimeError("cannot merge an incomplete continuous response group")
+        return worker._merge_expanded_output_batches(self.outputs)
+
+
+def validate_continuous_batching_config(server_args: Any) -> None:
+    pipeline_config = server_args.pipeline_config
+    supports = getattr(pipeline_config, "supports_continuous_batching", None)
+    if not callable(supports) or not supports():
+        raise ContinuousBatchingError(
+            "continuous batching is only supported by pipelines that explicitly "
+            "opt in via supports_continuous_batching()"
+        )
+
+    if pipeline_config.task_type != ModelTaskType.T2I:
+        raise ContinuousBatchingError(
+            "continuous batching v1 only supports text-to-image pipelines"
+        )
+
+    disagg_role = getattr(server_args, "disagg_role", RoleType.MONOLITHIC)
+    disagg_role_value = getattr(disagg_role, "value", disagg_role)
+    if disagg_role_value != RoleType.MONOLITHIC.value:
+        raise ContinuousBatchingError(
+            "continuous batching does not support disaggregated serving yet"
+        )
+
+    if getattr(server_args, "comfyui_mode", False):
+        raise ContinuousBatchingError(
+            "continuous batching does not support ComfyUI noise-pred requests"
+        )
+
+    if envs.SGLANG_CACHE_DIT_ENABLED or getattr(server_args, "cache_dit_config", None):
+        raise ContinuousBatchingError(
+            "continuous batching does not support Cache-DiT in v1"
+        )
+
+    if getattr(server_args, "lora_path", None):
+        raise ContinuousBatchingError(
+            "continuous batching does not support startup LoRA adapters in v1"
+        )
+
+    if getattr(server_args, "dit_cpu_offload", False):
+        raise ContinuousBatchingError(
+            "continuous batching does not support DiT CPU offload yet"
+        )
+
+    if getattr(server_args, "dit_layerwise_offload", False):
+        raise ContinuousBatchingError(
+            "continuous batching does not support DiT layerwise offload yet"
+        )
+
+    allowed_attention_backends = {"fa", "fa2", "torch_sdpa"}
+    attention_backend = getattr(server_args, "attention_backend", None)
+    if attention_backend not in {None, "", *allowed_attention_backends}:
+        raise ContinuousBatchingError(
+            f"continuous batching does not support attention backend {attention_backend!r}"
+        )
+
+    component_backends = (
+        getattr(server_args, "component_attention_backends", None) or {}
+    )
+    if isinstance(component_backends, dict):
+        for component_name, backend in component_backends.items():
+            if "transformer" not in str(component_name):
+                continue
+            if backend not in allowed_attention_backends:
+                raise ContinuousBatchingError(
+                    "continuous batching does not support attention backend "
+                    f"{backend!r} for component {component_name!r}"
+                )
+
+
+def validate_continuous_batching_request(req: "Req", server_args: Any) -> None:
+    from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+
+    if not isinstance(req, Req):
+        raise ContinuousBatchingError(
+            f"continuous batching only handles generation Req objects, got {type(req)}"
+        )
+
+    pipeline_config = server_args.pipeline_config
+    if pipeline_config.task_type != ModelTaskType.T2I:
+        raise ContinuousBatchingError(
+            "continuous batching v1 only supports text-to-image pipelines"
+        )
+
+    if not isinstance(getattr(req, "prompt", None), str):
+        raise ContinuousBatchingError(
+            "continuous batching v1 only supports a single text prompt per request"
+        )
+
+    if req.image_path is not None:
+        raise ContinuousBatchingError(
+            "continuous batching v1 does not support image-conditioned requests"
+        )
+
+    if getattr(req, "rollout", False):
+        raise ContinuousBatchingError(
+            "continuous batching v1 does not support rollout requests"
+        )
+
+    if getattr(req, "enable_teacache", False):
+        raise ContinuousBatchingError(
+            "continuous batching v1 does not support TeaCache requests"
+        )
+
+
+def _shape_of(value: Any) -> tuple[int, ...] | None:
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        return None
+    return tuple(int(dim) for dim in shape)
+
+
+def _shape_suffix_of(value: Any) -> tuple[int, ...] | None:
+    shape = _shape_of(value)
+    if shape is None:
+        return None
+    return shape[1:]
+
+
+def _device_of(value: Any) -> str:
+    device = getattr(value, "device", None)
+    return str(device) if device is not None else "unknown"
+
+
+def _dtype_of(value: Any) -> str:
+    dtype = getattr(value, "dtype", None)
+    return str(dtype) if dtype is not None else "unknown"
+
+
+def _attention_backend_name(stage: Any) -> str | None:
+    backend = getattr(stage, "attn_backend", None)
+    if backend is None:
+        return None
+    try:
+        enum_value = backend.get_enum()
+    except Exception:
+        enum_value = None
+    if isinstance(enum_value, AttentionBackendEnum):
+        return enum_value.name
+    return type(backend).__name__
+
+
+def _to_hashable_signature(value: Any) -> Any:
+    import torch
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, torch.Tensor):
+        return ("tensor", tuple(value.shape), str(value.dtype), str(value.device))
+    if is_dataclass(value):
+        return (
+            type(value).__name__,
+            tuple(
+                (item.name, _to_hashable_signature(getattr(value, item.name)))
+                for item in fields(value)
+            ),
+        )
+    if isinstance(value, dict):
+        return tuple(
+            sorted(
+                (str(key), _to_hashable_signature(item)) for key, item in value.items()
+            )
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_to_hashable_signature(item) for item in value)
+    return type(value).__name__
+
+
+def build_denoising_batch_key(
+    state: DenoisingRequestState,
+    denoising_stage: Any,
+    server_args: Any,
+) -> DenoisingBatchKey:
+    req = state.req
+    ctx = state.denoising_context
+    step = state.current_step
+    if step is None:
+        raise ValueError("state.current_step must be prepared before key building")
+
+    import torch
+
+    scheduler = ctx.scheduler
+    cfg_policy = ctx.cfg_policy
+    branches = tuple(branch.name for branch in getattr(cfg_policy, "branches", ()))
+    attn_metadata = getattr(step, "attn_metadata", None)
+    raw_latent_shape = getattr(req, "raw_latent_shape", None)
+    if isinstance(raw_latent_shape, torch.Size):
+        raw_latent_shape = tuple(int(dim) for dim in raw_latent_shape)
+    elif raw_latent_shape is not None:
+        raw_latent_shape = tuple(int(dim) for dim in raw_latent_shape)
+    if raw_latent_shape is not None:
+        raw_latent_shape = raw_latent_shape[1:]
+
+    return DenoisingBatchKey(
+        pipeline_config_type=type(server_args.pipeline_config).__name__,
+        model_phase=(
+            "transformer_2"
+            if getattr(step, "current_model", None)
+            is getattr(denoising_stage, "transformer_2", None)
+            else "transformer"
+        ),
+        current_model_type=type(getattr(step, "current_model", None)).__name__,
+        latent_shape=_shape_suffix_of(ctx.latents) or (),
+        latent_dtype=_dtype_of(ctx.latents),
+        latent_device=_device_of(ctx.latents),
+        timestep_shape=_shape_of(step.t_device) or (),
+        timestep_dtype=_dtype_of(step.t_device),
+        timestep_device=_device_of(step.t_device),
+        raw_latent_shape=raw_latent_shape,
+        image_latent_shape=_shape_suffix_of(getattr(req, "image_latent", None)),
+        cfg_branch_count=len(branches),
+        cfg_branch_names=branches,
+        do_classifier_free_guidance=bool(req.do_classifier_free_guidance),
+        scheduler_type=type(scheduler).__name__,
+        scheduler_order=getattr(scheduler, "order", None),
+        attention_backend=_attention_backend_name(denoising_stage),
+        attention_metadata_type=(
+            type(attn_metadata).__name__ if attn_metadata is not None else None
+        ),
+        attention_metadata_signature=_to_hashable_signature(attn_metadata),
+        tp_size=int(getattr(server_args, "tp_size", 1) or 1),
+        sp_degree=int(getattr(server_args, "sp_degree", 1) or 1),
+        ulysses_degree=int(getattr(server_args, "ulysses_degree", 1) or 1),
+        ring_degree=int(getattr(server_args, "ring_degree", 1) or 1),
+        cfg_parallel_degree=int(getattr(server_args, "cfg_parallel_degree", 1) or 1),
+        enable_cfg_parallel=bool(getattr(server_args, "enable_cfg_parallel", False)),
+        target_dtype=str(getattr(ctx, "target_dtype", "")),
+    )
+
+
+class ContinuousDenoisingScheduler:
+    def __init__(
+        self,
+        *,
+        worker: Any,
+        server_args: Any,
+        batching_max_size: int,
+    ) -> None:
+        self.worker = worker
+        self.server_args = server_args
+        self.batching_max_size = max(1, int(batching_max_size))
+        self.pipeline = worker.pipeline
+        self.denoising_stage = self.pipeline.get_denoising_stage()
+
+    def prepare_request_for_denoising_steps(
+        self,
+        *,
+        identity: bytes | None,
+        req: "Req",
+        response_group_id: str | None = None,
+        response_index: int = 0,
+        response_group_size: int = 1,
+    ) -> DenoisingRequestState:
+        validate_continuous_batching_request(req, self.server_args)
+
+        prepared_req = self.pipeline.run_stages_before_denoising(req, self.server_args)
+        if prepared_req.scheduler is not None:
+            prepared_req.scheduler = clone_scheduler_runtime(prepared_req.scheduler)
+        ctx = self.denoising_stage.prepare_denoising_context(
+            prepared_req,
+            self.server_args,
+            open_progress_bar=True,
+        )
+        try:
+            state = DenoisingRequestState(
+                req=prepared_req,
+                identity=identity,
+                denoising_context=ctx,
+                request_id=str(getattr(prepared_req, "request_id", "")),
+                response_group_id=response_group_id,
+                response_index=response_index,
+                response_group_size=response_group_size,
+            )
+            self.prepare_next_denoising_step(state)
+            return state
+        except Exception:
+            self.denoising_stage.close_denoising_progress(ctx)
+            raise
+
+    def prepare_next_denoising_step(self, state: DenoisingRequestState) -> bool:
+        if state.step_index >= state.num_timesteps:
+            state.current_step = None
+            state.denoising_batch_key = None
+            return False
+        state.current_step = self.denoising_stage.prepare_denoising_step_state(
+            state.denoising_context,
+            state.req,
+            self.server_args,
+            state.step_index,
+        )
+        state.denoising_batch_key = build_denoising_batch_key(
+            state,
+            self.denoising_stage,
+            self.server_args,
+        )
+        return True
+
+    def select_compatible_requests_for_next_step(
+        self,
+        active_states: list[DenoisingRequestState],
+    ) -> list[DenoisingRequestState]:
+        first_key = None
+        for state in active_states:
+            if state.is_complete:
+                continue
+            if state.current_step is None:
+                self.prepare_next_denoising_step(state)
+            first_key = state.denoising_batch_key
+            break
+        if first_key is None:
+            return []
+
+        selected = [
+            state
+            for state in active_states
+            if not state.is_complete and state.denoising_batch_key == first_key
+        ]
+        selected = selected[: self.batching_max_size]
+        can_pack_selected = self.denoising_stage.can_run_steps_in_one_forward_pass(
+            selected,
+            self.server_args,
+        )
+        if len(selected) > 1 and not can_pack_selected:
+            return selected[:1]
+        return selected
+
+    def run_selected_steps_and_advance_requests(
+        self,
+        states: list[DenoisingRequestState],
+        *,
+        build_output: bool = True,
+    ) -> list[DenoisingRequestState]:
+        if not states:
+            return []
+
+        self.denoising_stage.run_denoising_steps_for_requests(
+            states,
+            self.server_args,
+        )
+
+        completed: list[DenoisingRequestState] = []
+        for state in states:
+            state.step_index += 1
+            if state.step_index >= state.num_timesteps:
+                if build_output:
+                    self.finish_request_and_build_output(state)
+                else:
+                    self.finish_request(state)
+                completed.append(state)
+            else:
+                self.prepare_next_denoising_step(state)
+        return completed
+
+    def finish_request(self, state: DenoisingRequestState) -> None:
+        from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
+            OutputBatch,
+        )
+
+        self.denoising_stage.finish_denoising_context(
+            state.denoising_context,
+            state.req,
+            self.server_args,
+        )
+        state.output_batch = OutputBatch()
+        state.completed_time_s = time.monotonic()
+
+    def finish_request_and_build_output(self, state: DenoisingRequestState) -> None:
+        from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
+            OutputBatch,
+        )
+
+        self.finish_request(state)
+        result = self.pipeline.run_stages_after_denoising(state.req, self.server_args)
+        output_batch = self.worker._to_output_batch(result)
+        if not isinstance(output_batch, OutputBatch):
+            output_batch = OutputBatch(error=f"Unexpected output: {type(result)}")
+        self._prepare_output_for_return(state, output_batch)
+        state.output_batch = output_batch
+
+    def fail_request(self, state: DenoisingRequestState, error: str) -> None:
+        self.denoising_stage.close_denoising_progress(state.denoising_context)
+        state.set_error_output(error)
+
+    def _prepare_output_for_return(
+        self,
+        state: DenoisingRequestState,
+        output_batch: "OutputBatch",
+    ) -> None:
+        import torch
+
+        req = state.req
+        self.worker._record_output_peak_memory(output_batch)
+        if output_batch.metrics is not None:
+            output_batch.metrics.total_duration_ms = (
+                time.monotonic() - state.created_time_s
+            ) * 1000.0
+
+        if req.save_output and req.return_file_paths_only:
+            self.worker._save_output_paths(req, output_batch)
+            output_batch.output = None
+            output_batch.audio = None
+            output_batch.audio_sample_rate = None
+            if torch.cuda.is_initialized():
+                torch.cuda.empty_cache()
+
+        self.worker._materialize_frame_outputs_for_return(output_batch, req)

--- a/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
+++ b/python/sglang/multimodal_gen/runtime/managers/continuous_batching.py
@@ -166,12 +166,12 @@ def validate_continuous_batching_config(server_args: Any) -> None:
 
     if getattr(server_args, "dit_cpu_offload", False):
         raise ContinuousBatchingError(
-            "continuous batching does not support DiT CPU offload yet"
+            "continuous batching requires a GPU-resident DiT; disable --dit-cpu-offload"
         )
 
     if getattr(server_args, "dit_layerwise_offload", False):
         raise ContinuousBatchingError(
-            "continuous batching does not support DiT layerwise offload yet"
+            "continuous batching requires a GPU-resident DiT; disable --dit-layerwise-offload"
         )
 
     allowed_attention_backends = {"fa", "fa2", "torch_sdpa"}

--- a/python/sglang/multimodal_gen/runtime/managers/continuous_stage_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/continuous_stage_worker.py
@@ -1,15 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Async encode/decode worker for continuous diffusion batching.
+"""Async encode/decode workers for continuous diffusion batching.
 
-Runs text-encode admission and VAE-decode completion on a side CUDA stream
-so the scheduler can keep stepping the packed denoising batch.
+Text-encode admission and VAE-decode completion each run on their own
+worker thread with their own side CUDA stream so the scheduler can keep
+stepping the packed denoising batch while both stages overlap.
+
+Design points:
+
+- Bounded job queues: ``submit`` raises :class:`StageQueueFull` when a
+  worker's queue is at capacity, and callers apply backpressure (requests
+  stay queued / completed states stay in a backlog) instead of running the
+  work inline.
+- CUDA-event handoff: producers record an event at submit time and the
+  worker stream waits on exactly that event (not on everything enqueued to
+  the default stream afterwards). Each result carries a completion event;
+  results consumed on the GPU make the consumer stream wait on it, while
+  host-consumed kinds (finalize) synchronize before being returned.
+- Lifecycle states: each worker moves NEW -> RUNNING -> DRAINING -> STOPPED
+  (or FAILED); a dead worker surfaces synthetic error results for its
+  in-flight tickets instead of hanging pollers.
+- Robust shutdown: sentinels, bounded joins, and error results for any job
+  that never ran.
 """
 
 from __future__ import annotations
 
 import queue
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, Callable
 
 import torch
@@ -18,12 +37,35 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 
+# Result kinds consumed on the host (synchronize before returning); other
+# kinds are consumed on the scheduler's GPU stream (stream wait, no host sync).
+_HOST_CONSUMED_KINDS = frozenset({"finalize"})
+
+_DEFAULT_QUEUE_DEPTH = 8
+_BLOCK_POLL_INTERVAL_S = 0.1
+_DEFAULT_BLOCK_TIMEOUT_S = 600.0
+
+
+class StageQueueFull(Exception):
+    """The bounded stage queue is full; apply backpressure and retry later."""
+
+
+class WorkerState(Enum):
+    NEW = "new"
+    RUNNING = "running"
+    DRAINING = "draining"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
 
 @dataclass(slots=True)
 class StageJob:
     kind: str  # "encode" | "finalize"
     ticket: Any
-    payload: Any
+    payload: Callable[[], Any]
+    # Recorded on the producer stream at submit; the worker stream waits on
+    # it so the job only depends on work enqueued *before* submission.
+    submit_event: Any = None
 
 
 @dataclass(slots=True)
@@ -32,6 +74,21 @@ class StageResult:
     ticket: Any
     value: Any = None
     error: BaseException | None = None
+    # Recorded on the worker stream after the job; consumers order against it.
+    done_event: Any = None
+
+
+@dataclass(slots=True)
+class _WorkerHandle:
+    kind: str
+    jobs: queue.Queue[StageJob | None]
+    thread: threading.Thread
+    stream: Any = None
+    state: WorkerState = WorkerState.NEW
+    # Tickets submitted but not yet returned; used to error out jobs when a
+    # worker dies or is shut down before running them.
+    in_flight: dict[Any, str] = field(default_factory=dict)
+    lock: threading.Lock = field(default_factory=threading.Lock)
 
 
 def async_stages_supported(server_args: Any) -> bool:
@@ -49,79 +106,272 @@ def async_stages_supported(server_args: Any) -> bool:
 
 
 class AsyncContinuousStageWorker:
-    """One thread + side CUDA stream for running encode/finalize jobs."""
+    """Separate encode and finalize workers with bounded queues.
 
-    def __init__(self, device: torch.device | None = None) -> None:
-        self._jobs: queue.Queue[StageJob | None] = queue.Queue()
-        self._results: queue.Queue[StageResult] = queue.Queue()
+    The public surface (``submit`` / ``try_submit`` / ``poll_results`` /
+    ``pending`` / ``shutdown``) is thread-safe for a single producer (the
+    scheduler loop) and hides the per-kind workers behind one result queue.
+    """
+
+    def __init__(
+        self,
+        device: torch.device | None = None,
+        queue_depth: int = _DEFAULT_QUEUE_DEPTH,
+        kinds: tuple[str, ...] = ("encode", "finalize"),
+    ) -> None:
+        self._queue_depth = max(1, int(queue_depth))
         self._device = device
-        self._stream = None
-        if torch.cuda.is_available():
-            if device is None:
-                device = torch.device("cuda", torch.cuda.current_device())
-                self._device = device
-            self._stream = torch.cuda.Stream(device=device)
-        self._pending = 0
-        self._thread = threading.Thread(
-            target=self._run,
-            name="cb-stage-worker",
-            daemon=True,
+        self._use_cuda = torch.cuda.is_available()
+        if self._use_cuda and device is None:
+            self._device = torch.device("cuda", torch.cuda.current_device())
+        self._results: queue.Queue[StageResult] = queue.Queue()
+        self._pending_lock = threading.Lock()
+        self._pending_by_kind: dict[str, int] = {kind: 0 for kind in kinds}
+        self._shutdown = False
+        self._workers: dict[str, _WorkerHandle] = {}
+        for kind in kinds:
+            self._workers[kind] = self._start_worker(kind)
+
+    def _start_worker(self, kind: str) -> _WorkerHandle:
+        stream = torch.cuda.Stream(device=self._device) if self._use_cuda else None
+        handle = _WorkerHandle(
+            kind=kind,
+            jobs=queue.Queue(maxsize=self._queue_depth),
+            thread=threading.Thread(
+                name=f"cb-stage-{kind}",
+                daemon=True,
+                target=self._run_worker,
+                args=(kind,),
+            ),
+            stream=stream,
         )
-        self._thread.start()
+        self._workers[kind] = handle
+        handle.state = WorkerState.RUNNING
+        handle.thread.start()
+        return handle
+
+    # ------------------------------------------------------------------ #
+    # Producer API                                                         #
+    # ------------------------------------------------------------------ #
 
     @property
     def pending(self) -> int:
-        return self._pending
+        with self._pending_lock:
+            return sum(self._pending_by_kind.values())
+
+    def pending_for(self, kind: str) -> int:
+        with self._pending_lock:
+            return self._pending_by_kind.get(kind, 0)
+
+    def worker_state(self, kind: str) -> WorkerState:
+        return self._workers[kind].state
+
+    def can_submit(self, kind: str, count: int = 1) -> bool:
+        """Whether ``count`` more jobs fit in this worker's bounded queue."""
+        if self._shutdown:
+            return False
+        handle = self._workers.get(kind)
+        if handle is None or handle.state is not WorkerState.RUNNING:
+            return False
+        return (self._queue_depth - handle.jobs.qsize()) >= count
 
     def submit(self, kind: str, ticket: Any, fn: Callable[[], Any]) -> None:
-        self._pending += 1
-        self._jobs.put(StageJob(kind=kind, ticket=ticket, payload=fn))
+        """Queue one job; raises StageQueueFull when at capacity."""
+        if self._shutdown:
+            raise RuntimeError("stage worker is shut down")
+        handle = self._workers.get(kind)
+        if handle is None:
+            raise ValueError(f"unknown stage kind: {kind}")
+        if handle.state is not WorkerState.RUNNING:
+            raise RuntimeError(f"stage worker {kind} is {handle.state.value}")
+        submit_event = None
+        if handle.stream is not None:
+            submit_event = torch.cuda.Event()
+            submit_event.record(torch.cuda.current_stream(self._device))
+        job = StageJob(kind=kind, ticket=ticket, payload=fn, submit_event=submit_event)
+        with handle.lock:
+            handle.in_flight[ticket] = kind
+        try:
+            handle.jobs.put_nowait(job)
+        except queue.Full:
+            with handle.lock:
+                handle.in_flight.pop(ticket, None)
+            raise StageQueueFull(
+                f"stage {kind} queue is full ({self._queue_depth} jobs)"
+            ) from None
+        with self._pending_lock:
+            self._pending_by_kind[kind] = self._pending_by_kind.get(kind, 0) + 1
 
-    def poll_results(self, block_one: bool = False) -> list[StageResult]:
-        """Drain finished results, optionally blocking for one."""
+    def try_submit(self, kind: str, ticket: Any, fn: Callable[[], Any]) -> bool:
+        """Like submit() but returns False instead of raising on backpressure."""
+        try:
+            self.submit(kind, ticket, fn)
+            return True
+        except (StageQueueFull, RuntimeError):
+            return False
+
+    # ------------------------------------------------------------------ #
+    # Consumer API                                                         #
+    # ------------------------------------------------------------------ #
+
+    def poll_results(
+        self,
+        block_one: bool = False,
+        block_timeout_s: float = _DEFAULT_BLOCK_TIMEOUT_S,
+    ) -> list[StageResult]:
+        """Drain finished results, optionally blocking for one.
+
+        Blocking wakes early when every worker with in-flight jobs dies, in
+        which case synthetic error results are returned for those tickets.
+        """
         results: list[StageResult] = []
-        if block_one and self._pending > 0:
-            try:
-                results.append(self._results.get(timeout=600.0))
-            except queue.Empty:
-                logger.error("Timed out waiting for async stage result")
+        if block_one and self.pending > 0:
+            waited = 0.0
+            while waited < block_timeout_s:
+                try:
+                    results.append(self._results.get(timeout=_BLOCK_POLL_INTERVAL_S))
+                    break
+                except queue.Empty:
+                    waited += _BLOCK_POLL_INTERVAL_S
+                    dead = self._collect_dead_worker_results()
+                    if dead:
+                        results.extend(dead)
+                        break
+            else:
+                logger.error(
+                    "Timed out waiting %.0fs for an async stage result",
+                    block_timeout_s,
+                )
         while True:
             try:
                 results.append(self._results.get_nowait())
             except queue.Empty:
                 break
-        self._pending -= len(results)
+        results.extend(self._collect_dead_worker_results())
+        return [self._finish_result(result) for result in results]
+
+    def _finish_result(self, result: StageResult) -> StageResult:
+        handle = self._workers.get(result.kind)
+        if handle is not None:
+            with handle.lock:
+                handle.in_flight.pop(result.ticket, None)
+        with self._pending_lock:
+            current = self._pending_by_kind.get(result.kind, 0)
+            self._pending_by_kind[result.kind] = max(0, current - 1)
+        done_event = result.done_event
+        if done_event is not None:
+            if result.kind in _HOST_CONSUMED_KINDS:
+                # The caller serializes this value on the host right away.
+                done_event.synchronize()
+            else:
+                # The caller keeps using the value on the scheduler stream.
+                torch.cuda.current_stream(self._device).wait_event(done_event)
+        return result
+
+    def _collect_dead_worker_results(self) -> list[StageResult]:
+        """Turn in-flight jobs of dead workers into error results."""
+        results: list[StageResult] = []
+        for handle in self._workers.values():
+            if handle.state in (WorkerState.RUNNING, WorkerState.DRAINING):
+                if handle.thread.is_alive():
+                    continue
+                handle.state = WorkerState.FAILED
+            if handle.state not in (WorkerState.FAILED, WorkerState.STOPPED):
+                continue
+            with handle.lock:
+                tickets = list(handle.in_flight.items())
+                handle.in_flight.clear()
+            for ticket, kind in tickets:
+                results.append(
+                    StageResult(
+                        kind=kind,
+                        ticket=ticket,
+                        error=RuntimeError(
+                            f"stage worker {handle.kind} "
+                            f"{handle.state.value} before running the job"
+                        ),
+                    )
+                )
         return results
 
-    def shutdown(self) -> None:
-        self._jobs.put(None)
-        self._thread.join(timeout=60.0)
+    # ------------------------------------------------------------------ #
+    # Lifecycle                                                            #
+    # ------------------------------------------------------------------ #
 
-    def _run(self) -> None:
-        if self._device is not None and self._device.type == "cuda":
-            torch.cuda.set_device(self._device)
-        while True:
-            job = self._jobs.get()
-            if job is None:
-                return
-            result = StageResult(kind=job.kind, ticket=job.ticket)
-            try:
-                with torch.no_grad():
-                    if self._stream is not None:
-                        # Wait for the scheduler stream to finish the step that
-                        # produced the latents this job consumes.
-                        self._stream.wait_stream(
+    def shutdown(self, timeout_s: float = 60.0) -> None:
+        """Stop both workers; error out anything that never ran."""
+        self._shutdown = True
+        for handle in self._workers.values():
+            if handle.state is WorkerState.RUNNING:
+                handle.state = WorkerState.DRAINING
+                try:
+                    handle.jobs.put(None, timeout=timeout_s)
+                except queue.Full:
+                    logger.error(
+                        "Could not deliver shutdown sentinel to %s worker",
+                        handle.kind,
+                    )
+        for handle in self._workers.values():
+            handle.thread.join(timeout=timeout_s)
+            if handle.thread.is_alive():
+                logger.error(
+                    "Stage worker %s did not stop within %.0fs",
+                    handle.kind,
+                    timeout_s,
+                )
+                handle.state = WorkerState.FAILED
+            elif handle.state is not WorkerState.FAILED:
+                handle.state = WorkerState.STOPPED
+        # Surface any jobs that never ran so pollers do not wait forever.
+        for result in self._collect_dead_worker_results():
+            self._results.put(result)
+
+    # ------------------------------------------------------------------ #
+    # Worker loop                                                          #
+    # ------------------------------------------------------------------ #
+
+    def _run_worker(self, kind: str) -> None:
+        handle = self._workers[kind]
+        try:
+            if self._use_cuda and self._device is not None:
+                torch.cuda.set_device(self._device)
+            while True:
+                job = handle.jobs.get()
+                if job is None:
+                    handle.state = WorkerState.STOPPED
+                    return
+                result = self._run_job(handle, job)
+                # The job ran; it must not be errored again if the worker
+                # stops before this result is polled.
+                with handle.lock:
+                    handle.in_flight.pop(job.ticket, None)
+                self._results.put(result)
+        except BaseException:  # noqa: BLE001 - worker death is surfaced to pollers
+            handle.state = WorkerState.FAILED
+            logger.error("Stage worker %s crashed", kind, exc_info=True)
+            raise
+
+    def _run_job(self, handle: _WorkerHandle, job: StageJob) -> StageResult:
+        result = StageResult(kind=job.kind, ticket=job.ticket)
+        try:
+            with torch.no_grad():
+                if handle.stream is not None:
+                    if job.submit_event is not None:
+                        # Wait only for work enqueued before submission.
+                        handle.stream.wait_event(job.submit_event)
+                    else:
+                        handle.stream.wait_stream(
                             torch.cuda.default_stream(self._device)
                         )
-                        with torch.cuda.stream(self._stream):
-                            result.value = job.payload()
-                        # Synchronize before returning results to other streams/threads.
-                        self._stream.synchronize()
-                    else:
+                    with torch.cuda.stream(handle.stream):
                         result.value = job.payload()
-            except BaseException as e:  # noqa: BLE001 - forwarded to caller
-                logger.error(
-                    "Async %s stage job failed: %s", job.kind, e, exc_info=True
-                )
-                result.error = e
-            self._results.put(result)
+                    done_event = torch.cuda.Event()
+                    done_event.record(handle.stream)
+                    result.done_event = done_event
+                else:
+                    result.value = job.payload()
+        except BaseException as e:  # noqa: BLE001 - forwarded to caller
+            logger.error("Async %s stage job failed: %s", job.kind, e, exc_info=True)
+            result.error = e
+            result.done_event = None
+        return result

--- a/python/sglang/multimodal_gen/runtime/managers/continuous_stage_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/continuous_stage_worker.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Async encode/decode worker for continuous diffusion batching.
+
+Runs text-encode admission and VAE-decode completion on a side CUDA stream
+so the scheduler can keep stepping the packed denoising batch.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import torch
+
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+@dataclass(slots=True)
+class StageJob:
+    kind: str  # "encode" | "finalize"
+    ticket: Any
+    payload: Any
+
+
+@dataclass(slots=True)
+class StageResult:
+    kind: str
+    ticket: Any
+    value: Any = None
+    error: BaseException | None = None
+
+
+def async_stages_supported(server_args: Any) -> bool:
+    """Return True if encode/decode can run async without component offload."""
+    if not bool(getattr(server_args, "cb_async_stages", True)):
+        return False
+    offload_flags = (
+        "dit_cpu_offload",
+        "dit_layerwise_offload",
+        "text_encoder_cpu_offload",
+        "image_encoder_cpu_offload",
+        "vae_cpu_offload",
+    )
+    return not any(getattr(server_args, flag, False) for flag in offload_flags)
+
+
+class AsyncContinuousStageWorker:
+    """One thread + side CUDA stream for running encode/finalize jobs."""
+
+    def __init__(self, device: torch.device | None = None) -> None:
+        self._jobs: queue.Queue[StageJob | None] = queue.Queue()
+        self._results: queue.Queue[StageResult] = queue.Queue()
+        self._device = device
+        self._stream = None
+        if torch.cuda.is_available():
+            if device is None:
+                device = torch.device("cuda", torch.cuda.current_device())
+                self._device = device
+            self._stream = torch.cuda.Stream(device=device)
+        self._pending = 0
+        self._thread = threading.Thread(
+            target=self._run,
+            name="cb-stage-worker",
+            daemon=True,
+        )
+        self._thread.start()
+
+    @property
+    def pending(self) -> int:
+        return self._pending
+
+    def submit(self, kind: str, ticket: Any, fn: Callable[[], Any]) -> None:
+        self._pending += 1
+        self._jobs.put(StageJob(kind=kind, ticket=ticket, payload=fn))
+
+    def poll_results(self, block_one: bool = False) -> list[StageResult]:
+        """Drain finished results, optionally blocking for one."""
+        results: list[StageResult] = []
+        if block_one and self._pending > 0:
+            try:
+                results.append(self._results.get(timeout=600.0))
+            except queue.Empty:
+                logger.error("Timed out waiting for async stage result")
+        while True:
+            try:
+                results.append(self._results.get_nowait())
+            except queue.Empty:
+                break
+        self._pending -= len(results)
+        return results
+
+    def shutdown(self) -> None:
+        self._jobs.put(None)
+        self._thread.join(timeout=60.0)
+
+    def _run(self) -> None:
+        if self._device is not None and self._device.type == "cuda":
+            torch.cuda.set_device(self._device)
+        while True:
+            job = self._jobs.get()
+            if job is None:
+                return
+            result = StageResult(kind=job.kind, ticket=job.ticket)
+            try:
+                with torch.no_grad():
+                    if self._stream is not None:
+                        # Wait for the scheduler stream to finish the step that
+                        # produced the latents this job consumes.
+                        self._stream.wait_stream(
+                            torch.cuda.default_stream(self._device)
+                        )
+                        with torch.cuda.stream(self._stream):
+                            result.value = job.payload()
+                        # Synchronize before returning results to other streams/threads.
+                        self._stream.synchronize()
+                    else:
+                        result.value = job.payload()
+            except BaseException as e:  # noqa: BLE001 - forwarded to caller
+                logger.error(
+                    "Async %s stage job failed: %s", job.kind, e, exc_info=True
+                )
+                result.error = e
+            self._results.put(result)

--- a/python/sglang/multimodal_gen/runtime/managers/forward_context.py
+++ b/python/sglang/multimodal_gen/runtime/managers/forward_context.py
@@ -38,6 +38,9 @@ class ForwardContext:
     attn_metadata: "AttentionMetadata"  # set dynamically for each forward pass
     forward_batch: Optional["Req"] = None
     attention_backend_cls: Optional[Type] = None
+    # Row-level TeaCache plan for packed continuous-batching forwards; models
+    # that set ``supports_packed_teacache`` consume it (see cache/teacache.py).
+    teacache_plan: Optional[object] = None
 
     def set_attn_backend_cls(self, attention_backend_cls: Type):
         if self.attention_backend_cls:
@@ -64,7 +67,10 @@ def get_forward_context() -> "ForwardContext":
 # TODO(will): finalize the interface
 @contextmanager
 def set_forward_context(
-    current_timestep, attn_metadata, forward_batch: Optional["Req"] = None
+    current_timestep,
+    attn_metadata,
+    forward_batch: Optional["Req"] = None,
+    teacache_plan: Optional[object] = None,
 ):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
@@ -80,6 +86,7 @@ def set_forward_context(
         current_timestep=current_timestep,
         attn_metadata=attn_metadata,
         forward_batch=forward_batch,
+        teacache_plan=teacache_plan,
     )
 
     try:

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -39,7 +39,7 @@ from sglang.multimodal_gen.runtime.ipc_array import (
 )
 from sglang.multimodal_gen.runtime.managers.continuous_batching import (
     ContinuousBatchingError,
-    ContinuousDenoisingScheduler,
+    ContinuousDenoisingCoordinator,
     ContinuousResponseGroup,
     DenoisingRequestState,
 )
@@ -1114,41 +1114,101 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         output_batch: OutputBatch,
         identity: bytes | None,
         *,
+        req_or_group: Req | list[Req] | None = None,
         is_warmup: bool = False,
     ) -> bool:
+        should_not_return = is_warmup
+        if (
+            is_warmup
+            and req_or_group is not None
+            and should_return_warmup_result(req_or_group)
+        ):
+            output_batch.drop_payload_for_warmup()
+            should_not_return = False
         try:
-            self.return_result(output_batch, identity, is_warmup=is_warmup)
+            self.return_result(
+                output_batch,
+                identity,
+                should_not_return=should_not_return,
+            )
             return True
         except zmq.ZMQError as e:
             logger.error("ZMQ error sending continuous batching reply: %s", e)
             return False
 
+    @staticmethod
+    def _is_continuous_request_group(item: Any) -> bool:
+        return (
+            isinstance(item, list)
+            and item
+            and all(isinstance(req, Req) for req in item)
+        )
+
+    @staticmethod
+    def _continuous_item_is_warmup(item: Any) -> bool:
+        if isinstance(item, Req):
+            return item.is_warmup
+        if Scheduler._is_continuous_request_group(item):
+            return any(req.is_warmup for req in item)
+        return is_warmup_req(item)
+
+    def _validate_continuous_group_reqs(self, group_reqs: list[Req]) -> None:
+        has_warmup = any(req.is_warmup for req in group_reqs)
+        if has_warmup and not all(req.is_warmup for req in group_reqs):
+            raise ContinuousBatchingError(
+                "continuous batching does not support mixed warmup request groups"
+            )
+
+        validate_group_reqs = getattr(self.worker, "_validate_group_forward_reqs", None)
+        if validate_group_reqs is not None:
+            validate_group_reqs(group_reqs)
+
+    @staticmethod
+    def _move_recently_run_states_to_back(
+        active_states: list[DenoisingRequestState],
+        denoising_batch: list[DenoisingRequestState],
+    ) -> list[DenoisingRequestState]:
+        just_ran = {id(state) for state in denoising_batch}
+        return [state for state in active_states if id(state) not in just_ran] + [
+            state for state in active_states if id(state) in just_ran
+        ]
+
     def _admit_waiting_requests_to_continuous_loop(
         self,
-        continuous_scheduler: ContinuousDenoisingScheduler,
+        continuous_coordinator: ContinuousDenoisingCoordinator,
         active_states: list[DenoisingRequestState],
         pending_groups: dict[str, ContinuousResponseGroup],
     ) -> None:
         while self.waiting_queue:
-            if any(state.req.is_warmup for state in active_states):
-                break
-
             identity, req_or_group, enqueue_time = self.waiting_queue[0]
 
-            if (
-                isinstance(req_or_group, list)
-                and req_or_group
-                and all(isinstance(req, Req) for req in req_or_group)
+            if any(state.req.is_warmup for state in active_states) or (
+                active_states and self._continuous_item_is_warmup(req_or_group)
             ):
+                break
+
+            if self._is_continuous_request_group(req_or_group):
                 group_reqs = req_or_group
+                try:
+                    self._validate_continuous_group_reqs(group_reqs)
+                except Exception as e:
+                    self.waiting_queue.popleft()
+                    self._return_continuous_result(
+                        OutputBatch(error=str(e)),
+                        identity,
+                        req_or_group=group_reqs,
+                        is_warmup=self._continuous_item_is_warmup(group_reqs),
+                    )
+                    continue
+
                 reject_reason = self._get_continuous_admission_reject_reason(
                     active_states,
                     group_reqs,
                 )
                 if reject_reason is not None:
-                    self._record_batch_reject_metrics(reject_reason)
                     if active_states:
                         break
+                    self._record_batch_reject_metrics(reject_reason)
                     self.waiting_queue.popleft()
                     self._return_continuous_result(
                         OutputBatch(
@@ -1158,7 +1218,8 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                             )
                         ),
                         identity,
-                        is_warmup=any(req.is_warmup for req in group_reqs),
+                        req_or_group=group_reqs,
+                        is_warmup=self._continuous_item_is_warmup(group_reqs),
                     )
                     continue
 
@@ -1170,7 +1231,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 for index, req in enumerate(group_reqs):
                     try:
                         state = (
-                            continuous_scheduler.prepare_request_for_denoising_steps(
+                            continuous_coordinator.prepare_request_for_denoising_steps(
                                 identity=identity,
                                 req=req,
                                 response_group_id=group_id,
@@ -1195,15 +1256,23 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                             ),
                         )
                 self._return_response_group_if_complete(group_id, pending_groups)
-                if any(req.is_warmup for req in group_reqs):
+                if self._continuous_item_is_warmup(group_reqs):
                     break
                 continue
 
             if not isinstance(req_or_group, Req):
-                if active_states:
+                if active_states and not isinstance(req_or_group, ShutdownReq):
                     break
                 self.waiting_queue.popleft()
-                result = self._dispatch_single_request(req_or_group)
+                try:
+                    result = self._dispatch_single_request(req_or_group)
+                except Exception as e:
+                    logger.error(
+                        "Error executing control request in continuous scheduler loop: %s",
+                        e,
+                        exc_info=True,
+                    )
+                    result = OutputBatch(error=str(e))
                 self._return_continuous_result(result, identity)
                 if not self._running:
                     break
@@ -1214,22 +1283,26 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 [req_or_group],
             )
             if reject_reason is not None:
-                self._record_batch_reject_metrics(reject_reason)
                 if active_states:
                     break
+                self._record_batch_reject_metrics(reject_reason)
                 self.waiting_queue.popleft()
                 self._return_continuous_result(
                     OutputBatch(
-                        error=f"continuous batching admission rejected request: {reject_reason}"
+                        error=(
+                            "continuous batching admission rejected request: "
+                            f"{reject_reason}"
+                        )
                     ),
                     identity,
+                    req_or_group=req_or_group,
                     is_warmup=req_or_group.is_warmup,
                 )
                 continue
 
             self.waiting_queue.popleft()
             try:
-                state = continuous_scheduler.prepare_request_for_denoising_steps(
+                state = continuous_coordinator.prepare_request_for_denoising_steps(
                     identity=identity,
                     req=req_or_group,
                 )
@@ -1241,6 +1314,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 self._return_continuous_result(
                     OutputBatch(error=str(e)),
                     identity,
+                    req_or_group=req_or_group,
                     is_warmup=req_or_group.is_warmup,
                 )
             except Exception as e:
@@ -1252,6 +1326,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 self._return_continuous_result(
                     OutputBatch(error=f"continuous batching admission failed: {e}"),
                     identity,
+                    req_or_group=req_or_group,
                     is_warmup=req_or_group.is_warmup,
                 )
 
@@ -1265,10 +1340,11 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             return False
 
         merged = group.merge_outputs(self.worker)
-        self._log_warmup_result(merged, group.is_warmup)
+        self._log_warmup_result(merged, group.reqs, group.is_warmup)
         self._return_continuous_result(
             merged,
             group.identity,
+            req_or_group=group.reqs,
             is_warmup=group.is_warmup,
         )
         del pending_groups[group_id]
@@ -1282,10 +1358,11 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         output_batch = state.output_batch or OutputBatch(error=state.error)
         if state.response_group_id is None or state.response_group_size <= 1:
             is_warmup = state.req.is_warmup
-            self._log_warmup_result(output_batch, is_warmup)
+            self._log_warmup_result(output_batch, state.req, is_warmup)
             self._return_continuous_result(
                 output_batch,
                 state.identity,
+                req_or_group=state.req,
                 is_warmup=is_warmup,
             )
             return
@@ -1314,11 +1391,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             queued_count = sum(
                 1 for _, item, _ in self.waiting_queue if isinstance(item, Req)
             )
-        elif (
-            isinstance(req_or_group, list)
-            and req_or_group
-            and all(isinstance(req, Req) for req in req_or_group)
-        ):
+        elif self._is_continuous_request_group(req_or_group):
             queued_count = len(req_or_group)
         else:
             return False
@@ -1332,7 +1405,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             self._batching_max_size,
             self._batching_delay_s * 1000.0,
         )
-        continuous_scheduler = ContinuousDenoisingScheduler(
+        continuous_coordinator = ContinuousDenoisingCoordinator(
             worker=self.worker,
             server_args=self.server_args,
             batching_max_size=self._batching_max_size,
@@ -1377,13 +1450,13 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 continue
 
             self._admit_waiting_requests_to_continuous_loop(
-                continuous_scheduler,
+                continuous_coordinator,
                 active_states,
                 pending_groups,
             )
 
             denoising_batch = (
-                continuous_scheduler.select_compatible_requests_for_next_step(
+                continuous_coordinator.select_compatible_requests_for_next_step(
                     active_states
                 )
             )
@@ -1398,7 +1471,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
 
             try:
                 completed = (
-                    continuous_scheduler.run_selected_steps_and_advance_requests(
+                    continuous_coordinator.run_selected_steps_and_advance_requests(
                         denoising_batch
                     )
                 )
@@ -1427,18 +1500,37 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 )
                 completed = []
                 for state in denoising_batch:
-                    continuous_scheduler.fail_request(
+                    continuous_coordinator.fail_request(
                         state,
                         f"Continuous denoising failed: {e}",
                     )
                     completed.append(state)
 
             for state in completed:
-                self._return_completed_request_state(state, pending_groups)
+                try:
+                    self._return_completed_request_state(state, pending_groups)
+                except Exception as e:
+                    logger.error(
+                        "Error returning continuous batching result for request %s: %s",
+                        state.request_id,
+                        e,
+                        exc_info=True,
+                    )
+                    self._return_continuous_result(
+                        OutputBatch(error=f"continuous batching response failed: {e}"),
+                        state.identity,
+                        req_or_group=state.req,
+                        is_warmup=state.req.is_warmup,
+                    )
 
             active_states = [state for state in active_states if not state.is_complete]
+            if len(active_states) > 1:
+                active_states = self._move_recently_run_states_to_back(
+                    active_states,
+                    denoising_batch,
+                )
             self._admit_waiting_requests_to_continuous_loop(
-                continuous_scheduler,
+                continuous_coordinator,
                 active_states,
                 pending_groups,
             )

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -37,6 +37,12 @@ from sglang.multimodal_gen.runtime.ipc_array import (
     is_local_endpoint,
     spill_large_arrays_to_file_refs,
 )
+from sglang.multimodal_gen.runtime.managers.continuous_batching import (
+    ContinuousBatchingError,
+    ContinuousDenoisingScheduler,
+    ContinuousResponseGroup,
+    DenoisingRequestState,
+)
 from sglang.multimodal_gen.runtime.managers.cpu_worker import CPUWorker
 from sglang.multimodal_gen.runtime.managers.dynamic_batch_admission import (
     BatchAdmissionController,
@@ -152,6 +158,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         self._batch_metrics_enabled = server_args.enable_batching_metrics
         self._batch_metrics_window = BatchMetricsWindow()
         self._batch_admission = BatchAdmissionController(server_args, gpu_id=local_rank)
+        self._response_group_counter = 0
         self._poller = zmq.Poller()
         if self.receiver is not None:
             self._poller.register(self.receiver, zmq.POLLIN)
@@ -171,7 +178,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
 
         if self._batch_metrics_enabled:
             logger.info(
-                "Dynamic batch metrics enabled; logging summary every %d dispatches.",
+                "Batch metrics enabled; logging summary every %d dispatches.",
                 _BATCH_METRICS_LOG_INTERVAL,
             )
 
@@ -386,19 +393,18 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         )
         return ordered[index]
 
-    def _freeze_signature_value(self, value: Any):
-        """Convert a value into a hashable, order-stable form for signature comparison."""
+    def _make_batch_signature_value(self, value: Any):
         if isinstance(value, (str, int, float, bool, type(None))):
             return value
         if isinstance(value, Enum):
             return value.value
         if isinstance(value, dict):
-            return {
-                str(k): self._freeze_signature_value(v)
+            return tuple(
+                (str(k), self._make_batch_signature_value(v))
                 for k, v in sorted(value.items(), key=lambda kv: str(kv[0]))
-            }
+            )
         if isinstance(value, (list, tuple)):
-            return tuple(self._freeze_signature_value(v) for v in value)
+            return tuple(self._make_batch_signature_value(v) for v in value)
         return repr(value)
 
     def _sampling_param_signature_items(self, req: Req) -> list[tuple[str, Any]] | None:
@@ -413,13 +419,18 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             return None
 
         return [
-            (f.name, self._freeze_signature_value(getattr(sp, f.name, None)))
+            (
+                f.name,
+                self._make_batch_signature_value(getattr(sp, f.name, None)),
+            )
             for f in sp_fields
             if not f.metadata.get("batch_sig_exclude", False)
         ]
 
     def _diffusers_kwargs_signature_value(self, req: Req) -> Any:
-        return self._freeze_signature_value((req.extra or {}).get("diffusers_kwargs"))
+        return self._make_batch_signature_value(
+            (req.extra or {}).get("diffusers_kwargs")
+        )
 
     def _build_dynamic_batch_signature(self, req: Req) -> tuple[Any, ...] | None:
         """Build the request compatibility signature for dynamic batching.
@@ -438,7 +449,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 signature_items.append(
                     (
                         "diffusers_kwargs",
-                        self._freeze_signature_value(diffusers_kwargs),
+                        self._make_batch_signature_value(diffusers_kwargs),
                     )
                 )
 
@@ -553,17 +564,21 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         effective_max_batch_size: int,
         reject_reasons: list[str] | None = None,
         stop_reason: str | None = None,
+        active_requests: int | None = None,
+        queue_depth: int | None = None,
     ) -> None:
         if not self._batch_metrics_enabled:
             return
 
         effective_max_batch_size = max(1, effective_max_batch_size)
         logger.info(
-            "Dynamic batch dispatch: size=%d/%d, user_max=%d, queue_wait=%.2fms, stop_reason=%s",
+            "Batch dispatch: size=%d/%d, user_max=%d, queue_wait=%.2fms, active=%s, queue_depth=%s, stop_reason=%s",
             batch_size,
             effective_max_batch_size,
             self._batching_max_size,
             max(queue_wait_ms, 0.0),
+            active_requests if active_requests is not None else "-",
+            queue_depth if queue_depth is not None else "-",
             stop_reason or "unspecified",
         )
 
@@ -571,16 +586,31 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         window.dispatches += 1
         window.total_requests += batch_size
         window.total_capacity += effective_max_batch_size
+        window.batch_size_counts.update([batch_size])
         if batch_size > 1:
             window.merged_dispatches += 1
-        if self._dynamic_batching_enabled() and batch_size >= effective_max_batch_size:
+        if batch_size >= effective_max_batch_size:
             window.full_dispatches += 1
         window.wait_times_ms.append(max(queue_wait_ms, 0.0))
+        if active_requests is not None:
+            active_requests = max(0, int(active_requests))
+            window.active_request_samples.append(active_requests)
+            window.max_active_requests = max(
+                window.max_active_requests, active_requests
+            )
+        if queue_depth is not None:
+            window.queue_depth_samples.append(max(0, int(queue_depth)))
         if reject_reasons:
             window.reject_reasons.update(reject_reasons)
 
         if window.dispatches >= _BATCH_METRICS_LOG_INTERVAL:
             self._log_batch_metrics_summary()
+
+    def _record_batch_reject_metrics(self, reason: str) -> None:
+        if not self._batch_metrics_enabled:
+            return
+        logger.info("Batch admission rejected: %s", reason)
+        self._batch_metrics_window.reject_reasons.update([reason])
 
     def _log_batch_metrics_summary(self) -> None:
         if not self._batch_metrics_enabled:
@@ -594,8 +624,24 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         utilization = window.total_requests / max(1, window.total_capacity)
         avg_wait_ms = sum(window.wait_times_ms) / len(window.wait_times_ms)
         p95_wait_ms = self._percentile(window.wait_times_ms, 95.0)
+        avg_active = (
+            sum(window.active_request_samples) / len(window.active_request_samples)
+            if window.active_request_samples
+            else 0.0
+        )
+        avg_queue_depth = (
+            sum(window.queue_depth_samples) / len(window.queue_depth_samples)
+            if window.queue_depth_samples
+            else 0.0
+        )
         merged_rate = window.merged_dispatches / window.dispatches
         full_rate = window.full_dispatches / window.dispatches
+        batch_sizes = ", ".join(
+            f"{size}={count}"
+            for size, count in sorted(window.batch_size_counts.items())
+        )
+        if not batch_sizes:
+            batch_sizes = "none"
         top_rejects = ", ".join(
             f"{reason}={count}"
             for reason, count in window.reject_reasons.most_common(5)
@@ -604,7 +650,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             top_rejects = "none"
 
         logger.info(
-            "Dynamic batch stats (last %d dispatches): avg_size=%.2f, merged_rate=%.1f%%, full_rate=%.1f%%, utilization=%.1f%%, wait_avg=%.2fms, wait_p95=%.2fms, top_rejects=%s",
+            "Batch stats (last %d dispatches): avg_size=%.2f, merged_rate=%.1f%%, full_rate=%.1f%%, utilization=%.1f%%, wait_avg=%.2fms, wait_p95=%.2fms, active_avg=%.2f, active_max=%d, queue_avg=%.2f, batch_sizes=%s, top_rejects=%s",
             window.dispatches,
             avg_size,
             merged_rate * 100.0,
@@ -612,6 +658,10 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             utilization * 100.0,
             avg_wait_ms,
             p95_wait_ms,
+            avg_active,
+            window.max_active_requests,
+            avg_queue_depth,
+            batch_sizes,
             top_rejects,
         )
         self._batch_metrics_window = BatchMetricsWindow()
@@ -832,6 +882,14 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             return self._batch_admission.enabled and supports_dynamic_batching()
         return self._batch_admission.enabled
 
+    def _continuous_batching_enabled_for_pipeline(self) -> bool:
+        if self.server_args.batching_mode != "continuous":
+            return False
+        supports = getattr(
+            self.server_args.pipeline_config, "supports_continuous_batching", None
+        )
+        return callable(supports) and supports()
+
     def get_next_batch_to_run(self) -> list[tuple[bytes | None, Any]] | None:
         """Return the next dispatchable queue item or dynamic batch.
 
@@ -1017,6 +1075,381 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
 
         return recv_reqs
 
+    def _get_continuous_admission_reject_reason(
+        self,
+        active_states: list[DenoisingRequestState],
+        candidate_reqs: list[Req],
+    ) -> str | None:
+        proposed = [state.req for state in active_states] + candidate_reqs
+        if not proposed:
+            return None
+
+        limits = [self._batch_admission.limit_for(req) for req in proposed]
+        max_batch_size = min(
+            self._batching_max_size,
+            *(limit.max_batch_size for limit in limits),
+        )
+        if len(proposed) > max_batch_size:
+            return f"config_cap:{max_batch_size}"
+
+        max_costs = [limit.max_cost for limit in limits if limit.max_cost is not None]
+        if max_costs:
+            max_cost = min(max_costs)
+            batch_cost = self._batch_admission.estimate_batch_cost(proposed)
+            if batch_cost > max_cost:
+                return f"cost_budget:{batch_cost:.0f}>{max_cost:.0f}"
+        return None
+
+    def _get_continuous_effective_batch_cap(
+        self,
+        states: list[DenoisingRequestState],
+    ) -> int:
+        if not states:
+            return self._batching_max_size
+        limits = [self._batch_admission.limit_for(state.req) for state in states]
+        return min(self._batching_max_size, *(limit.max_batch_size for limit in limits))
+
+    def _return_continuous_result(
+        self,
+        output_batch: OutputBatch,
+        identity: bytes | None,
+        *,
+        is_warmup: bool = False,
+    ) -> bool:
+        try:
+            self.return_result(output_batch, identity, is_warmup=is_warmup)
+            return True
+        except zmq.ZMQError as e:
+            logger.error("ZMQ error sending continuous batching reply: %s", e)
+            return False
+
+    def _admit_waiting_requests_to_continuous_loop(
+        self,
+        continuous_scheduler: ContinuousDenoisingScheduler,
+        active_states: list[DenoisingRequestState],
+        pending_groups: dict[str, ContinuousResponseGroup],
+    ) -> None:
+        while self.waiting_queue:
+            if any(state.req.is_warmup for state in active_states):
+                break
+
+            identity, req_or_group, enqueue_time = self.waiting_queue[0]
+
+            if (
+                isinstance(req_or_group, list)
+                and req_or_group
+                and all(isinstance(req, Req) for req in req_or_group)
+            ):
+                group_reqs = req_or_group
+                reject_reason = self._get_continuous_admission_reject_reason(
+                    active_states,
+                    group_reqs,
+                )
+                if reject_reason is not None:
+                    self._record_batch_reject_metrics(reject_reason)
+                    if active_states:
+                        break
+                    self.waiting_queue.popleft()
+                    self._return_continuous_result(
+                        OutputBatch(
+                            error=(
+                                "continuous batching admission rejected request group: "
+                                f"{reject_reason}"
+                            )
+                        ),
+                        identity,
+                        is_warmup=any(req.is_warmup for req in group_reqs),
+                    )
+                    continue
+
+                self.waiting_queue.popleft()
+                group_id = f"response_group::{self._response_group_counter}"
+                self._response_group_counter += 1
+                group = ContinuousResponseGroup(identity=identity, reqs=group_reqs)
+                pending_groups[group_id] = group
+                for index, req in enumerate(group_reqs):
+                    try:
+                        state = (
+                            continuous_scheduler.prepare_request_for_denoising_steps(
+                                identity=identity,
+                                req=req,
+                                response_group_id=group_id,
+                                response_index=index,
+                                response_group_size=len(group_reqs),
+                            )
+                        )
+                        state.queue_wait_ms = (time.monotonic() - enqueue_time) * 1000.0
+                        active_states.append(state)
+                    except ContinuousBatchingError as e:
+                        group.set_member_output(index, OutputBatch(error=str(e)))
+                    except Exception as e:
+                        logger.error(
+                            "Error admitting grouped request for continuous batching: %s",
+                            e,
+                            exc_info=True,
+                        )
+                        group.set_member_output(
+                            index,
+                            OutputBatch(
+                                error=f"continuous batching admission failed: {e}"
+                            ),
+                        )
+                self._return_response_group_if_complete(group_id, pending_groups)
+                if any(req.is_warmup for req in group_reqs):
+                    break
+                continue
+
+            if not isinstance(req_or_group, Req):
+                if active_states:
+                    break
+                self.waiting_queue.popleft()
+                result = self._dispatch_single_request(req_or_group)
+                self._return_continuous_result(result, identity)
+                if not self._running:
+                    break
+                continue
+
+            reject_reason = self._get_continuous_admission_reject_reason(
+                active_states,
+                [req_or_group],
+            )
+            if reject_reason is not None:
+                self._record_batch_reject_metrics(reject_reason)
+                if active_states:
+                    break
+                self.waiting_queue.popleft()
+                self._return_continuous_result(
+                    OutputBatch(
+                        error=f"continuous batching admission rejected request: {reject_reason}"
+                    ),
+                    identity,
+                    is_warmup=req_or_group.is_warmup,
+                )
+                continue
+
+            self.waiting_queue.popleft()
+            try:
+                state = continuous_scheduler.prepare_request_for_denoising_steps(
+                    identity=identity,
+                    req=req_or_group,
+                )
+                state.queue_wait_ms = (time.monotonic() - enqueue_time) * 1000.0
+                active_states.append(state)
+                if req_or_group.is_warmup:
+                    break
+            except ContinuousBatchingError as e:
+                self._return_continuous_result(
+                    OutputBatch(error=str(e)),
+                    identity,
+                    is_warmup=req_or_group.is_warmup,
+                )
+            except Exception as e:
+                logger.error(
+                    "Error admitting request for continuous batching: %s",
+                    e,
+                    exc_info=True,
+                )
+                self._return_continuous_result(
+                    OutputBatch(error=f"continuous batching admission failed: {e}"),
+                    identity,
+                    is_warmup=req_or_group.is_warmup,
+                )
+
+    def _return_response_group_if_complete(
+        self, group_id: str, pending_groups: dict[str, ContinuousResponseGroup]
+    ) -> bool:
+        group = pending_groups.get(group_id)
+        if group is None:
+            return False
+        if not group.has_all_outputs:
+            return False
+
+        merged = group.merge_outputs(self.worker)
+        self._log_warmup_result(merged, group.is_warmup)
+        self._return_continuous_result(
+            merged,
+            group.identity,
+            is_warmup=group.is_warmup,
+        )
+        del pending_groups[group_id]
+        return True
+
+    def _return_completed_request_state(
+        self,
+        state: DenoisingRequestState,
+        pending_groups: dict[str, ContinuousResponseGroup],
+    ) -> None:
+        output_batch = state.output_batch or OutputBatch(error=state.error)
+        if state.response_group_id is None or state.response_group_size <= 1:
+            is_warmup = state.req.is_warmup
+            self._log_warmup_result(output_batch, is_warmup)
+            self._return_continuous_result(
+                output_batch,
+                state.identity,
+                is_warmup=is_warmup,
+            )
+            return
+
+        group = pending_groups.get(state.response_group_id)
+        if group is None:
+            logger.error(
+                "Missing continuous response group %s for request %s",
+                state.response_group_id,
+                state.request_id,
+            )
+            return
+        group.set_member_output(state.response_index, output_batch)
+        self._return_response_group_if_complete(
+            state.response_group_id,
+            pending_groups,
+        )
+
+    def _should_wait_for_more_initial_requests(
+        self, active_states: list[DenoisingRequestState]
+    ) -> bool:
+        if active_states or not self.waiting_queue or self._batching_delay_s <= 0:
+            return False
+        _identity, req_or_group, enqueue_time = self.waiting_queue[0]
+        if isinstance(req_or_group, Req):
+            queued_count = sum(
+                1 for _, item, _ in self.waiting_queue if isinstance(item, Req)
+            )
+        elif (
+            isinstance(req_or_group, list)
+            and req_or_group
+            and all(isinstance(req, Req) for req in req_or_group)
+        ):
+            queued_count = len(req_or_group)
+        else:
+            return False
+        if queued_count >= self._batching_max_size:
+            return False
+        return (time.monotonic() - enqueue_time) < self._batching_delay_s
+
+    def _run_continuous_batching_loop(self) -> None:
+        logger.info(
+            "Continuous batching scheduler enabled (max_active=%d, max_delay=%.2fms)",
+            self._batching_max_size,
+            self._batching_delay_s * 1000.0,
+        )
+        continuous_scheduler = ContinuousDenoisingScheduler(
+            worker=self.worker,
+            server_args=self.server_args,
+            batching_max_size=self._batching_max_size,
+        )
+        active_states: list[DenoisingRequestState] = []
+        pending_groups: dict[str, ContinuousResponseGroup] = {}
+
+        while self._running:
+            try:
+                new_reqs = self.recv_reqs()
+                new_reqs = self.process_received_reqs_with_req_based_warmup(new_reqs)
+                now = time.monotonic()
+                self.waiting_queue.extend(
+                    [(identity, req, now) for identity, req in new_reqs]
+                )
+                self._consecutive_error_count = 0
+            except Exception as e:
+                self._consecutive_error_count += 1
+                logger.error(
+                    "Error receiving requests in continuous scheduler loop "
+                    "(attempt %d/%d): %s",
+                    self._consecutive_error_count,
+                    self._max_consecutive_errors,
+                    e,
+                    exc_info=True,
+                )
+                if self._consecutive_error_count >= self._max_consecutive_errors:
+                    raise RuntimeError(
+                        "Continuous scheduler terminated after "
+                        f"{self._max_consecutive_errors} consecutive errors. "
+                        f"Last error: {e}"
+                    ) from e
+
+            if self._should_wait_for_more_initial_requests(active_states):
+                oldest_ts = self.waiting_queue[0][2]
+                elapsed_ms = (time.monotonic() - oldest_ts) * 1000.0
+                remaining_ms = max(0, self._batching_delay_s * 1000.0 - elapsed_ms)
+                if remaining_ms > 0 and self.receiver is not None:
+                    self._poller.poll(timeout=remaining_ms)
+                elif remaining_ms > 0:
+                    time.sleep(remaining_ms / 1000.0)
+                continue
+
+            self._admit_waiting_requests_to_continuous_loop(
+                continuous_scheduler,
+                active_states,
+                pending_groups,
+            )
+
+            denoising_batch = (
+                continuous_scheduler.select_compatible_requests_for_next_step(
+                    active_states
+                )
+            )
+            if not denoising_batch:
+                if self.waiting_queue and self.receiver is not None:
+                    self._poller.poll(
+                        timeout=max(1, int(self._batching_delay_s * 1000))
+                    )
+                else:
+                    time.sleep(0.001)
+                continue
+
+            try:
+                completed = (
+                    continuous_scheduler.run_selected_steps_and_advance_requests(
+                        denoising_batch
+                    )
+                )
+                self._record_batch_dispatch_metrics(
+                    batch_size=len(denoising_batch),
+                    queue_wait_ms=sum(state.queue_wait_ms for state in denoising_batch)
+                    / max(1, len(denoising_batch)),
+                    effective_max_batch_size=self._get_continuous_effective_batch_cap(
+                        denoising_batch
+                    ),
+                    stop_reason="denoising_batch_run",
+                    active_requests=len(active_states),
+                    queue_depth=len(self.waiting_queue),
+                )
+                if self._batch_metrics_enabled:
+                    logger.info(
+                        "Continuous denoising step batch: size=%d/%d",
+                        len(denoising_batch),
+                        self._batching_max_size,
+                    )
+            except Exception as e:
+                logger.error(
+                    "Error executing continuous denoising step batch: %s",
+                    e,
+                    exc_info=True,
+                )
+                completed = []
+                for state in denoising_batch:
+                    continuous_scheduler.fail_request(
+                        state,
+                        f"Continuous denoising failed: {e}",
+                    )
+                    completed.append(state)
+
+            for state in completed:
+                self._return_completed_request_state(state, pending_groups)
+
+            active_states = [state for state in active_states if not state.is_complete]
+            self._admit_waiting_requests_to_continuous_loop(
+                continuous_scheduler,
+                active_states,
+                pending_groups,
+            )
+
+        self._log_batch_metrics_summary()
+
+        if self.receiver is not None:
+            self.receiver.close()
+        self._cleanup_disagg()
+        self.context.destroy(linger=0)
+
     def event_loop(self) -> None:
         """
         The main event loop that listens for ZMQ requests.
@@ -1025,6 +1458,14 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         # Pool mode: all roles use the pool event loop
         if self._disagg_role != RoleType.MONOLITHIC:
             self._disagg_event_loop()
+            return
+
+        if self.server_args.batching_mode == "continuous":
+            if not self._continuous_batching_enabled_for_pipeline():
+                raise RuntimeError(
+                    "continuous batching is not enabled for this pipeline"
+                )
+            self._run_continuous_batching_loop()
             return
 
         logger.debug(

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -42,6 +42,11 @@ from sglang.multimodal_gen.runtime.managers.continuous_batching import (
     ContinuousDenoisingCoordinator,
     ContinuousResponseGroup,
     DenoisingRequestState,
+    validate_continuous_batching_request,
+)
+from sglang.multimodal_gen.runtime.managers.continuous_stage_worker import (
+    AsyncContinuousStageWorker,
+    async_stages_supported,
 )
 from sglang.multimodal_gen.runtime.managers.cpu_worker import CPUWorker
 from sglang.multimodal_gen.runtime.managers.dynamic_batch_admission import (
@@ -76,6 +81,19 @@ logger = init_logger(__name__)
 
 _MAX_RECV_REQS_PER_POLL = 1024
 _BATCH_METRICS_LOG_INTERVAL = 5
+
+
+@dataclasses.dataclass(slots=True)
+class _PendingAdmission:
+    """A request whose encode stages are running on the stage worker."""
+
+    identity: bytes | None
+    req: "Req"
+    raw_req_snapshot: "Req | None"
+    enqueue_time: float
+    group_id: str | None = None
+    group_index: int = 0
+    group_size: int = 1
 
 
 class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisaggMixin):
@@ -159,6 +177,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         self._batch_metrics_window = BatchMetricsWindow()
         self._batch_admission = BatchAdmissionController(server_args, gpu_id=local_rank)
         self._response_group_counter = 0
+        self._next_admission_ticket = 0
         self._poller = zmq.Poller()
         if self.receiver is not None:
             self._poller.register(self.receiver, zmq.POLLIN)
@@ -1079,8 +1098,13 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         self,
         active_states: list[DenoisingRequestState],
         candidate_reqs: list[Req],
+        pending_reqs: list[Req] | None = None,
     ) -> str | None:
-        proposed = [state.req for state in active_states] + candidate_reqs
+        proposed = (
+            [state.req for state in active_states]
+            + list(pending_reqs or [])
+            + candidate_reqs
+        )
         if not proposed:
             return None
 
@@ -1117,7 +1141,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         req_or_group: Req | list[Req] | None = None,
         is_warmup: bool = False,
     ) -> bool:
-        """Return a continuous-batching result using normal warmup policy."""
+        """Return a continuous-batching result, respecting warmup policy."""
         should_not_return = is_warmup
         if (
             is_warmup
@@ -1169,26 +1193,116 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         active_states: list[DenoisingRequestState],
         denoising_batch: list[DenoisingRequestState],
     ) -> list[DenoisingRequestState]:
-        """Rotate just-run states behind other active requests for fairness."""
+        """Move just-run states to the back of the active list."""
         just_ran = {id(state) for state in denoising_batch}
         return [state for state in active_states if id(state) not in just_ran] + [
             state for state in active_states if id(state) in just_ran
         ]
+
+    def _admit_single_continuous_request(
+        self,
+        continuous_coordinator: ContinuousDenoisingCoordinator,
+        active_states: list[DenoisingRequestState],
+        stage_worker: Any | None,
+        pending_admissions: dict[int, "_PendingAdmission"],
+        *,
+        identity: bytes | None,
+        req: Req,
+        enqueue_time: float,
+        group_id: str | None = None,
+        group_index: int = 0,
+        group_size: int = 1,
+        pending_groups: dict[str, ContinuousResponseGroup] | None = None,
+    ) -> None:
+        """Admit one request synchronously or via the async stage worker."""
+
+        def on_error(e: Exception, log: bool = False) -> None:
+            if log:
+                logger.error(
+                    "Error admitting request for continuous batching: %s",
+                    e,
+                    exc_info=True,
+                )
+                message = f"continuous batching admission failed: {e}"
+            else:
+                message = str(e)
+            if group_id is not None and pending_groups is not None:
+                group = pending_groups.get(group_id)
+                if group is not None:
+                    group.set_member_output(group_index, OutputBatch(error=message))
+                    self._return_response_group_if_complete(group_id, pending_groups)
+            else:
+                self._return_continuous_result(
+                    OutputBatch(error=message),
+                    identity,
+                    req_or_group=req,
+                    is_warmup=req.is_warmup,
+                )
+
+        if stage_worker is None or req.is_warmup:
+            try:
+                state = continuous_coordinator.prepare_request_state(
+                    identity=identity,
+                    req=req,
+                    response_group_id=group_id,
+                    response_index=group_index,
+                    response_group_size=group_size,
+                )
+                state.queue_wait_ms = (time.monotonic() - enqueue_time) * 1000.0
+                active_states.append(state)
+            except ContinuousBatchingError as e:
+                on_error(e)
+            except Exception as e:
+                on_error(e, log=True)
+            return
+
+        # Validate on the scheduler thread, then run encode on the side stream.
+        try:
+            validate_continuous_batching_request(req, self.server_args)
+        except ContinuousBatchingError as e:
+            on_error(e)
+            return
+        raw_req_snapshot = continuous_coordinator._snapshot_raw_request(req)
+        ticket = self._next_admission_ticket
+        self._next_admission_ticket += 1
+        pending_admissions[ticket] = _PendingAdmission(
+            identity=identity,
+            req=req,
+            raw_req_snapshot=raw_req_snapshot,
+            enqueue_time=enqueue_time,
+            group_id=group_id,
+            group_index=group_index,
+            group_size=group_size,
+        )
+        pipeline = continuous_coordinator.pipeline
+        server_args = self.server_args
+        stage_worker.submit(
+            "encode",
+            ticket,
+            lambda: pipeline.run_stages_before_denoising(req, server_args),
+        )
 
     def _admit_waiting_requests_to_continuous_loop(
         self,
         continuous_coordinator: ContinuousDenoisingCoordinator,
         active_states: list[DenoisingRequestState],
         pending_groups: dict[str, ContinuousResponseGroup],
+        stage_worker: Any | None = None,
+        pending_admissions: dict[int, "_PendingAdmission"] | None = None,
     ) -> None:
-        """Move queued requests into the active continuous denoising set."""
+        """Admit queued requests into the active continuous denoising set."""
+        if pending_admissions is None:
+            pending_admissions = {}
         while self.waiting_queue:
             identity, req_or_group, enqueue_time = self.waiting_queue[0]
+            has_inflight = bool(active_states) or bool(pending_admissions)
 
             if any(state.req.is_warmup for state in active_states) or (
-                active_states and self._continuous_item_is_warmup(req_or_group)
+                has_inflight and self._continuous_item_is_warmup(req_or_group)
             ):
                 break
+
+            pending_reqs = [item.req for item in pending_admissions.values()]
 
             if self._is_continuous_request_group(req_or_group):
                 group_reqs = req_or_group
@@ -1207,9 +1321,10 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 reject_reason = self._get_continuous_admission_reject_reason(
                     active_states,
                     group_reqs,
+                    pending_reqs,
                 )
                 if reject_reason is not None:
-                    if active_states:
+                    if has_inflight:
                         break
                     self._record_batch_reject_metrics(reject_reason)
                     self.waiting_queue.popleft()
@@ -1232,37 +1347,28 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 group = ContinuousResponseGroup(identity=identity, reqs=group_reqs)
                 pending_groups[group_id] = group
                 for index, req in enumerate(group_reqs):
-                    try:
-                        state = continuous_coordinator.prepare_request_state(
-                            identity=identity,
-                            req=req,
-                            response_group_id=group_id,
-                            response_index=index,
-                            response_group_size=len(group_reqs),
-                        )
-                        state.queue_wait_ms = (time.monotonic() - enqueue_time) * 1000.0
-                        active_states.append(state)
-                    except ContinuousBatchingError as e:
-                        group.set_member_output(index, OutputBatch(error=str(e)))
-                    except Exception as e:
-                        logger.error(
-                            "Error admitting grouped request for continuous batching: %s",
-                            e,
-                            exc_info=True,
-                        )
-                        group.set_member_output(
-                            index,
-                            OutputBatch(
-                                error=f"continuous batching admission failed: {e}"
-                            ),
-                        )
+                    self._admit_single_continuous_request(
+                        continuous_coordinator,
+                        active_states,
+                        stage_worker,
+                        pending_admissions,
+                        identity=identity,
+                        req=req,
+                        enqueue_time=enqueue_time,
+                        group_id=group_id,
+                        group_index=index,
+                        group_size=len(group_reqs),
+                        pending_groups=pending_groups,
+                    )
                 self._return_response_group_if_complete(group_id, pending_groups)
                 if self._continuous_item_is_warmup(group_reqs):
                     break
                 continue
 
             if not isinstance(req_or_group, Req):
-                if active_states and not isinstance(req_or_group, ShutdownReq):
+                if (active_states or pending_admissions) and not isinstance(
+                    req_or_group, ShutdownReq
+                ):
                     break
                 self.waiting_queue.popleft()
                 try:
@@ -1282,9 +1388,10 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             reject_reason = self._get_continuous_admission_reject_reason(
                 active_states,
                 [req_or_group],
+                pending_reqs,
             )
             if reject_reason is not None:
-                if active_states:
+                if has_inflight:
                     break
                 self._record_batch_reject_metrics(reject_reason)
                 self.waiting_queue.popleft()
@@ -1302,34 +1409,17 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 continue
 
             self.waiting_queue.popleft()
-            try:
-                state = continuous_coordinator.prepare_request_state(
-                    identity=identity,
-                    req=req_or_group,
-                )
-                state.queue_wait_ms = (time.monotonic() - enqueue_time) * 1000.0
-                active_states.append(state)
-                if req_or_group.is_warmup:
-                    break
-            except ContinuousBatchingError as e:
-                self._return_continuous_result(
-                    OutputBatch(error=str(e)),
-                    identity,
-                    req_or_group=req_or_group,
-                    is_warmup=req_or_group.is_warmup,
-                )
-            except Exception as e:
-                logger.error(
-                    "Error admitting request for continuous batching: %s",
-                    e,
-                    exc_info=True,
-                )
-                self._return_continuous_result(
-                    OutputBatch(error=f"continuous batching admission failed: {e}"),
-                    identity,
-                    req_or_group=req_or_group,
-                    is_warmup=req_or_group.is_warmup,
-                )
+            self._admit_single_continuous_request(
+                continuous_coordinator,
+                active_states,
+                stage_worker,
+                pending_admissions,
+                identity=identity,
+                req=req_or_group,
+                enqueue_time=enqueue_time,
+            )
+            if req_or_group.is_warmup:
+                break
 
     def _return_response_group_if_complete(
         self, group_id: str, pending_groups: dict[str, ContinuousResponseGroup]
@@ -1356,7 +1446,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         state: DenoisingRequestState,
         pending_groups: dict[str, ContinuousResponseGroup],
     ) -> None:
-        """Return a completed continuous request or attach it to its group."""
+        """Return a completed request or merge it into its response group."""
         output_batch = state.output_batch or OutputBatch(error=state.error)
         if state.response_group_id is None or state.response_group_size <= 1:
             is_warmup = state.req.is_warmup
@@ -1384,9 +1474,16 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         )
 
     def _should_wait_for_more_initial_requests(
-        self, active_states: list[DenoisingRequestState]
+        self,
+        active_states: list[DenoisingRequestState],
+        pending_admissions: dict[int, "_PendingAdmission"] | None = None,
     ) -> bool:
-        if active_states or not self.waiting_queue or self._batching_delay_s <= 0:
+        if (
+            active_states
+            or pending_admissions
+            or not self.waiting_queue
+            or self._batching_delay_s <= 0
+        ):
             return False
         _identity, req_or_group, enqueue_time = self.waiting_queue[0]
         if isinstance(req_or_group, Req):
@@ -1401,11 +1498,106 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             return False
         return (time.monotonic() - enqueue_time) < self._batching_delay_s
 
+    def _process_stage_worker_results(
+        self,
+        continuous_coordinator: ContinuousDenoisingCoordinator,
+        stage_worker: Any,
+        active_states: list[DenoisingRequestState],
+        pending_groups: dict[str, ContinuousResponseGroup],
+        pending_admissions: dict[int, _PendingAdmission],
+        pending_finalizes: dict[int, DenoisingRequestState],
+        *,
+        block_one: bool = False,
+    ) -> None:
+        """Apply finished async encode/finalize jobs to the active loop."""
+        for result in stage_worker.poll_results(block_one=block_one):
+            if result.kind == "encode":
+                pending = pending_admissions.pop(result.ticket, None)
+                if pending is None:
+                    continue
+                if result.error is not None:
+                    self._fail_pending_admission(pending, pending_groups, result.error)
+                    continue
+                try:
+                    state = continuous_coordinator.prepare_request_state_from_prepared(
+                        identity=pending.identity,
+                        prepared_req=result.value,
+                        raw_req_snapshot=pending.raw_req_snapshot,
+                        response_group_id=pending.group_id,
+                        response_index=pending.group_index,
+                        response_group_size=pending.group_size,
+                    )
+                    state.queue_wait_ms = (
+                        time.monotonic() - pending.enqueue_time
+                    ) * 1000.0
+                    active_states.append(state)
+                except Exception as e:
+                    self._fail_pending_admission(pending, pending_groups, e)
+            elif result.kind == "finalize":
+                state = pending_finalizes.pop(result.ticket, None)
+                if state is None:
+                    continue
+                if result.error is not None and state.output_batch is None:
+                    state.set_error_output(
+                        f"continuous batching completion failed: {result.error}"
+                    )
+                self._safe_return_completed_request_state(state, pending_groups)
+
+    def _fail_pending_admission(
+        self,
+        pending: _PendingAdmission,
+        pending_groups: dict[str, ContinuousResponseGroup],
+        error: BaseException,
+    ) -> None:
+        message = (
+            str(error)
+            if isinstance(error, ContinuousBatchingError)
+            else f"continuous batching admission failed: {error}"
+        )
+        if pending.group_id is not None:
+            group = pending_groups.get(pending.group_id)
+            if group is not None:
+                group.set_member_output(pending.group_index, OutputBatch(error=message))
+                self._return_response_group_if_complete(
+                    pending.group_id, pending_groups
+                )
+            return
+        self._return_continuous_result(
+            OutputBatch(error=message),
+            pending.identity,
+            req_or_group=pending.req,
+            is_warmup=pending.req.is_warmup,
+        )
+
+    def _safe_return_completed_request_state(
+        self,
+        state: DenoisingRequestState,
+        pending_groups: dict[str, ContinuousResponseGroup],
+    ) -> None:
+        try:
+            self._return_completed_request_state(state, pending_groups)
+        except Exception as e:
+            logger.error(
+                "Error returning continuous batching result for request %s: %s",
+                state.request_id,
+                e,
+                exc_info=True,
+            )
+            self._return_continuous_result(
+                OutputBatch(error=f"continuous batching response failed: {e}"),
+                state.identity,
+                req_or_group=state.req,
+                is_warmup=state.req.is_warmup,
+            )
+
     def _run_continuous_batching_loop(self) -> None:
         logger.info(
-            "Continuous batching scheduler enabled (max_active=%d, max_delay=%.2fms)",
+            "Continuous batching scheduler enabled "
+            "(max_active=%d, max_delay=%.2fms, policy=%s, async_stages=%s)",
             self._batching_max_size,
             self._batching_delay_s * 1000.0,
+            getattr(self.server_args, "cb_schedule_policy", "largest"),
+            async_stages_supported(self.server_args),
         )
         continuous_coordinator = ContinuousDenoisingCoordinator(
             worker=self.worker,
@@ -1414,6 +1606,25 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         )
         active_states: list[DenoisingRequestState] = []
         pending_groups: dict[str, ContinuousResponseGroup] = {}
+        pending_admissions: dict[int, _PendingAdmission] = {}
+        pending_finalizes: dict[int, DenoisingRequestState] = {}
+        stage_worker = (
+            AsyncContinuousStageWorker()
+            if async_stages_supported(self.server_args)
+            else None
+        )
+        rotate_policy = continuous_coordinator.schedule_policy == "rotate"
+
+        drain_dir = getattr(self.server_args, "cb_drain_export_dir", None)
+        if drain_dir:
+            resumed = continuous_coordinator.import_states_from_dir(drain_dir)
+            if resumed:
+                logger.info(
+                    "Resumed %d drained continuous batching request(s) from %s",
+                    len(resumed),
+                    drain_dir,
+                )
+                active_states.extend(resumed)
 
         while self._running:
             try:
@@ -1441,7 +1652,19 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                         f"Last error: {e}"
                     ) from e
 
-            if self._should_wait_for_more_initial_requests(active_states):
+            if stage_worker is not None:
+                self._process_stage_worker_results(
+                    continuous_coordinator,
+                    stage_worker,
+                    active_states,
+                    pending_groups,
+                    pending_admissions,
+                    pending_finalizes,
+                )
+
+            if self._should_wait_for_more_initial_requests(
+                active_states, pending_admissions
+            ):
                 oldest_ts = self.waiting_queue[0][2]
                 elapsed_ms = (time.monotonic() - oldest_ts) * 1000.0
                 remaining_ms = max(0, self._batching_delay_s * 1000.0 - elapsed_ms)
@@ -1455,13 +1678,26 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 continuous_coordinator,
                 active_states,
                 pending_groups,
+                stage_worker,
+                pending_admissions,
             )
 
             denoising_batch = continuous_coordinator.select_next_step_batch(
                 active_states
             )
             if not denoising_batch:
-                if self.waiting_queue and self.receiver is not None:
+                if stage_worker is not None and stage_worker.pending > 0:
+                    # No denoising work yet; block on the next async result.
+                    self._process_stage_worker_results(
+                        continuous_coordinator,
+                        stage_worker,
+                        active_states,
+                        pending_groups,
+                        pending_admissions,
+                        pending_finalizes,
+                        block_one=True,
+                    )
+                elif self.waiting_queue and self.receiver is not None:
                     self._poller.poll(
                         timeout=max(1, int(self._batching_delay_s * 1000))
                     )
@@ -1507,24 +1743,27 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     completed.append(state)
 
             for state in completed:
-                try:
-                    self._return_completed_request_state(state, pending_groups)
-                except Exception as e:
-                    logger.error(
-                        "Error returning continuous batching result for request %s: %s",
-                        state.request_id,
-                        e,
-                        exc_info=True,
+                if state.is_complete:
+                    # Already failed; return the error immediately.
+                    self._safe_return_completed_request_state(state, pending_groups)
+                elif stage_worker is not None and not state.req.is_warmup:
+                    # Offload VAE decode/postprocessing to keep denoising busy.
+                    ticket = self._next_admission_ticket
+                    self._next_admission_ticket += 1
+                    pending_finalizes[ticket] = state
+                    stage_worker.submit(
+                        "finalize",
+                        ticket,
+                        lambda state=state: (
+                            continuous_coordinator.finalize_completed_request(state)
+                        ),
                     )
-                    self._return_continuous_result(
-                        OutputBatch(error=f"continuous batching response failed: {e}"),
-                        state.identity,
-                        req_or_group=state.req,
-                        is_warmup=state.req.is_warmup,
-                    )
+                else:
+                    continuous_coordinator.finalize_completed_request(state)
+                    self._safe_return_completed_request_state(state, pending_groups)
 
             active_states = [state for state in active_states if not state.is_complete]
-            if len(active_states) > 1:
+            if rotate_policy and len(active_states) > 1:
                 active_states = self._move_recently_run_states_to_back(
                     active_states,
                     denoising_batch,
@@ -1533,6 +1772,32 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 continuous_coordinator,
                 active_states,
                 pending_groups,
+                stage_worker,
+                pending_admissions,
+            )
+
+        # Flush async work and drain-export remaining in-flight requests.
+        if stage_worker is not None:
+            while stage_worker.pending > 0:
+                self._process_stage_worker_results(
+                    continuous_coordinator,
+                    stage_worker,
+                    active_states,
+                    pending_groups,
+                    pending_admissions,
+                    pending_finalizes,
+                    block_one=True,
+                )
+            stage_worker.shutdown()
+
+        in_flight = [state for state in active_states if not state.is_complete]
+        if in_flight and drain_dir:
+            exported = continuous_coordinator.export_states_to_dir(in_flight, drain_dir)
+            logger.info(
+                "Drain-exported %d/%d in-flight continuous batching request(s) to %s",
+                len(exported),
+                len(in_flight),
+                drain_dir,
             )
 
         self._log_batch_metrics_summary()

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -1276,11 +1276,17 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         )
         pipeline = continuous_coordinator.pipeline
         server_args = self.server_args
-        stage_worker.submit(
-            "encode",
-            ticket,
-            lambda: pipeline.run_stages_before_denoising(req, server_args),
-        )
+        try:
+            stage_worker.submit(
+                "encode",
+                ticket,
+                lambda: pipeline.run_stages_before_denoising(req, server_args),
+            )
+        except Exception as e:
+            # Admission pre-checks queue capacity, so a submit failure means
+            # the worker died or the invariant broke; fail the request loudly.
+            pending_admissions.pop(ticket, None)
+            on_error(e, log=True)
 
     def _admit_waiting_requests_to_continuous_loop(
         self,
@@ -1301,6 +1307,24 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 has_inflight and self._continuous_item_is_warmup(req_or_group)
             ):
                 break
+
+            if (
+                stage_worker is not None
+                and not self._continuous_item_is_warmup(req_or_group)
+                and (
+                    isinstance(req_or_group, Req)
+                    or self._is_continuous_request_group(req_or_group)
+                )
+            ):
+                needed = (
+                    len(req_or_group)
+                    if self._is_continuous_request_group(req_or_group)
+                    else 1
+                )
+                if not stage_worker.can_submit("encode", needed):
+                    # Bounded encode queue: apply backpressure by leaving the
+                    # request in the waiting queue until capacity frees up.
+                    break
 
             pending_reqs = [item.req for item in pending_admissions.values()]
 
@@ -1590,6 +1614,46 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 is_warmup=state.req.is_warmup,
             )
 
+    def _drain_finalize_backlog(
+        self,
+        continuous_coordinator: ContinuousDenoisingCoordinator,
+        stage_worker: Any,
+        finalize_backlog: list[DenoisingRequestState],
+        pending_finalizes: dict[int, DenoisingRequestState],
+        pending_groups: dict[str, ContinuousResponseGroup],
+    ) -> None:
+        """Submit backlogged finalize jobs as bounded-queue capacity frees up."""
+        from sglang.multimodal_gen.runtime.managers.continuous_stage_worker import (
+            WorkerState,
+        )
+
+        if stage_worker.worker_state("finalize") is not WorkerState.RUNNING:
+            # The finalize worker died; fail the backlog loudly instead of
+            # silently decoding inline.
+            while finalize_backlog:
+                state = finalize_backlog.pop(0)
+                state.set_error_output(
+                    "continuous batching finalize worker is not running"
+                )
+                self._safe_return_completed_request_state(state, pending_groups)
+            return
+        while finalize_backlog and stage_worker.can_submit("finalize"):
+            state = finalize_backlog.pop(0)
+            ticket = self._next_admission_ticket
+            self._next_admission_ticket += 1
+            pending_finalizes[ticket] = state
+            submitted = stage_worker.try_submit(
+                "finalize",
+                ticket,
+                lambda state=state: (
+                    continuous_coordinator.finalize_completed_request(state)
+                ),
+            )
+            if not submitted:
+                pending_finalizes.pop(ticket, None)
+                finalize_backlog.insert(0, state)
+                break
+
     def _run_continuous_batching_loop(self) -> None:
         logger.info(
             "Continuous batching scheduler enabled "
@@ -1608,8 +1672,13 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         pending_groups: dict[str, ContinuousResponseGroup] = {}
         pending_admissions: dict[int, _PendingAdmission] = {}
         pending_finalizes: dict[int, DenoisingRequestState] = {}
+        finalize_backlog: list[DenoisingRequestState] = []
         stage_worker = (
-            AsyncContinuousStageWorker()
+            AsyncContinuousStageWorker(
+                queue_depth=int(
+                    getattr(self.server_args, "cb_stage_queue_depth", 8) or 8
+                )
+            )
             if async_stages_supported(self.server_args)
             else None
         )
@@ -1661,6 +1730,13 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     pending_admissions,
                     pending_finalizes,
                 )
+                self._drain_finalize_backlog(
+                    continuous_coordinator,
+                    stage_worker,
+                    finalize_backlog,
+                    pending_finalizes,
+                    pending_groups,
+                )
 
             if self._should_wait_for_more_initial_requests(
                 active_states, pending_admissions
@@ -1686,7 +1762,9 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 active_states
             )
             if not denoising_batch:
-                if stage_worker is not None and stage_worker.pending > 0:
+                if stage_worker is not None and (
+                    stage_worker.pending > 0 or finalize_backlog
+                ):
                     # No denoising work yet; block on the next async result.
                     self._process_stage_worker_results(
                         continuous_coordinator,
@@ -1696,6 +1774,13 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                         pending_admissions,
                         pending_finalizes,
                         block_one=True,
+                    )
+                    self._drain_finalize_backlog(
+                        continuous_coordinator,
+                        stage_worker,
+                        finalize_backlog,
+                        pending_finalizes,
+                        pending_groups,
                     )
                 elif self.waiting_queue and self.receiver is not None:
                     self._poller.poll(
@@ -1747,20 +1832,20 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     # Already failed; return the error immediately.
                     self._safe_return_completed_request_state(state, pending_groups)
                 elif stage_worker is not None and not state.req.is_warmup:
-                    # Offload VAE decode/postprocessing to keep denoising busy.
-                    ticket = self._next_admission_ticket
-                    self._next_admission_ticket += 1
-                    pending_finalizes[ticket] = state
-                    stage_worker.submit(
-                        "finalize",
-                        ticket,
-                        lambda state=state: (
-                            continuous_coordinator.finalize_completed_request(state)
-                        ),
-                    )
+                    # Offload VAE decode/postprocessing to keep denoising busy;
+                    # the bounded finalize queue is fed through the backlog.
+                    finalize_backlog.append(state)
                 else:
                     continuous_coordinator.finalize_completed_request(state)
                     self._safe_return_completed_request_state(state, pending_groups)
+            if stage_worker is not None:
+                self._drain_finalize_backlog(
+                    continuous_coordinator,
+                    stage_worker,
+                    finalize_backlog,
+                    pending_finalizes,
+                    pending_groups,
+                )
 
             active_states = [state for state in active_states if not state.is_complete]
             if rotate_policy and len(active_states) > 1:
@@ -1778,16 +1863,24 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
 
         # Flush async work and drain-export remaining in-flight requests.
         if stage_worker is not None:
-            while stage_worker.pending > 0:
-                self._process_stage_worker_results(
+            while stage_worker.pending > 0 or finalize_backlog:
+                self._drain_finalize_backlog(
                     continuous_coordinator,
                     stage_worker,
-                    active_states,
-                    pending_groups,
-                    pending_admissions,
+                    finalize_backlog,
                     pending_finalizes,
-                    block_one=True,
+                    pending_groups,
                 )
+                if stage_worker.pending > 0:
+                    self._process_stage_worker_results(
+                        continuous_coordinator,
+                        stage_worker,
+                        active_states,
+                        pending_groups,
+                        pending_admissions,
+                        pending_finalizes,
+                        block_one=True,
+                    )
             stage_worker.shutdown()
 
         in_flight = [state for state in active_states if not state.is_complete]

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -1117,6 +1117,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         req_or_group: Req | list[Req] | None = None,
         is_warmup: bool = False,
     ) -> bool:
+        """Return a continuous-batching result using normal warmup policy."""
         should_not_return = is_warmup
         if (
             is_warmup
@@ -1168,6 +1169,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         active_states: list[DenoisingRequestState],
         denoising_batch: list[DenoisingRequestState],
     ) -> list[DenoisingRequestState]:
+        """Rotate just-run states behind other active requests for fairness."""
         just_ran = {id(state) for state in denoising_batch}
         return [state for state in active_states if id(state) not in just_ran] + [
             state for state in active_states if id(state) in just_ran
@@ -1179,6 +1181,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         active_states: list[DenoisingRequestState],
         pending_groups: dict[str, ContinuousResponseGroup],
     ) -> None:
+        """Move queued requests into the active continuous denoising set."""
         while self.waiting_queue:
             identity, req_or_group, enqueue_time = self.waiting_queue[0]
 
@@ -1230,14 +1233,12 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 pending_groups[group_id] = group
                 for index, req in enumerate(group_reqs):
                     try:
-                        state = (
-                            continuous_coordinator.prepare_request_for_denoising_steps(
-                                identity=identity,
-                                req=req,
-                                response_group_id=group_id,
-                                response_index=index,
-                                response_group_size=len(group_reqs),
-                            )
+                        state = continuous_coordinator.prepare_request_state(
+                            identity=identity,
+                            req=req,
+                            response_group_id=group_id,
+                            response_index=index,
+                            response_group_size=len(group_reqs),
                         )
                         state.queue_wait_ms = (time.monotonic() - enqueue_time) * 1000.0
                         active_states.append(state)
@@ -1302,7 +1303,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
 
             self.waiting_queue.popleft()
             try:
-                state = continuous_coordinator.prepare_request_for_denoising_steps(
+                state = continuous_coordinator.prepare_request_state(
                     identity=identity,
                     req=req_or_group,
                 )
@@ -1355,6 +1356,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         state: DenoisingRequestState,
         pending_groups: dict[str, ContinuousResponseGroup],
     ) -> None:
+        """Return a completed continuous request or attach it to its group."""
         output_batch = state.output_batch or OutputBatch(error=state.error)
         if state.response_group_id is None or state.response_group_size <= 1:
             is_warmup = state.req.is_warmup
@@ -1455,10 +1457,8 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 pending_groups,
             )
 
-            denoising_batch = (
-                continuous_coordinator.select_compatible_requests_for_next_step(
-                    active_states
-                )
+            denoising_batch = continuous_coordinator.select_next_step_batch(
+                active_states
             )
             if not denoising_batch:
                 if self.waiting_queue and self.receiver is not None:

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -719,6 +719,9 @@ class QwenImageCrossAttention(nn.Module):
         sp_text_sharded = cross_attention_kwargs.get("sp_text_sharded", False)
         # Rows of tail padding inside THIS rank's text chunk (sp_shard meta).
         sp_txt_pad = _attn_mask_meta_local_pad(attn_mask_meta)
+        # Per-token RoPE positions for cross-resolution packed batches.
+        img_rope_positions = cross_attention_kwargs.get("img_rope_positions")
+        txt_rope_positions = cross_attention_kwargs.get("txt_rope_positions")
 
         (
             img_query,
@@ -757,6 +760,7 @@ class QwenImageCrossAttention(nn.Module):
                 head_dim=img_query.shape[-1],
                 cos_sin_cache=img_cache,
                 is_neox=False,
+                positions=img_rope_positions,
                 allow_inplace=True,
             )
             txt_query, txt_key = apply_qk_norm_with_optional_rope(
@@ -767,14 +771,23 @@ class QwenImageCrossAttention(nn.Module):
                 head_dim=txt_query.shape[-1],
                 cos_sin_cache=txt_cache,
                 is_neox=False,
+                positions=txt_rope_positions,
                 allow_inplace=True,
             )
         elif img_cache is not None and txt_cache is not None:
             img_query, img_key = apply_flashinfer_rope_qk_inplace(
-                img_query, img_key, img_cache, is_neox=False
+                img_query,
+                img_key,
+                img_cache,
+                is_neox=False,
+                positions=img_rope_positions,
             )
             txt_query, txt_key = apply_flashinfer_rope_qk_inplace(
-                txt_query, txt_key, txt_cache, is_neox=False
+                txt_query,
+                txt_key,
+                txt_cache,
+                is_neox=False,
+                positions=txt_rope_positions,
             )
 
         # Joint order [text, image]; join_seqs relocates any SP text tail-pad
@@ -1319,6 +1332,9 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
     _no_split_modules = ["QwenImageTransformerBlock"]
     _skip_layerwise_casting_patterns = ["pos_embed", "norm"]
     _repeated_blocks = ["QwenImageTransformerBlock"]
+    # Supports cross-resolution packed batches (per-row image masks and
+    # per-token RoPE positions via image_seq_lens / attention_kwargs).
+    supports_varlen_step_packing = True
 
     param_names_mapping = QwenImageDitConfig().arch_config.param_names_mapping
     _fsdp_shard_conditions = QwenImageDitConfig().arch_config._fsdp_shard_conditions
@@ -1474,6 +1490,7 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
         guidance: torch.Tensor = None,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         controlnet_block_samples=None,
+        image_seq_lens: Optional[List[int]] = None,
         return_dict: bool = True,
     ) -> Union[torch.Tensor, Transformer2DModelOutput]:
         """
@@ -1531,16 +1548,33 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
 
         block_attention_kwargs = attention_kwargs.copy() if attention_kwargs else {}
         sp_text_sharded = False
-        if encoder_hidden_states_mask is not None:
+        if encoder_hidden_states_mask is not None or image_seq_lens is not None:
+            batch_size, image_seq_len = hidden_states.shape[:2]
+            if encoder_hidden_states_mask is None:
+                encoder_hidden_states_mask = torch.ones(
+                    (batch_size, encoder_hidden_states.shape[1]),
+                    dtype=torch.bool,
+                    device=hidden_states.device,
+                )
             encoder_hidden_states_mask = encoder_hidden_states_mask.to(
                 device=hidden_states.device, dtype=torch.bool
             )
-            batch_size, image_seq_len = hidden_states.shape[:2]
-            image_mask = torch.ones(
-                (batch_size, image_seq_len),
-                dtype=torch.bool,
-                device=hidden_states.device,
-            )
+            if image_seq_lens is not None:
+                # Cross-resolution packing: image rows are right-padded to a
+                # shared length; mask off each row's padded tail.
+                lens = torch.as_tensor(
+                    image_seq_lens, dtype=torch.int64, device=hidden_states.device
+                )
+                image_mask = (
+                    torch.arange(image_seq_len, device=hidden_states.device)[None, :]
+                    < lens[:, None]
+                )
+            else:
+                image_mask = torch.ones(
+                    (batch_size, image_seq_len),
+                    dtype=torch.bool,
+                    device=hidden_states.device,
+                )
             joint_mask = torch.cat([encoder_hidden_states_mask, image_mask], dim=1)
             block_attention_kwargs["attn_mask"] = joint_mask
             if is_in_breakable_cuda_graph():

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -97,6 +97,23 @@ def _local_seq_len(seq_len: int, sp_world_size: int) -> int:
     return padded_len // sp_world_size
 
 
+def _pad_and_cat_sequence_tensors(values: List[torch.Tensor]) -> torch.Tensor:
+    max_seq_len = max(int(value.shape[1]) for value in values)
+    padded_values = []
+    for value in values:
+        seq_len = int(value.shape[1])
+        if seq_len < max_seq_len:
+            pad_shape = list(value.shape)
+            pad_shape[1] = max_seq_len - seq_len
+            pad_value = False if value.dtype == torch.bool else 0
+            value = torch.cat(
+                [value, value.new_full(pad_shape, pad_value)],
+                dim=1,
+            )
+        padded_values.append(value)
+    return torch.cat(padded_values, dim=0)
+
+
 def _get_qkv_projections(
     attn: "QwenImageCrossAttention", hidden_states, encoder_hidden_states=None
 ):
@@ -1492,9 +1509,11 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             )
 
         if isinstance(encoder_hidden_states, list):
-            encoder_hidden_states = encoder_hidden_states[0]
+            encoder_hidden_states = _pad_and_cat_sequence_tensors(encoder_hidden_states)
         if isinstance(encoder_hidden_states_mask, list):
-            encoder_hidden_states_mask = encoder_hidden_states_mask[0]
+            encoder_hidden_states_mask = _pad_and_cat_sequence_tensors(
+                encoder_hidden_states_mask
+            )
 
         hidden_states, _ = self.img_in(hidden_states)
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -903,6 +903,9 @@ class WanTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
     param_names_mapping = WanVideoConfig().param_names_mapping
     reverse_param_names_mapping = WanVideoConfig().reverse_param_names_mapping
     lora_param_names_mapping = WanVideoConfig().lora_param_names_mapping
+    # Continuous batching may pack TeaCache requests and drive per-row
+    # hit/miss decisions through a TeaCachePackedPlan (see forward()).
+    supports_packed_teacache = True
 
     def __init__(
         self,
@@ -1183,26 +1186,40 @@ class WanTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
         assert encoder_hidden_states.dtype == orig_dtype
 
         # 4. Transformer blocks
-        # if caching is enabled, we might be able to skip the forward pass
-        should_skip_forward = self.should_skip_forward_for_cached_states(
-            timestep_proj=timestep_proj, temb=temb
-        )
-
-        if should_skip_forward:
-            hidden_states = self.retrieve_cached_states(hidden_states)
+        teacache_plan = getattr(get_forward_context(), "teacache_plan", None)
+        if teacache_plan is not None:
+            # Packed continuous batching: per-request (per-row) TeaCache
+            # decisions with gather/scatter around the block loop.
+            hidden_states = self._forward_blocks_with_packed_teacache(
+                teacache_plan,
+                hidden_states,
+                encoder_hidden_states,
+                timestep_proj,
+                temb,
+                freqs_cis,
+                force_compute=sequence_shard_enabled or ts_seq_len is not None,
+            )
         else:
-            # if teacache is enabled, we need to cache the original hidden states
-            if self.enable_teacache:
-                original_hidden_states = hidden_states.clone()
+            # if caching is enabled, we might be able to skip the forward pass
+            should_skip_forward = self.should_skip_forward_for_cached_states(
+                timestep_proj=timestep_proj, temb=temb
+            )
 
-            for block in self.blocks:
-                hidden_states = block(
-                    hidden_states, encoder_hidden_states, timestep_proj, freqs_cis
-                )
-            # if teacache is enabled, we need to cache the original hidden states
-            if self.enable_teacache:
-                self.maybe_cache_states(hidden_states, original_hidden_states)
-        self.cnt += 1
+            if should_skip_forward:
+                hidden_states = self.retrieve_cached_states(hidden_states)
+            else:
+                # if teacache is enabled, we need to cache the original hidden states
+                if self.enable_teacache:
+                    original_hidden_states = hidden_states.clone()
+
+                for block in self.blocks:
+                    hidden_states = block(
+                        hidden_states, encoder_hidden_states, timestep_proj, freqs_cis
+                    )
+                # if teacache is enabled, we need to cache the original hidden states
+                if self.enable_teacache:
+                    self.maybe_cache_states(hidden_states, original_hidden_states)
+            self.cnt += 1
 
         if sequence_shard_enabled:
             hidden_states = hidden_states.contiguous()
@@ -1238,6 +1255,123 @@ class WanTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
         hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
         output = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
 
+        return output
+
+    def _forward_blocks_with_packed_teacache(
+        self,
+        plan: Any,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        timestep_proj: torch.Tensor,
+        temb: torch.Tensor,
+        freqs_cis,
+        *,
+        force_compute: bool = False,
+    ) -> torch.Tensor:
+        """Run transformer blocks with per-row TeaCache hit/miss gather-scatter.
+
+        Each plan member owns a row range of the packed batch and its own
+        cache state. Rows whose members decide to skip are patched with their
+        cached residual; the remaining rows are gathered into a compact
+        sub-batch for the block loop and scattered back afterwards. Rows not
+        covered by any member (e.g. bucket padding) always compute.
+
+        ``force_compute`` keeps member states coherent while disabling skips
+        for layouts this path cannot patch row-wise (sequence-parallel shards
+        and Wan TI2V per-token timesteps).
+        """
+        forward_batch = get_forward_context().forward_batch
+        is_cfg_negative = bool(
+            forward_batch is not None
+            and getattr(forward_batch, "is_cfg_negative", False)
+        )
+        row_count = int(hidden_states.shape[0])
+        compute_mask = [True] * row_count
+        decisions: list[tuple[Any, bool]] = []
+        for member in plan.members:
+            if member.enabled:
+                use_ret_steps = bool(
+                    getattr(member.teacache_params, "use_ret_steps", False)
+                )
+                modulated_source = timestep_proj if use_ret_steps else temb
+                should_calc = member.decide(
+                    modulated_source[member.row_slice], is_cfg_negative
+                )
+            else:
+                should_calc = True
+            if force_compute:
+                should_calc = True
+            member.advance()
+            decisions.append((member, should_calc))
+            if not should_calc:
+                for row in range(*member.row_slice.indices(row_count)):
+                    compute_mask[row] = False
+
+        def _stash(member: Any, out_rows: torch.Tensor, in_rows: torch.Tensor):
+            member.stash_residual(out_rows - in_rows, is_cfg_negative)
+
+        skip_rows = [row for row in range(row_count) if not compute_mask[row]]
+        if not skip_rows:
+            original_hidden_states = None
+            if any(member.enabled for member, _ in decisions):
+                original_hidden_states = hidden_states.clone()
+            for block in self.blocks:
+                hidden_states = block(
+                    hidden_states, encoder_hidden_states, timestep_proj, freqs_cis
+                )
+            if original_hidden_states is not None:
+                for member, should_calc in decisions:
+                    if member.enabled and should_calc:
+                        _stash(
+                            member,
+                            hidden_states[member.row_slice],
+                            original_hidden_states[member.row_slice],
+                        )
+            return hidden_states
+
+        output = torch.empty_like(hidden_states)
+        for member, should_calc in decisions:
+            if should_calc:
+                continue
+            residual = member.cached_residual(is_cfg_negative)
+            assert residual is not None, (
+                "TeaCache skip decision without a cached residual; "
+                "packed plan state is out of sync"
+            )
+            output[member.row_slice] = hidden_states[member.row_slice] + residual
+
+        compute_rows = [row for row in range(row_count) if compute_mask[row]]
+        if compute_rows:
+            index = torch.tensor(
+                compute_rows, device=hidden_states.device, dtype=torch.long
+            )
+            sub_hidden = hidden_states.index_select(0, index)
+            sub_encoder = encoder_hidden_states.index_select(0, index)
+            sub_proj = timestep_proj.index_select(0, index)
+            sub_original = None
+            if any(member.enabled and calc for member, calc in decisions):
+                sub_original = sub_hidden.clone()
+            for block in self.blocks:
+                sub_hidden = block(sub_hidden, sub_encoder, sub_proj, freqs_cis)
+            output.index_copy_(0, index, sub_hidden.to(output.dtype))
+            if sub_original is not None:
+                row_to_position = {
+                    row: position for position, row in enumerate(compute_rows)
+                }
+                for member, should_calc in decisions:
+                    if not (member.enabled and should_calc):
+                        continue
+                    member_rows = list(range(*member.row_slice.indices(row_count)))
+                    positions = torch.tensor(
+                        [row_to_position[row] for row in member_rows],
+                        device=sub_hidden.device,
+                        dtype=torch.long,
+                    )
+                    _stash(
+                        member,
+                        sub_hidden.index_select(0, positions),
+                        sub_original.index_select(0, positions),
+                    )
         return output
 
     def maybe_cache_states(

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -69,6 +69,46 @@ if USE_AITER:
     from aiter.ops.rope import rope_cached_2c_fwd_inplace
 
 
+def _pad_and_cat_sequence_tensors(values: list[torch.Tensor]) -> torch.Tensor:
+    if not values:
+        raise ValueError("expected at least one sequence tensor")
+    if any(not isinstance(value, torch.Tensor) for value in values):
+        raise TypeError("expected a list of sequence tensors")
+    first = values[0]
+    if first.ndim < 2:
+        raise ValueError("sequence tensors must have at least 2 dimensions")
+    if len(values) == 1:
+        return first
+
+    if all(
+        value.ndim >= 3
+        and tuple(value.shape[2:]) == tuple(first.shape[2:])
+        and value.dtype == first.dtype
+        and value.device == first.device
+        for value in values
+    ):
+        max_seq_len = max(int(value.shape[1]) for value in values)
+        padded_values = []
+        for value in values:
+            seq_len = int(value.shape[1])
+            if seq_len < max_seq_len:
+                pad_shape = list(value.shape)
+                pad_shape[1] = max_seq_len - seq_len
+                value = torch.cat([value, value.new_zeros(pad_shape)], dim=1)
+            padded_values.append(value)
+        return torch.cat(padded_values, dim=0)
+
+    if all(
+        tuple(value.shape[1:]) == tuple(first.shape[1:])
+        and value.dtype == first.dtype
+        and value.device == first.device
+        for value in values
+    ):
+        return torch.cat(values, dim=0)
+
+    raise ValueError("sequence tensors cannot be merged for batched Wan forward")
+
+
 class WanImageEmbedding(torch.nn.Module):
     def __init__(self, in_features: int, out_features: int):
         super().__init__()
@@ -1013,7 +1053,7 @@ class WanTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
 
         orig_dtype = hidden_states.dtype
         if not isinstance(encoder_hidden_states, torch.Tensor):
-            encoder_hidden_states = encoder_hidden_states[0]
+            encoder_hidden_states = _pad_and_cat_sequence_tensors(encoder_hidden_states)
         if (
             isinstance(encoder_hidden_states_image, list)
             and len(encoder_hidden_states_image) > 0

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/batched_solver.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/batched_solver.py
@@ -3,30 +3,116 @@
 
 Advances all packed rows in one fused update and keeps per-request scheduler
 state consistent so requests can leave the batch at any step.
+
+Packed execution has no per-request ``scheduler.step()`` fallback: only
+schedulers accepted by :func:`scheduler_is_batchable` may join a packed
+group, and a packed group that cannot build its solver is a hard error.
+Requests with unsupported schedulers simply run unpacked; the reason is
+surfaced through rate-limited diagnostics instead of a silent degradation.
+
+A fused CUDA kernel for the update was intentionally not added: the packed
+update is a couple of elementwise kernels on latents and profiling on the
+target GPUs should justify a custom kernel before one is introduced.
 """
 
 from __future__ import annotations
 
+import hashlib
+import threading
+from collections import OrderedDict
 from typing import Any
 
 import torch
+
+from sglang.multimodal_gen.runtime.pipelines_core.fallback_diagnostics import (
+    fallback_diagnostics,
+)
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
 
 # First-order FlowMatch-Euler update: prev = sample + (sigma_next - sigma) * model_output.
 _FLOW_MATCH_EULER_CLASS_NAMES = frozenset({"FlowMatchEulerDiscreteScheduler"})
 
 
-def _scheduler_is_plain_flow_match_euler(scheduler: Any) -> bool:
+class SolverRejection(Exception):
+    """The batched solver cannot handle these schedulers (with the reason)."""
+
+
+def _scheduler_rejection_reason(scheduler: Any) -> str | None:
+    """Why this scheduler cannot use the vectorized solver, or None if it can."""
     if type(scheduler).__name__ not in _FLOW_MATCH_EULER_CLASS_NAMES:
-        return False
+        return f"unsupported scheduler {type(scheduler).__name__}"
     if getattr(scheduler, "order", 1) != 1:
-        return False
+        return "scheduler order != 1"
     config = getattr(scheduler, "config", None)
     if config is not None and getattr(config, "stochastic_sampling", False):
-        return False
+        return "stochastic_sampling is not vectorized"
     sigmas = getattr(scheduler, "sigmas", None)
     if not isinstance(sigmas, torch.Tensor) or sigmas.ndim != 1:
-        return False
-    return True
+        return "scheduler sigmas are not a 1-D tensor"
+    return None
+
+
+def scheduler_is_batchable(scheduler: Any, *, diagnose: bool = False) -> bool:
+    """Whether this scheduler may join a packed (vectorized) step group.
+
+    With ``diagnose=True`` a rejection is recorded in the rate-limited
+    fallback diagnostics so operators can see why requests run unpacked.
+    """
+    reason = _scheduler_rejection_reason(scheduler)
+    if reason is None:
+        return True
+    if diagnose:
+        fallback_diagnostics.record("batched-solver", type(scheduler).__name__, reason)
+    return False
+
+
+class _SigmaTableCache:
+    """LRU cache of per-schedule sigma rows already resident on device.
+
+    Keyed by the schedule content (hash of the fp32 sigmas) and target device
+    so repeated group rebuilds with the same schedules skip the host-to-device
+    copies. Tables are tiny ([num_steps + 1] fp32) so a small LRU suffices.
+    """
+
+    def __init__(self, max_entries: int = 64) -> None:
+        self._max_entries = max_entries
+        self._lock = threading.Lock()
+        self._entries: OrderedDict[tuple[str, str], torch.Tensor] = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+
+    @staticmethod
+    def _fingerprint(sigmas: torch.Tensor) -> str:
+        cpu = sigmas.detach().to(device="cpu", dtype=torch.float32).contiguous()
+        return hashlib.sha1(cpu.numpy().tobytes()).hexdigest()
+
+    def get(self, sigmas: torch.Tensor, device: torch.device) -> torch.Tensor:
+        key = (self._fingerprint(sigmas), str(device))
+        with self._lock:
+            cached = self._entries.get(key)
+            if cached is not None:
+                self._entries.move_to_end(key)
+                self.hits += 1
+                return cached
+            self.misses += 1
+        row = sigmas.detach().to(device=device, dtype=torch.float32)
+        with self._lock:
+            self._entries[key] = row
+            self._entries.move_to_end(key)
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+        return row
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+            self.hits = 0
+            self.misses = 0
+
+
+sigma_table_cache = _SigmaTableCache()
 
 
 class BatchedFlowMatchEulerSolver:
@@ -54,26 +140,27 @@ class BatchedFlowMatchEulerSolver:
         cls,
         states: list[Any],
         device: torch.device,
-    ) -> BatchedFlowMatchEulerSolver | None:
-        """Build a vectorized solver for member states, or return None."""
+    ) -> BatchedFlowMatchEulerSolver:
+        """Build a vectorized solver for member states or raise SolverRejection."""
         schedulers = [state.denoising_context.scheduler for state in states]
-        if not all(_scheduler_is_plain_flow_match_euler(s) for s in schedulers):
-            return None
-
-        sigma_rows: list[torch.Tensor] = []
-        max_len = 0
         for scheduler in schedulers:
-            sigmas = scheduler.sigmas
-            max_len = max(max_len, int(sigmas.shape[0]))
+            reason = _scheduler_rejection_reason(scheduler)
+            if reason is not None:
+                raise SolverRejection(reason)
+
+        rows = [
+            sigma_table_cache.get(scheduler.sigmas, device) for scheduler in schedulers
+        ]
+        max_len = max(int(row.shape[0]) for row in rows)
         # +1 so sigma_{i+1} at the final step stays in range.
         table_len = max_len + 1
-        for scheduler in schedulers:
-            sigmas = scheduler.sigmas.to(dtype=torch.float32)
-            pad = table_len - int(sigmas.shape[0])
+        padded_rows = []
+        for row in rows:
+            pad = table_len - int(row.shape[0])
             if pad > 0:
-                sigmas = torch.cat([sigmas, sigmas[-1:].expand(pad)])
-            sigma_rows.append(sigmas)
-        sigma_table = torch.stack(sigma_rows).to(device=device, non_blocking=True)
+                row = torch.cat([row, row[-1:].expand(pad)])
+            padded_rows.append(row)
+        sigma_table = torch.stack(padded_rows)
 
         start_indices = torch.tensor(
             [int(state.step_index) for state in states],
@@ -129,11 +216,13 @@ class BatchedFlowMatchEulerSolver:
 def build_batched_solver(
     states: list[Any],
     device: torch.device,
-) -> BatchedFlowMatchEulerSolver | None:
-    """Build a batched solver, falling back to None on any error."""
+) -> BatchedFlowMatchEulerSolver:
+    """Build the batched solver for a packed group.
+
+    Raises :class:`SolverRejection` when any member's scheduler is not
+    vectorizable. Packed groups must not form around such schedulers, so a
+    rejection here means the packability pre-screen was bypassed.
+    """
     if not states:
-        return None
-    try:
-        return BatchedFlowMatchEulerSolver.try_build(states, device)
-    except Exception:
-        return None
+        raise SolverRejection("no member states")
+    return BatchedFlowMatchEulerSolver.try_build(states, device)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/batched_solver.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/batched_solver.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vectorized FlowMatch-Euler solver for packed continuous batches.
+
+Advances all packed rows in one fused update and keeps per-request scheduler
+state consistent so requests can leave the batch at any step.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+# First-order FlowMatch-Euler update: prev = sample + (sigma_next - sigma) * model_output.
+_FLOW_MATCH_EULER_CLASS_NAMES = frozenset({"FlowMatchEulerDiscreteScheduler"})
+
+
+def _scheduler_is_plain_flow_match_euler(scheduler: Any) -> bool:
+    if type(scheduler).__name__ not in _FLOW_MATCH_EULER_CLASS_NAMES:
+        return False
+    if getattr(scheduler, "order", 1) != 1:
+        return False
+    config = getattr(scheduler, "config", None)
+    if config is not None and getattr(config, "stochastic_sampling", False):
+        return False
+    sigmas = getattr(scheduler, "sigmas", None)
+    if not isinstance(sigmas, torch.Tensor) or sigmas.ndim != 1:
+        return False
+    return True
+
+
+class BatchedFlowMatchEulerSolver:
+    """Fused FlowMatch-Euler step across packed rows."""
+
+    def __init__(
+        self,
+        *,
+        sigma_table: torch.Tensor,
+        start_indices: torch.Tensor,
+        row_index: torch.Tensor | None,
+        num_rows: int,
+    ) -> None:
+        # [B, T_max + 1] padded with each row's final sigma for safe gathers.
+        self._sigma_table = sigma_table
+        # [B] step indices at build time.
+        self._start_indices = start_indices
+        # Maps packed rows to member index; None for 1 row per member.
+        self._row_index = row_index
+        self._num_rows = num_rows
+        self._steps_taken = 0
+
+    @classmethod
+    def try_build(
+        cls,
+        states: list[Any],
+        device: torch.device,
+    ) -> BatchedFlowMatchEulerSolver | None:
+        """Build a vectorized solver for member states, or return None."""
+        schedulers = [state.denoising_context.scheduler for state in states]
+        if not all(_scheduler_is_plain_flow_match_euler(s) for s in schedulers):
+            return None
+
+        sigma_rows: list[torch.Tensor] = []
+        max_len = 0
+        for scheduler in schedulers:
+            sigmas = scheduler.sigmas
+            max_len = max(max_len, int(sigmas.shape[0]))
+        # +1 so sigma_{i+1} at the final step stays in range.
+        table_len = max_len + 1
+        for scheduler in schedulers:
+            sigmas = scheduler.sigmas.to(dtype=torch.float32)
+            pad = table_len - int(sigmas.shape[0])
+            if pad > 0:
+                sigmas = torch.cat([sigmas, sigmas[-1:].expand(pad)])
+            sigma_rows.append(sigmas)
+        sigma_table = torch.stack(sigma_rows).to(device=device, non_blocking=True)
+
+        start_indices = torch.tensor(
+            [int(state.step_index) for state in states],
+            dtype=torch.long,
+            device=device,
+        )
+
+        row_counts = [int(state.denoising_context.latents.shape[0]) for state in states]
+        num_rows = sum(row_counts)
+        if all(count == 1 for count in row_counts):
+            row_index = None
+        else:
+            row_index = torch.repeat_interleave(
+                torch.arange(len(states), device=device),
+                torch.tensor(row_counts, device=device),
+            )
+        return cls(
+            sigma_table=sigma_table,
+            start_indices=start_indices,
+            row_index=row_index,
+            num_rows=num_rows,
+        )
+
+    def scale_model_input(self, packed_sample: torch.Tensor) -> torch.Tensor:
+        """FlowMatch-Euler does not scale the sample."""
+        return packed_sample
+
+    def step_rows(
+        self,
+        packed_model_output: torch.Tensor,
+        packed_sample: torch.Tensor,
+        states: list[Any],
+    ) -> torch.Tensor:
+        """Advance every packed row by one solver step."""
+        indices = self._start_indices + self._steps_taken
+        sigma = self._sigma_table.gather(1, indices.unsqueeze(1)).squeeze(1)
+        sigma_next = self._sigma_table.gather(1, (indices + 1).unsqueeze(1)).squeeze(1)
+        delta = sigma_next - sigma
+        if self._row_index is not None:
+            delta = delta.index_select(0, self._row_index)
+        delta = delta.view(-1, *([1] * (packed_sample.ndim - 1)))
+
+        prev_sample = packed_sample.to(torch.float32) + delta * packed_model_output
+        prev_sample = prev_sample.to(packed_model_output.dtype)
+
+        self._steps_taken += 1
+        for state in states:
+            # Mirror the completed step index into the scheduler counter.
+            state.denoising_context.scheduler._step_index = int(state.step_index) + 1
+        return prev_sample
+
+
+def build_batched_solver(
+    states: list[Any],
+    device: torch.device,
+) -> BatchedFlowMatchEulerSolver | None:
+    """Build a batched solver, falling back to None on any error."""
+    if not states:
+        return None
+    try:
+        return BatchedFlowMatchEulerSolver.try_build(states, device)
+    except Exception:
+        return None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -997,6 +997,73 @@ class ComposedPipelineBase(ABC):
 
         return self.executor.execute_with_profiling(self.stages, batch, server_args)
 
+    def _partition_stages_around_denoising(
+        self,
+    ) -> tuple[list[PipelineStage], DenoisingStage, list[PipelineStage]]:
+        denoising_index = None
+        denoising_stage = None
+        for index, stage in enumerate(self.stages):
+            if isinstance(stage, DenoisingStage):
+                denoising_index = index
+                denoising_stage = stage
+                break
+
+        if denoising_index is None or denoising_stage is None:
+            raise RuntimeError(
+                f"{self.__class__.__name__} has no DenoisingStage for continuous batching"
+            )
+
+        return (
+            list(self.stages[:denoising_index]),
+            denoising_stage,
+            list(self.stages[denoising_index + 1 :]),
+        )
+
+    def get_denoising_stage(self) -> DenoisingStage:
+        return self._partition_stages_around_denoising()[1]
+
+    @torch.no_grad()
+    def run_stages_before_denoising(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> Req:
+        pre_stages, _, _ = self._partition_stages_around_denoising()
+        if not pre_stages:
+            return batch
+
+        self.component_residency_manager = get_global_component_residency_manager(
+            self, server_args
+        )
+        self.executor.component_residency_manager = self.component_residency_manager
+        return self.executor.execute_with_profiling(pre_stages, batch, server_args)
+
+    @torch.no_grad()
+    def run_stages_after_denoising(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> OutputBatch:
+        _, _, post_stages = self._partition_stages_around_denoising()
+        if not post_stages:
+            return OutputBatch(
+                output=batch.output,
+                audio=getattr(batch, "audio", None),
+                audio_sample_rate=getattr(batch, "audio_sample_rate", None),
+                metrics=batch.metrics,
+                trajectory_timesteps=getattr(batch, "trajectory_timesteps", None),
+                trajectory_latents=getattr(batch, "trajectory_latents", None),
+                rollout_trajectory_data=getattr(batch, "rollout_trajectory_data", None),
+                noise_pred=getattr(batch, "noise_pred", None),
+                trajectory_decoded=getattr(batch, "trajectory_decoded", None),
+            )
+
+        self.component_residency_manager = get_global_component_residency_manager(
+            self, server_args
+        )
+        self.executor.component_residency_manager = self.component_residency_manager
+        return self.executor.execute_with_profiling(post_stages, batch, server_args)
+
     @torch.no_grad()
     def forward_batch(
         self,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -1007,6 +1007,10 @@ class ComposedPipelineBase(ABC):
                 denoising_index = index
                 denoising_stage = stage
                 break
+            if isinstance(stage, ProgressiveDenoisingStageRouter):
+                denoising_index = index
+                denoising_stage = stage.standard_stage
+                break
 
         if denoising_index is None or denoising_stage is None:
             raise RuntimeError(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/diffusion_scheduler_utils.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/diffusion_scheduler_utils.py
@@ -26,12 +26,12 @@ def get_or_create_request_scheduler(
     and avoids unnecessary deepcopy overhead. Set ``isolate=True`` only when a
     request can run concurrently or outlive the stage-local scheduler state.
     """
+    if isolate:
+        batch.scheduler = clone_scheduler_runtime(batch.scheduler or scheduler_template)
+        return batch.scheduler
+
     if batch.scheduler is None:
-        batch.scheduler = (
-            clone_scheduler_runtime(scheduler_template)
-            if isolate
-            else scheduler_template
-        )
+        batch.scheduler = scheduler_template
     return batch.scheduler
 
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/fallback_diagnostics.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/fallback_diagnostics.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rate-limited fallback diagnostics for continuous-batching hot paths.
+
+Packed-step and batched-solver fallbacks are correct but slower; operators
+need visibility into how often and *why* they happen without log spam. Every
+occurrence is counted and logged at DEBUG; the first occurrence of each
+(kind, key, reason) is logged at INFO and then re-logged at most once per
+interval with the accumulated count.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import Counter
+
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+_DEFAULT_INTERVAL_S = 600.0
+
+
+class FallbackDiagnostics:
+    """Counts fallback reasons and rate-limits operator-facing logs."""
+
+    def __init__(self, interval_s: float = _DEFAULT_INTERVAL_S) -> None:
+        self._interval_s = interval_s
+        self._lock = threading.Lock()
+        self._counts: Counter[tuple[str, str, str]] = Counter()
+        self._last_logged_s: dict[tuple[str, str, str], float] = {}
+
+    def record(self, kind: str, key: str, reason: str) -> None:
+        """Count one fallback and emit a rate-limited log."""
+        entry = (kind, key, reason)
+        now = time.monotonic()
+        with self._lock:
+            self._counts[entry] += 1
+            count = self._counts[entry]
+            last = self._last_logged_s.get(entry)
+            should_log_info = last is None or (now - last) >= self._interval_s
+            if should_log_info:
+                self._last_logged_s[entry] = now
+        if should_log_info:
+            logger.info(
+                "%s fallback for %s: %s (seen %d time(s); "
+                "running the slower per-request path)",
+                kind,
+                key,
+                reason,
+                count,
+            )
+        else:
+            logger.debug("%s fallback for %s: %s", kind, key, reason)
+
+    def snapshot(self) -> dict[tuple[str, str, str], int]:
+        """Return a copy of the fallback counters (for tests/metrics)."""
+        with self._lock:
+            return dict(self._counts)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._counts.clear()
+            self._last_logged_s.clear()
+
+
+# Process-wide diagnostics shared by the denoising stage and batched solver.
+fallback_diagnostics = FallbackDiagnostics()

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -17,7 +17,7 @@ import pprint
 from collections import Counter
 from copy import deepcopy
 from dataclasses import MISSING, asdict, dataclass, field, fields
-from typing import Any, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Union
 
 import PIL.Image
 import torch
@@ -29,10 +29,6 @@ from sglang.multimodal_gen.configs.sample.sampling_params import (
 from sglang.multimodal_gen.runtime.post_training.rl_dataclasses import (
     RolloutTrajectoryData,
 )
-from sglang.multimodal_gen.runtime.realtime.session import (
-    RealtimeSession,
-)
-from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import (
     _sanitize_for_logging,
     init_logger,
@@ -42,6 +38,10 @@ from sglang.multimodal_gen.utils import align_to
 from sglang.srt.observability.trace import TraceNullContext, TraceReqContext
 
 logger = init_logger(__name__)
+
+if TYPE_CHECKING:
+    from sglang.multimodal_gen.runtime.realtime.session import RealtimeSession
+    from sglang.multimodal_gen.runtime.server_args import ServerArgs
 
 SAMPLING_PARAMS_FIELDS = {f.name for f in fields(SamplingParams)}
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -59,6 +59,10 @@ class BatchMetricsWindow:
     total_capacity: int = 0
     merged_dispatches: int = 0
     full_dispatches: int = 0
+    max_active_requests: int = 0
+    active_request_samples: list[int] = field(default_factory=list)
+    queue_depth_samples: list[int] = field(default_factory=list)
+    batch_size_counts: Counter[int] = field(default_factory=Counter)
     wait_times_ms: list[float] = field(default_factory=list)
     reject_reasons: Counter[str] = field(default_factory=Counter)
 
@@ -233,13 +237,13 @@ class Req:
 
     def __init__(self, **kwargs):
         # Initialize dataclass fields
-        for name, field in self.__class__.__dataclass_fields__.items():
+        for name, field_info in self.__class__.__dataclass_fields__.items():
             if name in kwargs:
                 object.__setattr__(self, name, kwargs.pop(name))
-            elif field.default is not MISSING:
-                object.__setattr__(self, name, field.default)
-            elif field.default_factory is not MISSING:
-                object.__setattr__(self, name, field.default_factory())
+            elif field_info.default is not MISSING:
+                object.__setattr__(self, name, field_info.default)
+            elif field_info.default_factory is not MISSING:
+                object.__setattr__(self, name, field_info.default_factory())
 
         for name, value in kwargs.items():
             setattr(self, name, value)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -11,7 +11,7 @@ import time
 import weakref
 from collections.abc import Callable
 from contextlib import ExitStack, contextmanager
-from dataclasses import dataclass, field, fields, is_dataclass
+from dataclasses import dataclass, field, fields
 from enum import Enum
 from functools import lru_cache
 from typing import Any
@@ -21,7 +21,11 @@ import torch.nn as nn
 
 from sglang.jit_kernel.nvfp4 import prewarm_nvfp4_jit_modules
 from sglang.multimodal_gen import envs
-from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType, STA_Mode
+from sglang.multimodal_gen.configs.pipeline_configs.base import (
+    ModelTaskType,
+    PipelineConfig,
+    STA_Mode,
+)
 from sglang.multimodal_gen.configs.pipeline_configs.flux import (
     Flux2PipelineConfig,
     FluxPipelineConfig,
@@ -206,20 +210,40 @@ class DenoisingStepPackingError(ValueError):
 
 
 @dataclass(slots=True)
-class PackedDenoisingStepInputs:
-    states: list[Any]
+class PackedStepGroup:
+    """Persistent packed state for one continuous-batching membership.
+
+    Built once when membership changes and reused for every step.
+    """
+
+    member_ids: tuple[str, ...]
     row_slices: tuple[slice, ...]
-    latent_model_input: torch.Tensor
-    timestep: torch.Tensor
-    guidance: torch.Tensor | None
+    row_counts: tuple[int, ...]
+    total_rows: int
+    # Row count after batch-size bucketing; equals total_rows if bucketing is off.
+    padded_rows: int
     branch_kwargs: tuple[dict[str, Any], ...]
     branch_is_conditional: tuple[bool, ...]
+    # Merged cond/uncond kwargs for single-forward CFG; None if folded per branch.
+    folded_kwargs: dict[str, Any] | None
+    guidance: torch.Tensor | None
+    # Persistent packed latents; None when using per-request solver fallback.
+    packed_latents: torch.Tensor | None
+    solver: Any | None
     current_model: Any
+    model_phase_key: Any
     target_dtype: torch.dtype
     autocast_enabled: bool
     attn_metadata: Any | None
     forward_batch: Req
-    current_timestep: int | None
+    uses_wan_ti2v_timesteps: bool
+    # Maps packed row to member index; None for one row per member.
+    row_index: torch.Tensor | None
+    # True when CFG combine is vectorized over the packed batch.
+    vectorized_combine: bool
+    # Per-row valid sequence lengths for cross-resolution (varlen) packing;
+    # None when all rows share one sequence length.
+    varlen_row_seq_lens: tuple[int, ...] | None = None
 
     def slice_prediction(
         self, prediction: torch.Tensor | tuple[torch.Tensor, ...], index: int
@@ -228,6 +252,14 @@ class PackedDenoisingStepInputs:
         if isinstance(prediction, tuple):
             return tuple(item[row_slice] for item in prediction)
         return prediction[row_slice]
+
+    def matches_members(self, states: list[Any]) -> bool:
+        if len(states) != len(self.member_ids):
+            return False
+        return all(
+            state.request_id == member_id
+            for state, member_id in zip(states, self.member_ids)
+        )
 
 
 class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
@@ -1134,6 +1166,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         step_index: int,
         t_host: torch.Tensor,
         timesteps_cpu: torch.Tensor,
+        attn_metadata_override: Any | None = None,
+        use_attn_metadata_override: bool = False,
     ) -> DenoisingStepState:
         """Build state for one denoising step."""
         t_int = int(t_host.item())
@@ -1144,14 +1178,18 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             server_args=server_args,
             batch=batch,
         )
-        attn_metadata = self._prepare_step_attn_metadata(
-            ctx=ctx,
-            batch=batch,
-            server_args=server_args,
-            step_index=step_index,
-            t_int=t_int,
-            timesteps_cpu=timesteps_cpu,
-        )
+        if use_attn_metadata_override:
+            # Reuse step-invariant metadata built at admission.
+            attn_metadata = attn_metadata_override
+        else:
+            attn_metadata = self._prepare_step_attn_metadata(
+                ctx=ctx,
+                batch=batch,
+                server_args=server_args,
+                step_index=step_index,
+                t_int=t_int,
+                timesteps_cpu=timesteps_cpu,
+            )
         return DenoisingStepState(
             step_index=step_index,
             t_host=t_host,
@@ -1642,6 +1680,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         batch: Req,
         server_args: ServerArgs,
         step_index: int,
+        attn_metadata_override: Any | None = None,
+        use_attn_metadata_override: bool = False,
     ) -> DenoisingStepState:
         timesteps_cpu = ctx.extra.get("timesteps_cpu")
         if timesteps_cpu is None:
@@ -1654,6 +1694,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             step_index,
             timesteps_cpu[step_index],
             timesteps_cpu,
+            attn_metadata_override=attn_metadata_override,
+            use_attn_metadata_override=use_attn_metadata_override,
         )
 
     @torch.no_grad()
@@ -1737,19 +1779,27 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         self,
         states: list[Any],
         server_args: ServerArgs,
-    ) -> None:
-        if len(states) <= 1 or not self.can_run_steps_in_one_forward_pass(
-            states, server_args
-        ):
-            self._run_unpacked_denoising_steps(states, server_args)
-            return
+        packed_group: PackedStepGroup | None = None,
+    ) -> PackedStepGroup | None:
+        """Run one denoising step for selected states.
 
-        try:
-            batched_inputs = self._pack_denoising_step_inputs(states, server_args)
-        except DenoisingStepPackingError as exc:
-            logger.debug("Step batch packing fell back to local steps: %s", exc)
+        Reuse ``packed_group`` if it still matches; otherwise build a new one
+        or fall back to per-request execution. Returns the group used, or None.
+        """
+        if len(states) <= 1:
             self._run_unpacked_denoising_steps(states, server_args)
-            return
+            return None
+
+        group = packed_group
+        if group is not None and not self._packed_group_still_valid(group, states):
+            group = None
+        if group is None:
+            try:
+                group = self.build_packed_step_group(states, server_args)
+            except DenoisingStepPackingError as exc:
+                logger.debug("Step batch packing fell back to local steps: %s", exc)
+                self._run_unpacked_denoising_steps(states, server_args)
+                return None
 
         with ExitStack() as stack:
             for state in states:
@@ -1772,10 +1822,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                         record_as_step=True,
                     )
                 )
-            self._run_batched_step_forward_and_update_latents(
-                batched_inputs,
-                server_args,
-            )
+            self._run_packed_group_step(group, states, server_args)
         for state in states:
             self._update_denoising_progress(
                 state.denoising_context,
@@ -1783,6 +1830,28 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             )
             if not state.denoising_context.is_warmup:
                 self.step_profile()
+        return group
+
+    def _packed_group_still_valid(
+        self, group: PackedStepGroup, states: list[Any]
+    ) -> bool:
+        """Check whether a cached PackedStepGroup can be reused."""
+        if not group.matches_members(states):
+            return False
+        first_step = states[0].current_step
+        if first_step is None:
+            return False
+        # Two-expert pipelines (e.g. Wan2.2) switch models mid-schedule.
+        if first_step.current_model is not group.current_model:
+            return False
+        for state in states:
+            step = state.current_step
+            if step is None or step.current_model is not group.current_model:
+                return False
+            gate_state = state.denoising_context.extra.get("cfg_gate_state")
+            if gate_state and gate_state.get("active"):
+                return False
+        return True
 
     @torch.no_grad()
     def finish_denoising_context(
@@ -1845,6 +1914,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         if not first_branches:
             return False
 
+        varlen_allowed = self._varlen_step_packing_allowed(states, server_args)
         for state in states[1:]:
             step = state.current_step
             ctx = state.denoising_context
@@ -1875,12 +1945,42 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             ):
                 return False
             if tuple(ctx.latents.shape[1:]) != tuple(first_ctx.latents.shape[1:]):
-                return False
+                # Varlen packing tolerates different sequence lengths as long
+                # as rows agree on rank and channel dim ([1, seq, channels]).
+                if not (
+                    varlen_allowed
+                    and ctx.latents.ndim == 3
+                    and first_ctx.latents.ndim == 3
+                    and ctx.latents.shape[2] == first_ctx.latents.shape[2]
+                ):
+                    return False
             if ctx.latents.dtype != first_ctx.latents.dtype:
                 return False
             if ctx.latents.device != first_ctx.latents.device:
                 return False
         return True
+
+    def _varlen_step_packing_allowed(
+        self, states: list[Any], server_args: ServerArgs
+    ) -> bool:
+        """Whether cross-resolution sequence packing may be used for states."""
+        if not getattr(server_args, "cb_varlen_packing", False):
+            return False
+        if not getattr(
+            server_args.pipeline_config, "supports_varlen_step_packing", False
+        ):
+            return False
+        for attr in ("sp_degree", "ulysses_degree", "ring_degree"):
+            if int(getattr(server_args, attr, 1) or 1) != 1:
+                return False
+        first_step = states[0].current_step
+        model = getattr(first_step, "current_model", None) if first_step else None
+        if not getattr(model, "supports_varlen_step_packing", False):
+            return False
+        # zero_cond_t modulation indexes assume equal per-row sequence sizes.
+        if getattr(model, "zero_cond_t", False):
+            return False
+        return all(state.denoising_context.latents.ndim == 3 for state in states)
 
     @staticmethod
     def _can_share_packed_forward_batch_context(first: Req, current: Req) -> bool:
@@ -1895,76 +1995,32 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
 
     @staticmethod
     def _can_share_packed_attn_metadata(first: Any, current: Any) -> bool:
+        """Structural check for sharing attention metadata across packed rows.
+
+        No tensor-value compares (avoids device sync). Non-packable backends
+        are filtered out before this is called.
+        """
         if first is None or current is None:
             return first is None and current is None
         if type(first) is not type(current):
             return False
         if type(first).__name__ != "FlashAttentionMetadata":
-            return DenoisingStage._metadata_values_equal(first, current)
+            return False
         for attr in ("cu_seqlens_q", "cu_seqlens_k"):
             if getattr(first, attr, None) is not None:
                 return False
             if getattr(current, attr, None) is not None:
                 return False
         for attr in ("max_seqlen_q", "max_seqlen_k"):
-            first_value = getattr(first, attr, None)
-            current_value = getattr(current, attr, None)
-            if first_value != current_value:
+            if getattr(first, attr, None) != getattr(current, attr, None):
                 return False
         return True
-
-    @staticmethod
-    def _metadata_values_equal(first: Any, current: Any) -> bool:
-        if first is current:
-            return True
-        if first is None or current is None:
-            return first is None and current is None
-        if isinstance(first, (str, int, float, bool)):
-            return first == current
-        if isinstance(first, torch.Tensor):
-            return (
-                isinstance(current, torch.Tensor)
-                and tuple(first.shape) == tuple(current.shape)
-                and first.dtype == current.dtype
-                and first.device == current.device
-                and torch.equal(first, current)
-            )
-        if isinstance(first, (list, tuple)):
-            return (
-                isinstance(current, type(first))
-                and len(first) == len(current)
-                and all(
-                    DenoisingStage._metadata_values_equal(left, right)
-                    for left, right in zip(first, current, strict=True)
-                )
-            )
-        if isinstance(first, dict):
-            return (
-                isinstance(current, dict)
-                and set(first) == set(current)
-                and all(
-                    DenoisingStage._metadata_values_equal(first[key], current[key])
-                    for key in first
-                )
-            )
-        if is_dataclass(first):
-            if "cache" in type(first).__name__.lower():
-                return False
-            return all(
-                field_info.name != "cache"
-                and DenoisingStage._metadata_values_equal(
-                    getattr(first, field_info.name),
-                    getattr(current, field_info.name),
-                )
-                for field_info in fields(first)
-            )
-        return False
 
     @staticmethod
     def _merge_step_input_value(
         values: list[Any], *, allow_shared: bool = False, key: str | None = None
     ) -> Any:
-        """Merge one branch kwarg across requests for packed execution."""
+        """Merge one branch kwarg across requests along the batch dim."""
         first = values[0]
         if first is None:
             if any(value is not None for value in values):
@@ -2176,136 +2232,659 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             for key in keys
         }
 
-    def _pack_denoising_step_inputs(
+    @staticmethod
+    def _bucket_target_rows(total_rows: int, server_args: ServerArgs) -> int:
+        """Return the smallest bucket size >= total_rows."""
+        spec = getattr(server_args, "cb_batch_bucket_sizes", None)
+        if not spec:
+            return total_rows
+        if isinstance(spec, str):
+            buckets = sorted(
+                int(item) for item in spec.replace(" ", "").split(",") if item
+            )
+        else:
+            buckets = sorted(int(item) for item in spec)
+        for bucket in buckets:
+            if bucket >= total_rows:
+                return bucket
+        return total_rows
+
+    @staticmethod
+    def _pad_model_rows(tensor: torch.Tensor, target_rows: int) -> torch.Tensor:
+        """Right-pad the batch dim by repeating the last row.
+
+        Repeating a real row (instead of zero-filling) keeps padded rows
+        numerically well-behaved through norms and attention.
+        """
+        pad = target_rows - int(tensor.shape[0])
+        if pad <= 0:
+            return tensor
+        filler = tensor[-1:].expand(pad, *tensor.shape[1:])
+        return torch.cat([tensor, filler], dim=0)
+
+    @classmethod
+    def _pad_kwargs_rows(cls, value: Any, target_rows: int, total_rows: int) -> Any:
+        """Pad merged kwargs to the bucketed row count."""
+        if isinstance(value, torch.Tensor):
+            if value.ndim > 0 and int(value.shape[0]) == total_rows:
+                return cls._pad_model_rows(value, target_rows)
+            return value
+        if isinstance(value, list):
+            if len(value) == total_rows and value:
+                return value + [value[-1]] * (target_rows - total_rows)
+            return value
+        if isinstance(value, tuple):
+            return tuple(
+                cls._pad_kwargs_rows(item, target_rows, total_rows) for item in value
+            )
+        if isinstance(value, dict):
+            return {
+                key: cls._pad_kwargs_rows(item, target_rows, total_rows)
+                for key, item in value.items()
+            }
+        return value
+
+    def _supports_cfg_batch_folding(self, states: list[Any], server_args) -> bool:
+        """Return True if cond/uncond can run as one batched forward pass."""
+        if not getattr(server_args, "cb_fold_cfg_branches", False):
+            return False
+        if not getattr(
+            server_args.pipeline_config, "supports_cfg_batch_folding", False
+        ):
+            return False
+        branches = states[0].denoising_context.cfg_policy.branches
+        if len(branches) < 2:
+            return False
+        # TeaCache keys its cache on is_cfg_negative; such requests never
+        # reach the packed path, but keep the guard for safety.
+        return not any(state.req.enable_teacache for state in states)
+
+    def _fold_branch_kwargs_along_batch(
+        self, branch_kwargs: tuple[dict[str, Any], ...]
+    ) -> dict[str, Any]:
+        """Concatenate branch kwargs along the batch dimension."""
+        return self._merge_step_input_kwargs(list(branch_kwargs))
+
+    @staticmethod
+    def _pad_seq_dim(tensor: torch.Tensor, target_len: int) -> torch.Tensor:
+        """Right-pad dim 1 with zeros up to target_len."""
+        pad = target_len - int(tensor.shape[1])
+        if pad <= 0:
+            return tensor
+        pad_shape = list(tensor.shape)
+        pad_shape[1] = pad
+        return torch.cat([tensor, tensor.new_zeros(pad_shape)], dim=1)
+
+    def _prepare_varlen_branch_kwargs(
+        self,
+        states: list[Any],
+        branch_kwargs_by_index: list[list[dict[str, Any]]],
+    ) -> tuple[list[list[dict[str, Any]]], dict[str, Any]]:
+        """Normalize per-request branch kwargs for cross-resolution packing.
+
+        Pads text embeddings/masks to one shared width, pops per-request RoPE
+        caches (replaced by one concatenated table + per-token positions), and
+        collects the per-row text lengths needed to build those positions.
+        """
+        txt_pad = 0
+        for branch_kwargs in branch_kwargs_by_index:
+            for kwargs in branch_kwargs:
+                ehs = kwargs.get("encoder_hidden_states")
+                if not isinstance(ehs, torch.Tensor) or ehs.ndim != 3:
+                    raise DenoisingStepPackingError(
+                        "varlen packing requires tensor text embeddings"
+                    )
+                txt_pad = max(txt_pad, int(ehs.shape[1]))
+
+        # One rope table per request; rows index it via per-token positions.
+        img_tables: list[torch.Tensor] = []
+        txt_tables: list[torch.Tensor] = []
+        img_offsets: list[int] = []
+        txt_offsets: list[int] = []
+        img_offset = txt_offset = 0
+        for state_index in range(len(states)):
+            img_cache = txt_cache = None
+            for branch_kwargs in branch_kwargs_by_index:
+                freqs = branch_kwargs[state_index].get("freqs_cis")
+                if not (
+                    isinstance(freqs, tuple)
+                    and len(freqs) == 2
+                    and all(
+                        isinstance(item, torch.Tensor) and item.ndim == 2
+                        for item in freqs
+                    )
+                ):
+                    raise DenoisingStepPackingError(
+                        "varlen packing requires 2D cos/sin rope caches"
+                    )
+                if img_cache is None:
+                    img_cache, txt_cache = freqs
+                else:
+                    if tuple(freqs[0].shape) != tuple(img_cache.shape):
+                        raise DenoisingStepPackingError(
+                            "varlen packing branches disagree on image rope cache"
+                        )
+                    # Branch txt caches are prefix-consistent; keep the longest.
+                    if int(freqs[1].shape[0]) > int(txt_cache.shape[0]):
+                        txt_cache = freqs[1]
+            img_tables.append(img_cache)
+            txt_tables.append(txt_cache)
+            img_offsets.append(img_offset)
+            txt_offsets.append(txt_offset)
+            img_offset += int(img_cache.shape[0])
+            txt_offset += int(txt_cache.shape[0])
+
+        normalized: list[list[dict[str, Any]]] = []
+        txt_lens_by_branch: list[list[int]] = []
+        for branch_kwargs in branch_kwargs_by_index:
+            branch_norm: list[dict[str, Any]] = []
+            branch_txt_lens: list[int] = []
+            for state_index, kwargs in enumerate(branch_kwargs):
+                kwargs = dict(kwargs)
+                kwargs.pop("freqs_cis", None)
+                ehs = kwargs["encoder_hidden_states"]
+                rows = int(states[state_index].denoising_context.latents.shape[0])
+                mask = kwargs.get("encoder_hidden_states_mask")
+                if mask is None:
+                    mask = torch.ones(
+                        (int(ehs.shape[0]), int(ehs.shape[1])),
+                        dtype=torch.bool,
+                        device=ehs.device,
+                    )
+                txt_seq_lens = kwargs.get("txt_seq_lens")
+                if isinstance(txt_seq_lens, list) and len(txt_seq_lens) == rows:
+                    branch_txt_lens.extend(int(item) for item in txt_seq_lens)
+                else:
+                    branch_txt_lens.extend([int(ehs.shape[1])] * rows)
+                kwargs["encoder_hidden_states"] = self._pad_seq_dim(ehs, txt_pad)
+                kwargs["encoder_hidden_states_mask"] = self._pad_seq_dim(mask, txt_pad)
+                branch_norm.append(kwargs)
+            normalized.append(branch_norm)
+            txt_lens_by_branch.append(branch_txt_lens)
+
+        varlen_ctx = {
+            "txt_pad": txt_pad,
+            "img_table": torch.cat(img_tables, dim=0),
+            "txt_table": torch.cat(txt_tables, dim=0),
+            "img_offsets": img_offsets,
+            "txt_offsets": txt_offsets,
+            "txt_lens_by_branch": txt_lens_by_branch,
+        }
+        return normalized, varlen_ctx
+
+    @staticmethod
+    def _build_varlen_positions(
+        offsets: list[int],
+        row_lens: list[int],
+        row_state_index: list[int],
+        seq_len: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Flattened [rows * seq_len] rope positions, clamped per row."""
+        arange = torch.arange(seq_len, device=device)
+        rows = [
+            offsets[row_state_index[row]]
+            + torch.clamp(arange, max=max(row_lens[row] - 1, 0))
+            for row in range(len(row_lens))
+        ]
+        return torch.stack(rows).reshape(-1)
+
+    def _inject_varlen_kwargs(
+        self,
+        merged_branch_kwargs: tuple[dict[str, Any], ...],
+        folded_kwargs: dict[str, Any] | None,
+        varlen_ctx: dict[str, Any],
+        row_seq_lens: list[int],
+        row_state_index: list[int],
+        padded_rows: int,
+        device: torch.device,
+    ) -> None:
+        """Add shared rope tables, positions, and image lengths to kwargs."""
+        total_rows = len(row_seq_lens)
+        pad_count = padded_rows - total_rows
+        padded_seq_lens = row_seq_lens + [row_seq_lens[-1]] * pad_count
+        padded_state_index = row_state_index + [row_state_index[-1]] * pad_count
+        max_img_seq = max(row_seq_lens)
+        freqs_cis = (varlen_ctx["img_table"], varlen_ctx["txt_table"])
+
+        img_positions = self._build_varlen_positions(
+            varlen_ctx["img_offsets"],
+            padded_seq_lens,
+            padded_state_index,
+            max_img_seq,
+            device,
+        )
+        txt_positions_by_branch = []
+        for branch_txt_lens in varlen_ctx["txt_lens_by_branch"]:
+            padded_txt_lens = branch_txt_lens + [branch_txt_lens[-1]] * pad_count
+            txt_positions_by_branch.append(
+                self._build_varlen_positions(
+                    varlen_ctx["txt_offsets"],
+                    padded_txt_lens,
+                    padded_state_index,
+                    varlen_ctx["txt_pad"],
+                    device,
+                )
+            )
+
+        for branch_index, kwargs in enumerate(merged_branch_kwargs):
+            attention_kwargs = dict(kwargs.get("attention_kwargs") or {})
+            attention_kwargs["img_rope_positions"] = img_positions
+            attention_kwargs["txt_rope_positions"] = txt_positions_by_branch[
+                branch_index
+            ]
+            kwargs["attention_kwargs"] = attention_kwargs
+            kwargs["freqs_cis"] = freqs_cis
+            kwargs["image_seq_lens"] = list(padded_seq_lens)
+
+        if folded_kwargs is not None:
+            num_branches = len(merged_branch_kwargs)
+            attention_kwargs = dict(folded_kwargs.get("attention_kwargs") or {})
+            attention_kwargs["img_rope_positions"] = img_positions.repeat(num_branches)
+            attention_kwargs["txt_rope_positions"] = torch.cat(txt_positions_by_branch)
+            folded_kwargs["attention_kwargs"] = attention_kwargs
+            folded_kwargs["freqs_cis"] = freqs_cis
+            folded_kwargs["image_seq_lens"] = list(padded_seq_lens) * num_branches
+
+    def build_packed_step_group(
         self, states: list[Any], server_args: ServerArgs
-    ) -> PackedDenoisingStepInputs:
-        """Build packed model inputs for selected compatible request steps."""
+    ) -> PackedStepGroup:
+        """Build the persistent packed state for one membership."""
+        if not self.can_run_steps_in_one_forward_pass(states, server_args):
+            raise DenoisingStepPackingError("states are not packable together")
+
         first = states[0]
         first_ctx = first.denoising_context
         first_step = first.current_step
 
-        latent_inputs = []
-        timesteps = []
-        guidance_values = []
+        guidance_values = [state.denoising_context.guidance for state in states]
         branch_kwargs_by_index: list[list[dict[str, Any]]] = []
-        branch_is_conditional = []
-        row_slices = []
+        branch_is_conditional: list[bool] = []
+        row_slices: list[slice] = []
+        row_counts: list[int] = []
+        row_seq_lens: list[int] = []
+        row_state_index: list[int] = []
         row_offset = 0
-        for state in states:
+        uses_wan_ti2v = False
+        for state_index, state in enumerate(states):
             ctx = state.denoising_context
-            step = state.current_step
             req = state.req
-            latent_model_input = ctx.latents.to(ctx.target_dtype)
-            latent_model_input = ctx.scheduler.scale_model_input(
-                latent_model_input, step.t_device
-            )
-            timestep = self.expand_timestep_before_forward(
-                req,
-                server_args,
-                step.t_device,
-                ctx.target_dtype,
-                ctx.seq_len,
-                ctx.reserved_frames_mask,
-            )
-            latent_inputs.append(latent_model_input)
-            timesteps.append(timestep)
-            guidance_values.append(ctx.guidance)
+            uses_wan_ti2v = uses_wan_ti2v or should_apply_wan_ti2v(req, server_args)
             for branch_index, branch in enumerate(ctx.cfg_policy.branches):
                 if len(branch_kwargs_by_index) <= branch_index:
                     branch_kwargs_by_index.append([])
                     branch_is_conditional.append(branch.is_conditional)
-                branch.configure_batch(req)
                 branch_kwargs_by_index[branch_index].append(branch.kwargs)
-
             rows = int(ctx.latents.shape[0])
             row_slices.append(slice(row_offset, row_offset + rows))
+            row_counts.append(rows)
+            if ctx.latents.ndim == 3:
+                row_seq_lens.extend([int(ctx.latents.shape[1])] * rows)
+                row_state_index.extend([state_index] * rows)
             row_offset += rows
+        total_rows = row_offset
 
-        try:
-            latent_model_input = torch.cat(latent_inputs, dim=0)
-            timestep = torch.cat(timesteps, dim=0)
-            if any(guidance_value is None for guidance_value in guidance_values):
-                if not all(
-                    guidance_value is None for guidance_value in guidance_values
-                ):
-                    raise DenoisingStepPackingError(
-                        "step batch mixes guidance tensor presence"
-                    )
-                guidance = None
-            else:
-                guidance = torch.cat(guidance_values, dim=0)
-        except RuntimeError as exc:
-            raise DenoisingStepPackingError(
-                f"step batch tensor packing failed: {exc}"
-            ) from exc
+        # Cross-resolution packing: rows keep their own sequence length and
+        # are right-padded to the group max; masks and per-token rope
+        # positions make the padded tail inert.
+        varlen = len(row_seq_lens) == total_rows and len(set(row_seq_lens)) > 1
+        varlen_ctx = None
+        if varlen:
+            if uses_wan_ti2v or not self._varlen_step_packing_allowed(
+                states, server_args
+            ):
+                raise DenoisingStepPackingError(
+                    "mixed latent sequence lengths require varlen packing"
+                )
+            branch_kwargs_by_index, varlen_ctx = self._prepare_varlen_branch_kwargs(
+                states, branch_kwargs_by_index
+            )
+
+        if any(value is None for value in guidance_values):
+            if not all(value is None for value in guidance_values):
+                raise DenoisingStepPackingError(
+                    "step batch mixes guidance tensor presence"
+                )
+            guidance = None
+        else:
+            guidance = torch.cat(guidance_values, dim=0)
+
         merged_branch_kwargs = tuple(
             self._merge_step_input_kwargs(branch_kwargs)
             for branch_kwargs in branch_kwargs_by_index
         )
-        step_indices = {state.current_step.step_index for state in states}
-        return PackedDenoisingStepInputs(
-            states=states,
+
+        padded_rows = self._bucket_target_rows(total_rows, server_args)
+        if padded_rows != total_rows:
+            merged_branch_kwargs = tuple(
+                self._pad_kwargs_rows(kwargs, padded_rows, total_rows)
+                for kwargs in merged_branch_kwargs
+            )
+            if guidance is not None:
+                guidance = self._pad_model_rows(guidance, padded_rows)
+
+        folded_kwargs = None
+        if not uses_wan_ti2v and self._supports_cfg_batch_folding(states, server_args):
+            try:
+                folded_kwargs = self._fold_branch_kwargs_along_batch(
+                    merged_branch_kwargs
+                )
+            except DenoisingStepPackingError as exc:
+                logger.debug("CFG fold disabled for this group: %s", exc)
+                folded_kwargs = None
+
+        device = first_ctx.latents.device
+        if varlen_ctx is not None:
+            self._inject_varlen_kwargs(
+                merged_branch_kwargs,
+                folded_kwargs,
+                varlen_ctx,
+                row_seq_lens,
+                row_state_index,
+                padded_rows,
+                device,
+            )
+        if all(count == 1 for count in row_counts):
+            row_index = None
+        else:
+            row_index = torch.repeat_interleave(
+                torch.arange(len(states), device=device),
+                torch.tensor(row_counts, device=device),
+            )
+
+        solver = None
+        if not uses_wan_ti2v:
+            from sglang.multimodal_gen.runtime.pipelines_core.batched_solver import (
+                build_batched_solver,
+            )
+
+            solver = build_batched_solver(states, device)
+
+        packed_latents = None
+        if solver is not None:
+            try:
+                if varlen:
+                    max_img_seq = max(row_seq_lens)
+                    packed_latents = torch.cat(
+                        [
+                            self._pad_seq_dim(
+                                state.denoising_context.latents, max_img_seq
+                            )
+                            for state in states
+                        ],
+                        dim=0,
+                    )
+                else:
+                    packed_latents = torch.cat(
+                        [state.denoising_context.latents for state in states], dim=0
+                    )
+            except RuntimeError as exc:
+                raise DenoisingStepPackingError(
+                    f"step batch latent packing failed: {exc}"
+                ) from exc
+
+        pipeline_config = server_args.pipeline_config
+        vectorized_combine = (
+            solver is not None
+            and type(pipeline_config).postprocess_cfg_noise
+            is PipelineConfig.postprocess_cfg_noise
+            and type(pipeline_config).slice_noise_pred
+            is PipelineConfig.slice_noise_pred
+            and all(
+                not state.req.cfg_normalization
+                and not state.req.guidance_rescale
+                and type(state.denoising_context.cfg_policy) is CFGPolicy
+                for state in states
+            )
+        )
+
+        return PackedStepGroup(
+            member_ids=tuple(state.request_id for state in states),
             row_slices=tuple(row_slices),
-            latent_model_input=latent_model_input,
-            timestep=timestep,
-            guidance=guidance,
+            row_counts=tuple(row_counts),
+            total_rows=total_rows,
+            padded_rows=padded_rows,
             branch_kwargs=merged_branch_kwargs,
             branch_is_conditional=tuple(branch_is_conditional),
+            folded_kwargs=folded_kwargs,
+            guidance=guidance,
+            packed_latents=packed_latents,
+            solver=solver,
             current_model=first_step.current_model,
+            model_phase_key=id(first_step.current_model),
             target_dtype=first_ctx.target_dtype,
             autocast_enabled=first_ctx.autocast_enabled,
             attn_metadata=first_step.attn_metadata,
             forward_batch=first.req,
-            current_timestep=first_step.step_index if len(step_indices) == 1 else None,
+            uses_wan_ti2v_timesteps=uses_wan_ti2v,
+            row_index=row_index,
+            vectorized_combine=vectorized_combine,
+            varlen_row_seq_lens=tuple(row_seq_lens) if varlen else None,
         )
 
-    def _run_batched_step_forward_and_update_latents(
-        self, packed_inputs: PackedDenoisingStepInputs, server_args: ServerArgs
+    def _build_packed_timestep(
+        self,
+        group: PackedStepGroup,
+        states: list[Any],
+        server_args: ServerArgs,
+    ) -> torch.Tensor:
+        """Build the per-row timestep tensor for a packed step."""
+        if group.uses_wan_ti2v_timesteps:
+            timesteps = [
+                self.expand_timestep_before_forward(
+                    state.req,
+                    server_args,
+                    state.current_step.t_device,
+                    state.denoising_context.target_dtype,
+                    state.denoising_context.seq_len,
+                    state.denoising_context.reserved_frames_mask,
+                )
+                for state in states
+            ]
+            timestep = torch.cat(timesteps, dim=0)
+        else:
+            timestep = torch.stack([state.current_step.t_device for state in states])
+            if group.row_index is not None:
+                timestep = timestep.index_select(0, group.row_index)
+        return self._pad_model_rows(timestep, group.padded_rows)
+
+    def _packed_forward(
+        self,
+        group: PackedStepGroup,
+        latent_model_input: torch.Tensor,
+        timestep: torch.Tensor,
+        current_timestep: int | None,
+    ) -> list[torch.Tensor | tuple[torch.Tensor, ...]]:
+        """Run the packed model forward, folded or per-branch."""
+        with set_forward_context(
+            current_timestep=current_timestep,
+            attn_metadata=group.attn_metadata,
+            forward_batch=group.forward_batch,
+        ):
+            if group.folded_kwargs is not None:
+                num_branches = len(group.branch_kwargs)
+                folded_latent = latent_model_input.repeat(
+                    num_branches, *([1] * (latent_model_input.ndim - 1))
+                )
+                folded_timestep = timestep.repeat(
+                    num_branches, *([1] * (timestep.ndim - 1))
+                )
+                folded_guidance = (
+                    group.guidance.repeat(num_branches)
+                    if group.guidance is not None
+                    else None
+                )
+                group.forward_batch.is_cfg_negative = False
+                folded = self._predict_noise(
+                    current_model=group.current_model,
+                    latent_model_input=folded_latent,
+                    timestep=folded_timestep,
+                    target_dtype=group.target_dtype,
+                    guidance=folded_guidance,
+                    **group.folded_kwargs,
+                )
+                rows = group.padded_rows
+
+                def branch_rows(prediction, branch_index):
+                    section = slice(branch_index * rows, (branch_index + 1) * rows)
+                    if isinstance(prediction, tuple):
+                        return tuple(item[section] for item in prediction)
+                    return prediction[section]
+
+                return [
+                    branch_rows(folded, index)
+                    for index in range(len(group.branch_kwargs))
+                ]
+
+            branch_predictions = []
+            for branch_kwargs, is_conditional in zip(
+                group.branch_kwargs,
+                group.branch_is_conditional,
+                strict=True,
+            ):
+                group.forward_batch.is_cfg_negative = not is_conditional
+                branch_predictions.append(
+                    self._predict_noise(
+                        current_model=group.current_model,
+                        latent_model_input=latent_model_input,
+                        timestep=timestep,
+                        target_dtype=group.target_dtype,
+                        guidance=group.guidance,
+                        **branch_kwargs,
+                    )
+                )
+            return branch_predictions
+
+    def _combine_packed_predictions_vectorized(
+        self,
+        group: PackedStepGroup,
+        states: list[Any],
+        branch_predictions: list[torch.Tensor],
+        server_args: ServerArgs,
+    ) -> torch.Tensor:
+        """CFG combine across all packed rows in one kernel."""
+        pos = branch_predictions[0][: group.total_rows]
+        if len(branch_predictions) == 1:
+            return pos
+        neg = branch_predictions[1][: group.total_rows]
+        scales = torch.tensor(
+            [
+                server_args.pipeline_config.get_classifier_free_guidance_scale(
+                    state.req, state.current_step.current_guidance_scale
+                )
+                for state in states
+            ],
+            dtype=pos.dtype,
+            device=pos.device,
+        )
+        if group.row_index is not None:
+            scales = scales.index_select(0, group.row_index)
+        scales = scales.view(-1, *([1] * (pos.ndim - 1)))
+        return neg + scales * (pos - neg)
+
+    def _scatter_packed_latents(
+        self,
+        group: PackedStepGroup,
+        states: list[Any],
+        new_packed: torch.Tensor,
+        server_args: ServerArgs,
     ) -> None:
-        """Run one packed forward pass and update each request's scheduler state."""
+        """Point each request's latents at its rows of the packed buffer."""
+        group.packed_latents = new_packed
+        varlen_lens = group.varlen_row_seq_lens
+        for index, state in enumerate(states):
+            row_slice = group.row_slices[index]
+            latents = new_packed[row_slice]
+            if varlen_lens is not None:
+                latents = latents[:, : varlen_lens[row_slice.start]]
+            state.denoising_context.latents = latents
+            self._record_trajectory(
+                state.denoising_context,
+                state.current_step,
+                state.req,
+                server_args,
+            )
+
+    def _run_packed_group_step(
+        self,
+        group: PackedStepGroup,
+        states: list[Any],
+        server_args: ServerArgs,
+    ) -> None:
+        """Run one denoising step for a packed group."""
         use_nvtx = any(
             state.denoising_context.extra.get("use_nvtx", self.current_use_nvtx)
-            for state in packed_inputs.states
+            for state in states
         )
+        step_indices = {state.current_step.step_index for state in states}
+        current_timestep = (
+            states[0].current_step.step_index if len(step_indices) == 1 else None
+        )
+
+        # Assemble packed latents and per-row timesteps.
+        varlen_lens = group.varlen_row_seq_lens
+        max_seq = max(varlen_lens) if varlen_lens else None
+        if group.solver is not None and group.packed_latents is not None:
+            packed_latents = group.packed_latents
+            latent_model_input = group.solver.scale_model_input(packed_latents).to(
+                group.target_dtype
+            )
+        else:
+            per_request_inputs = []
+            for state in states:
+                ctx = state.denoising_context
+                scaled = ctx.scheduler.scale_model_input(
+                    ctx.latents.to(ctx.target_dtype),
+                    state.current_step.t_device,
+                )
+                if varlen_lens is not None:
+                    scaled = self._pad_seq_dim(scaled, max_seq)
+                per_request_inputs.append(scaled)
+            packed_latents = None
+            latent_model_input = torch.cat(per_request_inputs, dim=0)
+        latent_model_input = self._pad_model_rows(latent_model_input, group.padded_rows)
+        timestep = self._build_packed_timestep(group, states, server_args)
+
+        # Run one (folded) or per-branch packed forward.
         with maybe_nvtx_range("predict_noise", use_nvtx):
             with torch.autocast(
                 device_type=current_platform.device_type,
-                dtype=packed_inputs.target_dtype,
-                enabled=packed_inputs.autocast_enabled,
+                dtype=group.target_dtype,
+                enabled=group.autocast_enabled,
             ):
-                with set_forward_context(
-                    current_timestep=packed_inputs.current_timestep,
-                    attn_metadata=packed_inputs.attn_metadata,
-                    forward_batch=packed_inputs.forward_batch,
-                ):
-                    branch_predictions = []
-                    for branch_kwargs, is_conditional in zip(
-                        packed_inputs.branch_kwargs,
-                        packed_inputs.branch_is_conditional,
-                        strict=True,
-                    ):
-                        packed_inputs.forward_batch.is_cfg_negative = not is_conditional
-                        branch_predictions.append(
-                            self._predict_noise(
-                                current_model=packed_inputs.current_model,
-                                latent_model_input=packed_inputs.latent_model_input,
-                                timestep=packed_inputs.timestep,
-                                target_dtype=packed_inputs.target_dtype,
-                                guidance=packed_inputs.guidance,
-                                **branch_kwargs,
-                            )
-                        )
+                branch_predictions = self._packed_forward(
+                    group, latent_model_input, timestep, current_timestep
+                )
 
+        # Combine CFG branches and advance the solver.
         with maybe_nvtx_range("scheduler_step", use_nvtx):
-            for index, state in enumerate(packed_inputs.states):
+            if group.vectorized_combine and all(
+                not isinstance(prediction, tuple) for prediction in branch_predictions
+            ):
+                noise_pred_rows = self._combine_packed_predictions_vectorized(
+                    group, states, branch_predictions, server_args
+                )
+                new_packed = group.solver.step_rows(
+                    noise_pred_rows, packed_latents, states
+                )
+                self._scatter_packed_latents(group, states, new_packed, server_args)
+                return
+
+            noise_preds = []
+            for index, state in enumerate(states):
                 ctx = state.denoising_context
                 step = state.current_step
                 req = state.req
                 predictions = []
                 for branch_prediction in branch_predictions:
-                    sliced_prediction = packed_inputs.slice_prediction(
-                        branch_prediction, index
-                    )
+                    sliced_prediction = group.slice_prediction(branch_prediction, index)
+                    if varlen_lens is not None and isinstance(
+                        sliced_prediction, torch.Tensor
+                    ):
+                        # Drop the padded tail of varlen rows.
+                        sliced_prediction = sliced_prediction[
+                            :, : int(ctx.latents.shape[1])
+                        ]
                     pred_t = _wrap(sliced_prediction)
                     if len(pred_t) == 1:
                         pred_t = (
@@ -2329,8 +2908,33 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 )
                 if server_args.comfyui_mode:
                     req.noise_pred = noise_pred
+                noise_preds.append(noise_pred)
+
+            if (
+                group.solver is not None
+                and packed_latents is not None
+                and all(not isinstance(noise_pred, tuple) for noise_pred in noise_preds)
+            ):
+                if varlen_lens is not None:
+                    noise_preds = [
+                        self._pad_seq_dim(noise_pred, max_seq)
+                        for noise_pred in noise_preds
+                    ]
+                packed_noise_pred = torch.cat(noise_preds, dim=0)
+                new_packed = group.solver.step_rows(
+                    packed_noise_pred, packed_latents, states
+                )
+                self._scatter_packed_latents(group, states, new_packed, server_args)
+                return
+
+            # Per-request solver fallback; latents live per request.
+            group.packed_latents = None
+            for index, state in enumerate(states):
+                ctx = state.denoising_context
+                step = state.current_step
+                req = state.req
                 ctx.latents = ctx.scheduler.step(
-                    model_output=noise_pred,
+                    model_output=noise_preds[index],
                     timestep=step.t_device,
                     sample=ctx.latents,
                     **ctx.extra_step_kwargs,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -1859,6 +1859,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 return False
             if state.req.image_latent is not None:
                 return False
+            if not self._can_share_packed_forward_batch_context(first.req, state.req):
+                return False
             if (ctx.extra.get("cfg_gate_state") or {}).get("active"):
                 return False
             branches = getattr(ctx.cfg_policy, "branches", ())
@@ -1879,6 +1881,17 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             if ctx.latents.device != first_ctx.latents.device:
                 return False
         return True
+
+    @staticmethod
+    def _can_share_packed_forward_batch_context(first: Req, current: Req) -> bool:
+        attrs = (
+            "enable_sequence_shard",
+            "did_sp_shard_latents",
+            "sp_video_start_frame",
+        )
+        return all(
+            getattr(first, attr, None) == getattr(current, attr, None) for attr in attrs
+        )
 
     @staticmethod
     def _can_share_packed_attn_metadata(first: Any, current: Any) -> bool:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -227,7 +227,8 @@ class PackedStepGroup:
     # Merged cond/uncond kwargs for single-forward CFG; None if folded per branch.
     folded_kwargs: dict[str, Any] | None
     guidance: torch.Tensor | None
-    # Persistent packed latents; None when using per-request solver fallback.
+    # Persistent packed latents; packed groups always step through the
+    # vectorized solver (there is no per-request scheduler.step fallback).
     packed_latents: torch.Tensor | None
     solver: Any | None
     current_model: Any
@@ -1797,7 +1798,15 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             try:
                 group = self.build_packed_step_group(states, server_args)
             except DenoisingStepPackingError as exc:
-                logger.debug("Step batch packing fell back to local steps: %s", exc)
+                from sglang.multimodal_gen.runtime.pipelines_core.fallback_diagnostics import (
+                    fallback_diagnostics,
+                )
+
+                fallback_diagnostics.record(
+                    "step-packing",
+                    type(server_args.pipeline_config).__name__,
+                    str(exc),
+                )
                 self._run_unpacked_denoising_steps(states, server_args)
                 return None
 
@@ -1891,15 +1900,108 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         finally:
             self.close_denoising_progress(ctx)
 
+    def _model_phase_name(self, model: Any) -> str:
+        """Name the DiT phase for per-request cache snapshots."""
+        transformer_2 = getattr(self, "transformer_2", None)
+        if transformer_2 is not None and model is transformer_2:
+            return "transformer_2"
+        return "transformer"
+
+    def _packed_teacache_allowed(
+        self, states: list[Any], server_args: ServerArgs
+    ) -> bool:
+        """Whether TeaCache members may run packed via a per-row plan."""
+        teacache_states = [
+            state for state in states if getattr(state.req, "enable_teacache", False)
+        ]
+        if not teacache_states:
+            return True
+        if not (
+            getattr(server_args, "cb_allow_step_caches", True)
+            and getattr(server_args, "cb_packed_teacache", False)
+        ):
+            return False
+        for state in teacache_states:
+            step = state.current_step
+            model = getattr(step, "current_model", None) if step is not None else None
+            if not getattr(model, "supports_packed_teacache", False):
+                return False
+            if not hasattr(state, "teacache_state"):
+                # Only coordinator-managed states carry per-request snapshots.
+                return False
+            if should_apply_wan_ti2v(state.req, server_args):
+                return False
+        return True
+
+    def _build_packed_teacache_plan(
+        self, group: PackedStepGroup, states: list[Any]
+    ) -> Any | None:
+        """Build the per-row TeaCache plan for one packed step, or None."""
+        if group.varlen_row_seq_lens is not None or group.uses_wan_ti2v_timesteps:
+            return None
+        if not any(getattr(state.req, "enable_teacache", False) for state in states):
+            return None
+        from sglang.multimodal_gen.runtime.cache.teacache import (
+            TeaCachePackedMember,
+            TeaCachePackedPlan,
+            resolve_teacache_phase_state,
+        )
+
+        phase = self._model_phase_name(group.current_model)
+        members = []
+        for index, state in enumerate(states):
+            req = state.req
+            teacache_params = getattr(req, "teacache_params", None)
+            member_state = None
+            if (
+                getattr(req, "enable_teacache", False)
+                and teacache_params is not None
+                and hasattr(state, "teacache_state")
+            ):
+                phase_states = state.teacache_state
+                if phase_states is None:
+                    phase_states = {}
+                    state.teacache_state = phase_states
+                member_state = resolve_teacache_phase_state(
+                    phase_states, phase, create=True
+                )
+            members.append(
+                TeaCachePackedMember(
+                    row_slice=group.row_slices[index],
+                    state=member_state,
+                    step_index=int(state.current_step.step_index),
+                    num_inference_steps=int(
+                        getattr(req, "num_inference_steps", 0) or 0
+                    ),
+                    do_cfg=bool(getattr(req, "do_classifier_free_guidance", False)),
+                    teacache_params=teacache_params,
+                )
+            )
+        plan = TeaCachePackedPlan(members=members)
+        return plan if plan.any_enabled else None
+
     def can_run_steps_in_one_forward_pass(
         self, states: list[Any], server_args: ServerArgs
     ) -> bool:
+        from sglang.multimodal_gen.runtime.pipelines_core.batched_solver import (
+            scheduler_is_batchable,
+        )
+
         if not states:
             return False
         if type(self)._run_denoising_step is not DenoisingStage._run_denoising_step:
             return False
         if getattr(server_args, "enable_cfg_parallel", False):
             return False
+        if not self._packed_teacache_allowed(states, server_args):
+            return False
+        # Packed groups have no per-request scheduler.step() fallback, so only
+        # solver-batchable schedulers (and whole-tensor timesteps) may pack.
+        for state in states:
+            if not scheduler_is_batchable(state.denoising_context.scheduler):
+                return False
+            if should_apply_wan_ti2v(state.req, server_args):
+                return False
 
         first = states[0]
         first_step = first.current_step
@@ -1960,27 +2062,50 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 return False
         return True
 
+    def _varlen_step_packing_block_reason(
+        self, states: list[Any], server_args: ServerArgs
+    ) -> str | None:
+        """Why cross-resolution packing is unavailable, or None when allowed."""
+        if not getattr(server_args, "cb_varlen_packing", False):
+            return "disabled (--cb-varlen-packing false)"
+        if not getattr(
+            server_args.pipeline_config, "supports_varlen_step_packing", False
+        ):
+            return "pipeline does not support varlen step packing"
+        for attr in ("sp_degree", "ulysses_degree", "ring_degree"):
+            if int(getattr(server_args, attr, 1) or 1) != 1:
+                return f"sequence parallelism is unsupported ({attr} != 1)"
+        first_step = states[0].current_step
+        model = getattr(first_step, "current_model", None) if first_step else None
+        if not getattr(model, "supports_varlen_step_packing", False):
+            return "model does not support varlen step packing"
+        # zero_cond_t modulation indexes assume equal per-row sequence sizes.
+        if getattr(model, "zero_cond_t", False):
+            return "zero_cond_t modulation requires equal sequence sizes"
+        if not all(state.denoising_context.latents.ndim == 3 for state in states):
+            return "latents are not [batch, seq, channels] shaped"
+        return None
+
     def _varlen_step_packing_allowed(
         self, states: list[Any], server_args: ServerArgs
     ) -> bool:
         """Whether cross-resolution sequence packing may be used for states."""
-        if not getattr(server_args, "cb_varlen_packing", False):
-            return False
-        if not getattr(
-            server_args.pipeline_config, "supports_varlen_step_packing", False
-        ):
-            return False
-        for attr in ("sp_degree", "ulysses_degree", "ring_degree"):
-            if int(getattr(server_args, attr, 1) or 1) != 1:
-                return False
-        first_step = states[0].current_step
-        model = getattr(first_step, "current_model", None) if first_step else None
-        if not getattr(model, "supports_varlen_step_packing", False):
-            return False
-        # zero_cond_t modulation indexes assume equal per-row sequence sizes.
-        if getattr(model, "zero_cond_t", False):
-            return False
-        return all(state.denoising_context.latents.ndim == 3 for state in states)
+        reason = self._varlen_step_packing_block_reason(states, server_args)
+        if reason is None:
+            return True
+        if getattr(server_args, "cb_varlen_packing", False):
+            # Varlen was requested but cannot apply; surface why so mixed
+            # resolutions visibly split into separate groups.
+            from sglang.multimodal_gen.runtime.pipelines_core.fallback_diagnostics import (
+                fallback_diagnostics,
+            )
+
+            fallback_diagnostics.record(
+                "varlen-packing",
+                type(server_args.pipeline_config).__name__,
+                reason,
+            )
+        return False
 
     @staticmethod
     def _can_share_packed_forward_batch_context(first: Req, current: Req) -> bool:
@@ -2592,41 +2717,37 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 torch.tensor(row_counts, device=device),
             )
 
-        solver = None
-        if not uses_wan_ti2v:
-            from sglang.multimodal_gen.runtime.pipelines_core.batched_solver import (
-                build_batched_solver,
-            )
+        from sglang.multimodal_gen.runtime.pipelines_core.batched_solver import (
+            build_batched_solver,
+        )
 
-            solver = build_batched_solver(states, device)
+        # Packed groups step exclusively through the vectorized solver; the
+        # packability pre-screen guarantees this build succeeds, and a
+        # rejection here is a hard error rather than a silent fallback.
+        solver = build_batched_solver(states, device)
 
-        packed_latents = None
-        if solver is not None:
-            try:
-                if varlen:
-                    max_img_seq = max(row_seq_lens)
-                    packed_latents = torch.cat(
-                        [
-                            self._pad_seq_dim(
-                                state.denoising_context.latents, max_img_seq
-                            )
-                            for state in states
-                        ],
-                        dim=0,
-                    )
-                else:
-                    packed_latents = torch.cat(
-                        [state.denoising_context.latents for state in states], dim=0
-                    )
-            except RuntimeError as exc:
-                raise DenoisingStepPackingError(
-                    f"step batch latent packing failed: {exc}"
-                ) from exc
+        try:
+            if varlen:
+                max_img_seq = max(row_seq_lens)
+                packed_latents = torch.cat(
+                    [
+                        self._pad_seq_dim(state.denoising_context.latents, max_img_seq)
+                        for state in states
+                    ],
+                    dim=0,
+                )
+            else:
+                packed_latents = torch.cat(
+                    [state.denoising_context.latents for state in states], dim=0
+                )
+        except RuntimeError as exc:
+            raise DenoisingStepPackingError(
+                f"step batch latent packing failed: {exc}"
+            ) from exc
 
         pipeline_config = server_args.pipeline_config
         vectorized_combine = (
-            solver is not None
-            and type(pipeline_config).postprocess_cfg_noise
+            type(pipeline_config).postprocess_cfg_noise
             is PipelineConfig.postprocess_cfg_noise
             and type(pipeline_config).slice_noise_pred
             is PipelineConfig.slice_noise_pred
@@ -2694,12 +2815,14 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         latent_model_input: torch.Tensor,
         timestep: torch.Tensor,
         current_timestep: int | None,
+        teacache_plan: Any | None = None,
     ) -> list[torch.Tensor | tuple[torch.Tensor, ...]]:
         """Run the packed model forward, folded or per-branch."""
         with set_forward_context(
             current_timestep=current_timestep,
             attn_metadata=group.attn_metadata,
             forward_batch=group.forward_batch,
+            teacache_plan=teacache_plan,
         ):
             if group.folded_kwargs is not None:
                 num_branches = len(group.branch_kwargs)
@@ -2821,29 +2944,23 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             states[0].current_step.step_index if len(step_indices) == 1 else None
         )
 
-        # Assemble packed latents and per-row timesteps.
+        # Assemble packed latents and per-row timesteps. Packed groups always
+        # step through the vectorized solver; there is no per-request
+        # scheduler.step() fallback.
         varlen_lens = group.varlen_row_seq_lens
         max_seq = max(varlen_lens) if varlen_lens else None
-        if group.solver is not None and group.packed_latents is not None:
-            packed_latents = group.packed_latents
-            latent_model_input = group.solver.scale_model_input(packed_latents).to(
-                group.target_dtype
+        packed_latents = group.packed_latents
+        if group.solver is None or packed_latents is None:
+            raise RuntimeError(
+                "packed step group is missing its vectorized solver state; "
+                "non-batchable schedulers must not join packed groups"
             )
-        else:
-            per_request_inputs = []
-            for state in states:
-                ctx = state.denoising_context
-                scaled = ctx.scheduler.scale_model_input(
-                    ctx.latents.to(ctx.target_dtype),
-                    state.current_step.t_device,
-                )
-                if varlen_lens is not None:
-                    scaled = self._pad_seq_dim(scaled, max_seq)
-                per_request_inputs.append(scaled)
-            packed_latents = None
-            latent_model_input = torch.cat(per_request_inputs, dim=0)
+        latent_model_input = group.solver.scale_model_input(packed_latents).to(
+            group.target_dtype
+        )
         latent_model_input = self._pad_model_rows(latent_model_input, group.padded_rows)
         timestep = self._build_packed_timestep(group, states, server_args)
+        teacache_plan = self._build_packed_teacache_plan(group, states)
 
         # Run one (folded) or per-branch packed forward.
         with maybe_nvtx_range("predict_noise", use_nvtx):
@@ -2853,7 +2970,11 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 enabled=group.autocast_enabled,
             ):
                 branch_predictions = self._packed_forward(
-                    group, latent_model_input, timestep, current_timestep
+                    group,
+                    latent_model_input,
+                    timestep,
+                    current_timestep,
+                    teacache_plan=teacache_plan,
                 )
 
         # Combine CFG branches and advance the solver.
@@ -2910,44 +3031,20 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                     req.noise_pred = noise_pred
                 noise_preds.append(noise_pred)
 
-            if (
-                group.solver is not None
-                and packed_latents is not None
-                and all(not isinstance(noise_pred, tuple) for noise_pred in noise_preds)
-            ):
-                if varlen_lens is not None:
-                    noise_preds = [
-                        self._pad_seq_dim(noise_pred, max_seq)
-                        for noise_pred in noise_preds
-                    ]
-                packed_noise_pred = torch.cat(noise_preds, dim=0)
-                new_packed = group.solver.step_rows(
-                    packed_noise_pred, packed_latents, states
+            if any(isinstance(noise_pred, tuple) for noise_pred in noise_preds):
+                raise RuntimeError(
+                    "packed step groups require tensor noise predictions; "
+                    "multi-output models must not join packed groups"
                 )
-                self._scatter_packed_latents(group, states, new_packed, server_args)
-                return
-
-            # Per-request solver fallback; latents live per request.
-            group.packed_latents = None
-            for index, state in enumerate(states):
-                ctx = state.denoising_context
-                step = state.current_step
-                req = state.req
-                ctx.latents = ctx.scheduler.step(
-                    model_output=noise_preds[index],
-                    timestep=step.t_device,
-                    sample=ctx.latents,
-                    **ctx.extra_step_kwargs,
-                    return_dict=False,
-                )[0]
-                ctx.latents = self.post_forward_for_ti2v_task(
-                    req,
-                    server_args,
-                    ctx.reserved_frames_mask,
-                    ctx.latents,
-                    ctx.z,
-                )
-                self._record_trajectory(ctx, step, req, server_args)
+            if varlen_lens is not None:
+                noise_preds = [
+                    self._pad_seq_dim(noise_pred, max_seq) for noise_pred in noise_preds
+                ]
+            packed_noise_pred = torch.cat(noise_preds, dim=0)
+            new_packed = group.solver.step_rows(
+                packed_noise_pred, packed_latents, states
+            )
+            self._scatter_packed_latents(group, states, new_packed, server_args)
 
     def forward(
         self,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -1162,6 +1162,24 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             attn_metadata=attn_metadata,
         )
 
+    def _prepare_step_state(
+        self,
+        ctx: DenoisingContext,
+        batch: Req,
+        server_args: ServerArgs,
+        step_index: int,
+        t_host: torch.Tensor,
+        timesteps_cpu: torch.Tensor,
+    ) -> DenoisingStepState:
+        return self._build_denoising_step_state(
+            ctx,
+            batch,
+            server_args,
+            step_index,
+            t_host,
+            timesteps_cpu,
+        )
+
     def _prepare_step_attn_metadata(
         self,
         ctx: DenoisingContext,
@@ -1673,6 +1691,12 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         if progress_manager is not None:
             progress_manager.__exit__(None, None, None)
 
+    def cleanup_denoising_context(self, ctx: DenoisingContext) -> None:
+        try:
+            self._finish_active_component_use()
+        finally:
+            self.close_denoising_progress(ctx)
+
     @torch.no_grad()
     def _run_unpacked_denoising_steps(
         self,
@@ -1771,24 +1795,28 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             timesteps_cpu = ctx.timesteps.cpu()
         num_timesteps = int(timesteps_cpu.shape[0])
 
-        denoising_start_time = ctx.extra.get("denoising_start_time")
-        if denoising_start_time is not None and num_timesteps > 0 and not ctx.is_warmup:
-            self.log_info(
-                "average time per step: %.4f seconds",
-                (time.time() - denoising_start_time) / num_timesteps,
-            )
-
-        self._finish_active_component_use()
-
-        if batch.rollout:
-            self._postprocess_rollout_outputs(
-                batch=batch,
-                latents=ctx.latents,
-                num_inference_steps=num_timesteps,
-                final_timestep=timesteps_cpu.new_zeros(()),
-                server_args=server_args,
-            )
         try:
+            denoising_start_time = ctx.extra.get("denoising_start_time")
+            if (
+                denoising_start_time is not None
+                and num_timesteps > 0
+                and not ctx.is_warmup
+            ):
+                self.log_info(
+                    "average time per step: %.4f seconds",
+                    (time.time() - denoising_start_time) / num_timesteps,
+                )
+
+            self._finish_active_component_use()
+
+            if batch.rollout:
+                self._postprocess_rollout_outputs(
+                    batch=batch,
+                    latents=ctx.latents,
+                    num_inference_steps=num_timesteps,
+                    final_timestep=timesteps_cpu.new_zeros(()),
+                    server_args=server_args,
+                )
             self._finalize_denoising_loop(ctx, batch, server_args)
         finally:
             self.close_denoising_progress(ctx)
@@ -1796,6 +1824,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
     def can_run_steps_in_one_forward_pass(
         self, states: list[Any], server_args: ServerArgs
     ) -> bool:
+        if not states:
+            return False
         if getattr(server_args, "enable_cfg_parallel", False):
             return False
 
@@ -1805,6 +1835,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         if first_step is None:
             return False
         if first.req.image_latent is not None:
+            return False
+        if (first_ctx.extra.get("cfg_gate_state") or {}).get("active"):
             return False
         first_branches = getattr(first_ctx.cfg_policy, "branches", ())
         if not first_branches:
@@ -1823,6 +1855,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             if step.current_model is not first_step.current_model:
                 return False
             if state.req.image_latent is not None:
+                return False
+            if (ctx.extra.get("cfg_gate_state") or {}).get("active"):
                 return False
             branches = getattr(ctx.cfg_policy, "branches", ())
             if len(branches) != len(first_branches):
@@ -2102,9 +2136,10 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         return key in {"freqs_cis", "joint_attention_kwargs"}
 
     def _merge_step_input_kwargs(self, branch_kwargs: list[dict[str, Any]]) -> dict:
-        keys = set(branch_kwargs[0])
+        keys = tuple(branch_kwargs[0])
+        key_set = set(keys)
         for kwargs in branch_kwargs[1:]:
-            if set(kwargs) != keys:
+            if set(kwargs) != key_set:
                 raise DenoisingStepPackingError(
                     "step batch branch kwargs have mismatched keys"
                 )
@@ -2245,14 +2280,19 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                     sliced_prediction = packed_inputs.slice_prediction(
                         branch_prediction, index
                     )
-                    if not isinstance(sliced_prediction, tuple):
-                        sliced_prediction = server_args.pipeline_config.slice_noise_pred(
-                            sliced_prediction, ctx.latents
+                    pred_t = _wrap(sliced_prediction)
+                    if len(pred_t) == 1:
+                        pred_t = (
+                            server_args.pipeline_config.slice_noise_pred(
+                                pred_t[0], ctx.latents
+                            ),
                         )
-                    predictions.append(sliced_prediction)
-                cfg_scale = server_args.pipeline_config.get_classifier_free_guidance_scale(
-                    req,
-                    step.current_guidance_scale,
+                    predictions.append(_unwrap(pred_t))
+                cfg_scale = (
+                    server_args.pipeline_config.get_classifier_free_guidance_scale(
+                        req,
+                        step.current_guidance_scale,
+                    )
                 )
                 noise_pred = ctx.cfg_policy.combine(
                     predictions,
@@ -2322,7 +2362,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                         server_args,
                     )
         except Exception:
-            self.close_denoising_progress(ctx)
+            self.cleanup_denoising_context(ctx)
             raise
         self.finish_denoising_context(ctx, batch, server_args)
         return batch

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -10,8 +10,8 @@ import math
 import time
 import weakref
 from collections.abc import Callable
-from contextlib import contextmanager
-from dataclasses import dataclass, field, fields
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass, field, fields, is_dataclass
 from enum import Enum
 from functools import lru_cache
 from typing import Any
@@ -136,7 +136,7 @@ def _ensure_tensor_model_output(model_output):
 
 @dataclass(slots=True)
 class DenoisingContext:
-    """Loop-scoped state shared across the denoising skeleton and its hooks."""
+    """Mutable state for one request's denoising loop."""
 
     scheduler: Any
     extra_step_kwargs: dict[str, Any]
@@ -167,13 +167,12 @@ class DenoisingContext:
         return getattr(self, key, default)
 
     def to_kwargs(self) -> dict[str, Any]:
-        """Return a shallow field mapping for derived context construction."""
         return {item.name: getattr(self, item.name) for item in fields(self)}
 
 
 @dataclass(slots=True)
 class DenoisingStepState:
-    """Per-step hot-path state computed once and reused within a denoising step."""
+    """Prepared values for one request at one denoising step."""
 
     step_index: int
     t_host: torch.Tensor
@@ -193,6 +192,42 @@ class DualTransformerExecutionMode(str, Enum):
 
     BOUNDARY_EXPERTS = "boundary_experts"
     PAIRED_PER_STEP = "paired_per_step"
+
+
+@dataclass(slots=True)
+class DenoisingStepWorkItem:
+    req: Req
+    denoising_context: DenoisingContext
+    current_step: DenoisingStepState
+
+
+class DenoisingStepPackingError(ValueError):
+    pass
+
+
+@dataclass(slots=True)
+class PackedDenoisingStepInputs:
+    states: list[Any]
+    row_slices: tuple[slice, ...]
+    latent_model_input: torch.Tensor
+    timestep: torch.Tensor
+    guidance: torch.Tensor | None
+    branch_kwargs: tuple[dict[str, Any], ...]
+    branch_is_conditional: tuple[bool, ...]
+    current_model: Any
+    target_dtype: torch.dtype
+    autocast_enabled: bool
+    attn_metadata: Any | None
+    forward_batch: Req
+    current_timestep: int | None
+
+    def slice_prediction(
+        self, prediction: torch.Tensor | tuple[torch.Tensor, ...], index: int
+    ) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        row_slice = self.row_slices[index]
+        if isinstance(prediction, tuple):
+            return tuple(item[row_slice] for item in prediction)
+        return prediction[row_slice]
 
 
 class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
@@ -994,7 +1029,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
     def _before_denoising_loop(
         self, ctx: DenoisingContext, batch: Req, server_args: ServerArgs
     ) -> None:
-        """Prepare scheduler state before entering the shared denoising loop."""
+        """Reset scheduler state for one denoising pass."""
         self._reset_scheduler_loop_state(ctx.scheduler)
         ctx.scheduler.set_begin_index(0)
         self._init_cfg_gate_state(ctx, batch, server_args)
@@ -1091,7 +1126,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                     stack.append(wrapped)
         return None
 
-    def _prepare_step_state(
+    def _build_denoising_step_state(
         self,
         ctx: DenoisingContext,
         batch: Req,
@@ -1100,7 +1135,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         t_host: torch.Tensor,
         timesteps_cpu: torch.Tensor,
     ) -> DenoisingStepState:
-        """Build the per-step state shared by the loop and model-specific hooks."""
+        """Build state for one denoising step."""
         t_int = int(t_host.item())
         t_device = ctx.timesteps[step_index]
         current_model, current_guidance_scale = self._select_and_manage_model(
@@ -1137,8 +1172,6 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         timesteps_cpu: torch.Tensor,
     ) -> Any | None:
         """Build attention metadata for the current denoising step."""
-        # Keep attention metadata preparation overridable so model-specific stages
-        # can preserve their original semantics without duplicating step state setup.
         return self._build_attn_metadata(
             step_index,
             batch,
@@ -1174,7 +1207,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         inner ``predict_noise`` / ``scheduler_step`` NVTX markers emitted
         below; mirror them in the override if those markers are needed.
         """
-        use_nvtx = self.current_use_nvtx
+        use_nvtx = ctx.extra.get("use_nvtx", self.current_use_nvtx)
         # 1. Prepare latent inputs in the model's compute dtype.
         latent_model_input = ctx.latents.to(ctx.target_dtype)
         if batch.image_latent is not None:
@@ -1185,7 +1218,6 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 [latent_model_input, batch.image_latent], dim=1
             ).to(ctx.target_dtype)
 
-        # 2. Expand the timestep to the shape expected by the current model.
         timestep = self.expand_timestep_before_forward(
             batch,
             server_args,
@@ -1195,7 +1227,6 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             ctx.reserved_frames_mask,
         )
 
-        # 3. Apply scheduler-side input scaling before the model forward.
         latent_model_input = ctx.scheduler.scale_model_input(
             latent_model_input, step.t_device
         )
@@ -1230,7 +1261,6 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 return_dict=False,
             )[0]
 
-        # 6. Re-apply any model-specific latent constraints after the update.
         ctx.latents = self.post_forward_for_ti2v_task(
             batch,
             server_args,
@@ -1453,6 +1483,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             current_model: the next active dit, transformer_1 or transformer_2
         """
         manager = self._component_residency_manager
+        if manager is None:
+            return
 
         component_name = manager.component_name_for_module(current_model, current_phase)
         phase = str(batch.extra.get("ltx2_phase", current_phase))
@@ -1554,6 +1586,613 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         self._offloaded_dit_modules_for_compile.clear()
         yield
 
+    @torch.no_grad()
+    def prepare_denoising_context(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+        *,
+        open_progress_bar: bool = False,
+    ) -> DenoisingContext:
+        ctx = self._prepare_denoising_loop(batch, server_args)
+        if batch.rollout:
+            self._maybe_init_denoising_env_collection(
+                batch=batch,
+                pipeline_config=server_args.pipeline_config,
+                image_kwargs=ctx.image_kwargs,
+                pos_cond_kwargs=ctx.pos_cond_kwargs,
+                neg_cond_kwargs=ctx.neg_cond_kwargs,
+                guidance=ctx.guidance,
+            )
+        self._before_denoising_loop(ctx, batch, server_args)
+        timesteps_cpu = ctx.timesteps.cpu()
+        ctx.extra["timesteps_cpu"] = timesteps_cpu
+        ctx.extra["denoising_start_time"] = time.time()
+        ctx.extra["use_nvtx"] = self._apply_nvtx_gate(ctx.is_warmup)
+        if open_progress_bar:
+            progress_manager = self.progress_bar(
+                total=ctx.num_inference_steps, batch=batch
+            )
+            ctx.extra["progress_manager"] = progress_manager
+            ctx.extra["progress_bar"] = progress_manager.__enter__()
+        return ctx
+
+    def prepare_denoising_step_state(
+        self,
+        ctx: DenoisingContext,
+        batch: Req,
+        server_args: ServerArgs,
+        step_index: int,
+    ) -> DenoisingStepState:
+        timesteps_cpu = ctx.extra.get("timesteps_cpu")
+        if timesteps_cpu is None:
+            timesteps_cpu = ctx.timesteps.cpu()
+            ctx.extra["timesteps_cpu"] = timesteps_cpu
+        return self._build_denoising_step_state(
+            ctx,
+            batch,
+            server_args,
+            step_index,
+            timesteps_cpu[step_index],
+            timesteps_cpu,
+        )
+
+    @torch.no_grad()
+    def run_single_denoising_step(
+        self,
+        ctx: DenoisingContext,
+        step: DenoisingStepState,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> None:
+        with torch.autocast(
+            device_type=current_platform.device_type,
+            dtype=ctx.target_dtype,
+            enabled=ctx.autocast_enabled,
+        ):
+            self._run_denoising_step(ctx, step, batch, server_args)
+        self._record_trajectory(ctx, step, batch, server_args)
+
+    def _update_denoising_progress(
+        self, ctx: DenoisingContext, step_index: int
+    ) -> None:
+        progress_bar = ctx.extra.get("progress_bar")
+        if progress_bar is None:
+            return
+        timesteps_cpu = ctx.extra.get("timesteps_cpu")
+        num_timesteps = int(timesteps_cpu.shape[0]) if timesteps_cpu is not None else 0
+        if step_index == num_timesteps - 1 or (
+            (step_index + 1) > ctx.num_warmup_steps
+            and (step_index + 1) % ctx.scheduler.order == 0
+        ):
+            progress_bar.update()
+
+    def close_denoising_progress(self, ctx: DenoisingContext) -> None:
+        progress_manager = ctx.extra.pop("progress_manager", None)
+        ctx.extra.pop("progress_bar", None)
+        if progress_manager is not None:
+            progress_manager.__exit__(None, None, None)
+
+    @torch.no_grad()
+    def _run_unpacked_denoising_steps(
+        self,
+        states: list[Any],
+        server_args: ServerArgs,
+    ) -> None:
+        for state in states:
+            ctx = state.denoising_context
+            step = state.current_step
+            use_nvtx = ctx.extra.get("use_nvtx", self.current_use_nvtx)
+            step_marker = f"denoising_step_{step.step_index}_t{step.t_host.item():.4g}"
+            with (
+                maybe_nvtx_range(step_marker, use_nvtx),
+                StageProfiler(
+                    f"denoising_step_{step.step_index}",
+                    logger=logger,
+                    metrics=state.req.metrics,
+                    perf_dump_path_provided=state.req.perf_dump_path is not None,
+                    record_as_step=True,
+                ),
+            ):
+                self.run_single_denoising_step(
+                    ctx,
+                    step,
+                    state.req,
+                    server_args,
+                )
+                self._update_denoising_progress(
+                    ctx,
+                    step.step_index,
+                )
+                if not ctx.is_warmup:
+                    self.step_profile()
+
+    @torch.no_grad()
+    def run_denoising_steps_for_requests(
+        self,
+        states: list[Any],
+        server_args: ServerArgs,
+    ) -> None:
+        if len(states) <= 1 or not self.can_run_steps_in_one_forward_pass(
+            states, server_args
+        ):
+            self._run_unpacked_denoising_steps(states, server_args)
+            return
+
+        try:
+            batched_inputs = self._pack_denoising_step_inputs(states, server_args)
+        except DenoisingStepPackingError as exc:
+            logger.debug("Step batch packing fell back to local steps: %s", exc)
+            self._run_unpacked_denoising_steps(states, server_args)
+            return
+
+        with ExitStack() as stack:
+            for state in states:
+                step = state.current_step
+                use_nvtx = state.denoising_context.extra.get(
+                    "use_nvtx", self.current_use_nvtx
+                )
+                stack.enter_context(
+                    maybe_nvtx_range(
+                        f"denoising_step_{step.step_index}_t{step.t_host.item():.4g}",
+                        use_nvtx,
+                    )
+                )
+                stack.enter_context(
+                    StageProfiler(
+                        f"denoising_step_{step.step_index}",
+                        logger=logger,
+                        metrics=state.req.metrics,
+                        perf_dump_path_provided=state.req.perf_dump_path is not None,
+                        record_as_step=True,
+                    )
+                )
+            self._run_batched_step_forward_and_update_latents(
+                batched_inputs,
+                server_args,
+            )
+        for state in states:
+            self._update_denoising_progress(
+                state.denoising_context,
+                state.current_step.step_index,
+            )
+            if not state.denoising_context.is_warmup:
+                self.step_profile()
+
+    @torch.no_grad()
+    def finish_denoising_context(
+        self,
+        ctx: DenoisingContext,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> None:
+        timesteps_cpu = ctx.extra.get("timesteps_cpu")
+        if timesteps_cpu is None:
+            timesteps_cpu = ctx.timesteps.cpu()
+        num_timesteps = int(timesteps_cpu.shape[0])
+
+        denoising_start_time = ctx.extra.get("denoising_start_time")
+        if denoising_start_time is not None and num_timesteps > 0 and not ctx.is_warmup:
+            self.log_info(
+                "average time per step: %.4f seconds",
+                (time.time() - denoising_start_time) / num_timesteps,
+            )
+
+        self._finish_active_component_use()
+
+        if batch.rollout:
+            self._postprocess_rollout_outputs(
+                batch=batch,
+                latents=ctx.latents,
+                num_inference_steps=num_timesteps,
+                final_timestep=timesteps_cpu.new_zeros(()),
+                server_args=server_args,
+            )
+        try:
+            self._finalize_denoising_loop(ctx, batch, server_args)
+        finally:
+            self.close_denoising_progress(ctx)
+
+    def can_run_steps_in_one_forward_pass(
+        self, states: list[Any], server_args: ServerArgs
+    ) -> bool:
+        if getattr(server_args, "enable_cfg_parallel", False):
+            return False
+
+        first = states[0]
+        first_step = first.current_step
+        first_ctx = first.denoising_context
+        if first_step is None:
+            return False
+        if first.req.image_latent is not None:
+            return False
+        first_branches = getattr(first_ctx.cfg_policy, "branches", ())
+        if not first_branches:
+            return False
+
+        for state in states[1:]:
+            step = state.current_step
+            ctx = state.denoising_context
+            if step is None:
+                return False
+            if not self._can_share_packed_attn_metadata(
+                first_step.attn_metadata,
+                step.attn_metadata,
+            ):
+                return False
+            if step.current_model is not first_step.current_model:
+                return False
+            if state.req.image_latent is not None:
+                return False
+            branches = getattr(ctx.cfg_policy, "branches", ())
+            if len(branches) != len(first_branches):
+                return False
+            if tuple(branch.name for branch in branches) != tuple(
+                branch.name for branch in first_branches
+            ):
+                return False
+            if tuple(branch.is_conditional for branch in branches) != tuple(
+                branch.is_conditional for branch in first_branches
+            ):
+                return False
+            if tuple(ctx.latents.shape[1:]) != tuple(first_ctx.latents.shape[1:]):
+                return False
+            if ctx.latents.dtype != first_ctx.latents.dtype:
+                return False
+            if ctx.latents.device != first_ctx.latents.device:
+                return False
+        return True
+
+    @staticmethod
+    def _can_share_packed_attn_metadata(first: Any, current: Any) -> bool:
+        if first is None or current is None:
+            return first is None and current is None
+        if type(first) is not type(current):
+            return False
+        if type(first).__name__ != "FlashAttentionMetadata":
+            return DenoisingStage._metadata_values_equal(first, current)
+        for attr in ("cu_seqlens_q", "cu_seqlens_k"):
+            if getattr(first, attr, None) is not None:
+                return False
+            if getattr(current, attr, None) is not None:
+                return False
+        for attr in ("max_seqlen_q", "max_seqlen_k"):
+            first_value = getattr(first, attr, None)
+            current_value = getattr(current, attr, None)
+            if first_value != current_value:
+                return False
+        return True
+
+    @staticmethod
+    def _metadata_values_equal(first: Any, current: Any) -> bool:
+        if first is current:
+            return True
+        if first is None or current is None:
+            return first is None and current is None
+        if isinstance(first, (str, int, float, bool)):
+            return first == current
+        if isinstance(first, torch.Tensor):
+            return (
+                isinstance(current, torch.Tensor)
+                and tuple(first.shape) == tuple(current.shape)
+                and first.dtype == current.dtype
+                and first.device == current.device
+                and torch.equal(first, current)
+            )
+        if isinstance(first, (list, tuple)):
+            return (
+                isinstance(current, type(first))
+                and len(first) == len(current)
+                and all(
+                    DenoisingStage._metadata_values_equal(left, right)
+                    for left, right in zip(first, current, strict=True)
+                )
+            )
+        if isinstance(first, dict):
+            return (
+                isinstance(current, dict)
+                and set(first) == set(current)
+                and all(
+                    DenoisingStage._metadata_values_equal(first[key], current[key])
+                    for key in first
+                )
+            )
+        if is_dataclass(first):
+            if "cache" in type(first).__name__.lower():
+                return False
+            return all(
+                field_info.name != "cache"
+                and DenoisingStage._metadata_values_equal(
+                    getattr(first, field_info.name),
+                    getattr(current, field_info.name),
+                )
+                for field_info in fields(first)
+            )
+        return False
+
+    @staticmethod
+    def _merge_step_input_value(
+        values: list[Any], *, allow_shared: bool = False
+    ) -> Any:
+        first = values[0]
+        if first is None:
+            if any(value is not None for value in values):
+                raise DenoisingStepPackingError(
+                    "step batch kwargs mix None and non-None values"
+                )
+            return None
+
+        if isinstance(first, torch.Tensor):
+            if any(not isinstance(value, torch.Tensor) for value in values):
+                raise DenoisingStepPackingError(
+                    "step batch kwargs mix tensor and non-tensor values"
+                )
+            if allow_shared and all(
+                tuple(value.shape) == tuple(first.shape)
+                and value.dtype == first.dtype
+                and value.device == first.device
+                and torch.equal(value, first)
+                for value in values
+            ):
+                return first
+            if allow_shared:
+                raise DenoisingStepPackingError(
+                    "step batch shared tensor kwarg values differ"
+                )
+            if all(
+                value.ndim > 0
+                and first.ndim > 0
+                and tuple(value.shape[1:]) == tuple(first.shape[1:])
+                and value.dtype == first.dtype
+                and value.device == first.device
+                for value in values
+            ):
+                return torch.cat(values, dim=0)
+            raise DenoisingStepPackingError(
+                "step batch tensor kwarg is neither batch-concatable nor shared"
+            )
+
+        if isinstance(first, tuple):
+            if any(not isinstance(value, tuple) for value in values):
+                raise DenoisingStepPackingError(
+                    "step batch kwargs mix tuple and non-tuple values"
+                )
+            if any(len(value) != len(first) for value in values):
+                raise DenoisingStepPackingError(
+                    "step batch tuple kwargs have different lengths"
+                )
+            return tuple(
+                DenoisingStage._merge_step_input_value(
+                    [value[index] for value in values],
+                    allow_shared=allow_shared,
+                )
+                for index in range(len(first))
+            )
+
+        if isinstance(first, list):
+            if any(not isinstance(value, list) for value in values):
+                raise DenoisingStepPackingError(
+                    "step batch kwargs mix list and non-list values"
+                )
+            if any(len(value) != len(first) for value in values):
+                raise DenoisingStepPackingError(
+                    "step batch list kwargs have different lengths"
+                )
+            return [
+                DenoisingStage._merge_step_input_value(
+                    [value[index] for value in values],
+                    allow_shared=allow_shared,
+                )
+                for index in range(len(first))
+            ]
+
+        if isinstance(first, dict):
+            keys = set(first)
+            if any(
+                not isinstance(value, dict) or set(value) != keys for value in values
+            ):
+                raise DenoisingStepPackingError(
+                    "step batch dict kwargs have different keys"
+                )
+            return {
+                key: DenoisingStage._merge_step_input_value(
+                    [value[key] for value in values],
+                    allow_shared=allow_shared,
+                )
+                for key in first
+            }
+
+        try:
+            if all(value == first for value in values):
+                return first
+        except Exception:
+            if all(value is first for value in values):
+                return first
+        raise DenoisingStepPackingError(
+            f"step batch scalar kwarg values differ for {type(first).__name__}"
+        )
+
+    @staticmethod
+    def _step_input_can_be_shared(key: str) -> bool:
+        return key in {"freqs_cis", "joint_attention_kwargs"}
+
+    def _merge_step_input_kwargs(self, branch_kwargs: list[dict[str, Any]]) -> dict:
+        keys = set(branch_kwargs[0])
+        for kwargs in branch_kwargs[1:]:
+            if set(kwargs) != keys:
+                raise DenoisingStepPackingError(
+                    "step batch branch kwargs have mismatched keys"
+                )
+        return {
+            key: self._merge_step_input_value(
+                [kwargs[key] for kwargs in branch_kwargs],
+                allow_shared=self._step_input_can_be_shared(key),
+            )
+            for key in keys
+        }
+
+    def _pack_denoising_step_inputs(
+        self, states: list[Any], server_args: ServerArgs
+    ) -> PackedDenoisingStepInputs:
+        first = states[0]
+        first_ctx = first.denoising_context
+        first_step = first.current_step
+
+        latent_inputs = []
+        timesteps = []
+        guidance_values = []
+        branch_kwargs_by_index: list[list[dict[str, Any]]] = []
+        branch_is_conditional = []
+        row_slices = []
+        row_offset = 0
+        for state in states:
+            ctx = state.denoising_context
+            step = state.current_step
+            req = state.req
+            latent_model_input = ctx.latents.to(ctx.target_dtype)
+            latent_model_input = ctx.scheduler.scale_model_input(
+                latent_model_input, step.t_device
+            )
+            timestep = self.expand_timestep_before_forward(
+                req,
+                server_args,
+                step.t_device,
+                ctx.target_dtype,
+                ctx.seq_len,
+                ctx.reserved_frames_mask,
+            )
+            latent_inputs.append(latent_model_input)
+            timesteps.append(timestep)
+            guidance_values.append(ctx.guidance)
+            for branch_index, branch in enumerate(ctx.cfg_policy.branches):
+                if len(branch_kwargs_by_index) <= branch_index:
+                    branch_kwargs_by_index.append([])
+                    branch_is_conditional.append(branch.is_conditional)
+                branch.configure_batch(req)
+                branch_kwargs_by_index[branch_index].append(branch.kwargs)
+
+            rows = int(ctx.latents.shape[0])
+            row_slices.append(slice(row_offset, row_offset + rows))
+            row_offset += rows
+
+        try:
+            latent_model_input = torch.cat(latent_inputs, dim=0)
+            timestep = torch.cat(timesteps, dim=0)
+            if any(guidance_value is None for guidance_value in guidance_values):
+                if not all(
+                    guidance_value is None for guidance_value in guidance_values
+                ):
+                    raise DenoisingStepPackingError(
+                        "step batch mixes guidance tensor presence"
+                    )
+                guidance = None
+            else:
+                guidance = torch.cat(guidance_values, dim=0)
+        except RuntimeError as exc:
+            raise DenoisingStepPackingError(
+                f"step batch tensor packing failed: {exc}"
+            ) from exc
+        merged_branch_kwargs = tuple(
+            self._merge_step_input_kwargs(branch_kwargs)
+            for branch_kwargs in branch_kwargs_by_index
+        )
+        step_indices = {state.current_step.step_index for state in states}
+        return PackedDenoisingStepInputs(
+            states=states,
+            row_slices=tuple(row_slices),
+            latent_model_input=latent_model_input,
+            timestep=timestep,
+            guidance=guidance,
+            branch_kwargs=merged_branch_kwargs,
+            branch_is_conditional=tuple(branch_is_conditional),
+            current_model=first_step.current_model,
+            target_dtype=first_ctx.target_dtype,
+            autocast_enabled=first_ctx.autocast_enabled,
+            attn_metadata=first_step.attn_metadata,
+            forward_batch=first.req,
+            current_timestep=first_step.step_index if len(step_indices) == 1 else None,
+        )
+
+    def _run_batched_step_forward_and_update_latents(
+        self, packed_inputs: PackedDenoisingStepInputs, server_args: ServerArgs
+    ) -> None:
+        use_nvtx = any(
+            state.denoising_context.extra.get("use_nvtx", self.current_use_nvtx)
+            for state in packed_inputs.states
+        )
+        with maybe_nvtx_range("predict_noise", use_nvtx):
+            with torch.autocast(
+                device_type=current_platform.device_type,
+                dtype=packed_inputs.target_dtype,
+                enabled=packed_inputs.autocast_enabled,
+            ):
+                with set_forward_context(
+                    current_timestep=packed_inputs.current_timestep,
+                    attn_metadata=packed_inputs.attn_metadata,
+                    forward_batch=packed_inputs.forward_batch,
+                ):
+                    branch_predictions = []
+                    for branch_kwargs, is_conditional in zip(
+                        packed_inputs.branch_kwargs,
+                        packed_inputs.branch_is_conditional,
+                        strict=True,
+                    ):
+                        packed_inputs.forward_batch.is_cfg_negative = not is_conditional
+                        branch_predictions.append(
+                            self._predict_noise(
+                                current_model=packed_inputs.current_model,
+                                latent_model_input=packed_inputs.latent_model_input,
+                                timestep=packed_inputs.timestep,
+                                target_dtype=packed_inputs.target_dtype,
+                                guidance=packed_inputs.guidance,
+                                **branch_kwargs,
+                            )
+                        )
+
+        with maybe_nvtx_range("scheduler_step", use_nvtx):
+            for index, state in enumerate(packed_inputs.states):
+                ctx = state.denoising_context
+                step = state.current_step
+                req = state.req
+                predictions = []
+                for branch_prediction in branch_predictions:
+                    sliced_prediction = packed_inputs.slice_prediction(
+                        branch_prediction, index
+                    )
+                    if not isinstance(sliced_prediction, tuple):
+                        sliced_prediction = server_args.pipeline_config.slice_noise_pred(
+                            sliced_prediction, ctx.latents
+                        )
+                    predictions.append(sliced_prediction)
+                cfg_scale = server_args.pipeline_config.get_classifier_free_guidance_scale(
+                    req,
+                    step.current_guidance_scale,
+                )
+                noise_pred = ctx.cfg_policy.combine(
+                    predictions,
+                    req,
+                    cfg_scale,
+                    server_args.pipeline_config,
+                    cfg_parallel=False,
+                )
+                if server_args.comfyui_mode:
+                    req.noise_pred = noise_pred
+                ctx.latents = ctx.scheduler.step(
+                    model_output=noise_pred,
+                    timestep=step.t_device,
+                    sample=ctx.latents,
+                    **ctx.extra_step_kwargs,
+                    return_dict=False,
+                )[0]
+                ctx.latents = self.post_forward_for_ti2v_task(
+                    req,
+                    server_args,
+                    ctx.reserved_frames_mask,
+                    ctx.latents,
+                    ctx.z,
+                )
+                self._record_trajectory(ctx, step, req, server_args)
+
     def forward(
         self,
         batch: Req,
@@ -1571,108 +2210,35 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         """
         Run the denoising loop.
         """
-        ctx = self._prepare_denoising_loop(batch, server_args)
-        if batch.rollout:
-            self._maybe_init_denoising_env_collection(
-                batch=batch,
-                pipeline_config=server_args.pipeline_config,
-                image_kwargs=ctx.image_kwargs,
-                pos_cond_kwargs=ctx.pos_cond_kwargs,
-                neg_cond_kwargs=ctx.neg_cond_kwargs,
-                guidance=ctx.guidance,
-            )
-        denoising_start_time = time.time()
-        self._before_denoising_loop(ctx, batch, server_args)
-        # to avoid device-sync caused by timestep comparison
-        timesteps_cpu = ctx.timesteps.cpu()
-        num_timesteps = timesteps_cpu.shape[0]
-        # Re-resolve the explicit-range gate so the per-step markers
-        # below honor this request's is_warmup state. Layer hooks are
-        # registered by the residency manager at the use-site.
-        use_nvtx = self._apply_nvtx_gate(ctx.is_warmup)
-
-        with (
-            torch.autocast(
-                device_type=current_platform.device_type,
-                dtype=ctx.target_dtype,
-                enabled=ctx.autocast_enabled,
-            ),
-            maybe_nvtx_range("denoising_loop", use_nvtx),
-        ):
-            with self.progress_bar(
-                total=ctx.num_inference_steps, batch=batch
-            ) as progress_bar:
-                for step_index, t_host in enumerate(timesteps_cpu):
-                    # Use ``:.4g`` so flow-matching schedulers (e.g. FLUX) that
-                    # use non-integer timesteps keep their precision in markers.
-                    step_marker = f"denoising_step_{step_index}_t{t_host.item():.4g}"
-                    with (
-                        maybe_nvtx_range(step_marker, use_nvtx),
-                        StageProfiler(
-                            f"denoising_step_{step_index}",
-                            logger=logger,
-                            metrics=batch.metrics,
-                            perf_dump_path_provided=batch.perf_dump_path is not None,
-                            record_as_step=True,
-                        ),
-                    ):
-                        step = self._prepare_step_state(
-                            ctx,
-                            batch,
-                            server_args,
-                            step_index,
-                            t_host,
-                            timesteps_cpu,
+        ctx = self.prepare_denoising_context(batch, server_args, open_progress_bar=True)
+        timesteps_cpu = ctx.extra["timesteps_cpu"]
+        try:
+            with maybe_nvtx_range(
+                "denoising_loop", ctx.extra.get("use_nvtx", self.current_use_nvtx)
+            ):
+                for step_index, _t_host in enumerate(timesteps_cpu):
+                    step = self.prepare_denoising_step_state(
+                        ctx,
+                        batch,
+                        server_args,
+                        step_index,
+                    )
+                    if batch.rollout:
+                        batch._rollout_loop_step_index = step_index
+                        self._maybe_append_dit_trajectory_step(
+                            batch=batch,
+                            latents=ctx.latents,
+                            timestep_value=step.t_host,
+                            step_index=step_index,
                         )
-                        # Capture the raw (pre-scale, pre-I2V-concat) noisy latent
-                        # x_{t_i} for rollout trajectory collection. Must run
-                        # BEFORE _run_denoising_step so ctx.latents is still the
-                        # pre-step value. Gated on batch.rollout to keep the
-                        # non-rollout path strictly untouched.
-                        if batch.rollout:
-                            batch._rollout_loop_step_index = step_index
-                            self._maybe_append_dit_trajectory_step(
-                                batch=batch,
-                                latents=ctx.latents,
-                                timestep_value=step.t_host,
-                                step_index=step_index,
-                            )
-                        self._run_denoising_step(ctx, step, batch, server_args)
-                        self._record_trajectory(ctx, step, batch, server_args)
-
-                        if step_index == num_timesteps - 1 or (
-                            (step_index + 1) > ctx.num_warmup_steps
-                            and (step_index + 1) % ctx.scheduler.order == 0
-                            and progress_bar is not None
-                        ):
-                            progress_bar.update()
-
-                        if not ctx.is_warmup:
-                            self.step_profile()
-
-        denoising_end_time = time.time()
-
-        if num_timesteps > 0 and not ctx.is_warmup:
-            self.log_info(
-                "average time per step: %.4f seconds",
-                (denoising_end_time - denoising_start_time) / len(ctx.timesteps),
-            )
-
-        self._finish_active_component_use()
-
-        # Rollout postprocessing must run BEFORE _finalize_denoising_loop so
-        # the final scheduler.step output (ctx.latents) is still SP-sharded and
-        # can be gathered uniformly alongside the per-step dit_trajectory via
-        # gather_stacked_latents_for_sp.
-        if batch.rollout:
-            self._postprocess_rollout_outputs(
-                batch=batch,
-                latents=ctx.latents,
-                num_inference_steps=num_timesteps,
-                final_timestep=timesteps_cpu.new_zeros(()),
-                server_args=server_args,
-            )
-        self._finalize_denoising_loop(ctx, batch, server_args)
+                    self.run_denoising_steps_for_requests(
+                        [DenoisingStepWorkItem(batch, ctx, step)],
+                        server_args,
+                    )
+        except Exception:
+            self.close_denoising_progress(ctx)
+            raise
+        self.finish_denoising_context(ctx, batch, server_args)
         return batch
 
     def _get_extra_func_kwarg_names(self, func) -> tuple[bool, frozenset[str]]:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -1827,6 +1827,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
     ) -> bool:
         if not states:
             return False
+        if type(self)._run_denoising_step is not DenoisingStage._run_denoising_step:
+            return False
         if getattr(server_args, "enable_cfg_parallel", False):
             return False
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -2027,6 +2027,13 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 raise DenoisingStepPackingError(
                     "step batch kwargs mix list and non-list values"
                 )
+            if key == "encoder_hidden_states" and all(
+                all(torch.is_tensor(item) for item in value) for value in values
+            ):
+                merged = []
+                for value in values:
+                    merged.extend(value)
+                return merged
             if key in {"img_shapes", "txt_seq_lens"}:
                 merged = []
                 for value in values:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -1171,6 +1171,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         t_host: torch.Tensor,
         timesteps_cpu: torch.Tensor,
     ) -> DenoisingStepState:
+        """Compatibility wrapper for model-specific denoising subclasses."""
         return self._build_denoising_step_state(
             ctx,
             batch,
@@ -1948,6 +1949,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
     def _merge_step_input_value(
         values: list[Any], *, allow_shared: bool = False, key: str | None = None
     ) -> Any:
+        """Merge one branch kwarg across requests for packed execution."""
         first = values[0]
         if first is None:
             if any(value is not None for value in values):
@@ -2155,6 +2157,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
     def _pack_denoising_step_inputs(
         self, states: list[Any], server_args: ServerArgs
     ) -> PackedDenoisingStepInputs:
+        """Build packed model inputs for selected compatible request steps."""
         first = states[0]
         first_ctx = first.denoising_context
         first_step = first.current_step
@@ -2237,6 +2240,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
     def _run_batched_step_forward_and_update_latents(
         self, packed_inputs: PackedDenoisingStepInputs, server_args: ServerArgs
     ) -> None:
+        """Run one packed forward pass and update each request's scheduler state."""
         use_nvtx = any(
             state.denoising_context.extra.get("use_nvtx", self.current_use_nvtx)
             for state in packed_inputs.states

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -1912,7 +1912,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
 
     @staticmethod
     def _merge_step_input_value(
-        values: list[Any], *, allow_shared: bool = False
+        values: list[Any], *, allow_shared: bool = False, key: str | None = None
     ) -> Any:
         first = values[0]
         if first is None:
@@ -1921,6 +1921,9 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                     "step batch kwargs mix None and non-None values"
                 )
             return None
+
+        if key == "freqs_cis":
+            return DenoisingStage._merge_rope_cache(values)
 
         if isinstance(first, torch.Tensor):
             if any(not isinstance(value, torch.Tensor) for value in values):
@@ -1939,6 +1942,19 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 raise DenoisingStepPackingError(
                     "step batch shared tensor kwarg values differ"
                 )
+            if key in {
+                "encoder_hidden_states",
+                "encoder_hidden_states_mask",
+                "encoder_attention_mask",
+            } and all(
+                value.ndim >= 2
+                and first.ndim >= 2
+                and tuple(value.shape[2:]) == tuple(first.shape[2:])
+                and value.dtype == first.dtype
+                and value.device == first.device
+                for value in values
+            ):
+                return DenoisingStage._pad_and_cat_text_tensors(values)
             if all(
                 value.ndim > 0
                 and first.ndim > 0
@@ -1965,6 +1981,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 DenoisingStage._merge_step_input_value(
                     [value[index] for value in values],
                     allow_shared=allow_shared,
+                    key=key,
                 )
                 for index in range(len(first))
             )
@@ -1974,6 +1991,11 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 raise DenoisingStepPackingError(
                     "step batch kwargs mix list and non-list values"
                 )
+            if key in {"img_shapes", "txt_seq_lens"}:
+                merged = []
+                for value in values:
+                    merged.extend(value)
+                return merged
             if any(len(value) != len(first) for value in values):
                 raise DenoisingStepPackingError(
                     "step batch list kwargs have different lengths"
@@ -1982,6 +2004,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 DenoisingStage._merge_step_input_value(
                     [value[index] for value in values],
                     allow_shared=allow_shared,
+                    key=key,
                 )
                 for index in range(len(first))
             ]
@@ -1998,6 +2021,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 key: DenoisingStage._merge_step_input_value(
                     [value[key] for value in values],
                     allow_shared=allow_shared,
+                    key=str(key),
                 )
                 for key in first
             }
@@ -2011,6 +2035,67 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         raise DenoisingStepPackingError(
             f"step batch scalar kwarg values differ for {type(first).__name__}"
         )
+
+    @staticmethod
+    def _pad_and_cat_text_tensors(values: list[torch.Tensor]) -> torch.Tensor:
+        max_seq_len = max(int(value.shape[1]) for value in values)
+        padded_values = []
+        for value in values:
+            seq_len = int(value.shape[1])
+            if seq_len < max_seq_len:
+                pad_shape = list(value.shape)
+                pad_shape[1] = max_seq_len - seq_len
+                pad_value = False if value.dtype == torch.bool else 0
+                value = torch.cat(
+                    [value, value.new_full(pad_shape, pad_value)],
+                    dim=1,
+                )
+            padded_values.append(value)
+        return torch.cat(padded_values, dim=0)
+
+    @staticmethod
+    def _merge_rope_cache(values: list[Any]) -> Any:
+        first = values[0]
+        if isinstance(first, torch.Tensor):
+            if any(not isinstance(value, torch.Tensor) for value in values):
+                raise DenoisingStepPackingError(
+                    "step batch RoPE cache mixes tensor and non-tensor values"
+                )
+            if not all(
+                value.ndim == first.ndim
+                and tuple(value.shape[1:]) == tuple(first.shape[1:])
+                and value.dtype == first.dtype
+                and value.device == first.device
+                for value in values
+            ):
+                raise DenoisingStepPackingError(
+                    "step batch RoPE cache tensors are incompatible"
+                )
+            longest = max(values, key=lambda value: int(value.shape[0]))
+            for value in values:
+                if not torch.equal(longest[: value.shape[0]], value):
+                    raise DenoisingStepPackingError(
+                        "step batch RoPE cache tensors differ"
+                    )
+            return longest
+
+        if isinstance(first, tuple):
+            if any(not isinstance(value, tuple) for value in values):
+                raise DenoisingStepPackingError(
+                    "step batch RoPE cache mixes tuple and non-tuple values"
+                )
+            if any(len(value) != len(first) for value in values):
+                raise DenoisingStepPackingError(
+                    "step batch RoPE cache tuples have different lengths"
+                )
+            return tuple(
+                DenoisingStage._merge_rope_cache([value[index] for value in values])
+                for index in range(len(first))
+            )
+
+        if all(value == first for value in values):
+            return first
+        raise DenoisingStepPackingError("step batch RoPE cache values differ")
 
     @staticmethod
     def _step_input_can_be_shared(key: str) -> bool:
@@ -2027,6 +2112,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             key: self._merge_step_input_value(
                 [kwargs[key] for kwargs in branch_kwargs],
                 allow_shared=self._step_input_can_be_shared(key),
+                key=key,
             )
             for key in keys
         }

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/glm_image.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/glm_image.py
@@ -16,6 +16,9 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager im
     ComponentUse,
 )
 from sglang.multimodal_gen.runtime.models.dits.glm_image import GlmImageKVCache
+from sglang.multimodal_gen.runtime.pipelines_core.diffusion_scheduler_utils import (
+    clone_scheduler_runtime,
+)
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
     PipelineStage,
@@ -853,7 +856,11 @@ class GlmImageBeforeDenoisingStage(PipelineStage):
         )
 
         # Prepare timesteps
-        scheduler = self.scheduler
+        scheduler = (
+            clone_scheduler_runtime(self.scheduler)
+            if getattr(server_args, "batching_mode", "dynamic") == "continuous"
+            else self.scheduler
+        )
         image_seq_len = (
             (height // self.vae_scale_factor) * (width // self.vae_scale_factor)
         ) // (self.transformer.config.patch_size**2)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/timestep_preparation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/timestep_preparation.py
@@ -87,10 +87,23 @@ class TimestepPreparationStage(PipelineStage):
         Returns:
             The batch with prepared timesteps.
         """
+        isolate_scheduler = (
+            getattr(server_args, "batching_mode", "dynamic") == "continuous"
+        )
         if batch.scheduler is not None and batch.timesteps is not None:
+            if isolate_scheduler:
+                batch.scheduler = get_or_create_request_scheduler(
+                    batch,
+                    self.scheduler,
+                    isolate=True,
+                )
             return batch
 
-        scheduler = get_or_create_request_scheduler(batch, self.scheduler)
+        scheduler = get_or_create_request_scheduler(
+            batch,
+            self.scheduler,
+            isolate=isolate_scheduler,
+        )
         device = get_local_torch_device()
         num_inference_steps = batch.num_inference_steps
         timesteps = batch.timesteps

--- a/python/sglang/multimodal_gen/runtime/server_args/auto_tune.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/auto_tune.py
@@ -466,7 +466,8 @@ class ServerArgsAutoTuner:
             return False
 
         if (
-            args.pipeline_config.dmd_denoising_steps is not None
+            args.batching_mode == "continuous"
+            or args.pipeline_config.dmd_denoising_steps is not None
             or not current_platform.enable_dit_layerwise_offload_for_wan_by_default()
             or envs.SGLANG_CACHE_DIT_ENABLED
             or args.use_fsdp_inference

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -31,6 +31,9 @@ from sglang.multimodal_gen.runtime.layers.quantization.configs.nunchaku_config i
     NunchakuConfig,
 )
 from sglang.multimodal_gen.runtime.loader.utils import BYTES_PER_GB
+from sglang.multimodal_gen.runtime.managers.continuous_batching import (
+    validate_continuous_batching_config,
+)
 from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload_components import (
     LAYERWISE_OFFLOAD_ALL_COMPONENTS,
     LAYERWISE_OFFLOAD_DIT_GROUP,
@@ -1727,8 +1730,12 @@ class ServerArgs(DisaggServerArgsMixin):
             "--batching-mode",
             type=str,
             default=ServerArgs.batching_mode,
-            choices=["dynamic"],
-            help="Request batching scheduler mode. Currently only 'dynamic' is implemented.",
+            choices=["dynamic", "continuous"],
+            help=(
+                "Request batching scheduler mode. 'dynamic' merges compatible "
+                "requests before denoising; 'continuous' batches compatible "
+                "denoising steps from active requests."
+            ),
         )
         parser.add_argument(
             "--batching-max-size",
@@ -2363,12 +2370,14 @@ class ServerArgs(DisaggServerArgsMixin):
             )
 
     def _validate_batching(self):
-        if self.batching_mode != "dynamic":
-            raise ValueError("batching_mode must be one of: dynamic")
+        if self.batching_mode not in ("dynamic", "continuous"):
+            raise ValueError("batching_mode must be one of: dynamic, continuous")
         if self.batching_max_size < 1:
             raise ValueError("batching_max_size must be >= 1")
         if self.batching_delay_ms < 0:
             raise ValueError("batching_delay_ms must be >= 0")
+        if self.batching_mode == "continuous":
+            validate_continuous_batching_config(self)
 
     def _set_default_attention_backend(self) -> None:
         """Configure ROCm defaults when users do not specify an attention backend."""

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -347,6 +347,14 @@ class ServerArgs(DisaggServerArgsMixin):
     batching_delay_ms: float = 0.0
     batching_config: str | None = None
     enable_batching_metrics: bool = False
+    # Continuous batching tuning knobs (batching_mode == "continuous").
+    cb_schedule_policy: str = "largest"
+    cb_fold_cfg_branches: bool = True
+    cb_batch_bucket_sizes: str | None = None
+    cb_async_stages: bool = True
+    cb_allow_step_caches: bool = True
+    cb_varlen_packing: bool = False
+    cb_drain_export_dir: str | None = None
 
     # Strict port mode: fail if requested port is unavailable instead of auto-selecting
     strict_ports: bool = False
@@ -1772,6 +1780,61 @@ class ServerArgs(DisaggServerArgsMixin):
             help="Log periodic batch efficiency metrics such as realized batch size and queue wait time.",
         )
         parser.add_argument(
+            "--cb-schedule-policy",
+            type=str,
+            default=ServerArgs.cb_schedule_policy,
+            choices=["rotate", "largest", "srpt"],
+            help=(
+                "Continuous batching step-group policy: largest (default), "
+                "srpt (shortest remaining steps), or rotate (round-robin)."
+            ),
+        )
+        parser.add_argument(
+            "--cb-fold-cfg-branches",
+            type=lambda value: value.lower() in ("1", "true", "yes"),
+            default=ServerArgs.cb_fold_cfg_branches,
+            help="Fold CFG cond/uncond into one packed forward (batch 2B).",
+        )
+        parser.add_argument(
+            "--cb-batch-bucket-sizes",
+            type=str,
+            default=ServerArgs.cb_batch_bucket_sizes,
+            help=(
+                "Comma-separated packed-batch row buckets (e.g. '2,4') for "
+                "stable forward shapes. Empty disables bucketing."
+            ),
+        )
+        parser.add_argument(
+            "--cb-async-stages",
+            type=lambda value: value.lower() in ("1", "true", "yes"),
+            default=ServerArgs.cb_async_stages,
+            help=(
+                "Run encode/decode stages on a side stream so denoising "
+                "keeps running. Disabled when component offload is enabled."
+            ),
+        )
+        parser.add_argument(
+            "--cb-allow-step-caches",
+            type=lambda value: value.lower() in ("1", "true", "yes"),
+            default=ServerArgs.cb_allow_step_caches,
+            help="Allow TeaCache requests in the continuous loop (unpacked).",
+        )
+        parser.add_argument(
+            "--cb-varlen-packing",
+            type=lambda value: value.lower() in ("1", "true", "yes"),
+            default=ServerArgs.cb_varlen_packing,
+            help=(
+                "EXPERIMENTAL: pack different resolutions along the seq dim "
+                "(varlen attention) for supported pipelines."
+            ),
+        )
+        parser.add_argument(
+            "--cb-drain-export-dir",
+            type=str,
+            default=ServerArgs.cb_drain_export_dir,
+            help="Directory to drain/resume in-flight request state.",
+        )
+        parser.add_argument(
             "--host",
             type=str,
             default=ServerArgs.host,
@@ -2382,6 +2445,23 @@ class ServerArgs(DisaggServerArgsMixin):
             raise ValueError("batching_max_size must be >= 1")
         if self.batching_delay_ms < 0:
             raise ValueError("batching_delay_ms must be >= 0")
+        if self.cb_schedule_policy not in ("rotate", "largest", "srpt"):
+            raise ValueError("cb_schedule_policy must be one of: rotate, largest, srpt")
+        if self.cb_batch_bucket_sizes:
+            try:
+                buckets = [
+                    int(item)
+                    for item in str(self.cb_batch_bucket_sizes)
+                    .replace(" ", "")
+                    .split(",")
+                    if item
+                ]
+            except ValueError as e:
+                raise ValueError(
+                    "cb_batch_bucket_sizes must be a comma-separated list of ints"
+                ) from e
+            if any(bucket < 1 for bucket in buckets):
+                raise ValueError("cb_batch_bucket_sizes entries must be >= 1")
         if self.batching_mode == "continuous":
             validate_continuous_batching_config(self)
 

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -629,6 +629,12 @@ class ServerArgs(DisaggServerArgsMixin):
                 self.vae_cpu_offload = False
             return
 
+        if self.batching_mode == "continuous":
+            if self.dit_cpu_offload is None:
+                self.dit_cpu_offload = False
+            if self.dit_layerwise_offload is None:
+                self.dit_layerwise_offload = False
+
         # TODO: to be handled by each platform
         if current_platform.get_device_total_memory() / BYTES_PER_GB < 30:
             logger.info(

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -352,7 +352,9 @@ class ServerArgs(DisaggServerArgsMixin):
     cb_fold_cfg_branches: bool = True
     cb_batch_bucket_sizes: str | None = None
     cb_async_stages: bool = True
+    cb_stage_queue_depth: int = 8
     cb_allow_step_caches: bool = True
+    cb_packed_teacache: bool = False
     cb_varlen_packing: bool = False
     cb_drain_export_dir: str | None = None
 
@@ -1809,8 +1811,18 @@ class ServerArgs(DisaggServerArgsMixin):
             type=lambda value: value.lower() in ("1", "true", "yes"),
             default=ServerArgs.cb_async_stages,
             help=(
-                "Run encode/decode stages on a side stream so denoising "
-                "keeps running. Disabled when component offload is enabled."
+                "Run encode/decode stages on dedicated side-stream workers so "
+                "denoising keeps running. Disabled when component offload is "
+                "enabled."
+            ),
+        )
+        parser.add_argument(
+            "--cb-stage-queue-depth",
+            type=int,
+            default=ServerArgs.cb_stage_queue_depth,
+            help=(
+                "Bounded queue depth per async stage worker (encode/finalize). "
+                "Full queues apply backpressure instead of running inline."
             ),
         )
         parser.add_argument(
@@ -1818,6 +1830,15 @@ class ServerArgs(DisaggServerArgsMixin):
             type=lambda value: value.lower() in ("1", "true", "yes"),
             default=ServerArgs.cb_allow_step_caches,
             help="Allow TeaCache requests in the continuous loop (unpacked).",
+        )
+        parser.add_argument(
+            "--cb-packed-teacache",
+            type=lambda value: value.lower() in ("1", "true", "yes"),
+            default=ServerArgs.cb_packed_teacache,
+            help=(
+                "EXPERIMENTAL: pack TeaCache requests with per-row hit/miss "
+                "gather-scatter on models that support it (e.g. Wan)."
+            ),
         )
         parser.add_argument(
             "--cb-varlen-packing",
@@ -2462,6 +2483,8 @@ class ServerArgs(DisaggServerArgsMixin):
                 ) from e
             if any(bucket < 1 for bucket in buckets):
                 raise ValueError("cb_batch_bucket_sizes entries must be >= 1")
+        if self.cb_stage_queue_depth < 1:
+            raise ValueError("cb_stage_queue_depth must be >= 1")
         if self.batching_mode == "continuous":
             validate_continuous_batching_config(self)
 

--- a/python/sglang/multimodal_gen/test/unit/test_continuous_batching_teacache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_continuous_batching_teacache.py
@@ -1,0 +1,537 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for per-request TeaCache state in continuous batching.
+
+Covers the explicit cache-state interface, A/B/A swap isolation on a shared
+model, dual-transformer (per-phase) snapshots, drain/resume serialization,
+and the packed per-row hit/miss plan.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.multimodal_gen.runtime.cache.teacache import (
+    TeaCacheMixin,
+    TeaCachePackedMember,
+    TeaCachePackedPlan,
+    TeaCacheRequestState,
+    compute_l1_decision,
+    resolve_teacache_phase_state,
+)
+from sglang.multimodal_gen.runtime.managers.continuous_batching import (
+    ContinuousDenoisingCoordinator,
+    TeaCacheStateIsolator,
+)
+
+
+class _FakeTeaCacheModel(TeaCacheMixin):
+    """Minimal model exposing the mixin's state and explicit interface."""
+
+    def __init__(self, prefix: str = "wan"):
+        self.config = SimpleNamespace(prefix=prefix)
+        self._init_teacache_state()
+
+
+class _FakeTeaCacheParams:
+    def __init__(self, thresh=0.2, start=1, end=100, use_ret_steps=False):
+        self.teacache_thresh = thresh
+        self._start = start
+        self._end = end
+        self.use_ret_steps = use_ret_steps
+
+    def get_skip_boundaries(self, num_inference_steps, do_cfg):
+        return self._start, self._end
+
+    def get_coefficients(self):
+        # Identity polynomial: rescaled L1 == raw relative L1.
+        return [1.0, 0.0]
+
+
+def _fill_state(state: TeaCacheRequestState, seed: int) -> TeaCacheRequestState:
+    generator = torch.Generator().manual_seed(seed)
+    state.cnt = seed
+    state.accumulated_rel_l1_distance = 0.25 * seed
+    state.previous_modulated_input = torch.randn(2, 3, generator=generator)
+    state.previous_residual = torch.randn(2, 3, generator=generator)
+    return state
+
+
+class TestExplicitStateInterface(unittest.TestCase):
+    def test_capture_install_round_trip(self):
+        model = _FakeTeaCacheModel()
+        model.cnt = 7
+        model.accumulated_rel_l1_distance = 0.5
+        model.previous_modulated_input = torch.ones(2, 2)
+        model.previous_residual_negative = torch.zeros(3)
+
+        snapshot = model.capture_teacache_state()
+        self.assertIsInstance(snapshot, TeaCacheRequestState)
+        self.assertEqual(snapshot.cnt, 7)
+        self.assertIs(snapshot.previous_modulated_input, model.previous_modulated_input)
+
+        model.reset_teacache_state()
+        self.assertEqual(model.cnt, 0)
+        self.assertIsNone(model.previous_modulated_input)
+
+        model.install_teacache_state(snapshot)
+        self.assertEqual(model.cnt, 7)
+        self.assertEqual(model.accumulated_rel_l1_distance, 0.5)
+        self.assertIs(model.previous_modulated_input, snapshot.previous_modulated_input)
+        self.assertIs(
+            model.previous_residual_negative, snapshot.previous_residual_negative
+        )
+
+    def test_install_none_resets(self):
+        model = _FakeTeaCacheModel()
+        model.cnt = 3
+        model.previous_residual = torch.ones(4)
+        model.install_teacache_state(None)
+        self.assertEqual(model.cnt, 0)
+        self.assertIsNone(model.previous_residual)
+
+    def test_non_cfg_model_skips_negative_fields(self):
+        model = _FakeTeaCacheModel(prefix="flux")
+        self.assertFalse(model._supports_cfg_cache)
+        snapshot = TeaCacheRequestState(cnt=2, previous_residual_negative=torch.ones(2))
+        model.install_teacache_state(snapshot)
+        self.assertEqual(model.cnt, 2)
+        self.assertFalse(hasattr(model, "previous_residual_negative"))
+
+    def test_isolator_prefers_explicit_interface(self):
+        model = _FakeTeaCacheModel()
+        model.cnt = 5
+        snapshot = TeaCacheStateIsolator.capture(model)
+        self.assertIsInstance(snapshot, TeaCacheRequestState)
+        TeaCacheStateIsolator.install(model, None)
+        self.assertEqual(model.cnt, 0)
+        TeaCacheStateIsolator.install(model, snapshot)
+        self.assertEqual(model.cnt, 5)
+
+    def test_isolator_legacy_attr_scan(self):
+        class _LegacyModel:
+            def __init__(self):
+                self.cnt = 4
+                self.enable_teacache = True
+                self.is_cfg_negative = False
+                self.previous_residual = torch.ones(2)
+                self.accumulated_rel_l1_distance = 0.75
+                self.unrelated = "untouched"
+
+            def reset_teacache_state(self):
+                self.cnt = 0
+                self.previous_residual = None
+                self.accumulated_rel_l1_distance = 0.0
+
+        model = _LegacyModel()
+        snapshot = TeaCacheStateIsolator.capture(model)
+        self.assertIsInstance(snapshot, dict)
+        self.assertNotIn("unrelated", snapshot)
+        TeaCacheStateIsolator.install(model, None)
+        self.assertEqual(model.cnt, 0)
+        TeaCacheStateIsolator.install(model, snapshot)
+        self.assertEqual(model.cnt, 4)
+        self.assertEqual(model.accumulated_rel_l1_distance, 0.75)
+
+
+class _SwapHarness:
+    """Drives coordinator swap in/out without a full coordinator."""
+
+    def __init__(self, model, transformer_2=None):
+        self.model = model
+        self.transformer_2 = transformer_2
+
+    def make_coordinator(self):
+        coordinator = ContinuousDenoisingCoordinator.__new__(
+            ContinuousDenoisingCoordinator
+        )
+        coordinator.allow_step_caches = True
+        coordinator.server_args = SimpleNamespace(cb_packed_teacache=False)
+        coordinator.denoising_stage = SimpleNamespace(transformer_2=self.transformer_2)
+        return coordinator
+
+    def make_state(self, model):
+        return SimpleNamespace(
+            req=SimpleNamespace(enable_teacache=True),
+            current_step=SimpleNamespace(current_model=model),
+            teacache_state=None,
+        )
+
+
+class TestABASwapIsolation(unittest.TestCase):
+    def test_a_b_a_round_trip_is_isolated(self):
+        model = _FakeTeaCacheModel()
+        harness = _SwapHarness(model)
+        coordinator = harness.make_coordinator()
+        state_a = harness.make_state(model)
+        state_b = harness.make_state(model)
+
+        # A runs one step and stashes some cache state.
+        swap = coordinator._swap_in_teacache_state(state_a)
+        model.cnt = 3
+        model.previous_residual = torch.full((2,), 3.0)
+        model.accumulated_rel_l1_distance = 0.3
+        coordinator._swap_out_teacache_state(state_a, swap)
+        a_snapshot = state_a.teacache_state["transformer"]
+
+        # B runs with completely different state.
+        swap = coordinator._swap_in_teacache_state(state_b)
+        self.assertEqual(model.cnt, 0)  # fresh reset for B
+        model.cnt = 9
+        model.previous_residual = torch.full((2,), 9.0)
+        coordinator._swap_out_teacache_state(state_b, swap)
+
+        # A again: model must see exactly A's state, untouched by B.
+        swap = coordinator._swap_in_teacache_state(state_a)
+        self.assertEqual(model.cnt, 3)
+        self.assertEqual(model.accumulated_rel_l1_distance, 0.3)
+        torch.testing.assert_close(model.previous_residual, torch.full((2,), 3.0))
+        coordinator._swap_out_teacache_state(state_a, swap)
+        torch.testing.assert_close(
+            state_a.teacache_state["transformer"].previous_residual,
+            a_snapshot.previous_residual,
+        )
+        self.assertEqual(state_a.teacache_state["transformer"].cnt, 3)
+        self.assertEqual(state_b.teacache_state["transformer"].cnt, 9)
+
+    def test_dual_transformer_phase_snapshots(self):
+        model_1 = _FakeTeaCacheModel()
+        model_2 = _FakeTeaCacheModel()
+        harness = _SwapHarness(model_1, transformer_2=model_2)
+        coordinator = harness.make_coordinator()
+        state = harness.make_state(model_1)
+
+        # Phase 1 on the high-noise expert.
+        swap = coordinator._swap_in_teacache_state(state)
+        model_1.cnt = 11
+        model_1.previous_residual = torch.full((2,), 1.0)
+        coordinator._swap_out_teacache_state(state, swap)
+
+        # Cross the boundary onto the low-noise expert.
+        state.current_step = SimpleNamespace(current_model=model_2)
+        swap = coordinator._swap_in_teacache_state(state)
+        # cnt carries so skip windows keep meaning; tensors never cross.
+        self.assertEqual(model_2.cnt, 11)
+        self.assertIsNone(model_2.previous_residual)
+        model_2.cnt = 12
+        model_2.previous_residual = torch.full((2,), 2.0)
+        coordinator._swap_out_teacache_state(state, swap)
+
+        phase_states = state.teacache_state
+        self.assertEqual(set(phase_states), {"transformer", "transformer_2"})
+        torch.testing.assert_close(
+            phase_states["transformer"].previous_residual, torch.full((2,), 1.0)
+        )
+        torch.testing.assert_close(
+            phase_states["transformer_2"].previous_residual, torch.full((2,), 2.0)
+        )
+
+
+class TestPhaseResolution(unittest.TestCase):
+    def test_new_phase_seeds_counter_not_tensors(self):
+        phase_states = {}
+        first = resolve_teacache_phase_state(phase_states, "transformer", create=True)
+        _fill_state(first, seed=6)
+        second = resolve_teacache_phase_state(phase_states, "transformer_2")
+        self.assertIsNotNone(second)
+        self.assertEqual(second.cnt, 6)
+        self.assertIsNone(second.previous_modulated_input)
+        self.assertIsNone(second.previous_residual)
+        # Resolving again returns the same object.
+        self.assertIs(
+            resolve_teacache_phase_state(phase_states, "transformer_2"), second
+        )
+
+    def test_create_materializes_missing_state(self):
+        phase_states = {"transformer": None}
+        state = resolve_teacache_phase_state(phase_states, "transformer", create=True)
+        self.assertIsInstance(state, TeaCacheRequestState)
+        self.assertIs(phase_states["transformer"], state)
+
+
+class TestDrainResumeSerialization(unittest.TestCase):
+    def test_payload_round_trip(self):
+        state = _fill_state(TeaCacheRequestState(), seed=4)
+        payload = state.to_payload()
+        self.assertEqual(payload["cnt"], 4)
+        restored = TeaCacheRequestState.from_payload(payload, device="cpu")
+        self.assertEqual(restored.cnt, 4)
+        torch.testing.assert_close(
+            restored.previous_modulated_input, state.previous_modulated_input
+        )
+        torch.testing.assert_close(restored.previous_residual, state.previous_residual)
+
+    def test_coordinator_export_import(self):
+        request_state = SimpleNamespace(
+            teacache_state={
+                "transformer": _fill_state(TeaCacheRequestState(), seed=2),
+                "transformer_2": None,
+            }
+        )
+        payloads = ContinuousDenoisingCoordinator._export_teacache_states(request_state)
+        self.assertEqual(set(payloads), {"transformer"})
+        restored = ContinuousDenoisingCoordinator._import_teacache_states(
+            payloads, torch.device("cpu")
+        )
+        self.assertEqual(restored["transformer"].cnt, 2)
+        torch.testing.assert_close(
+            restored["transformer"].previous_residual,
+            request_state.teacache_state["transformer"].previous_residual,
+        )
+        self.assertIsNone(
+            ContinuousDenoisingCoordinator._export_teacache_states(
+                SimpleNamespace(teacache_state=None)
+            )
+        )
+
+
+class TestPackedMemberDecisions(unittest.TestCase):
+    def _mixin_reference_decisions(self, inputs, params, num_steps):
+        """Reference decisions using the mixin's attr-based path."""
+        model = _FakeTeaCacheModel()
+        model.reset_teacache_state()
+        decisions = []
+        for step, modulated in enumerate(inputs):
+            start, end = params.get_skip_boundaries(num_steps, False)
+            is_boundary = model.cnt < start or model.cnt >= end
+            should_calc = model._compute_teacache_decision(
+                modulated_inp=modulated,
+                is_boundary_step=is_boundary,
+                coefficients=params.get_coefficients(),
+                teacache_thresh=params.teacache_thresh,
+            )
+            decisions.append(should_calc)
+            model.cnt += 1
+        return decisions
+
+    def test_member_matches_mixin_reference(self):
+        torch.manual_seed(0)
+        num_steps = 6
+        params = _FakeTeaCacheParams(thresh=0.15, start=1, end=100)
+        base = torch.randn(1, 4)
+        # Small perturbations so some steps hit and some miss.
+        inputs = [
+            base + 0.01 * step * torch.ones_like(base) for step in range(num_steps)
+        ]
+
+        reference = self._mixin_reference_decisions(inputs, params, num_steps)
+
+        member = TeaCachePackedMember(
+            row_slice=slice(0, 1),
+            state=TeaCacheRequestState(),
+            step_index=0,
+            num_inference_steps=num_steps,
+            do_cfg=False,
+            teacache_params=params,
+        )
+        packed = []
+        for step, modulated in enumerate(inputs):
+            member.step_index = step
+            packed.append(member.decide(modulated, is_cfg_negative=False))
+            member.advance()
+        self.assertEqual(packed, reference)
+        # At least one skip must occur for this test to be meaningful.
+        self.assertIn(False, packed)
+
+    def test_disabled_member_always_computes(self):
+        member = TeaCachePackedMember(row_slice=slice(0, 1), state=None)
+        self.assertTrue(member.decide(torch.ones(1, 2), is_cfg_negative=False))
+        member.advance()  # no-op without state
+
+    def test_first_step_resets_state(self):
+        state = _fill_state(TeaCacheRequestState(), seed=9)
+        member = TeaCachePackedMember(
+            row_slice=slice(0, 1),
+            state=state,
+            step_index=0,
+            num_inference_steps=4,
+            do_cfg=False,
+            teacache_params=_FakeTeaCacheParams(),
+        )
+        self.assertTrue(member.decide(torch.ones(1, 2), is_cfg_negative=False))
+        self.assertEqual(state.cnt, 0)
+        self.assertIsNone(state.previous_residual)
+
+    def test_residual_stash_and_retrieve_per_branch(self):
+        state = TeaCacheRequestState()
+        member = TeaCachePackedMember(row_slice=slice(0, 1), state=state)
+        pos = torch.ones(1, 2)
+        neg = torch.zeros(1, 2)
+        member.stash_residual(pos, is_cfg_negative=False)
+        member.stash_residual(neg, is_cfg_negative=True)
+        torch.testing.assert_close(member.cached_residual(False), pos)
+        torch.testing.assert_close(member.cached_residual(True), neg)
+
+    def test_plan_partition(self):
+        params = _FakeTeaCacheParams(thresh=1000.0, start=0, end=100)
+        # Warm member: baseline set, huge threshold -> skips.
+        warm_state = TeaCacheRequestState(
+            cnt=2,
+            previous_modulated_input=torch.ones(1, 2),
+            previous_residual=torch.zeros(1, 2),
+        )
+        warm = TeaCachePackedMember(
+            row_slice=slice(0, 1),
+            state=warm_state,
+            step_index=2,
+            num_inference_steps=8,
+            teacache_params=params,
+        )
+        cold = TeaCachePackedMember(
+            row_slice=slice(1, 2),
+            state=TeaCacheRequestState(),
+            step_index=2,
+            num_inference_steps=8,
+            teacache_params=params,
+        )
+        disabled = TeaCachePackedMember(row_slice=slice(2, 3), state=None)
+        plan = TeaCachePackedPlan(members=[warm, cold, disabled])
+        self.assertTrue(plan.any_enabled)
+
+        modulated = torch.zeros(3, 2)
+        compute, skip = plan.partition(modulated, is_cfg_negative=False)
+        self.assertEqual([m.row_slice for m in skip], [slice(0, 1)])
+        self.assertEqual([m.row_slice for m in compute], [slice(1, 2), slice(2, 3)])
+
+
+class TestPackedGatherScatterForward(unittest.TestCase):
+    """Row-level gather/scatter through the Wan block loop."""
+
+    def _make_wan_stub(self):
+        try:
+            from sglang.multimodal_gen.runtime.models.dits.wanvideo import (
+                WanTransformer3DModel,
+            )
+        except Exception as e:  # pragma: no cover - env without heavy deps
+            self.skipTest(f"wanvideo import unavailable: {e}")
+
+        class _Block:
+            def __call__(self, hidden, encoder, proj, freqs):
+                # Row-local, deterministic transform.
+                return hidden + 1.0 + encoder.sum(dim=1, keepdim=True) * 0.0
+
+        stub = SimpleNamespace(blocks=[_Block(), _Block()])
+        return WanTransformer3DModel._forward_blocks_with_packed_teacache, stub
+
+    def test_skip_rows_use_cached_residual(self):
+        forward, stub = self._make_wan_stub()
+        from sglang.multimodal_gen.runtime.managers.forward_context import (
+            set_forward_context,
+        )
+
+        params = _FakeTeaCacheParams(thresh=1000.0, start=0, end=100)
+        warm_state = TeaCacheRequestState(
+            cnt=2,
+            previous_modulated_input=torch.ones(1, 6),
+            # Residual from a previous compute: out - in == +2 per block pair.
+            previous_residual=torch.full((1, 4, 3), 2.0),
+        )
+        warm = TeaCachePackedMember(
+            row_slice=slice(0, 1),
+            state=warm_state,
+            step_index=2,
+            num_inference_steps=8,
+            teacache_params=params,
+        )
+        cold = TeaCachePackedMember(
+            row_slice=slice(1, 2),
+            state=TeaCacheRequestState(),
+            step_index=2,
+            num_inference_steps=8,
+            teacache_params=params,
+        )
+        plan = TeaCachePackedPlan(members=[warm, cold])
+
+        hidden = torch.zeros(3, 4, 3)  # row 2 is uncovered padding
+        encoder = torch.zeros(3, 5, 3)
+        proj = torch.zeros(3, 6)
+        temb = torch.zeros(3, 6)
+
+        with set_forward_context(
+            current_timestep=None,
+            attn_metadata=None,
+            forward_batch=SimpleNamespace(is_cfg_negative=False),
+        ):
+            output = forward(stub, plan, hidden, encoder, proj, temb, None)
+
+        # Skip row: input + cached residual = 0 + 2.
+        torch.testing.assert_close(output[0], torch.full((4, 3), 2.0))
+        # Compute rows: two blocks add 1 each.
+        torch.testing.assert_close(output[1], torch.full((4, 3), 2.0))
+        torch.testing.assert_close(output[2], torch.full((4, 3), 2.0))
+        # The cold member stashed its fresh residual and advanced.
+        torch.testing.assert_close(
+            cold.state.previous_residual, torch.full((1, 4, 3), 2.0)
+        )
+        self.assertEqual(cold.state.cnt, 1)
+        self.assertEqual(warm.state.cnt, 3)
+
+    def test_force_compute_keeps_state_but_never_skips(self):
+        forward, stub = self._make_wan_stub()
+        from sglang.multimodal_gen.runtime.managers.forward_context import (
+            set_forward_context,
+        )
+
+        params = _FakeTeaCacheParams(thresh=1000.0, start=0, end=100)
+        warm_state = TeaCacheRequestState(
+            cnt=2,
+            previous_modulated_input=torch.ones(1, 6),
+            previous_residual=torch.full((1, 4, 3), 5.0),
+        )
+        warm = TeaCachePackedMember(
+            row_slice=slice(0, 1),
+            state=warm_state,
+            step_index=2,
+            num_inference_steps=8,
+            teacache_params=params,
+        )
+        plan = TeaCachePackedPlan(members=[warm])
+        hidden = torch.zeros(1, 4, 3)
+        encoder = torch.zeros(1, 5, 3)
+        proj = torch.zeros(1, 6)
+        temb = torch.zeros(1, 6)
+
+        with set_forward_context(
+            current_timestep=None,
+            attn_metadata=None,
+            forward_batch=SimpleNamespace(is_cfg_negative=False),
+        ):
+            output = forward(
+                stub, plan, hidden, encoder, proj, temb, None, force_compute=True
+            )
+
+        # Blocks ran (no skip), residual refreshed from this compute.
+        torch.testing.assert_close(output[0], torch.full((4, 3), 2.0))
+        torch.testing.assert_close(
+            warm.state.previous_residual, torch.full((1, 4, 3), 2.0)
+        )
+
+
+class TestPureDecisionFunction(unittest.TestCase):
+    def test_missing_baseline_forces_compute(self):
+        accum, should_calc = compute_l1_decision(
+            torch.ones(2), None, 0.5, [1.0, 0.0], 0.1
+        )
+        self.assertEqual(accum, 0.0)
+        self.assertTrue(should_calc)
+
+    def test_threshold_crossing_resets_accumulator(self):
+        baseline = torch.ones(4)
+        accum, should_calc = compute_l1_decision(
+            baseline * 2.0, baseline, 0.0, [1.0, 0.0], 0.5
+        )
+        # rel L1 = 1.0 >= 0.5 -> compute and reset.
+        self.assertTrue(should_calc)
+        self.assertEqual(accum, 0.0)
+
+    def test_below_threshold_accumulates(self):
+        baseline = torch.ones(4)
+        accum, should_calc = compute_l1_decision(
+            baseline * 1.1, baseline, 0.05, [1.0, 0.0], 0.5
+        )
+        self.assertFalse(should_calc)
+        self.assertAlmostEqual(accum, 0.15, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_continuous_batching_varlen.py
+++ b/python/sglang/multimodal_gen/test/unit/test_continuous_batching_varlen.py
@@ -10,7 +10,10 @@ from sglang.multimodal_gen.runtime.managers.continuous_batching import (
     build_denoising_batch_key,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.batched_solver import (
+    SolverRejection,
     build_batched_solver,
+    scheduler_is_batchable,
+    sigma_table_cache,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import (
     DenoisingStage,
@@ -195,10 +198,74 @@ class TestBatchedSolver(unittest.TestCase):
         self.assertEqual(scheduler_a._step_index, 3)
         self.assertEqual(scheduler_b._step_index, 1)
 
-    def test_try_build_rejects_unknown_scheduler(self):
+    def test_build_rejects_unknown_scheduler(self):
         scheduler = SimpleNamespace(sigmas=torch.linspace(1, 0, 5), order=1)
         state = _make_state(torch.randn(1, 4, 8), scheduler=scheduler)
-        self.assertIsNone(build_batched_solver([state], torch.device("cpu")))
+        self.assertFalse(scheduler_is_batchable(scheduler))
+        with self.assertRaises(SolverRejection):
+            build_batched_solver([state], torch.device("cpu"))
+
+    def test_scheduler_batchable_accepts_flow_match_euler(self):
+        scheduler = self._make_scheduler(4)
+        self.assertTrue(scheduler_is_batchable(scheduler))
+
+    def test_sigma_table_cache_reuses_rows(self):
+        scheduler = self._make_scheduler(6)
+        latents = torch.randn(1, 4, 8)
+        sigma_table_cache.clear()
+        state = _make_state(latents, step_index=0, scheduler=scheduler)
+        build_batched_solver([state], torch.device("cpu"))
+        self.assertEqual(sigma_table_cache.misses, 1)
+        build_batched_solver([state], torch.device("cpu"))
+        self.assertEqual(sigma_table_cache.hits, 1)
+        self.assertEqual(sigma_table_cache.misses, 1)
+
+    def test_repeated_steps_to_terminal_match_scheduler(self):
+        """Drive both members to their terminal step and compare each update."""
+        num_steps_a, num_steps_b = 4, 6
+        scheduler_a = self._make_scheduler(num_steps_a)
+        scheduler_b = self._make_scheduler(num_steps_b)
+        ref_a = self._make_scheduler(num_steps_a)
+        ref_b = self._make_scheduler(num_steps_b)
+
+        latents_a = torch.randn(1, 4, 8)
+        latents_b = torch.randn(1, 4, 8)
+        ref_latents_a = latents_a.clone()
+        ref_latents_b = latents_b.clone()
+        state_a = _make_state(latents_a, step_index=2, scheduler=scheduler_a)
+        state_b = _make_state(latents_b, step_index=0, scheduler=scheduler_b)
+        ref_a._step_index = 2
+        ref_b._step_index = 0
+
+        solver = build_batched_solver([state_a, state_b], torch.device("cpu"))
+        packed = torch.cat([latents_a, latents_b], dim=0)
+
+        # Step until member A hits its terminal step (indices 2..3).
+        for offset in range(num_steps_a - 2):
+            noise = torch.randn_like(packed)
+            packed = solver.step_rows(noise, packed, [state_a, state_b])
+
+            ref_latents_a = ref_a.step(
+                model_output=noise[0:1],
+                timestep=ref_a.timesteps[2 + offset],
+                sample=ref_latents_a,
+                return_dict=False,
+            )[0]
+            ref_latents_b = ref_b.step(
+                model_output=noise[1:2],
+                timestep=ref_b.timesteps[offset],
+                sample=ref_latents_b,
+                return_dict=False,
+            )[0]
+            state_a.step_index += 1
+            state_b.step_index += 1
+
+            torch.testing.assert_close(packed[0:1], ref_latents_a)
+            torch.testing.assert_close(packed[1:2], ref_latents_b)
+
+        # Member A is finished; scheduler counters stayed mirrored throughout.
+        self.assertEqual(scheduler_a._step_index, num_steps_a)
+        self.assertEqual(scheduler_b._step_index, 2)
 
 
 class TestVarlenBatchKey(unittest.TestCase):

--- a/python/sglang/multimodal_gen/test/unit/test_continuous_batching_varlen.py
+++ b/python/sglang/multimodal_gen/test/unit/test_continuous_batching_varlen.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for continuous batching varlen packing and the batched solver."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.multimodal_gen.runtime.managers.continuous_batching import (
+    build_denoising_batch_key,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.batched_solver import (
+    build_batched_solver,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import (
+    DenoisingStage,
+)
+
+
+class _VarlenModel:
+    supports_varlen_step_packing = True
+    zero_cond_t = False
+
+
+def _make_state(latents, step_index=0, scheduler=None):
+    return SimpleNamespace(
+        denoising_context=SimpleNamespace(latents=latents, scheduler=scheduler),
+        step_index=step_index,
+    )
+
+
+def _make_branch_kwargs(txt_len, img_cache_len, txt_cache_len, rows=1, mask=True):
+    encoder = torch.randn(rows, txt_len, 16)
+    kwargs = {
+        "encoder_hidden_states": encoder,
+        "encoder_hidden_states_mask": (
+            torch.ones(rows, txt_len, dtype=torch.bool) if mask else None
+        ),
+        "txt_seq_lens": [txt_len] * rows,
+        "img_shapes": [[(1, 2, 2)]] * rows,
+        "freqs_cis": (
+            torch.randn(img_cache_len, 8),
+            torch.randn(txt_cache_len, 8),
+        ),
+    }
+    return kwargs
+
+
+class TestVarlenKwargs(unittest.TestCase):
+    def setUp(self):
+        self.stage = DenoisingStage.__new__(DenoisingStage)
+
+    def test_pad_seq_dim(self):
+        tensor = torch.ones(2, 3, 4)
+        padded = DenoisingStage._pad_seq_dim(tensor, 5)
+        self.assertEqual(tuple(padded.shape), (2, 5, 4))
+        self.assertTrue(torch.all(padded[:, 3:] == 0))
+        self.assertIs(DenoisingStage._pad_seq_dim(tensor, 3), tensor)
+
+    def test_build_varlen_positions(self):
+        positions = DenoisingStage._build_varlen_positions(
+            offsets=[0, 10],
+            row_lens=[3, 5],
+            row_state_index=[0, 1],
+            seq_len=5,
+            device=torch.device("cpu"),
+        )
+        self.assertEqual(positions.tolist(), [0, 1, 2, 2, 2, 10, 11, 12, 13, 14])
+
+    def test_prepare_and_inject_varlen_kwargs(self):
+        states = [
+            _make_state(torch.randn(1, 4, 8)),
+            _make_state(torch.randn(1, 9, 8)),
+        ]
+        branch_kwargs_by_index = [
+            [
+                _make_branch_kwargs(5, img_cache_len=4, txt_cache_len=5),
+                _make_branch_kwargs(7, img_cache_len=9, txt_cache_len=7, mask=False),
+            ],
+            [
+                _make_branch_kwargs(3, img_cache_len=4, txt_cache_len=5),
+                _make_branch_kwargs(6, img_cache_len=9, txt_cache_len=7),
+            ],
+        ]
+        normalized, varlen_ctx = self.stage._prepare_varlen_branch_kwargs(
+            states, branch_kwargs_by_index
+        )
+
+        self.assertEqual(varlen_ctx["txt_pad"], 7)
+        self.assertEqual(varlen_ctx["img_offsets"], [0, 4])
+        self.assertEqual(varlen_ctx["txt_offsets"], [0, 5])
+        self.assertEqual(tuple(varlen_ctx["img_table"].shape), (13, 8))
+        self.assertEqual(tuple(varlen_ctx["txt_table"].shape), (12, 8))
+        self.assertEqual(varlen_ctx["txt_lens_by_branch"], [[5, 7], [3, 6]])
+        for branch in normalized:
+            for kwargs in branch:
+                self.assertNotIn("freqs_cis", kwargs)
+                self.assertEqual(kwargs["encoder_hidden_states"].shape[1], 7)
+                self.assertEqual(kwargs["encoder_hidden_states_mask"].shape[1], 7)
+        # Original kwargs are untouched.
+        self.assertIn("freqs_cis", branch_kwargs_by_index[0][0])
+
+        merged = tuple(
+            self.stage._merge_step_input_kwargs(branch) for branch in normalized
+        )
+        folded = self.stage._fold_branch_kwargs_along_batch(merged)
+        self.stage._inject_varlen_kwargs(
+            merged,
+            folded,
+            varlen_ctx,
+            row_seq_lens=[4, 9],
+            row_state_index=[0, 1],
+            padded_rows=2,
+            device=torch.device("cpu"),
+        )
+
+        for kwargs in merged:
+            self.assertEqual(kwargs["image_seq_lens"], [4, 9])
+            self.assertEqual(
+                kwargs["attention_kwargs"]["img_rope_positions"].numel(), 2 * 9
+            )
+            self.assertEqual(
+                kwargs["attention_kwargs"]["txt_rope_positions"].numel(), 2 * 7
+            )
+        # Row 0 image positions clamp at its own cache end (offset 0, len 4).
+        img_positions = merged[0]["attention_kwargs"]["img_rope_positions"]
+        self.assertEqual(img_positions[:9].max().item(), 3)
+        self.assertEqual(img_positions[9:].tolist(), [4 + i for i in range(9)])
+        # Branch txt positions clamp by that branch's per-row lengths.
+        txt_positions = merged[1]["attention_kwargs"]["txt_rope_positions"]
+        self.assertEqual(txt_positions[:7].max().item(), 2)
+
+        self.assertEqual(folded["image_seq_lens"], [4, 9, 4, 9])
+        self.assertEqual(
+            folded["attention_kwargs"]["img_rope_positions"].numel(), 4 * 9
+        )
+        self.assertEqual(
+            folded["attention_kwargs"]["txt_rope_positions"].numel(), 4 * 7
+        )
+        self.assertEqual(folded["encoder_hidden_states"].shape, (4, 7, 16))
+
+
+class TestBatchedSolver(unittest.TestCase):
+    def _make_scheduler(self, num_inference_steps):
+        try:
+            from diffusers import FlowMatchEulerDiscreteScheduler
+        except ImportError:
+            self.skipTest("diffusers is not installed")
+
+        scheduler = FlowMatchEulerDiscreteScheduler()
+        scheduler.set_timesteps(num_inference_steps=num_inference_steps)
+        return scheduler
+
+    def test_step_rows_matches_scheduler_step(self):
+        scheduler_a = self._make_scheduler(6)
+        scheduler_b = self._make_scheduler(4)
+        latents_a = torch.randn(1, 4, 8)
+        latents_b = torch.randn(1, 9, 8)
+        state_a = _make_state(latents_a, step_index=2, scheduler=scheduler_a)
+        state_b = _make_state(latents_b, step_index=0, scheduler=scheduler_b)
+
+        solver = build_batched_solver([state_a, state_b], torch.device("cpu"))
+        self.assertIsNotNone(solver)
+
+        packed = torch.cat(
+            [
+                DenoisingStage._pad_seq_dim(latents_a, 9),
+                DenoisingStage._pad_seq_dim(latents_b, 9),
+            ],
+            dim=0,
+        )
+        noise = torch.randn_like(packed)
+        new_packed = solver.step_rows(noise, packed, [state_a, state_b])
+
+        ref_scheduler_a = self._make_scheduler(6)
+        ref_scheduler_a._step_index = 2
+        expected_a = ref_scheduler_a.step(
+            model_output=noise[0:1, :4],
+            timestep=ref_scheduler_a.timesteps[2],
+            sample=latents_a,
+            return_dict=False,
+        )[0]
+        ref_scheduler_b = self._make_scheduler(4)
+        ref_scheduler_b._step_index = 0
+        expected_b = ref_scheduler_b.step(
+            model_output=noise[1:2, :9],
+            timestep=ref_scheduler_b.timesteps[0],
+            sample=latents_b,
+            return_dict=False,
+        )[0]
+
+        torch.testing.assert_close(new_packed[0:1, :4], expected_a)
+        torch.testing.assert_close(new_packed[1:2, :9], expected_b)
+        # Host-side counters mirror the per-request scheduler.step behavior.
+        self.assertEqual(scheduler_a._step_index, 3)
+        self.assertEqual(scheduler_b._step_index, 1)
+
+    def test_try_build_rejects_unknown_scheduler(self):
+        scheduler = SimpleNamespace(sigmas=torch.linspace(1, 0, 5), order=1)
+        state = _make_state(torch.randn(1, 4, 8), scheduler=scheduler)
+        self.assertIsNone(build_batched_solver([state], torch.device("cpu")))
+
+
+class TestVarlenBatchKey(unittest.TestCase):
+    def _make_key_state(self, seq_len):
+        req = SimpleNamespace(
+            raw_latent_shape=(1, 1, 16, seq_len, 8),
+            image_latent=None,
+            do_classifier_free_guidance=True,
+            enable_sequence_shard=None,
+            did_sp_shard_latents=False,
+            sp_video_start_frame=0,
+        )
+        ctx = SimpleNamespace(
+            latents=torch.randn(1, seq_len, 8),
+            scheduler=SimpleNamespace(order=1),
+            cfg_policy=None,
+            target_dtype=torch.bfloat16,
+        )
+        step = SimpleNamespace(
+            t_device=torch.tensor(1.0),
+            current_model=_VarlenModel(),
+            attn_metadata=None,
+        )
+        return SimpleNamespace(req=req, denoising_context=ctx, current_step=step)
+
+    def _make_server_args(self, varlen):
+        pipeline_config = SimpleNamespace(supports_varlen_step_packing=True)
+        return SimpleNamespace(
+            pipeline_config=pipeline_config,
+            cb_varlen_packing=varlen,
+            sp_degree=1,
+            ulysses_degree=1,
+            ring_degree=1,
+            tp_size=1,
+            cfg_parallel_degree=1,
+            enable_cfg_parallel=False,
+        )
+
+    def test_varlen_key_groups_resolutions(self):
+        stage = SimpleNamespace(attn_backend=None)
+        server_args = self._make_server_args(varlen=True)
+        key_small = build_denoising_batch_key(
+            self._make_key_state(16), stage, server_args
+        )
+        key_large = build_denoising_batch_key(
+            self._make_key_state(64), stage, server_args
+        )
+        self.assertTrue(key_small.varlen_packed)
+        self.assertEqual(key_small, key_large)
+
+    def test_key_separates_resolutions_without_varlen(self):
+        stage = SimpleNamespace(attn_backend=None)
+        server_args = self._make_server_args(varlen=False)
+        key_small = build_denoising_batch_key(
+            self._make_key_state(16), stage, server_args
+        )
+        key_large = build_denoising_batch_key(
+            self._make_key_state(64), stage, server_args
+        )
+        self.assertFalse(key_small.varlen_packed)
+        self.assertNotEqual(key_small, key_large)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_continuous_stage_worker.py
+++ b/python/sglang/multimodal_gen/test/unit/test_continuous_stage_worker.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the async continuous-batching stage workers.
+
+CPU-only: exercises bounded backpressure, separate encode/finalize workers,
+lifecycle states, and robust shutdown. CUDA stream/event handoff paths are
+covered implicitly (they no-op without a GPU).
+"""
+
+import threading
+import time
+import unittest
+
+from sglang.multimodal_gen.runtime.managers.continuous_stage_worker import (
+    AsyncContinuousStageWorker,
+    StageQueueFull,
+    WorkerState,
+    async_stages_supported,
+)
+
+
+def _wait_for(predicate, timeout_s=5.0):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+class TestAsyncStagesSupported(unittest.TestCase):
+    def _args(self, **kwargs):
+        defaults = {
+            "cb_async_stages": True,
+            "dit_cpu_offload": False,
+            "dit_layerwise_offload": False,
+            "text_encoder_cpu_offload": False,
+            "image_encoder_cpu_offload": False,
+            "vae_cpu_offload": False,
+        }
+        defaults.update(kwargs)
+        return type("Args", (), defaults)()
+
+    def test_enabled_by_default(self):
+        self.assertTrue(async_stages_supported(self._args()))
+
+    def test_disabled_by_flag(self):
+        self.assertFalse(async_stages_supported(self._args(cb_async_stages=False)))
+
+    def test_disabled_by_offload(self):
+        self.assertFalse(async_stages_supported(self._args(vae_cpu_offload=True)))
+
+
+class TestStageWorkerBasics(unittest.TestCase):
+    def setUp(self):
+        self.worker = AsyncContinuousStageWorker(queue_depth=2)
+
+    def tearDown(self):
+        self.worker.shutdown(timeout_s=5.0)
+
+    def test_jobs_run_and_results_return(self):
+        self.worker.submit("encode", 1, lambda: "encoded")
+        self.worker.submit("finalize", 2, lambda: "finalized")
+        self.assertTrue(_wait_for(lambda: self.worker.pending == 0 or True))
+
+        results = {}
+        deadline = time.monotonic() + 5.0
+        while len(results) < 2 and time.monotonic() < deadline:
+            for result in self.worker.poll_results():
+                results[result.ticket] = result
+            time.sleep(0.01)
+        self.assertEqual(results[1].value, "encoded")
+        self.assertEqual(results[2].value, "finalized")
+        self.assertIsNone(results[1].error)
+        self.assertEqual(self.worker.pending, 0)
+
+    def test_job_errors_are_forwarded(self):
+        def boom():
+            raise ValueError("bad job")
+
+        self.worker.submit("encode", 7, boom)
+        results = []
+        _wait_for(lambda: bool(results.extend(self.worker.poll_results()) or results))
+        self.assertEqual(results[0].ticket, 7)
+        self.assertIsInstance(results[0].error, ValueError)
+
+    def test_bounded_queue_backpressure(self):
+        release = threading.Event()
+        started = threading.Event()
+
+        def blocker():
+            started.set()
+            release.wait(timeout=10.0)
+            return "done"
+
+        self.worker.submit("encode", 1, blocker)
+        self.assertTrue(started.wait(timeout=5.0))
+        # Fill the bounded queue behind the in-flight job.
+        self.worker.submit("encode", 2, lambda: "queued-a")
+        self.worker.submit("encode", 3, lambda: "queued-b")
+        self.assertFalse(self.worker.can_submit("encode"))
+        with self.assertRaises(StageQueueFull):
+            self.worker.submit("encode", 4, lambda: "overflow")
+        self.assertFalse(self.worker.try_submit("encode", 5, lambda: "overflow"))
+        # The other worker is unaffected by encode backpressure.
+        self.assertTrue(self.worker.can_submit("finalize"))
+
+        release.set()
+        results = {}
+        deadline = time.monotonic() + 5.0
+        while len(results) < 3 and time.monotonic() < deadline:
+            for result in self.worker.poll_results():
+                results[result.ticket] = result
+            time.sleep(0.01)
+        self.assertEqual(set(results), {1, 2, 3})
+        self.assertTrue(self.worker.can_submit("encode"))
+
+    def test_workers_run_independently(self):
+        release = threading.Event()
+        started = threading.Event()
+
+        def blocker():
+            started.set()
+            release.wait(timeout=10.0)
+            return "slow-encode"
+
+        self.worker.submit("encode", 1, blocker)
+        self.assertTrue(started.wait(timeout=5.0))
+        self.worker.submit("finalize", 2, lambda: "fast-finalize")
+
+        results = {}
+        deadline = time.monotonic() + 5.0
+        while 2 not in results and time.monotonic() < deadline:
+            for result in self.worker.poll_results():
+                results[result.ticket] = result
+            time.sleep(0.01)
+        # Finalize finished while encode is still blocked.
+        self.assertEqual(results[2].value, "fast-finalize")
+        self.assertNotIn(1, results)
+        release.set()
+
+    def test_block_one_waits_for_result(self):
+        self.worker.submit("encode", 1, lambda: time.sleep(0.2) or "late")
+        results = self.worker.poll_results(block_one=True, block_timeout_s=5.0)
+        self.assertEqual(results[0].value, "late")
+
+
+class TestStageWorkerLifecycle(unittest.TestCase):
+    def test_states_and_shutdown(self):
+        worker = AsyncContinuousStageWorker(queue_depth=2)
+        self.assertIs(worker.worker_state("encode"), WorkerState.RUNNING)
+        self.assertIs(worker.worker_state("finalize"), WorkerState.RUNNING)
+
+        worker.shutdown(timeout_s=5.0)
+        self.assertIs(worker.worker_state("encode"), WorkerState.STOPPED)
+        self.assertIs(worker.worker_state("finalize"), WorkerState.STOPPED)
+        self.assertFalse(worker.can_submit("encode"))
+        with self.assertRaises(RuntimeError):
+            worker.submit("encode", 1, lambda: None)
+
+    def test_shutdown_drains_queued_jobs(self):
+        worker = AsyncContinuousStageWorker(queue_depth=4)
+        seen = []
+        for ticket in range(3):
+            worker.submit("encode", ticket, lambda t=ticket: seen.append(t) or t)
+        worker.shutdown(timeout_s=5.0)
+        results = worker.poll_results()
+        # Every queued job either ran or was errored out; none are lost.
+        self.assertEqual({result.ticket for result in results}, {0, 1, 2})
+        ran = {result.ticket for result in results if result.error is None}
+        errored = {result.ticket for result in results if result.error is not None}
+        self.assertEqual(ran | errored, {0, 1, 2})
+        self.assertEqual(worker.pending, 0)
+
+    def test_stuck_worker_errors_in_flight_jobs(self):
+        worker = AsyncContinuousStageWorker(queue_depth=4)
+        release = threading.Event()
+        started = threading.Event()
+
+        def blocker():
+            started.set()
+            release.wait(timeout=30.0)
+            return "eventually"
+
+        worker.submit("encode", 1, blocker)
+        self.assertTrue(started.wait(timeout=5.0))
+        worker.submit("encode", 2, lambda: "queued-behind")
+
+        # The blocked worker cannot honor a fast shutdown.
+        worker.shutdown(timeout_s=0.2)
+        self.assertIs(worker.worker_state("encode"), WorkerState.FAILED)
+
+        results = worker.poll_results()
+        errored = {r.ticket for r in results if r.error is not None}
+        self.assertIn(2, errored)  # never ran; surfaced instead of hanging
+        release.set()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Add T2I continuous batching support for SGLang-Diffusion

Continuous batching lets diffusion requests join and leave the active batch mid-flight by batching compatible denoising steps across active requests, instead of only batching requests before denoising starts. This is intended to improve throughput and latency under bursty or concurrent image-generation traffic.

## Modifications

## Accuracy Tests

baseline:
<img width="1024" height="1024" alt="qwen_1024_no_batch_seed_4401" src="https://github.com/user-attachments/assets/78598b3a-6d24-4382-b5f9-1a3f7e0cb815" />

continuous batching:
<img width="1024" height="1024" alt="qwen_1024_seed_4401_continuous_batched" src="https://github.com/user-attachments/assets/553bf19e-549f-457c-bada-14959ab843f5" />

## Speed Tests and Profiling

1x h100

Baseline
```bash
python3 -m sglang.multimodal_gen.runtime.entrypoints.cli.main serve \
  --model-path Qwen/Qwen-Image-2512 \
  --backend sglang \
  --num-gpus 1 \
  --host 0.0.0.0 \
  --port 30200 \
  --log-level info \
  --output-path "" \
  --warmup-mode off \
  --performance-mode speed \
  --dit-cpu-offload false \
```

Dynamic batching:

```bash
python3 -m sglang.multimodal_gen.runtime.entrypoints.cli.main serve \
  --model-path Qwen/Qwen-Image-2512 \
  --backend sglang \
  --num-gpus 1 \
  --host 0.0.0.0 \
  --port 30200 \
  --log-level info \
  --output-path "" \
  --warmup-mode off \
  --performance-mode speed \
  --dit-cpu-offload false \
  --batching-mode dynamic \
  --batching-max-size 4 \
  --batching-delay-ms 5 \
  --enable-batching-metrics
```

Continuous batching:

```bash
python3 -m sglang.multimodal_gen.runtime.entrypoints.cli.main serve \
  --model-path Qwen/Qwen-Image-2512 \
  --backend sglang \
  --num-gpus 1 \
  --host 0.0.0.0 \
  --port 30200 \
  --log-level info \
  --output-path "" \
  --warmup-mode off \
  --performance-mode speed \
  --dit-cpu-offload false \
  --batching-mode continuous \
  --batching-max-size 4 \
  --batching-delay-ms 5 \
  --enable-batching-metrics
```

| Resolution | Mode | n | Throughput (req/s) | Δ vs No Batch | Mean Lat (s) | Δ | P99 Lat (s) | Δ | Duration (s) | Δ | Peak Mem (MB) |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 512x512 | No Batching | 3 | 0.125 | baseline | 31.17 | baseline | 32.28 | baseline | 510.71 | baseline | 55071 |
| 512x512 | Dynamic Batching | 3 | 0.218 | +73.8% | 18.14 | -41.8% | 18.98 | -41.2% | 293.91 | -42.5% | 57699 |
| 512x512 | Continuous Batching | 3 | 0.294 | +134.5% | 13.60 | -56.4% | 13.73 | -57.5% | 217.80 | -57.4% | 57539 |
| 768x768 | No Batching | 3 | 0.116 | baseline | 33.64 | baseline | 34.66 | baseline | 551.12 | baseline | 56341 |
| 768x768 | Dynamic Batching | 3 | 0.135 | +16.4% | 29.26 | -13.0% | 31.85 | -8.1% | 473.34 | -14.1% | 61809 |
| 768x768 | Continuous Batching | 3 | 0.142 | +22.2% | 28.18 | -16.2% | 28.28 | -18.4% | 451.02 | -18.2% | 58028 |
| 1024x1024 | No Batching | 3 | 0.073 | baseline | 52.40 | baseline | 55.10 | baseline | 439.79 | baseline | 58602 |
| 1024x1024 | Dynamic Batching | 3 | 0.078 | +6.9% | 50.20 | -4.2% | 55.57 | +0.8% | 411.31 | -6.5% | 68127 |
| 1024x1024 | Continuous Batching | 3 | 0.078 | +7.3% | 51.20 | -2.3% | 51.47 | -6.6% | 409.94 | -6.8% | 58768 |

After Qwen benchmark, I also ran smaller benchmarks across Qwen, FLUX2 Klein, Z-Image, SANA, ERNIE, GLM, and Ideogram to verify model compatability

## Checklist

- [x] Format your code according to the pre-commit hooks.
- [ ] Add unit tests according to the contribution guide.
- [x] Update documentation according to the documentation guide.
- [x] Provide speed benchmark results.
- [x] Follow the SGLang code style guidance.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29277752170](https://github.com/sgl-project/sglang/actions/runs/29277752170)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29277751959](https://github.com/sgl-project/sglang/actions/runs/29277751959)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->