### PR TITLE
fix mamba radix partial page prefix matching

### DIFF
--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -1068,6 +1068,10 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         if self.disable or len(key) == 0:
             return None
 
+        key = key.page_aligned(self.page_size)
+        if len(key) == 0:
+            return None
+
         return key
 
     def _match_post_processor(
@@ -1137,6 +1141,9 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         )
 
     def _split_node(self, key: RadixKey, child: TreeNode, split_len: int) -> TreeNode:
+        assert (
+            0 < split_len < len(child.key)
+        ), f"split_len must create non-empty nodes, {split_len=}, {len(child.key)=}"
         # new_node -> child
         new_node = TreeNode()
         new_node.children = {key[split_len:].child_key(self.page_size): child}
@@ -1145,6 +1152,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         new_node.full_lock_ref = child.full_lock_ref
         new_node.mamba_lock_ref = 0
         new_node.key = child.key[:split_len]
+        assert len(new_node.key) > 0, f"new_node.key should not be empty"
         new_node.value = child.value[:split_len].clone()
 
         # child time should be later than parent's time for mamba tombstone
@@ -1155,6 +1163,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
             self.mamba_lru_list.remove_node(child)
         child.parent = new_node
         child.key = child.key[split_len:]
+        assert len(child.key) > 0, f"child.key should not be empty"
         child.value = child.value[split_len:].clone()
         new_node.parent.children[key.child_key(self.page_size)] = new_node
         new_node.hash_value, child.hash_value = split_node_hash_value(

--- a/test/registered/unit/mem_cache/test_mamba_unittest.py
+++ b/test/registered/unit/mem_cache/test_mamba_unittest.py
@@ -416,6 +416,58 @@ class TestMamba(unittest.TestCase):
         self.assertEqual(list(second_insert_events[0].token_ids), [5])
         self.assertEqual(second_insert_events[0].parent_block_hash, split_parent_hash)
 
+    def test_mamba_radix_cache_limited_partial_page_match_does_not_split(self):
+        page_size = 64
+        tree = self._setup_minimal_mamba_radix_cache(page_size)
+        token_ids = array("q", range(page_size))
+
+        tree.insert(
+            InsertParams(
+                key=RadixKey(token_ids, None),
+                value=torch.arange(page_size),
+                mamba_value=torch.tensor([0]),
+            )
+        )
+
+        match = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(token_ids, None, limit=page_size - 1))
+        )
+
+        self.assertEqual(len(match.device_indices), 0)
+        self.assertEqual(self._non_root_key_lengths(tree), [page_size])
+
+    def _setup_minimal_mamba_radix_cache(self, page_size: int) -> MambaRadixCache:
+        tree = MambaRadixCache.__new__(MambaRadixCache)
+        tree.page_size = page_size
+        tree.mamba_cache_chunk_size = page_size
+        tree.disable = False
+        tree.device = torch.device("cpu")
+        tree.enable_kv_cache_events = False
+        tree.kv_event_queue = []
+        tree.full_evictable_size_ = 0
+        tree.mamba_evictable_size_ = 0
+        tree.full_protected_size_ = 0
+        tree.mamba_protected_size_ = 0
+
+        tree.root_node = TreeNode()
+        tree.root_node.key = RadixKey(array("q"), None)
+        tree.root_node.value = []
+        tree.root_node.hash_value = []
+        tree.root_node.full_lock_ref = 1
+        tree.root_node.mamba_lock_ref = 1
+        tree.full_lru_list = LRUList(mamba=False)
+        tree.mamba_lru_list = LRUList(mamba=True)
+        return tree
+
+    def _non_root_key_lengths(self, tree: MambaRadixCache) -> list[int]:
+        lengths = []
+        stack = list(tree.root_node.children.values())
+        while stack:
+            node = stack.pop()
+            lengths.append(len(node.key))
+            stack.extend(node.children.values())
+        return lengths
+
     def _setup_tree_and_allocator(self, enable_kv_cache_events=False):
         """Helper to create a MambaRadixCache with allocator for testing."""
         server_args = ServerArgs(model_path="dummy", page_size=1)


### PR DESCRIPTION
This fixes a bug in MambaRadixCache (not unified) where it wasn't page aligning keys before prefix matching. With paged KV (like using trtllm_mha) a limited key like 63 logical tokens backed by 64 raw tokens could match a 64 token child, round match len down to 0, and create an invalid empty radix node. This would later surface during tombstone eviction which would crash with `parent does not have child key, ()`.

This fix page aligns mamba radix match keys before lookup and adds split invariants to prevent empty node corruption, along with a test to the existing mamba cache unit tests.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828063722](https://github.com/sgl-project/sglang/actions/runs/34828063722)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828063407](https://github.com/sgl-project/sglang/actions/runs/34828063407)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34828063559](https://github.com/sgl-project/sglang/actions/runs/34828063559)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->