### PR TITLE
fix(function-call): keep Hermes tool calls whose arguments contain </tool_call>

### DIFF
--- a/python/sglang/srt/function_call/hermes_detector.py
+++ b/python/sglang/srt/function_call/hermes_detector.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import re
 from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
@@ -12,6 +11,10 @@ from sglang.srt.function_call.core_types import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ``JSONDecoder`` is stateless and thread-safe; reuse one instance instead of
+# allocating a fresh decoder on every parse.
+_JSON_DECODER = json.JSONDecoder()
 
 
 class HermesDetector(BaseFormatDetector):
@@ -26,34 +29,39 @@ class HermesDetector(BaseFormatDetector):
         super().__init__()
         self.bot_token = "<tool_call>"
         self.eot_token = "</tool_call>"
-        self.tool_call_regex = re.compile(
-            r"<tool_call>(.*?)</tool_call>|<tool_call>(.*)", re.DOTALL
-        )
         self._normal_text_buffer = ""
 
     def has_tool_call(self, text: str) -> bool:
         return self.bot_token in text
 
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
-        """
-        One-time parsing: Detects and parses tool calls in the provided text.
-        """
-        idx = text.find(self.bot_token)
-        normal_text = text[:idx].strip() if idx != -1 else text
-        if self.bot_token not in text:
-            return StreamingParseResult(normal_text=normal_text, calls=[])
+        """One-time parsing: detect and parse every tool call in ``text``."""
+        first = text.find(self.bot_token)
+        if first == -1:
+            return StreamingParseResult(normal_text=text, calls=[])
+        normal_text = text[:first].strip()
 
+        # Decode one JSON value after each ``<tool_call>`` with a string-aware
+        # decoder instead of a ``<tool_call>(.*?)</tool_call>`` regex. The
+        # non-greedy regex stops at the first ``</tool_call>``, so an argument
+        # string that legitimately contains the literal end-token truncates the
+        # payload and the whole call is silently dropped -- which also makes this
+        # non-streaming path disagree with the streaming path. ``raw_decode``
+        # correctly ignores ``</tool_call>`` occurring inside string values.
         calls = []
+        pos = first
         try:
-            for match in self.tool_call_regex.findall(text):
-                raw = match[0] or match[1]
-                if not raw:
-                    continue
-                parsed = json.loads(raw.strip())
-                if isinstance(parsed, list):
-                    calls.extend(self.parse_base_json(parsed, tools))
-                else:
-                    calls.extend(self.parse_base_json(parsed, tools))
+            while (start := text.find(self.bot_token, pos)) != -1:
+                cursor = start + len(self.bot_token)
+                while cursor < len(text) and text[cursor] in " \t\r\n":
+                    cursor += 1
+                try:
+                    obj, pos = _JSON_DECODER.raw_decode(text, cursor)
+                except json.JSONDecodeError:
+                    # Truncated or malformed payload (e.g. a partial tail); the
+                    # remaining tool calls, if any, cannot be parsed reliably.
+                    break
+                calls.extend(self.parse_base_json(obj, tools))
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:
             logger.error(f"Error in detect_and_parse: {e}")

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -22,6 +22,7 @@ from sglang.srt.function_call.gigachat3_detector import GigaChat3Detector
 from sglang.srt.function_call.glm4_moe_detector import Glm4MoeDetector
 from sglang.srt.function_call.glm47_moe_detector import Glm47MoeDetector
 from sglang.srt.function_call.gpt_oss_detector import GptOssDetector
+from sglang.srt.function_call.hermes_detector import HermesDetector
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.function_call.kimik2_detector import KimiK2Detector
 from sglang.srt.function_call.lfm2_detector import Lfm2Detector
@@ -5370,6 +5371,83 @@ class TestGemma4Detector(unittest.TestCase):
         params1 = json.loads(tool_calls_by_index[1]["parameters"])
         self.assertEqual(params0["location"], "Paris")
         self.assertEqual(params1["timezone"], "UTC")
+
+
+class TestHermesDetector(unittest.TestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search for information",
+                    parameters={
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = HermesDetector()
+
+    def _calls(self, result: StreamingParseResult):
+        return [(c.name, json.loads(c.parameters)) for c in result.calls]
+
+    def test_parse_simple(self):
+        text = (
+            '<tool_call>{"name": "search", "arguments": {"query": "NYC"}}</tool_call>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(self._calls(result), [("search", {"query": "NYC"})])
+
+    def test_argument_string_containing_end_token_is_not_dropped(self):
+        # Regression: a `<tool_call>(.*?)</tool_call>` regex truncates the JSON at
+        # the first `</tool_call>` inside a string value, silently dropping the
+        # whole call. The call must be parsed intact instead.
+        text = (
+            '<tool_call>{"name": "search", '
+            '"arguments": {"query": "explain the </tool_call> token"}}</tool_call>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(
+            self._calls(result),
+            [("search", {"query": "explain the </tool_call> token"})],
+        )
+
+    def test_multiple_calls_with_end_token_in_arguments(self):
+        text = (
+            '<tool_call>{"name": "search", "arguments": '
+            '{"query": "a </tool_call> b"}}</tool_call>'
+            '<tool_call>{"name": "search", "arguments": {"query": "c"}}</tool_call>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(
+            self._calls(result),
+            [("search", {"query": "a </tool_call> b"}), ("search", {"query": "c"})],
+        )
+
+    def test_streaming_and_batch_agree_on_end_token_in_arguments(self):
+        text = (
+            '<tool_call>{"name": "search", '
+            '"arguments": {"query": "close </tool_call> tag"}}</tool_call>'
+        )
+        batch = self._calls(self.detector.detect_and_parse(text, self.tools))
+
+        streamer = HermesDetector()
+        names: dict = {}
+        args: dict = {}
+        for ch in text:
+            res = streamer.parse_streaming_increment(ch, self.tools)
+            for c in res.calls or []:
+                idx = c.tool_index if c.tool_index is not None else 0
+                if c.name:
+                    names[idx] = c.name
+                if c.parameters:
+                    args[idx] = args.get(idx, "") + c.parameters
+        stream = [(names.get(i), json.loads(args[i])) for i in sorted(args)]
+
+        self.assertEqual(batch, [("search", {"query": "close </tool_call> tag"})])
+        self.assertEqual(stream, batch)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`HermesDetector.detect_and_parse` (the non-streaming path) extracts each tool call with a `<tool_call>(.*?)</tool_call>` regex. The non-greedy `.*?` stops at the **first** `</tool_call>`, so when a string argument legitimately contains the literal end-token, the JSON payload is truncated, `json.loads` raises, and the blanket `except` returns `calls=[]` — silently dropping the call **and any other calls in the same message**.

It also makes the non-streaming path disagree with the streaming path (`parse_streaming_increment`), which parses the same input correctly.

### Reproduction

```python
from sglang.srt.function_call.hermes_detector import HermesDetector
text = '<tool_call>{"name": "search", "arguments": {"query": "explain the </tool_call> token"}}</tool_call>'
HermesDetector().detect_and_parse(text, tools).calls
# before: []   <- silently dropped
# after:  [ToolCallItem(name="search", parameters='{"query": "explain the </tool_call> token"}')]
```

## Modifications

- **`hermes_detector.py`** — decode one JSON value after each `<tool_call>` with a string-aware `json.JSONDecoder().raw_decode`, which ignores `</tool_call>` occurring inside string values. Removes the now-unused regex (and the `re` import) so the truncating pattern can't be reused, and reuses a module-level decoder.
- **`test/registered/unit/function_call/test_function_call_parser.py`** — add `TestHermesDetector` covering the end-token-in-argument case, multiple calls, and streaming/non-streaming agreement.

## Notes

Found via differential testing of the non-streaming vs streaming parse paths. The same `<tool_call>(.*?)</tool_call>` extraction pattern appears in a few other detectors (`qwen3_coder`, `hunyuan`, `kimik2`, `poolside_v1`); those degrade differently (e.g. truncated argument values rather than a full drop) and are intentionally left out of scope here — happy to follow up in a separate PR.

## Checklist

- [x] Format the code according to the Contributor Guide.
- [x] Add unit tests (`TestHermesDetector`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27800360867](https://github.com/sgl-project/sglang/actions/runs/27800360867)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27800360804](https://github.com/sgl-project/sglang/actions/runs/27800360804)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->