### PR TITLE
[AMD][Perf] Fuse QK RMSNorm + 3D mRoPE + KV-cache store into single aiter op for Qwen3.5-397B-A17B-MXFP4 (TP=2, ROCm/aiter) on HIP

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -66,6 +66,7 @@ from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.rotary_embedding.mrope import MRotaryEmbedding
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.cuda_graph_config import (
@@ -74,6 +75,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
@@ -125,6 +127,18 @@ _qknorm_use_alt_stream = _is_cuda or (
     get_bool_env_var("SGLANG_QK_NORM_ALT_STREAM", "False") and _hip_use_alt_stream
 )
 _is_amx_available = cpu_has_amx_support()
+
+# Fused QK-norm + 3D mRoPE + KV-cache store (ROCm/aiter). Imported lazily and
+# guarded so the common (non-aiter) path stays byte-identical.
+_has_fused_qk_norm_mrope = False
+if _use_aiter:
+    try:
+        from aiter import fused_qk_norm_mrope_3d_cache_pts_quant_shuffle
+
+        _has_fused_qk_norm_mrope = True
+        logger.info("aiter fused_qk_norm_mrope_3d kernel available")
+    except ImportError:
+        pass
 
 cached_get_processor = lru_cache(get_processor)
 
@@ -850,6 +864,108 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
 
         self.alt_stream = alt_stream
 
+        # Fused QK-norm + 3D mRoPE + KV-cache store (ROCm/aiter, decode only).
+        self.use_fused_qk_norm_mrope = (
+            _has_fused_qk_norm_mrope
+            and isinstance(self.rotary_emb, MRotaryEmbedding)
+            and getattr(self.rotary_emb, "mrope_section", None) is not None
+        )
+        if self.use_fused_qk_norm_mrope:
+            # Scale tensors MUST stay on CPU: the C++ kernel uses .item<float>()
+            # which triggers hipMemcpy D2H + sync on CUDA tensors, breaking graph
+            # capture. Explicit device='cpu' is required because SGLang builds
+            # models inside a `with torch.device('cuda'):` context.
+            self._fused_k_scale = torch.tensor(1.0, dtype=torch.float32, device="cpu")
+            self._fused_v_scale = torch.tensor(1.0, dtype=torch.float32, device="cpu")
+
+    def forward_prepare_aiter_fused_mrope(
+        self, positions, hidden_states, forward_batch
+    ):
+        """Fused QK-norm + 3D mRoPE + KV-cache write for decode (ROCm/aiter).
+
+        The fused HIP kernel replaces split -> QK GemmaRMSNorm -> mRoPE ->
+        cache write, so KV is already in the paged cache when this returns.
+        Returns (q, None, None, gate); caller passes save_kv_cache=False.
+
+        Gemma QK-norm uses (1 + weight); the fused kernel applies a plain
+        RMSNorm (weight * x), so we feed the precomputed `gemma_weight`
+        (= weight + 1) instead of the raw weight.
+        """
+        qkv, _ = self.qkv_proj(hidden_states)
+        num_tokens = qkv.shape[0]
+
+        if self.attn_output_gate:
+            q_gate, k, v = qkv.split(
+                [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
+            )
+            # q and gate are interleaved per head: [q(hd), gate(hd)] * num_heads
+            q_gate = q_gate.view(num_tokens, self.num_heads, 2, self.head_dim)
+            q = q_gate[:, :, 0, :].reshape(num_tokens, self.q_size)
+            gate = q_gate[:, :, 1, :].reshape(num_tokens, self.q_size)
+            # The fused op consumes a plain contiguous [q, k, v] buffer.
+            qkv = torch.cat((q, k, v), dim=-1).contiguous()
+        else:
+            gate = None
+            qkv = qkv.contiguous()
+
+        qkv_3d = qkv.view(num_tokens, -1, self.head_dim)
+
+        token_to_kv_pool = get_token_to_kv_pool()
+        k_cache, v_cache = token_to_kv_pool.get_kv_buffer(self.attn.layer_id)
+        slot_mapping = forward_batch.out_cache_loc
+
+        cos_sin = self.rotary_emb.cos_sin_cache
+        if cos_sin.dtype != qkv.dtype:
+            cos_sin = cos_sin.to(dtype=qkv.dtype)
+
+        q_out = torch.empty(
+            num_tokens,
+            self.num_heads,
+            self.head_dim,
+            dtype=qkv.dtype,
+            device=qkv.device,
+        )
+
+        fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(
+            qkv_3d,
+            self.q_norm.gemma_weight,
+            self.k_norm.gemma_weight,
+            cos_sin,
+            positions,
+            num_tokens,
+            self.num_heads,
+            self.num_kv_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            self.rotary_emb.is_neox_style,
+            self.rotary_emb.mrope_section,
+            self.rotary_emb.mrope_interleaved,
+            self.q_norm.variance_epsilon,
+            q_out,
+            k_cache,
+            v_cache,
+            slot_mapping,
+            self._fused_k_scale,
+            self._fused_v_scale,
+            None,
+            None,
+            False,
+            False,
+            0,
+            0,
+            # rotary_dim: MUST be passed explicitly for partial-rotary models
+            # (Qwen3.5 uses partial_rotary_factor=0.25 -> rotary_dim=64). When
+            # left at the default 0 the kernel falls back to head_size/2 (=128)
+            # and the internal check `sum(mrope_section) == rotary_dim/2` fails
+            # (mrope_section=[11,11,10] sums to 32 == 64/2, not 128), which
+            # previously aborted cuda-graph capture with
+            # "mrope_section sum (32) must equal rotary_dim/2 (128)".
+            self.rotary_emb.rotary_dim,
+        )
+
+        q = q_out.reshape(num_tokens, -1)
+        return q, None, None, gate
+
     def _apply_qk_norm(
         self, q: torch.Tensor, k: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -958,7 +1074,15 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         """Full attention forward pass."""
-        if _is_hip and self.attn_output_gate:
+        save_kv_cache = True
+        if self.use_fused_qk_norm_mrope and forward_batch.forward_mode.is_decode():
+            q, k, v, gate = self.forward_prepare_aiter_fused_mrope(
+                positions=positions,
+                hidden_states=hidden_states,
+                forward_batch=forward_batch,
+            )
+            save_kv_cache = False
+        elif _is_hip and self.attn_output_gate:
             q, k, v, gate = self.forward_prepare_hip(
                 positions=positions,
                 hidden_states=hidden_states,
@@ -979,7 +1103,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
                 forward_batch=forward_batch,
             )
 
-        attn_output = self.attn(q, k, v, forward_batch)
+        attn_output = self.attn(q, k, v, forward_batch, save_kv_cache=save_kv_cache)
 
         if self.attn_output_gate:
             if not _is_npu:


### PR DESCRIPTION
## Motivation

In Qwen3.5's full-attention layers on ROCm/aiter, the decode `forward_prepare` path runs three separate kernels per layer:

1. `_fused_qk_gemma_rmsnorm_gate_kernel` — Gemma QK RMSNorm + gate split (4.64 us)
2. `_triton_mrope_forward_fused` — 3D mRoPE rotary embedding (5.60 us)
3. `store_kvcache` — paged KV-cache write (4.20 us)

That is **14.44 us across three kernel launches** per full-attention layer, every decode step. aiter ships `fused_qk_norm_mrope_3d_cache_pts_quant_shuffle`, which collapses QK-norm + 3D mRoPE + KV-cache store into a **single HIP kernel**, eliminating two launches per layer and the intermediate buffer traffic between them. This PR dispatches the decode path to that fused op for Qwen3.5-397B-A17B-MXFP4 (TP=2).

## Modifications

- **python/sglang/srt/models/qwen3_5.py**: Add `forward_prepare_aiter_fused_mrope()`, which feeds a contiguous `[q, k, v]` buffer (de-interleaving the q/gate halves) into the fused aiter op so that QK-norm, 3D mRoPE, and the paged KV-cache write all happen in one kernel; KV is already resident on return, so the caller passes `save_kv_cache=False`. Dispatch is gated on a new `use_fused_qk_norm_mrope` flag (requires `_use_aiter`, an `MRotaryEmbedding` with a populated `mrope_section`) and on `forward_mode.is_decode()`. The fused op is imported lazily under `_use_aiter`; when it is unavailable or the forward mode is not decode, control falls through to the existing `forward_prepare_hip` / common path, which is **byte-identical** to before. The Gemma `(1 + weight)` scaling is handled by feeding the precomputed `gemma_weight` into the plain-RMSNorm kernel, and the per-layer FP32 scale tensors are pinned to CPU to keep cuda-graph capture clean.

- **Notes**: The fused op is decode-only by design; prefill/extend keep the original three-kernel path (dominated by large MXFP4 MoE GEMMs). The kernel's `rotary_dim` argument is passed explicitly (=64) because Qwen3.5 uses `partial_rotary_factor=0.25`, so the internal `sum(mrope_section) == rotary_dim/2` invariant holds during graph capture.

## Accuracy Tests

Model: Qwen3.5-397B-A17B-MXFP4, TP=2, ROCm/aiter, page_size=16, bf16 KV cache

| Benchmark | Score | Threshold | Status |
|-----------|:-----:|:---------:|:------:|
| GSM8K (200 questions, parallel=2000) | 0.940 | 0.850 | PASS |

## Speed Tests and Profiling

Apples-to-apples decode profiling (8 prompts, concurrency 4, in=8192 / out=1024). Decode kernel-call counts match between runs (~10.6–10.8k over 15 full-attention layers, ~708 decode steps), confirming a fair comparison.

### Kernel-level (per full-attention layer, decode)

| Kernel | Before (us) | After (us) | Notes |
|--------|:-:|:-:|-------|
| `_fused_qk_gemma_rmsnorm_gate_kernel` | 4.64 | — | eliminated |
| `_triton_mrope_forward_fused` | 5.60 | — | eliminated |
| `store_kvcache` | 4.20 | — | eliminated |
| `fused_mrope_rms_kv_kernel<bf16,256,neox,interleaved,3>` | — | 8.36 | new fused aiter kernel |
| **Attn-prep total** | **14.44** | **8.36** | **−6.08 us (−42.1%)** |

Savings per decode iteration: 6.08 us/layer × 15 full-attention layers = **~91.2 us** (the 45 linear-attention layers are unaffected).

### E2E benchmark (random in=8192 / out=1024, conc=4, 40 prompts)

| Metric | Before | After | Delta |
|--------|:-:|:-:|:-:|
| Total throughput (tok/s) | 3368.59 | 3313.68 | −1.63% |
| Output throughput (tok/s) | 374.73 | 368.62 | −1.63% |
| Median TTFT (ms) | 356.59 | 357.53 | +0.26% |
| Median ITL (ms) | 9.09 | 9.25 | +1.76% |
| Median TPOT (ms) | 10.03 | 10.23 | +1.99% |
| Median E2E latency (ms) | 9489.16 | 9639.01 | +1.58% |

**Honest assessment:** The kernel-region win is real and confirmed (42.1%, three launches → one), but the ~91.2 us saved is only ~1.0% of the ~9.09 ms baseline ITL — decode is dominated by MoE GEMMs and core attention. At concurrency 4 that micro-saving sits below the e2e benchmark noise floor, so the small negative e2e deltas above are run-to-run variance, not a regression. The value of this change is the **kernel-launch reduction and CUDA-path parity**, not a measurable end-to-end speedup. TTFT is unaffected (fusion is decode-only).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27802338401](https://github.com/sgl-project/sglang/actions/runs/27802338401)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27802338335](https://github.com/sgl-project/sglang/actions/runs/27802338335)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #27802338434](https://github.com/sgl-project/sglang/actions/runs/27802338434)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->