### PR TITLE
[Fix] Return 400 instead of 500 for malformed/unreadable images

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from transformers import BaseImageProcessor
 
 from sglang.srt.managers.schedule_batch import (
@@ -549,8 +549,8 @@ class BaseMultimodalProcessor(ABC):
             elif modality == Modality.AUDIO:
                 return load_audio(data, audio_sample_rate)
 
-        except ValueError as e:
-            # Bad input (e.g. invalid base64) -> 400, not 500.
+        except (ValueError, UnidentifiedImageError) as e:
+            # Bad input (e.g. invalid base64, unreadable image) -> 400, not 500.
             data_str = str(data)
             if len(data_str) > 100:
                 data_str = data_str[:100] + "..."
@@ -916,6 +916,11 @@ class BaseMultimodalProcessor(ABC):
         for modality, idx, future in futures:
             try:
                 result = await asyncio.wrap_future(future)
+            except ValueError as e:
+                # Bad input (unreadable/invalid media) -> 400, not 500.
+                raise ValueError(
+                    f"An exception occurred while loading {modality.name} data at index {idx}: {e}"
+                ) from e
             except Exception as e:
                 logger.exception(
                     "[load_mm_data(simple)] error loading %s data at index=%d",
@@ -1057,6 +1062,11 @@ class BaseMultimodalProcessor(ABC):
                 raise RuntimeError(
                     f"An exception occurred while loading multimodal data: {e}"
                 )
+            except ValueError as e:
+                # Bad input (unreadable/invalid media) -> 400, not 500.
+                raise ValueError(
+                    f"An exception occurred while loading multimodal data: {e}"
+                ) from e
             except Exception as e:
                 raise RuntimeError(
                     f"An exception occurred while loading multimodal data: {e}"


### PR DESCRIPTION
## Motivation

A request with an unreadable image returns HTTP 500. PIL raises `UnidentifiedImageError` (an `OSError`, not a `ValueError`), so it was never classified as bad input. Client input errors should be 400, not 500.

## Modifications

- Classify `UnidentifiedImageError` as bad input (`ValueError`) in `_load_single_item`.
- Preserve `ValueError` through `fast_load_mm_data` and `legacy_load_mm_data`, which previously re-wrapped every exception as `RuntimeError` (→ 500). It now propagates and maps to 400 in `serving_base`.

## Accuracy Tests

N/A — error-handling only, no model output change.

## Speed Tests and Profiling

N/A — error path only.

## Checklist

- [x] Format your code according to pre-commit
- [ ] Add unit tests
- [ ] Update documentation
- [ ] Provide accuracy and speed benchmark results (N/A — error path only)
- [x] Follow the SGLang code style guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27806855451](https://github.com/sgl-project/sglang/actions/runs/27806855451)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27806855330](https://github.com/sgl-project/sglang/actions/runs/27806855330)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->