### PR TITLE
refactor: unify RL weight-update fanout across target and draft/MTP

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1583,7 +1583,10 @@ class InitWeightsSendGroupForRemoteInstanceReqOutput(BaseReq):
 
 @dataclass
 class BeginWeightUpdateReqInput(BaseReq):
-    pass
+    # Which model runners this update session covers: "target" (main model only),
+    # "draft" (draft worker(s) only), or "all" (default). The selector is fixed for
+    # the whole begin -> update -> end session; end finalizes the same set.
+    selector: Literal["target", "draft", "all"] = "all"
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -127,13 +127,27 @@ class SchedulerWeightUpdaterManager:
             assert flush_cache_success, "Cache flush failed after updating weights"
 
     def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
-        """In-place update of the weights from disk."""
+        """In-place update of the weights from disk, fanning out to all runners
+        (target + draft). The draft loads from the same recv_req.model_path as the
+        target: in an RL rollout both are refreshed from one checkpoint, and
+        load_weights matches by parameter name."""
         with self._observe_weight_load("disk"):
-            success, message = self.tp_worker.update_weights_from_disk(recv_req)
-            tp_success = success
-            if success and self.draft_worker is not None:
-                success, message = self.draft_worker.update_weights_from_disk(recv_req)
-            if tp_success:
+            success, message = True, "Success"
+            target_success = False
+            for role, runner in self.get_model_runners("all"):
+                success, message = runner.update_weights_from_disk(
+                    recv_req.model_path,
+                    recv_req.load_format,
+                    recapture_cuda_graph=recv_req.recapture_cuda_graph,
+                )
+                if role == "":
+                    target_success = success
+                if not success:
+                    break
+            # Flush once the target succeeded, even if a later draft fails — matches
+            # the pre-refactor behavior where the target's KV cache was flushed off
+            # the target's own success, independent of the draft result.
+            if target_success:
                 self.flush_cache_after_weight_update(recv_req)
             if not success:
                 logger.error(message)
@@ -152,16 +166,27 @@ class SchedulerWeightUpdaterManager:
         success, message = self.tp_worker.destroy_weights_update_group(recv_req)
         return DestroyWeightsUpdateGroupReqOutput(success, message)
 
-    def get_model_runners(self, selector: str = "all") -> List[Tuple[str, Any]]:
-        """Resolve a {target, draft} selector to (role, ModelRunner) pairs, target
-        first. role is "" for the target runner; draft roles come from the draft
-        worker's iter_draft_runners()."""
+    def iter_weight_update_workers(self, selector: str = "all") -> List[Tuple[str, Any]]:
+        """Resolve a {target, draft, all} selector to (role, worker) pairs, target
+        first: the target worker and, when present, the draft worker. This is the
+        worker-level inclusion decision; each worker then contributes its own runners
+        via iter_runners()."""
         parsed = _parse_runner_selector(selector)
-        runners: List[Tuple[str, Any]] = []
+        workers: List[Tuple[str, Any]] = []
         if "target" in parsed:
-            runners.append(("", self.tp_worker.model_runner))
+            workers.append(("target", self.tp_worker))
         if "draft" in parsed and self.draft_worker is not None:
-            runners += self.draft_worker.iter_draft_runners()
+            workers.append(("draft", self.draft_worker))
+        return workers
+
+    def get_model_runners(self, selector: str = "all") -> List[Tuple[str, Any]]:
+        """Resolve a {target, draft, all} selector to (role, ModelRunner) pairs, target
+        first. Derived from iter_weight_update_workers: each selected worker yields its
+        own runners via iter_runners() — role "" for the target runner, draft roles
+        from the draft worker."""
+        runners: List[Tuple[str, Any]] = []
+        for _, worker in self.iter_weight_update_workers(selector):
+            runners += worker.iter_runners()
         return runners
 
     def update_weights_from_distributed(
@@ -227,13 +252,20 @@ class SchedulerWeightUpdaterManager:
             return UpdateWeightsFromTensorReqOutput(success, message)
 
     def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
-        """Update the online model parameter from IPC for checkpoint-engine integration."""
+        """Update the online model parameter from IPC for checkpoint-engine
+        integration, fanning out to all runners (target + draft)."""
         with self._observe_weight_load("ipc"):
-            success, message = self.tp_worker.update_weights_from_ipc(recv_req)
-            tp_success = success
-            if success and self.draft_worker is not None:
-                success, message = self.draft_worker.update_weights_from_ipc(recv_req)
-            if tp_success:
+            success, message = True, "Success"
+            target_success = False
+            for role, runner in self.get_model_runners("all"):
+                success, message = runner.update_weights_from_ipc(recv_req)
+                if role == "":
+                    target_success = success
+                if not success:
+                    break
+            # Flush off the target's own success, even if a later draft fails — see
+            # update_weights_from_disk for the rationale.
+            if target_success:
                 self.flush_cache_after_weight_update(recv_req)
             if not success:
                 logger.error(message)

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -277,26 +277,30 @@ class SchedulerWeightUpdaterManager:
         return GetWeightsByNameReqOutput(parameter)
 
     def begin_weight_update(self, recv_req: BeginWeightUpdateReqInput):
-        """Begin a weight-update session: restore in-place-packed weights to a loadable state."""
-        success, message = self.tp_worker.begin_weight_update()
+        """Begin a weight-update session: restore in-place-packed weights to a
+        loadable state on every runner (target + draft), so the draft model is
+        prepared identically to the target."""
+        for _, runner in self.get_model_runners("all"):
+            runner.begin_weight_update()
         self._weight_update_in_progress = True
         self._weight_update_loaded = False
         torch.distributed.barrier(group=self.tp_cpu_group)
-        return BeginWeightUpdateReqOutput(success, message)
+        return BeginWeightUpdateReqOutput(True, "Success")
 
     def end_weight_update(self, recv_req: EndWeightUpdateReqInput):
-        """End the weight-update session: quant finalize on the full model, plus
-        model.post_load_weights only when load_weights was bypassed this session (e.g. P2P/RDMA).
+        """End the weight-update session on every runner (target + draft): quant
+        finalize on the full model, plus model.post_load_weights only when
+        load_weights was bypassed this session (e.g. P2P/RDMA).
         """
         assert (
             self._weight_update_in_progress
         ), "end_weight_update called without begin_weight_update"
-        success, message = self.tp_worker.end_weight_update(
-            run_post_load=not self._weight_update_loaded
-        )
+        run_post_load = not self._weight_update_loaded
+        for _, runner in self.get_model_runners("all"):
+            runner.end_weight_update(run_post_load=run_post_load)
         self._weight_update_in_progress = False
         torch.distributed.barrier(group=self.tp_cpu_group)
-        return EndWeightUpdateReqOutput(success, message)
+        return EndWeightUpdateReqOutput(True, "Success")
 
     def release_memory_occupation(self, recv_req: ReleaseMemoryOccupationReqInput):
         assert (

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -103,6 +103,9 @@ class SchedulerWeightUpdaterManager:
     stashed_model_static_state: Any = None
     _weight_update_in_progress: bool = False
     _weight_update_loaded: bool = False
+    # Runner selector for the open session, recorded at begin_weight_update and
+    # reused by end_weight_update so the same set is restored and finalized.
+    _weight_update_selector: str = "all"
 
     @contextmanager
     def _observe_weight_load(self, source: str) -> Iterator[None]:
@@ -278,9 +281,14 @@ class SchedulerWeightUpdaterManager:
 
     def begin_weight_update(self, recv_req: BeginWeightUpdateReqInput):
         """Begin a weight-update session: restore in-place-packed weights to a
-        loadable state on every runner (target + draft), so the draft model is
-        prepared identically to the target."""
-        for _, runner in self.get_model_runners("all"):
+        loadable state on the selected runners (target and/or draft), so the draft
+        model is prepared identically to the target. The selector is recorded and
+        reused by end_weight_update so the same set is finalized."""
+        assert (
+            not self._weight_update_in_progress
+        ), "begin_weight_update called while a weight-update session is already open"
+        self._weight_update_selector = recv_req.selector
+        for _, runner in self.get_model_runners(recv_req.selector):
             runner.begin_weight_update()
         self._weight_update_in_progress = True
         self._weight_update_loaded = False
@@ -288,15 +296,15 @@ class SchedulerWeightUpdaterManager:
         return BeginWeightUpdateReqOutput(True, "Success")
 
     def end_weight_update(self, recv_req: EndWeightUpdateReqInput):
-        """End the weight-update session on every runner (target + draft): quant
-        finalize on the full model, plus model.post_load_weights only when
-        load_weights was bypassed this session (e.g. P2P/RDMA).
+        """End the weight-update session on the runners begin_weight_update opened
+        (its recorded selector): quant finalize on each, plus model.post_load_weights
+        only when load_weights was bypassed this session (e.g. P2P/RDMA).
         """
         assert (
             self._weight_update_in_progress
         ), "end_weight_update called without begin_weight_update"
         run_post_load = not self._weight_update_loaded
-        for _, runner in self.get_model_runners("all"):
+        for _, runner in self.get_model_runners(self._weight_update_selector):
             runner.end_weight_update(run_post_load=run_post_load)
         self._weight_update_in_progress = False
         torch.distributed.barrier(group=self.tp_cpu_group)

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -130,27 +130,13 @@ class SchedulerWeightUpdaterManager:
             assert flush_cache_success, "Cache flush failed after updating weights"
 
     def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
-        """In-place update of the weights from disk, fanning out to all runners
-        (target + draft). The draft loads from the same recv_req.model_path as the
-        target: in an RL rollout both are refreshed from one checkpoint, and
-        load_weights matches by parameter name."""
+        """In-place update of the weights from disk."""
         with self._observe_weight_load("disk"):
-            success, message = True, "Success"
-            target_success = False
-            for role, runner in self.get_model_runners("all"):
-                success, message = runner.update_weights_from_disk(
-                    recv_req.model_path,
-                    recv_req.load_format,
-                    recapture_cuda_graph=recv_req.recapture_cuda_graph,
-                )
-                if role == "":
-                    target_success = success
-                if not success:
-                    break
-            # Flush once the target succeeded, even if a later draft fails — matches
-            # the pre-refactor behavior where the target's KV cache was flushed off
-            # the target's own success, independent of the draft result.
-            if target_success:
+            success, message = self.tp_worker.update_weights_from_disk(recv_req)
+            tp_success = success
+            if success and self.draft_worker is not None:
+                success, message = self.draft_worker.update_weights_from_disk(recv_req)
+            if tp_success:
                 self.flush_cache_after_weight_update(recv_req)
             if not success:
                 logger.error(message)
@@ -255,20 +241,13 @@ class SchedulerWeightUpdaterManager:
             return UpdateWeightsFromTensorReqOutput(success, message)
 
     def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
-        """Update the online model parameter from IPC for checkpoint-engine
-        integration, fanning out to all runners (target + draft)."""
+        """Update the online model parameter from IPC for checkpoint-engine integration."""
         with self._observe_weight_load("ipc"):
-            success, message = True, "Success"
-            target_success = False
-            for role, runner in self.get_model_runners("all"):
-                success, message = runner.update_weights_from_ipc(recv_req)
-                if role == "":
-                    target_success = success
-                if not success:
-                    break
-            # Flush off the target's own success, even if a later draft fails — see
-            # update_weights_from_disk for the rationale.
-            if target_success:
+            success, message = self.tp_worker.update_weights_from_ipc(recv_req)
+            tp_success = success
+            if success and self.draft_worker is not None:
+                success, message = self.draft_worker.update_weights_from_ipc(recv_req)
+            if tp_success:
                 self.flush_cache_after_weight_update(recv_req)
             if not success:
                 logger.error(message)

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -39,11 +39,6 @@ from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
-from sglang.srt.model_loader.loader import (
-    post_load_weights,
-    postprocess_weight,
-    restore_weight,
-)
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import MultiprocessingSerializer, broadcast_pyobj, set_random_seed
 from sglang.srt.utils.hf_transformers_utils import (
@@ -136,19 +131,6 @@ class BaseTpWorker(ABC):
             recv_req.group_name,
         )
         return success, message
-
-    def begin_weight_update(self):
-        """Begin a new weight update session: restore packed weights to a loadable state."""
-        restore_weight(self.model_runner.model, torch.device(self.device))
-        return True, "Success"
-
-    def end_weight_update(self, run_post_load: bool):
-        """End the weight update session: optionally post_load_weights, then quant finalize."""
-        model = self.model_runner.model
-        if run_post_load:
-            post_load_weights(model)
-        postprocess_weight(model, torch.device(self.device))
-        return True, "Success"
 
     def get_weights_by_name(self, recv_req: GetWeightsByNameReqInput):
         parameter = self.model_runner.get_weights_by_name(

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -32,6 +32,8 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterReqInput,
     SendWeightsToRemoteInstanceReqInput,
     UnloadLoRAAdapterReqInput,
+    UpdateWeightFromDiskReqInput,
+    UpdateWeightsFromIPCReqInput,
 )
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
@@ -90,6 +92,14 @@ class BaseTpWorker(ABC):
             self.model_runner.token_to_kv_pool_allocator,
         )
 
+    def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
+        success, message = self.model_runner.update_weights_from_disk(
+            recv_req.model_path,
+            recv_req.load_format,
+            recapture_cuda_graph=recv_req.recapture_cuda_graph,
+        )
+        return success, message
+
     def init_weights_update_group(self, recv_req: InitWeightsUpdateGroupReqInput):
         success, message = self.model_runner.init_weights_update_group(
             recv_req.master_address,
@@ -130,6 +140,11 @@ class BaseTpWorker(ABC):
             recv_req.ports,
             recv_req.group_name,
         )
+        return success, message
+
+    def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
+        """Update weights from IPC for checkpoint-engine integration."""
+        success, message = self.model_runner.update_weights_from_ipc(recv_req)
         return success, message
 
     def get_weights_by_name(self, recv_req: GetWeightsByNameReqInput):

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -32,8 +32,6 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterReqInput,
     SendWeightsToRemoteInstanceReqInput,
     UnloadLoRAAdapterReqInput,
-    UpdateWeightFromDiskReqInput,
-    UpdateWeightsFromIPCReqInput,
 )
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
@@ -97,14 +95,6 @@ class BaseTpWorker(ABC):
             self.model_runner.token_to_kv_pool_allocator,
         )
 
-    def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
-        success, message = self.model_runner.update_weights_from_disk(
-            recv_req.model_path,
-            recv_req.load_format,
-            recapture_cuda_graph=recv_req.recapture_cuda_graph,
-        )
-        return success, message
-
     def init_weights_update_group(self, recv_req: InitWeightsUpdateGroupReqInput):
         success, message = self.model_runner.init_weights_update_group(
             recv_req.master_address,
@@ -145,11 +135,6 @@ class BaseTpWorker(ABC):
             recv_req.ports,
             recv_req.group_name,
         )
-        return success, message
-
-    def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
-        """Update weights from IPC for checkpoint-engine integration."""
-        success, message = self.model_runner.update_weights_from_ipc(recv_req)
         return success, message
 
     def begin_weight_update(self):
@@ -415,10 +400,12 @@ class TpModelWorker(BaseTpWorker):
     def model_runner(self) -> "ModelRunner":
         return self._model_runner
 
-    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
-        # The target worker shares this class (is_draft_worker=False) and returns [].
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+        # All (role, ModelRunner) pairs this worker contributes to a weight update.
+        # The target (is_draft_worker=False) yields its own runner under the empty
+        # role; a draft worker yields its draft runner(s).
         if not self.is_draft_worker:
-            return []
+            return [("", self.model_runner)]
         if self.model_runner_list:
             return [
                 (f"draft_step_{i}", r) for i, r in enumerate(self.model_runner_list)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -177,7 +177,13 @@ from sglang.srt.model_executor.piecewise_cuda_graph_runner import (
     PiecewiseCudaGraphRunner,
 )
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
-from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
+from sglang.srt.model_loader.loader import (
+    DefaultModelLoader,
+    get_model_loader,
+    post_load_weights,
+    postprocess_weight,
+    restore_weight,
+)
 from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     RemoteInstanceWeightLoaderBackend,
     register_memory_region,
@@ -1947,6 +1953,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def load_weights(self, weights) -> None:
         """Load an in-memory list of (name, tensor) weights into this runner's model."""
         self.model.load_weights(weights)
+
+    def begin_weight_update(self) -> None:
+        """Begin a weight-update session: restore in-place-packed weights to a
+        loadable state (no-op for schemes that don't repack)."""
+        restore_weight(self.model, torch.device(self.device))
+
+    def end_weight_update(self, run_post_load: bool) -> None:
+        """End the weight-update session: optionally run model.post_load_weights
+        (when load_weights was bypassed this session, e.g. P2P/RDMA), then finalize
+        quantized weights into kernel layout."""
+        if run_post_load:
+            post_load_weights(self.model)
+        postprocess_weight(self.model, torch.device(self.device))
 
     def receive_weights_from_distributed(
         self,

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -356,7 +356,7 @@ class DFlashWorker:
         # to flush here.
         pass
 
-    def iter_draft_runners(self) -> list[tuple[str, "ModelRunner"]]:
+    def iter_runners(self) -> list[tuple[str, "ModelRunner"]]:
         # Explicit so DFlash's __getattr__ doesn't delegate this to the target
         # (whose model_runner is aliased here) and miss the real draft.
         return [("draft", self.draft_model_runner)]

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -26,10 +26,6 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_backend_context,
 )
 from sglang.srt.layers.utils.logprob import compute_spec_v2_logprobs
-from sglang.srt.managers.io_struct import (
-    UpdateWeightFromDiskReqInput,
-    UpdateWeightsFromIPCReqInput,
-)
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -922,7 +918,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         # allocator and kv cache pool are shared with target worker, which are cleared in scheduler
         pass
 
-    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
         return [("draft", self.draft_worker.draft_runner)]
 
     def forward_batch_generation(self, batch: ScheduleBatch, on_publish=None):
@@ -1480,21 +1476,3 @@ class EAGLEWorkerV2(BaseSpecWorker):
         out = x.clone()
         out.view(bs, nd, *x.shape[1:])[:, :s1] = gathered.view(bs, s1, *x.shape[1:])
         return out
-
-    def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
-        success, message = self._draft_worker.draft_runner.update_weights_from_disk(
-            recv_req.model_path,
-            recv_req.load_format,
-            recapture_cuda_graph=recv_req.recapture_cuda_graph,
-        )
-        if not success:
-            return success, message
-        return True, "Succeeded to update model weights."
-
-    def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
-        success, message = self._draft_worker.draft_runner.update_weights_from_ipc(
-            recv_req
-        )
-        if not success:
-            return success, message
-        return True, "Succeeded to update model weights."

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -26,6 +26,10 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_backend_context,
 )
 from sglang.srt.layers.utils.logprob import compute_spec_v2_logprobs
+from sglang.srt.managers.io_struct import (
+    UpdateWeightFromDiskReqInput,
+    UpdateWeightsFromIPCReqInput,
+)
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -1476,3 +1480,21 @@ class EAGLEWorkerV2(BaseSpecWorker):
         out = x.clone()
         out.view(bs, nd, *x.shape[1:])[:, :s1] = gathered.view(bs, s1, *x.shape[1:])
         return out
+
+    def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
+        success, message = self._draft_worker.draft_runner.update_weights_from_disk(
+            recv_req.model_path,
+            recv_req.load_format,
+            recapture_cuda_graph=recv_req.recapture_cuda_graph,
+        )
+        if not success:
+            return success, message
+        return True, "Succeeded to update model weights."
+
+    def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
+        success, message = self._draft_worker.draft_runner.update_weights_from_ipc(
+            recv_req
+        )
+        if not success:
+            return success, message
+        return True, "Succeeded to update model weights."

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -203,7 +203,7 @@ class FrozenKVMTPWorker(TpModelWorker):
     def clear_cache_pool(self):
         pass
 
-    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
         return [("draft", self.draft_model_runner)]
 
     def _resolve_draft_backend_type(self) -> str:

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -21,6 +21,10 @@ import torch
 from sglang.srt.environ import envs
 from sglang.srt.layers.moe.utils import speculative_moe_backend_context
 from sglang.srt.layers.utils.logprob import compute_spec_v2_logprobs
+from sglang.srt.managers.io_struct import (
+    UpdateWeightFromDiskReqInput,
+    UpdateWeightsFromIPCReqInput,
+)
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -846,3 +850,25 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             indexer_topk_output=forward_batch_output.indexer_topk_output,
             extra_keep_alive_refs=[verify_forward_batch],
         )
+
+    def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
+        for i in range(self.speculative_num_steps):
+            success, message = self._draft_worker.draft_runner_list[
+                i
+            ].update_weights_from_disk(
+                recv_req.model_path,
+                recv_req.load_format,
+                recapture_cuda_graph=recv_req.recapture_cuda_graph,
+            )
+            if not success:
+                return success, message
+        return True, "Succeeded to update model weights."
+
+    def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
+        for i in range(self.speculative_num_steps):
+            success, message = self._draft_worker.draft_runner_list[
+                i
+            ].update_weights_from_ipc(recv_req)
+            if not success:
+                return success, message
+        return True, "Succeeded to update model weights."

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -21,10 +21,6 @@ import torch
 from sglang.srt.environ import envs
 from sglang.srt.layers.moe.utils import speculative_moe_backend_context
 from sglang.srt.layers.utils.logprob import compute_spec_v2_logprobs
-from sglang.srt.managers.io_struct import (
-    UpdateWeightFromDiskReqInput,
-    UpdateWeightsFromIPCReqInput,
-)
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -699,7 +695,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         # allocator and kv cache pool are shared with target worker, which are cleared in scheduler
         pass
 
-    def iter_draft_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
         return [(f"draft_step_{i}", r) for i, r in enumerate(self.draft_runner_list)]
 
     def forward_batch_generation(self, batch: ScheduleBatch, on_publish=None):
@@ -850,25 +846,3 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             indexer_topk_output=forward_batch_output.indexer_topk_output,
             extra_keep_alive_refs=[verify_forward_batch],
         )
-
-    def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
-        for i in range(self.speculative_num_steps):
-            success, message = self._draft_worker.draft_runner_list[
-                i
-            ].update_weights_from_disk(
-                recv_req.model_path,
-                recv_req.load_format,
-                recapture_cuda_graph=recv_req.recapture_cuda_graph,
-            )
-            if not success:
-                return success, message
-        return True, "Succeeded to update model weights."
-
-    def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
-        for i in range(self.speculative_num_steps):
-            success, message = self._draft_worker.draft_runner_list[
-                i
-            ].update_weights_from_ipc(recv_req)
-            if not success:
-                return success, message
-        return True, "Succeeded to update model weights."

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -86,8 +86,9 @@ class NGRAMWorker:
     def clear_cache_pool(self):
         self.ngram_corpus.reset()
 
-    def iter_draft_runners(self) -> list[tuple[str, "ModelRunner"]]:
-        # NGRAM shares the target's model_runner — no independent draft.
+    def iter_runners(self) -> list[tuple[str, "ModelRunner"]]:
+        # NGRAM shares the target's model_runner — no independent draft runner of its
+        # own (the target worker contributes its runner).
         return []
 
     def add_external_corpus(self, corpus_id: str, token_chunks: list[list[int]]) -> int:

--- a/test/srt/test_distributed_weight_update_spec_worker.py
+++ b/test/srt/test_distributed_weight_update_spec_worker.py
@@ -1,7 +1,10 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
 
-from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
+from sglang.srt.managers.io_struct import (
+    UpdateWeightFromDiskReqInput,
+    UpdateWeightsFromDistributedReqInput,
+)
 from sglang.srt.managers.scheduler_components.weight_updater import (
     SchedulerWeightUpdaterManager,
 )
@@ -18,10 +21,14 @@ def _distributed_req(selector="all"):
     )
 
 
+def _disk_req(flush_cache=True):
+    return UpdateWeightFromDiskReqInput(model_path="/tmp/model", flush_cache=flush_cache)
+
+
 def _manager(tp_worker, draft_worker):
     # metrics_collector defaults to None, so _observe_weight_load is a no-op and the
     # unused disagg/memory hooks below are never exercised by these tests.
-    return SchedulerWeightUpdaterManager(
+    manager = SchedulerWeightUpdaterManager(
         tp_worker=tp_worker,
         draft_worker=draft_worker,
         tp_cpu_group=object(),
@@ -32,6 +39,9 @@ def _manager(tp_worker, draft_worker):
         get_disagg_decode_prealloc_queue=Mock(return_value=None),
         get_disagg_prefill_bootstrap_queue=Mock(return_value=None),
     )
+    # update_weights_from_* assert an open begin_weight_update session.
+    manager._weight_update_in_progress = True
+    return manager
 
 
 def test_scheduler_distributed_update_receives_once_on_target_loads_into_each():
@@ -43,10 +53,11 @@ def test_scheduler_distributed_update_receives_once_on_target_loads_into_each():
     target_runner.receive_weights_from_distributed.return_value = weights
     draft_runner = Mock()
     manager = _manager(
-        tp_worker=SimpleNamespace(model_runner=target_runner),
-        draft_worker=SimpleNamespace(
-            iter_draft_runners=lambda: [("draft", draft_runner)]
+        tp_worker=SimpleNamespace(
+            model_runner=target_runner,
+            iter_runners=lambda: [("", target_runner)],
         ),
+        draft_worker=SimpleNamespace(iter_runners=lambda: [("draft", draft_runner)]),
     )
 
     output = manager.update_weights_from_distributed(_distributed_req())
@@ -72,7 +83,10 @@ def test_scheduler_distributed_update_target_only_selector_skips_draft():
     target_runner.receive_weights_from_distributed.return_value = weights
     draft_worker = Mock()
     manager = _manager(
-        tp_worker=SimpleNamespace(model_runner=target_runner),
+        tp_worker=SimpleNamespace(
+            model_runner=target_runner,
+            iter_runners=lambda: [("", target_runner)],
+        ),
         draft_worker=draft_worker,
     )
 
@@ -83,4 +97,62 @@ def test_scheduler_distributed_update_target_only_selector_skips_draft():
     assert output.success is True
     target_runner.receive_weights_from_distributed.assert_called_once()
     target_runner.load_weights.assert_called_once_with(weights)
-    draft_worker.iter_draft_runners.assert_not_called()
+    draft_worker.iter_runners.assert_not_called()
+
+
+def _disk_manager(target_runner, draft_runner):
+    return _manager(
+        tp_worker=SimpleNamespace(iter_runners=lambda: [("", target_runner)]),
+        draft_worker=SimpleNamespace(iter_runners=lambda: [("draft", draft_runner)]),
+    )
+
+
+def test_disk_update_fans_out_to_all_runners_and_flushes():
+    # disk update reaches both the target and the draft runner via get_model_runners,
+    # and the target's success drives the post-update cache flush.
+    target_runner = Mock()
+    target_runner.update_weights_from_disk.return_value = (True, "ok")
+    draft_runner = Mock()
+    draft_runner.update_weights_from_disk.return_value = (True, "ok")
+    manager = _disk_manager(target_runner, draft_runner)
+
+    output = manager.update_weights_from_disk(_disk_req(flush_cache=True))
+
+    assert output.success is True
+    # Both runners load from the same recv_req.model_path.
+    target_runner.update_weights_from_disk.assert_called_once()
+    draft_runner.update_weights_from_disk.assert_called_once()
+    manager.flush_cache.assert_called_once()
+
+
+def test_disk_update_flushes_on_target_success_even_when_draft_fails():
+    # Pre-refactor behavior preserved: the target's KV cache is flushed off the
+    # target's own success, independent of a later draft failure; the overall result
+    # still reports the failure.
+    target_runner = Mock()
+    target_runner.update_weights_from_disk.return_value = (True, "ok")
+    draft_runner = Mock()
+    draft_runner.update_weights_from_disk.return_value = (False, "draft boom")
+    manager = _disk_manager(target_runner, draft_runner)
+
+    output = manager.update_weights_from_disk(_disk_req(flush_cache=True))
+
+    assert output.success is False
+    assert "draft boom" in output.message
+    manager.flush_cache.assert_called_once()
+
+
+def test_disk_update_target_failure_short_circuits_draft_and_flush():
+    # The target runs first; its failure stops the fanout before the draft and skips
+    # the flush (target never succeeded).
+    target_runner = Mock()
+    target_runner.update_weights_from_disk.return_value = (False, "target boom")
+    draft_runner = Mock()
+    manager = _disk_manager(target_runner, draft_runner)
+
+    output = manager.update_weights_from_disk(_disk_req(flush_cache=True))
+
+    assert output.success is False
+    assert "target boom" in output.message
+    draft_runner.update_weights_from_disk.assert_not_called()
+    manager.flush_cache.assert_not_called()

--- a/test/srt/test_distributed_weight_update_spec_worker.py
+++ b/test/srt/test_distributed_weight_update_spec_worker.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
+
 from sglang.srt.managers.io_struct import (
     BeginWeightUpdateReqInput,
     EndWeightUpdateReqInput,
@@ -241,3 +243,45 @@ def test_model_runner_begin_end_wire_to_loader_hooks():
         mr.ModelRunner.end_weight_update(runner, run_post_load=False)
     post_load.assert_not_called()
     postprocess.assert_called_once()
+
+
+def test_begin_weight_update_selector_restores_only_selected_and_is_recorded():
+    # begin(selector="draft") opens the session on the draft only; the target is
+    # untouched, and the selector is recorded for end to reuse.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_in_progress = False
+
+    with patch("torch.distributed.barrier"):
+        manager.begin_weight_update(BeginWeightUpdateReqInput(selector="draft"))
+
+    target_runner.begin_weight_update.assert_not_called()
+    draft_runner.begin_weight_update.assert_called_once_with()
+    assert manager._weight_update_selector == "draft"
+
+
+def test_end_weight_update_reuses_session_selector_from_begin():
+    # end has no selector of its own; it finalizes exactly the set begin opened.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_in_progress = False
+
+    with patch("torch.distributed.barrier"):
+        manager.begin_weight_update(BeginWeightUpdateReqInput(selector="draft"))
+        manager.end_weight_update(EndWeightUpdateReqInput())
+
+    target_runner.end_weight_update.assert_not_called()
+    draft_runner.end_weight_update.assert_called_once()
+
+
+def test_begin_weight_update_rejects_reentry():
+    # A second begin while a session is open would leave the first session's
+    # restored runners unfinalized — reject it loudly.
+    manager = _session_manager(Mock(), Mock())
+    manager._weight_update_in_progress = True
+
+    with patch("torch.distributed.barrier"):
+        with pytest.raises(AssertionError, match="already open"):
+            manager.begin_weight_update(BeginWeightUpdateReqInput())

--- a/test/srt/test_distributed_weight_update_spec_worker.py
+++ b/test/srt/test_distributed_weight_update_spec_worker.py
@@ -6,7 +6,6 @@ import pytest
 from sglang.srt.managers.io_struct import (
     BeginWeightUpdateReqInput,
     EndWeightUpdateReqInput,
-    UpdateWeightFromDiskReqInput,
     UpdateWeightsFromDistributedReqInput,
 )
 from sglang.srt.managers.scheduler_components.weight_updater import (
@@ -23,10 +22,6 @@ def _distributed_req(selector="all"):
         flush_cache=False,
         selector=selector,
     )
-
-
-def _disk_req(flush_cache=True):
-    return UpdateWeightFromDiskReqInput(model_path="/tmp/model", flush_cache=flush_cache)
 
 
 def _manager(tp_worker, draft_worker):
@@ -102,64 +97,6 @@ def test_scheduler_distributed_update_target_only_selector_skips_draft():
     target_runner.receive_weights_from_distributed.assert_called_once()
     target_runner.load_weights.assert_called_once_with(weights)
     draft_worker.iter_runners.assert_not_called()
-
-
-def _disk_manager(target_runner, draft_runner):
-    return _manager(
-        tp_worker=SimpleNamespace(iter_runners=lambda: [("", target_runner)]),
-        draft_worker=SimpleNamespace(iter_runners=lambda: [("draft", draft_runner)]),
-    )
-
-
-def test_disk_update_fans_out_to_all_runners_and_flushes():
-    # disk update reaches both the target and the draft runner via get_model_runners,
-    # and the target's success drives the post-update cache flush.
-    target_runner = Mock()
-    target_runner.update_weights_from_disk.return_value = (True, "ok")
-    draft_runner = Mock()
-    draft_runner.update_weights_from_disk.return_value = (True, "ok")
-    manager = _disk_manager(target_runner, draft_runner)
-
-    output = manager.update_weights_from_disk(_disk_req(flush_cache=True))
-
-    assert output.success is True
-    # Both runners load from the same recv_req.model_path.
-    target_runner.update_weights_from_disk.assert_called_once()
-    draft_runner.update_weights_from_disk.assert_called_once()
-    manager.flush_cache.assert_called_once()
-
-
-def test_disk_update_flushes_on_target_success_even_when_draft_fails():
-    # Pre-refactor behavior preserved: the target's KV cache is flushed off the
-    # target's own success, independent of a later draft failure; the overall result
-    # still reports the failure.
-    target_runner = Mock()
-    target_runner.update_weights_from_disk.return_value = (True, "ok")
-    draft_runner = Mock()
-    draft_runner.update_weights_from_disk.return_value = (False, "draft boom")
-    manager = _disk_manager(target_runner, draft_runner)
-
-    output = manager.update_weights_from_disk(_disk_req(flush_cache=True))
-
-    assert output.success is False
-    assert "draft boom" in output.message
-    manager.flush_cache.assert_called_once()
-
-
-def test_disk_update_target_failure_short_circuits_draft_and_flush():
-    # The target runs first; its failure stops the fanout before the draft and skips
-    # the flush (target never succeeded).
-    target_runner = Mock()
-    target_runner.update_weights_from_disk.return_value = (False, "target boom")
-    draft_runner = Mock()
-    manager = _disk_manager(target_runner, draft_runner)
-
-    output = manager.update_weights_from_disk(_disk_req(flush_cache=True))
-
-    assert output.success is False
-    assert "target boom" in output.message
-    draft_runner.update_weights_from_disk.assert_not_called()
-    manager.flush_cache.assert_not_called()
 
 
 def _session_manager(target_runner, draft_runner):

--- a/test/srt/test_distributed_weight_update_spec_worker.py
+++ b/test/srt/test_distributed_weight_update_spec_worker.py
@@ -1,7 +1,9 @@
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from sglang.srt.managers.io_struct import (
+    BeginWeightUpdateReqInput,
+    EndWeightUpdateReqInput,
     UpdateWeightFromDiskReqInput,
     UpdateWeightsFromDistributedReqInput,
 )
@@ -156,3 +158,86 @@ def test_disk_update_target_failure_short_circuits_draft_and_flush():
     assert "target boom" in output.message
     draft_runner.update_weights_from_disk.assert_not_called()
     manager.flush_cache.assert_not_called()
+
+
+def _session_manager(target_runner, draft_runner):
+    return _manager(
+        tp_worker=SimpleNamespace(iter_runners=lambda: [("", target_runner)]),
+        draft_worker=SimpleNamespace(iter_runners=lambda: [("draft", draft_runner)]),
+    )
+
+
+def test_begin_weight_update_restores_target_and_draft():
+    # The session begins on every runner (target + draft): the draft model is
+    # restored to a loadable state identically to the target.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_in_progress = False
+
+    with patch("torch.distributed.barrier"):
+        output = manager.begin_weight_update(BeginWeightUpdateReqInput())
+
+    assert output.success is True
+    target_runner.begin_weight_update.assert_called_once_with()
+    draft_runner.begin_weight_update.assert_called_once_with()
+    assert manager._weight_update_in_progress is True
+    assert manager._weight_update_loaded is False
+
+
+def test_end_weight_update_runs_post_load_on_both_when_load_was_bypassed():
+    # No load_weights happened this session (e.g. P2P/RDMA), so end runs
+    # post_load_weights then quant finalize on BOTH target and draft.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_loaded = False
+
+    with patch("torch.distributed.barrier"):
+        output = manager.end_weight_update(EndWeightUpdateReqInput())
+
+    assert output.success is True
+    target_runner.end_weight_update.assert_called_once_with(run_post_load=True)
+    draft_runner.end_weight_update.assert_called_once_with(run_post_load=True)
+    assert manager._weight_update_in_progress is False
+
+
+def test_end_weight_update_skips_post_load_on_both_when_weights_loaded():
+    # A distributed/tensor load happened this session, so post_load is skipped on
+    # both runners; only quant finalize runs.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_loaded = True
+
+    with patch("torch.distributed.barrier"):
+        manager.end_weight_update(EndWeightUpdateReqInput())
+
+    target_runner.end_weight_update.assert_called_once_with(run_post_load=False)
+    draft_runner.end_weight_update.assert_called_once_with(run_post_load=False)
+
+
+def test_model_runner_begin_end_wire_to_loader_hooks():
+    # ModelRunner.begin/end delegate to the loader: begin restores; end runs
+    # post_load only when requested, always finalizes quant layout.
+    import sglang.srt.model_executor.model_runner as mr
+
+    runner = SimpleNamespace(model=object(), device="cpu")
+
+    with patch.object(mr, "restore_weight") as restore:
+        mr.ModelRunner.begin_weight_update(runner)
+    restore.assert_called_once()
+
+    with patch.object(mr, "post_load_weights") as post_load, patch.object(
+        mr, "postprocess_weight"
+    ) as postprocess:
+        mr.ModelRunner.end_weight_update(runner, run_post_load=True)
+    post_load.assert_called_once()
+    postprocess.assert_called_once()
+
+    with patch.object(mr, "post_load_weights") as post_load, patch.object(
+        mr, "postprocess_weight"
+    ) as postprocess:
+        mr.ModelRunner.end_weight_update(runner, run_post_load=False)
+    post_load.assert_not_called()
+    postprocess.assert_called_once()


### PR DESCRIPTION
## Summary
Unify weight-update runner fanout via a per-worker abstraction; extend begin/end to the draft

## Motivation
The scheduler reached weight-update runners two asymmetric ways — `tp_worker.model_runner` for the target, `draft_worker.iter_draft_runners()` for the draft — and `begin_weight_update` / `end_weight_update` ran on the target only, so the draft/MTP model was loaded with fresh weights yet never had its packed weights restored before the load or its quant layout finalized after. The from-disk and from-ipc paths are intentionally left unchanged here, scoping this PR to the distributed/tensor session; the Engine/HTTP API plus default behavior stay unchanged.

## Before / After
- **Before:** target runners came from `tp_worker.model_runner`, draft runners from `draft_worker.iter_draft_runners()`; begin/end ran on the target only.
- **After:** every worker exposes a uniform `iter_runners()`; `iter_weight_update_workers(selector)` picks participants; `get_model_runners` derives the runner list; begin/end fan out through it to the draft too.
- **What moved where:** `begin_weight_update` / `end_weight_update` bodies (`restore_weight` / `post_load_weights` / `postprocess_weight`) moved from `BaseTpWorker` onto `ModelRunner`.

## Behavior Preservation
- **Default fanout:** selector `"all"` keeps the target plus draft updated together.
- **Draft begin/end:** the draft now receives the same restore plus finalize as the target — a no-op for an unquantized draft, the fix for a quantized one previously loaded yet never restored.
- **Session selector:** `begin_weight_update` records its selector, reused by `end_weight_update`; a second begin during an open session is rejected.

## Verification
- **Existing test suite:** `test/srt/test_distributed_weight_update_spec_worker.py` passes 9 cases covering distributed selector fanout, begin/end draft fanout, both `run_post_load` branches, the begin-recorded session selector reused by end, begin re-entrancy rejection.

## Review Focus
- Scrutinize `ModelRunner.end_weight_update`: `run_post_load` is computed once from `_weight_update_loaded`, applied to every selected runner.
- Scrutinize `begin_weight_update`: the recorded `_weight_update_selector` is exactly what `end_weight_update` finalizes.
- Scrutinize `iter_runners` on `DFlashWorker`: it stays explicit so `__getattr__` does not delegate to the target.
