### PR TITLE
[router] Align sgl_router_ttft_seconds buckets with engine TTFT grid

### DIFF
--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -55,11 +55,34 @@ const OVERLAP_BLOCKS_BUCKETS: &[f64] = &[
 ];
 
 /// Histogram bucket upper bounds (seconds) for
-/// `sgl_router_request_duration_seconds` and `sgl_router_ttft_seconds`.
-/// Standard latency ladder spanning 5 ms → 30 s; the `+Inf` bucket catches
-/// anything slower (a request that outlives the upstream's own timeouts).
+/// `sgl_router_request_duration_seconds`. Standard latency ladder spanning
+/// 5 ms → 30 s; the `+Inf` bucket catches anything slower (a request that
+/// outlives the upstream's own timeouts).
 const REQUEST_DURATION_BUCKETS: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+];
+
+/// Histogram bucket upper bounds (seconds) for `sgl_router_ttft_seconds`.
+///
+/// From 0.1 s up these edges are IDENTICAL to the SGLang engine's
+/// `sglang:time_to_first_token_seconds` histogram (defined in
+/// `python/sglang/srt/observability/metrics_collector.py`). Matching edges is
+/// what makes a `histogram_quantile` comparison between the router and the
+/// engine meaningful: the quantile interpolates within the same bucket on both
+/// sides, so `quantile(router) - quantile(engine)` reflects real router
+/// overhead rather than grid skew. With mismatched grids the two interpolations
+/// run on different bucket widths and the difference can even go negative — the
+/// router P50 reading *below* the engine P50 despite the router sitting in
+/// front of it.
+///
+/// The four sub-100 ms edges have no engine counterpart (the engine's first
+/// bucket is `[0, 0.1]`, so it cannot resolve a sub-100 ms TTFT at all). They
+/// are router-only headroom: harmless for the comparison (they sit below the
+/// engine's range) while letting the router resolve a genuinely fast TTFT.
+const TTFT_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, // router-only sub-100 ms head
+    0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 20.0, 40.0, 60.0, 80.0, 100.0, 200.0,
+    400.0,
 ];
 
 /// Recordable outcome for a request — narrowed to a handful of variants so
@@ -332,8 +355,9 @@ impl MetricsRegistry {
     /// the interval from request receipt to the first response chunk arriving
     /// from the upstream worker. Recorded only for successful *streaming*
     /// responses; non-streaming "first token" equals total latency, which
-    /// `sgl_router_request_duration_seconds` already captures. Shares the
-    /// latency bucket ladder ([`REQUEST_DURATION_BUCKETS`]).
+    /// `sgl_router_request_duration_seconds` already captures. Uses
+    /// [`TTFT_BUCKETS`], whose edges align with the engine's TTFT histogram so
+    /// the two are directly comparable in `histogram_quantile`.
     pub fn observe_ttft(&self, model_id: &str, seconds: f64) {
         // See `observe_request_duration` — drop non-finite before the map.
         if !seconds.is_finite() {
@@ -342,7 +366,7 @@ impl MetricsRegistry {
         let mut guard = self.ttft_seconds.lock();
         let hist = guard
             .entry(model_id.to_owned())
-            .or_insert_with(|| Histogram::new(REQUEST_DURATION_BUCKETS));
+            .or_insert_with(|| Histogram::new(TTFT_BUCKETS));
         hist.observe(seconds);
     }
 
@@ -821,8 +845,31 @@ mod tests {
             out.contains(r#"sgl_router_ttft_seconds_bucket{model_id="tiny",le="0.05"} 1"#),
             "expected le=0.05 bucket = 1; got:\n{out}",
         );
-        // le=0.25 is cumulative over both observations.
-        assert!(out.contains(r#"sgl_router_ttft_seconds_bucket{model_id="tiny",le="0.25"} 2"#));
+        // le=0.2 (an engine-aligned edge) is cumulative over both observations.
+        assert!(out.contains(r#"sgl_router_ttft_seconds_bucket{model_id="tiny",le="0.2"} 2"#));
+    }
+
+    #[test]
+    fn ttft_buckets_align_with_engine_grid() {
+        // The engine's `sglang:time_to_first_token_seconds` edges from 0.1 s up.
+        // These MUST all appear verbatim in the router's TTFT histogram, else a
+        // `histogram_quantile` comparison silently interpolates on mismatched
+        // grids. The sub-100 ms head (0.005..0.05) is router-only and not
+        // asserted here.
+        let reg = MetricsRegistry::new();
+        reg.observe_ttft("m", 0.5);
+        let out = reg.render();
+        for le in [
+            "0.1", "0.2", "0.4", "0.6", "0.8", "1", "2", "4", "6", "8", "10", "20", "40", "60",
+            "80", "100", "200", "400",
+        ] {
+            assert!(
+                out.contains(&format!(
+                    r#"sgl_router_ttft_seconds_bucket{{model_id="m",le="{le}"}}"#
+                )),
+                "missing engine-aligned TTFT bucket le={le}; got:\n{out}",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The experimental `sgl-router` records `sgl_router_ttft_seconds` on the
generic latency ladder it shares with request-duration
(`0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30`), while the
SGLang engine records `sglang:time_to_first_token_seconds` on a different
grid (`0.1, 0.2, 0.4, 0.6, 0.8, 1, 2, 4, 6, 8, 10, 20, 40, ...`).

`histogram_quantile` linearly interpolates the quantile **within whichever
bucket holds it, assuming uniform spread**. When the two histograms have
different bucket edges, the two interpolated quantiles sit on different
bucket widths, the error terms don't cancel, and a dashboard panel like:

```promql
histogram_quantile(0.5, sum by(le)(rate(sgl_router_ttft_seconds_bucket[$__rate_interval])))
- histogram_quantile(0.5, sum by(le)(rate(sglang_time_to_first_token_seconds_bucket[$__rate_interval])))
```

can go **negative** — the router P50 reading below the engine P50 despite the
router sitting in front of the engine. The sign flips with load (it depends
on where the bucket-mass fraction lands relative to each grid's edges), which
is why it shows up only "sometimes".

### Measured on a live DeepSeek-V4-Flash PD deployment

Re-binning the **same** engine TTFT samples from the engine grid onto the
router's coarser grid:

| Grid | Computed P50 |
|---|---|
| Engine's own grid | **0.629 s** |
| Router's coarser grid (same data) | **0.742 s** |

An ~110 ms swing from bucket choice alone — the same order of magnitude as
the router overhead the metric is meant to surface. In the 0.25–1 s band
where this deployment's TTFT lives, the router grid (`0.25, 0.5, 1`) is
actually *coarser* than the engine grid (`0.2, 0.4, 0.6, 0.8, 1`), so the
router's wide `[0.5, 1.0]` bucket is the main culprit.

## Change

Give TTFT its own bucket constant `TTFT_BUCKETS`, decoupled from
`REQUEST_DURATION_BUCKETS`. From `0.1 s` up the edges are **identical** to the
engine's, so `histogram_quantile` lands in the same bucket on both sides and
the router-vs-engine difference reflects real overhead instead of grid skew.

Four sub-100 ms edges (`0.005, 0.01, 0.025, 0.05`) are kept as router-only
headroom: the engine's first bucket is `[0, 0.1]` and can't resolve a
sub-100 ms TTFT at all, so these are harmless for the comparison while letting
the router resolve a genuinely fast TTFT.

## Tests

- Updated `observe_ttft_writes_buckets_sum_and_count` (old grid asserted
  `le="0.25"`, which no longer exists → `le="0.2"`).
- Added `ttft_buckets_align_with_engine_grid`, which asserts every
  engine-aligned edge (`0.1 … 400`) is present in the router histogram, so the
  grids can't silently drift apart again.
- `cargo test --lib server::metrics` (18 pass), `cargo clippy`, `cargo fmt`,
  pre-commit all clean.

## Compatibility note

This changes the histogram bucket layout. Dashboards/alerts that **hardcode**
specific `le=` values for `sgl_router_ttft_seconds` need updating.
`histogram_quantile` queries (which don't hardcode `le`) keep working and get
more accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27810846212](https://github.com/sgl-project/sglang/actions/runs/27810846212)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27834591123](https://github.com/sgl-project/sglang/actions/runs/27834591123)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->