### PR TITLE
[CI] Fail fast on empty install_script in Rerun Test workflow

### DIFF
--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -112,6 +112,16 @@ jobs:
           if [[ "${{ inputs.runs_on }}" == "1-gpu-5090" ]]; then
             source /etc/profile.d/sglang-ci.sh
           fi
+          # Fail fast on an empty install_script. `bash <empty>` is a silent
+          # no-op that "succeeds" without installing sglang, so the test step
+          # then dies with `ModuleNotFoundError: No module named 'sglang'`.
+          # /rerun-test resolves install_script from runner_configs.yml; a manual
+          # workflow_dispatch must pass it explicitly (it can't be derived from
+          # runs_on, which is shared across configs, e.g. default vs deepep).
+          if [ -z "${{ inputs.install_script }}" ]; then
+            echo "::error::install_script is required for cuda mode (empty would silently skip installing sglang). Pass e.g. scripts/ci/cuda/ci_install_dependency.sh"
+            exit 1
+          fi
           bash ${{ inputs.install_script }}
 
       - name: Run test


### PR DESCRIPTION
A manual `Rerun Test` `workflow_dispatch` can leave `install_script` empty. The install step then runs `bash` with no argument — a silent no-op that "succeeds" without installing sglang, so the test step dies with `ModuleNotFoundError: No module named 'sglang'` (and only runs ~14s). Fail fast with a clear error instead. The `/rerun-test` comment path is unaffected (it resolves `install_script` from `runner_configs.yml`).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27816111070](https://github.com/sgl-project/sglang/actions/runs/27816111070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27816110940](https://github.com/sgl-project/sglang/actions/runs/27816110940)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->