### PR TITLE
[UnifiedTree] Use dense model for HiCache+CP KL tests 

### DIFF
--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_cp.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_cp.py
@@ -13,11 +13,11 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=950, stage="extra-b", runner_config="4-gpu-h100")
 
-QWEN3_30B_MODEL = "Qwen/Qwen3-30B-A3B-FP8"
+QWEN3_32B_MODEL = "Qwen/Qwen3-32B"
 
 
 class TestUnifiedQwen3HiCacheCP(UnifiedRadixTreeTestMixin, CustomTestCase):
-    """Qwen3-30B-A3B-FP8 + HiCache + CP + UnifiedRadixCache."""
+    """Qwen3-32B + HiCache + CP + UnifiedRadixCache."""
 
     hicache_io_backend = "kernel"
     hicache_mem_layout = "page_first"
@@ -28,7 +28,7 @@ class TestUnifiedQwen3HiCacheCP(UnifiedRadixTreeTestMixin, CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.model = QWEN3_30B_MODEL
+        cls.model = QWEN3_32B_MODEL
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
             cls.model,
@@ -37,10 +37,6 @@ class TestUnifiedQwen3HiCacheCP(UnifiedRadixTreeTestMixin, CustomTestCase):
             other_args=[
                 "--trust-remote-code",
                 "--tp-size",
-                "4",
-                "--moe-dp-size",
-                "1",
-                "--ep-size",
                 "4",
                 "--attn-cp-size",
                 "2",
@@ -51,6 +47,8 @@ class TestUnifiedQwen3HiCacheCP(UnifiedRadixTreeTestMixin, CustomTestCase):
                 "32",
                 "--max-running-requests",
                 str(cls.max_running_requests),
+                "--max-total-tokens",
+                "14000",  # loadback trigger
                 "--disable-piecewise-cuda-graph",
                 "--model-loader-extra-config",
                 '{"enable_multithread_load": true, "num_threads": 64}',


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In issue https://github.com/sgl-project/sglang/issues/28023#issuecomment-4732689963, it was revealed that the Qwen3-32B is a much less noisy model for the KL test with CP than the current Qwen3-30B-A3B used.

Results of 12 repeated tests:
```
============================================================================================================================
config                            cap    T reps mean_smpl  p99_smpl  max_smpl   max_avg  avg_over  smpl_over  verdict
----------------------------------------------------------------------------------------------------------------------------
TestDenseCpLoadback             14000  1.0   12   0.00067   0.00204   0.00286   0.00116    0/12      0/48          ok
TestDenseCpNoLoadback           60000  1.0   12   0.00060   0.00105   0.00117   0.00074    0/12      0/48          ok
TestDenseTpLoadback             14000  1.0   12   0.00057   0.00092   0.00093   0.00074    0/12      0/48          ok
TestDenseCpLoadbackGreedy       14000  0.0   12   0.00010   0.00041   0.00049   0.00015    0/12      0/48          ok
TestDenseCpNoLoadbackGreedy     60000  0.0   12   0.00011   0.00045   0.00045   0.00017    0/12      0/48          ok
TestMoeCpLoadback               14000  1.0   12   0.00307   0.01134   0.01196   0.00763    1/12      7/48        FAIL
TestMoeCpNoLoadback             60000  1.0   12   0.00423   0.04625   0.07810   0.02103    1/12      7/48        FAIL
TestMoeTpLoadback               14000  1.0   12   0.00304   0.01350   0.01453   0.00858    2/12     10/48        FAIL
TestMoeCpLoadbackGreedy         14000  0.0   12   0.00072   0.01044   0.01173   0.00521    1/12      2/48        FAIL
TestMoeCpNoLoadbackGreedy       60000  0.0   12   0.00066   0.01135   0.01724   0.00547    1/12      1/48        FAIL
============================================================================================================================
```

## Modifications

Model changed
`max-total-tokens` added to trigger loadback

## Accuracy Tests

```
pytest test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_cp.py
======================================================================================================================================= test session starts ========================================================================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /workspace/forks/sglang/test
configfile: pytest.ini
plugins: anyio-4.13.0, typeguard-4.5.2
collected 5 items

test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_cp.py .....                                                                                                                                                                                                       [100%]

============================================================================================================================ 5 passed, 9 warnings in 236.79s (0:03:56) =============================================================================================================================
```







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27824827785](https://github.com/sgl-project/sglang/actions/runs/27824827785)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27824827627](https://github.com/sgl-project/sglang/actions/runs/27824827627)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->