### PR TITLE
[Diffusion] Fix FastWan2.1 default 480p resolution

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/wan.py
+++ b/python/sglang/multimodal_gen/configs/sample/wan.py
@@ -171,7 +171,7 @@ class FastWanT2V480PConfig(WanT2V_1_3B_SamplingParams):
     # dmd_denoising_steps: list[int] | None = field(default_factory=lambda: [1000, 757, 522])
     num_inference_steps: int = 3
     num_frames: int = 61
-    height: int = 448
+    height: int = 480
     width: int = 832
     fps: int = 16
 

--- a/python/sglang/multimodal_gen/test/unit/test_sampling_params.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sampling_params.py
@@ -24,6 +24,7 @@ from sglang.multimodal_gen.configs.sample.sampling_params import (
 )
 from sglang.multimodal_gen.configs.sample.teacache import TeaCacheParams
 from sglang.multimodal_gen.configs.sample.wan import (
+    FastWanT2V480PConfig,
     WanI2V_14B_480P_SamplingParam,
     WanI2V_14B_720P_SamplingParam,
     WanT2V_1_3B_SamplingParams,
@@ -101,6 +102,12 @@ class TestSamplingParamsSubclass(unittest.TestCase):
     def test_diffusers_generic_calls_base_post_init(self):
         with self.assertRaises(AssertionError):
             DiffusersGenericSamplingParams(num_frames=0)
+
+    def test_fastwan_480p_default_resolution_is_supported(self):
+        params = FastWanT2V480PConfig()
+
+        self.assertEqual((params.width, params.height), (832, 480))
+        self.assertIn((params.width, params.height), params.supported_resolutions)
 
     def test_output_file_name_supports_callable_teacache_params(self):
         def coefficients_callback(_: TeaCacheParams) -> list[float]:


### PR DESCRIPTION
## Summary

**This PR fixes: FastWan2.1 T2V default sampling requested `832x448`, while the `FastWanT2V480PConfig` class and model support table define the 480p landscape size as `832x480`.**

Before this PR, the default path generated at an unsupported resolution and emitted this warning:

```text
Unsupported resolution: 832x448, output quality may suffer. Supported resolutions: 832x480, 480x832
```

The fix changes the default height from `448` to `480`, and adds a regression test that checks the FastWan2.1 default `(width, height)` is included in `supported_resolutions`.

## Generated Video Comparison

Prompt:

```text
A calm cinematic shot of a red tram crossing a rainy city street at night, neon reflections on wet pavement, smooth camera motion
```

Run settings: seed `42`, `61` frames, `16` fps, `3` steps, `ion-b200` GPU4.

| Run | Size | Unsupported warning | SHA256 | Artifact |
| --- | ---: | --- | --- | --- |
| `main` default | `832x448` | yes | `4bbd553f7535d106ca19ecffb9301757261c7b1e749ab818280b54efd7875a45` | [main_default.mp4](https://github.com/BBuf/sglang/releases/download/fastwan21-resolution-validation-20260620/main_default.mp4) |
| `main --width 832 --height 480` | `832x480` | no | `64c19f1a42346c9fa535f7cfb732ca97101ea3569a266110d540d3e1386581e7` | [main_explicit_480p.mp4](https://github.com/BBuf/sglang/releases/download/fastwan21-resolution-validation-20260620/main_explicit_480p.mp4) |
| this PR default | `832x480` | no | `64c19f1a42346c9fa535f7cfb732ca97101ea3569a266110d540d3e1386581e7` | [pr_default.mp4](https://github.com/BBuf/sglang/releases/download/fastwan21-resolution-validation-20260620/pr_default.mp4) |

`main` with explicit `832x480` and this PR's default output are byte-identical, so the PR does not introduce a new generation path. It makes the default request match the already-supported 480p path.

Default before/after:

![main default vs PR default](https://github.com/BBuf/sglang/releases/download/fastwan21-resolution-validation-20260620/main_default_vs_pr_default.gif)

Supported-control comparison:

![main explicit 480p vs PR default](https://github.com/BBuf/sglang/releases/download/fastwan21-resolution-validation-20260620/main_explicit_480p_vs_pr_default.gif)

Frame 30 contact sheet: `main` default / `main` explicit 480p / this PR default

![frame30 contact sheet](https://github.com/BBuf/sglang/releases/download/fastwan21-resolution-validation-20260620/frame30_contact_sheet.jpg)

Full artifact bundle: https://github.com/BBuf/sglang/releases/tag/fastwan21-resolution-validation-20260620

## Benchmark

This is a correctness/config fix, not a speed optimization. Timings below are one-off `sglang generate` runs after the model cache was available. The first denoising step includes initialization/JIT overhead, so small run-to-run drift is expected.

| Run | Total pixel generation | Text encode | Denoise | Decode | Peak reserved memory | Perf dump |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| `main` default `832x448` | 15.48s | 0.83s | 13.20s | 1.43s | 17,874 MB | [json](https://github.com/BBuf/sglang/releases/download/fastwan21-resolution-validation-20260620/main_default_perf.json) |
| `main` explicit `832x480` | 16.79s | 1.19s | 14.14s | 1.44s | 20,278 MB | [json](https://github.com/BBuf/sglang/releases/download/fastwan21-resolution-validation-20260620/main_explicit_480p_perf.json) |
| this PR default `832x480` | 18.75s | 1.31s | 14.96s | 2.23s | 17,476 MB | [json](https://github.com/BBuf/sglang/releases/download/fastwan21-resolution-validation-20260620/pr_default_perf.json) |

## Reproduce

```bash
CUDA_VISIBLE_DEVICES=4 \
HF_HOME=/tmp/hfc_fastwan21_resolution_pr \
FLASHINFER_DISABLE_VERSION_CHECK=1 \
PYTHONPATH=python \
sglang generate \
  --model-path FastVideo/FastWan2.1-T2V-1.3B-Diffusers \
  --prompt "A calm cinematic shot of a red tram crossing a rainy city street at night, neon reflections on wet pavement, smooth camera motion" \
  --seed 42 \
  --save-output \
  --output-path /home/sglang-omni/bbuf/fastwan21_resolution_pr_artifacts_20260620/pr_default \
  --output-file-name pr_default.mp4 \
  --perf-dump-path /home/sglang-omni/bbuf/fastwan21_resolution_pr_artifacts_20260620/pr_default_perf.json
```

Temporary validation cache was removed after the run:

```bash
rm -rf /tmp/hfc_fastwan21_resolution_pr
```

## Tests

- `git diff --check`
- `PYTHONPATH=python python3 -m pytest python/sglang/multimodal_gen/test/unit/test_sampling_params.py -q`
  - B200 container result: `26 passed, 20 warnings, 8 subtests passed`
- Three GPU generation checks listed above on `ion-b200` GPU4.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27837525178](https://github.com/sgl-project/sglang/actions/runs/27837525178)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27837708497](https://github.com/sgl-project/sglang/actions/runs/27837708497)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->