### PR TITLE
[Quant] Add ScaleSweep MSE NVFP4 activation quantization (#27246)

### DIFF
--- a/python/sglang/srt/layers/quantization/fp4_utils.py
+++ b/python/sglang/srt/layers/quantization/fp4_utils.py
@@ -168,3 +168,38 @@ def get_fp4_gemm_runner_backend() -> Fp4GemmRunnerBackend:
     if FP4_GEMM_RUNNER_BACKEND is None:
         FP4_GEMM_RUNNER_BACKEND = Fp4GemmRunnerBackend.AUTO
     return FP4_GEMM_RUNNER_BACKEND
+
+
+# NVFP4 activation-quantization algorithm: "absmax" (default flashinfer path)
+# or "scalesweep" (ScaleSweep MSE, see sgl-project/sglang#27246).
+FP4_QUANT_ALGO: str = "absmax"
+
+
+def initialize_fp4_quant_config(server_args: ServerArgs) -> None:
+    """Initialize the NVFP4 activation-quant algorithm from server args."""
+    global FP4_QUANT_ALGO
+    FP4_QUANT_ALGO = server_args.fp4_quant_algo
+
+
+def get_fp4_quant_algo() -> str:
+    """Get the selected NVFP4 activation-quant algorithm."""
+    return FP4_QUANT_ALGO
+
+
+def fp4_quantize_activation(
+    input: torch.Tensor, input_scale_inv: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize activations to NVFP4, dispatching on the selected algorithm.
+
+    Returns ``(packed uint8 FP4, swizzled FP8-E4M3 block scales)`` matching the
+    flashinfer ``fp4_quantize`` output, so it is drop-in for the FP4 GEMM.
+    """
+    if get_fp4_quant_algo() == "scalesweep":
+        from sglang.srt.layers.quantization.scalesweep_nvfp4 import (
+            scaled_fp4_quant as _scalesweep_fp4_quant,
+        )
+
+        return _scalesweep_fp4_quant(
+            input, input_scale_inv, is_sf_swizzled_layout=True
+        )
+    return fp4_quantize(input, input_scale_inv)

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -39,6 +39,7 @@ from sglang.srt.layers.quantization.base_config import (
 )
 from sglang.srt.layers.quantization.fp4_utils import (
     fp4_quantize,
+    fp4_quantize_activation,
     get_fp4_gemm_runner_backend,
 )
 from sglang.srt.layers.quantization.fp8_kernel import scaled_fp8_quant
@@ -1646,7 +1647,9 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
             x_m = x_fp4.shape[0]
             output_dtype = layer.params_dtype
         else:
-            x_fp4, x_scale_interleaved = fp4_quantize(x, layer.input_scale_inv)
+            x_fp4, x_scale_interleaved = fp4_quantize_activation(
+                x, layer.input_scale_inv
+            )
             x_m, _ = x.shape
             output_dtype = x.dtype
 

--- a/python/sglang/srt/layers/quantization/scalesweep_nvfp4/__init__.py
+++ b/python/sglang/srt/layers/quantization/scalesweep_nvfp4/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+# ScaleSweep NVFP4 quantization, ported from https://github.com/efsotr/nvfp4quant_test
+# (MIT License, Copyright (c) 2026 Li Lin). See issue sgl-project/sglang#27246.
+from sglang.srt.layers.quantization.scalesweep_nvfp4.scalesweep_mse_nvfp4_quant import (
+    scaled_fp4_quant,
+    scalesweep_mse_nvfp4_quant,
+)
+
+__all__ = ["scaled_fp4_quant", "scalesweep_mse_nvfp4_quant"]

--- a/python/sglang/srt/layers/quantization/scalesweep_nvfp4/absmax_nvfp4_quant_simulate.py
+++ b/python/sglang/srt/layers/quantization/scalesweep_nvfp4/absmax_nvfp4_quant_simulate.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+# Ported from https://github.com/efsotr/nvfp4quant_test (MIT, Copyright (c) 2026
+# Li Lin) for sgl-project/sglang#27246. ScaleSweep MSE NVFP4 quantization.
+
+import torch
+
+try:
+    from .scalesweep_mse_nvfp4_quant_simulate import (
+        BLOCK_SIZE,
+        create_fp4_output_tensors,
+        round_up,
+    )
+except ImportError:
+    from scalesweep_mse_nvfp4_quant_simulate import (
+        BLOCK_SIZE,
+        create_fp4_output_tensors,
+        round_up,
+    )
+
+
+def _torch_round_to_fp4_code(x: torch.Tensor) -> torch.Tensor:
+    ax = torch.abs(x)
+    le2 = ax <= 2.0
+    le4 = ax <= 4.0
+    exp = torch.where(le2, 0.5, torch.where(le4, 1.0, 2.0))
+    r = torch.floor(ax / exp + 0.5)
+    mag = torch.where(le2, r, torch.where(le4, r + 2.0, torch.clamp(r + 4.0, max=7.0))).to(torch.uint8)
+    sign = (x < 0.0).to(torch.uint8) << 3
+    return mag | sign
+
+
+def _swizzled_scale_indices(
+    num_blocks: int,
+    blocks_per_out: int,
+    blocks_per_out_pad: int,
+    device: torch.device,
+) -> torch.Tensor:
+    block_offsets = torch.arange(num_blocks, device=device, dtype=torch.int64)
+    row = block_offsets // blocks_per_out
+    col = block_offsets % blocks_per_out
+
+    major_m = row >> 7
+    row_in_tile = row & 127
+    tile_m = row_in_tile >> 5
+    inner_m = row_in_tile & 31
+
+    major_k = col >> 2
+    inner_k = col & 3
+
+    return (
+        major_m * (blocks_per_out_pad * 128)
+        + major_k * 512
+        + inner_m * 16
+        + tile_m * 4
+        + inner_k
+    )
+
+
+@torch.inference_mode()
+def absmax_nvfp4_quant_simulate(
+    input: torch.Tensor,
+    global_scale_inv: torch.Tensor,
+    is_sf_swizzled_layout: bool = True,
+    backend: str = "absmax_simulate",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del backend
+
+    assert input.ndim >= 1, f"input.ndim needs to be >= 1, but got {input.ndim}."
+    other_dims = 1 if input.ndim == 1 else -1
+    input = input.reshape(other_dims, input.shape[-1])
+    m, n = input.shape
+
+    assert n % BLOCK_SIZE == 0, (
+        f"last dim has to be multiple of {BLOCK_SIZE}, but got {n}."
+    )
+    assert input.dtype in (torch.float16, torch.bfloat16), (
+        f"input.dtype needs to be fp16 or bf16 but got {input.dtype}."
+    )
+    assert global_scale_inv.dtype == torch.float32, (
+        f"global_scale_inv.dtype needs to be fp32 but got {global_scale_inv.dtype}."
+    )
+
+    output, output_scale = create_fp4_output_tensors(
+        m,
+        n,
+        input.device,
+        is_sf_swizzled_layout,
+    )
+
+    blocks_per_out = n // BLOCK_SIZE
+    blocks = input.contiguous().view(m, blocks_per_out, BLOCK_SIZE).to(torch.float32)
+    blocks = blocks * global_scale_inv
+
+    scale = (torch.amax(torch.abs(blocks), dim=-1) * (1.0 / 6.0)).to(torch.float8_e4m3fn)
+    scale_f32 = scale.to(torch.float32)
+    inv_scale = torch.where(scale_f32 == 0.0, 0.0, 1.0 / scale_f32)
+
+    code = _torch_round_to_fp4_code(blocks * inv_scale.unsqueeze(-1))
+    packed = code[:, :, 0::2] | (code[:, :, 1::2] << 4)
+    output.copy_(packed.reshape(m, n // 2))
+
+    if is_sf_swizzled_layout:
+        indices = _swizzled_scale_indices(
+            m * blocks_per_out,
+            blocks_per_out,
+            round_up(blocks_per_out, 4),
+            input.device,
+        )
+        output_scale.view(-1)[indices] = scale.reshape(-1)
+    else:
+        output_scale.copy_(scale)
+
+    return output, output_scale
+
+
+scaled_fp4_quant_simulate = absmax_nvfp4_quant_simulate

--- a/python/sglang/srt/layers/quantization/scalesweep_nvfp4/scalesweep_mse_nvfp4_quant.py
+++ b/python/sglang/srt/layers/quantization/scalesweep_nvfp4/scalesweep_mse_nvfp4_quant.py
@@ -1,0 +1,446 @@
+# SPDX-License-Identifier: MIT
+# Ported from https://github.com/efsotr/nvfp4quant_test (MIT, Copyright (c) 2026
+# Li Lin) for sgl-project/sglang#27246. ScaleSweep MSE NVFP4 quantization.
+
+import torch
+import triton
+import triton.language as tl
+
+BLOCK_SIZE = 16
+LOWER_BOUND = -3
+UPPER_BOUND = 7
+FP4_E2M1_MAX = 6.0
+FP8_E4M3_MAX = 256.0
+REF_MAX_SCALE_RAW = 126
+
+
+def round_up(x: int, y: int) -> int:
+    return ((x + y - 1) // y) * y
+
+
+def create_fp4_scale_tensor(
+    m: int,
+    n: int,
+    device: torch.device,
+    is_sf_swizzled_layout: bool,
+) -> torch.Tensor:
+    if is_sf_swizzled_layout:
+        rounded_m = round_up(m, 128)
+        rounded_n = round_up(n // BLOCK_SIZE, 4)
+        return torch.empty((rounded_m, rounded_n), device=device, dtype=torch.float8_e4m3fn)
+    return torch.empty((m, n // BLOCK_SIZE), device=device, dtype=torch.float8_e4m3fn)
+
+
+def create_fp4_output_tensors(
+    m: int,
+    n: int,
+    device: torch.device,
+    is_sf_swizzled_layout: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    output = torch.empty((m, n // 2), device=device, dtype=torch.uint8)
+    output_scale = create_fp4_scale_tensor(m, n, device, is_sf_swizzled_layout)
+    return output, output_scale
+
+
+@triton.jit
+def swizzled_scale_offsets(
+    block_offsets,
+    BLOCKS_PER_OUT: tl.constexpr,
+    BLOCKS_PER_OUT_PAD: tl.constexpr,
+):
+    row = block_offsets // BLOCKS_PER_OUT
+    col = block_offsets % BLOCKS_PER_OUT
+
+    major_m = row >> 7
+    row_in_tile = row & 127
+    tile_m = row_in_tile >> 5
+    inner_m = row_in_tile & 31
+
+    major_k = col >> 2
+    inner_k = col & 3
+
+    return major_m * (BLOCKS_PER_OUT_PAD * 128) + major_k * 512 + inner_m * 16 + tile_m * 4 + inner_k
+
+
+@triton.jit
+def _fp32x16_to_e2m1_u32x2(
+    x0, x1, x2, x3,
+    x4, x5, x6, x7,
+    x8, x9, x10, x11,
+    x12, x13, x14, x15,
+):
+    lo, hi = tl.inline_asm_elementwise(
+        asm="""
+        {
+          .reg .b8 b0;
+          .reg .b8 b1;
+          .reg .b8 b2;
+          .reg .b8 b3;
+          .reg .b8 b4;
+          .reg .b8 b5;
+          .reg .b8 b6;
+          .reg .b8 b7;
+
+          cvt.rn.satfinite.e2m1x2.f32 b0,  $3,  $2;
+          cvt.rn.satfinite.e2m1x2.f32 b1,  $5,  $4;
+          cvt.rn.satfinite.e2m1x2.f32 b2,  $7,  $6;
+          cvt.rn.satfinite.e2m1x2.f32 b3,  $9,  $8;
+          cvt.rn.satfinite.e2m1x2.f32 b4,  $11, $10;
+          cvt.rn.satfinite.e2m1x2.f32 b5,  $13, $12;
+          cvt.rn.satfinite.e2m1x2.f32 b6,  $15, $14;
+          cvt.rn.satfinite.e2m1x2.f32 b7,  $17, $16;
+
+          mov.b32 $0, {b0, b1, b2, b3};
+          mov.b32 $1, {b4, b5, b6, b7};
+        }
+        """,
+        constraints="=r,=r,f,f,f,f,f,f,f,f,f,f,f,f,f,f,f,f",
+        args=[
+            x0, x1, x2, x3,
+            x4, x5, x6, x7,
+            x8, x9, x10, x11,
+            x12, x13, x14, x15,
+        ],
+        dtype=(tl.uint32, tl.uint32),
+        is_pure=True,
+        pack=1,
+    )
+    return lo, hi
+
+
+@triton.jit
+def _fp32x2_e2m1_quant_squared_error(x0, x1):
+    return tl.inline_asm_elementwise(
+        asm=r"""
+        {
+          .reg .b8  b;
+          .reg .b32 h;
+          .reg .b16 lo;
+          .reg .b16 hi;
+          .reg .f32 q0;
+          .reg .f32 q1;
+          .reg .f32 d0;
+          .reg .f32 d1;
+
+          cvt.rn.satfinite.e2m1x2.f32 b, $2, $1;
+          cvt.rn.f16x2.e2m1x2 h, b;
+
+          mov.b32 {lo, hi}, h;
+          cvt.f32.f16 q0, lo;
+          cvt.f32.f16 q1, hi;
+
+          sub.rn.f32 d0, q0, $1;
+          sub.rn.f32 d1, q1, $2;
+          mul.rn.f32 d0, d0, d0;
+          fma.rn.f32 $0, d1, d1, d0;
+        }
+        """,
+        constraints="=f,f,f",
+        args=[x0, x1],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _fp32x2_e2m1_quant_squared_error_acc(acc, x0, x1):
+    return tl.inline_asm_elementwise(
+        asm=r"""
+        {
+          .reg .b8  b;
+          .reg .b32 h;
+          .reg .b16 lo;
+          .reg .b16 hi;
+          .reg .f32 q0;
+          .reg .f32 q1;
+          .reg .f32 d0;
+          .reg .f32 d1;
+
+          cvt.rn.satfinite.e2m1x2.f32 b, $2, $1;
+          cvt.rn.f16x2.e2m1x2 h, b;
+
+          mov.b32 {lo, hi}, h;
+          cvt.f32.f16 q0, lo;
+          cvt.f32.f16 q1, hi;
+
+          sub.rn.f32 d0, q0, $1;
+          sub.rn.f32 d1, q1, $2;
+          fma.rn.f32 d0, d0, d0, $3;
+          fma.rn.f32 $0, d1, d1, d0;
+        }
+        """,
+        constraints="=f,f,f,f",
+        args=[x0, x1, acc],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _scaled_fp32x16_e2m1_quant_squared_error(
+    x0, x1, x2, x3,
+    x4, x5, x6, x7,
+    x8, x9, x10, x11,
+    x12, x13, x14, x15,
+):
+    err = _fp32x2_e2m1_quant_squared_error(x0, x1)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x2, x3)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x4, x5)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x6, x7)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x8, x9)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x10, x11)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x12, x13)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x14, x15)
+
+    return err
+
+
+@triton.jit
+def _fp32x16_e2m1_quant_squared_error(
+    v0, v1, v2, v3,
+    v4, v5, v6, v7,
+    v8, v9, v10, v11,
+    v12, v13, v14, v15,
+    inv_scale,
+    scale,
+):
+    squared_error = _scaled_fp32x16_e2m1_quant_squared_error(
+        v0 * inv_scale, v1 * inv_scale, v2 * inv_scale, v3 * inv_scale,
+        v4 * inv_scale, v5 * inv_scale, v6 * inv_scale, v7 * inv_scale,
+        v8 * inv_scale, v9 * inv_scale, v10 * inv_scale, v11 * inv_scale,
+        v12 * inv_scale, v13 * inv_scale, v14 * inv_scale, v15 * inv_scale,
+    )
+    return squared_error * (scale * scale)
+
+
+@triton.jit
+def _max_abs_16(
+    v0, v1, v2, v3,
+    v4, v5, v6, v7,
+    v8, v9, v10, v11,
+    v12, v13, v14, v15,
+):
+    m0 = tl.maximum(tl.abs(v0), tl.abs(v1))
+    m1 = tl.maximum(tl.abs(v2), tl.abs(v3))
+    m2 = tl.maximum(tl.abs(v4), tl.abs(v5))
+    m3 = tl.maximum(tl.abs(v6), tl.abs(v7))
+    m4 = tl.maximum(tl.abs(v8), tl.abs(v9))
+    m5 = tl.maximum(tl.abs(v10), tl.abs(v11))
+    m6 = tl.maximum(tl.abs(v12), tl.abs(v13))
+    m7 = tl.maximum(tl.abs(v14), tl.abs(v15))
+
+    m01 = tl.maximum(m0, m1)
+    m23 = tl.maximum(m2, m3)
+    m45 = tl.maximum(m4, m5)
+    m67 = tl.maximum(m6, m7)
+    return tl.maximum(tl.maximum(m01, m23), tl.maximum(m45, m67))
+
+
+@triton.jit
+def _load_normalized_16_cols(ptr, block_offsets, block_mask, global_scale_inv):
+    base_elem = block_offsets * 16
+
+    v0 = tl.load(ptr + base_elem + 0, mask=block_mask, other=0.0).to(tl.float32)
+    v1 = tl.load(ptr + base_elem + 1, mask=block_mask, other=0.0).to(tl.float32)
+    v2 = tl.load(ptr + base_elem + 2, mask=block_mask, other=0.0).to(tl.float32)
+    v3 = tl.load(ptr + base_elem + 3, mask=block_mask, other=0.0).to(tl.float32)
+    v4 = tl.load(ptr + base_elem + 4, mask=block_mask, other=0.0).to(tl.float32)
+    v5 = tl.load(ptr + base_elem + 5, mask=block_mask, other=0.0).to(tl.float32)
+    v6 = tl.load(ptr + base_elem + 6, mask=block_mask, other=0.0).to(tl.float32)
+    v7 = tl.load(ptr + base_elem + 7, mask=block_mask, other=0.0).to(tl.float32)
+    v8 = tl.load(ptr + base_elem + 8, mask=block_mask, other=0.0).to(tl.float32)
+    v9 = tl.load(ptr + base_elem + 9, mask=block_mask, other=0.0).to(tl.float32)
+    v10 = tl.load(ptr + base_elem + 10, mask=block_mask, other=0.0).to(tl.float32)
+    v11 = tl.load(ptr + base_elem + 11, mask=block_mask, other=0.0).to(tl.float32)
+    v12 = tl.load(ptr + base_elem + 12, mask=block_mask, other=0.0).to(tl.float32)
+    v13 = tl.load(ptr + base_elem + 13, mask=block_mask, other=0.0).to(tl.float32)
+    v14 = tl.load(ptr + base_elem + 14, mask=block_mask, other=0.0).to(tl.float32)
+    v15 = tl.load(ptr + base_elem + 15, mask=block_mask, other=0.0).to(tl.float32)
+
+    return (
+        v0 * global_scale_inv, v1 * global_scale_inv,
+        v2 * global_scale_inv, v3 * global_scale_inv,
+        v4 * global_scale_inv, v5 * global_scale_inv,
+        v6 * global_scale_inv, v7 * global_scale_inv,
+        v8 * global_scale_inv, v9 * global_scale_inv,
+        v10 * global_scale_inv, v11 * global_scale_inv,
+        v12 * global_scale_inv, v13 * global_scale_inv,
+        v14 * global_scale_inv, v15 * global_scale_inv,
+    )
+
+
+SCALESWEEP_CONFIGS = [
+    triton.Config({"BLOCKS_PER_PROGRAM": 32}, num_warps=1),
+    triton.Config({"BLOCKS_PER_PROGRAM": 64}, num_warps=2),
+    triton.Config({"BLOCKS_PER_PROGRAM": 128}, num_warps=4),
+    triton.Config({"BLOCKS_PER_PROGRAM": 256}, num_warps=8),
+    triton.Config({"BLOCKS_PER_PROGRAM": 512}, num_warps=16),
+    triton.Config({"BLOCKS_PER_PROGRAM": 1024}, num_warps=32),
+]
+
+
+@triton.autotune(
+    configs=SCALESWEEP_CONFIGS,
+    key=[
+        "NUM_BLOCKS",
+        "LOWER_BOUND",
+        "NUM_CANDIDATES",
+        "MAX_SCALE_RAW",
+        "BLOCKS_PER_OUT",
+        "BLOCKS_PER_OUT_PAD",
+        "IS_SWIZZLE_SCALE",
+    ],
+)
+@triton.jit
+def _scalesweep_mse_nvfp4_quant_kernel(
+    input_ptr,
+    output_scale_ptr,
+    output_i32_ptr,
+    global_scale_inv_ptr,
+    NUM_BLOCKS: tl.constexpr,
+    BLOCKS_PER_OUT: tl.constexpr,
+    LOWER_BOUND: tl.constexpr,
+    NUM_CANDIDATES: tl.constexpr,
+    MAX_SCALE_RAW: tl.constexpr,
+    IS_SWIZZLE_SCALE: tl.constexpr,
+    BLOCKS_PER_OUT_PAD: tl.constexpr,
+    BLOCKS_PER_PROGRAM: tl.constexpr,
+):
+    global_scale_inv = tl.load(global_scale_inv_ptr)
+    pid = tl.program_id(0)
+    block_offsets = pid * BLOCKS_PER_PROGRAM + tl.arange(0, BLOCKS_PER_PROGRAM)
+    block_mask = block_offsets < NUM_BLOCKS
+
+    (
+        v0, v1, v2, v3,
+        v4, v5, v6, v7,
+        v8, v9, v10, v11,
+        v12, v13, v14, v15,
+    ) = _load_normalized_16_cols(input_ptr, block_offsets, block_mask, global_scale_inv)
+
+    abs_max = _max_abs_16(
+        v0, v1, v2, v3,
+        v4, v5, v6, v7,
+        v8, v9, v10, v11,
+        v12, v13, v14, v15,
+    )
+    base_scale = abs_max * (1.0 / 6.0)
+    base_raw = base_scale.to(tl.float8e4nv).to(tl.uint8, bitcast=True).to(tl.int32)
+
+    best_mse = tl.full((BLOCKS_PER_PROGRAM,), float("inf"), tl.float32)
+    best_scale_fp8 = tl.full((BLOCKS_PER_PROGRAM,), 0, tl.float8e4nv)
+
+    for i in tl.static_range(0, NUM_CANDIDATES):
+        raw_i = tl.minimum(
+            tl.maximum(base_raw + LOWER_BOUND + i, 1),
+            MAX_SCALE_RAW,
+        ).to(tl.uint8)
+        scale_fp8 = raw_i.to(tl.float8e4nv, bitcast=True)
+        scale_i = scale_fp8.to(tl.float32)
+        inv_scale_i = 1.0 / scale_i
+
+        mse_i = _fp32x16_e2m1_quant_squared_error(
+            v0, v1, v2, v3,
+            v4, v5, v6, v7,
+            v8, v9, v10, v11,
+            v12, v13, v14, v15,
+            inv_scale_i,
+            scale_i,
+        )
+
+        better = mse_i < best_mse
+        best_mse = tl.where(better, mse_i, best_mse)
+        best_scale_fp8 = tl.where(better, scale_fp8, best_scale_fp8)
+
+    scale_offsets = block_offsets
+    if IS_SWIZZLE_SCALE:
+        scale_offsets = swizzled_scale_offsets(block_offsets, BLOCKS_PER_OUT, BLOCKS_PER_OUT_PAD)
+    tl.store(output_scale_ptr + scale_offsets, best_scale_fp8, mask=block_mask)
+
+    inv_scale = 1.0 / best_scale_fp8.to(tl.float32)
+    lo, hi = _fp32x16_to_e2m1_u32x2(
+        v0 * inv_scale, v1 * inv_scale, v2 * inv_scale, v3 * inv_scale,
+        v4 * inv_scale, v5 * inv_scale, v6 * inv_scale, v7 * inv_scale,
+        v8 * inv_scale, v9 * inv_scale, v10 * inv_scale, v11 * inv_scale,
+        v12 * inv_scale, v13 * inv_scale, v14 * inv_scale, v15 * inv_scale,
+    )
+
+    output_i32_offsets = block_offsets * 2
+    tl.store(output_i32_ptr + output_i32_offsets, lo, mask=block_mask)
+    tl.store(output_i32_ptr + output_i32_offsets + 1, hi, mask=block_mask)
+
+
+def _scalesweep_mse_nvfp4_quant(
+    input: torch.Tensor,
+    global_scale_inv: torch.Tensor,
+    is_sf_swizzled_layout: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m, n = input.shape
+    num_blocks = input.numel() // BLOCK_SIZE
+    blocks_per_out = n // BLOCK_SIZE
+
+    output, output_scale = create_fp4_output_tensors(
+        m,
+        n,
+        input.device,
+        is_sf_swizzled_layout,
+    )
+    output_i32 = output.view(torch.int32)
+
+    grid = lambda meta: (triton.cdiv(num_blocks, meta["BLOCKS_PER_PROGRAM"]),)
+    _scalesweep_mse_nvfp4_quant_kernel[grid](
+        input,
+        output_scale,
+        output_i32,
+        global_scale_inv,
+        num_blocks,
+        BLOCKS_PER_OUT=blocks_per_out,
+        LOWER_BOUND=LOWER_BOUND,
+        NUM_CANDIDATES=UPPER_BOUND - LOWER_BOUND + 1,
+        MAX_SCALE_RAW=REF_MAX_SCALE_RAW,
+        IS_SWIZZLE_SCALE=is_sf_swizzled_layout,
+        BLOCKS_PER_OUT_PAD=round_up(blocks_per_out, 4),
+    )
+    return output.view(torch.uint8), output_scale
+
+
+def scalesweep_mse_nvfp4_quant(
+    input: torch.Tensor,
+    global_scale_inv: torch.Tensor,
+    is_sf_swizzled_layout: bool = True,
+    backend: str = "scalesweep_mse",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize input to packed NVFP4 using ScaleSweep MSE.
+
+    ``global_scale_inv`` is the reciprocal global scale. For this ScaleSweep
+    MSE variant the global scale is computed with FP8_MAX=256.
+    """
+    del backend
+
+    assert input.ndim >= 1, f"input.ndim needs to be >= 1, but got {input.ndim}."
+    other_dims = 1 if input.ndim == 1 else -1
+    input = input.reshape(other_dims, input.shape[-1])
+    m, n = input.shape
+
+    assert n % BLOCK_SIZE == 0, (
+        f"last dim has to be multiple of {BLOCK_SIZE}, but got {n}."
+    )
+    assert input.dtype in (torch.float16, torch.bfloat16), (
+        f"input.dtype needs to be fp16 or bf16 but got {input.dtype}."
+    )
+    assert global_scale_inv.dtype == torch.float32, (
+        f"global_scale_inv.dtype needs to be fp32 but got {global_scale_inv.dtype}."
+    )
+
+    output, output_scale = _scalesweep_mse_nvfp4_quant(
+        input.contiguous(),
+        global_scale_inv,
+        is_sf_swizzled_layout,
+    )
+    return output, output_scale
+
+
+scaled_fp4_quant = scalesweep_mse_nvfp4_quant

--- a/python/sglang/srt/layers/quantization/scalesweep_nvfp4/scalesweep_mse_nvfp4_quant_simulate.py
+++ b/python/sglang/srt/layers/quantization/scalesweep_nvfp4/scalesweep_mse_nvfp4_quant_simulate.py
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: MIT
+# Ported from https://github.com/efsotr/nvfp4quant_test (MIT, Copyright (c) 2026
+# Li Lin) for sgl-project/sglang#27246. ScaleSweep MSE NVFP4 quantization.
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+BLOCK_SIZE = 16
+LOWER_BOUND = -3
+UPPER_BOUND = 7
+FP4_E2M1_MAX = 6.0
+FP8_E4M3_MAX = 256.0
+REF_MAX_SCALE_RAW = 126
+
+
+def round_up(x: int, y: int) -> int:
+    return ((x + y - 1) // y) * y
+
+
+def create_fp4_scale_tensor(
+    m: int,
+    n: int,
+    device: torch.device,
+    is_sf_swizzled_layout: bool,
+) -> torch.Tensor:
+    if is_sf_swizzled_layout:
+        rounded_m = round_up(m, 128)
+        rounded_n = round_up(n // BLOCK_SIZE, 4)
+        return torch.empty((rounded_m, rounded_n), device=device, dtype=torch.float8_e4m3fn)
+    return torch.empty((m, n // BLOCK_SIZE), device=device, dtype=torch.float8_e4m3fn)
+
+
+def create_fp4_output_tensors(
+    m: int,
+    n: int,
+    device: torch.device,
+    is_sf_swizzled_layout: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    output = torch.empty((m, n // 2), device=device, dtype=torch.uint8)
+    output_scale = create_fp4_scale_tensor(m, n, device, is_sf_swizzled_layout)
+    return output, output_scale
+
+
+@triton.jit
+def swizzled_scale_offsets(
+    block_offsets,
+    BLOCKS_PER_OUT: tl.constexpr,
+    BLOCKS_PER_OUT_PAD: tl.constexpr,
+):
+    row = block_offsets // BLOCKS_PER_OUT
+    col = block_offsets % BLOCKS_PER_OUT
+
+    major_m = row >> 7
+    row_in_tile = row & 127
+    tile_m = row_in_tile >> 5
+    inner_m = row_in_tile & 31
+
+    major_k = col >> 2
+    inner_k = col & 3
+
+    return major_m * (BLOCKS_PER_OUT_PAD * 128) + major_k * 512 + inner_m * 16 + tile_m * 4 + inner_k
+
+
+@triton.jit
+def fp32_round_to_fp4_code(x):
+    ax = tl.abs(x)
+    le2 = ax <= 2.0
+    le4 = ax <= 4.0
+    exp = tl.where(le2, 0.5, tl.where(le4, 1.0, 2.0))
+    r = libdevice.round(ax / exp)
+    mag = tl.where(le2, r, tl.where(le4, r + 2.0, tl.minimum(r + 4.0, 7.0))).to(tl.uint8)
+    sign = (x < 0.0).to(tl.uint8) << 3
+    return mag | sign
+
+
+@triton.jit
+def fp32_round_to_fp4_value(x):
+    ax = tl.abs(x)
+    exp = tl.where(ax <= 2.0, 0.5, tl.where(ax <= 4.0, 1.0, 2.0))
+    q = libdevice.round(x / exp) * exp
+    return tl.minimum(tl.maximum(q, -6.0), 6.0)
+
+
+@triton.jit
+def _fp32x16_to_e2m1_u32x2(
+    x0, x1, x2, x3,
+    x4, x5, x6, x7,
+    x8, x9, x10, x11,
+    x12, x13, x14, x15,
+):
+    b0 = (fp32_round_to_fp4_code(x0) | (fp32_round_to_fp4_code(x1) << 4)).to(tl.uint32)
+    b1 = (fp32_round_to_fp4_code(x2) | (fp32_round_to_fp4_code(x3) << 4)).to(tl.uint32)
+    b2 = (fp32_round_to_fp4_code(x4) | (fp32_round_to_fp4_code(x5) << 4)).to(tl.uint32)
+    b3 = (fp32_round_to_fp4_code(x6) | (fp32_round_to_fp4_code(x7) << 4)).to(tl.uint32)
+    b4 = (fp32_round_to_fp4_code(x8) | (fp32_round_to_fp4_code(x9) << 4)).to(tl.uint32)
+    b5 = (fp32_round_to_fp4_code(x10) | (fp32_round_to_fp4_code(x11) << 4)).to(tl.uint32)
+    b6 = (fp32_round_to_fp4_code(x12) | (fp32_round_to_fp4_code(x13) << 4)).to(tl.uint32)
+    b7 = (fp32_round_to_fp4_code(x14) | (fp32_round_to_fp4_code(x15) << 4)).to(tl.uint32)
+
+    lo, hi = tl.inline_asm_elementwise(
+        asm="""
+        {
+          .reg .b8 b0;
+          .reg .b8 b1;
+          .reg .b8 b2;
+          .reg .b8 b3;
+          .reg .b8 b4;
+          .reg .b8 b5;
+          .reg .b8 b6;
+          .reg .b8 b7;
+
+          cvt.u8.u32 b0, $2;
+          cvt.u8.u32 b1, $3;
+          cvt.u8.u32 b2, $4;
+          cvt.u8.u32 b3, $5;
+          cvt.u8.u32 b4, $6;
+          cvt.u8.u32 b5, $7;
+          cvt.u8.u32 b6, $8;
+          cvt.u8.u32 b7, $9;
+
+          mov.b32 $0, {b0, b1, b2, b3};
+          mov.b32 $1, {b4, b5, b6, b7};
+        }
+        """,
+        constraints="=r,=r,r,r,r,r,r,r,r,r",
+        args=[b0, b1, b2, b3, b4, b5, b6, b7],
+        dtype=(tl.uint32, tl.uint32),
+        is_pure=True,
+        pack=1,
+    )
+    return lo, hi
+
+
+@triton.jit
+def _fp32x2_e2m1_quant_squared_error(x0, x1):
+    q0 = fp32_round_to_fp4_value(x0)
+    q1 = fp32_round_to_fp4_value(x1)
+    return tl.inline_asm_elementwise(
+        asm=r"""
+        {
+          .reg .f32 d0;
+          .reg .f32 d1;
+
+          sub.rn.f32 d0, $3, $1;
+          sub.rn.f32 d1, $4, $2;
+          mul.rn.f32 d0, d0, d0;
+          fma.rn.f32 $0, d1, d1, d0;
+        }
+        """,
+        constraints="=f,f,f,f,f",
+        args=[x0, x1, q0, q1],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _fp32x2_e2m1_quant_squared_error_acc(acc, x0, x1):
+    q0 = fp32_round_to_fp4_value(x0)
+    q1 = fp32_round_to_fp4_value(x1)
+    return tl.inline_asm_elementwise(
+        asm=r"""
+        {
+          .reg .f32 d0;
+          .reg .f32 d1;
+
+          sub.rn.f32 d0, $3, $1;
+          sub.rn.f32 d1, $4, $2;
+          fma.rn.f32 d0, d0, d0, $5;
+          fma.rn.f32 $0, d1, d1, d0;
+        }
+        """,
+        constraints="=f,f,f,f,f,f",
+        args=[x0, x1, q0, q1, acc],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _scaled_fp32x16_e2m1_quant_squared_error(
+    x0, x1, x2, x3,
+    x4, x5, x6, x7,
+    x8, x9, x10, x11,
+    x12, x13, x14, x15,
+):
+    err = _fp32x2_e2m1_quant_squared_error(x0, x1)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x2, x3)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x4, x5)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x6, x7)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x8, x9)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x10, x11)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x12, x13)
+    err = _fp32x2_e2m1_quant_squared_error_acc(err, x14, x15)
+
+    return err
+
+
+@triton.jit
+def _fp32x16_e2m1_quant_squared_error(
+    v0, v1, v2, v3,
+    v4, v5, v6, v7,
+    v8, v9, v10, v11,
+    v12, v13, v14, v15,
+    inv_scale,
+    scale,
+):
+    squared_error = _scaled_fp32x16_e2m1_quant_squared_error(
+        v0 * inv_scale, v1 * inv_scale, v2 * inv_scale, v3 * inv_scale,
+        v4 * inv_scale, v5 * inv_scale, v6 * inv_scale, v7 * inv_scale,
+        v8 * inv_scale, v9 * inv_scale, v10 * inv_scale, v11 * inv_scale,
+        v12 * inv_scale, v13 * inv_scale, v14 * inv_scale, v15 * inv_scale,
+    )
+    return squared_error * (scale * scale)
+
+
+@triton.jit
+def _max_abs_16(
+    v0, v1, v2, v3,
+    v4, v5, v6, v7,
+    v8, v9, v10, v11,
+    v12, v13, v14, v15,
+):
+    m0 = tl.maximum(tl.abs(v0), tl.abs(v1))
+    m1 = tl.maximum(tl.abs(v2), tl.abs(v3))
+    m2 = tl.maximum(tl.abs(v4), tl.abs(v5))
+    m3 = tl.maximum(tl.abs(v6), tl.abs(v7))
+    m4 = tl.maximum(tl.abs(v8), tl.abs(v9))
+    m5 = tl.maximum(tl.abs(v10), tl.abs(v11))
+    m6 = tl.maximum(tl.abs(v12), tl.abs(v13))
+    m7 = tl.maximum(tl.abs(v14), tl.abs(v15))
+
+    m01 = tl.maximum(m0, m1)
+    m23 = tl.maximum(m2, m3)
+    m45 = tl.maximum(m4, m5)
+    m67 = tl.maximum(m6, m7)
+    return tl.maximum(tl.maximum(m01, m23), tl.maximum(m45, m67))
+
+
+@triton.jit
+def _load_normalized_16_cols(ptr, block_offsets, block_mask, global_scale_inv):
+    base_elem = block_offsets * 16
+
+    v0 = tl.load(ptr + base_elem + 0, mask=block_mask, other=0.0).to(tl.float32)
+    v1 = tl.load(ptr + base_elem + 1, mask=block_mask, other=0.0).to(tl.float32)
+    v2 = tl.load(ptr + base_elem + 2, mask=block_mask, other=0.0).to(tl.float32)
+    v3 = tl.load(ptr + base_elem + 3, mask=block_mask, other=0.0).to(tl.float32)
+    v4 = tl.load(ptr + base_elem + 4, mask=block_mask, other=0.0).to(tl.float32)
+    v5 = tl.load(ptr + base_elem + 5, mask=block_mask, other=0.0).to(tl.float32)
+    v6 = tl.load(ptr + base_elem + 6, mask=block_mask, other=0.0).to(tl.float32)
+    v7 = tl.load(ptr + base_elem + 7, mask=block_mask, other=0.0).to(tl.float32)
+    v8 = tl.load(ptr + base_elem + 8, mask=block_mask, other=0.0).to(tl.float32)
+    v9 = tl.load(ptr + base_elem + 9, mask=block_mask, other=0.0).to(tl.float32)
+    v10 = tl.load(ptr + base_elem + 10, mask=block_mask, other=0.0).to(tl.float32)
+    v11 = tl.load(ptr + base_elem + 11, mask=block_mask, other=0.0).to(tl.float32)
+    v12 = tl.load(ptr + base_elem + 12, mask=block_mask, other=0.0).to(tl.float32)
+    v13 = tl.load(ptr + base_elem + 13, mask=block_mask, other=0.0).to(tl.float32)
+    v14 = tl.load(ptr + base_elem + 14, mask=block_mask, other=0.0).to(tl.float32)
+    v15 = tl.load(ptr + base_elem + 15, mask=block_mask, other=0.0).to(tl.float32)
+
+    return (
+        v0 * global_scale_inv, v1 * global_scale_inv,
+        v2 * global_scale_inv, v3 * global_scale_inv,
+        v4 * global_scale_inv, v5 * global_scale_inv,
+        v6 * global_scale_inv, v7 * global_scale_inv,
+        v8 * global_scale_inv, v9 * global_scale_inv,
+        v10 * global_scale_inv, v11 * global_scale_inv,
+        v12 * global_scale_inv, v13 * global_scale_inv,
+        v14 * global_scale_inv, v15 * global_scale_inv,
+    )
+
+
+SCALESWEEP_CONFIGS = [
+    triton.Config({"BLOCKS_PER_PROGRAM": 32}, num_warps=1),
+    triton.Config({"BLOCKS_PER_PROGRAM": 64}, num_warps=2),
+    triton.Config({"BLOCKS_PER_PROGRAM": 128}, num_warps=4),
+    triton.Config({"BLOCKS_PER_PROGRAM": 256}, num_warps=8),
+    triton.Config({"BLOCKS_PER_PROGRAM": 512}, num_warps=16),
+    triton.Config({"BLOCKS_PER_PROGRAM": 1024}, num_warps=32),
+]
+
+
+@triton.autotune(
+    configs=SCALESWEEP_CONFIGS,
+    key=[
+        "NUM_BLOCKS",
+        "LOWER_BOUND",
+        "NUM_CANDIDATES",
+        "MAX_SCALE_RAW",
+        "BLOCKS_PER_OUT",
+        "BLOCKS_PER_OUT_PAD",
+        "IS_SWIZZLE_SCALE",
+    ],
+)
+@triton.jit
+def _scalesweep_mse_nvfp4_quant_simulate_kernel(
+    input_ptr,
+    output_scale_ptr,
+    output_i32_ptr,
+    global_scale_inv_ptr,
+    NUM_BLOCKS: tl.constexpr,
+    BLOCKS_PER_OUT: tl.constexpr,
+    LOWER_BOUND: tl.constexpr,
+    NUM_CANDIDATES: tl.constexpr,
+    MAX_SCALE_RAW: tl.constexpr,
+    IS_SWIZZLE_SCALE: tl.constexpr,
+    BLOCKS_PER_OUT_PAD: tl.constexpr,
+    BLOCKS_PER_PROGRAM: tl.constexpr,
+):
+    global_scale_inv = tl.load(global_scale_inv_ptr)
+    pid = tl.program_id(0)
+    block_offsets = pid * BLOCKS_PER_PROGRAM + tl.arange(0, BLOCKS_PER_PROGRAM)
+    block_mask = block_offsets < NUM_BLOCKS
+
+    (
+        v0, v1, v2, v3,
+        v4, v5, v6, v7,
+        v8, v9, v10, v11,
+        v12, v13, v14, v15,
+    ) = _load_normalized_16_cols(input_ptr, block_offsets, block_mask, global_scale_inv)
+
+    abs_max = _max_abs_16(
+        v0, v1, v2, v3,
+        v4, v5, v6, v7,
+        v8, v9, v10, v11,
+        v12, v13, v14, v15,
+    )
+    base_scale = abs_max * (1.0 / 6.0)
+    base_raw = base_scale.to(tl.float8e4nv).to(tl.uint8, bitcast=True).to(tl.int32)
+
+    best_mse = tl.full((BLOCKS_PER_PROGRAM,), float("inf"), tl.float32)
+    best_scale_fp8 = tl.full((BLOCKS_PER_PROGRAM,), 0, tl.float8e4nv)
+
+    for i in tl.static_range(0, NUM_CANDIDATES):
+        raw_i = tl.minimum(
+            tl.maximum(base_raw + LOWER_BOUND + i, 1),
+            MAX_SCALE_RAW,
+        ).to(tl.uint8)
+        scale_fp8 = raw_i.to(tl.float8e4nv, bitcast=True)
+        scale_i = scale_fp8.to(tl.float32)
+        inv_scale_i = 1.0 / scale_i
+
+        mse_i = _fp32x16_e2m1_quant_squared_error(
+            v0, v1, v2, v3,
+            v4, v5, v6, v7,
+            v8, v9, v10, v11,
+            v12, v13, v14, v15,
+            inv_scale_i,
+            scale_i,
+        )
+
+        better = mse_i < best_mse
+        best_mse = tl.where(better, mse_i, best_mse)
+        best_scale_fp8 = tl.where(better, scale_fp8, best_scale_fp8)
+
+    scale_offsets = block_offsets
+    if IS_SWIZZLE_SCALE:
+        scale_offsets = swizzled_scale_offsets(block_offsets, BLOCKS_PER_OUT, BLOCKS_PER_OUT_PAD)
+    tl.store(output_scale_ptr + scale_offsets, best_scale_fp8, mask=block_mask)
+
+    inv_scale = 1.0 / best_scale_fp8.to(tl.float32)
+    lo, hi = _fp32x16_to_e2m1_u32x2(
+        v0 * inv_scale, v1 * inv_scale, v2 * inv_scale, v3 * inv_scale,
+        v4 * inv_scale, v5 * inv_scale, v6 * inv_scale, v7 * inv_scale,
+        v8 * inv_scale, v9 * inv_scale, v10 * inv_scale, v11 * inv_scale,
+        v12 * inv_scale, v13 * inv_scale, v14 * inv_scale, v15 * inv_scale,
+    )
+
+    output_i32_offsets = block_offsets * 2
+    tl.store(output_i32_ptr + output_i32_offsets, lo, mask=block_mask)
+    tl.store(output_i32_ptr + output_i32_offsets + 1, hi, mask=block_mask)
+
+
+def _scalesweep_mse_nvfp4_quant_simulate(
+    input: torch.Tensor,
+    global_scale_inv: torch.Tensor,
+    is_sf_swizzled_layout: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m, n = input.shape
+    num_blocks = input.numel() // BLOCK_SIZE
+    blocks_per_out = n // BLOCK_SIZE
+
+    output, output_scale = create_fp4_output_tensors(
+        m,
+        n,
+        input.device,
+        is_sf_swizzled_layout,
+    )
+    output_i32 = output.view(torch.int32)
+
+    grid = lambda meta: (triton.cdiv(num_blocks, meta["BLOCKS_PER_PROGRAM"]),)
+    _scalesweep_mse_nvfp4_quant_simulate_kernel[grid](
+        input,
+        output_scale,
+        output_i32,
+        global_scale_inv,
+        num_blocks,
+        BLOCKS_PER_OUT=blocks_per_out,
+        LOWER_BOUND=LOWER_BOUND,
+        NUM_CANDIDATES=UPPER_BOUND - LOWER_BOUND + 1,
+        MAX_SCALE_RAW=REF_MAX_SCALE_RAW,
+        IS_SWIZZLE_SCALE=is_sf_swizzled_layout,
+        BLOCKS_PER_OUT_PAD=round_up(blocks_per_out, 4),
+    )
+    return output.view(torch.uint8), output_scale
+
+
+def scalesweep_mse_nvfp4_quant_simulate(
+    input: torch.Tensor,
+    global_scale_inv: torch.Tensor,
+    is_sf_swizzled_layout: bool = True,
+    backend: str = "scalesweep_mse",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize input to packed simulated NVFP4 using ScaleSweep MSE.
+
+    ``global_scale_inv`` is the reciprocal global scale. For this ScaleSweep
+    MSE variant the global scale is computed with FP8_MAX=256.
+    """
+    del backend
+
+    assert input.ndim >= 1, f"input.ndim needs to be >= 1, but got {input.ndim}."
+    other_dims = 1 if input.ndim == 1 else -1
+    input = input.reshape(other_dims, input.shape[-1])
+    m, n = input.shape
+
+    assert n % BLOCK_SIZE == 0, (
+        f"last dim has to be multiple of {BLOCK_SIZE}, but got {n}."
+    )
+    assert input.dtype in (torch.float16, torch.bfloat16), (
+        f"input.dtype needs to be fp16 or bf16 but got {input.dtype}."
+    )
+    assert global_scale_inv.dtype == torch.float32, (
+        f"global_scale_inv.dtype needs to be fp32 but got {global_scale_inv.dtype}."
+    )
+
+    output, output_scale = _scalesweep_mse_nvfp4_quant_simulate(
+        input.contiguous(),
+        global_scale_inv,
+        is_sf_swizzled_layout,
+    )
+    return output, output_scale
+
+
+scalesweep_mse_nvfp4_quant = scalesweep_mse_nvfp4_quant_simulate
+scaled_fp4_quant = scalesweep_mse_nvfp4_quant_simulate
+scaled_fp4_quant_simulate = scalesweep_mse_nvfp4_quant_simulate

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -78,7 +78,10 @@ from sglang.srt.layers.dp_attention import (
     get_attention_tp_group,
 )
 from sglang.srt.layers.moe import initialize_moe_config
-from sglang.srt.layers.quantization.fp4_utils import initialize_fp4_gemm_config
+from sglang.srt.layers.quantization.fp4_utils import (
+    initialize_fp4_gemm_config,
+    initialize_fp4_quant_config,
+)
 from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
 from sglang.srt.lora.lora_drainer import LoRADrainer
 from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
@@ -750,6 +753,7 @@ class Scheduler(
         # Initialize GEMM-related configuration for FP8 and FP4 backends.
         initialize_fp8_gemm_config(self.server_args)
         initialize_fp4_gemm_config(self.server_args)
+        initialize_fp4_quant_config(self.server_args)
 
         # This must be called after initialize_moe_config
         self.require_mlp_sync = require_mlp_sync(self.server_args)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -598,6 +598,7 @@ class ServerArgs:
     mm_attention_backend: Optional[str] = None
     fp8_gemm_runner_backend: str = "auto"
     fp4_gemm_runner_backend: str = "auto"
+    fp4_quant_algo: str = "absmax"
     dsa_prefill_backend: Optional[str] = (
         None  # None = auto-detect based on hardware/kv_cache_dtype
     )
@@ -6024,6 +6025,18 @@ class ServerArgs:
             "'flashinfer_cutedsl' (FlashInfer CuTe DSL backend), "
             "'flashinfer_trtllm' (FlashInfer TensorRT-LLM backend, requires different weight preparation with shuffling), "
             "'marlin' (weight-only W4A16 fallback for SM80+). ",
+        )
+        parser.add_argument(
+            "--fp4-quant-algo",
+            type=str,
+            choices=["absmax", "scalesweep"],
+            default=ServerArgs.fp4_quant_algo,
+            dest="fp4_quant_algo",
+            help="Algorithm for NVFP4 activation quantization. "
+            "'absmax' (default; the flashinfer absmax-based path), "
+            "'scalesweep' (ScaleSweep MSE: sweeps FP8 block scales around the "
+            "absmax base to minimize FP4 reconstruction error; requires SM100+ "
+            "for native FP4). See sgl-project/sglang#27246.",
         )
         parser.add_argument(
             "--disable-flashinfer-autotune",

--- a/test/registered/kernels/test_scalesweep_nvfp4_quant.py
+++ b/test/registered/kernels/test_scalesweep_nvfp4_quant.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Kernel-level tests for ScaleSweep NVFP4 quantization (sgl-project/sglang#27246).
+
+Validates the ported Triton ScaleSweep kernel against a PyTorch reference and
+checks that it reduces FP4 reconstruction error versus the absmax baseline.
+Native FP4 requires SM100+ (Blackwell).
+"""
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("NVFP4 tests require CUDA.", allow_module_level=True)
+
+from sglang.srt.layers.quantization.scalesweep_nvfp4.scalesweep_mse_nvfp4_quant import (
+    BLOCK_SIZE,
+    FP4_E2M1_MAX,
+    LOWER_BOUND,
+    REF_MAX_SCALE_RAW,
+    UPPER_BOUND,
+    create_fp4_output_tensors,
+    round_up,
+    scalesweep_mse_nvfp4_quant,
+)
+
+DTYPES = [torch.float16, torch.bfloat16]
+SHAPES = [(1, 16), (3, 64), (32, 128), (128, 64), (150, 80)]
+# SGLang's NVFP4 block-scale convention (matches `448 * 6 / amax`).
+FP8_BLOCK_SCALE_MAX = 448.0
+
+E2M1_TO_FLOAT32 = [
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+    0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+]
+
+
+def _cast_from_fp4(x, m, n):
+    lut = torch.tensor(E2M1_TO_FLOAT32, device=x.device, dtype=torch.float32)
+    c = torch.stack((x & 0xF, (x >> 4) & 0xF), dim=-1).long()
+    return lut[c].reshape(m, n)
+
+
+def _cast_to_fp4(x):
+    sign = torch.sign(x)
+    x = torch.abs(x)
+    out = torch.empty_like(x)
+    out[(x >= 0.0) & (x <= 0.25)] = 0.0
+    out[(x > 0.25) & (x < 0.75)] = 0.5
+    out[(x >= 0.75) & (x <= 1.25)] = 1.0
+    out[(x > 1.25) & (x < 1.75)] = 1.5
+    out[(x >= 1.75) & (x <= 2.5)] = 2.0
+    out[(x > 2.5) & (x < 3.5)] = 3.0
+    out[(x >= 3.5) & (x <= 5.0)] = 4.0
+    out[x > 5.0] = 6.0
+    return out * sign
+
+
+def _global_scale_inv(x):
+    amax = torch.abs(x).max().to(torch.float32)
+    return FP8_BLOCK_SCALE_MAX * FP4_E2M1_MAX / amax
+
+
+def _recover_swizzled_scales(scale, m, n):
+    scale_n = n // BLOCK_SIZE
+    rounded_m, rounded_n = round_up(m, 128), round_up(scale_n, 4)
+    tmp = scale.reshape(1, rounded_m // 128, rounded_n // 4, 32, 4, 4)
+    tmp = tmp.permute(0, 1, 4, 3, 2, 5)
+    return tmp.reshape(rounded_m, rounded_n).to(torch.float32)[:m, :scale_n]
+
+
+def _ref_quant(x, global_scale_inv, sweep):
+    """PyTorch reference. ``sweep=False`` is the absmax baseline (offset 0 only)."""
+    m, n = x.shape
+    blocks = x.reshape(m, n // BLOCK_SIZE, BLOCK_SIZE).to(torch.float32) * global_scale_inv
+    abs_max = blocks.abs().amax(dim=-1)
+    base_raw = (abs_max / FP4_E2M1_MAX).to(torch.float8_e4m3fn).view(torch.uint8).to(torch.int32)
+    lo, hi = (LOWER_BOUND, UPPER_BOUND) if sweep else (0, 0)
+    offsets = torch.arange(lo, hi + 1, device=x.device, dtype=torch.int32)
+    scale_raw = torch.clamp(base_raw.unsqueeze(-1) + offsets, 1, REF_MAX_SCALE_RAW).to(torch.uint8)
+    scales = scale_raw.view(torch.float8_e4m3fn).to(torch.float32)
+    scaled = blocks.unsqueeze(2) / scales.unsqueeze(-1)
+    quantized = _cast_to_fp4(scaled)
+    recon = quantized * scales.unsqueeze(-1)
+    sq_err = ((recon - blocks.unsqueeze(2)) ** 2).sum(dim=-1)
+    best = torch.argmin(sq_err, dim=-1)
+    best_scale = torch.gather(scale_raw, 2, best.unsqueeze(-1)).squeeze(-1).view(torch.float8_e4m3fn)
+    best_q = torch.gather(
+        quantized, 2, best[:, :, None, None].expand(-1, -1, 1, BLOCK_SIZE)
+    ).squeeze(2)
+    mse = torch.gather(sq_err, 2, best.unsqueeze(-1)).mean().item() / BLOCK_SIZE
+    return best_q.reshape(m, n), best_scale, mse
+
+
+def _require_blackwell():
+    major, minor = torch.cuda.get_device_capability()
+    if major < 10:
+        pytest.skip(f"native FP4 requires SM100+, got {major}.{minor}")
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("is_sf_swizzled_layout", [True, False])
+@torch.inference_mode()
+def test_scalesweep_matches_reference(dtype, shape, is_sf_swizzled_layout):
+    _require_blackwell()
+    torch.manual_seed(42)
+    x = torch.randn(shape, device="cuda:0", dtype=dtype)
+    gsi = _global_scale_inv(x)
+
+    out_ref, scale_ref, _ = _ref_quant(x, gsi, sweep=True)
+    out, out_scale = scalesweep_mse_nvfp4_quant(
+        x, gsi, is_sf_swizzled_layout=is_sf_swizzled_layout
+    )
+    exp_out, exp_scale = create_fp4_output_tensors(
+        shape[0], shape[1], torch.device("cuda:0"), is_sf_swizzled_layout
+    )
+
+    assert out.shape == exp_out.shape and out.dtype == torch.uint8
+    assert out_scale.shape == exp_scale.shape and out_scale.dtype == torch.float8_e4m3fn
+
+    out_vals = _cast_from_fp4(out, *shape)
+    scale_vals = (
+        _recover_swizzled_scales(out_scale, *shape)
+        if is_sf_swizzled_layout
+        else out_scale.to(torch.float32)
+    )
+    torch.testing.assert_close(out_vals, out_ref)
+    torch.testing.assert_close(scale_vals, scale_ref.to(torch.float32))
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_scalesweep_beats_absmax_mse(dtype):
+    _require_blackwell()
+    torch.manual_seed(0)
+    x = torch.randn(2048, 4096, device="cuda:0", dtype=dtype)
+    gsi = _global_scale_inv(x)
+    _, _, mse_sweep = _ref_quant(x, gsi, sweep=True)
+    _, _, mse_absmax = _ref_quant(x, gsi, sweep=False)
+    assert mse_sweep < mse_absmax, (mse_sweep, mse_absmax)


### PR DESCRIPTION
## Motivation

Closes #27246. NVFP4 quantizes each 16-element block with an FP8-E4M3 scale. The
current path takes that scale from the block absmax. **ScaleSweep** instead sweeps
a small analytically-derived range around the absmax base scale and keeps the one
with minimum FP4 reconstruction error — better accuracy at essentially no latency
cost (the reference reports ~1.006x latency on Blackwell).

## Modifications

- New `scalesweep_nvfp4` Triton module (native + simulate + absmax reference),
  ported from https://github.com/efsotr/nvfp4quant_test (MIT, attributed). It
  emits the same packed `uint8` FP4 + swizzled `float8_e4m3fn` block-scale layout
  as the existing flashinfer path, so it is drop-in for the NVFP4 GEMM.
- Opt-in via `--fp4-quant-algo {absmax,scalesweep}` (default `absmax`, behavior
  unchanged). Plumbed through `fp4_utils.fp4_quantize_activation` and selected at
  the ModelOpt FP4 linear `apply` seam.

## Accuracy / Tests

Validated on a B200 (native FP4, SM100):
- **Correctness:** the ported Triton kernel matches a PyTorch reference across all
  shapes/dtypes and both scale layouts — `24/24` from the upstream project's own
  test suite, run against the (byte-identical) ported kernel. The included
  `test/registered/kernels/test_scalesweep_nvfp4_quant.py` ports the same
  assertions for SGLang's Blackwell CI; it was not run locally (needs an SM100+
  runner), so reviewers should confirm it on CI.
- **Quality:** a standalone round-trip MSE check I ran on the B200 shows FP4 MSE
  drops ~27% vs absmax (ratio ~0.73) under SGLang's `448 * 6 / amax` block-scale
  convention.
- The swizzled scale layout is the standard NVFP4 SF (128x4) layout; the upstream
  reference independently validates it through CUTLASS `scaled_fp4_mm` (GEMM MSE
  444 vs 562 absmax). This PR does not yet validate ScaleSweep end-to-end through
  SGLang's own FP4 GEMM.

Scope notes: the dense ModelOpt FP4 linear path is wired here; the fused-MoE path
is a natural follow-up. End-to-end NVFP4-model accuracy on Blackwell CI is the
recommended next gate.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27842553890](https://github.com/sgl-project/sglang/actions/runs/27842553890)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27842553767](https://github.com/sgl-project/sglang/actions/runs/27842553767)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->