### PR TITLE
[CI] Bump actions/github-script to v8 (Node 24 runtime)

### DIFF
--- a/.github/actions/check-pr-test-health/action.yml
+++ b/.github/actions/check-pr-test-health/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Check PR test health
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         SKIP_PR_TEST_HEALTH_CHECK: ${{ env.SKIP_PR_TEST_HEALTH_CHECK }}
       with:

--- a/.github/actions/wait-for-jobs/action.yml
+++ b/.github/actions/wait-for-jobs/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Wait for jobs to complete
       id: wait
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         INPUT_STAGE_NAME: ${{ inputs.stage-name }}
         INPUT_JOBS: ${{ inputs.jobs }}

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check and close inactive issues
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Fetch latest PR info
         if: github.event_name == 'pull_request'
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -79,7 +79,7 @@ jobs:
 
       - name: Enforce rate limit for low-permission actors (optional)
         if: github.event_name == 'pull_request' && inputs.cool-down-minutes > 0
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update CI states block in PR body
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const RETRY_ATTEMPTS = 3;


### PR DESCRIPTION
Bumps all `actions/github-script@v6/v7` usages to `@v8` to silence the Node 20 deprecation warning (v8 runs on Node 24). Pure version bump; the scripts only use stable `github.rest.*` / `github.paginate` / `core.*` / `context.*` APIs.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27848722832](https://github.com/sgl-project/sglang/actions/runs/27848722832)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27848722793](https://github.com/sgl-project/sglang/actions/runs/27848722793)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->