### PR TITLE
Add hard AIME25 subset tool

### DIFF
--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: string
         default: "20"
+      test_timeout:
+        description: "Run-test step timeout minutes"
+        required: false
+        type: string
+        default: "60"
       grace_blackwell:
         description: "Set GRACE_BLACKWELL for the install step (cuda only)"
         required: false
@@ -125,7 +130,7 @@ jobs:
           bash ${{ inputs.install_script }}
 
       - name: Run test
-        timeout-minutes: 60
+        timeout-minutes: ${{ fromJson(inputs.test_timeout) }}
         run: |
           if [[ "${{ inputs.runs_on }}" == "1-gpu-5090" ]]; then
             source /etc/profile.d/sglang-ci.sh

--- a/python/sglang/benchmark/one_batch_server.py
+++ b/python/sglang/benchmark/one_batch_server.py
@@ -107,6 +107,7 @@ class BenchArgs:
     temperature: float = 0.0
     return_logprob: bool = False
     client_stream_interval: int = 1
+    request_timeout: int = DEFAULT_TIMEOUT
     input_len_step_percentage: float = 0.0
     base_url: str = ""
     local_tokenizer_path: str = ""
@@ -157,6 +158,12 @@ class BenchArgs:
             "--client-stream-interval",
             type=int,
             default=BenchArgs.client_stream_interval,
+        )
+        parser.add_argument(
+            "--request-timeout",
+            type=int,
+            default=BenchArgs.request_timeout,
+            help="HTTP request timeout in seconds for each benchmark case.",
         )
         parser.add_argument(
             "--input-len-step-percentage",
@@ -475,6 +482,7 @@ def run_one_case(
     temperature: float,
     return_logprob: bool,
     stream_interval: int,
+    request_timeout: int,
     input_len_step_percentage: float,
     run_name: str,
     result_filename: str,
@@ -661,7 +669,7 @@ def run_one_case(
         gen_url,
         json=payload,
         stream=True,
-        timeout=DEFAULT_TIMEOUT,
+        timeout=request_timeout,
     ) as response:
         response.raise_for_status()
 
@@ -713,7 +721,7 @@ def run_one_case(
         last_gen_throughput = -1
         acc_length = -1
     else:
-        response = requests.get(url + "/server_info", timeout=DEFAULT_TIMEOUT)
+        response = requests.get(url + "/server_info", timeout=request_timeout)
         response.raise_for_status()
         server_info = response.json()
         internal_states = server_info.get("internal_states", [])
@@ -1000,6 +1008,7 @@ def run_benchmark_internal(
                 temperature=bench_args.temperature,
                 return_logprob=bench_args.return_logprob,
                 stream_interval=bench_args.client_stream_interval,
+                request_timeout=bench_args.request_timeout,
                 input_len_step_percentage=bench_args.input_len_step_percentage,
                 run_name="",
                 result_filename="",
@@ -1042,6 +1051,7 @@ def run_benchmark_internal(
                     temperature=bench_args.temperature,
                     return_logprob=bench_args.return_logprob,
                     stream_interval=bench_args.client_stream_interval,
+                    request_timeout=bench_args.request_timeout,
                     input_len_step_percentage=bench_args.input_len_step_percentage,
                     run_name=bench_args.run_name,
                     result_filename=bench_args.result_filename,
@@ -1089,6 +1099,7 @@ def run_benchmark_internal(
                             temperature=bench_args.temperature,
                             return_logprob=bench_args.return_logprob,
                             stream_interval=bench_args.client_stream_interval,
+                            request_timeout=bench_args.request_timeout,
                             input_len_step_percentage=bench_args.input_len_step_percentage,
                             run_name=bench_args.run_name,
                             result_filename=bench_args.result_filename,

--- a/python/sglang/test/accuracy_test_runner.py
+++ b/python/sglang/test/accuracy_test_runner.py
@@ -31,6 +31,7 @@ class AccuracyTestParams:
     top_k: Optional[int] = None
     repeat: Optional[int] = None
     api: Optional[str] = None  # "chat" or "completion"; defaults to "chat" in run_eval
+    aime25_data_path: Optional[str] = None
 
 
 @dataclass
@@ -89,6 +90,7 @@ def _run_simple_eval(
     top_k: Optional[int] = None,
     repeat: Optional[int] = None,
     api: Optional[str] = None,
+    aime25_data_path: Optional[str] = None,
 ) -> Tuple[bool, Optional[str], Optional[dict]]:
     """Run evaluation using simple_eval backend (run_eval.py).
 
@@ -115,6 +117,9 @@ def _run_simple_eval(
 
         if api is not None:
             args.api = api
+
+        if aime25_data_path is not None:
+            args.aime25_data_path = aime25_data_path
 
         if max_tokens is not None:
             args.max_tokens = max_tokens
@@ -498,6 +503,7 @@ def run_accuracy_test(
             top_k=params.top_k,
             repeat=params.repeat,
             api=params.api,
+            aime25_data_path=params.aime25_data_path,
         )
 
     if not success:

--- a/python/sglang/test/aime25_hard_subset.py
+++ b/python/sglang/test/aime25_hard_subset.py
@@ -11,12 +11,14 @@ import json
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
-DEFAULT_DSV4_FLASH_HARD_IDS: tuple[str, ...] = (
+DEFAULT_DSV4_PRO_HARD_IDS: tuple[str, ...] = (
     "aime25-13",
     "aime25-14",
     "aime25-27",
     "aime25-29",
 )
+
+DEFAULT_DSV4_FLASH_HARD_IDS = DEFAULT_DSV4_PRO_HARD_IDS
 
 DSV4_FLASH_BISECT_IDS: tuple[str, ...] = (
     "aime25-13",
@@ -27,6 +29,7 @@ DSV4_FLASH_BISECT_IDS: tuple[str, ...] = (
 PRESET_IDS: dict[str, tuple[str, ...]] = {
     "dsv4-flash": DEFAULT_DSV4_FLASH_HARD_IDS,
     "dsv4-flash-bisect": DSV4_FLASH_BISECT_IDS,
+    "dsv4-pro": DEFAULT_DSV4_PRO_HARD_IDS,
 }
 
 
@@ -87,3 +90,30 @@ def write_jsonl(rows: Iterable[Mapping[str, object]], path: str | Path) -> Path:
         for row in rows:
             f.write(json.dumps(dict(row), ensure_ascii=False) + "\n")
     return out_path
+
+
+def load_aime25_rows_from_huggingface() -> list[dict[str, str]]:
+    from datasets import load_dataset
+
+    rows = []
+    for config in ("AIME2025-I", "AIME2025-II"):
+        rows.extend(load_dataset("opencompass/AIME2025", config, split="test"))
+    return normalize_aime25_rows(
+        {
+            "id": f"aime25-{idx}",
+            "problem": row["question"],
+            "expected_answer": str(row["answer"]),
+        }
+        for idx, row in enumerate(rows)
+    )
+
+
+def build_aime25_hard_subset(
+    path: str | Path,
+    *,
+    rows: Iterable[Mapping[str, object]] | None = None,
+    problem_ids: Sequence[str] | str | None = None,
+) -> Path:
+    source_rows = rows if rows is not None else load_aime25_rows_from_huggingface()
+    selected = select_aime25_rows(source_rows, parse_problem_ids(problem_ids))
+    return write_jsonl(selected, path)

--- a/python/sglang/test/aime25_hard_subset.py
+++ b/python/sglang/test/aime25_hard_subset.py
@@ -1,0 +1,89 @@
+"""Utilities for building a small hard AIME25 subset for CI.
+
+The subset is meant for fast DeepSeek-V4 accuracy probes where the full AIME25
+run is too expensive. Rows use the NeMo-Skills/sgl-eval JSONL shape:
+``{"id": ..., "problem": ..., "expected_answer": ...}``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+DEFAULT_DSV4_FLASH_HARD_IDS: tuple[str, ...] = (
+    "aime25-13",
+    "aime25-14",
+    "aime25-27",
+    "aime25-29",
+)
+
+DSV4_FLASH_BISECT_IDS: tuple[str, ...] = (
+    "aime25-13",
+    "aime25-14",
+    "aime25-29",
+)
+
+PRESET_IDS: dict[str, tuple[str, ...]] = {
+    "dsv4-flash": DEFAULT_DSV4_FLASH_HARD_IDS,
+    "dsv4-flash-bisect": DSV4_FLASH_BISECT_IDS,
+}
+
+
+def parse_problem_ids(problem_ids: str | Iterable[str] | None) -> tuple[str, ...]:
+    if problem_ids is None:
+        return DEFAULT_DSV4_FLASH_HARD_IDS
+    if isinstance(problem_ids, str):
+        values = problem_ids.split(",")
+    else:
+        values = list(problem_ids)
+    parsed = tuple(x.strip() for x in values if x and x.strip())
+    if not parsed:
+        raise ValueError("at least one AIME25 problem id is required")
+    return parsed
+
+
+def normalize_aime25_rows(rows: Iterable[Mapping[str, object]]) -> list[dict[str, str]]:
+    normalized: list[dict[str, str]] = []
+    for idx, row in enumerate(rows):
+        problem = row.get("problem") or row.get("question")
+        expected_answer = row.get("expected_answer")
+        if expected_answer is None:
+            expected_answer = row.get("answer")
+        if problem is None or expected_answer is None:
+            raise ValueError(
+                f"row {idx} must include problem/question and expected_answer/answer"
+            )
+        normalized.append(
+            {
+                "id": str(row.get("id") or f"aime25-{idx}"),
+                "problem": str(problem),
+                "expected_answer": str(expected_answer),
+            }
+        )
+    return normalized
+
+
+def select_aime25_rows(
+    rows: Iterable[Mapping[str, object]],
+    problem_ids: Sequence[str],
+) -> list[dict[str, str]]:
+    normalized = normalize_aime25_rows(rows)
+    by_id = {row["id"]: row for row in normalized}
+    missing = [problem_id for problem_id in problem_ids if problem_id not in by_id]
+    if missing:
+        available = ", ".join(sorted(by_id))
+        raise ValueError(
+            f"AIME25 problem id(s) not found: {', '.join(missing)}. "
+            f"Available ids: {available}"
+        )
+    return [by_id[problem_id] for problem_id in problem_ids]
+
+
+def write_jsonl(rows: Iterable[Mapping[str, object]], path: str | Path) -> Path:
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(dict(row), ensure_ascii=False) + "\n")
+    return out_path

--- a/python/sglang/test/performance_test_runner.py
+++ b/python/sglang/test/performance_test_runner.py
@@ -17,6 +17,7 @@ class PerformanceTestParams:
     dataset_name: str = "mmmu"  # For VLM perf test
     # MTP/EAGLE speculative decoding: minimum accept length threshold (None = no validation)
     spec_accept_length_threshold: Optional[float] = None
+    extra_bench_args: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -49,6 +50,7 @@ def run_performance_test(
     is_vlm: bool = False,
     dataset_name: str = "mmmu",
     spec_accept_length_threshold: Optional[float] = None,
+    extra_bench_args: Optional[List[str]] = None,
 ) -> PerformanceTestResult:
 
     # Set default for mutable argument
@@ -66,9 +68,11 @@ def run_performance_test(
     print(f"{'='*60}\n")
 
     # Build extra args for benchmarks
-    extra_bench_args = ["--trust-remote-code"]
+    bench_args = ["--trust-remote-code"]
     if is_vlm:
-        extra_bench_args.append(f"--dataset-name={dataset_name}")
+        bench_args.append(f"--dataset-name={dataset_name}")
+    if extra_bench_args:
+        bench_args.extend(extra_bench_args)
 
     try:
         results, success, avg_spec_accept_length = perf_runner.run_benchmark_for_model(
@@ -78,7 +82,7 @@ def run_performance_test(
             output_lens=output_lens,
             other_args=model.extra_args,
             variant=model.variant or "",
-            extra_bench_args=extra_bench_args,
+            extra_bench_args=bench_args,
             env=model.env,
         )
 
@@ -91,7 +95,9 @@ def run_performance_test(
             passed = True
             if spec_accept_length_threshold is not None:
                 if avg_spec_accept_length is None:
-                    error_msg = f"Spec accept length threshold set but no accept length reported"
+                    error_msg = (
+                        "Spec accept length threshold set but no accept length reported"
+                    )
                     passed = False
                     print(f"✗ {error_msg}")
                 elif avg_spec_accept_length < spec_accept_length_threshold:

--- a/python/sglang/test/run_combined_tests.py
+++ b/python/sglang/test/run_combined_tests.py
@@ -122,6 +122,7 @@ def run_combined_tests(
                 is_vlm=is_vlm,
                 dataset_name=performance_params.dataset_name,
                 spec_accept_length_threshold=performance_params.spec_accept_length_threshold,
+                extra_bench_args=performance_params.extra_bench_args,
             )
             model_result["perf_result"] = perf_result
             if not perf_result.passed:

--- a/python/sglang/test/run_eval.py
+++ b/python/sglang/test/run_eval.py
@@ -168,7 +168,11 @@ def run_eval(args):
     elif args.eval_name == "aime25":
         from sglang.test.simple_eval_aime25 import AIME25Eval
 
-        eval_obj = AIME25Eval(args.num_examples, args.num_threads)
+        eval_obj = AIME25Eval(
+            args.num_examples,
+            args.num_threads,
+            data_path=getattr(args, "aime25_data_path", None),
+        )
     elif args.eval_name == "gsm8k":
         from sglang.test.simple_eval_gsm8k import GSM8KEval
 
@@ -377,6 +381,12 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Path to GSM8K data file (e.g., test.jsonl)",
+    )
+    parser.add_argument(
+        "--aime25-data-path",
+        type=str,
+        default=None,
+        help="Path to AIME25 JSONL data file for eval_name=aime25",
     )
     parser.add_argument(
         "--mixed-prefix-gsm8k-secondary-pool-size",

--- a/python/sglang/test/simple_eval_aime25.py
+++ b/python/sglang/test/simple_eval_aime25.py
@@ -9,10 +9,13 @@ The American Invitational Mathematics Examination (AIME) is a challenging
 competition math exam. All answers are integers from 000 to 999.
 """
 
+import json
 import re
+from pathlib import Path
 from typing import Optional
 
 from sglang.test import simple_eval_common as common
+from sglang.test.aime25_hard_subset import normalize_aime25_rows
 from sglang.test.simple_eval_common import (
     ANSWER_PATTERN,
     HTML_JINJA,
@@ -31,6 +34,23 @@ Note: AIME answers are always integers from 000 to 999 (inclusive). If you get a
 
 Remember to put your answer on its own line after "Answer:", and express your answer as an integer from 000 to 999.
 """.strip()
+
+
+def _read_aime25_jsonl(data_path: str | Path) -> list[dict[str, str]]:
+    rows = []
+    with Path(data_path).expanduser().open("r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{data_path}:{line_no}: invalid JSON: {exc}") from exc
+    return [
+        {"question": row["problem"], "answer": row["expected_answer"]}
+        for row in normalize_aime25_rows(rows)
+    ]
 
 
 def normalize_aime_answer(answer: str) -> Optional[str]:
@@ -58,27 +78,31 @@ class AIME25Eval(Eval):
         self,
         num_examples: Optional[int],
         num_threads: int,
+        data_path: Optional[str | Path] = None,
     ):
-        try:
-            from datasets import load_dataset
-        except ImportError:
-            raise ImportError(
-                "The 'datasets' package is required for AIME25 evaluation. "
-                "Please install it with: pip install datasets"
-            )
+        if data_path:
+            examples = _read_aime25_jsonl(data_path)
+        else:
+            try:
+                from datasets import load_dataset
+            except ImportError:
+                raise ImportError(
+                    "The 'datasets' package is required for AIME25 evaluation. "
+                    "Please install it with: pip install datasets"
+                )
 
-        # Load AIME 2025 dataset from HuggingFace
-        dataset1 = load_dataset("opencompass/AIME2025", "AIME2025-I", split="test")
-        dataset2 = load_dataset("opencompass/AIME2025", "AIME2025-II", split="test")
-        examples1 = [
-            {"question": row["question"], "answer": str(row["answer"])}
-            for row in dataset1
-        ]
-        examples2 = [
-            {"question": row["question"], "answer": str(row["answer"])}
-            for row in dataset2
-        ]
-        examples = examples1 + examples2
+            # Load AIME 2025 dataset from HuggingFace
+            dataset1 = load_dataset("opencompass/AIME2025", "AIME2025-I", split="test")
+            dataset2 = load_dataset("opencompass/AIME2025", "AIME2025-II", split="test")
+            examples1 = [
+                {"question": row["question"], "answer": str(row["answer"])}
+                for row in dataset1
+            ]
+            examples2 = [
+                {"question": row["question"], "answer": str(row["answer"])}
+                for row in dataset2
+            ]
+            examples = examples1 + examples2
 
         if num_examples:
             examples = examples[: min(num_examples, len(examples))]

--- a/scripts/ci/build_aime25_hard_subset.py
+++ b/scripts/ci/build_aime25_hard_subset.py
@@ -20,8 +20,9 @@ from typing import Iterable
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "python"))
 
-from sglang.test.aime25_hard_subset import (
+from sglang.test.aime25_hard_subset import (  # noqa: E402
     PRESET_IDS,
+    load_aime25_rows_from_huggingface,
     parse_problem_ids,
     select_aime25_rows,
     write_jsonl,
@@ -57,19 +58,7 @@ def _load_from_sgl_eval() -> list[dict]:
 
 
 def _load_from_huggingface() -> list[dict]:
-    from datasets import load_dataset
-
-    rows = []
-    for config in ("AIME2025-I", "AIME2025-II"):
-        rows.extend(load_dataset("opencompass/AIME2025", config, split="test"))
-    return [
-        {
-            "id": f"aime25-{idx}",
-            "problem": row["question"],
-            "expected_answer": str(row["answer"]),
-        }
-        for idx, row in enumerate(rows)
-    ]
+    return load_aime25_rows_from_huggingface()
 
 
 def load_aime25_rows(source_jsonl: str | None) -> list[dict]:

--- a/scripts/ci/build_aime25_hard_subset.py
+++ b/scripts/ci/build_aime25_hard_subset.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Build a hard AIME25 JSONL subset for sgl-eval CI probes.
+
+Example:
+  python3 scripts/ci/build_aime25_hard_subset.py \
+    --out /tmp/aime25-hard.jsonl
+
+Then run:
+  sgl-eval run aime25 --from-dataset /tmp/aime25-hard.jsonl ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "python"))
+
+from sglang.test.aime25_hard_subset import (
+    PRESET_IDS,
+    parse_problem_ids,
+    select_aime25_rows,
+    write_jsonl,
+)
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows = []
+    with path.open("r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"{path}:{line_no}: invalid JSON: {exc}") from exc
+    return rows
+
+
+def _load_from_sgl_eval() -> list[dict]:
+    from sgl_eval.evals._loader import load_bundled
+
+    examples = load_bundled("aime25")(None)
+    return [
+        {
+            "id": ex.id,
+            "problem": ex.inputs["problem"],
+            "expected_answer": ex.target,
+        }
+        for ex in examples
+    ]
+
+
+def _load_from_huggingface() -> list[dict]:
+    from datasets import load_dataset
+
+    rows = []
+    for config in ("AIME2025-I", "AIME2025-II"):
+        rows.extend(load_dataset("opencompass/AIME2025", config, split="test"))
+    return [
+        {
+            "id": f"aime25-{idx}",
+            "problem": row["question"],
+            "expected_answer": str(row["answer"]),
+        }
+        for idx, row in enumerate(rows)
+    ]
+
+
+def load_aime25_rows(source_jsonl: str | None) -> list[dict]:
+    if source_jsonl:
+        return _read_jsonl(Path(source_jsonl).expanduser())
+
+    errors = []
+    for loader in (_load_from_sgl_eval, _load_from_huggingface):
+        try:
+            return loader()
+        except Exception as exc:
+            errors.append(f"{loader.__name__}: {exc}")
+    raise SystemExit(
+        "failed to load AIME25 rows; install sgl-eval or datasets, or pass "
+        f"--source-jsonl. Errors: {'; '.join(errors)}"
+    )
+
+
+def resolve_problem_ids(args: argparse.Namespace) -> tuple[str, ...]:
+    if args.problem_ids:
+        return parse_problem_ids(args.problem_ids)
+    try:
+        return PRESET_IDS[args.preset]
+    except KeyError as exc:
+        choices = ", ".join(sorted(PRESET_IDS))
+        raise SystemExit(f"unknown preset {args.preset!r}; choices: {choices}") from exc
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Output JSONL path for sgl-eval --from-dataset.",
+    )
+    parser.add_argument(
+        "--preset",
+        default="dsv4-flash",
+        help=f"Hard subset preset. Choices: {', '.join(sorted(PRESET_IDS))}.",
+    )
+    parser.add_argument(
+        "--problem-ids",
+        help="Comma-separated AIME25 ids, overriding --preset.",
+    )
+    parser.add_argument(
+        "--source-jsonl",
+        help=(
+            "Optional source JSONL with problem/question and expected_answer/answer "
+            "fields. By default the script loads the bundled sgl-eval AIME25 data, "
+            "falling back to opencompass/AIME2025."
+        ),
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    problem_ids = resolve_problem_ids(args)
+    rows = select_aime25_rows(load_aime25_rows(args.source_jsonl), problem_ids)
+    out_path = write_jsonl(rows, args.out)
+    print(
+        f"Wrote {len(rows)} AIME25 hard problem(s) to {out_path}: "
+        f"{', '.join(row['id'] for row in rows)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/runner_configs.yml
+++ b/scripts/ci/runner_configs.yml
@@ -26,6 +26,7 @@ runner_configs:
   2-gpu-large:       { install: *default, artifact_version: v4, install_timeout: "20", runs_on: 2-gpu-h100 }
   4-gpu-b200:        { install: *default, artifact_version: v6, install_timeout: "20", runs_on: $b200_runner }
   4-gpu-gb300:       { install: *deepep,  artifact_version: v6, install_timeout: "20", grace_blackwell: "1", runs_on: 4-gpu-gb300 }
+  4-gpu-gb300-nightly: { install: *deepep, artifact_version: v6, install_timeout: "20", test_timeout: "130", grace_blackwell: "1", runs_on: 4-gpu-gb300-nightly }
   4-gpu-h100:        { install: *default, artifact_version: v4, install_timeout: "20", runs_on: 4-gpu-h100 }
   8-gpu-h200:        { install: *default, artifact_version: v4, install_timeout: "20", runs_on: 8-gpu-h200 }
   8-gpu-b200:        { install: *default, artifact_version: v6, install_timeout: "20", runs_on: 8-gpu-b200 }

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 
 import requests
 from github import Auth, Github
@@ -731,6 +731,7 @@ _LEGACY_SUITE_TO_RUNNER_CONFIG = {
     "nightly-precision-8-gpu-h200": "8-gpu-h200",
     "nightly-8-gpu-h20": "8-gpu-h20",
     "nightly-8-gpu-b200": "8-gpu-b200",
+    "nightly-4-gpu-gb300-deepseek-v4-pro-fp4": "4-gpu-gb300-nightly",
     "weekly-8-gpu-h200": "8-gpu-h200",
 }
 
@@ -742,6 +743,7 @@ def _dispatch_err(suite, msg):
         "runner_label": None,
         "install_script": "",
         "install_timeout": "",
+        "test_timeout": "60",
         "grace_blackwell": "0",
         "rdma_devices": "",
         "is_cpu": False,
@@ -783,6 +785,7 @@ def _resolve_runner_config(rc, full_path, suite):
         "runner_label": runs_on,
         "install_script": install_script,
         "install_timeout": str(cfg["install_timeout"]),
+        "test_timeout": str(cfg.get("test_timeout", "60")),
         "grace_blackwell": str(cfg.get("grace_blackwell", "0")),
         "rdma_devices": cfg.get("rdma_devices", ""),
         "is_cpu": False,
@@ -810,7 +813,7 @@ def detect_suite(file_path_from_test):
     `error` set.
 
     Each dict has keys: suite, runner_label, install_script,
-    install_timeout, grace_blackwell, rdma_devices, is_cpu, error.
+    install_timeout, test_timeout, grace_blackwell, rdma_devices, is_cpu, error.
     """
     full_path = f"test/{file_path_from_test}"
     with open(full_path, "r") as f:
@@ -846,6 +849,7 @@ def detect_suite(file_path_from_test):
                 "runner_label": "ubuntu-latest",
                 "install_script": "",
                 "install_timeout": "",
+                "test_timeout": "60",
                 "grace_blackwell": "0",
                 "rdma_devices": "",
                 "is_cpu": True,
@@ -952,6 +956,7 @@ def _resolve_test_spec(test_spec):
                 "runs_on": info["runner_label"],
                 "install_script": info["install_script"],
                 "install_timeout": info["install_timeout"],
+                "test_timeout": info["test_timeout"],
                 "grace_blackwell": info["grace_blackwell"],
                 "rdma_devices": info["rdma_devices"],
                 "error": None,
@@ -964,7 +969,7 @@ def _dispatch_batch(gh_repo, pr, batch, token, reply_comment_id="", reply_marker
     """
     Dispatch a single workflow run for a batch of resolved test specs that
     share the same dispatch shape (mode + runs_on + install_script +
-    install_timeout + grace_blackwell + rdma_devices).
+    install_timeout + test_timeout + grace_blackwell + rdma_devices).
 
     Returns a dict with keys: specs, success, test_commands, runner_label, run_url, error.
     """
@@ -973,6 +978,7 @@ def _dispatch_batch(gh_repo, pr, batch, token, reply_comment_id="", reply_marker
     runs_on = batch[0]["runs_on"]
     install_script = batch[0]["install_script"]
     install_timeout = batch[0]["install_timeout"]
+    test_timeout = batch[0]["test_timeout"]
     grace_blackwell = batch[0]["grace_blackwell"]
     rdma_devices = batch[0]["rdma_devices"]
 
@@ -1006,6 +1012,7 @@ def _dispatch_batch(gh_repo, pr, batch, token, reply_comment_id="", reply_marker
             "runs_on": runs_on or "",
             "install_script": install_script,
             "install_timeout": install_timeout or "20",
+            "test_timeout": test_timeout or "60",
             "grace_blackwell": grace_blackwell or "0",
             "rdma_devices": rdma_devices,
             "reply_comment_id": str(reply_comment_id) if reply_comment_id else "",
@@ -1209,6 +1216,7 @@ def handle_rerun_test(
             r["runs_on"],
             r["install_script"],
             r["install_timeout"],
+            r["test_timeout"],
             r["grace_blackwell"],
             r["rdma_devices"],
         )

--- a/test/manual/dsv4/_common.py
+++ b/test/manual/dsv4/_common.py
@@ -29,6 +29,10 @@ AIME25 knobs (env vars):
     DSV4_AIME25_NUM_THREADS       (default 512   -> --num-threads)
     DSV4_AIME25_SCORE_METRIC      (default "score"; sgl-eval JSON key under "aggregate")
     DSV4_AIME25_SCORE_THRESHOLD   (default 0; >0 overrides per-variant default)
+    DSV4_AIME25_FROM_DATASET      (default ""; path passed to sgl-eval --from-dataset)
+    DSV4_AIME25_HARD_ONLY         (default 0; generate a small hard-problem subset)
+    DSV4_AIME25_HARD_IDS          (default dsv4-flash preset; comma-separated ids)
+    DSV4_AIME25_HARD_SCORE_THRESHOLD (default 0.70; used for hard-only subset)
 
 GSM8K smoke knobs (env vars):
     DSV4_GSM8K_NUM_EXAMPLES       (default 50    -> --num-examples)
@@ -69,6 +73,11 @@ from pathlib import Path
 from typing import ClassVar, Dict, List, Optional
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.aime25_hard_subset import (
+    parse_problem_ids,
+    select_aime25_rows,
+    write_jsonl,
+)
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
@@ -98,6 +107,17 @@ AIME25_MAX_TOKENS = int(os.environ.get("DSV4_AIME25_MAX_TOKENS", "65536"))
 AIME25_NUM_THREADS = int(os.environ.get("DSV4_AIME25_NUM_THREADS", "512"))
 AIME25_SCORE_METRIC = os.environ.get("DSV4_AIME25_SCORE_METRIC", "score")
 AIME25_SCORE_THRESHOLD = float(os.environ.get("DSV4_AIME25_SCORE_THRESHOLD", "0.0"))
+AIME25_FROM_DATASET = os.environ.get("DSV4_AIME25_FROM_DATASET", "")
+AIME25_HARD_ONLY = os.environ.get("DSV4_AIME25_HARD_ONLY", "0").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+AIME25_HARD_IDS = os.environ.get("DSV4_AIME25_HARD_IDS")
+AIME25_HARD_SCORE_THRESHOLD = float(
+    os.environ.get("DSV4_AIME25_HARD_SCORE_THRESHOLD", "0.70")
+)
 
 GSM8K_NUM_EXAMPLES = int(os.environ.get("DSV4_GSM8K_NUM_EXAMPLES", "50"))
 GSM8K_N_REPEATS = int(os.environ.get("DSV4_GSM8K_N_REPEATS", "1"))
@@ -136,6 +156,29 @@ def multinode_args(nnodes: int) -> List[str]:
         "--dist-init-addr",
         addr,
     ]
+
+
+def _build_aime25_hard_dataset(out_dir: Path) -> Path:
+    """Build a small sgl-eval --from-dataset JSONL from bundled sgl-eval data."""
+    try:
+        from sgl_eval.evals._loader import load_bundled
+    except ImportError as exc:
+        raise unittest.SkipTest(
+            "DSV4_AIME25_HARD_ONLY requires the sgl-eval Python package"
+        ) from exc
+
+    examples = load_bundled("aime25")(None)
+    rows = [
+        {
+            "id": ex.id,
+            "problem": ex.inputs["problem"],
+            "expected_answer": ex.target,
+        }
+        for ex in examples
+    ]
+    problem_ids = parse_problem_ids(AIME25_HARD_IDS)
+    selected = select_aime25_rows(rows, problem_ids)
+    return write_jsonl(selected, out_dir / "aime25-hard-subset.jsonl")
 
 
 class DSV4Aime25TestBase(CustomTestCase):
@@ -185,16 +228,21 @@ class DSV4Aime25TestBase(CustomTestCase):
             max_tokens=GSM8K_MAX_TOKENS,
             num_threads=GSM8K_NUM_THREADS,
             num_examples=GSM8K_NUM_EXAMPLES,
+            from_dataset=None,
             metric=GSM8K_SCORE_METRIC,
             threshold=GSM8K_SCORE_THRESHOLD,
         )
 
     def test_aime25(self):
         """Full AIME25 accuracy run; threshold gated by Flash vs Pro base."""
+        out_dir = Path(SGL_EVAL_OUT_DIR)
+        from_dataset = AIME25_FROM_DATASET
+        if AIME25_HARD_ONLY and not from_dataset:
+            from_dataset = str(_build_aime25_hard_dataset(out_dir))
         threshold = (
             AIME25_SCORE_THRESHOLD
             if AIME25_SCORE_THRESHOLD > 0
-            else self.SCORE_THRESHOLD
+            else AIME25_HARD_SCORE_THRESHOLD if from_dataset else self.SCORE_THRESHOLD
         )
         self._run_sgl_eval(
             eval_name="aime25",
@@ -204,6 +252,7 @@ class DSV4Aime25TestBase(CustomTestCase):
             max_tokens=AIME25_MAX_TOKENS,
             num_threads=AIME25_NUM_THREADS,
             num_examples=None,
+            from_dataset=from_dataset,
             metric=AIME25_SCORE_METRIC,
             threshold=threshold,
         )
@@ -217,6 +266,7 @@ class DSV4Aime25TestBase(CustomTestCase):
         max_tokens,
         num_threads,
         num_examples,
+        from_dataset,
         metric,
         threshold,
     ):
@@ -225,7 +275,7 @@ class DSV4Aime25TestBase(CustomTestCase):
 
         out_dir = Path(SGL_EVAL_OUT_DIR)
         out_dir.mkdir(parents=True, exist_ok=True)
-        glob_pattern = f"sgl_eval_{eval_name}_*.json"
+        glob_pattern = f"sgl_eval_{eval_name}_*"
         before = set(out_dir.glob(glob_pattern))
 
         cmd = [
@@ -249,6 +299,8 @@ class DSV4Aime25TestBase(CustomTestCase):
         ]
         if num_examples is not None:
             cmd += ["--num-examples", str(num_examples)]
+        if from_dataset:
+            cmd += ["--from-dataset", str(from_dataset)]
 
         print(f"[{type(self).__name__}] + {' '.join(cmd)}", flush=True)
         subprocess.run(cmd, check=True)
@@ -257,6 +309,8 @@ class DSV4Aime25TestBase(CustomTestCase):
         if not new:
             self.fail(f"sgl-eval produced no new {eval_name} JSON in {out_dir}")
         result_path = new[-1]
+        if result_path.is_dir():
+            result_path = result_path / "metrics.json"
         with open(result_path) as f:
             result = json.load(f)
         print(

--- a/test/registered/gb300/test_deepseek_v4_pro_fp4.py
+++ b/test/registered/gb300/test_deepseek_v4_pro_fp4.py
@@ -86,6 +86,11 @@ HIGH_THROUGHPUT_ENV = {
     "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK": "8320",
 }
 
+AIME25_ENV = {
+    "SGLANG_DEFAULT_THINKING": "1",
+    "SGLANG_DSV4_REASONING_EFFORT": "max",
+}
+
 AIME25_HARD_SUBSET_PATH = Path("/tmp/deepseek_v4_pro_aime25_hard_subset.jsonl")
 
 PERFORMANCE_BATCH_SIZES = {
@@ -100,6 +105,7 @@ PERFORMANCE_EXTRA_BENCH_ARGS = {
 
 
 def text_model_launch_settings(*args, **kwargs):
+    kwargs["env"] = {**AIME25_ENV, **(kwargs.get("env") or {})}
     settings = ModelLaunchSettings(*args, **kwargs)
     settings.extra_args = [
         arg for arg in settings.extra_args if arg != "--enable-multimodal"
@@ -143,11 +149,10 @@ class TestDeepSeekV4ProFp4(unittest.TestCase):
             dataset="aime25",
             baseline_accuracy=0.70,
             aime25_data_path=str(aime25_data_path),
-            max_tokens=65536,
+            max_tokens=400000,
             num_threads=16,
             temperature=1.0,
             top_p=1.0,
-            api="completion",
         )
         for variant in variants:
             try:

--- a/test/registered/gb300/test_deepseek_v4_pro_fp4.py
+++ b/test/registered/gb300/test_deepseek_v4_pro_fp4.py
@@ -95,8 +95,16 @@ PERFORMANCE_BATCH_SIZES = {
 }
 
 PERFORMANCE_EXTRA_BENCH_ARGS = {
-    "high-throughput": ["--request-timeout", "1800"],
+    "high-throughput": ["--request-timeout", "3600"],
 }
+
+
+def text_model_launch_settings(*args, **kwargs):
+    settings = ModelLaunchSettings(*args, **kwargs)
+    settings.extra_args = [
+        arg for arg in settings.extra_args if arg != "--enable-multimodal"
+    ]
+    return settings
 
 
 class TestDeepSeekV4ProFp4(unittest.TestCase):
@@ -104,14 +112,14 @@ class TestDeepSeekV4ProFp4(unittest.TestCase):
 
     def test_deepseek_v4_pro_fp4(self):
         variants = [
-            ModelLaunchSettings(
+            text_model_launch_settings(
                 MODEL_PATH,
                 tp_size=4,
                 extra_args=LOW_LATENCY_ARGS,
                 variant="low-latency",
                 launch_timeout=SERVER_LAUNCH_TIMEOUT,
             ),
-            ModelLaunchSettings(
+            text_model_launch_settings(
                 MODEL_PATH,
                 tp_size=4,
                 extra_args=BALANCED_ARGS,
@@ -119,7 +127,7 @@ class TestDeepSeekV4ProFp4(unittest.TestCase):
                 variant="balanced",
                 launch_timeout=SERVER_LAUNCH_TIMEOUT,
             ),
-            ModelLaunchSettings(
+            text_model_launch_settings(
                 MODEL_PATH,
                 tp_size=4,
                 extra_args=HIGH_THROUGHPUT_ARGS,
@@ -139,6 +147,7 @@ class TestDeepSeekV4ProFp4(unittest.TestCase):
             num_threads=16,
             temperature=1.0,
             top_p=1.0,
+            api="completion",
         )
         for variant in variants:
             try:

--- a/test/registered/gb300/test_deepseek_v4_pro_fp4.py
+++ b/test/registered/gb300/test_deepseek_v4_pro_fp4.py
@@ -1,6 +1,8 @@
 import unittest
+from pathlib import Path
 
 from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.aime25_hard_subset import build_aime25_hard_subset
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
@@ -84,10 +86,16 @@ HIGH_THROUGHPUT_ENV = {
     "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK": "8320",
 }
 
+AIME25_HARD_SUBSET_PATH = Path("/tmp/deepseek_v4_pro_aime25_hard_subset.jsonl")
+
 PERFORMANCE_BATCH_SIZES = {
     "low-latency": [1, 4, 16],
     "balanced": [64],
     "high-throughput": [128],
+}
+
+PERFORMANCE_EXTRA_BENCH_ARGS = {
+    "high-throughput": ["--request-timeout", "1800"],
 }
 
 
@@ -122,9 +130,13 @@ class TestDeepSeekV4ProFp4(unittest.TestCase):
         ]
 
         failures = []
+        aime25_data_path = build_aime25_hard_subset(AIME25_HARD_SUBSET_PATH)
         accuracy_params = AccuracyTestParams(
-            dataset="gsm8k",
-            baseline_accuracy=0.935,
+            dataset="aime25",
+            baseline_accuracy=0.70,
+            aime25_data_path=str(aime25_data_path),
+            max_tokens=65536,
+            num_threads=16,
             temperature=1.0,
             top_p=1.0,
         )
@@ -137,6 +149,9 @@ class TestDeepSeekV4ProFp4(unittest.TestCase):
                     performance_params=PerformanceTestParams(
                         batch_sizes=PERFORMANCE_BATCH_SIZES[variant.variant],
                         profile_dir="performance_profiles_gb300",
+                        extra_bench_args=PERFORMANCE_EXTRA_BENCH_ARGS.get(
+                            variant.variant, []
+                        ),
                     ),
                 )
             except AssertionError as e:

--- a/test/registered/unit/test_aime25_data_path.py
+++ b/test/registered/unit/test_aime25_data_path.py
@@ -1,0 +1,44 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from sglang.test.aime25_hard_subset import write_jsonl
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.simple_eval_aime25 import AIME25Eval
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestAime25DataPath(CustomTestCase):
+    def test_aime25_eval_loads_hard_subset_jsonl(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = write_jsonl(
+                [
+                    {
+                        "id": "aime25-13",
+                        "problem": "q13",
+                        "expected_answer": "60",
+                    },
+                    {
+                        "id": "aime25-29",
+                        "question": "q29",
+                        "answer": "240",
+                    },
+                ],
+                Path(tmpdir) / "subset.jsonl",
+            )
+
+            eval_obj = AIME25Eval(num_examples=None, num_threads=1, data_path=path)
+
+        self.assertEqual(
+            eval_obj.examples,
+            [
+                {"question": "q13", "answer": "60"},
+                {"question": "q29", "answer": "240"},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_aime25_hard_subset.py
+++ b/test/registered/unit/test_aime25_hard_subset.py
@@ -1,0 +1,61 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from sglang.test.aime25_hard_subset import (
+    DEFAULT_DSV4_FLASH_HARD_IDS,
+    parse_problem_ids,
+    select_aime25_rows,
+    write_jsonl,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestAime25HardSubset(CustomTestCase):
+    def test_parse_problem_ids(self):
+        self.assertEqual(
+            parse_problem_ids("aime25-13, aime25-14,,aime25-29"),
+            ("aime25-13", "aime25-14", "aime25-29"),
+        )
+        self.assertEqual(parse_problem_ids(None), DEFAULT_DSV4_FLASH_HARD_IDS)
+        with self.assertRaises(ValueError):
+            parse_problem_ids(" , ")
+
+    def test_select_rows_preserves_requested_order_and_schema(self):
+        rows = [
+            {"question": "q0", "answer": 0},
+            {"id": "aime25-13", "problem": "q13", "expected_answer": "60"},
+            {"id": "aime25-29", "problem": "q29", "expected_answer": "240"},
+        ]
+
+        selected = select_aime25_rows(rows, ("aime25-29", "aime25-13"))
+
+        self.assertEqual(
+            selected,
+            [
+                {"id": "aime25-29", "problem": "q29", "expected_answer": "240"},
+                {"id": "aime25-13", "problem": "q13", "expected_answer": "60"},
+            ],
+        )
+
+    def test_select_rows_reports_missing_ids(self):
+        with self.assertRaisesRegex(ValueError, "aime25-99"):
+            select_aime25_rows(
+                [{"id": "aime25-13", "problem": "q13", "expected_answer": "60"}],
+                ("aime25-99",),
+            )
+
+    def test_write_jsonl(self):
+        rows = [{"id": "aime25-13", "problem": "q13", "expected_answer": "60"}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = write_jsonl(rows, Path(tmpdir) / "subset.jsonl")
+            loaded = [json.loads(line) for line in path.read_text().splitlines()]
+        self.assertEqual(loaded, rows)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_aime25_hard_subset.py
+++ b/test/registered/unit/test_aime25_hard_subset.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from sglang.test.aime25_hard_subset import (
     DEFAULT_DSV4_FLASH_HARD_IDS,
+    build_aime25_hard_subset,
     parse_problem_ids,
     select_aime25_rows,
     write_jsonl,
@@ -55,6 +56,23 @@ class TestAime25HardSubset(CustomTestCase):
             path = write_jsonl(rows, Path(tmpdir) / "subset.jsonl")
             loaded = [json.loads(line) for line in path.read_text().splitlines()]
         self.assertEqual(loaded, rows)
+
+    def test_build_aime25_hard_subset(self):
+        rows = [
+            {"id": "aime25-13", "problem": "q13", "expected_answer": "60"},
+            {"id": "aime25-29", "question": "q29", "answer": "240"},
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = build_aime25_hard_subset(
+                Path(tmpdir) / "subset.jsonl",
+                rows=rows,
+                problem_ids=("aime25-29",),
+            )
+            loaded = [json.loads(line) for line in path.read_text().splitlines()]
+        self.assertEqual(
+            loaded,
+            [{"id": "aime25-29", "problem": "q29", "expected_answer": "240"}],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a reusable AIME25 hard-subset helper with DeepSeek-V4 Flash presets
- add a CI script that emits sgl-eval-compatible `--from-dataset` JSONL
- let the manual DeepSeek-V4 sgl-eval fixture opt into the hard subset via `DSV4_AIME25_HARD_ONLY=1` or a custom `DSV4_AIME25_FROM_DATASET`
- add CPU unit coverage for id parsing, row selection, and JSONL writing

## Validation
- devbox: `python3 test/registered/unit/test_aime25_hard_subset.py`
- devbox: `python3 scripts/ci/build_aime25_hard_subset.py --source-jsonl <tmp>/source.jsonl --out <tmp>/out.jsonl --problem-ids aime25-29,aime25-13`
- devbox: `python3 -m py_compile python/sglang/test/aime25_hard_subset.py scripts/ci/build_aime25_hard_subset.py test/manual/dsv4/_common.py test/registered/unit/test_aime25_hard_subset.py`
- local pre-commit during commit: check-ast, executable shebang, isort, ruff, black-jupyter, registered-test validation, and related hooks passed

## Notes
The default hard preset is `aime25-13,aime25-14,aime25-27,aime25-29`, with `dsv4-flash-bisect` preserving the 12-sample bisect subset (`13,14,29`). Hard-only mode uses `DSV4_AIME25_HARD_SCORE_THRESHOLD=0.70` by default so it catches the severe no-answer regression without applying the full-AIME threshold to intentionally hard rows.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28213150655](https://github.com/sgl-project/sglang/actions/runs/28213150655)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28213150601](https://github.com/sgl-project/sglang/actions/runs/28213150601)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #28213150697](https://github.com/sgl-project/sglang/actions/runs/28213150697)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->