### PR TITLE
fix(hisparse): account for host_to_device_ratio in DSA indexer memory…

### DIFF
--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -194,7 +194,24 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 element_size = torch._utils._element_size(
                     DSATokenToKVPool.index_k_with_scale_buffer_dtype
                 )
-                cell_size += indexer_size_per_token * num_layers * element_size
+                # HiSparse allocates the indexer device buffer at
+                # index_buf_size = size * host_to_device_ratio (see
+                # HiSparseDSATokenToKVPool). The per-token budget must scale the
+                # indexer term by the same ratio, otherwise max_total_num_tokens
+                # is over-estimated and startup OOMs when ratio > 1.
+                indexer_ratio = 1
+                if mr.enable_hisparse:
+                    from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+                    indexer_ratio = parse_hisparse_config(
+                        mr.server_args
+                    ).host_to_device_ratio
+                cell_size += (
+                    indexer_size_per_token
+                    * num_layers
+                    * element_size
+                    * indexer_ratio
+                )
         else:
             cell_size = (
                 model_config.get_num_kv_heads(tp_size)

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -206,11 +206,8 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                     indexer_ratio = parse_hisparse_config(
                         mr.server_args
                     ).host_to_device_ratio
-                cell_size += (
-                    indexer_size_per_token
-                    * num_layers
-                    * element_size
-                    * indexer_ratio
+                cell_size += int(
+                    indexer_size_per_token * num_layers * element_size * indexer_ratio
                 )
         else:
             cell_size = (


### PR DESCRIPTION


HiSparseDSATokenToKVPool allocates the DSA indexer device buffer at index_buf_size = size * host_to_device_ratio, but _compute_cell_size only budgeted the indexer term at size * 1. This over-estimated max_total_num_tokens and caused startup OOM whenever host_to_device_ratio > 1. Scale only the indexer per-token term by host_to_device_ratio when HiSparse is enabled; the main MLA kv_buffer stays at the un-scaled device size.

@huangtingwei9988 @hzh0425 























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27853805004](https://github.com/sgl-project/sglang/actions/runs/27853805004)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27853804933](https://github.com/sgl-project/sglang/actions/runs/27853804933)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->