### PR TITLE
[Spec] Unify decode KV-commit bookkeeping across spec-v2 workers

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -558,13 +558,12 @@ class SchedulerBatchResultProcessor:
         for i, req in enumerate(batch.reqs):
             accept_tokens = next_token_ids[i * stride : i * stride + accept_lens[i]]
 
-            if req.is_retracted:
-                # reset_for_retract() already zeroes committed/allocated KV.
+            if req.is_retracted or req.finished():
+                # retracted: reset_for_retract() already zeroed KV. finished:
+                # nothing to settle -- prepare_for_decode does not pre-claim the
+                # bonus (it is not in KV yet), so kv_committed_len already holds
+                # the committed prefix.
                 pass
-            elif req.finished():
-                if not batch.spec_algorithm.is_dflash():
-                    # EAGLE prepare_for_decode pre-claimed the bonus slot.
-                    req.kv_committed_len -= 1
             else:
                 if req.grammar is not None:
                     # Stop accepting once the grammar terminates, so the
@@ -573,13 +572,11 @@ class SchedulerBatchResultProcessor:
                     # grammar.finished.
                     accept_tokens = self._accept_grammar_tokens(req, accept_tokens)
 
+                # Commit the full accepted run (drafts + bonus). No worker
+                # pre-claims the bonus in prepare_for_decode, so the count is
+                # uniform across EAGLE / DFLASH / Frozen / ngram.
                 num_accept_tokens = len(accept_tokens)
-                if batch.spec_algorithm.is_dflash():
-                    # DFLASH materialized accepted draft tokens plus the bonus token.
-                    req.kv_committed_len += num_accept_tokens
-                else:
-                    # EAGLE prepare_for_decode pre-claimed the bonus slot.
-                    req.kv_committed_len += num_accept_tokens - 1
+                req.kv_committed_len += num_accept_tokens
                 req.spec_verify_ct += 1
 
                 num_correct_drafts = result.num_correct_drafts_per_req_cpu[i]

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -559,10 +559,8 @@ class SchedulerBatchResultProcessor:
             accept_tokens = next_token_ids[i * stride : i * stride + accept_lens[i]]
 
             if req.is_retracted or req.finished():
-                # retracted: reset_for_retract() already zeroed KV. finished:
-                # nothing to settle -- prepare_for_decode does not pre-claim the
-                # bonus (it is not in KV yet), so kv_committed_len already holds
-                # the committed prefix.
+                # Nothing to settle: no worker pre-claims the bonus, so
+                # kv_committed_len already holds the committed prefix.
                 pass
             else:
                 if req.grammar is not None:
@@ -572,9 +570,7 @@ class SchedulerBatchResultProcessor:
                     # grammar.finished.
                     accept_tokens = self._accept_grammar_tokens(req, accept_tokens)
 
-                # Commit the full accepted run (drafts + bonus). No worker
-                # pre-claims the bonus in prepare_for_decode, so the count is
-                # uniform across EAGLE / DFLASH / Frozen / ngram.
+                # Commit the full accepted run (drafts + bonus).
                 num_accept_tokens = len(accept_tokens)
                 req.kv_committed_len += num_accept_tokens
                 req.spec_verify_ct += 1

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -331,19 +331,15 @@ class StreamingSession(BasePrefixCache):
         finished_len = (
             req.finished_len if req.finished_len is not None else len(req.output_ids)
         )
-        # Authoritative committed length at finish: output_ids[:finished_len] all
-        # have their KV written, so origin + finished_len is the real count. We set
-        # it on the *slot* (not the req clock) so the next turn inherits the full
-        # prefix without depending on whether the committed clock has caught up.
-        # Under overlap + honest committed (no bonus pre-claim), the clock lags the
-        # in-flight verify by ~1 at save time; min() in _trim_overshoot would let
-        # that lag through and the next turn inherits one short. Setting the slot
-        # directly decouples streaming inheritance from the committed clock's timing.
         target = len(req.origin_input_ids) + finished_len
         self._trim_overshoot(req, finished_len)
 
         slot.save_from_req(req, is_first=is_first)
-        slot.kv_committed_len = target
+        # Inherit the authoritative finished length on the slot, not the lagging
+        # req clock (under overlap + honest committed the clock lags the in-flight
+        # verify by ~1, which would short-change inheritance). Clamp to allocated
+        # to keep committed <= allocated for prepare_for_decode.
+        slot.kv_committed_len = min(target, slot.kv_allocated_len)
 
         # Update req_nodes to this successfully finished request.
         req.session.finish_req(req)

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -331,9 +331,19 @@ class StreamingSession(BasePrefixCache):
         finished_len = (
             req.finished_len if req.finished_len is not None else len(req.output_ids)
         )
+        # Authoritative committed length at finish: output_ids[:finished_len] all
+        # have their KV written, so origin + finished_len is the real count. We set
+        # it on the *slot* (not the req clock) so the next turn inherits the full
+        # prefix without depending on whether the committed clock has caught up.
+        # Under overlap + honest committed (no bonus pre-claim), the clock lags the
+        # in-flight verify by ~1 at save time; min() in _trim_overshoot would let
+        # that lag through and the next turn inherits one short. Setting the slot
+        # directly decouples streaming inheritance from the committed clock's timing.
+        target = len(req.origin_input_ids) + finished_len
         self._trim_overshoot(req, finished_len)
 
         slot.save_from_req(req, is_first=is_first)
+        slot.kv_committed_len = target
 
         # Update req_nodes to this successfully finished request.
         req.session.finish_req(req)

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -47,11 +47,9 @@ class EagleDraftInputV2Mixin:
         num_needed_tokens = 0
         for i, r in enumerate(batch.reqs):
             cur = r.kv_allocated_len
-            # max(cur, ...) clamps so adaptive downswitch (smaller alloc_len_per_decode)
-            # cannot make nxt < cur and corrupt allocator state. kv_committed_len is
-            # the truly-committed length: the bonus token isn't in KV yet (resolve
-            # commits the full accepted run, incl. bonus), so it lags batch.seq_lens
-            # by ~1 verify in overlap mode; the 2*alloc buffer absorbs that lag.
+            # max(cur, ...) clamps so adaptive downswitch cannot make nxt < cur.
+            # kv_committed_len is honest (bonus committed in resolve, not here),
+            # so it lags batch.seq_lens by ~1 verify in overlap; 2*alloc absorbs.
             nxt = max(cur, r.kv_committed_len + double_alloc)
             cur_kv_lens[i] = cur
             nxt_kv_lens[i] = nxt

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -48,18 +48,16 @@ class EagleDraftInputV2Mixin:
         for i, r in enumerate(batch.reqs):
             cur = r.kv_allocated_len
             # max(cur, ...) clamps so adaptive downswitch (smaller alloc_len_per_decode)
-            # cannot make nxt < cur and corrupt allocator state. kv_committed_len lags
-            # batch.seq_lens by ~1 verify in overlap mode, so we react to adaptive
-            # switches one batch later than a seq_lens-based baseline; the 2*alloc
-            # over-allocation buffer absorbs that lag.
+            # cannot make nxt < cur and corrupt allocator state. kv_committed_len is
+            # the truly-committed length: the bonus token isn't in KV yet (resolve
+            # commits the full accepted run, incl. bonus), so it lags batch.seq_lens
+            # by ~1 verify in overlap mode; the 2*alloc buffer absorbs that lag.
             nxt = max(cur, r.kv_committed_len + double_alloc)
             cur_kv_lens[i] = cur
             nxt_kv_lens[i] = nxt
             num_needed_tokens += nxt - cur
             r.kv_allocated_len = nxt
             r.decode_batch_idx += 1
-            # Pre-claim bonus slot here (like normal decode); resolve subtracts 1.
-            r.kv_committed_len += 1
 
         cur_kv_lens_cpu = torch.tensor(cur_kv_lens, dtype=torch.int32, device="cpu")
         nxt_kv_lens_cpu = torch.tensor(nxt_kv_lens, dtype=torch.int32, device="cpu")

--- a/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
+++ b/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
@@ -106,9 +106,8 @@ class TestSpecV2GrammarTruncation(CustomTestCase):
         predict_tokens = proc._resolve_spec_v2_tokens(result, _FakeBatch([req]))
 
         self.assertEqual(predict_tokens, [[101, 102]])
-        # EAGLE commits (retained - 1): prepare_for_decode pre-claimed the bonus
-        # slot, and the dropped suffix is never committed.
-        self.assertEqual(req.kv_committed_len, 2 - 1)
+        # No pre-claim: commit the full retained run (no -1 refund).
+        self.assertEqual(req.kv_committed_len, 2)
 
     def test_resolve_keeps_all_when_grammar_not_terminated(self):
         req = _make_req(terminate_after=99)
@@ -118,7 +117,7 @@ class TestSpecV2GrammarTruncation(CustomTestCase):
         predict_tokens = proc._resolve_spec_v2_tokens(result, _FakeBatch([req]))
 
         self.assertEqual(predict_tokens, [[201, 202, 203]])
-        self.assertEqual(req.kv_committed_len, 3 - 1)
+        self.assertEqual(req.kv_committed_len, 3)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
+++ b/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
@@ -55,16 +55,10 @@ _OWNER_SITES = {
     (_SB, "ScheduleBatch.prepare_for_extend", "kv_allocated_len"): 1,
     ("mem_cache/common.py", "alloc_for_extend", "evict"): 1,
     ("mem_cache/common.py", "alloc_for_decode", "evict"): 1,
-    # spec v2: the scheduler-driven mixin only advances iter / alloc; the bonus
-    # slot is NOT pre-claimed (no kv_committed_len mutation here). All workers
-    # commit the full accepted run (incl. bonus) uniformly in resolve.
+    # spec v2: no pre-claim; resolve commits the full accepted run uniformly.
     (*_MIXIN, "decode_batch_idx"): 1,
     (*_MIXIN, "evict"): 1,
     (*_MIXIN, "kv_allocated_len"): 1,
-    # Single resolve mutation: running req commits the full accepted run
-    # (drafts + bonus). Finished/retracted are no-ops; grammar truncation commits
-    # only the retained (pre-termination) length so the dropped suffix is never
-    # over-committed.
     (*_RESOLVE, "kv_committed_len"): 1,
     (*_RESOLVE, "spec_verify_ct"): 1,
     (
@@ -93,9 +87,7 @@ _OWNER_SITES = {
     (_SS, "StreamingSession._trim_overshoot", "kv_committed_len"): 1,
     (_SS, "StreamingSession._trim_overshoot", "kv_allocated_len"): 1,
     (_SS, "StreamingSession.try_cache_finished_req", "kv_allocated_len"): 1,
-    # Honest committed: the slot inherits the authoritative finished length
-    # directly (not the lagging req clock), decoupling streaming inheritance
-    # from the committed clock's overlap timing.
+    # Inherit the authoritative finished length (not the lagging req clock).
     (_SS, "StreamingSession.try_cache_finished_req", "kv_committed_len"): 1,
 }
 

--- a/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
+++ b/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
@@ -55,16 +55,17 @@ _OWNER_SITES = {
     (_SB, "ScheduleBatch.prepare_for_extend", "kv_allocated_len"): 1,
     ("mem_cache/common.py", "alloc_for_extend", "evict"): 1,
     ("mem_cache/common.py", "alloc_for_decode", "evict"): 1,
-    # spec v2: pre-claim in the scheduler-driven mixin, settle in resolve
+    # spec v2: the scheduler-driven mixin only advances iter / alloc; the bonus
+    # slot is NOT pre-claimed (no kv_committed_len mutation here). All workers
+    # commit the full accepted run (incl. bonus) uniformly in resolve.
     (*_MIXIN, "decode_batch_idx"): 1,
     (*_MIXIN, "evict"): 1,
-    (*_MIXIN, "kv_committed_len"): 1,
     (*_MIXIN, "kv_allocated_len"): 1,
-    # 3rd resolve mutation: DFLASH settles its full commit_lens here (no
-    # pre-claim in prepare_for_decode, unlike the EAGLE mixin).
-    # Spec grammar truncation commits only the retained (pre-termination) length
-    # here, so the dropped suffix is never over-committed (no later rollback).
-    (*_RESOLVE, "kv_committed_len"): 3,
+    # Single resolve mutation: running req commits the full accepted run
+    # (drafts + bonus). Finished/retracted are no-ops; grammar truncation commits
+    # only the retained (pre-termination) length so the dropped suffix is never
+    # over-committed.
+    (*_RESOLVE, "kv_committed_len"): 1,
     (*_RESOLVE, "spec_verify_ct"): 1,
     (
         "speculative/dflash_info_v2.py",
@@ -92,6 +93,10 @@ _OWNER_SITES = {
     (_SS, "StreamingSession._trim_overshoot", "kv_committed_len"): 1,
     (_SS, "StreamingSession._trim_overshoot", "kv_allocated_len"): 1,
     (_SS, "StreamingSession.try_cache_finished_req", "kv_allocated_len"): 1,
+    # Honest committed: the slot inherits the authoritative finished length
+    # directly (not the lagging req clock), decoupling streaming inheritance
+    # from the committed clock's overlap timing.
+    (_SS, "StreamingSession.try_cache_finished_req", "kv_committed_len"): 1,
 }
 
 


### PR DESCRIPTION
## Summary

Drop the bonus-slot pre-claim from EAGLE's `prepare_for_decode`. With no pre-claim, every spec-v2 worker commits the full accepted run uniformly in `_resolve_spec_v2_tokens`, so the `is_dflash()` fork there is deleted. `kv_committed_len` now honestly records "tokens in KV" across all workers.

Post-resolve `kv_committed_len` is byte-identical to main; only the transient in-flight pre-claim (and the refund that undid it) goes away. DFLASH already worked this way.

## The whole point is streaming-session inheritance

Outside streaming sessions, dropping the pre-claim is a no-op for correctness: non-streaming finish releases `[0, allocated)` regardless of committed; the alloc path's `double_alloc` buffer absorbs the ±1; DFLASH was already honest. The pre-claim existed for exactly one reason — streaming-session `save_from_req`:

```python
def save_from_req(self, req):
    self.kv_committed_len = req.kv_committed_len   # next turn inherits this
```

Under overlap, the committed clock lags the in-flight verify by ~1, so at finish `save_from_req` captures `committed = origin + finished_len - 1` and the next turn inherits one token short (#22651). Pre-claim papered over that by inflating the *req clock* — but inflating a shared clock is what forced the `is_dflash()` fork in the first place (DFLASH reads committed as its attention seq_len and can't tolerate the +1).

This PR moves the fix off the clock and onto the slot: at finish, set the slot's committed to the authoritative finished length directly.

```python
slot.kv_committed_len = min(target, slot.kv_allocated_len)   # target = origin + finished_len
```

The req clock is never touched, so the page-release paths (`_trim_overshoot`, `release_session`) are unaffected, and the clock stays honest for all workers.

## Why `min(target, allocated)` (only matters under retract)

In normal decode, `allocated = committed + double_alloc` keeps `allocated > target`, so `min` is a no-op and the slot inherits `target` exactly. `target > allocated` only happens under retract, where `reset_for_retract`/`_trim_overshoot` can leave `allocated` below the finished length.

Without the clamp, `committed(145) > allocated(144)` breaks the invariant `prepare_for_decode` relies on (`nxt = max(allocated, committed + double_alloc)`); the alloc kernel then operates on a layout inconsistent with the `req_to_token` row, hands out a page still owned by another session → cross-session page alias → double-count at `close_session` → invariant crash.

Confirmed on H200 (`TestStreamingSessionEagleV2RetractLargePage`):

| variant | runs | result |
|---|---|---|
| main (with pre-claim) | 8 | 8/8 clean |
| `slot = target` (no clamp) | 5 | 2/5 leak (~40%) |
| `slot = min(target, allocated)` | 5 | 5/5 clean |

The clamp is a no-op except under retract, where it restores the exact invariant pre-claim guarded (`committed <= allocated`). `test_kv_cache_inheritance` (the #22651 ground truth) passes reliably.

## Files

- `speculative/eagle_info_v2.py`: drop `r.kv_committed_len += 1` in `prepare_for_decode`.
- `managers/scheduler_components/batch_result_processor.py`: unify `_resolve_spec_v2_tokens` to `committed += num_accept_tokens`; delete the `is_dflash()` fork and the finished `-1` settle.
- `session/streaming_session.py`: `slot.kv_committed_len = min(target, slot.kv_allocated_len)` at finish.
- `test/registered/unit/spec/test_decode_bookkeeping_ownership.py`: update the allowlist (mixin `kv_committed_len` 1→0, resolve 3→1, +1 at `try_cache_finished_req`).






















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28009800310](https://github.com/sgl-project/sglang/actions/runs/28009800310)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28009800146](https://github.com/sgl-project/sglang/actions/runs/28009800146)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
