### PR TITLE
[codex] Avoid max-autotune compile default on Blackwell

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -7,7 +7,6 @@ Denoising stage for diffusion pipelines.
 
 import inspect
 import math
-import os
 import time
 import weakref
 from collections.abc import Callable
@@ -108,6 +107,9 @@ from sglang.multimodal_gen.runtime.utils.precision import (
     resolve_precision,
 )
 from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
+from sglang.multimodal_gen.runtime.utils.torch_compile import (
+    resolve_torch_compile_mode,
+)
 from sglang.multimodal_gen.utils import dict_to_3d_list
 from sglang.srt.utils.common import get_compiler_backend
 
@@ -329,11 +331,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             except ImportError:
                 pass
             dit_config = getattr(self.server_args.pipeline_config, "dit_config", None)
-            mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE") or getattr(
-                dit_config,
-                "torch_compile_mode",
-                "max-autotune-no-cudagraphs",
-            )
+            mode = resolve_torch_compile_mode(dit_config)
             compile_kwargs["mode"] = mode
             logger.info(f"Compiling transformer with mode: {mode}")
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/hunyuan3d/paint.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/hunyuan3d/paint.py
@@ -33,6 +33,9 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.torch_compile import (
+    resolve_torch_compile_mode,
+)
 from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 
 logger = init_logger(__name__)
@@ -617,11 +620,7 @@ class Hunyuan3DPaintTexGenStage(PipelineStage):
         ).to(self.device)
         if server_args.enable_torch_compile:
             dit_config = getattr(server_args.pipeline_config, "dit_config", None)
-            compile_mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE") or getattr(
-                dit_config,
-                "torch_compile_mode",
-                "max-autotune-no-cudagraphs",
-            )
+            compile_mode = resolve_torch_compile_mode(dit_config)
             logger.info("Compiling paint transformer with mode: %s", compile_mode)
             self.transformer.compile(mode=compile_mode, fullgraph=False, dynamic=None)
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import functools
 import inspect
-import os
 
 import torch
 import torch.nn as nn
@@ -32,6 +31,9 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_classifier_free_guidance_rank,
     get_sp_parallel_rank,
     get_sp_world_size,
+)
+from sglang.multimodal_gen.runtime.utils.torch_compile import (
+    resolve_torch_compile_mode,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
 
@@ -271,11 +273,7 @@ class MOVADenoisingStage(PipelineStage):
                 _inductor_cfg.reorder_for_compute_comm_overlap = True
             except ImportError:
                 pass
-            mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE") or getattr(
-                model_config,
-                "torch_compile_mode",
-                "max-autotune-no-cudagraphs",
-            )
+            mode = resolve_torch_compile_mode(model_config)
             compile_kwargs["mode"] = mode
             logger.info("Compiling %s with mode: %s", module.__class__.__name__, mode)
 

--- a/python/sglang/multimodal_gen/runtime/utils/torch_compile.py
+++ b/python/sglang/multimodal_gen/runtime/utils/torch_compile.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Utilities for diffusion ``torch.compile`` configuration."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from sglang.multimodal_gen.runtime.platforms import current_platform
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+DEFAULT_TORCH_COMPILE_MODE = "max-autotune-no-cudagraphs"
+BLACKWELL_TORCH_COMPILE_MODE = "default"
+TORCH_COMPILE_MODE_ENV = "SGLANG_TORCH_COMPILE_MODE"
+
+
+def resolve_torch_compile_mode(
+    model_config: Any | None,
+    default: str = DEFAULT_TORCH_COMPILE_MODE,
+) -> str:
+    """Resolve DiT ``torch.compile`` mode with a Blackwell-safe default.
+
+    PyTorch Inductor's max-autotune path can try Triton GEMM candidates that
+    exceed SM100 resource limits and then fall back to ATen/cuBLAS anyway. Keep
+    explicit user and model choices intact, but avoid that default autotune path
+    on Blackwell when no override is provided.
+    """
+    env_mode = os.environ.get(TORCH_COMPILE_MODE_ENV)
+    if env_mode:
+        return env_mode
+
+    mode = getattr(model_config, "torch_compile_mode", default)
+    if mode == DEFAULT_TORCH_COMPILE_MODE and current_platform.is_blackwell():
+        logger.info(
+            "Using torch.compile mode %s on Blackwell instead of %s. "
+            "Set %s to override.",
+            BLACKWELL_TORCH_COMPILE_MODE,
+            DEFAULT_TORCH_COMPILE_MODE,
+            TORCH_COMPILE_MODE_ENV,
+        )
+        return BLACKWELL_TORCH_COMPILE_MODE
+
+    return mode

--- a/python/sglang/multimodal_gen/test/unit/test_torch_compile_utils.py
+++ b/python/sglang/multimodal_gen/test/unit/test_torch_compile_utils.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.multimodal_gen.runtime.utils.torch_compile import (
+    BLACKWELL_TORCH_COMPILE_MODE,
+    DEFAULT_TORCH_COMPILE_MODE,
+    TORCH_COMPILE_MODE_ENV,
+    resolve_torch_compile_mode,
+)
+
+
+def test_resolve_torch_compile_mode_uses_env_override(monkeypatch):
+    monkeypatch.setenv(TORCH_COMPILE_MODE_ENV, "max-autotune")
+
+    with patch(
+        "sglang.multimodal_gen.runtime.utils.torch_compile.current_platform.is_blackwell",
+        return_value=True,
+    ):
+        assert resolve_torch_compile_mode(None) == "max-autotune"
+
+
+def test_resolve_torch_compile_mode_keeps_default_off_blackwell(monkeypatch):
+    monkeypatch.delenv(TORCH_COMPILE_MODE_ENV, raising=False)
+
+    with patch(
+        "sglang.multimodal_gen.runtime.utils.torch_compile.current_platform.is_blackwell",
+        return_value=False,
+    ):
+        assert resolve_torch_compile_mode(None) == DEFAULT_TORCH_COMPILE_MODE
+
+
+def test_resolve_torch_compile_mode_uses_default_on_blackwell(monkeypatch):
+    monkeypatch.delenv(TORCH_COMPILE_MODE_ENV, raising=False)
+
+    with patch(
+        "sglang.multimodal_gen.runtime.utils.torch_compile.current_platform.is_blackwell",
+        return_value=True,
+    ):
+        assert resolve_torch_compile_mode(None) == BLACKWELL_TORCH_COMPILE_MODE
+
+
+def test_resolve_torch_compile_mode_keeps_explicit_model_mode(monkeypatch):
+    monkeypatch.delenv(TORCH_COMPILE_MODE_ENV, raising=False)
+    config = SimpleNamespace(torch_compile_mode="reduce-overhead")
+
+    with patch(
+        "sglang.multimodal_gen.runtime.utils.torch_compile.current_platform.is_blackwell",
+        return_value=True,
+    ):
+        assert resolve_torch_compile_mode(config) == "reduce-overhead"


### PR DESCRIPTION
## What changed

This PR routes diffusion `torch.compile` mode resolution through a shared helper and uses `default` instead of `max-autotune-no-cudagraphs` on Blackwell when no explicit override is set.

The override order remains:

1. `SGLANG_TORCH_COMPILE_MODE`
2. model/pipeline `torch_compile_mode`
3. Blackwell-safe fallback from the global default max-autotune mode to `default`

The helper is used by the standard denoising stage, MOVA denoising, and Hunyuan3D paint compile paths.

## Why

On B200 / SM100, PyTorch Inductor max-autotune can try Triton GEMM candidates that exceed the hardware resource limit, e.g. `Required: 262160 Hardware limit:232448`, and then falls back to ATen/cuBLAS. The bad candidates add compile/autotune noise without improving the chosen kernel for the observed diffusion shapes.

A minimal SANA-shaped repro showed:

- `max-autotune-no-cudagraphs`: hit the SM100 resource-limit error; best kernel was `bias_addmm`; first compiled call ~4372 ms
- `default`: no invalid candidates; first compiled call ~1682 ms

## Validation

Local:

- `python3 -m compileall -q ...` for touched files
- `git diff --check`
- `ruff check` on the new helper/test plus denoising and Hunyuan3D paint files
- `ruff check --select F401` on MOVA to ensure the new import is used

B200 (`ion-b200`, GPU4):

- `PYTHONPATH=python pytest -q python/sglang/multimodal_gen/test/unit/test_torch_compile_utils.py` -> 4 passed
- `python3 -m compileall -q ...` for touched files
- helper smoke: no env resolves to `default`; env override resolves back to `max-autotune-no-cudagraphs`
- SANA 600M native-path smoke with no env: logs `Using torch.compile mode default on Blackwell...`, compiles with `default`, and `INVALID_COUNT=0`

Note: the current SANA 600M smoke reaches denoising successfully but then hits an unrelated VAE decode dtype mismatch on current main (`BFloat16` input vs `float` bias). I treated that separately from this torch.compile mode issue.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27856024455](https://github.com/sgl-project/sglang/actions/runs/27856024455)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27856024401](https://github.com/sgl-project/sglang/actions/runs/27856024401)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->