### PR TITLE
refactor(attn): deprecate use_bound parameter on _compute_forward_metadata

### DIFF
--- a/python/sglang/srt/layers/attention/cutlass_mla_backend.py
+++ b/python/sglang/srt/layers/attention/cutlass_mla_backend.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
 
 import torch
-import triton
 
 from sglang.srt.layers.attention.flashinfer_mla_backend import FlashInferMLAAttnBackend
 from sglang.srt.layers.attention.utils import (
@@ -108,90 +107,48 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
         seq_lens = forward_batch.seq_lens
 
         if forward_mode.is_decode_or_idle() and spec_info is None:
-            # Converged decode+no-spec body (identical to the eager
-            # init_forward_metadata body, modulo the `in_capture or` below; the
-            # two are merged into a shared helper in a follow-up commit).
-            # use_bound selects the pre-bound cuda-graph block table + bound
-            # workspace (capture / replay / eager-at-captured-bs) vs a fresh
-            # block table + workspace. In out_graph use_bound is always True
-            # (capture sets in_capture; replay pads to a captured bs), matching
-            # the old always-bound behavior; setting forward_metadata on replay
-            # is harmless (replay never reads it -- the captured kernel uses the
-            # baked buffer addresses).
-            use_bound = in_capture or (
-                getattr(self, "cuda_graph_kv_indices", None) is not None
-                and bs <= self.cuda_graph_kv_indices.shape[0]
-            )
-            self._compute_decode_metadata(forward_batch, use_bound=use_bound)
+            # Single converged decode+no-spec body: every path (eager, capture,
+            # replay) writes into the pre-bound `cuda_graph_kv_indices` + uses
+            # the pre-bound `cuda_graph_mla_workspace` allocated once at init.
+            self._compute_decode_metadata(forward_batch)
         else:
             super().init_forward_metadata_out_graph(
                 forward_batch, in_capture=in_capture
             )
 
-    def _compute_decode_metadata(self, forward_batch: ForwardBatch, *, use_bound: bool):
+    def _compute_decode_metadata(self, forward_batch: ForwardBatch):
         """Cutlass-MLA decode (no-spec) metadata, shared by eager/capture/replay.
 
-        ``use_bound`` selects the pre-bound cuda-graph block table + bound
-        workspace (capture / replay / eager-at-captured-bs) vs a freshly
-        allocated block table + workspace (pure-eager / bs beyond capacity).
+        Writes into the pre-bound ``cuda_graph_kv_indices`` (block table) and
+        uses the pre-bound ``cuda_graph_mla_workspace``, both allocated once at
+        ``init_static_metadata_buffers``. The Cutlass-MLA read kernel guards on
+        ``seq_lens`` so trailing sentinel slots in the block table are never
+        accessed.
         """
         bs = forward_batch.batch_size
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens
 
-        if use_bound:
-            block_kv_indices = self.cuda_graph_kv_indices
-            create_flashmla_kv_indices_triton[
-                (
-                    bs,
-                    get_num_kv_index_blocks_flashmla(
-                        block_kv_indices.stride(0), PAGE_SIZE
-                    ),
-                )
-            ](
-                self.req_to_token,
-                req_pool_indices[:bs],
-                seq_lens[:bs],
-                None,
-                block_kv_indices,
-                self.req_to_token.stride(0),
-                block_kv_indices.stride(0),
-                PAGED_SIZE=PAGE_SIZE,
+        block_kv_indices = self.cuda_graph_kv_indices
+        create_flashmla_kv_indices_triton[
+            (
+                bs,
+                get_num_kv_index_blocks_flashmla(block_kv_indices.stride(0), PAGE_SIZE),
             )
-            self.forward_metadata = CutlassMLADecodeMetadata(
-                self.cuda_graph_mla_workspace,
-                block_kv_indices[:bs, : block_kv_indices.shape[1]],
-            )
-        else:
-            max_seqlen_pad = triton.cdiv(
-                forward_batch.seq_lens_cpu.max().item(), PAGE_SIZE
-            )
-            block_kv_indices = torch.full(
-                (bs, max_seqlen_pad),
-                -1,
-                dtype=torch.int32,
-                device=seq_lens.device,
-            )
-            create_flashmla_kv_indices_triton[
-                (bs, get_num_kv_index_blocks_flashmla(max_seqlen_pad, PAGE_SIZE))
-            ](
-                self.req_to_token,
-                req_pool_indices,
-                seq_lens,
-                None,
-                block_kv_indices,
-                self.req_to_token.stride(0),
-                max_seqlen_pad,
-                PAGED_SIZE=PAGE_SIZE,
-            )
-            workspace_size = cutlass_mla_get_workspace_size(
-                max_seqlen_pad * PAGE_SIZE, bs, num_kv_splits=1
-            )
-            workspace = torch.empty(workspace_size, device="cuda", dtype=torch.uint8)
-            self.forward_metadata = CutlassMLADecodeMetadata(
-                workspace,
-                block_kv_indices,
-            )
+        ](
+            self.req_to_token,
+            req_pool_indices[:bs],
+            seq_lens[:bs],
+            None,
+            block_kv_indices,
+            self.req_to_token.stride(0),
+            block_kv_indices.stride(0),
+            PAGED_SIZE=PAGE_SIZE,
+        )
+        self.forward_metadata = CutlassMLADecodeMetadata(
+            self.cuda_graph_mla_workspace,
+            block_kv_indices[:bs, : block_kv_indices.shape[1]],
+        )
 
     def init_static_metadata_buffers(
         self,
@@ -200,9 +157,12 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
         block_kv_indices: Optional[torch.Tensor] = None,
     ):
         if block_kv_indices is None:
+            # -1 is the "no kv index" sentinel matching the fresh-alloc eager
+            # path; the read kernel guards on `seq_lens` so trailing slots are
+            # never accessed.
             cuda_graph_kv_indices = torch.full(
                 (max_bs, (self.max_context_len + PAGE_SIZE) // PAGE_SIZE),
-                1,
+                -1,
                 dtype=torch.int32,
                 device="cuda",
             )

--- a/python/sglang/srt/layers/attention/cutlass_mla_backend.py
+++ b/python/sglang/srt/layers/attention/cutlass_mla_backend.py
@@ -124,12 +124,37 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
         ``init_static_metadata_buffers``. The Cutlass-MLA read kernel guards on
         ``seq_lens`` so trailing sentinel slots in the block table are never
         accessed.
+
+        Oversized eager fallback: when ``bs`` exceeds the cuda-graph block
+        table's row count (max_running_requests > cuda_graph_max_bs_decode and
+        DecodeCudaGraphRunner rejects -> eager), the Triton kv-indices fill is
+        launched with grid bs > buffer rows. Allocate a fresh per-iter block
+        table + workspace for those iters (mirrors the pre-use_bound fresh
+        path that FlashMLA already has).
         """
         bs = forward_batch.batch_size
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens
 
-        block_kv_indices = self.cuda_graph_kv_indices
+        if bs <= self.cuda_graph_kv_indices.shape[0]:
+            block_kv_indices = self.cuda_graph_kv_indices
+            workspace = self.cuda_graph_mla_workspace
+            block_table_view = block_kv_indices[:bs, : block_kv_indices.shape[1]]
+        else:
+            max_seqlen_pad = triton.cdiv(
+                forward_batch.seq_lens_cpu.max().item(), PAGE_SIZE
+            )
+            block_kv_indices = torch.full(
+                (bs, max_seqlen_pad),
+                -1,
+                dtype=torch.int32,
+                device=seq_lens.device,
+            )
+            workspace_size = cutlass_mla_get_workspace_size(
+                max_seqlen_pad * PAGE_SIZE, bs, num_kv_splits=1
+            )
+            workspace = torch.empty(workspace_size, device="cuda", dtype=torch.uint8)
+            block_table_view = block_kv_indices
         create_flashmla_kv_indices_triton[
             (
                 bs,
@@ -146,8 +171,8 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
             PAGED_SIZE=PAGE_SIZE,
         )
         self.forward_metadata = CutlassMLADecodeMetadata(
-            self.cuda_graph_mla_workspace,
-            block_kv_indices[:bs, : block_kv_indices.shape[1]],
+            workspace,
+            block_table_view,
         )
 
     def init_static_metadata_buffers(

--- a/python/sglang/srt/layers/attention/cutlass_mla_backend.py
+++ b/python/sglang/srt/layers/attention/cutlass_mla_backend.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
 
 import torch
+import triton
 
 from sglang.srt.layers.attention.flashinfer_mla_backend import FlashInferMLAAttnBackend
 from sglang.srt.layers.attention.utils import (

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1010,7 +1010,9 @@ class DeepseekV4AttnBackend(
         if logical_forward_mode.is_target_verify():
             spec_info = forward_batch.spec_info
             if spec_info is not None and getattr(spec_info, "num_tokens_per_req", 0):
-                verify_bs = forward_batch.input_ids.shape[0] // spec_info.num_tokens_per_req
+                verify_bs = (
+                    forward_batch.input_ids.shape[0] // spec_info.num_tokens_per_req
+                )
         self.online_c128_mtp.prepare_forward(
             logical_forward_mode,
             req_pool_indices,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -934,20 +934,10 @@ class DeepseekV4AttnBackend(
                 )
             )
 
-    def _use_cuda_graph_buffers(self, bs: int, forward_mode: ForwardMode) -> bool:
-        """Eager/replay seam, resolved by backend STATE (no argument).
-
-        Returns True when this ``(bs, forward_mode)`` has a pre-bound cuda-graph
-        metadata object in ``cuda_graph_metadata_of_bucket_and_bs[bucket][bs]``:
-        i.e. at graph replay (the runner always pads to a captured bucket) and
-        harmlessly at an eager forward that lands on a captured bs+mode in a
-        graph-enabled server -- ``replay_cuda_graph_metadata_from`` then copies
-        into the bound metadata, which ``out_graph`` always rebuilds before the
-        next ``graph.replay()``, so a transient eager build cannot leak into a
-        later replay. Returns False for pure-eager runs (no metadata was ever
-        captured for this bs/mode, or the cuda-graph state was never inited) and
-        for any mode without a graph bucket (e.g. plain EXTEND) -> build fresh
-        eager metadata.
+    def _has_captured_metadata(self, bs: int, forward_mode: ForwardMode) -> bool:
+        """Whether ``(bs, forward_mode)`` has a captured cuda-graph metadata
+        object in ``cuda_graph_metadata_of_bucket_and_bs[bucket][bs]``. Internal
+        to ``_compute_forward_metadata``; see that method for the seam.
         """
         bucket_metadata = getattr(self, "cuda_graph_metadata_of_bucket_and_bs", None)
         if bucket_metadata is None:
@@ -963,14 +953,10 @@ class DeepseekV4AttnBackend(
         forward_batch: ForwardBatch,
         in_capture: bool = False,
     ) -> None:
-        # Single eager == replay == capture metadata path; `use_bound` selects
-        # the pre-bound cuda-graph metadata object vs a fresh eager build.
-        use_bound = in_capture or self._use_cuda_graph_buffers(
-            forward_batch.batch_size, forward_batch.forward_mode
-        )
-        self._compute_forward_metadata(
-            forward_batch, use_bound=use_bound, in_capture=in_capture
-        )
+        # Single eager == replay == capture metadata path. The seam between
+        # the captured cuda-graph bucket metadata and a fresh eager build is
+        # internal to _compute_forward_metadata.
+        self._compute_forward_metadata(forward_batch, in_capture=in_capture)
 
         if in_capture:
             # Preserve _current_capture_raw for on_after_cuda_graph_warmup
@@ -988,20 +974,20 @@ class DeepseekV4AttnBackend(
         self,
         forward_batch: ForwardBatch,
         *,
-        use_bound: bool,
         in_capture: bool = False,
     ) -> None:
         """Single source of truth for DSV4 forward metadata, shared by eager,
         capture, and replay.
 
-        ``use_bound`` selects where the metadata is planned: the per-bs pre-bound
-        cuda-graph metadata object (capture / replay / eager-at-captured-bs, via
-        replay_cuda_graph_metadata_from) vs a fresh eager build. ``in_capture``
-        synthesizes a dummy out_cache_loc / capture-time seq-len locals (the
-        captured graph does no real cache writes); it is only ever True together
-        with use_bound=True. Plain EXTEND has no graph bucket and only ever runs
-        with use_bound=False (the decode graph never captures it), so
-        _GraphBucket.of is resolved lazily inside the bound branch.
+        Internally selects between the per-bs pre-bound cuda-graph metadata
+        object (capture / replay / eager-at-captured-bs, via
+        ``replay_cuda_graph_metadata_from``) and a fresh eager build. The
+        ``in_capture`` flag synthesizes a dummy out_cache_loc / capture-time
+        seq-len locals (the captured graph does no real cache writes); it is
+        only ever True together with the captured-bucket path. Plain EXTEND has
+        no graph bucket and only ever runs through the fresh path (the decode
+        graph never captures it), so ``_GraphBucket.of`` is resolved lazily
+        inside the captured branch.
         """
         bs = forward_batch.batch_size
         req_pool_indices = forward_batch.req_pool_indices
@@ -1032,7 +1018,13 @@ class DeepseekV4AttnBackend(
             verify_bs=verify_bs,
         )
 
-        if use_bound:
+        # Internalize the captured-bucket seam — every caller goes through
+        # this method; the public API does not expose it.
+        _has_captured = in_capture or self._has_captured_metadata(
+            bs, forward_batch.forward_mode
+        )
+
+        if _has_captured:
             if in_capture:
                 # Captured graph does no real cache writes, so synthesize a dummy
                 # out_cache_loc per bucket (replay supplies the real value).

--- a/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
@@ -23,7 +23,7 @@ from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.flashattention_backend import (
     FlashAttentionMetadata,
 )
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.runtime_context import get_parallel
 
 if TYPE_CHECKING:
@@ -174,43 +174,19 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
         end_head = start_head + self.num_heads
         return [layer_sparse_attention_config[i] for i in range(start_head, end_head)]
 
-    def _use_cuda_graph_buffers(self, bs: int, forward_mode: ForwardMode) -> bool:
-        """Eager/replay seam, resolved by backend STATE (no argument).
-
-        Returns True when this ``(bs, forward_mode)`` has a pre-bound cuda-graph
-        metadata object: i.e. at decode-graph replay (the runner always pads to a
-        captured bucket) and harmlessly at an eager forward that lands on a
-        captured bs in a graph-enabled server -- there is one forward stream per
-        backend, and the bound metadata buffers are always re-filled by
-        ``out_graph`` before the next ``graph.replay()``, so a transient eager
-        write cannot leak into a later replay. Only decode/idle is ever captured
-        (``_bind_metadata_buffers``). Returns False for pure-eager runs
-        (``init_cuda_graph_state`` never ran -> no ``decode_metadata``) and for
-        prefill -> build a fresh metadata object. Never raises KeyError.
-        """
-        if not forward_mode.is_decode_or_idle():
-            return False
-        return bs in getattr(self, "decode_metadata", {})
-
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
         in_capture: bool = False,
     ):
-        bs = forward_batch.batch_size
-        req_pool_indices = forward_batch.req_pool_indices
-        forward_mode = forward_batch.forward_mode
+        # Single eager == replay == capture path. Decode builds a metadata
+        # view over the shared max-bs buffers (allocated once in
+        # init_static_metadata_buffers) and mutates the views in place — the
+        # storage is stable across iters so cuda graph data_ptrs are stable.
+        # Prefill builds fresh metadata (no captured graph).
+        self._compute_forward_metadata(forward_batch)
 
-        if in_capture:
-            self._bind_metadata_buffers(bs, req_pool_indices, forward_mode)
-
-        # Single eager == replay == capture metadata path; `use_bound` selects the
-        # pre-bound cuda-graph metadata object vs a freshly built one (see
-        # _use_cuda_graph_buffers). Always bound at capture.
-        use_bound = in_capture or self._use_cuda_graph_buffers(bs, forward_mode)
-        self._compute_forward_metadata(forward_batch, use_bound=use_bound)
-
-        if in_capture and forward_mode.is_decode_or_idle():
+        if in_capture and forward_batch.forward_mode.is_decode_or_idle():
             # Restore max_seq_len scalars — replay sets actual values but CUDA
             # graph needs the safe upper bound baked in at capture time.
             md = self.forward_metadata
@@ -219,28 +195,41 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
             md.max_seq_len_succ = self.max_context_len
             md.max_seq_len_inter = self.max_context_len
 
-    def _compute_forward_metadata(
-        self, forward_batch: ForwardBatch, *, use_bound: bool
-    ):
-        """Single source of truth for Dual-Chunk FlashAttention forward metadata,
-        shared by eager, capture, and replay.
+    def _compute_forward_metadata(self, forward_batch: ForwardBatch):
+        """Single source of truth for Dual-Chunk FlashAttention forward
+        metadata, shared by eager, capture, and replay.
 
-        ``use_bound`` selects the metadata destination: the per-bs pre-bound
-        cuda-graph metadata object in ``decode_metadata`` (capture / replay /
-        eager-at-captured-bs; decode-only) vs a freshly built
-        ``DualChunkFlashAttentionMetadata`` (pure-eager prefill or decode).
+        Decode writes into the shared max-bs buffers from
+        ``init_static_metadata_buffers`` (sliced [:bs] per-iter). The storage
+        is stable across iterations so the cuda graph's captured data_ptrs
+        remain valid; capture, replay, and eager all execute the same body.
+        Prefill builds a fresh metadata object — no captured graph for it.
         """
         bs = forward_batch.batch_size
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens
         forward_mode = forward_batch.forward_mode
 
-        if use_bound:
-            # Bound cuda-graph buffers (decode-only).
-            assert forward_mode.is_decode()
+        if forward_mode.is_decode_or_idle():
+            # Decode: rebuild metadata view over shared max-bs buffers; mutate
+            # the views in place. Storage is stable so cuda-graph captured
+            # data_ptrs stay valid across iters (capture / replay / eager all
+            # execute this same body).
             seq_lens = seq_lens[:bs]
             req_pool_indices = req_pool_indices[:bs]
-            metadata = self.decode_metadata[bs]
+            metadata = DualChunkFlashAttentionMetadata()
+            metadata.seq_lens_tensor = self.decode_metadata["seq_lens_tensor"][:bs]
+            metadata.orig_seq_lens_tensor = self.decode_metadata[
+                "orig_seq_lens_tensor"
+            ][:bs]
+            metadata.block_tables = self.decode_metadata["block_tables"]
+            metadata.block_tables_intra = self.decode_metadata["block_tables_intra"]
+            metadata.block_tables_succ = self.decode_metadata["block_tables_succ"]
+            metadata.seq_lens_intra = self.decode_metadata["seq_lens_intra"][:bs]
+            metadata.seq_lens_succ = self.decode_metadata["seq_lens_succ"][:bs]
+            metadata.seq_lens_inter = self.decode_metadata["seq_lens_inter"][:bs]
+            if self.original_max_position_embeddings > 0:
+                metadata.scaling_factor = self.decode_metadata["scaling_factor"][:bs]
 
             metadata.seq_lens_tensor.copy_(seq_lens.to(torch.int32))
             metadata.seq_lens = seq_lens.tolist()
@@ -320,8 +309,8 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
 
             self.forward_metadata = metadata
         else:
-            # Freshly built metadata object (pure-eager prefill or decode).
-            assert forward_mode.is_prefill() or forward_mode.is_decode()
+            # Prefill: fresh-built metadata (no graph capture in this path).
+            assert forward_mode.is_prefill()
             batch_size = forward_batch.batch_size
 
             metadata = DualChunkFlashAttentionMetadata()
@@ -687,51 +676,6 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
                 max_bs, dtype=torch.int32, device=self.device
             ),
         }
-
-    def _bind_metadata_buffers(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        forward_mode: ForwardMode,
-    ):
-        """Allocate persistent metadata buffers for CUDA graph capture."""
-        metadata = DualChunkFlashAttentionMetadata()
-
-        if forward_mode.is_decode_or_idle():
-            if self.original_max_position_embeddings > 0:
-                metadata.scaling_factor = self.decode_metadata["scaling_factor"][:bs]
-
-            metadata.seq_lens_tensor = self.decode_metadata["seq_lens_tensor"][:bs]
-            metadata.orig_seq_lens_tensor = self.decode_metadata[
-                "orig_seq_lens_tensor"
-            ][:bs]
-            metadata.max_seq_len = self.max_context_len
-            metadata.block_tables = self.decode_metadata["block_tables"][
-                req_pool_indices, :
-            ]
-
-            # intra
-            metadata.max_seq_len_intra = self.max_context_len
-            metadata.seq_lens_intra = self.decode_metadata["seq_lens_intra"][:bs]
-
-            metadata.block_tables_intra = self.decode_metadata["block_tables_intra"][
-                :bs, :
-            ]
-
-            # succ
-            metadata.seq_lens_succ = self.decode_metadata["seq_lens_succ"][:bs]
-            metadata.max_seq_len_succ = self.max_context_len
-
-            metadata.block_tables_succ = self.decode_metadata["block_tables_succ"][
-                :bs, :
-            ]
-
-            metadata.seq_lens_inter = self.decode_metadata["seq_lens_inter"][:bs]
-            metadata.max_seq_len_inter = self.max_context_len
-
-            self.decode_metadata[bs] = metadata
-
-        self.forward_metadata = metadata
 
     def get_cuda_graph_seq_len_fill_value(self):
         """Get the fill value for sequence length in CUDA graph."""

--- a/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
@@ -217,19 +217,30 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
             # execute this same body).
             seq_lens = seq_lens[:bs]
             req_pool_indices = req_pool_indices[:bs]
-            metadata = DualChunkFlashAttentionMetadata()
-            metadata.seq_lens_tensor = self.decode_metadata["seq_lens_tensor"][:bs]
-            metadata.orig_seq_lens_tensor = self.decode_metadata[
-                "orig_seq_lens_tensor"
-            ][:bs]
-            metadata.block_tables = self.decode_metadata["block_tables"]
-            metadata.block_tables_intra = self.decode_metadata["block_tables_intra"]
-            metadata.block_tables_succ = self.decode_metadata["block_tables_succ"]
-            metadata.seq_lens_intra = self.decode_metadata["seq_lens_intra"][:bs]
-            metadata.seq_lens_succ = self.decode_metadata["seq_lens_succ"][:bs]
-            metadata.seq_lens_inter = self.decode_metadata["seq_lens_inter"][:bs]
-            if self.original_max_position_embeddings > 0:
-                metadata.scaling_factor = self.decode_metadata["scaling_factor"][:bs]
+            # Oversized eager fallback: when bs exceeds the captured ceiling
+            # the cuda-graph runner rejects this batch and dispatches eager;
+            # the shared max-bs views are too small for [:bs].copy_ and would
+            # raise on shape mismatch (or scribble past the buffer on the 2D
+            # block_tables fields). Fresh-alloc per-iter for this path.
+            cg_max_bs = getattr(self, "cuda_graph_max_bs", None)
+            if cg_max_bs is not None and bs > cg_max_bs:
+                metadata = self._build_fresh_decode_metadata(bs)
+            else:
+                metadata = DualChunkFlashAttentionMetadata()
+                metadata.seq_lens_tensor = self.decode_metadata["seq_lens_tensor"][:bs]
+                metadata.orig_seq_lens_tensor = self.decode_metadata[
+                    "orig_seq_lens_tensor"
+                ][:bs]
+                metadata.block_tables = self.decode_metadata["block_tables"]
+                metadata.block_tables_intra = self.decode_metadata["block_tables_intra"]
+                metadata.block_tables_succ = self.decode_metadata["block_tables_succ"]
+                metadata.seq_lens_intra = self.decode_metadata["seq_lens_intra"][:bs]
+                metadata.seq_lens_succ = self.decode_metadata["seq_lens_succ"][:bs]
+                metadata.seq_lens_inter = self.decode_metadata["seq_lens_inter"][:bs]
+                if self.original_max_position_embeddings > 0:
+                    metadata.scaling_factor = self.decode_metadata["scaling_factor"][
+                        :bs
+                    ]
 
             metadata.seq_lens_tensor.copy_(seq_lens.to(torch.int32))
             metadata.seq_lens = seq_lens.tolist()
@@ -631,6 +642,37 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
         ).squeeze(1)
         return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
+    def _build_fresh_decode_metadata(self, bs: int):
+        """Fresh per-iter equivalent of the bound ``self.decode_metadata`` dict,
+        used when the live bs exceeds the captured ceiling and the cuda-graph
+        runner has dispatched this batch through the eager fallback.
+        """
+        metadata = DualChunkFlashAttentionMetadata()
+        block_cols = (self.max_context_len - 1) // self.page_size + 1
+        metadata.seq_lens_tensor = torch.zeros(
+            bs, dtype=torch.int32, device=self.device
+        )
+        metadata.orig_seq_lens_tensor = torch.zeros(
+            bs, dtype=torch.int32, device=self.device
+        )
+        metadata.block_tables = torch.zeros(
+            bs, block_cols, dtype=torch.int32, device=self.device
+        )
+        metadata.block_tables_intra = torch.zeros(
+            bs, block_cols, dtype=torch.int32, device=self.device
+        )
+        metadata.block_tables_succ = torch.zeros(
+            bs, block_cols, dtype=torch.int32, device=self.device
+        )
+        metadata.seq_lens_intra = torch.zeros(bs, dtype=torch.int32, device=self.device)
+        metadata.seq_lens_succ = torch.zeros(bs, dtype=torch.int32, device=self.device)
+        metadata.seq_lens_inter = torch.zeros(bs, dtype=torch.int32, device=self.device)
+        if self.original_max_position_embeddings > 0:
+            metadata.scaling_factor = torch.zeros(
+                bs, dtype=torch.float32, device=self.device
+            )
+        return metadata
+
     def init_static_metadata_buffers(self, max_bs: int, max_num_tokens: int):
         """Initialize CUDA graph state for the attention backend.
 
@@ -640,6 +682,10 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
         This creates fixed-size tensors that will be reused during CUDA graph replay
         to avoid memory allocations.
         """
+        # Remembered so _compute_forward_metadata can detect oversized eager
+        # decode (bs > captured ceiling) and route through the fresh-alloc
+        # path instead of size-mismatching .copy_ into the max_bs-sized views.
+        self.cuda_graph_max_bs = max_bs
         self.decode_metadata = {
             "seq_lens_tensor": torch.zeros(
                 max_bs, dtype=torch.int32, device=self.device

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -324,15 +324,12 @@ class FlashAttentionBackend(AttentionBackend):
                 )
                 return
 
-        # Single eager == replay == capture metadata path; `use_bound` selects
-        # the pre-bound cuda-graph FlashAttentionMetadata buffers (capture /
-        # replay / eager-at-captured-bs; in-place fused-kernel fill) vs a fresh
-        # eager FlashAttentionMetadata (torch ops). Eager reaches the same
-        # _compute_forward_metadata via the base init_forward_metadata wrapper
-        # (out_graph(in_capture=False) + in_graph); the capture-only pre-roll
-        # above and fixups below are skipped there.
-        use_bound = in_capture or self._use_cuda_graph_buffers(bs, forward_mode)
-        self._compute_forward_metadata(forward_batch, use_bound=use_bound)
+        # Single eager == replay == capture metadata path; the seam between
+        # pre-bound cuda-graph FlashAttentionMetadata buffers (in-place
+        # fused-kernel fill) and a fresh per-iter FlashAttentionMetadata
+        # (torch ops) is internal to _compute_forward_metadata. Eager reaches
+        # the same body via the base init_forward_metadata wrapper.
+        self._compute_forward_metadata(forward_batch, in_capture=in_capture)
 
         if in_capture:
             if forward_mode.is_decode_or_idle() and spec_info is None:
@@ -360,17 +357,10 @@ class FlashAttentionBackend(AttentionBackend):
                 # sees num_tokens_per_bs (not 1) for all replays of this graph.
                 self.forward_metadata.max_seq_len_q = num_tokens // bs
 
-    def _use_cuda_graph_buffers(self, bs: int, forward_mode: ForwardMode) -> bool:
-        """Eager/replay seam, resolved by backend STATE (no argument).
-
-        Returns True when this ``(bs, forward_mode)`` has a pre-bound cuda-graph
-        metadata buffer for that mode (keyed exactly like the use_bound=True
-        branches of :py:meth:`_compute_forward_metadata`): i.e. at decode-graph
-        replay (the runner always pads to a captured bucket) and harmlessly at
-        an eager forward landing on a captured bs+mode (one forward stream per
-        backend; the bound buffer is refilled by out_graph before the next
-        ``graph.replay()``). Returns False for pure-eager runs (the dicts were
-        never populated) and for plain EXTEND (never captured).
+    def _has_captured_metadata(self, bs: int, forward_mode: ForwardMode) -> bool:
+        """Whether ``(bs, forward_mode)`` has a captured cuda-graph metadata
+        buffer for that mode. Internal to ``_compute_forward_metadata``; see
+        that method for the seam semantics.
         """
         if forward_mode.is_decode_or_idle():
             if self.topk > 1:
@@ -385,18 +375,17 @@ class FlashAttentionBackend(AttentionBackend):
         return False
 
     def _compute_forward_metadata(
-        self, forward_batch: ForwardBatch, *, use_bound: bool
+        self, forward_batch: ForwardBatch, *, in_capture: bool = False
     ):
         """Single source of truth for FlashAttention forward metadata, shared by
         eager, capture, and replay.
 
-        ``use_bound`` selects the metadata storage: the per-bs pre-bound
-        cuda-graph ``FlashAttentionMetadata`` buffers, filled in place via the
-        fused kernels + ``.copy_()`` (capture / replay / eager-at-captured-bs),
-        vs a fresh ``FlashAttentionMetadata`` built with torch ops (pure eager /
-        plain EXTEND). Plain EXTEND only ever runs with use_bound=False (the
-        decode graph never captures it; the use_bound per-mode branches only
-        cover the modes the runner captures).
+        Internally selects between the per-bs pre-bound cuda-graph
+        ``FlashAttentionMetadata`` (filled in place via the fused kernels +
+        ``.copy_()``) and a fresh ``FlashAttentionMetadata`` built with torch
+        ops (pure eager / plain EXTEND / non-captured bs). Plain EXTEND never
+        has a captured metadata; the captured-bucket per-mode branches only
+        cover the modes the runner captures.
         """
         bs = forward_batch.batch_size
         req_pool_indices = forward_batch.req_pool_indices
@@ -407,13 +396,17 @@ class FlashAttentionBackend(AttentionBackend):
         out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
         # During capture the runner sets a consistent seq_lens_cpu (see
         # decode_cuda_graph_runner), so reading the forward_batch field here
-        # matches the old in-capture `seq_lens.cpu()`. The use_bound path slices
-        # [:bs]; the eager path reads full tensors.
+        # matches the old in-capture `seq_lens.cpu()`. The captured-bucket path
+        # slices [:bs]; the fresh path reads full tensors.
         seq_lens_cpu = forward_batch.seq_lens_cpu
 
-        if use_bound:
-            # ---- bound cuda-graph buffers: in-place fused-kernel fill -------
-            # (old _apply_cuda_graph_metadata body, verbatim) ----------------
+        # Internalize the captured-bucket seam — every caller goes through
+        # this method; the public API does not expose it.
+        _has_captured = in_capture or self._has_captured_metadata(bs, forward_mode)
+
+        if _has_captured:
+            # ---- captured-bucket cuda-graph buffers: in-place fused-kernel
+            # fill (old _apply_cuda_graph_metadata body, verbatim) -----------
             seq_lens = seq_lens[:bs]
             seq_lens_cpu = seq_lens_cpu[:bs]
             req_pool_indices = req_pool_indices[:bs]
@@ -778,8 +771,8 @@ class FlashAttentionBackend(AttentionBackend):
                     f"FA3 cuda-graph metadata only supports the modes the "
                     f"full cuda-graph runner captures (decode / idle / target_verify "
                     f"/ draft_extend / draft_extend_v2). Got {forward_mode=}. "
-                    f"Piecewise / breakable capture must route through the eager "
-                    f"path (use_bound=False) instead."
+                    f"Piecewise / breakable capture must route through the "
+                    f"fresh per-iter path instead."
                 )
 
             if encoder_lens is not None:

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -365,7 +365,7 @@ class FlashInferAttnBackend(AttentionBackend):
         self.prefill_cuda_graph_metadata = {}  # For verify
         self.draft_extend_cuda_graph_metadata = {}  # For draft extend
 
-    def _use_cuda_graph_buffers(self, bs: int, forward_mode: ForwardMode) -> bool:
+    def _has_captured_metadata(self, bs: int, forward_mode: ForwardMode) -> bool:
         """Eager/replay seam, resolved by backend STATE (no argument).
 
         Returns True when this ``(bs, forward_mode)`` has a pre-bound
@@ -550,15 +550,13 @@ class FlashInferAttnBackend(AttentionBackend):
             num_tokens = forward_batch.positions.numel()
             self._prepare_cuda_graph_metadata(bs, num_tokens, forward_mode, spec_info)
 
-        # Single eager == replay == capture metadata path; `use_bound` selects
-        # the pre-bound cuda-graph wrapper vs the persistent eager wrapper.
-        use_bound = in_capture or self._use_cuda_graph_buffers(bs, forward_mode)
-        self._compute_forward_metadata(forward_batch, use_bound=use_bound)
+        # Single eager == replay == capture metadata path. The seam between
+        # the captured per-bs cuda-graph wrapper and the persistent eager
+        # wrapper is internal to _compute_forward_metadata.
+        self._compute_forward_metadata(forward_batch, in_capture=in_capture)
 
         # in_capture-only tail: fast_decode_plan install + binding the freshly
-        # refilled SWA buffer slice onto the just-created capture metadata. These
-        # depend on in_capture (not use_bound) so they stay out of the converged
-        # body, which is merged into a shared helper in a follow-up commit.
+        # refilled SWA buffer slice onto the just-created capture metadata.
         if in_capture and forward_mode.is_decode_or_idle():
             # fast_decode_plan needs _cached_module from the initial begin_forward
             # above, so install it only after that first plan has run.
@@ -576,18 +574,18 @@ class FlashInferAttnBackend(AttentionBackend):
             ]
 
     def _compute_forward_metadata(
-        self, forward_batch: ForwardBatch, *, use_bound: bool
+        self, forward_batch: ForwardBatch, *, in_capture: bool = False
     ):
         """Single source of truth for FlashInfer forward metadata, shared by
         eager, capture, and replay.
 
-        ``use_bound`` selects the wrapper the metadata is planned into: the
-        per-bs pre-bound cuda-graph wrapper (capture / replay / eager-at-
-        captured-bs) vs the persistent eager wrapper. Plain EXTEND (and eager
-        DLLM_EXTEND) only ever run with use_bound=False (the decode graph never
-        captures plain EXTEND). The in_capture-only side effects (pre-roll,
-        fast_decode_plan install, capture SWA binding) live in
-        init_forward_metadata_out_graph around this call.
+        Internally selects between the per-bs pre-bound cuda-graph wrapper
+        (capture / replay / eager-at-captured-bs) and the persistent eager
+        wrapper. Plain EXTEND (and eager DLLM_EXTEND) only ever run through
+        the eager wrapper (the decode graph never captures plain EXTEND). The
+        ``in_capture``-only side effects (pre-roll, fast_decode_plan install,
+        capture SWA binding) live in ``init_forward_metadata_out_graph``
+        around this call.
         """
         bs = forward_batch.batch_size
         req_pool_indices = forward_batch.req_pool_indices
@@ -598,11 +596,15 @@ class FlashInferAttnBackend(AttentionBackend):
         forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
 
+        # Internalize the captured-bucket seam — every caller goes through
+        # this method; the public API does not expose it.
+        _has_captured = in_capture or self._has_captured_metadata(bs, forward_mode)
+
         # Eager-only SWA write-target translation (the bound path refills the
         # captured cuda_graph_swa_out_cache_loc buffer in the tail below).
         swa_out_cache_loc = None
         if (
-            not use_bound
+            not _has_captured
             and self.use_sliding_window_kv_pool
             and forward_batch.out_cache_loc is not None
         ):
@@ -612,7 +614,7 @@ class FlashInferAttnBackend(AttentionBackend):
             )
 
         if forward_mode.is_decode_or_idle():
-            if use_bound:
+            if _has_captured:
                 self.indices_updater_decode.update(
                     req_pool_indices[:bs],
                     seq_lens[:bs],
@@ -652,7 +654,7 @@ class FlashInferAttnBackend(AttentionBackend):
                     self.decode_wrappers, swa_out_cache_loc=swa_out_cache_loc
                 )
         elif forward_mode.is_target_verify():
-            if use_bound:
+            if _has_captured:
                 self.indices_updater_prefill.update(
                     req_pool_indices[:bs],
                     seq_lens[:bs],
@@ -690,7 +692,7 @@ class FlashInferAttnBackend(AttentionBackend):
                     False,
                     swa_out_cache_loc=swa_out_cache_loc,
                 )
-        elif forward_mode.is_dllm_extend() and use_bound:
+        elif forward_mode.is_dllm_extend() and _has_captured:
             self.indices_updater_prefill.update(
                 req_pool_indices[:bs],
                 seq_lens[:bs],
@@ -705,7 +707,7 @@ class FlashInferAttnBackend(AttentionBackend):
         else:
             # Plain EXTEND (and eager DLLM_EXTEND) -- eager only; the decode
             # graph never captures plain EXTEND, and eager DLLM_EXTEND lands here
-            # with use_bound=False (matching the old eager body's `else`).
+            # with captured=False (matching the old eager body's `else`).
             prefix_lens = forward_batch.extend_prefix_lens
 
             # Disable ragged wrapper and ensure prefix handling for multimodal and multi-item scoring
@@ -754,12 +756,12 @@ class FlashInferAttnBackend(AttentionBackend):
                 swa_out_cache_loc=swa_out_cache_loc,
             )
 
-        # Bound-path SWA: refill the captured write-target buffer from the live
-        # out_cache_loc before replay (bound onto the metadata at capture by the
-        # in_capture tail below). The eager (use_bound=False) path instead
+        # Captured-bucket SWA: refill the captured write-target buffer from
+        # the live out_cache_loc before replay (bound onto the metadata at
+        # capture by the in_capture tail below). The fresh path instead
         # threads swa_out_cache_loc through the metadata constructed above.
         if (
-            use_bound
+            _has_captured
             and self.use_sliding_window_kv_pool
             and forward_batch.out_cache_loc is not None
         ):

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -145,7 +145,24 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         max_seqlen_pad = triton.cdiv(seq_max, PAGE_SIZE)
         q_head_mult = self.num_draft_tokens if forward_mode.is_target_verify() else 1
 
-        block_kv_indices = self.cuda_graph_kv_indices
+        # cuda_graph_kv_indices is sized for the cuda-graph max_bs at init;
+        # eager fallback when ``bs > cuda_graph_config.decode.max_bs`` (i.e.
+        # ``can_run_graph`` rejects so the runner dispatches eager) would
+        # launch the Triton fill with grid bs > buffer rows and then
+        # ``cuda_graph_num_splits[: bs + 1].copy_`` would index past the
+        # preallocated buffer. Fall back to a fresh ``(bs, max_seqlen_pad)``
+        # allocation for over-sized eager batches, matching pre-refactor.
+        if bs <= self.cuda_graph_kv_indices.shape[0]:
+            block_kv_indices = self.cuda_graph_kv_indices
+            use_bound_num_splits = True
+        else:
+            block_kv_indices = torch.full(
+                (bs, max_seqlen_pad),
+                -1,
+                dtype=self.cuda_graph_kv_indices.dtype,
+                device=self.cuda_graph_kv_indices.device,
+            )
+            use_bound_num_splits = False
         create_flashmla_kv_indices_triton[
             (
                 bs,
@@ -187,12 +204,18 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
             self.cuda_graph_mla_metadata_view = self.cuda_graph_mla_metadata[
                 :actual_num_sm_parts
             ]
-        self.cuda_graph_num_splits_view = self.cuda_graph_num_splits[: bs + 1]
+        if use_bound_num_splits:
+            self.cuda_graph_num_splits_view = self.cuda_graph_num_splits[: bs + 1]
+            self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
+            num_splits_for_metadata = self.cuda_graph_num_splits_view
+        else:
+            # Fresh allocation when bs exceeds the cuda-graph num_splits buffer
+            # (parallel to the block_kv_indices fallback above).
+            num_splits_for_metadata = num_splits
         self.cuda_graph_mla_metadata[:actual_num_sm_parts].copy_(mla_metadata)
-        self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
         self.forward_metadata = FlashMLADecodeMetadata(
             self.cuda_graph_mla_metadata_view,
-            self.cuda_graph_num_splits_view,
+            num_splits_for_metadata,
             block_kv_indices[:bs, :max_seqlen_pad],
         )
 

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -112,31 +112,17 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
     ):
         forward_mode = forward_batch.forward_mode
         if forward_mode.is_decode_or_idle() or forward_mode.is_target_verify():
-            bs = forward_batch.batch_size
-            # use_bound selects the pre-bound cuda-graph buffers (capture /
-            # replay / eager-at-captured-bs) vs freshly allocated tensors. In
-            # out_graph use_bound is always True (capture sets in_capture; replay
-            # pads to a captured bs), matching the old always-bound path.
-            use_bound = in_capture or (
-                getattr(self, "cuda_graph_kv_indices", None) is not None
-                and bs <= self.cuda_graph_kv_indices.shape[0]
-            )
-            self._compute_decode_target_verify_metadata(
-                forward_batch, use_bound=use_bound
-            )
+            self._compute_decode_target_verify_metadata(forward_batch)
         else:
             super().init_forward_metadata_out_graph(
                 forward_batch, in_capture=in_capture
             )
 
-    def _compute_decode_target_verify_metadata(
-        self, forward_batch: ForwardBatch, *, use_bound: bool
-    ):
+    def _compute_decode_target_verify_metadata(self, forward_batch: ForwardBatch):
         """Single source of truth for FlashMLA decode/target-verify metadata,
-        shared by eager / capture / replay.
-
-        ``use_bound`` selects the pre-bound cuda-graph buffers (capture / replay
-        / eager-at-captured-bs) vs freshly allocated tensors.
+        shared by eager / capture / replay. Writes into the pre-bound
+        ``cuda_graph_*`` buffers (allocated once at
+        ``init_static_metadata_buffers`` for both eager and graph runs).
         """
         forward_mode = forward_batch.forward_mode
         bs = forward_batch.batch_size
@@ -159,42 +145,21 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         max_seqlen_pad = triton.cdiv(seq_max, PAGE_SIZE)
         q_head_mult = self.num_draft_tokens if forward_mode.is_target_verify() else 1
 
-        if use_bound:
-            block_kv_indices = self.cuda_graph_kv_indices
-            create_flashmla_kv_indices_triton[
-                (
-                    bs,
-                    get_num_kv_index_blocks_flashmla(
-                        block_kv_indices.stride(0), PAGE_SIZE
-                    ),
-                )
-            ](
-                self.req_to_token,
-                req_pool_indices[:bs],
-                seq_lens,
-                None,
-                block_kv_indices,
-                self.req_to_token.stride(0),
-                block_kv_indices.stride(0),
+        block_kv_indices = self.cuda_graph_kv_indices
+        create_flashmla_kv_indices_triton[
+            (
+                bs,
+                get_num_kv_index_blocks_flashmla(block_kv_indices.stride(0), PAGE_SIZE),
             )
-        else:
-            block_kv_indices = torch.full(
-                (bs, max_seqlen_pad),
-                -1,
-                dtype=torch.int32,
-                device=seq_lens.device,
-            )
-            create_flashmla_kv_indices_triton[
-                (bs, get_num_kv_index_blocks_flashmla(max_seqlen_pad, PAGE_SIZE))
-            ](
-                self.req_to_token,
-                req_pool_indices[:bs],
-                seq_lens,
-                None,
-                block_kv_indices,
-                self.req_to_token.stride(0),
-                max_seqlen_pad,
-            )
+        ](
+            self.req_to_token,
+            req_pool_indices[:bs],
+            seq_lens,
+            None,
+            block_kv_indices,
+            self.req_to_token.stride(0),
+            block_kv_indices.stride(0),
+        )
 
         mla_metadata, num_splits = get_mla_metadata(
             seq_lens.to(torch.int32),
@@ -203,40 +168,33 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
             is_fp8_kvcache=self.is_fp8_kvcache,
         )
 
-        if use_bound:
-            actual_num_sm_parts = mla_metadata.shape[0]
-            assert actual_num_sm_parts <= self.cuda_graph_mla_metadata.shape[0], (
-                f"num_sm_parts {actual_num_sm_parts} exceeds preallocated max "
-                f"{self.cuda_graph_mla_metadata.shape[0]}"
-            )
-            if (
-                self.cuda_graph_mla_metadata_view is None
-                or actual_num_sm_parts != self.cuda_graph_mla_metadata_view.shape[0]
-            ):
-                if self.cuda_graph_mla_metadata_view is not None:
-                    logger.warning(
-                        f"num_sm_parts mismatch in CUDA Graph replay: "
-                        f"capture={self.cuda_graph_mla_metadata_view.shape[0]}, "
-                        f"replay={actual_num_sm_parts}. "
-                        f"This may indicate batch size changed between capture and replay."
-                    )
-                self.cuda_graph_mla_metadata_view = self.cuda_graph_mla_metadata[
-                    :actual_num_sm_parts
-                ]
-            self.cuda_graph_num_splits_view = self.cuda_graph_num_splits[: bs + 1]
-            self.cuda_graph_mla_metadata[:actual_num_sm_parts].copy_(mla_metadata)
-            self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
-            self.forward_metadata = FlashMLADecodeMetadata(
-                self.cuda_graph_mla_metadata_view,
-                self.cuda_graph_num_splits_view,
-                block_kv_indices[:bs, :max_seqlen_pad],
-            )
-        else:
-            self.forward_metadata = FlashMLADecodeMetadata(
-                mla_metadata,
-                num_splits,
-                block_kv_indices,
-            )
+        actual_num_sm_parts = mla_metadata.shape[0]
+        assert actual_num_sm_parts <= self.cuda_graph_mla_metadata.shape[0], (
+            f"num_sm_parts {actual_num_sm_parts} exceeds preallocated max "
+            f"{self.cuda_graph_mla_metadata.shape[0]}"
+        )
+        if (
+            self.cuda_graph_mla_metadata_view is None
+            or actual_num_sm_parts != self.cuda_graph_mla_metadata_view.shape[0]
+        ):
+            if self.cuda_graph_mla_metadata_view is not None:
+                logger.warning(
+                    f"num_sm_parts mismatch in CUDA Graph replay: "
+                    f"capture={self.cuda_graph_mla_metadata_view.shape[0]}, "
+                    f"replay={actual_num_sm_parts}. "
+                    f"This may indicate batch size changed between capture and replay."
+                )
+            self.cuda_graph_mla_metadata_view = self.cuda_graph_mla_metadata[
+                :actual_num_sm_parts
+            ]
+        self.cuda_graph_num_splits_view = self.cuda_graph_num_splits[: bs + 1]
+        self.cuda_graph_mla_metadata[:actual_num_sm_parts].copy_(mla_metadata)
+        self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
+        self.forward_metadata = FlashMLADecodeMetadata(
+            self.cuda_graph_mla_metadata_view,
+            self.cuda_graph_num_splits_view,
+            block_kv_indices[:bs, :max_seqlen_pad],
+        )
 
     def init_static_metadata_buffers(
         self,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -380,12 +380,25 @@ class TritonAttnBackend(AttentionBackend):
         pre-use_bound behavior.
         """
         bs = forward_batch.batch_size
+        spec_info = forward_batch.spec_info
+        # Multi-step draft decode rewires bs from spec_info.kv_indptr.shape[0]-1
+        # later in the bound branch — when topk > 1 that expanded bs is what the
+        # decode kernels' grid scales with, and the bound per-token buffers
+        # (cuda_graph_attn_logits, cuda_graph_attn_lse, cuda_graph_num_kv_splits)
+        # are only `max_num_tokens` deep. Detect the spec-expanded oversize here
+        # so the fresh-alloc path catches it too.
+        effective_decode_bs = bs
         if (
             forward_batch.forward_mode.is_decode_or_idle()
-            and bs > self.cuda_graph_num_kv_splits.shape[0]
+            and spec_info is not None
+            and getattr(spec_info, "kv_indptr", None) is not None
+        ):
+            effective_decode_bs = spec_info.kv_indptr.shape[0] - 1
+        if (
+            forward_batch.forward_mode.is_decode_or_idle()
+            and effective_decode_bs > self.cuda_graph_num_kv_splits.shape[0]
         ):
             return self._compute_forward_metadata_fresh_decode(forward_batch)
-        spec_info = forward_batch.spec_info
         swa = self.sliding_window_size is not None and self.sliding_window_size > 0
 
         window_kv_indptr = self.window_kv_indptr

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -365,14 +365,26 @@ class TritonAttnBackend(AttentionBackend):
         capture, and replay.
 
         Per-iter output tensors are the pre-bound ``cuda_graph_*`` buffers
-        allocated once in ``init_static_metadata_buffers`` (called for every
-        run from ``ModelRunner.init_backends``, at the EagerRunner's union-max
-        sizing). The index scratch (``self.kv_indptr`` / ``qo_indptr`` /
+        allocated once in ``init_static_metadata_buffers`` at the cuda-graph
+        capture max. The index scratch (``self.kv_indptr`` / ``qo_indptr`` /
         ``mask_indptr``) is shared by all modes. Plain EXTEND still
         fresh-allocates ``kv_indices`` since its size depends on
         ``extend_prefix_lens`` which is not bounded by ``max_bs``.
+
+        Oversized eager fallback: when the live ``bs`` exceeds the captured
+        max (``max_running_requests > cuda_graph_max_bs_decode`` and
+        ``can_run_graph`` rejects -> eager), reading the bound buffers via
+        ``[:bs]`` would silently truncate and downstream copies would size-
+        mismatch (or Triton kernels grid-bs would index past the buffer).
+        Delegate those iters to a fresh-alloc path that mirrors the
+        pre-use_bound behavior.
         """
         bs = forward_batch.batch_size
+        if (
+            forward_batch.forward_mode.is_decode_or_idle()
+            and bs > self.cuda_graph_num_kv_splits.shape[0]
+        ):
+            return self._compute_forward_metadata_fresh_decode(forward_batch)
         spec_info = forward_batch.spec_info
         swa = self.sliding_window_size is not None and self.sliding_window_size > 0
 
@@ -619,6 +631,100 @@ class TritonAttnBackend(AttentionBackend):
             bs, kv_lens, req_pool_indices, self.cuda_graph_kv_indices
         )
         return qo_indptr, kv_indptr, num_tokens_per_bs
+
+    def _compute_forward_metadata_fresh_decode(
+        self, forward_batch: ForwardBatch
+    ) -> ForwardMetadata:
+        """Pre-PR-5 fresh-allocation eager decode path, restored for the
+        ``bs > cuda_graph_max_bs`` case (oversized eager batches that the
+        cuda-graph runner rejects via ``can_run_graph``). Allocates per-iter
+        tensors instead of writing past the cuda-graph-sized static buffers.
+        """
+        bs = forward_batch.batch_size
+        spec_info = forward_batch.spec_info
+        swa = self.sliding_window_size is not None and self.sliding_window_size > 0
+
+        if spec_info is None or spec_info.kv_indptr is None:
+            seq_lens_sum = forward_batch.seq_lens_sum
+            if seq_lens_sum is None:
+                seq_lens_sum = bs * self.max_context_len
+            kv_indices = torch.empty(
+                seq_lens_sum, dtype=torch.int64, device=self.device
+            )
+            kv_indptr = self._fill_kv_indptr_and_indices(
+                bs,
+                forward_batch.seq_lens,
+                forward_batch.req_pool_indices,
+                kv_indices,
+            )
+            window_kv_indptr = self.window_kv_indptr
+            window_kv_indices = None
+            window_num_kv_splits = None
+            window_kv_offsets = None
+            swa_attn_logits = None
+            if swa:
+                window_kv_indptr, window_kv_indices, window_kv_lens, _ = (
+                    update_sliding_window_buffer(
+                        self.window_kv_indptr,
+                        self.req_to_token,
+                        self.sliding_window_size,
+                        forward_batch.seq_lens,
+                        forward_batch.req_pool_indices,
+                        bs,
+                        self.device,
+                        self.token_to_kv_pool,
+                    )
+                )
+                window_num_kv_splits = torch.empty(
+                    (bs,), dtype=torch.int32, device=self.device
+                )
+                self.get_num_kv_splits(window_num_kv_splits, window_kv_lens)
+        else:
+            kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
+            bs = kv_indptr.shape[0] - 1
+            window_kv_indptr = self.window_kv_indptr
+            window_kv_indices = None
+            window_num_kv_splits = None
+            window_kv_offsets = None
+
+        attn_logits = torch.empty(
+            (bs, self.num_head, self.max_kv_splits, self.v_head_dim),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        if self.swa_v_head_dim is not None:
+            swa_attn_logits = torch.empty(
+                (bs, self.num_head, self.max_kv_splits, self.swa_v_head_dim),
+                dtype=torch.float32,
+                device=self.device,
+            )
+        else:
+            swa_attn_logits = None
+        attn_lse = torch.empty(
+            (bs, self.num_head, self.max_kv_splits),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        num_kv_splits = torch.empty((bs,), dtype=torch.int32, device=self.device)
+        self.get_num_kv_splits(num_kv_splits, forward_batch.seq_lens)
+
+        return ForwardMetadata(
+            attn_logits,
+            attn_lse,
+            None,  # max_extend_len
+            num_kv_splits,
+            kv_indptr,
+            kv_indices,
+            None,  # qo_indptr
+            None,  # custom_mask
+            None,  # mask_indptr
+            window_kv_indptr,
+            window_kv_indices,
+            window_num_kv_splits,
+            window_kv_offsets,
+            swa_attn_logits,
+            None,  # swa_out_cache_loc
+        )
 
     def init_forward_metadata_out_graph(
         self,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -138,6 +138,11 @@ class TritonAttnBackend(AttentionBackend):
         self.use_sliding_window_kv_pool = isinstance(self.token_to_kv_pool, SWAKVPool)
         self.num_draft_tokens = model_runner.server_args.speculative_num_draft_tokens
         self.speculative_num_steps = model_runner.server_args.speculative_num_steps
+        # bs values that the draft-extend cuda-graph runner has captured. Eager
+        # draft-extend-v2 (--disable-cuda-graph or non-captured bs) must NOT use
+        # the bound fixed-width layout in _compute_forward_metadata; the runner
+        # adds bs here as it captures each shape.
+        self._draft_extend_v2_captured_bs: set[int] = set()
         self.topk = model_runner.server_args.speculative_eagle_topk or 0
         # Split-KV verify matches extend_attention_fwd only when the EAGLE tree
         # reduces to a pure-causal chain, i.e. topk == 1 (the same condition the
@@ -475,10 +480,15 @@ class TritonAttnBackend(AttentionBackend):
             num_kv_splits = None
             attn_logits = None
             attn_lse = None
-        elif forward_batch.forward_mode.is_draft_extend_v2():
+        elif (
+            forward_batch.forward_mode.is_draft_extend_v2()
+            and bs in self._draft_extend_v2_captured_bs
+        ):
             # Captured draft-extend (v2 only; EAGLE v1 DRAFT_EXTEND was removed):
             # constant per-req token layout written into the bound buffers (no
-            # graph-illegal host sync).
+            # graph-illegal host sync). Eager draft_extend_v2 (--disable-cuda-graph
+            # or a live bs that wasn't captured) falls through to the EXTEND
+            # branch below so per-req extend_seq_lens drive the layout.
             qo_indptr, kv_indptr, num_tokens_per_bs = self._build_draft_extend_indptrs(
                 bs,
                 forward_batch.seq_lens[:bs],

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -708,6 +708,16 @@ class TritonAttnBackend(AttentionBackend):
         num_kv_splits = torch.empty((bs,), dtype=torch.int32, device=self.device)
         self.get_num_kv_splits(num_kv_splits, forward_batch.seq_lens)
 
+        # Hybrid-SWA: forward_decode wraps swa_out_cache_loc in KVWriteLoc and
+        # SWAKVPool.set_kv_buffer asserts non-None for SWA layers. Translate
+        # out_cache_loc directly here (the cuda_graph_swa_out_cache_loc buffer
+        # is sized for capture and not safe for oversized eager).
+        swa_out_cache_loc = None
+        if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
+            swa_out_cache_loc = self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                forward_batch.out_cache_loc
+            )
+
         return ForwardMetadata(
             attn_logits,
             attn_lse,
@@ -723,7 +733,7 @@ class TritonAttnBackend(AttentionBackend):
             window_num_kv_splits,
             window_kv_offsets,
             swa_attn_logits,
-            None,  # swa_out_cache_loc
+            swa_out_cache_loc,
         )
 
     def init_forward_metadata_out_graph(

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -552,9 +552,18 @@ class TritonAttnBackend(AttentionBackend):
                 forward_batch.out_cache_loc
             )
             n = translated.shape[0]
-            self.cuda_graph_swa_out_cache_loc[n:].zero_()
-            self.cuda_graph_swa_out_cache_loc[:n].copy_(translated)
-            swa_out_cache_loc = self.cuda_graph_swa_out_cache_loc[:n]
+            # cuda_graph_swa_out_cache_loc is sized for decode shapes
+            # (max_bs * num_tokens_per_bs); chunked prefill / plain EXTEND can
+            # produce n > buffer length. Capturable modes need to write the
+            # captured buffer (so the cuda graph's data_ptr stays valid);
+            # plain extend never goes through a captured graph, so return the
+            # translated tensor directly to avoid overflowing the buffer.
+            if n <= self.cuda_graph_swa_out_cache_loc.shape[0]:
+                self.cuda_graph_swa_out_cache_loc[n:].zero_()
+                self.cuda_graph_swa_out_cache_loc[:n].copy_(translated)
+                swa_out_cache_loc = self.cuda_graph_swa_out_cache_loc[:n]
+            else:
+                swa_out_cache_loc = translated
 
         return ForwardMetadata(
             attn_logits,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -352,37 +352,20 @@ class TritonAttnBackend(AttentionBackend):
         )
         return kv_indptr
 
-    def _use_cuda_graph_buffers(self, bs: int) -> bool:
-        """Whether to build metadata into the pre-bound ``cuda_graph_*`` buffers.
-
-        This is the single eager/replay seam — resolved by backend STATE, not
-        an argument. It is True at decode-graph capture/replay (the bs is a
-        captured bucket) and harmlessly True when an eager forward lands on a
-        captured bs in a graph-enabled server: there is one forward stream per
-        backend (TBO / pdmux use separate instances), and the bound buffers are
-        always refilled by ``out_graph`` before the next ``graph.replay()``, so
-        a transient eager write cannot leak into a later replay. It is False for
-        pure-eager runs (``init_cuda_graph_state`` never ran → no buffers) and
-        for any bs beyond the captured capacity → allocate fresh.
-        """
-        buf = getattr(self, "cuda_graph_attn_logits", None)
-        return buf is not None and bs <= buf.shape[0]
-
     def _compute_forward_metadata(
         self,
         forward_batch: ForwardBatch,
-        *,
-        use_bound: bool,
     ) -> ForwardMetadata:
         """Single source of truth for Triton forward metadata, shared by eager,
         capture, and replay.
 
-        ``use_bound`` selects the per-iter output tensors: the pre-bound
-        ``cuda_graph_*`` buffers (capture / replay / eager-at-captured-bs) vs
-        freshly allocated tensors (pure-eager / bs beyond captured capacity).
-        The index scratch (``self.kv_indptr`` / ``qo_indptr`` / ``mask_indptr``)
-        is shared by both paths. All forward modes are handled here (incl. plain
-        EXTEND, which only ever runs with ``use_bound=False``).
+        Per-iter output tensors are the pre-bound ``cuda_graph_*`` buffers
+        allocated once in ``init_static_metadata_buffers`` (called for every
+        run from ``ModelRunner.init_backends``, at the EagerRunner's union-max
+        sizing). The index scratch (``self.kv_indptr`` / ``qo_indptr`` /
+        ``mask_indptr``) is shared by all modes. Plain EXTEND still
+        fresh-allocates ``kv_indices`` since its size depends on
+        ``extend_prefix_lens`` which is not bounded by ``max_bs``.
         """
         bs = forward_batch.batch_size
         spec_info = forward_batch.spec_info
@@ -398,16 +381,7 @@ class TritonAttnBackend(AttentionBackend):
             if spec_info is None or spec_info.kv_indptr is None:
                 # Plain decode/idle (also draft-extend's idle batch: no tree
                 # indices → build from seq_lens).
-                if use_bound:
-                    kv_indices = self.cuda_graph_kv_indices
-                else:
-                    # gpu_only: seq_lens_sum may be None; ub-allocate is safe.
-                    seq_lens_sum = forward_batch.seq_lens_sum
-                    if seq_lens_sum is None:
-                        seq_lens_sum = bs * self.max_context_len
-                    kv_indices = torch.empty(
-                        seq_lens_sum, dtype=torch.int64, device=self.device
-                    )
+                kv_indices = self.cuda_graph_kv_indices
                 kv_indptr = self._fill_kv_indptr_and_indices(
                     bs,
                     forward_batch.seq_lens[:bs],
@@ -425,17 +399,10 @@ class TritonAttnBackend(AttentionBackend):
                             bs,
                             self.device,
                             self.token_to_kv_pool,
-                            window_kv_indices=(
-                                self.cuda_graph_window_kv_indices if use_bound else None
-                            ),
+                            window_kv_indices=self.cuda_graph_window_kv_indices,
                         )
                     )
-                    if use_bound:
-                        window_num_kv_splits = self.cuda_graph_window_num_kv_splits
-                    else:
-                        window_num_kv_splits = torch.empty(
-                            (bs,), dtype=torch.int32, device=self.device
-                        )
+                    window_num_kv_splits = self.cuda_graph_window_num_kv_splits
                     self.get_num_kv_splits(
                         window_num_kv_splits[:bs], window_kv_lens[:bs]
                     )
@@ -445,31 +412,10 @@ class TritonAttnBackend(AttentionBackend):
                 kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
                 bs = kv_indptr.shape[0] - 1
 
-            if use_bound:
-                attn_logits = self.cuda_graph_attn_logits
-                attn_lse = self.cuda_graph_attn_lse
-                num_kv_splits = self.cuda_graph_num_kv_splits
-                swa_attn_logits = self.cuda_graph_swa_attn_logits
-            else:
-                attn_logits = torch.empty(
-                    (bs, self.num_head, self.max_kv_splits, self.v_head_dim),
-                    dtype=torch.float32,
-                    device=self.device,
-                )
-                attn_lse = torch.empty(
-                    (bs, self.num_head, self.max_kv_splits),
-                    dtype=torch.float32,
-                    device=self.device,
-                )
-                num_kv_splits = torch.empty(
-                    (bs,), dtype=torch.int32, device=self.device
-                )
-                if self.swa_v_head_dim is not None:
-                    swa_attn_logits = torch.empty(
-                        (bs, self.num_head, self.max_kv_splits, self.swa_v_head_dim),
-                        dtype=torch.float32,
-                        device=self.device,
-                    )
+            attn_logits = self.cuda_graph_attn_logits
+            attn_lse = self.cuda_graph_attn_lse
+            num_kv_splits = self.cuda_graph_num_kv_splits
+            swa_attn_logits = self.cuda_graph_swa_attn_logits
             self.get_num_kv_splits(num_kv_splits[:bs], forward_batch.seq_lens[:bs])
 
             qo_indptr = None
@@ -486,16 +432,7 @@ class TritonAttnBackend(AttentionBackend):
                 dtype=torch.int32,
                 device=self.device,
             )
-            if use_bound:
-                kv_indices = self.cuda_graph_kv_indices
-            else:
-                # gpu_only: seq_lens_sum may be None; ub-allocate is safe.
-                seq_lens_sum = forward_batch.seq_lens_sum
-                if seq_lens_sum is None:
-                    seq_lens_sum = bs * self.max_context_len
-                kv_indices = torch.empty(
-                    seq_lens_sum, dtype=torch.int64, device=self.device
-                )
+            kv_indices = self.cuda_graph_kv_indices
             kv_indptr = self._fill_kv_indptr_and_indices(
                 bs,
                 forward_batch.seq_lens[:bs],
@@ -503,12 +440,8 @@ class TritonAttnBackend(AttentionBackend):
                 kv_indices,
             )
             if swa:
-                window_kv_indices = (
-                    self.cuda_graph_window_kv_indices if use_bound else None
-                )
-                window_kv_offsets_buf = (
-                    self.cuda_graph_window_kv_offsets if use_bound else None
-                )
+                window_kv_indices = self.cuda_graph_window_kv_indices
+                window_kv_offsets_buf = self.cuda_graph_window_kv_offsets
                 (
                     window_kv_indptr,
                     window_kv_indices,
@@ -525,16 +458,14 @@ class TritonAttnBackend(AttentionBackend):
                     self.token_to_kv_pool,
                     window_kv_indices=window_kv_indices,
                 )
-                if use_bound:
-                    window_num_kv_splits = self.cuda_graph_window_num_kv_splits
-                    window_kv_offsets_buf[:bs] = window_kv_offsets
-                    window_kv_offsets = window_kv_offsets_buf
+                window_num_kv_splits = self.cuda_graph_window_num_kv_splits
+                window_kv_offsets_buf[:bs] = window_kv_offsets
+                window_kv_offsets = window_kv_offsets_buf
 
             custom_mask = spec_info.custom_mask if spec_info is not None else None
-            if use_bound:
-                if custom_mask is not None:
-                    self.cuda_graph_custom_mask[: custom_mask.shape[0]] = custom_mask
-                    custom_mask = self.cuda_graph_custom_mask
+            if custom_mask is not None:
+                self.cuda_graph_custom_mask[: custom_mask.shape[0]] = custom_mask
+                custom_mask = self.cuda_graph_custom_mask
             seq_mask_len = self.num_draft_tokens * (
                 forward_batch.seq_lens[:bs] + self.num_draft_tokens
             )
@@ -544,11 +475,10 @@ class TritonAttnBackend(AttentionBackend):
             num_kv_splits = None
             attn_logits = None
             attn_lse = None
-        elif use_bound and forward_batch.forward_mode.is_draft_extend_v2():
+        elif forward_batch.forward_mode.is_draft_extend_v2():
             # Captured draft-extend (v2 only; EAGLE v1 DRAFT_EXTEND was removed):
             # constant per-req token layout written into the bound buffers (no
-            # graph-illegal host sync). Eager draft_extend_v2 (rare: warmup /
-            # fallback) falls through to the EXTEND branch below.
+            # graph-illegal host sync).
             qo_indptr, kv_indptr, num_tokens_per_bs = self._build_draft_extend_indptrs(
                 bs,
                 forward_batch.seq_lens[:bs],
@@ -611,13 +541,10 @@ class TritonAttnBackend(AttentionBackend):
             translated = self.token_to_kv_pool.translate_loc_from_full_to_swa(
                 forward_batch.out_cache_loc
             )
-            if use_bound:
-                n = translated.shape[0]
-                self.cuda_graph_swa_out_cache_loc[n:].zero_()
-                self.cuda_graph_swa_out_cache_loc[:n].copy_(translated)
-                swa_out_cache_loc = self.cuda_graph_swa_out_cache_loc[:n]
-            else:
-                swa_out_cache_loc = translated
+            n = translated.shape[0]
+            self.cuda_graph_swa_out_cache_loc[n:].zero_()
+            self.cuda_graph_swa_out_cache_loc[:n].copy_(translated)
+            swa_out_cache_loc = self.cuda_graph_swa_out_cache_loc[:n]
 
         return ForwardMetadata(
             attn_logits,
@@ -679,17 +606,13 @@ class TritonAttnBackend(AttentionBackend):
         forward_batch: ForwardBatch,
         in_capture: bool = False,
     ):
-        # Single eager == replay == capture metadata path. `use_bound` selects
-        # the pre-bound cuda_graph_* buffers vs fresh tensors: always bound at
-        # capture; otherwise decided by backend state (see
-        # _use_cuda_graph_buffers — replay and eager-at-captured-bs use bound,
-        # pure-eager / oversize bs use fresh). No eager/replay argument.
+        # Single eager == replay == capture metadata path. The pre-bound
+        # ``cuda_graph_*`` buffers are allocated once at init for every run
+        # (ModelRunner.init_backends sizes them at the EagerRunner's union-max),
+        # so this body unconditionally writes into them.
         if in_capture:
             assert forward_batch.encoder_lens is None, "Not supported"
-        use_bound = in_capture or self._use_cuda_graph_buffers(forward_batch.batch_size)
-        self.forward_metadata = self._compute_forward_metadata(
-            forward_batch, use_bound=use_bound
-        )
+        self.forward_metadata = self._compute_forward_metadata(forward_batch)
 
     def init_static_metadata_buffers(
         self,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -399,6 +399,17 @@ class TritonAttnBackend(AttentionBackend):
             and effective_decode_bs > self.cuda_graph_num_kv_splits.shape[0]
         ):
             return self._compute_forward_metadata_fresh_decode(forward_batch)
+        # Target-verify oversized eager: bound qo_indptr / mask_indptr /
+        # cuda_graph_kv_indices / cuda_graph_custom_mask are sized at the
+        # captured max_bs * num_draft_tokens. When the cuda-graph runner
+        # rejects this bs (eager fallback at bs > captured max), the bound
+        # writes would either size-mismatch or scribble past the buffer.
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            and getattr(self, "cuda_graph_max_bs", None) is not None
+            and len(forward_batch.req_pool_indices) > self.cuda_graph_max_bs
+        ):
+            return self._compute_forward_metadata_fresh_target_verify(forward_batch)
         swa = self.sliding_window_size is not None and self.sliding_window_size > 0
 
         window_kv_indptr = self.window_kv_indptr
@@ -583,10 +594,15 @@ class TritonAttnBackend(AttentionBackend):
             # captured buffer (so the cuda graph's data_ptr stays valid);
             # plain extend never goes through a captured graph, so return the
             # translated tensor directly to avoid overflowing the buffer.
-            if n <= self.cuda_graph_swa_out_cache_loc.shape[0]:
-                self.cuda_graph_swa_out_cache_loc[n:].zero_()
-                self.cuda_graph_swa_out_cache_loc[:n].copy_(translated)
-                swa_out_cache_loc = self.cuda_graph_swa_out_cache_loc[:n]
+            # The buffer is also missing when this backend is the prefill leg
+            # of a HybridAttnBackend split (only the decode leg gets
+            # init_static_metadata_buffers in non-spec hybrid SWA) — in that
+            # case there's no captured graph either, so route to translated.
+            swa_buf = getattr(self, "cuda_graph_swa_out_cache_loc", None)
+            if swa_buf is not None and n <= swa_buf.shape[0]:
+                swa_buf[n:].zero_()
+                swa_buf[:n].copy_(translated)
+                swa_out_cache_loc = swa_buf[:n]
             else:
                 swa_out_cache_loc = translated
 
@@ -749,6 +765,100 @@ class TritonAttnBackend(AttentionBackend):
             swa_out_cache_loc,
         )
 
+    def _compute_forward_metadata_fresh_target_verify(
+        self, forward_batch: ForwardBatch
+    ) -> ForwardMetadata:
+        """Pre-PR-5 fresh-allocation target-verify path, restored for the
+        ``bs > cuda_graph_max_bs`` case (oversized eager batches the cuda-graph
+        runner rejects via ``can_run_graph``). Bound qo_indptr / mask_indptr
+        live on the (req_pool-sized) ``self.qo_indptr`` / ``self.mask_indptr``
+        which always fit, so only the per-iter kv / custom_mask / SWA paths
+        need fresh storage here.
+        """
+        spec_info = forward_batch.spec_info
+        bs = len(forward_batch.req_pool_indices)
+        swa = self.sliding_window_size is not None and self.sliding_window_size > 0
+
+        qo_indptr = self.qo_indptr[: bs + 1]
+        qo_indptr[: bs + 1] = torch.arange(
+            0,
+            (1 + bs) * self.num_draft_tokens,
+            step=self.num_draft_tokens,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        # Fresh kv_indices sized to the live sum, mirroring the eager EXTEND
+        # branch (gpu-only sum fallback if seq_lens_sum unavailable).
+        seq_lens_sum = forward_batch.seq_lens_sum
+        if seq_lens_sum is None:
+            seq_lens_sum = bs * self.max_context_len
+        kv_indices = torch.empty(seq_lens_sum, dtype=torch.int64, device=self.device)
+        kv_indptr = self._fill_kv_indptr_and_indices(
+            bs,
+            forward_batch.seq_lens[:bs],
+            forward_batch.req_pool_indices[:bs],
+            kv_indices,
+        )
+
+        window_kv_indptr = self.window_kv_indptr
+        window_kv_indices = None
+        window_num_kv_splits = None
+        window_kv_offsets = None
+        if swa:
+            (
+                window_kv_indptr,
+                window_kv_indices,
+                window_kv_lens,
+                window_kv_offsets,
+            ) = update_sliding_window_buffer(
+                self.window_kv_indptr,
+                self.req_to_token,
+                self.sliding_window_size,
+                forward_batch.seq_lens[:bs],
+                forward_batch.req_pool_indices[:bs],
+                bs,
+                self.device,
+                self.token_to_kv_pool,
+            )
+            window_num_kv_splits = torch.empty(
+                (bs,), dtype=torch.int32, device=self.device
+            )
+            self.get_num_kv_splits(window_num_kv_splits, window_kv_lens)
+
+        # Use the spec_info custom_mask directly — the bound copy into
+        # cuda_graph_custom_mask would size-mismatch at oversized bs.
+        custom_mask = spec_info.custom_mask if spec_info is not None else None
+        seq_mask_len = self.num_draft_tokens * (
+            forward_batch.seq_lens[:bs] + self.num_draft_tokens
+        )
+        mask_indptr = self.mask_indptr[: bs + 1]
+        mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
+
+        swa_out_cache_loc = None
+        if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
+            swa_out_cache_loc = self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                forward_batch.out_cache_loc
+            )
+
+        return ForwardMetadata(
+            attn_logits=None,
+            attn_lse=None,
+            max_extend_len=self.num_draft_tokens,
+            num_kv_splits=None,
+            kv_indptr=kv_indptr,
+            kv_indices=kv_indices,
+            qo_indptr=qo_indptr,
+            custom_mask=custom_mask,
+            mask_indptr=mask_indptr,
+            window_kv_indptr=window_kv_indptr,
+            window_kv_indices=window_kv_indices,
+            window_num_kv_splits=window_num_kv_splits,
+            window_kv_offsets=window_kv_offsets,
+            swa_attn_logits=None,
+            swa_out_cache_loc=swa_out_cache_loc,
+        )
+
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
@@ -769,6 +879,11 @@ class TritonAttnBackend(AttentionBackend):
         kv_indices_buf: Optional[torch.Tensor] = None,
         cuda_graph_num_kv_splits_buf: Optional[torch.Tensor] = None,
     ):
+        # Remembered so _compute_forward_metadata can fall through to the
+        # fresh-alloc path for live bs above the captured ceiling (eager
+        # fallback at oversized bs — affects decode + target_verify + spec
+        # multi-step draft).
+        self.cuda_graph_max_bs = max_bs
         self.cuda_graph_attn_logits = torch.zeros(
             (max_num_tokens, self.num_head, self.max_kv_splits, self.v_head_dim),
             dtype=torch.float32,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -144,20 +144,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         #   KV fp8: q_type = fp8, out_type=model_runner.dtype
         self.is_xqa_impl = is_sm90_supported() or is_sm120_supported()
 
-    def _has_captured_metadata(self, bs: int, forward_mode: ForwardMode) -> bool:
-        """Whether `(bs, forward_mode)` has a captured cuda-graph metadata
-        object — only True when a cuda-graph runner previously captured this
-        bucket. Internal to `_compute_forward_metadata` (not part of the
-        backend API; see that method for the seam semantics).
-        """
-        if forward_mode.is_decode_or_idle():
-            return bs in self.decode_cuda_graph_metadata
-        if forward_mode.is_target_verify():
-            return bs in self.target_verify_metadata
-        if forward_mode.is_draft_extend_v2():
-            return bs in getattr(self, "draft_extend_metadata", {})
-        return False
-
     @staticmethod
     def _resolve_swa_kv_pool(model_runner: ModelRunner) -> Optional[SWAKVPool]:
         """Return the SWAKVPool to translate against, or None for non-SWA models.
@@ -255,8 +241,18 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
     ):
         """Initialize CUDA graph state for TRTLLM MHA."""
         max_num_pages = (self.max_context_len + self.page_size - 1) // self.page_size
+        # cu_seqlens_q is always pre-allocated (was previously gated on
+        # speculative_num_draft_tokens > 0). The per-iter view rebuild in
+        # _compute_forward_metadata slices [:bs+1] for every mode, so the
+        # shared buffer must exist for both spec and non-spec deployments.
         self.decode_cuda_graph_metadata = {
             "cache_seqlens": torch.zeros(max_bs, dtype=torch.int32, device=self.device),
+            "cu_seqlens_q": torch.arange(
+                0, max_bs + 1, dtype=torch.int32, device=self.device
+            ),
+            "cu_seqlens_k": torch.zeros(
+                max_bs + 1, dtype=torch.int32, device=self.device
+            ),
             "page_table": torch.zeros(
                 max_bs,
                 max_num_pages,
@@ -269,8 +265,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ),
         }
 
-        # SWA write-target buffer; bound as a [:num_tokens] view in
-        # _build_cuda_graph_metadata, refilled before each replay in
+        # SWA write-target buffer; sliced as a [:num_tokens] view per-iter
+        # by _compute_forward_metadata, and refilled before each replay in
         # init_forward_metadata_out_graph.
         self.cuda_graph_swa_out_cache_loc = (
             torch.zeros(max_num_tokens, dtype=torch.int64, device=self.device)
@@ -282,12 +278,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             self.speculative_num_draft_tokens is not None
             and self.speculative_num_draft_tokens > 0
         ):
-            self.decode_cuda_graph_metadata["cu_seqlens_q"] = torch.arange(
-                0, max_bs + 1, dtype=torch.int32, device=self.device
-            )
-            self.decode_cuda_graph_metadata["cu_seqlens_k"] = torch.zeros(
-                max_bs + 1, dtype=torch.int32, device=self.device
-            )
             self.decode_cuda_graph_metadata["page_table_draft_decode"] = torch.zeros(
                 max_bs,
                 max_num_pages,
@@ -348,104 +338,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 ),
             }
 
-    def _build_cuda_graph_metadata(
-        self,
-        bs: int,
-        num_tokens: int,
-        forward_mode: ForwardMode,
-        spec_info,
-        device: torch.device,
-    ) -> TRTLLMMHAMetadata:
-        """Create TRTLLMMHAMetadata with pre-allocated buffer slice refs, stored in the dict."""
-        metadata = TRTLLMMHAMetadata()
-
-        if forward_mode.is_decode_or_idle():
-            if spec_info is not None:
-                # Draft Decode (topk = 1)
-                metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
-                    "cache_seqlens"
-                ][:bs]
-                metadata.cu_seqlens_q = self.decode_cuda_graph_metadata["cu_seqlens_q"][
-                    : bs + 1
-                ]
-                metadata.cu_seqlens_k = self.decode_cuda_graph_metadata["cu_seqlens_k"][
-                    : bs + 1
-                ]
-                metadata.page_table = self.decode_cuda_graph_metadata[
-                    "page_table_draft_decode"
-                ][:bs, :]
-                self._bind_swa_page_table(
-                    metadata,
-                    self.decode_cuda_graph_metadata,
-                    "swa_page_table_draft_decode",
-                    bs,
-                )
-                self.decode_cuda_graph_metadata[bs] = metadata
-            else:
-                # Normal Decode
-                metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
-                    "cache_seqlens"
-                ][:bs]
-                metadata.cu_seqlens_q = torch.arange(
-                    0, bs + 1, dtype=torch.int32, device=device
-                )
-                metadata.cu_seqlens_k = torch.zeros(
-                    bs + 1, dtype=torch.int32, device=device
-                )
-                metadata.page_table = self.decode_cuda_graph_metadata["page_table"][
-                    :bs, :
-                ]
-                self._bind_swa_page_table(
-                    metadata,
-                    self.decode_cuda_graph_metadata,
-                    "swa_page_table",
-                    bs,
-                )
-                self.decode_cuda_graph_metadata[bs] = metadata
-        elif forward_mode.is_target_verify():
-            # Target Verify (topk = 1)
-            tokens_per_req = num_tokens // bs
-            metadata.cache_seqlens_int32 = self.target_verify_metadata["cache_seqlens"][
-                :bs
-            ]
-            metadata.cu_seqlens_q = self.target_verify_metadata["cu_seqlens_q"][
-                : bs + 1
-            ]
-            metadata.cu_seqlens_k = self.target_verify_metadata["cu_seqlens_k"][
-                : bs + 1
-            ]
-            metadata.max_seq_len_q = tokens_per_req
-            metadata.page_table = self.target_verify_metadata["page_table"][:bs, :]
-            self._bind_swa_page_table(
-                metadata,
-                self.target_verify_metadata,
-                "swa_page_table",
-                bs,
-            )
-            self.target_verify_metadata[bs] = metadata
-        elif forward_mode.is_draft_extend_v2():
-            num_tokens_per_bs = num_tokens // bs
-            metadata.cache_seqlens_int32 = self.draft_extend_metadata["cache_seqlens"][
-                :bs
-            ]
-            metadata.cu_seqlens_q = self.draft_extend_metadata["cu_seqlens_q"][: bs + 1]
-            metadata.cu_seqlens_k = self.draft_extend_metadata["cu_seqlens_k"][: bs + 1]
-            metadata.max_seq_len_q = num_tokens_per_bs
-            metadata.page_table = self.draft_extend_metadata["page_table"][:bs, :]
-            self._bind_swa_page_table(
-                metadata,
-                self.draft_extend_metadata,
-                "swa_page_table",
-                bs,
-            )
-            self.draft_extend_metadata[bs] = metadata
-
-        # Bind the SWA write-target buffer slice (refilled at replay).
-        if self.use_sliding_window_kv_pool:
-            metadata.swa_out_cache_loc = self.cuda_graph_swa_out_cache_loc[:num_tokens]
-
-        return metadata
-
     def update_verify_buffers_to_fill_after_draft(
         self, spec_info: SpecInput, cuda_graph_bs: Optional[int]
     ):
@@ -494,16 +386,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
 
-        if in_capture:
-            num_tokens = forward_batch.positions.numel()
-            self._build_cuda_graph_metadata(
-                bs, num_tokens, forward_mode, spec_info, forward_batch.seq_lens.device
-            )
-
-        # Single eager == replay == capture metadata path. The seam between
-        # the pre-bound per-bs cuda-graph metadata (refilled in place) and a
-        # freshly-built per-iter object is internal to _compute_forward_metadata;
-        # callers do not need to know which path is taken.
+        # Single eager == replay == capture path: capturable modes rebuild a
+        # metadata view per-iter from the shared max-bs buffers (storage stable
+        # across iters → cuda graph captured data_ptrs stay valid); plain
+        # EXTEND builds a fresh per-iter metadata. No pre-bound dict needed.
         self._compute_forward_metadata(forward_batch, in_capture=in_capture)
 
     def _compute_forward_metadata(
@@ -512,57 +398,80 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         """Single source of truth for TRTLLM-MHA forward metadata, shared by
         eager, capture, and replay.
 
-        Internally selects between the pre-bound per-bs cuda-graph metadata
-        (refilled in place at capture / replay / eager-at-captured-bs) and a
-        fresh per-iter object (pure-eager / non-captured bs; plain EXTEND;
-        eager draft_extend_v2). The captured pre-roll
-        (_build_cuda_graph_metadata) is called by init_forward_metadata_out_graph
-        before this method when ``in_capture`` is True.
+        Capturable modes (decode_or_idle / target_verify / draft_extend_v2)
+        rebuild a metadata view per-iter from the shared max-bs buffers
+        allocated in ``init_static_metadata_buffers``; storage is stable
+        across iters so cuda graph captured data_ptrs remain valid. Plain
+        EXTEND (and eager DLLM_EXTEND) builds a fresh per-iter metadata.
         """
         bs = forward_batch.batch_size
         forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
 
-        # Internalize the captured-bucket seam — every caller goes through this
-        # function; the public API does not expose it.
-        _has_captured_metadata = in_capture or self._has_captured_metadata(
-            bs, forward_mode
-        )
-
-        if _has_captured_metadata:
-            # Bound cuda-graph path (replay / capture / eager-at-captured-bs):
-            # refill the pre-bound per-bs metadata in place. Mirrors the old
-            # _apply_cuda_graph_metadata body exactly ([:bs] slicing, in-place
-            # copy_ into the captured buffer slices).
+        if (
+            forward_mode.is_decode_or_idle()
+            or forward_mode.is_target_verify()
+            or forward_mode.is_draft_extend_v2()
+        ):
+            # Capturable modes: rebuild a TRTLLMMHAMetadata view per-iter
+            # from the shared max-bs buffers (init_static_metadata_buffers
+            # allocates them once). Storage is stable across iters so cuda
+            # graph data_ptrs stay valid — capture, replay, and eager all
+            # execute this single body.
             seq_lens = forward_batch.seq_lens[:bs]
             seq_lens_cpu = forward_batch.seq_lens_cpu[:bs]
             req_pool_indices = forward_batch.req_pool_indices[:bs]
-            metadata = None
+            metadata = TRTLLMMHAMetadata()
             if forward_mode.is_decode_or_idle():
                 if spec_info is not None:
-                    # Draft Decode
-                    # Here we only support topk = 1 for now.
-                    metadata = self.decode_cuda_graph_metadata[bs]
+                    # Draft Decode (topk = 1)
                     metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
                         "cache_seqlens"
                     ][:bs]
+                    metadata.cu_seqlens_q = self.decode_cuda_graph_metadata[
+                        "cu_seqlens_q"
+                    ][: bs + 1]
+                    metadata.cu_seqlens_k = self.decode_cuda_graph_metadata[
+                        "cu_seqlens_k"
+                    ][: bs + 1]
+                    metadata.page_table = self.decode_cuda_graph_metadata[
+                        "page_table_draft_decode"
+                    ][:bs, :]
+                    self._bind_swa_page_table(
+                        metadata,
+                        self.decode_cuda_graph_metadata,
+                        "swa_page_table_draft_decode",
+                        bs,
+                    )
                     metadata.cache_seqlens_int32.copy_(
                         seq_lens + self.speculative_step_id + 1
                     )
                     metadata.max_seq_len_k = seq_lens.max().item() + (
                         self.speculative_step_id + 1
                     )
-
                     max_seq_pages = (
                         metadata.max_seq_len_k + self.page_size - 1
                     ) // self.page_size
                 else:
                     # Normal Decode
-                    metadata = self.decode_cuda_graph_metadata[bs]
+                    metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
+                        "cache_seqlens"
+                    ][:bs]
+                    metadata.cu_seqlens_q = self.decode_cuda_graph_metadata[
+                        "cu_seqlens_q"
+                    ][: bs + 1]
+                    metadata.cu_seqlens_k = self.decode_cuda_graph_metadata[
+                        "cu_seqlens_k"
+                    ][: bs + 1]
+                    metadata.page_table = self.decode_cuda_graph_metadata["page_table"][
+                        :bs, :
+                    ]
+                    self._bind_swa_page_table(
+                        metadata, self.decode_cuda_graph_metadata, "swa_page_table", bs
+                    )
                     max_len = seq_lens_cpu.max().item()
                     max_seq_pages = (max_len + self.page_size - 1) // self.page_size
                     metadata.max_seq_len_k = max_len
-
                     metadata.cache_seqlens_int32.copy_(seq_lens)
 
                 metadata.cu_seqlens_k[1:].copy_(
@@ -579,14 +488,25 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 )
                 self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
             elif forward_mode.is_target_verify():
-                # Here we only support topk = 1 for now.
-                metadata = self.target_verify_metadata[bs]
+                # Target Verify (topk = 1)
+                metadata.cache_seqlens_int32 = self.target_verify_metadata[
+                    "cache_seqlens"
+                ][:bs]
+                metadata.cu_seqlens_q = self.target_verify_metadata["cu_seqlens_q"][
+                    : bs + 1
+                ]
+                metadata.cu_seqlens_k = self.target_verify_metadata["cu_seqlens_k"][
+                    : bs + 1
+                ]
+                metadata.page_table = self.target_verify_metadata["page_table"][:bs, :]
+                metadata.max_seq_len_q = self.speculative_num_draft_tokens
+                self._bind_swa_page_table(
+                    metadata, self.target_verify_metadata, "swa_page_table", bs
+                )
                 metadata.cache_seqlens_int32.copy_(seq_lens + metadata.max_seq_len_q)
-
                 metadata.max_seq_len_k = (
                     seq_lens_cpu.max().item() + metadata.max_seq_len_q
                 )
-                max_len = seq_lens_cpu.max().item()
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
                 )
@@ -602,43 +522,41 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 )
                 self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
             elif forward_mode.is_draft_extend_v2():
-                metadata = self.draft_extend_metadata[bs]
+                metadata.cache_seqlens_int32 = self.draft_extend_metadata[
+                    "cache_seqlens"
+                ][:bs]
+                metadata.cu_seqlens_q = self.draft_extend_metadata["cu_seqlens_q"][
+                    : bs + 1
+                ]
+                metadata.cu_seqlens_k = self.draft_extend_metadata["cu_seqlens_k"][
+                    : bs + 1
+                ]
+                metadata.page_table = self.draft_extend_metadata["page_table"][:bs, :]
+                self._bind_swa_page_table(
+                    metadata, self.draft_extend_metadata, "swa_page_table", bs
+                )
                 metadata.cache_seqlens_int32.copy_(seq_lens)
-
                 metadata.max_seq_len_k = seq_lens_cpu.max().item()
-                max_len = seq_lens_cpu.max().item()
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
                 )
-                if forward_mode.is_draft_extend_v2():
-                    num_tokens_per_bs = spec_info.num_tokens_per_req
-                    if num_tokens_per_bs <= 0:
-                        # Capture uses a synthetic EagleDraftExtendInput; infer the
-                        # fixed V2 stride from the capture buffer when it is unset.
-                        num_tokens_per_bs = int(
-                            spec_info.num_accept_tokens[:bs].max().item()
-                        )
-                    metadata.max_seq_len_q = num_tokens_per_bs
-                    metadata.cu_seqlens_q[1:].copy_(
-                        torch.arange(
-                            num_tokens_per_bs,
-                            bs * num_tokens_per_bs + 1,
-                            num_tokens_per_bs,
-                            dtype=torch.int32,
-                            device=metadata.cu_seqlens_q.device,
-                        )
+                num_tokens_per_bs = spec_info.num_tokens_per_req
+                if num_tokens_per_bs <= 0:
+                    # Capture uses a synthetic EagleDraftExtendInput; infer the
+                    # fixed V2 stride from the capture buffer when it is unset.
+                    num_tokens_per_bs = int(
+                        spec_info.num_accept_tokens[:bs].max().item()
                     )
-                else:
-                    extend_lens = spec_info.num_accept_tokens[:bs]
-                    if spec_info.num_accept_tokens_cpu:
-                        metadata.max_seq_len_q = max(spec_info.num_accept_tokens_cpu)
-                    else:
-                        metadata.max_seq_len_q = 1
-
-                    metadata.cu_seqlens_q[1:].copy_(
-                        torch.cumsum(extend_lens, dim=0, dtype=torch.int32)
+                metadata.max_seq_len_q = num_tokens_per_bs
+                metadata.cu_seqlens_q[1:].copy_(
+                    torch.arange(
+                        num_tokens_per_bs,
+                        bs * num_tokens_per_bs + 1,
+                        num_tokens_per_bs,
+                        dtype=torch.int32,
+                        device=metadata.cu_seqlens_q.device,
                     )
-
+                )
                 max_seq_pages = (
                     metadata.max_seq_len_k + self.page_size - 1
                 ) // self.page_size
@@ -782,12 +700,15 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
             self.forward_metadata = metadata
 
-        # Captured-bucket SWA: refill the captured write-target buffer from
-        # the live out_cache_loc before replay (the per-bs metadata holds a
-        # view bound in _build_cuda_graph_metadata). The fresh path sets
-        # metadata.swa_out_cache_loc directly inside the body above.
+        # Capturable-mode SWA: refill the shared write-target buffer from the
+        # live out_cache_loc before replay. The plain-EXTEND fresh path sets
+        # metadata.swa_out_cache_loc directly inside its body above.
         if (
-            _has_captured_metadata
+            (
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
+            )
             and self.use_sliding_window_kv_pool
             and forward_batch.out_cache_loc is not None
         ):

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -728,6 +728,15 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     forward_batch.out_cache_loc
                 )
             )
+            # Bind the [:n] view back onto the freshly built metadata so
+            # forward_decode/extend's KV write passes a non-None swa_out_cache_loc
+            # to KVWriteLoc; SWAKVPool.set_kv_buffer asserts non-None for SWA
+            # layers, so without this hybrid-SWA models crash on the first KV
+            # write of every capturable forward.
+            if self.forward_metadata is not None:
+                self.forward_metadata.swa_out_cache_loc = (
+                    self.cuda_graph_swa_out_cache_loc[:n]
+                )
 
     def forward_decode(
         self,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -412,7 +412,18 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
 
-        if (
+        # The shared max-bs buffers (decode_cuda_graph_metadata,
+        # target_verify_metadata, draft_extend_metadata) are sized at
+        # cuda-graph max_bs from init_static_metadata_buffers. If max_running_
+        # requests > cuda_graph_max_bs_decode and the runner dispatches eager,
+        # the [:bs] slicing below truncates and metadata.cache_seqlens_int32.
+        # copy_(seq_lens) size-mismatches. Force oversized eager onto the
+        # fresh per-iter else branch (which already handles plain extend).
+        cache_seqlens_buf = self.decode_cuda_graph_metadata.get("cache_seqlens")
+        bs_fits_buffer = (
+            cache_seqlens_buf is not None and bs <= cache_seqlens_buf.shape[0]
+        )
+        if bs_fits_buffer and (
             forward_mode.is_decode_or_idle()
             or forward_mode.is_target_verify()
             or (
@@ -425,8 +436,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             # allocates them once). Storage is stable across iters so cuda
             # graph data_ptrs stay valid — capture, replay, and eager all
             # execute this single body. Eager draft_extend_v2 at a non-
-            # captured bs falls through to the fresh per-iter branch so
-            # the layout follows live extend_seq_lens.
+            # captured bs (or oversized eager bs above the buffer ceiling)
+            # falls through to the fresh per-iter branch so the layout
+            # follows live extend_seq_lens.
             seq_lens = forward_batch.seq_lens[:bs]
             seq_lens_cpu = forward_batch.seq_lens_cpu[:bs]
             req_pool_indices = forward_batch.req_pool_indices[:bs]

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -144,18 +144,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         #   KV fp8: q_type = fp8, out_type=model_runner.dtype
         self.is_xqa_impl = is_sm90_supported() or is_sm120_supported()
 
-    def _use_cuda_graph_buffers(self, bs: int, forward_mode: ForwardMode) -> bool:
-        """Eager/replay seam, resolved by backend STATE (no argument).
-
-        Returns True when this ``(bs, forward_mode)`` has a pre-bound
-        cuda-graph metadata object: i.e. at cuda-graph replay (the runner always
-        pads to a captured bucket) and harmlessly at an eager forward that lands
-        on a captured bs+mode in a graph-enabled server -- there is one forward
-        stream per backend, and the bound metadata is always refilled by
-        ``out_graph`` before the next ``graph.replay()``, so a transient eager
-        plan cannot leak into a later replay. Returns False for pure-eager runs
-        (no metadata was ever captured for this bs/mode) and for plain EXTEND
-        (never captured) -> build a fresh per-iter metadata.
+    def _has_captured_metadata(self, bs: int, forward_mode: ForwardMode) -> bool:
+        """Whether `(bs, forward_mode)` has a captured cuda-graph metadata
+        object — only True when a cuda-graph runner previously captured this
+        bucket. Internal to `_compute_forward_metadata` (not part of the
+        backend API; see that method for the seam semantics).
         """
         if forward_mode.is_decode_or_idle():
             return bs in self.decode_cuda_graph_metadata
@@ -507,30 +500,36 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 bs, num_tokens, forward_mode, spec_info, forward_batch.seq_lens.device
             )
 
-        # Single eager == replay == capture metadata path; `use_bound` selects
-        # the pre-bound per-bs cuda-graph metadata (refilled in place) vs a
-        # fresh per-iter metadata.
-        use_bound = in_capture or self._use_cuda_graph_buffers(bs, forward_mode)
-        self._compute_forward_metadata(forward_batch, use_bound=use_bound)
+        # Single eager == replay == capture metadata path. The seam between
+        # the pre-bound per-bs cuda-graph metadata (refilled in place) and a
+        # freshly-built per-iter object is internal to _compute_forward_metadata;
+        # callers do not need to know which path is taken.
+        self._compute_forward_metadata(forward_batch, in_capture=in_capture)
 
     def _compute_forward_metadata(
-        self, forward_batch: ForwardBatch, *, use_bound: bool
+        self, forward_batch: ForwardBatch, *, in_capture: bool = False
     ):
         """Single source of truth for TRTLLM-MHA forward metadata, shared by
         eager, capture, and replay.
 
-        ``use_bound`` selects whether the metadata is the per-bs pre-bound
-        cuda-graph object (refilled in place; capture / replay / eager-at-
-        captured-bs) or a fresh per-iter object. Plain EXTEND (and eager
-        draft_extend_v2) only ever run with use_bound=False. The in_capture-only
-        pre-roll (_build_cuda_graph_metadata) lives in
-        init_forward_metadata_out_graph around this call.
+        Internally selects between the pre-bound per-bs cuda-graph metadata
+        (refilled in place at capture / replay / eager-at-captured-bs) and a
+        fresh per-iter object (pure-eager / non-captured bs; plain EXTEND;
+        eager draft_extend_v2). The captured pre-roll
+        (_build_cuda_graph_metadata) is called by init_forward_metadata_out_graph
+        before this method when ``in_capture`` is True.
         """
         bs = forward_batch.batch_size
         forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
 
-        if use_bound:
+        # Internalize the captured-bucket seam — every caller goes through this
+        # function; the public API does not expose it.
+        _has_captured_metadata = in_capture or self._has_captured_metadata(
+            bs, forward_mode
+        )
+
+        if _has_captured_metadata:
             # Bound cuda-graph path (replay / capture / eager-at-captured-bs):
             # refill the pre-bound per-bs metadata in place. Mirrors the old
             # _apply_cuda_graph_metadata body exactly ([:bs] slicing, in-place
@@ -653,9 +652,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
             self.forward_metadata = metadata
         else:
-            # Eager (use_bound=False) path: build a fresh per-iter metadata.
-            # Mirrors the old eager init_forward_metadata body exactly (plain
-            # EXTEND and eager draft_extend_v2 both land in the final `else`).
+            # Fresh per-iter metadata (pure-eager / non-captured bs; plain
+            # EXTEND; eager draft_extend_v2). Mirrors the old eager
+            # init_forward_metadata body exactly.
             metadata = TRTLLMMHAMetadata()
             seqlens_in_batch = forward_batch.seq_lens
             batch_size = forward_batch.batch_size
@@ -783,12 +782,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
             self.forward_metadata = metadata
 
-        # Bound-path SWA: refill the captured write-target buffer from the live
-        # out_cache_loc before replay (the per-bs metadata holds a view bound in
-        # _build). The eager (use_bound=False) path instead sets
+        # Captured-bucket SWA: refill the captured write-target buffer from
+        # the live out_cache_loc before replay (the per-bs metadata holds a
+        # view bound in _build_cuda_graph_metadata). The fresh path sets
         # metadata.swa_out_cache_loc directly inside the body above.
         if (
-            use_bound
+            _has_captured_metadata
             and self.use_sliding_window_kv_pool
             and forward_batch.out_cache_loc is not None
         ):

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -126,6 +126,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self.speculative_num_draft_tokens = (
             model_runner.server_args.speculative_num_draft_tokens
         )
+        # bs values that the draft-extend cuda-graph runner has captured. Used
+        # to gate the bound fixed-width DRAFT_EXTEND_V2 layout; eager / non-
+        # captured bs falls through to the fresh per-iter metadata branch.
+        self._draft_extend_v2_captured_bs: set[int] = set()
 
         # SWA hybrid models split the KV cache into full and SWA pools with
         # separate index spaces; SWA layers need a translated page_table.
@@ -411,13 +415,18 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         if (
             forward_mode.is_decode_or_idle()
             or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend_v2()
+            or (
+                forward_mode.is_draft_extend_v2()
+                and bs in self._draft_extend_v2_captured_bs
+            )
         ):
             # Capturable modes: rebuild a TRTLLMMHAMetadata view per-iter
             # from the shared max-bs buffers (init_static_metadata_buffers
             # allocates them once). Storage is stable across iters so cuda
             # graph data_ptrs stay valid — capture, replay, and eager all
-            # execute this single body.
+            # execute this single body. Eager draft_extend_v2 at a non-
+            # captured bs falls through to the fresh per-iter branch so
+            # the layout follows live extend_seq_lens.
             seq_lens = forward_batch.seq_lens[:bs]
             seq_lens_cpu = forward_batch.seq_lens_cpu[:bs]
             req_pool_indices = forward_batch.req_pool_indices[:bs]

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -723,12 +723,21 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         # Capturable-mode SWA: refill the shared write-target buffer from the
         # live out_cache_loc before replay. The plain-EXTEND fresh path sets
-        # metadata.swa_out_cache_loc directly inside its body above.
+        # metadata.swa_out_cache_loc directly inside its body above; the same
+        # is true for non-captured DRAFT_EXTEND_V2 (it falls through to the
+        # else branch), so skip the refill there too — copying live tokens
+        # into the cuda_graph_swa_out_cache_loc buffer (sized for the
+        # captured static token count) would slice-mismatch on oversized
+        # fallback batches.
         if (
-            (
+            bs_fits_buffer
+            and (
                 forward_mode.is_decode_or_idle()
                 or forward_mode.is_target_verify()
-                or forward_mode.is_draft_extend_v2()
+                or (
+                    forward_mode.is_draft_extend_v2()
+                    and bs in self._draft_extend_v2_captured_bs
+                )
             )
             and self.use_sliding_window_kv_pool
             and forward_batch.out_cache_loc is not None

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -494,6 +494,34 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
         self._compute_decode_metadata(forward_batch, in_capture=in_capture)
 
+    def _build_fresh_decode_metadata(
+        self, forward_batch: ForwardBatch
+    ) -> TRTLLMMLADecodeMetadata:
+        """Allocate per-iter decode metadata sized to the live ``bs``.
+
+        Used when eager dispatch is forced (e.g. ``max_running_requests >
+        cuda_graph_max_bs_decode``) and the singleton ``eager_decode_metadata``
+        (sized at cuda-graph max_bs) would overflow on the seq_lens[:bs]
+        write. Mirrors the pre-use_bound eager-build path.
+        """
+        bs = forward_batch.batch_size
+        device = forward_batch.seq_lens.device
+        max_blocks_per_seq = self._calc_padded_blocks(self.max_context_len)
+        metadata = TRTLLMMLADecodeMetadata()
+        metadata.seq_lens_k = torch.zeros((bs,), dtype=torch.int32, device=device)
+        metadata.cu_seqlens_q = torch.zeros(
+            (bs + 1,), dtype=torch.int32, device=device
+        )
+        metadata.seq_lens_q = torch.zeros((bs,), dtype=torch.int32, device=device)
+        metadata.block_kv_indices = torch.full(
+            (bs, max_blocks_per_seq), -1, dtype=torch.int32, device=device
+        )
+        metadata.max_seq_len_k = self.max_context_len
+        # max_seq_len_q is set per-mode by the caller (and overwritten for
+        # spec); seed with a safe default.
+        metadata.max_seq_len_q = 1
+        return metadata
+
     def _compute_decode_metadata(
         self, forward_batch: ForwardBatch, *, in_capture: bool = False
     ):
@@ -516,6 +544,14 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         bs = forward_batch.batch_size
 
         metadata = self.decode_cuda_graph_metadata.get(bs, self.eager_decode_metadata)
+        # Oversized eager: eager_decode_metadata buffers are sized at the
+        # cuda-graph max_bs; if max_running_requests > cuda_graph_max_bs_decode
+        # and DecodeCudaGraphRunner rejects (-> eager), the subsequent
+        # [:bs].copy_(seq_lens[:bs]) below would size-mismatch on max-bs-sized
+        # destinations with bs-sized sources. Build a fresh live-sized metadata
+        # for those iters (mirrors the pre-use_bound fresh path).
+        if metadata is self.eager_decode_metadata and bs > metadata.seq_lens_k.shape[0]:
+            metadata = self._build_fresh_decode_metadata(forward_batch)
         seq_lens = forward_batch.seq_lens
 
         # Reset any stale prefill metadata (the backend instance persists across

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -492,9 +492,11 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 forward_batch.seq_lens.device,
             )
 
-        self._compute_decode_metadata(forward_batch)
+        self._compute_decode_metadata(forward_batch, in_capture=in_capture)
 
-    def _compute_decode_metadata(self, forward_batch: ForwardBatch):
+    def _compute_decode_metadata(
+        self, forward_batch: ForwardBatch, *, in_capture: bool = False
+    ):
         """Single source of truth for TRTLLM-MLA decode / target-verify /
         draft-extend-v2 metadata, shared by eager / capture / replay.
 
@@ -523,23 +525,33 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             self.forward_prefill_metadata = None
 
         # Pre-refactor's fresh-build path set max_seq_len_k from the LIVE batch
-        # (seq_lens_cpu.max()); the converged path needs the same for normal
-        # decode so long-context models don't pay max_context_len kernel
-        # scheduling cost on short requests. (Spec branches set their own
-        # max_seq_len_k below — captured replays don't care since max_seq_len_k
-        # is a host-side int, not a graph-captured pointer.)
+        # (seq_lens_cpu.max()); the converged path needs the same for eager /
+        # replay so long-context models don't pay max_context_len kernel
+        # scheduling cost on short requests.
+        #
+        # During CAPTURE, DecodeCudaGraphRunner seeds seq_lens_cpu with the
+        # backend's fill value (1), and max_seq_len_k is a host int captured
+        # into the trtllm-gen graph. Recording the live max here would freeze
+        # the captured graph at max_seq_len_k=1, breaking replay for any KV
+        # length > 1. Keep max_context_len for capture; use live max only
+        # outside the capture path.
         seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
         if seq_lens_cpu is not None:
             live_max_seq_len_k = int(seq_lens_cpu[:bs].max().item())
         else:
             live_max_seq_len_k = int(seq_lens[:bs].max().item())
-        metadata.max_seq_len_k = live_max_seq_len_k
+        if not in_capture:
+            metadata.max_seq_len_k = live_max_seq_len_k
+        else:
+            metadata.max_seq_len_k = self.max_context_len
 
         if forward_mode.is_target_verify():
             seq_lens = seq_lens[:bs] + self.num_draft_tokens
             metadata.seq_lens_k[:bs].copy_(seq_lens.to(dtype=torch.int32))
             # Spec target verify reserves draft tokens past the live max.
-            metadata.max_seq_len_k = live_max_seq_len_k + self.num_draft_tokens
+            if not in_capture:
+                metadata.max_seq_len_k = live_max_seq_len_k + self.num_draft_tokens
+            # In capture, leave max_seq_len_k = max_context_len from above.
         elif forward_mode.is_draft_extend_v2():
             if bs in self._draft_extend_v2_captured_bs:
                 # Captured/replay layout: fixed num_draft_tokens per req.

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -205,6 +205,10 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
         self.num_draft_tokens = model_runner.server_args.speculative_num_draft_tokens
         self.cuda_graph_custom_mask = None
+        # bs values that the draft-extend cuda-graph runner has captured. Used
+        # to gate the bound fixed-width DRAFT_EXTEND_V2 layout; eager / non-
+        # captured bs uses live extend_seq_lens via the fresh branch.
+        self._draft_extend_v2_captured_bs: set[int] = set()
 
     def _calc_padded_blocks(self, max_seq_len: int) -> int:
         """
@@ -524,21 +528,38 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             metadata.seq_lens_k[:bs].copy_(seq_lens.to(dtype=torch.int32))
             metadata.max_seq_len_k = self.max_context_len
         elif forward_mode.is_draft_extend_v2():
-            num_tokens_per_bs = self.num_draft_tokens
-            metadata.max_seq_len_q = num_tokens_per_bs
-            metadata.sum_seq_lens_q = num_tokens_per_bs * bs
-            metadata.cu_seqlens_q[: bs + 1].copy_(
-                torch.arange(
-                    0,
-                    bs * num_tokens_per_bs + 1,
-                    step=num_tokens_per_bs,
-                    dtype=torch.int32,
-                    device=seq_lens.device,
+            if bs in self._draft_extend_v2_captured_bs:
+                # Captured/replay layout: fixed num_draft_tokens per req.
+                num_tokens_per_bs = self.num_draft_tokens
+                metadata.max_seq_len_q = num_tokens_per_bs
+                metadata.sum_seq_lens_q = num_tokens_per_bs * bs
+                metadata.cu_seqlens_q[: bs + 1].copy_(
+                    torch.arange(
+                        0,
+                        bs * num_tokens_per_bs + 1,
+                        step=num_tokens_per_bs,
+                        dtype=torch.int32,
+                        device=seq_lens.device,
+                    )
                 )
-            )
-            metadata.seq_lens_q[:bs].fill_(num_tokens_per_bs)
-            # see NOTE(draft_extend seq_len handling)
-            seq_lens = seq_lens[:bs] - metadata.seq_lens_q[:bs] + metadata.max_seq_len_q
+                metadata.seq_lens_q[:bs].fill_(num_tokens_per_bs)
+                # see NOTE(draft_extend seq_len handling)
+                seq_lens = (
+                    seq_lens[:bs] - metadata.seq_lens_q[:bs] + metadata.max_seq_len_q
+                )
+            else:
+                # Eager / non-captured: per-req extend_seq_lens drives the layout.
+                extend_seq_lens = forward_batch.extend_seq_lens[:bs].to(torch.int32)
+                metadata.seq_lens_q[:bs].copy_(extend_seq_lens)
+                metadata.max_seq_len_q = int(extend_seq_lens.max().item())
+                metadata.sum_seq_lens_q = int(extend_seq_lens.sum().item())
+                metadata.cu_seqlens_q[0] = 0
+                metadata.cu_seqlens_q[1 : bs + 1].copy_(
+                    torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32)
+                )
+                seq_lens = (
+                    seq_lens[:bs] - metadata.seq_lens_q[:bs] + metadata.max_seq_len_q
+                )
             metadata.seq_lens_k[:bs].copy_(seq_lens.to(torch.int32))
             metadata.max_seq_len_k = self.max_context_len
 

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -869,11 +869,18 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             self.init_forward_metadata(forward_batch)
             metadata = forward_batch.decode_trtllm_mla_metadata
 
+        # eager_decode_metadata is sized at the static max_bs; for live bs
+        # below it (eager at a non-captured bs, e.g. bs=63 falling through
+        # the captured set [..., 64]) the bound block_kv_indices keeps
+        # max_bs rows even though only [:bs] is freshly filled. Flashinfer's
+        # `_check_trtllm_gen_mla_shape` asserts that query and block_table
+        # share batch_size, so pass the live-bs slice explicitly.
+        live_bs = query.shape[0]
         raw_out = self._run_decode_kernel(
             query=query,
             kv_cache=kv_cache,
-            block_tables=metadata.block_kv_indices,
-            seq_lens=forward_batch.seq_lens,
+            block_tables=metadata.block_kv_indices[:live_bs],
+            seq_lens=forward_batch.seq_lens[:live_bs],
             max_seq_len=metadata.max_seq_len_k,
             layer=layer,
         )
@@ -1036,11 +1043,16 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
             assert kv_cache.dtype == self.data_type
 
+            # Same eager-bs-vs-static-buffer slicing rationale as plain decode
+            # above: the bound metadata may carry max_bs-sized rows even at
+            # live bs below the captured ceiling. q.shape[0] is the live bs
+            # here after the per-mode .view(bs, …, ...) reshape.
+            live_bs = q.shape[0]
             raw_out = self._run_decode_kernel(
                 query=q,
                 kv_cache=kv_cache,
-                block_tables=metadata.block_kv_indices,
-                seq_lens=metadata.seq_lens_k,
+                block_tables=metadata.block_kv_indices[:live_bs],
+                seq_lens=metadata.seq_lens_k[:live_bs],
                 max_seq_len=max_seq_len,
                 layer=layer,
             )

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -328,6 +328,29 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
         super().init_static_metadata_buffers(max_bs, max_num_tokens, kv_indices_buf)
 
+        # Pre-allocate an eager metadata holding union-max-sized mode fields,
+        # plus a view over the shared kv-indices buffer. Used as the fallback
+        # when the live bs has no captured bucket entry (eager-only mode, or
+        # graph-enabled mode at non-captured bs). The cuda-graph capture path
+        # still creates per-bucket entries via _init_cuda_graph_metadata.
+        eager_metadata = TRTLLMMLADecodeMetadata()
+        eager_metadata.seq_lens_k = torch.zeros(
+            (max_bs,), dtype=torch.int32, device=self.device
+        )
+        num_tokens_per_bs = max_num_tokens // max_bs
+        eager_metadata.cu_seqlens_q = torch.zeros(
+            (max_bs + 1,), dtype=torch.int32, device=self.device
+        )
+        eager_metadata.seq_lens_q = torch.zeros(
+            (max_bs,), dtype=torch.int32, device=self.device
+        )
+        eager_metadata.block_kv_indices = self.decode_cuda_graph_kv_indices[
+            :max_bs, :max_blocks_per_seq
+        ]
+        eager_metadata.max_seq_len_k = self.max_context_len
+        eager_metadata.max_seq_len_q = num_tokens_per_bs
+        self.eager_decode_metadata = eager_metadata
+
     def get_verify_buffers_to_fill_after_draft(self):
         return [self.cuda_graph_custom_mask, None]
 
@@ -383,27 +406,6 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 forward_batch, disable_flashinfer_ragged=True
             )
 
-    def _use_cuda_graph_buffers(self, bs: int, forward_mode: ForwardMode) -> bool:
-        """Eager/replay seam, resolved by backend STATE (no argument).
-
-        Returns True when this ``(bs, forward_mode)`` has a pre-bound
-        cuda-graph metadata object: all decode-family modes (decode / idle /
-        target-verify / draft-extend-v2) capture into the single
-        ``decode_cuda_graph_metadata`` dict, so at decode-graph replay (the
-        runner always pads to a captured bucket) and harmlessly at an eager
-        forward that lands on a captured bs+mode this picks the pre-bound
-        buffers. Returns False for pure-eager runs (no metadata was ever
-        captured for this bs) and for plain EXTEND (never captured) -> build a
-        fresh metadata object. Mode-aware so it never KeyErrors.
-        """
-        if (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend_v2()
-        ):
-            return bs in self.decode_cuda_graph_metadata
-        return False
-
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Eager entry point. FlashInferMLAAttnBackend (our parent) ships its
         own init_forward_metadata that only handles its own DecodeMetadata /
@@ -417,6 +419,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         """
         self.init_forward_metadata_out_graph(forward_batch)
         self.init_forward_metadata_in_graph(forward_batch)
+
 
     def init_forward_metadata_out_graph(
         self,
@@ -486,20 +489,18 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 forward_batch.seq_lens.device,
             )
 
-        # Single eager == replay == capture decode-family metadata path;
-        # `use_bound` selects the pre-bound cuda-graph metadata object (capture /
-        # replay / eager-at-captured-bs) vs a freshly allocated one. In out_graph
-        # use_bound is always True (capture sets in_capture; replay pads to a
-        # captured bs), matching the old always-bound path.
-        use_bound = in_capture or self._use_cuda_graph_buffers(bs, forward_mode)
-        self._compute_decode_metadata(forward_batch, use_bound=use_bound)
+        self._compute_decode_metadata(forward_batch)
 
-    def _compute_decode_metadata(self, forward_batch: ForwardBatch, *, use_bound: bool):
+    def _compute_decode_metadata(self, forward_batch: ForwardBatch):
         """Single source of truth for TRTLLM-MLA decode / target-verify /
         draft-extend-v2 metadata, shared by eager / capture / replay.
 
-        ``use_bound`` selects the pre-bound cuda-graph metadata object (capture /
-        replay / eager-at-captured-bs) vs a freshly allocated one.
+        Looks up the captured per-bs metadata when present (replay /
+        eager-at-captured-bs) and falls back to the union-max
+        ``eager_decode_metadata`` allocated in ``init_static_metadata_buffers``
+        otherwise (pure-eager / non-captured bs). Either way the body is the
+        same in-place mutation of buffers whose storage is stable across
+        iters, so the cuda graph's captured data_ptrs stay valid.
 
         Deliberately NOT named ``_compute_forward_metadata`` -- that is the
         FlashInferMLA base's full-mode helper, reached via super() for delegated
@@ -509,101 +510,59 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         forward_mode = forward_batch.forward_mode
         bs = forward_batch.batch_size
 
-        if use_bound:
-            metadata = self.decode_cuda_graph_metadata[bs]
-            seq_lens = forward_batch.seq_lens
+        metadata = self.decode_cuda_graph_metadata.get(bs, self.eager_decode_metadata)
+        seq_lens = forward_batch.seq_lens
 
-            if forward_mode.is_target_verify():
-                seq_lens = seq_lens[:bs] + self.num_draft_tokens
-                metadata.seq_lens_k.copy_(seq_lens.to(dtype=torch.int32))
-            elif forward_mode.is_draft_extend_v2():
-                num_tokens_per_bs = self.num_draft_tokens
-                metadata.max_seq_len_q = num_tokens_per_bs
-                metadata.sum_seq_lens_q = num_tokens_per_bs * bs
-                metadata.cu_seqlens_q[: bs + 1].copy_(
-                    torch.arange(
-                        0,
-                        bs * num_tokens_per_bs + 1,
-                        step=num_tokens_per_bs,
-                        dtype=torch.int32,
-                        device=seq_lens.device,
-                    )
-                )
-                metadata.seq_lens_q[:bs].fill_(num_tokens_per_bs)
-                # see NOTE(draft_extend seq_len handling)
-                seq_lens = (
-                    seq_lens[:bs] - metadata.seq_lens_q[:bs] + metadata.max_seq_len_q
-                )
-                metadata.seq_lens_k.copy_(seq_lens.to(torch.int32))
+        # Reset any stale prefill metadata (the backend instance persists across
+        # forward passes, and forward_prefill_metadata from a previous regular
+        # extend call could still be set).
+        if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
+            self.forward_prefill_metadata = None
 
-            # Update block indices for new sequences.
-            create_flashmla_kv_indices_triton[
-                (
-                    bs,
-                    get_num_kv_index_blocks_flashmla(
-                        metadata.block_kv_indices.shape[1], self.page_size
-                    ),
+        if forward_mode.is_target_verify():
+            seq_lens = seq_lens[:bs] + self.num_draft_tokens
+            metadata.seq_lens_k[:bs].copy_(seq_lens.to(dtype=torch.int32))
+            metadata.max_seq_len_k = self.max_context_len
+        elif forward_mode.is_draft_extend_v2():
+            num_tokens_per_bs = self.num_draft_tokens
+            metadata.max_seq_len_q = num_tokens_per_bs
+            metadata.sum_seq_lens_q = num_tokens_per_bs * bs
+            metadata.cu_seqlens_q[: bs + 1].copy_(
+                torch.arange(
+                    0,
+                    bs * num_tokens_per_bs + 1,
+                    step=num_tokens_per_bs,
+                    dtype=torch.int32,
+                    device=seq_lens.device,
                 )
-            ](
-                self.req_to_token,
-                forward_batch.req_pool_indices[:bs],
-                seq_lens,
-                None,
-                metadata.block_kv_indices,
-                self.req_to_token.stride(0),
-                metadata.block_kv_indices.shape[1],
-                PAGED_SIZE=self.page_size,
             )
-        else:
-            self.forward_decode_metadata = TRTLLMMLADecodeMetadata()
-            # This is necessary because the backend instance persists across forward passes,
-            # and forward_prefill_metadata from a previous regular extend call could still be set.
-            if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
-                self.forward_prefill_metadata = None
-            # Get maximum sequence length.
-            if getattr(forward_batch, "seq_lens_cpu", None) is not None:
-                max_seq = forward_batch.seq_lens_cpu.max().item()
-            else:
-                max_seq = forward_batch.seq_lens.max().item()
+            metadata.seq_lens_q[:bs].fill_(num_tokens_per_bs)
+            # see NOTE(draft_extend seq_len handling)
+            seq_lens = seq_lens[:bs] - metadata.seq_lens_q[:bs] + metadata.max_seq_len_q
+            metadata.seq_lens_k[:bs].copy_(seq_lens.to(torch.int32))
+            metadata.max_seq_len_k = self.max_context_len
 
-            seq_lens = forward_batch.seq_lens
-
-            if forward_mode.is_target_verify():
-                max_seq = max_seq + self.num_draft_tokens
-                seq_lens = seq_lens + self.num_draft_tokens
-                self.forward_decode_metadata.seq_lens_k = seq_lens.to(torch.int32)
-            elif forward_mode.is_draft_extend_v2():
-                sum_seq_lens_q = sum(forward_batch.extend_seq_lens_cpu)
-                max_seq_len_q = max(forward_batch.extend_seq_lens_cpu)
-                cu_seqlens_q = torch.nn.functional.pad(
-                    torch.cumsum(
-                        forward_batch.extend_seq_lens, dim=0, dtype=torch.int32
-                    ),
-                    (1, 0),
-                )
-                # see NOTE(draft_extend seq_len handling)
-                seq_lens = seq_lens - forward_batch.extend_seq_lens + max_seq_len_q
-
-                self.forward_decode_metadata.max_seq_len_q = max_seq_len_q
-                self.forward_decode_metadata.sum_seq_lens_q = sum_seq_lens_q
-                self.forward_decode_metadata.cu_seqlens_q = cu_seqlens_q
-                self.forward_decode_metadata.seq_lens_q = forward_batch.extend_seq_lens
-                self.forward_decode_metadata.seq_lens_k = seq_lens.to(torch.int32)
-
-            max_seqlen_pad = self._calc_padded_blocks(max_seq)
-            block_kv_indices = self._create_block_kv_indices(
+        # Update block indices for new sequences.
+        create_flashmla_kv_indices_triton[
+            (
                 bs,
-                max_seqlen_pad,
-                forward_batch.req_pool_indices,
-                seq_lens,
-                seq_lens.device,
+                get_num_kv_index_blocks_flashmla(
+                    metadata.block_kv_indices.shape[1], self.page_size
+                ),
             )
-
-            self.forward_decode_metadata.block_kv_indices = block_kv_indices
-            self.forward_decode_metadata.max_seq_len_k = int(max_seq)
-            self.forward_decode_metadata.batch_size = bs
-
-            forward_batch.decode_trtllm_mla_metadata = self.forward_decode_metadata
+        ](
+            self.req_to_token,
+            forward_batch.req_pool_indices[:bs],
+            seq_lens,
+            None,
+            metadata.block_kv_indices,
+            self.req_to_token.stride(0),
+            metadata.block_kv_indices.shape[1],
+            PAGED_SIZE=self.page_size,
+        )
+        metadata.batch_size = bs
+        forward_batch.decode_trtllm_mla_metadata = metadata
+        self.forward_decode_metadata = metadata
 
     def pad_draft_extend_query(
         self,

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -424,7 +424,6 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         self.init_forward_metadata_out_graph(forward_batch)
         self.init_forward_metadata_in_graph(forward_batch)
 
-
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
@@ -523,10 +522,24 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
             self.forward_prefill_metadata = None
 
+        # Pre-refactor's fresh-build path set max_seq_len_k from the LIVE batch
+        # (seq_lens_cpu.max()); the converged path needs the same for normal
+        # decode so long-context models don't pay max_context_len kernel
+        # scheduling cost on short requests. (Spec branches set their own
+        # max_seq_len_k below — captured replays don't care since max_seq_len_k
+        # is a host-side int, not a graph-captured pointer.)
+        seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+        if seq_lens_cpu is not None:
+            live_max_seq_len_k = int(seq_lens_cpu[:bs].max().item())
+        else:
+            live_max_seq_len_k = int(seq_lens[:bs].max().item())
+        metadata.max_seq_len_k = live_max_seq_len_k
+
         if forward_mode.is_target_verify():
             seq_lens = seq_lens[:bs] + self.num_draft_tokens
             metadata.seq_lens_k[:bs].copy_(seq_lens.to(dtype=torch.int32))
-            metadata.max_seq_len_k = self.max_context_len
+            # Spec target verify reserves draft tokens past the live max.
+            metadata.max_seq_len_k = live_max_seq_len_k + self.num_draft_tokens
         elif forward_mode.is_draft_extend_v2():
             if bs in self._draft_extend_v2_captured_bs:
                 # Captured/replay layout: fixed num_draft_tokens per req.
@@ -561,7 +574,8 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                     seq_lens[:bs] - metadata.seq_lens_q[:bs] + metadata.max_seq_len_q
                 )
             metadata.seq_lens_k[:bs].copy_(seq_lens.to(torch.int32))
-            metadata.max_seq_len_k = self.max_context_len
+            # max_seq_len_k was already set to live max above; keep it as-is.
+            # (Pre-refactor's fresh build did not bump max_seq for draft_extend_v2.)
 
         # Update block indices for new sequences.
         create_flashmla_kv_indices_triton[

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -509,9 +509,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         max_blocks_per_seq = self._calc_padded_blocks(self.max_context_len)
         metadata = TRTLLMMLADecodeMetadata()
         metadata.seq_lens_k = torch.zeros((bs,), dtype=torch.int32, device=device)
-        metadata.cu_seqlens_q = torch.zeros(
-            (bs + 1,), dtype=torch.int32, device=device
-        )
+        metadata.cu_seqlens_q = torch.zeros((bs + 1,), dtype=torch.int32, device=device)
         metadata.seq_lens_q = torch.zeros((bs,), dtype=torch.int32, device=device)
         metadata.block_kv_indices = torch.full(
             (bs, max_blocks_per_seq), -1, dtype=torch.int32, device=device

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -450,9 +450,13 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 self.disable_chunked_prefix_cache and has_prefix
             ) or is_in_tc_piecewise_cuda_graph()
             if fallback_to_flashinfer_impl:
-                super().init_forward_metadata_out_graph(
-                    forward_batch, in_capture=in_capture
-                )
+                # Parent's init_forward_metadata_out_graph routes plain EXTEND
+                # into _apply_cuda_graph_metadata which only handles decode /
+                # target_verify and raises on EXTEND. The fallback wants the
+                # parent's *eager* prefill setup (indices_updater_prefill +
+                # PrefillMetadata wrapper) — that lives on
+                # init_forward_metadata, not init_forward_metadata_out_graph.
+                super().init_forward_metadata(forward_batch)
 
             seq_lens = forward_batch.seq_lens - forward_batch.extend_prefix_lens
             cum_seq_lens_q = torch.cat(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -913,7 +913,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # cg bucket). Both eager (graph-disabled mode AND eager fallback at
         # non-captured bs) and the cuda-graph runners then share the same
         # backend buffers — backends bind into them, and load_metadata refills
-        # per-iter. This is the foundation for collapsing the `use_bound` seam.
+        # per-iter. This is the foundation for the captured-bucket seam that
+        # each backend internalizes inside its `_compute_forward_metadata`.
         self._init_static_metadata_buffers_from_eager()
 
         # cuda-graph capture: prefill before decode, so both coalesce onto the

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -917,6 +917,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # each backend internalizes inside its `_compute_forward_metadata`.
         self._init_static_metadata_buffers_from_eager()
 
+        # Warmup (FlashInfer autotune + PP DeepGEMM) runs init_forward_metadata
+        # via _dummy_run, which reads the static metadata buffers. Must run
+        # AFTER _init_static_metadata_buffers_from_eager.
+        self.eager_runner.warmup()
+
         # cuda-graph capture: prefill before decode, so both coalesce onto the
         # eager buffer allocated above. (init_prefill_cuda_graph routes prefill
         # to the eager runner when the prefill graph is disabled.)

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -130,8 +130,13 @@ class EagerRunner(BaseRunner):
             ),
             dp_size=sa.dp_size,
         )
-        # Eager has no capture step, so warm up here (run-once via mr._kernel_warmed_up).
-        self.warmup()
+        # NOTE: warmup() is deferred to ModelRunner.init_backends (after the
+        # attention static metadata buffers are allocated). FlashInfer autotune
+        # and PP DeepGEMM warmup both call attn_backend.init_forward_metadata
+        # via _dummy_run, which reads pre-bound cuda_graph_* buffers; running
+        # warmup before init_static_metadata_buffers would AttributeError on
+        # backends (e.g. Triton) that no longer keep a fresh-allocation eager
+        # fallback after the use_bound deprecation.
 
     def _autotune_buffers(self) -> Tuple[Any, int]:
         """Adapter over the eager registry for the autotune dummy forward; fills

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -405,6 +405,16 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         with forward_context(
             ForwardContext(attn_backend=self.draft_extend_attn_backend)
         ):
+            # Register this bs as captured BEFORE init_forward_metadata_out_graph
+            # so the bound fixed-width DRAFT_EXTEND_V2 branch fires during the
+            # capture call itself (the gate also catches eager replays at the
+            # same bs later). Non-captured eager bs falls through to the
+            # per-req live-length branch.
+            captured = getattr(
+                self.draft_extend_attn_backend, "_draft_extend_v2_captured_bs", None
+            )
+            if captured is not None:
+                captured.add(bs)
             self.draft_extend_attn_backend.init_forward_metadata_out_graph(
                 forward_batch, in_capture=True
             )

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -489,6 +489,11 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             return ret
 
         with forward_context(ForwardContext(attn_backend=attn_backend)):
+            # Register bs BEFORE init_forward_metadata_out_graph so the bound
+            # DRAFT_EXTEND_V2 branch fires during the capture call itself.
+            captured = getattr(attn_backend, "_draft_extend_v2_captured_bs", None)
+            if captured is not None:
+                captured.add(bs)
             attn_backend.init_forward_metadata_out_graph(forward_batch, in_capture=True)
             self.deepep_adapter.capture(is_extend_in_batch=True)
             shape_key = self._make_graph_key(bs)

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
@@ -982,6 +982,23 @@ def build_dense_attention_fixture(
         backend = ATTENTION_BACKENDS[case.backend](runner)
     except (AssertionError, ImportError, ModuleNotFoundError) as exc:
         testcase.skipTest(f"{case.backend} backend is not available: {exc}")
+    # Mirror ModelRunner.init_backends: allocate the backend's static metadata
+    # buffers up front for backends that own them (i.e., override the ABC's
+    # NotImplementedError default). After the use_bound seam was deprecated,
+    # the eager forward path on these backends writes into the bound buffers
+    # and needs them allocated up front. CPU backends (torch_native /
+    # torch_flex / intel_amx / xpu) keep the ABC default and fresh-allocate
+    # inside their own init_forward_metadata override.
+    from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+
+    if (
+        type(backend).init_static_metadata_buffers
+        is not AttentionBackend.init_static_metadata_buffers
+    ):
+        backend.init_static_metadata_buffers(
+            max_bs=case.batch_size,
+            max_num_tokens=case.num_input_tokens,
+        )
 
     actual_module = ProjectedDenseAttention(
         hidden_size=hidden_size,

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dual_chunk_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dual_chunk_attention.py
@@ -646,6 +646,18 @@ def build_dual_chunk_attention_fixture(
         backend = ATTENTION_BACKENDS[case.backend](runner)
     except (AssertionError, ImportError, ModuleNotFoundError) as exc:
         testcase.skipTest(f"{case.backend} backend is not available: {exc}")
+    # Mirror ModelRunner.init_backends: allocate static metadata buffers up
+    # front (use_bound deprecated — eager writes into the bound buffers).
+    from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+
+    if (
+        type(backend).init_static_metadata_buffers
+        is not AttentionBackend.init_static_metadata_buffers
+    ):
+        backend.init_static_metadata_buffers(
+            max_bs=case.batch_size,
+            max_num_tokens=case.num_input_tokens,
+        )
 
     actual_module = ProjectedDualChunkAttention(
         hidden_size=hidden_size,

--- a/python/sglang/test/kits/attention_unittest/attention_methods/gdn_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/gdn_attention.py
@@ -586,6 +586,21 @@ def build_gdn_attention_fixture(
     initialize_linear_attn_config(runner.server_args)
     linear_backend = GDNAttnBackend(runner)
     backend = HybridLinearAttnBackend(full_backend, linear_backend, full_attn_layers=[])
+    # Mirror ModelRunner.init_backends: allocate static metadata buffers up
+    # front for backends that own them (use_bound deprecated → eager writes
+    # into the bound buffers). Init on the inner full_backend (HybridLinear
+    # routes through it).
+    from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+
+    if (
+        type(full_backend).init_static_metadata_buffers
+        is not AttentionBackend.init_static_metadata_buffers
+    ):
+        full_backend.init_static_metadata_buffers(
+            max_bs=case.batch_size,
+            max_num_tokens=case.num_input_tokens,
+        )
+
     actual_module = ProjectedGDNAttention(
         num_k_heads=case.num_k_heads,
         num_v_heads=case.num_v_heads,

--- a/python/sglang/test/kits/attention_unittest/attention_methods/kda_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/kda_attention.py
@@ -597,6 +597,21 @@ def build_kda_attention_fixture(
     initialize_linear_attn_config(runner.server_args)
     linear_backend = KDAAttnBackend(runner)
     backend = HybridLinearAttnBackend(full_backend, linear_backend, full_attn_layers=[])
+    # Mirror ModelRunner.init_backends: allocate static metadata buffers up
+    # front for backends that own them (use_bound deprecated → eager writes
+    # into the bound buffers). Init on the inner full_backend (HybridLinear
+    # routes through it).
+    from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+
+    if (
+        type(full_backend).init_static_metadata_buffers
+        is not AttentionBackend.init_static_metadata_buffers
+    ):
+        full_backend.init_static_metadata_buffers(
+            max_bs=case.batch_size,
+            max_num_tokens=case.num_input_tokens,
+        )
+
     actual_module = ProjectedKDAAttention(
         num_k_heads=case.num_k_heads,
         num_v_heads=case.num_v_heads,

--- a/python/sglang/test/kits/attention_unittest/attention_methods/mla_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/mla_attention.py
@@ -890,6 +890,20 @@ def build_mla_attention_fixture(
         backend = ATTENTION_BACKENDS[case.backend](runner)
     except (AssertionError, ImportError, ModuleNotFoundError) as exc:
         testcase.skipTest(f"{case.backend} backend is not available: {exc}")
+    # Mirror ModelRunner.init_backends: allocate the backend's static metadata
+    # buffers up front for backends that own them (override the ABC's
+    # NotImplementedError default). use_bound was deprecated so the eager
+    # forward path writes into the bound buffers and needs them allocated.
+    from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+
+    if (
+        type(backend).init_static_metadata_buffers
+        is not AttentionBackend.init_static_metadata_buffers
+    ):
+        backend.init_static_metadata_buffers(
+            max_bs=case.batch_size,
+            max_num_tokens=case.num_input_tokens,
+        )
 
     actual_module = TinyDeepseekMLAAttention(
         hidden_size=hidden_size,

--- a/python/sglang/test/kits/attention_unittest/runner_modes/cuda_graph_decode_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/cuda_graph_decode_runner.py
@@ -291,6 +291,15 @@ def _init_cuda_graph_capture_metadata(backend, capture_batch_size: int, batch):
         max_bs=capture_batch_size,
         max_num_tokens=batch.input_ids.numel(),
     )
+    # Mirror EAGLEDraftExtendCudaGraphRunner.capture_one_shape: register the
+    # captured bs so the backend's _compute_forward_metadata takes the bound
+    # DRAFT_EXTEND_V2 layout. Without this, MLA draft-extend-v2 cuda-graph
+    # cases fall through to the plain-EXTEND branch which the SimpleNamespace
+    # fb_view doesn't support (no extend_prefix_lens_cpu).
+    if batch.forward_mode.is_draft_extend_v2():
+        captured = getattr(backend, "_draft_extend_v2_captured_bs", None)
+        if captured is not None:
+            captured.add(capture_batch_size)
     backend.init_forward_metadata_out_graph(batch, in_capture=True)
     backend.init_forward_metadata_in_graph(batch)
 

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_extend_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_extend_runner.py
@@ -536,6 +536,13 @@ def _build_eagle_draft_extend_fixture(
         max_num_tokens=settings.capture_batch_size
         * (settings.speculative_num_draft_tokens or settings.speculative_num_steps),
     )
+    # Mirror EAGLEDraftExtendCudaGraphRunner.capture_one_shape: register the
+    # captured bs so the backend's _compute_forward_metadata takes the bound
+    # DRAFT_EXTEND_V2 layout (instead of falling through to the plain-EXTEND
+    # eager branch which the SimpleNamespace fb_view doesn't support).
+    captured = getattr(draft_extend_attn_backend, "_draft_extend_v2_captured_bs", None)
+    if captured is not None:
+        captured.add(settings.capture_batch_size)
     worker_cls = (
         _EagleDraftExtendV2WorkerHarness
         if case.forward_mode.is_draft_extend_v2()

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_extend_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_extend_runner.py
@@ -529,6 +529,13 @@ def _build_eagle_draft_extend_fixture(
         testcase.skipTest(f"{case.backend} draft-extend backend is not available")
     fixture.runner.draft_extend_attn_backend = draft_extend_attn_backend
     fixture.runner.attn_backend = draft_extend_attn_backend
+    # Mirror ModelRunner.init_backends: bound static metadata buffers must
+    # exist before any forward path touches the backend (use_bound deprecated).
+    draft_extend_attn_backend.init_static_metadata_buffers(
+        max_bs=settings.capture_batch_size,
+        max_num_tokens=settings.capture_batch_size
+        * (settings.speculative_num_draft_tokens or settings.speculative_num_steps),
+    )
     worker_cls = (
         _EagleDraftExtendV2WorkerHarness
         if case.forward_mode.is_draft_extend_v2()

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
@@ -373,6 +373,14 @@ def _build_eagle_draft_fixture(
         settings.speculative_num_steps,
     ).create_decode_backend()
     fixture.runner.draft_attn_backend = draft_attn_backend
+    # Mirror ModelRunner.init_backends: bound static metadata buffers must
+    # exist before any forward path (eager OR cuda-graph capture) touches the
+    # backend, since use_bound was deprecated and _compute_forward_metadata is
+    # bound-only.
+    draft_attn_backend.init_static_metadata_buffers(
+        max_bs=settings.capture_batch_size,
+        max_num_tokens=settings.capture_batch_size * settings.speculative_num_steps,
+    )
     worker = _EagleDraftWorkerHarness(
         fixture=fixture,
         draft_attn_backend=draft_attn_backend,


### PR DESCRIPTION
## Summary

Drop the `use_bound: bool` parameter from each backend's `_compute_forward_metadata`. The captured-vs-fresh routing decision is no longer exposed to callers — it's resolved internally where it's still meaningful, or eliminated entirely where the two paths produce semantically equivalent metadata.

### Per-backend approach

- **triton / flashmla / cutlass-mla** (buffer-based seam): the bound and fresh paths produced the same metadata via different storage. The fresh `torch.empty(...)` allocation branches are deleted; the bound-buffer path becomes the only path. `_use_cuda_graph_buffers` helper and `use_bound` parameter are removed.
- **dual_chunk** (buffer-based, fully unified): per-iter view rebuild from shared max-bs buffers replaces both the dict-of-per-bucket-metadata cache and the fresh-allocation path. `_bind_metadata_buffers` and the dict's integer keys are dropped.
- **trtllm-mla** (buffer-based, fully unified): pre-allocate an eager metadata at union-max in `init_static_metadata_buffers`; the lookup falls back to it when the live bs misses a captured bucket. `_init_cuda_graph_metadata` is dropped.
- **trtllm-mha / flashattention / flashinfer-MHA / deepseek-v4** (dict/wrapper-based seam): the conditional structure stays as an internal implementation detail; the `use_bound` parameter is gone from the function signature; the helper is renamed `_use_cuda_graph_buffers → _has_captured_metadata` to describe what it actually checks.

### Why

`use_bound` exposed a backend-internal seam to callers. With static metadata buffers now allocated at eager init (every forward path has bound buffers available), the parameter no longer carries information the caller needs — the backend resolves the routing from its own state, or the routing disappears entirely.

## Test plan

- [ ] Full attn unittests sweep across all backend dirs
- [ ] e2e smoke: Qwen3-0.6B (graph + `--disable-cuda-graph`), DeepSeek-V2-Lite (MLA), DeepSeek-Coder-V2-Lite-FP8 (DSV4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34811033718](https://github.com/sgl-project/sglang/actions/runs/34811033718)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34811033624](https://github.com/sgl-project/sglang/actions/runs/34811033624)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34811033682](https://github.com/sgl-project/sglang/actions/runs/34811033682)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->