### PR TITLE
Guard FlashInfer MIS uint16 metadata overflow

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -60,6 +60,25 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+FLASHINFER_MIS_MAX_ITEM_LEN = (1 << 16) - 1
+
+
+def _max_multi_item_scoring_item_len(delimiter_indices_cpu, seq_len: int) -> int:
+    """Return the largest item length represented by delimiter indices."""
+    if len(delimiter_indices_cpu) == 0:
+        return 0
+
+    delimiter_indices = delimiter_indices_cpu.tolist()
+    if not isinstance(delimiter_indices, list):
+        delimiter_indices = [delimiter_indices]
+    delimiter_indices = [int(index) for index in delimiter_indices]
+
+    max_item_len = max(0, int(seq_len) - delimiter_indices[-1] - 1)
+    for prev_delim, next_delim in zip(delimiter_indices, delimiter_indices[1:]):
+        max_item_len = max(max_item_len, next_delim - prev_delim - 1)
+
+    return max_item_len
+
 
 def _cuda_graph_capture_max_bs(server_args, max_bs: int) -> int:
     """Pad max_bs to the alignment cuda-graph capture uses (see get_batch_sizes_to_capture)."""
@@ -445,7 +464,7 @@ class FlashInferAttnBackend(AttentionBackend):
 
         prefix_cache_lens = getattr(forward_batch, "extend_prefix_lens_cpu", None)
         extend_seq_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
-        prefix_len_ptr, token_pos_in_items_ptr = [], []
+        prefix_len_ptr, token_pos_in_items_ptr, max_item_lens = [], [], []
         token_pos_in_items_len = 0
         device = forward_batch.input_ids.device
 
@@ -462,11 +481,24 @@ class FlashInferAttnBackend(AttentionBackend):
                 continue
 
             first_delim = delimiter_indices_cpu[0].item()  # CPU .item(), no GPU sync
+            max_item_len = _max_multi_item_scoring_item_len(
+                delimiter_indices_cpu, seq_len
+            )
+            if max_item_len > FLASHINFER_MIS_MAX_ITEM_LEN:
+                raise ValueError(
+                    "FlashInfer multi-item scoring uses uint16 item-position "
+                    f"metadata and supports item lengths up to "
+                    f"{FLASHINFER_MIS_MAX_ITEM_LEN} tokens, but sequence {i} "
+                    f"contains an item with {max_item_len} tokens. Disable "
+                    "--enable-mis or split the scored item into shorter chunks."
+                )
+
             delimiter_indices = delimiter_indices_cpu.to(device, non_blocking=True)
             prefix_len = first_delim + (
                 prefix_cache_lens[i] if prefix_cache_lens is not None else 0
             )
             prefix_len_ptr.append(prefix_len)
+            max_item_lens.append(max_item_len)
 
             # Compute relative positions within items using searchsorted (no GPU sync).
             #   suffix_range      = [0, 1, 2, 3, 4, ...]
@@ -517,12 +549,8 @@ class FlashInferAttnBackend(AttentionBackend):
             ),
             token_pos_in_items_ptr=torch.cat(token_pos_in_items_ptr, dim=0),
             token_pos_in_items_len=token_pos_in_items_len & 0xFFFFFFFF,
-            max_item_len_ptr=torch.stack(
-                [
-                    t.to(torch.int32).max().to(torch.uint16)
-                    for t in token_pos_in_items_ptr
-                ],
-                dim=0,
+            max_item_len_ptr=torch.tensor(
+                max_item_lens, dtype=torch.uint16, device=device
             ),
         )
 

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -62,6 +62,25 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+FLASHINFER_MIS_MAX_ITEM_LEN = (1 << 16) - 1
+
+
+def _max_multi_item_scoring_item_len(delimiter_indices_cpu, seq_len: int) -> int:
+    """Return the largest item length represented by delimiter indices."""
+    if len(delimiter_indices_cpu) == 0:
+        return 0
+
+    delimiter_indices = delimiter_indices_cpu.tolist()
+    if not isinstance(delimiter_indices, list):
+        delimiter_indices = [delimiter_indices]
+    delimiter_indices = [int(index) for index in delimiter_indices]
+
+    max_item_len = max(0, int(seq_len) - delimiter_indices[-1] - 1)
+    for prev_delim, next_delim in zip(delimiter_indices, delimiter_indices[1:]):
+        max_item_len = max(max_item_len, next_delim - prev_delim - 1)
+
+    return max_item_len
+
 
 if envs.SGLANG_ENABLE_TORCH_COMPILE.get():
     torch._logging.set_logs(dynamo=logging.ERROR)
@@ -610,7 +629,7 @@ class FlashInferAttnBackend(AttentionBackend):
 
         prefix_cache_lens = getattr(forward_batch, "extend_prefix_lens_cpu", None)
         extend_seq_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
-        prefix_len_ptr, token_pos_in_items_ptr = [], []
+        prefix_len_ptr, token_pos_in_items_ptr, max_item_lens = [], [], []
         token_pos_in_items_len = 0
         device = forward_batch.input_ids.device
 
@@ -627,11 +646,24 @@ class FlashInferAttnBackend(AttentionBackend):
                 continue
 
             first_delim = delimiter_indices_cpu[0].item()  # CPU .item(), no GPU sync
+            max_item_len = _max_multi_item_scoring_item_len(
+                delimiter_indices_cpu, seq_len
+            )
+            if max_item_len > FLASHINFER_MIS_MAX_ITEM_LEN:
+                raise ValueError(
+                    "FlashInfer multi-item scoring uses uint16 item-position "
+                    f"metadata and supports item lengths up to "
+                    f"{FLASHINFER_MIS_MAX_ITEM_LEN} tokens, but sequence {i} "
+                    f"contains an item with {max_item_len} tokens. Disable "
+                    "--enable-mis or split the scored item into shorter chunks."
+                )
+
             delimiter_indices = delimiter_indices_cpu.to(device, non_blocking=True)
             prefix_len = first_delim + (
                 prefix_cache_lens[i] if prefix_cache_lens is not None else 0
             )
             prefix_len_ptr.append(prefix_len)
+            max_item_lens.append(max_item_len)
 
             # Compute relative positions within items using searchsorted (no GPU sync).
             #   suffix_range      = [0, 1, 2, 3, 4, ...]
@@ -682,12 +714,8 @@ class FlashInferAttnBackend(AttentionBackend):
             ),
             token_pos_in_items_ptr=torch.cat(token_pos_in_items_ptr, dim=0),
             token_pos_in_items_len=token_pos_in_items_len & 0xFFFFFFFF,
-            max_item_len_ptr=torch.stack(
-                [
-                    t.to(torch.int32).max().to(torch.uint16)
-                    for t in token_pos_in_items_ptr
-                ],
-                dim=0,
+            max_item_len_ptr=torch.tensor(
+                max_item_lens, dtype=torch.uint16, device=device
             ),
         )
 

--- a/test/registered/unit/layers/attention/test_flashinfer_mis_metadata.py
+++ b/test/registered/unit/layers/attention/test_flashinfer_mis_metadata.py
@@ -1,17 +1,27 @@
+"""Regression coverage for FlashInfer multi-item scoring metadata bounds."""
+
 import unittest
 from types import SimpleNamespace
 
 import torch
 
-from sglang.srt.layers.attention.flashinfer_backend import (
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.attention.flashinfer_backend import (  # noqa: E402
     FLASHINFER_MIS_MAX_ITEM_LEN,
     FlashInferAttnBackend,
     _max_multi_item_scoring_item_len,
 )
 
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
-class TestFlashInferMISMetadata(unittest.TestCase):
-    def _make_forward_batch(self, delimiter_indices, seq_len):
+
+class TestFlashInferMISMetadata(CustomTestCase):
+    @staticmethod
+    def _make_forward_batch(delimiter_indices, seq_len):
         return SimpleNamespace(
             forward_mode=None,
             multi_item_delimiter_indices=[torch.tensor(delimiter_indices)],
@@ -21,7 +31,8 @@ class TestFlashInferMISMetadata(unittest.TestCase):
             positions=torch.zeros(seq_len, dtype=torch.int64),
         )
 
-    def test_max_item_len_from_delimiters(self):
+    def test_max_item_len_tracks_largest_delimited_span(self):
+        """The bound must cover the largest item, including a non-final item."""
         self.assertEqual(
             _max_multi_item_scoring_item_len(torch.tensor([4, 65005]), 65006),
             65000,
@@ -32,6 +43,7 @@ class TestFlashInferMISMetadata(unittest.TestCase):
         )
 
     def test_allows_uint16_boundary(self):
+        """An item at the vendor metadata limit must remain representable."""
         backend = SimpleNamespace(enable_mis=True)
         forward_batch = self._make_forward_batch(
             [4, 4 + FLASHINFER_MIS_MAX_ITEM_LEN + 1],
@@ -48,6 +60,7 @@ class TestFlashInferMISMetadata(unittest.TestCase):
         self.assertEqual(params.max_item_len_ptr.item(), FLASHINFER_MIS_MAX_ITEM_LEN)
 
     def test_rejects_item_len_that_overflows_uint16_positions(self):
+        """Reject silent uint16 wrap instead of scoring with corrupted positions."""
         backend = SimpleNamespace(enable_mis=True)
         forward_batch = self._make_forward_batch(
             [4, 4 + FLASHINFER_MIS_MAX_ITEM_LEN + 2],

--- a/test/registered/unit/layers/test_flashinfer_mis_metadata.py
+++ b/test/registered/unit/layers/test_flashinfer_mis_metadata.py
@@ -8,6 +8,9 @@ from sglang.srt.layers.attention.flashinfer_backend import (
     FlashInferAttnBackend,
     _max_multi_item_scoring_item_len,
 )
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestFlashInferMISMetadata(unittest.TestCase):

--- a/test/registered/unit/layers/test_flashinfer_mis_metadata.py
+++ b/test/registered/unit/layers/test_flashinfer_mis_metadata.py
@@ -1,0 +1,62 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.attention.flashinfer_backend import (
+    FLASHINFER_MIS_MAX_ITEM_LEN,
+    FlashInferAttnBackend,
+    _max_multi_item_scoring_item_len,
+)
+
+
+class TestFlashInferMISMetadata(unittest.TestCase):
+    def _make_forward_batch(self, delimiter_indices, seq_len):
+        return SimpleNamespace(
+            forward_mode=None,
+            multi_item_delimiter_indices=[torch.tensor(delimiter_indices)],
+            extend_prefix_lens_cpu=None,
+            extend_seq_lens_cpu=[seq_len],
+            input_ids=torch.empty(seq_len, dtype=torch.int64),
+            positions=torch.zeros(seq_len, dtype=torch.int64),
+        )
+
+    def test_max_item_len_from_delimiters(self):
+        self.assertEqual(
+            _max_multi_item_scoring_item_len(torch.tensor([4, 65005]), 65006),
+            65000,
+        )
+        self.assertEqual(
+            _max_multi_item_scoring_item_len(torch.tensor([4, 21, 70022]), 70023),
+            70000,
+        )
+
+    def test_allows_uint16_boundary(self):
+        backend = SimpleNamespace(enable_mis=True)
+        forward_batch = self._make_forward_batch(
+            [4, 4 + FLASHINFER_MIS_MAX_ITEM_LEN + 1],
+            4 + FLASHINFER_MIS_MAX_ITEM_LEN + 2,
+        )
+
+        params = FlashInferAttnBackend._process_multi_item_scoring(
+            backend, forward_batch
+        )
+
+        self.assertTrue(params.is_enabled())
+        self.assertEqual(params.token_pos_in_items_ptr.dtype, torch.uint16)
+        self.assertEqual(params.max_item_len_ptr.dtype, torch.uint16)
+        self.assertEqual(params.max_item_len_ptr.item(), FLASHINFER_MIS_MAX_ITEM_LEN)
+
+    def test_rejects_item_len_that_overflows_uint16_positions(self):
+        backend = SimpleNamespace(enable_mis=True)
+        forward_batch = self._make_forward_batch(
+            [4, 4 + FLASHINFER_MIS_MAX_ITEM_LEN + 2],
+            4 + FLASHINFER_MIS_MAX_ITEM_LEN + 3,
+        )
+
+        with self.assertRaisesRegex(ValueError, "uint16 item-position metadata"):
+            FlashInferAttnBackend._process_multi_item_scoring(backend, forward_batch)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses #26629.

FlashInfer multi-item scoring stores per-token item positions and maximum item lengths as `uint16`. Items longer than 65,535 tokens were cast without validation, so their metadata wrapped and scoring silently used incorrect positions.

This change:

- computes the maximum item length from CPU delimiter metadata before constructing GPU position tensors;
- rejects unsupported items with an actionable error instead of returning incorrect scores;
- builds `max_item_len_ptr` from the validated lengths; and
- adds boundary coverage for a 65,535-token item and rejection coverage for 65,536 tokens.

Validation on rebased head `4891cb6f8`:

- rebased cleanly onto current `main` (`3e2a26708`);
- `TORCHDYNAMO_DISABLE=1 PYTHONPATH=python .venv/bin/python test/registered/unit/layers/attention/test_flashinfer_mis_metadata.py` — 3 tests passed;
- fault injection removing the explicit overflow guard makes the 65,536-token regression test fail with `ValueError not raised`, while the other two tests still pass;
- repository pre-commit checks passed for both changed files;
- `python -m py_compile` and `git diff --check upstream/main...HEAD` passed.

The focused test ran with CPU PyTorch on macOS. No GPU or FlashInfer kernel execution was claimed; remote CI remains authoritative for platform integration.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31389403357](https://github.com/sgl-project/sglang/actions/runs/31389403357)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31389403091](https://github.com/sgl-project/sglang/actions/runs/31389403091)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->