### PR TITLE
[Diffusion] Keep FastHunyuan VAE resident on high-memory GPUs

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
@@ -20,6 +20,9 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     PipelineConfig,
     TextConditioningOutput,
 )
+from sglang.multimodal_gen.configs.pipeline_configs.model_deployment_config import (
+    ModelDeploymentConfig,
+)
 
 PROMPT_TEMPLATE_ENCODE_VIDEO = (
     "<|start_header_id|>system<|end_header_id|>\n\nDescribe the video by detailing the following aspects: "
@@ -158,3 +161,9 @@ class FastHunyuanConfig(HunyuanConfig):
 
     # No need to re-specify guidance_scale or embedded_cfg_scale as they
     # already have the desired values from HunyuanConfig
+
+    def get_model_deployment_config(self) -> ModelDeploymentConfig:
+        return ModelDeploymentConfig(
+            auto_disable_component_offload_min_available_memory_gb=150,
+            auto_disable_component_offload_components=("vae",),
+        )

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
@@ -6,7 +6,7 @@ ModelDeploymentConfig provides model-specific config on how to deploy a model op
 from dataclasses import dataclass
 from typing import Literal
 
-OffloadComponentName = Literal["dit", "text_encoder", "image_encoder"]
+OffloadComponentName = Literal["dit", "text_encoder", "image_encoder", "vae"]
 
 
 @dataclass(frozen=True)

--- a/python/sglang/multimodal_gen/runtime/server_args_auto_tune.py
+++ b/python/sglang/multimodal_gen/runtime/server_args_auto_tune.py
@@ -108,6 +108,20 @@ class ServerArgsAutoTuner:
                 self._deployment_config().auto_disable_component_offload_components
             )
             if (
+                args.layerwise_offload_components is not None
+                and not args.is_arg_explicitly_set("layerwise_offload_components")
+            ):
+                layerwise_components = [
+                    component_name
+                    for component_name in args.layerwise_offload_components
+                    if component_name not in components
+                ]
+                if layerwise_components != args.layerwise_offload_components:
+                    args.layerwise_offload_components = layerwise_components or None
+                    changed.append(
+                        f"layerwise_offload_components={args.layerwise_offload_components}"
+                    )
+            if (
                 args.dit_cpu_offload
                 and "dit" in components
                 and not args.is_arg_explicitly_set("dit_cpu_offload")

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -15,6 +15,7 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
     PipelineConfig,
 )
+from sglang.multimodal_gen.configs.pipeline_configs.hunyuan import FastHunyuanConfig
 from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import LTX2PipelineConfig
 from sglang.multimodal_gen.configs.pipeline_configs.mova import MOVAPipelineConfig
 from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import (
@@ -793,6 +794,7 @@ class TestOffloadDefaults(unittest.TestCase):
         qwen_deployment = QwenImagePipelineConfig().get_model_deployment_config()
         wan_deployment = WanT2V480PConfig().get_model_deployment_config()
         mova_deployment = MOVAPipelineConfig().get_model_deployment_config()
+        fast_hunyuan_deployment = FastHunyuanConfig().get_model_deployment_config()
         zimage_deployment = ZImagePipelineConfig().get_model_deployment_config()
         ltx_deployment = LTX2PipelineConfig().get_model_deployment_config()
         sana_wm_deployment = SanaWMPipelineConfig().get_model_deployment_config()
@@ -805,6 +807,15 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertIsNone(mova_deployment.fsdp_auto_min_available_memory_gb)
         self.assertTrue(mova_deployment.auto_dit_layerwise_offload)
+
+        self.assertEqual(
+            fast_hunyuan_deployment.auto_disable_component_offload_min_available_memory_gb,
+            150,
+        )
+        self.assertEqual(
+            fast_hunyuan_deployment.auto_disable_component_offload_components,
+            ("vae",),
+        )
 
         self.assertEqual(zimage_deployment.fsdp_auto_min_available_memory_gb, 40)
         self.assertTrue(zimage_deployment.fsdp_auto_requires_cfg)
@@ -1041,6 +1052,43 @@ class TestOffloadDefaults(unittest.TestCase):
             FastWan2_2_TI2V_5B_Config(),
             kwargs={
                 "model_path": "FastVideo/FastWan2.2-TI2V-5B-FullAttn-Diffusers",
+                "performance_mode": "auto",
+            },
+        )
+
+        self.assertTrue(args.dit_cpu_offload)
+        self.assertEqual(
+            args.layerwise_offload_components,
+            ["text_encoder", "image_encoder", "vae"],
+        )
+
+    def test_auto_fast_hunyuan_high_memory_keeps_vae_resident(self):
+        args = self._from_dict_with_pipeline_config(
+            FastHunyuanConfig(),
+            memory_gb=180,
+            available_memory_gb=170,
+            kwargs={
+                "model_path": "FastVideo/FastHunyuan-diffusers",
+                "performance_mode": "auto",
+            },
+        )
+
+        self.assertTrue(args.dit_cpu_offload)
+        self.assertFalse(args.text_encoder_cpu_offload)
+        self.assertFalse(args.image_encoder_cpu_offload)
+        self.assertFalse(args.vae_cpu_offload)
+        self.assertEqual(
+            args.layerwise_offload_components,
+            ["text_encoder", "image_encoder"],
+        )
+
+    def test_auto_fast_hunyuan_low_memory_keeps_vae_layerwise(self):
+        args = self._from_dict_with_pipeline_config(
+            FastHunyuanConfig(),
+            memory_gb=140,
+            available_memory_gb=140,
+            kwargs={
+                "model_path": "FastVideo/FastHunyuan-diffusers",
                 "performance_mode": "auto",
             },
         )

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -15,7 +15,6 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
     PipelineConfig,
 )
-from sglang.multimodal_gen.configs.pipeline_configs.hunyuan import FastHunyuanConfig
 from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import LTX2PipelineConfig
 from sglang.multimodal_gen.configs.pipeline_configs.mova import MOVAPipelineConfig
 from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import (
@@ -794,7 +793,6 @@ class TestOffloadDefaults(unittest.TestCase):
         qwen_deployment = QwenImagePipelineConfig().get_model_deployment_config()
         wan_deployment = WanT2V480PConfig().get_model_deployment_config()
         mova_deployment = MOVAPipelineConfig().get_model_deployment_config()
-        fast_hunyuan_deployment = FastHunyuanConfig().get_model_deployment_config()
         zimage_deployment = ZImagePipelineConfig().get_model_deployment_config()
         ltx_deployment = LTX2PipelineConfig().get_model_deployment_config()
         sana_wm_deployment = SanaWMPipelineConfig().get_model_deployment_config()
@@ -807,15 +805,6 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertIsNone(mova_deployment.fsdp_auto_min_available_memory_gb)
         self.assertTrue(mova_deployment.auto_dit_layerwise_offload)
-
-        self.assertEqual(
-            fast_hunyuan_deployment.auto_disable_component_offload_min_available_memory_gb,
-            150,
-        )
-        self.assertEqual(
-            fast_hunyuan_deployment.auto_disable_component_offload_components,
-            ("vae",),
-        )
 
         self.assertEqual(zimage_deployment.fsdp_auto_min_available_memory_gb, 40)
         self.assertTrue(zimage_deployment.fsdp_auto_requires_cfg)
@@ -1052,43 +1041,6 @@ class TestOffloadDefaults(unittest.TestCase):
             FastWan2_2_TI2V_5B_Config(),
             kwargs={
                 "model_path": "FastVideo/FastWan2.2-TI2V-5B-FullAttn-Diffusers",
-                "performance_mode": "auto",
-            },
-        )
-
-        self.assertTrue(args.dit_cpu_offload)
-        self.assertEqual(
-            args.layerwise_offload_components,
-            ["text_encoder", "image_encoder", "vae"],
-        )
-
-    def test_auto_fast_hunyuan_high_memory_keeps_vae_resident(self):
-        args = self._from_dict_with_pipeline_config(
-            FastHunyuanConfig(),
-            memory_gb=180,
-            available_memory_gb=170,
-            kwargs={
-                "model_path": "FastVideo/FastHunyuan-diffusers",
-                "performance_mode": "auto",
-            },
-        )
-
-        self.assertTrue(args.dit_cpu_offload)
-        self.assertFalse(args.text_encoder_cpu_offload)
-        self.assertFalse(args.image_encoder_cpu_offload)
-        self.assertFalse(args.vae_cpu_offload)
-        self.assertEqual(
-            args.layerwise_offload_components,
-            ["text_encoder", "image_encoder"],
-        )
-
-    def test_auto_fast_hunyuan_low_memory_keeps_vae_layerwise(self):
-        args = self._from_dict_with_pipeline_config(
-            FastHunyuanConfig(),
-            memory_gb=140,
-            available_memory_gb=140,
-            kwargs={
-                "model_path": "FastVideo/FastHunyuan-diffusers",
                 "performance_mode": "auto",
             },
         )


### PR DESCRIPTION
## Summary

**This PR fixes: FastHunyuan's automatic high-memory policy still selected `vae` for layerwise offload on B200-class GPUs, even though keeping the VAE resident is practical there and avoids extra VAE decode/copy overhead.**

Changes:

- Keep FastHunyuan VAE GPU-resident when selected GPUs have at least 150 GiB free memory.
- Preserve the existing low-memory behavior, where VAE offload remains selected.
- Add `vae` to the typed deployment component names because the auto-policy already uses that component name.

FastWan2.1 resolution handling is intentionally not changed here because #28733 already covers that related fix.

## Problem Log

The observed high-memory startup policy selected the VAE for layerwise offload:

```text
Auto memory policy for FastHunyuanConfig selected layerwise offload components: text_encoder, image_encoder, vae
```

That is not ideal for FastVideo/FastHunyuan-diffusers on B200-class GPUs. The model is no longer purely denoise-bound in the observed fast path, and VAE residency is a better default when memory headroom is available.

With this PR, the default model hint is still logged first, then the high-memory auto-tune pass removes VAE from component offload:

```text
Disabling component offload for FastHunyuanConfig because minimum available memory on selected GPUs is 177.74 GiB: layerwise_offload_components=['text_encoder', 'image_encoder']
```

The final resolved server args confirm the VAE no longer uses layerwise offload on this B200 run:

```text
"layerwise_offload_components": ["text_encoder", "image_encoder"]
```

## Behavior / Benchmark Table

| Scenario | Before | After | Validation |
| --- | --- | --- | --- |
| FastHunyuan on B200-class high-memory GPU, >= 150 GiB free | `text_encoder, image_encoder, vae` selected for layerwise offload | `text_encoder, image_encoder`; VAE remains resident | Implemented in FastHunyuan deployment hints and auto-tune filtering |
| FastHunyuan on lower-memory GPU | `text_encoder, image_encoder, vae` | unchanged | Existing low-memory policy remains the fallback |
| Explicit user layerwise components | user value wins | unchanged | existing ServerArgs behavior preserved |

Model-backed benchmark on ion-b200, 1x B200, `FastVideo/FastHunyuan-diffusers`, 1280x720, 125 frames, 6 inference steps, seed 42:

| Metric | Baseline main merge-base `7516f0db9f` | This PR `7885c02032` | Diff |
| --- | ---: | ---: | ---: |
| E2E latency from perf dump | 121090.06 ms | 117188.01 ms | -3902.05 ms (-3.2%) |
| TextEncodingStage | 12008.46 ms | 11939.71 ms | -68.76 ms (-0.6%) |
| DenoisingStage | 90073.13 ms | 86346.36 ms | -3726.77 ms (-4.1%) |
| DecodingStage | 18938.93 ms | 18838.59 ms | -100.34 ms (-0.5%) |
| CLI "pixel data generated" log | 123.83 s | 119.49 s | -4.34 s |
| Peak reserved memory | 53544 MB | 53416 MB | -128 MB |

Artifacts:

- [compare_perf.md](https://github.com/BBuf/sglang/releases/download/fast-hunyuan-vae-residency-validation-20260620/compare_perf.md)
- [baseline perf json](https://github.com/BBuf/sglang/releases/download/fast-hunyuan-vae-residency-validation-20260620/base_perf.json)
- [PR perf json](https://github.com/BBuf/sglang/releases/download/fast-hunyuan-vae-residency-validation-20260620/pr_perf.json)
- [baseline log](https://github.com/BBuf/sglang/releases/download/fast-hunyuan-vae-residency-validation-20260620/base.log)
- [PR log](https://github.com/BBuf/sglang/releases/download/fast-hunyuan-vae-residency-validation-20260620/pr.log)

## Generated Video / Result Comparison

The baseline and PR videos are byte-identical for the same prompt, seed, and sampling shape:

```text
b0d9240c63652c94626e87996b104c76261440a3f62172fb3368462f0cdeb815  base.mp4
b0d9240c63652c94626e87996b104c76261440a3f62172fb3368462f0cdeb815  pr.mp4
```

![FastHunyuan baseline top / PR bottom frames 0,30,60,90,124](https://github.com/BBuf/sglang/releases/download/fast-hunyuan-vae-residency-validation-20260620/frame_contact_sheet.jpg)

- [baseline video](https://github.com/BBuf/sglang/releases/download/fast-hunyuan-vae-residency-validation-20260620/base.mp4)
- [PR video](https://github.com/BBuf/sglang/releases/download/fast-hunyuan-vae-residency-validation-20260620/pr.mp4)

## Validation

Local:

- `git diff --check`
- `python3 -m py_compile python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py python/sglang/multimodal_gen/runtime/server_args_auto_tune.py`

B200 model-backed:

- Ran baseline merge-base `7516f0db9f476ade2cde892fe9eaf41af4605ae4` and PR head `7885c02032d73dbed1ba618fcfd2dab54760e86b` with the same prompt, shape, steps, and seed.
- Confirmed the resolved PR server args use `layerwise_offload_components=["text_encoder", "image_encoder"]`.
- Confirmed generated `base.mp4` and `pr.mp4` are byte-identical.
- Checked logs for fallback warnings; no `Falling back to diffusers`, `Using diffusers backend`, or `Loaded diffusers pipeline` fallback message was present.

No unit test file changes are kept in this PR per maintainer request; `test_server_args.py` matches `main`.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27859515584](https://github.com/sgl-project/sglang/actions/runs/27859515584)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27859515522](https://github.com/sgl-project/sglang/actions/runs/27859515522)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->