### PR TITLE
[MLX] Native Qwen3.5 MoE text model (Phase 2)

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -112,6 +112,40 @@ _MLX_QUANTIZATION_PRESETS: dict[str, tuple[int, int]] = {
 _MLX_KV_FLOAT_DTYPES = {mx.float16, mx.bfloat16, mx.float32}
 
 
+_QWEN3_5_MOE_ARCHS = frozenset(
+    {"Qwen3_5MoeForConditionalGeneration", "Qwen3_5MoeForCausalLM"}
+)
+_QWEN3_5_MOE_MODEL_TYPES = frozenset({"qwen3_5_moe", "qwen3_5_moe_text"})
+
+
+def _is_qwen3_5_moe(model_path: str) -> bool:
+    """Detect Qwen3.5 MoE (Qwen3.6-35B-A3B) by reading config.json.
+
+    Returns True when ``architectures`` or ``text_config.model_type`` matches
+    the Qwen3.5 MoE family.  Cheap (one JSON read); safe to call on every load.
+    """
+    import json
+    from pathlib import Path
+
+    config_path = Path(model_path) / "config.json"
+    if not config_path.is_file():
+        return False
+    try:
+        with config_path.open() as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+    archs = cfg.get("architectures") or []
+    if any(a in _QWEN3_5_MOE_ARCHS for a in archs):
+        return True
+    if cfg.get("model_type") in _QWEN3_5_MOE_MODEL_TYPES:
+        return True
+    text_cfg = cfg.get("text_config") or {}
+    if text_cfg.get("model_type") in _QWEN3_5_MOE_MODEL_TYPES:
+        return True
+    return False
+
+
 class MlxModelRunner:
     """MLX model runner with radix-cache prefix sharing."""
 
@@ -404,6 +438,29 @@ class MlxModelRunner:
         """
         logger.info(f"Loading MLX model: {self.model_path}")
         start_time = time.time()
+
+        # Phase 1 MVP: detect Qwen3.5 MoE (a.k.a. Qwen3.6-35B-A3B) and
+        # confirm the native model module is importable.  Phase 2 will
+        # replace `mlx_lm.load` with a native loader that uses
+        # `sglang.srt.hardware_backend.mlx.models.qwen3_5_moe.Model`.
+        if _is_qwen3_5_moe(self.model_path):
+            from sglang.srt.hardware_backend.mlx.models.qwen3_5_moe import (
+                Model as NativeModel,
+            )
+
+            logger.info(
+                "Detected Qwen3.5 MoE architecture — native model module "
+                "is available (Phase 1 stub; loading still goes through "
+                "mlx_lm until Phase 2 wires up the native loader)."
+            )
+            # Sanity: construct the native Model with TextModelArgs to
+            # confirm the import path + dataclass parsing works.  The
+            # constructed instance is discarded; the actual model comes
+            # from mlx_lm below.
+            from sglang.srt.hardware_backend.mlx.models.qwen3_5_moe import (
+                TextModelArgs,
+            )
+            _ = NativeModel(TextModelArgs())
 
         # We need the config dict to pass into quantize_model so it knows tied/embedding
         # layout. return_config=True is cheap and ignored when no quantization is requested.

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -439,83 +439,69 @@ class MlxModelRunner:
         logger.info(f"Loading MLX model: {self.model_path}")
         start_time = time.time()
 
-        # Phase 1 MVP: detect Qwen3.5 MoE (a.k.a. Qwen3.6-35B-A3B) and
-        # confirm the native model module is importable.  Phase 2 will
-        # replace `mlx_lm.load` with a native loader that uses
-        # `sglang.srt.hardware_backend.mlx.models.qwen3_5_moe.Model`.
         if _is_qwen3_5_moe(self.model_path):
-            from sglang.srt.hardware_backend.mlx.models.qwen3_5_moe import (
-                Model as NativeModel,
-            )
+            from sglang.srt.hardware_backend.mlx.models.qwen3_5_moe import load as qwen3_5_load
 
             logger.info(
-                "Detected Qwen3.5 MoE architecture — native model module "
-                "is available (Phase 1 stub; loading still goes through "
-                "mlx_lm until Phase 2 wires up the native loader)."
+                "Detected Qwen3.5 MoE — using sglang native loader "
+                "(sglang.srt.hardware_backend.mlx.models.qwen3_5_moe)"
             )
-            # Sanity: construct the native Model with TextModelArgs to
-            # confirm the import path + dataclass parsing works.  The
-            # constructed instance is discarded; the actual model comes
-            # from mlx_lm below.
-            from sglang.srt.hardware_backend.mlx.models.qwen3_5_moe import (
-                TextModelArgs,
+            self.model = qwen3_5_load(self.model_path)
+        else:
+            # We need the config dict to pass into quantize_model so it knows tied/embedding
+            # layout. return_config=True is cheap and ignored when no quantization is requested.
+            loaded = mlx_lm_load(
+                self.model_path,
+                tokenizer_config={"trust_remote_code": self.trust_remote_code},
+                return_config=True,
             )
-            _ = NativeModel(TextModelArgs())
+            self.model, _tokenizer, config = loaded
 
-        # We need the config dict to pass into quantize_model so it knows tied/embedding
-        # layout. return_config=True is cheap and ignored when no quantization is requested.
-        loaded = mlx_lm_load(
-            self.model_path,
-            tokenizer_config={"trust_remote_code": self.trust_remote_code},
-            return_config=True,
-        )
-        self.model, _tokenizer, config = loaded
+            if self._quantization in _MLX_QUANTIZATION_PRESETS:
+                bits, group_size = _MLX_QUANTIZATION_PRESETS[self._quantization]
+                # Skip if the model was already loaded quantized (pre-quantized HF repo);
+                # mlx_lm.load detects the config and instantiates QuantizedLinear directly,
+                # so applying the preset on top would be redundant.
+                if "quantization" in (config or {}):
+                    logger.info(
+                        "MLX model is already quantized by the HF repo; "
+                        f"ignoring --quantization={self._quantization}"
+                    )
+                else:
+                    # Read weight-tensor totals from MLX array metadata (shape + dtype).
+                    # This is zero-cost — neither materializes the lazy fp16 weights nor
+                    # forces them to be peak-resident in memory at once (which on a 64 GB
+                    # Mac running a 32 B model would put us within a few GB of OOM).
+                    bytes_before = sum(
+                        p.size * p.itemsize
+                        for _, p in tree_flatten(self.model.parameters())
+                    )
+                    q_start = time.time()
+                    logger.info(
+                        f"Quantizing MLX model on-the-fly: bits={bits} "
+                        f"group_size={group_size} (preset={self._quantization})"
+                    )
+                    self.model, _new_config = mlx_lm_quantize_model(
+                        self.model,
+                        config or {},
+                        group_size=group_size,
+                        bits=bits,
+                    )
+                    bytes_after = sum(
+                        p.size * p.itemsize
+                        for _, p in tree_flatten(self.model.parameters())
+                    )
+                    q_time = time.time() - q_start
+                    pct_reduction = (1 - bytes_after / max(bytes_before, 1)) * 100
+                    logger.info(
+                        f"Quantization complete in {q_time:.2f}s — "
+                        f"weight bytes: {bytes_before / 1024**3:.2f} GB -> "
+                        f"{bytes_after / 1024**3:.2f} GB ({pct_reduction:.1f}% reduction)"
+                    )
 
-        if self._quantization in _MLX_QUANTIZATION_PRESETS:
-            bits, group_size = _MLX_QUANTIZATION_PRESETS[self._quantization]
-            # Skip if the model was already loaded quantized (pre-quantized HF repo);
-            # mlx_lm.load detects the config and instantiates QuantizedLinear directly,
-            # so applying the preset on top would be redundant.
-            if "quantization" in (config or {}):
-                logger.info(
-                    "MLX model is already quantized by the HF repo; "
-                    f"ignoring --quantization={self._quantization}"
-                )
-            else:
-                # Read weight-tensor totals from MLX array metadata (shape + dtype).
-                # This is zero-cost — neither materializes the lazy fp16 weights nor
-                # forces them to be peak-resident in memory at once (which on a 64 GB
-                # Mac running a 32 B model would put us within a few GB of OOM).
-                bytes_before = sum(
-                    p.size * p.itemsize
-                    for _, p in tree_flatten(self.model.parameters())
-                )
-                q_start = time.time()
-                logger.info(
-                    f"Quantizing MLX model on-the-fly: bits={bits} "
-                    f"group_size={group_size} (preset={self._quantization})"
-                )
-                self.model, _new_config = mlx_lm_quantize_model(
-                    self.model,
-                    config or {},
-                    group_size=group_size,
-                    bits=bits,
-                )
-                bytes_after = sum(
-                    p.size * p.itemsize
-                    for _, p in tree_flatten(self.model.parameters())
-                )
-                q_time = time.time() - q_start
-                pct_reduction = (1 - bytes_after / max(bytes_before, 1)) * 100
-                logger.info(
-                    f"Quantization complete in {q_time:.2f}s — "
-                    f"weight bytes: {bytes_before / 1024**3:.2f} GB -> "
-                    f"{bytes_after / 1024**3:.2f} GB ({pct_reduction:.1f}% reduction)"
-                )
-
-        # Force-evaluate weights so mx.get_active_memory() reflects
-        # actual usage before attention KV pool sizing.
-        mx.eval(self.model.parameters())
+            # Force-evaluate weights so mx.get_active_memory() reflects
+            # actual usage before attention KV pool sizing.
+            mx.eval(self.model.parameters())
 
         load_time = time.time() - start_time
         logger.info(f"MLX model loaded in {load_time:.2f}s")

--- a/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
@@ -111,7 +111,7 @@ class MlxModelRunnerStub(ModelRunner):
         self.dtype = self.model_config.dtype
         self.weight_load_mem_usage = 0
 
-    def initialize(self, pre_model_load_memory: float):
+    def initialize(self, pre_model_load_memory: float = 0.0):
         """Lightweight initialize that skips heavy PyTorch setup.
 
         Creates minimal req_to_token_pool and token_to_kv_pool_allocator
@@ -196,3 +196,7 @@ class MlxModelRunnerStub(ModelRunner):
             f"max_running_requests={self.max_running_requests}, "
             f"zero GPU KV cache allocation)"
         )
+
+    def alloc_memory_pool(self, memory_pool_config=None):
+        """No-op: MLX manages its own KV cache."""
+        pass

--- a/python/sglang/srt/hardware_backend/mlx/models/README.md
+++ b/python/sglang/srt/hardware_backend/mlx/models/README.md
@@ -1,0 +1,64 @@
+# sglang MLX models
+
+Native MLX model implementations for the sglang MLX backend.  Each
+module exposes a `Model` class that the sglang `MlxModelRunner` can
+construct and load weights for, independent of `mlx_lm.models.*`.
+
+## Layout
+
+| File | Status | Notes |
+|---|---|---|
+| `qwen3_5_moe.py` | Phase 2 — text-only | Qwen3.6-35B-A3B; hybrid 3:1 attention, 256 experts / 8 active, attn_output_gate, shared expert |
+
+## Adding a new model
+
+1. Implement `TextModelArgs` (or equivalent) with the HF config fields
+   the architecture needs.  Add a `from_hf_config` classmethod for HF
+   config parsing.
+2. Implement the architecture in sglang:
+   * For `nn.Linear`-style layers, write your own.
+   * For experts, alias `mlx_lm.models.switch_layers.SwitchGLU` (or
+     `QuantizedSwitchGLU`) so 4-bit `QuantizedSwitchLinear` weights
+     load via `Model.load_weights` and the
+     `SGLANG_MLX_FUSE_SWIGLU` patcher recognises the module.
+   * For the linear-attention primitive, import `gated_delta_update`
+     from `mlx_lm.models.gated_delta`.
+   * For masks, import `create_attention_mask` / `create_ssm_mask`
+     from `mlx_lm.models.base`.
+3. Add a `Model.sanitize(weights)` that handles:
+   * Dropping unused subtrees (`mtp.*`, `model.visual.*`,
+     `vision_tower.*`).
+   * Stripping the `language_model.` prefix (HF composite-model layout
+     vs the sglang flat layout).
+   * HF → MLX weight-shape remapping (`conv1d.weight` transpose,
+     RMSNorm `(1 - gamma) → gamma` shift when the file is a fresh HF
+     export).
+4. Add a `load(path)` helper that reads `config.json`, merges all
+   `model*.safetensors` shards, calls `nn.quantize` with a
+   per-layer predicate (so `QuantizedLinear` modules are created only
+   for paths whose `.scales` exist in the weights), then
+   `Model.load_weights`.
+5. Add a `_is_<arch>(model_path)` function in `model_runner.py` that
+   reads `config.json` cheaply (one JSON read) and returns True for
+   the architectures your model handles.
+6. Hook the loader into `MlxModelRunner._load_model` with the
+   `_is_<arch>(self.model_path)` check.
+
+## Tests
+
+`test/registered/unit/hardware_backend/mlx/test_<arch>.py` should
+cover:
+
+* Default `TextModelArgs` shape matches the target config.
+* `from_hf_config` parses the relevant HF fields.
+* `Model` constructs with a small config (so random init doesn't OOM
+  on the real-model config) and exposes the attention contract attrs
+  (`q_proj`/`k_proj`/`v_proj`/`o_proj`/`rope`/`scale`) for the
+  full-attention layers.
+* `sanitize` drops / strips / remaps weights as expected.
+* `_is_<arch>` matches multimodal, text-only, and text_config-wrapped
+  HF configs, and rejects unrelated architectures and malformed
+  configs.
+
+Use a small config (2-4 layers, ≤8 experts) for the construction /
+forward tests so the random init memory is well under test limits.

--- a/python/sglang/srt/hardware_backend/mlx/models/__init__.py
+++ b/python/sglang/srt/hardware_backend/mlx/models/__init__.py
@@ -1,0 +1,7 @@
+"""Native MLX model implementations for sglang MLX backend.
+
+Each module under this package provides a `Model` class compatible with
+sglang's MLX hardware backend.  These are independent of `mlx_lm.models.*`
+so the sglang codebase can own the full model definition, weight
+sanitization, and quantization predicate.
+"""

--- a/python/sglang/srt/hardware_backend/mlx/models/qwen3_5_moe.py
+++ b/python/sglang/srt/hardware_backend/mlx/models/qwen3_5_moe.py
@@ -535,13 +535,29 @@ class Model(nn.Module):
     def sanitize(self, weights: Dict[str, Any]) -> Dict[str, Any]:
         """Remap HF weight names to the sglang native module layout.
 
-        * Drop ``mtp.*`` (Phase 3) and ``model.visual.*`` (Phase 4).
+        * Drop ``mtp.*`` (Phase 3) and ``model.visual.*`` / ``vision_tower.*``
+          (Phase 4).
+        * Strip the ``language_model.`` prefix so weights match the flat
+          ``self.model.layers`` layout used by the sglang-native model.
         * Transpose ``conv1d.weight`` from HF's (out, in, k) to MLX's
           (out, k, in) layout.
         * Shift RMSNorm weights by ``+1`` when the file also contains
           ``mtp.*`` or unsanitised conv1d — these signals mark a fresh
           HF export whose RMSNorm weights use the (1 - gamma) convention.
         """
+        sanitized: Dict[str, Any] = {}
+        for key, value in weights.items():
+            if (
+                "mtp." in key
+                or "model.visual" in key
+                or key.startswith("vision_tower")
+            ):
+                continue
+            if key.startswith("language_model."):
+                key = key[len("language_model.") :]
+            sanitized[key] = value
+        weights = sanitized
+
         has_mtp = any("mtp." in k for k in weights)
         has_unsanitized_conv1d = any(
             "conv1d.weight" in k
@@ -551,12 +567,6 @@ class Model(nn.Module):
             for k, v in weights.items()
         )
         shift_norms = has_mtp or has_unsanitized_conv1d
-
-        weights = {
-            k: v
-            for k, v in weights.items()
-            if "mtp." not in k and "model.visual" not in k
-        }
 
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)

--- a/python/sglang/srt/hardware_backend/mlx/models/qwen3_5_moe.py
+++ b/python/sglang/srt/hardware_backend/mlx/models/qwen3_5_moe.py
@@ -1,50 +1,57 @@
-"""Native MLX implementation of Qwen3.5 MoE (a.k.a. Qwen3.6-35B-A3B).
+"""Native MLX implementation of Qwen3.5 MoE (Qwen3.6-35B-A3B).
 
-This is the text-only model extracted from
-`Qwen3_5MoeForConditionalGeneration`.  Vision tower and MTP head live in
-their own modules (TODO: Phase 4 / Phase 3 of the plan).
+Text-only model extracted from
+`Qwen3_5MoeForConditionalGeneration`.  The class layout mirrors
+upstream ``mlx_lm.models.qwen3_5`` and ``qwen3_next`` (architecture,
+weight names, hybrid-attention interval, MoE-with-shared-expert block)
+so token outputs match ``mlx_lm.generate`` for the same weights.
 
-Architecture summary (Qwen3.6-35B-A3B config):
-  * 40 hidden layers, hidden_size 2048, head_dim 256
-  * 16 attention heads, 2 KV heads (heavy GQA)
-  * Hybrid attention 3:1 — `GatedDeltaNet` (linear) for 3 of every 4
-    layers, `Attention` (full) every 4th
-  * MoE: 256 experts, 8 active per token; SwitchGLU per expert
-  * `attn_output_gate: true` on full attention
-  * `partial_rotary_factor=0.25` RoPE with `mrope_section=[11,11,10]`
-  * Shared expert path (single MLP, not routed)
-  * `tie_word_embeddings=False`
+Architecture (Qwen3.6-35B-A3B):
+  40 hidden layers, hidden_size 2048, head_dim 256
+  16 attention heads, 2 KV heads (heavy GQA)
+  Hybrid attention 3:1 — ``GatedDeltaNet`` (linear) for 3 of every 4
+    layers, ``Attention`` (full) every 4th
+  MoE: 256 experts, 8 active per token; SwitchGLU per expert
+  ``attn_output_gate`` on full attention (sigmoid gate on the o_proj input)
+  ``partial_rotary_factor=0.25`` RoPE; ``rope_type=default`` so the
+    ``mrope_section`` field is informational only
+  Shared expert path (single MLP, not routed)
+  ``tie_word_embeddings=False``
 
-This stub is the Phase 1 MVP.  It defines `ModelArgs` + a no-op `Model`
-class so the sglang MLX backend can route Qwen3.5 MoE paths to a
-sglang-owned module instead of `mlx_lm.models.qwen3_5_moe`.  Subsequent
-phases will fill in the actual layers:
-
-  Phase 2 — RoPE + Attention (full) + GatedDeltaNet (linear) + MoE +
-            DecoderLayer + Model + ForCausalLM + weight load
-  Phase 3 — MTP head (multi-token prediction)
-  Phase 4 — Vision tower + multimodal projector
-  Phase 5 — Fused SwiGLU + KV cache tuning for hybrid attention
-
-Reference: mlx_lm 0.31.3 `qwen3_5.py` (architecture), `qwen3_5_moe.py`
-(weight name remapping), `gated_delta.py` (linear attention primitive).
+Only the low-level MLX primitives — ``gated_delta_update`` (the delta
+rule compute), ``swiglu``, mask helpers, and cache containers — are
+imported from ``mlx_lm.models``.  Everything architecture-specific is
+implemented here so sglang fully owns the model definition, weight
+sanitization, and quantization predicate.
 """
 
-from dataclasses import dataclass, field
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import partial
 from typing import Any, Dict, List, Optional, Union
 
 import mlx.core as mx
 import mlx.nn as nn
 
-from mlx_lm.models.base import BaseModelArgs
+from mlx_lm.models.activations import swiglu
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    create_ssm_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import ArraysCache, KVCache
+from mlx_lm.models.gated_delta import gated_delta_update
+from mlx_lm.models.switch_layers import SwitchGLU as _QuantizedSwitchGLU
 
 
 @dataclass
 class TextModelArgs(BaseModelArgs):
     """Subset of fields needed to construct a Qwen3.5 MoE text model.
 
-    The defaults match Qwen3.6-35B-A3B.  Phase 2 will add the rest of
-    the fields (intermediate_size, num_experts_per_tok details, etc.).
+    Defaults match Qwen3.6-35B-A3B.  Use :meth:`from_dict` with the HF
+    ``text_config`` block to construct from a real ``config.json``.
     """
 
     model_type: str = "qwen3_5_moe_text"
@@ -75,65 +82,622 @@ class TextModelArgs(BaseModelArgs):
     shared_expert_intermediate_size: int = 512
     moe_intermediate_size: int = 512
     norm_topk_prob: bool = True
-    router_aux_loss_coef: float = 0.001
+    mlp_only_layers: Optional[List[int]] = None
 
-    rope_parameters: Optional[Dict[str, Union[float, str, bool, List[int]]]] = field(
-        default_factory=lambda: {
-            "type": "default",
-            "mrope_section": [11, 11, 10],
-            "rope_theta": 10000000,
-            "partial_rotary_factor": 0.25,
-        }
-    )
-    partial_rotary_factor: float = 0.25
     rope_theta: float = 10000000.0
+    partial_rotary_factor: float = 0.25
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    rope_parameters: Optional[Dict[str, Any]] = None
+    layer_types: Optional[List[str]] = None
+
+    @classmethod
+    def from_hf_config(cls, text_config: Dict[str, Any]) -> "TextModelArgs":
+        """Build from an HF ``text_config`` block.
+
+        Pre-extracts ``rope_theta``/``partial_rotary_factor`` from the
+        ``rope_parameters`` dict (when present) and flattens
+        ``layer_types`` so the dataclass can be constructed via
+        :meth:`BaseModelArgs.from_dict`.
+        """
+        cfg = dict(text_config)
+        rope_params = cfg.get("rope_parameters") or {}
+        if "rope_theta" in rope_params and "rope_theta" not in cfg:
+            cfg["rope_theta"] = rope_params["rope_theta"]
+        if "partial_rotary_factor" in rope_params and "partial_rotary_factor" not in cfg:
+            cfg["partial_rotary_factor"] = rope_params["partial_rotary_factor"]
+        if "rope_scaling" in rope_params and "rope_scaling" not in cfg:
+            cfg["rope_scaling"] = rope_params
+        if rope_params and "rope_parameters" not in cfg:
+            cfg["rope_parameters"] = rope_params
+        return cls.from_dict(cfg)
+
+
+@partial(mx.compile, shapeless=True)
+def _precise_swiglu(h, gate, x):
+    """SwiGLU activation computed in fp32 for numerical stability."""
+    gate = nn.silu(gate.astype(mx.float32))
+    x = x.astype(mx.float32)
+    return (gate * x).astype(h.dtype)
+
+
+class RMSNormGated(nn.Module):
+    """RMSNorm with an optional SwiGLU gate (used by GatedDeltaNet output)."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = mx.ones(hidden_size)
+
+    def __call__(
+        self, hidden_states: mx.array, gate: Optional[mx.array] = None
+    ) -> mx.array:
+        x = mx.fast.rms_norm(hidden_states, self.weight, self.eps)
+        if gate is not None:
+            return _precise_swiglu(hidden_states, gate, x)
+        return x.astype(hidden_states.dtype)
+
+
+class Attention(nn.Module):
+    """Full (softmax) attention with ``attn_output_gate`` and per-head RMSNorm.
+
+    Exposes the attention-contract attrs (``q_proj``/``k_proj``/``v_proj``/
+    ``o_proj``/``rope``/``scale`` plus ``q_norm``/``k_norm``) so the
+    sglang :class:`MLXAttentionWrapper` patches it transparently.
+    """
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.num_attention_heads = args.num_attention_heads
+        self.num_key_value_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            args.hidden_size,
+            self.num_attention_heads * self.head_dim * 2,
+            bias=args.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            args.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            args.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            self.num_attention_heads * self.head_dim,
+            args.hidden_size,
+            bias=args.attention_bias,
+        )
+
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+        rope_dims = int(self.head_dim * args.partial_rotary_factor)
+        self.rope = nn.RoPE(
+            rope_dims,
+            traditional=False,
+            base=args.rope_theta,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        q_proj_output = self.q_proj(x)
+        queries, gate = mx.split(
+            q_proj_output.reshape(B, L, self.num_attention_heads, -1), 2, axis=-1
+        )
+        gate = gate.reshape(B, L, -1)
+
+        keys = self.k_proj(x)
+        values = self.v_proj(x)
+
+        queries = self.q_norm(queries).transpose(0, 2, 1, 3)
+        keys = self.k_norm(keys.reshape(B, L, self.num_key_value_heads, -1)).transpose(
+            0, 2, 1, 3
+        )
+        values = values.reshape(B, L, self.num_key_value_heads, -1).transpose(
+            0, 2, 1, 3
+        )
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output * mx.sigmoid(gate))
+
+
+class MLP(nn.Module):
+    """Standard SwiGLU MLP — used for the shared expert path."""
+
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class SwitchGLU(_QuantizedSwitchGLU):
+    """sglang-named alias for the mlx_lm SwitchGLU.
+
+    Uses the upstream class verbatim so 4-bit ``QuantizedSwitchLinear``
+    weights load directly via :meth:`Model.load_weights` and the
+    sglang Path B fusion (``SGLANG_MLX_FUSE_SWIGLU=1``) can patch it.
+    """
+
+
+class GatedDeltaNet(nn.Module):
+    """Linear attention block — Q/K/V from a depthwise conv, delta-rule update.
+
+    Has no ``q_proj``/``k_proj``/``v_proj``/``o_proj``/``rope``/``scale``
+    attrs so the sglang attention contract skips it (no KV pool needed;
+    cache state is a 2-slot ``ArraysCache``).
+    """
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.num_v_heads = args.linear_num_value_heads
+        self.num_k_heads = args.linear_num_key_heads
+        self.head_k_dim = args.linear_key_head_dim
+        self.head_v_dim = args.linear_value_head_dim
+        self.key_dim = self.head_k_dim * self.num_k_heads
+        self.value_dim = self.head_v_dim * self.num_v_heads
+        if self.num_v_heads % self.num_k_heads != 0:
+            raise ValueError(
+                f"num_v_heads ({self.num_v_heads}) must be divisible by "
+                f"num_k_heads ({self.num_k_heads})"
+            )
+
+        self.conv_kernel_size = args.linear_conv_kernel_dim
+        self.eps = args.rms_norm_eps
+
+        self.conv_dim = self.key_dim * 2 + self.value_dim
+        self.conv1d = nn.Conv1d(
+            in_channels=self.conv_dim,
+            out_channels=self.conv_dim,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.conv_dim,
+            padding=0,
+        )
+
+        self.in_proj_qkv = nn.Linear(
+            args.hidden_size, self.key_dim * 2 + self.value_dim, bias=False
+        )
+        self.in_proj_z = nn.Linear(args.hidden_size, self.value_dim, bias=False)
+        self.in_proj_b = nn.Linear(args.hidden_size, self.num_v_heads, bias=False)
+        self.in_proj_a = nn.Linear(args.hidden_size, self.num_v_heads, bias=False)
+
+        self.dt_bias = mx.ones(self.num_v_heads)
+        a_init = mx.random.uniform(low=0, high=16, shape=(self.num_v_heads,))
+        self.A_log = mx.log(a_init)
+
+        self.norm = RMSNormGated(self.head_v_dim, eps=self.eps)
+        self.out_proj = nn.Linear(self.value_dim, args.hidden_size, bias=False)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, S, _ = x.shape
+
+        qkv = self.in_proj_qkv(x)
+        z = self.in_proj_z(x).reshape(B, S, self.num_v_heads, self.head_v_dim)
+        b = self.in_proj_b(x)
+        a = self.in_proj_a(x)
+
+        if cache is not None and cache[0] is not None:
+            conv_state = cache[0]
+        else:
+            conv_state = mx.zeros(
+                (B, self.conv_kernel_size - 1, self.conv_dim),
+                dtype=x.dtype,
+            )
+
+        if mask is not None:
+            qkv = mx.where(mask[..., None], qkv, 0)
+        conv_input = mx.concatenate([conv_state, qkv], axis=1)
+        if cache is not None:
+            n_keep = self.conv_kernel_size - 1
+            if cache.lengths is not None:
+                ends = mx.clip(cache.lengths, 0, S)
+                positions = (ends[:, None] + mx.arange(n_keep))[..., None]
+                cache[0] = mx.take_along_axis(conv_input, positions, axis=1)
+            else:
+                cache[0] = mx.contiguous(conv_input[:, -n_keep:, :])
+        conv_out = nn.silu(self.conv1d(conv_input))
+
+        q, k, v = [
+            t.reshape(B, S, h, d)
+            for t, h, d in zip(
+                mx.split(conv_out, [self.key_dim, 2 * self.key_dim], -1),
+                [self.num_k_heads, self.num_k_heads, self.num_v_heads],
+                [self.head_k_dim, self.head_k_dim, self.head_v_dim],
+            )
+        ]
+
+        state = cache[1] if cache else None
+        inv_scale = k.shape[-1] ** -0.5
+        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+
+        out, state = gated_delta_update(
+            q,
+            k,
+            v,
+            a,
+            b,
+            self.A_log,
+            self.dt_bias,
+            state,
+            mask,
+            use_kernel=not self.training,
+        )
+
+        if cache is not None:
+            cache[1] = state
+            cache.advance(S)
+
+        out = self.norm(out, z)
+        return self.out_proj(out.reshape(B, S, -1))
+
+
+class SparseMoeBlock(nn.Module):
+    """Routed MoE + shared expert with sigmoid gate on the shared path."""
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.norm_topk_prob = args.norm_topk_prob
+        self.num_experts = args.num_experts
+        self.top_k = args.num_experts_per_tok
+
+        self.gate = nn.Linear(args.hidden_size, self.num_experts, bias=False)
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size, args.moe_intermediate_size, self.num_experts
+        )
+        self.shared_expert = MLP(
+            args.hidden_size, args.shared_expert_intermediate_size
+        )
+        self.shared_expert_gate = nn.Linear(args.hidden_size, 1, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gates = self.gate(x)
+        gates = mx.softmax(gates, axis=-1, precise=True)
+
+        k = self.top_k
+        inds = mx.argpartition(gates, kth=-k, axis=-1)[..., -k:]
+        scores = mx.take_along_axis(gates, inds, axis=-1)
+        if self.norm_topk_prob:
+            scores = scores / scores.sum(axis=-1, keepdims=True)
+
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2)
+
+        shared_y = self.shared_expert(x)
+        shared_y = mx.sigmoid(self.shared_expert_gate(x)) * shared_y
+
+        return y + shared_y
+
+
+class DecoderLayer(nn.Module):
+    """One transformer block: hybrid attention + MoE."""
+
+    def __init__(self, args: TextModelArgs, layer_idx: int, is_linear: bool):
+        super().__init__()
+        self.is_linear = is_linear
+        self.layer_idx = layer_idx
+        if self.is_linear:
+            self.linear_attn = GatedDeltaNet(args)
+        else:
+            self.self_attn = Attention(args)
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+        self.mlp = SparseMoeBlock(args)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        if self.is_linear:
+            r = self.linear_attn(self.input_layernorm(x), mask, cache)
+        else:
+            r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        out = h + self.mlp(self.post_attention_layernorm(h))
+        return out
+
+
+class TextModel(nn.Module):
+    """Qwen3.5 MoE text-only backbone."""
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.args = args
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            DecoderLayer(
+                args=args,
+                layer_idx=i,
+                is_linear=self._is_linear_layer(
+                    args.layer_types, i, args.full_attention_interval
+                ),
+            )
+            for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.ssm_idx = 0
+        self.fa_idx = self._pick_fa_idx(args)
+
+    @staticmethod
+    def _pick_fa_idx(args: TextModelArgs) -> int:
+        """Index of a full-attention layer to source the causal mask from.
+
+        Prefers the explicit ``layer_types`` list; falls back to the
+        ``full_attention_interval`` formula.  Clamps to the last layer
+        so small test configs (num_hidden_layers < interval) still build.
+        """
+        if args.layer_types is not None:
+            for i, kind in enumerate(args.layer_types):
+                if kind == "full_attention":
+                    return min(i, args.num_hidden_layers - 1)
+        interval = max(1, args.full_attention_interval)
+        candidate = interval - 1
+        return min(candidate, args.num_hidden_layers - 1)
+
+    @staticmethod
+    def _is_linear_layer(
+        layer_types: Optional[List[str]],
+        layer_idx: int,
+        full_attention_interval: int,
+    ) -> bool:
+        """Resolve per-layer attention kind from ``layer_types`` or the
+        ``full_attention_interval`` formula (one full-attn layer per N)."""
+        if layer_types is not None and layer_idx < len(layer_types):
+            return layer_types[layer_idx] != "full_attention"
+        interval = max(1, full_attention_interval)
+        return (layer_idx + 1) % interval != 0
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        hidden_states = self.embed_tokens(inputs)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        fa_mask = create_attention_mask(hidden_states, cache[self.fa_idx])
+        ssm_mask = create_ssm_mask(hidden_states, cache[self.ssm_idx])
+
+        for layer, c in zip(self.layers, cache):
+            mask = ssm_mask if layer.is_linear else fa_mask
+            hidden_states = layer(hidden_states, mask=mask, cache=c)
+
+        return self.norm(hidden_states)
 
 
 class Model(nn.Module):
-    """Phase 1 MVP stub.
-
-    Holds the config and a minimal structure so sglang MLX backend can
-    route to it.  Forward is intentionally a no-op — Phase 2 wires up
-    the real layers.
-    """
+    """Top-level: text-only Qwen3.5 MoE with LM head."""
 
     def __init__(self, args: TextModelArgs):
         super().__init__()
         self.args = args
         self.model_type = args.model_type
+        self.model = TextModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
 
-    def __call__(self, *args, **kwargs):  # pragma: no cover - stub
-        raise NotImplementedError(
-            "Qwen3.5 MoE native forward is implemented in Phase 2."
-        )
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        out = self.model(inputs, cache)
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(out)
+        return self.lm_head(out)
+
+    @property
+    def layers(self) -> List[DecoderLayer]:
+        return self.model.layers
+
+    def make_cache(self) -> List[Any]:
+        return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
 
     def sanitize(self, weights: Dict[str, Any]) -> Dict[str, Any]:
-        """Phase 1 passthrough.
+        """Remap HF weight names to the sglang native module layout.
 
-        Phase 2 will remap HF weight names (e.g. `experts.gate_up_proj` →
-        `switch_mlp.{gate,up}_proj.weight`, `experts.down_proj` →
-        `switch_mlp.down_proj.weight`, drop `model.visual.*`, etc.) —
-        see `mlx_lm.models.qwen3_5_moe.Model.sanitize` for the upstream
-        version we will mirror.
+        * Drop ``mtp.*`` (Phase 3) and ``model.visual.*`` (Phase 4).
+        * Transpose ``conv1d.weight`` from HF's (out, in, k) to MLX's
+          (out, k, in) layout.
+        * Shift RMSNorm weights by ``+1`` when the file also contains
+          ``mtp.*`` or unsanitised conv1d — these signals mark a fresh
+          HF export whose RMSNorm weights use the (1 - gamma) convention.
         """
-        return dict(weights)
+        has_mtp = any("mtp." in k for k in weights)
+        has_unsanitized_conv1d = any(
+            "conv1d.weight" in k
+            and isinstance(v, mx.array)
+            and v.ndim == 3
+            and v.shape[-1] != 1
+            for k, v in weights.items()
+        )
+        shift_norms = has_mtp or has_unsanitized_conv1d
+
+        weights = {
+            k: v
+            for k, v in weights.items()
+            if "mtp." not in k and "model.visual" not in k
+        }
+
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        norm_keys = (
+            ".input_layernorm.weight",
+            ".post_attention_layernorm.weight",
+            "model.norm.weight",
+            ".q_norm.weight",
+            ".k_norm.weight",
+        )
+        for k, v in list(weights.items()):
+            if "conv1d.weight" in k and v.ndim == 3 and v.shape[-1] != 1:
+                weights[k] = v.moveaxis(2, 1)
+            if shift_norms and any(k.endswith(sfx) for sfx in norm_keys):
+                if v.ndim == 1:
+                    weights[k] = v + 1.0
+        return weights
 
     @property
     def quant_predicate(self):
-        """Phase 1 predicate that excludes nothing.
+        """Exclude the router and shared-expert gate from 4-bit quant.
 
-        Phase 2 will return a predicate that excludes `mlp.gate` and
-        `shared_expert.*` from quantization (matching the upstream
-        Qwen3.5 MoE behaviour).
+        Matches the upstream Qwen3.5 MoE behaviour: ``mlp.gate`` and
+        ``shared_expert_gate`` stay at 8-bit so routing quality is
+        preserved while the bulk of the model is 4-bit.
         """
-        return lambda path, _module: True
+
+        def predicate(path: str, _: Any) -> Any:
+            if path.endswith("mlp.gate") or path.endswith("shared_expert_gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
 
     @property
-    def layers(self):
-        """Phase 1 returns an empty list so attention patching is a no-op.
+    def cast_predicate(self):
+        def predicate(path: str) -> bool:
+            if path.endswith("A_log"):
+                return False
+            return True
 
-        Phase 2 will return the real `DecoderLayer` list and the existing
-        sglang `model_patching.py` will pick it up.
-        """
-        return []
+        return predicate
+
+
+def load(path: str) -> "Model":
+    """Load a Qwen3.5 MoE checkpoint from a local directory.
+
+    Mirrors ``mlx_lm.utils.load_model`` for the Qwen3.5 MoE family:
+    reads ``config.json``, merges all ``model*.safetensors`` shards,
+    applies :meth:`Model.sanitize`, then calls ``load_weights`` so the
+    model's random-init buffers are replaced in place.  The HF/MLX
+    4-bit repos already store the routed experts stacked, so no
+    per-expert stacking is required.
+    """
+    import glob
+    import json
+    from pathlib import Path
+
+    from mlx.utils import tree_flatten
+
+    model_path = Path(path)
+    with (model_path / "config.json").open() as f:
+        cfg = json.load(f)
+    text_cfg = cfg.get("text_config", cfg)
+
+    args = TextModelArgs.from_hf_config(text_cfg)
+    model = Model(args)
+
+    weight_files = sorted(glob.glob(str(model_path / "model*.safetensors")))
+    if not weight_files:
+        raise FileNotFoundError(f"No safetensors found in {model_path}")
+
+    weights: Dict[str, mx.array] = {}
+    for wf in weight_files:
+        weights.update(mx.load(wf))
+
+    weights = model.sanitize(weights)
+
+    quant_cfg = cfg.get("quantization_config") or cfg.get("quantization")
+    if quant_cfg is not None and isinstance(quant_cfg, dict):
+        _quantize_modules(model, weights, quant_cfg)
+
+    n_loaded, n_expected = model.load_weights(list(weights.items()))
+    if n_loaded == 0:
+        raise RuntimeError(f"No weights loaded from {model_path}")
+
+    mx.eval(tree_flatten(model.parameters()))
+    del weights
+
+    return model
+
+
+def _quantize_modules(
+    model: "Model",
+    weights: Dict[str, mx.array],
+    quant_cfg: Dict[str, Any],
+) -> None:
+    """Convert ``nn.Linear`` / ``SwitchLinear`` modules to their
+    quantized counterparts when the loaded weights carry ``.scales``.
+
+    Honors per-layer overrides from ``quantization_config``: any path
+    whose dict specifies a different ``bits`` value is skipped or
+    quantized at that value via :func:`mlx.nn.quantize`.
+    """
+    group_size = int(quant_cfg.get("group_size", 64))
+    bits = int(quant_cfg.get("bits", 4))
+    mode = quant_cfg.get("mode", "affine")
+
+    per_layer = {
+        k: v for k, v in quant_cfg.items() if isinstance(v, dict) and "bits" in v
+    }
+
+    def class_predicate(path: str, module: Any) -> bool:
+        if not hasattr(module, "to_quantized"):
+            return False
+        if module.weight.shape[-1] % group_size != 0:
+            return False
+        if any(path.endswith(sfx) or sfx.endswith(path) for sfx in ("A_log",)):
+            return False
+        return f"{path}.scales" in weights
+
+    nn.quantize(model, group_size=group_size, bits=bits, mode=mode, class_predicate=class_predicate)
+
+    # Re-quantize any per-layer override that landed on a different bits
+    # value (e.g. mlp.gate is 8bit while the model default is 4bit).
+    for path, override in per_layer.items():
+        ov_bits = int(override.get("bits", bits))
+        ov_group = int(override.get("group_size", group_size))
+        ov_mode = override.get("mode", mode)
+        if ov_bits == bits and ov_group == group_size and ov_mode == mode:
+            continue
+        leaf = model
+        for part in path.split("."):
+            leaf = getattr(leaf, part, None) if leaf is not None else None
+            if leaf is None:
+                break
+        if leaf is None or not hasattr(leaf, "to_quantized"):
+            continue
+        if isinstance(leaf, _QuantizedSwitchGLU):
+            continue
+        leaf.update(
+            leaf.to_quantized(group_size=ov_group, bits=ov_bits, mode=ov_mode)
+        )

--- a/python/sglang/srt/hardware_backend/mlx/models/qwen3_5_moe.py
+++ b/python/sglang/srt/hardware_backend/mlx/models/qwen3_5_moe.py
@@ -1,0 +1,139 @@
+"""Native MLX implementation of Qwen3.5 MoE (a.k.a. Qwen3.6-35B-A3B).
+
+This is the text-only model extracted from
+`Qwen3_5MoeForConditionalGeneration`.  Vision tower and MTP head live in
+their own modules (TODO: Phase 4 / Phase 3 of the plan).
+
+Architecture summary (Qwen3.6-35B-A3B config):
+  * 40 hidden layers, hidden_size 2048, head_dim 256
+  * 16 attention heads, 2 KV heads (heavy GQA)
+  * Hybrid attention 3:1 — `GatedDeltaNet` (linear) for 3 of every 4
+    layers, `Attention` (full) every 4th
+  * MoE: 256 experts, 8 active per token; SwitchGLU per expert
+  * `attn_output_gate: true` on full attention
+  * `partial_rotary_factor=0.25` RoPE with `mrope_section=[11,11,10]`
+  * Shared expert path (single MLP, not routed)
+  * `tie_word_embeddings=False`
+
+This stub is the Phase 1 MVP.  It defines `ModelArgs` + a no-op `Model`
+class so the sglang MLX backend can route Qwen3.5 MoE paths to a
+sglang-owned module instead of `mlx_lm.models.qwen3_5_moe`.  Subsequent
+phases will fill in the actual layers:
+
+  Phase 2 — RoPE + Attention (full) + GatedDeltaNet (linear) + MoE +
+            DecoderLayer + Model + ForCausalLM + weight load
+  Phase 3 — MTP head (multi-token prediction)
+  Phase 4 — Vision tower + multimodal projector
+  Phase 5 — Fused SwiGLU + KV cache tuning for hybrid attention
+
+Reference: mlx_lm 0.31.3 `qwen3_5.py` (architecture), `qwen3_5_moe.py`
+(weight name remapping), `gated_delta.py` (linear attention primitive).
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.base import BaseModelArgs
+
+
+@dataclass
+class TextModelArgs(BaseModelArgs):
+    """Subset of fields needed to construct a Qwen3.5 MoE text model.
+
+    The defaults match Qwen3.6-35B-A3B.  Phase 2 will add the rest of
+    the fields (intermediate_size, num_experts_per_tok details, etc.).
+    """
+
+    model_type: str = "qwen3_5_moe_text"
+    hidden_size: int = 2048
+    intermediate_size: int = 8192
+    num_hidden_layers: int = 40
+    num_attention_heads: int = 16
+    rms_norm_eps: float = 1e-6
+    vocab_size: int = 248320
+    num_key_value_heads: int = 2
+    max_position_embeddings: int = 262144
+    head_dim: int = 256
+    full_attention_interval: int = 4
+
+    linear_num_value_heads: int = 32
+    linear_num_key_heads: int = 16
+    linear_key_head_dim: int = 128
+    linear_value_head_dim: int = 128
+    linear_conv_kernel_dim: int = 4
+
+    tie_word_embeddings: bool = False
+    attention_bias: bool = False
+    attn_output_gate: bool = True
+
+    num_experts: int = 256
+    num_experts_per_tok: int = 8
+    decoder_sparse_step: int = 1
+    shared_expert_intermediate_size: int = 512
+    moe_intermediate_size: int = 512
+    norm_topk_prob: bool = True
+    router_aux_loss_coef: float = 0.001
+
+    rope_parameters: Optional[Dict[str, Union[float, str, bool, List[int]]]] = field(
+        default_factory=lambda: {
+            "type": "default",
+            "mrope_section": [11, 11, 10],
+            "rope_theta": 10000000,
+            "partial_rotary_factor": 0.25,
+        }
+    )
+    partial_rotary_factor: float = 0.25
+    rope_theta: float = 10000000.0
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+
+
+class Model(nn.Module):
+    """Phase 1 MVP stub.
+
+    Holds the config and a minimal structure so sglang MLX backend can
+    route to it.  Forward is intentionally a no-op — Phase 2 wires up
+    the real layers.
+    """
+
+    def __init__(self, args: TextModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+
+    def __call__(self, *args, **kwargs):  # pragma: no cover - stub
+        raise NotImplementedError(
+            "Qwen3.5 MoE native forward is implemented in Phase 2."
+        )
+
+    def sanitize(self, weights: Dict[str, Any]) -> Dict[str, Any]:
+        """Phase 1 passthrough.
+
+        Phase 2 will remap HF weight names (e.g. `experts.gate_up_proj` →
+        `switch_mlp.{gate,up}_proj.weight`, `experts.down_proj` →
+        `switch_mlp.down_proj.weight`, drop `model.visual.*`, etc.) —
+        see `mlx_lm.models.qwen3_5_moe.Model.sanitize` for the upstream
+        version we will mirror.
+        """
+        return dict(weights)
+
+    @property
+    def quant_predicate(self):
+        """Phase 1 predicate that excludes nothing.
+
+        Phase 2 will return a predicate that excludes `mlp.gate` and
+        `shared_expert.*` from quantization (matching the upstream
+        Qwen3.5 MoE behaviour).
+        """
+        return lambda path, _module: True
+
+    @property
+    def layers(self):
+        """Phase 1 returns an empty list so attention patching is a no-op.
+
+        Phase 2 will return the real `DecoderLayer` list and the existing
+        sglang `model_patching.py` will pick it up.
+        """
+        return []

--- a/scripts/verify_qwen3_5_moe_native.sh
+++ b/scripts/verify_qwen3_5_moe_native.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Verify the sglang-native Qwen3.5 MoE model loads weights and forwards
+# a few tokens.  Compares the first generated token against mlx_lm
+# generate for the same prompt.
+
+set -euo pipefail
+
+SGLANG_PYTHON=${SGLANG_PYTHON:-/Users/toufupi/miniconda3/envs/sglang/bin/python}
+SGLANG_ROOT=${SGLANG_ROOT:-/Users/toufupi/project/SGLang/sglang}
+MODEL_PATH=${MODEL_PATH:-/Users/toufupi/models/Qwen3.6-35B-A3B-UD-MLX-4bit}
+PROMPT=${PROMPT:-"The capital of France is"}
+MAX_TOKENS=${MAX_TOKENS:-10}
+
+export PYTHONPATH="${SGLANG_ROOT}/python:${PYTHONPATH:-}"
+
+echo "=== Step 1: forward pass through sglang-native model ==="
+"${SGLANG_PYTHON}" - <<EOF
+import mlx.core as mx
+from sglang.srt.hardware_backend.mlx.models.qwen3_5_moe import load, TextModelArgs
+
+print("Loading sglang-native Qwen3.5 MoE...")
+model = load("${MODEL_PATH}")
+print("Loaded.")
+
+prompt_ids = [9707, 13, 8377, 13, 359, 1181, 374, 298]  # "The capital of France is"
+inputs = mx.array([prompt_ids], dtype=mx.int32)
+out = model(inputs)
+mx.eval(out)
+top_id = int(mx.argmax(out[0, -1]))
+print(f"sglang top-1 token id for prompt: {top_id}")
+EOF
+
+echo ""
+echo "=== Step 2: mlx_lm baseline (same prompt) ==="
+"${SGLANG_PYTHON}" - <<EOF
+import mlx.core as mx
+from mlx_lm import load as mlx_load, generate
+
+print("Loading mlx_lm Qwen3.5 MoE...")
+model, tok = mlx_load("${MODEL_PATH}")
+out = generate(model, tok, prompt="${PROMPT}", max_tokens=${MAX_TOKENS}, verbose=False)
+print(f"mlx_lm output: {out!r}")
+EOF

--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -423,6 +423,7 @@ class TestMlxAuxiliaryStateRunnerCache(unittest.TestCase):
         runner = object.__new__(MlxModelRunner)
         runner._req_token_ids = {"r0": [8]}
         runner._decode_step_ct = 0
+        runner._clear_steps = 0
         calls = []
         runner._store_auxiliary_state = lambda req_pool_idx, cache: calls.append(
             (req_pool_idx, cache)
@@ -1180,7 +1181,7 @@ class TestMlxOverlapScheduler(unittest.TestCase):
             model_config=None,
             token_to_kv_pool_allocator=None,
             tree_cache=tree_cache,
-            hisparse_coordinator=None,
+            hisparse_coordinator=SimpleNamespace(request_finished=lambda req: None),
             req_to_token_pool=None,
             decode_offload_manager=None,
             metrics_collector=None,
@@ -1195,33 +1196,64 @@ class TestMlxOverlapScheduler(unittest.TestCase):
             output_streamer=None,
             abort_request=lambda req: None,
         )
+        # Stub out the methods _handle_finish_state_updated_req calls that
+        # are not relevant to this test.  SchedulerBatchResultProcessor is
+        # @dataclass(slots=True, frozen=True), so patches go on the class.
+        noop_stubs = {
+            "_mamba_prefix_cache_update": lambda *a, **k: None,
+            "_maybe_collect_routed_experts": lambda *a, **k: None,
+            "_maybe_collect_indexer_topk": lambda *a, **k: None,
+            "_maybe_collect_customized_info": lambda *a, **k: None,
+        }
+        saved = {
+            name: getattr(SchedulerBatchResultProcessor, name)
+            for name in noop_stubs
+        }
+        for name, value in noop_stubs.items():
+            setattr(SchedulerBatchResultProcessor, name, value)
         req = SimpleNamespace(
             rid="r0",
             finished=lambda: True,
             multimodal_inputs=None,
             session=None,
             return_routed_experts=False,
+            mamba_lazy_is_insert=True,
             time_stats=SimpleNamespace(
                 set_completion_time=lambda: events.append(("completion", "r0"))
             ),
         )
+        batch = SimpleNamespace()
+        result = SimpleNamespace()
+        i = 0
+        logits_output = SimpleNamespace(customized_info=None)
         original_release = batch_result_processor_module.release_kv_cache
         original_get_indexer = batch_result_processor_module.get_global_indexer_capturer
+        original_get_server_args = (
+            batch_result_processor_module.get_global_server_args
+        )
 
-        def fake_release_kv_cache(release_req, tree_cache):
+        def fake_release_kv_cache(release_req, tree_cache, is_insert=False):
             events.append(("release", release_req.rid))
             self.assertIs(tree_cache, processor.tree_cache)
 
         batch_result_processor_module.release_kv_cache = fake_release_kv_cache
         batch_result_processor_module.get_global_indexer_capturer = lambda: None
+        batch_result_processor_module.get_global_server_args = lambda: SimpleNamespace(
+            enable_mamba_extra_buffer_lazy=lambda: False
+        )
         try:
-            SchedulerBatchResultProcessor._handle_finished_req(
-                processor, req, 0, SimpleNamespace(customized_info=None)
+            SchedulerBatchResultProcessor._handle_finish_state_updated_req(
+                processor, req, batch, result, i, logits_output
             )
         finally:
+            for name, original in saved.items():
+                setattr(SchedulerBatchResultProcessor, name, original)
             batch_result_processor_module.release_kv_cache = original_release
             batch_result_processor_module.get_global_indexer_capturer = (
                 original_get_indexer
+            )
+            batch_result_processor_module.get_global_server_args = (
+                original_get_server_args
             )
 
         self.assertEqual(

--- a/test/registered/unit/hardware_backend/mlx/test_qwen3_5_moe.py
+++ b/test/registered/unit/hardware_backend/mlx/test_qwen3_5_moe.py
@@ -1,22 +1,26 @@
 """Unit tests for the native Qwen3.5 MoE MLX model module.
 
-Phase 1 MVP coverage:
-  1. Module imports cleanly (`Model`, `TextModelArgs`)
+Coverage:
+  1. Module imports cleanly (`Model`, `TextModelArgs`).
   2. `TextModelArgs` dataclass constructs with sane defaults matching
      Qwen3.6-35B-A3B (40 layers, 256 experts / 8 active, hybrid
-     attention interval=4, partial_rotary=0.25)
-  3. `Model` instantiates, exposes `model_type`, empty `layers` list,
-     and a passthrough `sanitize`
-  4. `quant_predicate` returns a callable that always accepts
-  5. `_is_qwen3_5_moe` (in `model_runner.py`) detects the architecture
+     attention interval=4, partial_rotary=0.25).
+  3. `TextModelArgs.from_hf_config` parses an HF `text_config` block,
+     including `rope_parameters` and `layer_types`.
+  4. `Model` instantiates with a small config; `model_type` and the
+     per-layer attention kind (`is_linear`) match `layer_types`.
+  5. `sanitize` drops `mtp.*` / `model.visual.*`, transposes `conv1d`,
+     and shifts RMSNorm weights by `+1` only when the file is in the
+     un-sanitised HF layout.
+  6. `quant_predicate` returns a callable that forces 8-bit on the
+     router and shared-expert gate.
+  7. `_is_qwen3_5_moe` (in `model_runner.py`) detects the architecture
      from config.json in three flavours: multimodal
      `Qwen3_5MoeForConditionalGeneration`, text-only
-     `qwen3_5_moe` model_type, and a negative case
+     `qwen3_5_moe` model_type, and a negative case.
 
-The tests do NOT exercise real model weights — that arrives in
-Phase 2 (text-only Qwen3.5 MoE full implementation) and Phase 4
-(vision tower).  These tests guarantee the wiring is correct so
-Phase 2 can focus on the architecture itself.
+Tests use a small (2-layer, 4-expert) config for model construction
+and forward so the test process does not OOM on the 35B random init.
 """
 
 import json
@@ -25,8 +29,14 @@ import unittest
 from pathlib import Path
 
 from sglang.srt.hardware_backend.mlx.models.qwen3_5_moe import (
+    Attention,
+    DecoderLayer,
+    GatedDeltaNet,
     Model,
+    SparseMoeBlock,
+    SwitchGLU,
     TextModelArgs,
+    load,
 )
 from sglang.srt.hardware_backend.mlx.model_runner import _is_qwen3_5_moe
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -34,7 +44,30 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=20, suite="unit-test-mlx")
 
 
-class TestQwen3_5MoEStub(unittest.TestCase):
+# A small config that keeps random-init memory well under test limits
+# (2 layers, 4 experts, hidden_size=128, intermediate=64).
+SMALL = dict(
+    num_hidden_layers=2,
+    hidden_size=128,
+    intermediate_size=64,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=32,
+    linear_num_value_heads=4,
+    linear_num_key_heads=2,
+    linear_key_head_dim=16,
+    linear_value_head_dim=16,
+    linear_conv_kernel_dim=4,
+    num_experts=4,
+    num_experts_per_tok=2,
+    moe_intermediate_size=64,
+    shared_expert_intermediate_size=64,
+    vocab_size=64,
+    layer_types=["linear_attention", "full_attention"],
+)
+
+
+class TestTextModelArgs(unittest.TestCase):
     def test_import(self):
         self.assertTrue(callable(Model))
         self.assertTrue(callable(TextModelArgs))
@@ -50,30 +83,228 @@ class TestQwen3_5MoEStub(unittest.TestCase):
         self.assertTrue(args.attn_output_gate)
         self.assertEqual(args.moe_intermediate_size, 512)
         self.assertEqual(args.shared_expert_intermediate_size, 512)
+        self.assertEqual(args.linear_num_value_heads, 32)
+        self.assertEqual(args.linear_key_head_dim, 128)
+        self.assertEqual(args.linear_conv_kernel_dim, 4)
 
-    def test_rope_parameters_default(self):
-        args = TextModelArgs()
+    def test_from_hf_config_parses_rope_parameters(self):
+        text_cfg = {
+            "model_type": "qwen3_5_moe_text",
+            "hidden_size": 2048,
+            "num_hidden_layers": 40,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 2,
+            "head_dim": 256,
+            "linear_num_value_heads": 32,
+            "linear_num_key_heads": 16,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "num_experts": 256,
+            "num_experts_per_tok": 8,
+            "moe_intermediate_size": 512,
+            "shared_expert_intermediate_size": 512,
+            "full_attention_interval": 4,
+            "layer_types": ["linear_attention"] * 39 + ["full_attention"],
+            "rope_parameters": {
+                "mrope_interleaved": True,
+                "mrope_section": [11, 11, 10],
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 10000000,
+                "rope_type": "default",
+            },
+        }
+        args = TextModelArgs.from_hf_config(text_cfg)
+        self.assertEqual(args.rope_theta, 10000000)
+        self.assertEqual(args.partial_rotary_factor, 0.25)
         self.assertEqual(args.rope_parameters["mrope_section"], [11, 11, 10])
-        self.assertEqual(args.rope_parameters["partial_rotary_factor"], 0.25)
-        self.assertEqual(args.rope_parameters["rope_theta"], 10000000)
+        self.assertEqual(args.layer_types[-1], "full_attention")
 
-    def test_model_construction(self):
-        m = Model(TextModelArgs())
+
+class TestModelConstruction(unittest.TestCase):
+    def test_model_construction_small(self):
+        args = TextModelArgs(**SMALL)
+        m = Model(args)
         self.assertEqual(m.model_type, "qwen3_5_moe_text")
-        self.assertEqual(m.layers, [])
+        self.assertEqual(len(m.layers), 2)
         self.assertIsNotNone(m.args)
 
-    def test_sanitize_passthrough(self):
-        m = Model(TextModelArgs())
-        weights = {"a.b.c": 1, "d.e": 2}
-        self.assertEqual(m.sanitize(weights), weights)
+    def test_layer_attention_kind_matches_layer_types(self):
+        args = TextModelArgs(
+            num_hidden_layers=4,
+            hidden_size=128,
+            intermediate_size=64,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=32,
+            linear_num_value_heads=4,
+            linear_num_key_heads=2,
+            linear_key_head_dim=16,
+            linear_value_head_dim=16,
+            linear_conv_kernel_dim=4,
+            num_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=64,
+            shared_expert_intermediate_size=64,
+            vocab_size=64,
+            layer_types=["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+        )
+        m = Model(args)
+        self.assertTrue(m.layers[0].is_linear)
+        self.assertTrue(m.layers[1].is_linear)
+        self.assertTrue(m.layers[2].is_linear)
+        self.assertFalse(m.layers[3].is_linear)
+        self.assertIsInstance(m.layers[0].linear_attn, GatedDeltaNet)
+        self.assertIsInstance(m.layers[3].self_attn, Attention)
 
-    def test_quant_predicate_accepts_all(self):
-        m = Model(TextModelArgs())
+    def test_layer_attention_kind_from_interval_fallback(self):
+        # No layer_types — derive from full_attention_interval=4.
+        args = TextModelArgs(
+            num_hidden_layers=4,
+            hidden_size=128,
+            intermediate_size=64,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=32,
+            linear_num_value_heads=4,
+            linear_num_key_heads=2,
+            linear_key_head_dim=16,
+            linear_value_head_dim=16,
+            linear_conv_kernel_dim=4,
+            num_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=64,
+            shared_expert_intermediate_size=64,
+            vocab_size=64,
+            full_attention_interval=4,
+        )
+        m = Model(args)
+        self.assertTrue(m.layers[0].is_linear)
+        self.assertTrue(m.layers[1].is_linear)
+        self.assertTrue(m.layers[2].is_linear)
+        self.assertFalse(m.layers[3].is_linear)
+
+    def test_decoder_layer_composition(self):
+        args = TextModelArgs(**SMALL)
+        m = Model(args)
+        layer0 = m.layers[0]
+        self.assertIsInstance(layer0, DecoderLayer)
+        self.assertIsInstance(layer0.linear_attn, GatedDeltaNet)
+        self.assertIsInstance(layer0.mlp, SparseMoeBlock)
+        self.assertIsInstance(layer0.mlp.switch_mlp, SwitchGLU)
+
+    def test_quant_predicate_routes_mlp_gate_to_8bit(self):
+        args = TextModelArgs(**SMALL)
+        m = Model(args)
         predicate = m.quant_predicate
         self.assertTrue(callable(predicate))
-        self.assertTrue(predicate("any.weight", None))
-        self.assertTrue(predicate("mlp.experts.0.gate_proj.weight", None))
+        self.assertEqual(predicate("model.layers.0.mlp.gate", None), {"group_size": 64, "bits": 8})
+        self.assertEqual(predicate("model.layers.0.mlp.shared_expert_gate", None), {"group_size": 64, "bits": 8})
+        self.assertTrue(predicate("model.layers.0.mlp.switch_mlp.gate_proj", None))
+        self.assertTrue(predicate("model.layers.0.self_attn.q_proj", None))
+
+
+class TestSanitize(unittest.TestCase):
+    def test_sanitize_drops_mtp_and_visual(self):
+        args = TextModelArgs(**SMALL)
+        m = Model(args)
+        weights = {
+            "model.layers.0.mlp.gate.weight": "x",
+            "model.layers.0.self_attn.q_proj.weight": "y",
+            "mtp.layers.0.weight": "drop",
+            "model.visual.blocks.0.weight": "drop",
+        }
+        sanitized = m.sanitize(weights)
+        self.assertIn("model.layers.0.mlp.gate.weight", sanitized)
+        self.assertIn("model.layers.0.self_attn.q_proj.weight", sanitized)
+        self.assertNotIn("mtp.layers.0.weight", sanitized)
+        self.assertNotIn("model.visual.blocks.0.weight", sanitized)
+
+    def test_sanitize_transposes_conv1d_when_unsanitised(self):
+        import mlx.core as mx
+
+        args = TextModelArgs(**SMALL)
+        m = Model(args)
+        # (out, k, in) layout with last-dim != 1 means "needs transpose".
+        weight = mx.zeros((4, 16, 3))
+        weights = {
+            "model.layers.0.linear_attn.conv1d.weight": weight,
+            "model.norm.weight": mx.zeros((128,)),
+        }
+        sanitized = m.sanitize(weights)
+        self.assertEqual(sanitized["model.layers.0.linear_attn.conv1d.weight"].shape, (4, 3, 16))
+
+    def test_sanitize_does_not_shift_norms_when_already_sanitised(self):
+        import mlx.core as mx
+
+        args = TextModelArgs(**SMALL)
+        m = Model(args)
+        # Already-sanitised conv1d (last-dim == 1) and no mtp -> no norm shift.
+        weights = {
+            "model.layers.0.linear_attn.conv1d.weight": mx.zeros((4, 3, 1)),
+            "model.norm.weight": mx.zeros((128,)),
+        }
+        sanitized = m.sanitize(weights)
+        self.assertTrue(
+            mx.allclose(sanitized["model.norm.weight"], mx.zeros((128,))).item()
+        )
+
+    def test_sanitize_shifts_norms_when_mtp_present(self):
+        import mlx.core as mx
+
+        args = TextModelArgs(**SMALL)
+        m = Model(args)
+        norm = mx.zeros((128,))
+        weights = {
+            "model.layers.0.linear_attn.conv1d.weight": mx.zeros((4, 3, 16)),
+            "model.norm.weight": norm,
+            "mtp.layers.0.weight": "trigger",
+        }
+        sanitized = m.sanitize(weights)
+        self.assertTrue(
+            mx.allclose(sanitized["model.norm.weight"], mx.zeros((128,)) + 1.0).item()
+        )
+        self.assertNotIn("mtp.layers.0.weight", sanitized)
+
+    def test_sanitize_drops_lm_head_when_tied(self):
+        args = TextModelArgs(**SMALL, tie_word_embeddings=True)
+        m = Model(args)
+        weights = {
+            "lm_head.weight": "drop",
+            "model.embed_tokens.weight": "keep",
+        }
+        sanitized = m.sanitize(weights)
+        self.assertNotIn("lm_head.weight", sanitized)
+        self.assertIn("model.embed_tokens.weight", sanitized)
+
+
+class TestLoadMissingFiles(unittest.TestCase):
+    def test_load_raises_on_missing_safetensors(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "config.json").write_text(json.dumps({
+                "model_type": "qwen3_5_moe",
+                "text_config": {
+                    "model_type": "qwen3_5_moe_text",
+                    "num_hidden_layers": 2,
+                    "hidden_size": 128,
+                    "intermediate_size": 64,
+                    "num_attention_heads": 4,
+                    "num_key_value_heads": 2,
+                    "head_dim": 32,
+                    "linear_num_value_heads": 4,
+                    "linear_num_key_heads": 2,
+                    "linear_key_head_dim": 16,
+                    "linear_value_head_dim": 16,
+                    "linear_conv_kernel_dim": 4,
+                    "num_experts": 4,
+                    "num_experts_per_tok": 2,
+                    "moe_intermediate_size": 64,
+                    "shared_expert_intermediate_size": 64,
+                    "vocab_size": 64,
+                },
+            }))
+            with self.assertRaises(FileNotFoundError):
+                load(d)
 
 
 class TestIsQwen3_5MoEDetection(unittest.TestCase):

--- a/test/registered/unit/hardware_backend/mlx/test_qwen3_5_moe.py
+++ b/test/registered/unit/hardware_backend/mlx/test_qwen3_5_moe.py
@@ -220,6 +220,19 @@ class TestSanitize(unittest.TestCase):
         self.assertNotIn("mtp.layers.0.weight", sanitized)
         self.assertNotIn("model.visual.blocks.0.weight", sanitized)
 
+    def test_sanitize_strips_language_model_prefix(self):
+        args = TextModelArgs(**SMALL)
+        m = Model(args)
+        weights = {
+            "language_model.model.layers.0.mlp.gate.weight": "x",
+            "language_model.lm_head.weight": "y",
+            "vision_tower.blocks.0.weight": "drop",
+        }
+        sanitized = m.sanitize(weights)
+        self.assertIn("model.layers.0.mlp.gate.weight", sanitized)
+        self.assertIn("lm_head.weight", sanitized)
+        self.assertNotIn("vision_tower.blocks.0.weight", sanitized)
+
     def test_sanitize_transposes_conv1d_when_unsanitised(self):
         import mlx.core as mx
 

--- a/test/registered/unit/hardware_backend/mlx/test_qwen3_5_moe.py
+++ b/test/registered/unit/hardware_backend/mlx/test_qwen3_5_moe.py
@@ -1,0 +1,123 @@
+"""Unit tests for the native Qwen3.5 MoE MLX model module.
+
+Phase 1 MVP coverage:
+  1. Module imports cleanly (`Model`, `TextModelArgs`)
+  2. `TextModelArgs` dataclass constructs with sane defaults matching
+     Qwen3.6-35B-A3B (40 layers, 256 experts / 8 active, hybrid
+     attention interval=4, partial_rotary=0.25)
+  3. `Model` instantiates, exposes `model_type`, empty `layers` list,
+     and a passthrough `sanitize`
+  4. `quant_predicate` returns a callable that always accepts
+  5. `_is_qwen3_5_moe` (in `model_runner.py`) detects the architecture
+     from config.json in three flavours: multimodal
+     `Qwen3_5MoeForConditionalGeneration`, text-only
+     `qwen3_5_moe` model_type, and a negative case
+
+The tests do NOT exercise real model weights — that arrives in
+Phase 2 (text-only Qwen3.5 MoE full implementation) and Phase 4
+(vision tower).  These tests guarantee the wiring is correct so
+Phase 2 can focus on the architecture itself.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from sglang.srt.hardware_backend.mlx.models.qwen3_5_moe import (
+    Model,
+    TextModelArgs,
+)
+from sglang.srt.hardware_backend.mlx.model_runner import _is_qwen3_5_moe
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=20, suite="unit-test-mlx")
+
+
+class TestQwen3_5MoEStub(unittest.TestCase):
+    def test_import(self):
+        self.assertTrue(callable(Model))
+        self.assertTrue(callable(TextModelArgs))
+
+    def test_default_args_match_qwen3_6_35b_a3b(self):
+        args = TextModelArgs()
+        self.assertEqual(args.model_type, "qwen3_5_moe_text")
+        self.assertEqual(args.num_hidden_layers, 40)
+        self.assertEqual(args.num_experts, 256)
+        self.assertEqual(args.num_experts_per_tok, 8)
+        self.assertEqual(args.full_attention_interval, 4)
+        self.assertEqual(args.partial_rotary_factor, 0.25)
+        self.assertTrue(args.attn_output_gate)
+        self.assertEqual(args.moe_intermediate_size, 512)
+        self.assertEqual(args.shared_expert_intermediate_size, 512)
+
+    def test_rope_parameters_default(self):
+        args = TextModelArgs()
+        self.assertEqual(args.rope_parameters["mrope_section"], [11, 11, 10])
+        self.assertEqual(args.rope_parameters["partial_rotary_factor"], 0.25)
+        self.assertEqual(args.rope_parameters["rope_theta"], 10000000)
+
+    def test_model_construction(self):
+        m = Model(TextModelArgs())
+        self.assertEqual(m.model_type, "qwen3_5_moe_text")
+        self.assertEqual(m.layers, [])
+        self.assertIsNotNone(m.args)
+
+    def test_sanitize_passthrough(self):
+        m = Model(TextModelArgs())
+        weights = {"a.b.c": 1, "d.e": 2}
+        self.assertEqual(m.sanitize(weights), weights)
+
+    def test_quant_predicate_accepts_all(self):
+        m = Model(TextModelArgs())
+        predicate = m.quant_predicate
+        self.assertTrue(callable(predicate))
+        self.assertTrue(predicate("any.weight", None))
+        self.assertTrue(predicate("mlp.experts.0.gate_proj.weight", None))
+
+
+class TestIsQwen3_5MoEDetection(unittest.TestCase):
+    def _write_config(self, dirpath: str, cfg: dict):
+        Path(dirpath, "config.json").write_text(json.dumps(cfg))
+
+    def test_detects_multimodal_arch(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_config(d, {
+                "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                "text_config": {"model_type": "qwen3_5_moe_text"},
+            })
+            self.assertTrue(_is_qwen3_5_moe(d))
+
+    def test_detects_text_only_model_type(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_config(d, {"model_type": "qwen3_5_moe"})
+            self.assertTrue(_is_qwen3_5_moe(d))
+
+    def test_detects_text_config_model_type(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_config(d, {
+                "model_type": "qwen3_5_moe",
+                "text_config": {"model_type": "qwen3_5_moe_text"},
+            })
+            self.assertTrue(_is_qwen3_5_moe(d))
+
+    def test_rejects_unrelated_arch(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_config(d, {
+                "architectures": ["LlamaForCausalLM"],
+                "model_type": "llama",
+            })
+            self.assertFalse(_is_qwen3_5_moe(d))
+
+    def test_rejects_missing_config(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertFalse(_is_qwen3_5_moe(d))
+
+    def test_rejects_malformed_config(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "config.json").write_text("not valid json {{")
+            self.assertFalse(_is_qwen3_5_moe(d))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Native MLX implementation of Qwen3.5 MoE (a.k.a. Qwen3.6-35B-A3B)
so the sglang MLX backend can run the Qwen3_5MoeForConditionalGeneration
family on Apple Silicon without going through `mlx_lm.models.qwen3_5`.

The model lives in
`python/sglang/srt/hardware_backend/mlx/models/qwen3_5_moe.py`
alongside a `load()` helper.  `MlxModelRunner._load_model` routes
Qwen3.5 MoE checkpoints through the new loader (and falls through to
`mlx_lm.load` for every other architecture).

## Architecture

Qwen3.6-35B-A3B (text-only, vision tower deferred to a follow-up):

* 40 hidden layers, hidden_size 2048, head_dim 256
* 16 attention heads, 2 KV heads (heavy GQA)
* **Hybrid 3:1 attention** — `GatedDeltaNet` (linear) for 3 of every
  4 layers, full softmax `Attention` every 4th
* MoE: **256 experts, 8 active** per token; SwitchGLU per expert
* `attn_output_gate` on full attention (sigmoid gate on `o_proj`)
* `partial_rotary_factor=0.25` RoPE; `rope_type=default` so the
  `mrope_section` field is informational only
* Shared expert path (single MLP, not routed)
* `tie_word_embeddings=False`

## Implementation

* High-level orchestration (`DecoderLayer`, `TextModel`, `Model`,
  `load`, `sanitize`, `quant_predicate`) is sglang-owned.
* Low-level primitives (`gated_delta_update`, `swiglu`, mask helpers,
  cache containers) are imported from `mlx_lm.models`.
* `SwitchGLU` is aliased to `mlx_lm.models.switch_layers.SwitchGLU` so
  4-bit `QuantizedSwitchLinear` weights load via `Model.load_weights`
  and the sglang `SGLANG_MLX_FUSE_SWIGLU` patcher still recognises it.

## Changes

* **NEW** `python/sglang/srt/hardware_backend/mlx/models/__init__.py`
  (package init; no symbols exported yet)
* **NEW** `python/sglang/srt/hardware_backend/mlx/models/qwen3_5_moe.py`
  — `TextModelArgs`, `Attention`, `GatedDeltaNet`, `RMSNormGated`,
  `MLP`, `SwitchGLU`, `SparseMoeBlock`, `DecoderLayer`, `TextModel`,
  `Model`, `load(path)`, `_quantize_modules(...)`.
* **NEW** `python/sglang/srt/hardware_backend/mlx/models/README.md`
  — guide for adding new native MLX models.
* `python/sglang/srt/hardware_backend/mlx/model_runner.py` —
  `_load_model` detects Qwen3.5 MoE and dispatches to the native
  loader instead of `mlx_lm.load`.
* **NEW** `test/registered/unit/hardware_backend/mlx/test_qwen3_5_moe.py`
  — 21 tests covering `TextModelArgs` defaults, `from_hf_config`
  parsing, small-config construction, `layer_types` vs
  `full_attention_interval` fallback, decoder composition,
  `quant_predicate` routing, `sanitize` (mtp/visual/conv1d/norm
  shift/tied-embeddings/prefix-strip), `load` error on missing
  safetensors, and three flavours of `_is_qwen3_5_moe` config
  detection.
* **NEW** `scripts/verify_qwen3_5_moe_native.sh` — runs a forward
  pass on a fixed prompt and compares against `mlx_lm.generate`
  (requires the full model download).

## Test plan

```bash
# 21 unit tests (no model required)
python -m pytest test/registered/unit/hardware_backend/mlx/test_qwen3_5_moe.py -v

# Existing 67 MLX tests — no regression
python -m pytest test/registered/unit/hardware_backend/mlx/ -v --ignore=test/registered/unit/hardware_backend/mlx/test_quantization.py
```

## Follow-up (not in this PR)

* Phase 3: MTP head (`mtp_num_hidden_layers=1` in the config).
* Phase 4: vision tower + multimodal projector + image processor.
* Phase 5: `SGLANG_MLX_FUSE_SWIGLU=1` Path B fusion runs on the
  sglang-native `SwitchGLU` (works today via the mlx_lm alias).
* End-to-end `bench_one_batch` numbers once the 5-shard model
  download finishes (currently mid-download).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->