### PR TITLE
[AMD] Optimize rope triton kernel performance for v4 model

### DIFF
--- a/python/sglang/srt/layers/deepseek_v4_rope.py
+++ b/python/sglang/srt/layers/deepseek_v4_rope.py
@@ -306,7 +306,13 @@ def apply_rotary_emb_triton(
         # 3D (attention-output / q-k rope): contiguous-load kernel (ATOM-style).
         if is_3d:
             RD = max(triton.next_power_of_2(rope_dim), 2)
-            grid = (triton.cdiv(batch_size, BLOCK_M), n_heads)
+            # The contig kernel does a per-program reshape+flip over [BLOCK_M, RD];
+            # a small BLOCK_M (more programs, smaller tile) maximizes CU occupancy
+            # and keeps the flip cheap. Microbench (MI300, rope_dim=64): BLOCK_M=8
+            # + num_warps=4 is ~1.6-1.8x faster than BLOCK_M=32 at 8k/16k tokens
+            # (~3.5 vs ~1.9 TB/s effective BW), numerically identical.
+            CONTIG_BLOCK_M = 8
+            grid = (triton.cdiv(batch_size, CONTIG_BLOCK_M), n_heads)
             apply_rotary_emb_contig_kernel[grid](
                 x,
                 freqs_real,
@@ -320,9 +326,10 @@ def apply_rotary_emb_triton(
                 freqs_real.stride(1),
                 USE_POS=(positions is not None),
                 IS_INVERSE=inverse,
-                BLOCK_M=BLOCK_M,
+                BLOCK_M=CONTIG_BLOCK_M,
                 RD=RD,
                 RDH=RD // 2,
+                num_warps=4,
             )
             return x
         BLOCK_P = max(triton.next_power_of_2(rope_dim // 2), 1)


### PR DESCRIPTION
## Motivation

The contiguous-load RoPE Triton kernel (`apply_rotary_emb_contig_kernel`, ATOM-style GPT-J rope used for the DeepSeek-V4 attention q/k position embedding) was launched with `BLOCK_M=32` and the Triton-default `num_warps`. On AMD MI300 this configuration is memory-bandwidth inefficient for prefill-sized inputs: each program processes a `[BLOCK_M, RD]` tile and performs a per-program `reshape -> flip -> reshape` over the rope pairs. With `BLOCK_M=32` the grid produces too few programs to saturate the CUs and the per-program flip/register pressure grows, leaving the kernel at only ~1.9 TB/s effective bandwidth (HBM peak ~5.3 TB/s).

## Modifications

- In `apply_rotary_emb_triton` (3D contig path in `python/sglang/srt/layers/deepseek_v4_rope.py`), use a dedicated `CONTIG_BLOCK_M = 8` and pass `num_warps=4` explicitly to the contig kernel launch.
- Smaller `BLOCK_M` -> 4x more programs (better CU occupancy) and a smaller per-program tile (cheaper flip), which together push the kernel toward being properly memory-bound.
- The 2D batched path (`apply_rotary_emb_triton_kernel_batched`) is left unchanged (`BLOCK_M=32`).
- No kernel logic changes; only launch configuration. Output is numerically identical.

## Accuracy Tests

**End-to-end GSM8k (DeepSeek-V4-Pro, TP8 + DP attention, 5-shot)** with this change:

| Tasks | Filter | n-shot | Metric | Value | Stderr |
|---|---|---|---|---|---|
| gsm8k | flexible-extract | 5 | exact_match | **0.9484** | ±0.0061 |
| gsm8k | strict-match | 5 | exact_match | **0.9484** | ±0.0061 |

Additionally, the contig kernel output is equivalent across `BLOCK_M in {8, 16, 32}` (the only differences are the expected bf16 rounding vs. the per-token reference kernel), for both forward and inverse rope:

| inverse | BLOCK_M=8 | BLOCK_M=16 | BLOCK_M=32 |
|---|---|---|---|
| False | 3.9e-03 | 3.9e-03 | 3.9e-03 |
| True  | 1.6e-02 | 1.6e-02 | 1.6e-02 |

(max abs error vs. per-token kernel; identical across BLOCK_M -> the change does not affect numerics.)

## Speed Tests and Profiling

Microbenchmark on MI300, `rope_dim=64`, inverse rope, realistic DeepSeek-V4 prefill shapes (TP8 -> 16 q heads), best-of-5:

| shape | old (`BLOCK_M=32`, `num_warps=4`) | new (`BLOCK_M=8`, `num_warps=4`) | speedup |
|---|---|---|---|
| q_pe 8k tokens (16 heads)  | 17.8 us / 1.9 TB/s | **11.4 us / 2.9 TB/s** | ~1.6x |
| q_pe 16k tokens (16 heads) | 34.2 us / 2.0 TB/s | **19.0 us / 3.5 TB/s** | ~1.8x |
| q_pe 4k / k_pe (1 head)    | ~11.5 us (launch floor) | ~11.5 us | no change |

A full sweep of `BLOCK_M in {8,16,32,64,128,256}` x `num_warps in {1,2,4,8}` confirmed `BLOCK_M=8, num_warps=4` is the best (or tied-best) config across all prefill sizes; small shapes are already latency/launch-floored (~11.5 us), so the smaller `BLOCK_M` causes no regression there.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.
