### PR TITLE
Pass DSA topk through PP warmup proxy buffers

### DIFF
--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -78,6 +78,7 @@ def _allocate_decode_buffers(
     enable_mamba_track: bool,
     ne_token_table: Optional[torch.Tensor] = None,
     hc_hidden_size: Optional[int] = None,
+    pp_proxy_topk_size: Optional[int] = None,
 ) -> SimpleNamespace:
     """Allocate the FB-shared decode buffers."""
     with torch.device(device):
@@ -114,6 +115,10 @@ def _allocate_decode_buffers(
             if not is_mhc:
                 pp_proxy_tensors["residual"] = torch.zeros(
                     (max_bs, hidden_size), dtype=dtype
+                )
+            if pp_proxy_topk_size is not None:
+                pp_proxy_tensors["topk_indices"] = torch.zeros(
+                    (max_num_token, pp_proxy_topk_size), dtype=torch.int32
                 )
         else:
             pp_proxy_tensors = None
@@ -429,6 +434,7 @@ class BaseRunner(ABC):
             cache_loc_dtype=torch.int64,
             enable_mamba_track=False,
             hc_hidden_size=getattr(mr.model_config, "hc_hidden_size", None),
+            pp_proxy_topk_size=mr.get_pp_proxy_topk_size(),
         )
 
     def _dummy_run(

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -190,6 +190,11 @@ class EagerRunner(BaseRunner):
                 pp_proxy_tensors["residual"] = torch.zeros(
                     (rows, hidden_size), dtype=mr.dtype, device=mr.device
                 )
+            pp_proxy_topk_size = mr.get_pp_proxy_topk_size()
+            if pp_proxy_topk_size is not None:
+                pp_proxy_tensors["topk_indices"] = torch.zeros(
+                    (rows, pp_proxy_topk_size), dtype=torch.int32, device=mr.device
+                )
 
         adapter = SimpleNamespace(
             input_ids=_slot("input_ids"),

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2387,6 +2387,13 @@ class DeepseekV2Model(nn.Module):
     def get_input_embeddings(self) -> torch.Tensor:
         return self.embed_tokens
 
+    def _dsa_forward_uses_topk(self) -> bool:
+        if not self.use_dsa:
+            return False
+        backend = get_attn_backend()
+        backend = getattr(backend, "primary", backend)
+        return not getattr(backend, "use_mha", False)
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -2396,6 +2403,7 @@ class DeepseekV2Model(nn.Module):
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> Union[torch.Tensor, PPProxyTensors]:
         total_num_layers = self.end_layer - self.start_layer
+        dsa_forward_uses_topk = self._dsa_forward_uses_topk()
         if self.pp_group.is_first_rank:
             if input_embeds is None:
                 hidden_states = self.embed_tokens(input_ids)
@@ -2411,6 +2419,7 @@ class DeepseekV2Model(nn.Module):
                 not forward_batch.forward_mode.is_idle()
                 and hidden_states.shape[0] != 0
                 and self.use_dsa
+                and dsa_forward_uses_topk
                 and dsa_layer_skips_topk(self.config, self.start_layer)
                 and topk_indices is None
             ), (
@@ -2515,6 +2524,7 @@ class DeepseekV2Model(nn.Module):
             }
             if (
                 self.use_dsa
+                and dsa_forward_uses_topk
                 and self.end_layer < self.config.num_hidden_layers
                 and dsa_layer_skips_topk(self.config, self.end_layer)
             ):


### PR DESCRIPTION
## Summary

Fixes #28659 as a tiny follow-up to #28532 after #28740 moved autotune to runner-owned dummy buffers, adding `topk_indices` to those PP warmup proxy buffers too for GLM-5.2 DSA splits.

It also avoids asking for top-k on short extend batches that take the dense MHA path, since that path does not produce top-k.

## Verification

Ran on GB300:

```bash
CUDA_VISIBLE_DEVICES=0,1 sglang serve \
  --model-path mmangkad/GLM-5.2-NVFP4 \
  --pipeline-parallel-size 2 \
  --quantization modelopt_fp4 \
  --mem-fraction-static 0.9 \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --trust-remote-code
```

```bash
sgl-eval run \
  --base-url http://127.0.0.1:30000/v1 \
  --num-threads 2048 \
  --temperature 1.0 \
  gsm8k
```

Score: `97.95%`























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27890508901](https://github.com/sgl-project/sglang/actions/runs/27890508901)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27890583594](https://github.com/sgl-project/sglang/actions/runs/27890583594)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->