### PR TITLE
[B300] Enable FlashInfer allreduce for Qwen3-VL MoE

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2764,10 +2764,11 @@ class ServerArgs:
 
         # Auto-enable FlashInfer AllReduce Fusion on SM100 only, for models with
         # explicit support (DeepseekV3, GptOss, Glm4Moe, MistralLarge3,
-        # Qwen3/Qwen3Next/Qwen3.5 MoE families). SM90 is not auto-enabled because
-        # auto resolves to mnnvl, which requires a working NVLink multicast fabric
-        # that SM90 nodes do not reliably have; SM90 users can opt in explicitly
-        # via --flashinfer-allreduce-fusion-backend.
+        # Qwen3/Qwen3-VL/Qwen3Next/Qwen3.5 MoE families). SM90 is not
+        # auto-enabled because auto resolves to mnnvl, which requires a working
+        # NVLink multicast fabric that SM90 nodes do not reliably have; SM90
+        # users can opt in explicitly via
+        # --flashinfer-allreduce-fusion-backend.
         if (
             self.flashinfer_allreduce_fusion_backend is None
             and model_arch
@@ -2780,6 +2781,7 @@ class ServerArgs:
                 "Glm4MoeLiteForCausalLM",
                 "MistralLarge3ForCausalLM",
                 "Qwen3MoeForCausalLM",
+                "Qwen3VLMoeForConditionalGeneration",
                 "Qwen3NextForCausalLM",
                 "KimiK25ForConditionalGeneration",
                 "Qwen3_5MoeForConditionalGeneration",


### PR DESCRIPTION
## Summary

This PR enables FlashInfer allreduce fusion by default for Qwen3-VL MoE on the existing SM100 auto-enable path used by other supported MoE models:

- add `Qwen3VLMoeForConditionalGeneration` to the FlashInfer allreduce-fusion allowlist
- keep the existing guards unchanged: `flashinfer_allreduce_fusion_backend is None`, TP > 1, no DP attention, and `moe_a2a_backend == "none"`
- no FlashInfer JIT/AOT workaround is included in this PR

Qwen3-VL MoE reuses the Qwen3 MoE decoder/layer-communicator path, and the optimization already works when explicitly enabled with FlashInfer allreduce fusion. This PR makes that optimized path the default under the same safety conditions as the other supported MoE families.

## Environment Note

During B300 validation, the container had a FlashInfer package mismatch:

| Package | Version |
| --- | --- |
| `flashinfer-python` | `0.6.12` |
| `flashinfer-cubin` | `0.6.12` |
| `flashinfer-jit-cache` | `0.6.11.post1+cu130` |

That mismatch made FlashInfer 0.6.12 Python pass `weight_bias` to a stale 0.6.11 AOT `trtllm_mnnvl_allreduce_fusion` binary, causing a 16-arg vs 15-arg ABI error. The benchmark used a test-environment workaround to load the compatible 0.6.12 JIT cache. That workaround is intentionally not part of this PR.

## Benchmark

Hardware and workload:

- single-node 8x NVIDIA B300 SXM6 AC
- FP8 checkpoint: `Qwen/Qwen3-VL-235B-A22B-Instruct-FP8`
- random workload, 80 prompts each
- `chat`: 1000 input / 1000 output
- `summarization`: 8000 input / 1000 output
- request rate 4, max concurrency 8
- SLA: p50 TTFT <= 1500 ms, p50 TPOT <= 30 ms, success rate >= 0.99

Effect of enabling FlashInfer allreduce fusion:

| Candidate | Chat req/s | Summ req/s | Geomean req/s | Notes |
| --- | ---: | ---: | ---: | --- |
| SGLang before enabling | 0.9976 | 0.8937 | 0.9442 | same 8x B300 budget |
| SGLang with FlashInfer AR fusion | 1.0385 | 0.9570 | 0.9969 | selected run |
| SGLang with FlashInfer AR fusion repeat | 1.0257 | 0.9574 | 0.9900 | repeat run |

Improvement over the SGLang pre-enable baseline:

| Run | Chat | Summarization | Geomean |
| --- | ---: | ---: | ---: |
| Selected | +4.1% | +7.1% | +5.6% |
| Repeat | +2.8% | +7.1% | +4.9% |

Framework comparison under the same workload/SLA:

| Candidate | Chat req/s | Chat output tok/s | Chat p50 TTFT | Chat p50 TPOT | Summ req/s | Summ output tok/s | Summ p50 TTFT | Summ p50 TPOT |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| SGLang with FlashInfer AR fusion | 1.0385 | 497.37 | 107.57 ms | 14.55 ms | 0.9570 | 457.39 | 150.83 ms | 15.79 ms |
| SGLang repeat | 1.0257 | 491.22 | 153.31 ms | 14.71 ms | 0.9574 | 457.58 | 141.67 ms | 15.77 ms |
| vLLM best | 1.0305 | 493.54 | 85.17 ms | 14.78 ms | 0.9649 | 461.14 | 140.94 ms | 15.75 ms |
| TensorRT-LLM best | 0.9676 | 463.41 | 90.76 ms | 15.61 ms | 0.8946 | 427.54 | 148.70 ms | 16.86 ms |

## Accuracy / Correctness Report

Full accuracy was validated with the same SGLang serving configuration used for the selected benchmark run, with FlashInfer allreduce fusion enabled. This PR only changes default enablement policy, but the full evals below verify the optimized path used by the benchmark.

| Check | Configuration | Examples | Score | Std | Evidence |
| --- | --- | ---: | ---: | ---: | --- |
| MMLU full | SGLang + FlashInfer AR fusion, `--max-tokens 1024`, temperature 0 | 14042 | 0.874519 | 0.331263 | `accuracy/selected_mixedchunk_full_accuracy/run_20260620_092945/results/mmlu_full.json` |
| GSM8K full | SGLang + FlashInfer AR fusion, 5-shot, `--max-tokens 512`, temperature 0 | 1314 | 0.957382 | 0.201994 | `accuracy/selected_mixedchunk_gsm8k_full/run_20260620_100009/results/gsm8k_full.json` |
| VLM smoke | OpenAI-compatible image request with a 1x1 red image | 1 | returned `Red` | n/a | HTTP 200 `/v1/chat/completions` smoke |

MMLU category breakdown:

| Category | Score |
| --- | ---: |
| STEM | 0.901590 |
| Social sciences | 0.916802 |
| Humanities | 0.816366 |
| Other | 0.893584 |

## Validation

- `python3 -m compileall -q python/sglang/srt/server_args.py`
- `git diff --check origin/main...HEAD`
- remote PR branch is based on the latest fetched `sgl-project/sglang:main`
- fixed fair benchmark against SGLang/vLLM/TensorRT-LLM
- full MMLU and GSM8K evals through the selected SGLang serving command

NCU was not collected because this PR only changes the default enablement policy and does not edit CUDA/Triton kernels.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27872922126](https://github.com/sgl-project/sglang/actions/runs/27872922126)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27872922027](https://github.com/sgl-project/sglang/actions/runs/27872922027)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->