### PR TITLE
[Test] Add unit tests for prefill_delayer and template_detection (#20865)

### DIFF
--- a/test/registered/unit/managers/test_prefill_delayer.py
+++ b/test/registered/unit/managers/test_prefill_delayer.py
@@ -1,0 +1,273 @@
+"""Unit tests for sglang.srt.managers.prefill_delayer."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.managers.prefill_delayer import (
+    PrefillDelayer,
+    PrefillDelayerSinglePassExecutor,
+    _NegotiateOutput,
+    _State,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_delayer_mock(
+    *,
+    max_delay_passes: int = 3,
+    token_usage_low_watermark=None,
+    queue_trigger_enabled: bool = False,
+    queue_min_ratio=None,
+    max_delay_ms: float = 5000.0,
+    enable_dp_attention: bool = True,
+    dp_size: int = 1,
+    skip_first_delayer: bool = False,
+) -> MagicMock:
+    """Return a minimal MagicMock usable with _negotiate_should_allow_prefill_pure."""
+    mock = MagicMock(spec=PrefillDelayer)
+    mock._max_delay_passes = max_delay_passes
+    mock._token_usage_low_watermark = token_usage_low_watermark
+    mock._queue_trigger_enabled = queue_trigger_enabled
+    mock._queue_min_ratio = queue_min_ratio
+    mock._max_delay_ms = max_delay_ms
+    mock.enable_dp_attention = enable_dp_attention
+    mock.dp_size = dp_size
+    mock.skip_first_delayer = skip_first_delayer
+    return mock
+
+
+def _gather_side_effect(rows):
+    """Return a callable that makes _gather_info return an int64 tensor for the given rows."""
+    t = torch.tensor(rows, dtype=torch.int64)
+
+    def _fn(*args, **kwargs):
+        return t
+
+    return _fn
+
+
+class TestState(CustomTestCase):
+    def test_initial_delayed_count_is_zero(self):
+        """Default _State has delayed_count of zero."""
+        state = _State()
+        self.assertEqual(state.delayed_count, 0)
+
+    def test_bump_delayed_count_increments_by_one(self):
+        """bump_delayed_count returns a new _State with delayed_count incremented by one."""
+        state = _State(delayed_count=2)
+        self.assertEqual(state.bump_delayed_count().delayed_count, 3)
+
+    def test_bump_delayed_count_returns_new_instance(self):
+        """bump_delayed_count produces a new instance without modifying the original."""
+        state = _State(delayed_count=0)
+        bumped = state.bump_delayed_count()
+        self.assertEqual(state.delayed_count, 0)
+        self.assertIsNot(state, bumped)
+
+    def test_multiple_bumps_accumulate(self):
+        """Successive bump_delayed_count calls accumulate correctly."""
+        state = _State()
+        for _ in range(5):
+            state = state.bump_delayed_count()
+        self.assertEqual(state.delayed_count, 5)
+
+
+class TestNegotiateOutput(CustomTestCase):
+    def test_default_wait_fields_are_zero(self):
+        """wait_forward_passes and wait_seconds default to 0 and 0.0."""
+        out = _NegotiateOutput(
+            next_state=None,
+            input_estimation="all",
+            output_allow=True,
+            output_reason="no_wait",
+            num_prefillable=1,
+            num_token_watermark_force_allow=0,
+        )
+        self.assertEqual(out.wait_forward_passes, 0)
+        self.assertAlmostEqual(out.wait_seconds, 0.0)
+
+    def test_explicit_wait_fields_stored_correctly(self):
+        """Explicit wait_forward_passes and wait_seconds are stored correctly."""
+        out = _NegotiateOutput(
+            next_state=None,
+            input_estimation="mixed",
+            output_allow=False,
+            output_reason="delay",
+            num_prefillable=1,
+            num_token_watermark_force_allow=0,
+            wait_forward_passes=4,
+            wait_seconds=2.5,
+        )
+        self.assertEqual(out.wait_forward_passes, 4)
+        self.assertAlmostEqual(out.wait_seconds, 2.5)
+
+
+class TestNegotiateShouldAllowPrefillPure(CustomTestCase):
+    """Tests for PrefillDelayer._negotiate_should_allow_prefill_pure via a mocked self."""
+
+    def _call(
+        self,
+        mock,
+        prev_state=None,
+        local_prefillable=True,
+        token_usage=0.5,
+        running_batch=0,
+        max_prefill_bs=0,
+        max_running_requests=0,
+        waiting_queue_len=0,
+    ):
+        return PrefillDelayer._negotiate_should_allow_prefill_pure(
+            mock,
+            prev_state=prev_state,
+            local_prefillable=local_prefillable,
+            token_usage=token_usage,
+            running_batch=running_batch,
+            max_prefill_bs=max_prefill_bs,
+            max_running_requests=max_running_requests,
+            waiting_queue_len=waiting_queue_len,
+        )
+
+    def test_none_prefillable_status_always_allows(self):
+        """prefillable_status=none (all ranks non-prefillable) always returns output_allow=True."""
+        mock = _make_delayer_mock()
+        mock._gather_info.side_effect = _gather_side_effect([[0, 0, 0, 0, 0]])
+        out = self._call(mock)
+        self.assertTrue(out.output_allow)
+        self.assertEqual(out.input_estimation, "none")
+
+    def test_all_global_token_watermark_force_allows(self):
+        """prefillable_status=all with global watermark force flag returns token_watermark reason."""
+        mock = _make_delayer_mock()
+        # col 0: prefillable=1 -> "all"; col 1: token_watermark_force_allow=1 -> force allow
+        mock._gather_info.side_effect = _gather_side_effect([[1, 1, 0, 0, 0]])
+        out = self._call(mock)
+        self.assertTrue(out.output_allow)
+        self.assertEqual(out.output_reason, "token_watermark")
+
+    def test_all_no_condition_no_prev_state_returns_no_wait(self):
+        """prefillable_status=all with no slot/queue condition and no prev_state returns no_wait."""
+        mock = _make_delayer_mock()
+        # running_batch=1, max_prefill_bs=1; max_running_requests=100 -> slot_condition False
+        mock._gather_info.side_effect = _gather_side_effect([[1, 0, 1, 1, 0]])
+        out = self._call(mock, max_running_requests=100, max_prefill_bs=1)
+        self.assertTrue(out.output_allow)
+        self.assertEqual(out.output_reason, "no_wait")
+
+    def test_all_prev_state_no_condition_returns_wait_success(self):
+        """prefillable_status=all with prev_state and no condition returns wait_success."""
+        mock = _make_delayer_mock()
+        mock._gather_info.side_effect = _gather_side_effect([[1, 0, 1, 1, 0]])
+        prev = _State(delayed_count=2)
+        out = self._call(
+            mock, prev_state=prev, max_running_requests=100, max_prefill_bs=1
+        )
+        self.assertTrue(out.output_allow)
+        self.assertEqual(out.output_reason, "wait_success")
+        self.assertEqual(out.wait_forward_passes, 2)
+
+    def test_all_skip_first_delayer_allows_on_slot_condition(self):
+        """skip_first_delayer=True causes the first slot-condition hit to be skipped."""
+        mock = _make_delayer_mock(skip_first_delayer=True)
+        # slot_condition: max_running_requests=10, running_batch=9, max_prefill_bs=5 -> 10-9=1 < 5
+        mock._gather_info.side_effect = _gather_side_effect([[1, 0, 9, 5, 0]])
+        out = self._call(mock, max_running_requests=10, max_prefill_bs=5)
+        self.assertTrue(out.output_allow)
+        self.assertFalse(mock.skip_first_delayer)
+
+    def test_all_slot_condition_delays_prefill(self):
+        """prefillable_status=all with slot condition and skip_first_delayer=False delays."""
+        mock = _make_delayer_mock(skip_first_delayer=False)
+        # slot_condition: 10 - 9 = 1 < 5
+        mock._gather_info.side_effect = _gather_side_effect([[1, 0, 9, 5, 0]])
+        out = self._call(mock, max_running_requests=10, max_prefill_bs=5)
+        self.assertFalse(out.output_allow)
+        self.assertEqual(out.output_reason, "delay")
+
+    def test_mixed_global_token_watermark_force_allows(self):
+        """prefillable_status=mixed with global watermark force flag returns token_watermark reason."""
+        mock = _make_delayer_mock()
+        # two ranks: one prefillable, one not -> "mixed"; first rank has token_watermark=1
+        mock._gather_info.side_effect = _gather_side_effect(
+            [[1, 1, 0, 0, 0], [0, 0, 0, 0, 0]]
+        )
+        out = self._call(mock)
+        self.assertTrue(out.output_allow)
+        self.assertEqual(out.output_reason, "token_watermark")
+
+    def test_mixed_delays_within_max_passes(self):
+        """prefillable_status=mixed delays when delayed_count < max_delay_passes - 1."""
+        mock = _make_delayer_mock(max_delay_passes=3)
+        mock._gather_info.side_effect = _gather_side_effect(
+            [[1, 0, 0, 0, 0], [0, 0, 0, 0, 0]]
+        )
+        prev = _State(delayed_count=0)
+        out = self._call(mock, prev_state=prev)
+        self.assertFalse(out.output_allow)
+        self.assertEqual(out.output_reason, "delay")
+        self.assertEqual(out.next_state.delayed_count, 1)
+
+    def test_mixed_timeout_allows_after_max_passes(self):
+        """prefillable_status=mixed allows with wait_timeout when delayed_count >= max_delay_passes - 1."""
+        mock = _make_delayer_mock(max_delay_passes=3)
+        mock._gather_info.side_effect = _gather_side_effect(
+            [[1, 0, 0, 0, 0], [0, 0, 0, 0, 0]]
+        )
+        prev = _State(delayed_count=2)
+        out = self._call(mock, prev_state=prev)
+        self.assertTrue(out.output_allow)
+        self.assertEqual(out.output_reason, "wait_timeout")
+
+
+class TestPrefillDelayerSinglePassExecutor(CustomTestCase):
+    def _make_executor(self, output_allow: bool = True):
+        delayer = MagicMock(spec=PrefillDelayer)
+        delayer._metrics_collector = None
+        delayer._negotiate_should_allow_prefill.return_value = _NegotiateOutput(
+            next_state=None,
+            input_estimation="all",
+            output_allow=output_allow,
+            output_reason="no_wait",
+            num_prefillable=1,
+            num_token_watermark_force_allow=0,
+        )
+        return PrefillDelayerSinglePassExecutor(delayer, token_usage=0.5), delayer
+
+    def test_negotiate_is_idempotent(self):
+        """negotiate_should_allow_prefill called multiple times only invokes delayer once."""
+        executor, delayer = self._make_executor(output_allow=True)
+        result1 = executor.negotiate_should_allow_prefill(local_prefillable=True)
+        result2 = executor.negotiate_should_allow_prefill(local_prefillable=False)
+        self.assertEqual(result1, result2)
+        delayer._negotiate_should_allow_prefill.assert_called_once()
+
+    def test_finalize_without_prior_negotiate_calls_negotiate_with_false(self):
+        """finalize with no prior negotiate call invokes negotiate with local_prefillable=False."""
+        executor, delayer = self._make_executor()
+        delayer._negotiate_should_allow_prefill.assert_not_called()
+        executor.finalize(actual_prefill=False)
+        delayer._negotiate_should_allow_prefill.assert_called_once_with(
+            local_prefillable=False,
+            token_usage=0.5,
+            running_batch=0,
+            max_prefill_bs=0,
+            max_running_requests=0,
+            waiting_queue_len=0,
+        )
+
+    def test_finalize_after_negotiate_does_not_call_negotiate_again(self):
+        """finalize after negotiate_should_allow_prefill does not trigger a second negotiate call."""
+        executor, delayer = self._make_executor()
+        executor.negotiate_should_allow_prefill(local_prefillable=True)
+        delayer._negotiate_should_allow_prefill.assert_called_once()
+        executor.finalize(actual_prefill=True)
+        delayer._negotiate_should_allow_prefill.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_prefill_delayer.py
+++ b/test/registered/unit/managers/test_prefill_delayer.py
@@ -4,6 +4,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
+import time
 import unittest
 from unittest.mock import MagicMock
 
@@ -222,6 +223,60 @@ class TestNegotiateShouldAllowPrefillPure(CustomTestCase):
         out = self._call(mock, prev_state=prev)
         self.assertTrue(out.output_allow)
         self.assertEqual(out.output_reason, "wait_timeout")
+
+    def test_all_queue_condition_delays_prefill(self):
+        """prefillable_status=all with queue condition delays prefill."""
+        mock = _make_delayer_mock(
+            queue_trigger_enabled=True,
+            queue_min_ratio=0.5,
+            skip_first_delayer=False,
+        )
+        # col 2: running_batch=10, col 3: max_prefill_bs=4, col 4: waiting_queue_len=2
+        # queue_min_effective = min(int(10 * 0.5), 4) = 4; waiting_queue_len=2 < 4 -> delay.
+        # slot_condition: max_running_requests=100 -> 100 - 10 = 90 < 4 is False, so only
+        # the queue trigger fires.
+        mock._gather_info.side_effect = _gather_side_effect([[1, 0, 10, 4, 2]])
+        out = self._call(mock, max_running_requests=100, max_prefill_bs=4)
+        self.assertFalse(out.output_allow)
+        self.assertEqual(out.output_reason, "delay")
+
+    def test_all_queue_condition_within_timeout_still_delays(self):
+        """prefillable_status=all with queue condition and elapsed < max_delay_ms still delays."""
+        mock = _make_delayer_mock(
+            queue_trigger_enabled=True,
+            queue_min_ratio=0.5,
+            max_delay_ms=5000.0,
+            skip_first_delayer=False,
+        )
+        mock._gather_info.side_effect = _gather_side_effect([[1, 0, 10, 4, 2]])
+        # prev_state started "now", so elapsed is ~0ms << 5000ms: timeout does not fire,
+        # queue_condition stays True and the prefill is delayed.
+        prev = _State()
+        out = self._call(
+            mock, prev_state=prev, max_running_requests=100, max_prefill_bs=4
+        )
+        self.assertFalse(out.output_allow)
+        self.assertEqual(out.output_reason, "delay")
+
+    def test_all_queue_condition_timeout_allows_prefill(self):
+        """prefillable_status=all with queue condition but elapsed >= max_delay_ms allows prefill."""
+        mock = _make_delayer_mock(
+            queue_trigger_enabled=True,
+            queue_min_ratio=0.5,
+            max_delay_ms=100.0,
+            skip_first_delayer=False,
+        )
+        mock._gather_info.side_effect = _gather_side_effect([[1, 0, 10, 4, 2]])
+        # start_time 200ms in the past > 100ms max_delay_ms: the wall-clock timeout
+        # resets queue_condition to False, so the prefill is released. Because a
+        # prev_state exists, the reason is "wait_success" (not "wait_timeout", which
+        # only the "mixed" branch produces).
+        prev = _State(start_time=time.perf_counter() - 0.2)
+        out = self._call(
+            mock, prev_state=prev, max_running_requests=100, max_prefill_bs=4
+        )
+        self.assertTrue(out.output_allow)
+        self.assertEqual(out.output_reason, "wait_success")
 
 
 class TestPrefillDelayerSinglePassExecutor(CustomTestCase):

--- a/test/registered/unit/managers/test_template_detection.py
+++ b/test/registered/unit/managers/test_template_detection.py
@@ -1,0 +1,224 @@
+"""Unit tests for sglang.srt.managers.template_detection."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import re
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.managers.template_detection import (
+    DetectionRule,
+    ReasoningToggleConfig,
+    TemplateDetectionContext,
+    build_detection_context,
+    detect_reasoning_parser,
+    detect_reasoning_pattern,
+    detect_tool_call_parser,
+    match_rules,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestReasoningToggleConfig(CustomTestCase):
+    def test_always_on_true_when_special_case_is_always(self):
+        """always_on is True when special_case is 'always'."""
+        cfg = ReasoningToggleConfig(special_case="always")
+        self.assertTrue(cfg.always_on)
+
+    def test_always_on_false_when_special_case_is_other_value(self):
+        """always_on is False when special_case is any value other than 'always'."""
+        cfg = ReasoningToggleConfig(special_case="mistral")
+        self.assertFalse(cfg.always_on)
+
+    def test_always_on_false_when_special_case_is_none(self):
+        """always_on is False when special_case is None."""
+        cfg = ReasoningToggleConfig()
+        self.assertFalse(cfg.always_on)
+
+
+class TestTemplateDetectionContext(CustomTestCase):
+    def setUp(self):
+        self.ctx = TemplateDetectionContext(
+            template="hello <|channel|> world",
+            reasoning_config=None,
+            force_reasoning=False,
+            vocab={"<think>", "<tool_call>"},
+        )
+
+    def test_has_text_present(self):
+        """has_text returns True when the needle is a substring of the template."""
+        self.assertTrue(self.ctx.has_text("<|channel|>"))
+
+    def test_has_text_absent(self):
+        """has_text returns False when the needle is not in the template."""
+        self.assertFalse(self.ctx.has_text("<missing>"))
+
+    def test_has_vocab_present(self):
+        """has_vocab returns True when the token exists in the vocabulary set."""
+        self.assertTrue(self.ctx.has_vocab("<think>"))
+
+    def test_has_vocab_absent(self):
+        """has_vocab returns False when the token is not in the vocabulary set."""
+        self.assertFalse(self.ctx.has_vocab("<unknown>"))
+
+    def test_has_pattern_matches(self):
+        """has_pattern returns True when the regex matches the template."""
+        self.assertTrue(self.ctx.has_pattern(r"<\|channel\|>"))
+
+    def test_has_pattern_no_match(self):
+        """has_pattern returns False when the regex does not match the template."""
+        self.assertFalse(self.ctx.has_pattern(r"<missing>"))
+
+    def test_has_pattern_with_dotall_flag(self):
+        """has_pattern with re.DOTALL matches a pattern that spans a newline."""
+        ctx = TemplateDetectionContext(
+            template="start\nend",
+            reasoning_config=None,
+            force_reasoning=False,
+            vocab=set(),
+        )
+        self.assertTrue(ctx.has_pattern(r"start.end", re.DOTALL))
+        self.assertFalse(ctx.has_pattern(r"start.end"))
+
+
+class TestBuildDetectionContext(CustomTestCase):
+    def test_none_template_returns_none(self):
+        """build_detection_context returns None when template is None."""
+        self.assertIsNone(build_detection_context(None, tokenizer=None))
+
+    def test_none_tokenizer_yields_empty_vocab(self):
+        """build_detection_context with tokenizer=None produces an empty vocab."""
+        ctx = build_detection_context("some template", tokenizer=None)
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx.vocab, set())
+
+    def test_tokenizer_vocab_is_loaded(self):
+        """build_detection_context populates vocab from tokenizer.get_vocab()."""
+        mock_tok = MagicMock()
+        mock_tok.get_vocab.return_value = {"<think>": 0, "<tool_call>": 1}
+        ctx = build_detection_context("template", mock_tok)
+        self.assertIn("<think>", ctx.vocab)
+        self.assertIn("<tool_call>", ctx.vocab)
+
+    def test_tokenizer_get_vocab_exception_yields_empty_vocab(self):
+        """build_detection_context returns empty vocab when tokenizer.get_vocab() raises."""
+        mock_tok = MagicMock()
+        mock_tok.get_vocab.side_effect = RuntimeError("broken vocab")
+        ctx = build_detection_context("template", mock_tok)
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx.vocab, set())
+
+
+class TestMatchRules(CustomTestCase):
+    def setUp(self):
+        self.ctx = TemplateDetectionContext(
+            template="",
+            reasoning_config=None,
+            force_reasoning=False,
+            vocab=set(),
+        )
+
+    def test_first_matching_rule_is_returned(self):
+        """match_rules returns the value of the first rule whose predicate is True."""
+        rules = (
+            DetectionRule(name="r1", value="v1", predicate=lambda c: True),
+            DetectionRule(name="r2", value="v2", predicate=lambda c: True),
+        )
+        self.assertEqual(match_rules(self.ctx, rules, "test"), "v1")
+
+    def test_no_matching_rule_returns_none(self):
+        """match_rules returns None when no predicate matches."""
+        rules = (DetectionRule(name="r1", value="v1", predicate=lambda c: False),)
+        self.assertIsNone(match_rules(self.ctx, rules, "test"))
+
+    def test_exception_in_predicate_skips_that_rule(self):
+        """match_rules skips a rule whose predicate raises and continues to the next rule."""
+
+        def _bad_predicate(ctx):
+            raise ValueError("oops")
+
+        rules = (
+            DetectionRule(name="bad", value="bad_val", predicate=_bad_predicate),
+            DetectionRule(name="good", value="good_val", predicate=lambda c: True),
+        )
+        self.assertEqual(match_rules(self.ctx, rules, "test"), "good_val")
+
+
+class TestDetectReasoningPattern(CustomTestCase):
+    def test_none_template_returns_false_and_none(self):
+        """detect_reasoning_pattern returns (False, None) for None template."""
+        is_always_on, config = detect_reasoning_pattern(None)
+        self.assertFalse(is_always_on)
+        self.assertIsNone(config)
+
+    def test_unrecognized_template_returns_false_and_none(self):
+        """detect_reasoning_pattern returns (False, None) for a template with no known markers."""
+        is_always_on, config = detect_reasoning_pattern(
+            "plain template without special markers"
+        )
+        self.assertFalse(is_always_on)
+        self.assertIsNone(config)
+
+    def test_gpt_oss_channel_marker_detected_as_always_on(self):
+        """Template containing <|channel|> is detected as always-on reasoning."""
+        is_always_on, config = detect_reasoning_pattern("some text <|channel|> here")
+        self.assertTrue(is_always_on)
+        self.assertEqual(config, ReasoningToggleConfig(special_case="always"))
+
+    def test_force_reasoning_pattern_detected_as_always_on(self):
+        """Template with im_start/think pattern is detected as always-on when thinking is absent."""
+        # literal \\n (backslash-n) in the template string matches the \\\\n in the regex
+        template = "<|im_start|>assistant\\n<think>\\n"
+        is_always_on, config = detect_reasoning_pattern(template)
+        self.assertTrue(is_always_on)
+        self.assertEqual(config, ReasoningToggleConfig(special_case="always"))
+
+    def test_mistral_reasoning_effort_detected(self):
+        """Template with reasoning_effort and [THINK] is detected as mistral reasoning config."""
+        template = "reasoning_effort [THINK] is supported"
+        is_always_on, config = detect_reasoning_pattern(template)
+        self.assertFalse(is_always_on)
+        self.assertEqual(config, ReasoningToggleConfig(special_case="mistral"))
+
+    def test_explicit_enable_thinking_default_false_detected(self):
+        """Template with enable_thinking=false default block is detected correctly."""
+        template = (
+            "{% if not enable_thinking is defined %}"
+            "{% set enable_thinking = false %}"
+        )
+        is_always_on, config = detect_reasoning_pattern(template)
+        self.assertFalse(is_always_on)
+        self.assertEqual(
+            config,
+            ReasoningToggleConfig(
+                toggle_param="enable_thinking", default_enabled=False
+            ),
+        )
+
+
+class TestDetectReasoningParser(CustomTestCase):
+    def test_none_template_returns_none(self):
+        """detect_reasoning_parser returns None when template is None."""
+        self.assertIsNone(detect_reasoning_parser(None, None))
+
+    def test_kimi_template_detected(self):
+        """Template with kimi thinking marker is detected as kimi reasoning parser."""
+        result = detect_reasoning_parser("text with \u25c1think\u25b7 marker", None)
+        self.assertEqual(result, "kimi")
+
+
+class TestDetectToolCallParser(CustomTestCase):
+    def test_none_template_returns_none(self):
+        """detect_tool_call_parser returns None when template is None."""
+        self.assertIsNone(detect_tool_call_parser(None, None))
+
+    def test_minimax_template_detected(self):
+        """Template with minimax marker is detected as minimax-m2 tool-call parser."""
+        result = detect_tool_call_parser("uses <minimax:tool_call>", None)
+        self.assertEqual(result, "minimax-m2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
No server, no GPU, no model loading.
Ref: #20865

48 tests covering PrefillDelayer and template detection utilities.

## Motivation

Added two new test files: `test/registered/unit/managers/test_prefill_delayer.py` and `test/registered/unit/managers/test_template_detection.py`

`managers/prefill_delayer.py` and `managers/template_detection.py` currently have no dedicated unit tests.

The prefill delayer implements a distributed negotiation protocol that decides whether to allow or delay prefill on each forward pass. Its core logic (`_negotiate_should_allow_prefill_pure`) branches across three global prefillability states (all/none/mixed), a token-watermark force-allow path, a slot-condition delay path with a skip-first-delayer guard, and a wall-clock timeout. The `PrefillDelayerSinglePassExecutor` wraps this with an idempotency contract and a finalize path. Both can regress silently.

The template detection module provides rule-based auto-detection of reasoning mode, reasoning parser, and tool-call parser from chat templates and tokenizer vocabularies. It powers `--reasoning-parser=auto` and `--tool-call-parser=auto`. The detection rules cover a wide range of model families (Kimi, Mistral, DeepSeek, Qwen3, GLM, MiniMax, GPT-OSS, etc.) and combine text matching, regex patterns, and vocabulary lookups. Regressions here silently disable parser auto-detection for affected models.

## Coverage

`prefill_delayer.py` (18 tests):

- `_State` — initial delayed_count, bump increments by one, returns new instance, multiple bumps accumulate.
- `_NegotiateOutput` — default wait fields are zero, explicit wait fields stored correctly.
- `_negotiate_should_allow_prefill_pure` — prefillable_status=none always allows; prefillable_status=all with global token watermark force-allows; all with no condition and no prev_state returns no_wait; all with prev_state returns wait_success with correct wait_forward_passes; skip_first_delayer=True skips first slot-condition hit; slot condition with skip_first_delayer=False delays prefill; mixed with global watermark force-allows; mixed delays within max_delay_passes; mixed allows with wait_timeout after max_delay_passes.
- `PrefillDelayerSinglePassExecutor` — negotiate is idempotent (delayer called exactly once); finalize without prior negotiate calls negotiate with local_prefillable=False; finalize after negotiate does not call negotiate again.

`template_detection.py` (27 tests):

- `ReasoningToggleConfig.always_on` — True when special_case is "always", False for other values, False when None.
- `TemplateDetectionContext` — has_text present/absent, has_vocab present/absent, has_pattern match/no-match, has_pattern with re.DOTALL across newlines.
- `build_detection_context` — None template returns None, None tokenizer yields empty vocab, tokenizer vocab is loaded, get_vocab exception yields empty vocab.
- `match_rules` — first matching rule returned, no match returns None, exception in predicate skips that rule.
- `detect_reasoning_pattern` — None template, unrecognized template, gpt_oss channel marker detected as always-on, force_reasoning pattern detected as always-on, mistral reasoning effort detected, explicit enable_thinking=false default detected.
- `detect_reasoning_parser` — None template returns None, kimi marker detected.
- `detect_tool_call_parser` — None template returns None, minimax marker detected.

The tests are CPU-only and do not start a server or load a model. `_negotiate_should_allow_prefill_pure` is tested via a `MagicMock` self with `_gather_info` patched to return controlled tensors, avoiding the `torch.distributed` all-gather. All other tests operate on real class instances. Both files are registered via:

```python
register_cpu_ci(est_time=5, suite="base-a-test-cpu")
```

## Test plan

```
python3 test/registered/unit/managers/test_prefill_delayer.py -v
```

```
test_default_wait_fields_are_zero (__main__.TestNegotiateOutput) ... ok
test_explicit_wait_fields_stored_correctly (__main__.TestNegotiateOutput) ... ok
test_all_global_token_watermark_force_allows (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_all_no_condition_no_prev_state_returns_no_wait (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_all_prev_state_no_condition_returns_wait_success (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_all_queue_condition_delays_prefill (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_all_queue_condition_timeout_allows_prefill (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_all_queue_condition_within_timeout_still_delays (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_all_skip_first_delayer_allows_on_slot_condition (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_all_slot_condition_delays_prefill (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_mixed_delays_within_max_passes (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_mixed_global_token_watermark_force_allows (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_mixed_timeout_allows_after_max_passes (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_none_prefillable_status_always_allows (__main__.TestNegotiateShouldAllowPrefillPure) ... ok
test_finalize_after_negotiate_does_not_call_negotiate_again (__main__.TestPrefillDelayerSinglePassExecutor) ... ok
test_finalize_without_prior_negotiate_calls_negotiate_with_false (__main__.TestPrefillDelayerSinglePassExecutor) ... ok
test_negotiate_is_idempotent (__main__.TestPrefillDelayerSinglePassExecutor) ... ok
test_bump_delayed_count_increments_by_one (__main__.TestState) ... ok
test_bump_delayed_count_returns_new_instance (__main__.TestState) ... ok
test_initial_delayed_count_is_zero (__main__.TestState) ... ok
test_multiple_bumps_accumulate (__main__.TestState) ... ok

----------------------------------------------------------------------
Ran 21 tests in 0.028s
```

```
python3 test/registered/unit/managers/test_template_detection.py -v
```

```
test_none_template_returns_none (__main__.TestBuildDetectionContext) ... ok
test_none_tokenizer_yields_empty_vocab (__main__.TestBuildDetectionContext) ... ok
test_tokenizer_get_vocab_exception_yields_empty_vocab (__main__.TestBuildDetectionContext) ... ok
test_tokenizer_vocab_is_loaded (__main__.TestBuildDetectionContext) ... ok
test_kimi_template_detected (__main__.TestDetectReasoningParser) ... ok
test_none_template_returns_none (__main__.TestDetectReasoningParser) ... ok
test_explicit_enable_thinking_default_false_detected (__main__.TestDetectReasoningPattern) ... ok
test_force_reasoning_pattern_detected_as_always_on (__main__.TestDetectReasoningPattern) ... ok
test_gpt_oss_channel_marker_detected_as_always_on (__main__.TestDetectReasoningPattern) ... ok
test_mistral_reasoning_effort_detected (__main__.TestDetectReasoningPattern) ... ok
test_none_template_returns_false_and_none (__main__.TestDetectReasoningPattern) ... ok
test_unrecognized_template_returns_false_and_none (__main__.TestDetectReasoningPattern) ... ok
test_minimax_template_detected (__main__.TestDetectToolCallParser) ... ok
test_none_template_returns_none (__main__.TestDetectToolCallParser) ... ok
test_exception_in_predicate_skips_that_rule (__main__.TestMatchRules) ... ok
test_first_matching_rule_is_returned (__main__.TestMatchRules) ... ok
test_no_matching_rule_returns_none (__main__.TestMatchRules) ... ok
test_always_on_false_when_special_case_is_none (__main__.TestReasoningToggleConfig) ... ok
test_always_on_false_when_special_case_is_other_value (__main__.TestReasoningToggleConfig) ... ok
test_always_on_true_when_special_case_is_always (__main__.TestReasoningToggleConfig) ... ok
test_has_pattern_matches (__main__.TestTemplateDetectionContext) ... ok
test_has_pattern_no_match (__main__.TestTemplateDetectionContext) ... ok
test_has_pattern_with_dotall_flag (__main__.TestTemplateDetectionContext) ... ok
test_has_text_absent (__main__.TestTemplateDetectionContext) ... ok
test_has_text_present (__main__.TestTemplateDetectionContext) ... ok
test_has_vocab_absent (__main__.TestTemplateDetectionContext) ... ok
test_has_vocab_present (__main__.TestTemplateDetectionContext) ... ok

----------------------------------------------------------------------
Ran 27 tests in 0.002s
```

## Accuracy Tests
N/A — this is a test-only change. No kernel or model-forward code is touched.

## Speed Tests and Profiling
N/A — this PR only adds unit tests and does not affect the inference path.

## Checklist
- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27882520584](https://github.com/sgl-project/sglang/actions/runs/27882520584)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27882520524](https://github.com/sgl-project/sglang/actions/runs/27882520524)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->