### PR TITLE
fix(io_struct): forward per-sample session_params in GenerateReqInput.__getitem__

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -728,8 +728,8 @@ class GenerateReqInput:
             return_indexer_topk=self.return_indexer_topk,
             modalities=self.modalities[i] if self.modalities else None,
             session_params=(
-                self.session_params[i]
-                if isinstance(self.session_params, list)
+                self.session_params[i % len(self.session_params)]
+                if isinstance(self.session_params, list) and self.session_params
                 else self.session_params
             ),
             lora_path=self.lora_path[i] if self.lora_path is not None else None,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -727,7 +727,11 @@ class GenerateReqInput:
             routed_experts_start_len=self.routed_experts_start_len,
             return_indexer_topk=self.return_indexer_topk,
             modalities=self.modalities[i] if self.modalities else None,
-            session_params=self.session_params,
+            session_params=(
+                self.session_params[i]
+                if isinstance(self.session_params, list)
+                else self.session_params
+            ),
             lora_path=self.lora_path[i] if self.lora_path is not None else None,
             lora_id=self.lora_id[i] if self.lora_id is not None else None,
             custom_logit_processor=(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -237,7 +237,7 @@ class GenerateReqInput:
     # The modalities of the image data [image, multi-images, video]
     modalities: Optional[List[str]] = None
     # Session info for continual prompting
-    session_params: Optional[Dict[str, Any]] = None
+    session_params: Optional[Union[List[Dict[str, Any]], Dict[str, Any]]] = None
 
     # The path to the LoRA adaptors
     lora_path: Optional[Union[List[Optional[str]], str]] = None
@@ -380,6 +380,7 @@ class GenerateReqInput:
         self._determine_batch_size()
         if self.session_id is not None and self.session_params is not None:
             raise ValueError("session_id and session_params cannot both be set.")
+        self._normalize_session_params()
         self._handle_parallel_sampling()
 
         if self.is_single:
@@ -471,6 +472,18 @@ class GenerateReqInput:
                 self.input_ids = [self.input_ids]
             if self.input_embeds is not None:
                 self.input_embeds = [self.input_embeds]
+
+    def _normalize_session_params(self):
+        if self.session_params is None or isinstance(self.session_params, dict):
+            return
+        if not isinstance(self.session_params, list) or not all(
+            isinstance(item, dict) for item in self.session_params
+        ):
+            raise ValueError("session_params must be a dict or a list of dicts.")
+        if not self.session_params or len(self.session_params) != self.batch_size:
+            raise ValueError("session_params length must equal the batch size.")
+        if self.is_single:
+            self.session_params = self.session_params[0]
 
     def _normalize_single_inputs(self):
         """Normalize inputs for a single example."""
@@ -802,7 +815,11 @@ class GenerateReqInput:
             routed_experts_start_len=self.routed_experts_start_len,
             return_indexer_topk=self.return_indexer_topk,
             modalities=self.modalities[i] if self.modalities else None,
-            session_params=self.session_params,
+            session_params=(
+                self.session_params[i]
+                if isinstance(self.session_params, list)
+                else self.session_params
+            ),
             lora_path=self.lora_path[i] if self.lora_path is not None else None,
             lora_id=self.lora_id[i] if self.lora_id is not None else None,
             custom_logit_processor=(

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -608,6 +608,29 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(item0.custom_logit_processor, "processor1")
         self.assertEqual(item0.return_hidden_states, True)
 
+    def test_getitem_session_params_per_sample(self):
+        """#27218: a list-valued session_params is indexed per subrequest; a
+        scalar dict is forwarded whole."""
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            sampling_params=[{}, {}],
+            rid=["id1", "id2"],
+            session_params=[{"id": "s1"}, {"id": "s2"}],
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req[0].session_params, {"id": "s1"})
+        self.assertEqual(req[1].session_params, {"id": "s2"})
+
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            sampling_params=[{}, {}],
+            rid=["id1", "id2"],
+            session_params={"id": "shared"},
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req[0].session_params, {"id": "shared"})
+        self.assertEqual(req[1].session_params, {"id": "shared"})
+
     def test_getitem_preserves_return_prompt_token_ids(self):
         """Batch subrequests must keep the prompt-token-id return flag."""
         req = GenerateReqInput(

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -623,6 +623,18 @@ class TestGenerateReqInputNormalization(CustomTestCase):
 
         req = GenerateReqInput(
             text=["Hello", "World"],
+            sampling_params={"n": 3},
+            rid=["id1", "id2"],
+            session_params=[{"id": "s1"}, {"id": "s2"}],
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req[0].session_params, {"id": "s1"})
+        self.assertEqual(req[1].session_params, {"id": "s2"})
+        self.assertEqual(req[2].session_params, {"id": "s1"})
+        self.assertEqual(req[5].session_params, {"id": "s2"})
+
+        req = GenerateReqInput(
+            text=["Hello", "World"],
             sampling_params=[{}, {}],
             rid=["id1", "id2"],
             session_params={"id": "shared"},

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -584,21 +584,41 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(req.custom_logit_processor, ["processor1", "processor2"])
 
     def test_session_params_handling(self):
-        """Test handling of session_params."""
-        # Test with dict
-        req = GenerateReqInput(
+        shared = GenerateReqInput(
             text=["Hello", "World"], session_params={"id": "session1", "offset": 10}
         )
-        req.normalize_batch_and_arguments()
-        self.assertEqual(req.session_params, {"id": "session1", "offset": 10})
+        shared.normalize_batch_and_arguments()
+        self.assertEqual(shared[0].session_params, {"id": "session1", "offset": 10})
+        self.assertEqual(shared[1].session_params, {"id": "session1", "offset": 10})
 
-        # Test with list of dicts
-        req = GenerateReqInput(
+        per_sample = [{"id": "session1"}, {"id": "session2"}]
+        batched = GenerateReqInput(
             text=["Hello", "World"],
-            session_params=[{"id": "session1"}, {"id": "session2"}],
+            sampling_params={"n": 3},
+            session_params=per_sample,
         )
-        req.normalize_batch_and_arguments()
-        self.assertEqual(req.session_params, [{"id": "session1"}, {"id": "session2"}])
+        batched.normalize_batch_and_arguments()
+        self.assertEqual(batched.batch_size, 2)
+        self.assertEqual(
+            [batched[i].session_params for i in range(batched.batch_size)], per_sample
+        )
+
+        single = GenerateReqInput(text="Hello", session_params=[{"id": "session1"}])
+        single.normalize_batch_and_arguments()
+        self.assertEqual(single.session_params, {"id": "session1"})
+
+    def test_session_params_validation(self):
+        invalid_cases = [
+            ([], "length must equal"),
+            ([{"id": "session1"}], "length must equal"),
+            ([{"id": "session1"}, "invalid"], "dict or a list of dicts"),
+        ]
+        for session_params, error in invalid_cases:
+            with self.subTest(session_params=session_params):
+                with self.assertRaisesRegex(ValueError, error):
+                    GenerateReqInput(
+                        text=["Hello", "World"], session_params=session_params
+                    ).normalize_batch_and_arguments()
 
     def test_session_id_handling(self):
         req = GenerateReqInput(

--- a/test/registered/unit/managers/test_tokenizer_manager_session_params.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_session_params.py
@@ -1,0 +1,82 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import GenerateReqInput  # noqa: E402
+from sglang.srt.managers.tokenizer_manager import TokenizerManager  # noqa: E402
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestTokenizerManagerSessionParams(unittest.IsolatedAsyncioTestCase):
+    async def test_parallel_sampling_preserves_per_prompt_session_params(self):
+        batch = GenerateReqInput(
+            text=["first", "second"],
+            rid=["prompt-1", "prompt-2"],
+            sampling_params={"n": 3},
+            session_params=[{"id": "s1"}, {"id": "s2"}],
+        )
+        batch.normalize_batch_and_arguments()
+
+        manager = object.__new__(TokenizerManager)
+        manager.rid_to_state = {
+            rid: SimpleNamespace(
+                time_stats=SimpleNamespace(set_finished_time=lambda: None)
+            )
+            for rid in batch.rid
+        }
+
+        async def tokenize(request):
+            return SimpleNamespace(
+                rid=request.rid,
+                input_ids=[],
+                mm_inputs=None,
+                sampling_params=SimpleNamespace(max_new_tokens=16),
+                session_params=request.session_params,
+            )
+
+        sent = []
+
+        def init_state(request):
+            manager.rid_to_state[request.rid] = SimpleNamespace(
+                time_stats=SimpleNamespace()
+            )
+
+        async def wait_one_response(_request, _http_request):
+            yield {}
+
+        async def collect_batch_responses(_generators):
+            return []
+
+        manager._tokenize_one_request = tokenize
+        manager._init_req_state = init_state
+        manager._send_one_request = sent.append
+        manager._wait_one_response = wait_one_response
+        manager._collect_batch_responses = collect_batch_responses
+
+        outputs = [output async for output in manager._handle_batch_request(batch)]
+
+        self.assertEqual(outputs, [[]])
+        self.assertEqual(
+            [request.session_params for request in sent[:2]],
+            [{"id": "s1"}, {"id": "s2"}],
+        )
+        self.assertEqual(
+            [request.session_params for request in sent[2:]],
+            [
+                {"id": "s1"},
+                {"id": "s1"},
+                {"id": "s1"},
+                {"id": "s2"},
+                {"id": "s2"},
+                {"id": "s2"},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Normalize `GenerateReqInput.session_params` at the request boundary before per-sample fan-out.

- a scalar dictionary remains shared request metadata
- a list represents per-original-request metadata and must be nonempty, contain only dictionaries, and match the original batch size
- a singleton list is normalized to its dictionary
- `__getitem__` directly indexes validated per-sample metadata
- parallel sampling copies each already-correct per-sample object; no modulo fallback can cross-assign session metadata
- invalid lists fail before parallel-sampling mutation

This builds on the earlier boundary analysis in #27257. Thanks @he-yufeng for the original report/fix and @chengcuiping for identifying that modulo fallback was unsafe and validation belonged at the request boundary.

## Verification

- scalar, singleton, batched, and `n=3` per-sample normalization cases
- behavior-level coverage through the real `TokenizerManager._handle_batch_request` fan-out: prefix warm-up preserves `s1,s2`, then six dispatched children remain prompt-major `s1,s1,s1,s2,s2,s2`
- empty, wrong-length, and non-dictionary lists reject
- existing `session_id` conflict remains enforced
- Ruff, formatting, compilation, source behavior probes, and `git diff --check` pass
- fresh exact-head review found no correctness, ordering, ownership, redundancy, or maintainability findings on `09e029c18b36ebdd3c65dda597e7505a5c7ca584`

Hosted CI remains the runtime gate.
