### PR TITLE
fix(function_call): handle non-finite numbers in tool-call argument coercion

### DIFF
--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -16,6 +16,7 @@ import ast
 import html
 import json
 import logging
+import math
 import re
 from typing import Any, Dict, List
 
@@ -23,6 +24,7 @@ from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import StreamingParseResult, _GetInfoFunc
+from sglang.srt.function_call.utils import is_json_finite
 
 logger = logging.getLogger(__name__)
 
@@ -76,20 +78,24 @@ def _convert_param_value(
     elif param_type.startswith("num") or param_type.startswith("float"):
         try:
             float_param_value = float(param_value)
-            return (
-                float_param_value
-                if float_param_value - int(float_param_value) != 0
-                else int(float_param_value)
-            )
         except (ValueError, TypeError):
+            float_param_value = math.nan
+        # Reject inf/-inf/nan: int(float("inf")) raises and they serialize to
+        # invalid JSON (Infinity/NaN). Keep the raw string instead.
+        if not math.isfinite(float_param_value):
             logger.warning(
-                "Parsed value '%s' of parameter '%s' is not a float "
+                "Parsed value '%s' of parameter '%s' is not a finite float "
                 "in tool '%s', degenerating to string.",
                 param_value,
                 param_name,
                 func_name,
             )
             return param_value
+        return (
+            float_param_value
+            if float_param_value - int(float_param_value) != 0
+            else int(float_param_value)
+        )
     elif param_type in ["boolean", "bool", "binary"]:
         param_value = param_value.lower()
         if param_value not in ["true", "false"]:
@@ -109,8 +115,7 @@ def _convert_param_value(
             or param_type.startswith("list")
         ):
             try:
-                param_value = json.loads(param_value)
-                return param_value
+                parsed = json.loads(param_value)
             except (json.JSONDecodeError, TypeError, ValueError):
                 logger.warning(
                     "Parsed value '%s' of parameter '%s' cannot be "
@@ -120,8 +125,20 @@ def _convert_param_value(
                     param_name,
                     func_name,
                 )
+            else:
+                # Reject e.g. json.loads("[1e999]") -> [inf] (invalid JSON).
+                if not is_json_finite(parsed):
+                    logger.warning(
+                        "Parsed value '%s' of parameter '%s' is a non-finite "
+                        "number in tool '%s', degenerating to string.",
+                        param_value,
+                        param_name,
+                        func_name,
+                    )
+                    return param_value
+                return parsed
         try:
-            param_value = ast.literal_eval(param_value)  # safer
+            parsed = ast.literal_eval(param_value)  # safer
         except (ValueError, SyntaxError, TypeError):
             logger.warning(
                 "Parsed value '%s' of parameter '%s' cannot be "
@@ -131,7 +148,19 @@ def _convert_param_value(
                 param_name,
                 func_name,
             )
-        return param_value
+            return param_value
+        # ast.literal_eval accepts non-JSON literals json.loads rejects (e.g.
+        # "(1e999,)"), so it can still yield a non-finite number; reject it.
+        if not is_json_finite(parsed):
+            logger.warning(
+                "Parsed value '%s' of parameter '%s' is a non-finite "
+                "number in tool '%s', degenerating to string.",
+                param_value,
+                param_name,
+                func_name,
+            )
+            return param_value
+        return parsed
 
 
 class MiMoDetector(BaseFormatDetector):

--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -15,6 +15,7 @@
 import html
 import json
 import logging
+import math
 import re
 from typing import Any, Dict, List
 
@@ -22,7 +23,7 @@ from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import StreamingParseResult, _GetInfoFunc
-from sglang.srt.function_call.utils import safe_literal_eval
+from sglang.srt.function_call.utils import is_json_finite, safe_literal_eval
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,8 @@ def _convert_param_value(
     elif param_type.startswith("num") or param_type.startswith("float"):
         try:
             float_param_value = float(param_value)
+            if not math.isfinite(float_param_value):
+                raise ValueError
             return (
                 float_param_value
                 if float_param_value - int(float_param_value) != 0
@@ -109,8 +112,9 @@ def _convert_param_value(
             or param_type.startswith("list")
         ):
             try:
-                param_value = json.loads(param_value)
-                return param_value
+                parsed = json.loads(param_value)
+                if is_json_finite(parsed):
+                    return parsed
             except (json.JSONDecodeError, TypeError, ValueError):
                 logger.warning(
                     "Parsed value '%s' of parameter '%s' cannot be "
@@ -121,7 +125,7 @@ def _convert_param_value(
                     func_name,
                 )
         try:
-            param_value = safe_literal_eval(param_value)
+            parsed = safe_literal_eval(param_value)
         except (ValueError, SyntaxError, TypeError):
             logger.warning(
                 "Parsed value '%s' of parameter '%s' cannot be "
@@ -131,7 +135,8 @@ def _convert_param_value(
                 param_name,
                 func_name,
             )
-        return param_value
+            return param_value
+        return parsed if is_json_finite(parsed) else param_value
 
 
 class MiMoDetector(BaseFormatDetector):

--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import re
 from typing import Any, Dict, List, Tuple
 
@@ -10,6 +11,7 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
+from sglang.srt.function_call.utils import is_json_finite
 
 logger = logging.getLogger(__name__)
 
@@ -178,9 +180,12 @@ class MinimaxM2Detector(BaseFormatDetector):
             elif param_type in ["number", "float"]:
                 try:
                     val = float(value)
-                    return val if val != int(val) else int(val)
                 except (ValueError, TypeError):
                     continue
+                # inf/nan: int(val) raises and they serialize to invalid JSON.
+                if not math.isfinite(val):
+                    continue
+                return val if val != int(val) else int(val)
             elif param_type in ["boolean", "bool"]:
                 lower_val = value.lower().strip()
                 if lower_val in ["true", "1", "yes", "on"]:
@@ -190,15 +195,19 @@ class MinimaxM2Detector(BaseFormatDetector):
                 continue
             elif param_type in ["object", "array"]:
                 try:
-                    return json.loads(value)
+                    parsed = json.loads(value)
                 except json.JSONDecodeError:
                     continue
+                if is_json_finite(parsed):
+                    return parsed
+                continue
 
         # Fallback: try JSON parse, then return as string
         try:
-            return json.loads(value)
+            parsed = json.loads(value)
         except json.JSONDecodeError:
             return value
+        return parsed if is_json_finite(parsed) else value
 
     def _get_param_types_from_config(
         self, param_name: str, param_config: dict

--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import re
 from typing import Any, Dict, List, Tuple
 
@@ -10,6 +11,7 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
+from sglang.srt.function_call.utils import is_json_finite
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +180,8 @@ class MinimaxM2Detector(BaseFormatDetector):
             elif param_type in ["number", "float"]:
                 try:
                     val = float(value)
+                    if not math.isfinite(val):
+                        continue
                     return val if val != int(val) else int(val)
                 except (ValueError, TypeError):
                     continue
@@ -190,15 +194,18 @@ class MinimaxM2Detector(BaseFormatDetector):
                 continue
             elif param_type in ["object", "array"]:
                 try:
-                    return json.loads(value)
+                    parsed = json.loads(value)
                 except json.JSONDecodeError:
                     continue
+                if is_json_finite(parsed):
+                    return parsed
 
         # Fallback: try JSON parse, then return as string
         try:
-            return json.loads(value)
+            parsed = json.loads(value)
         except json.JSONDecodeError:
             return value
+        return parsed if is_json_finite(parsed) else value
 
     def _get_param_types_from_config(
         self, param_name: str, param_config: dict

--- a/python/sglang/srt/function_call/poolside_v1_detector.py
+++ b/python/sglang/srt/function_call/poolside_v1_detector.py
@@ -183,10 +183,10 @@ class PoolsideV1Detector(BaseFormatDetector):
         for decoder in decoders:
             try:
                 result = decoder(raw)
-                # ast.literal_eval can return non-JSON-serializable values
-                # (sets, complex numbers); reject so json.dumps downstream
-                # doesn't choke.
-                json.dumps(result)
+                # Reject values json.dumps can't emit as valid JSON: sets/complex
+                # from ast.literal_eval (TypeError), and non-finite floats like
+                # "[1e999]" -> [inf] (ValueError under allow_nan=False).
+                json.dumps(result, allow_nan=False)
                 return result
             except (ValueError, SyntaxError, TypeError):
                 continue

--- a/python/sglang/srt/function_call/poolside_v1_detector.py
+++ b/python/sglang/srt/function_call/poolside_v1_detector.py
@@ -168,11 +168,9 @@ class PoolsideV1Detector(BaseFormatDetector):
           - everything else (int,
             number, bool, object, …)  → json.loads, then safe_literal_eval
 
-        Each decoder result is round-tripped through `json.dumps` before being
-        returned; non-JSON-serializable values (sets / complex / bytes from
-        `ast.literal_eval`) are rejected to the next decoder, ultimately
-        falling through to the raw-string fallback rather than crashing the
-        streaming JSON emission downstream.
+        Each decoder result is encoded with `allow_nan=False` before being
+        returned. Non-JSON values and non-finite numbers are rejected to the
+        next decoder, then to the raw-string fallback.
         """
         spec = schema.get(key) if isinstance(schema, dict) else None
         param_type = str(spec.get("type", "")).lower() if isinstance(spec, dict) else ""
@@ -183,10 +181,8 @@ class PoolsideV1Detector(BaseFormatDetector):
         for decoder in decoders:
             try:
                 result = decoder(raw)
-                # ast.literal_eval can return non-JSON-serializable values
-                # (sets, complex numbers); reject so json.dumps downstream
-                # doesn't choke.
-                json.dumps(result)
+                # Reject values that downstream cannot encode as standard JSON.
+                json.dumps(result, allow_nan=False)
                 return result
             except (ValueError, SyntaxError, TypeError):
                 continue

--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -1,6 +1,7 @@
 import ast
 import json
 import logging
+import math
 import re
 from typing import Any, List, Optional
 
@@ -11,6 +12,7 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
+from sglang.srt.function_call.utils import is_json_finite
 
 logger = logging.getLogger(__name__)
 
@@ -127,19 +129,23 @@ class Qwen3CoderDetector(BaseFormatDetector):
                 )
             return param_value
         elif param_type.startswith("num") or param_type.startswith("float"):
+            maybe_convert = (
+                False if "." in param_value or "e" in param_value.lower() else True
+            )
             try:
-                maybe_convert = (
-                    False if "." in param_value or "e" in param_value.lower() else True
-                )
-                param_value: float = float(param_value)
-                if maybe_convert and param_value.is_integer():
-                    param_value = int(param_value)
+                converted = float(param_value)
             except Exception:
+                converted = math.nan
+            # Reject inf/-inf/nan: they serialize to invalid JSON (Infinity/NaN).
+            if not math.isfinite(converted):
                 logger.warning(
-                    f"Parsed value '{param_value}' of parameter '{param_name}' is not a float in tool "
+                    f"Parsed value '{param_value}' of parameter '{param_name}' is not a finite float in tool "
                     f"'{func_name}', degenerating to string."
                 )
-            return param_value
+                return param_value
+            if maybe_convert and converted.is_integer():
+                return int(converted)
+            return converted
         elif param_type in ["boolean", "bool", "binary"]:
             param_value = param_value.lower()
             if param_value not in ["true", "false"]:
@@ -154,20 +160,36 @@ class Qwen3CoderDetector(BaseFormatDetector):
                 or param_type.startswith("list")
             ):
                 try:
-                    param_value = json.loads(param_value)
-                    return param_value
+                    parsed = json.loads(param_value)
                 except Exception:
                     logger.warning(
                         f"Parsed value '{param_value}' of parameter '{param_name}' cannot be parsed with json.loads in tool "
                         f"'{func_name}', will try other methods to parse it."
                     )
+                else:
+                    # Reject e.g. json.loads("[1e999]") -> [inf] (invalid JSON).
+                    if not is_json_finite(parsed):
+                        logger.warning(
+                            f"Parsed value '{param_value}' of parameter '{param_name}' is a non-finite number in tool "
+                            f"'{func_name}', degenerating to string."
+                        )
+                        return param_value
+                    return parsed
             try:
-                param_value = ast.literal_eval(param_value)  # safer
+                parsed = ast.literal_eval(param_value)  # safer
             except Exception:
                 logger.warning(
                     f"Parsed value '{param_value}' of parameter '{param_name}' cannot be converted via Python `ast.literal_eval()` in tool '{func_name}', degenerating to string."
                 )
-            return param_value
+                return param_value
+            # ast.literal_eval accepts non-JSON literals (e.g. "(1e999,)") that
+            # can still yield a non-finite number; reject it like json.loads.
+            if not is_json_finite(parsed):
+                logger.warning(
+                    f"Parsed value '{param_value}' of parameter '{param_name}' is a non-finite number in tool '{func_name}', degenerating to string."
+                )
+                return param_value
+            return parsed
 
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         """One-shot parsing for non-streaming scenarios."""

--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import re
 from typing import Any, List, Optional
 
@@ -12,6 +13,7 @@ from sglang.srt.function_call.core_types import (
 )
 from sglang.srt.function_call.utils import (
     infer_type_from_json_schema,
+    is_json_finite,
     safe_literal_eval,
 )
 
@@ -135,9 +137,12 @@ class Qwen3CoderDetector(BaseFormatDetector):
                 maybe_convert = (
                     False if "." in param_value or "e" in param_value.lower() else True
                 )
-                param_value: float = float(param_value)
-                if maybe_convert and param_value.is_integer():
-                    param_value = int(param_value)
+                converted = float(param_value)
+                if not math.isfinite(converted):
+                    raise ValueError
+                if maybe_convert and converted.is_integer():
+                    return int(converted)
+                return converted
             except Exception:
                 logger.warning(
                     f"Parsed value '{param_value}' of parameter '{param_name}' is not a float in tool "
@@ -158,20 +163,22 @@ class Qwen3CoderDetector(BaseFormatDetector):
                 or param_type.startswith("list")
             ):
                 try:
-                    param_value = json.loads(param_value)
-                    return param_value
+                    parsed = json.loads(param_value)
+                    if is_json_finite(parsed):
+                        return parsed
                 except Exception:
                     logger.warning(
                         f"Parsed value '{param_value}' of parameter '{param_name}' cannot be parsed with json.loads in tool "
                         f"'{func_name}', will try other methods to parse it."
                     )
             try:
-                param_value = safe_literal_eval(param_value)
+                parsed = safe_literal_eval(param_value)
             except Exception:
                 logger.warning(
                     f"Parsed value '{param_value}' of parameter '{param_name}' cannot be converted via Python `ast.literal_eval()` in tool '{func_name}', degenerating to string."
                 )
-            return param_value
+                return param_value
+            return parsed if is_json_finite(parsed) else param_value
 
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         """One-shot parsing for non-streaming scenarios."""

--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -1,3 +1,4 @@
+import json
 from json import JSONDecodeError, JSONDecoder
 from json.decoder import WHITESPACE
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
@@ -7,6 +8,20 @@ import partial_json_parser
 from partial_json_parser.core.options import Allow
 
 from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
+
+
+def is_json_finite(obj: Any) -> bool:
+    """Whether ``obj`` serializes to valid JSON, i.e. has no non-finite floats.
+
+    ``json.dumps(allow_nan=False)`` rejects ``inf``/``-inf``/``nan`` anywhere in
+    the value, including nested ones (``json.loads("[1e999]") -> [inf]``).
+    """
+    try:
+        json.dumps(obj, allow_nan=False)
+        return True
+    except (ValueError, TypeError):
+        return False
+
 
 _STANDARD_JSON_SCHEMA_TYPES = {
     "null",

--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import threading
 import warnings
 from json import JSONDecodeError, JSONDecoder
@@ -8,7 +9,6 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 import orjson
 import partial_json_parser
 from partial_json_parser.core.options import Allow
-
 from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
 
 _STANDARD_JSON_SCHEMA_TYPES = {
@@ -254,6 +254,15 @@ def _run_ast_quiet(fn, *args):
 
 def safe_literal_eval(value: str) -> Any:
     return _run_ast_quiet(ast.literal_eval, value)
+
+
+def is_json_finite(value: Any) -> bool:
+    """Return whether value can be encoded as standards-compliant JSON."""
+    try:
+        json.dumps(value, allow_nan=False)
+        return True
+    except (TypeError, ValueError):
+        return False
 
 
 def safe_ast_parse(source: str) -> ast.Module:

--- a/test/registered/function_call/test_nonfinite_coercion.py
+++ b/test/registered/function_call/test_nonfinite_coercion.py
@@ -1,0 +1,88 @@
+"""Tool-call argument coercion must reject non-finite numbers.
+
+A model can emit a numeric argument like "1e999"/"inf"/"nan". These must not
+crash coercion (int(float("inf")) raises OverflowError) nor leak into the
+tool-call output as invalid JSON (Infinity/NaN); they degrade to the raw
+string. Ports vllm-project/vllm#43984 across SGLang's typed-coercion detectors.
+"""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.mimo_detector import _convert_param_value as _mimo_convert
+from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
+from sglang.srt.function_call.poolside_v1_detector import PoolsideV1Detector
+from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(3, "base-a-test-cpu")
+
+NON_FINITE_NUMBERS = ["inf", "-inf", "Infinity", "1e999", "-1e999", "nan", "NaN"]
+NON_FINITE_CONTAINERS = [
+    "[1e999]",
+    "[1, 2, 1e999]",
+    "[Infinity]",
+    "[NaN]",
+    '{"x": 1e999}',
+    # Non-JSON Python literals that json.loads rejects but ast.literal_eval
+    # accepts (exercises the ast fallback path).
+    "(1e999,)",
+    "{'x': 1e999}",
+]
+
+
+def _mimo(raw, ptype):
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="f",
+            parameters={"type": "object", "properties": {"p": {"type": ptype}}},
+        ),
+    )
+    return _mimo_convert(raw, "p", "f", [tool])
+
+
+def _minimax(raw, ptype):
+    return MinimaxM2Detector()._convert_param_value(raw, ptype)
+
+
+def _qwen3(raw, ptype):
+    return Qwen3CoderDetector()._convert_param_value(
+        raw, "p", {"p": {"type": ptype}}, "f"
+    )
+
+
+def _poolside(raw, ptype):
+    return PoolsideV1Detector._convert_param_value(raw, {"p": {"type": ptype}}, "p")
+
+
+COERCERS = {
+    "mimo": _mimo,
+    "minimax_m2": _minimax,
+    "qwen3_coder": _qwen3,
+    "poolside_v1": _poolside,
+}
+
+
+class TestNonFiniteCoercion(unittest.TestCase):
+    def test_non_finite_degrades_to_string(self):
+        for name, coerce in COERCERS.items():
+            for raw in NON_FINITE_NUMBERS:
+                with self.subTest(detector=name, value=raw):
+                    self.assertEqual(coerce(raw, "number"), raw)
+            for raw in NON_FINITE_CONTAINERS:
+                with self.subTest(detector=name, value=raw):
+                    ptype = "object" if raw.startswith("{") else "array"
+                    self.assertEqual(coerce(raw, ptype), raw)
+
+    def test_finite_values_still_coerced(self):
+        for name, coerce in COERCERS.items():
+            with self.subTest(detector=name):
+                self.assertEqual(coerce("42", "number"), 42)
+                self.assertEqual(coerce("3.14", "number"), 3.14)
+                self.assertEqual(coerce("[1, 2, 3]", "array"), [1, 2, 3])
+                self.assertEqual(coerce('{"a": 1}', "object"), {"a": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/function_call/test_nonfinite_coercion.py
+++ b/test/registered/function_call/test_nonfinite_coercion.py
@@ -1,0 +1,81 @@
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.mimo_detector import _convert_param_value as mimo_convert
+from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
+from sglang.srt.function_call.poolside_v1_detector import PoolsideV1Detector
+from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _mimo(raw, param_type):
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="f",
+            parameters={
+                "type": "object",
+                "properties": {"p": {"type": param_type}},
+            },
+        ),
+    )
+    return mimo_convert(raw, "p", "f", [tool])
+
+
+def _minimax(raw, param_type):
+    return MinimaxM2Detector()._convert_param_value(raw, param_type)
+
+
+def _qwen3(raw, param_type):
+    return Qwen3CoderDetector()._convert_param_value(
+        raw, "p", {"p": {"type": param_type}}, "f"
+    )
+
+
+def _poolside(raw, param_type):
+    return PoolsideV1Detector._convert_param_value(
+        raw, {"p": {"type": param_type}}, "p"
+    )
+
+
+COERCERS = (_mimo, _minimax, _qwen3, _poolside)
+
+
+class TestNonFiniteCoercion(unittest.TestCase):
+    def test_non_finite_numbers_remain_strings(self):
+        for coerce in COERCERS:
+            for param_type in ("integer", "number"):
+                for raw in ("inf", "-inf", "Infinity", "1e999", "nan"):
+                    with self.subTest(
+                        detector=coerce.__name__, param_type=param_type, value=raw
+                    ):
+                        self.assertEqual(coerce(raw, param_type), raw)
+
+    def test_non_finite_containers_remain_strings(self):
+        cases = (
+            ("array", "[1e999]"),
+            ("array", "[NaN]"),
+            ("array", "(1e999,)"),
+            ("object", '{"x": 1e999}'),
+            ("object", "{'x': 1e999}"),
+        )
+        for coerce in COERCERS:
+            for param_type, raw in cases:
+                with self.subTest(
+                    detector=coerce.__name__, param_type=param_type, value=raw
+                ):
+                    self.assertEqual(coerce(raw, param_type), raw)
+
+    def test_finite_values_are_still_coerced(self):
+        for coerce in COERCERS:
+            with self.subTest(detector=coerce.__name__):
+                self.assertEqual(coerce("42", "number"), 42)
+                self.assertEqual(coerce("3.14", "number"), 3.14)
+                self.assertEqual(coerce("[1, 2, 3]", "array"), [1, 2, 3])
+                self.assertEqual(coerce('{"a": 1}', "object"), {"a": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make tool-call argument coercion fail safely on non-finite numbers and non-JSON parsed values across MiMo, MiniMax M2, Qwen3 Coder, and Poolside v1.

- finite scalar and container coercion remains unchanged
- scalar `Infinity`, `-Infinity`, `NaN`, and overflow literals never reach `int(...)` or JSON output
- JSON and AST fallback containers are checked recursively
- any scalar or nested non-finite/non-JSON result preserves the original model string
- Poolside uses standards-compliant `json.dumps(..., allow_nan=False)` validation rather than permissive JSON serialization

Ported from [vllm-project/vllm#43984](https://github.com/vllm-project/vllm/pull/43984) by Ashish Patel (@ashishpatel26).

## Verification

- compact matrix covers four detectors, scalar numbers, JSON containers, AST containers, and finite regressions
- exact converter probes passed for positive/negative infinity, NaN, overflow, nested values, sets/complex/bytes, and finite values
- Ruff checks, AST compilation, and `git diff --check` passed across all six files
- fresh exact-head review found no correctness, coverage, redundancy, duplicate, or attribution issues

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31561561388](https://github.com/sgl-project/sglang/actions/runs/31561561388)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31561561152](https://github.com/sgl-project/sglang/actions/runs/31561561152)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->