### PR TITLE
fix(tokenizer_manager): validate top_logprobs against vocab size

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1097,9 +1097,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # upstream, like _validate_token_ids_logprob). It feeds logprobs.topk(k),
         # which raises when k > vocab_size; reject that at the boundary instead.
         top_logprobs_num = obj.top_logprobs_num
-        if not top_logprobs_num:
+        if top_logprobs_num is None:
             return
-        if not isinstance(top_logprobs_num, int):
+        if isinstance(top_logprobs_num, bool) or not isinstance(top_logprobs_num, int):
             raise ValueError("top_logprobs_num must be an integer.")
         vocab_size = self.model_config.vocab_size
         if top_logprobs_num < 0 or top_logprobs_num > vocab_size:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1011,6 +1011,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Validate generation-specific fields
         if isinstance(obj, GenerateReqInput):
             self._validate_token_ids_logprob(obj)
+            self._validate_top_logprobs_num(obj)
             if (
                 obj.return_hidden_states
                 and not self.server_args.enable_return_hidden_states
@@ -1090,6 +1091,22 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     f"token_ids_logprob contains out-of-vocabulary token id "
                     f"{token_id}; valid range is [0, {vocab_size})."
                 )
+
+    def _validate_top_logprobs_num(self, obj: GenerateReqInput) -> None:
+        # top_logprobs_num is a single int here (batch requests are split
+        # upstream, like _validate_token_ids_logprob). It feeds logprobs.topk(k),
+        # which raises when k > vocab_size; reject that at the boundary instead.
+        top_logprobs_num = obj.top_logprobs_num
+        if not top_logprobs_num:
+            return
+        if not isinstance(top_logprobs_num, int):
+            raise ValueError("top_logprobs_num must be an integer.")
+        vocab_size = self.model_config.vocab_size
+        if top_logprobs_num < 0 or top_logprobs_num > vocab_size:
+            raise ValueError(
+                f"Requested top_logprobs_num ({top_logprobs_num}) is out of "
+                f"range; valid range is [0, {vocab_size}]."
+            )
 
     def _validate_input_ids_in_vocab(
         self, input_ids: Union[List[int], List[List[int]]], vocab_size: int

--- a/test/registered/unit/managers/test_validate_top_logprobs.py
+++ b/test/registered/unit/managers/test_validate_top_logprobs.py
@@ -1,0 +1,42 @@
+"""top_logprobs must be validated against the vocab at the API boundary.
+
+top_logprobs_num flows into logprobs.topk(k); k > vocab_size raises a
+RuntimeError deep in the model forward, so reject it up front with a clean
+error. Mirrors vLLM's SamplingParams._validate_logprobs.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(3, "base-a-test-cpu")
+
+VOCAB_SIZE = 1000
+
+
+def _validate(top_logprobs_num):
+    tm = TokenizerManager.__new__(TokenizerManager)
+    tm.model_config = SimpleNamespace(vocab_size=VOCAB_SIZE)
+    obj = GenerateReqInput(text="hello")
+    obj.top_logprobs_num = top_logprobs_num
+    tm._validate_top_logprobs_num(obj)
+
+
+class TestValidateTopLogprobsNum(unittest.TestCase):
+    def test_in_range_ok(self):
+        for ok in (None, 0, 20, VOCAB_SIZE):  # topk(vocab_size) is valid
+            with self.subTest(top_logprobs_num=ok):
+                _validate(ok)
+
+    def test_out_of_range_raises(self):
+        for bad in (VOCAB_SIZE + 1, 100000, -1):
+            with self.subTest(top_logprobs_num=bad):
+                with self.assertRaises(ValueError):
+                    _validate(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_validate_top_logprobs.py
+++ b/test/registered/unit/managers/test_validate_top_logprobs.py
@@ -31,6 +31,12 @@ class TestValidateTopLogprobsNum(unittest.TestCase):
             with self.subTest(top_logprobs_num=ok):
                 _validate(ok)
 
+    def test_non_integer_raises(self):
+        for bad in (False, True, 0.0, [], ""):
+            with self.subTest(top_logprobs_num=bad):
+                with self.assertRaises(ValueError):
+                    _validate(bad)
+
     def test_out_of_range_raises(self):
         for bad in (VOCAB_SIZE + 1, 100000, -1):
             with self.subTest(top_logprobs_num=bad):


### PR DESCRIPTION
## Motivation

`top_logprobs_num` flows into `logprobs.topk(k)` (`srt/layers/utils/logprob.py`, `max_k = max(top_logprobs_nums)`). When `k > vocab_size`, `torch.topk` raises a `RuntimeError` deep in the model forward, so a request with e.g. `top_logprobs: 100000` fails with an opaque internal error instead of a clean client-facing one. This mirrors vLLM's `SamplingParams._validate_logprobs`, which rejects the same case at the API boundary.

## Modifications

- `python/sglang/srt/managers/tokenizer_manager.py`: add `_validate_top_logprobs_num` and call it from the existing `_validate_one_request` choke point, right next to the sibling `_validate_token_ids_logprob` vocab check. It rejects `top_logprobs_num` outside `[0, vocab_size]` with a `ValueError`. The bound is inclusive on top because `topk(vocab_size)` is valid and `topk(vocab_size + 1)` is what raises.

  At this point `top_logprobs_num` is already a single `int` (batch requests are split by `normalize_batch_and_arguments` + `__getitem__` before validation), so the check stays a simple scalar comparison, matching the sibling validator.

- `test/registered/unit/managers/test_validate_top_logprobs.py`: unit test covering in-range (`None`, `0`, `vocab_size`), out-of-range (`vocab_size + 1`, large, negative), and non-integer (`False`, `True`, `0.0`, list, string) values.

Behavior change: a negative `top_logprobs` (previously silently treated as "no top logprobs") is now rejected with a `ValueError`.

Note: `None` is the only no-op sentinel. `0` still goes through the normal integer/range path and passes because `topk(0)` means no top-logprobs, while bools and other non-integers are rejected before the range check.

## Accuracy Tests

Not applicable — no change to kernels or the model forward path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28888280468](https://github.com/sgl-project/sglang/actions/runs/28888280468)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28888280064](https://github.com/sgl-project/sglang/actions/runs/28888280064)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->