### PR TITLE
fix(multimodal): bound audio decode duration to prevent decompression bombs

### DIFF
--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -88,6 +88,16 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Block size (in MB) for sequential checkpoint prefetch reads that warm the OS page cache before workers load weights via mmap</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>16</code></td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_MAX_AUDIO_DECODE_DURATION_S</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum accepted decoded duration in seconds from one compressed audio input. Fractional seconds are supported. Finite values less than or equal to <code>0</code> disable the operator limit; model-specific lower duration limits still apply. Invalid and non-finite values emit a warning and use the default.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>600</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_MAX_AUDIO_DECODE_BYTES</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum application-visible projected or accumulated PCM bytes from one compressed audio input. SoundFile and TorchCodec request at most the cap plus one logical output interleaved sample frame to prove end-of-file at the exact boundary. Finite integer values less than or equal to <code>0</code> disable the limit. Invalid values emit a warning and use the default. This does not limit encoded input bytes, decoder/resampler-owned native frames, TorchCodec returned-tensor backing storage, filter buffers, library scratch space, or aggregate memory across concurrent decodes.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>268435456</code> (256 MiB)</td>
+    </tr>
 </tbody>
 </table>
 

--- a/python/sglang/srt/entrypoints/openai/serving_transcription.py
+++ b/python/sglang/srt/entrypoints/openai/serving_transcription.py
@@ -48,9 +48,9 @@ from sglang.srt.entrypoints.openai.realtime import (
 from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
 from sglang.srt.entrypoints.openai.streaming_asr import (
     StreamingASRState,
+    iter_audio_chunks,
     needs_space,
     process_asr_chunk,
-    split_audio_chunks,
 )
 from sglang.srt.entrypoints.openai.transcription_adapters import resolve_adapter
 from sglang.srt.managers.io_struct import GenerateReqInput
@@ -395,13 +395,12 @@ class OpenAIServingTranscription(OpenAIServingBase):
         last_char = ""
 
         try:
-            chunks = split_audio_chunks(request.audio_data, state.chunk_size_sec)
+            chunks = iter_audio_chunks(request.audio_data, state.chunk_size_sec)
 
-            for i, chunk_audio in enumerate(chunks):
+            for chunk_audio, is_last in chunks:
                 if await raw_request.is_disconnected():
                     logger.info("[streaming_asr] client disconnected, stopping")
                     break
-                is_last = i == len(chunks) - 1
 
                 delta = await process_asr_chunk(
                     tokenizer_manager=self.tokenizer_manager,
@@ -413,6 +412,9 @@ class OpenAIServingTranscription(OpenAIServingBase):
                     raw_request=raw_request,
                     routing_key=self.extract_routing_key(raw_request),
                 )
+                # The next cumulative prefix may be as large as this one. Drop
+                # the completed encoding before advancing the lazy iterator.
+                del chunk_audio
 
                 if delta:
                     for word in delta.split(" "):

--- a/python/sglang/srt/entrypoints/openai/streaming_asr.py
+++ b/python/sglang/srt/entrypoints/openai/streaming_asr.py
@@ -3,7 +3,7 @@ import io
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, Optional
 
 import soundfile as sf
 from fastapi import Request
@@ -13,6 +13,7 @@ from sglang.srt.entrypoints.openai.transcription_adapters.base import (
 )
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.utils.common import _decode_audio_with_soundfile
 
 logger = logging.getLogger(__name__)
 
@@ -96,29 +97,39 @@ class StreamingASRState:
         return self._record_emit(" ".join(all_words[common_count:]))
 
 
-def split_audio_chunks(audio_data: bytes, chunk_size_sec: float) -> List[bytes]:
+def _encode_wav_prefix(data, sample_rate: int) -> bytes:
+    output = io.BytesIO()
+    try:
+        sf.write(output, data, sample_rate, format="WAV")
+        return output.getvalue()
+    finally:
+        output.close()
+
+
+def iter_audio_chunks(
+    audio_data: bytes, chunk_size_sec: float
+) -> Iterator[tuple[bytes, bool]]:
+    """Yield cumulative WAV prefixes without retaining prior encodings."""
     if not audio_data:
         raise ValueError("audio_data is empty")
     if chunk_size_sec <= 0:
         raise ValueError(f"chunk_size_sec must be positive, got {chunk_size_sec}")
-    audio_file = io.BytesIO(audio_data)
-    try:
-        data, sample_rate = sf.read(audio_file, dtype="float32")
-    except sf.LibsndfileError as e:
-        raise ValueError(f"failed to decode audio: {e}") from e
+    data, sample_rate = _decode_audio_with_soundfile(audio_data, dtype="float32")
     if len(data.shape) > 1:
         data = data.mean(axis=1)
     chunk_size_samples = int(chunk_size_sec * sample_rate)
+    if chunk_size_samples <= 0:
+        raise ValueError(
+            f"chunk_size_sec is smaller than one sample at {sample_rate} Hz"
+        )
     total_samples = len(data)
-    chunks = []
     for end in range(
         chunk_size_samples, total_samples + chunk_size_samples, chunk_size_samples
     ):
         end = min(end, total_samples)
-        buf = io.BytesIO()
-        sf.write(buf, data[:end], sample_rate, format="WAV")
-        chunks.append(buf.getvalue())
-    return chunks
+        # Yield the helper result directly so the suspended generator frame does
+        # not retain the prior encoded prefix while the consumer processes it.
+        yield _encode_wav_prefix(data[:end], sample_rate), end == total_samples
 
 
 def normalize_whitespace(text: str) -> str:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -717,6 +717,11 @@ class Envs:
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)
     SGLANG_IMAGE_MAX_PIXELS = EnvInt(16384 * 28 * 28)
     SGLANG_RESIZE_RESAMPLE = EnvStr("")
+    # Reject audio that decodes to more than this many seconds, so a small
+    # compressed payload cannot expand into a huge PCM buffer (decompression
+    # bomb). 0 or negative disables the cap. Default mirrors vLLM's
+    # VLLM_MAX_AUDIO_DECODE_DURATION_S.
+    SGLANG_MAX_AUDIO_DECODE_DURATION_S = EnvInt(600)
     SGLANG_MM_BUFFER_SIZE_MB = EnvInt(0)
     SGLANG_MM_PRECOMPUTE_HASH = EnvBool(False)
     SGLANG_VIT_ENABLE_CUDA_GRAPH = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import math
 import os
 import subprocess
 import warnings
@@ -190,6 +191,14 @@ class EnvFloat(EnvField):
             return float(value)
         except ValueError:
             raise ValueError(f'"{value}" is not a valid float value')
+
+
+class EnvFiniteFloat(EnvFloat):
+    def parse(self, value: str) -> float:
+        parsed = super().parse(value)
+        if not math.isfinite(parsed):
+            raise ValueError(f'"{value}" is not a valid finite float value')
+        return parsed
 
 
 class GateGemvMode(IntEnum):
@@ -940,6 +949,15 @@ class Envs:
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)
     SGLANG_IMAGE_MAX_PIXELS = EnvInt(16384 * 28 * 28)
     SGLANG_RESIZE_RESAMPLE = EnvStr("")
+    # Reject audio whose accepted decoded duration exceeds this value. 0 or
+    # negative disables the cap. Default mirrors vLLM's
+    # VLLM_MAX_AUDIO_DECODE_DURATION_S.
+    SGLANG_MAX_AUDIO_DECODE_DURATION_S = EnvFiniteFloat(600.0)
+    # Limit application-visible projected or accumulated PCM bytes,
+    # independently of duration. Decoder/resampler native frames and
+    # TorchCodec returned-tensor backing storage are outside this cap. 0 or
+    # negative disables it. Default mirrors vLLM's 256 MiB limit.
+    SGLANG_MAX_AUDIO_DECODE_BYTES = EnvInt(268_435_456)
     SGLANG_MM_BUFFER_SIZE_MB = EnvInt(0)
     SGLANG_MM_PRECOMPUTE_HASH = EnvBool(False)
     SGLANG_VIT_ENABLE_CUDA_GRAPH = EnvBool(False)

--- a/python/sglang/srt/multimodal/audio_from_video.py
+++ b/python/sglang/srt/multimodal/audio_from_video.py
@@ -37,6 +37,10 @@ class _AudioContainerDecodeError(ValueError):
     pass
 
 
+class _AudioDecodeLimitError(ValueError):
+    pass
+
+
 def is_audio_container(data: bytes) -> bool:
     """Return whether the header identifies a supported media container."""
     return any(
@@ -50,10 +54,36 @@ def _append_resampled_frames(
     frames,
     *,
     mono: bool,
-) -> None:
+    max_samples: int | None,
+    max_decode_bytes: int | None,
+    sample_count: int,
+    decoded_bytes: int,
+) -> tuple[int, int]:
     for frame in frames:
+        # The resampler is configured for float32 output. PyAV already owns the
+        # returned frame; reject from its dimensions before projecting it to an
+        # application-owned NumPy buffer or retaining it for concatenation.
+        frame_samples = int(frame.samples)
+        channels = 1 if mono else len(frame.layout.channels)
+        prospective_samples = sample_count + frame_samples
+        if max_samples is not None and prospective_samples > max_samples:
+            raise _AudioDecodeLimitError(
+                "Audio exceeds the maximum allowed decode duration. Set "
+                "SGLANG_MAX_AUDIO_DECODE_DURATION_S to change this limit."
+            )
+        prospective_bytes = decoded_bytes + frame_samples * channels * 4
+        if max_decode_bytes is not None and prospective_bytes > max_decode_bytes:
+            raise _AudioDecodeLimitError(
+                "Audio exceeds the maximum allowed decoded size. Set "
+                "SGLANG_MAX_AUDIO_DECODE_BYTES to change this limit."
+            )
+
         array = frame.to_ndarray()
-        chunks.append(array.reshape(-1) if mono else array.T)
+        chunk = array.reshape(-1) if mono else array.T
+        sample_count = prospective_samples
+        decoded_bytes = prospective_bytes
+        chunks.append(chunk)
+    return sample_count, decoded_bytes
 
 
 def decode_audio_container(
@@ -61,12 +91,27 @@ def decode_audio_container(
     *,
     target_sr: int,
     mono: bool,
+    max_duration_s: float | None = None,
+    max_decode_bytes: int | None = None,
 ) -> np.ndarray:
     """Strictly decode the first audio stream from a supported container."""
     if not isinstance(target_sr, int) or target_sr <= 0:
         raise ValueError(_INVALID_AUDIO_CONTAINER_MESSAGE)
     if isinstance(source, bytes) and not source:
         raise ValueError(_INVALID_AUDIO_CONTAINER_MESSAGE)
+    from sglang.srt.utils.common import (
+        _audio_decode_byte_limit,
+        _audio_decode_duration_limit,
+        _audio_duration_frame_count,
+    )
+
+    max_duration_s = _audio_decode_duration_limit(max_duration_s)
+    max_decode_bytes = _audio_decode_byte_limit(max_decode_bytes)
+    max_samples = (
+        _audio_duration_frame_count(max_duration_s, target_sr)
+        if max_duration_s is not None
+        else None
+    )
 
     try:
         import av
@@ -87,25 +132,35 @@ def decode_audio_container(
                 )
 
             chunks: list[np.ndarray] = []
+            sample_count = 0
+            decoded_bytes = 0
             skipped_packets = 0
             first_decode_error = None
             for packet in container.demux(audio_stream):
                 try:
                     for frame in packet.decode():
-                        _append_resampled_frames(
+                        sample_count, decoded_bytes = _append_resampled_frames(
                             chunks,
                             resampler.resample(frame),
                             mono=mono,
+                            max_samples=max_samples,
+                            max_decode_bytes=max_decode_bytes,
+                            sample_count=sample_count,
+                            decoded_bytes=decoded_bytes,
                         )
                 except av.error.FFmpegError as error:
                     skipped_packets += 1
                     if first_decode_error is None:
                         first_decode_error = error
 
-            _append_resampled_frames(
+            sample_count, decoded_bytes = _append_resampled_frames(
                 chunks,
                 resampler.resample(None),
                 mono=mono,
+                max_samples=max_samples,
+                max_decode_bytes=max_decode_bytes,
+                sample_count=sample_count,
+                decoded_bytes=decoded_bytes,
             )
             if skipped_packets:
                 logger.warning(
@@ -115,7 +170,7 @@ def decode_audio_container(
                     len(chunks),
                     first_decode_error,
                 )
-    except _AudioContainerDecodeError:
+    except (_AudioContainerDecodeError, _AudioDecodeLimitError):
         raise
     except Exception as error:
         raise ValueError(_INVALID_AUDIO_CONTAINER_MESSAGE) from error

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -831,6 +831,12 @@ def _audio_too_long(duration_s: float, max_duration_s: float) -> _AudioTooLongEr
     )
 
 
+def _validate_audio_sample_rate(sample_rate: Optional[int], name: str) -> int:
+    if sample_rate is None or sample_rate <= 0:
+        raise ValueError(f"{name} must be positive, got {sample_rate}.")
+    return sample_rate
+
+
 def load_audio(
     audio_file: str,
     sr: Optional[int] = None,
@@ -839,6 +845,8 @@ def load_audio(
 ) -> np.ndarray:
     if sr is None:
         sr = 16000
+    else:
+        sr = _validate_audio_sample_rate(sr, "Sample rate")
     if max_duration_s is None:
         max_duration_s = envs.SGLANG_MAX_AUDIO_DECODE_DURATION_S.get()
     # A small compressed payload can expand into hours of PCM (decompression
@@ -916,8 +924,10 @@ def load_audio(
 
     audio_input = BytesIO(source) if isinstance(source, bytes) else source
     with sf.SoundFile(audio_input) as f:
-        original_sr = f.samplerate
-        if cap is not None and original_sr:
+        original_sr = _validate_audio_sample_rate(
+            f.samplerate, "Audio file sample rate"
+        )
+        if cap is not None:
             # Bounded read: pull at most cap-worth of frames (+1 to detect
             # overflow), so an over-long or mis-declared file is rejected
             # without reading the whole PCM payload into memory.

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -819,11 +819,31 @@ def get_mm_http_session() -> requests.Session:
     return session
 
 
+class _AudioTooLongError(ValueError):
+    """Audio exceeds the configured maximum decode duration."""
+
+
+def _audio_too_long(duration_s: float, max_duration_s: float) -> _AudioTooLongError:
+    return _AudioTooLongError(
+        f"Audio exceeds the maximum allowed decode duration of "
+        f"{max_duration_s}s (input is at least {float(duration_s):.1f}s). Set "
+        f"SGLANG_MAX_AUDIO_DECODE_DURATION_S to change this limit."
+    )
+
+
 def load_audio(
-    audio_file: str, sr: Optional[int] = None, mono: bool = True
+    audio_file: str,
+    sr: Optional[int] = None,
+    mono: bool = True,
+    max_duration_s: Optional[float] = None,
 ) -> np.ndarray:
     if sr is None:
         sr = 16000
+    if max_duration_s is None:
+        max_duration_s = envs.SGLANG_MAX_AUDIO_DECODE_DURATION_S.get()
+    # A small compressed payload can expand into hours of PCM (decompression
+    # bomb). cap bounds how much audio we will materialize; <= 0 disables it.
+    cap = max_duration_s if max_duration_s and max_duration_s > 0 else None
 
     # Normalize input: resolve URL / base64 / file:// to bytes or path
     if isinstance(audio_file, bytes):
@@ -853,26 +873,60 @@ def load_audio(
                 sample_rate=sr,
                 num_channels=1 if mono else None,
             )
-            samples = decoder.get_all_samples()
-            if mono:
-                return samples.data.squeeze(0).numpy()
-            return samples.data.T.numpy()
         except Exception as e:
             # torchcodec's bytes-buffer IO can fail on WAV files that carry
             # large trailing metadata chunks. Fall back to soundfile, which reads the PCM payload directly.
             logger.warning(
                 f"torchcodec AudioDecoder failed ({e}); falling back to soundfile + torchaudio."
             )
+        else:
+            try:
+                if cap is None:
+                    samples = decoder.get_all_samples()
+                else:
+                    # Fast-reject from header metadata when it is trustworthy.
+                    metadata = decoder.metadata
+                    header_s = getattr(
+                        metadata, "duration_seconds_from_header", None
+                    ) or getattr(metadata, "duration_seconds", None)
+                    if header_s is not None and header_s > cap:
+                        raise _audio_too_long(header_s, cap)
+                    # Bounded decode: only ever materialize ~cap seconds of PCM,
+                    # so a missing or forged header cannot become a memory bomb.
+                    samples = decoder.get_samples_played_in_range(
+                        0.0, stop_seconds=cap + 1.0
+                    )
+                    if samples.data.shape[-1] / sr > cap:
+                        raise _audio_too_long(samples.data.shape[-1] / sr, cap)
+            except _AudioTooLongError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    f"torchcodec decode failed ({e}); falling back to soundfile + torchaudio."
+                )
+            else:
+                if mono:
+                    return samples.data.squeeze(0).numpy()
+                return samples.data.T.numpy()
 
     # Fallback: soundfile + torchaudio (ARM / no FFmpeg / torchcodec failure)
     import soundfile as sf
     import torch
     import torchaudio
 
-    if isinstance(source, bytes):
-        audio, original_sr = sf.read(BytesIO(source))
-    else:
-        audio, original_sr = sf.read(source)
+    audio_input = BytesIO(source) if isinstance(source, bytes) else source
+    with sf.SoundFile(audio_input) as f:
+        original_sr = f.samplerate
+        if cap is not None and original_sr:
+            # Bounded read: pull at most cap-worth of frames (+1 to detect
+            # overflow), so an over-long or mis-declared file is rejected
+            # without reading the whole PCM payload into memory.
+            max_frames = int(cap * original_sr)
+            audio = f.read(frames=max_frames + 1)
+            if len(audio) > max_frames:
+                raise _audio_too_long(len(audio) / original_sr, cap)
+        else:
+            audio = f.read()
 
     if mono and len(audio.shape) > 1:
         audio = np.mean(audio, axis=1)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1532,11 +1532,345 @@ CLIENT_MEDIA_EXCEPTIONS = (
 )
 
 
+class _AudioDecodeLimitError(ValueError):
+    """Audio exceeds a configured decode limit."""
+
+
+def _audio_too_long(duration_s: float, max_duration_s: float) -> _AudioDecodeLimitError:
+    return _AudioDecodeLimitError(
+        f"Audio exceeds the maximum allowed decode duration of "
+        f"{max_duration_s}s (input is at least {float(duration_s):.1f}s). Set "
+        f"SGLANG_MAX_AUDIO_DECODE_DURATION_S to change this limit."
+    )
+
+
+def _audio_too_large(
+    decoded_bytes: int, max_decode_bytes: int
+) -> _AudioDecodeLimitError:
+    return _AudioDecodeLimitError(
+        f"Audio exceeds the maximum allowed decoded size of {max_decode_bytes} "
+        f"bytes (input requires at least {decoded_bytes} bytes). Set "
+        f"SGLANG_MAX_AUDIO_DECODE_BYTES to change this limit."
+    )
+
+
+def _audio_decode_duration_limit(
+    max_duration_s: Optional[float],
+) -> Optional[float]:
+    if max_duration_s is None:
+        max_duration_s = envs.SGLANG_MAX_AUDIO_DECODE_DURATION_S.get()
+    try:
+        max_duration_s = float(max_duration_s)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError(
+            "Maximum audio decode duration must be a finite number, got "
+            f"{max_duration_s!r}."
+        ) from error
+    if not math.isfinite(max_duration_s):
+        raise ValueError(
+            "Maximum audio decode duration must be a finite number, got "
+            f"{max_duration_s!r}."
+        )
+    return max_duration_s if max_duration_s > 0 else None
+
+
+def _audio_decode_byte_limit(max_decode_bytes: Optional[int]) -> Optional[int]:
+    if max_decode_bytes is None:
+        max_decode_bytes = envs.SGLANG_MAX_AUDIO_DECODE_BYTES.get()
+    if isinstance(max_decode_bytes, int):
+        parsed_value = max_decode_bytes
+    elif isinstance(max_decode_bytes, str):
+        try:
+            parsed_value = int(max_decode_bytes)
+        except ValueError as error:
+            raise ValueError(
+                "Maximum decoded audio bytes must be a finite integer, got "
+                f"{max_decode_bytes!r}."
+            ) from error
+    else:
+        try:
+            numeric_value = float(max_decode_bytes)
+        except (TypeError, ValueError, OverflowError) as error:
+            raise ValueError(
+                "Maximum decoded audio bytes must be a finite integer, got "
+                f"{max_decode_bytes!r}."
+            ) from error
+        if not math.isfinite(numeric_value) or not numeric_value.is_integer():
+            raise ValueError(
+                "Maximum decoded audio bytes must be a finite integer, got "
+                f"{max_decode_bytes!r}."
+            )
+        parsed_value = int(numeric_value)
+    return parsed_value if parsed_value > 0 else None
+
+
+def _validate_audio_count(value: Optional[int], name: str, *, allow_zero: bool) -> int:
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        qualifier = "non-negative" if allow_zero else "positive"
+        raise ValueError(
+            f"{name} must be a {qualifier} integer, got {value}."
+        ) from error
+    minimum = 0 if allow_zero else 1
+    if (
+        not math.isfinite(numeric_value)
+        or not numeric_value.is_integer()
+        or numeric_value < minimum
+    ):
+        qualifier = "non-negative" if allow_zero else "positive"
+        raise ValueError(f"{name} must be a {qualifier} integer, got {value}.")
+    return int(numeric_value)
+
+
+def _validate_audio_sample_rate(sample_rate: Optional[int], name: str) -> int:
+    return _validate_audio_count(sample_rate, name, allow_zero=False)
+
+
+def _audio_duration_frame_count(
+    duration_s: float, sample_rate: int, *, round_up: bool = False
+) -> int:
+    duration_s = float(duration_s)
+    if not math.isfinite(duration_s) or duration_s < 0:
+        raise ValueError(
+            f"Audio duration must be a non-negative finite number, got {duration_s}."
+        )
+    sample_rate = _validate_audio_sample_rate(sample_rate, "Audio sample rate")
+    numerator, denominator = duration_s.as_integer_ratio()
+    frame_numerator = numerator * sample_rate
+    if round_up:
+        return (frame_numerator + denominator - 1) // denominator
+    return frame_numerator // denominator
+
+
+def _audio_resampled_frame_count(
+    frame_count: int, original_sr: int, target_sr: int
+) -> int:
+    frame_count = _validate_audio_count(
+        frame_count, "Audio frame count", allow_zero=True
+    )
+    original_sr = _validate_audio_sample_rate(original_sr, "Original sample rate")
+    target_sr = _validate_audio_sample_rate(target_sr, "Target sample rate")
+    return (frame_count * target_sr + original_sr - 1) // original_sr
+
+
+def _check_audio_pcm_size(
+    frame_count: int,
+    channels: int,
+    bytes_per_sample: int,
+    max_decode_bytes: Optional[int],
+) -> int:
+    frame_count = _validate_audio_count(
+        frame_count, "Audio frame count", allow_zero=True
+    )
+    channels = _validate_audio_count(channels, "Audio channel count", allow_zero=False)
+    bytes_per_sample = _validate_audio_count(
+        bytes_per_sample, "Audio sample size", allow_zero=False
+    )
+    decoded_bytes = frame_count * channels * bytes_per_sample
+    byte_cap = _audio_decode_byte_limit(max_decode_bytes)
+    if byte_cap is not None and decoded_bytes > byte_cap:
+        raise _audio_too_large(decoded_bytes, byte_cap)
+    return decoded_bytes
+
+
+def _check_audio_resample_size(
+    frame_count: int,
+    channels: int,
+    bytes_per_sample: int,
+    original_sr: int,
+    target_sr: int,
+    max_decode_bytes: Optional[int],
+) -> int:
+    output_frames = _audio_resampled_frame_count(frame_count, original_sr, target_sr)
+    _check_audio_pcm_size(output_frames, channels, bytes_per_sample, max_decode_bytes)
+    return output_frames
+
+
+def _decode_audio_with_torchcodec(
+    source,
+    *,
+    sample_rate: Optional[int] = None,
+    num_channels: Optional[int] = None,
+    max_duration_s: Optional[float] = None,
+    max_decode_bytes: Optional[int] = None,
+):
+    duration_cap = _audio_decode_duration_limit(max_duration_s)
+    byte_cap = _audio_decode_byte_limit(max_decode_bytes)
+
+    from torchcodec.decoders import AudioDecoder
+
+    decoder_kwargs = {}
+    if sample_rate is not None:
+        decoder_kwargs["sample_rate"] = _validate_audio_sample_rate(
+            sample_rate, "Requested sample rate"
+        )
+    if num_channels is not None:
+        decoder_kwargs["num_channels"] = _validate_audio_count(
+            num_channels, "Requested channel count", allow_zero=False
+        )
+    decoder = AudioDecoder(source, **decoder_kwargs)
+
+    if duration_cap is None and byte_cap is None:
+        return decoder.get_all_samples()
+
+    metadata = decoder.metadata
+    decoded_sr = _validate_audio_sample_rate(
+        (
+            sample_rate
+            if sample_rate is not None
+            else getattr(metadata, "sample_rate", None)
+        ),
+        "Decoded sample rate",
+    )
+    decoded_channels = _validate_audio_count(
+        (
+            num_channels
+            if num_channels is not None
+            else getattr(metadata, "num_channels", None)
+        ),
+        "Decoded channel count",
+        allow_zero=False,
+    )
+    bytes_per_frame = decoded_channels * np.dtype(np.float32).itemsize
+
+    metadata_duration_s = getattr(metadata, "duration_seconds", None)
+    if metadata_duration_s is not None:
+        try:
+            metadata_duration_s = float(metadata_duration_s)
+        except (TypeError, ValueError, OverflowError):
+            metadata_duration_s = None
+        if metadata_duration_s is not None and (
+            not math.isfinite(metadata_duration_s) or metadata_duration_s < 0
+        ):
+            metadata_duration_s = None
+
+    metadata_frames = None
+    if metadata_duration_s is not None:
+        # Metadata is only a fast-reject hint. Use a lower bound here because
+        # floating duration values can sit just above an exact frame boundary;
+        # the requested-range output below is the authoritative check.
+        metadata_frames = _audio_duration_frame_count(metadata_duration_s, decoded_sr)
+        if duration_cap is not None:
+            duration_frame_limit = _audio_duration_frame_count(duration_cap, decoded_sr)
+            if metadata_frames > duration_frame_limit:
+                raise _audio_too_long(metadata_frames / decoded_sr, duration_cap)
+        metadata_bytes = metadata_frames * bytes_per_frame
+        if byte_cap is not None and metadata_bytes > byte_cap:
+            raise _audio_too_large(metadata_bytes, byte_cap)
+
+    allowed_frame_limit = None
+    byte_frame_limit = None
+    if duration_cap is not None:
+        allowed_frame_limit = _audio_duration_frame_count(duration_cap, decoded_sr)
+    if byte_cap is not None:
+        byte_frame_limit = byte_cap // bytes_per_frame
+        if byte_frame_limit == 0:
+            raise _audio_too_large(bytes_per_frame, byte_cap)
+        if allowed_frame_limit is None or byte_frame_limit < allowed_frame_limit:
+            allowed_frame_limit = byte_frame_limit
+
+    assert allowed_frame_limit is not None
+    # Decode one frame beyond the active boundary. An exact-size result is only
+    # accepted when the decoder reaches EOF instead of silently truncating at
+    # potentially inaccurate container metadata.
+    decode_frame_limit = allowed_frame_limit + 1
+    samples = decoder.get_samples_played_in_range(
+        0.0, stop_seconds=decode_frame_limit / decoded_sr
+    )
+    actual_sr = _validate_audio_sample_rate(samples.sample_rate, "Decoded sample rate")
+    if actual_sr != decoded_sr:
+        raise ValueError(
+            f"Decoded sample rate changed from {decoded_sr} to {actual_sr}."
+        )
+    actual_frames = samples.data.shape[-1]
+    duration_s = actual_frames / actual_sr
+    if duration_cap is not None and duration_s > duration_cap:
+        raise _audio_too_long(duration_s, duration_cap)
+    actual_bytes = samples.data.numel() * samples.data.element_size()
+    if byte_cap is not None and actual_bytes > byte_cap:
+        raise _audio_too_large(actual_bytes, byte_cap)
+    return samples
+
+
+def _decode_audio_with_soundfile(
+    source: str | bytes,
+    *,
+    max_duration_s: Optional[float] = None,
+    max_decode_bytes: Optional[int] = None,
+    dtype: Optional[str] = None,
+) -> tuple[np.ndarray, int]:
+    import soundfile as sf
+
+    duration_cap = _audio_decode_duration_limit(max_duration_s)
+    byte_cap = _audio_decode_byte_limit(max_decode_bytes)
+    audio_input = BytesIO(source) if isinstance(source, bytes) else source
+    read_kwargs = {"dtype": dtype} if dtype is not None else {}
+    decode_dtype = np.dtype(dtype if dtype is not None else "float64")
+    try:
+        with sf.SoundFile(audio_input) as audio_file:
+            original_sr = _validate_audio_sample_rate(
+                audio_file.samplerate, "Audio file sample rate"
+            )
+            channels = _validate_audio_count(
+                audio_file.channels, "Audio file channel count", allow_zero=False
+            )
+            frames = _validate_audio_count(
+                audio_file.frames, "Audio file frame count", allow_zero=True
+            )
+            duration_frame_limit = (
+                _audio_duration_frame_count(duration_cap, original_sr)
+                if duration_cap is not None
+                else None
+            )
+            if duration_frame_limit is not None and frames > duration_frame_limit:
+                raise _audio_too_long(frames / original_sr, duration_cap)
+            decoded_bytes = frames * channels * decode_dtype.itemsize
+            if byte_cap is not None and decoded_bytes > byte_cap:
+                raise _audio_too_large(decoded_bytes, byte_cap)
+            if byte_cap is not None and channels * decode_dtype.itemsize > byte_cap:
+                raise _audio_too_large(channels * decode_dtype.itemsize, byte_cap)
+
+            if duration_cap is None and byte_cap is None:
+                audio = audio_file.read(**read_kwargs)
+            else:
+                byte_frame_limit = (
+                    byte_cap // (channels * decode_dtype.itemsize)
+                    if byte_cap is not None
+                    else None
+                )
+                limits = [
+                    limit
+                    for limit in (duration_frame_limit, byte_frame_limit)
+                    if limit is not None
+                ]
+                # One additional frame is the EOF proof for an exact-boundary
+                # input. The temporary overshoot is at most one PCM frame.
+                audio = audio_file.read(frames=min(limits) + 1, **read_kwargs)
+            if duration_frame_limit is not None and len(audio) > duration_frame_limit:
+                raise _audio_too_long(len(audio) / original_sr, duration_cap)
+            if byte_cap is not None and audio.nbytes > byte_cap:
+                raise _audio_too_large(audio.nbytes, byte_cap)
+    except sf.LibsndfileError as error:
+        raise ValueError(f"Could not decode audio: {error}") from error
+    return audio, original_sr
+
+
 def load_audio(
-    audio_file: str, sr: Optional[int] = None, mono: bool = True
+    audio_file: str | bytes,
+    sr: Optional[int] = None,
+    mono: bool = True,
+    max_duration_s: Optional[float] = None,
+    max_decode_bytes: Optional[int] = None,
 ) -> np.ndarray:
     if sr is None:
         sr = 16000
+    else:
+        sr = _validate_audio_sample_rate(sr, "Sample rate")
+    # A small compressed payload can expand into hours or gigabytes of PCM.
+    # The limits compose, and <= 0 disables either one independently.
+    duration_cap = _audio_decode_duration_limit(max_duration_s)
+    byte_cap = _audio_decode_byte_limit(max_decode_bytes)
 
     # Normalize input: resolve URL / base64 / file:// to bytes or path
     if isinstance(audio_file, bytes):
@@ -1573,45 +1907,56 @@ def load_audio(
             source,
             target_sr=sr,
             mono=mono,
+            max_duration_s=duration_cap if duration_cap is not None else 0.0,
+            max_decode_bytes=byte_cap if byte_cap is not None else 0,
         )
 
     if _BACKEND == "torchcodec":
-        from torchcodec.decoders import AudioDecoder
-
         try:
-            decoder = AudioDecoder(
+            samples = _decode_audio_with_torchcodec(
                 source,
                 sample_rate=sr,
                 num_channels=1 if mono else None,
+                max_duration_s=duration_cap if duration_cap is not None else 0.0,
+                max_decode_bytes=byte_cap if byte_cap is not None else 0,
             )
-            samples = decoder.get_all_samples()
+        except _AudioDecodeLimitError:
+            raise
+        except Exception as e:
+            # torchcodec's bytes-buffer IO can fail on WAV files that carry
+            # large trailing metadata chunks. Fall back to soundfile, which
+            # reads the PCM payload directly.
+            logger.warning(
+                f"torchcodec decode failed ({e}); falling back to soundfile + torchaudio."
+            )
+        else:
             if mono:
                 return samples.data.squeeze(0).numpy()
             return samples.data.T.numpy()
-        except Exception as e:
-            # torchcodec's bytes-buffer IO can fail on WAV files that carry
-            # large trailing metadata chunks. Fall back to soundfile, which reads the PCM payload directly.
-            logger.warning(
-                f"torchcodec AudioDecoder failed ({e}); falling back to soundfile + torchaudio."
-            )
 
     # Fallback: soundfile + torchaudio (ARM / no FFmpeg / torchcodec failure)
-    import soundfile as sf
     import torch
     import torchaudio
 
-    try:
-        if isinstance(source, bytes):
-            audio, original_sr = sf.read(BytesIO(source))
-        else:
-            audio, original_sr = sf.read(source)
-    except sf.LibsndfileError as e:
-        raise ValueError(f"Could not decode audio: {e}") from e
+    audio, original_sr = _decode_audio_with_soundfile(
+        source,
+        max_duration_s=duration_cap if duration_cap is not None else 0.0,
+        max_decode_bytes=byte_cap if byte_cap is not None else 0,
+    )
 
     if mono and len(audio.shape) > 1:
         audio = np.mean(audio, axis=1)
 
     if original_sr != sr:
+        channels = 1 if audio.ndim == 1 else audio.shape[1]
+        _check_audio_resample_size(
+            len(audio),
+            channels,
+            np.dtype(np.float32).itemsize,
+            original_sr,
+            sr,
+            byte_cap if byte_cap is not None else 0,
+        )
         audio_tensor = torch.from_numpy(audio).float()
         if audio_tensor.dim() == 1:
             audio_tensor = audio_tensor.unsqueeze(0)
@@ -1624,6 +1969,12 @@ def load_audio(
             audio = audio_tensor.squeeze(0).numpy()
         else:
             audio = audio_tensor.T.numpy()
+        _check_audio_pcm_size(
+            len(audio),
+            1 if audio.ndim == 1 else audio.shape[1],
+            audio.dtype.itemsize,
+            byte_cap if byte_cap is not None else 0,
+        )
 
     return audio
 

--- a/test/registered/unit/multimodal/test_audio_container_decode.py
+++ b/test/registered/unit/multimodal/test_audio_container_decode.py
@@ -15,6 +15,7 @@ import soundfile
 
 from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.multimodal.audio_from_video import (
+    _append_resampled_frames,
     decode_audio_container,
     extract_audio_from_video_bytes,
     is_audio_container,
@@ -175,6 +176,67 @@ class TestAudioContainerDecode(CustomTestCase):
         with patch("sglang.srt.utils.common._BACKEND", "torchcodec"):
             waveform = load_audio(self.mp4, sr=16000)
         self.assertGreater(len(waveform), 0)
+
+    def test_mp4_duration_cap_rejects_before_concatenation(self):
+        with (
+            patch(
+                "sglang.srt.multimodal.audio_from_video.np.concatenate"
+            ) as concatenate,
+            self.assertRaisesRegex(ValueError, "maximum allowed decode duration"),
+        ):
+            load_audio(self.mp4, sr=16000, max_duration_s=0.01)
+        concatenate.assert_not_called()
+
+    def test_mp4_byte_cap_rejects_before_concatenation(self):
+        with (
+            patch(
+                "sglang.srt.multimodal.audio_from_video.np.concatenate"
+            ) as concatenate,
+            self.assertRaisesRegex(ValueError, "maximum allowed decoded size"),
+        ):
+            load_audio(
+                self.mp4,
+                sr=16000,
+                max_duration_s=0,
+                max_decode_bytes=1024,
+            )
+        concatenate.assert_not_called()
+
+    def test_mp4_exact_pcm_bound_is_accepted_at_eof(self):
+        baseline = decode_audio_container(
+            self.mp4,
+            target_sr=8000,
+            mono=True,
+            max_duration_s=0,
+            max_decode_bytes=0,
+        )
+        waveform = decode_audio_container(
+            self.mp4,
+            target_sr=8000,
+            mono=True,
+            max_duration_s=len(baseline) / 8000,
+            max_decode_bytes=baseline.nbytes,
+        )
+        np.testing.assert_array_equal(waveform, baseline)
+
+    def test_oversized_resampled_frame_rejects_before_numpy_projection(self):
+        class Frame:
+            samples = 1024
+            layout = type("Layout", (), {"channels": (object(),)})()
+
+            def to_ndarray(self):
+                raise AssertionError("oversized PCM must reject before projection")
+
+        with self.assertRaisesRegex(ValueError, "maximum allowed decoded size"):
+            _append_resampled_frames(
+                [],
+                [Frame()],
+                mono=True,
+                max_samples=None,
+                max_decode_bytes=1024,
+                sample_count=0,
+                decoded_bytes=0,
+            )
 
     def test_wav_keeps_existing_decoder_path(self):
         """Ordinary WAV must not be redirected to the container decoder."""

--- a/test/registered/unit/utils/test_load_audio_duration.py
+++ b/test/registered/unit/utils/test_load_audio_duration.py
@@ -11,7 +11,7 @@ import unittest
 import numpy as np
 
 import sglang.srt.utils.common as common_utils
-from sglang.srt.utils.common import load_audio
+from sglang.srt.utils.common import _validate_audio_sample_rate, load_audio
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(5, "base-a-test-cpu")
@@ -81,6 +81,18 @@ class TestLoadAudioDuration(unittest.TestCase):
                 os.environ.pop(ENV, None)
 
         self._run_both_backends(check)
+
+    def test_nonpositive_requested_sample_rate_rejected(self):
+        with self.assertRaises(ValueError):
+            load_audio(self.short, sr=0)
+        with self.assertRaises(ValueError):
+            load_audio(self.short, sr=-1)
+
+    def test_invalid_header_sample_rate_rejected(self):
+        for sample_rate in (None, 0, -1):
+            with self.subTest(sample_rate=sample_rate):
+                with self.assertRaises(ValueError):
+                    _validate_audio_sample_rate(sample_rate, "Audio file sample rate")
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/utils/test_load_audio_duration.py
+++ b/test/registered/unit/utils/test_load_audio_duration.py
@@ -1,0 +1,87 @@
+"""load_audio bounds decode duration on both backends (decompression-bomb DoS).
+
+Ports vllm-project/vllm#45908: a small compressed payload must not expand into
+hours of PCM. Enforced via SGLANG_MAX_AUDIO_DECODE_DURATION_S (default 600s).
+"""
+
+import io
+import os
+import unittest
+
+import numpy as np
+
+import sglang.srt.utils.common as common_utils
+from sglang.srt.utils.common import load_audio
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(5, "base-a-test-cpu")
+
+SR = 16000
+ENV = "SGLANG_MAX_AUDIO_DECODE_DURATION_S"
+
+
+def _wav_bytes(duration_s: float, sr: int = SR) -> bytes:
+    import soundfile as sf
+
+    t = np.linspace(0, duration_s, int(sr * duration_s), endpoint=False)
+    data = (0.1 * np.sin(2 * np.pi * 440 * t)).astype("float32")
+    buf = io.BytesIO()
+    sf.write(buf, data, sr, format="WAV")
+    return buf.getvalue()
+
+
+class TestLoadAudioDuration(unittest.TestCase):
+    def setUp(self):
+        self.short = _wav_bytes(2.0)  # a 2-second clip
+
+    def _run_both_backends(self, check):
+        """Run ``check`` against each decode backend explicitly."""
+        for backend in ("torchcodec", "soundfile"):
+            if backend == "torchcodec":
+                try:
+                    import torchcodec  # noqa: F401
+                except Exception:
+                    continue  # torchcodec not available in this env
+            original = common_utils._BACKEND
+            common_utils._BACKEND = backend
+            try:
+                with self.subTest(backend=backend):
+                    check()
+            finally:
+                common_utils._BACKEND = original
+
+    def test_under_cap_ok(self):
+        def check():
+            audio = load_audio(self.short, sr=SR, max_duration_s=10)
+            self.assertGreater(len(audio), 0)
+
+        self._run_both_backends(check)
+
+    def test_over_cap_rejected(self):
+        def check():
+            with self.assertRaises(ValueError):
+                load_audio(self.short, sr=SR, max_duration_s=1)
+
+        self._run_both_backends(check)
+
+    def test_nonpositive_cap_disables_check(self):
+        def check():
+            audio = load_audio(self.short, sr=SR, max_duration_s=0)
+            self.assertGreater(len(audio), 0)
+
+        self._run_both_backends(check)
+
+    def test_default_cap_read_from_env(self):
+        def check():
+            os.environ[ENV] = "1"
+            try:
+                with self.assertRaises(ValueError):
+                    load_audio(self.short, sr=SR)  # no explicit cap
+            finally:
+                os.environ.pop(ENV, None)
+
+        self._run_both_backends(check)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_load_audio_duration.py
+++ b/test/registered/unit/utils/test_load_audio_duration.py
@@ -1,0 +1,390 @@
+"""Invariant tests for application-level audio decode limits."""
+
+import gc
+import io
+import math
+import os
+import sys
+import types
+import unittest
+import warnings
+import weakref
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import torch
+
+import sglang.srt.utils.common as common_utils
+from sglang.srt.environ import envs
+from sglang.srt.utils.common import load_audio
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(5, "base-a-test-cpu")
+
+SAMPLE_RATE = 16_000
+DURATION_ENV = "SGLANG_MAX_AUDIO_DECODE_DURATION_S"
+BYTE_ENV = "SGLANG_MAX_AUDIO_DECODE_BYTES"
+
+
+def _audio_bytes(duration_s: float, *, sample_rate: int = SAMPLE_RATE) -> bytes:
+    import soundfile as sf
+
+    samples = np.zeros(round(sample_rate * duration_s), dtype=np.float32)
+    output = io.BytesIO()
+    sf.write(output, samples, sample_rate, format="FLAC")
+    return output.getvalue()
+
+
+def _patch_torchcodec(decoder_cls):
+    torchcodec = types.ModuleType("torchcodec")
+    decoders = types.ModuleType("torchcodec.decoders")
+    decoders.AudioDecoder = decoder_cls
+    torchcodec.decoders = decoders
+    return patch.dict(
+        sys.modules,
+        {"torchcodec": torchcodec, "torchcodec.decoders": decoders},
+    )
+
+
+class TestLoadAudioDecodeLimits(unittest.TestCase):
+    def setUp(self):
+        self.audio = _audio_bytes(2.0)
+
+    def test_real_compressed_audio_honors_composed_limits(self):
+        with patch.object(common_utils, "_BACKEND", "soundfile"):
+            decoded = load_audio(
+                self.audio,
+                sr=SAMPLE_RATE,
+                max_duration_s=2,
+                max_decode_bytes=256_000,
+            )
+            self.assertEqual(decoded.shape, (2 * SAMPLE_RATE,))
+
+            with self.assertRaisesRegex(ValueError, "decode duration"):
+                load_audio(
+                    self.audio,
+                    sr=SAMPLE_RATE,
+                    max_duration_s=1,
+                    max_decode_bytes=0,
+                )
+            with self.assertRaisesRegex(ValueError, "decoded size"):
+                load_audio(
+                    self.audio,
+                    sr=SAMPLE_RATE,
+                    max_duration_s=0,
+                    max_decode_bytes=255_999,
+                )
+
+            decoded = load_audio(
+                self.audio,
+                sr=SAMPLE_RATE,
+                max_duration_s=0,
+                max_decode_bytes=0,
+            )
+            self.assertEqual(decoded.shape, (2 * SAMPLE_RATE,))
+
+    def test_soundfile_exact_boundary_requires_eof(self):
+        import soundfile as sf
+
+        class FakeSoundFile:
+            samplerate = SAMPLE_RATE
+            channels = 1
+            frames = 4
+            returned_frames = 4
+            requested_frames = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                pass
+
+            def read(self, *, frames, dtype):
+                self.requested_frames = frames
+                return np.zeros(self.returned_frames, dtype=dtype)
+
+        audio_file = FakeSoundFile()
+        with patch.object(sf, "SoundFile", return_value=audio_file):
+            audio, _ = common_utils._decode_audio_with_soundfile(
+                b"compressed-audio",
+                dtype="float32",
+                max_duration_s=0,
+                max_decode_bytes=16,
+            )
+        self.assertEqual(audio.shape, (4,))
+        self.assertEqual(audio_file.requested_frames, 5)
+
+        audio_file = FakeSoundFile()
+        audio_file.returned_frames = 5
+        with (
+            patch.object(sf, "SoundFile", return_value=audio_file),
+            self.assertRaisesRegex(ValueError, "decoded size"),
+        ):
+            common_utils._decode_audio_with_soundfile(
+                b"compressed-audio",
+                dtype="float32",
+                max_duration_s=0,
+                max_decode_bytes=16,
+            )
+
+    def test_soundfile_rejects_oversized_header_before_read(self):
+        import soundfile as sf
+
+        class FakeSoundFile:
+            samplerate = 192_000
+            channels = 32
+            frames = 192_000
+            read_called = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                pass
+
+            def read(self, **_kwargs):
+                self.read_called = True
+                raise AssertionError("oversized PCM must be rejected before read")
+
+        audio_file = FakeSoundFile()
+        with (
+            patch.object(sf, "SoundFile", return_value=audio_file),
+            self.assertRaisesRegex(ValueError, "decoded size"),
+        ):
+            common_utils._decode_audio_with_soundfile(
+                b"compressed-audio",
+                max_duration_s=2,
+                max_decode_bytes=1_048_576,
+            )
+        self.assertFalse(audio_file.read_called)
+
+    def test_torchcodec_exact_boundary_requires_eof(self):
+        class FakeAudioDecoder:
+            returned_frames = 4
+            requested_range = None
+
+            def __init__(self, _source, **_kwargs):
+                self.metadata = SimpleNamespace(
+                    duration_seconds=math.nextafter(4 / SAMPLE_RATE, math.inf),
+                    sample_rate=SAMPLE_RATE,
+                    num_channels=1,
+                )
+
+            def get_samples_played_in_range(self, start_seconds, *, stop_seconds):
+                FakeAudioDecoder.requested_range = (start_seconds, stop_seconds)
+                return SimpleNamespace(
+                    data=torch.zeros((1, self.returned_frames), dtype=torch.float32),
+                    sample_rate=SAMPLE_RATE,
+                )
+
+        with _patch_torchcodec(FakeAudioDecoder):
+            samples = common_utils._decode_audio_with_torchcodec(
+                b"compressed-audio",
+                max_duration_s=0,
+                max_decode_bytes=16,
+            )
+        self.assertEqual(samples.data.shape, (1, 4))
+        self.assertEqual(
+            FakeAudioDecoder.requested_range,
+            (0.0, 5 / SAMPLE_RATE),
+        )
+
+        FakeAudioDecoder.returned_frames = 5
+        with (
+            _patch_torchcodec(FakeAudioDecoder),
+            self.assertRaisesRegex(ValueError, "decoded size"),
+        ):
+            common_utils._decode_audio_with_torchcodec(
+                b"compressed-audio",
+                max_duration_s=0,
+                max_decode_bytes=16,
+            )
+
+    def test_torchcodec_uses_metadata_and_bounded_range(self):
+        class FakeAudioDecoder:
+            range_called = False
+
+            def __init__(self, _source, **_kwargs):
+                self.metadata = SimpleNamespace(
+                    duration_seconds=1.0,
+                    sample_rate=192_000,
+                    num_channels=32,
+                )
+
+            def get_all_samples(self):
+                raise AssertionError("range-limited decode must not read all samples")
+
+            def get_samples_played_in_range(self, *_args, **_kwargs):
+                FakeAudioDecoder.range_called = True
+                raise AssertionError("oversized metadata must reject before decode")
+
+        with (
+            _patch_torchcodec(FakeAudioDecoder),
+            self.assertRaisesRegex(ValueError, "decoded size"),
+        ):
+            common_utils._decode_audio_with_torchcodec(
+                b"compressed-audio",
+                max_duration_s=2,
+                max_decode_bytes=1_048_576,
+            )
+        self.assertFalse(FakeAudioDecoder.range_called)
+
+    def test_torchcodec_unknown_duration_still_limits_logical_output_bytes(self):
+        class FakeAudioDecoder:
+            requested_range = None
+
+            def __init__(self, _source, **_kwargs):
+                self.metadata = SimpleNamespace(
+                    duration_seconds=None,
+                    sample_rate=192_000,
+                    num_channels=8,
+                )
+
+            def get_all_samples(self):
+                raise AssertionError("range-limited decode must not read all samples")
+
+            def get_samples_played_in_range(self, start_seconds, *, stop_seconds):
+                FakeAudioDecoder.requested_range = (start_seconds, stop_seconds)
+                return SimpleNamespace(
+                    data=torch.zeros((8, 31), dtype=torch.float32),
+                    sample_rate=192_000,
+                )
+
+        with _patch_torchcodec(FakeAudioDecoder):
+            samples = common_utils._decode_audio_with_torchcodec(
+                b"compressed-audio",
+                max_duration_s=0,
+                max_decode_bytes=1024,
+            )
+        self.assertEqual(FakeAudioDecoder.requested_range, (0.0, 33 / 192_000))
+        self.assertEqual(samples.data.numel() * samples.data.element_size(), 992)
+
+    def test_torchcodec_limit_error_does_not_fallback(self):
+        with (
+            patch.object(common_utils, "_BACKEND", "torchcodec"),
+            patch.object(
+                common_utils,
+                "_decode_audio_with_torchcodec",
+                side_effect=common_utils._AudioDecodeLimitError("decode limit"),
+            ),
+            patch.object(common_utils, "_decode_audio_with_soundfile") as fallback,
+            self.assertRaisesRegex(ValueError, "decode limit"),
+        ):
+            load_audio(b"compressed-audio")
+        fallback.assert_not_called()
+
+    def test_resample_expansion_is_rejected_before_allocation(self):
+        with (
+            patch.object(common_utils, "_BACKEND", "soundfile"),
+            patch.object(
+                common_utils,
+                "_check_audio_resample_size",
+                wraps=common_utils._check_audio_resample_size,
+            ) as size_check,
+            self.assertRaisesRegex(ValueError, "decoded size"),
+        ):
+            load_audio(
+                _audio_bytes(1.0, sample_rate=8_000),
+                sr=24_000,
+                max_duration_s=0,
+                max_decode_bytes=80_000,
+            )
+        size_check.assert_called_once_with(8_000, 1, 4, 8_000, 24_000, 80_000)
+
+    def test_invalid_limits_and_sample_rates_fail_closed(self):
+        for duration in (float("nan"), float("inf"), "invalid"):
+            with self.subTest(duration=duration), self.assertRaises(ValueError):
+                load_audio(self.audio, max_duration_s=duration)
+        for byte_cap in (float("nan"), float("inf"), 1.5, "invalid"):
+            with self.subTest(byte_cap=byte_cap), self.assertRaises(ValueError):
+                load_audio(self.audio, max_decode_bytes=byte_cap)
+        for sample_rate in (0, -1):
+            with self.subTest(sample_rate=sample_rate), self.assertRaises(ValueError):
+                load_audio(self.audio, sr=sample_rate)
+
+    def test_environment_defaults_and_invalid_duration_fallback(self):
+        with (
+            patch.object(common_utils, "_BACKEND", "soundfile"),
+            patch.dict(os.environ, {DURATION_ENV: "1", BYTE_ENV: "0"}),
+            self.assertRaisesRegex(ValueError, "decode duration"),
+        ):
+            load_audio(self.audio, sr=SAMPLE_RATE)
+
+        with (
+            patch.object(common_utils, "_BACKEND", "soundfile"),
+            patch.dict(os.environ, {DURATION_ENV: "0", BYTE_ENV: "255999"}),
+            self.assertRaisesRegex(ValueError, "decoded size"),
+        ):
+            load_audio(self.audio, sr=SAMPLE_RATE)
+
+        for value in ("invalid", "nan", "inf"):
+            with (
+                self.subTest(value=value),
+                patch.dict(os.environ, {DURATION_ENV: value}),
+                warnings.catch_warnings(record=True) as caught,
+            ):
+                warnings.simplefilter("always")
+                self.assertEqual(envs.SGLANG_MAX_AUDIO_DECODE_DURATION_S.get(), 600.0)
+                self.assertRegex(str(caught[-1].message), "using default")
+
+
+class TestChunkedTranscriptionMemory(unittest.TestCase):
+    def test_iterator_uses_bounded_loader(self):
+        from sglang.srt.entrypoints.openai import streaming_asr
+
+        with (
+            patch.object(
+                streaming_asr,
+                "_decode_audio_with_soundfile",
+                side_effect=ValueError("decode limit"),
+            ) as decoder,
+            self.assertRaisesRegex(ValueError, "decode limit"),
+        ):
+            next(streaming_asr.iter_audio_chunks(b"compressed-audio", 2.0))
+        decoder.assert_called_once_with(b"compressed-audio", dtype="float32")
+
+    def test_iterator_releases_prior_prefix_and_preserves_cumulative_output(self):
+        import soundfile as sf
+
+        from sglang.srt.entrypoints.openai import streaming_asr
+
+        class Payload:
+            pass
+
+        class FakeBuffer:
+            def getvalue(self):
+                return Payload()
+
+            def close(self):
+                pass
+
+        with (
+            patch.object(
+                streaming_asr,
+                "_decode_audio_with_soundfile",
+                return_value=(np.zeros(4, dtype=np.float32), 2),
+            ),
+            patch.object(streaming_asr.io, "BytesIO", FakeBuffer),
+            patch.object(streaming_asr.sf, "write"),
+        ):
+            chunks = streaming_asr.iter_audio_chunks(b"compressed-audio", 1.0)
+            first, first_is_last = next(chunks)
+            first_ref = weakref.ref(first)
+            del first
+            gc.collect()
+            self.assertIsNone(first_ref())
+            second, second_is_last = next(chunks)
+
+        self.assertFalse(first_is_last)
+        self.assertTrue(second_is_last)
+        self.assertIsInstance(second, Payload)
+
+        chunks = list(streaming_asr.iter_audio_chunks(_audio_bytes(4.0), 2.0))
+        lengths = [len(sf.read(io.BytesIO(chunk))[0]) for chunk, _ in chunks]
+        self.assertEqual(lengths, [2 * SAMPLE_RATE, 4 * SAMPLE_RATE])
+        self.assertEqual([is_last for _, is_last in chunks], [False, True])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Compressed audio accepted by `load_audio`, its PyAV container path, and HTTP chunked transcription could accumulate unbounded application-owned PCM. A small compressed payload could therefore expand into enough retained/projected data to exhaust host memory.

This is adapted from [vllm-project/vllm#45908](https://github.com/vllm-project/vllm/pull/45908) by Juan Pérez de Algaba.

## Contract

Two independent operator limits apply:

- `SGLANG_MAX_AUDIO_DECODE_DURATION_S` (default `600`)
- `SGLANG_MAX_AUDIO_DECODE_BYTES` (default `268435456`, 256 MiB)

A nonpositive value disables that limit.

The limits bound PCM accepted, projected, or retained by SGLang:

- SoundFile and TorchCodec request at most the active limit plus one logical output interleaved frame to prove EOF; exact-boundary input is accepted only at EOF.
- PyAV checks target-rate float32 dimensions and cumulative output before NumPy projection, retention, and concatenation.
- HTTP chunked transcription keeps cumulative output semantics but lazily materializes one WAV prefix at a time instead of retaining every prefix.

The byte limit is intentionally an application-level accumulation bound. Decoder/resampler-owned native frames, filter buffers, TorchCodec tensor backing storage, library scratch space, encoded input bytes, and aggregate concurrent requests are outside this guarantee and are documented explicitly.

## Verification

- real SoundFile/FLAC under-, exact-, and over-limit probes
- real PyAV AAC/MP4 duration, byte, exact-boundary, projection, and accumulation probes
- focused TorchCodec range/metadata/EOF contract probes
- resample expansion, deceptive/unknown metadata, fallback propagation, disabled/invalid environment settings, and lazy-prefix lifetime coverage
- all applicable touched-file pre-commit hooks, compilation, formatting, and `git diff --check` passed
- multiple fresh-context security reviews resolved scope and ownership findings; the final exact-head review found no blocker

Inkling, MiMo, and MiniMax H3 direct decoder paths are not claimed or changed by this PR; they require separate model-owned follow-ups.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31557646400](https://github.com/sgl-project/sglang/actions/runs/31557646400)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31557646240](https://github.com/sgl-project/sglang/actions/runs/31557646240)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->