### PR TITLE
fix(openai): accept explicit null for parallel_tool_calls

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -794,6 +794,10 @@ class ChatCompletionRequest(BaseModel):
                 values["tool_choice"] = "none"
             else:
                 values["tool_choice"] = "auto"
+        # An explicit null parallel_tool_calls means "use the default" (True),
+        # not False — normalize it so downstream consumers never see None.
+        if values.get("parallel_tool_calls") is None:
+            values["parallel_tool_calls"] = True
         return values
 
     @model_validator(mode="before")

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -795,8 +795,8 @@ class ChatCompletionRequest(BaseModel):
             else:
                 values["tool_choice"] = "auto"
         # An explicit null parallel_tool_calls means "use the default" (True),
-        # not False — normalize it so downstream consumers never see None.
-        if values.get("parallel_tool_calls") is None:
+        # not False; omitted values should keep the model field default.
+        if "parallel_tool_calls" in values and values["parallel_tool_calls"] is None:
             values["parallel_tool_calls"] = True
         return values
 

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -891,6 +891,12 @@ class ChatCompletionRequest(BaseModel):
                 values["tool_choice"] = "none"
             else:
                 values["tool_choice"] = "auto"
+        # An explicit null parallel_tool_calls means "use the field default",
+        # not False, so downstream consumers never see None.
+        if values.get("parallel_tool_calls") is None:
+            values["parallel_tool_calls"] = cls.model_fields[
+                "parallel_tool_calls"
+            ].default
         return values
 
     @field_validator("reasoning_effort", mode="before")

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -892,8 +892,8 @@ class ChatCompletionRequest(BaseModel):
             else:
                 values["tool_choice"] = "auto"
         # An explicit null parallel_tool_calls means "use the field default",
-        # not False, so downstream consumers never see None.
-        if values.get("parallel_tool_calls") is None:
+        # not False; omitted values should leave default ownership to Pydantic.
+        if "parallel_tool_calls" in values and values["parallel_tool_calls"] is None:
             values["parallel_tool_calls"] = cls.model_fields[
                 "parallel_tool_calls"
             ].default

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -140,6 +140,12 @@ class TestChatCompletionRequest(unittest.TestCase):
             ).parallel_tool_calls
         )
 
+    def test_parallel_tool_calls_absent_is_not_injected_by_validator(self):
+        values = ChatCompletionRequest.set_tool_choice_default(
+            {"model": "x", "messages": [{"role": "user", "content": "Hello"}]}
+        )
+        self.assertNotIn("parallel_tool_calls", values)
+
     def test_sampling_param_build(self):
         req = ChatCompletionRequest(
             model="x",

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -125,6 +125,21 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertFalse(request.stream)  # default
         self.assertEqual(request.tool_choice, "none")  # default when no tools
 
+    def test_parallel_tool_calls_null_resolves_to_default(self):
+        """Explicit null must be accepted (not 422) and resolve to the default
+        True, so downstream tool-call constraints don't read it as False."""
+        messages = [{"role": "user", "content": "Hello"}]
+        self.assertTrue(
+            ChatCompletionRequest(
+                model="x", messages=messages, parallel_tool_calls=None
+            ).parallel_tool_calls
+        )
+        self.assertFalse(
+            ChatCompletionRequest(
+                model="x", messages=messages, parallel_tool_calls=False
+            ).parallel_tool_calls
+        )
+
     def test_sampling_param_build(self):
         req = ChatCompletionRequest(
             model="x",


### PR DESCRIPTION
## Motivation

Some OpenAI-compatible clients send `parallel_tool_calls: null` to request default behavior. `ChatCompletionRequest` intentionally exposes a strict `bool = True`, so explicit null currently fails validation with HTTP 422 even though omission selects the default.

This is a tolerant compatibility normalization; the published OpenAI schema documents an optional boolean with default `true`, but does not explicitly document JSON null.

## Changes

- Normalize only an explicitly present null value in the existing request before-validator.
- Read the declared Pydantic field default instead of duplicating literal `True`.
- Keep the field non-optional, so no downstream tool-constraint builder can receive `None`.

The boundary contract is:

- omitted -> declared default `True`
- explicit null -> declared default `True`
- explicit false -> `False`

Omitted input remains absent from `model_fields_set` and `model_dump(exclude_unset=True)`; explicit null remains marked as explicitly supplied.

## Verification

- Protocol suite: 36 tests passed, plus 16 subtests.
- Direct Pydantic probes confirmed omitted/null/false values and field-set behavior.
- Both JSON-schema and structural-tag constraint paths receive the expected boolean.
- File-scoped pre-commit and `git diff --check` passed.
- Rebased onto current `main` and independently reviewed with no findings.

## Accuracy Tests

N/A. This is request validation only; no model or kernel path changes.

## Speed Tests and Profiling

N/A. The change is one request-boundary default lookup.

## Checklist

- [x] Format code with pre-commit.
- [x] Add focused unit coverage.
- [ ] Update documentation - not required for this compatibility fix.
- [ ] Provide accuracy and speed benchmarks - not applicable; see above.
- [x] Follow SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31550830480](https://github.com/sgl-project/sglang/actions/runs/31550830480)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31550830317](https://github.com/sgl-project/sglang/actions/runs/31550830317)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->