### PR TITLE
fix(openai): report cached_tokens=0 when cache reporting is enabled

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -652,10 +652,9 @@ class OpenAIServingChat(OpenAIServingBase):
     def _continuous_usage_cached_details(
         self, content: Dict[str, Any]
     ) -> Optional[PromptTokensDetails]:
-        if not self.tokenizer_manager.server_args.enable_cache_report:
-            return None
-        return UsageProcessor._details_if_cached(
-            content["meta_info"].get("cached_tokens", 0)
+        return UsageProcessor._cache_details_if_enabled(
+            content["meta_info"].get("cached_tokens", 0),
+            self.tokenizer_manager.server_args.enable_cache_report,
         )
 
     def _reported_prompt_tokens(self, meta_info: Dict[str, Any]) -> int:

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -385,6 +385,10 @@ class OpenAIServingCompletion(OpenAIServingBase):
                         prompt_tokens=prompt_tokens.get(index, 0),
                         completion_tokens=completion_tokens.get(index, 0),
                         reasoning_tokens=reasoning_tokens.get(index, 0),
+                        cached_tokens=UsageProcessor._cache_details_if_enabled(
+                            cached_tokens.get(index, 0),
+                            self.tokenizer_manager.server_args.enable_cache_report,
+                        ),
                     )
 
                 yield f"data: {chunk.model_dump_json()}\n\n"

--- a/python/sglang/srt/entrypoints/openai/usage_processor.py
+++ b/python/sglang/srt/entrypoints/openai/usage_processor.py
@@ -10,9 +10,11 @@ class UsageProcessor:
     """Stateless helpers that turn raw token counts into a UsageInfo."""
 
     @staticmethod
-    def _details_if_cached(count: int) -> Optional[PromptTokensDetails]:
-        """Return PromptTokensDetails only when count > 0 (keeps JSON slim)."""
-        return PromptTokensDetails(cached_tokens=count) if count > 0 else None
+    def _details_if_cached(count: int) -> PromptTokensDetails:
+        """Build cache details. Callers gate on enable_cache_report, so a count
+        of 0 is still reported (distinguishing "enabled, nothing cached" from
+        "reporting disabled")."""
+        return PromptTokensDetails(cached_tokens=count)
 
     @staticmethod
     def calculate_response_usage(

--- a/python/sglang/srt/entrypoints/openai/usage_processor.py
+++ b/python/sglang/srt/entrypoints/openai/usage_processor.py
@@ -10,9 +10,10 @@ class UsageProcessor:
     """Stateless helpers that turn raw token counts into a UsageInfo."""
 
     @staticmethod
-    def _details_if_cached(count: int) -> Optional[PromptTokensDetails]:
-        """Return PromptTokensDetails only when count > 0 (keeps JSON slim)."""
-        return PromptTokensDetails(cached_tokens=count) if count > 0 else None
+    def _cache_details_if_enabled(
+        count: int, enable_cache_report: bool
+    ) -> Optional[PromptTokensDetails]:
+        return PromptTokensDetails(cached_tokens=count) if enable_cache_report else None
 
     @staticmethod
     def calculate_response_usage(
@@ -36,13 +37,13 @@ class UsageProcessor:
             r["meta_info"].get("reasoning_tokens", 0) for r in responses
         )
 
-        cached_details = None
-        if enable_cache_report:
-            cached_total = sum(
-                responses[i]["meta_info"].get("cached_tokens", 0)
-                for i in range(0, len(responses), n_choices)
-            )
-            cached_details = UsageProcessor._details_if_cached(cached_total)
+        cached_total = sum(
+            responses[i]["meta_info"].get("cached_tokens", 0)
+            for i in range(0, len(responses), n_choices)
+        )
+        cached_details = UsageProcessor._cache_details_if_enabled(
+            cached_total, enable_cache_report
+        )
 
         return UsageProcessor.calculate_token_usage(
             prompt_tokens=prompt_tokens,
@@ -73,12 +74,9 @@ class UsageProcessor:
         total_reasoning_tokens = sum(reasoning_tokens.values())
         total_completion_tokens = sum(completion_tokens.values())
 
-        cached_details = (
-            UsageProcessor._details_if_cached(
-                sum(tok for idx, tok in cached_tokens.items() if idx % n_choices == 0)
-            )
-            if enable_cache_report
-            else None
+        cached_details = UsageProcessor._cache_details_if_enabled(
+            sum(tok for idx, tok in cached_tokens.items() if idx % n_choices == 0),
+            enable_cache_report,
         )
 
         return UsageProcessor.calculate_token_usage(

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -335,6 +335,65 @@ class ServingCompletionTestCase(unittest.TestCase):
                 for choice in choices[1:]:
                     self.assertNotIn("prompt_token_ids", choice)
 
+    def _collect_continuous_usage(self, cached_tokens, enable_cache_report):
+        async def _mock_generate(*args, **kwargs):
+            yield {
+                "text": "response",
+                "meta_info": {
+                    "id": "cmpl-continuous-usage",
+                    "prompt_tokens": 10,
+                    "completion_tokens": 2,
+                    "cached_tokens": cached_tokens,
+                    "finish_reason": {"type": "stop", "matched": None},
+                },
+                "index": 0,
+            }
+
+        self.sc.tokenizer_manager.generate_request = _mock_generate
+        self.sc.tokenizer_manager.server_args.enable_cache_report = enable_cache_report
+        self.sc.tokenizer_manager.server_args.stream_response_default_include_usage = (
+            False
+        )
+        self.sc.tokenizer_manager.server_args.incremental_streaming_output = False
+        req = CompletionRequest(
+            model="x",
+            prompt="Hello world",
+            stream=True,
+            stream_options={"continuous_usage_stats": True},
+        )
+        adapted_request, _ = self.sc._convert_to_internal_request(req)
+
+        async def _collect():
+            return [
+                chunk
+                async for chunk in self.sc._generate_completion_stream(
+                    adapted_request, req, self.fastapi_request
+                )
+            ]
+
+        chunks = get_or_create_event_loop().run_until_complete(_collect())
+        return [
+            json.loads(chunk[len("data: ") :])["usage"]
+            for chunk in chunks
+            if chunk.startswith("data: ") and chunk.strip() != "data: [DONE]"
+        ]
+
+    def test_continuous_usage_cache_reporting_for_text_requests(self):
+        for enable_cache_report, cached_tokens, expected in (
+            (False, 7, None),
+            (True, 0, {"cached_tokens": 0}),
+            (True, 7, {"cached_tokens": 7}),
+        ):
+            with self.subTest(
+                enable_cache_report=enable_cache_report,
+                cached_tokens=cached_tokens,
+            ):
+                usages = self._collect_continuous_usage(
+                    cached_tokens, enable_cache_report
+                )
+                self.assertEqual(len(usages), 1)
+                self.assertEqual(usages[0]["prompt_tokens_details"], expected)
+
     def test_non_streaming_cached_tokens_details_emits_sglext(self):
         """Test that non-streaming completion responses emit cached token details in sglext."""
 

--- a/test/registered/unit/entrypoints/openai/test_usage_cached_tokens.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_cached_tokens.py
@@ -1,0 +1,49 @@
+"""When cache reporting is enabled, cached_tokens=0 must still be reported.
+
+Returning None for a 0 count makes "cache reporting on, nothing cached"
+indistinguishable from "cache reporting off" for the client.
+"""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(3, "base-a-test-cpu")
+
+
+def _responses(cached_tokens):
+    return [
+        {
+            "meta_info": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "cached_tokens": cached_tokens,
+            }
+        }
+    ]
+
+
+class TestCachedTokensReporting(unittest.TestCase):
+    def test_zero_reported_when_enabled(self):
+        usage = UsageProcessor.calculate_response_usage(
+            _responses(0), enable_cache_report=True
+        )
+        self.assertIsNotNone(usage.prompt_tokens_details)
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 0)
+
+    def test_nonzero_reported_when_enabled(self):
+        usage = UsageProcessor.calculate_response_usage(
+            _responses(7), enable_cache_report=True
+        )
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 7)
+
+    def test_not_reported_when_disabled(self):
+        usage = UsageProcessor.calculate_response_usage(
+            _responses(0), enable_cache_report=False
+        )
+        self.assertIsNone(usage.prompt_tokens_details)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_usage_cached_tokens.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_cached_tokens.py
@@ -1,0 +1,49 @@
+import unittest
+
+from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(3, "base-a-test-cpu")
+
+
+def _response_usage(cached_tokens, enabled):
+    return UsageProcessor.calculate_response_usage(
+        [{"meta_info": {"cached_tokens": cached_tokens}}],
+        enable_cache_report=enabled,
+    )
+
+
+def _streaming_usage(cached_tokens, enabled):
+    return UsageProcessor.calculate_streaming_usage(
+        prompt_tokens={0: 0},
+        reasoning_tokens={0: 0},
+        completion_tokens={0: 0},
+        cached_tokens={0: cached_tokens},
+        n_choices=1,
+        enable_cache_report=enabled,
+    )
+
+
+class TestCachedTokensReporting(unittest.TestCase):
+    def test_cache_details_follow_reporting_flag(self):
+        for calculate in (_response_usage, _streaming_usage):
+            for enabled, cached_tokens, expected in (
+                (False, 0, None),
+                (False, 7, None),
+                (True, 0, {"cached_tokens": 0}),
+                (True, 7, {"cached_tokens": 7}),
+            ):
+                with self.subTest(
+                    calculate=calculate.__name__,
+                    enabled=enabled,
+                    cached_tokens=cached_tokens,
+                ):
+                    usage = calculate(cached_tokens, enabled)
+                    actual = usage.model_dump(exclude_none=True).get(
+                        "prompt_tokens_details"
+                    )
+                    self.assertEqual(actual, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With `--enable-cache-report`, a zero cache hit is meaningful: reporting was enabled and nothing was cached. Current usage handling collapses that state into `prompt_tokens_details=None`, making it indistinguishable from disabled reporting. The legacy Completions continuous-stream path also omitted cache details entirely.

## Changes

- Make `enable_cache_report` the single presence gate for cache details.
- When enabled, report `cached_tokens` for both zero and nonzero counts.
- Preserve `None` for disabled text-only requests; multimodal usage may still legitimately create prompt details.
- Apply the same owner across nonstreaming responses, final streaming usage, Chat continuous usage, and legacy Completions continuous usage.
- Preserve existing `n`-choice aggregation.

This extends the Chat continuous-usage plumbing already on main through #29703. It also completes the earlier Chat + legacy Completions gap identified in #20203; thanks @rlrs for the prior investigation and implementation.

## Verification

- Added response/final-stream zero, nonzero, and disabled cases.
- Added handler-level legacy Completions continuous-stream coverage for the same matrix.
- Black, isort, Ruff, `py_compile`, `git diff --check`, source-level behavior probes, and a fresh-context review pass on exact head `2e5bf81c6c8cbe83862bf7815d6ae60eb2445c44`.

Hosted CI and human review remain required before merge.
