### PR TITLE
fix(openai): honor encoding_format=base64 for embeddings

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1086,7 +1086,7 @@ class EmbeddingRequest(BaseModel):
 
 
 class EmbeddingObject(BaseModel):
-    embedding: List[float]
+    embedding: Union[List[float], str]
     index: int
     object: str = "embedding"
 

--- a/python/sglang/srt/entrypoints/openai/serving_embedding.py
+++ b/python/sglang/srt/entrypoints/openai/serving_embedding.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import base64
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import jinja2
+import numpy as np
 from fastapi import Request
 from fastapi.responses import ORJSONResponse
 
@@ -41,6 +43,12 @@ class OpenAIServingEmbedding(OpenAIServingBase):
 
     def _validate_request(self, request: EmbeddingRequest) -> Optional[str]:
         """Validate that the input is not empty or whitespace only."""
+        if request.encoding_format not in ("float", "base64"):
+            return (
+                f"Unsupported encoding_format: {request.encoding_format!r}. "
+                "Expected 'float' or 'base64'."
+            )
+
         if not (input := request.input):
             return "Input cannot be empty"
 
@@ -254,18 +262,25 @@ class OpenAIServingEmbedding(OpenAIServingBase):
         if not isinstance(ret, list):
             ret = [ret]
 
-        response = self._build_embedding_response(ret)
+        response = self._build_embedding_response(ret, request.encoding_format)
         return response
 
-    def _build_embedding_response(self, ret: List[Dict[str, Any]]) -> EmbeddingResponse:
-        """Build the embedding response"""
+    def _build_embedding_response(
+        self, ret: List[Dict[str, Any]], encoding_format: str
+    ) -> EmbeddingResponse:
+        """Build the embedding response (encoding_format validated upstream)."""
         embedding_objects = []
         prompt_tokens = 0
 
         for idx, ret_item in enumerate(ret):
+            embedding = ret_item["embedding"]
+            if encoding_format == "base64":
+                embedding = base64.b64encode(
+                    np.asarray(embedding, dtype="<f4").tobytes()
+                ).decode("ascii")
             embedding_objects.append(
                 EmbeddingObject(
-                    embedding=ret_item["embedding"],
+                    embedding=embedding,
                     index=idx,
                 )
             )

--- a/test/registered/unit/entrypoints/openai/test_serving_embedding.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_embedding.py
@@ -2,6 +2,7 @@
 Unit tests for the OpenAIServingEmbedding class from serving_embedding.py.
 """
 
+import base64
 import importlib
 import importlib.abc
 import importlib.machinery
@@ -12,6 +13,7 @@ import uuid
 from unittest.mock import MagicMock, Mock
 
 import jinja2
+import numpy as np
 
 
 # Stub out sgl_kernel (and all submodules) before any sglang import so
@@ -338,6 +340,29 @@ class ServingEmbeddingTestCase(unittest.TestCase):
             self.serving_embedding._convert_to_internal_request(
                 self.image_only_multimodal_req
             )
+
+    def test_build_response_float_returns_list(self):
+        embedding = [0.1, 0.2, 0.3, 0.4, 0.5]
+        ret = [{"embedding": embedding, "meta_info": {"prompt_tokens": 5}}]
+        response = self.serving_embedding._build_embedding_response(ret, "float")
+        self.assertEqual(response.data[0].embedding, embedding)
+
+    def test_build_response_base64_round_trips(self):
+        embedding = [0.1, 0.2, 0.3, 0.4, 0.5]
+        ret = [{"embedding": embedding, "meta_info": {"prompt_tokens": 5}}]
+
+        response = self.serving_embedding._build_embedding_response(ret, "base64")
+
+        encoded = response.data[0].embedding
+        self.assertIsInstance(encoded, str)
+        decoded = np.frombuffer(base64.b64decode(encoded), dtype="<f4")
+        np.testing.assert_allclose(decoded, embedding, rtol=1e-6)
+
+    def test_validate_request_rejects_unsupported_encoding_format(self):
+        err = self.serving_embedding._validate_request(
+            EmbeddingRequest(input="x", encoding_format="int8")
+        )
+        self.assertIn("encoding_format", err)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

The `/v1/embeddings` endpoint ignored `request.encoding_format` and always returned float lists. The official `openai-python` SDK sends `encoding_format="base64"` **by default** and decodes the base64 client-side, so SGLang's float-only responses break the canonical client. Unsupported values were also silently accepted instead of being rejected.

## Modifications

- `serving_embedding.py`: `_build_embedding_response` now takes `encoding_format` and, for `"base64"`, encodes each embedding as base64 of its little-endian float32 bytes (`np.asarray(..., dtype="<f4").tobytes()`); `"float"`/default keeps returning `List[float]`. This matches the OpenAI float32 base64 layout the SDK expects.
- `_validate_request` rejects any `encoding_format` other than `"float"`/`"base64"` before the forward pass, returning a clear error.
- `protocol.py`: widen `EmbeddingObject.embedding` to `Union[List[float], str]` so the base64 string is representable.
- No behavior change for existing callers: the default is still `"float"` and returns a list.
- Tests (`test_serving_embedding.py`): `"float"` returns the original list, `"base64"` round-trips back to the input floats, and an unsupported value is rejected by `_validate_request`.

## Accuracy Tests

Not applicable — no change to kernels or the model forward path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28888273572](https://github.com/sgl-project/sglang/actions/runs/28888273572)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28888273342](https://github.com/sgl-project/sglang/actions/runs/28888273342)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->