### PR TITLE
fix(constrained): reject JSON schemas xgrammar cannot enforce

### DIFF
--- a/python/sglang/srt/constrained/xgrammar_backend.py
+++ b/python/sglang/srt/constrained/xgrammar_backend.py
@@ -56,6 +56,52 @@ logger = logging.getLogger(__name__)
 MAX_ROLLBACK_TOKENS = 200
 
 
+def has_xgrammar_unsupported_json_features(schema: dict) -> bool:
+    """Whether the JSON schema uses keywords xgrammar silently ignores.
+
+    These keywords need counting/arithmetic/regex-keyed matching that a
+    context-free grammar cannot express, so xgrammar compiles the schema
+    without error but does not enforce them and generation can violate the
+    schema. Detecting this lets the caller fail loudly instead. (The string
+    ``format`` keyword is deliberately not checked: which formats xgrammar
+    supports is version-dependent, so flagging it risks false positives.)
+    """
+
+    def check(obj) -> bool:
+        if not isinstance(obj, dict):
+            return False
+
+        # "type" may be a single string or a list (e.g. ["integer", "null"] for a
+        # nullable field); normalize to a set before testing membership.
+        raw_type = obj.get("type")
+        types = (
+            {raw_type}
+            if isinstance(raw_type, str)
+            else set(raw_type) if isinstance(raw_type, list) else set()
+        )
+        if types & {"integer", "number"} and "multipleOf" in obj:
+            return True
+        if "array" in types and any(
+            key in obj for key in ("uniqueItems", "contains", "maxContains")
+        ):
+            return True
+        if "object" in types and any(
+            key in obj for key in ("patternProperties", "propertyNames")
+        ):
+            return True
+
+        for value in obj.values():
+            if isinstance(value, dict):
+                if check(value):
+                    return True
+            elif isinstance(value, list):
+                if any(isinstance(item, dict) and check(item) for item in value):
+                    return True
+        return False
+
+    return check(schema)
+
+
 class XGrammarGrammar(BaseGrammarObject):
 
     def __init__(
@@ -320,6 +366,16 @@ class XGrammarGrammarBackend(BaseGrammarBackend):
                 # Note: This builtin JSON grammar includes *all* valid JSON (including, for example, arrays at the root)
                 ctx = self.grammar_compiler.compile_builtin_json_grammar()
             else:
+                schema = json.loads(key_string)
+                if isinstance(schema, dict) and has_xgrammar_unsupported_json_features(
+                    schema
+                ):
+                    raise RuntimeError(
+                        "JSON schema uses features unsupported by xgrammar "
+                        "(e.g. multipleOf, uniqueItems, contains, "
+                        "patternProperties, propertyNames); the constraint "
+                        "would otherwise be silently ignored"
+                    )
                 ctx = self.grammar_compiler.compile_json_schema(
                     schema=key_string, any_whitespace=self.any_whitespace
                 )

--- a/python/sglang/srt/constrained/xgrammar_backend.py
+++ b/python/sglang/srt/constrained/xgrammar_backend.py
@@ -67,39 +67,67 @@ def has_xgrammar_unsupported_json_features(schema: dict) -> bool:
     supports is version-dependent, so flagging it risks false positives.)
     """
 
-    def check(obj) -> bool:
+    schema_array_keywords = (
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "prefixItems",
+    )
+    schema_keywords = (
+        "additionalItems",
+        "additionalProperties",
+        "contains",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    )
+    schema_map_keywords = (
+        "$defs",
+        "dependentSchemas",
+        "definitions",
+        "patternProperties",
+        "properties",
+    )
+    unsupported_keywords = (
+        "contains",
+        "maxContains",
+        "minContains",
+        "multipleOf",
+        "patternProperties",
+        "propertyNames",
+        "uniqueItems",
+    )
+
+    def check_schema(obj) -> bool:
         if not isinstance(obj, dict):
             return False
 
-        # "type" may be a single string or a list (e.g. ["integer", "null"] for a
-        # nullable field); normalize to a set before testing membership.
-        raw_type = obj.get("type")
-        types = (
-            {raw_type}
-            if isinstance(raw_type, str)
-            else set(raw_type) if isinstance(raw_type, list) else set()
-        )
-        if types & {"integer", "number"} and "multipleOf" in obj:
-            return True
-        if "array" in types and any(
-            key in obj for key in ("uniqueItems", "contains", "maxContains")
-        ):
-            return True
-        if "object" in types and any(
-            key in obj for key in ("patternProperties", "propertyNames")
-        ):
+        if any(key in obj for key in unsupported_keywords):
             return True
 
-        for value in obj.values():
+        for key in schema_keywords:
+            if check_schema(obj.get(key)):
+                return True
+
+        for key in schema_array_keywords:
+            value = obj.get(key)
+            if isinstance(value, list) and any(check_schema(item) for item in value):
+                return True
+
+        for key in schema_map_keywords:
+            value = obj.get(key)
             if isinstance(value, dict):
-                if check(value):
+                if any(check_schema(item) for item in value.values()):
                     return True
-            elif isinstance(value, list):
-                if any(isinstance(item, dict) and check(item) for item in value):
-                    return True
+
         return False
 
-    return check(schema)
+    return check_schema(schema)
 
 
 class XGrammarGrammar(BaseGrammarObject):

--- a/test/registered/unit/constrained/test_xgrammar_unsupported_schema.py
+++ b/test/registered/unit/constrained/test_xgrammar_unsupported_schema.py
@@ -1,0 +1,60 @@
+"""Unit tests for xgrammar's unsupported-JSON-feature detection."""
+
+import unittest
+
+from sglang.srt.constrained.xgrammar_backend import (
+    has_xgrammar_unsupported_json_features,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestHasXGrammarUnsupportedJsonFeatures(unittest.TestCase):
+    def test_supported_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+                "tags": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["name"],
+        }
+        self.assertFalse(has_xgrammar_unsupported_json_features(schema))
+
+    def test_unsupported_keywords(self):
+        cases = [
+            {"type": "integer", "multipleOf": 2},
+            {"type": "number", "multipleOf": 0.5},
+            # Nullable field: "type" as a list must still be detected.
+            {"type": ["integer", "null"], "multipleOf": 2},
+            {"type": "array", "items": {"type": "integer"}, "uniqueItems": True},
+            {
+                "type": "array",
+                "items": {"type": "integer"},
+                "contains": {"type": "integer"},
+            },
+            {"type": "array", "items": {"type": "integer"}, "maxContains": 2},
+            {"type": "object", "patternProperties": {"^x": {"type": "string"}}},
+            {"type": "object", "propertyNames": {"pattern": "^x"}},
+        ]
+        for schema in cases:
+            with self.subTest(schema=schema):
+                self.assertTrue(has_xgrammar_unsupported_json_features(schema))
+
+    def test_unsupported_feature_nested(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {"type": "integer", "multipleOf": 3},
+                }
+            },
+        }
+        self.assertTrue(has_xgrammar_unsupported_json_features(schema))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/constrained/test_xgrammar_unsupported_schema.py
+++ b/test/registered/unit/constrained/test_xgrammar_unsupported_schema.py
@@ -25,18 +25,25 @@ class TestHasXGrammarUnsupportedJsonFeatures(unittest.TestCase):
 
     def test_unsupported_keywords(self):
         cases = [
+            {"multipleOf": 2},
             {"type": "integer", "multipleOf": 2},
             {"type": "number", "multipleOf": 0.5},
             # Nullable field: "type" as a list must still be detected.
             {"type": ["integer", "null"], "multipleOf": 2},
+            {"uniqueItems": True},
             {"type": "array", "items": {"type": "integer"}, "uniqueItems": True},
+            {"contains": {"type": "integer"}},
             {
                 "type": "array",
                 "items": {"type": "integer"},
                 "contains": {"type": "integer"},
             },
+            {"minContains": 1},
+            {"maxContains": 2},
             {"type": "array", "items": {"type": "integer"}, "maxContains": 2},
+            {"patternProperties": {"^x": {"type": "string"}}},
             {"type": "object", "patternProperties": {"^x": {"type": "string"}}},
+            {"propertyNames": {"pattern": "^x"}},
             {"type": "object", "propertyNames": {"pattern": "^x"}},
         ]
         for schema in cases:
@@ -54,6 +61,21 @@ class TestHasXGrammarUnsupportedJsonFeatures(unittest.TestCase):
             },
         }
         self.assertTrue(has_xgrammar_unsupported_json_features(schema))
+
+    def test_property_names_that_match_unsupported_keywords_are_allowed(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "multipleOf": {"type": "number"},
+                "uniqueItems": {"type": "boolean"},
+                "contains": {"type": "string"},
+                "patternProperties": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                },
+            },
+        }
+        self.assertFalse(has_xgrammar_unsupported_json_features(schema))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

xgrammar (sglang's default constrained-decoding backend) compiles JSON schemas that use `multipleOf`, `uniqueItems`, `contains`/`minContains`/`maxContains`, `patternProperties`, or `propertyNames`, but **silently ignores** those keywords — compilation succeeds and generation can violate the schema with no error. These keywords require counting / arithmetic / regex-keyed matching that a context-free grammar cannot express, so xgrammar drops them.

## Modifications

- `python/sglang/srt/constrained/xgrammar_backend.py`:
  - Add `has_xgrammar_unsupported_json_features(schema)` — recursively walks parsed schema positions and returns `True` if any unenforceable keyword appears, even when the schema omits an explicit `type`. The string `format` keyword is deliberately **not** flagged: which formats xgrammar supports is version-dependent, so flagging it would risk false positives.
  - In `dispatch_json`, parse the schema and run the check before `compile_json_schema`; on a hit, `raise RuntimeError(...)`, which flows through the existing `except` and returns `InvalidGrammarObject` with a clear message. Array-root schemas (`json.loads` returns a list) are passed through unchanged via an `isinstance(schema, dict)` guard.
  - Detection walks only actual schema positions, so schemas that omit `type` are still rejected, while a property merely *named* after one of these keywords is not falsely flagged.

  Detect-and-reject only, no auto-fallback: sglang selects one grammar backend globally, so there is no per-request backend to fall back to.

- `test/registered/unit/constrained/test_xgrammar_unsupported_schema.py`: each unsupported keyword is detected (including nested, list-typed `type`, and no-`type` schemas); plain schemas and property names that match unsupported keywords are not flagged.

**Behavior change:** a schema using these keywords previously compiled and ran silently unconstrained; it now returns `InvalidGrammarObject` (a clear error) instead of producing output that violates the schema.

## Accuracy Tests

Not applicable — no change to kernels or the model forward path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29485217972](https://github.com/sgl-project/sglang/actions/runs/29485217972)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29485213851](https://github.com/sgl-project/sglang/actions/runs/29485213851)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->