### PR TITLE
fix(tokenizer_manager): give each parallel sample a distinct seed

### DIFF
--- a/docs/docs/advanced_features/deterministic_inference.mdx
+++ b/docs/docs/advanced_features/deterministic_inference.mdx
@@ -164,7 +164,17 @@ print(response.json())
 
 #### Generating Multiple Reproducible Responses
 
-To sample different responses from the same prompt while maintaining reproducibility (e.g., for GRPO training), provide different sampling seeds in your requests:
+For an OpenAI request with `n > 1`, SGLang assigns each choice a distinct,
+reproducible seed. An explicit seed produces `seed`, `seed + 1`, and so on; if
+the seed is omitted, deterministic inference starts from the default seed of
+`42`. Derived seeds wrap with signed 64-bit arithmetic. User-provided seeds must
+be signed 64-bit integers.
+
+Distinct seeds select distinct random streams, but they do not guarantee
+distinct text (for example, greedy decoding may still produce identical
+choices).
+
+You can also provide seeds explicitly when issuing separate requests:
 
 ```python Example
 import requests
@@ -187,13 +197,13 @@ for seed in sampling_seeds:
     )
     responses.append(response.json())
 
-# Each seed will produce a different but reproducible response
-# Using the same seed will always produce the same response
+# Each seed selects a distinct, reproducible random stream
+# Using the same seed reproduces that stream across runs
 ```
 
 This approach ensures that:
-- Different seeds produce diverse responses
-- The same seed always produces the same response across different runs
+- Different seeds select distinct random streams
+- The same seed reproduces the same stream across runs
 - Results are reproducible for debugging and evaluation
 
 

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -51,6 +51,7 @@ from openai.types.responses.response_format_text_json_schema_config import (
 from openai.types.shared.response_format_json_object import ResponseFormatJSONObject
 from pydantic import (
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
     field_serializer,
@@ -68,6 +69,19 @@ except:
 from sglang.utils import convert_json_schema_to_str
 
 logger = logging.getLogger(__name__)
+
+
+def _reject_bool_seed(value: Any) -> Any:
+    if isinstance(value, bool):
+        raise ValueError("seed must be a signed 64-bit integer")
+    return value
+
+
+_SamplingSeed = Annotated[
+    int,
+    BeforeValidator(_reject_bool_seed),
+    Field(ge=-(1 << 63), le=(1 << 63) - 1),
+]
 
 DEFAULT_MODEL_NAME = "default"
 
@@ -336,7 +350,7 @@ class CompletionRequest(BaseModel):
     max_tokens: int = 16
     n: int = 1
     presence_penalty: float = 0.0
-    seed: Optional[int] = None
+    seed: Optional[_SamplingSeed] = None
     stop: Optional[Union[str, List[str]]] = None
     stream: bool = False
     stream_options: Optional[StreamOptions] = None
@@ -768,7 +782,7 @@ class ChatCompletionRequest(BaseModel):
     n: int = 1
     presence_penalty: float = 0.0
     response_format: Optional[Union[ResponseFormat, StructuralTagResponseFormat]] = None
-    seed: Optional[int] = None
+    seed: Optional[_SamplingSeed] = None
     stop: Optional[Union[str, List[str]]] = None
     stream: bool = False
     stream_options: Optional[StreamOptions] = None

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -252,7 +252,7 @@ def _seed_for_parallel_sample(
     if sampling_params.sampling_seed is None:
         return sampling_params
     offset = copy.copy(sampling_params)
-    offset.sampling_seed += sample_index
+    offset.sampling_seed = (offset.sampling_seed + sample_index) & 0xFFFFFFFFFFFFFFFF
     return offset
 
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -241,6 +241,21 @@ class InputFormat(Enum):
     CROSS_ENCODER_PAIRS = 3  # Cross-encoder pairs like [["query", "document"]]
 
 
+def _seed_for_parallel_sample(
+    sampling_params: SamplingParams, sample_index: int
+) -> SamplingParams:
+    """Offset the seed for the sample_index-th parallel sample (unseeded: as-is).
+
+    multinomial_with_seed hashes sampling_seed, so without this an n>1 request
+    with a fixed seed yields N identical completions.
+    """
+    if sampling_params.sampling_seed is None:
+        return sampling_params
+    offset = copy.copy(sampling_params)
+    offset.sampling_seed += sample_index
+    return offset
+
+
 class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     """TokenizerManager is a process that tokenizes the text."""
 
@@ -1628,7 +1643,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
             # Expand requests, assign new rids for them, and send them
             for i in range(batch_size):
-                for _ in range(obj.parallel_sample_num):
+                for j in range(obj.parallel_sample_num):
                     tmp_obj = copy.copy(objs[i])
                     tokenized_obj = copy.copy(tokenized_objs[i])
                     # Ensure independent mm_items so wrap_shm_features won't mutate the original
@@ -1637,6 +1652,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         tokenized_obj.mm_inputs.mm_items = [
                             copy.copy(item) for item in tokenized_obj.mm_inputs.mm_items
                         ]
+                    tokenized_obj.sampling_params = _seed_for_parallel_sample(
+                        tokenized_obj.sampling_params, j
+                    )
                     tokenized_obj.rid = tmp_obj.regenerate_rid()
                     self._init_req_state(tmp_obj)
                     state = self.rid_to_state[tmp_obj.rid]

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -371,6 +371,20 @@ _SERVER_ARGS_FIELDS = frozenset(f.name for f in dataclasses.fields(ServerArgs))
 _MANAGER_OWNED_FIELDS = ("model_path", "served_model_name")
 
 
+def _seed_for_parallel_sample(
+    sampling_params: SamplingParams, sample_index: int, *, deterministic: bool
+) -> SamplingParams:
+    seed = sampling_params.sampling_seed_for_sample(
+        sample_index, deterministic=deterministic
+    )
+    if seed is None:
+        return sampling_params
+
+    offset = copy.copy(sampling_params)
+    offset.sampling_seed = seed
+    return offset
+
+
 class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     """TokenizerManager is a process that tokenizes the text."""
 
@@ -1869,7 +1883,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
             # Expand requests, assign new rids for them, and send them
             for i in range(batch_size):
-                for _ in range(obj.parallel_sample_num):
+                for j in range(obj.parallel_sample_num):
                     tmp_obj = copy.copy(objs[i])
                     tokenized_obj = copy.copy(tokenized_objs[i])
                     # Ensure independent mm_items so wrap_shm_features won't mutate the original
@@ -1878,6 +1892,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         tokenized_obj.mm_inputs.mm_items = [
                             copy.copy(item) for item in tokenized_obj.mm_inputs.mm_items
                         ]
+                    tokenized_obj.sampling_params = _seed_for_parallel_sample(
+                        tokenized_obj.sampling_params,
+                        j,
+                        deterministic=self.server_args.enable_deterministic_inference,
+                    )
                     tokenized_obj.rid = tmp_obj.regenerate_rid()
                     self._init_req_state(tmp_obj)
                     state = self.rid_to_state[tmp_obj.rid]

--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -37,6 +37,9 @@ CustomParamValue = Union[
 ]
 
 _SAMPLING_EPS = 1e-6
+_SAMPLING_SEED_MIN = -(1 << 63)
+_SAMPLING_SEED_MAX = (1 << 63) - 1
+_DETERMINISTIC_DEFAULT_SEED = 42
 TOP_K_ALL = 1 << 30
 
 logger = logging.getLogger(__name__)
@@ -149,6 +152,14 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
             self.top_k = TOP_K_ALL  # whole vocabulary
 
     def verify(self, vocab_size):
+        if self.sampling_seed is not None and (
+            type(self.sampling_seed) is not int
+            or not _SAMPLING_SEED_MIN <= self.sampling_seed <= _SAMPLING_SEED_MAX
+        ):
+            raise ValueError(
+                "sampling_seed must be a signed 64-bit integer, got "
+                f"{self.sampling_seed}."
+            )
         if not math.isfinite(self.temperature) or self.temperature < 0.0:
             raise ValueError(
                 f"temperature must be a non-negative finite number, got {self.temperature}."
@@ -208,6 +219,19 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
             raise ValueError(
                 "Only one of json_schema, regex, ebnf, or structural_tag can be set."
             )
+
+    def sampling_seed_for_sample(
+        self, sample_index: int, *, deterministic: bool
+    ) -> Optional[int]:
+        seed = self.sampling_seed
+        if seed is None:
+            if not deterministic:
+                return None
+            seed = _DETERMINISTIC_DEFAULT_SEED
+
+        return ((seed + sample_index - _SAMPLING_SEED_MIN) % (1 << 64)) + (
+            _SAMPLING_SEED_MIN
+        )
 
     def normalize(self, tokenizer):
         # Process stop strings

--- a/rust/sglang-server/src/api_server/openai.rs
+++ b/rust/sglang-server/src/api_server/openai.rs
@@ -26,10 +26,26 @@ use super::frame::OutputAccumulator;
 use super::guard::AbortGuard;
 use super::submit::submit;
 use crate::ids::Rid;
-use crate::message::{ChunkEvent, EgressItem, GenerateRequest, RequestKind};
+use crate::message::{ChunkEvent, EgressItem, GenerateRequest, RequestKind, SamplingParams};
 use crate::runtime::ServerArgs;
 
 const MAX_OPENAI_CHOICES: usize = 4096;
+const DETERMINISTIC_DEFAULT_SEED: i64 = 42;
+
+fn sampling_for_choice(
+    sampling: &SamplingParams,
+    choice_index: usize,
+    deterministic: bool,
+) -> SamplingParams {
+    let mut choice = sampling.clone();
+    if let Some(seed) = sampling
+        .sampling_seed
+        .or(deterministic.then_some(DETERMINISTIC_DEFAULT_SEED))
+    {
+        choice.sampling_seed = Some(seed.wrapping_add(choice_index as i64));
+    }
+    choice
+}
 
 /// The routes this module owns, mounted by `api_server::serve`.
 pub(super) fn routes() -> Router<AppState> {
@@ -238,3 +254,31 @@ fn contains_media(value: &serde_json::Value) -> bool {
 
 #[cfg(test)]
 mod test_utils;
+
+#[cfg(test)]
+mod seed_tests {
+    use super::sampling_for_choice;
+    use crate::message::SamplingParams;
+
+    #[test]
+    fn choice_seeds_are_distinct_and_wrap_as_signed_i64() {
+        let cases = [
+            (Some(7), true, 2, Some(9)),
+            (None, true, 2, Some(44)),
+            (Some(i64::MAX), true, 1, Some(i64::MIN)),
+            (Some(i64::MIN), true, 1, Some(i64::MIN + 1)),
+            (None, false, 2, None),
+        ];
+        for (seed, deterministic, index, expected) in cases {
+            let sampling = SamplingParams {
+                sampling_seed: seed,
+                ..Default::default()
+            };
+            assert_eq!(
+                sampling_for_choice(&sampling, index, deterministic).sampling_seed,
+                expected
+            );
+            assert_eq!(sampling.sampling_seed, seed);
+        }
+    }
+}

--- a/rust/sglang-server/src/api_server/openai/chat.rs
+++ b/rust/sglang-server/src/api_server/openai/chat.rs
@@ -34,7 +34,7 @@ use super::tools::{
 };
 use super::{
     AppState, ChatFormatter, collect_output, contains_media, indexed_egress_stream, openai_error,
-    streaming_error, submit_generation, unix_seconds_u32,
+    sampling_for_choice, streaming_error, submit_generation, unix_seconds_u32,
 };
 use crate::ids::Rid;
 use crate::message::{ChunkExtras, EgressItem, GenerateRequest, OneOrMany, SamplingParams};
@@ -180,7 +180,11 @@ async fn chat_completions(
             // Rendered templates own their special tokens — the pool must not
             // add another BOS/EOS (Python's `add_special_tokens=False`).
             skip_special_tokens: true,
-            sampling_params: sampling.clone(),
+            sampling_params: sampling_for_choice(
+                &sampling,
+                index,
+                state.server_args.enable_deterministic_inference,
+            ),
             stream,
             return_logprob: want_logprobs,
             logprob_start_len: -1,
@@ -833,6 +837,7 @@ pub(super) fn chat_logprobs(extras: Option<&ChunkExtras>) -> ChatChoiceLogprobs 
 
 #[cfg(test)]
 mod tests {
+    use super::super::sampling_for_choice;
     use super::super::test_utils::{chat_submitted, chunk, senders};
     use super::{
         SamplingDefaults, chat_event_stream, chat_logprobs, chat_sampling_params,
@@ -840,6 +845,7 @@ mod tests {
     };
     use crate::api_server::guard::AbortGuard;
     use crate::message::ChunkExtras;
+    use crate::message::SamplingParams;
     use crate::runtime::DefaultSamplingParams;
     use axum::http::StatusCode;
     use dynamo_protocols::types::{CreateChatCompletionRequest, Stop};
@@ -851,6 +857,18 @@ mod tests {
             "messages": [{"role": "user", "content": "hi"}]
         }))
         .unwrap()
+    }
+
+    #[test]
+    fn chat_choices_receive_sequential_seeds() {
+        let sampling = SamplingParams {
+            sampling_seed: Some(17),
+            ..Default::default()
+        };
+        let seeds: Vec<_> = (0..3)
+            .map(|index| sampling_for_choice(&sampling, index, true).sampling_seed)
+            .collect();
+        assert_eq!(seeds, [Some(17), Some(18), Some(19)]);
     }
 
     /// Python `to_sampling_params` priority: user value > model generation

--- a/rust/sglang-server/src/api_server/openai/completions.rs
+++ b/rust/sglang-server/src/api_server/openai/completions.rs
@@ -24,7 +24,7 @@ use super::super::guard::AbortGuard;
 use super::super::submit::submit;
 use super::{
     AppState, MAX_OPENAI_CHOICES, collect_output, indexed_egress_stream, openai_error,
-    streaming_error, submit_generation, unix_seconds_u32,
+    sampling_for_choice, streaming_error, submit_generation, unix_seconds_u32,
 };
 use crate::ids::Rid;
 use crate::message::{
@@ -159,7 +159,11 @@ async fn completions(
                 rid: rid.clone(),
                 text: text.clone(),
                 input_ids: input_ids.clone(),
-                sampling_params: sampling.clone(),
+                sampling_params: sampling_for_choice(
+                    &sampling,
+                    sample_index,
+                    state.server_args.enable_deterministic_inference,
+                ),
                 stream,
                 return_logprob: request.logprobs.is_some(),
                 logprob_start_len: if echo && request.logprobs.is_some() {
@@ -714,6 +718,7 @@ fn append_top_logprobs(
 
 #[cfg(test)]
 mod tests {
+    use super::super::sampling_for_choice;
     use super::super::test_utils::{chunk, senders, submitted};
     use super::{
         ChoiceExtensions, PromptSpec, completion_event_stream, completion_logprobs,
@@ -721,6 +726,7 @@ mod tests {
     };
     use crate::api_server::guard::AbortGuard;
     use crate::message::ChunkExtras;
+    use crate::message::SamplingParams;
     use axum::http::StatusCode;
     use dynamo_protocols::types::{
         Choice, CreateCompletionRequest, CreateCompletionResponse, Prompt,
@@ -743,6 +749,22 @@ mod tests {
         assert!(matches!(request.prompt, Prompt::StringArray(_)));
         assert_eq!(request.n, Some(2));
         assert!(request.stream_options.unwrap().continuous_usage_stats);
+    }
+
+    #[test]
+    fn completion_choice_seeds_reset_for_each_prompt() {
+        let sampling = SamplingParams {
+            sampling_seed: Some(17),
+            ..Default::default()
+        };
+        let seeds: Vec<_> = (0..2)
+            .flat_map(|_| 0..3)
+            .map(|sample_index| sampling_for_choice(&sampling, sample_index, true).sampling_seed)
+            .collect();
+        assert_eq!(
+            seeds,
+            [Some(17), Some(18), Some(19), Some(17), Some(18), Some(19)]
+        );
     }
 
     #[test]

--- a/rust/sglang-server/src/runtime/config.rs
+++ b/rust/sglang-server/src/runtime/config.rs
@@ -128,6 +128,10 @@ pub struct ServerArgs {
     /// `TokenizerManager._validate_one_request`).
     #[serde(default)]
     pub allow_auto_truncate: bool,
+    /// Whether omitted sampling seeds use the deterministic default. OpenAI
+    /// fans out `n` in this process, before requests reach the scheduler.
+    #[serde(default)]
+    pub enable_deterministic_inference: bool,
     /// `return_hidden_states` is refused unless the server was launched with it:
     /// the scheduler simply won't produce them, so the request would 200 with the
     /// field silently missing.
@@ -296,5 +300,29 @@ impl ServerArgs {
     pub fn api_worker_num(&self) -> usize {
         4.max(self.tokenizer_worker_num)
             .max(self.detokenizer_worker_num)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ServerArgs;
+
+    #[test]
+    fn deterministic_inference_defaults_to_false() {
+        assert!(
+            !ServerArgs::from_json("{}")
+                .unwrap()
+                .enable_deterministic_inference
+        );
+        assert!(
+            ServerArgs::from_json(r#"{"enable_deterministic_inference":true}"#)
+                .unwrap()
+                .enable_deterministic_inference
+        );
+        assert!(
+            !ServerArgs::from_json(r#"{"enable_deterministic_inference":false}"#)
+                .unwrap()
+                .enable_deterministic_inference
+        );
     }
 }

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -109,6 +109,34 @@ class TestCompletionRequest(unittest.TestCase):
         with self.assertRaises(ValidationError):
             CompletionRequest(model="test-model")  # missing prompt
 
+    def test_sampling_seed_uses_the_signed_int64_domain(self):
+        request_types = (
+            (CompletionRequest, {"model": "test-model", "prompt": "hello"}),
+            (
+                ChatCompletionRequest,
+                {
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+            ),
+        )
+        for request_type, request_args in request_types:
+            for seed, expected in (
+                (-(2**63), -(2**63)),
+                (2**63 - 1, 2**63 - 1),
+                ("7", 7),
+                (7.0, 7),
+            ):
+                with self.subTest(request_type=request_type.__name__, seed=seed):
+                    self.assertEqual(
+                        request_type(**request_args, seed=seed).seed, expected
+                    )
+
+            for seed in (True, -(2**63) - 1, 2**63):
+                with self.subTest(request_type=request_type.__name__, seed=seed):
+                    with self.assertRaises(ValidationError):
+                        request_type(**request_args, seed=seed)
+
 
 class TestChatCompletionRequest(unittest.TestCase):
     """Test ChatCompletionRequest protocol model"""

--- a/test/registered/unit/managers/test_parallel_sampling_seed.py
+++ b/test/registered/unit/managers/test_parallel_sampling_seed.py
@@ -1,0 +1,30 @@
+"""Each parallel sample must get a distinct seed (deterministic inference).
+
+multinomial_with_seed hashes sampling_seed, so an n>1 request with a fixed seed
+would otherwise produce N byte-identical completions.
+"""
+
+import unittest
+
+from sglang.srt.managers.tokenizer_manager import _seed_for_parallel_sample
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(3, "base-a-test-cpu")
+
+
+class TestSeedForParallelSample(unittest.TestCase):
+    def test_seeded_samples_get_offset_seeds(self):
+        base = SamplingParams(sampling_seed=42)
+        seeds = [_seed_for_parallel_sample(base, j).sampling_seed for j in range(4)]
+        self.assertEqual(seeds, [42, 43, 44, 45])
+        # The base params must not be mutated.
+        self.assertEqual(base.sampling_seed, 42)
+
+    def test_unseeded_sample_is_returned_unchanged(self):
+        base = SamplingParams(sampling_seed=None)
+        self.assertIs(_seed_for_parallel_sample(base, 3), base)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_parallel_sampling_seed.py
+++ b/test/registered/unit/managers/test_parallel_sampling_seed.py
@@ -21,6 +21,11 @@ class TestSeedForParallelSample(unittest.TestCase):
         # The base params must not be mutated.
         self.assertEqual(base.sampling_seed, 42)
 
+    def test_large_seed_wraps_to_uint64(self):
+        base = SamplingParams(sampling_seed=2**64 - 1)
+        seeds = [_seed_for_parallel_sample(base, j).sampling_seed for j in range(2)]
+        self.assertEqual(seeds, [2**64 - 1, 0])
+
     def test_unseeded_sample_is_returned_unchanged(self):
         base = SamplingParams(sampling_seed=None)
         self.assertIs(_seed_for_parallel_sample(base, 3), base)

--- a/test/registered/unit/managers/test_parallel_sampling_seed.py
+++ b/test/registered/unit/managers/test_parallel_sampling_seed.py
@@ -1,0 +1,161 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from sglang.srt.managers.tokenizer_manager import (
+    TokenizerManager,
+    _seed_for_parallel_sample,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(3, "base-a-test-cpu")
+
+
+class TestSeedForParallelSample(unittest.TestCase):
+    def test_parallel_samples_get_distinct_signed_int64_seeds(self):
+        cases = [
+            (42, True, [42, 43, 44, 45]),
+            (None, True, [42, 43, 44, 45]),
+            (2**63 - 1, True, [2**63 - 1, -(2**63)]),
+            (-(2**63), True, [-(2**63), -(2**63) + 1]),
+        ]
+        for seed, deterministic, expected in cases:
+            with self.subTest(seed=seed, deterministic=deterministic):
+                base = SamplingParams(sampling_seed=seed)
+                params = [
+                    _seed_for_parallel_sample(base, j, deterministic=deterministic)
+                    for j in range(len(expected))
+                ]
+                self.assertEqual([item.sampling_seed for item in params], expected)
+                self.assertTrue(all(item is not base for item in params))
+                self.assertEqual(base.sampling_seed, seed)
+
+    def test_explicit_seed_is_derived_outside_deterministic_mode(self):
+        base = SamplingParams(sampling_seed=7)
+        self.assertEqual(
+            _seed_for_parallel_sample(base, 2, deterministic=False).sampling_seed, 9
+        )
+
+    def test_unseeded_sample_is_returned_unchanged(self):
+        base = SamplingParams(sampling_seed=None)
+        self.assertIs(_seed_for_parallel_sample(base, 3, deterministic=False), base)
+
+
+class _Request:
+    next_rid = 0
+
+    def __init__(self, rid, sampling_params):
+        self.rid = rid
+        self.sampling_params = sampling_params
+        self.return_prompt_token_ids = False
+
+    def regenerate_rid(self):
+        type(self).next_rid += 1
+        self.rid = f"child-{type(self).next_rid}"
+        return self.rid
+
+
+class _Batch:
+    stream = False
+
+    def __init__(self, requests, parallel_sample_num=3):
+        self.requests = requests
+        self.batch_size = len(requests)
+        self.parallel_sample_num = parallel_sample_num
+
+    def __getitem__(self, index):
+        return self.requests[index]
+
+
+class TestParallelSamplingManagerWiring(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _manager(requests, tokenized, *, deterministic=True):
+        states = {
+            request.rid: SimpleNamespace(
+                time_stats=SimpleNamespace(set_finished_time=lambda: None)
+            )
+            for request in requests
+        }
+        sent = []
+        manager = object.__new__(TokenizerManager)
+        manager.server_args = SimpleNamespace(
+            enable_deterministic_inference=deterministic
+        )
+        manager.rid_to_state = states
+        manager._tokenize_one_request = AsyncMock(
+            side_effect=lambda request: tokenized[requests.index(request)]
+        )
+
+        def init_state(request):
+            states[request.rid] = SimpleNamespace(time_stats=SimpleNamespace())
+
+        async def wait_one_response(request, http_request):
+            yield {}
+
+        manager._init_req_state = init_state
+        manager._send_one_request = sent.append
+        manager._wait_one_response = wait_one_response
+        manager._collect_batch_responses = AsyncMock(return_value=[])
+        manager._should_use_batch_tokenization = lambda batch_size, obj: False
+        return manager, sent
+
+    async def test_batch_expansion_is_prompt_major_and_does_not_mutate_inputs(self):
+        requests = [
+            _Request("prompt-0", SamplingParams(sampling_seed=10)),
+            _Request("prompt-1", SamplingParams()),
+        ]
+        tokenized = [
+            SimpleNamespace(
+                sampling_params=request.sampling_params,
+                input_ids=[index],
+                mm_inputs=None,
+            )
+            for index, request in enumerate(requests)
+        ]
+        manager, sent = self._manager(requests, tokenized)
+
+        output = [
+            item async for item in manager._handle_batch_request(_Batch(requests))
+        ]
+
+        self.assertEqual(output, [[]])
+        self.assertEqual(
+            [item.sampling_params.sampling_seed for item in sent[2:]],
+            [10, 11, 12, 42, 43, 44],
+        )
+        self.assertEqual(
+            [item.sampling_params.max_new_tokens for item in sent[:2]], [0, 0]
+        )
+        self.assertEqual(
+            [item.sampling_params.sampling_seed for item in tokenized], [10, None]
+        )
+
+    async def test_single_samples_keep_explicit_and_omitted_seeds(self):
+        requests = [
+            _Request("prompt-0", SamplingParams(sampling_seed=2**63 - 1)),
+            _Request("prompt-1", SamplingParams()),
+        ]
+        tokenized = [
+            SimpleNamespace(sampling_params=request.sampling_params, input_ids=[index])
+            for index, request in enumerate(requests)
+        ]
+        manager, sent = self._manager(requests, tokenized)
+
+        output = [
+            item
+            async for item in manager._handle_batch_request(
+                _Batch(requests, parallel_sample_num=1)
+            )
+        ]
+
+        self.assertEqual(output, [[]])
+        self.assertEqual(
+            [item.sampling_params.sampling_seed for item in sent],
+            [2**63 - 1, None],
+        )
+        self.assertEqual(sent, tokenized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -105,6 +105,19 @@ class TestSamplingParamsVerify(CustomTestCase):
         sp = self._make()
         sp.verify(self.VOCAB_SIZE)
 
+    def test_sampling_seed_signed_int64_boundaries_are_valid(self):
+        for seed in (-(2**63), 2**63 - 1):
+            with self.subTest(seed=seed):
+                self._make(sampling_seed=seed).verify(self.VOCAB_SIZE)
+
+    def test_sampling_seed_rejects_invalid_values(self):
+        for seed in (-(2**63) - 1, 2**63, True, 1.5, "1"):
+            with self.subTest(seed=seed):
+                with self.assertRaisesRegex(
+                    ValueError, "sampling_seed must be a signed 64-bit integer"
+                ):
+                    self._make(sampling_seed=seed).verify(self.VOCAB_SIZE)
+
     def test_negative_temperature_raises(self):
         """Test that verify() rejects negative temperature (must be >= 0)."""
         sp = self._make(temperature=-0.5)


### PR DESCRIPTION
## Motivation

With deterministic inference, an `n > 1` request reused one seed for every choice. Python and Rust OpenAI fan-out therefore produced identical deterministic random streams.

## Contract

- Public request seeds use the signed 64-bit integer domain.
- Boolean and out-of-range values are rejected at native/Python OpenAI boundaries; Rust already deserializes `i64`.
- User-provided seeds are never modulo-normalized.
- Choice `j` derives `base + j` modulo 2^64, represented as signed int64 for the scheduler transport.
- `base` is the explicit seed, or deterministic default `42` when deterministic inference is enabled.
- Nondeterministic requests with no seed remain unset.
- `n = 1` keeps its existing behavior apart from consistent input validation.
- The guarantee is distinct deterministic random streams, not necessarily distinct output text.

The same derivation is applied before dispatch in Python native/OpenAI paths and in Rust OpenAI Chat and Completions. Completions restart the choice offset for each prompt.

## Implementation

- `SamplingParams` owns signed-int64 validation and the derived-offset primitive.
- `TokenizerManager` applies it during Python parallel expansion.
- Chat/Completion protocol fields enforce the same boundary without changing the existing accepted numeric-string/integral-float coercion.
- Rust server config preserves `enable_deterministic_inference` with a backward-compatible default.
- One shared Rust OpenAI helper owns choice-seed derivation for both handlers.
- Deterministic-inference documentation now states the seed domain and `n > 1` behavior.

## Verification

- Python native and Chat/Completion boundary probes passed.
- Python/Rust derivation parity passed across 10,000 randomized signed-int64 cases.
- Actual Python manager and Rust handler wiring inspected and covered by focused tests.
- Black, Ruff fatal checks, `py_compile`, test registration, `git diff --check`, `cargo fmt`, and Cargo metadata passed.
- Fresh exact-head review found no correctness, parity, redundancy, duplicate, or credit issues.

Full Rust compilation/tests were not completed locally because the filesystem reached ENOSPC; current-head hosted Python/Rust CI is required before merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31558344669](https://github.com/sgl-project/sglang/actions/runs/31558344669)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31558344488](https://github.com/sgl-project/sglang/actions/runs/31558344488)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->