### PR TITLE
[Bugfix] w8a8_int8: error on unquantized checkpoint instead of serving garbage

### DIFF
--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -169,6 +169,15 @@ class W8A8Int8LinearMethod(LinearMethodBase):
                 assert False, "W8A8Int8LinearMethod on CPU only works on AMX or Arm64"
         else:
             layer.weight = Parameter(layer.weight.t(), requires_grad=False)
+        if torch.isnan(layer.weight_scale).any():
+            raise ValueError(
+                "W8A8Int8: weight_scale was not loaded from the checkpoint. "
+                "`--quantization w8a8_int8` requires a pre-quantized (e.g. "
+                "compressed-tensors INT8) checkpoint; the given model appears to be "
+                "unquantized (bf16/fp16). Loading bf16 weights into the int8 buffer "
+                "with an uninitialized scale silently produces garbage output. Use an "
+                "INT8 checkpoint, or `--quantization fp8` for on-the-fly quantization."
+            )
         layer.weight_scale = Parameter(layer.weight_scale.data, requires_grad=False)
 
     def create_weights(
@@ -196,7 +205,12 @@ class W8A8Int8LinearMethod(LinearMethodBase):
         layer.register_parameter("weight", weight)
 
         weight_scale = ChannelQuantScaleParameter(
-            data=torch.empty((sum(output_partition_sizes), 1), dtype=torch.float32),
+            # NaN sentinel: an unquantized checkpoint provides no weight_scale, so the
+            # NaN survives and is caught in process_weights_after_loading instead of
+            # being used as an uninitialized scale -> silently garbage output.
+            data=torch.full(
+                (sum(output_partition_sizes), 1), float("nan"), dtype=torch.float32
+            ),
             output_dim=0,
             weight_loader=weight_loader,
         )

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -169,7 +169,10 @@ class W8A8Int8LinearMethod(LinearMethodBase):
                 assert False, "W8A8Int8LinearMethod on CPU only works on AMX or Arm64"
         else:
             layer.weight = Parameter(layer.weight.t(), requires_grad=False)
-        if torch.isnan(layer.weight_scale).any():
+        ws = layer.weight_scale
+        # Guard the NaN check against meta-device tensors (model init / tracing
+        # paths), where a boolean reduction on a meta tensor raises (review note).
+        if ws.device.type != "meta" and torch.isnan(ws).any():
             raise ValueError(
                 "W8A8Int8: weight_scale was not loaded from the checkpoint. "
                 "`--quantization w8a8_int8` requires a pre-quantized (e.g. "


### PR DESCRIPTION
## Summary
`--quantization w8a8_int8` on an **unquantized** (bf16/fp16) model boots cleanly, passes `/health`, and serves **deterministic garbage** — with no error or warning. This guards it with a clear error.

## Reproduction (SGLang 0.5.13, H100, Qwen3-8B)
```bash
python -m sglang.launch_server --model-path Qwen/Qwen3-8B --quantization w8a8_int8 --port 8011
# /health -> 200; then:
curl localhost:8011/v1/chat/completions -d '{"model":"...","messages":[{"role":"user","content":"Name the capital of France."}]}'
# -> "䘺斯坦 contacto khỏieya_PATCH Briefibus..."  (identical garbage for EVERY prompt)
```
The output is identical regardless of input — the logits are degenerate.

## Root cause
`W8A8Int8LinearMethod` is **checkpoint-only**: `create_weights` allocates `weight` as int8 and `weight_scale` as **uninitialized `torch.empty`**, and `process_weights_after_loading` never quantizes bf16 weights or computes a scale. So an unquantized checkpoint pours bf16 bytes into the int8 buffer and multiplies by an uninitialized scale → garbage. There is no on-the-fly weight quant and no validation (unlike `--quantization fp8`).

## Fix
Minimal, localized to `w8a8_int8.py`:
1. Allocate `weight_scale` with a **NaN sentinel** instead of `torch.empty` (a real INT8 checkpoint overwrites it; an unquantized one leaves NaN).
2. In `process_weights_after_loading`, raise `ValueError` if it is still NaN, pointing to a quantized checkpoint or `--quantization fp8`.

No change to the valid pre-quantized path.

## Testing
Verified on H100 / Qwen3-8B: before, garbage serves; after, the server exits at load with:
```
ValueError: W8A8Int8: weight_scale was not loaded from the checkpoint. ... Use an INT8 checkpoint, or --quantization fp8 for on-the-fly quantization.
```
(A pre-quantized-checkpoint positive-path test is recommended in CI; I did not have an INT8 Qwen3 checkpoint on hand.)

## Not a duplicate
`gh pr list --repo sgl-project/sglang --state open --search "w8a8_int8 unquantized"` (and related) show no PR addressing this; #19478 is a separate mixed-precision feature.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27890314964](https://github.com/sgl-project/sglang/actions/runs/27890314964)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27890314938](https://github.com/sgl-project/sglang/actions/runs/27890314938)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->