### PR TITLE
Clean up startup log noise

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -278,10 +278,6 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
             "Non-overlap (synchronous) spec v2 is used for eagle/eagle3/standalone "
             "speculative decoding."
         )
-    else:
-        logger.warning(
-            "Overlap spec v2 is enabled by default for eagle/eagle3/standalone speculative decoding."
-        )
 
     if server_args.enable_mixed_chunk:
         server_args.enable_mixed_chunk = False

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -19,7 +19,7 @@ from sglang.srt.distributed.device_communicators.custom_all_reduce_vmm_utils imp
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
 )
-from sglang.srt.utils import is_sm100_supported, log_info_on_rank0
+from sglang.srt.utils import is_sm100_supported
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,6 @@ class CustomAllReduceV2:
         )
         self._post_init_obj()
         self.disabled = False
-        log_info_on_rank0(logger, "Custom allreduce v2 initialized successfully")
 
     def override_shot(self, shot: int | None):
         if shot is None:
@@ -129,9 +128,6 @@ class CustomAllReduceV2:
         offsets_all = self._share_list(offsets)
         result = [list(zip(o, h)) for o, h in zip(offsets_all, handles_all)]
         self.obj.register_inputs(result)
-        log_info_on_rank0(
-            logger, f"Registered {len(pairs)} cuda graph addresses via IPC"
-        )
 
     def should_custom_ar(self, inp: torch.Tensor) -> bool:
         """Check if the input tensor is suitable for custom all-reduce."""

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -314,14 +314,8 @@ class FlashInferAttnBackend(AttentionBackend):
         fmha_backend = "auto"
         if is_sm100_supported():
             # Disable CUTLASS backend when piecewise cuda graph is enabled
-            # due to TMA descriptor initialization issues on B200
-            if check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE):
-                logger.info(
-                    "CUTLASS backend is disabled when piecewise cuda graph is enabled "
-                    "due to TMA descriptor initialization issues on SM100 GPUs. "
-                    "Using auto backend instead for stability."
-                )
-            else:
+            # due to TMA descriptor initialization issues on SM100 GPUs.
+            if not check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE):
                 fmha_backend = "cutlass"
         self.prefill_wrapper_ragged = BatchPrefillWithRaggedKVCacheWrapper(
             self.workspace_buffer, "NHD", backend=fmha_backend

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -1003,10 +1003,6 @@ class ModelRunnerKVCacheMixin:
                 requested_per_worker,
                 max_num_reqs,
             )
-        logger.info(
-            f"Max concurrent requests (per dp worker) from the finalized token capacity: "
-            f"max_num_reqs={max_num_reqs}."
-        )
         return max_num_reqs
 
     def _apply_memory_pool_config(self: ModelRunner, config: MemoryPoolConfig):


### PR DESCRIPTION
Summary:
- Remove noisy startup logs from custom allreduce v2, speculative decoding, and finalized token capacity handling.
- Keep the SM100 CUTLASS fallback behavior while removing the repeated startup sentence.

Test Plan:
- python3 -m compileall -q python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py python/sglang/srt/arg_groups/speculative_hook.py python/sglang/srt/layers/attention/flashinfer_backend.py
- git diff --check
- Reviewed qwen.log from Qwen/Qwen3-8B --tp 2 startup.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27884149876](https://github.com/sgl-project/sglang/actions/runs/27884149876)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27884355667](https://github.com/sgl-project/sglang/actions/runs/27884355667)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->