### PR TITLE
Remove threading atexit monkey patch

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -42,9 +42,6 @@ from typing import (
     Union,
 )
 
-# Fix a bug of Python threading
-setattr(threading, "_register_atexit", lambda *args, **kwargs: None)
-
 import torch
 import uvloop
 import zmq

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -38,10 +38,6 @@ from typing import (
     Union,
 )
 
-# Fix a bug of Python threading
-setattr(threading, "_register_atexit", lambda *args, **kwargs: None)
-
-
 import numpy as np
 import requests
 import uvicorn


### PR DESCRIPTION
Summary:
- Remove the global threading._register_atexit monkey patch from the HTTP server and Engine entrypoints.
- Let CPython keep its normal threading atexit hooks, including ThreadPoolExecutor shutdown handling.

Tests:
- python3 -m py_compile python/sglang/srt/entrypoints/http_server.py python/sglang/srt/entrypoints/engine.py
- git diff --check
- rg -n "_register_atexit|Fix a bug of Python threading|Fix a Python bug" python/sglang/srt/entrypoints python/sglang/launch_server.py















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27886057416](https://github.com/sgl-project/sglang/actions/runs/27886057416)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27886057370](https://github.com/sgl-project/sglang/actions/runs/27886057370)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->