### PR TITLE
Add project rule: prefer msgspec.Struct over dataclasses

### DIFF
--- a/.claude/rules/no-dataclasses.md
+++ b/.claude/rules/no-dataclasses.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "**/*.py"
+---
+
+# Use `msgspec.Struct`, not `@dataclass`
+
+Define data containers as `msgspec.Struct`. Do not add new
+`dataclasses.dataclass` (or `attrs`) — they weaken strict type checking and
+don't map onto Rust structs for the planned Rust migration.
+
+```python
+import msgspec
+
+class LoadSnapshot(msgspec.Struct):   # frozen=, kw_only=, omit_defaults= as needed
+    dp_rank: int = 0
+    tokens: list[int] = []            # mutable defaults are safe
+```
+
+- Methods / `@classmethod` constructors go on the `Struct`; see
+  `python/sglang/srt/managers/load_snapshot.py`.
+- New code only. Existing `@dataclass` is grandfathered — migrate opportunistically
+  while editing the file, not in drive-by sweeps.
+- If a third-party API forces `@dataclass`, keep it at that boundary only.


### PR DESCRIPTION
## Motivation

Adds a project-wide rule banning new uses of `dataclasses.dataclass` (and `attrs`) in favor of `msgspec.Struct`. Rationale captured in the rule:

- **Stricter typing** — `msgspec.Struct` enforces field types and works better with strict type checkers.
- **Future Rust migration** — `Struct` maps cleanly onto Rust structs with a defined wire format; `@dataclass` carries Python-only semantics.

## Notes

- The rule lives in `.claude/rules/` and is **path-scoped to `**/*.py`** via frontmatter, so it only loads into agent context when working on Python files (no token cost on CI/docs sessions).
- Applies to **new code only** — the ~200 existing `@dataclass` usages are grandfathered and migrated opportunistically.
- This is guidance for AI coding agents, not hard enforcement (no CI lint added).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27889216118](https://github.com/sgl-project/sglang/actions/runs/27889216118)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27889216038](https://github.com/sgl-project/sglang/actions/runs/27889216038)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->