### PR TITLE
[Bug] fix(FrozenKVMTP): reset stale out_cache_loc on eager draft path

### DIFF
--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -434,16 +434,8 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         self._set_positions(forward_batch)
         self._expand_for_topk_draft(forward_batch)
 
-        # batch.out_cache_loc may hold the stale extend-step allocation (e.g.
-        # shape [prefill_len]) because eagle_info_v2.prepare_for_decode allocates
-        # new target slots but does not update batch.out_cache_loc.  The frozen
-        # draft reads target KV via _target_kv_pool_view and never writes new KV
-        # entries, so the values don't matter — only the shape does.  Set it to
-        # batch_size (= bs * topk after expansion) so load_batch's
-        # raw_num_tokens copy succeeds.
-        forward_batch.out_cache_loc = forward_batch.seq_lens.new_zeros(
-            forward_batch.batch_size
-        )
+        # Frozen draft never writes KV; None signals fill_from to skip the slot.
+        forward_batch.out_cache_loc = None
 
         can_run_cuda_graph = (
             self.cuda_graph_runner

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -434,6 +434,17 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         self._set_positions(forward_batch)
         self._expand_for_topk_draft(forward_batch)
 
+        # batch.out_cache_loc may hold the stale extend-step allocation (e.g.
+        # shape [prefill_len]) because eagle_info_v2.prepare_for_decode allocates
+        # new target slots but does not update batch.out_cache_loc.  The frozen
+        # draft reads target KV via _target_kv_pool_view and never writes new KV
+        # entries, so the values don't matter — only the shape does.  Set it to
+        # batch_size (= bs * topk after expansion) so load_batch's
+        # raw_num_tokens copy succeeds.
+        forward_batch.out_cache_loc = forward_batch.seq_lens.new_zeros(
+            forward_batch.batch_size
+        )
+
         can_run_cuda_graph = (
             self.cuda_graph_runner
             and self.cuda_graph_runner.can_run_graph(forward_batch)

--- a/test/registered/spec/test_frozen_kv_mtp.py
+++ b/test/registered/spec/test_frozen_kv_mtp.py
@@ -171,18 +171,7 @@ class TestFrozenKVMTP(CustomTestCase):
                 self._run_gsm8k_mtp(topk)
 
     def test_eager_path_no_crash(self) -> None:
-        """Regression for #28264: eager draft path must not crash with stale out_cache_loc.
-
-        EagleDraftInputV2Mixin.prepare_for_decode() allocates new target KV
-        slots but never assigns them to batch.out_cache_loc, leaving it shaped
-        [prefill_len] from the extend step.  On the first decode call
-        EagerRunner.load_batch computes raw_num_tokens = input_ids.shape[0] = bs
-        and CudaGraphBufferRegistry.fill_from tries to copy out_cache_loc[:bs]
-        <- stale out_cache_loc, causing a shape-mismatch RuntimeError.
-
-        The fix resets forward_batch.out_cache_loc to zeros of shape [batch_size]
-        in FrozenKVMTPDraftWorker.draft() after _expand_for_topk_draft().
-        """
+        """Regression for #28264: stale out_cache_loc on eager draft path."""
         process = None
         data = None
         avg_accept = None
@@ -193,8 +182,6 @@ class TestFrozenKVMTP(CustomTestCase):
                 timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 3,
                 other_args=self._server_args_eager(),
             )
-            # Multi-token prompt ensures prefill_len >> 1 so the stale shape
-            # mismatch ([1] vs [prefill_len]) would trigger without the fix.
             resp = requests.post(
                 self.base_url + "/generate",
                 json={
@@ -215,9 +202,8 @@ class TestFrozenKVMTP(CustomTestCase):
 
         self.assertIn("text", data, "Response missing 'text' field")
         self.assertGreater(len(data.get("text", "")), 0, "Expected non-empty output")
-        # With num_steps=1, topk=1 the bonus token is always accepted: floor is 1.0.
-        if avg_accept is not None:
-            self.assertGreaterEqual(avg_accept, 1.0, "Accept length below minimum")
+        self.assertIsNotNone(avg_accept)
+        self.assertGreaterEqual(avg_accept, 1.0, "Accept length below minimum")
 
 
 if __name__ == "__main__":

--- a/test/registered/spec/test_frozen_kv_mtp.py
+++ b/test/registered/spec/test_frozen_kv_mtp.py
@@ -78,6 +78,24 @@ class TestFrozenKVMTP(CustomTestCase):
         ] + cls._common_server_args()
 
     @classmethod
+    def _server_args_eager(cls) -> list[str]:
+        # num_steps=1 causes the frozen-KV CUDA-graph runner to skip graph
+        # capture, forcing every draft call through the eager (EagerRunner)
+        # path — which is the path that exposed the stale out_cache_loc bug.
+        return [
+            "--speculative-algorithm",
+            "NEXTN",
+            "--speculative-draft-model-path",
+            "google/gemma-4-E4B-it-assistant",
+            "--speculative-num-steps",
+            "1",
+            "--speculative-eagle-topk",
+            "1",
+            "--speculative-num-draft-tokens",
+            "2",
+        ] + cls._common_server_args()
+
+    @classmethod
     def _gsm8k_args(cls) -> SimpleNamespace:
         return SimpleNamespace(
             base_url=cls.base_url,
@@ -151,6 +169,55 @@ class TestFrozenKVMTP(CustomTestCase):
         for topk in (1, 3):
             with self.subTest(topk=topk):
                 self._run_gsm8k_mtp(topk)
+
+    def test_eager_path_no_crash(self) -> None:
+        """Regression for #28264: eager draft path must not crash with stale out_cache_loc.
+
+        EagleDraftInputV2Mixin.prepare_for_decode() allocates new target KV
+        slots but never assigns them to batch.out_cache_loc, leaving it shaped
+        [prefill_len] from the extend step.  On the first decode call
+        EagerRunner.load_batch computes raw_num_tokens = input_ids.shape[0] = bs
+        and CudaGraphBufferRegistry.fill_from tries to copy out_cache_loc[:bs]
+        <- stale out_cache_loc, causing a shape-mismatch RuntimeError.
+
+        The fix resets forward_batch.out_cache_loc to zeros of shape [batch_size]
+        in FrozenKVMTPDraftWorker.draft() after _expand_for_topk_draft().
+        """
+        process = None
+        data = None
+        avg_accept = None
+        try:
+            process = popen_launch_server(
+                "google/gemma-4-E4B-it",
+                self.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 3,
+                other_args=self._server_args_eager(),
+            )
+            # Multi-token prompt ensures prefill_len >> 1 so the stale shape
+            # mismatch ([1] vs [prefill_len]) would trigger without the fix.
+            resp = requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": (
+                        "Explain how speculative decoding improves LLM inference "
+                        "throughput while preserving the output distribution."
+                    ),
+                    "sampling_params": {"max_new_tokens": 32, "temperature": 0},
+                },
+                timeout=120,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            avg_accept = get_avg_spec_accept_length(self.base_url)
+        finally:
+            if process is not None:
+                self._stop_process(process)
+
+        self.assertIn("text", data, "Response missing 'text' field")
+        self.assertGreater(len(data.get("text", "")), 0, "Expected non-empty output")
+        # With num_steps=1, topk=1 the bonus token is always accepted: floor is 1.0.
+        if avg_accept is not None:
+            self.assertGreaterEqual(avg_accept, 1.0, "Accept length below minimum")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #28264.

Frozen-KV MTP (NEXTN) crashes with a shape-mismatch error on the eager draft path — triggered by `--speculative-num-steps 1` (no draft CUDA graph is captured) or `--disable-cuda-graph`:

```
RuntimeError: output with shape [1] doesn't match the broadcast shape [271]
```

**Root cause:** `EagleDraftInputV2Mixin.prepare_for_decode()` allocates new target-KV slots into a local `out_cache_loc` variable and writes them into `req_to_token_pool`, but never assigns the result back to `batch.out_cache_loc`. So `batch.out_cache_loc` stays stale from the prefill (shape `[prefill_len]`).

`ForwardBatch.init_new` copies this stale value verbatim. On the first decode step `input_ids` is overridden to the bonus tokens (shape `[bs]`), so `EagerRunner.load_batch` computes `raw_num_tokens = bs = 1` and `CudaGraphBufferRegistry.fill_from` tries:

```
dst = buffer[:1]               # shape [1]
src = out_cache_loc            # shape [prefill_len]  ← stale → CRASH
torch._foreach_copy_([dst], [src])
```

EAGLE is unaffected because `base_spec_worker.prepare_for_draft()` overwrites `batch.out_cache_loc` with draft-pool slots before `ForwardBatch` is created. The CUDA-graph draft path is also unaffected because `FrozenKVMTPCudaGraphRunner.execute()` never reads `out_cache_loc`.

## Modifications

**`python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py`**

Reset `forward_batch.out_cache_loc` to a zeros tensor of shape `[batch_size]` in `FrozenKVMTPDraftWorker.draft()` immediately after `_expand_for_topk_draft()` (so `batch_size` already reflects the topk expansion). The frozen draft reads target KV via `_target_kv_pool_view` and never writes new KV entries, so the values do not matter — only the shape does.

**`test/registered/spec/test_frozen_kv_mtp.py`**

Add `test_eager_path_no_crash` regression test. Uses `--speculative-num-steps 1` to force the eager draft path (no draft CUDA graph is captured with only 1 step) and verifies that a multi-token prompt (`prefill_len >> 1`) generates successfully without crashing.

The existing `test_gsm8k_mtp` only tested `--speculative-num-steps 5` with CUDA graph enabled, leaving the eager path uncovered.

## Accuracy Tests

No change to model outputs — the fix only corrects the shape of a buffer that the frozen draft never reads or writes.

## Speed Tests and Profiling

Not applicable — one extra `new_zeros([batch_size])` per decode step, negligible.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). *(N/A — bug fix, no new APIs or flags)*
- [x] Provide accuracy and speed benchmark results. *(N/A — no output or speed change)*
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28213552882](https://github.com/sgl-project/sglang/actions/runs/28213552882)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28213552744](https://github.com/sgl-project/sglang/actions/runs/28213552744)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->