### PR TITLE
Fix H20 torch import reinstall fallback

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -288,13 +288,19 @@ install_sglang_kernel() {
     fi
 
     # Reinstall torch with matching CUDA version if needed
-    # H20 repro note: this path imports torch before any reinstall decision.
     # TODO: Remove after torch 2.11 where cu13 is enabled by default
-    TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')")
-    echo "Detected torch CUDA version: ${TORCH_CUDA_VER}"
+    REINSTALL_TORCH=false
+    if TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')" 2>&1); then
+        echo "Detected torch CUDA version: ${TORCH_CUDA_VER}"
+    else
+        TORCH_IMPORT_ERROR="${TORCH_CUDA_VER}"
+        TORCH_CUDA_VER=""
+        echo "WARNING: importing torch failed while probing CUDA version; force-reinstalling torch packages."
+        printf '%s\n' "${TORCH_IMPORT_ERROR}"
+        REINSTALL_TORCH=true
+    fi
     TORCHAUDIO_CUDA_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p' || true)
     TORCHVISION_CUDA_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p' || true)
-    REINSTALL_TORCH=false
     if [ "${TORCH_CUDA_VER}" != "${CU_VERSION}" ]; then
         REINSTALL_TORCH=true
     else
@@ -309,6 +315,11 @@ install_sglang_kernel() {
         TORCH_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
         TORCHAUDIO_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
         TORCHVISION_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
+        if [ -z "${TORCH_VER}" ] || [ -z "${TORCHAUDIO_VER}" ] || [ -z "${TORCHVISION_VER}" ]; then
+            echo "ERROR: could not determine installed torch package versions before reinstall."
+            pip show torch torchaudio torchvision || true
+            exit 1
+        fi
         echo "Reinstalling torch==${TORCH_VER} torchaudio==${TORCHAUDIO_VER} torchvision==${TORCHVISION_VER} from ${CU_VERSION} index to match torch..."
         $PIP_CMD install "torch==${TORCH_VER}" "torchaudio==${TORCHAUDIO_VER}" "torchvision==${TORCHVISION_VER}" --index-url "https://download.pytorch.org/whl/${CU_VERSION}" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
     fi

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -288,6 +288,7 @@ install_sglang_kernel() {
     fi
 
     # Reinstall torch with matching CUDA version if needed
+    # H20 repro note: this path imports torch before any reinstall decision.
     # TODO: Remove after torch 2.11 where cu13 is enabled by default
     TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')")
     echo "Detected torch CUDA version: ${TORCH_CUDA_VER}"


### PR DESCRIPTION
Fixes the H20 dependency install failure where the script tried to import torch before deciding whether to force-reinstall torch packages. If the CUDA-version probe import fails, the install now logs the import traceback and falls through to the existing force-reinstall path.

Validation:
- Reproduced original failure on H20: https://github.com/sgl-project/sglang/actions/runs/27889811234/job/82531258331
  - Runner: h20-ydzf15
  - Failure: ModuleNotFoundError: No module named torchgen.code_template during the torch import probe
- Retried after fix via /rerun-test test/registered/disaggregation/test_disaggregation_pp.py: https://github.com/sgl-project/sglang/actions/runs/27890675221/job/82533503610
  - Runner: h20-bfv8sr
  - Result: install dependencies passed; test passed

Note: the successful rerun landed on a different H20 host, so the fallback branch was not exercised in that run; torch imported cleanly and reported cu130. The code path is now guarded for the broken-import case that caused the repro failure.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27890666844](https://github.com/sgl-project/sglang/actions/runs/27890666844)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27890666793](https://github.com/sgl-project/sglang/actions/runs/27890666793)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->