### PR TITLE
[Platform] Fix OOT platform entry point hint

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -97,6 +97,7 @@ from typing_extensions import Literal
 from sglang.srt.environ import envs
 from sglang.srt.observability.func_timer import enable_func_timer
 from sglang.srt.platforms import current_platform
+from sglang.srt.plugins import PLATFORM_PLUGINS_GROUP
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils.video_decoder import _BACKEND, VideoDecoderWrapper
 
@@ -522,7 +523,7 @@ def get_available_gpu_memory(
             raise ValueError(
                 f"Unsupported device type: {device!r}. "
                 "If this is an OOT platform, ensure it is properly registered "
-                "via the 'sglang.platform_plugins' entry point."
+                f"via the '{PLATFORM_PLUGINS_GROUP}' entry point."
             )
         total_mem = current_platform.get_device_total_memory(gpu_id)
         used_mem = current_platform.get_current_memory_usage()

--- a/test/registered/unit/platforms/test_platform_interface.py
+++ b/test/registered/unit/platforms/test_platform_interface.py
@@ -431,6 +431,20 @@ class TestPinMemoryAvailability(CustomTestCase):
         mock_cuda_available.assert_not_called()
 
 
+class TestCommonPlatformHelpers(CustomTestCase):
+    """Tests for common helpers that surface platform registration hints."""
+
+    def test_unsupported_device_points_to_platform_entry_point_group(self):
+        from sglang.srt.utils import common as common_utils
+
+        with patch.object(common_utils, "current_platform", SRTPlatform()):
+            with self.assertRaises(ValueError) as cm:
+                common_utils.get_available_gpu_memory("fake_accel", 0)
+
+        self.assertIn("'sglang.srt.platforms' entry point", str(cm.exception))
+        self.assertNotIn("sglang.platform_plugins", str(cm.exception))
+
+
 # ---------------------------------------------------------------------------
 # Platform Discovery: _resolve_platform
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation
The unsupported-device error for non-OOT platforms points users to the stale `sglang.platform_plugins` entry point. The platform plugin entry point group used by SGLang is `sglang.srt.platforms`, so the hint should match the actual registration path.

## Modifications
- Use `PLATFORM_PLUGINS_GROUP` in the unsupported-device OOT platform registration hint.
- Add a focused platform unit test that verifies the error message includes the current platform entry point group and no longer includes the stale `sglang.platform_plugins` hint.
- No platform discovery, runtime fallback, memory hook, or public API behavior is changed.

## Accuracy Tests
N/A. This only updates an error message and its unit-test coverage.

## Speed Tests and Profiling
N/A. This is not performance-related.

## Checklist
- Focused unit test added.
- Ran `python3 -m pytest -p no:cacheprovider test/registered/unit/platforms/test_platform_interface.py -q`.
- Ran `python3 -m py_compile python/sglang/srt/utils/common.py test/registered/unit/platforms/test_platform_interface.py`.
- Ran `git diff --check`.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29472644791](https://github.com/sgl-project/sglang/actions/runs/29472644791)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29472644727](https://github.com/sgl-project/sglang/actions/runs/29472644727)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->