### PR TITLE
feat(openai): add system_fingerprint to Python OpenAI chat/completion responses

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -439,11 +439,14 @@ class CompletionResponse(BaseModel):
     choices: List[CompletionResponseChoice]
     usage: UsageInfo
     metadata: Optional[Dict[str, Any]] = None
+    system_fingerprint: Optional[str] = None
     sglext: Optional[SglExt] = None
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
+        if self.system_fingerprint is None:
+            data.pop("system_fingerprint", None)
         if self.sglext is None:
             data.pop("sglext", None)
         return data
@@ -472,11 +475,14 @@ class CompletionStreamResponse(BaseModel):
     model: str
     choices: List[CompletionResponseStreamChoice]
     usage: Optional[UsageInfo] = None
+    system_fingerprint: Optional[str] = None
     sglext: Optional[SglExt] = None
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
+        if self.system_fingerprint is None:
+            data.pop("system_fingerprint", None)
         if self.sglext is None:
             data.pop("sglext", None)
         return data
@@ -992,11 +998,14 @@ class ChatCompletionResponse(BaseModel):
     choices: List[ChatCompletionResponseChoice]
     usage: UsageInfo
     metadata: Optional[Dict[str, Any]] = None
+    system_fingerprint: Optional[str] = None
     sglext: Optional[SglExt] = None
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
+        if self.system_fingerprint is None:
+            data.pop("system_fingerprint", None)
         if self.sglext is None:
             data.pop("sglext", None)
         return data
@@ -1036,11 +1045,14 @@ class ChatCompletionStreamResponse(BaseModel):
     model: str
     choices: List[ChatCompletionResponseStreamChoice]
     usage: Optional[UsageInfo] = None
+    system_fingerprint: Optional[str] = None
     sglext: Optional[SglExt] = None
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
+        if self.system_fingerprint is None:
+            data.pop("system_fingerprint", None)
         if self.sglext is None:
             data.pop("sglext", None)
         return data

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1193,6 +1193,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     choices=[],  # Empty choices array as per OpenAI spec
                     model=request.model,
                     usage=usage,
+                    system_fingerprint=content["meta_info"]["weight_version"],
                 )
                 yield f"data: {usage_chunk.model_dump_json()}\n\n"
 
@@ -1371,6 +1372,7 @@ class OpenAIServingChat(OpenAIServingBase):
             choices=choices,
             usage=usage,
             metadata={"weight_version": ret[0]["meta_info"]["weight_version"]},
+            system_fingerprint=ret[0]["meta_info"]["weight_version"],
             sglext=response_sglext,
         )
 

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -429,6 +429,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     choices=[],
                     model=request.model,
                     usage=usage,
+                    system_fingerprint=content["meta_info"]["weight_version"],
                 )
                 final_usage_data = final_usage_chunk.model_dump_json(exclude_none=True)
                 yield f"data: {final_usage_data}\n\n"
@@ -557,6 +558,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             choices=choices,
             usage=usage,
             metadata={"weight_version": ret[0]["meta_info"]["weight_version"]},
+            system_fingerprint=ret[0]["meta_info"]["weight_version"],
             sglext=response_sglext,
         )
 

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -22,8 +22,15 @@ from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
     ChatMessage,
     CompletionRequest,
+    CompletionResponse,
+    CompletionResponseChoice,
+    CompletionResponseStreamChoice,
+    CompletionStreamResponse,
+    DeltaMessage,
     Function,
     ModelCard,
     ModelList,
@@ -524,6 +531,72 @@ class TestParsedResponseFieldsProtocol(unittest.TestCase):
             reasoning_content = None
 
         self.assertIsInstance(MockFields(), ParsedResponseFields)
+
+
+class TestSystemFingerprint(unittest.TestCase):
+    """Test that system_fingerprint serializes only when set."""
+
+    def _chat_response(self, system_fingerprint):
+        return ChatCompletionResponse(
+            id="test-id",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(role="assistant", content="Hello"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=UsageInfo(prompt_tokens=5, completion_tokens=1, total_tokens=6),
+            system_fingerprint=system_fingerprint,
+        )
+
+    def _completion_response(self, system_fingerprint):
+        return CompletionResponse(
+            id="test-id",
+            model="test-model",
+            choices=[
+                CompletionResponseChoice(index=0, text="Hello", finish_reason="stop")
+            ],
+            usage=UsageInfo(prompt_tokens=5, completion_tokens=1, total_tokens=6),
+            system_fingerprint=system_fingerprint,
+        )
+
+    def test_excluded_when_none(self):
+        self.assertNotIn("system_fingerprint", self._chat_response(None).model_dump())
+        self.assertNotIn(
+            "system_fingerprint", self._completion_response(None).model_dump()
+        )
+
+    def test_included_when_set(self):
+        data = self._chat_response("default").model_dump()
+        self.assertEqual(data["system_fingerprint"], "default")
+        data = self._completion_response("v2").model_dump()
+        self.assertEqual(data["system_fingerprint"], "v2")
+
+    def test_stream_responses(self):
+        chat_chunk = ChatCompletionStreamResponse(
+            id="test-id",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseStreamChoice(
+                    index=0, delta=DeltaMessage(content="Hi"), finish_reason=None
+                )
+            ],
+        )
+        self.assertNotIn("system_fingerprint", chat_chunk.model_dump())
+        chat_chunk.system_fingerprint = "default"
+        self.assertEqual(chat_chunk.model_dump()["system_fingerprint"], "default")
+
+        completion_chunk = CompletionStreamResponse(
+            id="test-id",
+            model="test-model",
+            choices=[
+                CompletionResponseStreamChoice(index=0, text="Hi", finish_reason=None)
+            ],
+            system_fingerprint="default",
+        )
+        self.assertEqual(completion_chunk.model_dump()["system_fingerprint"], "default")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Motivation

The Python OpenAI endpoints (`/v1/chat/completions`, `/v1/completions`) do not expose a top-level `system_fingerprint` field, while OpenAI clients expect it and the Rust `sgl-model-gateway` already stamps one from the model's `weight_version` (`.maybe_system_fingerprint(dispatch.weight_version)` in `routers/grpc/regular/{processor,streaming}.rs`). So a client talking to the Python server directly gets a response shape that differs from both the gateway and OpenAI, and has no top-level signal to detect a weight reload.

This adds `system_fingerprint` to the Python serving path, sourced from the same `weight_version` the gateway uses, so a client can detect a weight change (e.g. after `/update_weight_version`) from the response alone.

## Modifications

- `protocol.py`: add optional `system_fingerprint` to `CompletionResponse`, `ChatCompletionResponse`, `CompletionStreamResponse`, `ChatCompletionStreamResponse`. The existing `model_serializer` omits it when `None`, same as `sglext`, so responses are unchanged when it is unset.
- `serving_chat.py` / `serving_completions.py`: set `system_fingerprint` from `meta_info["weight_version"]` on the non-streaming responses and on the final streaming usage chunk.
- Keep the existing `metadata.weight_version` for backward compatibility. No new server arg; the value follows the existing `--weight-version` (default `"default"`).
- Add `TestSystemFingerprint` to `test/registered/unit/entrypoints/openai/test_protocol.py`.

## Testing

Unit:

```
python -m pytest test/registered/unit/entrypoints/openai/test_protocol.py -q   # 32 passed
```

Launched a server and checked both endpoints:

```
python -m sglang.launch_server --model-path Qwen/Qwen3-0.6B --port 30000 --weight-version v1

curl -s http://localhost:30000/v1/chat/completions -H 'Content-Type: application/json' \
  -d '{"messages":[{"role":"user","content":"hi"}],"max_tokens":3}'
# -> ... "metadata":{"weight_version":"v1"},"system_fingerprint":"v1"}

curl -s http://localhost:30000/v1/completions -H 'Content-Type: application/json' \
  -d '{"prompt":"hi","max_tokens":3}'
# -> ... "metadata":{"weight_version":"v1"},"system_fingerprint":"v1"}
```

In streaming the field rides the final usage chunk (sent when `stream_options.include_usage` is set); per-delta chunks omit it, consistent with how usage is surfaced. Updating the weight version at runtime flips the field, which is the intended use:

```
curl -s http://localhost:30000/update_weight_version -H 'Content-Type: application/json' \
  -d '{"new_version":"v2"}'
# subsequent chat/completion (stream and non-stream) now report "system_fingerprint":"v2"
```

Default startup (no `--weight-version`) reports `"system_fingerprint":"default"`. Also verified on Qwen2.5-VL-3B-Instruct (multimodal chat) and Qwen3-8B-AWQ (quantized). Verified against current `main`, with `--attention-backend triton --sampling-backend pytorch --disable-cuda-graph`. Before the change the same responses carry only `metadata.weight_version` and no top-level `system_fingerprint`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A: frontend-only change, model outputs unchanged.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27893381936](https://github.com/sgl-project/sglang/actions/runs/27893381936)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27893381884](https://github.com/sgl-project/sglang/actions/runs/27893381884)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->