### PR TITLE
fix: GLM-5.2 DSA fails to load with PP>1 and wrong qk_rope_head_dim

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2342,7 +2342,7 @@ class DeepseekV2Model(nn.Module):
         if (
             _use_aiter_gfx95
             and config.n_routed_experts == 256
-            and getattr(self.embed_tokens, "embedding_dim", 0) == 7168
+            and getattr(self.embed_tokens, "embedding_dim", config.hidden_size) == 7168
         ):
             num_moe_layers = sum(
                 [

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2342,7 +2342,7 @@ class DeepseekV2Model(nn.Module):
         if (
             _use_aiter_gfx95
             and config.n_routed_experts == 256
-            and self.embed_tokens.embedding_dim == 7168
+            and getattr(self.embed_tokens, "embedding_dim", 0) == 7168
         ):
             num_moe_layers = sum(
                 [
@@ -2372,7 +2372,7 @@ class DeepseekV2Model(nn.Module):
                     config.n_routed_experts,
                     num_moe_layers,
                     allocate_size,
-                    self.embed_tokens.embedding_dim,
+                    getattr(self.embed_tokens, "embedding_dim", config.hidden_size),
                 )
             )
         self.layers_to_capture = []

--- a/python/sglang/srt/utils/hf_transformers_patches.py
+++ b/python/sglang/srt/utils/hf_transformers_patches.py
@@ -60,6 +60,7 @@ def apply_all():
     _patch_image_processor_kwargs()
     _patch_image_process_cuda_tensor()
     _patch_nemotron_h_pattern()
+    _patch_glm_moe_dsa_attribute_map()
 
     # v5 general patches
     _ensure_clean_up_tokenization_compat()
@@ -354,6 +355,38 @@ def _patch_nemotron_h_pattern():
     except ImportError:
         logger.debug(
             "_patch_nemotron_h_pattern: NemotronHConfig not importable, patch skipped"
+        )
+
+
+def _patch_glm_moe_dsa_attribute_map():
+    """Fix ``GlmMoeDsaConfig.attribute_map`` overwriting ``qk_rope_head_dim``.
+
+    Transformers' ``GlmMoeDsaConfig`` maps ``"head_dim"`` to
+    ``"qk_rope_head_dim"`` in its ``attribute_map``.  When a model's
+    ``config.json`` contains both ``head_dim`` (e.g. 192) and
+    ``qk_rope_head_dim`` (e.g. 64), the ``attribute_map`` causes the
+    ``head_dim`` value to silently overwrite ``qk_rope_head_dim`` during
+    config initialization.
+
+    This results in a wrong fused QKV projection size and weight-loading
+    failures for GLM-5.2-FP8 DSA models.
+
+    Fix: remove the ``"head_dim"`` → ``"qk_rope_head_dim"`` mapping.
+    SGLang's ``model_config.py`` already sets ``head_dim`` correctly for
+    MLA architectures, so this mapping is unnecessary.
+
+    TODO(upstream): report to HF transformers.
+    """
+    try:
+        from transformers.models.glm_moe_dsa.configuration_glm_moe_dsa import (
+            GlmMoeDsaConfig,
+        )
+
+        if "head_dim" in GlmMoeDsaConfig.attribute_map:
+            del GlmMoeDsaConfig.attribute_map["head_dim"]
+    except ImportError:
+        logger.debug(
+            "_patch_glm_moe_dsa_attribute_map: GlmMoeDsaConfig not importable, patch skipped"
         )
 
 


### PR DESCRIPTION
## Description

Fix two bugs preventing **GLM-5.2-FP8 DSA** (`GlmMoeDsaForCausalLM`) from loading in SGLang.

## Bug 1: PPMissingLayer.embedding_dim AttributeError

**File**: `python/sglang/srt/models/deepseek_v2.py`

When `pp_size > 1`, non-first pipeline stages have `self.embed_tokens` set to `PPMissingLayer`, which does not have an `embedding_dim` attribute. The aiter gfx95 optimization check accesses `self.embed_tokens.embedding_dim` directly, causing `AttributeError`.

**Fix**: Use `getattr(self.embed_tokens, "embedding_dim", ...)` with safe defaults.

## Bug 2: GlmMoeDsaConfig.attribute_map overwrites qk_rope_head_dim

**File**: `python/sglang/srt/utils/hf_transformers_patches.py`

Transformers `GlmMoeDsaConfig` has `attribute_map = {"head_dim": "qk_rope_head_dim"}`. When `config.json` contains both `head_dim: 192` and `qk_rope_head_dim: 64`, the `attribute_map` causes `head_dim` to silently overwrite `qk_rope_head_dim` during config initialization.

This results in a wrong fused QKV projection size (`2752` vs correct `2624`) and weight-loading failure.

**Fix**: Add a monkey-patch in `hf_transformers_patches.py` to remove the `"head_dim"` → `"qk_rope_head_dim"` mapping at import time, following the existing pattern of `_patch_nemotron_h_pattern()`.

## Testing

Tested on **MI355X (ROCm 7.2.4)** with GLM-5.2-FP8 DSA:

| Configuration | Chat | Tool Calling | Streaming | Streaming + Tool |
|---|---|---|---|---|
| PP1+TP8 (8 GPUs) | ✅ | ✅ | ✅ | ✅ |
| PP2+TP4 (8 GPUs, 4/stage) | ✅ | ✅ | ✅ | ✅ |

SGLang PP2 tool calling works correctly (unlike vLLM PP2 which produces garbled output due to `condense()` token corruption).

## Related Issues

- Closes #28826

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28025787530](https://github.com/sgl-project/sglang/actions/runs/28025787530)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28025786808](https://github.com/sgl-project/sglang/actions/runs/28025786808)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->