### PR TITLE
[Fix] multimodal: decode JPEG to RGB on GPU path to fix grayscale crash

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -89,7 +89,7 @@ from starlette.routing import Mount
 from torch import nn
 from torch.library import Library
 from torch.utils._contextlib import _DecoratorContextManager
-from torchvision.io import decode_jpeg
+from torchvision.io import ImageReadMode, decode_jpeg
 from typing_extensions import Literal
 
 from sglang.srt.environ import envs
@@ -919,7 +919,10 @@ def _load_image(
     if is_jpeg_with_cuda(image_bytes, gpu_image_decode):
         try:
             encoded_image = torch.frombuffer(image_bytes, dtype=torch.uint8)
-            image_tensor = decode_jpeg(encoded_image, device="cuda")
+            # Force RGB so grayscale JPEGs decode to 3 channels
+            image_tensor = decode_jpeg(
+                encoded_image, mode=ImageReadMode.RGB, device="cuda"
+            )
             return image_tensor
         except Exception as e:
             logger.warning(

--- a/test/registered/unit/utils/test_common.py
+++ b/test/registered/unit/utils/test_common.py
@@ -1,9 +1,11 @@
+import io
 import unittest
 from array import array
 
 import torch
+from PIL import Image
 
-from sglang.srt.utils.common import flatten_arrays_to_int64_tensor
+from sglang.srt.utils.common import _load_image, flatten_arrays_to_int64_tensor
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -44,6 +46,43 @@ class TestFlattenArraysToInt64Tensor(CustomTestCase):
             array("q", [1000]),
         ]
         self._check(parts, [10, 20, 30, 100, 200, 1000])
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA (nvJPEG GPU decode)")
+class TestLoadImageGpuJpegRGB(CustomTestCase):
+    """`_load_image` GPU fast-path must decode JPEGs to 3 channels regardless of
+    the source channel count. With the torchvision default
+    (ImageReadMode.UNCHANGED) a grayscale JPEG decodes to a [1, H, W] tensor,
+    which later breaks torch.stack against 3-channel images during multimodal
+    batching. Forcing ImageReadMode.RGB keeps every JPEG at [3, H, W], matching
+    the PIL fallback's convert("RGB").
+    """
+
+    @staticmethod
+    def _jpeg_bytes(mode: str, size=(64, 48)) -> bytes:
+        color = 128 if mode == "L" else (130, 90, 60)
+        buf = io.BytesIO()
+        Image.new(mode, size, color=color).save(buf, format="JPEG")
+        return buf.getvalue()
+
+    def _decode_on_gpu(self, mode: str) -> torch.Tensor:
+        img = _load_image(image_bytes=self._jpeg_bytes(mode), gpu_image_decode=True)
+        # The GPU fast-path returns a device tensor; if nvJPEG is unavailable it
+        # falls back to PIL, which this test cannot exercise.
+        if not isinstance(img, torch.Tensor):
+            self.skipTest("nvJPEG GPU decode unavailable; fell back to PIL")
+        return img
+
+    def test_grayscale_jpeg_decodes_to_3_channels(self):
+        self.assertEqual(self._decode_on_gpu("L").shape[0], 3)
+
+    def test_rgb_jpeg_stays_3_channels(self):
+        self.assertEqual(self._decode_on_gpu("RGB").shape[0], 3)
+
+    def test_grayscale_and_rgb_are_stackable(self):
+        # Regression: [1, H, W] vs [3, H, W] previously made torch.stack raise.
+        stacked = torch.stack([self._decode_on_gpu("L"), self._decode_on_gpu("RGB")])
+        self.assertEqual(tuple(stacked.shape[:2]), (2, 3))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

A grayscale JPEG decoded via the nvJPEG GPU fast-path returns a 1-channel `[1, H, W]` tensor, and the RGB normalization in `BaseMultimodalProcessor._load_single_item` is skipped for tensors (guarded by `not isinstance(img, torch.Tensor)`). The 1-channel tensor then breaks `torch.stack` against 3-channel images:

```
RuntimeError: stack expects each tensor to be equal size, but got [1, H, W] at entry 0 and [3, H, W] at entry 1
```

This crashes VLM inference (e.g. Qwen2.5/3-VL) on any request that mixes a grayscale and an RGB JPEG, returned to the client as a 500. The CPU/PIL fallback is unaffected because `convert("RGB")` already runs for PIL images. Same root cause as the channel-count bug discussed in #26751.

## Modifications

- `python/sglang/srt/utils/common.py` — in `_load_image`, decode JPEG with `mode=ImageReadMode.RGB` instead of the default `ImageReadMode.UNCHANGED`, so grayscale JPEGs come out as 3-channel tensors. JPEG has no alpha channel, so forcing RGB is always safe and matches the PIL fallback's `convert("RGB")`. Fixes the channel count at the decode source for every model in one place.
- `test/registered/unit/utils/test_common.py` — added `TestLoadImageGpuJpegRGB`: a CUDA-gated regression test asserting the GPU fast-path decodes grayscale and RGB JPEGs to 3 channels and that the two are `torch.stack`-able (the exact failure above). Skips cleanly if nvJPEG is unavailable and falls back to PIL.

Repro (CUDA host so the nvJPEG fast-path is taken; PNG won't trigger it — only JPEG hits `is_jpeg_with_cuda`):

```python
import base64, io
from PIL import Image
from openai import OpenAI

def b64_jpeg(mode):
    buf = io.BytesIO()
    Image.new(mode, (64, 64), color=128 if mode == "L" else (130, 90, 60)).save(buf, "JPEG")
    return base64.b64encode(buf.getvalue()).decode()

OpenAI(base_url="http://localhost:30000/v1", api_key="None").chat.completions.create(
    model="Qwen/Qwen2.5-VL-7B-Instruct",
    messages=[{"role": "user", "content": [
        {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64_jpeg('L')}"}},
        {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64_jpeg('RGB')}"}},
    ]}],
)
```

## Accuracy Tests

Not applicable — preprocessing-only change, no model forward / kernel changes. Grayscale JPEGs are now decoded to 3 channels, identical to the existing PIL fallback path; RGB JPEGs are unchanged.

## Speed Tests and Profiling

Not applicable — no inference-path performance impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation — n/a (internal preprocessing fix, no user-facing docs affected).
- [ ] Provide accuracy and speed benchmark results — n/a (no model forward / kernel change).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
