### PR TITLE
[misc] Make NaN-logit sanitization opt-in (default off)

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -656,7 +656,7 @@ class Envs:
     SGLANG_ENABLE_ASYNC_ASSERT = EnvBool(False)
     # Sanitize NaN logits before sampling kernels and log a throttled warning
     # (see sanitize_nan_logits).
-    SGLANG_SANITIZE_NAN_LOGITS = EnvBool(True)
+    SGLANG_SANITIZE_NAN_LOGITS = EnvBool(False)
 
     # VLM
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)

--- a/scripts/ci/amd/amd_ci_exec.sh
+++ b/scripts/ci/amd/amd_ci_exec.sh
@@ -21,10 +21,6 @@ declare -A ENV_MAP=(
   # the MXFP4 EAGLE-MTP decode path and abort the queue with an HSA hardware
   # exception.
   [SGLANG_ENABLE_ASYNC_ASSERT]=0
-  # Disabled on AMD: the per-step NaN-logit probe/sanitize kernels (#27883) in
-  # the sampler hot path lower single-batch decode fwd_occupancy below the
-  # base-a sanity threshold.
-  [SGLANG_SANITIZE_NAN_LOGITS]=0
   [SGLANG_USE_AITER]=1
 )
 

--- a/test/registered/4-gpu-models/test_deepseek_v3_cutedsl_4gpu.py
+++ b/test/registered/4-gpu-models/test_deepseek_v3_cutedsl_4gpu.py
@@ -146,6 +146,7 @@ class TestDummyWithSBO(CustomTestCase):
                 # exception, crash-time coredump) so NaN is sanitized with a
                 # warning instead of killing the scheduler.
                 "SGLANG_ENABLE_ASYNC_ASSERT": "0",
+                "SGLANG_SANITIZE_NAN_LOGITS": "1",
                 "SGLANG_CUDA_COREDUMP": "0",
                 # Already injected into os.environ by the test process when
                 # SGLANG_CUDA_COREDUMP=1, so it must be overridden explicitly.


### PR DESCRIPTION
## Motivation

`sanitize_nan_logits` runs an in-place `nan_to_num_` over the `[batch, vocab]`
logits on every sampler step. With a clean model this is pure overhead on the
sampler hot path, and it measurably lowers single-batch decode occupancy. Make
it **opt-in**: off by default, enabled with `SGLANG_SANITIZE_NAN_LOGITS=1` for
deployments that want NaN logits healed instead of crashing.

CI keeps its NaN safety net regardless of this flag: `SGLANG_ENABLE_ASYNC_ASSERT`
(on in CI) already fail-fasts on NaN at the next CUDA sync.

## Why a separate flag from `SGLANG_ENABLE_ASYNC_ASSERT`

The two env vars control **orthogonal** behaviors inside `sanitize_nan_logits` —
they are intentionally not folded into one switch:

| Effect | Owned solely by | What it does |
|---|---|---|
| Crash (`torch._assert_async`) | `SGLANG_ENABLE_ASYNC_ASSERT` | Read-only NaN probe; fail-fast at next CUDA sync |
| Heal (in-place `nan_to_num_`) | `SGLANG_SANITIZE_NAN_LOGITS` | Mutates logits so NaN never reaches the sampling kernels |

Full cross-product — the crash axis and the heal axis are fully independent:

| `ENABLE_ASYNC_ASSERT` | `SANITIZE_NAN_LOGITS` | assert fires | `nan_to_num_` | throttled warn |
|:---:|:---:|:---:|:---:|:---:|
| 0 | 0 | no | no | no |
| 0 | 1 | no | yes | yes |
| 1 | 0 | yes | no | no (deduped) |
| 1 | 1 | yes | yes | no (deduped) |

The only coupling is the throttled warning, suppressed when the assert path is on
to avoid double-reporting NaN. The dummy DeepSeek CutEDSL test relies on the
`(0, 1)` heal-only cell (random weights legitimately produce NaN; it wants
sanitize-without-crash), which is exactly why the flag must stay independently
switchable.

## Modifications

- Change `SGLANG_SANITIZE_NAN_LOGITS` default from `true` to `false` — the
  per-step `nan_to_num_` is no longer paid on the sampler hot path in production.
- Explicitly set `SGLANG_SANITIZE_NAN_LOGITS=1` in the dummy DeepSeek CutEDSL
  test that relies on heal-only (no-crash) NaN handling.
- Drop the now-redundant `SGLANG_SANITIZE_NAN_LOGITS=0` override in
  `scripts/ci/amd/amd_ci_exec.sh`; the new default already disables it on AMD.

## Accuracy Tests

Not run; this changes the default of an expert env flag.

## Speed Tests and Profiling

Not run.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Local checks:
- `PYTHONPATH=python python3 -m py_compile python/sglang/srt/environ.py test/registered/4-gpu-models/test_deepseek_v3_cutedsl_4gpu.py`
- `bash -n scripts/ci/amd/amd_ci_exec.sh`
- `git diff --check`
- isolated `environ.py` load with `SGLANG_SANITIZE_NAN_LOGITS.clear(); get() == False`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27918062912](https://github.com/sgl-project/sglang/actions/runs/27918062912)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27918062818](https://github.com/sgl-project/sglang/actions/runs/27918062818)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
