### PR TITLE
[codex] Fix SGLang-Diffusion probe failures

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
@@ -783,22 +783,30 @@ class QwenImageLayeredPipelineConfig(QwenImageEditPipelineConfig):
         return cond_kwargs
 
     def _unpad_and_unpack_latents(self, latents, batch):
-        vae_scale_factor = self.get_vae_scale_factor()
         channels = self.dit_config.arch_config.in_channels
         batch_size = latents.shape[0]
-        layers = batch.num_frames
 
-        height = 2 * (int(batch.height) // (vae_scale_factor * 2))
-        width = 2 * (int(batch.width) // (vae_scale_factor * 2))
+        generated_shapes = batch.img_shapes[0][:-1]
+        if not generated_shapes:
+            raise ValueError("Qwen-Image-Layered requires generated latent shapes.")
+        if len({tuple(shape) for shape in generated_shapes}) != 1:
+            raise ValueError(
+                "Qwen-Image-Layered generated latent shapes must match, got "
+                f"{generated_shapes}."
+            )
+        layers = len(generated_shapes)
+        _, latent_height, latent_width = generated_shapes[0]
+        height = 2 * int(latent_height)
+        width = 2 * int(latent_width)
 
         latents = maybe_unpad_latents(latents, batch)
         latents = latents.view(
-            batch_size, layers + 1, height // 2, width // 2, channels // 4, 2, 2
+            batch_size, layers, height // 2, width // 2, channels // 4, 2, 2
         )
         latents = latents.permute(0, 1, 4, 2, 5, 3, 6)
 
         latents = latents.reshape(
-            batch_size, layers + 1, channels // (2 * 2), height, width
+            batch_size, layers, channels // (2 * 2), height, width
         )
         latents = latents.permute(0, 2, 1, 3, 4)  # (b, c, f, h, w)
         return latents, batch_size, channels, height, width

--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -603,7 +603,7 @@ class DiffGenerator:
         # sends the shutdown command to the server
         if self.local_scheduler_process and self.owns_scheduler_client:
             try:
-                sync_scheduler_client.forward(ShutdownReq())
+                sync_scheduler_client.forward(ShutdownReq(), timeout_ms=5000)
             except Exception:
                 pass
 
@@ -615,11 +615,40 @@ class DiffGenerator:
                         f"Local worker {process.name} did not terminate gracefully, forcing."
                     )
                     process.terminate()
+                    process.join(timeout=1)
+                    if process.is_alive():
+                        process.kill()
+                        process.join(timeout=1)
             self.local_scheduler_process = None
 
         if self.owns_scheduler_client:
             sync_scheduler_client.close()
             self.owns_scheduler_client = False
+
+    def _force_shutdown_local_processes(self) -> None:
+        local_scheduler_process = getattr(self, "local_scheduler_process", None)
+        if local_scheduler_process:
+            for process in local_scheduler_process:
+                if process.is_alive():
+                    logger.warning(
+                        f"Local worker {process.name} did not terminate gracefully, forcing."
+                    )
+                    process.terminate()
+            for process in local_scheduler_process:
+                process.join(timeout=1)
+                if process.is_alive():
+                    logger.warning(
+                        f"Local worker {process.name} did not terminate after terminate(), killing."
+                    )
+                    process.kill()
+                    process.join(timeout=1)
+            self.local_scheduler_process = None
+
+        if getattr(self, "owns_scheduler_client", False):
+            try:
+                sync_scheduler_client.close()
+            finally:
+                self.owns_scheduler_client = False
 
     def __enter__(self):
         return self
@@ -633,12 +662,12 @@ class DiffGenerator:
         if owns_scheduler_client:
             logger.warning(
                 "Generator was garbage collected without being shut down. "
-                "Attempting to shut down the local server and client."
+                "Forcing local server and client cleanup."
             )
-            self.shutdown()
+            self._force_shutdown_local_processes()
         elif local_scheduler_process:
             logger.warning(
                 "Generator was garbage collected without being shut down. "
-                "Attempting to shut down the local server."
+                "Forcing local server cleanup."
             )
-            self.shutdown()
+            self._force_shutdown_local_processes()

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/qwen_image_layered.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/qwen_image_layered.py
@@ -512,6 +512,8 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         multiple_of = self.vae_scale_factor * 2
         width = width // multiple_of * multiple_of
         height = height // multiple_of * multiple_of
+        batch.width = width
+        batch.height = height
 
         # if image is not None and not (isinstance(image, torch.Tensor) and image.size(1) == self.latent_channels):
         image = self.image_processor.resize(image, calculated_height, calculated_width)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/base.py
@@ -838,9 +838,11 @@ class SanaWMDenoisingStage(DenoisingStage):
         scheduler = getattr(
             batch, "scheduler", None
         ) or get_or_create_request_scheduler(batch, self.scheduler)
+        self._move_scheduler_tensors_to_device(scheduler, device)
         timesteps = batch.timesteps
         if timesteps is None:
             raise ValueError("SANA-WM denoising requires prepared timesteps.")
+        timesteps = timesteps.to(device=device)
 
         latents = batch.latents.to(device=device, dtype=target_dtype)
         init_latents = latents.clone()
@@ -1039,6 +1041,13 @@ class SanaWMDenoisingStage(DenoisingStage):
         )
         batch.latents = server_args.pipeline_config.post_denoising_loop(latents, batch)
         return batch
+
+    @staticmethod
+    def _move_scheduler_tensors_to_device(scheduler: object, device) -> None:
+        for name in ("sigmas", "timesteps"):
+            value = getattr(scheduler, name, None)
+            if isinstance(value, torch.Tensor):
+                setattr(scheduler, name, value.to(device=device))
 
 
 class SanaWMBeforeDenoisingStage(PipelineStage):

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -78,8 +78,12 @@ class SchedulerClient:
             f"SchedulerClient connected to backend scheduler at {scheduler_endpoint}"
         )
 
-    def forward(self, batch: Any) -> Any:
+    def forward(self, batch: Any, timeout_ms: int | None = None) -> Any:
         """Sends a batch or request to the scheduler and waits for the response."""
+        previous_timeout_ms = None
+        if timeout_ms is not None:
+            previous_timeout_ms = self.scheduler_socket.getsockopt(zmq.RCVTIMEO)
+            self.scheduler_socket.setsockopt(zmq.RCVTIMEO, timeout_ms)
         try:
             self.scheduler_socket.send_pyobj(batch)
             output_batch = self.scheduler_socket.recv_pyobj()
@@ -88,6 +92,9 @@ class SchedulerClient:
         except zmq.error.Again:
             logger.error("Timeout waiting for response from scheduler.")
             raise TimeoutError("Scheduler did not respond in time.")
+        finally:
+            if previous_timeout_ms is not None and self.scheduler_socket is not None:
+                self.scheduler_socket.setsockopt(zmq.RCVTIMEO, previous_timeout_ms)
 
     def ping(self) -> bool:
         """

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -1945,6 +1945,15 @@ class ServerArgs(DisaggServerArgsMixin):
             )
 
         # validate layerwise offload conflicts
+        if envs.SGLANG_CACHE_DIT_ENABLED and self.use_fsdp_inference:
+            raise ValueError(
+                "FSDP inference cannot be enabled together with cache-dit. "
+                "cache-dit wraps known DiT block structures, while FSDP wraps "
+                "and shards modules before cache-dit can inspect them. "
+                "Please disable --use-fsdp-inference or disable "
+                "SGLANG_CACHE_DIT_ENABLED."
+            )
+
         if self.layerwise_offload_components:
             if self.dit_offload_prefetch_size < 0.0:
                 raise ValueError("dit_offload_prefetch_size must be non-negative")

--- a/python/sglang/multimodal_gen/test/unit/sana_wm/test_pipeline_config.py
+++ b/python/sglang/multimodal_gen/test/unit/sana_wm/test_pipeline_config.py
@@ -1079,6 +1079,21 @@ class TestSanaWMDenoisingStage(unittest.TestCase):
         self.assertTrue(torch.allclose(combined_from_pos_rank, serial))
         self.assertTrue(torch.allclose(combined_from_neg_rank, serial))
 
+    def test_scheduler_tensors_move_to_target_device(self) -> None:
+        scheduler = SimpleNamespace(
+            sigmas=torch.tensor([1.0, 0.0]),
+            timesteps=torch.tensor([1000.0, 0.0]),
+            untouched="value",
+        )
+
+        SanaWMDenoisingStage._move_scheduler_tensors_to_device(
+            scheduler, torch.device("cpu")
+        )
+
+        self.assertEqual(scheduler.sigmas.device.type, "cpu")
+        self.assertEqual(scheduler.timesteps.device.type, "cpu")
+        self.assertEqual(scheduler.untouched, "value")
+
 
 class TestSanaWMNativeDiTChunking(unittest.TestCase):
     def test_softmax_chunking_is_disabled_by_default_for_upstream_parity(self) -> None:

--- a/python/sglang/multimodal_gen/test/unit/test_diffusion_generator_shutdown.py
+++ b/python/sglang/multimodal_gen/test/unit/test_diffusion_generator_shutdown.py
@@ -1,0 +1,81 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sglang.multimodal_gen.runtime.entrypoints import diffusion_generator as dg
+from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import DiffGenerator
+from sglang.multimodal_gen.runtime.entrypoints.utils import ShutdownReq
+
+
+class _FakeProcess:
+    name = "fake-worker"
+
+    def __init__(self):
+        self.alive = True
+        self.join_timeouts = []
+        self.terminated = False
+        self.killed = False
+
+    def join(self, timeout=None):
+        self.join_timeouts.append(timeout)
+
+    def is_alive(self):
+        return self.alive
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+        self.alive = False
+
+
+class TestDiffGeneratorShutdown(unittest.TestCase):
+    def test_shutdown_uses_bounded_scheduler_timeout_and_forces_worker(self):
+        generator = object.__new__(DiffGenerator)
+        process = _FakeProcess()
+        generator.local_scheduler_process = [process]
+        generator.owns_scheduler_client = True
+
+        client = SimpleNamespace(
+            forward=Mock(side_effect=TimeoutError("blocked")),
+            close=Mock(),
+        )
+
+        with patch.object(dg, "sync_scheduler_client", client):
+            generator.shutdown()
+
+        request = client.forward.call_args.args[0]
+        self.assertIsInstance(request, ShutdownReq)
+        self.assertEqual(client.forward.call_args.kwargs, {"timeout_ms": 5000})
+        self.assertTrue(process.terminated)
+        self.assertTrue(process.killed)
+        self.assertEqual(process.join_timeouts, [10, 1, 1])
+        self.assertIsNone(generator.local_scheduler_process)
+        self.assertFalse(generator.owns_scheduler_client)
+        client.close.assert_called_once_with()
+
+    def test_del_forces_cleanup_without_scheduler_request(self):
+        generator = object.__new__(DiffGenerator)
+        process = _FakeProcess()
+        generator.local_scheduler_process = [process]
+        generator.owns_scheduler_client = True
+
+        client = SimpleNamespace(
+            forward=Mock(),
+            close=Mock(),
+        )
+
+        with patch.object(dg, "sync_scheduler_client", client):
+            generator.__del__()
+
+        client.forward.assert_not_called()
+        client.close.assert_called_once_with()
+        self.assertTrue(process.terminated)
+        self.assertTrue(process.killed)
+        self.assertIsNone(generator.local_scheduler_process)
+        self.assertFalse(generator.owns_scheduler_client)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_qwen_image_layered.py
+++ b/python/sglang/multimodal_gen/test/unit/test_qwen_image_layered.py
@@ -1,0 +1,47 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import (
+    QwenImageLayeredPipelineConfig,
+)
+
+
+class TestQwenImageLayeredPipelineConfig(unittest.TestCase):
+    def test_unpack_uses_layered_img_shapes_not_stale_request_size(self):
+        config = QwenImageLayeredPipelineConfig()
+        channels = config.dit_config.arch_config.in_channels
+        generated_layers = 2
+        latent_height = 40
+        latent_width = 40
+        latents = torch.empty(
+            1,
+            generated_layers * latent_height * latent_width,
+            channels,
+        )
+        batch = SimpleNamespace(
+            height=512,
+            width=512,
+            raw_latent_shape=latents.shape,
+            img_shapes=[
+                [
+                    (1, latent_height, latent_width),
+                    (1, latent_height, latent_width),
+                    (1, latent_height, latent_width),
+                ]
+            ],
+        )
+
+        unpacked, batch_size, unpacked_channels, height, width = (
+            config._unpad_and_unpack_latents(latents, batch)
+        )
+
+        self.assertEqual(batch_size, 1)
+        self.assertEqual(unpacked_channels, channels)
+        self.assertEqual((height, width), (80, 80))
+        self.assertEqual(unpacked.shape, (1, channels // 4, generated_layers, 80, 80))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -833,6 +833,18 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertTrue(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
 
+    def test_cache_dit_rejects_explicit_fsdp(self):
+        with patch.dict(os.environ, {"SGLANG_CACHE_DIT_ENABLED": "true"}):
+            with self.assertRaisesRegex(ValueError, "FSDP inference"):
+                self._from_dict_with_pipeline_config(
+                    SanaWMPipelineConfig(),
+                    kwargs={
+                        "model_path": "Efficient-Large-Model/SANA-WM_bidirectional",
+                        "num_gpus": 2,
+                        "use_fsdp_inference": True,
+                    },
+                )
+
     def test_auto_multi_gpu_sana_wm_realtime_disables_cfg_parallel(self):
         args = self._from_dict_with_pipeline_config(
             SanaWMRealtimeConfig(),


### PR DESCRIPTION
## Summary

- Fix Qwen-Image-Layered latent unpack to use actual layered `img_shapes` instead of stale request dimensions.
- Reject unsupported Cache-DiT + FSDP at `ServerArgs` validation.
- Move SANA-WM scheduler tensors/timesteps to the local CFG-parallel rank device.
- Make `DiffGenerator` local shutdown/GC cleanup bounded so dynamic LoRA failures do not hang.

## Root Cause

- Qwen-Image-Layered prepares latents at its configured `resolution=640`, but post-denoising unpack still used stale request dimensions such as 512x512.
- Cache-DiT needs to inspect DiT block structure, while FSDP wraps/shards modules before that inspection.
- SANA-WM CFG-parallel rank-local latents can be on `cuda:1` while scheduler tensors remain on `cuda:0`.
- `DiffGenerator.__del__` previously called full shutdown, which could block on the scheduler socket after dynamic LoRA request errors.

## Validation

- `pre-commit run --files ...`
- Remote H200 unit run: `5 passed, 20 warnings in 0.32s`
- Remote Qwen-Image-Layered repro: generation completed; output image decodes and is non-blank.
- Remote SANA-WM CFG-parallel repro: generation completed; ffprobe reported 512x288, duration 1.0s, 8 frames.
- Remote Cache-DiT + FSDP repro: fails fast with the new expected validation error.
- Remote Z-Image dynamic LoRA invalid multi-adapter repro: exits quickly with expected error and no cleanup hang.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27899974502](https://github.com/sgl-project/sglang/actions/runs/27899974502)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27899974456](https://github.com/sgl-project/sglang/actions/runs/27899974456)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->