### PR TITLE
[diffusion] fix: reject cache-dit with fsdp

### DIFF
--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -1945,6 +1945,20 @@ class ServerArgs(DisaggServerArgsMixin):
             )
 
         # validate layerwise offload conflicts
+        if envs.SGLANG_CACHE_DIT_ENABLED and self.use_fsdp_inference:
+            if self.is_arg_explicitly_set("use_fsdp_inference"):
+                raise ValueError(
+                    "FSDP inference cannot be enabled together with cache-dit. "
+                    "cache-dit wraps known DiT block structures, while FSDP wraps "
+                    "and shards modules before cache-dit can inspect them. "
+                    "Please disable --use-fsdp-inference or disable "
+                    "SGLANG_CACHE_DIT_ENABLED."
+                )
+            logger.warning(
+                "cache-dit is enabled, automatically disabling use_fsdp_inference."
+            )
+            self.use_fsdp_inference = False
+
         if self.layerwise_offload_components:
             if self.dit_offload_prefetch_size < 0.0:
                 raise ValueError("dit_offload_prefetch_size must be non-negative")

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -833,6 +833,32 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertTrue(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
 
+    def test_cache_dit_rejects_explicit_fsdp(self):
+        with patch.dict(os.environ, {"SGLANG_CACHE_DIT_ENABLED": "true"}):
+            with self.assertRaisesRegex(ValueError, "FSDP inference"):
+                self._from_dict_with_pipeline_config(
+                    SanaWMPipelineConfig(),
+                    kwargs={
+                        "model_path": "Efficient-Large-Model/SANA-WM_bidirectional",
+                        "num_gpus": 2,
+                        "use_fsdp_inference": True,
+                    },
+                )
+
+    def test_cache_dit_auto_disables_implicit_fsdp(self):
+        with patch.dict(os.environ, {"SGLANG_CACHE_DIT_ENABLED": "true"}):
+            args = self._from_dict_with_pipeline_config(
+                SanaWMPipelineConfig(),
+                kwargs={
+                    "model_path": "Efficient-Large-Model/SANA-WM_bidirectional",
+                    "num_gpus": 2,
+                    "performance_mode": "auto",
+                },
+            )
+
+        self.assertFalse(args.use_fsdp_inference)
+        self.assertTrue(args.enable_cfg_parallel)
+
     def test_auto_multi_gpu_sana_wm_realtime_disables_cfg_parallel(self):
         args = self._from_dict_with_pipeline_config(
             SanaWMRealtimeConfig(),


### PR DESCRIPTION
## Summary

- Reject `SGLANG_CACHE_DIT_ENABLED=true` together with `--use-fsdp-inference` during `ServerArgs` validation.
- Add unit coverage for the unsupported combination.

## Root Cause

Cache-DiT expects to inspect known DiT block structures, while FSDP wraps and shards modules before Cache-DiT can safely inspect them. The old behavior let this unsupported combination fail later at runtime.

## Validation

- `pre-commit run --files python/sglang/multimodal_gen/runtime/server_args.py python/sglang/multimodal_gen/test/unit/test_server_args.py`
- Remote H200 unit coverage included `test_server_args.py::TestOffloadDefaults::test_cache_dit_rejects_explicit_fsdp`.
- Remote CLI repro now fails fast with the expected validation error.





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27905489920](https://github.com/sgl-project/sglang/actions/runs/27905489920)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27905489885](https://github.com/sgl-project/sglang/actions/runs/27905489885)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->