### PR TITLE
fix(server_args): gate trtllm_mla prefill (not decode) off SM120/SM121

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1701,10 +1701,36 @@ def _mla_kv_cache_dtype_checks(view: Any) -> dict:
     if (
         view.attention_backend == "trtllm_mla"
         or view.decode_attention_backend == "trtllm_mla"
+        or view.prefill_attention_backend == "trtllm_mla"
     ):
-        if not is_blackwell_supported():
+        # trtllm_mla prefill (trtllm_ragged_attention_deepseek) has kernels only
+        # for SM100/SM103 (datacenter Blackwell); on SM120/SM121 (workstation/
+        # consumer Blackwell) it crashes inside FlashInfer with "Unsupported
+        # architecture". Decode auto-dispatches to xqa and works on all
+        # Blackwell, so gate prefill and decode separately (as trtllm_mha does
+        # at the legacy slot).
+        prefill_backend = (
+            view.prefill_attention_backend
+            if view.prefill_attention_backend is not None
+            else view.attention_backend
+        )
+        if prefill_backend == "trtllm_mla" and not is_sm100_supported():
             raise ValueError(
-                "TRTLLM MLA backend is only supported on Blackwell GPUs (SM100/SM12x). Please use a different backend."
+                "TRTLLM MLA backend for prefill is only supported on SM100/SM103 "
+                "(datacenter Blackwell, e.g. B200/B300); its kernels are not built "
+                "for SM120/SM121 (workstation/consumer Blackwell, e.g. RTX PRO 6000 "
+                "/ RTX 5090). Please use a different prefill attention backend "
+                "(e.g. --attention-backend flashinfer) on this GPU."
+            )
+        decode_backend = (
+            view.decode_attention_backend
+            if view.decode_attention_backend is not None
+            else view.attention_backend
+        )
+        if decode_backend == "trtllm_mla" and not is_blackwell_supported():
+            raise ValueError(
+                "TRTLLM MLA backend for decode is only supported on Blackwell GPUs "
+                "(SM100/SM103/SM120/SM121). Please use a different decode backend."
             )
         if view.kv_cache_dtype not in ["fp8_e4m3", "fp4_e2m1", "bf16", "auto"]:
             raise ValueError(

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1247,11 +1247,18 @@ def _mla_kv_cache_dtype_checks(view: Any) -> dict:
     handler: the TRT-LLM and tokenspeed MLA backends constrain the resolved
     kv-cache dtype (declarations never reach the field, so the checks read
     the view)."""
-    if (
-        view.attention_backend == "trtllm_mla"
-        or view.decode_attention_backend == "trtllm_mla"
-    ):
-        if not get_platform().is_blackwell:
+    prefill_backend, decode_backend = attention_backends_of(view)
+    if "trtllm_mla" in (prefill_backend, decode_backend):
+        platform = get_platform()
+        if prefill_backend == "trtllm_mla" and not platform.is_sm100:
+            raise ValueError(
+                "TRTLLM MLA backend for prefill is only supported on SM100/SM103 "
+                "(datacenter Blackwell, e.g. B200/B300); its kernels are not built "
+                "for SM120/SM121 (workstation/consumer Blackwell, e.g. RTX PRO 6000 "
+                "/ RTX 5090). Please use a different prefill attention backend "
+                "(e.g. --attention-backend flashinfer) on this GPU."
+            )
+        if decode_backend == "trtllm_mla" and not platform.is_blackwell:
             raise ValueError(
                 "TRTLLM MLA backend is only supported on Blackwell GPUs (SM100/SM12x). Please use a different backend."
             )

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1647,5 +1647,41 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestTrtllmMlaArchGuard(CustomTestCase):
+    """trtllm_mla prefill kernels exist only for SM100/SM103; decode works on all
+    Blackwell (SM120/SM121 auto-dispatch to xqa).
+
+    So on SM120/SM121 (consumer/workstation Blackwell, e.g. RTX PRO 6000 / RTX
+    5090) trtllm_mla *prefill* must be rejected with a clear error instead of
+    crashing inside FlashInfer with "Unsupported architecture", while trtllm_mla
+    *decode* must still be allowed. Regression for #24633; mirrors the
+    trtllm_mha prefill/decode split.
+    """
+
+    @patch("sglang.srt.arg_groups.overrides.is_blackwell_supported", return_value=True)
+    @patch("sglang.srt.arg_groups.overrides.is_sm100_supported", return_value=False)
+    def test_trtllm_mla_prefill_rejected_on_sm120(self, _mock_sm100, _mock_blackwell):
+        # A unified attention_backend implies the prefill path -> reject on SM120.
+        with self.assertRaises(ValueError) as ctx:
+            ServerArgs(
+                model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+                attention_backend="trtllm_mla",
+                device="cuda",
+            )
+        self.assertIn("prefill", str(ctx.exception))
+        self.assertIn("SM100/SM103", str(ctx.exception))
+
+    @patch("sglang.srt.arg_groups.overrides.is_blackwell_supported", return_value=True)
+    @patch("sglang.srt.arg_groups.overrides.is_sm100_supported", return_value=False)
+    def test_trtllm_mla_decode_allowed_on_sm120(self, _mock_sm100, _mock_blackwell):
+        # Decode-only trtllm_mla auto-dispatches to xqa and is supported on SM120.
+        args = ServerArgs(
+            model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+            decode_attention_backend="trtllm_mla",
+            device="cuda",
+        )
+        self.assertEqual(args.decode_attention_backend, "trtllm_mla")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -3162,6 +3162,105 @@ class TestDcpKvEventContract(CustomTestCase):
         self.assertEqual(kv_event_block_size_of(resolving_view(args)), 8)
 
 
+class TestTrtllmMlaArchGuard(CustomTestCase):
+    def _make_args(self, **overrides):
+        args = ServerArgs(model_path="dummy", device="cuda")
+        args._model_config = MagicMock()
+        args._model_config.is_encoder_decoder = False
+        args._model_config.context_len = 1
+        args._model_config.hf_config.architectures = []
+        args._model_config.hf_config.dual_chunk_attention_config = None
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    @override_platform(is_sm100=False, is_sm120=True, is_blackwell=True)
+    def test_combined_trtllm_mla_prefill_rejected_on_sm120(self):
+        with self.assertRaisesRegex(ValueError, "SM100/SM103"):
+            handle_attention_backend_compatibility(
+                self._make_args(attention_backend="trtllm_mla")
+            )
+
+    @override_platform(is_sm100=False, is_sm120=True, is_blackwell=True)
+    def test_explicit_trtllm_mla_prefill_rejected_on_sm120(self):
+        with self.assertRaisesRegex(ValueError, "SM100/SM103"):
+            handle_attention_backend_compatibility(
+                self._make_args(
+                    attention_backend="triton",
+                    prefill_attention_backend="trtllm_mla",
+                )
+            )
+
+    @override_platform(is_sm100=False, is_sm120=True, is_blackwell=True)
+    def test_safe_prefill_with_trtllm_mla_decode_allowed_on_sm120(self):
+        args = self._make_args(
+            attention_backend="triton",
+            prefill_attention_backend="flashinfer",
+            decode_attention_backend="trtllm_mla",
+        )
+
+        handle_attention_backend_compatibility(args)
+
+        self.assertEqual(resolution_result(args, "attention_backend"), "triton")
+        self.assertEqual(
+            resolution_result(args, "prefill_attention_backend"), "flashinfer"
+        )
+        self.assertEqual(
+            resolution_result(args, "decode_attention_backend"), "trtllm_mla"
+        )
+
+    def test_trtllm_mla_prefill_allowed_on_sm100_family(self):
+        for sm in (100, 103):
+            with (
+                self.subTest(sm=sm),
+                override_platform(
+                    is_cuda=True,
+                    is_sm100=True,
+                    is_sm120=False,
+                    is_blackwell=True,
+                    device_sm=sm,
+                ),
+            ):
+                args = self._make_args(
+                    attention_backend="triton",
+                    prefill_attention_backend="trtllm_mla",
+                )
+                handle_attention_backend_compatibility(args)
+                self.assertEqual(
+                    resolution_result(args, "prefill_attention_backend"),
+                    "trtllm_mla",
+                )
+
+    @override_platform(is_sm100=False, is_sm120=False, is_blackwell=False)
+    def test_trtllm_mla_decode_rejected_off_blackwell(self):
+        with self.assertRaises(ValueError) as context:
+            handle_attention_backend_compatibility(
+                self._make_args(
+                    attention_backend="triton",
+                    decode_attention_backend="trtllm_mla",
+                )
+            )
+        self.assertEqual(
+            str(context.exception),
+            "TRTLLM MLA backend is only supported on Blackwell GPUs (SM100/SM12x). Please use a different backend.",
+        )
+
+    @override_platform(is_sm100=True, is_sm120=False, is_blackwell=True)
+    def test_trtllm_mla_invalid_kv_cache_dtype_rejected(self):
+        with self.assertRaises(ValueError) as context:
+            handle_attention_backend_compatibility(
+                self._make_args(
+                    attention_backend="triton",
+                    decode_attention_backend="trtllm_mla",
+                    kv_cache_dtype="float16",
+                )
+            )
+        self.assertEqual(
+            str(context.exception),
+            "TensorRT-LLM MLA backend only supports kv-cache-dtype of fp8_e4m3, fp4_e2m1, bf16, or auto.",
+        )
+
+
 class TestTheInputIsSealedDuringResolution(CustomTestCase):
     """The record holds what the operator asked for, and resolution does not
     write it -- enforced, not merely observed.


### PR DESCRIPTION
## Motivation

Fixes #24633. On SM120/SM121 (consumer/workstation Blackwell, e.g. RTX PRO 6000 / RTX 5090), selecting the `trtllm_mla` MLA backend passes arg validation and then crashes deep inside FlashInfer with `Unsupported architecture`.

Root cause: the guard used `is_blackwell_supported()` (compute-capability majors `[10, 11, 12]`), so SM120/121 (major 12) slipped through — but the `trtllm_mla` **prefill** kernels (`trtllm_ragged_attention_deepseek`) are built only for SM100/SM103 (datacenter Blackwell). The error string also incorrectly listed "SM12x" as supported.

As @bkryu (FlashInfer) confirmed on #24633, those prefill kernels exist only for SM100/SM103 with no SM120/121 roadmap. **Decode** works on SM120/121 (it auto-dispatches to xqa) — which is why #24848 was closed (it over-rejected decode; @b8zhong asked to keep decode enabled).

## Modifications

- Gate `trtllm_mla` **prefill** on `is_sm100_supported()` (SM100/SM103) and keep **decode** on all Blackwell — the check now lives in the `_mla_kv_cache_dtype_checks` post-process pass (`python/sglang/srt/arg_groups/overrides.py`) after the server-args resolution refactor, mirroring the `trtllm_mha` prefill/decode split at its legacy slot.
- Correct the error message (SM100/SM103, not SM12x) and point users at a working SM120 MLA fallback (`--attention-backend flashinfer`).
- Add regression tests (`TestTrtllmMlaArchGuard`): prefill rejected on SM120, decode allowed on SM120.

## Accuracy Test / Verification

- Verified on a real RTX PRO 6000 (SM120, CUDA 13): `--attention-backend trtllm_mla` now raises a clear prefill-only error; `--decode-attention-backend trtllm_mla` is accepted.
- `pytest test/registered/unit/server_args/test_server_args.py::TestTrtllmMlaArchGuard` → 2 passed. Re-run after the rebase onto the arg-resolution refactor: full file 109 passed.

## Checklist

- [x] Format the code and run unit tests for the change.
- [x] Update documentation / regression tests as needed.

 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34681392184](https://github.com/sgl-project/sglang/actions/runs/34681392184)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34681391862](https://github.com/sgl-project/sglang/actions/runs/34681391862)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34681392114](https://github.com/sgl-project/sglang/actions/runs/34681392114)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
