### PR TITLE
CI: Pin flash-attn-4 for diffusion CI consistency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "easydict",  # Required by remote model code (e.g. DeepSeek-OCR) loaded via trust_remote_code; validated by transformers 5.4+ check_imports
   "einops",
   "fastapi",
-  "flash-attn-4>=4.0.0b9",
+  "flash-attn-4==4.0.0b15",
   "flashinfer_cubin==0.6.12",
   "flashinfer_python[cu13]==0.6.12", # keep it aligned with jit-cache version in Dockerfile
   "gguf",


### PR DESCRIPTION
## Summary

Pin `flash-attn-4` to `4.0.0b15` instead of leaving it as `>=4.0.0b9`.

## Root Cause

PR #28811 only sorted `python/pyproject.toml`, but it changed the CI dependency resolution outcome for the B200 multimodal generation job. The affected CI jobs show that the previously passing runs installed:

- `flash-attn-4==4.0.0b15`
- `quack-kernels==0.4.1`

After #28811, the same B200 job started installing:

- `flash-attn-4==4.0.0b18`
- `quack-kernels==0.5.0`

That dependency drift changed the deterministic outputs for the ModelOpt/NVFP4 diffusion consistency cases and caused the B200 consistency checks to fail.

## Fix

Pin `flash-attn-4==4.0.0b15` so the consistency-sensitive diffusion CI path does not depend on resolver behavior or runner-local package state.

## Validation

- `pre-commit run --files python/pyproject.toml`

The B200 CI job should be rerun on this branch to confirm the affected NVFP4 consistency cases are restored.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27903939758](https://github.com/sgl-project/sglang/actions/runs/27903939758)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27903939657](https://github.com/sgl-project/sglang/actions/runs/27903939657)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->