### PR TITLE
Support TBO prefill-only mode  for non-PD deployments

### DIFF
--- a/docs_new/docs/references/environment_variables.mdx
+++ b/docs_new/docs/references/environment_variables.mdx
@@ -163,6 +163,11 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`false`</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`SGLANG_DISABLE_TBO_FOR_DECODE`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Disable two-batch overlap for decode and target-verify batches while keeping it enabled for prefill/extend</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`false`</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`SGLANG_SCHEDULER_MAX_RECV_PER_POLL`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Set the maximum number of requests per poll, with a negative value indicating no limit</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`-1`</td>

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -23,6 +23,7 @@ from sglang.srt.layers.moe import (
     get_deepep_mode,
     get_moe_a2a_backend,
     get_tbo_token_distribution_threshold,
+    is_decode_tbo_enabled,
     is_tbo_enabled,
 )
 from sglang.srt.layers.moe.token_dispatcher import (
@@ -412,13 +413,23 @@ class TboDPAttentionPreparer:
                 token_num_per_seq=token_num_per_seq,
             )
             resolved_deepep_mode = deepep_mode.resolve(local_batch.is_extend_in_batch)
-            local_can_run_tbo = (self.local_tbo_split_seq_index is not None) and not (
-                (
-                    local_batch.forward_mode.is_extend()
-                    and not local_batch.forward_mode.is_target_verify()
+            local_can_run_tbo = (
+                (self.local_tbo_split_seq_index is not None)
+                and not (
+                    (
+                        local_batch.forward_mode.is_extend()
+                        and not local_batch.forward_mode.is_target_verify()
+                    )
+                    and enable_a2a_moe
+                    and (resolved_deepep_mode.is_low_latency())
                 )
-                and enable_a2a_moe
-                and (resolved_deepep_mode.is_low_latency())
+                and not (
+                    not is_decode_tbo_enabled()
+                    and (
+                        local_batch.forward_mode.is_decode()
+                        or local_batch.forward_mode.is_target_verify()
+                    )
+                )
             )
         else:
             self.local_tbo_split_seq_index = 0

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -547,6 +547,7 @@ class Envs:
 
     # TBO
     SGLANG_TBO_DEBUG = EnvBool(False)
+    SGLANG_DISABLE_TBO_FOR_DECODE = EnvBool(False)
 
     # DeepGemm
     SGLANG_ENABLE_JIT_DEEPGEMM = EnvBool(True)

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Callable, List
 
 from sglang.srt.batch_overlap import two_batch_overlap
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.moe import is_decode_tbo_enabled
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -54,6 +55,12 @@ class TboAttnBackend(AttentionBackend):
         bs = fb_view.batch_size
         forward_mode = fb_view.forward_mode
         spec_info = fb_view.spec_info
+        if not is_decode_tbo_enabled() and (
+            forward_mode.is_decode() or forward_mode.is_target_verify()
+        ):
+            # Decode-only TBO disabled: replay_prepare did not split this batch,
+            # so there are no children to dispatch.
+            return
         token_num_per_seq = two_batch_overlap.get_token_num_per_seq(
             forward_mode=forward_mode, spec_info=spec_info
         )

--- a/python/sglang/srt/layers/moe/__init__.py
+++ b/python/sglang/srt/layers/moe/__init__.py
@@ -9,6 +9,7 @@ from sglang.srt.layers.moe.utils import (
     get_moe_runner_backend,
     get_tbo_token_distribution_threshold,
     initialize_moe_config,
+    is_decode_tbo_enabled,
     is_tbo_enabled,
     should_skip_post_experts_all_reduce,
     should_use_dp_reduce_scatterv,
@@ -29,6 +30,7 @@ __all__ = [
     "should_use_dp_reduce_scatterv",
     "should_use_flashinfer_cutlass_moe_fp4_allgather",
     "is_tbo_enabled",
+    "is_decode_tbo_enabled",
     "get_tbo_token_distribution_threshold",
     "get_deepep_config",
 ]

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -356,8 +356,14 @@ def is_tbo_enabled() -> bool:
     return IS_TBO_ENABLED
 
 
+_IS_DECODE_TBO_ENABLED: Optional[bool] = None
+
+
 def is_decode_tbo_enabled() -> bool:
-    return not envs.SGLANG_DISABLE_TBO_FOR_DECODE.get()
+    global _IS_DECODE_TBO_ENABLED
+    if _IS_DECODE_TBO_ENABLED is None:
+        _IS_DECODE_TBO_ENABLED = not envs.SGLANG_DISABLE_TBO_FOR_DECODE.get()
+    return _IS_DECODE_TBO_ENABLED
 
 
 def is_sbo_enabled() -> bool:

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -356,6 +356,10 @@ def is_tbo_enabled() -> bool:
     return IS_TBO_ENABLED
 
 
+def is_decode_tbo_enabled() -> bool:
+    return not envs.SGLANG_DISABLE_TBO_FOR_DECODE.get()
+
+
 def is_sbo_enabled() -> bool:
     global IS_SBO_ENABLED
     if IS_SBO_ENABLED is None:

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -52,6 +52,7 @@ from sglang.srt.layers.dp_attention import (
     set_is_extend_in_batch,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.moe.utils import is_decode_tbo_enabled
 from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
 from sglang.srt.model_executor.cuda_graph_buffer_registry import (
     CudaGraphBufferRegistry,
@@ -448,7 +449,18 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             or requested_capture_hidden_mode == self.capture_hidden_mode
         )
         is_tbo_supported = (
-            forward_batch.can_run_tbo if self.enable_two_batch_overlap else True
+            (
+                forward_batch.can_run_tbo
+                or (
+                    not is_decode_tbo_enabled()
+                    and (
+                        forward_batch.forward_mode.is_decode()
+                        or forward_batch.forward_mode.is_target_verify()
+                    )
+                )
+            )
+            if self.enable_two_batch_overlap
+            else True
         )
 
         is_ngram_supported = (
@@ -766,7 +778,16 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         # DeepEP adapter, …) so they must run inside the same ForwardContext
         # that wraps the warmup/capture forward.
         with forward_context(ForwardContext(attn_backend=attn_backend)):
-            self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
+            if not (
+                not is_decode_tbo_enabled()
+                and (
+                    self.capture_forward_mode.is_decode()
+                    or self.capture_forward_mode.is_target_verify()
+                )
+            ):
+                self.tbo_plugin.capture_one_batch_size(
+                    forward_batch, num_tokens=num_tokens
+                )
 
             if forward_batch.lora_ids is not None:
                 self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
@@ -925,7 +946,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         ):
             buffers.input_embeds[:raw_num_token].copy_(forward_batch.input_embeds)
         # Padded tokens aren't read, so skip zeroing them.
-        if self.enable_two_batch_overlap:
+        if self.enable_two_batch_overlap and not (
+            not is_decode_tbo_enabled()
+            and (
+                self.capture_forward_mode.is_decode()
+                or self.capture_forward_mode.is_target_verify()
+            )
+        ):
             self.tbo_plugin.replay_prepare(
                 forward_mode=self.capture_forward_mode,
                 bs=bs,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -454,8 +454,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 or (
                     not is_decode_tbo_enabled()
                     and (
-                        forward_batch.forward_mode.is_decode()
-                        or forward_batch.forward_mode.is_target_verify()
+                        self.capture_forward_mode.is_decode()
+                        or self.capture_forward_mode.is_target_verify()
                     )
                 )
             )

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -52,7 +52,7 @@ from sglang.srt.layers.dp_attention import (
     set_is_extend_in_batch,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.layers.moe.utils import is_decode_tbo_enabled
+from sglang.srt.layers.moe import is_decode_tbo_enabled
 from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
 from sglang.srt.model_executor.cuda_graph_buffer_registry import (
     CudaGraphBufferRegistry,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR adds a prefill-only mode for two-batch-overlap (TBO).  

On some single-node and multi-node non-PD-disaggregated deployments, it is useful to keep TBO enabled for prefill/extend while disabling it for decode and target-verify batches. This allows deployments to benefit from TBO on prefill-heavy workloads without forcing decode CUDA graph capture/replay and attention metadata paths to use TBO splitting.  

By default, the existing behavior is unchanged. Decode TBO remains enabled unless `SGLANG_DISABLE_TBO_FOR_DECODE=true` is set.  

## Modifications

<!-- Detail the changes made in this pull request. -->

- Added a new environment variable:
  - `SGLANG_DISABLE_TBO_FOR_DECODE`
  - Default: `false`
  - When set to `true`, TBO is disabled for decode and target-verify batches while remaining enabled for prefill/extend.

- Added `is_decode_tbo_enabled()` in the MoE utility layer and exported it through `sglang.srt.layers.moe`.

- Updated TBO scheduling/metadata logic to skip decode-side TBO when the new env var is enabled:
  - In `TboDPAttentionPreparer`, decode/target-verify batches no longer set `can_run_tbo` when decode TBO is disabled.
  - In the decode CUDA graph runner, TBO capture and replay preparation are skipped for decode/target-verify when decode TBO is disabled.
  - Decode CUDA graph support checks still allow non-TBO decode graphs to be captured/replayed when decode TBO is disabled.
  - In `TboAttnBackend`, replay-view child dispatch is skipped for decode/target-verify when decode TBO is disabled.

- Preserved the default behavior:
  - If `SGLANG_DISABLE_TBO_FOR_DECODE` is unset or `false`, decode TBO behavior is unchanged.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

On other machines (non-NVIDIA GPUs),  the DeepSeek model achieves 0.97 accuracy on the MATH-500 benchmark.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Due to limited machine resources, the `num_hidden_layers` of the DeepSeek-R1-0528 model was changed to 41. The server was deployed on a single node with 8x H20 GPUs as follows:

```bash
export SGLANG_DISABLE_TBO_FOR_DECODE=1

nohup python -m sglang.launch_server \
    --model-path /workspace1/models/DeepSeek-R1-0528 \
    --trust-remote-code \
    --host 0.0.0.0 \
    --port 30000 \
    --tp 8 \
    --ep 8 \
    --mem-fraction-static 0.8 \
    --dp-size 8 \
    --enable-dp-attention \
    --moe-a2a-backend deepep \
    --deepep-mode auto \
    --enable-two-batch-overlap \
    --tbo-token-distribution-threshold 0.0 \
    --disable-prefill-cuda-graph \
    --max-prefill-tokens 8280 \
    --disable-radix-cache \
    --cuda-graph-max-bs 32 \
    --max-running-requests 256 \
    --page-size 64 \
    --chunked-prefill-size -1 \
    > "$LOG_FILE" 2>&1 &
```

Benchmark script:

```bash
python3 -m sglang.bench_serving \
    --host 127.0.0.1 \
    --port 30000 \
    --backend sglang \
    --model /workspace1/models/DeepSeek-R1-0528 \
    --dataset-name random-ids \
    --num-prompts 128 \
    --max-concurrency 128 \
    --random-input-len 2048 \
    --random-output-len 256 \
    --random-range-ratio 1.0 \
    >> log_128_2K_256.log 2>&1
```

Benchmark Results Summary

| Configuration                            | Mean TTFT (ms) | Mean TPOT (ms) |
|------------------------------------------|----------------|----------------|
| TBO disabled                              | 13166.72       | 134.41         |
| TBO enabled                               | 13278.05       | 177.64         |
| TBO enabled + `SGLANG_DISABLE_TBO_FOR_DECODE=1` | 13884.69       | 134.57         |

On other machines (non-NVIDIA GPUs), with tp size=16, ep size=16, dp size=16: when TBO is enabled, TTFT is 80% of the TBO-disabled baseline. After enabling the `SGLANG_DISABLE_TBO_FOR_DECODE` environment variable, TPOT matches the TBO-disabled baseline; without it, TPOT increases by 50%–100% compared to the TBO-disabled baseline.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28035201549](https://github.com/sgl-project/sglang/actions/runs/28035201549)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28035199442](https://github.com/sgl-project/sglang/actions/runs/28035199442)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->