### PR TITLE
[core] Fine-grained overlap-schedule WAR barrier via metadata-read-done event

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1792,8 +1792,7 @@ class SchedulerDisaggregationDecodeMixin:
                 continue
 
             # WAR barrier: this iter's schedule writes to shared GPU buffers wait for prev forward's reads.
-            if self._war_barrier_enabled:
-                self.schedule_stream.wait_stream(self.forward_stream)
+            self.apply_war_barrier()
 
             # Get the next batch to run
             batch = self.get_next_disagg_decode_batch_to_run()

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -512,8 +512,7 @@ class SchedulerDisaggregationPrefillMixin:
                 continue
 
             # WAR barrier on shared GPU buffers (req_to_token_pool / SWA mapping).
-            if self._war_barrier_enabled:
-                self.schedule_stream.wait_stream(self.forward_stream)
+            self.apply_war_barrier()
 
             # Get the next batch to run
             batch = self.get_next_disagg_prefill_batch_to_run()

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -89,6 +89,15 @@ class AttentionBackend(ABC):
     # Opt out only when this backend never reads seq_lens_cpu / seq_lens_sum.
     needs_cpu_seq_lens: bool = True
 
+    # True if the backend pre-gathers req_to_token / seq_lens into private
+    # metadata buffers during init_forward_metadata (the read of the
+    # schedule-owned shared buffers finishes before the attention kernel runs).
+    # This lets the overlap-schedule WAR barrier wait on a fine-grained
+    # "metadata read done" event instead of the whole forward. Opt out (set
+    # False) for any backend that reads req_to_token live inside its kernel; the
+    # scheduler then falls back to the coarse wait_stream(forward_stream).
+    pregathers_page_table: bool = True
+
     # Most attention backends can rebuild and replace forward metadata before
     # every forward. BCG capture is different: some backends expose metadata
     # tensors to kernels across graph breaks, so the captured graph depends on

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -17,6 +17,10 @@ class TboAttnBackend(AttentionBackend):
         # reads through TboAttnBackend resolve to the underlying pool.
         self.token_to_kv_pool = primary.token_to_kv_pool
         self.req_to_token_pool = primary.req_to_token_pool
+        # Only fine-grained-WAR-safe if every wrapped backend pre-gathers.
+        self.pregathers_page_table = getattr(
+            primary, "pregathers_page_table", False
+        ) and all(getattr(c, "pregathers_page_table", False) for c in children)
 
     @classmethod
     def init_new(cls, creator: Callable[[], AttentionBackend]):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1224,6 +1224,24 @@ class Scheduler(
         else:
             attn_backends = (self.tp_worker.model_runner.attn_backend,)
         needs_cpu_seq_lens = decide_needs_cpu_seq_lens(self.server_args, attn_backends)
+        # Fine-grained overlap-schedule WAR barrier: when every active attention
+        # backend pre-gathers req_to_token/seq_lens into private metadata buffers
+        # (read of the schedule-owned buffers finishes during init_forward_metadata),
+        # the barrier can wait on the forward's "metadata read done" event instead
+        # of the whole forward, letting schedule(N) writes overlap forward(N-1)'s
+        # compute tail. Restricted to the non-spec path (the draft worker forwards
+        # on a separate stream/event that this barrier does not track); spec keeps
+        # the coarse wait_stream. getattr default False -> any undeclared backend
+        # stays on the safe coarse path.
+        self._war_fine_grained = (
+            os.environ.get("SGLANG_WAR_FINE_GRAINED", "1") != "0"
+            and self.draft_worker is None
+            and all(
+                getattr(b, "pregathers_page_table", False)
+                for b in attn_backends
+                if b is not None
+            )
+        )
         self.future_map = self.spec_algorithm.create_future_map(
             self.device,
             self.req_to_token_pool,
@@ -1469,6 +1487,27 @@ class Scheduler(
         with self.device_module.StreamContext(self.schedule_stream):
             dispatch_event_loop(self)
 
+    def apply_war_barrier(self) -> None:
+        """Order this iter's schedule writes to shared GPU buffers after the
+        previous forward's reads of those buffers (write-after-read hazard on
+        req_to_token / new_seq_lens_buf). Shared by the overlap loop and both
+        disaggregation overlap loops.
+
+        Fine-grained path: wait only on the forward's metadata-read-done event,
+        so schedule(N) writes overlap forward(N-1)'s compute tail. Coarse
+        fallback: wait on the whole forward stream.
+        """
+        if not self._war_barrier_enabled:
+            return
+        if self._war_fine_grained:
+            event = self.tp_worker.model_runner.sched_buffers_read_done
+            # event is None only before the first forward records it; there is no
+            # prior forward to race with, so nothing to wait on.
+            if event is not None:
+                self.schedule_stream.wait_event(event)
+        else:
+            self.schedule_stream.wait_stream(self.forward_stream)
+
     @DynamicGradMode()
     def event_loop_normal(self):
         """A normal scheduler loop."""
@@ -1516,8 +1555,7 @@ class Scheduler(
                 continue
 
             # WAR barrier: this iter's schedule writes to shared GPU buffers wait for prev forward's reads.
-            if self._war_barrier_enabled:
-                self.schedule_stream.wait_stream(self.forward_stream)
+            self.apply_war_barrier()
 
             # Get the next batch to run
             batch = self.get_next_batch_to_run()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -541,6 +541,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         # Init forward stream for overlap schedule
         self.forward_stream = torch.get_device_module(self.device).Stream()
+        # Fires (on forward_stream) once a forward has finished READING the
+        # schedule-owned shared GPU buffers (req_to_token / seq_lens) during
+        # attention-metadata prep. The overlap-schedule WAR barrier waits on
+        # this instead of the whole forward, so the next iter's schedule writes
+        # overlap this forward's compute tail. Lazily created on first record.
+        self.sched_buffers_read_done = None
 
         # CPU offload
         set_offloader(create_offloader_from_server_args(server_args, dp_rank=dp_rank))
@@ -2857,6 +2863,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     ) -> LogitsProcessorOutput:
         if forward_batch.split_index == 0 or reinit_attn_backend:
             self.attn_backend.init_forward_metadata(forward_batch)
+            self.record_sched_buffers_read_done()
         next_split_index = min(
             forward_batch.split_index + forward_count,
             self.model_config.num_hidden_layers,
@@ -2966,6 +2973,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.maybe_recover_ep_ranks()
 
         return output
+
+    def record_sched_buffers_read_done(self):
+        """Mark, on forward_stream, that this forward has finished READING the
+        schedule-owned shared GPU buffers (req_to_token / seq_lens) during
+        attention-metadata prep.
+
+        Call right after init_forward_metadata (eager) / load_batch (graph),
+        before the model compute is enqueued: the recorded point must sit between
+        the metadata gather and the bulk forward so the overlap-schedule WAR
+        barrier waits only on the gather, not the whole forward. Must run on
+        forward_stream (the forward path is wrapped in forward_stream_ctx).
+
+        EVERY real forward must call this — a stale event from an earlier forward
+        gives the next iter's schedule writes no protection against this forward's
+        reads. Capture-time metadata init (cuda-graph capture) must NOT call it.
+        """
+        if self.sched_buffers_read_done is None:
+            self.sched_buffers_read_done = torch.get_device_module(self.device).Event()
+        self.sched_buffers_read_done.record(self.forward_stream)
 
     def _forward_raw(
         self,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -979,6 +979,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         )
         with timer_ctx, self.backend.replay_session():
             self.load_batch(forward_batch, pp_proxy_tensors)
+            # load_batch gathered req_to_token/seq_lens into the static metadata
+            # buffers; the captured graph reads only those. Mark the
+            # schedule-owned-buffer read as done before firing the graph so the
+            # overlap WAR barrier overlaps the next schedule with this compute.
+            self.model_runner.record_sched_buffers_read_done()
             output = self.backend.replay(self._replay_graph_key, forward_batch)
 
         if isinstance(output, LogitsProcessorOutput):

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -285,6 +285,7 @@ class EagerRunner(BaseRunner):
                 # e.g. Moss-VL's prefill cross-attention custom mask.
                 model_runner.model.prepare_forward_batch(forward_batch)
             attn_backend.init_forward_metadata(forward_batch)
+            model_runner.record_sched_buffers_read_done()
         # FIXME: add pp_proxy_tensors arg to all models
         kwargs = model_runner._pp_kwargs(pp_proxy_tensors)
 
@@ -319,6 +320,7 @@ class EagerRunner(BaseRunner):
                 # e.g. Moss-VL's prefill cross-attention custom mask.
                 model_runner.model.prepare_forward_batch(forward_batch)
             model_runner.attn_backend.init_forward_metadata(forward_batch)
+            model_runner.record_sched_buffers_read_done()
 
         cp_v2_active = is_cp_v2_active(forward_batch)
         forward_positions = forward_batch.positions
@@ -419,6 +421,7 @@ class EagerRunner(BaseRunner):
             if not model_runner.server_args.enable_pdmux:
                 forward_batch = self.load_batch(forward_batch, pp_proxy_tensors)
             model_runner.attn_backend.init_forward_metadata(forward_batch)
+            model_runner.record_sched_buffers_read_done()
         else:
             model_runner.attn_backend.forward_metadata = None
 

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -790,6 +790,10 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
         with self.backend.replay_session():
             static_forward_batch = self.load_batch(forward_batch, **kwargs)
+            # load_batch finished reading the schedule-owned shared buffers
+            # (req_to_token/seq_lens); mark it before the compute so the overlap
+            # WAR barrier overlaps the next schedule with this forward.
+            self.model_runner.record_sched_buffers_read_done()
             static_num_tokens = len(static_forward_batch.input_ids)
             raw_num_tokens = self.raw_num_tokens
 


### PR DESCRIPTION
> **Superseded by #28363**, which lands the same read-done-event WAR-barrier approach by the original author (with a runtime isolation check + spec coverage). Keeping this PR's measurements here for reference; closing in favor of #28363.

## Summary

The overlap-schedule WAR barrier (`schedule_stream.wait_stream(forward_stream)`) waits on the **whole** previous forward, serializing `forward(N-1) → schedule(N) → forward(N)` and removing schedule/forward overlap. Attention backends pre-gather `req_to_token`/`seq_lens` into private metadata during `init_forward_metadata`, so the shared-buffer reads finish right after metadata prep. This records a CUDA event there and has the barrier `wait_event(read_done)` instead of the whole forward stream, gated by a per-backend `pregathers_page_table` capability flag, the non-spec path, and a `SGLANG_WAR_FINE_GRAINED` toggle.

## Results

`openai/gpt-oss-120b`, 1×GB200 (4 GPUs, TP=4), cc=1 decode, ISL=OSL=1000, latest `main`. **before** = coarse barrier, **after** = this change (same build, env toggle). **3 fresh boots per side** to separate signal from boot-to-boot noise:

| workload | before (mean, 3 boots) | after (mean, 3 boots) | Δ |
| --- | ---: | ---: | ---: |
| decode | 463.4 (461.2–464.9) | 472.4 (469.7–475.4) | +1.9% |
| decode, `min_new_tokens=1000` | 456.2 (454.1–457.6) | 468.4 (466.4–470.6) | +2.7% |

Not noise: the before/after ranges **do not overlap** on either workload (after-min > before-max). Boot-to-boot spread is ~0.8–1.2%; the gain is larger and one-directional.

GSM8K (5-shot, 200 Q): **0.855 → 0.875** — accuracy-neutral (Δ within sampling noise).

(Note: on this latest-`main` baseline the gain is ~2–3%; the regression's larger component on older builds was already addressed by other merged changes. At cc=1 the decode step is gap-dominated, so an nsys stream timeline does not add a clean visual beyond these numbers.)

## Reproduce

1×Blackwell node, TP=4. `after` = default; `before` = `SGLANG_WAR_FINE_GRAINED=0`:

```bash
python3 -m sglang.launch_server --model-path openai/gpt-oss-120b \
  --tp-size 4 --trust-remote-code --host 0.0.0.0 --port 30000
```

cc=1, ISL=1000, OSL=1000 (add `min_new_tokens=1000` for the second row):

```python
import time, json, urllib.request
URL = "http://127.0.0.1:30000/generate"
def one(min_tokens=False):
    sp = {"temperature": 0.0, "max_new_tokens": 1000, "ignore_eos": True}
    if min_tokens: sp["min_new_tokens"] = 1000
    body = {"input_ids": [100]*1000, "sampling_params": sp}
    req = urllib.request.Request(URL, data=json.dumps(body).encode(), headers={"Content-Type":"application/json"})
    t = time.perf_counter(); out = json.load(urllib.request.urlopen(req, timeout=600))
    return out["meta_info"]["completion_tokens"]/(time.perf_counter()-t)
for _ in range(2): one()
print(sum(one() for _ in range(40))/40, "tok/s")
```
