### PR TITLE
[AMD] register kv_canary + mock_model e2e tests to extra-a (2-gpu-large)

### DIFF
--- a/.github/workflows/pr-test-amd-extra.yml
+++ b/.github/workflows/pr-test-amd-extra.yml
@@ -177,6 +177,37 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite extra-a-test-1-gpu-large-amd --timeout-per-file 1800 ${{ inputs.continue_on_error == true && '--continue-on-error' || '' }}
 
+  # =============================================== extra-a (2-gpu-large) ===============================================
+  # Two-GPU mock-model / kv_canary *e2e* tests (PP/TP), the AMD mirror of the
+  # CUDA extra-a 2-gpu-large gating. Single unpartitioned job on the 2-gpu pool
+  # for the same setup-cost reason as the 1-gpu jobs above.
+  extra-a-test-2-gpu-large-amd:
+    name: ${{ format('extra-a-test-2-gpu-large-amd{0} (linux-{1}-2gpu-sglang)', inputs.rocm_version && format('-{0}', inputs.rocm_version) || '', inputs.runner_arch || 'mi325') }}
+    needs: [call-gate]
+    if: ${{ !cancelled() && needs.call-gate.result == 'success' }}
+    runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi325') }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh ${{ inputs.rocm_version && format('--rocm-version {0}', inputs.rocm_version) || '' }}
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Run test
+        timeout-minutes: 75
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite extra-a-test-2-gpu-large-amd --timeout-per-file 2700 ${{ inputs.continue_on_error == true && '--continue-on-error' || '' }}
+
   # =============================================== aggregator ====================================================
   # Single fan-in job so branch protection / notifications depend on one job
   # rather than every matrix leg. Fails if any dependent failed or was
@@ -187,6 +218,7 @@ jobs:
         call-gate,
         extra-a-test-1-gpu-small-amd,
         extra-a-test-1-gpu-large-amd,
+        extra-a-test-2-gpu-large-amd,
       ]
     if: always()
     runs-on: ubuntu-latest

--- a/test/registered/kv_canary/test_self_e2e_pp_baseline.py
+++ b/test/registered/kv_canary/test_self_e2e_pp_baseline.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import unittest
 
 from sglang.srt.kv_canary.config import CanaryMode
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kv_canary.pp_fixture import CanaryPPFixture
 
 register_cuda_ci(est_time=220, stage="extra-a", runner_config="2-gpu-large")
+register_amd_ci(est_time=330, suite="stage-b-test-2-gpu-large-amd")
 
 
 class TestPPBaselineSwa(CanaryPPFixture):

--- a/test/registered/kv_canary/test_self_e2e_pp_baseline.py
+++ b/test/registered/kv_canary/test_self_e2e_pp_baseline.py
@@ -7,7 +7,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kv_canary.pp_fixture import CanaryPPFixture
 
 register_cuda_ci(est_time=220, stage="extra-a", runner_config="2-gpu-large")
-register_amd_ci(est_time=330, stage="stage-b", runner_config="2-gpu-large-amd")
+register_amd_ci(est_time=330, stage="extra-a", runner_config="2-gpu-large-amd")
 
 
 class TestPPBaselineSwa(CanaryPPFixture):

--- a/test/registered/kv_canary/test_self_e2e_pp_baseline.py
+++ b/test/registered/kv_canary/test_self_e2e_pp_baseline.py
@@ -7,7 +7,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kv_canary.pp_fixture import CanaryPPFixture
 
 register_cuda_ci(est_time=220, stage="extra-a", runner_config="2-gpu-large")
-register_amd_ci(est_time=330, suite="stage-b-test-2-gpu-large-amd")
+register_amd_ci(est_time=330, stage="stage-b", runner_config="2-gpu-large-amd")
 
 
 class TestPPBaselineSwa(CanaryPPFixture):

--- a/test/registered/kv_canary/test_self_e2e_pp_perturb.py
+++ b/test/registered/kv_canary/test_self_e2e_pp_perturb.py
@@ -5,10 +5,11 @@ from typing import ClassVar
 
 from sglang.srt.kv_canary.config import CanaryMode
 from sglang.srt.kv_canary.perturb.config import TargetGroupKind
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kv_canary.pp_fixture import CanaryPPFixture
 
 register_cuda_ci(est_time=220, stage="extra-a", runner_config="2-gpu-large")
+register_amd_ci(est_time=330, suite="stage-b-test-2-gpu-large-amd")
 
 
 class TestPPPerturbSwaSwa(CanaryPPFixture):

--- a/test/registered/kv_canary/test_self_e2e_pp_perturb.py
+++ b/test/registered/kv_canary/test_self_e2e_pp_perturb.py
@@ -9,7 +9,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kv_canary.pp_fixture import CanaryPPFixture
 
 register_cuda_ci(est_time=220, stage="extra-a", runner_config="2-gpu-large")
-register_amd_ci(est_time=330, suite="stage-b-test-2-gpu-large-amd")
+register_amd_ci(est_time=330, stage="stage-b", runner_config="2-gpu-large-amd")
 
 
 class TestPPPerturbSwaSwa(CanaryPPFixture):

--- a/test/registered/kv_canary/test_self_e2e_pp_perturb.py
+++ b/test/registered/kv_canary/test_self_e2e_pp_perturb.py
@@ -9,7 +9,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kv_canary.pp_fixture import CanaryPPFixture
 
 register_cuda_ci(est_time=220, stage="extra-a", runner_config="2-gpu-large")
-register_amd_ci(est_time=330, stage="stage-b", runner_config="2-gpu-large-amd")
+register_amd_ci(est_time=330, stage="extra-a", runner_config="2-gpu-large-amd")
 
 
 class TestPPPerturbSwaSwa(CanaryPPFixture):

--- a/test/registered/mock_model/test_e2e_pp.py
+++ b/test/registered/mock_model/test_e2e_pp.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import unittest
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.mock_model.utils import run_mock_model_bench_serving
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=600, stage="extra-a", runner_config="2-gpu-large")
+register_amd_ci(est_time=900, suite="stage-b-test-2-gpu-large-amd")
 
 
 class TestE2EPipelineParallel(CustomTestCase):

--- a/test/registered/mock_model/test_e2e_pp.py
+++ b/test/registered/mock_model/test_e2e_pp.py
@@ -7,7 +7,7 @@ from sglang.test.mock_model.utils import run_mock_model_bench_serving
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=600, stage="extra-a", runner_config="2-gpu-large")
-register_amd_ci(est_time=900, suite="stage-b-test-2-gpu-large-amd")
+register_amd_ci(est_time=900, stage="stage-b", runner_config="2-gpu-large-amd")
 
 
 class TestE2EPipelineParallel(CustomTestCase):

--- a/test/registered/mock_model/test_e2e_pp.py
+++ b/test/registered/mock_model/test_e2e_pp.py
@@ -7,7 +7,7 @@ from sglang.test.mock_model.utils import run_mock_model_bench_serving
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=600, stage="extra-a", runner_config="2-gpu-large")
-register_amd_ci(est_time=900, stage="stage-b", runner_config="2-gpu-large-amd")
+register_amd_ci(est_time=900, stage="extra-a", runner_config="2-gpu-large-amd")
 
 
 class TestE2EPipelineParallel(CustomTestCase):

--- a/test/registered/mock_model/test_e2e_tp.py
+++ b/test/registered/mock_model/test_e2e_tp.py
@@ -7,7 +7,7 @@ from sglang.test.mock_model.utils import run_mock_model_bench_serving
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=600, stage="extra-a", runner_config="2-gpu-large")
-register_amd_ci(est_time=900, suite="stage-b-test-2-gpu-large-amd")
+register_amd_ci(est_time=900, stage="stage-b", runner_config="2-gpu-large-amd")
 
 
 class TestE2ETensorParallel(CustomTestCase):

--- a/test/registered/mock_model/test_e2e_tp.py
+++ b/test/registered/mock_model/test_e2e_tp.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import unittest
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.mock_model.utils import run_mock_model_bench_serving
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=600, stage="extra-a", runner_config="2-gpu-large")
+register_amd_ci(est_time=900, suite="stage-b-test-2-gpu-large-amd")
 
 
 class TestE2ETensorParallel(CustomTestCase):

--- a/test/registered/mock_model/test_e2e_tp.py
+++ b/test/registered/mock_model/test_e2e_tp.py
@@ -7,7 +7,7 @@ from sglang.test.mock_model.utils import run_mock_model_bench_serving
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=600, stage="extra-a", runner_config="2-gpu-large")
-register_amd_ci(est_time=900, stage="stage-b", runner_config="2-gpu-large-amd")
+register_amd_ci(est_time=900, stage="extra-a", runner_config="2-gpu-large-amd")
 
 
 class TestE2ETensorParallel(CustomTestCase):

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -49,12 +49,16 @@ PER_COMMIT_SUITES = {
         # carries the mock-model / kv_canary *unit* tests; 1-gpu-large carries
         # the subset of model e2e tests validated to pass on mi325 (quant
         # fp8kv-triton, sessions streaming-session EAGLE3, spec standalone
-        # triton-backend variant). The rest of CUDA
-        # extra-a tests fail on ROCm (missing flash_attn.cute/flash_ops
-        # kernels, OOM, or accuracy regressions — e.g. gemma4-mtp-31b dips
-        # below the gsm8k floor on the topk=3 leg) and stay CUDA-only for now.
+        # triton-backend variant); 2-gpu-large carries the mock-model /
+        # kv_canary *e2e* tests (PP/TP), kept in extra-a to mirror their
+        # CUDA gating now that the canary JIT kernel is ported to ROCm. The
+        # rest of CUDA extra-a tests fail on ROCm (missing
+        # flash_attn.cute/flash_ops kernels, OOM, or accuracy regressions —
+        # e.g. gemma4-mtp-31b dips below the gsm8k floor on the topk=3 leg)
+        # and stay CUDA-only for now.
         "extra-a-test-1-gpu-small-amd",
         "extra-a-test-1-gpu-large-amd",
+        "extra-a-test-2-gpu-large-amd",
     ],
     HWBackend.MUSA: [],
     HWBackend.CUDA: [


### PR DESCRIPTION
## Summary
- Register four 2-GPU kv_canary/mock_model e2e tests to the **`extra-a-test-2-gpu-large-amd`** suite, mirroring their CUDA `register_cuda_ci(stage="extra-a", runner_config="2-gpu-large")` gating (label-gated / opt-in, not per-commit), now that the ROCm kv_canary kernel port (#28357) and the HiCache write-back/write-check fixes have landed.
- Add a new `extra-a-test-2-gpu-large-amd` job to the shared `pr-test-amd-extra.yml` (covers both the mi325 default and the rocm720 chain via `rocm_version`), wired into `pr-test-amd-extra-finish`, and register the suite in `test/run_suite.py`.
- AMD `est_time` ≈ 1.5× CUDA: 900s for mock_model PP/TP, 330s for kv_canary PP baseline/perturb (conservative vs. measured runtime below).

## Tests added (suite `extra-a-test-2-gpu-large-amd`)

| Test file | est_time | mi325 actual | rocm720 actual |
|-----------|---------:|-------------:|---------------:|
| `mock_model/test_e2e_pp.py` | 900s | 64s | 64s |
| `mock_model/test_e2e_tp.py` | 900s | 144s | 168s |
| `kv_canary/test_self_e2e_pp_baseline.py` | 330s | 186s | 189s |
| `kv_canary/test_self_e2e_pp_perturb.py` | 330s | 351s | 267s |
| **Total** | **2460s** | **745s** | **688s** |

## Test plan
- `python3 -m py_compile` on the four edited test files (clean).
- Import-free CI collector over `test/registered/**/*.py`: `extra-a-test-2-gpu-large-amd` collects exactly the four files; `stage-b-test-2-gpu-large-amd` unchanged.
- `pr-test-amd-extra.yml` parses; new job present and in `pr-test-amd-extra-finish.needs`.
- **mi325** — `extra-a-test-2-gpu-large-amd` ✅ 4/4 passed: https://github.com/sgl-project/sglang/actions/runs/27918108641
- **rocm720** — `extra-a-test-2-gpu-large-amd-rocm720` ✅ 4/4 passed: https://github.com/sgl-project/sglang/actions/runs/27917623157

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27917351386](https://github.com/sgl-project/sglang/actions/runs/27917351386)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27917351332](https://github.com/sgl-project/sglang/actions/runs/27917351332)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->