### PR TITLE
fix(harmony): opt-in retry on invalid JSON tool-call args for gpt-oss

### DIFF
--- a/python/sglang/srt/entrypoints/context.py
+++ b/python/sglang/srt/entrypoints/context.py
@@ -21,6 +21,7 @@ from sglang.srt.entrypoints.harmony_utils import (
     render_for_completion,
 )
 from sglang.srt.entrypoints.tool import Tool
+from sglang.srt.environ import envs
 
 
 class ConversationContext(ABC):
@@ -58,6 +59,26 @@ class SimpleContext(ConversationContext):
 
     def render_for_completion(self) -> list[int]:
         raise NotImplementedError("Should not be called.")
+
+
+def _create_json_parse_error_messages(
+    last_msg: Message, e: orjson.JSONDecodeError
+) -> list[Message]:
+    """Create a tool error message when JSON parsing of tool args failed."""
+    error_msg = (
+        f"Error parsing tool arguments as JSON: {str(e)}. "
+        "Please ensure the tool call arguments are valid JSON and try again."
+    )
+    content = TextContent(text=error_msg)
+    author = Author(role=Role.TOOL, name=last_msg.recipient)
+    return [
+        Message(
+            author=author,
+            content=[content],
+            recipient=Role.ASSISTANT,
+            channel=last_msg.channel,
+        )
+    ]
 
 
 class HarmonyContext(ConversationContext):
@@ -141,7 +162,13 @@ class HarmonyContext(ConversationContext):
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
         tool_name = last_msg.recipient.split(".")[1]
-        args = orjson.loads(last_msg.content[0].text)
+        if envs.SGLANG_TOOL_JSON_ERROR_AUTOMATIC_RETRY.get():
+            try:
+                args = orjson.loads(last_msg.content[0].text)
+            except orjson.JSONDecodeError as e:
+                return _create_json_parse_error_messages(last_msg, e)
+        else:
+            args = orjson.loads(last_msg.content[0].text)
         result = await tool_session.call_tool(tool_name, args)
         result_str = result.content[0].text
         content = TextContent(text=result_str)

--- a/python/sglang/srt/entrypoints/context.py
+++ b/python/sglang/srt/entrypoints/context.py
@@ -61,9 +61,7 @@ class SimpleContext(ConversationContext):
         raise NotImplementedError("Should not be called.")
 
 
-def _create_json_parse_error_messages(
-    last_msg: Message, e: orjson.JSONDecodeError
-) -> list[Message]:
+def _create_json_parse_error_messages(last_msg: Message, e: Exception) -> list[Message]:
     """Create a tool error message when JSON parsing of tool args failed."""
     error_msg = (
         f"Error parsing tool arguments as JSON: {str(e)}. "
@@ -165,7 +163,9 @@ class HarmonyContext(ConversationContext):
         if envs.SGLANG_TOOL_JSON_ERROR_AUTOMATIC_RETRY.get():
             try:
                 args = orjson.loads(last_msg.content[0].text)
-            except orjson.JSONDecodeError as e:
+                if not isinstance(args, dict):
+                    raise ValueError("Tool arguments must be a JSON object")
+            except (orjson.JSONDecodeError, ValueError) as e:
                 return _create_json_parse_error_messages(last_msg, e)
         else:
             args = orjson.loads(last_msg.content[0].text)

--- a/python/sglang/srt/entrypoints/harmony_utils.py
+++ b/python/sglang/srt/entrypoints/harmony_utils.py
@@ -5,7 +5,7 @@
 import datetime
 import logging
 from collections.abc import Iterable
-from typing import Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import orjson
 from openai.types.responses import (
@@ -236,6 +236,24 @@ def get_streamable_parser_for_assistant() -> StreamableParser:
     return StreamableParser(get_encoding(), role=Role.ASSISTANT)
 
 
+def parse_browser_call_args(content_text: str) -> dict[str, Any]:
+    """Parse browser call args without crashing retry output construction."""
+    try:
+        browser_call = orjson.loads(content_text)
+        if not isinstance(browser_call, dict):
+            raise ValueError("Expected a JSON object")
+        return browser_call
+    except (orjson.JSONDecodeError, ValueError):
+        json_retry_output_message = (
+            f"Invalid JSON args, caught and retried: {content_text}"
+        )
+        return {
+            "query": json_retry_output_message,
+            "url": json_retry_output_message,
+            "pattern": json_retry_output_message,
+        }
+
+
 def parse_output_message(message: Message):
     if message.author.role != "assistant":
         # This is a message from a tool to the assistant (e.g., search result).
@@ -249,21 +267,7 @@ def parse_output_message(message: Message):
         if len(message.content) != 1:
             raise ValueError("Invalid number of contents in browser message")
         content = message.content[0]
-        # With retry on, call_search_tool already returned a tool error for this
-        # invalid JSON; render a placeholder so output building does not crash.
-        try:
-            browser_call = orjson.loads(content.text)
-            if not isinstance(browser_call, dict):
-                raise ValueError("Expected a JSON object")
-        except (orjson.JSONDecodeError, ValueError):
-            json_retry_output_message = (
-                f"Invalid JSON args, caught and retried: {content.text}"
-            )
-            browser_call = {
-                "query": json_retry_output_message,
-                "url": json_retry_output_message,
-                "pattern": json_retry_output_message,
-            }
+        browser_call = parse_browser_call_args(content.text)
         # TODO: translate to url properly!
         if recipient == "browser.search":
             action = ActionSearch(

--- a/python/sglang/srt/entrypoints/harmony_utils.py
+++ b/python/sglang/srt/entrypoints/harmony_utils.py
@@ -253,7 +253,9 @@ def parse_output_message(message: Message):
         # invalid JSON; render a placeholder so output building does not crash.
         try:
             browser_call = orjson.loads(content.text)
-        except orjson.JSONDecodeError:
+            if not isinstance(browser_call, dict):
+                raise ValueError("Expected a JSON object")
+        except (orjson.JSONDecodeError, ValueError):
             json_retry_output_message = (
                 f"Invalid JSON args, caught and retried: {content.text}"
             )

--- a/python/sglang/srt/entrypoints/harmony_utils.py
+++ b/python/sglang/srt/entrypoints/harmony_utils.py
@@ -249,7 +249,19 @@ def parse_output_message(message: Message):
         if len(message.content) != 1:
             raise ValueError("Invalid number of contents in browser message")
         content = message.content[0]
-        browser_call = orjson.loads(content.text)
+        # With retry on, call_search_tool already returned a tool error for this
+        # invalid JSON; render a placeholder so output building does not crash.
+        try:
+            browser_call = orjson.loads(content.text)
+        except orjson.JSONDecodeError:
+            json_retry_output_message = (
+                f"Invalid JSON args, caught and retried: {content.text}"
+            )
+            browser_call = {
+                "query": json_retry_output_message,
+                "url": json_retry_output_message,
+                "pattern": json_retry_output_message,
+            }
         # TODO: translate to url properly!
         if recipient == "browser.search":
             action = ActionSearch(

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -48,6 +48,7 @@ from sglang.srt.entrypoints.harmony_utils import (
     get_stop_tokens_for_assistant_actions,
     get_system_message,
     get_user_message,
+    parse_browser_call_args,
     parse_output_message,
     parse_remaining_state,
     parse_response_input,
@@ -1524,7 +1525,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 ):
                     function_name = previous_item.recipient[len("browser.") :]
                     action = None
-                    parsed_args = orjson.loads(previous_item.content[0].text)
+                    parsed_args = parse_browser_call_args(previous_item.content[0].text)
                     if function_name == "search":
                         action = openai_responses_types.response_function_web_search.ActionSearch(
                             type="search",

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -368,6 +368,7 @@ class Envs:
 
     # Tool Calling
     SGLANG_FORWARD_UNKNOWN_TOOLS = EnvBool(False)
+    SGLANG_TOOL_JSON_ERROR_AUTOMATIC_RETRY = EnvBool(False)
 
     # Hi-Cache
     SGLANG_HICACHE_HF3FS_CONFIG_PATH = EnvStr(None)

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -8,7 +8,7 @@ from openai.types.responses import (
     ResponseReasoningItem,
 )
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
-from utils import make_serving
+from utils import event_payloads, make_serving
 
 from sglang.srt.entrypoints.context import SimpleContext
 from sglang.srt.entrypoints.openai.protocol import (
@@ -589,6 +589,73 @@ class HarmonyResponsesTestCase(unittest.TestCase):
         items = parse_output_message(msg)
         self.assertEqual(len(items), 1)
         self.assertIn("caught and retried", items[0].action.query)
+
+    def test_streaming_browser_action_tolerates_malformed_json_args(self):
+        from types import SimpleNamespace
+
+        async def stream_browser_action(raw_args: str):
+            serving = make_serving()
+            serving.supports_browsing = True
+            request = ResponsesRequest(
+                model="x",
+                input="search",
+                request_id="resp_stream_browser",
+                store=False,
+            )
+            metadata = RequestResponseMetadata(request_id=request.request_id)
+            msg = SimpleNamespace(
+                recipient="browser.search",
+                content=[SimpleNamespace(text=raw_args)],
+            )
+            ctx = SimpleNamespace(
+                parser=SimpleNamespace(
+                    messages=[msg],
+                    last_content_delta="",
+                    current_channel=None,
+                    current_recipient=None,
+                ),
+                is_expecting_start=lambda: False,
+                is_assistant_action_turn=lambda: True,
+            )
+
+            async def fake_result_generator():
+                yield ctx
+
+            events = []
+            generator = serving.responses_stream_generator(
+                request,
+                sampling_params={},
+                result_generator=fake_result_generator(),
+                context=ctx,
+                model_name="x",
+                tokenizer=serving.tokenizer_manager.tokenizer,
+                request_metadata=metadata,
+                created_time=123,
+            )
+            try:
+                async for chunk in generator:
+                    events.append(chunk)
+                    if chunk.startswith("event: response.output_item.done"):
+                        break
+            finally:
+                await generator.aclose()
+            return events
+
+        for raw_args in ("{bad json", "[1, 2, 3]"):
+            with self.subTest(raw_args=raw_args):
+                events = asyncio.run(stream_browser_action(raw_args))
+                payloads = event_payloads(events)
+                done_events = [
+                    payload
+                    for payload in payloads
+                    if payload["type"] == "response.output_item.done"
+                ]
+                self.assertEqual(len(done_events), 1)
+                item = done_events[0]["item"]
+                self.assertEqual(item["type"], "web_search_call")
+                self.assertEqual(item["status"], "completed")
+                self.assertEqual(item["action"]["type"], "search")
+                self.assertIn("caught and retried", item["action"]["query"])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -543,6 +543,25 @@ class HarmonyResponsesTestCase(unittest.TestCase):
         self.assertEqual(result[0].author.role, "tool")
         self.assertIn("valid JSON", result[0].content[0].text)
 
+    def test_call_search_tool_retry_returns_tool_error_on_non_dict_json(self):
+        from types import SimpleNamespace
+
+        from sglang.srt.entrypoints.context import HarmonyContext
+        from sglang.srt.environ import envs
+
+        msg = SimpleNamespace(
+            recipient="browser.search",
+            channel="commentary",
+            content=[SimpleNamespace(text="[1, 2, 3]")],
+        )
+        with envs.SGLANG_TOOL_JSON_ERROR_AUTOMATIC_RETRY.override(True):
+            result = asyncio.run(
+                HarmonyContext.call_search_tool(SimpleNamespace(), Mock(), msg)
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].author.role, "tool")
+        self.assertIn("valid JSON", result[0].content[0].text)
+
     def test_parse_output_message_tolerates_invalid_browser_json(self):
         from types import SimpleNamespace
 
@@ -552,6 +571,20 @@ class HarmonyResponsesTestCase(unittest.TestCase):
             author=SimpleNamespace(role="assistant"),
             recipient="browser.search",
             content=[SimpleNamespace(text="{bad json")],
+        )
+        items = parse_output_message(msg)
+        self.assertEqual(len(items), 1)
+        self.assertIn("caught and retried", items[0].action.query)
+
+    def test_parse_output_message_tolerates_non_dict_browser_json(self):
+        from types import SimpleNamespace
+
+        from sglang.srt.entrypoints.harmony_utils import parse_output_message
+
+        msg = SimpleNamespace(
+            author=SimpleNamespace(role="assistant"),
+            recipient="browser.search",
+            content=[SimpleNamespace(text="[1, 2, 3]")],
         )
         items = parse_output_message(msg)
         self.assertEqual(len(items), 1)

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -524,6 +524,39 @@ class HarmonyResponsesTestCase(unittest.TestCase):
         msg = get_developer_message(instructions="be helpful", tools=tools)
         self.assertIsNotNone(msg)
 
+    def test_call_search_tool_retry_returns_tool_error_on_invalid_json(self):
+        from types import SimpleNamespace
+
+        from sglang.srt.entrypoints.context import HarmonyContext
+        from sglang.srt.environ import envs
+
+        msg = SimpleNamespace(
+            recipient="browser.search",
+            channel="commentary",
+            content=[SimpleNamespace(text="{bad json")],
+        )
+        with envs.SGLANG_TOOL_JSON_ERROR_AUTOMATIC_RETRY.override(True):
+            result = asyncio.run(
+                HarmonyContext.call_search_tool(SimpleNamespace(), Mock(), msg)
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].author.role, "tool")
+        self.assertIn("valid JSON", result[0].content[0].text)
+
+    def test_parse_output_message_tolerates_invalid_browser_json(self):
+        from types import SimpleNamespace
+
+        from sglang.srt.entrypoints.harmony_utils import parse_output_message
+
+        msg = SimpleNamespace(
+            author=SimpleNamespace(role="assistant"),
+            recipient="browser.search",
+            content=[SimpleNamespace(text="{bad json")],
+        )
+        items = parse_output_message(msg)
+        self.assertEqual(len(items), 1)
+        self.assertIn("caught and retried", items[0].action.query)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

## Motivation

When a gpt-oss / Harmony builtin tool call (e.g. `browser.search`) emits malformed JSON arguments, `HarmonyContext.call_search_tool` (`python/sglang/srt/entrypoints/context.py`) runs `orjson.loads(last_msg.content[0].text)` with no guard, so the `orjson.JSONDecodeError` bubbles up and fails the whole Responses / tool loop. `parse_output_message` (`harmony_utils.py`) parses the same browser-call text and crashes there too. Models occasionally emit invalid JSON for tool args, so this is an agent stability problem rather than a programming error.

This is the SGLang analog of vLLM-project/vllm#27675.

## Modifications

- `environ.py`: add opt-in `SGLANG_TOOL_JSON_ERROR_AUTOMATIC_RETRY` (`EnvBool(False)`) under the existing `# Tool Calling` group. Default off, so existing behavior is unchanged.
- `context.py`: when the flag is on, `call_search_tool` catches `orjson.JSONDecodeError` and returns a `Role.TOOL` error message (via new helper `_create_json_parse_error_messages`) telling the model the args were not valid JSON, so it can self-correct on the next turn. Flag off keeps the original `raise`.
- `harmony_utils.py`: `parse_output_message` guards the same browser-call parse, rendering a placeholder action instead of 500-ing on the invalid JSON the retry path tolerated.
- `call_python_tool` passes its text straight through as `code` and never `orjson.loads` it, so there is no analog of vLLM's second `call_container_tool` hunk.

## Testing

The fault is the model emitting invalid JSON for tool args, which is not deterministically reproducible through real inference. The repro drives the exact functions a live `/v1/responses` builtin-tool request runs, with the malformed JSON a model would emit, and shows the behavior flip on current main:

<details>
<summary>Repro script + before/after output (current main, CPU)</summary>

```
$ SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK=1 python repro_harmony_json_retry.py
=== call_search_tool, flag OFF (default, unchanged) ===
  raises JSONDecodeError: unexpected end of data: line 1 column 19 (char 18)  -> whole Responses/tool loop fails
=== call_search_tool, flag ON (fix) ===
  returns 1 Role.TOOL msg -> model can retry
  text: Error parsing tool arguments as JSON: unexpected end of data: line 1 column 19 (char 18). Please ensure the tool call arguments are valid JSON and try again.
=== parse_output_message, invalid browser JSON ===
  renders placeholder action (no 500): query='cursor:Invalid JSON args, caught and retried: {"query": "weather'
```

```python
import asyncio
from types import SimpleNamespace

import orjson

from sglang.srt.entrypoints.context import HarmonyContext
from sglang.srt.entrypoints.harmony_utils import parse_output_message
from sglang.srt.environ import envs

BAD = '{"query": "weather'  # truncated -> invalid JSON, as a model may emit


def search_msg():
    return SimpleNamespace(
        recipient="browser.search", channel="commentary",
        content=[SimpleNamespace(text=BAD)],
    )


def output_msg():
    return SimpleNamespace(
        author=SimpleNamespace(role="assistant"),
        recipient="browser.search", content=[SimpleNamespace(text=BAD)],
    )


print("=== call_search_tool, flag OFF (default, unchanged) ===")
try:
    asyncio.run(HarmonyContext.call_search_tool(SimpleNamespace(), object(), search_msg()))
    print("  no error (unexpected)")
except orjson.JSONDecodeError as e:
    print(f"  raises {type(e).__name__}: {e}  -> whole Responses/tool loop fails")

print("=== call_search_tool, flag ON (fix) ===")
with envs.SGLANG_TOOL_JSON_ERROR_AUTOMATIC_RETRY.override(True):
    res = asyncio.run(HarmonyContext.call_search_tool(SimpleNamespace(), object(), search_msg()))
print(f"  returns {len(res)} Role.{res[0].author.role.upper()} msg -> model can retry")
print(f"  text: {res[0].content[0].text}")

print("=== parse_output_message, invalid browser JSON ===")
items = parse_output_message(output_msg())
print(f"  renders placeholder action (no 500): query={items[0].action.query!r}")
```

</details>

Regression guard: 2 cases appended to `test/registered/unit/entrypoints/openai/test_serving_responses.py` (`HarmonyResponsesTestCase`), one per fixed call site. `python -m pytest test_serving_responses.py` gives **18 passed**; reverting the three source files makes exactly those 2 new cases fail (`AttributeError` for the missing flag, and `orjson.JSONDecodeError` from the unguarded parse), confirming they are not tautologies.

Serving sanity (A800-80GB): `gpt-oss-20b` boots with the flag on and answers a normal `/v1/responses` request, confirming the guard does not regress serving.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc @hnyls2002 @JustinTong0323

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28474506941](https://github.com/sgl-project/sglang/actions/runs/28474506941)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28474506839](https://github.com/sgl-project/sglang/actions/runs/28474506839)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->