### PR TITLE
[AMD CI] Add nightly Miles ROCm 7.2 MI350X suites

### DIFF
--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     # Runs after the 12:00 UTC miles image build has pushed the dated image.
     - cron: "30 17 * * *"
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/nightly-test-amd-miles-rocm720.yml"
   workflow_dispatch:
     inputs:
       image_tag:

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Login to Docker Hub (AMD)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
+
       - name: Resolve newest miles ROCm 7.2 image
         run: |
           repo="rocm/sgl-dev"
@@ -47,10 +53,12 @@ jobs:
           tag="${{ inputs.image_tag }}"
           if [ -z "${tag}" ]; then
             # Walk back from today; the build job pushes a dated tag at 12:00 UTC.
+            # Probe with `manifest inspect` so we don't pull a multi-GB image just
+            # to test existence; the real pull happens in amd_ci_start_container.sh.
             for i in $(seq 0 6); do
               d=$(date -u -d "-${i} day" +%Y%m%d)
               candidate="${base}-${d}"
-              if docker pull "${repo}:${candidate}" >/dev/null 2>&1; then
+              if docker manifest inspect "${repo}:${candidate}" >/dev/null 2>&1; then
                 tag="${candidate}"
                 break
               fi

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -88,6 +88,6 @@ jobs:
             -e PYTHONPATH=/root/miles:/opt/tilelang \
             -e GITHUB_STEP_SUMMARY=/sglang-checkout/github_summary.md \
             python3 tests/ci/run_suite.py --hw rocm --suite ${{ matrix.suite }} --match-all-labels \
-            ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+            ${{ (github.event_name != 'workflow_dispatch' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           cat "${GITHUB_WORKSPACE}/github_summary.md" >> "$GITHUB_STEP_SUMMARY" || true
           exit ${TEST_EXIT_CODE}

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Resolve newest miles ROCm 7.2 image
         run: |
-          registry="10.245.143.50:5000"
           repo="rocm/sgl-dev"
           base="miles-rocm720-mi35x"
           tag="${{ inputs.image_tag }}"
@@ -56,18 +55,18 @@ jobs:
             for i in $(seq 0 6); do
               d=$(date -u -d "-${i} day" +%Y%m%d)
               candidate="${base}-${d}"
-              if docker pull "${registry}/${repo}:${candidate}" >/dev/null 2>&1; then
+              if docker pull "${repo}:${candidate}" >/dev/null 2>&1; then
                 tag="${candidate}"
                 break
               fi
             done
           fi
           if [ -z "${tag}" ]; then
-            echo "::error::No ${repo}:${base}-<date> image found in ${registry} for the last 7 days"
+            echo "::error::No ${repo}:${base}-<date> image found on Docker Hub for the last 7 days"
             exit 1
           fi
-          echo "MILES_IMAGE=${registry}/${repo}:${tag}" >> "$GITHUB_ENV"
-          echo "Using miles image: ${registry}/${repo}:${tag}"
+          echo "MILES_IMAGE=${repo}:${tag}" >> "$GITHUB_ENV"
+          echo "Using miles image: ${repo}:${tag}"
 
       - name: Ensure VRAM is clear
         run: bash scripts/ci/amd/ensure_vram_clear.sh rocm

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -35,6 +35,10 @@ jobs:
         include:
           - suite: stage-c-2-gpu-mi350
             runner: linux-mi35x-gpu-2
+          # No dedicated 4-GPU mi35x runner upstream; run on the 8-GPU pool, same
+          # as the existing nightly-4-gpu-mi35x-minimax-m25 job.
+          - suite: stage-c-4-gpu-mi350
+            runner: linux-mi35x-gpu-8
           - suite: stage-c-8-gpu-mi350
             runner: linux-mi35x-gpu-8
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -35,8 +35,7 @@ jobs:
         include:
           - suite: stage-c-2-gpu-mi350
             runner: linux-mi35x-gpu-2
-          # No dedicated 4-GPU mi35x runner upstream; run on the 8-GPU pool, same
-          # as the existing nightly-4-gpu-mi35x-minimax-m25 job.
+          # Use 8-GPU MI35X pool for 4-GPU suite.
           - suite: stage-c-4-gpu-mi350
             runner: linux-mi35x-gpu-8
           - suite: stage-c-8-gpu-mi350

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -82,18 +82,6 @@ jobs:
         timeout-minutes: 120
         run: |
           touch "${GITHUB_WORKSPACE}/github_summary.md"
-
-          # Guard against a silently green run: run_suite.py exits 0 when a suite
-          # matches zero tests (e.g. the baked /root/miles image lacks the
-          # register_rocm_ci entries). Fail loudly instead.
-          plan=$(bash scripts/ci/amd/amd_ci_exec.sh -w /root/miles \
-            python3 tests/ci/run_suite.py --hw rocm --suite ${{ matrix.suite }} --match-all-labels --list-only 2>&1)
-          echo "${plan}"
-          if echo "${plan}" | grep -q "No tests to run"; then
-            echo "::error::Suite ${{ matrix.suite }} matched 0 tests on this image (missing register_rocm_ci?)"
-            exit 1
-          fi
-
           TEST_EXIT_CODE=0
           bash scripts/ci/amd/amd_ci_exec.sh -w /root/miles \
             -e GITHUB_STEP_SUMMARY=/sglang-checkout/github_summary.md \

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -84,6 +84,7 @@ jobs:
           touch "${GITHUB_WORKSPACE}/github_summary.md"
           TEST_EXIT_CODE=0
           bash scripts/ci/amd/amd_ci_exec.sh -w /root/miles \
+            -e PYTHONPATH=/root/miles \
             -e GITHUB_STEP_SUMMARY=/sglang-checkout/github_summary.md \
             python3 tests/ci/run_suite.py --hw rocm --suite ${{ matrix.suite }} --match-all-labels \
             ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -1,0 +1,82 @@
+name: Nightly Test Miles (AMD ROCm 7.2)
+
+on:
+  schedule:
+    # Runs after the 12:00 UTC miles image build has pushed the dated image.
+    - cron: "30 17 * * *"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/nightly-test-amd-miles-rocm720.yml"
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Override miles image tag (e.g. miles-rocm720-mi35x-20260621); empty = newest by date"
+        required: false
+        type: string
+        default: ""
+      continue_on_error:
+        description: "Continue on error (do not fail the workflow on test failures)"
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test-miles-mi35x:
+    if: github.repository == 'sgl-project/sglang'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: stage-c-2-gpu-mi350
+            runner: linux-mi35x-gpu-2
+          - suite: stage-c-8-gpu-mi350
+            runner: linux-mi35x-gpu-8
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve newest miles ROCm 7.2 image
+        run: |
+          registry="10.245.143.50:5000"
+          repo="rocm/sgl-dev"
+          base="miles-rocm720-mi35x"
+          tag="${{ inputs.image_tag }}"
+          if [ -z "${tag}" ]; then
+            # Walk back from today; the build job pushes a dated tag at 12:00 UTC.
+            for i in $(seq 0 6); do
+              d=$(date -u -d "-${i} day" +%Y%m%d)
+              candidate="${base}-${d}"
+              if docker pull "${registry}/${repo}:${candidate}" >/dev/null 2>&1; then
+                tag="${candidate}"
+                break
+              fi
+            done
+          fi
+          if [ -z "${tag}" ]; then
+            echo "::error::No ${repo}:${base}-<date> image found in ${registry} for the last 7 days"
+            exit 1
+          fi
+          echo "MILES_IMAGE=${registry}/${repo}:${tag}" >> "$GITHUB_ENV"
+          echo "Using miles image: ${registry}/${repo}:${tag}"
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Start container from the miles image
+        run: bash scripts/ci/amd/amd_ci_start_container.sh --custom-image "${MILES_IMAGE}"
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Run miles CI suite ${{ matrix.suite }}
+        timeout-minutes: 120
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w /root/miles \
+            python3 tests/ci/run_suite.py --hw rocm --suite ${{ matrix.suite }} --match-all-labels \
+            ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -83,7 +83,7 @@ jobs:
           touch "${GITHUB_WORKSPACE}/github_summary.md"
           TEST_EXIT_CODE=0
           bash scripts/ci/amd/amd_ci_exec.sh -w /root/miles \
-            -e PYTHONPATH=/root/miles \
+            -e PYTHONPATH=/root/miles:/opt/tilelang \
             -e GITHUB_STEP_SUMMARY=/sglang-checkout/github_summary.md \
             python3 tests/ci/run_suite.py --hw rocm --suite ${{ matrix.suite }} --match-all-labels \
             ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -81,6 +81,23 @@ jobs:
       - name: Run miles CI suite ${{ matrix.suite }}
         timeout-minutes: 120
         run: |
+          touch "${GITHUB_WORKSPACE}/github_summary.md"
+
+          # Guard against a silently green run: run_suite.py exits 0 when a suite
+          # matches zero tests (e.g. the baked /root/miles image lacks the
+          # register_rocm_ci entries). Fail loudly instead.
+          plan=$(bash scripts/ci/amd/amd_ci_exec.sh -w /root/miles \
+            python3 tests/ci/run_suite.py --hw rocm --suite ${{ matrix.suite }} --match-all-labels --list-only 2>&1)
+          echo "${plan}"
+          if echo "${plan}" | grep -q "No tests to run"; then
+            echo "::error::Suite ${{ matrix.suite }} matched 0 tests on this image (missing register_rocm_ci?)"
+            exit 1
+          fi
+
+          TEST_EXIT_CODE=0
           bash scripts/ci/amd/amd_ci_exec.sh -w /root/miles \
+            -e GITHUB_STEP_SUMMARY=/sglang-checkout/github_summary.md \
             python3 tests/ci/run_suite.py --hw rocm --suite ${{ matrix.suite }} --match-all-labels \
-            ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
+            ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          cat "${GITHUB_WORKSPACE}/github_summary.md" >> "$GITHUB_STEP_SUMMARY" || true
+          exit ${TEST_EXIT_CODE}


### PR DESCRIPTION
Co-authored-with: @JessicaJiang-123


## Summary

Add a nightly GitHub Actions workflow for the Miles ROCm 7.2 MI350X e2e suites.

It resolves the latest dated `miles-rocm720-mi35x-<date>` image and runs:

- `stage-c-2-gpu-mi350`
- `stage-c-4-gpu-mi350`
- `stage-c-8-gpu-mi350`

## Notes

This is a new AMD nightly workflow only. It does not change CUDA paths or shared CI scripts.

The 4-GPU suite runs on the 8-GPU MI35X runner because there is no dedicated 4-GPU MI35X runner upstream.



















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28231975791](https://github.com/sgl-project/sglang/actions/runs/28231975791)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28231975559](https://github.com/sgl-project/sglang/actions/runs/28231975559)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->