### PR TITLE
[Spec] Enable FR-Spec in EAGLE draft-extend CUDA graph by sizing logits buffer from the draft head

### DIFF
--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -195,6 +195,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
                 global_num_tokens_gpu = None
                 global_num_tokens_for_logprob_gpu = None
 
+            hot_token_id = getattr(self.eagle_worker, "hot_token_id", None)
             if hasattr(
                 self.model_runner.model_config.hf_config, "draft_vocab_size"
             ):  # llama_eagle
@@ -203,6 +204,12 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
                 self.model_runner.model_config.hf_config, "hot_vocab_size"
             ):  # llama_eagle3
                 vocab_size = self.model_runner.model_config.hf_config.hot_vocab_size
+            elif hot_token_id is not None:
+                # FR-Spec: an external speculative_token_map slices the draft head to
+                # len(hot_token_id), but hf_config does not carry this size (it is
+                # injected via a late json_model_override_args after hf_config is
+                # built), so size the logits buffer from the worker's reduced head.
+                vocab_size = len(hot_token_id)
             else:
                 vocab_size = self.model_runner.model_config.vocab_size
 

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -205,10 +205,8 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             ):  # llama_eagle3
                 vocab_size = self.model_runner.model_config.hf_config.hot_vocab_size
             elif hot_token_id is not None:
-                # FR-Spec: an external speculative_token_map slices the draft head to
-                # len(hot_token_id), but hf_config does not carry this size (it is
-                # injected via a late json_model_override_args after hf_config is
-                # built), so size the logits buffer from the worker's reduced head.
+                # FR-Spec: reduced vocab is injected via a late
+                # json_model_override_args, so hf_config lacks it; size from the head.
                 vocab_size = len(hot_token_id)
             else:
                 vocab_size = self.model_runner.model_config.vocab_size

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -408,25 +408,19 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 self.draft_attn_backend, AiterMultiStepDraftBackend
             )
 
-        draft_extend_backend = self.draft_extend_attn_backend
         graph_supported_backend = isinstance(
-            draft_extend_backend,
+            self.draft_extend_attn_backend,
             (
                 TritonAttnBackend,
                 TRTLLMMLABackend,
                 TRTLLMHAAttnBackend,
                 TokenspeedMLABackend,
+                FlashInferAttnBackend,
             ),
         )
-        # FlashInfer draft-extend graph does not support a reduced draft vocab
-        # (speculative_token_map / FR-Spec); fall back to eager in that case.
-        flashinfer_graph_supported = (
-            isinstance(draft_extend_backend, FlashInferAttnBackend)
-            and self.server_args.speculative_token_map is None
-        )
-        supports_cuda_draft_extend_graph = (_is_cuda or _is_musa) and (
-            graph_supported_backend or flashinfer_graph_supported
-        )
+        supports_cuda_draft_extend_graph = (
+            _is_cuda or _is_musa
+        ) and graph_supported_backend
         # Capture extend
         # TODO: support draft extend cuda graph for more attention backends
         if self.draft_extend_attn_backend and (


### PR DESCRIPTION
FR-Spec (`--speculative-token-map`) injects the reduced draft vocab via a late `json_model_override_args`, so the draft model's `hf_config` lacks `hot_vocab_size` and the draft-extend CUDA graph sized `next_token_logits_buffer` to the full vocab — mismatching the reduced head (graph capture crashed, so FlashInfer fell back to eager). Size the buffer from the worker's reduced head (`len(hot_token_id)`) instead, and drop the FlashInfer `speculative_token_map is None` guard so FR-Spec runs the draft-extend graph.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27919006760](https://github.com/sgl-project/sglang/actions/runs/27919006760)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27919006698](https://github.com/sgl-project/sglang/actions/runs/27919006698)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->