### PR TITLE
[Bugfix] Fix gemma4 tool parser array parsing of bracketed strings and stray brackets

### DIFF
--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -88,6 +88,11 @@ def _parse_gemma4_array(arr_str: str) -> list:
             sub_start = i + 1
             i += 1
             while i < n and depth > 0:
+                if arr_str[i : i + len(STRING_DELIM)] == STRING_DELIM:
+                    i += len(STRING_DELIM)
+                    next_delim = arr_str.find(STRING_DELIM, i)
+                    i = next_delim + len(STRING_DELIM) if next_delim != -1 else n
+                    continue
                 if arr_str[i] == "[":
                     depth += 1
                 elif arr_str[i] == "]":
@@ -100,6 +105,9 @@ def _parse_gemma4_array(arr_str: str) -> list:
             val_start = i
             while i < n and arr_str[i] not in (",", "]"):
                 i += 1
+            if i == val_start:
+                # Stray delimiter we never consume — abort to avoid a hang.
+                break
             items.append(_parse_gemma4_value(arr_str[val_start:i]))
 
     return items

--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -88,6 +88,11 @@ def _parse_gemma4_array(arr_str: str) -> list:
             sub_start = i + 1
             i += 1
             while i < n and depth > 0:
+                if arr_str[i : i + len(STRING_DELIM)] == STRING_DELIM:
+                    i += len(STRING_DELIM)
+                    next_delim = arr_str.find(STRING_DELIM, i)
+                    i = next_delim + len(STRING_DELIM) if next_delim != -1 else n
+                    continue
                 if arr_str[i] == "[":
                     depth += 1
                 elif arr_str[i] == "]":
@@ -100,6 +105,8 @@ def _parse_gemma4_array(arr_str: str) -> list:
             val_start = i
             while i < n and arr_str[i] not in (",", "]"):
                 i += 1
+            if i == val_start:
+                break
             items.append(_parse_gemma4_value(arr_str[val_start:i]))
 
     return items

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -5033,6 +5033,24 @@ class TestGemma4Detector(unittest.TestCase):
         self.assertIsInstance(result[3], dict)
         self.assertEqual(result[3]["key"], "val")
 
+    def test_parse_gemma4_array_nested_strings_with_brackets(self):
+        cases = (
+            (
+                '[<|"|>a]b<|"|>,<|"|>c<|"|>],<|"|>tail<|"|>',
+                [["a]b", "c"], "tail"],
+            ),
+            (
+                '[<|"|>a[b]c<|"|>,<|"|>d<|"|>]',
+                [["a[b]c", "d"]],
+            ),
+        )
+        for payload, expected in cases:
+            with self.subTest(payload=payload):
+                self.assertEqual(_parse_gemma4_array(payload), expected)
+
+    def test_parse_gemma4_array_stray_closing_bracket(self):
+        self.assertEqual(_parse_gemma4_array("42,]trailing"), [42])
+
     def test_parse_gemma4_value_types(self):
         self.assertIs(_parse_gemma4_value("true"), True)
         self.assertIs(_parse_gemma4_value("false"), False)

--- a/test/registered/unit/function_call/test_gemma4_detector.py
+++ b/test/registered/unit/function_call/test_gemma4_detector.py
@@ -1,0 +1,60 @@
+import signal
+import unittest
+from contextlib import contextmanager
+
+from sglang.srt.function_call.gemma4_detector import _parse_gemma4_array
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1.0, suite="base-a-test-cpu")
+
+
+@contextmanager
+def _time_limit(seconds: int):
+    # signal.alarm is POSIX-only; on other platforms run without a hard timeout
+    # (the assertions still catch a wrong/corrupted parse).
+    if not hasattr(signal, "SIGALRM"):
+        yield
+        return
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+
+    def _raise(_signum, _frame):
+        raise TimeoutError("gemma4 parser did not terminate")
+
+    signal.signal(signal.SIGALRM, _raise)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+
+class TestGemma4ArrayParser(CustomTestCase):
+    def test_nested_array_string_elements_with_brackets(self):
+        cases = [
+            (
+                '[<|"|>a]b<|"|>,<|"|>c<|"|>],<|"|>tail<|"|>',
+                [["a]b", "c"], "tail"],
+            ),
+            (
+                '[<|"|>a[b<|"|>,<|"|>c<|"|>],<|"|>tail<|"|>',
+                [["a[b", "c"], "tail"],
+            ),
+            ('[<|"|>a[b]c<|"|>,<|"|>d<|"|>]', [["a[b]c", "d"]]),
+        ]
+        for payload, expected in cases:
+            with self.subTest(payload=payload):
+                with _time_limit(5):
+                    result = _parse_gemma4_array(payload)
+                self.assertEqual(result, expected)
+
+    def test_stray_closing_bracket_terminates(self):
+        with _time_limit(5):
+            result = _parse_gemma4_array("42,]trailing")
+        self.assertEqual(result, [42])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix two Gemma4 tool-parser array edge cases, following the already-merged vLLM fix in [vllm-project/vllm#41991](https://github.com/vllm-project/vllm/pull/41991):

- quoted string spans are opaque while balancing nested-array brackets, so a literal `]` inside a string cannot terminate the sub-array early
- a stray `]` in the bare-value path stops when the scan makes zero progress instead of looping forever

The no-progress guard is intentionally limited to `_parse_gemma4_array`. SGLang's object parser legitimately reaches its bare-value path for empty values and its key scan already advances, so copying the guard there would change valid tail behavior without fixing a hang.

## Verification

- current-main stray-bracket hang reproduced; candidate terminates and preserves the tail
- mixed nested arrays, quoted `[`/`]`, valid empty arrays, and stray brackets covered in the consolidated function-call parser test owner
- parser probes, compile checks, all applicable file-scoped pre-commit hooks, and `git diff --check` passed
- fresh exact-head review found no correctness, termination, streaming-tail, redundancy, or maintainability issues

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31555228207](https://github.com/sgl-project/sglang/actions/runs/31555228207)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31555228033](https://github.com/sgl-project/sglang/actions/runs/31555228033)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->