### PR TITLE
[Bugfix] Validate n and reject empty stop strings in SamplingParams.verify()

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -453,11 +453,17 @@ class GenerateReqInput:
             self.parallel_sample_num = 1
             return
         elif isinstance(self.sampling_params, dict):
-            self.parallel_sample_num = self.sampling_params.get("n", 1)
+            self.parallel_sample_num = SamplingParams.normalize_n(
+                self.sampling_params.get("n")
+            )
         else:  # isinstance(self.sampling_params, list):
-            self.parallel_sample_num = self.sampling_params[0].get("n", 1)
+            self.parallel_sample_num = SamplingParams.normalize_n(
+                self.sampling_params[0].get("n")
+            )
             for sampling_params in self.sampling_params:
-                if self.parallel_sample_num != sampling_params.get("n", 1):
+                if self.parallel_sample_num != SamplingParams.normalize_n(
+                    sampling_params.get("n")
+                ):
                     raise ValueError(
                         "The parallel_sample_num should be the same for all samples in sample params."
                     )

--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -178,6 +178,8 @@ class SamplingParams(msgspec.Struct, kw_only=True, omit_defaults=True):
             raise ValueError(
                 f"temperature must be a non-negative finite number, got {self.temperature}."
             )
+        if self.n < 1:
+            raise ValueError(f"n must be at least 1, got {self.n}.")
         if not 0.0 < self.top_p <= 1.0:
             raise ValueError(f"top_p must be in (0, 1], got {self.top_p}.")
         if not 0.0 <= self.min_p <= 1.0:
@@ -222,6 +224,12 @@ class SamplingParams(msgspec.Struct, kw_only=True, omit_defaults=True):
                         f"logit_bias must has keys in [0, {vocab_size - 1}], got "
                         f"{token_id}."
                     )
+        if self.stop_strs is not None:
+            stop_strs = (
+                [self.stop_strs] if isinstance(self.stop_strs, str) else self.stop_strs
+            )
+            if any(s == "" for s in stop_strs):
+                raise ValueError("stop cannot contain an empty string.")
 
         grammars = [
             self.json_schema,

--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -224,12 +224,19 @@ class SamplingParams(msgspec.Struct, kw_only=True, omit_defaults=True):
                         f"logit_bias must has keys in [0, {vocab_size - 1}], got "
                         f"{token_id}."
                     )
-        if self.stop_strs is not None:
-            stop_strs = (
-                [self.stop_strs] if isinstance(self.stop_strs, str) else self.stop_strs
-            )
-            if any(s == "" for s in stop_strs):
-                raise ValueError("stop cannot contain an empty string.")
+        for name, values in (
+            ("stop", self.stop_strs),
+            ("stop_regex", self.stop_regex_strs),
+        ):
+            if values is None:
+                continue
+            values = [values] if isinstance(values, str) else values
+            if not isinstance(values, list):
+                raise ValueError(f"{name} must be a string or a list of strings.")
+            if not all(isinstance(s, str) for s in values):
+                raise ValueError(f"{name} must be a string or a list of strings.")
+            if any(s == "" for s in values):
+                raise ValueError(f"{name} cannot contain an empty string.")
 
         grammars = [
             self.json_schema,

--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -88,6 +88,31 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
     stop_regex_max_len: int = 0  # set by normalize()
     is_normalized: bool = False  # set by normalize()
 
+    @staticmethod
+    def normalize_n(n: object) -> int:
+        if n is None:
+            return 1
+        if type(n) is not int or n < 1:
+            raise ValueError(f"n must be a positive integer, got {n!r}.")
+        return n
+
+    @staticmethod
+    def _normalize_stop_strings(value: object, name: str) -> List[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            values = [value]
+        elif isinstance(value, list):
+            values = value
+        else:
+            raise ValueError(f"{name} must be a string or a list of strings.")
+
+        if not all(isinstance(item, str) for item in values):
+            raise ValueError(f"{name} must be a string or a list of strings.")
+        if any(item == "" for item in values):
+            raise ValueError(f"{name} cannot contain an empty string.")
+        return values
+
     def __post_init__(self):
         # For non-optional params, treat None as "use default" so that callers
         # (e.g. /generate) can pass null without crashing verify().
@@ -97,13 +122,15 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
         if self.is_normalized:
             return
 
-        self.stop_strs = self.stop
+        self.stop_strs = self._normalize_stop_strings(self.stop, "stop")
         if self.stop_token_ids:
             filtered = {int(t) for t in self.stop_token_ids if t is not None}
             self.stop_token_ids = filtered or None
         else:
             self.stop_token_ids = None
-        self.stop_regex_strs = self.stop_regex
+        self.stop_regex_strs = self._normalize_stop_strings(
+            self.stop_regex, "stop_regex"
+        )
         self.temperature = self.temperature if self.temperature is not None else 1.0
         self.top_p = self.top_p if self.top_p is not None else 1.0
         self.top_k = self.top_k if self.top_k is not None else -1
@@ -120,7 +147,7 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
         self.min_new_tokens = (
             self.min_new_tokens if self.min_new_tokens is not None else 0
         )
-        self.n = self.n if self.n is not None else 1
+        self.n = self.normalize_n(self.n)
         self.ignore_eos = self.ignore_eos if self.ignore_eos is not None else False
         self.skip_special_tokens = (
             self.skip_special_tokens if self.skip_special_tokens is not None else True
@@ -153,6 +180,7 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
             raise ValueError(
                 f"temperature must be a non-negative finite number, got {self.temperature}."
             )
+        self.normalize_n(self.n)
         if not 0.0 < self.top_p <= 1.0:
             raise ValueError(f"top_p must be in (0, 1], got {self.top_p}.")
         if not 0.0 <= self.min_p <= 1.0:
@@ -197,6 +225,8 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
                         f"logit_bias must has keys in [0, {vocab_size - 1}], got "
                         f"{token_id}."
                     )
+        self._normalize_stop_strings(self.stop_strs, "stop")
+        self._normalize_stop_strings(self.stop_regex_strs, "stop_regex")
 
         grammars = [
             self.json_schema,
@@ -211,37 +241,26 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
 
     def normalize(self, tokenizer):
         # Process stop strings
-        if self.stop_strs is None:
-            self.stop_strs = []
-            self.stop_str_max_len = 0
-        else:
-            if isinstance(self.stop_strs, str):
-                self.stop_strs = [self.stop_strs]
-
-            stop_str_max_len = 0
-            for stop_str in self.stop_strs:
-                if tokenizer is not None:
-                    stop_str_ids = tokenizer.encode(stop_str, add_special_tokens=False)
-                    stop_str_max_len = max(stop_str_max_len, len(stop_str_ids))
-                else:
-                    stop_str_max_len = max(stop_str_max_len, len(stop_str))
-            self.stop_str_max_len = stop_str_max_len
+        stop_strs = self._normalize_stop_strings(self.stop_strs, "stop")
+        self.stop_strs = stop_strs
+        stop_str_max_len = 0
+        for stop_str in stop_strs:
+            if tokenizer is not None:
+                stop_str_ids = tokenizer.encode(stop_str, add_special_tokens=False)
+                stop_str_max_len = max(stop_str_max_len, len(stop_str_ids))
+            else:
+                stop_str_max_len = max(stop_str_max_len, len(stop_str))
+        self.stop_str_max_len = stop_str_max_len
 
         # Process stop regex strings
-        if self.stop_regex_strs is None:
-            self.stop_regex_strs = []
-            self.stop_regex_max_len = 0
-        else:
-            if isinstance(self.stop_regex_strs, str):
-                self.stop_regex_strs = [self.stop_regex_strs]
-
-            stop_regex_max_len = 0
-            for stop_regex in self.stop_regex_strs:
-                stop_regex_max_len = max(
-                    stop_regex_max_len, get_max_seq_length(stop_regex)
-                )
-
-            self.stop_regex_max_len = stop_regex_max_len
+        stop_regex_strs = self._normalize_stop_strings(
+            self.stop_regex_strs, "stop_regex"
+        )
+        self.stop_regex_strs = stop_regex_strs
+        stop_regex_max_len = 0
+        for stop_regex in stop_regex_strs:
+            stop_regex_max_len = max(stop_regex_max_len, get_max_seq_length(stop_regex))
+        self.stop_regex_max_len = stop_regex_max_len
 
         # Validate tokenizer is available for tokenizer-dependent features
         raise_if_tokenizer_required(

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -164,6 +164,33 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         # Check text expansion
         self.assertEqual(req.text, expected_text)
 
+    def test_invalid_parallel_sample_count_is_rejected_before_expansion(self):
+        invalid_sampling_params = (
+            {"n": 0},
+            {"n": -1},
+            {"n": False},
+            {"n": 1.5},
+            {"n": "2"},
+            [{"n": 0}, {"n": 0}],
+        )
+
+        for sampling_params in invalid_sampling_params:
+            with self.subTest(sampling_params=sampling_params):
+                req = GenerateReqInput(
+                    text=["Hello", "World"], sampling_params=sampling_params
+                )
+                with self.assertRaisesRegex(ValueError, "n must be a positive integer"):
+                    req.normalize_batch_and_arguments()
+                self.assertEqual(req.text, ["Hello", "World"])
+
+    def test_null_parallel_sample_count_uses_default(self):
+        req = GenerateReqInput(text=["Hello", "World"], sampling_params={"n": None})
+
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req.parallel_sample_num, 1)
+        self.assertEqual(req.text, ["Hello", "World"])
+
     def test_return_hidden_states_expands_with_parallel_sampling(self):
         req = GenerateReqInput(
             text=["Prompt 1", "Prompt 2"],

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -289,6 +289,25 @@ class TestSamplingParamsVerify(CustomTestCase):
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
+    # --- n ---
+    def test_n_below_one_raises(self):
+        """n=0 expands to a degenerate empty batch; verify() must reject it."""
+        with self.assertRaises(ValueError):
+            self._make(n=0).verify(self.VOCAB_SIZE)
+
+    # --- stop ---
+    def test_empty_stop_string_raises(self):
+        """An empty stop string matches every position and truncates output."""
+        with self.assertRaises(ValueError):
+            self._make(stop="").verify(self.VOCAB_SIZE)
+
+    def test_empty_stop_in_list_raises(self):
+        with self.assertRaises(ValueError):
+            self._make(stop=["ok", ""]).verify(self.VOCAB_SIZE)
+
+    def test_non_empty_stop_is_valid(self):
+        self._make(stop=["</s>"]).verify(self.VOCAB_SIZE)
+
 
 class TestSamplingParamsNormalize(CustomTestCase):
 

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -305,8 +305,28 @@ class TestSamplingParamsVerify(CustomTestCase):
         with self.assertRaises(ValueError):
             self._make(stop=["ok", ""]).verify(self.VOCAB_SIZE)
 
+    def test_invalid_stop_type_raises(self):
+        with self.assertRaises(ValueError):
+            self._make(stop=["ok", 1]).verify(self.VOCAB_SIZE)
+
     def test_non_empty_stop_is_valid(self):
         self._make(stop=["</s>"]).verify(self.VOCAB_SIZE)
+
+    # --- stop_regex ---
+    def test_empty_stop_regex_string_raises(self):
+        with self.assertRaises(ValueError):
+            self._make(stop_regex="").verify(self.VOCAB_SIZE)
+
+    def test_empty_stop_regex_in_list_raises(self):
+        with self.assertRaises(ValueError):
+            self._make(stop_regex=["ok", ""]).verify(self.VOCAB_SIZE)
+
+    def test_invalid_stop_regex_type_raises(self):
+        with self.assertRaises(ValueError):
+            self._make(stop_regex=[r"\d+", 1]).verify(self.VOCAB_SIZE)
+
+    def test_non_empty_stop_regex_is_valid(self):
+        self._make(stop_regex=[r"\d+"]).verify(self.VOCAB_SIZE)
 
 
 class TestSamplingParamsNormalize(CustomTestCase):

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -8,7 +8,7 @@ register_xpu_ci(est_time=10, suite="stage-a-test-1-gpu-xpu")
 
 import copy
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import msgspec
 
@@ -309,6 +309,35 @@ class TestSamplingParamsVerify(CustomTestCase):
             with self.subTest(grammar=grammar):
                 self._make(**{grammar: value}).verify(self.VOCAB_SIZE)
 
+    def test_n_is_a_positive_integer(self):
+        for value in (0, -1, False, 1.5, "2"):
+            with (
+                self.subTest(value=value),
+                self.assertRaisesRegex(ValueError, "n must be a positive integer"),
+            ):
+                self._make(n=value)
+
+        for value, expected in ((None, 1), (1, 1), (2, 2)):
+            with self.subTest(value=value):
+                self.assertEqual(self._make(n=value).n, expected)
+
+    def test_stop_values_are_normalized_and_validated(self):
+        valid_values = ((None, []), ("done", ["done"]), (["a", "b"], ["a", "b"]))
+        invalid_values = ("", ["ok", ""], ["ok", 1], 1, ("done",))
+
+        for name in ("stop", "stop_regex"):
+            internal_name = f"{name}_strs"
+            for value, expected in valid_values:
+                with self.subTest(name=name, value=value):
+                    params = self._make(**{name: value})
+                    self.assertEqual(getattr(params, internal_name), expected)
+            for value in invalid_values:
+                with (
+                    self.subTest(name=name, value=value),
+                    self.assertRaises(ValueError),
+                ):
+                    self._make(**{name: value})
+
 
 class TestSamplingParamsNormalize(CustomTestCase):
 
@@ -322,6 +351,22 @@ class TestSamplingParamsNormalize(CustomTestCase):
         else:
             tokenizer.encode.return_value = [1]  # Default: 1 token
         return tokenizer
+
+    def test_malformed_stop_values_fail_before_normalization_effects(self):
+        for internal_name in ("stop_strs", "stop_regex_strs"):
+            with self.subTest(internal_name=internal_name):
+                params = SamplingParams()
+                setattr(params, internal_name, ["valid", 1])
+                tokenizer = self._mock_tokenizer()
+                with (
+                    patch(
+                        "sglang.srt.sampling.sampling_params.get_max_seq_length"
+                    ) as parse_regex,
+                    self.assertRaises(ValueError),
+                ):
+                    params.normalize(tokenizer)
+                tokenizer.encode.assert_not_called()
+                parse_regex.assert_not_called()
 
     def test_none_stop_strs_becomes_empty_list(self):
         """Test that normalize() converts None stop to empty list with max_len=0."""


### PR DESCRIPTION
## Summary

Validate structural sampling inputs before they can trigger batch expansion, tokenization, or regex work.

`SamplingParams` remains the single owner of the rules:

- omitted or explicit-null `n` normalizes to 1
- `n` must otherwise be a positive integer (booleans and numeric lookalikes are rejected)
- `stop` and `stop_regex` normalize from null/scalar/list into validated string lists
- empty strings and non-string elements are rejected before tokenizer or regex side effects
- native batched generation calls the same `n` owner before parallel-sample expansion, preventing `n=0` from becoming an empty batch

Existing valid batching and parallel-sampling behavior is unchanged.

## Verification

- exact-source focused harness: all 74 sampling tests passed
- exact-source `GenerateReqInput` harness: all 33 normalization tests passed
- msgspec round-trip and side-effect probes passed
- all applicable file-scoped pre-commit hooks passed
- `git diff --check` passed
- fresh exact-head review found no correctness, ownership, regression, or maintainability findings

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31554564123](https://github.com/sgl-project/sglang/actions/runs/31554564123)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31554563786](https://github.com/sgl-project/sglang/actions/runs/31554563786)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->