### PR TITLE
[Bugfix] Treat null completion max_tokens like the default

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -393,6 +393,20 @@ class CompletionRequest(BaseModel):
     def _handle_deprecated_dp_rank(cls, values):
         return _migrate_deprecated_dp_rank(values)
 
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_null_max_tokens(cls, values):
+        # Treat an explicit ``max_tokens: null`` like an omitted field (OpenAI
+        # behavior); an omitted field skips the copy below.
+        if (
+            isinstance(values, dict)
+            and "max_tokens" in values
+            and values["max_tokens"] is None
+        ):
+            values = values.copy()
+            values["max_tokens"] = cls.model_fields["max_tokens"].default
+        return values
+
     @field_validator("max_tokens")
     @classmethod
     def validate_max_tokens_positive(cls, v):

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -401,6 +401,13 @@ class CompletionRequest(BaseModel):
     def _handle_deprecated_dp_rank(cls, values):
         return _migrate_deprecated_dp_rank(values)
 
+    @field_validator("max_tokens", mode="before")
+    @classmethod
+    def normalize_null_max_tokens(cls, value):
+        if value is None:
+            return cls.model_fields["max_tokens"].default
+        return value
+
     @field_validator("max_tokens")
     @classmethod
     def validate_max_tokens_positive(cls, v):

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -109,6 +109,16 @@ class TestCompletionRequest(unittest.TestCase):
         with self.assertRaises(ValidationError):
             CompletionRequest(model="test-model")  # missing prompt
 
+    def test_null_max_tokens_uses_default(self):
+        """Explicit max_tokens=None falls back to the default (like OpenAI)"""
+        request = CompletionRequest(model="test-model", prompt="Hello", max_tokens=None)
+        self.assertEqual(request.max_tokens, 16)
+
+    def test_zero_max_tokens_rejected(self):
+        """max_tokens=0 still fails validation"""
+        with self.assertRaises(ValidationError):
+            CompletionRequest(model="test-model", prompt="Hello", max_tokens=0)
+
 
 class TestChatCompletionRequest(unittest.TestCase):
     """Test ChatCompletionRequest protocol model"""

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -109,6 +109,14 @@ class TestCompletionRequest(unittest.TestCase):
         with self.assertRaises(ValidationError):
             CompletionRequest(model="test-model")  # missing prompt
 
+    def test_null_max_tokens_uses_default(self):
+        request = CompletionRequest(model="test-model", prompt="Hello", max_tokens=None)
+        self.assertEqual(
+            request.max_tokens,
+            CompletionRequest.model_fields["max_tokens"].default,
+        )
+        self.assertIn("max_tokens", request.model_fields_set)
+
 
 class TestChatCompletionRequest(unittest.TestCase):
     """Test ChatCompletionRequest protocol model"""
@@ -648,10 +656,16 @@ class TestValidationEdgeCases(unittest.TestCase):
                 model="test-model", messages=messages, tool_choice=123
             )
 
-    def test_negative_token_limits(self):
-        """Test negative token limits"""
-        with self.assertRaises(ValidationError):
-            CompletionRequest(model="test-model", prompt="Hello", max_tokens=-1)
+    def test_non_positive_token_limits(self):
+        """Test non-positive token limits"""
+        for max_tokens in (0, -1):
+            with (
+                self.subTest(max_tokens=max_tokens),
+                self.assertRaises(ValidationError),
+            ):
+                CompletionRequest(
+                    model="test-model", prompt="Hello", max_tokens=max_tokens
+                )
 
 
 class TestParsedResponseFieldsProtocol(unittest.TestCase):


### PR DESCRIPTION
## Motivation

`CompletionRequest.max_tokens` is declared as a non-optional integer with default `16`. An explicit JSON null currently fails Pydantic validation instead of selecting the same default as omission, although the OpenAI Completions API accepts null.

Ported from [vllm-project/vllm#45491](https://github.com/vllm-project/vllm/pull/45491).

## Changes

- Normalize only an explicitly supplied null at the `CompletionRequest.max_tokens` field boundary.
- Read the field's declared default instead of duplicating `16`.
- Preserve omission versus explicit-field tracking.
- Preserve the existing positive-token contract: zero and negative values still reject.
- Do not alter Chat Completions or Responses token-limit ownership.

## Verification

- Omitted input remains unset and uses the default.
- Explicit null remains explicitly set and uses the default.
- Positive values remain unchanged; zero and negative reject.
- The full focused protocol module passed 35 tests.
- File-scoped pre-commit, compilation, `git diff --check`, and a fresh-context exact-head review passed on `df5eed7b548f9f90258805dc4f42d21b62d1c934`.

Hosted CI and human review remain required before merge.
