### PR TITLE
[Bugfix] Map reasoning_effort to enable_thinking for all tiers

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -824,15 +824,18 @@ class ChatCompletionRequest(BaseModel):
                 ctk.setdefault("enable_thinking", True)
                 values["chat_template_kwargs"] = ctk
 
-        if values.get("reasoning_effort") == "none":
+        effort = values.get("reasoning_effort")
+        if effort is not None:
+            # Any tier other than "none" enables thinking.
+            thinking = effort != "none"
             ctk = values.get("chat_template_kwargs")
             if not isinstance(ctk, dict):
                 ctk = {}
             # different models check different keys:
             # - "thinking" for deepseek-v3, kimi_k2
             # - "enable_thinking" for qwen3, glm45, nemotron_3, interns1
-            ctk.setdefault("thinking", False)
-            ctk.setdefault("enable_thinking", False)
+            ctk.setdefault("thinking", thinking)
+            ctk.setdefault("enable_thinking", thinking)
             values["chat_template_kwargs"] = ctk
 
         return values

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -800,6 +800,7 @@ class ChatCompletionRequest(BaseModel):
     @classmethod
     def normalize_reasoning_inputs(cls, values: Dict):
         r = values.get("reasoning")
+        thinking = None
 
         if r is not None and isinstance(r, dict):
             effort = r.get("effort") or r.get("reasoning_effort")
@@ -814,20 +815,13 @@ class ChatCompletionRequest(BaseModel):
             if isinstance(enabled, str):
                 enabled = enabled.strip().lower() in {"1", "true", "yes", "y", "on"}
             if enabled:
-                ctk = values.get("chat_template_kwargs")
-                if not isinstance(ctk, dict):
-                    ctk = {}
-                # different models check different keys:
-                # - "thinking" for deepseek-v3, kimi_k2
-                # - "enable_thinking" for qwen3, glm45, nemotron_3, interns1, mimo
-                ctk.setdefault("thinking", True)
-                ctk.setdefault("enable_thinking", True)
-                values["chat_template_kwargs"] = ctk
+                thinking = True
 
         effort = values.get("reasoning_effort")
         if effort is not None:
-            # Any tier other than "none" enables thinking.
             thinking = effort != "none"
+
+        if thinking is not None:
             ctk = values.get("chat_template_kwargs")
             if not isinstance(ctk, dict):
                 ctk = {}

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -248,6 +248,17 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertFalse(request.chat_template_kwargs.get("thinking"))
         self.assertFalse(request.chat_template_kwargs.get("enable_thinking"))
 
+    def test_chat_completion_reasoning_effort_none_overrides_enabled(self):
+        messages = [{"role": "user", "content": "Hello"}]
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            reasoning={"enabled": True, "effort": "none"},
+        )
+        self.assertEqual(request.reasoning_effort, "none")
+        self.assertFalse(request.chat_template_kwargs.get("thinking"))
+        self.assertFalse(request.chat_template_kwargs.get("enable_thinking"))
+
     def test_chat_completion_reasoning_effort_max(self):
         """`max` is an sglang extension on chat completion's top-level
         `reasoning_effort` only; the Responses-API-style nested

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -210,6 +210,20 @@ class TestChatCompletionRequest(unittest.TestCase):
             {"thinking": True, "enable_thinking": True},
         )
 
+    def test_chat_completion_reasoning_effort_high_enables_thinking(self):
+        """Top-level reasoning_effort='high' enables thinking."""
+        messages = [{"role": "user", "content": "Hello"}]
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            reasoning_effort="high",
+        )
+        self.assertEqual(request.reasoning_effort, "high")
+        self.assertEqual(
+            request.chat_template_kwargs,
+            {"thinking": True, "enable_thinking": True},
+        )
+
     def test_chat_completion_reasoning_effort_none(self):
         """Test reasoning_effort='none' disables thinking"""
         messages = [{"role": "user", "content": "Hello"}]


### PR DESCRIPTION
## Summary
`normalize_reasoning_inputs` only handled top-level `reasoning_effort="none"` (injecting `enable_thinking=False`). A top-level `reasoning_effort` of `low`/`medium`/`high`/`max` never enabled thinking, so thinking-gated models (qwen3, glm45, gemma4, granite) ignored the standard field — the enable path only existed via the nested `reasoning.enabled`. Now any non-None tier sets the thinking flags (`none`→False, others→True) via `setdefault` (explicit `chat_template_kwargs` still win). Scoped to the resolved top-level field only.

Port of vLLM #43401.

## Test
`test/registered/unit/entrypoints/openai/test_protocol.py`: `reasoning_effort="high"` enables thinking; existing `none`/`max` tests stay green. The `high` case produces no thinking flags on current `main`.















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28888260896](https://github.com/sgl-project/sglang/actions/runs/28888260896)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28888260206](https://github.com/sgl-project/sglang/actions/runs/28888260206)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->