### PR TITLE
[Bugfix] Fix Cohere2MoeConfig import crash from huggingface_hub @strict

### DIFF
--- a/python/sglang/srt/configs/cohere2_moe.py
+++ b/python/sglang/srt/configs/cohere2_moe.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Cohere2Moe text config used by the Cohere Command-A Plus checkpoints."""
 
+from dataclasses import dataclass
+
 from transformers.configuration_utils import PreTrainedConfig
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
@@ -13,6 +15,7 @@ except ImportError:  # older huggingface_hub
 
 
 @strict
+@dataclass
 class Cohere2MoeConfig(PreTrainedConfig):
     model_type = "cohere2_moe"
     keys_to_ignore_at_inference = ["past_key_values"]

--- a/python/sglang/srt/configs/cohere2_moe.py
+++ b/python/sglang/srt/configs/cohere2_moe.py
@@ -54,9 +54,7 @@ class Cohere2MoeConfig(PreTrainedConfig):
         self.num_hidden_layers = num_hidden_layers
         self.num_attention_heads = num_attention_heads
         self.num_key_value_heads = (
-            num_attention_heads
-            if num_key_value_heads is None
-            else num_key_value_heads
+            num_attention_heads if num_key_value_heads is None else num_key_value_heads
         )
         self.head_dim = head_dim
         self.hidden_act = hidden_act

--- a/python/sglang/srt/configs/cohere2_moe.py
+++ b/python/sglang/srt/configs/cohere2_moe.py
@@ -1,76 +1,91 @@
 # SPDX-License-Identifier: Apache-2.0
 """Cohere2Moe text config used by the Cohere Command-A Plus checkpoints."""
 
-from dataclasses import dataclass
-
 from transformers.configuration_utils import PreTrainedConfig
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
-try:
-    from huggingface_hub.dataclasses import strict
-except ImportError:  # older huggingface_hub
 
-    def strict(cls):  # type: ignore[misc]
-        return cls
-
-
-@strict
-@dataclass
 class Cohere2MoeConfig(PreTrainedConfig):
     model_type = "cohere2_moe"
     keys_to_ignore_at_inference = ["past_key_values"]
 
-    vocab_size: int = 256000
-    hidden_size: int = 8192
-    intermediate_size: int = 22528
-    logit_scale: float = 0.0625
-    num_hidden_layers: int = 40
-    num_attention_heads: int = 64
-    num_key_value_heads: int | None = None
-    head_dim: int = 128
-    hidden_act: str = "silu"
-    max_position_embeddings: int = 8192
-    initializer_range: float = 0.02
-    layer_norm_eps: float = 1e-5
-    use_cache: bool = True
-    pad_token_id: int | None = 0
-    bos_token_id: int | None = 5
-    eos_token_id: int | list[int] | None = 255001
-    tie_word_embeddings: bool = True
-    rope_theta: float | int = 10000.0
-    rope_scaling: dict | None = None
-    attention_bias: bool = False
-    attention_dropout: float = 0.0
-    sliding_window: int | None = 4096
-    num_experts_per_tok: int = 2
-    num_experts: int = 8
-    num_shared_experts: int = 0
-    shared_expert_combination_strategy: str = "average"
-    expert_selection_fn: str = "softmax"
-    layer_types: list[str] | None = None
-    first_k_dense_replace: int = 0
-    prefix_dense_sliding_window_pattern: int = 1
-    norm_topk_prob: bool = True
-    prefix_dense_intermediate_size: int | None = None
-    rms_norm_eps: float | None = None
-    sliding_window_pattern: int = 4
+    def __init__(
+        self,
+        vocab_size: int = 256000,
+        hidden_size: int = 8192,
+        intermediate_size: int = 22528,
+        logit_scale: float = 0.0625,
+        num_hidden_layers: int = 40,
+        num_attention_heads: int = 64,
+        num_key_value_heads: int | None = None,
+        head_dim: int = 128,
+        hidden_act: str = "silu",
+        max_position_embeddings: int = 8192,
+        initializer_range: float = 0.02,
+        layer_norm_eps: float = 1e-5,
+        use_cache: bool = True,
+        pad_token_id: int | None = 0,
+        bos_token_id: int | None = 5,
+        eos_token_id: int | list[int] | None = 255001,
+        tie_word_embeddings: bool = True,
+        rope_theta: float | int = 10000.0,
+        rope_scaling: dict | None = None,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        sliding_window: int | None = 4096,
+        num_experts_per_tok: int = 2,
+        num_experts: int = 8,
+        num_shared_experts: int = 0,
+        shared_expert_combination_strategy: str = "average",
+        expert_selection_fn: str = "softmax",
+        layer_types: list[str] | None = None,
+        first_k_dense_replace: int = 0,
+        prefix_dense_sliding_window_pattern: int = 1,
+        norm_topk_prob: bool = True,
+        prefix_dense_intermediate_size: int | None = None,
+        rms_norm_eps: float | None = None,
+        sliding_window_pattern: int = 4,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.logit_scale = logit_scale
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = (
+            num_attention_heads
+            if num_key_value_heads is None
+            else num_key_value_heads
+        )
+        self.head_dim = head_dim
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.initializer_range = initializer_range
+        self.layer_norm_eps = layer_norm_eps
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.sliding_window = sliding_window
+        self.num_experts_per_tok = num_experts_per_tok
+        self.num_experts = num_experts
+        self.num_shared_experts = num_shared_experts
+        self.shared_expert_combination_strategy = shared_expert_combination_strategy
+        self.expert_selection_fn = expert_selection_fn
+        self.first_k_dense_replace = first_k_dense_replace
+        self.prefix_dense_sliding_window_pattern = prefix_dense_sliding_window_pattern
+        self.norm_topk_prob = norm_topk_prob
+        self.prefix_dense_intermediate_size = prefix_dense_intermediate_size
+        self.rms_norm_eps = rms_norm_eps
+        self.sliding_window_pattern = sliding_window_pattern
 
-    def __post_init__(self, **kwargs):
-        if self.num_key_value_heads is None:
-            self.num_key_value_heads = self.num_attention_heads
-
-        if hasattr(self, "standardize_rope_params"):
-            try:
-                self.standardize_rope_params()
-                self.validate_rope()
-            except Exception:
-                pass
-
-        if self.layer_types is None:
+        if layer_types is None:
             prefix_layers = [
                 (
                     "sliding_attention"
-                    if ((i + 1) % self.prefix_dense_sliding_window_pattern) != 0
+                    if ((i + 1) % prefix_dense_sliding_window_pattern) != 0
                     else "full_attention"
                 )
                 for i in range(self.first_k_dense_replace)
@@ -78,14 +93,29 @@ class Cohere2MoeConfig(PreTrainedConfig):
             rest_layers = [
                 (
                     "sliding_attention"
-                    if ((i + 1) % self.sliding_window_pattern) != 0
+                    if ((i + 1) % sliding_window_pattern) != 0
                     else "full_attention"
                 )
                 for i in range(self.num_hidden_layers - self.first_k_dense_replace)
             ]
             self.layer_types = prefix_layers + rest_layers
+        else:
+            self.layer_types = layer_types
 
-        super().__post_init__(**kwargs)
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+        if hasattr(self, "standardize_rope_params"):
+            try:
+                self.standardize_rope_params()
+                self.validate_rope()
+            except Exception:
+                pass
 
 
 try:

--- a/test/registered/unit/configs/test_cohere2_moe_config.py
+++ b/test/registered/unit/configs/test_cohere2_moe_config.py
@@ -1,0 +1,31 @@
+"""Regression tests for Cohere2MoeConfig import (sgl-project/sglang#28233)."""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestCohere2MoeConfig(CustomTestCase):
+    def test_configs_package_imports(self):
+        """Importing the configs package must not crash at module load."""
+        import sglang.srt.configs  # noqa: F401
+
+    def test_config_instantiates(self):
+        from sglang.srt.configs.cohere2_moe import Cohere2MoeConfig
+
+        cfg = Cohere2MoeConfig()
+        self.assertEqual(cfg.model_type, "cohere2_moe")
+
+    def test_post_init_defaults_num_key_value_heads(self):
+        """``__post_init__`` must still run and default kv heads to attn heads."""
+        from sglang.srt.configs.cohere2_moe import Cohere2MoeConfig
+
+        cfg = Cohere2MoeConfig()
+        self.assertEqual(cfg.num_key_value_heads, cfg.num_attention_heads)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/configs/test_cohere2_moe_config.py
+++ b/test/registered/unit/configs/test_cohere2_moe_config.py
@@ -19,12 +19,20 @@ class TestCohere2MoeConfig(CustomTestCase):
         cfg = Cohere2MoeConfig()
         self.assertEqual(cfg.model_type, "cohere2_moe")
 
-    def test_post_init_defaults_num_key_value_heads(self):
-        """``__post_init__`` must still run and default kv heads to attn heads."""
+    def test_config_sets_derived_defaults(self):
         from sglang.srt.configs.cohere2_moe import Cohere2MoeConfig
 
         cfg = Cohere2MoeConfig()
         self.assertEqual(cfg.num_key_value_heads, cfg.num_attention_heads)
+        self.assertEqual(len(cfg.layer_types), cfg.num_hidden_layers)
+
+    def test_config_supports_pretrained_config_serialization(self):
+        from sglang.srt.configs.cohere2_moe import Cohere2MoeConfig
+
+        cfg = Cohere2MoeConfig(foo="bar")
+        cfg_dict = cfg.to_dict()
+        self.assertEqual(cfg_dict["model_type"], "cohere2_moe")
+        self.assertEqual(cfg_dict["foo"], "bar")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
`Cohere2MoeConfig` applied `@strict` from `huggingface_hub.dataclasses`, which crashes at import time in the reported environment (`transformers==5.3.0`, `huggingface_hub==1.9.0`). Adding `@dataclass` alone is not enough: `@strict` then treats inherited `validate_rope(...)` as a class validator and fails on its signature.

This PR removes the `@strict` dependency and uses the standard Transformers config pattern instead: explicit `__init__`, assigned config fields, derived defaults for `num_key_value_heads` and `layer_types`, then `PreTrainedConfig.__init__` for base serialization and extra kwargs.

Fixes #28233.

## Test
`test/registered/unit/configs/test_cohere2_moe_config.py` covers package import, config construction, derived defaults, and `to_dict()` behavior.

I also verified the config module directly against the reported package versions:

```bash
uv run --isolated --python 3.12   --with transformers==5.3.0   --with huggingface-hub==1.9.0   python <direct Cohere2MoeConfig import/instantiation probe>
```























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28888258083](https://github.com/sgl-project/sglang/actions/runs/28888258083)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28888257701](https://github.com/sgl-project/sglang/actions/runs/28888257701)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->