### PR TITLE
[Bugfix] Reject named tool_choice that matches no tool

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -869,6 +869,28 @@ class ChatCompletionRequest(BaseModel):
 
         return values
 
+    @model_validator(mode="after")
+    def check_tool_usage(self) -> ChatCompletionRequest:
+        # A named tool_choice with no matching tool yields no schema and crashes
+        # downstream; reject it here (400) instead.
+        if not isinstance(self.tool_choice, ToolChoice):
+            return self
+
+        if not self.tools:
+            raise ValueError("When using `tool_choice`, `tools` must be set.")
+
+        fn_name = self.tool_choice.function.name
+        if not fn_name:
+            raise ValueError("Expected field `name` in `function` of `tool_choice`.")
+
+        if fn_name not in {tool.function.name for tool in self.tools}:
+            raise ValueError(
+                "The tool specified in `tool_choice` does not match any "
+                "of the specified `tools`"
+            )
+
+        return self
+
     def to_sampling_params(
         self,
         stop: List[str],

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -485,6 +485,34 @@ class TestValidationEdgeCases(unittest.TestCase):
                 model="test-model", messages=messages, tool_choice=123
             )
 
+    def test_named_tool_choice_mismatch_rejected(self):
+        """A named tool_choice that matches no tool is rejected."""
+        messages = [{"role": "user", "content": "Hello"}]
+        tools = [
+            {"type": "function", "function": {"name": "a"}},
+        ]
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest(
+                model="test-model",
+                messages=messages,
+                tools=tools,
+                tool_choice={"type": "function", "function": {"name": "b"}},
+            )
+
+    def test_named_tool_choice_match_accepted(self):
+        """A named tool_choice that matches a declared tool is accepted."""
+        messages = [{"role": "user", "content": "Hello"}]
+        tools = [
+            {"type": "function", "function": {"name": "a"}},
+        ]
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            tools=tools,
+            tool_choice={"type": "function", "function": {"name": "a"}},
+        )
+        self.assertEqual(request.tool_choice.function.name, "a")
+
     def test_negative_token_limits(self):
         """Test negative token limits"""
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
## Summary
A `ChatCompletionRequest` whose named `tool_choice` references a function that is not present in `tools` returned an opaque **HTTP 500** (the constraint lookup returns `None`, which then crashes in `convert_json_schema_to_str`/`issubclass`). Validate it in a `model_validator` and raise a clear error (→400), mirroring vLLM's `check_tool_usage` — covering missing `tools`, an empty function name, and a name matching no tool.

## Behavior change
Such requests now return a 400 instead of a 500.

## Test
`test/registered/unit/entrypoints/openai/test_protocol.py`: a mismatched named `tool_choice` is rejected; a matching one is accepted. The mismatch case fails on current `main`.







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28888254442](https://github.com/sgl-project/sglang/actions/runs/28888254442)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28888254407](https://github.com/sgl-project/sglang/actions/runs/28888254407)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->