### PR TITLE
[Bugfix] Validate lora_path list length against batch size

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -484,6 +484,10 @@ class GenerateReqInput:
             if isinstance(self.lora_path, str):
                 self.lora_path = [self.lora_path] * num
             elif isinstance(self.lora_path, list):
+                if len(self.lora_path) != self.batch_size:
+                    raise ValueError(
+                        "The length of lora_path should be equal to the batch size."
+                    )
                 self.lora_path = self.lora_path * self.parallel_sample_num
             else:
                 raise ValueError("lora_path should be a list or a string.")

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -474,6 +474,12 @@ class GenerateReqInput:
 
     def _normalize_single_inputs(self):
         """Normalize inputs for a single example."""
+        if isinstance(self.lora_path, list):
+            if len(self.lora_path) != self.batch_size:
+                raise ValueError(
+                    "The length of lora_path should be equal to the batch size."
+                )
+            self.lora_path = self.lora_path[0]
         if self.sampling_params is None:
             self.sampling_params = {}
         if self.rid is None:
@@ -537,6 +543,10 @@ class GenerateReqInput:
             if isinstance(self.lora_path, str):
                 self.lora_path = [self.lora_path] * num
             elif isinstance(self.lora_path, list):
+                if len(self.lora_path) != self.batch_size:
+                    raise ValueError(
+                        "The length of lora_path should be equal to the batch size."
+                    )
                 self.lora_path = self.lora_path * self.parallel_sample_num
             else:
                 raise ValueError("lora_path should be a list or a string.")

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -419,6 +419,18 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         req.normalize_batch_and_arguments()
         self.assertEqual(req.lora_path, expected_lora_paths)
 
+        req = GenerateReqInput(text=["a", "b", "c"], lora_path=["x", "y"])
+        with self.assertRaisesRegex(ValueError, "batch size"):
+            req.normalize_batch_and_arguments()
+
+        req = GenerateReqInput(text=["a", "b", "c"], lora_path=["x", "y", "z", "w"])
+        with self.assertRaisesRegex(ValueError, "batch size"):
+            req.normalize_batch_and_arguments()
+
+        req = GenerateReqInput(text=["a", "b", "c"], lora_path=["x", "y", "z"])
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.lora_path, ["x", "y", "z"])
+
     def test_extra_key_normalization(self):
         """Test normalization of extra_key."""
         # Per-request list

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -437,6 +437,21 @@ class TestGenerateReqInputNormalization(CustomTestCase):
 
     def test_lora_path_normalization(self):
         """Test normalization of lora_path."""
+        req = GenerateReqInput(text="Hello", lora_path=["path1"])
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.lora_path, "path1")
+
+        req = GenerateReqInput(
+            text="Hello", lora_path=["path1"], sampling_params={"n": 2}
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.lora_path, ["path1", "path1"])
+        self.assertEqual([req[i].lora_path for i in range(2)], ["path1", "path1"])
+
+        req = GenerateReqInput(text="Hello", lora_path=["path1", "path2"])
+        with self.assertRaisesRegex(ValueError, "batch size"):
+            req.normalize_batch_and_arguments()
+
         # Test single lora_path with batch input
         req = GenerateReqInput(text=["Hello", "World"], lora_path="path/to/lora")
 
@@ -467,6 +482,12 @@ class TestGenerateReqInputNormalization(CustomTestCase):
 
         req.normalize_batch_and_arguments()
         self.assertEqual(req.lora_path, expected_lora_paths)
+
+        for lora_paths in (["x", "y"], ["x", "y", "z", "w"]):
+            with self.subTest(lora_paths=lora_paths):
+                req = GenerateReqInput(text=["a", "b", "c"], lora_path=lora_paths)
+                with self.assertRaisesRegex(ValueError, "batch size"):
+                    req.normalize_batch_and_arguments()
 
     def test_extra_key_normalization(self):
         """Test normalization of extra_key."""


### PR DESCRIPTION
## Summary

Normalize generation-request LoRA adapter paths against the original request cardinality before parallel-sample expansion.

- a scalar `lora_path` broadcasts to the batch
- a list is per original request and must have exactly `batch_size` entries
- a singleton list for a scalar request is validated and unwrapped to a scalar
- parallel sampling repeats the validated paths in the same block ordering as prompts
- each split `GenerateReqInput` owns a scalar `lora_path`
- shorter or longer lists fail with `ValueError` before registry acquisition, tokenization, or scheduler/backend effects

This is orthogonal to #28864, which validates blank identifiers at the dynamic adapter-load endpoints.

## Verification

- scalar, singleton-list, empty, batched scalar/list, under/over-cardinality, and single/batched parallel cases covered
- single-plus-parallel coverage asserts both expanded parent paths and scalar subrequest projection
- full touched-file pre-commit, compilation, focused normalization probes, and `git diff --check` passed
- fresh exact-head review found no correctness, ordering, ownership, redundancy, duplicate, or credit issues

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31558114922](https://github.com/sgl-project/sglang/actions/runs/31558114922)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31558114793](https://github.com/sgl-project/sglang/actions/runs/31558114793)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->