### PR TITLE
[Bugfix] Reject empty or blank lora_name/lora_path in load_lora_adapter

### DIFF
--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -551,6 +551,9 @@ class TokenizerControlMixin:
                     "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
                 )
 
+            if not obj.lora_name or not obj.lora_path:
+                raise ValueError("Both 'lora_name' and 'lora_path' must be provided.")
+
             # TODO (lifuhuang): Remove this after we verify that dynamic lora loading works
             # with dp_size > 1.
             assert (
@@ -628,6 +631,9 @@ class TokenizerControlMixin:
                 raise ValueError(
                     "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
                 )
+
+            if not obj.lora_name:
+                raise ValueError("'lora_name' must be provided.")
 
             assert (
                 self.server_args.dp_size == 1

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -551,7 +551,12 @@ class TokenizerControlMixin:
                     "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
                 )
 
-            if not obj.lora_name or not obj.lora_path:
+            if (
+                not obj.lora_name
+                or not obj.lora_name.strip()
+                or not obj.lora_path
+                or not obj.lora_path.strip()
+            ):
                 raise ValueError("Both 'lora_name' and 'lora_path' must be provided.")
 
             # TODO (lifuhuang): Remove this after we verify that dynamic lora loading works
@@ -632,7 +637,7 @@ class TokenizerControlMixin:
                     "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
                 )
 
-            if not obj.lora_name:
+            if not obj.lora_name or not obj.lora_name.strip():
                 raise ValueError("'lora_name' must be provided.")
 
             assert (

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -597,6 +597,14 @@ class TokenizerControlMixin:
                     "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
                 )
 
+            if (
+                not obj.lora_name
+                or not obj.lora_name.strip()
+                or not obj.lora_path
+                or not obj.lora_path.strip()
+            ):
+                raise ValueError("Both 'lora_name' and 'lora_path' must be provided.")
+
             assert (
                 self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
             ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
@@ -674,6 +682,9 @@ class TokenizerControlMixin:
                 raise ValueError(
                     "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
                 )
+
+            if not obj.lora_name or not obj.lora_name.strip():
+                raise ValueError("'lora_name' must be provided.")
 
             assert (
                 self.server_args.dp_size == 1 or self.server_args.enable_dp_attention

--- a/test/registered/unit/managers/test_load_lora_adapter_validation.py
+++ b/test/registered/unit/managers/test_load_lora_adapter_validation.py
@@ -58,10 +58,49 @@ class TestLoadLoRAAdapterValidation(unittest.TestCase):
             "Both 'lora_name' and 'lora_path' must be provided.",
         )
 
+    def test_whitespace_only_lora_name_rejected(self):
+        stub = _make_stub_self()
+        obj = LoadLoRAAdapterReqInput(lora_name="   ", lora_path="/some/path")
+
+        result = asyncio.run(TokenizerControlMixin.load_lora_adapter(stub, obj))
+
+        self.assertFalse(result.success)
+        self.assertEqual(
+            result.error_message,
+            "Both 'lora_name' and 'lora_path' must be provided.",
+        )
+
+    def test_whitespace_only_lora_path_rejected(self):
+        stub = _make_stub_self()
+        obj = LoadLoRAAdapterReqInput(lora_name="adapter", lora_path="   ")
+
+        result = asyncio.run(TokenizerControlMixin.load_lora_adapter(stub, obj))
+
+        self.assertFalse(result.success)
+        self.assertEqual(
+            result.error_message,
+            "Both 'lora_name' and 'lora_path' must be provided.",
+        )
+
     def test_empty_lora_name_from_tensors_rejected(self):
         stub = _make_stub_self()
         obj = LoadLoRAAdapterFromTensorsReqInput(
             lora_name="",
+            config_dict={},
+            serialized_tensors="",
+        )
+
+        result = asyncio.run(
+            TokenizerControlMixin.load_lora_adapter_from_tensors(stub, obj)
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_message, "'lora_name' must be provided.")
+
+    def test_whitespace_only_lora_name_from_tensors_rejected(self):
+        stub = _make_stub_self()
+        obj = LoadLoRAAdapterFromTensorsReqInput(
+            lora_name="   ",
             config_dict={},
             serialized_tensors="",
         )

--- a/test/registered/unit/managers/test_load_lora_adapter_validation.py
+++ b/test/registered/unit/managers/test_load_lora_adapter_validation.py
@@ -1,0 +1,78 @@
+import asyncio
+import types
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import (
+    LoadLoRAAdapterFromTensorsReqInput,
+    LoadLoRAAdapterReqInput,
+)
+from sglang.srt.managers.tokenizer_control_mixin import TokenizerControlMixin
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_stub_self():
+    # update_lora_adapter_communicator raises so the test fails if the guard
+    # is bypassed and the backend call is reached.
+    def _fail(*args, **kwargs):
+        raise AssertionError(
+            "update_lora_adapter_communicator should not be reached when "
+            "lora_name/lora_path validation fails"
+        )
+
+    stub = types.SimpleNamespace(
+        auto_create_handle_loop=lambda: None,
+        server_args=types.SimpleNamespace(enable_lora=True, dp_size=1),
+        update_lora_adapter_communicator=_fail,
+    )
+    return stub
+
+
+class TestLoadLoRAAdapterValidation(unittest.TestCase):
+    def test_empty_lora_name_rejected(self):
+        stub = _make_stub_self()
+        obj = LoadLoRAAdapterReqInput(lora_name="", lora_path="/some/path")
+
+        result = asyncio.run(TokenizerControlMixin.load_lora_adapter(stub, obj))
+
+        self.assertFalse(result.success)
+        self.assertEqual(
+            result.error_message,
+            "Both 'lora_name' and 'lora_path' must be provided.",
+        )
+
+    def test_empty_lora_path_rejected(self):
+        stub = _make_stub_self()
+        obj = LoadLoRAAdapterReqInput(lora_name="adapter", lora_path="")
+
+        result = asyncio.run(TokenizerControlMixin.load_lora_adapter(stub, obj))
+
+        self.assertFalse(result.success)
+        self.assertEqual(
+            result.error_message,
+            "Both 'lora_name' and 'lora_path' must be provided.",
+        )
+
+    def test_empty_lora_name_from_tensors_rejected(self):
+        stub = _make_stub_self()
+        obj = LoadLoRAAdapterFromTensorsReqInput(
+            lora_name="",
+            config_dict={},
+            serialized_tensors="",
+        )
+
+        result = asyncio.run(
+            TokenizerControlMixin.load_lora_adapter_from_tensors(stub, obj)
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_message, "'lora_name' must be provided.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_load_lora_adapter_validation.py
+++ b/test/registered/unit/managers/test_load_lora_adapter_validation.py
@@ -1,0 +1,75 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import (
+    LoadLoRAAdapterFromTensorsReqInput,
+    LoadLoRAAdapterReqInput,
+)
+from sglang.srt.managers.tokenizer_control_mixin import TokenizerControlMixin
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_stub_self():
+    def _fail(*args, **kwargs):
+        raise AssertionError("LoRA backend should not be reached")
+
+    return SimpleNamespace(
+        auto_create_handle_loop=lambda: None,
+        server_args=SimpleNamespace(enable_lora=True, dp_size=1),
+        lora_update_lock=asyncio.Lock(),
+        update_lora_adapter_communicator=_fail,
+    )
+
+
+class TestLoadLoRAAdapterValidation(unittest.TestCase):
+    def test_file_adapter_rejects_blank_name_or_path(self):
+        for lora_name, lora_path in (
+            ("", "/some/path"),
+            ("   ", "/some/path"),
+            ("adapter", ""),
+            ("adapter", "   "),
+        ):
+            with self.subTest(lora_name=lora_name, lora_path=lora_path):
+                result = asyncio.run(
+                    TokenizerControlMixin.load_lora_adapter(
+                        _make_stub_self(),
+                        LoadLoRAAdapterReqInput(
+                            lora_name=lora_name,
+                            lora_path=lora_path,
+                        ),
+                    )
+                )
+
+                self.assertFalse(result.success)
+                self.assertEqual(
+                    result.error_message,
+                    "Both 'lora_name' and 'lora_path' must be provided.",
+                )
+
+    def test_tensor_adapter_rejects_blank_name(self):
+        for lora_name in ("", "   "):
+            with self.subTest(lora_name=lora_name):
+                result = asyncio.run(
+                    TokenizerControlMixin.load_lora_adapter_from_tensors(
+                        _make_stub_self(),
+                        LoadLoRAAdapterFromTensorsReqInput(
+                            lora_name=lora_name,
+                            config_dict={},
+                            serialized_named_tensors=[],
+                        ),
+                    )
+                )
+
+                self.assertFalse(result.success)
+                self.assertEqual(result.error_message, "'lora_name' must be provided.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
`load_lora_adapter` accepted empty `lora_name` / `lora_path` values because the backend check only tests `is not None`. That can surface an empty-string adapter id via `/v1/models`.

Reject empty or whitespace-only `lora_name` / `lora_path` with a clear error. `load_lora_adapter_from_tensors` gets the same validation for `lora_name`. Both paths use the existing `ValueError -> success=False` handling.

## Test
`test/registered/unit/managers/test_load_lora_adapter_validation.py` covers empty and whitespace-only values and verifies validation happens before the backend call.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31555020388](https://github.com/sgl-project/sglang/actions/runs/31555020388)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31555020171](https://github.com/sgl-project/sglang/actions/runs/31555020171)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->