### PR TITLE
[AMD] Pin httpx>=0.25.0 to fix anthropic SDK socket_options error

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -30,7 +30,6 @@ runtime_common = [
   "einops",
   "fastapi",
   "gguf",
-  "httpx>=0.25.0",
   "interegular",
   "IPython",
   "llguidance>=0.7.11,<0.8.0",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -30,6 +30,7 @@ runtime_common = [
   "einops",
   "fastapi",
   "gguf",
+  "httpx>=0.25.0",
   "interegular",
   "IPython",
   "llguidance>=0.7.11,<0.8.0",

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -122,6 +122,14 @@ else
 
   docker exec ci_sglang bash -c 'rm -rf python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml'
   install_with_retry docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e "python[${EXTRAS}]"
+
+  # The anthropic SDK passes `socket_options` to httpx.HTTPTransport, which only
+  # exists in httpx>=0.25.0. The CI image ships an older httpx that pip's editable
+  # reinstall above does not upgrade (only-if-needed strategy keeps the pre-baked
+  # version), so test_anthropic_server fails with:
+  #   TypeError: HTTPTransport.__init__() got an unexpected keyword argument 'socket_options'
+  # Force the upgrade explicitly.
+  install_with_retry docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache --upgrade 'httpx>=0.25.0'
 fi
 
 if [[ -n "${SKIP_TT_DEPS}" ]]; then

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -72,6 +72,16 @@ install_with_retry() {
   return 1
 }
 
+# The anthropic SDK passes `socket_options` to httpx.HTTPTransport, which only
+# exists in httpx>=0.25.0. The CI image ships an older httpx, and several deps
+# installed below (lmms-eval, aiter's requirements.txt, etc.) can pull a stale
+# httpx back in, so test_anthropic_server fails with:
+#   TypeError: HTTPTransport.__init__() got an unexpected keyword argument 'socket_options'
+# Call this as the LAST pip operation so nothing can downgrade httpx afterwards.
+ensure_httpx() {
+  install_with_retry docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache --upgrade 'httpx>=0.25.0'
+}
+
 # Helper function to git clone with retries
 git_clone_with_retry() {
   local repo_url="$1"
@@ -122,14 +132,6 @@ else
 
   docker exec ci_sglang bash -c 'rm -rf python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml'
   install_with_retry docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e "python[${EXTRAS}]"
-
-  # The anthropic SDK passes `socket_options` to httpx.HTTPTransport, which only
-  # exists in httpx>=0.25.0. The CI image ships an older httpx that pip's editable
-  # reinstall above does not upgrade (only-if-needed strategy keeps the pre-baked
-  # version), so test_anthropic_server fails with:
-  #   TypeError: HTTPTransport.__init__() got an unexpected keyword argument 'socket_options'
-  # Force the upgrade explicitly.
-  install_with_retry docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache --upgrade 'httpx>=0.25.0'
 fi
 
 if [[ -n "${SKIP_TT_DEPS}" ]]; then
@@ -220,6 +222,7 @@ if docker exec ci_sglang test -d /sgl-workspace/mori; then
 fi
 
 if [[ -n "${SKIP_AITER_BUILD}" ]]; then
+  ensure_httpx
   exit 0
 fi
 
@@ -339,6 +342,10 @@ if [[ "${NEED_REBUILD}" == "true" ]]; then
 fi
 
 echo "[CI-AITER-CHECK] === AITER VERSION CHECK END ==="
+
+# Must be the final pip operation: force httpx>=0.25.0 so the anthropic SDK can
+# construct its httpx transport (see ensure_httpx definition above).
+ensure_httpx
 
 
 # # Clear pre-built AITER kernels from Docker image to avoid segfaults


### PR DESCRIPTION
## Motivation

The AMD CI job `test_anthropic_server.py` started failing on `test_in_messages_system_role` (added in 26773), which is the first test to instantiate the real `anthropic` SDK client instead of using `requests` directly:


### Root cause
The `anthropic` SDK's `SyncHttpxClientWrapper` passes `socket_options` to `httpx.HTTPTransport`, but that argument only exists in **httpx >= 0.25.0**. The AMD CI image ships an older httpx, and SGLang only pinned `anthropic>=0.20.0` without any lower bound on httpx (httpx is a transitive dependency), so the stale httpx in the image was never upgraded.
This was not caught before because no test/code had ever exercised the `anthropic` SDK client until 26773.

## Modifications
- `scripts/ci/amd/amd_ci_install_dependency.sh`: add an `ensure_httpx` helper that force-upgrades `httpx>=0.25.0`, and invoke it as the final pip operation (after AITER build, and before the early `--skip-aiter-build` exit), so nothing can downgrade httpx afterwards.
Note: `lmms-eval==0.4.1` still declares `httpx==0.23.3`, which now surfaces as a non-fatal pip dependency-conflict warning. httpx 0.28.x is backward-compatible for lmms-eval's usage in CI; the anthropic SDK requires the newer httpx, so the newer version wins intentionally.



## Accuracy Tests
<img width="443" height="92" alt="image" src="https://github.com/user-attachments/assets/cbfdcf3a-ca06-43e7-8816-3dbe7a19b064" />

<img width="1204" height="303" alt="image" src="https://github.com/user-attachments/assets/fd6edb0e-6c3c-489e-bb04-e302f94d72c3" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27932510537](https://github.com/sgl-project/sglang/actions/runs/27932510537)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27932510387](https://github.com/sgl-project/sglang/actions/runs/27932510387)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->