### PR TITLE
memory optimize

### DIFF
--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -623,6 +623,9 @@ class DeepseekV2WeightLoaderMixin:
                 self_attn.w_vc = bind_or_assign(self_attn.w_vc, w_vc.contiguous())
                 self_attn.use_deep_gemm_bmm = True
 
+            if not hasattr(self_attn.kv_b_proj, "qweight"):
+                self_attn.kv_b_proj.weight.data.untyped_storage().resize_(0)
+
     @classmethod
     def generate_weight_name_filter(cls, logical_experts_map: Dict[int, List[int]]):
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

We found that GLM5.2-w4a8 weight loading consumes nearly 3 GB more memory compared with the vLLM and kv_b_proj weight is not released after use

## Modifications

python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py

## Accuracy Tests

start command
```
# high performance cpu
echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0
sysctl -w kernel.sched_migration_cost_ns=50000
# bind cpu
export SGLANG_SET_CPU_AFFINITY=1

unset https_proxy
unset http_proxy
unset HTTPS_PROXY
unset HTTP_PROXY
unset ASCEND_LAUNCH_BLOCKING
# cann
source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh

export STREAMS_PER_DEVICE=32
export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=600
export SGLANG_ENABLE_SPEC_V2=1
export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1
# export SGLANG_NPU_USE_MULTI_STREAM=1
export HCCL_BUFFSIZE=1000
export HCCL_OP_EXPANSION_MODE=AIV
export HCCL_SOCKET_IFNAME=enp196s0f0
export GLOO_SOCKET_IFNAME=enp196s0f0
export TRANSFORMERS_VERBOSITY=error

MODEL_PATH=/home/weights/GLM-5.1-w4a8
export SGLANG_NPU_PROFILING=0
export SGLANG_NPU_PROFILING_BS=16
export PYTHONPATH=/home/***/sglang/python:$PYTHONPATH

D_IP=('***' '***')
LOCAL_HOST1=`hostname -I|awk -F " " '{print$1}'`
LOCAL_HOST2=`hostname -I|awk -F " " '{print$2}'`
export DEEP_NORMAL_MODE_USE_INT8_QUANT=1
export DEEPEP_NORMAL_LONG_SEQ_ROUND=72
export DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=1024
export DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ=1
#export SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE=1
#export SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES=200

for i in "${!D_IP[@]}";
do
    if [[ "$LOCAL_HOST1" == "${D_IP[$i]}" || "$LOCAL_HOST2" == "${D_IP[$i]}" ]];
    then
      python3 -m sglang.launch_server \
        --model-path $MODEL_PATH \
        --attention-backend ascend \
        --device npu \
        --host ${D_IP[$i]} \
        --dist-init-addr ***:50000  \
        --tp-size 32 \
        --nnodes 2 --node-rank $i \
        --dp-size 32 \
        --enable-dp-attention \
        --chunked-prefill-size -1 \
        --max-prefill-tokens 28672 \
        --trust-remote-code \
        --mem-fraction-static 0.8 \
        --served-model-name GLM-5.1-w4a8 \
        --cuda-graph-bs 1 \
        --max-running-requests 32 \
        --quantization modelslim \
        --speculative-draft-model-quantization unquant \
        --moe-a2a-backend deepep --deepep-mode auto \
        --load-balance-method round_robin \
        --speculative-algorithm NEXTN --speculative-num-steps 4 --speculative-eagle-topk 1 --speculative-num-draft-tokens 5  \
        --device npu --port 7439 --tokenizer-worker-num 32
        NODE_RANK=$i
        break
    fi
done

exit
```
result
```
The markdown format results is as below:

| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| aime2025 | 4835d7 | accuracy | gen | 100.00 |
```

## Speed Tests and Profiling
start command on NPU
```
# high performance cpu
echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0
sysctl -w kernel.sched_migration_cost_ns=50000
# bind cpu
export SGLANG_SET_CPU_AFFINITY=1

unset https_proxy
unset http_proxy
unset HTTPS_PROXY
unset HTTP_PROXY
unset ASCEND_LAUNCH_BLOCKING
# cann
source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh

export STREAMS_PER_DEVICE=32
export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=600
export SGLANG_ENABLE_SPEC_V2=1
export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1
# export SGLANG_NPU_USE_MULTI_STREAM=1
export HCCL_BUFFSIZE=1000
export HCCL_OP_EXPANSION_MODE=AIV
export HCCL_SOCKET_IFNAME=lo
export GLOO_SOCKET_IFNAME=lo
export TRANSFORMERS_VERBOSITY=error


MODEL_PATH=/home/weights/GLM-5.2-w4a8
export SGLANG_NPU_PROFILING=0
export SGLANG_NPU_PROFILING_BS=16
export DEEPEP_NORMAL_LONG_SEQ_ROUND=72
export DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=1024
export DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ=1
export SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE=1
export SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES=100

export DEEP_NORMAL_MODE_USE_INT8_QUANT=1
python3 -m sglang.launch_server \
        --model-path $MODEL_PATH \
        --attention-backend ascend \
        --device npu \
        --tp-size 16 \
        --nnodes 1 \
        --dp-size 16 \
        --enable-dp-attention \
        --chunked-prefill-size -1 \
        --max-prefill-tokens 65536 \
        --trust-remote-code \
        --mem-fraction-static 0.75 \
        --served-model-name GLM-5.2-w4a8 \
        --cuda-graph-bs 1 2 3 4 5 6 7 \
        --max-running-requests 102 \
        --quantization modelslim \
	      --speculative-draft-model-quantization unquant \
        --moe-a2a-backend deepep --deepep-mode auto \
        --load-balance-method round_robin \
	      --speculative-algorithm NEXTN --speculative-num-steps 4 --speculative-eagle-topk 1 --speculative-num-draft-tokens 5  \
        --device npu --host *** --port 7439

exit
```


before this pr, after load main model
```
[2026-06-22 06:40:09 DP0 TP0 EP0] Load weight end. elapsed=80.40 s, type=GlmMoeDsaForCausalLM, avail mem=17.02 GB, mem usage=43.73 GB.
[2026-06-22 06:40:09 DP5 TP5 EP5] Load weight end. elapsed=80.91 s, type=GlmMoeDsaForCausalLM, avail mem=17.34 GB, mem usage=43.73 GB.
[2026-06-22 06:40:09 DP7 TP7 EP7] Load weight end. elapsed=81.01 s, type=GlmMoeDsaForCausalLM, avail mem=17.36 GB, mem usage=43.73 GB.
[2026-06-22 06:40:10 DP4 TP4 EP4] Load weight end. elapsed=81.16 s, type=GlmMoeDsaForCausalLM, avail mem=17.09 GB, mem usage=43.73 GB
```

after this pr, after load main model
```
[2026-06-22 07:02:19 DP4 TP4 EP4] Load weight end. elapsed=79.36 s, type=GlmMoeDsaForCausalLM, avail mem=19.59 GB, mem usage=41.22 GB.
[2026-06-22 07:02:19 DP15 TP15 EP15] Load weight end. elapsed=79.33 s, type=GlmMoeDsaForCausalLM, avail mem=19.85 GB, mem usage=41.22 GB.
[2026-06-22 07:02:20 DP14 TP14 EP14] Load weight end. elapsed=79.92 s, type=GlmMoeDsaForCausalLM, avail mem=19.59 GB, mem usage=41.22 GB.
[2026-06-22 07:02:20 DP13 TP13 EP13] Load weight end. elapsed=80.19 s, type=GlmMoeDsaForCausalLM, avail mem=19.85 GB, mem usage=41.22 GB.
[2026-06-22 07:02:21 DP12 TP12 EP12] Load weight end. elapsed=81.72 s, type=GlmMoeDsaForCausalLM, avail mem=19.59 GB, mem usage=41.22 GB
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27928118711](https://github.com/sgl-project/sglang/actions/runs/27928118711)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27928118602](https://github.com/sgl-project/sglang/actions/runs/27928118602)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->