### PR TITLE
[DeepSeek-V4] Emit fp32 directly in linear_bf16_fp32 (drop .float() copy)

### DIFF
--- a/python/sglang/jit_kernel/dsv4/gemm.py
+++ b/python/sglang/jit_kernel/dsv4/gemm.py
@@ -15,7 +15,14 @@ _linear_bf16_fp32_algo = envs.SGLANG_OPT_BF16_FP32_GEMM_ALGO.get()
 
 def linear_bf16_fp32(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     if _use_aiter:
-        return tgemm.mm(x, y, otype=x.dtype).float()
+        # Request fp32 output directly instead of computing a bf16 GEMM and then
+        # casting with `.float()`. The explicit cast shows up as a separate
+        # `bfloat16tofloat32_copy` kernel per call in the DSV4 indexer
+        # (compute_kv_score) path; emitting fp32 from the GEMM epilogue removes
+        # that copy and also avoids rounding the result to bf16 first.
+        # Requires AITER to expose a native fp32-output tuned kernel for these
+        # shapes (companion AITER change); otherwise tgemm falls back internally.
+        return tgemm.mm(x, y, otype=torch.float32)
     elif _linear_bf16_fp32_algo == "deep_gemm":
         z = torch.empty(x.size(0), y.size(0), dtype=torch.float32, device=x.device)
         deep_gemm_wrapper.gemm_nt_bf16bf16f32(x, y, z)


### PR DESCRIPTION
## Motivation

In the DSV4 indexer kv_score path, `linear_bf16_fp32` (AITER branch) computes a bf16 GEMM and then casts to fp32 with `.float()`:

```python
return tgemm.mm(x, y, otype=x.dtype).float()
```

Profiling DeepSeek-V4 (8xMI355, tp=8) shows this `.float()` as a separate `bfloat16tofloat32_copy` kernel launched once per call (per layer, per step), e.g. output shapes `[256, {512,1024,2048}]`, launched from `compute_kv_score` -> `linear_bf16_fp32`. It is small individually but recurs every decode step, and computing in bf16 then up-casting also loses precision.

## Modifications

- Request fp32 output directly from the GEMM (`otype=torch.float32`) so the up-cast is fused into the epilogue and the separate copy kernel is removed.

## Dependency

This is the consumer-side half. To actually avoid the copy (rather than relocate it), AITER must expose a native fp32-output tuned kernel for these bf16xbf16 shapes — companion: ROCm/aiter#3836. Without it, `tgemm` falls back internally (correctness unaffected, but the copy/torch-fallback may remain), which is why this is kept as a draft until the AITER configs land.

## Accuracy / Speed

- Functionally identical math; emitting fp32 directly is strictly more accurate than bf16-GEMM + up-cast (avoids intermediate bf16 rounding).
- Removes one `bfloat16tofloat32_copy` kernel per `linear_bf16_fp32` call.

## Checklist

- [ ] Land companion AITER fp32-output GEMM tuned configs (ROCm/aiter#3836)
- [ ] Re-profile to confirm `bfloat16tofloat32_copy` is gone in the kv_score path
- [ ] Confirm no GEMM perf regression vs the current tuned bf16 kernel + cast







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27928226891](https://github.com/sgl-project/sglang/actions/runs/27928226891)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27928226844](https://github.com/sgl-project/sglang/actions/runs/27928226844)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->