### PR TITLE
Fix DSV4 HiSparse PD state page sizes

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -993,6 +993,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 )
 
             seq_len = len(decode_req.req.origin_input_ids)
+            swa_state_page_size = getattr(
+                self.token_to_kv_pool, "swa_page_size", page_size
+            )
 
             def _mamba_payload():
                 return [
@@ -1006,7 +1009,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             def _swa_payload():
                 window_size = self.scheduler.sliding_window_size
                 window_start = max(0, seq_len - window_size)
-                window_start = page_align_floor(window_start, page_size)
+                window_start = page_align_floor(window_start, swa_state_page_size)
                 window_kv_indices_full = self.req_to_token_pool.req_to_token[
                     decode_req.req.req_pool_idx, window_start:seq_len
                 ]
@@ -1016,7 +1019,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     )
                 )
                 return kv_to_page_indices(
-                    window_kv_indices_swa.cpu().numpy(), page_size
+                    window_kv_indices_swa.cpu().numpy(), swa_state_page_size
                 )
 
             def _dsa_payload():

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -964,7 +964,8 @@ class SchedulerDisaggregationPrefillMixin:
         """
         Send a prefilled chunk to the decode server
         """
-        page_size = self.token_to_kv_pool_allocator.page_size
+        token_to_kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
+        page_size = token_to_kv_pool.page_size
         start_idx = req.start_send_idx
         end_idx = (
             end_idx
@@ -1001,6 +1002,7 @@ class SchedulerDisaggregationPrefillMixin:
             # token crosses a page boundary, which mismatched src/dst lengths in
             # group_concurrent_contiguous.
             seq_len = min(req.fill_len, len(req.origin_input_ids))
+            swa_state_page_size = getattr(token_to_kv_pool, "swa_page_size", page_size)
 
             def _mamba_payload():
                 return [
@@ -1014,7 +1016,9 @@ class SchedulerDisaggregationPrefillMixin:
             def _swa_payload():
                 window_size = self.sliding_window_size
                 window_start = max(0, seq_len - window_size)
-                window_start = (window_start // page_size) * page_size
+                window_start = (window_start // swa_state_page_size) * (
+                    swa_state_page_size
+                )
                 window_kv_indices_full = self.req_to_token_pool.req_to_token[
                     req.req_pool_idx, window_start:seq_len
                 ]
@@ -1024,14 +1028,16 @@ class SchedulerDisaggregationPrefillMixin:
                     )
                 )
                 return kv_to_page_indices(
-                    window_kv_indices_swa.cpu().numpy(), page_size
+                    window_kv_indices_swa.cpu().numpy(), swa_state_page_size
                 )
 
             def _dsa_payload():
                 kv_indices_full = self.req_to_token_pool.req_to_token[
                     req.req_pool_idx, :seq_len
                 ]
-                return kv_to_page_indices(kv_indices_full.cpu().numpy(), page_size)
+                return kv_to_page_indices(
+                    kv_indices_full.cpu().numpy(), token_to_kv_pool.page_size
+                )
 
             def _swa_ring_payload():
                 # Unified_kv SWA ring rows (req_pool_idx*ring_stride + pos%ring_stride)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DSV4 HiSparse PD transfer uses different page-size semantics for the allocator wrapper, the underlying KV pool, and SWA state pages. The existing code used the allocator wrapper `page_size` when building SWA state page indices, which can make prefill and decode compute different state page boundaries or page lists.

This can cause PD state transfer mismatches, and in the worst case transfer the wrong SWA state rows.

## Modifications

- Use the underlying KV pool `page_size` for prefill KV chunk page indices.
- Use the underlying KV pool `swa_page_size` when building SWA state page indices on both prefill and decode.
- Keep the existing `page_size` fallback for KV pools that do not expose `swa_page_size`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27928828572](https://github.com/sgl-project/sglang/actions/runs/27928828572)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27928828488](https://github.com/sgl-project/sglang/actions/runs/27928828488)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->