### PR TITLE
fix(pp): sync running-timeout abort across PP stages to prevent tensor-size mismatch

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1723,6 +1723,10 @@ class AbortReq(BaseReq):
     # The finished reason data
     finished_reason: Optional[Dict[str, Any]] = None
     abort_message: Optional[str] = None
+    # Optional HTTP status code to attach to the resulting FINISH_ABORT.
+    # Used when the abort is triggered internally (e.g. running timeout) so
+    # that the client-visible error matches the single-stage behavior.
+    abort_status_code: Optional[int] = None
 
     def __post_init__(self):
         # FIXME: This is a hack to keep the same with the old code

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1428,6 +1428,12 @@ class Scheduler(
 
     def _abort_on_running_timeout(self):
         # NOTE: this should be called before a batch is launched.
+        # In PP mode, this check is done in event_loop_pp by
+        # _pp_check_and_sync_running_timeout, which aborts timed-out
+        # requests on the first PP stage and forwards the AbortReq to
+        # every subsequent stage so all stages agree on the abort.
+        if self.ps.pp_size > 1:
+            return
         timeout_s = envs.SGLANG_REQ_RUNNING_TIMEOUT.get()
         if timeout_s <= 0:
             return
@@ -3853,8 +3859,25 @@ class Scheduler(
                         remaining_retracted.append(decode_req)
                 self.disagg_decode_prealloc_queue.retracted_queue = remaining_retracted
 
-        # Delete requests in the running batch
-        if self.cur_batch is self.running_batch or self.cur_batch is None:
+        # Delete requests in the running batch.
+        # In PP mode a request's decode copy lives in one of the per micro-batch
+        # running_mbs slots, not necessarily self.running_batch (which is the
+        # slot for the current mb_id). Scanning only self.running_batch misses
+        # the copy when it is staged in another slot, which leaves the
+        # downstream PP stage waiting for proxy tensors that the first stage
+        # stopped sending after finishing the aborted copy -> PP ring deadlock.
+        # Scan every running_mbs slot (plus the about-to-launch cur_batch) so
+        # the AbortReq applies on every stage regardless of which slot holds
+        # the copy.
+        if self.ps.pp_size > 1 and getattr(self, "running_mbs", None) is not None:
+            candidate_batches = list(self.running_mbs)
+            if self.cur_batch is not None and self.cur_batch not in candidate_batches:
+                candidate_batches.append(self.cur_batch)
+            reqs = []
+            for batch in candidate_batches:
+                if batch is not None:
+                    reqs.extend(batch.reqs)
+        elif self.cur_batch is self.running_batch or self.cur_batch is None:
             reqs = self.running_batch.reqs
         else:
             reqs = self.running_batch.reqs + self.cur_batch.reqs
@@ -3867,7 +3890,10 @@ class Scheduler(
                 # The request will still run one decode forward pass.
                 # Then we reuse all existing code to clean up the KV cache allocation.
                 logger.debug(f"Abort running request. {req.rid=}")
-                req.to_finish = FINISH_ABORT()
+                req.to_finish = FINISH_ABORT(
+                    recv_req.abort_message,
+                    recv_req.abort_status_code,
+                )
 
     def _pause_engine(self) -> Tuple[List[Req], int]:
         raise NotImplementedError()

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -6,6 +6,7 @@ import time
 from array import array
 from collections import defaultdict, deque
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -23,6 +24,7 @@ from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
     set_is_extend_in_batch,
 )
+from sglang.srt.managers.io_struct import AbortReq
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.utils import (
     GenerationBatchResult,
@@ -99,6 +101,10 @@ class SchedulerPPMixin:
                 with torch.profiler.record_function("recv_requests"):
                     recv_reqs = self.request_receiver.recv_requests()
                     self.process_input_requests(recv_reqs)
+
+                # Close timed-out requests before the batch is launched.
+                self._pp_check_and_sync_running_timeout(recv_reqs)
+
                 if not self.pp_group.is_last_rank:
                     self._pp_commit_comm_work(self.send_req_work)
                     with torch.profiler.record_function("send_reqs_to_next_stage"):
@@ -535,6 +541,57 @@ class SchedulerPPMixin:
 
             if server_is_idle and queue_size == 0:
                 self.on_idle()
+
+    def _pp_check_and_sync_running_timeout(self: Scheduler, recv_reqs: List):
+        """Abort timed-out running requests on the first PP stage and forward
+        the abort to every subsequent stage so all stages agree.
+
+        Only the first PP stage decides: it owns the request lifecycle from
+        the tokenizer, so its running_batch is the authoritative place to
+        detect a stall. forward_entry_time is recorded per-stage at local
+        first-forward (see set_forward_entry_time), so it does NOT match
+        across stages — checking on a non-first stage would both miss
+        requests that stalled before reaching it and diverge from the stage
+        that actually owns the request.
+
+        For each timed-out rid the first stage builds an AbortReq carrying
+        the timeout message and HTTP 503, applies it locally via
+        abort_request (sets to_finish = FINISH_ABORT on the running req),
+        and appends it to recv_reqs. recv_reqs is then forwarded to the
+        next stage by event_loop_pp, so every subsequent stage receives the
+        AbortReq through the normal process_input_requests path and aborts
+        its own copy of the request. This reuses the existing abort
+        forwarding chain and keeps FINISH_ABORT semantics end-to-end
+        (client gets an error, not a fake EOS).
+        """
+        timeout_s = envs.SGLANG_REQ_RUNNING_TIMEOUT.get()
+        if timeout_s <= 0:
+            return
+        if not self.pp_group.is_first_rank:
+            return
+        if self.running_batch.is_empty():
+            return
+
+        deadline = time.perf_counter() - timeout_s
+        for req in self.running_batch.reqs:
+            if not req.finished() and 0 < req.time_stats.forward_entry_time < deadline:
+                logger.warning(
+                    "PP running timeout: rid=%s forward_entry_time=%.2fs deadline=%.2fs timeout_s=%s",
+                    req.rid,
+                    req.time_stats.forward_entry_time,
+                    deadline,
+                    timeout_s,
+                )
+                abort_req = AbortReq(
+                    rid=req.rid,
+                    abort_message="Request running timeout reached.",
+                    abort_status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                )
+                # Apply locally on the first stage so its own running_batch
+                # is aborted in this iteration.
+                self.abort_request(abort_req)
+                # Forward to subsequent stages via the recv_reqs pipeline.
+                recv_reqs.append(abort_req)
 
     def init_pp_loop_state(self: Scheduler):
         self.pp_loop_size: int = self.ps.pp_size + self.server_args.pp_async_batch_depth


### PR DESCRIPTION
## Summary

Fixes #25887.

In PP mode (especially with CP), `_abort_on_running_timeout` ran per-stage and only scanned `self.running_batch`. A request's decode copy on a downstream stage lives in one of the per-micro-batch `running_mbs` slots, not necessarily `self.running_batch`, so the abort was applied on some stages but not others. The first stage then stopped sending `pp_proxy_tensors` for the aborted copy while the downstream stage still expected them, producing:

```
RuntimeError: The size of tensor a (4) must match the size of tensor b (8) at non-singleton dimension 0
```

after the server had been running for a while (~17h in the issue's repro).

### Changes
- Skip the per-stage `_abort_on_running_timeout` when `pp_size > 1`.
- Add `SchedulerPPMixin._pp_check_and_sync_running_timeout`, called from `event_loop_pp` after `recv_requests`. Only the first PP stage detects timed-out requests (it owns the request lifecycle; `forward_entry_time` is per-stage and does not match across stages), builds an `AbortReq` carrying the timeout message and HTTP 503, applies it locally via `abort_request`, and appends it to `recv_reqs` so `event_loop_pp` forwards it to every subsequent stage through the normal `process_input_requests` path.
- Extend `abort_request` to scan every `running_mbs` slot (plus `cur_batch`) in PP mode so the `AbortReq` applies on every stage regardless of which slot holds the copy, and propagate `abort_message` / `abort_status_code` into `FINISH_ABORT` so the client-visible error matches the single-stage behavior.
- Add optional `abort_status_code` field to `AbortReq`.

## Test plan

- [ ] Reproduce the original CP+PP scenario from #25887 (GLM-5.1-FP8, `--tp 8 --pp-size 2 --attn-cp-size 8 --enable-nsa-prefill-context-parallel`), set a short `SGLANG_REQ_RUNNING_TIMEOUT`, confirm the timed-out request is aborted on every PP stage simultaneously and no `tensor size mismatch` RuntimeError is raised.
- [ ] Confirm the client still receives a 503 with `"Request running timeout reached."` (matching single-stage behavior).
- [ ] Confirm non-PP path is unaffected (`_abort_on_running_timeout` still runs when `pp_size == 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27930136664](https://github.com/sgl-project/sglang/actions/runs/27930136664)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27930136502](https://github.com/sgl-project/sglang/actions/runs/27930136502)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->