### PR TITLE
[Lint] Fix black formatting of DeepSeek-R1-MXFP4 MI35x tests

### DIFF
--- a/test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_tp2_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_tp2_mi35x.py
@@ -112,7 +112,9 @@ def run_gsm8k_benchmark(
 class TestDeepSeekR1MXFP4TP2MI35x(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model = os.environ.get("DEEPSEEK_R1_MXFP4_MODEL_PATH", "amd/DeepSeek-R1-MXFP4-Preview")
+        cls.model = os.environ.get(
+            "DEEPSEEK_R1_MXFP4_MODEL_PATH", "amd/DeepSeek-R1-MXFP4-Preview"
+        )
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.num_questions = int(os.environ.get("GSM8K_NUM_QUESTIONS", "1319"))
 

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_tp4_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_tp4_mi35x.py
@@ -111,7 +111,9 @@ def run_gsm8k_benchmark(
 class TestDeepSeekR1MXFP4TP4MI35x(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model = os.environ.get("DEEPSEEK_R1_MXFP4_MODEL_PATH", "amd/DeepSeek-R1-MXFP4-Preview")
+        cls.model = os.environ.get(
+            "DEEPSEEK_R1_MXFP4_MODEL_PATH", "amd/DeepSeek-R1-MXFP4-Preview"
+        )
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.num_questions = int(os.environ.get("GSM8K_NUM_QUESTIONS", "1319"))
 


### PR DESCRIPTION
## Problem

The `Lint` workflow is red on `main`: [run 27930042667](https://github.com/sgl-project/sglang/actions/runs/27930042667) (triggered by #27243) fails the `black-jupyter` pre-commit hook with:

```
reformatted test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_tp2_mi35x.py
reformatted test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_tp4_mi35x.py
pre-commit hook(s) made changes.
```

Because `lint.yml` runs `pre-commit run --all-files`, a single unformatted file on `main` turns the job red on **every** push and cascades to every PR branching off `main` (fast-fails the whole `pr-test` suite).

## Root cause

PR #27243 inlined the `get_model_path()` helper into a single-line call:

```python
cls.model = os.environ.get("DEEPSEEK_R1_MXFP4_MODEL_PATH", "amd/DeepSeek-R1-MXFP4-Preview")
```

With 8-space class-method indentation this exceeds black's default 88-char line width, so `black-jupyter` (black 26.1.0, pinned in `.pre-commit-config.yaml`) wants it wrapped. `isort`/`ruff` don't enforce line length, so only `black-jupyter` catches it.

(Note: PR #27243's own lint run was already red — run 27668777918 — but the merge went through anyway, which is how the break reached `main`.)

## Fix

Reformat the two affected files with black 26.1.0:

```python
cls.model = os.environ.get(
    "DEEPSEEK_R1_MXFP4_MODEL_PATH", "amd/DeepSeek-R1-MXFP4-Preview"
)
```

Pure formatting, no semantic change.

## Verification

- `pre-commit run --files <the two files>` → all hooks Passed (incl. `black-jupyter`, `isort`, `ruff`, `codespell`, `validate registered test CI registries`)
- No runtime / forward / kernel / quant / attention code touched (test-file formatting only), so no e2e needed.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27930958570](https://github.com/sgl-project/sglang/actions/runs/27930958570)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #27932920411](https://github.com/sgl-project/sglang/actions/runs/27932920411)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->