### PR TITLE
[DSV4][Perf] Use native DeepGEMM next-n layout on SM100

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -35,6 +35,7 @@ from sglang.srt.layers.attention.dsv4.metadata import (
     PagedIndexerMetadata,
     copy_metadata,
     maybe_copy_inplace,
+    use_deep_gemm_fp8_indexer,
 )
 from sglang.srt.layers.attention.dsv4.metadata_kernel import (
     init_compression_metadata as _init_compression_metadata_triton,
@@ -51,7 +52,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.utils import ceil_align, is_xpu
-from sglang.srt.utils.common import is_sm120_supported
+from sglang.srt.utils.common import is_sm100_supported, is_sm120_supported
 
 if TYPE_CHECKING:
     from sgl_kernel.flash_mla import FlashMLASchedMeta
@@ -549,12 +550,31 @@ class DeepseekV4AttnBackend(
         core_attn_metadata: DSV4AttnMetadata,
         *,
         use_prefill_cuda_graph: bool = False,
+        native_next_n: Optional[int] = None,
     ):
+        c4_seq_lens_native = None
+        c4_page_table_native = None
+        use_native_deep_gemm_indexer = (
+            native_next_n is not None
+            and native_next_n >= 2
+            and is_sm100_supported()
+            and (self.enable_deepseek_v4_fp4_indexer or use_deep_gemm_fp8_indexer())
+        )
+        if use_native_deep_gemm_indexer:
+            c4_seq_lens = core_attn_metadata.c4_topk_lengths_raw
+            assert c4_seq_lens is not None
+            assert c4_seq_lens.numel() % native_next_n == 0
+            c4_seq_lens_native = c4_seq_lens.view(-1, native_next_n).contiguous()
+            c4_page_table = core_attn_metadata.page_table
+            assert c4_page_table.shape[0] % native_next_n == 0
+            c4_page_table_native = c4_page_table[::native_next_n].contiguous()
         return PagedIndexerMetadata(
             page_size=self.page_size,
             page_table=core_attn_metadata.page_table,
             c4_seq_lens=core_attn_metadata.c4_topk_lengths_raw,
             use_prefill_cuda_graph=use_prefill_cuda_graph,
+            c4_seq_lens_native=c4_seq_lens_native,
+            c4_page_table_native=c4_page_table_native,
         )
 
     def init_forward_metadata_decode(
@@ -615,6 +635,7 @@ class DeepseekV4AttnBackend(
         extend_start_loc: Optional[torch.Tensor] = None,
         need_compress: bool = True,
         use_prefill_cuda_graph: bool = False,
+        indexer_native_next_n: Optional[int] = None,
         online_c128_state_slot_offset: int = 0,
     ) -> DSV4Metadata:
         seq_lens_casual, req_pool_indices_repeated = self.expand_prefill_casually(
@@ -640,6 +661,7 @@ class DeepseekV4AttnBackend(
             self.init_forward_metadata_indexer(
                 core_attn_metadata,
                 use_prefill_cuda_graph=use_prefill_cuda_graph,
+                native_next_n=indexer_native_next_n,
             )
             if need_compress
             else None
@@ -773,6 +795,7 @@ class DeepseekV4AttnBackend(
             extend_start_loc=None,
             need_compress=True,
             use_prefill_cuda_graph=use_prefill_cuda_graph,
+            indexer_native_next_n=self.speculative_num_draft_tokens,
             online_c128_state_slot_offset=online_c128_state_slot_offset,
         )
 
@@ -803,7 +826,9 @@ class DeepseekV4AttnBackend(
             out_loc=out_cache_loc,
             need_compress=True,
         )
-        indexer_metadata = self.init_forward_metadata_indexer(core_attn_metadata)
+        indexer_metadata = self.init_forward_metadata_indexer(
+            core_attn_metadata, native_next_n=num_draft_tokens
+        )
         create = functools.partial(
             create_paged_compressor_data,
             is_prefill=True,

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -20,6 +20,7 @@ from sglang.srt.layers.attention.dsv4.compressor import Compressor
 from sglang.srt.layers.attention.dsv4.metadata import (
     NonPagedIndexerPlan,
     PagedIndexerMetadata,
+    use_deep_gemm_fp8_indexer,
 )
 from sglang.srt.layers.dp_attention import get_attention_cp_size
 from sglang.srt.layers.linear import ReplicatedLinear
@@ -644,14 +645,36 @@ class C4IndexerBackendMixin:
 
         use_fp4_indexer = c4_indexer.use_fp4_indexer
 
+        query_rows = q_indexer[0].shape[0] if use_fp4_indexer else q_indexer.shape[0]
+        c4_seq_lens_native = getattr(indexer_metadata, "c4_seq_lens_native", None)
+        use_native_deep_gemm_indexer = (
+            (use_fp4_indexer or use_deep_gemm_fp8_indexer())
+            and c4_seq_lens_native is not None
+            and c4_seq_lens_native.dim() == 2
+            and query_rows == c4_seq_lens_native.numel()
+        )
+
         if use_fp4_indexer:
             q_fp4, q_sf = q_indexer
             assert len(q_fp4.shape) == 3
             assert len(q_sf.shape) == 2
-            q = (q_fp4.unsqueeze(1), q_sf.unsqueeze(1))
+            if use_native_deep_gemm_indexer:
+                batch_size, next_n = c4_seq_lens_native.shape
+                q = (
+                    q_fp4.view(batch_size, next_n, q_fp4.shape[1], q_fp4.shape[2]),
+                    q_sf.view(batch_size, next_n, q_sf.shape[1]),
+                )
+            else:
+                q = (q_fp4.unsqueeze(1), q_sf.unsqueeze(1))
         else:
             assert len(q_indexer.shape) == 3
-            q = q_indexer.unsqueeze(1)
+            if use_native_deep_gemm_indexer:
+                batch_size, next_n = c4_seq_lens_native.shape
+                q = q_indexer.view(
+                    batch_size, next_n, q_indexer.shape[1], q_indexer.shape[2]
+                )
+            else:
+                q = q_indexer.unsqueeze(1)
 
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
@@ -674,8 +697,6 @@ class C4IndexerBackendMixin:
         else:
             from deep_gemm import fp8_paged_mqa_logits as fn
 
-        query_rows = q_indexer[0].shape[0] if use_fp4_indexer else q_indexer.shape[0]
-
         def match_num_queries(tensor: torch.Tensor, value: int) -> torch.Tensor:
             if tensor.shape[0] == query_rows:
                 return tensor
@@ -687,6 +708,17 @@ class C4IndexerBackendMixin:
         c4_seq_lens = match_num_queries(indexer_metadata.c4_seq_lens, value=1)
         _c4sl = c4_seq_lens
         page_table = match_num_queries(indexer_metadata.page_table, value=0)
+        logits_page_table = page_table
+        if use_native_deep_gemm_indexer:
+            assert c4_seq_lens_native is not None
+            next_n = c4_seq_lens_native.shape[1]
+            _c4sl = c4_seq_lens_native
+            page_table_native = getattr(indexer_metadata, "c4_page_table_native", None)
+            logits_page_table = (
+                page_table_native
+                if page_table_native is not None
+                else page_table[::next_n].contiguous()
+            )
         c4_sparse_page_indices = match_num_queries(
             core_metadata.c4_sparse_page_indices, value=-1
         )
@@ -696,6 +728,18 @@ class C4IndexerBackendMixin:
         _use_aiter = envs.SGLANG_OPT_USE_AITER_INDEXER.get() and not use_fp4_indexer
         if _c4sl.dim() == 1 and not _use_tilelang and not _use_aiter:
             _c4sl = _c4sl.unsqueeze(-1)
+        if use_native_deep_gemm_indexer:
+            batch_size, next_n = _c4sl.shape
+            assert logits_page_table.shape[0] == batch_size
+            assert page_table.shape[0] == batch_size * next_n
+            assert weights.shape[0] == batch_size * next_n
+            if use_fp4_indexer:
+                assert isinstance(q, tuple)
+                assert q[0].shape[:2] == (batch_size, next_n)
+                assert q[1].shape[:2] == (batch_size, next_n)
+            else:
+                assert isinstance(q, torch.Tensor)
+                assert q.shape[:2] == (batch_size, next_n)
         nonpaged_plan = self._get_nonpaged_indexer_plan(
             c4_indexer=c4_indexer,
             forward_batch=forward_batch,
@@ -727,7 +771,7 @@ class C4IndexerBackendMixin:
                 c4_indexer_kv_cache,
                 weights,
                 _c4sl,
-                page_table,
+                logits_page_table,
                 indexer_metadata.deep_gemm_metadata,
                 indexer_metadata.max_c4_seq_len,
                 False,

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -457,12 +457,7 @@ class C4IndexerBackendMixin:
             or indexer_metadata.use_prefill_cuda_graph
         ):
             return False
-        if (
-            c4_indexer.use_fp4_indexer
-            or envs.SGLANG_OPT_USE_TILELANG_INDEXER.get()
-            or envs.SGLANG_OPT_USE_AITER_INDEXER.get()
-            or envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
-        ):
+        if c4_indexer.use_fp4_indexer or not use_deep_gemm_fp8_indexer():
             return False
         if (
             get_attention_cp_size() != 1
@@ -646,7 +641,7 @@ class C4IndexerBackendMixin:
         use_fp4_indexer = c4_indexer.use_fp4_indexer
 
         query_rows = q_indexer[0].shape[0] if use_fp4_indexer else q_indexer.shape[0]
-        c4_seq_lens_native = getattr(indexer_metadata, "c4_seq_lens_native", None)
+        c4_seq_lens_native = indexer_metadata.c4_seq_lens_native
         use_native_deep_gemm_indexer = (
             (use_fp4_indexer or use_deep_gemm_fp8_indexer())
             and c4_seq_lens_native is not None
@@ -713,7 +708,7 @@ class C4IndexerBackendMixin:
             assert c4_seq_lens_native is not None
             next_n = c4_seq_lens_native.shape[1]
             _c4sl = c4_seq_lens_native
-            page_table_native = getattr(indexer_metadata, "c4_page_table_native", None)
+            page_table_native = indexer_metadata.c4_page_table_native
             logits_page_table = (
                 page_table_native
                 if page_table_native is not None

--- a/python/sglang/srt/layers/attention/dsv4/metadata.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata.py
@@ -13,6 +13,14 @@ if TYPE_CHECKING:
     pass
 
 
+def use_deep_gemm_fp8_indexer() -> bool:
+    return not (
+        envs.SGLANG_OPT_USE_TILELANG_INDEXER.get()
+        or envs.SGLANG_OPT_USE_AITER_INDEXER.get()
+        or envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
+    )
+
+
 """
 Some comments on the common terms used in DeepSeekV4Backend:
 
@@ -113,6 +121,8 @@ class PagedIndexerMetadata:
     page_table: torch.Tensor
     c4_seq_lens: torch.Tensor
     use_prefill_cuda_graph: bool = False
+    c4_seq_lens_native: Optional[torch.Tensor] = None
+    c4_page_table_native: Optional[torch.Tensor] = None
     deep_gemm_metadata: Any = field(init=False, repr=False)
     topk_metadata: torch.Tensor = field(init=False, repr=False)
     nonpaged_plan: Optional[NonPagedIndexerPlan] = field(
@@ -120,24 +130,28 @@ class PagedIndexerMetadata:
     )
 
     def __post_init__(self):
-        if (
-            envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
-            or envs.SGLANG_OPT_USE_AITER_INDEXER.get()
-        ):
+        if not use_deep_gemm_fp8_indexer():
             self.deep_gemm_metadata = None
         else:
             import deep_gemm
 
-            use_jit_indexer = (
+            schedule_c4_seq_lens = (
+                self.c4_seq_lens_native
+                if self.c4_seq_lens_native is not None
+                else self.c4_seq_lens
+            )
+            # The local SGLang JIT metadata kernel is flat-only; native
+            # DeepGEMM next-n scheduling needs the 2D context-lens contract.
+            use_jit_indexer = self.c4_seq_lens_native is None and (
                 envs.SGLANG_OPT_USE_JIT_INDEXER_METADATA.get()
-                or self.c4_seq_lens.numel() > _LARGE_INDEXER_QUERY_THRESHOLD
+                or schedule_c4_seq_lens.numel() > _LARGE_INDEXER_QUERY_THRESHOLD
             )
             if use_jit_indexer:
                 from sglang.jit_kernel.dsv4 import get_paged_mqa_logits_metadata
             else:
                 from deep_gemm import get_paged_mqa_logits_metadata
 
-            _c4 = self.c4_seq_lens.to(torch.int32)
+            _c4 = schedule_c4_seq_lens.to(torch.int32)
             if _c4.dim() == 1:
                 _c4 = _c4.unsqueeze(-1)
             self.deep_gemm_metadata = get_paged_mqa_logits_metadata(
@@ -171,10 +185,23 @@ class PagedIndexerMetadata:
 
     def copy_(self, other: PagedIndexerMetadata):
         if is_hip():
-            copy_fields = ["page_table", "c4_seq_lens"]
+            # HIP does not use the native DeepGEMM indexer path, but
+            # copy_metadata requires every dataclass field to be accounted for.
+            copy_fields = [
+                "page_table",
+                "c4_seq_lens",
+                "c4_seq_lens_native",
+                "c4_page_table_native",
+            ]
             assign_fields = ["deep_gemm_metadata", "nonpaged_plan"]
         else:
-            copy_fields = ["page_table", "c4_seq_lens", "deep_gemm_metadata"]
+            copy_fields = [
+                "page_table",
+                "c4_seq_lens",
+                "c4_seq_lens_native",
+                "c4_page_table_native",
+                "deep_gemm_metadata",
+            ]
             assign_fields = ["nonpaged_plan"]
         copy_fields += ["topk_metadata"]
         copy_metadata(

--- a/python/sglang/srt/layers/attention/dsv4/metadata.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata.py
@@ -195,6 +195,8 @@ class PagedIndexerMetadata:
             ]
             assign_fields = ["deep_gemm_metadata", "nonpaged_plan"]
         else:
+            # c4_seq_lens_native may alias c4_seq_lens storage; copy_metadata
+            # still requires every dataclass field to be accounted for.
             copy_fields = [
                 "page_table",
                 "c4_seq_lens",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5907,6 +5907,16 @@ class ServerArgs:
                 "--enable-deepseek-v4-fp4-indexer requires SM100 GPUs with "
                 "DeepGEMM FP4 indexer support."
             )
+        if self.enable_deepseek_v4_fp4_indexer and (
+            envs.SGLANG_OPT_USE_TILELANG_INDEXER.get()
+            or envs.SGLANG_OPT_USE_AITER_INDEXER.get()
+            or envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
+        ):
+            raise ValueError(
+                "--enable-deepseek-v4-fp4-indexer requires the DeepGEMM indexer "
+                "path and cannot be combined with FP8 TileLang, AITER, or torch "
+                "paged MQA logits fallback envs."
+            )
         # FP8 W_o GEMM requires Blackwell (sm100+). Auto-disable on Hopper.
         if is_cuda() and envs.SGLANG_OPT_FP8_WO_A_GEMM.get() and get_device_sm() < 100:
             if envs.SGLANG_OPT_FP8_WO_A_GEMM.is_set():

--- a/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
@@ -7,7 +7,10 @@ import torch
 
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsv4.indexer import FP8_DTYPE, C4IndexerBackendMixin
-from sglang.srt.layers.attention.dsv4.metadata import NonPagedIndexerPlan
+from sglang.srt.layers.attention.dsv4.metadata import (
+    NonPagedIndexerPlan,
+    PagedIndexerMetadata,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -258,6 +261,88 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         torch.testing.assert_close(call.args[3], plan.ks)
         torch.testing.assert_close(call.args[4], plan.ke)
         self.assertEqual(call.kwargs, {"clean_logits": False, "max_seqlen_k": 128})
+
+    def test_native_nextn_paged_dispatch_keeps_topk_flat(self):
+        batch_size = 2
+        next_n = 4
+        query_rows = batch_size * next_n
+        num_heads = 2
+        head_dim = 128
+        page_table = torch.arange(query_rows * 3, dtype=torch.int32).view(query_rows, 3)
+        page_table_native = page_table[::next_n].contiguous()
+        c4_seq_lens = torch.arange(10, 10 + query_rows, dtype=torch.int32)
+        c4_seq_lens_native = c4_seq_lens.view(batch_size, next_n)
+
+        indexer_metadata = object.__new__(PagedIndexerMetadata)
+        indexer_metadata.page_size = 256
+        indexer_metadata.page_table = page_table
+        indexer_metadata.c4_seq_lens = c4_seq_lens
+        indexer_metadata.use_prefill_cuda_graph = False
+        indexer_metadata.c4_seq_lens_native = c4_seq_lens_native
+        indexer_metadata.c4_page_table_native = page_table_native
+        indexer_metadata.deep_gemm_metadata = torch.tensor([], dtype=torch.int32)
+        indexer_metadata.topk_metadata = torch.empty((0,))
+        indexer_metadata.nonpaged_plan = None
+
+        c4_sparse_page_indices = torch.full((query_rows, 512), -1, dtype=torch.int32)
+        core_metadata = SimpleNamespace(
+            positions=torch.arange(query_rows, dtype=torch.int32),
+            page_table=page_table,
+            c4_sparse_page_indices=c4_sparse_page_indices,
+            c4_sparse_raw_indices=None,
+        )
+        backend = SimpleNamespace(
+            token_to_kv_pool=MagicMock(),
+            forward_metadata=SimpleNamespace(
+                indexer_metadata=indexer_metadata,
+                core_metadata=core_metadata,
+            ),
+            debug_use_external_c4_sparse_indices=False,
+            hisparse_coordinator=None,
+            _forward_prepare_normal=MagicMock(
+                return_value=(
+                    torch.zeros((query_rows, num_heads, head_dim), dtype=torch.float32),
+                    torch.ones((query_rows, num_heads, 1), dtype=torch.float32),
+                )
+            ),
+            _get_nonpaged_indexer_plan=MagicMock(return_value=None),
+        )
+        backend.token_to_kv_pool.get_index_k_with_scale_buffer.return_value = (
+            torch.zeros((5, 64 * 132), dtype=torch.uint8)
+        )
+        c4_indexer = SimpleNamespace(use_fp4_indexer=False, layer_id=17)
+        forward_batch = SimpleNamespace(forward_mode=ForwardMode.EXTEND)
+        logits = torch.zeros((query_rows, 32), dtype=torch.float32)
+        deep_gemm = SimpleNamespace(fp8_paged_mqa_logits=MagicMock(return_value=logits))
+
+        with (
+            patch.dict(sys.modules, {"deep_gemm": deep_gemm}),
+            patch(f"{_INDEXER}.topk_transform_512") as topk_transform,
+            patch(f"{_INDEXER}.get_global_indexer_capturer", return_value=None),
+            envs.SGLANG_OPT_USE_TILELANG_INDEXER.override(False),
+            envs.SGLANG_OPT_USE_AITER_INDEXER.override(False),
+            envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.override(False),
+            envs.SGLANG_TOPK_TRANSFORM_512_TORCH.override(False),
+            envs.SGLANG_OPT_USE_TOPK_V2.override(False),
+        ):
+            C4IndexerBackendMixin.forward_c4_indexer(
+                backend,
+                x=torch.empty((query_rows, 1)),
+                q_lora=torch.empty((query_rows, 1)),
+                c4_indexer=c4_indexer,
+                forward_batch=forward_batch,
+            )
+
+        call = deep_gemm.fp8_paged_mqa_logits.call_args
+        self.assertEqual(call.args[0].shape, (batch_size, next_n, num_heads, head_dim))
+        torch.testing.assert_close(call.args[2], torch.ones((query_rows, num_heads)))
+        self.assertIs(call.args[3], c4_seq_lens_native)
+        self.assertIs(call.args[4], page_table_native)
+
+        topk_call = topk_transform.call_args
+        self.assertIs(topk_call.args[1], c4_seq_lens)
+        self.assertIs(topk_call.args[2], page_table)
+        self.assertIs(topk_call.args[3], c4_sparse_page_indices)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

DeepGEMM's SM100 paged MQA logits kernels can consume the native `next_n` dimension directly. For DSV4 speculative target verify, SGLang already supported `next_n=4`, but the DeepGEMM indexer call was still flattened from `(B, next_n)` into `(B * next_n, 1)`. This PR keeps the target verify layout as `(B, next_n)` for the DeepGEMM FP8 and FP4 indexer paths on SM100-family GPUs.

| Version | DeepGEMM input layout |
| --- | --- |
| Before | `(B * next_n, 1, ...)` |
| After | `(B, next_n, ...)` |

## Modifications

- Add DSV4 C4 indexer metadata for the native speculative target verify DeepGEMM path on SM100-family GPUs.
- Reshape FP8 and FP4 indexer queries from `(B * next_n, ...)` back to `(B, next_n, ...)` before calling DeepGEMM when `next_n >= 2`.
- Build DeepGEMM schedule metadata from the matching `(B, next_n)` C4 context lengths for this path.
- Keep the flattened page table for the top-k transform, and pass the matching native page table to the DeepGEMM logits call.
- Keep the existing flattened path for non-SM100-family GPUs and for FP8 TileLang/AITER/torch fallback indexers.

## Accuracy Tests

GSM8K:

| Indexer | Before | After |
| --- | ---: | ---: |
| FP8 | 96.51% | 96.97% |
| FP4 | 96.36% | 96.66% |

## Speed Tests and Profiling

Benchmark setup:

| Setting | Value |
| --- | --- |
| Model | `deepseek-ai/DeepSeek-V4-Flash` |
| Batch size | 32 |
| Input / output len | 8192 / 1024 |
| Speculative config | steps=3, eagle top-k=1, draft tokens=4 |

### Profiler trace

FP8 before:

<img width="1631" height="747" alt="Screenshot 2026-06-12 193313" src="https://github.com/user-attachments/assets/a44eb439-a712-4f23-8364-687097ad730e" />

FP8 after:

<img width="1632" height="748" alt="Screenshot 2026-06-12 192549" src="https://github.com/user-attachments/assets/898d9c37-d537-48db-8477-8db9d5c95145" />

FP4 before:

<img width="1632" height="747" alt="Screenshot 2026-06-12 193058" src="https://github.com/user-attachments/assets/980c9cd2-f0ca-42d9-9cdd-bc3abc423005" />

FP4 after:

<img width="1632" height="747" alt="Screenshot 2026-06-12 192740" src="https://github.com/user-attachments/assets/9240ea4c-5518-4338-be87-5641cfaf1bd4" />

The FP8 and FP4 kernel names change from `<1u, ...>` to `<4u, ...>`, confirming that DeepGEMM sees `next_n=4` in the patched path.

### E2E numbers

| Indexer | Before out tok/s | After out tok/s | Diff | Accept len |
| --- | ---: | ---: | ---: | ---: |
| FP8 | 2902.38 | 3036.07 | +4.6% | 2.80 -> 2.78 |
| FP4 | 2934.26 | 3073.79 | +4.8% | 2.77 -> 2.77 |

































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28912115071](https://github.com/sgl-project/sglang/actions/runs/28912115071)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #28912114993](https://github.com/sgl-project/sglang/actions/runs/28912114993)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->