### PR TITLE
[BugFix] Support DSA draft indexer restore in HiCache

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -251,6 +251,7 @@ class HiCacheController:
         self.has_draft = False
         self.mem_pool_device_draft = None
         self.mem_pool_host_draft = None
+        self.mem_pool_host_draft_indexer = None
         self.draft_page_get_func = None
         self.draft_page_set_func = None
 
@@ -698,13 +699,7 @@ class HiCacheController:
             self.mem_pool_host.backup_from_device_all_layer(
                 self.mem_pool_device, host_indices, device_indices, self.io_backend
             )
-            if self.has_draft:
-                self.mem_pool_host_draft.backup_from_device_all_layer(
-                    self.mem_pool_device_draft,
-                    host_indices,
-                    device_indices,
-                    self.io_backend,
-                )
+            self._backup_draft_from_device_all_layer(host_indices, device_indices)
             finish_event.record()
             # NOTE: We must save the host indices and device indices here,
             # this is because we need to guarantee that these tensors are
@@ -778,14 +773,7 @@ class HiCacheController:
                     i,
                     self.io_backend,
                 )
-                if self.has_draft and i < self.mem_pool_host_draft.layer_num:
-                    self.mem_pool_host_draft.load_to_device_per_layer(
-                        self.mem_pool_device_draft,
-                        host_indices,
-                        device_indices,
-                        i,
-                        self.io_backend,
-                    )
+                self._load_draft_to_device_per_layer(host_indices, device_indices, i)
                 producer_event.complete(i)
             # NOTE: We must save the host indices and device indices here,
             # this is because we need to guarantee that these tensors are
@@ -815,15 +803,68 @@ class HiCacheController:
         self.mem_pool_host.free(host_indices)
         return len(host_indices)
 
-    def set_draft_kv_pool(self, draft_device_pool, draft_host_pool) -> None:
+    def _backup_draft_from_device_all_layer(
+        self, host_indices: torch.Tensor, device_indices: torch.Tensor
+    ) -> None:
+        if not self.has_draft or host_indices.numel() == 0:
+            return
+
+        self.mem_pool_host_draft.backup_from_device_all_layer(
+            self.mem_pool_device_draft,
+            host_indices,
+            device_indices,
+            self.io_backend,
+        )
+        if self.mem_pool_host_draft_indexer is not None:
+            self.mem_pool_host_draft_indexer.backup_from_device_all_layer(
+                self.mem_pool_device_draft,
+                host_indices,
+                device_indices,
+                self.io_backend,
+            )
+
+    def _load_draft_to_device_per_layer(
+        self,
+        host_indices: torch.Tensor,
+        device_indices: torch.Tensor,
+        layer_id: int,
+    ) -> None:
+        if not self.has_draft or host_indices.numel() == 0:
+            return
+
+        if layer_id < self.mem_pool_host_draft.layer_num:
+            self.mem_pool_host_draft.load_to_device_per_layer(
+                self.mem_pool_device_draft,
+                host_indices,
+                device_indices,
+                layer_id,
+                self.io_backend,
+            )
+        if (
+            self.mem_pool_host_draft_indexer is not None
+            and layer_id < self.mem_pool_host_draft_indexer.layer_num
+        ):
+            self.mem_pool_host_draft_indexer.load_to_device_per_layer(
+                self.mem_pool_device_draft,
+                host_indices,
+                device_indices,
+                layer_id,
+                self.io_backend,
+            )
+
+    def set_draft_kv_pool(
+        self, draft_device_pool, draft_host_pool, draft_indexer_host_pool=None
+    ) -> None:
         """Register draft KV pools so L2/L3 ops piggyback draft transfers."""
         self.has_draft = True
         self.mem_pool_device_draft = draft_device_pool
         self.mem_pool_host_draft = draft_host_pool
+        self.mem_pool_host_draft_indexer = draft_indexer_host_pool
         logger.info(
-            "HiCache draft KV registered: %s (host %d slots)",
+            "HiCache draft KV registered: %s (host %d slots, dsa_indexer=%s)",
             type(draft_device_pool).__name__,
             draft_host_pool.size,
+            draft_indexer_host_pool is not None,
         )
 
         # If storage is already attached, wire up the draft I/O path now.
@@ -850,6 +891,10 @@ class HiCacheController:
             self.storage_backend.register_mem_host_pool_v2(
                 self.mem_pool_host_draft, PoolName.DRAFT
             )
+            if self.mem_pool_host_draft_indexer is not None:
+                self.storage_backend.register_mem_host_pool_v2(
+                    self.mem_pool_host_draft_indexer, PoolName.DRAFT_INDEXER
+                )
             self.draft_page_get_func = self._draft_page_get_v2
             self.draft_page_set_func = self._draft_page_set_v2
             return
@@ -1119,49 +1164,60 @@ class HiCacheController:
 
     def _draft_page_set_v2(self, hash_values, host_indices) -> None:
         self.storage_backend.batch_set_v2(
-            [
-                PoolTransfer(
-                    name=PoolName.DRAFT,
-                    host_indices=host_indices,
-                    keys=list(hash_values),
-                )
-            ]
+            self._draft_pool_transfers(hash_values, host_indices)
         )
 
     def _draft_page_get_v2(self, hash_values, host_indices) -> None:
         self.storage_backend.batch_get_v2(
-            [
+            self._draft_pool_transfers(hash_values, host_indices)
+        )
+
+    def _draft_pool_transfers(self, hash_values, host_indices) -> List[PoolTransfer]:
+        transfers = [
+            PoolTransfer(
+                name=PoolName.DRAFT,
+                host_indices=host_indices,
+                keys=list(hash_values),
+            )
+        ]
+        if self.mem_pool_host_draft_indexer is not None:
+            transfers.append(
                 PoolTransfer(
-                    name=PoolName.DRAFT,
+                    name=PoolName.DRAFT_INDEXER,
                     host_indices=host_indices,
                     keys=list(hash_values),
                 )
-            ]
-        )
+            )
+        return transfers
+
+    def _draft_generic_host_pools(self):
+        yield PoolName.DRAFT, self.mem_pool_host_draft
+        if self.mem_pool_host_draft_indexer is not None:
+            yield PoolName.DRAFT_INDEXER, self.mem_pool_host_draft_indexer
 
     def _draft_page_set_generic(self, hash_values, host_indices) -> None:
         # `{hash}.draft` mirrors HiCacheStorage._get_component_key's
         # `{key}.{pool_name}` convention so target/draft pages never collide.
-        draft_keys = [f"{h}.{PoolName.DRAFT}" for h in hash_values]
-        draft_data = [
-            self.mem_pool_host_draft.get_data_page(host_indices[i * self.page_size])
-            for i in range(len(draft_keys))
-        ]
-        self.storage_backend.batch_set(draft_keys, draft_data)
+        for pool_name, host_pool in self._draft_generic_host_pools():
+            draft_keys = [f"{h}.{pool_name}" for h in hash_values]
+            draft_data = [
+                host_pool.get_data_page(host_indices[i * self.page_size])
+                for i in range(len(draft_keys))
+            ]
+            self.storage_backend.batch_set(draft_keys, draft_data)
 
     def _draft_page_get_generic(self, hash_values, host_indices) -> None:
-        draft_keys = [f"{h}.{PoolName.DRAFT}" for h in hash_values]
-        draft_dummy = [
-            self.mem_pool_host_draft.get_dummy_flat_data_page() for _ in draft_keys
-        ]
-        draft_pages = self.storage_backend.batch_get(draft_keys, draft_dummy)
-        if draft_pages is None:
-            return
-        for i, p in enumerate(draft_pages):
-            if p is not None:
-                self.mem_pool_host_draft.set_from_flat_data_page(
-                    host_indices[i * self.page_size], p
-                )
+        for pool_name, host_pool in self._draft_generic_host_pools():
+            draft_keys = [f"{h}.{pool_name}" for h in hash_values]
+            draft_dummy = [host_pool.get_dummy_flat_data_page() for _ in draft_keys]
+            draft_pages = self.storage_backend.batch_get(draft_keys, draft_dummy)
+            if draft_pages is None:
+                continue
+            for i, p in enumerate(draft_pages):
+                if p is not None:
+                    host_pool.set_from_flat_data_page(
+                        host_indices[i * self.page_size], p
+                    )
 
     # Backup batch by batch
     def _page_backup(self, operation):

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -70,8 +70,9 @@ class PoolName(str, Enum):
     DEEPSEEK_V4_C4_INDEXER_STATE = "deepseek_v4_c4_indexer_state"
     DEEPSEEK_V4_C128_STATE = "deepseek_v4_c128_state"
 
-    # Draft KV pool
+    # Draft KV pools
     DRAFT = "draft"
+    DRAFT_INDEXER = "draft_indexer"
 
     def __str__(self) -> str:
         return self.value

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -420,13 +420,7 @@ class HybridCacheController(BaseHiCacheController):
                 self.io_backend,
                 pool_transfers=resolved_pool_transfers,
             )
-            if self.has_draft and host_indices.numel() > 0:
-                self.mem_pool_host_draft.backup_from_device_all_layer(
-                    self.mem_pool_device_draft,
-                    host_indices,
-                    device_indices,
-                    self.io_backend,
-                )
+            self._backup_draft_from_device_all_layer(host_indices, device_indices)
             finish_event.record()
             self._record_transfer_indices_on_stream(
                 self.write_stream,
@@ -501,18 +495,7 @@ class HybridCacheController(BaseHiCacheController):
                     self.io_backend,
                     pool_transfers=resolved_pool_transfers,
                 )
-                if (
-                    self.has_draft
-                    and host_indices.numel() > 0
-                    and i < self.mem_pool_host_draft.layer_num
-                ):
-                    self.mem_pool_host_draft.load_to_device_per_layer(
-                        self.mem_pool_device_draft,
-                        host_indices,
-                        device_indices,
-                        i,
-                        self.io_backend,
-                    )
+                self._load_draft_to_device_per_layer(host_indices, device_indices, i)
                 producer_event.complete(i)
             self._record_transfer_indices_on_stream(
                 self.load_stream,

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -84,11 +84,13 @@ def maybe_register_hicache_draft(
         return
 
     from sglang.srt.mem_cache.memory_pool import (
+        DSATokenToKVPool,
         HybridLinearKVPool,
         MHATokenToKVPool,
         MLATokenToKVPool,
     )
     from sglang.srt.mem_cache.memory_pool_host import (
+        DSAIndexerPoolHost,
         MLATokenToKVPoolHost,
         get_mha_host_pool_cls,
     )
@@ -106,7 +108,18 @@ def maybe_register_hicache_draft(
         page_size=page_size,
         layout=server_args.hicache_mem_layout,
     )
-    if isinstance(pool, MHATokenToKVPool):
+    draft_indexer_host_pool = None
+    if isinstance(pool, DSATokenToKVPool):
+        draft_host_pool = MLATokenToKVPoolHost(
+            pool, **kw, override_kv_cache_dim=pool.kv_cache_dim
+        )
+        draft_indexer_host_pool = DSAIndexerPoolHost(
+            pool,
+            draft_host_pool,
+            server_args.hicache_mem_layout,
+            allocator_type=server_args.hicache_storage_backend,
+        )
+    elif isinstance(pool, MHATokenToKVPool):
         draft_host_pool = get_mha_host_pool_cls(pool)(pool, **kw)
     elif isinstance(pool, MLATokenToKVPool):
         draft_host_pool = MLATokenToKVPoolHost(pool, **kw)
@@ -117,7 +130,9 @@ def maybe_register_hicache_draft(
         )
         return
 
-    tree_cache.cache_controller.set_draft_kv_pool(pool, draft_host_pool)
+    tree_cache.cache_controller.set_draft_kv_pool(
+        pool, draft_host_pool, draft_indexer_host_pool
+    )
 
 
 def build_kv_cache(

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -681,6 +681,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 ]
         elif pool_name in (
             PoolName.INDEXER,
+            PoolName.DRAFT_INDEXER,
             PoolName.DEEPSEEK_V4_C4,
             PoolName.DEEPSEEK_V4_C4_INDEXER,
             PoolName.DEEPSEEK_V4_C128,


### PR DESCRIPTION
## Motivation

DSA models such as `GLM5.1` maintain draft-side indexer state in addition to draft KV cache. When L3 HiCache is enabled and restored cache is hit, only restoring draft KV can leave the DSA draft indexer cache incomplete or stale.

This can reduce MTP acceptance rate after cache restore, **increasing TPOT and E2E latency**. (issue: https://github.com/sgl-project/sglang/issues/28895)

## Modifications

This PR adds HiCache restore support for DSA draft indexer cache.

  - Add `PoolName.DRAFT_INDEXER` for draft-side DSA indexer storage.
  - Create and register `DSAIndexerPoolHost` when the draft pool is `DSATokenToKVPool`.
  - Extend draft L2 backup / restore to include the draft indexer host pool.
  - Extend draft L3 backup / restore to include both `draft` and `draft_indexer` pools.
  - Add Mooncake v2 storage key support for `draft_indexer`.


## Tests

### Command

1. start mooncake server
```bash
# Mooncake env
export MOONCAKE_MASTER_IP=10.104.149.239
export MOONCAKE_MASTER=${MOONCAKE_MASTER_IP}:50051
export MOONCAKE_TE_META_DATA_SERVER=http://${MOONCAKE_MASTER_IP}:8080/metadata
export MOONCAKE_PROTOCOL=tcp
export MOONCAKE_DEVICE=""
export MOONCAKE_GLOBAL_SEGMENT_SIZE=64gb

# metadata server
python -m mooncake.http_metadata_server --port 8080

# master server
mooncake_master --port 50051
```

2. start sglang server (2 machines，16x H800)

```bash
sglang serve \
    --model-path /models/GLM-5.1-FP8 \
    --tp 16 \
    --kv-cache-dtype fp8_e4m3 \
    --reasoning-parser glm45 \
    --tool-call-parser glm47 \
    --speculative-algorithm EAGLE \
    --mem-fraction-static 0.8 \
    --cuda-graph-max-bs 8 \
    --nnodes 2 \
    --dist-init-addr ${master_ip}:5000 \
    --node-rank ${node_rank} \
    --enable-cache-report \
    --decode-log-interval 1 \
    --host 0.0.0.0 \
    --port 8000 \
    --page-size 64 \
    --log-level debug \
    --enable-hierarchical-cache \
    --hicache-ratio 2 \
    --hicache-write-policy write_through \
    --hicache-io-backend direct \
    --hicache-mem-layout page_first_direct \
    --hicache-storage-backend mooncake \
    --hicache-storage-prefetch-policy wait_complete
```

3. bench serving

```bash
python3 -m sglang.bench_serving \
    --base-url "http://127.0.0.1:8000" \
    --model /models/GLM-5.1-FP8 \
    --dataset-name random \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
    --backend sglang-oai-chat \
    --random-range-ratio 0.5 \
    --random-input-len 16000 \
    --random-output-len 256 \
    --max-concurrency 8 \
    --num-prompts 24
```

### Results

- first send requests to populate the L3 cache
- `flush_cache`, clear L1 and L2
- send same requests and compare results

**Before:**

|  Round   | Accept Length  | TTFT (ms)  | TPOT (ms)  | E2E (s) |
|  ----  | ----  | ----  | ----  | ----  |
| First  | 2.98 | 3655.67 | 107.62 | 31.1 |
| Second  | 1.75 | 2496.82 | 164.74 | 44.5 |

**After:**

|  Round   | Accept Length  | TTFT (ms)  | TPOT (ms)  | E2E (s) |
|  ----  | ----  | ----  | ----  | ----  |
| First  | 2.96 | 3521.77 | 108.70 | 31.2 |
| Second  | 2.96 | 2788.51 | 102.77 | 29.0 |



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27935946155](https://github.com/sgl-project/sglang/actions/runs/27935946155)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27935945959](https://github.com/sgl-project/sglang/actions/runs/27935945959)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->