### PR TITLE
[PP] Reuse DSA topk proxy send buffer to avoid memory leak in GLM 5.2

### DIFF
--- a/python/sglang/srt/models/deepseek_common/pp_proxy.py
+++ b/python/sglang/srt/models/deepseek_common/pp_proxy.py
@@ -1,0 +1,32 @@
+from typing import Optional
+
+import torch
+
+
+class PPProxyTopKBuffer:
+    __slots__ = ("buffer",)
+
+    def __init__(self):
+        self.buffer: Optional[torch.Tensor] = None
+
+    def copy(self, topk_indices: torch.Tensor) -> torch.Tensor:
+        if topk_indices.numel() == 0:
+            return topk_indices
+
+        buffer = self.buffer
+        if (
+            buffer is None
+            or buffer.numel() < topk_indices.numel()
+            or buffer.dtype != topk_indices.dtype
+            or buffer.device != topk_indices.device
+        ):
+            buffer = torch.empty(
+                topk_indices.numel(),
+                dtype=topk_indices.dtype,
+                device=topk_indices.device,
+            )
+            self.buffer = buffer
+
+        buffer_view = buffer[: topk_indices.numel()].view_as(topk_indices)
+        buffer_view.copy_(topk_indices)
+        return buffer_view

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -148,6 +148,7 @@ from sglang.srt.models.deepseek_common.attention_forward_methods import (
 from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
     DeepseekV2WeightLoaderMixin,
 )
+from sglang.srt.models.deepseek_common.pp_proxy import PPProxyTopKBuffer
 from sglang.srt.models.deepseek_common.utils import (
     _device_sm,
     _get_llama_4_scaling,
@@ -2265,6 +2266,7 @@ class DeepseekV2Model(nn.Module):
         self.vocab_size = config.vocab_size
         self.first_k_dense_replace = config.first_k_dense_replace
         self.pp_group = get_pp_group()
+        self.pp_proxy_topk_buffer = PPProxyTopKBuffer()
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         self.mla_enable_prefill_cp = (
             is_prefill_context_parallel_enabled() and not self.use_dsa
@@ -2541,6 +2543,8 @@ class DeepseekV2Model(nn.Module):
                     topk_indices = hidden_states.new_empty(
                         (0, get_dsa_index_topk(self.config)), dtype=torch.int32
                     )
+                else:
+                    topk_indices = self.pp_proxy_topk_buffer.copy(topk_indices)
                 proxy_tensors["topk_indices"] = topk_indices
             return PPProxyTensors(proxy_tensors)
         else:

--- a/test/registered/unit/models/test_deepseek_pp_proxy.py
+++ b/test/registered/unit/models/test_deepseek_pp_proxy.py
@@ -1,0 +1,56 @@
+import unittest
+
+import torch
+
+from sglang.srt.models.deepseek_common.pp_proxy import PPProxyTopKBuffer
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestPPProxyTopKBuffer(unittest.TestCase):
+    def test_copy_uses_distinct_reusable_storage(self):
+        buffer = PPProxyTopKBuffer()
+        source = torch.arange(6, dtype=torch.int32).view(2, 3)
+
+        first = buffer.copy(source)
+
+        self.assertTrue(torch.equal(first, source))
+        self.assertNotEqual(first.data_ptr(), source.data_ptr())
+        self.assertEqual(first.data_ptr(), buffer.buffer.data_ptr())
+
+        source.fill_(-1)
+        self.assertTrue(
+            torch.equal(first, torch.arange(6, dtype=torch.int32).view(2, 3))
+        )
+
+        second_source = torch.full((2, 3), 7, dtype=torch.int32)
+        second = buffer.copy(second_source)
+
+        self.assertEqual(second.data_ptr(), first.data_ptr())
+        self.assertTrue(torch.equal(second, second_source))
+
+    def test_copy_grows_buffer_when_needed(self):
+        buffer = PPProxyTopKBuffer()
+        small = buffer.copy(torch.ones((2, 3), dtype=torch.int32))
+        small_ptr = small.data_ptr()
+
+        large_source = torch.arange(12, dtype=torch.int32).view(3, 4)
+        large = buffer.copy(large_source)
+
+        self.assertNotEqual(large.data_ptr(), small_ptr)
+        self.assertGreaterEqual(buffer.buffer.numel(), large_source.numel())
+        self.assertTrue(torch.equal(large, large_source))
+
+    def test_empty_tensor_does_not_allocate_buffer(self):
+        buffer = PPProxyTopKBuffer()
+        empty = torch.empty((0, 2048), dtype=torch.int32)
+
+        copied = buffer.copy(empty)
+
+        self.assertIs(copied, empty)
+        self.assertIsNone(buffer.buffer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Related: #28902

`#28532` fixed the original GLM-5.2 PP crash by forwarding DSA `topk_indices` across PP stages. Deployments that already include `#28532` then exposed a new regression: with `pp-size=2`, `PP=0` steadily grows host memory while `PP=1` stays stable.

The regression comes from the new sender-side payload introduced by `#28532`:

- `DeepseekV2Model.forward()` now adds `topk_indices` into `PPProxyTensors` when the next stage starts on a skip-topk layer.
- `scheduler_pp_mixin.py` sends that proxy dict with `async_send=True`.
- `parallel_state.py::send_tensor_dict()` wraps each async payload as `P2PWork(work, tensor)`.
- `hidden_states` / `residual` did not surface this issue, but `topk_indices` is a fresh `int32` tensor produced per batch, so the sender path keeps feeding new storage into the async communication lifetime and `PP=0` RSS keeps climbing.

## Modifications

- Add a small `PPProxyTopKBuffer` helper that owns a grow-only reusable buffer for PP proxy `topk_indices` sends.
- Instantiate that helper in `DeepseekV2Model`.
- Before attaching non-empty `topk_indices` to the outgoing PP proxy, copy it into the reusable buffer and send the buffer view instead of the per-batch fresh storage.
- Keep the empty-tensor path unchanged.

Why this shape:

- It keeps PP send ordering and `async_send=True` unchanged.
- It avoids broad changes to generic `P2PWork` / `send_tensor_dict()` behavior.
- It scopes the fix to the regression introduced by the `#28532` topk handoff path.

## Accuracy Tests

Not run. This change is intended to be output-preserving because it only changes sender-side storage reuse for PP proxy transport; it does not change the logical contents of `topk_indices`.

## Speed Tests and Profiling

Not run. No material speed change is expected because the PP proxy already sends `topk_indices`; this only makes the sender-side storage reusable.

## Verification

- `PYTHONPATH=python python3 test/registered/unit/models/test_deepseek_pp_proxy.py`
- `python3 -m ruff check python/sglang/srt/models/deepseek_v2.py python/sglang/srt/models/deepseek_common/pp_proxy.py test/registered/unit/models/test_deepseek_pp_proxy.py`
- `pre-commit` hooks passed during commit creation

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27937861870](https://github.com/sgl-project/sglang/actions/runs/27937861870)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27937861761](https://github.com/sgl-project/sglang/actions/runs/27937861761)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
