### PR TITLE
Fix Kimi K2.6 compressed-tensors MoE w2 scale loading

### DIFF
--- a/test/registered/amd/accuracy/mi30x/test_kimi_k26_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_kimi_k26_eval_amd.py
@@ -53,7 +53,7 @@ class TestKimiK26EvalAMD(CustomTestCase):
             "aiter",
             "--trust-remote-code",
             "--model-loader-extra-config",
-            '{"enable_multithread_load": true}',
+            '{"enable_multithread_load": false}',
         ]
         env = os.environ.copy()
         env["SGLANG_USE_AITER"] = "1"

--- a/test/registered/amd/accuracy/mi35x/test_kimi_k26_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_kimi_k26_eval_mi35x.py
@@ -55,7 +55,7 @@ class TestKimiK26EvalMI35x(CustomTestCase):
             "aiter",
             "--trust-remote-code",
             "--model-loader-extra-config",
-            '{"enable_multithread_load": true}',
+            '{"enable_multithread_load": false}',
             "--watchdog-timeout",
             "1200",
         ]


### PR DESCRIPTION
## Summary
- Treat missing/false/static actorder as non-actorder in compressed-tensors WNA16 MoE.
- Avoid allocating/loading full TP-width `w2_weight_scale` for checkpoints whose w2 scales are already per-rank, such as Kimi-K2.6.
- Keep full w2 scale loading for real actorder/g_idx cases.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/sglang-pycache python3 -m py_compile python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py`
- pre-commit hooks from `git commit`

## CI
- MI35x Kimi-K2.6: https://github.com/sgl-project/sglang/actions/runs/27938672153



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28089355031](https://github.com/sgl-project/sglang/actions/runs/28089355031)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28089354818](https://github.com/sgl-project/sglang/actions/runs/28089354818)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->