### PR TITLE
[diffusion] CI: fix turbo_wan/flux invisible CI cases

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -938,13 +938,14 @@ class SamplingParams:
         )
         add_argument(
             "--image-path",
+            "--image-paths",
             type=str,
             nargs="+",
             help=(
                 "Path(s) to input image(s) for image-to-image / image-to-video "
-                "generation. For multiple images, pass them as space-separated "
-                "values, e.g.: "
-                '--image-path "img1.png" "img2.png"'
+                "generation. For multiple images, pass them space-separated "
+                "(alias: --image-paths), e.g.: "
+                '--image-paths "img1.png" "img2.png"'
             ),
         )
         add_argument(

--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -463,6 +463,11 @@ if not current_platform.is_hip():
             DiffusionServerArgs(
                 model_path="IPostYellow/TurboWan2.1-T2V-1.3B-Diffusers",
             ),
+            # Pin CI's shared T2V_PROMPT ("A curious raccoon") instead of relying on
+            # prompt=None / unconditional generation — the latter drifts as the
+            # pipeline evolves, which is why this (previously planner-invisible) case
+            # diverged from its stale sglang_generated GT.
+            T2V_sampling_params,
         )
     )
 # Skip all ModelOpt tests on AMD: FP8 requires torch._scaled_mm (HIPBLAS_STATUS_NOT_SUPPORTED

--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -463,10 +463,6 @@ if not current_platform.is_hip():
             DiffusionServerArgs(
                 model_path="IPostYellow/TurboWan2.1-T2V-1.3B-Diffusers",
             ),
-            # Pin CI's shared T2V_PROMPT ("A curious raccoon") instead of relying on
-            # prompt=None / unconditional generation — the latter drifts as the
-            # pipeline evolves, which is why this (previously planner-invisible) case
-            # diverged from its stale sglang_generated GT.
             T2V_sampling_params,
         )
     )

--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -463,6 +463,10 @@ if not current_platform.is_hip():
             DiffusionServerArgs(
                 model_path="IPostYellow/TurboWan2.1-T2V-1.3B-Diffusers",
             ),
+            # Pin CI's shared T2V_PROMPT ("A curious raccoon") instead of relying on
+            # prompt=None / unconditional generation — the latter drifts as the
+            # pipeline evolves, which is why this (previously planner-invisible) case
+            # diverged from its stale sglang_generated GT.
             T2V_sampling_params,
         )
     )

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "4f7f8dfbb8c6baae3fff1e5dc63c8c0ef9dcf744"
+SGL_TEST_FILES_CI_DATA_REVISION = "14a963c21b96bcc4bb3811be02076977e8f8439b"
 
 if current_platform.is_npu():
     SGL_TEST_FILES_CI_DATA_REVISION = "670d66a8a290b62c0c3c077b3e9b0f4a4d9a44e7"

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "66370f48f239c08c044ac47e6eb898a01be37519"
+SGL_TEST_FILES_CI_DATA_REVISION = "4f7f8dfbb8c6baae3fff1e5dc63c8c0ef9dcf744"
 
 if current_platform.is_npu():
     SGL_TEST_FILES_CI_DATA_REVISION = "670d66a8a290b62c0c3c077b3e9b0f4a4d9a44e7"

--- a/scripts/ci/utils/diffusion/diffusion_case_parser.py
+++ b/scripts/ci/utils/diffusion/diffusion_case_parser.py
@@ -102,10 +102,19 @@ class DiffusionTestCaseVisitor(ast.NodeVisitor):
             if case_id:
                 self.factory_case_ids[stmt.name] = case_id
 
-        for stmt in node.body:
-            if isinstance(stmt, ast.Expr):
-                self._process_expr(stmt.value)
+        self.generic_visit(node)
 
+    def visit_Expr(self, node: ast.Expr):
+        """Handle ``LIST.append(...)`` mutations at any nesting level.
+
+        Previously only module-top-level ``ast.Expr`` statements were scanned for
+        ``.append()`` calls, so cases registered under a platform guard such as
+        ``if not current_platform.is_hip(): ONE_GPU_CASES.append(...)`` (used by
+        ``hunyuan3d_shape_gen`` and ``turbo_wan2_1_t2v_1.3b``) were invisible to
+        the partition planner and therefore never scheduled in CI. Visiting every
+        ``Expr`` lets ``generic_visit`` reach appends inside ``if``/``else`` blocks.
+        """
+        self._process_expr(node.value)
         self.generic_visit(node)
 
     def visit_Assign(self, node: ast.Assign):

--- a/scripts/ci/utils/diffusion/diffusion_case_parser.py
+++ b/scripts/ci/utils/diffusion/diffusion_case_parser.py
@@ -102,19 +102,10 @@ class DiffusionTestCaseVisitor(ast.NodeVisitor):
             if case_id:
                 self.factory_case_ids[stmt.name] = case_id
 
-        self.generic_visit(node)
+        for stmt in node.body:
+            if isinstance(stmt, ast.Expr):
+                self._process_expr(stmt.value)
 
-    def visit_Expr(self, node: ast.Expr):
-        """Handle ``LIST.append(...)`` mutations at any nesting level.
-
-        Previously only module-top-level ``ast.Expr`` statements were scanned for
-        ``.append()`` calls, so cases registered under a platform guard such as
-        ``if not current_platform.is_hip(): ONE_GPU_CASES.append(...)`` (used by
-        ``hunyuan3d_shape_gen`` and ``turbo_wan2_1_t2v_1.3b``) were invisible to
-        the partition planner and therefore never scheduled in CI. Visiting every
-        ``Expr`` lets ``generic_visit`` reach appends inside ``if``/``else`` blocks.
-        """
-        self._process_expr(node.value)
         self.generic_visit(node)
 
     def visit_Assign(self, node: ast.Assign):


### PR DESCRIPTION
Fixes two previously planner-invisible diffusion CI cases — `turbo_wan2_1_t2v_1.3b` and `flux_2_ti2i_multi_image_cache_dit`. Both are pre-existing main cases (added in #22879) registered via `if not is_hip(): ONE_GPU_CASES.append(...)` (an intentional AMD-skip), so the partition planner never scheduled them and their `sglang_generated` consistency GT went stale across pipeline evolution.

Verified on GPU that the outputs are **correct, not broken**:
- **flux**: cache_dit off-vs-on is bit-exact (mean_abs_diff 0.00) → Cache-DiT is faithful; output matches the prompt (two robed bears). Stale GT only.
- **turbo**: run1-vs-run2 deterministic (0.00); its prompt was `None` (unconditional generation, which drifts as the pipeline evolves). Now pinned to CI's shared `T2V_PROMPT` ("A curious raccoon").

**CI-verified**: with #28781's Fix B temporarily cherry-picked so the planner schedules them, both cases PASS consistency in CI — run [27949923680](https://github.com/sgl-project/sglang/actions/runs/27949923680), 1-gpu partition 2: `turbo_wan2_1_t2v_1.3b: PASSED`, `flux_2_ti2i_multi_image_cache_dit: PASSED`. That cherry-pick has been reverted; this PR carries only the fix.

### Changes
- `turbo_wan2_1_t2v_1.3b`: pin `T2V_sampling_params` (was prompt=None / unconditional).
- `--image-path`: add `--image-paths` alias (`nargs="+"` reads more naturally plural).
- Rebuilt `sglang_generated` GT for the two cases and bumped `SGL_TEST_FILES_CI_DATA_REVISION` → `14a963c`. Every other case's GT stays at the `66370f48` baseline (a nightly rebaseline of `ltx_2_3_hq_pipeline`'s GT was reverted — it didn't match CI's ltx output, ssim 0.26 vs 0.48 threshold).

**Depends on #28781** — its Fix B is what makes these cases visible to the partition planner (it also fixes `hunyuan3d_shape_gen`'s `cfg_policy` crash, another guarded-append case Fix B exposes). Once #28781 lands, rebasing brings Fix A+B from main and all three cases run + pass.

> `call-gate (Extra)` / `pr-test-extra-finish` fail only because this diffusion-only PR has no `run-ci-extra` label (PR Test Extra is all-skipped); diffusion CI runs via the `diffusion` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27951805687](https://github.com/sgl-project/sglang/actions/runs/27951805687)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27951805015](https://github.com/sgl-project/sglang/actions/runs/27951805015)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
