### PR TITLE
[server_args] clamp decode capture bs to DeepEP low_latency buffer

### DIFF
--- a/python/sglang/srt/model_executor/runner/base_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_cuda_graph_runner.py
@@ -22,6 +22,7 @@ from abc import abstractmethod
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, List, Sequence, Tuple
 
+from sglang.srt.environ import envs
 from sglang.srt.model_executor.runner.base_runner import BaseRunner
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import require_gathered_buffer
@@ -90,6 +91,17 @@ def get_batch_sizes_to_capture(
     capture_bs = [bs for bs in capture_bs if bs * num_tokens_per_bs % mul_base == 0]
     capture_bs = [bs for bs in capture_bs if bs <= num_max_requests]
     capture_bs = list(sorted(set(capture_bs)))
+
+    # DeepEP low_latency dispatch caps per-rank dispatch tokens at
+    # num_max_dispatch_tokens_per_rank (default 128). When the MoE A2A backend is
+    # DeepEP and the mode runs the low_latency path (auto/low_latency, not normal),
+    # a decode capture bs above that cap overflows the dispatch buffer and trips an
+    # assertion during graph capture. Clamp the list so the default capture list
+    # works without forcing the user to set --max-running-requests just to dodge it.
+    if server_args.moe_a2a_backend == "deepep" and server_args.deepep_mode != "normal":
+        deepep_cap = envs.SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
+        if max(capture_bs) > deepep_cap:
+            capture_bs = [bs for bs in capture_bs if bs <= deepep_cap]
 
     assert len(capture_bs) > 0 and capture_bs[0] > 0, f"{capture_bs=}"
     compile_bs = (

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1154,5 +1154,97 @@ class TestSamplingBackendTokenOracleEnvGate(CustomTestCase):
         self.assertEqual(parsed.sampling_backend, "token_oracle")
 
 
+class TestDeepEPCaptureBsClamp(unittest.TestCase):
+    """get_batch_sizes_to_capture clamps the decode capture list to the
+    DeepEP low_latency dispatch buffer when deepep runs the low_latency path,
+    so HT can drop --max-running-requests without tripping the dispatch
+    assertion during graph capture.
+    """
+
+    def _make_runner(self, deepep_mode, max_running_requests=None):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="deepep",
+            deepep_mode=deepep_mode,
+        )
+        server_args.deepep_mode = deepep_mode
+        server_args.enable_torch_compile = False
+        # Default decode capture list (max_bs=512): includes 256 and 512.
+        server_args.cuda_graph_config.decode.bs = (
+            server_args._generate_decode_cuda_graph_batch_sizes(512)
+        )
+        runner = MagicMock()
+        runner.server_args = server_args
+        # req_to_token_pool.size large enough not to clamp before the DeepEP gate.
+        runner.req_to_token_pool.size = 2048
+        return runner
+
+    @patch(
+        "sglang.srt.model_executor.runner.base_cuda_graph_runner.require_gathered_buffer",
+        return_value=False,
+    )
+    @patch("sglang.srt.model_executor.runner.base_cuda_graph_runner.get_parallel")
+    def test_clamps_to_deepep_buffer_in_auto_mode(self, mock_get_parallel, _):
+        from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+            get_batch_sizes_to_capture,
+        )
+
+        mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
+        runner = self._make_runner("auto")
+        capture_bs, _ = get_batch_sizes_to_capture(runner)
+        self.assertGreater(max(capture_bs), 0)
+        # DeepEP low_latency buffer default is 128; capture list must not exceed it.
+        self.assertLessEqual(max(capture_bs), 128)
+        self.assertIn(128, capture_bs)
+
+    @patch(
+        "sglang.srt.model_executor.runner.base_cuda_graph_runner.require_gathered_buffer",
+        return_value=False,
+    )
+    @patch("sglang.srt.model_executor.runner.base_cuda_graph_runner.get_parallel")
+    def test_clamps_to_deepep_buffer_in_low_latency_mode(self, mock_get_parallel, _):
+        from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+            get_batch_sizes_to_capture,
+        )
+
+        mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
+        runner = self._make_runner("low_latency")
+        capture_bs, _ = get_batch_sizes_to_capture(runner)
+        self.assertLessEqual(max(capture_bs), 128)
+
+    @patch(
+        "sglang.srt.model_executor.runner.base_cuda_graph_runner.require_gathered_buffer",
+        return_value=False,
+    )
+    @patch("sglang.srt.model_executor.runner.base_cuda_graph_runner.get_parallel")
+    def test_does_not_clamp_in_normal_mode(self, mock_get_parallel, _):
+        # normal mode disables cuda graph; the clamp must not fire.
+        from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+            get_batch_sizes_to_capture,
+        )
+
+        mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
+        runner = self._make_runner("normal")
+        capture_bs, _ = get_batch_sizes_to_capture(runner)
+        # 512 is in the default list and normal mode must NOT clamp it away.
+        self.assertIn(512, capture_bs)
+
+    @patch(
+        "sglang.srt.model_executor.runner.base_cuda_graph_runner.require_gathered_buffer",
+        return_value=False,
+    )
+    @patch("sglang.srt.model_executor.runner.base_cuda_graph_runner.get_parallel")
+    def test_does_not_clamp_non_deepep_backend(self, mock_get_parallel, _):
+        from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+            get_batch_sizes_to_capture,
+        )
+
+        mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
+        runner = self._make_runner("auto")
+        runner.server_args.moe_a2a_backend = "none"
+        capture_bs, _ = get_batch_sizes_to_capture(runner)
+        self.assertIn(512, capture_bs)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1161,17 +1161,24 @@ class TestDeepEPCaptureBsClamp(unittest.TestCase):
     assertion during graph capture.
     """
 
-    def _make_runner(self, deepep_mode, max_running_requests=None):
-        server_args = ServerArgs(
-            model_path="dummy",
-            moe_a2a_backend="deepep",
-            deepep_mode=deepep_mode,
+    def _make_runner(self, moe_a2a_backend="deepep", deepep_mode="auto"):
+        # The non-spec decode capture list for max_bs=512 (see
+        # _generate_decode_cuda_graph_batch_sizes): includes 256 and 512.
+        decode_bs = (
+            [1, 2, 4, 8, 12]
+            + list(range(16, 257, 8))
+            + list(range(272, 512, 16))
+            + [512]
         )
-        server_args.deepep_mode = deepep_mode
-        server_args.enable_torch_compile = False
-        # Default decode capture list (max_bs=512): includes 256 and 512.
-        server_args.cuda_graph_config.decode.bs = (
-            server_args._generate_decode_cuda_graph_batch_sizes(512)
+        server_args = SimpleNamespace(
+            moe_a2a_backend=moe_a2a_backend,
+            deepep_mode=deepep_mode,
+            enable_two_batch_overlap=False,
+            enable_torch_compile=False,
+            torch_compile_max_bs=32,
+            cuda_graph_config=SimpleNamespace(
+                decode=SimpleNamespace(bs=list(decode_bs)),
+            ),
         )
         runner = MagicMock()
         runner.server_args = server_args
@@ -1190,7 +1197,7 @@ class TestDeepEPCaptureBsClamp(unittest.TestCase):
         )
 
         mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
-        runner = self._make_runner("auto")
+        runner = self._make_runner("deepep", "auto")
         capture_bs, _ = get_batch_sizes_to_capture(runner)
         self.assertGreater(max(capture_bs), 0)
         # DeepEP low_latency buffer default is 128; capture list must not exceed it.
@@ -1208,7 +1215,7 @@ class TestDeepEPCaptureBsClamp(unittest.TestCase):
         )
 
         mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
-        runner = self._make_runner("low_latency")
+        runner = self._make_runner("deepep", "low_latency")
         capture_bs, _ = get_batch_sizes_to_capture(runner)
         self.assertLessEqual(max(capture_bs), 128)
 
@@ -1224,7 +1231,7 @@ class TestDeepEPCaptureBsClamp(unittest.TestCase):
         )
 
         mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
-        runner = self._make_runner("normal")
+        runner = self._make_runner("deepep", "normal")
         capture_bs, _ = get_batch_sizes_to_capture(runner)
         # 512 is in the default list and normal mode must NOT clamp it away.
         self.assertIn(512, capture_bs)
@@ -1240,8 +1247,7 @@ class TestDeepEPCaptureBsClamp(unittest.TestCase):
         )
 
         mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
-        runner = self._make_runner("auto")
-        runner.server_args.moe_a2a_backend = "none"
+        runner = self._make_runner("none", "auto")
         capture_bs, _ = get_batch_sizes_to_capture(runner)
         self.assertIn(512, capture_bs)
 


### PR DESCRIPTION
## What & why

DeepEP's `low_latency_dispatch` caps per-rank dispatch tokens at `num_max_dispatch_tokens_per_rank` (env `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK`, default 128). This cap bites in **two** places for high-throughput (DP + deepep) recipes:

1. **cuda-graph capture:** the default decode capture list (max_bs=512) includes bs above the cap, so capture trips `deep_ep.cpp:1262` (`x.size(0) <= num_max_dispatch_tokens_per_rank`).
2. **runtime decode:** at high concurrency the live decode batch also exceeds the cap, tripping the same assertion during serving.

Previously HT worked around both by setting `--max-running-requests` to clamp the decode batch below the buffer — counter to the goal that runtime defaults "just work".

## Change

Clamp `get_batch_sizes_to_capture`'s decode list to the buffer cap when `moe_a2a_backend == "deepep"` and `deepep_mode` runs the low_latency path (`auto`/`low_latency`; `normal` disables cuda graph and is excluded). This fixes the **capture** side (1) without forcing `--max-running-requests`.

The **runtime** side (2) still needs the buffer raised for HT-scale concurrency: set `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=512`. Without the capture clamp, raising the buffer OOMs capture (the larger capture list eats GPU mem); the clamp keeps capture bounded so the larger buffer is affordable.

## Verification (4×GB300, GLM-5.2-FP8, TP4, deepep auto, drop-flags HT — no mrr)

| config | capture | runtime c1024 |
|---|---|---|
| before fix, buf=128 (default) | assertion crash | — |
| before fix, buf=1024 | OOM at capture | — |
| **after fix, buf=128** | ✅ clamp→[1..128] | runtime assertion at c1024 |
| **after fix, buf=512** | ✅ clamp→[1..512] | ✅ 2048/2048 reqs, 449 tok/s/gpu, serve alive |

- With the fix + `buf=512`, HT drops all hand-set serve flags (mfs/cgbs/mrr) and serves + benchmarks at c1024 with 0 assertion / 0 OOM.
- Unit tests: `TestDeepEPCaptureBsClamp` (clamp in auto/low_latency; no clamp in normal / non-deepep).
- pre-commit + py_compile pass.

## Context

Companion to the cookbook drop-flags work (#28731): the GB300 HT cell uses `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=512` + this capture clamp to drop `--max-running-requests`.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27942180033](https://github.com/sgl-project/sglang/actions/runs/27942180033)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27942178675](https://github.com/sgl-project/sglang/actions/runs/27942178675)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->