### PR TITLE
[DSV4] Fix DeepSeek-V4 DP-attention hang and DeepEP MNNVL bootstrap failure on multi-node H20 with tp != dp

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -566,6 +566,8 @@ class Envs:
     SGLANG_MAX_KV_CHUNK_CAPACITY = EnvInt(128 * 1024)
 
     # DeepEP
+    # On hardware without cross-node NVLink (e.g. H20), this must stay False,
+    SGLANG_DEEPEP_ALLOW_MNNVL = EnvBool(False)
     SGLANG_DEEPEP_BF16_DISPATCH = EnvBool(False) # This argument is deprecated
     SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_DEEPEP_LL_COMBINE_SEND_NUM_SMS = EnvInt(32)

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -237,8 +237,8 @@ class DeepEPBuffer:
         buffer_kwargs = dict(
             low_latency_mode=deepep_mode.enable_low_latency(),
             num_qps_per_rank=num_qps_per_rank,
-            # TODO can be false when unneeded
-            allow_mnnvl=True,
+            # FIXME can be false when unneeded
+            allow_mnnvl=envs.SGLANG_DEEPEP_ALLOW_MNNVL.get(),
         )
         # Use CU_MEM_HANDLE_TYPE_FABRIC on hardware that advertises MNNVL fabric
         # support, so cross-pod GB200/GB300 EP groups use

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -470,6 +470,8 @@ class MQALayer(nn.Module):
         self.use_fused_qk_norm_rope = (
             _is_hip and envs.SGLANG_OPT_USE_FUSED_QK_NORM_ROPE.get()
         )
+        if is_dp_attention_enabled() and hasattr(self, "wo_b"):
+            self.wo_b.use_dp_attention_reduce = True
 
         # KV cache write is always fused into the K kernel
         # (`_compute_kv_to_cache`), so the legacy "overlap store cache" flag
@@ -921,6 +923,9 @@ class MQALayer(nn.Module):
         x_quant=None,
     ) -> torch.Tensor:
         if not get_attn_tp_context().input_scattered and x.shape[0] == 0:
+            assert (
+                not self.wo_b.reduce_results or self.wo_b.use_dp_attention_reduce
+            ), "short-circuiting allreduce will lead to hangs"
             return x
 
         attn_backend = get_attn_backend()


### PR DESCRIPTION
## Motivation
[Bug] DeepSeek-v4-pro on a multi-node H20 cluster with tp != dp hang #28915

Running DeepSeek-V4-Pro-FP8 on a 4-node H20 cluster with `--enable-dp-attention`
and `--moe-a2a-backend deepep` fails in two ways:

1. **All-reduce hang under DP attention.** When some DP ranks receive an empty
   batch they `fast return`, while other DP ranks still enter the attention
   output projection (`wo_b`) and call all-reduce. If `wo_b` uses the global TP
   group, the collective becomes a barrier over all TP ranks but only the
   non-empty ranks show up:
- DP0 / TP0-3: has tokens -> enters wo_b -> calls all-reduce -> blocks 
- DP1 / TP4-7: empty batch -> fast return -> never calls this all-reduce


The empty-batch ranks skip the collective, so the global all-reduce never
completes -> permanent hang.

2. **DeepEP MNNVL bootstrap failure.** `DeepEPBuffer` created the buffer with
`allow_mnnvl=True`. MNNVL (multi-node NVLink) fabric is the cross-pod
GPU-to-GPU memory path that only exists on GB200/GB300 NVL systems. On H20
(no cross-node NVLink), the NVSHMEM/DeepEP bootstrap receives
unexpected-length messages and fails/hangs.

## Modifications

- `models/deepseek_v4.py`: in `MQALayer.__init__`, set
`wo_b.use_dp_attention_reduce = True` when DP attention is enabled, so the
attention output projection reduces within the attention TP group instead of
the global TP group. Added an assertion on the empty-batch `fast return` path
to guarantee a short-circuit can never skip a required global all-reduce.
- `layers/moe/token_dispatcher/deepep.py`: replace the hard-coded
`allow_mnnvl=True` with `envs.SGLANG_DEEPEP_ALLOW_MNNVL.get()`, defaulting to
off so MNNVL fabric is only used when explicitly opted in.
- `environ.py`: add `SGLANG_DEEPEP_ALLOW_MNNVL` (default `False`). Set it to `1`
only on GB200/GB300 NVL hardware; keep it `False` on H20 and other clusters
without cross-node NVLink.

## Accuracy Tests

```json
{
    "name": "DeepSeek-V4-Pro-FP8@gsm8k",
    "dataset_name": "gsm8k",
    "dataset_pretty_name": "GSM8K",
    "dataset_description": "\n## Overview\n\nGSM8K (Grade School Math 8K) is a high-quality dataset of 8.5K linguistically diverse grade school math word problems created by human problem writers. The dataset is specifically designed to evaluate and improve the multi-step mathematical reasoning capabilities of language models.\n\n## Task Description\n\n- **Task Type**: Mathematical Word Problem Solving\n- **Input**: Natural language math word problem\n- **Output**: Numerical answer derived through step-by-step reasoning\n- **Difficulty**: Grade school level (2-8 reasoning steps required)\n\n## Key Features\n\n- Problems require basic arithmetic operations (addition, subtraction, multiplication, division)\n- Solutions involve 2 to 8 sequential reasoning steps\n- High linguistic diversity in problem formulations\n- Human-written problems ensuring natural language quality\n- Clear numerical answers for objective evaluation\n\n## Evaluation Notes\n\n- Default configuration uses **4-shot** examples with Chain-of-Thought (CoT) prompting\n- Answers should be formatted within `\\boxed{}` for proper extraction\n- The metric extracts numerical values for accuracy comparison\n- Supports both zero-shot and few-shot evaluation modes\n",
    "model_name": "DeepSeek-V4-Pro-FP8",
    "score": 0.9674,
    "metrics": [
        {
            "name": "mean_acc",
            "num": 1319,
            "score": 0.9674,
            "macro_score": 0.9674,
            "categories": [
                {
                    "name": [
                        "default"
                    ],
                    "num": 1319,
                    "score": 0.9674,
                    "macro_score": 0.9674,
                    "subsets": [
                        {
                            "name": "main",
                            "score": 0.9674,
                            "num": 1319
                        }
                    ]
                }
            ]
        }
    ],
    "analysis": "N/A"
}
```

## Speed Tests and Profiling

No performance impact expected: the DP-attention path reduces over a smaller
communicator (attention TP group), and the MNNVL change only gates an
initialization-time buffer option.

## Checklist

- [ ] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [ ] Follow the SGLang code style guidance.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27943593529](https://github.com/sgl-project/sglang/actions/runs/27943593529)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27943593422](https://github.com/sgl-project/sglang/actions/runs/27943593422)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->