### PR TITLE
Support DSV4 HiSparse online C128 MTP with EAGLE

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c128_online_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c128_online_v2.cuh
@@ -533,9 +533,7 @@ struct OnlineDecodePlanParams {
   const int64_t* __restrict__ seq_lens;
   const int64_t* __restrict__ req_pool_indices;
   const int32_t* __restrict__ req_to_token;
-  const int64_t* __restrict__ full_to_swa;  // (full_cache_size,) int64
   int64_t stride_r2t;
-  int32_t swa_page_size;
   int32_t state_slot_offset;
   uint32_t batch_size;
 };
@@ -545,10 +543,7 @@ __global__ void plan_c128_online_decode_kernel(const OnlineDecodePlanParams para
   if (idx >= params.batch_size) return;
   const auto seq_len = static_cast<uint32_t>(params.seq_lens[idx]);
   const auto rid = params.req_pool_indices[idx];
-  const int32_t chunk_start = static_cast<int32_t>((seq_len - 1u) / 128u * 128u);
-  const int32_t full_loc = params.req_to_token[rid * params.stride_r2t + chunk_start];
-  const int32_t swa_loc = static_cast<int32_t>(params.full_to_swa[full_loc]);
-  const int32_t slot = swa_loc / params.swa_page_size + params.state_slot_offset;
+  const int32_t slot = static_cast<int32_t>(rid) + params.state_slot_offset;
   params.plan_d[idx] = DecodePlan{
       .seq_len = seq_len,
       .write_loc = slot,
@@ -566,9 +561,7 @@ inline void plan_online_decode(
     const tvm::ffi::TensorView seq_lens,
     const tvm::ffi::TensorView req_pool_indices,
     const tvm::ffi::TensorView req_to_token,
-    const tvm::ffi::TensorView full_to_swa,
     const tvm::ffi::TensorView plan_d_dev_,
-    const int32_t swa_page_size,
     const int32_t state_slot_offset) {
   auto B = SymbolicSize{"batch_size"};
   auto device_ = SymbolicDevice{};
@@ -587,15 +580,10 @@ inline void plan_online_decode(
       .with_dtype<int32_t>()
       .with_device(device_)
       .verify(req_to_token);
-  TensorMatcher({-1})  //
-      .with_dtype<int64_t>()
-      .with_device(device_)
-      .verify(full_to_swa);
   TensorMatcher({B, sizeof(DecodePlan)})  //
       .with_dtype<uint8_t>()
       .with_device(device_)
       .verify(plan_d_dev_);
-  RuntimeCheck(swa_page_size > 0);
   RuntimeCheck(state_slot_offset >= 0);
 
   const auto batch_size = static_cast<uint32_t>(B.unwrap());
@@ -610,9 +598,7 @@ inline void plan_online_decode(
       .seq_lens = static_cast<const int64_t*>(seq_lens.data_ptr()),
       .req_pool_indices = static_cast<const int64_t*>(req_pool_indices.data_ptr()),
       .req_to_token = static_cast<const int32_t*>(req_to_token.data_ptr()),
-      .full_to_swa = static_cast<const int64_t*>(full_to_swa.data_ptr()),
       .stride_r2t = stride_r2t,
-      .swa_page_size = swa_page_size,
       .state_slot_offset = state_slot_offset,
       .batch_size = batch_size,
   };
@@ -685,9 +671,7 @@ struct OnlinePrefillStage1Params {
   CompressPlan* __restrict__ plan_w;
   const int64_t* __restrict__ req_pool_indices;  // (batch_size,)
   const int32_t* __restrict__ req_to_token;      // (num_reqs, max_tokens)
-  const int64_t* __restrict__ full_to_swa;       // (full_cache_size,)
   int64_t stride_r2t;
-  int32_t swa_page_size;
   int32_t state_slot_offset;
   uint32_t num_c;
   uint32_t num_w;
@@ -704,11 +688,7 @@ __global__ void plan_c128_online_prefill_kernel(const OnlinePrefillStage1Params 
   if (plan.is_invalid()) return;
   const auto batch_id = plan.read_page_0;
   const auto rid = params.req_pool_indices[batch_id];
-  const int32_t position = static_cast<int32_t>(plan.seq_len - 1u);
-  const int32_t chunk_start = (position / 128) * 128;
-  const int32_t full_loc = params.req_to_token[rid * params.stride_r2t + chunk_start];
-  const int32_t swa_loc = static_cast<int32_t>(params.full_to_swa[full_loc]);
-  const int32_t main_slot = swa_loc / params.swa_page_size;
+  const int32_t main_slot = static_cast<int32_t>(rid);
   plan.read_page_0 = main_slot + params.state_slot_offset;
   plan.read_page_1 = main_slot;
   *plan_ptr = plan;
@@ -721,12 +701,10 @@ inline OnlinePrefillPlan plan_online_prefill(
     const tvm::ffi::TensorView extend_lens,
     const tvm::ffi::TensorView req_pool_indices,
     const tvm::ffi::TensorView req_to_token,
-    const tvm::ffi::TensorView full_to_swa,
     const tvm::ffi::TensorView plan_c_pin,
     const tvm::ffi::TensorView plan_w_pin,
     const tvm::ffi::TensorView plan_c_dev_,
     const tvm::ffi::TensorView plan_w_dev_,
-    const int32_t swa_page_size,
     const int32_t state_slot_offset,
     const bool use_cuda_graph) {
   auto B = SymbolicSize{"batch_size"};
@@ -749,10 +727,6 @@ inline OnlinePrefillPlan plan_online_prefill(
       .with_dtype<int32_t>()
       .with_device(device_)
       .verify(req_to_token);
-  TensorMatcher({-1})  //
-      .with_dtype<int64_t>()
-      .with_device(device_)
-      .verify(full_to_swa);
   TensorMatcher({N, sizeof(CompressPlan)})  //
       .with_dtype<uint8_t>()
       .with_device(cpu)
@@ -878,9 +852,7 @@ inline OnlinePrefillPlan plan_online_prefill(
         .plan_w = plan_w_dev_ptr,
         .req_pool_indices = static_cast<const int64_t*>(req_pool_indices.data_ptr()),
         .req_to_token = static_cast<const int32_t*>(req_to_token.data_ptr()),
-        .full_to_swa = static_cast<const int64_t*>(full_to_swa.data_ptr()),
         .stride_r2t = req_to_token.stride(0),
-        .swa_page_size = swa_page_size,
         .state_slot_offset = state_slot_offset,
         .num_c = num_c_padded,
         .num_w = num_w_padded,

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
@@ -53,7 +53,7 @@ struct Prefill1Params {
   PlanW* plan_w;
   const RID_T* rid_ptr;  // [batch_size]
   const R2T_T* r2t_ptr;  // [num_reqs, stride_r2t]
-  const F2S_T* f2s_ptr;  // [num_swa_slots]
+  const F2S_T* f2s_ptr;  // [num_full_slots], full_loc -> swa_loc
   int64_t stride_r2t;
   uint32_t num_c;
   uint32_t num_w;
@@ -69,7 +69,7 @@ struct DecodeParams {
   PlanD* plan_d;
   const RID_T* rid_ptr;  // [batch_size]
   const R2T_T* r2t_ptr;  // [num_reqs, stride_r2t]
-  const F2S_T* f2s_ptr;  // [num_swa_slots]
+  const F2S_T* f2s_ptr;  // [num_full_slots], full_loc -> swa_loc
   const IDX_T* seq_ptr;  // [batch_size]
   int64_t stride_r2t;
   uint32_t batch_size;
@@ -297,6 +297,9 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
     const auto ring_offset = swa_loc % params.ring_size;
     return swa_page * params.ring_size + ring_offset;
   };
+  const auto compute_c128_loc = [&](int64_t rid, int32_t position) {
+    return static_cast<int32_t>(rid * params.ring_size + position % params.ring_size);
+  };
 
   if (!plan_c.is_invalid()) {  // 1. in bound. 2. not masked
     if (plan_c.buffer_len > 0) {
@@ -307,12 +310,17 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
       const auto position_1 = static_cast<int32_t>(plan_c.seq_len - 1);
       // only used for c4, harmless for c128
       const auto position_0 = max(position_1 - params.compress_ratio, 0);
-      const auto raw_loc_0 = mapping[position_0];
-      const auto raw_loc_1 = mapping[position_1];
-      const auto swa_loc_0 = params.f2s_ptr[raw_loc_0];
-      const auto swa_loc_1 = params.f2s_ptr[raw_loc_1];
-      plan_c.read_page_0 = compute_loc(swa_loc_0) / params.compress_ratio;
-      plan_c.read_page_1 = compute_loc(swa_loc_1) / params.compress_ratio;
+      if (params.compress_ratio == 128) {
+        plan_c.read_page_0 = compute_c128_loc(rid, position_0) / 128;
+        plan_c.read_page_1 = compute_c128_loc(rid, position_1) / 128;
+      } else {
+        const auto raw_loc_0 = mapping[position_0];
+        const auto raw_loc_1 = mapping[position_1];
+        const auto state_loc_0 = params.f2s_ptr[raw_loc_0];
+        const auto state_loc_1 = params.f2s_ptr[raw_loc_1];
+        plan_c.read_page_0 = compute_loc(state_loc_0) / params.compress_ratio;
+        plan_c.read_page_1 = compute_loc(state_loc_1) / params.compress_ratio;
+      }
       params.plan_c[idx] = plan_c;
     }
   } else if (idx < params.num_c_padded) {
@@ -325,10 +333,13 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
     const auto mapping = params.r2t_ptr + rid * params.stride_r2t;
     // `seq_len` (`write_loc`) may not be aligned here
     const auto position = static_cast<int32_t>(plan_w.write_loc - 1);
-    const auto raw_loc = mapping[position];
-    const auto swa_loc = params.f2s_ptr[raw_loc];
     plan_w.ragged_id = ragged_id;
-    plan_w.write_loc = compute_loc(swa_loc);
+    if (params.compress_ratio == 128) {
+      plan_w.write_loc = compute_c128_loc(rid, position);
+    } else {
+      const auto raw_loc = mapping[position];
+      plan_w.write_loc = compute_loc(params.f2s_ptr[raw_loc]);
+    }
     params.plan_w[idx] = plan_w;
   } else if (idx < params.num_w_padded) {
     params.plan_w[idx] = PlanW::invalid();
@@ -345,16 +356,28 @@ __global__ void plan_compress_decode_kernel(const DecodeParams params) {
     const auto ring_offset = swa_loc % params.ring_size;
     return swa_page * params.ring_size + ring_offset;
   };
+  const auto compute_c128_loc = [&](int64_t rid, int32_t position) {
+    return static_cast<int32_t>(rid * params.ring_size + position % params.ring_size);
+  };
   const auto seq_len = static_cast<int32_t>(params.seq_ptr[idx]);
   const auto position_1 = static_cast<int32_t>(seq_len - 1);
   const auto position_0 = max(position_1 - params.compress_ratio, 0);
-  const auto raw_loc_0 = mapping[position_0];
-  const auto raw_loc_1 = mapping[position_1];
-  const auto swa_loc_0 = params.f2s_ptr[raw_loc_0];
-  const auto swa_loc_1 = params.f2s_ptr[raw_loc_1];
-  const auto write_loc = compute_loc(swa_loc_1);
-  const auto read_page_0 = compute_loc(swa_loc_0) / params.compress_ratio;
-  const auto read_page_1 = write_loc / params.compress_ratio;
+  int32_t write_loc;
+  int32_t read_page_0;
+  int32_t read_page_1;
+  if (params.compress_ratio == 128) {
+    write_loc = compute_c128_loc(rid, position_1);
+    read_page_0 = compute_c128_loc(rid, position_0) / 128;
+    read_page_1 = compute_c128_loc(rid, position_1) / 128;
+  } else {
+    const auto raw_loc_0 = mapping[position_0];
+    const auto raw_loc_1 = mapping[position_1];
+    const auto state_loc_0 = params.f2s_ptr[raw_loc_0];
+    const auto state_loc_1 = params.f2s_ptr[raw_loc_1];
+    write_loc = static_cast<int32_t>(compute_loc(state_loc_1));
+    read_page_0 = static_cast<int32_t>(compute_loc(state_loc_0) / params.compress_ratio);
+    read_page_1 = static_cast<int32_t>(write_loc / params.compress_ratio);
+  }
   params.plan_d[idx] = {
       .seq_len = static_cast<uint32_t>(seq_len),
       .write_loc = write_loc,
@@ -425,9 +448,9 @@ __global__ void plan_compress_decode_legacy_kernel(const DecodeParamsLegacy para
   const auto seq_len = static_cast<int32_t>(params.seq_ptr[idx]);
   const auto position_1 = seq_len - 1;
   const auto position_0 = max(position_1 - params.compress_ratio, 0);
-  const auto write_loc = legacy_compute_loc(rid, position_1);
-  const auto read_page_0 = legacy_compute_page(rid, position_0);
-  const auto read_page_1 = legacy_compute_page(rid, position_1);
+  const int32_t write_loc = legacy_compute_loc(rid, position_1);
+  const int32_t read_page_0 = legacy_compute_page(rid, position_0);
+  const int32_t read_page_1 = legacy_compute_page(rid, position_1);
   params.plan_d[idx] = {
       .seq_len = static_cast<uint32_t>(seq_len),
       .write_loc = write_loc,
@@ -443,7 +466,9 @@ using PrefillPlan = tvm::ffi::Tuple<tvm::ffi::Tensor, tvm::ffi::Tensor>;
  * Inputs (all CPU-resident):
  * @param req_pool_indices  `[batch_size]` int64_t
  * @param req_to_token      `[num_reqs, max_tokens_per_req]` int64_t
- * @param full_to_swa       `[num_swa_slots]` int64_t
+ * @param full_to_state     `[full_cache_size]` int64_t. For c4 this maps
+ *                          full loc -> SWA loc; ignored for c128, whose
+ *                          state slot is request-scoped.
  * @param seq_lens          `[batch_size]` int64
  * @param extend_lens       `[batch_size]` int64
  * @param compress_plan     `[num_q_tokens, 16]` uint8 (output)
@@ -455,7 +480,7 @@ using PrefillPlan = tvm::ffi::Tuple<tvm::ffi::Tensor, tvm::ffi::Tensor>;
 inline PrefillPlan plan_compress_prefill(
     const tvm::ffi::TensorView req_pool_indices,  // GPU
     const tvm::ffi::TensorView req_to_token,      // GPU
-    const tvm::ffi::TensorView full_to_swa,       // GPU
+    const tvm::ffi::TensorView full_to_state,     // GPU
     const tvm::ffi::TensorView seq_lens,          // CPU/GPU
     const tvm::ffi::TensorView extend_lens,       // CPU/GPU
     const tvm::ffi::TensorView pin_buffer,        // CPU
@@ -482,7 +507,7 @@ inline PrefillPlan plan_compress_prefill(
   TensorMatcher({-1})  //
       .with_dtype<F2S_T>()
       .with_device(device_)
-      .verify(full_to_swa);
+      .verify(full_to_state);
   TensorMatcher({B})  //
       .with_dtype<IDX_T>()
       .with_device(cpu_or_gpu)
@@ -500,7 +525,7 @@ inline PrefillPlan plan_compress_prefill(
   const auto ext_ptr = static_cast<const IDX_T*>(extend_lens.data_ptr());
   const auto rid_ptr = static_cast<const RID_T*>(req_pool_indices.data_ptr());
   const auto r2t_ptr = static_cast<const R2T_T*>(req_to_token.data_ptr());
-  const auto f2s_ptr = static_cast<const F2S_T*>(full_to_swa.data_ptr());
+  const auto f2s_ptr = static_cast<const F2S_T*>(full_to_state.data_ptr());
 
   const auto batch_size = static_cast<uint32_t>(B.unwrap());
   constexpr auto kMaxTokens = static_cast<uint32_t>(std::numeric_limits<uint16_t>::max());
@@ -637,7 +662,7 @@ inline PrefillPlan plan_compress_prefill(
 inline tvm::ffi::Tensor plan_compress_decode(
     const tvm::ffi::TensorView req_pool_indices,  // GPU
     const tvm::ffi::TensorView req_to_token,      // GPU
-    const tvm::ffi::TensorView full_to_swa,       // GPU
+    const tvm::ffi::TensorView full_to_state,     // GPU
     const tvm::ffi::TensorView seq_lens,          // CPU/GPU
     const int32_t compress_ratio,
     const int32_t swa_page_size,
@@ -657,7 +682,7 @@ inline tvm::ffi::Tensor plan_compress_decode(
   TensorMatcher({-1})  //
       .with_dtype<F2S_T>()
       .with_device(device_)
-      .verify(full_to_swa);
+      .verify(full_to_state);
   TensorMatcher({B})  //
       .with_dtype<IDX_T>()
       .with_device(device_)
@@ -670,7 +695,7 @@ inline tvm::ffi::Tensor plan_compress_decode(
       .plan_d = static_cast<PlanD*>(D.data_ptr()),
       .rid_ptr = static_cast<const RID_T*>(req_pool_indices.data_ptr()),
       .r2t_ptr = static_cast<const R2T_T*>(req_to_token.data_ptr()),
-      .f2s_ptr = static_cast<const F2S_T*>(full_to_swa.data_ptr()),
+      .f2s_ptr = static_cast<const F2S_T*>(full_to_state.data_ptr()),
       .seq_ptr = static_cast<const IDX_T*>(seq_lens.data_ptr()),
       .stride_r2t = req_to_token.size(1),
       .batch_size = batch_size,

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/online_c128_mtp.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/online_c128_mtp.cuh
@@ -23,7 +23,6 @@ struct OnlineC128MTPWritePrefixParams {
   const TSeq* __restrict__ seq_lens;
   const TReq* __restrict__ req_pool_indices;
   const int32_t* __restrict__ req_to_token;
-  const int64_t* __restrict__ full_to_swa;
   const float* __restrict__ ape;
   float* __restrict__ state;
   int64_t kv_score_stride_b;
@@ -31,7 +30,6 @@ struct OnlineC128MTPWritePrefixParams {
   int64_t ape_stride_r;
   int64_t state_stride_b;
   int64_t layer_bs;
-  int64_t swa_page_size;
   int64_t num_verify_tokens;
   int64_t state_slot_stride;
 };
@@ -50,13 +48,11 @@ struct OnlineC128MTPCommitPendingParams {
   const TSeq* __restrict__ cur_seq_lens;
   const TReq* __restrict__ cur_req_pool_indices;
   const int32_t* __restrict__ req_to_token;
-  const int64_t* __restrict__ full_to_swa;
   const int64_t* __restrict__ pending_seq_lens;
   float* __restrict__ state;
   int64_t cur_bs;
   int64_t req_to_token_stride_b;
   int64_t state_stride_b;
-  int64_t swa_page_size;
   int64_t num_verify_tokens;
   int64_t state_slot_stride;
   int64_t max_num_reqs;
@@ -94,10 +90,7 @@ __global__ void online_c128_mtp_commit_pending_kernel(const OnlineC128MTPCommitP
   const int64_t final_seq = old_seq + accept;
   if ((final_seq & 127) == 0) return;
 
-  const int64_t chunk_start = ((final_seq - 1) / 128) * 128;
-  const int64_t full_loc = static_cast<int64_t>(params.req_to_token[req * params.req_to_token_stride_b + chunk_start]);
-  const int64_t swa_loc = params.full_to_swa[full_loc];
-  const int64_t slot = swa_loc / params.swa_page_size;
+  const int64_t slot = req;
   const float* const src = params.state + (slot + accept * params.state_slot_stride) * params.state_stride_b;
   float* const dst = params.state + slot * params.state_stride_b;
 
@@ -118,11 +111,7 @@ __global__ void online_c128_mtp_write_prefix_kernel(const OnlineC128MTPWritePref
 
   int64_t init_slot = 0;
   if (has_partial) {
-    const int64_t chunk_start = ((seq_before - 1) / 128) * 128;
-    const int64_t full_loc =
-        static_cast<int64_t>(params.req_to_token[req_idx * params.req_to_token_stride_b + chunk_start]);
-    const int64_t swa_loc = params.full_to_swa[full_loc];
-    init_slot = swa_loc / params.swa_page_size;
+    init_slot = req_idx;
   }
 
   const int64_t d = static_cast<int64_t>(threadIdx.x);
@@ -173,11 +162,7 @@ __global__ void online_c128_mtp_write_prefix_kernel(const OnlineC128MTPWritePref
 
     const int64_t final_seq = seq_before + step + 1;
     if ((final_seq & 127) != 0) {
-      const int64_t chunk_start = ((final_seq - 1) / 128) * 128;
-      const int64_t full_loc =
-          static_cast<int64_t>(params.req_to_token[req_idx * params.req_to_token_stride_b + chunk_start]);
-      const int64_t swa_loc = params.full_to_swa[full_loc];
-      const int64_t slot = swa_loc / params.swa_page_size + (step + 1) * params.state_slot_stride;
+      const int64_t slot = req_idx + (step + 1) * params.state_slot_stride;
       float* const out = params.state + slot * params.state_stride_b;
       out[d] = run_max;
       out[kHeadDim + d] = run_sum;
@@ -192,19 +177,16 @@ __global__ void online_c128_mtp_write_prefix_kernel(const OnlineC128MTPWritePref
   }
 }
 
-template <int64_t kHeadDim>
+template <int64_t kHeadDim, typename TSeq, typename TReq>
 struct OnlineC128MTPWritePrefixKernel {
-  template <typename TSeq, typename TReq>
   static void launch(
       tvm::ffi::TensorView kv_score_input,
       tvm::ffi::TensorView seq_lens,
       tvm::ffi::TensorView req_pool_indices,
       tvm::ffi::TensorView req_to_token,
-      tvm::ffi::TensorView full_to_swa,
       tvm::ffi::TensorView ape,
       tvm::ffi::TensorView state,
       int64_t layer_bs,
-      int64_t swa_page_size,
       int64_t num_verify_tokens,
       int64_t state_slot_stride,
       DLDevice device) {
@@ -215,7 +197,6 @@ struct OnlineC128MTPWritePrefixKernel {
         .seq_lens = static_cast<const TSeq*>(seq_lens.data_ptr()),
         .req_pool_indices = static_cast<const TReq*>(req_pool_indices.data_ptr()),
         .req_to_token = static_cast<const int32_t*>(req_to_token.data_ptr()),
-        .full_to_swa = static_cast<const int64_t*>(full_to_swa.data_ptr()),
         .ape = static_cast<const float*>(ape.data_ptr()),
         .state = static_cast<float*>(state.data_ptr()),
         .kv_score_stride_b = kv_score_input.stride(0),
@@ -223,7 +204,6 @@ struct OnlineC128MTPWritePrefixKernel {
         .ape_stride_r = ape.stride(0),
         .state_stride_b = state.stride(0),
         .layer_bs = layer_bs,
-        .swa_page_size = swa_page_size,
         .num_verify_tokens = num_verify_tokens,
         .state_slot_stride = state_slot_stride,
     };
@@ -239,25 +219,20 @@ struct OnlineC128MTPWritePrefixKernel {
       tvm::ffi::TensorView seq_lens,
       tvm::ffi::TensorView req_pool_indices,
       tvm::ffi::TensorView req_to_token,
-      tvm::ffi::TensorView full_to_swa,
       tvm::ffi::TensorView ape,
       tvm::ffi::TensorView state,
       int64_t layer_bs,
-      int64_t swa_page_size,
       int64_t num_verify_tokens,
       int64_t state_slot_stride) {
     using namespace host;
 
-    auto seq_dtype = SymbolicDType{};
-    auto req_dtype = SymbolicDType{};
     auto device = SymbolicDevice{};
     device.set_options<kDLCUDA>();
 
     TensorMatcher({-1, kHeadDim * 2}).with_dtype<float>().with_device(device).verify(kv_score_input);
-    TensorMatcher({-1}).with_dtype<int32_t, int64_t>(seq_dtype).with_device(device).verify(seq_lens);
-    TensorMatcher({-1}).with_dtype<int32_t, int64_t>(req_dtype).with_device(device).verify(req_pool_indices);
+    TensorMatcher({-1}).with_dtype<TSeq>().with_device(device).verify(seq_lens);
+    TensorMatcher({-1}).with_dtype<TReq>().with_device(device).verify(req_pool_indices);
     TensorMatcher({-1, -1}).with_dtype<int32_t>().with_device(device).verify(req_to_token);
-    TensorMatcher({-1}).with_dtype<int64_t>().with_device(device).verify(full_to_swa);
     TensorMatcher({128, kHeadDim}).with_dtype<float>().with_device(device).verify(ape);
     TensorMatcher({-1, kHeadDim * 3}).with_dtype<float>().with_device(device).verify(state);
 
@@ -268,73 +243,22 @@ struct OnlineC128MTPWritePrefixKernel {
     RuntimeCheck(layer_bs <= req_pool_indices.shape()[0], "layer_bs exceeds req_pool_indices rows");
     RuntimeCheck(layer_bs * num_verify_tokens <= kv_score_input.shape()[0], "kv_score_input is too small");
 
-    if (seq_dtype.is_type<int32_t>()) {
-      if (req_dtype.is_type<int32_t>()) {
-        launch<int32_t, int32_t>(
-            kv_score_input,
-            seq_lens,
-            req_pool_indices,
-            req_to_token,
-            full_to_swa,
-            ape,
-            state,
-            layer_bs,
-            swa_page_size,
-            num_verify_tokens,
-            state_slot_stride,
-            device.unwrap());
-      } else {
-        launch<int32_t, int64_t>(
-            kv_score_input,
-            seq_lens,
-            req_pool_indices,
-            req_to_token,
-            full_to_swa,
-            ape,
-            state,
-            layer_bs,
-            swa_page_size,
-            num_verify_tokens,
-            state_slot_stride,
-            device.unwrap());
-      }
-    } else {
-      if (req_dtype.is_type<int32_t>()) {
-        launch<int64_t, int32_t>(
-            kv_score_input,
-            seq_lens,
-            req_pool_indices,
-            req_to_token,
-            full_to_swa,
-            ape,
-            state,
-            layer_bs,
-            swa_page_size,
-            num_verify_tokens,
-            state_slot_stride,
-            device.unwrap());
-      } else {
-        launch<int64_t, int64_t>(
-            kv_score_input,
-            seq_lens,
-            req_pool_indices,
-            req_to_token,
-            full_to_swa,
-            ape,
-            state,
-            layer_bs,
-            swa_page_size,
-            num_verify_tokens,
-            state_slot_stride,
-            device.unwrap());
-      }
-    }
+    launch(
+        kv_score_input,
+        seq_lens,
+        req_pool_indices,
+        req_to_token,
+        ape,
+        state,
+        layer_bs,
+        num_verify_tokens,
+        state_slot_stride,
+        device.unwrap());
   }
 };
 
-template <int64_t kHeadDim>
+template <int64_t kHeadDim, typename TSeq, typename TReq>
 struct OnlineC128MTPMarkPendingKernel {
-  template <typename TSeq, typename TReq>
   static void launch(
       tvm::ffi::TensorView seq_lens,
       tvm::ffi::TensorView req_pool_indices,
@@ -368,13 +292,11 @@ struct OnlineC128MTPMarkPendingKernel {
       int64_t max_num_reqs) {
     using namespace host;
 
-    auto seq_dtype = SymbolicDType{};
-    auto req_dtype = SymbolicDType{};
     auto device = SymbolicDevice{};
     device.set_options<kDLCUDA>();
 
-    TensorMatcher({-1}).with_dtype<int32_t, int64_t>(seq_dtype).with_device(device).verify(seq_lens);
-    TensorMatcher({-1}).with_dtype<int32_t, int64_t>(req_dtype).with_device(device).verify(req_pool_indices);
+    TensorMatcher({-1}).with_dtype<TSeq>().with_device(device).verify(seq_lens);
+    TensorMatcher({-1}).with_dtype<TReq>().with_device(device).verify(req_pool_indices);
     TensorMatcher({-1}).with_dtype<int64_t>().with_device(device).verify(pending_seq_lens);
 
     if (bs <= 0) return;
@@ -382,34 +304,19 @@ struct OnlineC128MTPMarkPendingKernel {
     RuntimeCheck(bs <= req_pool_indices.shape()[0], "bs exceeds req_pool_indices rows");
     RuntimeCheck(max_num_reqs <= pending_seq_lens.shape()[0], "max_num_reqs exceeds pending rows");
 
-    if (seq_dtype.is_type<int32_t>()) {
-      if (req_dtype.is_type<int32_t>()) {
-        launch<int32_t, int32_t>(seq_lens, req_pool_indices, pending_seq_lens, bs, max_num_reqs, device.unwrap());
-      } else {
-        launch<int32_t, int64_t>(seq_lens, req_pool_indices, pending_seq_lens, bs, max_num_reqs, device.unwrap());
-      }
-    } else {
-      if (req_dtype.is_type<int32_t>()) {
-        launch<int64_t, int32_t>(seq_lens, req_pool_indices, pending_seq_lens, bs, max_num_reqs, device.unwrap());
-      } else {
-        launch<int64_t, int64_t>(seq_lens, req_pool_indices, pending_seq_lens, bs, max_num_reqs, device.unwrap());
-      }
-    }
+    launch(seq_lens, req_pool_indices, pending_seq_lens, bs, max_num_reqs, device.unwrap());
   }
 };
 
-template <int64_t kHeadDim>
+template <int64_t kHeadDim, typename TSeq, typename TReq>
 struct OnlineC128MTPCommitPendingKernel {
-  template <typename TSeq, typename TReq>
   static void launch(
       tvm::ffi::TensorView cur_seq_lens,
       tvm::ffi::TensorView cur_req_pool_indices,
       tvm::ffi::TensorView req_to_token,
-      tvm::ffi::TensorView full_to_swa,
       tvm::ffi::TensorView pending_seq_lens,
       tvm::ffi::TensorView state,
       int64_t cur_bs,
-      int64_t swa_page_size,
       int64_t num_verify_tokens,
       int64_t state_slot_stride,
       int64_t max_num_reqs,
@@ -420,13 +327,11 @@ struct OnlineC128MTPCommitPendingKernel {
         .cur_seq_lens = static_cast<const TSeq*>(cur_seq_lens.data_ptr()),
         .cur_req_pool_indices = static_cast<const TReq*>(cur_req_pool_indices.data_ptr()),
         .req_to_token = static_cast<const int32_t*>(req_to_token.data_ptr()),
-        .full_to_swa = static_cast<const int64_t*>(full_to_swa.data_ptr()),
         .pending_seq_lens = static_cast<const int64_t*>(pending_seq_lens.data_ptr()),
         .state = static_cast<float*>(state.data_ptr()),
         .cur_bs = cur_bs,
         .req_to_token_stride_b = req_to_token.stride(0),
         .state_stride_b = state.stride(0),
-        .swa_page_size = swa_page_size,
         .num_verify_tokens = num_verify_tokens,
         .state_slot_stride = state_slot_stride,
         .max_num_reqs = max_num_reqs,
@@ -441,25 +346,20 @@ struct OnlineC128MTPCommitPendingKernel {
   run(tvm::ffi::TensorView cur_seq_lens,
       tvm::ffi::TensorView cur_req_pool_indices,
       tvm::ffi::TensorView req_to_token,
-      tvm::ffi::TensorView full_to_swa,
       tvm::ffi::TensorView pending_seq_lens,
       tvm::ffi::TensorView state,
       int64_t cur_bs,
-      int64_t swa_page_size,
       int64_t num_verify_tokens,
       int64_t state_slot_stride,
       int64_t max_num_reqs) {
     using namespace host;
 
-    auto seq_dtype = SymbolicDType{};
-    auto req_dtype = SymbolicDType{};
     auto device = SymbolicDevice{};
     device.set_options<kDLCUDA>();
 
-    TensorMatcher({-1}).with_dtype<int32_t, int64_t>(seq_dtype).with_device(device).verify(cur_seq_lens);
-    TensorMatcher({-1}).with_dtype<int32_t, int64_t>(req_dtype).with_device(device).verify(cur_req_pool_indices);
+    TensorMatcher({-1}).with_dtype<TSeq>().with_device(device).verify(cur_seq_lens);
+    TensorMatcher({-1}).with_dtype<TReq>().with_device(device).verify(cur_req_pool_indices);
     TensorMatcher({-1, -1}).with_dtype<int32_t>().with_device(device).verify(req_to_token);
-    TensorMatcher({-1}).with_dtype<int64_t>().with_device(device).verify(full_to_swa);
     TensorMatcher({-1}).with_dtype<int64_t>().with_device(device).verify(pending_seq_lens);
     TensorMatcher({-1, kHeadDim * 3}).with_dtype<float>().with_device(device).verify(state);
 
@@ -470,67 +370,17 @@ struct OnlineC128MTPCommitPendingKernel {
     RuntimeCheck(cur_bs <= cur_req_pool_indices.shape()[0], "cur_bs exceeds req rows");
     RuntimeCheck(max_num_reqs <= pending_seq_lens.shape()[0], "max_num_reqs exceeds pending rows");
 
-    if (seq_dtype.is_type<int32_t>()) {
-      if (req_dtype.is_type<int32_t>()) {
-        launch<int32_t, int32_t>(
-            cur_seq_lens,
-            cur_req_pool_indices,
-            req_to_token,
-            full_to_swa,
-            pending_seq_lens,
-            state,
-            cur_bs,
-            swa_page_size,
-            num_verify_tokens,
-            state_slot_stride,
-            max_num_reqs,
-            device.unwrap());
-      } else {
-        launch<int32_t, int64_t>(
-            cur_seq_lens,
-            cur_req_pool_indices,
-            req_to_token,
-            full_to_swa,
-            pending_seq_lens,
-            state,
-            cur_bs,
-            swa_page_size,
-            num_verify_tokens,
-            state_slot_stride,
-            max_num_reqs,
-            device.unwrap());
-      }
-    } else {
-      if (req_dtype.is_type<int32_t>()) {
-        launch<int64_t, int32_t>(
-            cur_seq_lens,
-            cur_req_pool_indices,
-            req_to_token,
-            full_to_swa,
-            pending_seq_lens,
-            state,
-            cur_bs,
-            swa_page_size,
-            num_verify_tokens,
-            state_slot_stride,
-            max_num_reqs,
-            device.unwrap());
-      } else {
-        launch<int64_t, int64_t>(
-            cur_seq_lens,
-            cur_req_pool_indices,
-            req_to_token,
-            full_to_swa,
-            pending_seq_lens,
-            state,
-            cur_bs,
-            swa_page_size,
-            num_verify_tokens,
-            state_slot_stride,
-            max_num_reqs,
-            device.unwrap());
-      }
-    }
+    launch(
+        cur_seq_lens,
+        cur_req_pool_indices,
+        req_to_token,
+        pending_seq_lens,
+        state,
+        cur_bs,
+        num_verify_tokens,
+        state_slot_stride,
+        max_num_reqs,
+        device.unwrap());
   }
 };
 

--- a/python/sglang/jit_kernel/dsv4/attn.py
+++ b/python/sglang/jit_kernel/dsv4/attn.py
@@ -122,18 +122,21 @@ def create_paged_compress_data_kernel(
         else:
             pos = write_overlap_pos
         pos = tl.maximum(pos, 0)
-        loc = tl.load(
-            req_to_token_ptr
-            + rid.to(tl.int64) * stride_req_to_token_0
-            + pos.to(tl.int64) * stride_req_to_token_1,
-            mask=mask,
-            other=0,
-        ).to(tl.int32)
-        swa_loc = tl.load(full_to_swa_index_mapping_ptr + loc, mask=mask, other=0).to(
-            tl.int32
-        )
-        swa_page = swa_loc // swa_page_size
-        state_loc = swa_page * ring_size + (swa_loc % ring_size)
+        if compress_ratio == 128:
+            state_loc = rid * ring_size + (pos % ring_size)
+        else:
+            loc = tl.load(
+                req_to_token_ptr
+                + rid.to(tl.int64) * stride_req_to_token_0
+                + pos.to(tl.int64) * stride_req_to_token_1,
+                mask=mask,
+                other=0,
+            ).to(tl.int32)
+            swa_loc = tl.load(
+                full_to_swa_index_mapping_ptr + loc, mask=mask, other=0
+            ).to(tl.int32)
+            swa_page = swa_loc // swa_page_size
+            state_loc = swa_page * ring_size + (swa_loc % ring_size)
         state_loc = state_loc // cr
         if i == 0:
             v0 = state_loc

--- a/python/sglang/jit_kernel/dsv4/compress.py
+++ b/python/sglang/jit_kernel/dsv4/compress.py
@@ -125,7 +125,7 @@ class CompressorDecodePlan(NamedTuple):
         compress_ratio: Literal[4, 128],
         req_pool_indices: torch.Tensor,
         req_to_token: torch.Tensor,
-        full_to_swa: torch.Tensor,
+        full_to_state: torch.Tensor,
         seq_lens: torch.Tensor,
         swa_page_size: int,
         ring_size: int,
@@ -134,7 +134,7 @@ class CompressorDecodePlan(NamedTuple):
         plan_d = module.plan_decode(
             req_pool_indices,
             req_to_token,
-            full_to_swa,
+            full_to_state,
             seq_lens,
             int(compress_ratio),
             int(swa_page_size),
@@ -157,8 +157,6 @@ class CompressorDecodePlan(NamedTuple):
         seq_lens: torch.Tensor,
         req_pool_indices: torch.Tensor,
         req_to_token: torch.Tensor,
-        full_to_swa: torch.Tensor,
-        swa_page_size: int,
         state_slot_offset: int = 0,
     ) -> CompressorDecodePlan:
         batch_size = int(seq_lens.shape[0])
@@ -172,9 +170,7 @@ class CompressorDecodePlan(NamedTuple):
             seq_lens,
             req_pool_indices,
             req_to_token,
-            full_to_swa,
             plan_d,
-            swa_page_size,
             int(state_slot_offset),
         )
         return CompressorDecodePlan(128, plan_d)
@@ -203,7 +199,7 @@ class CompressorPrefillPlan(NamedTuple):
         seq_lens: torch.Tensor,
         extend_lens: torch.Tensor,
         req_to_token: torch.Tensor,
-        full_to_swa: torch.Tensor,
+        full_to_state: torch.Tensor,
         swa_page_size: int,
         ring_size: int,
         num_q_tokens: int,
@@ -219,7 +215,7 @@ class CompressorPrefillPlan(NamedTuple):
         plan_c, plan_w = module.plan_prefill(
             req_pool_indices,
             req_to_token,
-            full_to_swa,
+            full_to_state,
             seq_lens,
             extend_lens,
             pin_buffer,
@@ -274,9 +270,7 @@ class CompressorPrefillPlan(NamedTuple):
         extend_lens: torch.Tensor,
         req_pool_indices: torch.Tensor,
         req_to_token: torch.Tensor,
-        full_to_swa: torch.Tensor,
         num_q_tokens: int,
-        swa_page_size: int,
         use_cuda_graph: bool = False,
         state_slot_offset: int = 0,
     ) -> CompressorPrefillPlan:
@@ -284,7 +278,6 @@ class CompressorPrefillPlan(NamedTuple):
         extend_lens_cpu = extend_lens.detach().to(torch.int64).cpu()
         rid_i64 = req_pool_indices.to(torch.int64)
         r2t_i32 = req_to_token.to(torch.int32)
-        f2s_i64 = full_to_swa.to(torch.int64)
         pin_buffer = torch.empty(
             (2, num_q_tokens, 16), dtype=torch.uint8, pin_memory=True
         )
@@ -298,12 +291,10 @@ class CompressorPrefillPlan(NamedTuple):
             extend_lens_cpu,
             rid_i64,
             r2t_i32,
-            f2s_i64,
             plan_c_pin,
             plan_w_pin,
             plan_c_dev,
             plan_w_dev,
-            int(swa_page_size),
             int(state_slot_offset),
             bool(use_cuda_graph),
         )

--- a/python/sglang/jit_kernel/dsv4/online_c128_mtp.py
+++ b/python/sglang/jit_kernel/dsv4/online_c128_mtp.py
@@ -14,8 +14,10 @@ if TYPE_CHECKING:
 
 
 @cache_once
-def _jit_online_c128_mtp_module(head_dim: int) -> Module:
-    args = make_cpp_args(head_dim)
+def _jit_online_c128_mtp_module(
+    head_dim: int, seq_dtype: torch.dtype, req_dtype: torch.dtype
+) -> Module:
+    args = make_cpp_args(head_dim, seq_dtype, req_dtype)
     return load_jit(
         make_name(f"online_c128_mtp_{head_dim}"),
         *args,
@@ -77,12 +79,14 @@ class OnlineC128MTPController:
         if head_dim is None or self._num_verify_tokens() == 0:
             return
         token_to_kv_pool = self.backend.token_to_kv_pool
-        _jit_online_c128_mtp_module(head_dim).mark_pending(
+        _jit_online_c128_mtp_module(
+            head_dim, seq_lens.dtype, req_pool_indices.dtype
+        ).mark_pending(
             seq_lens,
             req_pool_indices,
             token_to_kv_pool.get_online_c128_mtp_pending_seq_lens(),
             min(seq_lens.shape[0], req_pool_indices.shape[0]),
-            token_to_kv_pool.max_num_reqs,
+            token_to_kv_pool.get_online_c128_state_num_req_slots(),
         )
 
     def clear(self) -> None:
@@ -157,16 +161,16 @@ class OnlineC128MTPController:
         if layer_bs <= 0:
             return
 
-        _jit_online_c128_mtp_module(head_dim).write_prefix_states(
+        _jit_online_c128_mtp_module(
+            head_dim, ctx.seq_lens.dtype, ctx.req_pool_indices.dtype
+        ).write_prefix_states(
             kv_score_input,
             ctx.seq_lens,
             ctx.req_pool_indices,
             self.backend.req_to_token,
-            token_to_kv_pool.full_to_swa_index_mapping,
             compressor.ape.reshape(128, head_dim),
             state_pool.kv_score_buffer.kv_score,
             layer_bs,
-            token_to_kv_pool.swa_page_size,
             num_verify_tokens,
             state_pool.online_mtp_state_slot_offset,
         )
@@ -195,18 +199,18 @@ class OnlineC128MTPController:
         cur_bs = min(seq_lens.shape[0], req_pool_indices.shape[0])
 
         for runtime in self._iter_layer_runtimes():
-            _jit_online_c128_mtp_module(runtime.head_dim).commit_pending(
+            _jit_online_c128_mtp_module(
+                runtime.head_dim, seq_lens.dtype, req_pool_indices.dtype
+            ).commit_pending(
                 seq_lens,
                 req_pool_indices,
                 backend.req_to_token,
-                token_to_kv_pool.full_to_swa_index_mapping,
                 pending_seq_lens,
                 runtime.main_state,
                 cur_bs,
-                token_to_kv_pool.swa_page_size,
                 num_verify_tokens,
                 runtime.state_slot_offset,
-                token_to_kv_pool.max_num_reqs,
+                token_to_kv_pool.get_online_c128_state_num_req_slots(),
             )
 
         self.clear()

--- a/python/sglang/jit_kernel/tests/deepseek_v4/common.py
+++ b/python/sglang/jit_kernel/tests/deepseek_v4/common.py
@@ -103,7 +103,7 @@ class PagedContext:
             seq_lens=seq_lens_cpu,
             extend_lens=extend_lens_cpu,
             req_to_token=self.req_to_token,
-            full_to_swa=self.full_to_swa,
+            full_to_state=self.full_to_swa,
             swa_page_size=self.swa_page_size,
             ring_size=self.ring_size,
             num_q_tokens=num_q_tokens,
@@ -114,7 +114,7 @@ class PagedContext:
             compress_ratio=self.compress_ratio,  # type: ignore
             req_pool_indices=self.req_pool_indices,
             req_to_token=self.req_to_token,
-            full_to_swa=self.full_to_swa,
+            full_to_state=self.full_to_swa,
             seq_lens=seq_lens_gpu,
             swa_page_size=self.swa_page_size,
             ring_size=self.ring_size,

--- a/python/sglang/srt/arg_groups/hisparse_hook.py
+++ b/python/sglang/srt/arg_groups/hisparse_hook.py
@@ -91,6 +91,57 @@ def validate_hisparse_kv_cache_dtype(server_args: ServerArgs) -> None:
     )
 
 
+def _validate_dsv4_hisparse_online_c128_mtp(server_args: ServerArgs) -> None:
+    """Validate the DSV4 HiSparse + online C128 MTP combination early."""
+    from sglang.srt.environ import envs
+
+    if not envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+        return
+
+    if server_args.speculative_algorithm is None:
+        return
+
+    if not envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.get():
+        raise ValueError(
+            "DSV4 HiSparse online C128 with speculative decode requires "
+            "SGLANG_EXPERIMENTAL_ONLINE_C128_MTP=1."
+        )
+
+    if server_args.speculative_algorithm != "EAGLE":
+        raise ValueError(
+            "DSV4 HiSparse online C128 MTP is currently only validated for "
+            f"EAGLE, got {server_args.speculative_algorithm!r}."
+        )
+
+    if server_args.speculative_eagle_topk not in (None, 1):
+        raise ValueError(
+            "DSV4 HiSparse online C128 MTP requires "
+            f"--speculative-eagle-topk 1, got {server_args.speculative_eagle_topk}."
+        )
+
+    speculative_num_steps = int(server_args.speculative_num_steps or 0)
+    if speculative_num_steps > 2:
+        raise ValueError(
+            "DSV4 HiSparse online C128 MTP is currently validated only for "
+            f"EAGLE step1/step2, got speculative_num_steps={speculative_num_steps}."
+        )
+
+    if not envs.SGLANG_OPT_USE_COMPRESSOR_V2.get():
+        raise ValueError(
+            "DSV4 HiSparse online C128 MTP requires "
+            "SGLANG_OPT_USE_COMPRESSOR_V2=1 because the v2 compressor carries "
+            "online state-slot metadata."
+        )
+
+    logger.warning(
+        "DSV4 HiSparse online C128 MTP enabled: C4 stays on the HiSparse "
+        "host mirror; C128 uses online EAGLE state banks; eagle_steps=%d, "
+        "draft_tokens=%s.",
+        speculative_num_steps,
+        server_args.speculative_num_draft_tokens,
+    )
+
+
 def validate_hisparse(server_args: ServerArgs) -> None:
     """Validate --enable-hisparse constraints (model class, radix cache, DSA backend)."""
     if not server_args.enable_hisparse:
@@ -115,6 +166,9 @@ def validate_hisparse(server_args: ServerArgs) -> None:
 
     # DSv4 hisparse handles its own dtype/backend pairing elsewhere; the dtype-
     # aware checks below only apply to the DSA hisparse path.
+    if is_v4_hisparse:
+        _validate_dsv4_hisparse_online_c128_mtp(server_args)
+
     if is_hip and is_v4_hisparse:
         # TEMPORARY GUARD: DSv4 HiSparse is not supported on the unified-KV path.
         # In unified-KV mode c4_kv_pool is None, so DeepSeekV4HiSparseTokenToKVPoolAllocator

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -21,6 +21,8 @@ class StateType(str, enum.Enum):
     # DeepSeek-V4 unified_kv SWA ring: addressed per-row by ring slot
     # (req_pool_idx * ring_stride + pos % ring_stride), needs its own component.
     SWA_RING = "swa_ring"
+    # DeepSeek-V4 online C128 request-scoped state.
+    C128_STATE = "c128_state"
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -23,6 +23,7 @@ from sglang.srt.disaggregation.base.conn import (
     KVArgs,
     KVPoll,
     KVTransferMetric,
+    StateType,
 )
 from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
@@ -521,7 +522,10 @@ class CommonKVManager(BaseKVManager):
         return src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage
 
     def get_mla_kv_ptrs_with_pp(
-        self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int]
+        self,
+        src_kv_ptrs: List[int],
+        dst_kv_ptrs: List[int],
+        state_type: Optional[StateType] = None,
     ) -> Tuple[List[int], List[int], int]:
         # Fast path: both sides use exactly the same PP layout
         if len(src_kv_ptrs) == len(dst_kv_ptrs):
@@ -534,7 +538,7 @@ class CommonKVManager(BaseKVManager):
             # layer, so we locate the sub-range for this PP stage inside each
             # section of the dst flat list.
             sliced_src_kv_ptrs, sliced_dst_kv_ptrs = self._mla_slice_ptrs_for_pp(
-                src_kv_ptrs, dst_kv_ptrs, mla_ratios
+                src_kv_ptrs, dst_kv_ptrs, mla_ratios, state_type
             )
             return (
                 sliced_src_kv_ptrs,
@@ -554,6 +558,7 @@ class CommonKVManager(BaseKVManager):
         src_kv_ptrs: List[int],
         dst_kv_ptrs: List[int],
         mla_ratios: List[int],
+        state_type: Optional[StateType] = None,
     ) -> Tuple[List[int], List[int]]:
         """Produce aligned (src, dst) pointer lists for compressed-MLA
         pools (e.g. DeepSeek V4) under PP.
@@ -568,15 +573,18 @@ class CommonKVManager(BaseKVManager):
           Each section is indexed by compressed-layer id within that
           compression bucket.
 
-        - state_data layout, length = swa_L + 2 * c4_L + c128_L:
+        - SWA state_data layout, length = swa_L + 2 * c4_L:
             [swa_layer_{0..swa_L-1},
-             compress_state_{non-None, c4_L + c128_L},
-             indexer_compress_state_{non-None, c4_L}]
+             c4_compress_state_{0..c4_L-1},
+             c4_indexer_compress_state_{0..c4_L-1}]
           ``swa_L`` is the SWA pool's actual buffer count
           (``num_effective_layers``), which can be smaller than
           ``len(mla_ratios)`` when the HF config's ``compress_ratios``
           list contains entries for layers not materialized into the SWA
           pool (e.g. an MTP/nextn slot at the tail).
+
+        - C128_STATE layout, length = c128_L:
+            [c128_compress_state_{0..c128_L-1}]
 
         src is already PP-filtered on the prefill side. dst is the
         decode-side full-model list (when decode is PP=1). We slice dst to
@@ -599,7 +607,18 @@ class CommonKVManager(BaseKVManager):
         c128_off_s = sum(1 for r in mla_ratios[:start_layer] if r == 128)
         c128_off_e = sum(1 for r in mla_ratios[:end_layer] if r == 128)
 
-        if len(dst_kv_ptrs) == kv_layout_len:
+        if state_type == StateType.C128_STATE:
+            return src_kv_ptrs, list(dst_kv_ptrs[c128_off_s:c128_off_e])
+
+        if state_type == StateType.SWA_RING:
+            swa_s = min(start_layer, len(dst_kv_ptrs))
+            swa_e = min(end_layer, len(dst_kv_ptrs))
+            return src_kv_ptrs, list(dst_kv_ptrs[swa_s:swa_e])
+
+        if (
+            state_type not in (StateType.SWA, StateType.SWA_RING, StateType.C128_STATE)
+            and len(dst_kv_ptrs) == kv_layout_len
+        ):
             sliced_dst = (
                 list(dst_kv_ptrs[c4_off_s:c4_off_e])
                 + list(dst_kv_ptrs[c4_full + c4_off_s : c4_full + c4_off_e])
@@ -607,39 +626,33 @@ class CommonKVManager(BaseKVManager):
             )
             return src_kv_ptrs, sliced_dst
 
-        # State-data layout. ``swa_L`` is derived from the actual dst
-        # length so we tolerate cases where the SWA pool has fewer
-        # buffers than ``len(mla_ratios)`` (e.g. nextn padding).
-        swa_L = len(dst_kv_ptrs) - 2 * c4_full - c128_full
+        # SWA state-data layout. ``swa_L`` is derived from the actual dst
+        # length so we tolerate cases where the SWA pool has fewer buffers
+        # than ``len(mla_ratios)`` (e.g. nextn padding). C128 state ships as
+        # a separate StateType.C128_STATE component and must not be counted
+        # here.
+        swa_L = len(dst_kv_ptrs) - 2 * c4_full
         if swa_L < 0 or swa_L > len(mla_ratios):
             raise ValueError(
                 f"Unexpected compressed-MLA dst_kv_ptrs length "
                 f"{len(dst_kv_ptrs)}; expected either {kv_layout_len} "
-                f"(kv_data) or swa_L + {2 * c4_full + c128_full} "
+                f"(kv_data) or swa_L + {2 * c4_full} "
                 f"(state_data) given compression_ratios "
                 f"(c4={c4_full}, c128={c128_full}, "
                 f"total={len(mla_ratios)})."
             )
-        # Guard against asking the prefill side to read past the SWA
-        # pool boundary.
-        assert end_layer <= swa_L, (
-            f"prefill_end_layer ({end_layer}) exceeds dst SWA pool "
-            f"buffer count ({swa_L}); compression_ratios may include "
-            f"layers (e.g. nextn) that the SWA pool does not cover."
-        )
 
-        # compress_state non-None count up to L = count(r != 0).
-        c_non_zero_s = sum(1 for r in mla_ratios[:start_layer] if r != 0)
-        c_non_zero_e = sum(1 for r in mla_ratios[:end_layer] if r != 0)
+        swa_s = min(start_layer, swa_L)
+        swa_e = min(end_layer, swa_L)
         compress_section_start = swa_L
-        indexer_section_start = swa_L + (c4_full + c128_full)
+        indexer_section_start = swa_L + c4_full
         sliced_dst = (
-            list(dst_kv_ptrs[start_layer:end_layer])
+            list(dst_kv_ptrs[swa_s:swa_e])
             + list(
                 dst_kv_ptrs[
                     compress_section_start
-                    + c_non_zero_s : compress_section_start
-                    + c_non_zero_e
+                    + c4_off_s : compress_section_start
+                    + c4_off_e
                 ]
             )
             + list(

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -50,6 +50,7 @@ from sglang.srt.disaggregation.utils import (
     ReqToMetadataIdxAllocator,
     TransferBackend,
     _is_fake_transfer,
+    get_dsv4_c128_state_indices,
     get_kv_class,
     is_mla_backend,
     poll_and_all_reduce,
@@ -1040,6 +1041,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 ring_rows = state_slot * ring_stride + (positions % ring_stride)
                 return ring_rows.astype(np.int32)
 
+            def _c128_state_payload():
+                online = envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get()
+                ring_size = 1 if online else self.token_to_kv_pool.get_ring_size(128)
+                return get_dsv4_c128_state_indices(
+                    int(decode_req.req.req_pool_idx),
+                    seq_len,
+                    online=online,
+                    ring_size=ring_size,
+                )
+
             state_types = self.kv_manager.kv_args.state_types
             state_indices: Optional[List] = []
             for st in state_types:
@@ -1051,6 +1062,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     state_indices.append(_dsa_payload())
                 elif st == StateType.SWA_RING:
                     state_indices.append(_swa_ring_payload())
+                elif st == StateType.C128_STATE:
+                    state_indices.append(_c128_state_payload())
                 else:
                     state_indices.append(None)
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -586,6 +586,7 @@ class MooncakeKVManager(CommonKVManager):
         prefill_data_indices: npt.NDArray[np.int32],
         dst_data_indices: npt.NDArray[np.int32],
         executor: concurrent.futures.ThreadPoolExecutor,
+        state_type: Optional[StateType] = None,
     ) -> int:
         """
         Generic KV cache transfer supporting both MHA and MLA architectures.
@@ -601,7 +602,7 @@ class MooncakeKVManager(CommonKVManager):
         # Decode pp size should be equal to prefill pp size or 1
         if self.is_mla_backend:
             src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
-                self.get_mla_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs)
+                self.get_mla_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs, state_type)
             )
             layers_params = [
                 (
@@ -996,7 +997,12 @@ class MooncakeKVManager(CommonKVManager):
                         )
                         or rc
                     )
-            elif st in (StateType.SWA, StateType.DSA, StateType.SWA_RING):
+            elif st in (
+                StateType.SWA,
+                StateType.DSA,
+                StateType.SWA_RING,
+                StateType.C128_STATE,
+            ):
                 if (
                     target_rank_registration_info is not None
                     and not self.is_mla_backend
@@ -1009,12 +1015,13 @@ class MooncakeKVManager(CommonKVManager):
                 src_indices = list(indices)
                 dst_indices_local = list(dst_indices)
                 if len(src_indices) != len(dst_indices_local):
-                    # SWA_RING is positional: truncating silently misaligns rows
-                    # and corrupts KV, so fail loud. Paged SWA/DSA tolerate a
-                    # 1-page drift -> keep the lenient truncation below.
-                    if st == StateType.SWA_RING:
+                    # These components are position- or request-indexed:
+                    # truncating silently misaligns rows and corrupts KV.
+                    # Paged SWA/DSA tolerate a 1-page drift -> keep the
+                    # lenient truncation below.
+                    if st in (StateType.SWA_RING, StateType.C128_STATE):
                         raise RuntimeError(
-                            "SWA_RING state index length mismatch: "
+                            f"{st.upper()} state index length mismatch: "
                             f"prefill={len(src_indices)}, dst={len(dst_indices_local)}"
                         )
                     logger.warning(
@@ -1033,6 +1040,7 @@ class MooncakeKVManager(CommonKVManager):
                         prefill_data_indices=np.array(src_indices, dtype=np.int32),
                         dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
                         executor=executor,
+                        state_type=st,
                     )
                     or rc
                 )

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1092,7 +1092,7 @@ class MoriKVManager(CommonKVManager):
                         dst_dims,
                     )
                 )
-            elif st in ("swa", "dsa", "swa_ring"):
+            elif st in ("swa", "dsa", "swa_ring", "c128_state"):
                 statuses.extend(
                     self._send_swa_dsa_state(
                         peer_info,
@@ -1226,12 +1226,12 @@ class MoriKVManager(CommonKVManager):
                 f"No overlapping state indices for state_type={state_type}"
             )
         if src_state_indices.size != dst_state_indices.size:
-            # SWA_RING is positional: truncating silently misaligns rows and
-            # corrupts KV, so fail loud. Paged swa/dsa tolerate a 1-page drift
-            # -> keep truncation.
-            if state_type == "swa_ring":
+            # These components are position- or request-indexed: truncating
+            # silently misaligns rows and corrupts KV. Paged swa/dsa tolerate
+            # a 1-page drift -> keep truncation.
+            if state_type in ("swa_ring", "c128_state"):
                 raise RuntimeError(
-                    "SWA_RING state index length mismatch: "
+                    f"{state_type.upper()} state index length mismatch: "
                     f"src={src_state_indices.size}, dst={dst_state_indices.size}"
                 )
             logger.warning(

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -951,6 +951,7 @@ class NixlKVManager(CommonKVManager):
         dst_data_indices: npt.NDArray[np.int32],
         dst_gpu_id: int,
         notif: str,
+        state_type: Optional[StateType] = None,
     ):
         """Generic KV cache transfer supporting both MHA and MLA architectures.
         Used by both send_kvcache and maybe_send_extra."""
@@ -1008,7 +1009,7 @@ class NixlKVManager(CommonKVManager):
         # Make descs
         if self.is_mla_backend:
             src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
-                self.get_mla_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs)
+                self.get_mla_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs, state_type)
             )
             layers_params = [
                 (
@@ -1612,7 +1613,12 @@ class NixlKVManager(CommonKVManager):
                         dst_gpu_id,
                         comp_notif,
                     )
-            elif st in (StateType.SWA, StateType.DSA, StateType.SWA_RING):
+            elif st in (
+                StateType.SWA,
+                StateType.DSA,
+                StateType.SWA_RING,
+                StateType.C128_STATE,
+            ):
                 if not self.is_mla_backend and self.attn_tp_size != decode_tp_size:
                     raise RuntimeError(
                         f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {st.upper()} hybrid models yet."
@@ -1631,6 +1637,7 @@ class NixlKVManager(CommonKVManager):
                     dst_data_indices=np.array(dst_indices, dtype=np.int32),
                     dst_gpu_id=dst_gpu_id,
                     notif=comp_notif,
+                    state_type=st,
                 )
             else:
                 raise RuntimeError(

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -39,6 +39,7 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    get_dsv4_c128_state_indices,
     get_kv_class,
     is_aborted,
     is_mla_backend,
@@ -1044,6 +1045,22 @@ class SchedulerDisaggregationPrefillMixin:
                 ring_rows = state_slot * ring_stride + (positions % ring_stride)
                 return ring_rows.astype(np.int32)
 
+            def _c128_state_payload():
+                online = envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get()
+                ring_size = (
+                    1
+                    if online
+                    else self.token_to_kv_pool_allocator.get_kvcache().get_ring_size(
+                        128
+                    )
+                )
+                return get_dsv4_c128_state_indices(
+                    int(req.req_pool_idx),
+                    seq_len,
+                    online=online,
+                    ring_size=ring_size,
+                )
+
             state_types = (
                 self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
             )
@@ -1057,6 +1074,8 @@ class SchedulerDisaggregationPrefillMixin:
                     state_indices.append(_dsa_payload())
                 elif st == StateType.SWA_RING:
                     state_indices.append(_swa_ring_payload())
+                elif st == StateType.C128_STATE:
+                    state_indices.append(_c128_state_payload())
                 else:
                     state_indices.append(None)
 

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -32,6 +32,25 @@ if TYPE_CHECKING:
 FAKE_BOOTSTRAP_HOST = "2.2.2.2"
 
 
+def get_dsv4_c128_state_indices(
+    req_pool_idx: int,
+    seq_len: int,
+    *,
+    online: bool,
+    ring_size: int,
+) -> np.ndarray:
+    """Return the PD transfer row/page indices for DSV4 C128 state."""
+    if online:
+        return np.array([int(req_pool_idx)], dtype=np.int32)
+    if seq_len == 0 or seq_len % 128 == 0:
+        return np.empty((0,), dtype=np.int32)
+
+    assert ring_size % 128 == 0, f"C128 ring_size must be 128-aligned, got {ring_size}"
+    pages_per_req = ring_size // 128
+    page = int(req_pool_idx) * pages_per_req + ((seq_len - 1) % ring_size) // 128
+    return np.array([page], dtype=np.int32)
+
+
 class DisaggregationMode(Enum):
     NULL = "null"
     PREFILL = "prefill"
@@ -667,6 +686,18 @@ def setup_state_kv_args(
                         ring_ptrs,
                         ring_lens,
                         ring_item_lens,
+                    )
+            if hasattr(token_to_kv_pool, "get_c128_state_buf_infos"):
+                c128_ptrs, c128_lens, c128_item_lens = (
+                    token_to_kv_pool.get_c128_state_buf_infos()
+                )
+                if c128_ptrs:
+                    append_state_component(
+                        kv_args,
+                        StateType.C128_STATE,
+                        c128_ptrs,
+                        c128_lens,
+                        c128_item_lens,
                     )
         elif isinstance(token_to_kv_pool, HybridLinearKVPool):
             dim = (

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -790,6 +790,7 @@ class Envs:
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)
     SGLANG_EXPERIMENTAL_ONLINE_C128_MTP = EnvBool(False)
     SGLANG_DSV4_COMPRESS_STATE_DTYPE = EnvStr("float32")
+    # Deprecated: DSV4 compressor V2 is always used.
     SGLANG_OPT_USE_COMPRESSOR_V2 = EnvBool(True)
     SGLANG_FP8_PAGED_MQA_LOGITS_TORCH = EnvBool(False)
     SGLANG_TOPK_TRANSFORM_512_TORCH = EnvBool(False)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -18,25 +18,14 @@ from typing import (
 import torch
 import torch.nn.functional as F
 
+from sglang.jit_kernel.dsv4.online_c128_mtp import OnlineC128MTPController
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
-from sglang.srt.runtime_context import get_parallel
-
-if envs.SGLANG_OPT_USE_COMPRESSOR_V2.get():
-    # NOTE: should eventually be the only compressor backend
-    from sglang.srt.layers.attention.dsv4.compressor_v2 import (
-        CompressorBackendMixin,
-        FusedCompressMetadata,
-        create_paged_compressor_data,
-    )
-else:
-    from sglang.srt.layers.attention.dsv4.compressor import (
-        CompressorBackendMixin,
-        FusedCompressMetadata,
-        create_paged_compressor_data,
-    )
-
-from sglang.jit_kernel.dsv4.online_c128_mtp import OnlineC128MTPController
+from sglang.srt.layers.attention.dsv4.compressor_v2 import (
+    CompressorBackendMixin,
+    FusedCompressMetadata,
+    create_paged_compressor_data,
+)
 from sglang.srt.layers.attention.dsv4.dequant_k_cache import (
     dequantize_k_cache_paged,
 )
@@ -58,6 +47,7 @@ from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.utils import ceil_align
 from sglang.srt.utils.common import is_sm120_supported

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -521,7 +521,9 @@ class DeepseekV4AttnBackend(
             for pool in self.token_to_kv_pool.compress_state_pools
             if pool is not None and pool.ratio == 128
         )
-        state_slot_offset = self.token_to_kv_pool.get_online_c128_mtp_state_slot_offset()
+        state_slot_offset = (
+            self.token_to_kv_pool.get_online_c128_mtp_state_slot_offset()
+        )
         max_draft_tokens = self.token_to_kv_pool.get_online_c128_mtp_max_draft_tokens()
 
         if getattr(model_runner, "is_draft_worker", False):
@@ -1159,9 +1161,7 @@ class DeepseekV4AttnBackend(
             if max_seq_len_override is None
             else max_seq_len_override
         )
-        verify_bs = self._active_batch_size(
-            forward_batch, req_pool_indices, seq_lens
-        )
+        verify_bs = self._active_batch_size(forward_batch, req_pool_indices, seq_lens)
         online_c128_state_slot_offset = self.online_c128_mtp.prepare_forward(
             logical_forward_mode,
             req_pool_indices,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -516,10 +516,60 @@ class DeepseekV4AttnBackend(
             DSV4RawDecodeMetadata,
         ] = None
         self.online_c128_mtp = OnlineC128MTPController(self)
+        self._log_hisparse_online_c128_mtp_state(model_runner)
 
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
         return pin_tensor.to(self.device, non_blocking=True)
+
+    def _log_hisparse_online_c128_mtp_state(self, model_runner: ModelRunner) -> None:
+        if not model_runner.enable_hisparse or not self.online_c128_mtp.enabled():
+            return
+
+        c128_state_layers = sum(
+            1
+            for pool in self.token_to_kv_pool.compress_state_pools
+            if pool is not None and pool.ratio == 128
+        )
+        state_slot_offset = self.token_to_kv_pool.get_online_c128_mtp_state_slot_offset()
+        max_draft_tokens = self.token_to_kv_pool.get_online_c128_mtp_max_draft_tokens()
+
+        if getattr(model_runner, "is_draft_worker", False):
+            logger.info(
+                "DSV4 HiSparse online C128 MTP draft runner initialized: "
+                "c128_state_layers=%d, draft_banks=%d.",
+                c128_state_layers,
+                max_draft_tokens,
+            )
+            return
+
+        if c128_state_layers > 0 and state_slot_offset <= 0:
+            raise RuntimeError(
+                "DSV4 HiSparse online C128 MTP target runner has C128 state "
+                "layers but no pending state-bank offset."
+            )
+        if max_draft_tokens <= 0:
+            raise RuntimeError(
+                "DSV4 HiSparse online C128 MTP target runner has no draft banks."
+            )
+
+        logger.warning(
+            "DSV4 HiSparse online C128 MTP target runner initialized: "
+            "c128_state_layers=%d, state_slot_offset=%d, draft_banks=%d. "
+            "C4 host mirror remains handled by HiSparseCoordinator.",
+            c128_state_layers,
+            state_slot_offset,
+            max_draft_tokens,
+        )
+
+    @staticmethod
+    def _active_batch_size(
+        forward_batch: ForwardBatch,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> int:
+        raw_bs = _get_target_verify_bs(forward_batch)
+        return min(raw_bs, int(req_pool_indices.shape[0]), int(seq_lens.shape[0]))
 
     def _make_target_verify_c128_metadata(
         self,
@@ -1011,7 +1061,9 @@ class DeepseekV4AttnBackend(
                 out_cache_loc=out_cache_loc_padded,
             )
         elif bucket == _GraphBucket.TARGET_VERIFY:
-            verify_bs = _get_target_verify_bs(forward_batch)
+            verify_bs = self._active_batch_size(
+                forward_batch, req_pool_indices, seq_lens
+            )
             if self.online_c128_mtp.enabled() and verify_bs == 0:
                 self.online_c128_mtp.clear()
                 self.forward_metadata = self.cuda_graph_metadata_of_bucket_and_bs[
@@ -1117,7 +1169,9 @@ class DeepseekV4AttnBackend(
             if max_seq_len_override is None
             else max_seq_len_override
         )
-        verify_bs = _get_target_verify_bs(forward_batch)
+        verify_bs = self._active_batch_size(
+            forward_batch, req_pool_indices, seq_lens
+        )
         online_c128_state_slot_offset = self.online_c128_mtp.prepare_forward(
             logical_forward_mode,
             req_pool_indices,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -20,21 +20,11 @@ import torch.nn.functional as F
 
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
-from sglang.srt.runtime_context import get_parallel
-
-if envs.SGLANG_OPT_USE_COMPRESSOR_V2.get():
-    from sglang.srt.layers.attention.dsv4.compressor_v2 import (
-        CompressorBackendMixin,
-        FusedCompressMetadata,
-        create_paged_compressor_data,
-    )
-else:
-    from sglang.srt.layers.attention.dsv4.compressor import (
-        CompressorBackendMixin,
-        FusedCompressMetadata,
-        create_paged_compressor_data,
-    )
-
+from sglang.srt.layers.attention.dsv4.compressor_v2 import (
+    CompressorBackendMixin,
+    FusedCompressMetadata,
+    create_paged_compressor_data,
+)
 from sglang.srt.layers.attention.dsv4.indexer import C4IndexerBackendMixin
 from sglang.srt.layers.attention.dsv4.metadata import (
     PagedIndexerMetadata,
@@ -49,6 +39,7 @@ from sglang.srt.layers.attention.dsv4.quant_k_cache import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.utils import ceil_align
 

--- a/python/sglang/srt/layers/attention/dsv4/compress_hip.py
+++ b/python/sglang/srt/layers/attention/dsv4/compress_hip.py
@@ -210,13 +210,18 @@ class CompressorHip(_CompressorBase):
             pre_state_indices = self.compute_state_len_indices(
                 seq_len=prefix_lens[i], ratio=self.ratio
             ).to(device)
-            raw_loc = torch.where(
-                pre_state_indices < 0,
-                -1,
-                req_to_token[req_pool_indices[i], pre_state_indices],
-            )
-            swa_loc = token_to_kv_pool.translate_loc_from_full_to_swa(raw_loc)
-            state_loc = state_pool.translate_from_swa_loc_to_state_loc(swa_loc)
+            if self.ratio == 128:
+                state_loc = state_pool.translate_from_req_position_to_state_loc(
+                    req_pool_indices[i], pre_state_indices
+                )
+            else:
+                raw_loc = torch.where(
+                    pre_state_indices < 0,
+                    -1,
+                    req_to_token[req_pool_indices[i], pre_state_indices],
+                )
+                swa_loc = token_to_kv_pool.translate_loc_from_full_to_swa(raw_loc)
+                state_loc = state_pool.translate_from_swa_loc_to_state_loc(swa_loc)
             pre_kv_state = state_pool.get_state_by_state_loc(state_loc)
             kv_and_score_buffer = KVAndScore.cat([pre_kv_state, kv_and_score], dim=0)
             valid_kv_len = kv_and_score_buffer.kv.size(0)
@@ -227,15 +232,22 @@ class CompressorHip(_CompressorBase):
             post_state_len = post_state_indices.size(0)
 
             assert post_state_len <= valid_kv_len
-            post_raw_loc = torch.where(
-                post_state_indices < 0,
-                -1,
-                req_to_token[req_pool_indices[i], post_state_indices],
-            )
-            post_swa_loc = token_to_kv_pool.translate_loc_from_full_to_swa(post_raw_loc)
-            post_state_loc = state_pool.translate_from_swa_loc_to_state_loc(
-                post_swa_loc
-            )
+            if self.ratio == 128:
+                post_state_loc = state_pool.translate_from_req_position_to_state_loc(
+                    req_pool_indices[i], post_state_indices
+                )
+            else:
+                post_raw_loc = torch.where(
+                    post_state_indices < 0,
+                    -1,
+                    req_to_token[req_pool_indices[i], post_state_indices],
+                )
+                post_swa_loc = token_to_kv_pool.translate_loc_from_full_to_swa(
+                    post_raw_loc
+                )
+                post_state_loc = state_pool.translate_from_swa_loc_to_state_loc(
+                    post_swa_loc
+                )
             post_state_to_set = kv_and_score_buffer[valid_kv_len - post_state_len :]
             state_pool.set_state_by_state_loc(post_state_loc, post_state_to_set)
 
@@ -337,10 +349,14 @@ class CompressorHip(_CompressorBase):
             seq_lens = seq_lens_2d.view(-1)
             req_pool_indices = req_pool_indices.repeat_interleave(draft_tokens)
 
-        raw_locs = req_to_token[req_pool_indices, seq_lens - 1]
-
-        swa_locs = token_to_kv_pool.translate_loc_from_full_to_swa(raw_locs)
-        state_locs = state_pool.translate_from_swa_loc_to_state_loc(swa_locs)
+        if self.ratio == 128:
+            state_locs = state_pool.translate_from_req_position_to_state_loc(
+                req_pool_indices, seq_lens - 1
+            )
+        else:
+            raw_locs = req_to_token[req_pool_indices, seq_lens - 1]
+            swa_locs = token_to_kv_pool.translate_loc_from_full_to_swa(raw_locs)
+            state_locs = state_pool.translate_from_swa_loc_to_state_loc(swa_locs)
         state_pool.set_state_by_state_loc(state_locs, kv_and_scores)
 
         compress_bulk_len = self.ratio * self.coff
@@ -348,17 +364,24 @@ class CompressorHip(_CompressorBase):
             -compress_bulk_len, 0, device=seq_lens.device
         )
         compress_indices.clamp_(min=-1)
-        compress_indices_raw = torch.where(
-            compress_indices < 0,
-            -1,
-            req_to_token[req_pool_indices[:, None], compress_indices],
-        )
-        compress_indices_swa = token_to_kv_pool.translate_loc_from_full_to_swa(
-            compress_indices_raw
-        )
-        compress_indices_state = state_pool.translate_from_swa_loc_to_state_loc(
-            compress_indices_swa
-        )
+        if self.ratio == 128:
+            compress_indices_state = (
+                state_pool.translate_from_req_position_to_state_loc(
+                    req_pool_indices[:, None], compress_indices
+                )
+            )
+        else:
+            compress_indices_raw = torch.where(
+                compress_indices < 0,
+                -1,
+                req_to_token[req_pool_indices[:, None], compress_indices],
+            )
+            compress_indices_swa = token_to_kv_pool.translate_loc_from_full_to_swa(
+                compress_indices_raw
+            )
+            compress_indices_state = state_pool.translate_from_swa_loc_to_state_loc(
+                compress_indices_swa
+            )
         kv_and_score_to_compress = state_pool.get_state_by_state_loc(
             compress_indices_state.view(-1)
         ).view(-1, self.ratio, self.coff * self.head_dim)

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -31,15 +31,9 @@ from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.models.deepseek_v2 import _is_hip
 from sglang.srt.runtime_context import get_parallel
-from sglang.srt.utils import add_prefix, get_bool_env_var, is_npu, set_weight_attrs
+from sglang.srt.utils import add_prefix, is_npu, set_weight_attrs
 
 _is_npu = is_npu()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
-_tgemm = None
-if _use_aiter:
-    from aiter.tuned_gemm import tgemm
-
-    _tgemm = tgemm
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -287,10 +281,13 @@ def create_paged_compressor_data(
 
     def get_raw_loc(positions: torch.Tensor) -> torch.Tensor:
         positions = positions.masked_fill(positions < 0, 0)
-        loc = req_to_token[req_pool_indices, positions]
-        swa_loc = token_to_kv_pool.translate_loc_from_full_to_swa(loc)
-        swa_pages = swa_loc // swa_page_size
-        state_loc = swa_pages * ring_size + swa_loc % ring_size
+        if compress_ratio == 128:
+            state_loc = req_pool_indices * ring_size + positions % ring_size
+        else:
+            loc = req_to_token[req_pool_indices, positions]
+            swa_loc = token_to_kv_pool.translate_loc_from_full_to_swa(loc)
+            swa_pages = swa_loc // swa_page_size
+            state_loc = swa_pages * ring_size + swa_loc % ring_size
         return (state_loc // compress_ratio).to(torch.int32)
 
     is_overlap = is_overlap_compress(compress_ratio)
@@ -423,12 +420,7 @@ class Compressor(MultiPlatformOp):
         return ret
 
     def compute_kv_score(self, x: torch.Tensor, forward_batch: ForwardBatch):
-        if _tgemm is not None and not envs.SGLANG_OPT_USE_COMPRESSOR_V2.get():
-            # v1 compress goes through fused_compress_triton, which promotes
-            # bf16->fp32 internally, so skip the .float() cast.
-            kv_score = _tgemm.mm(x, self.wkv_gate.weight, otype=x.dtype)
-        else:
-            kv_score = linear_bf16_fp32(x, self.wkv_gate.weight)
+        kv_score = linear_bf16_fp32(x, self.wkv_gate.weight)
 
         # CUDA path: delegate to backend
         if dsa_use_prefill_cp(forward_batch):
@@ -487,9 +479,3 @@ class Compressor(MultiPlatformOp):
             )
 
         return get_attn_backend().forward_compress(self, x, forward_batch)
-
-
-if _is_hip and not envs.SGLANG_OPT_USE_COMPRESSOR_V2.get():
-    from sglang.srt.layers.attention.dsv4.compress_hip import (  # noqa: F811
-        CompressorHip as Compressor,
-    )

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -731,7 +731,7 @@ def create_paged_compressor_data(
             seq_lens=seq_lens_planner,
             extend_lens=extend_lens_planner,
             req_to_token=req_to_token,
-            full_to_swa=full_to_swa,
+            full_to_state=full_to_swa,
             swa_page_size=swa_page_size,
             ring_size=ring_size,
             num_q_tokens=num_q_tokens,
@@ -742,7 +742,7 @@ def create_paged_compressor_data(
             compress_ratio=compress_ratio,
             req_pool_indices=req_pool_indices_i64,
             req_to_token=req_to_token,
-            full_to_swa=full_to_swa,
+            full_to_state=full_to_swa,
             seq_lens=seq_lens.to(torch.int64),
             swa_page_size=swa_page_size,
             ring_size=ring_size,
@@ -763,8 +763,6 @@ def _create_online_paged_compressor_data(
     num_q_tokens: Optional[int],
     online_state_slot_offset: int = 0,
 ) -> CompressMetadata:
-    swa_page_size = int(token_to_kv_pool.swa_page_size)
-    full_to_swa = token_to_kv_pool.full_to_swa_index_mapping.detach()
     req_pool_indices = req_pool_indices.to(torch.int64)
 
     if is_prefill:
@@ -787,9 +785,7 @@ def _create_online_paged_compressor_data(
             extend_lens=extend_lens_planner,
             req_pool_indices=req_pool_indices,
             req_to_token=req_to_token,
-            full_to_swa=full_to_swa,
             num_q_tokens=int(num_q_tokens_planner),
-            swa_page_size=swa_page_size,
             use_cuda_graph=use_prefill_cuda_graph,
             state_slot_offset=online_state_slot_offset,
         )
@@ -798,7 +794,5 @@ def _create_online_paged_compressor_data(
             seq_lens=seq_lens.to(torch.int64),
             req_pool_indices=req_pool_indices,
             req_to_token=req_to_token,
-            full_to_swa=full_to_swa,
-            swa_page_size=swa_page_size,
             state_slot_offset=online_state_slot_offset,
         )

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -182,7 +182,7 @@ class SchedulePolicy:
             and get_global_server_args().disaggregation_mode != "decode"
         ):
             for r in waiting_queue:
-                match_prefix_for_req(self.tree_cache, r)
+                match_prefix_for_req(self.tree_cache, r, include_req=True)
 
         if self.policy == CacheAgnosticPolicy.FCFS:
             if self.enable_priority_scheduling:
@@ -257,7 +257,9 @@ class SchedulePolicy:
         for r in waiting_queue:
             prefix_ids = r.origin_input_ids + r.output_ids
             extra_key = r.extra_key
-            match_result = match_prefix_for_req(self.tree_cache, r, prefix_ids)
+            match_result = match_prefix_for_req(
+                self.tree_cache, r, prefix_ids, include_req=True
+            )
 
             # NOTE(sang): This logic is for in-batch prefix caching;
             # If there are more than 1 request that have small matching prefix from

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -505,6 +505,10 @@ def alloc_for_extend(
         batch.req_to_token_pool,
     )
 
+    restore_c128_state = getattr(batch.tree_cache, "restore_c128_state_for_reqs", None)
+    if restore_c128_state is not None:
+        restore_c128_state(batch.reqs)
+
     # DSV4-NPU hook: write c4/c128/swa per-req tables from the stashed bundle.
     # No-op on non-DSV4 paths (out_cache_loc_dsv4 stays None there).
     if _is_npu:

--- a/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
@@ -197,6 +197,13 @@ class CompressStatePool:
         state_loc = torch.where(swa_loc < 0, -1, state_loc)
         return state_loc
 
+    def translate_from_req_position_to_state_loc(
+        self, req_pool_indices: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        state_loc = req_pool_indices * self.ring_size + positions % self.ring_size
+        state_loc = torch.where(positions < 0, -1, state_loc)
+        return state_loc
+
     def get_state_by_state_loc(self, state_loc: torch.Tensor) -> KVAndScore:
         return self.kv_score_buffer[state_loc]
 

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -32,11 +32,13 @@ def get_compress_state_ring_size(
 ) -> int:
     assert compress_ratio in [4, 128], f"Unsupported {compress_ratio = }"
     # Online c128 keeps a single (max, sum, kv) state per index instead of a
-    # 128-slot ring buffer of raw tokens, so ring_size collapses to 1. Online
-    # is incompatible with speculative decode for now.
+    # 128-slot ring buffer of raw tokens, so ring_size collapses to 1. The
+    # experimental MTP path uses request-scoped C128 state banks for EAGLE.
     if compress_ratio == 128 and ONLINE_C128:
         if is_speculative and not envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.get():
-            raise AssertionError("online c128 does not support MTP")
+            raise AssertionError(
+                "online c128 MTP requires SGLANG_EXPERIMENTAL_ONLINE_C128_MTP=1"
+            )
         return 1
     if is_speculative:
         return 16 if compress_ratio == 4 else 256

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -494,15 +494,27 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self.c4_logical_size = c4_logical_size
         self.c128_size = c128_size
         self.c4_state_pool_size = c4_state_pool_size
+        c128_ring_size = self.get_ring_size(128)
+        if ONLINE_C128:
+            # Request-scoped online C128 state is indexed by req_pool_idx.
+            # PD decode can allocate pre-transfer slots beyond
+            # max_num_reqs, so size to the actual req_to_token row count.
+            c128_state_pool_size = max(c128_state_pool_size, self.num_req_slots)
+        else:
+            # Offline C128 keeps a per-request raw state ring.
+            c128_state_pool_size = max(
+                c128_state_pool_size, self.num_req_slots * c128_ring_size
+            )
         self.c128_state_pool_size = c128_state_pool_size
         self.c4_state_dtype = c4_state_dtype
         self.c128_state_dtype = c128_state_dtype
         self.compression_ratios = compression_ratios
         self.online_mtp_max_draft_tokens = online_mtp_max_draft_tokens
+        self.online_c128_state_num_req_slots = c128_state_pool_size
         self.online_c128_mtp_pending_seq_lens: Optional[torch.Tensor] = None
         if ONLINE_C128 and envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.get():
             self.online_c128_mtp_pending_seq_lens = torch.empty(
-                max_num_reqs, dtype=torch.int64, device=device
+                self.online_c128_state_num_req_slots, dtype=torch.int64, device=device
             )
 
         # Determine this PP stage's absolute layer range
@@ -602,11 +614,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             global_page_size=page_size,
         )
 
-        indexer_size = (
-            self.c4_logical_size
-            if (not _is_hip or envs.SGLANG_OPT_USE_COMPRESSOR_V2.get())
-            else c4_size
-        )
+        indexer_size = self.c4_logical_size
         self.c4_indexer_kv_pool = self._make_indexer_pool(
             indexer_size,
             c4_page_size,
@@ -731,12 +739,30 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             for pool in pools:
                 if pool is None:
                     continue
+                if pool.ratio == 128:
+                    continue
                 t = pool.kv_score_buffer.kv_score
                 assert t.ndim == 2, f"expected 2D buffer, got {t.ndim}D"
                 data_ptrs.append(t.data_ptr())
                 data_lens.append(t.nbytes)
                 item_lens.append(t[0].nbytes * pool.ring_size)
 
+        return data_ptrs, data_lens, item_lens
+
+    def get_c128_state_buf_infos(
+        self,
+    ) -> Tuple[List[int], List[int], List[int]]:
+        data_ptrs: List[int] = []
+        data_lens: List[int] = []
+        item_lens: List[int] = []
+        for pool in self.compress_state_pools:
+            if pool is None or pool.ratio != 128:
+                continue
+            t = pool.kv_score_buffer.kv_score
+            assert t.ndim == 2, f"expected 2D buffer, got {t.ndim}D"
+            data_ptrs.append(t.data_ptr())
+            data_lens.append(t.nbytes)
+            item_lens.append(t[0].nbytes if ONLINE_C128 else t[0].nbytes * 128)
         return data_ptrs, data_lens, item_lens
 
     def _make_kv_pool(
@@ -909,9 +935,69 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 return int(pool.online_mtp_max_draft_tokens)
         return 0
 
+    def get_online_c128_state_num_req_slots(self) -> int:
+        return self.online_c128_state_num_req_slots
+
     def get_online_c128_mtp_pending_seq_lens(self) -> torch.Tensor:
         assert self.online_c128_mtp_pending_seq_lens is not None
         return self.online_c128_mtp_pending_seq_lens
+
+    def snapshot_c128_radix_state(
+        self, req_pool_idx: int, seq_len: int
+    ) -> Optional[List[torch.Tensor]]:
+        """Snapshot request-scoped C128 state for a radix cache node."""
+        if seq_len % 128 == 0:
+            return None
+
+        snapshots: List[torch.Tensor] = []
+        for pool in self.compress_state_pools:
+            if pool is None or pool.ratio != 128:
+                continue
+            state = pool.kv_score_buffer.kv_score
+            if ONLINE_C128:
+                snapshots.append(state[req_pool_idx : req_pool_idx + 1].clone())
+            else:
+                start = req_pool_idx * pool.ring_size
+                state_len = seq_len % pool.ring_size
+                if state_len == 0:
+                    continue
+                snapshot = state.new_empty((pool.ring_size, state.shape[-1]))
+                half = snapshot.shape[-1] // 2
+                snapshot[:, :half].zero_()
+                snapshot[:, half:].fill_(float("-inf"))
+                positions = torch.arange(
+                    seq_len - state_len,
+                    seq_len,
+                    device=state.device,
+                    dtype=torch.long,
+                )
+                slots = positions % pool.ring_size
+                snapshot[slots] = state[start + slots]
+                snapshots.append(snapshot)
+        return snapshots or None
+
+    def restore_c128_radix_state(
+        self, req_pool_idx: int, snapshots: Optional[List[torch.Tensor]]
+    ) -> None:
+        """Restore radix-cached C128 state into the current request slot."""
+        if not snapshots:
+            return
+
+        snapshot_idx = 0
+        for pool in self.compress_state_pools:
+            if pool is None or pool.ratio != 128:
+                continue
+            snapshot = snapshots[snapshot_idx]
+            snapshot_idx += 1
+
+            state = pool.kv_score_buffer.kv_score
+            if ONLINE_C128:
+                state[req_pool_idx : req_pool_idx + 1].copy_(snapshot)
+            else:
+                start = req_pool_idx * pool.ring_size
+                state[start : start + pool.ring_size].copy_(snapshot)
+
+        assert snapshot_idx == len(snapshots)
 
     def get_indexer_compress_states(self, layer_id: int) -> CompressStatePool:
         self.wait_layer_transfer(layer_id)

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -22,7 +22,7 @@ The radix tree data structure for managing the hybrid (full and SWA) KV cache.
 import heapq
 import time
 from collections import defaultdict
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import torch
 from numpy import float64
@@ -80,6 +80,8 @@ class TreeNode:
         self.host_value = None
         # store hash values of each page
         self.hash_value: Optional[List[str]] = None
+        # C128 state snapshots keyed by the local token offset inside this node.
+        self.c128_state_snapshots: Optional[Dict[int, List[torch.Tensor]]] = None
 
         # for lru list, invariant:
         # 1. prev has greater last_access_time
@@ -386,6 +388,109 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         self.swa_lru_list = LRUList(is_swa_list=True)
         self._record_all_cleared_event()
 
+    def _dsv4_kv_pool(self):
+        if self.token_to_kv_pool_allocator is None:
+            return None
+        get_kvcache = getattr(self.token_to_kv_pool_allocator, "get_kvcache", None)
+        if get_kvcache is None:
+            return None
+        kv_pool = get_kvcache()
+        if not hasattr(kv_pool, "snapshot_c128_radix_state") or not hasattr(
+            kv_pool, "restore_c128_radix_state"
+        ):
+            return None
+        return kv_pool
+
+    def _snapshot_c128_state_for_req(
+        self, req: Req, seq_len: int
+    ) -> Optional[List[torch.Tensor]]:
+        kv_pool = self._dsv4_kv_pool()
+        if kv_pool is None or req.req_pool_idx is None or seq_len <= 0:
+            return None
+        return kv_pool.snapshot_c128_radix_state(int(req.req_pool_idx), seq_len)
+
+    def _node_prefix_len(self, node: TreeNode) -> int:
+        prefix_len = 0
+        while node is not None and node is not self.root_node:
+            prefix_len += len(node.value)
+            node = node.parent
+        return prefix_len
+
+    def _get_c128_snapshot_at_node_end(
+        self, node: TreeNode
+    ) -> Optional[List[torch.Tensor]]:
+        if node.c128_state_snapshots is None:
+            return None
+        return node.c128_state_snapshots.get(len(node.value))
+
+    def _is_c128_restorable_node(self, node: TreeNode) -> bool:
+        if node is self.root_node:
+            return True
+        if self._get_c128_snapshot_at_node_end(node) is not None:
+            return True
+        return self._node_prefix_len(node) % 128 == 0
+
+    def _store_c128_snapshot_at_prefix_len(
+        self,
+        node: TreeNode,
+        prefix_len: int,
+        snapshot: Optional[List[torch.Tensor]],
+    ) -> None:
+        if snapshot is None or prefix_len <= 0:
+            return
+
+        path: List[TreeNode] = []
+        cur = node
+        while cur is not None and cur is not self.root_node:
+            path.append(cur)
+            cur = cur.parent
+
+        remaining = prefix_len
+        for cur in reversed(path):
+            if remaining <= len(cur.value):
+                if cur.c128_state_snapshots is None:
+                    cur.c128_state_snapshots = {}
+                cur.c128_state_snapshots[remaining] = snapshot
+                return
+            remaining -= len(cur.value)
+
+    def _store_c128_partial_snapshot_for_req(
+        self, req: Req, node: TreeNode, prefix_len: int
+    ) -> None:
+        if prefix_len % 128 == 0:
+            return
+        snapshot = self._snapshot_c128_state_for_req(req, prefix_len)
+        self._store_c128_snapshot_at_prefix_len(node, prefix_len, snapshot)
+
+    def _find_c128_restorable_node(self, node: TreeNode) -> TreeNode:
+        if self._dsv4_kv_pool() is None:
+            return node
+        while node is not self.root_node and not self._is_c128_restorable_node(node):
+            prefix_len = self._node_prefix_len(node)
+            aligned_prefix_len = prefix_len // 128 * 128
+            parent_prefix_len = prefix_len - len(node.value)
+            if aligned_prefix_len > parent_prefix_len:
+                split_len = aligned_prefix_len - parent_prefix_len
+                return self._split_node(node.key, node, split_len)
+            node = node.parent
+        return node
+
+    def restore_c128_state_for_reqs(self, reqs: List[Req]) -> None:
+        kv_pool = self._dsv4_kv_pool()
+        if kv_pool is None:
+            return
+        for req in reqs:
+            if req.req_pool_idx is None:
+                continue
+            node = getattr(req, "last_node", self.root_node)
+            prefix_len = len(getattr(req, "prefix_indices", []))
+            snapshot = self._get_c128_snapshot_at_node_end(node)
+            if node is self.root_node or not self._is_c128_restorable_node(node):
+                continue
+            assert self._node_prefix_len(node) == prefix_len
+            if snapshot is not None:
+                kv_pool.restore_c128_radix_state(int(req.req_pool_idx), snapshot)
+
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         """Find the matching prefix from the radix tree.
         Args:
@@ -468,6 +573,12 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
                     swa_evicted_seqlen=req.swa_evicted_seqlen,
                 )
             )
+            match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
+            if len(match_result.device_indices) == page_aligned_len:
+                last_node = match_result.last_device_node
+                self._store_c128_partial_snapshot_for_req(
+                    req, last_node, page_aligned_len
+                )
         else:
             self.token_to_kv_pool_allocator.free(
                 kv_indices[old_prefix_len:page_aligned_len]
@@ -551,6 +662,7 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
             req.prefix_indices = new_indices
         req.last_node = new_last_node
         req.swa_uuid_for_lock = swa_uuid_for_lock
+        self._store_c128_partial_snapshot_for_req(req, new_last_node, len(new_indices))
 
     def pretty_print(self) -> None:
         self._print_helper(self.root_node, 0)
@@ -960,6 +1072,12 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         else:
             value = torch.empty((0,), dtype=torch.int64, device=self.device)
 
+        if params.req is not None and len(value) > 0:
+            last_node = self._find_c128_restorable_node(last_node)
+            c128_prefix_len = self._node_prefix_len(last_node)
+            if c128_prefix_len < len(value):
+                value = value[:c128_prefix_len]
+
         return MatchResult(
             device_indices=value,
             last_device_node=last_node,
@@ -997,6 +1115,12 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
                 is_bigram=node.key.is_bigram,
             )
             node.value = torch.cat([node.value, child.value])
+            if child.c128_state_snapshots is not None:
+                offset = len(node.value) - len(child.value)
+                if node.c128_state_snapshots is None:
+                    node.c128_state_snapshots = {}
+                for rel_len, snapshot in child.c128_state_snapshots.items():
+                    node.c128_state_snapshots[offset + rel_len] = snapshot
             node.children = child.children
             for grandchild in node.children.values():
                 grandchild.parent = node
@@ -1075,6 +1199,19 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         child.key = child.key[split_len:]
         assert len(child.key) > 0, f"child.key should not be empty"
         child.value = child.value[split_len:].clone()
+        if child.c128_state_snapshots is not None:
+            parent_snapshots = {
+                rel_len: snapshot
+                for rel_len, snapshot in child.c128_state_snapshots.items()
+                if rel_len <= split_len
+            }
+            child_snapshots = {
+                rel_len - split_len: snapshot
+                for rel_len, snapshot in child.c128_state_snapshots.items()
+                if rel_len > split_len
+            }
+            new_node.c128_state_snapshots = parent_snapshots or None
+            child.c128_state_snapshots = child_snapshots or None
         new_node.parent.children[key.child_key(self.page_size)] = new_node
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -927,7 +927,7 @@ class ModelRunnerKVCacheMixin:
                     self.token_to_kv_pool_allocator,
                 )
                 assert swa_allocator.__class__ == SWATokenToKVPoolAllocator
-                self.token_to_kv_pool.full_to_swa_index_mapping = (
+                self.token_to_kv_pool.register_mapping(
                     swa_allocator.full_to_swa_index_mapping
                 )
 
@@ -1072,6 +1072,7 @@ class ModelRunnerKVCacheMixin:
         config.max_running_requests = self._resolve_max_num_reqs(
             config.max_total_num_tokens
         )
+        config = configurator.finalize_with_max_running_requests(config)
         config.mem_fraction_static = self.server_args.mem_fraction_static
         return config
 

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -31,6 +31,7 @@ from sglang.srt.mem_cache.deepseek_v4_memory_pool import get_compress_state_ring
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
 from sglang.srt.utils.common import (
     ceil_align,
+    ceil_div,
     is_float4_e2m1fn_x2,
     spec_decode_alloc_len_per_request,
 )
@@ -103,6 +104,11 @@ class MemoryPoolConfigurator:
     ) -> MemoryPoolConfig:
         """Constraint path: recalculate pool sizes from a constrained max_tokens."""
         raise NotImplementedError
+
+    def finalize_with_max_running_requests(
+        self, config: MemoryPoolConfig
+    ) -> MemoryPoolConfig:
+        return config
 
 
 class DefaultPoolConfigurator(MemoryPoolConfigurator):
@@ -459,6 +465,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.qk_nope_head_dim = cfg.qk_nope_head_dim
         self.qk_rope_head_dim = cfg.qk_rope_head_dim
         self.indexer_head_dim = cfg.index_head_dim
+        self.context_len = mr.model_config.context_len
         # PP-local slice; matches DeepSeekV4TokenToKVPool's stage_ratios.
         self.compression_ratios = cfg.compress_ratios[mr.start_layer : mr.end_layer]
         if mr.pp_size > 1:
@@ -472,6 +479,15 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.is_speculative = mr.server_args.speculative_algorithm is not None
         self.online_c128_mtp_max_draft_tokens = (
             mr.server_args.max_speculative_num_draft_tokens or 0
+        )
+        self.requested_max_running_requests_per_worker = (
+            mr.server_args.max_running_requests // mr.dp_size
+            if mr.server_args.max_running_requests is not None
+            else None
+        )
+        self.disaggregation_mode = mr.server_args.disaggregation_mode
+        self.disaggregation_decode_extra_slots = (
+            mr.server_args.disaggregation_decode_extra_slots or 0
         )
         if mr.enable_hisparse:
             from sglang.srt.mem_cache.sparsity import parse_hisparse_config
@@ -555,9 +571,10 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         c4_indexer_state_bytes = 2 * 2 * self.indexer_head_dim * c4_state_dtype_size
 
         c4_state_ratio = self.c4_ring_size / self.swa_page_size
-        c128_state_ratio = self.c128_ring_size / self.swa_page_size
-        if c128_online and envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.get():
-            c128_state_ratio *= 1 + self.online_c128_mtp_max_draft_tokens
+        # C128 state is request-scoped and is finalized after
+        # max_running_requests is known, so it should not scale with
+        # full-token capacity here.
+        c128_state_ratio = 0
 
         c4_frac = 1 / (4 * self.c4_shrink_factor)
         return (
@@ -566,10 +583,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             + 1 / 128 * kv_bytes * self.num_layers_ca128
             + 1 / 4 * indexer_bytes * self.num_layers_ca4
             + self.swa_ratio * c4_state_ratio * c4_state_bytes * self.num_layers_ca4
-            + self.swa_ratio
-            * c128_state_ratio
-            * c128_state_bytes
-            * self.num_layers_ca128
+            + c128_state_ratio * c128_state_bytes * self.num_layers_ca128
             + self.swa_ratio
             * c4_state_ratio
             * c4_indexer_state_bytes
@@ -585,8 +599,48 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             c4_max_total_num_tokens=full_token // (4 * self.c4_shrink_factor),
             c128_max_total_num_tokens=full_token // 128,
             c4_state_pool_size=swa_tokens // self.swa_page_size * self.c4_ring_size,
-            c128_state_pool_size=swa_tokens // self.swa_page_size * self.c128_ring_size,
+            c128_state_pool_size=0,
         )
+
+    def _get_num_req_slots(self, max_running_requests: int) -> int:
+        if self.disaggregation_mode == "decode":
+            return max_running_requests + self.disaggregation_decode_extra_slots + 1
+        return max_running_requests + 1
+
+    def _get_c128_state_fixed_bytes(self, max_running_requests: int) -> int:
+        if self.num_layers_ca128 == 0:
+            return 0
+
+        _, c128_state_dtype_size = _get_dsv4_compress_state_dtype_sizes()
+        attn_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        num_req_slots = self._get_num_req_slots(max_running_requests)
+
+        if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+            state_rows = num_req_slots + self.c128_ring_size + 1
+            state_rows *= 1 + self.online_c128_mtp_max_draft_tokens
+            state_last_dim = 3 * attn_head_dim
+        else:
+            state_pool_size = num_req_slots * self.c128_ring_size
+            state_rows = state_pool_size + self.c128_ring_size + 1
+            state_rows = ceil_div(state_rows, 128) * 128
+            state_last_dim = 2 * attn_head_dim
+
+        return (
+            state_rows * state_last_dim * c128_state_dtype_size * self.num_layers_ca128
+        )
+
+    def _get_c128_state_fixed_bytes_for_token_capacity(
+        self, token_capacity: int
+    ) -> int:
+        if self.requested_max_running_requests_per_worker is not None:
+            return self._get_c128_state_fixed_bytes(
+                self.requested_max_running_requests_per_worker
+            )
+
+        estimated = int(token_capacity / self.context_len * 512)
+        estimated = max(min(estimated, 4096), 2048)
+        max_running_requests = min(estimated, token_capacity // 2)
+        return self._get_c128_state_fixed_bytes(max_running_requests)
 
     def _to_config(self, sizes: _DSV4PoolSizes) -> MemoryPoolConfig:
         full = sizes.full_max_total_num_tokens
@@ -608,6 +662,17 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             c128_state_pool_size=sizes.c128_state_pool_size,
         )
 
+    def finalize_with_max_running_requests(
+        self, config: MemoryPoolConfig
+    ) -> MemoryPoolConfig:
+        assert config.max_running_requests is not None
+        num_req_slots = self._get_num_req_slots(config.max_running_requests)
+        if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+            config.c128_state_pool_size = num_req_slots
+        else:
+            config.c128_state_pool_size = num_req_slots * self.c128_ring_size
+        return config
+
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
@@ -615,12 +680,25 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             page_size % 128 == 0
         ), "page_size must be multiple of 128 for compressed attention"
 
-        full_token = int(available_bytes / self.bytes_per_full_token)
+        if self.requested_max_running_requests_per_worker is not None:
+            c128_state_fixed_bytes = self._get_c128_state_fixed_bytes(
+                self.requested_max_running_requests_per_worker
+            )
+        else:
+            full_token = int(available_bytes / self.bytes_per_full_token)
+            c128_state_fixed_bytes = (
+                self._get_c128_state_fixed_bytes_for_token_capacity(full_token)
+            )
+
+        available_bytes_for_tokens = max(available_bytes - c128_state_fixed_bytes, 0)
+        full_token = int(available_bytes_for_tokens / self.bytes_per_full_token)
+
         sizes = self._compute_dsv4_sizes(full_token, page_size)
         logger.info(
             f"DSV4 memory calculation: "
             f"bytes_per_full_token={self.bytes_per_full_token:.2f}, "
             f"available_bytes={available_bytes / (1 << 30):.2f} GB, "
+            f"c128_state_fixed={c128_state_fixed_bytes / (1 << 30):.2f} GB, "
             f"full_token={sizes.full_max_total_num_tokens}"
         )
         return self._to_config(sizes)

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -518,19 +518,18 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             target_layers = self.num_layers_total
             self.bytes_per_full_token *= (target_layers + draft_layers) / target_layers
 
-        # Online c128 keeps a single in-progress (max, sum, kv) state per index
-        # and assumes a strict forward-only schedule. Speculative decode (MTP)
-        # would need rollback / replay across draft and verify, which the
-        # online path doesn't support yet.
+        # Online c128 keeps a single in-progress (max, sum, kv) state per index.
+        # Speculative decode is only supported for the experimental EAGLE path
+        # that uses request-scoped state banks for draft/verify replay.
         if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
             allow_experimental_online_c128_mtp = (
                 envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.get()
                 and mr.spec_algorithm.is_eagle()
             )
             assert mr.spec_algorithm.is_none() or allow_experimental_online_c128_mtp, (
-                "SGLANG_OPT_USE_ONLINE_COMPRESS does not support speculative decode "
-                "(MTP) yet, except the experimental EAGLE topk=1 path gated by "
-                "SGLANG_EXPERIMENTAL_ONLINE_C128_MTP=1"
+                "SGLANG_OPT_USE_ONLINE_COMPRESS with speculative decode requires "
+                "the experimental EAGLE topk=1 path gated by "
+                "SGLANG_EXPERIMENTAL_ONLINE_C128_MTP=1."
             )
             if allow_experimental_online_c128_mtp:
                 assert self.online_c128_mtp_max_draft_tokens > 0, (

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -9,6 +9,7 @@ from sglang.srt.disaggregation.common.utils import (
     unpack_int_lists,
     unpack_list_of_buffers,
 )
+from sglang.srt.disaggregation.utils import get_dsv4_c128_state_indices
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
@@ -88,6 +89,26 @@ class TestGroupConcurrentContiguous(unittest.TestCase):
     def test_mismatched_nonempty_lengths_raise(self):
         with self.assertRaises(ValueError):
             group_concurrent_contiguous(self._arr([1, 2, 3]), self._arr([1, 2]))
+
+
+class TestDSV4C128StateIndices(unittest.TestCase):
+    def test_online_uses_request_slot(self):
+        np.testing.assert_array_equal(
+            get_dsv4_c128_state_indices(7, 256, online=True, ring_size=1),
+            np.array([7], dtype=np.int32),
+        )
+
+    def test_offline_aligned_boundary_has_no_partial_state(self):
+        np.testing.assert_array_equal(
+            get_dsv4_c128_state_indices(7, 256, online=False, ring_size=128),
+            np.empty((0,), dtype=np.int32),
+        )
+
+    def test_offline_partial_boundary_uses_request_local_page(self):
+        np.testing.assert_array_equal(
+            get_dsv4_c128_state_indices(7, 129, online=False, ring_size=256),
+            np.array([15], dtype=np.int32),
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -11,11 +11,12 @@ from sglang.srt.disaggregation.common.utils import (
 )
 from sglang.srt.disaggregation.utils import get_dsv4_c128_state_indices
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
-class TestDisaggregationWire(unittest.TestCase):
+class TestDisaggregationWire(CustomTestCase):
     def test_int_lists_roundtrip(self):
         cases = [
             ("Q", [[1, 2, 3], [4]]),
@@ -47,7 +48,7 @@ class TestDisaggregationWire(unittest.TestCase):
         self.assertEqual(unpack_list_of_buffers(pack_list_of_buffers(bufs)), bufs)
 
 
-class TestGroupConcurrentContiguous(unittest.TestCase):
+class TestGroupConcurrentContiguous(CustomTestCase):
     @staticmethod
     def _arr(values):
         return np.array(values, dtype=np.int32)
@@ -91,7 +92,7 @@ class TestGroupConcurrentContiguous(unittest.TestCase):
             group_concurrent_contiguous(self._arr([1, 2, 3]), self._arr([1, 2]))
 
 
-class TestDSV4C128StateIndices(unittest.TestCase):
+class TestDSV4C128StateIndices(CustomTestCase):
     def test_online_uses_request_slot(self):
         np.testing.assert_array_equal(
             get_dsv4_c128_state_indices(7, 256, online=True, ring_size=1),

--- a/test/registered/unit/managers/test_hisparse_online_c128_mtp.py
+++ b/test/registered/unit/managers/test_hisparse_online_c128_mtp.py
@@ -5,6 +5,10 @@ from unittest.mock import patch
 
 from sglang.srt.arg_groups.hisparse_hook import validate_hisparse
 from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
 def _make_server_args(**overrides):
@@ -25,7 +29,7 @@ def _make_server_args(**overrides):
     return args
 
 
-class TestHiSparseOnlineC128MTPValidation(unittest.TestCase):
+class TestHiSparseOnlineC128MTPValidation(CustomTestCase):
     def _validate(self, args, *, online=True, experimental=True, compressor_v2=True):
         with ExitStack() as stack:
             stack.enter_context(envs.SGLANG_OPT_USE_ONLINE_COMPRESS.override(online))

--- a/test/registered/unit/managers/test_hisparse_online_c128_mtp.py
+++ b/test/registered/unit/managers/test_hisparse_online_c128_mtp.py
@@ -1,0 +1,90 @@
+import unittest
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.arg_groups.hisparse_hook import validate_hisparse
+from sglang.srt.environ import envs
+
+
+def _make_server_args(**overrides):
+    args = SimpleNamespace(
+        enable_hisparse=True,
+        disable_radix_cache=True,
+        kv_cache_dtype="auto",
+        dsa_prefill_backend=None,
+        dsa_decode_backend=None,
+        speculative_algorithm="EAGLE",
+        speculative_eagle_topk=1,
+        speculative_num_steps=2,
+        speculative_num_draft_tokens=3,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    args.get_model_config = lambda: SimpleNamespace(hf_config=object())
+    return args
+
+
+class TestHiSparseOnlineC128MTPValidation(unittest.TestCase):
+    def _validate(self, args, *, online=True, experimental=True, compressor_v2=True):
+        with ExitStack() as stack:
+            stack.enter_context(envs.SGLANG_OPT_USE_ONLINE_COMPRESS.override(online))
+            stack.enter_context(
+                envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.override(experimental)
+            )
+            stack.enter_context(envs.SGLANG_OPT_USE_COMPRESSOR_V2.override(compressor_v2))
+            stack.enter_context(
+                patch("sglang.srt.arg_groups.hisparse_hook._is_hip", return_value=False)
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.configs.model_config.is_deepseek_v4",
+                    return_value=True,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.configs.model_config.is_deepseek_dsa",
+                    return_value=False,
+                )
+            )
+            validate_hisparse(args)
+
+    def test_accepts_dsv4_hisparse_online_c128_eagle(self):
+        self._validate(_make_server_args())
+
+    def test_requires_experimental_online_c128_mtp_for_speculative(self):
+        with self.assertRaisesRegex(ValueError, "SGLANG_EXPERIMENTAL_ONLINE_C128_MTP"):
+            self._validate(_make_server_args(), experimental=False)
+
+    def test_rejects_non_eagle_speculative_algorithm(self):
+        with self.assertRaisesRegex(ValueError, "only validated for EAGLE"):
+            self._validate(_make_server_args(speculative_algorithm="NGRAM"))
+
+    def test_rejects_eagle_topk_greater_than_one(self):
+        with self.assertRaisesRegex(ValueError, "speculative-eagle-topk 1"):
+            self._validate(_make_server_args(speculative_eagle_topk=2))
+
+    def test_rejects_eagle_step3(self):
+        with self.assertRaisesRegex(ValueError, "step1/step2"):
+            self._validate(_make_server_args(speculative_num_steps=3))
+
+    def test_requires_compressor_v2(self):
+        with self.assertRaisesRegex(ValueError, "SGLANG_OPT_USE_COMPRESSOR_V2=1"):
+            self._validate(_make_server_args(), compressor_v2=False)
+
+    def test_non_speculative_online_c128_keeps_existing_hisparse_path(self):
+        self._validate(
+            _make_server_args(
+                speculative_algorithm=None,
+                speculative_eagle_topk=None,
+                speculative_num_steps=None,
+                speculative_num_draft_tokens=None,
+            ),
+            experimental=False,
+            compressor_v2=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_hisparse_online_c128_mtp.py
+++ b/test/registered/unit/managers/test_hisparse_online_c128_mtp.py
@@ -36,7 +36,9 @@ class TestHiSparseOnlineC128MTPValidation(CustomTestCase):
             stack.enter_context(
                 envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.override(experimental)
             )
-            stack.enter_context(envs.SGLANG_OPT_USE_COMPRESSOR_V2.override(compressor_v2))
+            stack.enter_context(
+                envs.SGLANG_OPT_USE_COMPRESSOR_V2.override(compressor_v2)
+            )
             stack.enter_context(
                 patch("sglang.srt.arg_groups.hisparse_hook._is_hip", return_value=False)
             )

--- a/test/registered/unit/mem_cache/test_dsv4_c128_radix_state.py
+++ b/test/registered/unit/mem_cache/test_dsv4_c128_radix_state.py
@@ -1,0 +1,177 @@
+import unittest
+from array import array
+
+import torch
+
+from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
+from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.mem_cache.swa_radix_cache import RadixKey, SWARadixCache
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-b-test-cpu")
+
+
+class FakeDSV4KVPool(BaseSWAKVPool):
+    def __init__(self):
+        self.full_kv_pool = None
+        self.swa_kv_pool = None
+        self.restored = []
+        self.snapshotted = []
+
+    def get_key_buffer(self, layer_id: int) -> torch.Tensor:
+        raise NotImplementedError
+
+    def get_value_buffer(self, layer_id: int) -> torch.Tensor:
+        raise NotImplementedError
+
+    def get_kv_buffer(self, layer_id: int):
+        raise NotImplementedError
+
+    def set_kv_buffer(self, layer, loc, cache_k, cache_v) -> None:
+        raise NotImplementedError
+
+    def register_mapping(self, full_to_swa_index_mapping: torch.Tensor) -> None:
+        pass
+
+    def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor) -> torch.Tensor:
+        return kv_indices
+
+    def get_state_buf_infos(self):
+        return [], [], []
+
+    def snapshot_c128_radix_state(self, req_pool_idx: int, seq_len: int):
+        self.snapshotted.append((req_pool_idx, seq_len))
+        return [torch.tensor([req_pool_idx, seq_len], dtype=torch.int64)]
+
+    def restore_c128_radix_state(self, req_pool_idx: int, snapshots):
+        self.restored.append((req_pool_idx, snapshots))
+
+
+class FakeReq:
+    def __init__(self, req_pool_idx: int):
+        self.req_pool_idx = req_pool_idx
+        self.prefix_indices = []
+        self.last_node = None
+
+
+class TestDSV4C128RadixState(unittest.TestCase):
+    def _make_cache(self):
+        kv_pool = FakeDSV4KVPool()
+        allocator = SWATokenToKVPoolAllocator(
+            size=512,
+            size_swa=512,
+            page_size=1,
+            dtype=torch.float16,
+            device="cpu",
+            kvcache=kv_pool,
+            need_sort=False,
+        )
+        req_to_token_pool = ReqToTokenPool(
+            size=4, max_context_len=512, device="cpu", enable_memory_saver=False
+        )
+        cache = SWARadixCache(
+            CacheInitParams(
+                disable=False,
+                req_to_token_pool=req_to_token_pool,
+                token_to_kv_pool_allocator=allocator,
+                page_size=1,
+                sliding_window_size=512,
+            )
+        )
+        return cache, kv_pool
+
+    def _insert_tokens(self, cache: SWARadixCache, length: int):
+        key = RadixKey(array("q", range(length)))
+        value = torch.arange(length, dtype=torch.int64)
+        cache.insert(InsertParams(key=key, value=value))
+        match = cache.match_prefix(MatchPrefixParams(key=key))
+        self.assertEqual(len(match.device_indices), length)
+        return match.last_device_node
+
+    def test_aligned_c128_boundary_does_not_need_snapshot(self):
+        cache, kv_pool = self._make_cache()
+        self._insert_tokens(cache, 260)
+
+        req = FakeReq(req_pool_idx=2)
+        match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", range(128))), req=req)
+        )
+
+        self.assertEqual(len(match.device_indices), 128)
+        self.assertIsNone(match.last_device_node.c128_state_snapshots)
+
+        req.prefix_indices = match.device_indices
+        req.last_node = match.last_device_node
+        cache.restore_c128_state_for_reqs([req])
+        self.assertEqual(kv_pool.restored, [])
+
+    def test_partial_c128_snapshot_moves_to_split_node_and_restores(self):
+        cache, kv_pool = self._make_cache()
+        leaf = self._insert_tokens(cache, 260)
+
+        snapshot = [torch.tensor([7, 130], dtype=torch.int64)]
+        cache._store_c128_snapshot_at_prefix_len(leaf, 130, snapshot)
+
+        req = FakeReq(req_pool_idx=3)
+        match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", range(130))), req=req)
+        )
+
+        self.assertEqual(len(match.device_indices), 130)
+        self.assertIs(
+            match.last_device_node.c128_state_snapshots[130],
+            snapshot,
+        )
+
+        req.prefix_indices = match.device_indices
+        req.last_node = match.last_device_node
+        cache.restore_c128_state_for_reqs([req])
+
+        self.assertEqual(len(kv_pool.restored), 1)
+        restored_req_pool_idx, restored_snapshot = kv_pool.restored[0]
+        self.assertEqual(restored_req_pool_idx, 3)
+        self.assertIs(restored_snapshot, snapshot)
+
+    def test_missing_partial_snapshot_falls_back_to_aligned_boundary(self):
+        cache, kv_pool = self._make_cache()
+        self._insert_tokens(cache, 260)
+
+        req = FakeReq(req_pool_idx=3)
+        match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", range(130))), req=req)
+        )
+
+        self.assertEqual(len(match.device_indices), 128)
+        self.assertEqual(cache._node_prefix_len(match.last_device_node), 128)
+
+        req.prefix_indices = match.device_indices
+        req.last_node = match.last_device_node
+        cache.restore_c128_state_for_reqs([req])
+        self.assertEqual(kv_pool.restored, [])
+
+    def test_store_partial_snapshot_uses_requested_prefix_length(self):
+        cache, kv_pool = self._make_cache()
+        leaf = self._insert_tokens(cache, 260)
+        req = FakeReq(req_pool_idx=4)
+
+        cache._store_c128_partial_snapshot_for_req(req, leaf, 130)
+
+        self.assertEqual(kv_pool.snapshotted, [(4, 130)])
+        self.assertIn(130, leaf.c128_state_snapshots)
+
+    def test_store_aligned_boundary_skips_snapshot(self):
+        cache, kv_pool = self._make_cache()
+        leaf = self._insert_tokens(cache, 260)
+        req = FakeReq(req_pool_idx=4)
+
+        cache._store_c128_partial_snapshot_for_req(req, leaf, 128)
+
+        self.assertEqual(kv_pool.snapshotted, [])
+        self.assertIsNone(leaf.c128_state_snapshots)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_dsv4_c128_radix_state.py
+++ b/test/registered/unit/mem_cache/test_dsv4_c128_radix_state.py
@@ -10,8 +10,9 @@ from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.swa_radix_cache import RadixKey, SWARadixCache
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=5, suite="base-b-test-cpu")
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class FakeDSV4KVPool(BaseSWAKVPool):
@@ -57,7 +58,7 @@ class FakeReq:
         self.last_node = None
 
 
-class TestDSV4C128RadixState(unittest.TestCase):
+class TestDSV4C128RadixState(CustomTestCase):
     def _make_cache(self):
         kv_pool = FakeDSV4KVPool()
         allocator = SWATokenToKVPoolAllocator(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Enable DeepSeek-V4 HiSparse to work with online C128 MTP under EAGLE speculative decoding.

The C4 HiSparse path continues to use the existing host mirror / SWA sliding-window flow. For C128, this PR uses the request-scoped C128 state design introduced in #28612, so online MTP state is no longer derived from `full_to_swa_index_mapping`. This avoids coupling C128 state lifetime to SWA mappings, which can be cleared or reused while the full KV prefix is still alive in radix cache.

## Modifications

- Add validation for DSV4 HiSparse + online C128 MTP.
  - EAGLE only
  - `speculative_eagle_topk <= 1`
  - `speculative_num_steps <= 2`
  - `SGLANG_EXPERIMENTAL_ONLINE_C128_MTP=1`
  - compressor v2 required
- Wire online C128 MTP state-bank preparation in the DSV4 backend for target verify and CUDA graph replay.
- Use request-scoped C128 state slots.
  - online C128 uses `req_pool_idx`
  - offline C128 uses request-local ring slots
  - C4 remains on the existing SWA/sliding-window path
- Add explicit `C128_STATE` metadata for PD transfer.
- Add radix-cache snapshot/restore support for partial C128 state prefixes.
- Add unit tests for HiSparse online C128 MTP validation, C128 state indexing, and radix C128 state restoration.

## Accuracy Tests

This PR changes C128 state indexing and online C128 MTP planning. GPU accuracy validation is required before merge.

Suggested tests:
- DSV4 HiSparse + online C128 + EAGLE smoke test
- MMLU / GSM8K comparison against online C128 without HiSparse
- PD decode smoke test with Mooncake transfer

Local static checks:
- `python3 -m compileall -q python/sglang/jit_kernel/dsv4 python/sglang/srt/disaggregation python/sglang/srt/layers/attention python/sglang/srt/managers python/sglang/srt/mem_cache python/sglang/srt/model_executor test/registered/unit/disaggregation/test_disaggregation_wire.py test/registered/unit/mem_cache/test_dsv4_c128_radix_state.py test/registered/unit/managers/test_hisparse_online_c128_mtp.py`
- `git diff --check upstream/main...HEAD`
- Verified that online C128 MTP JIT paths no longer reference `full_to_swa_index_mapping`.


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27944899414](https://github.com/sgl-project/sglang/actions/runs/27944899414)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27944899243](https://github.com/sgl-project/sglang/actions/runs/27944899243)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->