### PR TITLE
[function_call] Fix MiniMax-M2 single-shot tool_index ordinals

### DIFF
--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -47,9 +47,9 @@ class MinimaxM2Detector(BaseFormatDetector):
         # Streaming state variables
         self._current_function_name: str = ""
         self._current_parameters: Dict[str, Any] = {}
-        self._streamed_parameters: Dict[str, str] = (
-            {}
-        )  # Track what parameter content we've streamed
+        self._streamed_parameters: Dict[
+            str, str
+        ] = {}  # Track what parameter content we've streamed
         self._in_tool_call: bool = False
         self._function_name_sent: bool = False
 
@@ -471,10 +471,12 @@ class MinimaxM2Detector(BaseFormatDetector):
                 break
             block = text[s : e + len(self.tool_call_end_token)]
             cursor = e + len(self.tool_call_end_token)
-            calls.extend(self._parse_block(block, tools))
+            calls.extend(self._parse_block(block, tools, index_offset=len(calls)))
         return "".join(normal_parts), calls
 
-    def _parse_block(self, block: str, tools: List[Tool]) -> List[ToolCallItem]:
+    def _parse_block(
+        self, block: str, tools: List[Tool], index_offset: int = 0
+    ) -> List[ToolCallItem]:
         res: List[ToolCallItem] = []
         for m in self.tool_call_function_regex.findall(block):
             txt = m[0] if m[0] else m[1]
@@ -494,9 +496,14 @@ class MinimaxM2Detector(BaseFormatDetector):
                 params[pname] = self._parse_parameter(fname, pname, pval, tools)
             raw = {"name": fname, "arguments": params}
             try:
-                # TODO: fix idx in function call, the index for a function
-                # call will always be -1 in parse_base_json
-                res.extend(self.parse_base_json(raw, tools))
+                for call in self.parse_base_json(raw, tools):
+                    res.append(
+                        ToolCallItem(
+                            tool_index=index_offset + len(res),
+                            name=call.name,
+                            parameters=call.parameters,
+                        )
+                    )
             except Exception:
                 logger.warning("invalid tool call for %s dropped", fname)
         return res

--- a/test/registered/unit/function_call/test_minimax_m2_tool_index.py
+++ b/test/registered/unit/function_call/test_minimax_m2_tool_index.py
@@ -1,0 +1,119 @@
+"""Unit tests for MiniMax-M2 tool call indices — no server, no model loading."""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.environ import envs
+from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+def _make_tools():
+    def tool(name, properties):
+        return Tool(
+            type="function",
+            function=Function(
+                name=name,
+                description=f"{name} tool",
+                parameters={"type": "object", "properties": properties},
+            ),
+        )
+
+    return [
+        tool("get_weather", {"city": {"type": "string"}}),
+        tool("search_web", {"query": {"type": "string"}}),
+        tool("calculate", {"expr": {"type": "string"}}),
+    ]
+
+
+def _build_message(calls):
+    parts = ["<minimax:tool_call>"]
+    for name, parameters in calls:
+        parts.append(f'<invoke name="{name}">')
+        for key, value in parameters.items():
+            parts.append(f'<parameter name="{key}">{value}</parameter>')
+        parts.append("</invoke>")
+    parts.append("</minimax:tool_call>")
+    return "\n".join(parts)
+
+
+class TestMinimaxM2ToolIndex(CustomTestCase):
+    def setUp(self):
+        self.tools = _make_tools()
+
+    def _single_shot_calls(self, text):
+        return MinimaxM2Detector().detect_and_parse(text, self.tools).calls
+
+    def _single_shot_indices(self, text):
+        return [call.tool_index for call in self._single_shot_calls(text)]
+
+    def _streaming_name_indices(self, text):
+        result = MinimaxM2Detector().parse_streaming_increment(text, self.tools)
+        return [call.tool_index for call in result.calls if call.name is not None]
+
+    def test_parallel_same_tool_indices_single_shot(self):
+        text = _build_message(
+            [
+                ("get_weather", {"city": "Tokyo"}),
+                ("get_weather", {"city": "Paris"}),
+            ]
+        )
+
+        self.assertEqual(self._single_shot_indices(text), [0, 1])
+
+    def test_index_is_ordinal_not_registry_slot(self):
+        text = _build_message([("calculate", {"expr": "2+2"})])
+
+        self.assertEqual(self._single_shot_indices(text), [0])
+
+    def test_indices_are_dense_when_unknown_tool_is_dropped(self):
+        text = _build_message(
+            [
+                ("get_weather", {"city": "Tokyo"}),
+                ("unknown_tool", {"city": "Paris"}),
+                ("calculate", {"expr": "2+2"}),
+            ]
+        )
+
+        with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(False):
+            calls = self._single_shot_calls(text)
+
+        self.assertEqual([call.name for call in calls], ["get_weather", "calculate"])
+        self.assertEqual([call.tool_index for call in calls], [0, 1])
+
+    def test_forwarded_unknown_tool_gets_ordinal_index(self):
+        text = _build_message(
+            [
+                ("get_weather", {"city": "Tokyo"}),
+                ("unknown_tool", {"city": "Paris"}),
+                ("calculate", {"expr": "2+2"}),
+            ]
+        )
+
+        with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(True):
+            calls = self._single_shot_calls(text)
+
+        self.assertEqual(
+            [call.name for call in calls],
+            ["get_weather", "unknown_tool", "calculate"],
+        )
+        self.assertEqual([call.tool_index for call in calls], [0, 1, 2])
+
+    def test_single_shot_matches_streaming_indices(self):
+        text = _build_message(
+            [
+                ("get_weather", {"city": "Tokyo"}),
+                ("get_weather", {"city": "Paris"}),
+            ]
+        )
+
+        self.assertEqual(
+            self._single_shot_indices(text), self._streaming_name_indices(text)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The MiniMax-M2 function-call detector assigned different `tool_index` semantics in the streaming and non-streaming paths.

The streaming path already uses `current_tool_id`, so parallel calls are indexed by their local ordinal position in the emitted response: `0, 1, 2, ...`.

The single-shot path parsed each `<invoke>` through `parse_base_json(...)`, which uses the function's position in the request `tools` list. That makes the emitted `tool_index` a registry slot instead of the local call ordinal.

Observed on `upstream/main`:

```text
parallel same-tool single-shot: [(0, 'get_weather'), (0, 'get_weather')]
slot-2 single-shot: [(2, 'calculate')]
mixed unknown dropped: [(0, 'get_weather'), (2, 'calculate')]
mixed unknown forwarded: [(0, 'get_weather'), (-1, 'unknown_tool'), (2, 'calculate')]
streaming name indices: [(0, 'get_weather'), (1, 'get_weather')]
```

After this change:

```text
parallel same-tool single-shot: [(0, 'get_weather'), (1, 'get_weather')]
slot-2 single-shot: [(0, 'calculate')]
mixed unknown dropped: [(0, 'get_weather'), (1, 'calculate')]
mixed unknown forwarded: [(0, 'get_weather'), (1, 'unknown_tool'), (2, 'calculate')]
streaming name indices: [(0, 'get_weather'), (1, 'get_weather')]
```

This is the same class of issue as #25075 for Gemma4. MiniMax-M2 needs a detector-local fix because it calls `parse_base_json(...)` once per `<invoke>`, so a base-level `enumerate(action)` fix would not see the full per-message call list.

## Modifications

- Thread an `index_offset` from `_extract(...)` into `_parse_block(...)`.
- Preserve `parse_base_json(...)` for tool validation and parameter serialization.
- Construct a fresh `ToolCallItem` with `tool_index=index_offset + len(res)`, so indices advance by emitted calls, not raw `<invoke>` count.
- Add CPU unit coverage for:
  - duplicate same-tool calls getting `[0, 1]`
  - a slot-2 tool call getting `[0]`
  - mixed valid/unknown tools staying dense when unknown tools are dropped
  - forwarded unknown tools receiving ordinal indices, matching the Gemma4 behavior in #25075
  - single-shot indices matching streaming indices
- Ruff reformatted the existing `_streamed_parameters` annotation in `minimax_m2.py`.

Blast radius: this only changes MiniMax-M2 single-shot tool-call indices. The shared `parse_base_json(...)` behavior is unchanged, and the MiniMax-M2 streaming path already used ordinal indices.

## Accuracy Tests

Not applicable. This is a parser/indexing correctness fix and does not change model weights or generation logic.

## Speed Tests and Profiling

Not applicable. This is a small parser bookkeeping change and should not affect inference performance.

## Validation

Validated locally through the registered CPU unit-test path. Full CI will run on the PR.

```bash
PYTHONPATH=python .venv/bin/python -m pytest test/registered/unit/function_call/test_minimax_m2_tool_index.py -q
```

```text
5 passed, 3 warnings in 4.86s
```

The warnings were local environment warnings reported as SWIG deprecation warnings and macOS Triton CPU fallback.

Also ran:

```bash
PYTHONPATH=python .venv/bin/python test/registered/unit/function_call/test_minimax_m2_tool_index.py -q
uvx ruff check python/sglang/srt/function_call/minimax_m2.py test/registered/unit/function_call/test_minimax_m2_tool_index.py
uvx ruff format --check python/sglang/srt/function_call/minimax_m2.py test/registered/unit/function_call/test_minimax_m2_tool_index.py
git diff --check
```

## Checklist

- [x] Format your code according to the code style guidance.
- [x] Add unit tests according to the unit test guidance.
- [x] Documentation update is not needed for this internal parser correctness fix.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #27993725630](https://github.com/sgl-project/sglang/actions/runs/27993725630)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #27993725195](https://github.com/sgl-project/sglang/actions/runs/27993725195)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->