### PR TITLE
[function_call] Fix Hunyuan single-shot tool_index ordinals

### DIFF
--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -244,7 +244,7 @@ class HunyuanDetector(BaseFormatDetector):
 
                 calls.append(
                     ToolCallItem(
-                        tool_index=tool_indices.get(function_name, -1),
+                        tool_index=len(calls),
                         name=function_name,
                         parameters=json.dumps(arg_dict, ensure_ascii=False),
                     )

--- a/test/registered/unit/function_call/test_hunyuan_detector.py
+++ b/test/registered/unit/function_call/test_hunyuan_detector.py
@@ -4,6 +4,7 @@ import json
 import unittest
 
 from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.environ import envs
 from sglang.srt.function_call.hunyuan_detector import HunyuanDetector
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -195,6 +196,7 @@ class TestHunyuanDetectorDetectAndParse(CustomTestCase):
         )
         result = self.detector.detect_and_parse(text, self.tools)
         self.assertEqual(len(result.calls), 2)
+        self.assertEqual([call.tool_index for call in result.calls], [0, 1])
         self.assertEqual(json.loads(result.calls[0].parameters)["city"], "Beijing")
         self.assertEqual(json.loads(result.calls[1].parameters)["city"], "Hangzhou")
 
@@ -227,6 +229,39 @@ class TestHunyuanDetectorDetectAndParse(CustomTestCase):
         self.assertEqual(len(result.calls), 2)
         self.assertEqual(result.calls[0].name, "get_current_date")
         self.assertEqual(result.calls[1].name, "search")
+        self.assertEqual([call.tool_index for call in result.calls], [0, 1])
+
+    def test_forwarded_unknown_tool_gets_ordinal_index(self):
+        text = (
+            "<tool_calls>"
+            "<tool_call>get_current_date<tool_sep></tool_call>"
+            "<tool_call>nonexistent<tool_sep></tool_call>"
+            "<tool_call>search<tool_sep>"
+            "<arg_key>query</arg_key><arg_value>test</arg_value>"
+            "</tool_call>"
+            "</tool_calls>"
+        )
+        with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(True):
+            result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 3)
+        self.assertEqual(
+            [call.name for call in result.calls],
+            ["get_current_date", "nonexistent", "search"],
+        )
+        self.assertEqual([call.tool_index for call in result.calls], [0, 1, 2])
+
+    def test_single_slot_three_tool_gets_zero_index(self):
+        text = (
+            "<tool_calls><tool_call>calculate<tool_sep>"
+            "<arg_key>expression</arg_key><arg_value>2+2</arg_value>"
+            "</tool_call></tool_calls>"
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "calculate")
+        self.assertEqual(result.calls[0].tool_index, 0)
 
     def test_three_parallel_tool_calls(self):
         text = (
@@ -245,9 +280,7 @@ class TestHunyuanDetectorDetectAndParse(CustomTestCase):
         self.assertEqual(result.calls[0].name, "get_weather")
         self.assertEqual(result.calls[1].name, "get_weather")
         self.assertEqual(result.calls[2].name, "get_current_date")
-        # tool_index maps to position in tools list
-        self.assertEqual(result.calls[0].tool_index, 1)  # get_weather is index 1
-        self.assertEqual(result.calls[2].tool_index, 0)  # get_current_date is index 0
+        self.assertEqual([call.tool_index for call in result.calls], [0, 1, 2])
 
 
 class TestHunyuanDetectorArgDeserialization(CustomTestCase):
@@ -351,9 +384,7 @@ class TestHunyuanDetectorStreaming(CustomTestCase):
     def test_complete_tool_call_single_chunk(self):
         detector = self._new_detector()
         text = (
-            "<tool_calls>"
-            "<tool_call>get_current_date<tool_sep></tool_call>"
-            "</tool_calls>"
+            "<tool_calls><tool_call>get_current_date<tool_sep></tool_call></tool_calls>"
         )
         result = detector.parse_streaming_increment(text, self.tools)
         collected = _collect_streamed_tool_calls(result.calls)


### PR DESCRIPTION
## Motivation

Hunyuan's non-streaming tool-call parser assigned `ToolCallItem.tool_index` from the tool's position in the request `tools` list:

```py
tool_indices.get(function_name, -1)
```

That is different from the local ordinal position of the emitted tool call in the response. As a result, repeated calls to the same tool could share the same index, and a single call to a later tool in the registry could be emitted with a non-zero index.

This matches the same local-ordinal semantics addressed for other detectors in #25075 / #28923. It is independent of #25796 because Hunyuan assigns `tool_index` directly in `detect_and_parse` instead of going through `parse_base_json`.

## Modifications

- Assign Hunyuan non-streaming `tool_index` from the current emitted call count with `len(calls)`.
- Keep unknown-tool behavior dense:
  - unknown tools skipped by default do not leave index gaps;
  - forwarded unknown tools receive normal ordinal indices, matching the positive ordinal behavior in #25075.
- Extend `test_hunyuan_detector.py` coverage for:
  - repeated same-tool calls: `[0, 1]`;
  - a single slot-3 tool call: `[0]`;
  - mixed known/unknown calls with unknown dropped: `[0, 1]`;
  - mixed known/unknown calls with unknown forwarded: `[0, 1, 2]`;
  - three parallel calls: `[0, 1, 2]`.
- Ruff also normalized one existing adjacent test string in the same file; no behavior change there.

Red/green check:

On `upstream/main`:

```text
duplicate same-tool: [(1, 'get_weather'), (1, 'get_weather')]
slot-3 single call: [(3, 'calculate')]
mixed unknown dropped: [(0, 'get_current_date'), (2, 'search')]
mixed unknown forwarded: [(0, 'get_current_date'), (-1, 'nonexistent'), (2, 'search')]
```

With this patch:

```text
duplicate same-tool: [(0, 'get_weather'), (1, 'get_weather')]
slot-3 single call: [(0, 'calculate')]
mixed unknown dropped: [(0, 'get_current_date'), (1, 'search')]
mixed unknown forwarded: [(0, 'get_current_date'), (1, 'nonexistent'), (2, 'search')]
```

## Accuracy Tests

Not applicable. This only changes parser metadata indices, not model output quality or numerical behavior.

## Speed Tests and Profiling

Not applicable. This is a non-streaming parser metadata fix and does not touch inference or kernel paths.

## Validation

Validated locally in a uv-managed Python 3.12 environment. Full CI will run on the PR.

```sh
PYTHONPATH=python .venv/bin/python -m pytest test/registered/unit/function_call/test_hunyuan_detector.py -q
# 52 passed, 3 warnings

PYTHONPATH=python .venv/bin/python test/registered/unit/function_call/test_hunyuan_detector.py -q
# Ran 52 tests ... OK

uvx ruff check python/sglang/srt/function_call/hunyuan_detector.py test/registered/unit/function_call/test_hunyuan_detector.py
# All checks passed

uvx ruff format --check python/sglang/srt/function_call/hunyuan_detector.py test/registered/unit/function_call/test_hunyuan_detector.py
# 2 files already formatted

git diff --check
# passed
```

The local warnings were SWIG deprecation warnings and a macOS Triton CPU fallback warning.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not needed for this parser metadata fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #27993724937](https://github.com/sgl-project/sglang/actions/runs/27993724937)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #27993724792](https://github.com/sgl-project/sglang/actions/runs/27993724792)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->