### PR TITLE
[CI] Update nixl installation to include nixl-cu13 for h20 runner

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -441,16 +441,19 @@ stabilize_flashinfer_jit_paths() {
 }
 
 install_extra_deps() {
+    MOONCAKE_VERSION="0.3.11.post1"
+    NIXL_VERSION="1.3.0"
+    NIXL_PKG="nixl==${NIXL_VERSION}"
     if [ "$CU_MAJOR" = "13" ]; then
-        MOONCAKE_PKG="mooncake-transfer-engine-cuda13==0.3.11.post1"
+        MOONCAKE_PKG="mooncake-transfer-engine-cuda13==${MOONCAKE_VERSION}"
         MOONCAKE_STALE_PKG="mooncake-transfer-engine"
-        NIXL_BIN_PKG="nixl-cu13"
+        NIXL_BIN_PKG="nixl-cu13==${NIXL_VERSION}"
         NIXL_STALE_BIN_PKG="nixl-cu12"
         EXTRA_NVIDIA_SPECS="nvidia-cuda-nvrtc"
     else
-        MOONCAKE_PKG="mooncake-transfer-engine==0.3.11.post1"
+        MOONCAKE_PKG="mooncake-transfer-engine==${MOONCAKE_VERSION}"
         MOONCAKE_STALE_PKG="mooncake-transfer-engine-cuda13"
-        NIXL_BIN_PKG="nixl-cu12"
+        NIXL_BIN_PKG="nixl-cu12==${NIXL_VERSION}"
         NIXL_STALE_BIN_PKG="nixl-cu13"
         EXTRA_NVIDIA_SPECS="nvidia-cuda-nvrtc-cu12"
     fi
@@ -463,12 +466,12 @@ install_extra_deps() {
         $PIP_UNINSTALL_CMD ${MOONCAKE_STALE_PKG} $PIP_UNINSTALL_SUFFIX || true
         $PIP_CMD install ${MOONCAKE_PKG} --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
     fi
-    $PIP_CMD install ${MOONCAKE_PKG} ${EXTRA_NVIDIA_SPECS} py-spy scipy huggingface_hub[hf_xet] pytest $PIP_INSTALL_SUFFIX
     # Best-effort NIXL install for decode-radix disaggregation coverage.
     if pip show ${NIXL_STALE_BIN_PKG} >/dev/null 2>&1; then
         $PIP_UNINSTALL_CMD ${NIXL_STALE_BIN_PKG} $PIP_UNINSTALL_SUFFIX || true
-        $PIP_CMD install nixl ${NIXL_BIN_PKG} --force-reinstall --no-deps $PIP_INSTALL_SUFFIX || echo "Warning: nixl install failed; continuing without nixl"
+        $PIP_CMD install ${NIXL_PKG} ${NIXL_BIN_PKG} --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
     fi
+    $PIP_CMD install ${MOONCAKE_PKG} ${NIXL_PKG} ${NIXL_BIN_PKG} ${EXTRA_NVIDIA_SPECS} py-spy scipy huggingface_hub[hf_xet] pytest $PIP_INSTALL_SUFFIX
 
     if [ "$IS_BLACKWELL" != "1" ]; then
         git clone --branch v0.5 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -444,10 +444,14 @@ install_extra_deps() {
     if [ "$CU_MAJOR" = "13" ]; then
         MOONCAKE_PKG="mooncake-transfer-engine-cuda13==0.3.11.post1"
         MOONCAKE_STALE_PKG="mooncake-transfer-engine"
+        NIXL_BIN_PKG="nixl-cu13"
+        NIXL_STALE_BIN_PKG="nixl-cu12"
         EXTRA_NVIDIA_SPECS="nvidia-cuda-nvrtc"
     else
         MOONCAKE_PKG="mooncake-transfer-engine==0.3.11.post1"
         MOONCAKE_STALE_PKG="mooncake-transfer-engine-cuda13"
+        NIXL_BIN_PKG="nixl-cu12"
+        NIXL_STALE_BIN_PKG="nixl-cu13"
         EXTRA_NVIDIA_SPECS="nvidia-cuda-nvrtc-cu12"
     fi
     # Both variants own the same mooncake/ package files and bin/ scripts
@@ -460,9 +464,11 @@ install_extra_deps() {
         $PIP_CMD install ${MOONCAKE_PKG} --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
     fi
     $PIP_CMD install ${MOONCAKE_PKG} ${EXTRA_NVIDIA_SPECS} py-spy scipy huggingface_hub[hf_xet] pytest $PIP_INSTALL_SUFFIX
-
     # Best-effort NIXL install for decode-radix disaggregation coverage.
-    $PIP_CMD install nixl nixl-cu13 --force-reinstall --no-deps $PIP_INSTALL_SUFFIX || echo "Warning: nixl install failed; continuing without nixl"
+    if pip show ${NIXL_STALE_BIN_PKG} >/dev/null 2>&1; then
+        $PIP_UNINSTALL_CMD ${NIXL_STALE_BIN_PKG} $PIP_UNINSTALL_SUFFIX || true
+        $PIP_CMD install nixl ${NIXL_BIN_PKG} --force-reinstall --no-deps $PIP_INSTALL_SUFFIX || echo "Warning: nixl install failed; continuing without nixl"
+    fi
 
     if [ "$IS_BLACKWELL" != "1" ]; then
         git clone --branch v0.5 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -462,7 +462,7 @@ install_extra_deps() {
     $PIP_CMD install ${MOONCAKE_PKG} ${EXTRA_NVIDIA_SPECS} py-spy scipy huggingface_hub[hf_xet] pytest $PIP_INSTALL_SUFFIX
 
     # Best-effort NIXL install for decode-radix disaggregation coverage.
-    $PIP_CMD install nixl --force-reinstall --no-deps $PIP_INSTALL_SUFFIX || echo "Warning: nixl install failed; continuing without nixl"
+    $PIP_CMD install nixl nixl-cu13 --force-reinstall --no-deps $PIP_INSTALL_SUFFIX || echo "Warning: nixl install failed; continuing without nixl"
 
     if [ "$IS_BLACKWELL" != "1" ]; then
         git clone --branch v0.5 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
## Motivation
The `8-gpu-h20` CI runner (CUDA 13) ships a pre-installed `nixl` stack that is incompatible with our disaggregation tests:
- The runner image may contain an older `nixl` release (e.g. `1.0.1`) that `uv pip install nixl` does not upgrade, because the install command has no version pin and no reinstall flag — pip/uv reports the package as already satisfied and exits immediately.
- The `nixl` stub package defaults to the CUDA 12 backend (`nixl-cu12`), but H20 runners require `nixl-cu13`. Without selecting the correct binary wheel, `test/registered/disaggregation/test_disaggregation_decode_radix_cache.py` fails on the NIXL transfer backend.
This PR fixes NIXL installation in `scripts/ci/cuda/ci_install_dependency.sh`, mirroring the existing Mooncake CUDA-major variant handling.
## Modifications
- Pin `NIXL_VERSION=1.3.0` and install `nixl==${NIXL_VERSION}` together with the CUDA-major-specific binary wheel (`nixl-cu13` on CU13, `nixl-cu12` on CU12).
- Select `NIXL_BIN_PKG` / `NIXL_STALE_BIN_PKG` based on `CU_MAJOR`, following the same pattern as `MOONCAKE_PKG` / `MOONCAKE_STALE_PKG`.
- Uninstall the wrong-CUDA backend wheel when present and force-reinstall the stub + correct binary with `--no-deps` to recover shared `nixl/` files (same rationale as the Mooncake stale-variant handling).
- Include NIXL in the unconditional final `pip install` line so fresh runners and version upgrades are always covered.
- Extract `MOONCAKE_VERSION` into a variable for consistency with the new NIXL version pin.


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27951923898](https://github.com/sgl-project/sglang/actions/runs/27951923898)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27951923494](https://github.com/sgl-project/sglang/actions/runs/27951923494)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->