### PR TITLE
fix(cache): propagate extra_key through KV hash mirrors

### DIFF
--- a/experimental/sgl-router/src/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/src/policies/cache_aware_zmq.rs
@@ -24,8 +24,9 @@
 //!    for callers that didn't pre-tokenize. On any failure (no tokens, no
 //!    tokenizer, encode error, empty), fall through to step 4 (min-load).
 //! 3. **Hash + match.** Compute block hashes via
-//!    [`super::kv_events::compute_block_hashes`], query the shared hash tree
-//!    for the longest matching prefix. If `match_rate > cache_threshold`,
+//!    [`super::kv_events::compute_block_hashes_with_extra_key`], including the
+//!    request's `cache_salt`/`extra_key` namespace when present, then query the
+//!    shared hash tree for the longest matching prefix. If `match_rate > cache_threshold`,
 //!    pick the lowest-load worker whose `url` appears in the match result.
 //!    Otherwise, fall through.
 //! 4. **Min-load fallback.** Pick the lowest-load worker by
@@ -38,9 +39,10 @@
 use crate::config::CacheAwareConfig;
 
 use crate::policies::kv_events::{
-    compute_block_hashes, compute_block_hashes_bigram, BlockSizeOracle, HashTree,
+    compute_block_hashes_bigram_with_extra_key, compute_block_hashes_with_extra_key,
+    BlockSizeOracle, HashTree,
 };
-use crate::policies::{request_tokens_for, Policy, SelectionContext};
+use crate::policies::{request_extra_key_for, request_tokens_for, Policy, SelectionContext};
 use crate::server::metrics::MetricsRegistry;
 use crate::tokenizer::TokenizerRegistry;
 use crate::workers::Worker;
@@ -149,8 +151,15 @@ impl Policy for CacheAwareZmqPolicy {
         //    callers that don't pre-tokenize (e.g. unit tests). In production
         //    the ingress always pre-tokenizes, so this is a single tokenize.
         let fallback_ids;
+        let extra_key: Option<String>;
         let tokens: &[u32] = match ctx.request_tokens() {
-            Some(t) if !t.is_empty() => t,
+            Some(t) if !t.is_empty() => {
+                extra_key = ctx
+                    .request_body()
+                    .and_then(|body| serde_json::from_slice::<serde_json::Value>(body).ok())
+                    .and_then(|value| request_extra_key_for(&value));
+                t
+            }
             _ => {
                 let body = match ctx.request_body() {
                     Some(b) if !b.is_empty() => b,
@@ -159,6 +168,7 @@ impl Policy for CacheAwareZmqPolicy {
                 let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
                     return Self::pick_min_load(workers);
                 };
+                extra_key = request_extra_key_for(&value);
                 let Some(rt) = request_tokens_for(&self.tokenizers, ctx.model(), &value) else {
                     return Self::pick_min_load(workers);
                 };
@@ -185,9 +195,13 @@ impl Policy for CacheAwareZmqPolicy {
         // reported flag.
         let is_bigram = self.block_size_oracle.is_bigram();
         let block_hashes = if is_bigram {
-            compute_block_hashes_bigram(tokens, block_size as usize)
+            compute_block_hashes_bigram_with_extra_key(
+                tokens,
+                block_size as usize,
+                extra_key.as_deref(),
+            )
         } else {
-            compute_block_hashes(tokens, block_size as usize)
+            compute_block_hashes_with_extra_key(tokens, block_size as usize, extra_key.as_deref())
         };
         if block_hashes.is_empty() {
             return Self::pick_min_load(workers);
@@ -255,7 +269,7 @@ mod tests {
     use crate::config::CacheAwareConfig;
     use crate::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
     use crate::policies::kv_events::tree::KvWorkerId;
-    use crate::policies::kv_events::HashTree;
+    use crate::policies::kv_events::{compute_block_hashes, compute_block_hashes_bigram, HashTree};
     use crate::tokenizer::adapter;
 
     fn cfg_default() -> CacheAwareConfig {
@@ -390,6 +404,54 @@ mod tests {
         let ctx = SelectionContext::new(&model, Some(&body));
         let chosen = policy.select(&workers, &ctx).expect("must pick");
         assert_eq!(chosen.url, "http://w0:30000");
+    }
+
+    #[test]
+    fn cache_salt_participates_in_route_hashes_with_precomputed_tokens() {
+        let tree = Arc::new(HashTree::new());
+        let registry = tokenizer_registry_with_tiny();
+        let text = "hello world hello world hello world";
+        let tok = registry.get("tiny").unwrap();
+        let ids = adapter::encode(&tok, text).unwrap();
+        let block_size = 4u32;
+        let salted_hashes =
+            compute_block_hashes_with_extra_key(&ids, block_size as usize, Some("salt-A"));
+        assert!(!salted_hashes.is_empty());
+        tree.insert(
+            &KvWorkerId::new("http://w0:30000".into(), 0),
+            None,
+            &salted_hashes,
+        );
+
+        let policy = CacheAwareZmqPolicy::new(
+            CacheAwareConfig {
+                cache_threshold: 0.0,
+                balance_abs_threshold: 32,
+                balance_rel_threshold: 1.1,
+            },
+            tree,
+            registry,
+            oracle_for_tests(4),
+        );
+        let w0 = worker("http://w0:30000", "tiny");
+        let w1 = worker("http://w1:30000", "tiny");
+        let _w0_load = w0.load_guard();
+        let workers = vec![Arc::clone(&w0), Arc::clone(&w1)];
+        let model = ModelId("tiny".into());
+
+        let body_a =
+            serde_json::to_vec(&serde_json::json!({"prompt": text, "cache_salt": "salt-A"}))
+                .unwrap();
+        let ctx_a = SelectionContext::new(&model, Some(&body_a)).with_request_tokens(Some(&ids));
+        let chosen_a = policy.select(&workers, &ctx_a).expect("must pick");
+        assert_eq!(chosen_a.url, "http://w0:30000");
+
+        let body_b =
+            serde_json::to_vec(&serde_json::json!({"prompt": text, "cache_salt": "salt-B"}))
+                .unwrap();
+        let ctx_b = SelectionContext::new(&model, Some(&body_b)).with_request_tokens(Some(&ids));
+        let chosen_b = policy.select(&workers, &ctx_b).expect("must pick");
+        assert_eq!(chosen_b.url, "http://w1:30000");
     }
 
     /// The cache-aware path records the matched prefix-overlap block count

--- a/experimental/sgl-router/src/policies/kv_events/hash.rs
+++ b/experimental/sgl-router/src/policies/kv_events/hash.rs
@@ -9,11 +9,13 @@
 //!
 //! For each page (chunk of `block_size` tokens, last page possibly short):
 //! 1. Initialize a SHA256 hasher.
-//! 2. If a prior page exists, feed the prior page's **full 32-byte SHA256
+//! 2. If the request has a `RadixKey.extra_key` namespace, feed its UTF-8 byte
+//!    length as a 4-byte little-endian integer followed by the UTF-8 bytes.
+//! 3. If a prior page exists, feed the prior page's **full 32-byte SHA256
 //!    digest** (raw bytes, not the truncated i64) into the hasher.
-//! 3. Feed each token in the page as 4 little-endian unsigned bytes.
-//! 4. Take the 32-byte digest as the new "prior" for the next page.
-//! 5. Truncate the digest to a signed i64 by reading the first 16 hex chars
+//! 4. Feed each token in the page as 4 little-endian unsigned bytes.
+//! 5. Take the 32-byte digest as the new "prior" for the next page.
+//! 6. Truncate the digest to a signed i64 by reading the first 16 hex chars
 //!    (top 64 bits) and reinterpreting as signed.
 //!
 //! ### Why no `parent_hash: Option<i64>` argument
@@ -55,6 +57,18 @@ use sha2::{Digest, Sha256};
 /// up-front against the worker-published `block_size`; an invalid value is
 /// a programmer/config bug, not a runtime input we should swallow.
 pub fn compute_block_hashes(token_ids: &[u32], block_size: usize) -> Vec<i64> {
+    compute_block_hashes_with_extra_key(token_ids, block_size, None)
+}
+
+/// Compute per-block i64 hashes with SGLang's `RadixKey.extra_key` namespace.
+///
+/// The namespace is folded into every page before the parent digest. This mirrors
+/// `RadixKey.hash_page` and `mem_cache.utils.get_hash_str`.
+pub fn compute_block_hashes_with_extra_key(
+    token_ids: &[u32],
+    block_size: usize,
+    extra_key: Option<&str>,
+) -> Vec<i64> {
     assert!(block_size > 0, "block_size must be positive");
     if token_ids.is_empty() {
         return Vec::new();
@@ -68,7 +82,7 @@ pub fn compute_block_hashes(token_ids: &[u32], block_size: usize) -> Vec<i64> {
     let mut start = 0;
     while start < n {
         let end = (start + block_size).min(n);
-        let digest = chain_block(prior.as_ref(), &token_ids[start..end]);
+        let digest = chain_block(prior.as_ref(), &token_ids[start..end], extra_key);
         out.push(sha256_to_i64(&digest));
         prior = Some(digest);
         start = end;
@@ -80,8 +94,13 @@ pub fn compute_block_hashes(token_ids: &[u32], block_size: usize) -> Vec<i64> {
 /// Hash a single page, optionally chained to a parent block's full 32-byte
 /// SHA256 digest. Returns the new 32-byte digest.
 #[inline]
-fn chain_block(parent_digest: Option<&[u8; 32]>, block_tokens: &[u32]) -> [u8; 32] {
+fn chain_block(
+    parent_digest: Option<&[u8; 32]>,
+    block_tokens: &[u32],
+    extra_key: Option<&str>,
+) -> [u8; 32] {
     let mut hasher = Sha256::new();
+    update_hasher_with_extra_key(&mut hasher, extra_key);
     if let Some(parent) = parent_digest {
         hasher.update(parent);
     }
@@ -89,6 +108,17 @@ fn chain_block(parent_digest: Option<&[u8; 32]>, block_tokens: &[u32]) -> [u8; 3
         hasher.update(t.to_le_bytes());
     }
     hasher.finalize().into()
+}
+
+#[inline]
+fn update_hasher_with_extra_key(hasher: &mut Sha256, extra_key: Option<&str>) {
+    let Some(extra_key) = extra_key else {
+        return;
+    };
+    let encoded = extra_key.as_bytes();
+    let len = u32::try_from(encoded.len()).expect("extra_key length exceeds u32");
+    hasher.update(len.to_le_bytes());
+    hasher.update(encoded);
 }
 
 /// Convert a full 32-byte SHA256 digest to the signed i64 truncation that
@@ -127,6 +157,15 @@ pub fn sha256_to_i64(digest: &[u8; 32]) -> i64 {
 /// hashes won't match the worker's stored bigram block hashes and cache-aware
 /// routing silently degrades to min-load.
 pub fn compute_block_hashes_bigram(token_ids: &[u32], block_size: usize) -> Vec<i64> {
+    compute_block_hashes_bigram_with_extra_key(token_ids, block_size, None)
+}
+
+/// Bigram variant of [`compute_block_hashes_with_extra_key`].
+pub fn compute_block_hashes_bigram_with_extra_key(
+    token_ids: &[u32],
+    block_size: usize,
+    extra_key: Option<&str>,
+) -> Vec<i64> {
     assert!(block_size > 0, "block_size must be positive");
     // N raw tokens -> N-1 overlapping bigrams; fewer than 2 tokens -> no blocks.
     let logical_len = token_ids.len().saturating_sub(1);
@@ -140,7 +179,7 @@ pub fn compute_block_hashes_bigram(token_ids: &[u32], block_size: usize) -> Vec<
     let mut start = 0;
     while start < logical_len {
         let end = (start + block_size).min(logical_len);
-        let digest = chain_block_bigram(prior.as_ref(), token_ids, start, end);
+        let digest = chain_block_bigram(prior.as_ref(), token_ids, start, end, extra_key);
         out.push(sha256_to_i64(&digest));
         prior = Some(digest);
         start = end;
@@ -160,8 +199,10 @@ fn chain_block_bigram(
     tokens: &[u32],
     start: usize,
     end: usize,
+    extra_key: Option<&str>,
 ) -> [u8; 32] {
     let mut hasher = Sha256::new();
+    update_hasher_with_extra_key(&mut hasher, extra_key);
     if let Some(parent) = parent_digest {
         hasher.update(parent);
     }
@@ -182,6 +223,42 @@ mod tests {
     // the deployed DeepSeek-V4-Flash engine. These lock byte-exact equivalence
     // with the worker's stored block hashes — the contract that makes
     // cache-aware routing actually match for EAGLE/bigram models.
+
+    #[test]
+    fn extra_key_namespaces_first_block_and_propagates() {
+        assert_eq!(
+            compute_block_hashes_with_extra_key(&[1, 2, 3, 4], 4, Some("salt-A")),
+            vec![1848708812856982025_i64]
+        );
+        assert_eq!(
+            compute_block_hashes_with_extra_key(&[1, 2, 3, 4], 4, Some("salt-B")),
+            vec![-3770730224180675262_i64]
+        );
+        assert_eq!(
+            compute_block_hashes_with_extra_key(&[1, 2, 3, 4, 5], 4, Some("salt-A")),
+            vec![1848708812856982025_i64, -844459331919182630_i64]
+        );
+    }
+
+    #[test]
+    fn empty_extra_key_is_a_namespace() {
+        assert_eq!(
+            compute_block_hashes_with_extra_key(&[1, 2, 3, 4], 4, Some("")),
+            vec![-1934027550307904538_i64]
+        );
+        assert_eq!(
+            compute_block_hashes_with_extra_key(&[1, 2, 3, 4], 4, None),
+            vec![-3488128144981237669_i64]
+        );
+    }
+
+    #[test]
+    fn bigram_extra_key_namespaces_first_block_and_propagates() {
+        assert_eq!(
+            compute_block_hashes_bigram_with_extra_key(&[10, 20, 30, 40, 50], 2, Some("salt-A"),),
+            vec![-3307084293699386976_i64, -4477231418096748271_i64]
+        );
+    }
 
     #[test]
     fn bigram_golden_single_block_full() {

--- a/experimental/sgl-router/src/policies/kv_events/mod.rs
+++ b/experimental/sgl-router/src/policies/kv_events/mod.rs
@@ -25,7 +25,10 @@ pub mod wire;
 pub use block_size_oracle::BlockSizeOracle;
 pub(crate) use discovery::classify_bigram;
 pub use discovery::{fetch_event_config, EventConfig};
-pub use hash::{compute_block_hashes, compute_block_hashes_bigram, sha256_to_i64};
+pub use hash::{
+    compute_block_hashes, compute_block_hashes_bigram, compute_block_hashes_bigram_with_extra_key,
+    compute_block_hashes_with_extra_key, sha256_to_i64,
+};
 pub use index::KvEventIndex;
 pub use subscriber::{KvEventSubscriberRegistry, WorkerEvent};
 pub use tree::{HashTree, KvWorkerId, MatchResult};

--- a/experimental/sgl-router/src/policies/mod.rs
+++ b/experimental/sgl-router/src/policies/mod.rs
@@ -75,6 +75,26 @@ pub fn request_tokens_for(
     })
 }
 
+/// Compute the radix-cache namespace SGLang will attach to this request.
+///
+/// Mirrors `OpenAIServingBase._compute_extra_key`: non-empty string
+/// `cache_salt` and `extra_key` fields are concatenated in that order.
+pub fn request_extra_key_for(value: &serde_json::Value) -> Option<String> {
+    let mut out = String::new();
+    for key in ["cache_salt", "extra_key"] {
+        if let Some(part) = value.get(key).and_then(|v| v.as_str()) {
+            if !part.is_empty() {
+                out.push_str(part);
+            }
+        }
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
 /// Tokenize `text` for `model_id` via the shared registry. Returns `None` if
 /// no tokenizer is loaded (the model_id may be misconfigured) or if encoding
 /// fails / yields no tokens. An encode error logs at WARN (a loaded-but-erroring

--- a/experimental/sgl-router/tests/component/policies/kv_events_hash_parity.rs
+++ b/experimental/sgl-router/tests/component/policies/kv_events_hash_parity.rs
@@ -19,7 +19,7 @@
 //! whatever fixture is checked in.
 
 use serde::Deserialize;
-use sgl_router::policies::kv_events::compute_block_hashes;
+use sgl_router::policies::kv_events::compute_block_hashes_with_extra_key;
 use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
@@ -27,6 +27,7 @@ struct ParityCase {
     name: String,
     tokens: Vec<u32>,
     block_size: usize,
+    extra_key: Option<String>,
     expected_i64_hashes: Vec<i64>,
 }
 
@@ -65,7 +66,11 @@ fn rust_block_hashes_match_python_radix_cache() {
         // doesn't include a 0 case, so unwrap is safe.
         let block_size = std::num::NonZeroUsize::new(case.block_size)
             .unwrap_or_else(|| panic!("case {} has block_size=0 which is invalid", case.name));
-        let got = compute_block_hashes(&case.tokens, block_size.get());
+        let got = compute_block_hashes_with_extra_key(
+            &case.tokens,
+            block_size.get(),
+            case.extra_key.as_deref(),
+        );
         assert_eq!(
             got, case.expected_i64_hashes,
             "case {}: tokens={:?} block_size={} — Rust produced {:?}, fixture says {:?}",

--- a/experimental/sgl-router/tests/fixtures/kv_events_hash_parity.json
+++ b/experimental/sgl-router/tests/fixtures/kv_events_hash_parity.json
@@ -228,5 +228,49 @@
       3368460852864325515,
       1233425155141659070
     ]
+  },
+  {
+    "name": "salted_single_full_block",
+    "tokens": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "block_size": 4,
+    "expected_i64_hashes": [
+      1848708812856982025
+    ],
+    "extra_key": "salt-A"
+  },
+  {
+    "name": "salted_multi_block",
+    "tokens": [
+      1,
+      2,
+      3,
+      4,
+      5
+    ],
+    "block_size": 4,
+    "expected_i64_hashes": [
+      1848708812856982025,
+      -844459331919182630
+    ],
+    "extra_key": "salt-A"
+  },
+  {
+    "name": "empty_extra_key_namespace",
+    "tokens": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "block_size": 4,
+    "expected_i64_hashes": [
+      -1934027550307904538
+    ],
+    "extra_key": ""
   }
 ]

--- a/experimental/sgl-router/tests/scripts/generate_kv_events_hash_parity.py
+++ b/experimental/sgl-router/tests/scripts/generate_kv_events_hash_parity.py
@@ -25,7 +25,9 @@ Source-of-truth implementation:
 sglang`) so the script runs without the heavy SGLang dependency tree and
 can be audited at a glance. The algorithm is intentionally tiny:
 
-    sha256(prior_digest_bytes ++ token_LE_u32 ++ token_LE_u32 ++ ...)
+    sha256(token_LE_u32 ++ token_LE_u32 ++ ...)
+    or, with extra_key and/or parent digest:
+    sha256(len(extra_key_utf8)_LE_u32 ++ extra_key_utf8 ++ prior_digest_bytes ++ token_LE_u32 ++ ...)
     truncate to i64 = signed(first 16 hex chars)
 
 If SGLang ever changes the algorithm, update both the SGLang side AND
@@ -41,6 +43,7 @@ A JSON array of cases. Each case is:
       "name": "<descriptive label>",
       "tokens": [<u32>, ...],
       "block_size": <usize>,
+      "extra_key": "<optional namespace>",
       "expected_i64_hashes": [<i64>, ...]
     }
 """
@@ -54,7 +57,9 @@ import pathlib
 import sys
 
 
-def hash_page_chain(tokens: list[int], block_size: int) -> list[int]:
+def hash_page_chain(
+    tokens: list[int], block_size: int, extra_key: str | None = None
+) -> list[int]:
     """Compute the i64-truncated block hashes for `tokens` using SGLang's
     `RadixKey.hash_page` algorithm + `hash_str_to_int64`.
 
@@ -75,6 +80,10 @@ def hash_page_chain(tokens: list[int], block_size: int) -> list[int]:
     while start < n:
         end = min(start + block_size, n)
         hasher = hashlib.sha256()
+        if extra_key is not None:
+            encoded_extra_key = extra_key.encode("utf-8")
+            hasher.update(len(encoded_extra_key).to_bytes(4, byteorder="little"))
+            hasher.update(encoded_extra_key)
         if prior_digest is not None:
             hasher.update(prior_digest)
         for t in tokens[start:end]:
@@ -133,19 +142,42 @@ CASES: list[dict] = [
         "tokens": list(range(1, 129)),
         "block_size": 16,
     },
+    {
+        "name": "salted_single_full_block",
+        "tokens": [1, 2, 3, 4],
+        "block_size": 4,
+        "extra_key": "salt-A",
+    },
+    {
+        "name": "salted_multi_block",
+        "tokens": [1, 2, 3, 4, 5],
+        "block_size": 4,
+        "extra_key": "salt-A",
+    },
+    {
+        "name": "empty_extra_key_namespace",
+        "tokens": [1, 2, 3, 4],
+        "block_size": 4,
+        "extra_key": "",
+    },
 ]
 
 
 def _materialize_cases() -> list[dict]:
-    return [
-        {
+    cases_out = []
+    for c in CASES:
+        out = {
             "name": c["name"],
             "tokens": c["tokens"],
             "block_size": c["block_size"],
-            "expected_i64_hashes": hash_page_chain(c["tokens"], c["block_size"]),
+            "expected_i64_hashes": hash_page_chain(
+                c["tokens"], c["block_size"], c.get("extra_key")
+            ),
         }
-        for c in CASES
-    ]
+        if "extra_key" in c:
+            out["extra_key"] = c["extra_key"]
+        cases_out.append(out)
+    return cases_out
 
 
 def _validate_against_sglang() -> int:
@@ -167,7 +199,7 @@ def _validate_against_sglang() -> int:
 
     failures: list[str] = []
     for c in CASES:
-        local = hash_page_chain(c["tokens"], c["block_size"])
+        local = hash_page_chain(c["tokens"], c["block_size"], c.get("extra_key"))
         if c["block_size"] == 0 or not c["tokens"]:
             # `RadixKey.hash_page` requires a non-empty page; the local
             # replica handles edge cases (empty input → empty list)
@@ -176,10 +208,10 @@ def _validate_against_sglang() -> int:
             continue
         sglang_hashes: list[int] = []
         prior_hex: str | None = None
+        key = RadixKey(token_ids=c["tokens"], extra_key=c.get("extra_key"))
         for start in range(0, len(c["tokens"]), c["block_size"]):
-            page = c["tokens"][start : start + c["block_size"]]
-            key = RadixKey(token_ids=page, extra_key=None)
-            hex_digest = key.hash_page(prior_hex)
+            end = min(start + c["block_size"], len(c["tokens"]))
+            hex_digest = key.hash_page(start, end, prior_hex)
             # SGLang's hash_page returns the hex digest; truncate to i64
             # the same way `hash_str_to_int64` does.
             uint64_val = int(hex_digest[:16], 16)

--- a/python/sglang/srt/disaggregation/decode_hicache_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_hicache_mixin.py
@@ -86,6 +86,7 @@ class DecodeHiCachePreallocMixin:
                     suffix_tokens,
                     last_hash,
                     prefix_keys,
+                    req.extra_key,
                 )
 
         return DecodePrefixMatch(
@@ -124,7 +125,12 @@ class DecodeHiCachePreallocMixin:
                 else None
             )
             self.tree_cache.prefetch_from_storage(
-                req.rid, prefix_match.last_host_node, suffix, last_hash, prefix_keys
+                req.rid,
+                prefix_match.last_host_node,
+                suffix,
+                last_hash,
+                prefix_keys,
+                req.extra_key,
             )
             prefix_match.prefetch_registered = (
                 req.rid in self.tree_cache.ongoing_prefetch

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -147,7 +147,7 @@ class DecodeKVCacheOffloadManager:
         state = self.offloaded_state.get(req.rid)
         if state is None:
             prefill_hashes = self._compute_prefix_hash(
-                req.origin_input_ids[:prefill_offloaded_len]
+                req.origin_input_ids[:prefill_offloaded_len], extra_key=req.extra_key
             )
             last_prefill_hash = (
                 prefill_hashes[-1] if prefill_offloaded_len > 0 else None
@@ -317,7 +317,9 @@ class DecodeKVCacheOffloadManager:
         self, req, host_indices, incremental_tokens, start_time, prior_hash
     ):
         """Trigger async backup from host to storage."""
-        page_hashes = self._compute_prefix_hash(incremental_tokens, prior_hash)
+        page_hashes = self._compute_prefix_hash(
+            incremental_tokens, prior_hash, extra_key=req.extra_key
+        )
         ack_id = self.cache_controller.write_storage(
             host_indices,
             incremental_tokens,
@@ -326,12 +328,14 @@ class DecodeKVCacheOffloadManager:
         self.ongoing_backup[ack_id] = (req.rid, host_indices, start_time)
         return page_hashes[-1] if len(page_hashes) > 0 else prior_hash
 
-    def _compute_prefix_hash(self, tokens, prior_hash=""):
+    def _compute_prefix_hash(self, tokens, prior_hash="", extra_key=None):
         page_hashes = []
         last_hash = prior_hash
         for offset in range(0, len(tokens), self.page_size):
             page_tokens = tokens[offset : offset + self.page_size]
-            last_hash = self.cache_controller.get_hash_str(page_tokens, last_hash)
+            last_hash = self.cache_controller.get_hash_str(
+                page_tokens, last_hash, extra_key=extra_key
+            )
             page_hashes.append(last_hash)
         return page_hashes
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2438,6 +2438,7 @@ class Scheduler(
                     new_input_tokens,
                     tree_cache.get_last_hash_value(req.last_host_node),
                     prefix_keys,
+                    req.extra_key,
                 )
 
     def _add_request_to_queue(self, req: Req, is_retracted: bool = False):

--- a/python/sglang/srt/mem_cache/cpp_utils/hash_binding.cpp
+++ b/python/sglang/srt/mem_cache/cpp_utils/hash_binding.cpp
@@ -59,11 +59,46 @@ parse_prior_digest(py::object prior_digest_obj, bool *has_prior_digest) {
   return prior_digest;
 }
 
+struct ExtraKey {
+  bool present = false;
+  std::array<unsigned char, 4> length_bytes{};
+  std::string encoded;
+};
+
+ExtraKey parse_extra_key(py::object extra_key_obj) {
+  ExtraKey extra_key;
+  if (extra_key_obj.is_none()) {
+    return extra_key;
+  }
+
+  extra_key.present = true;
+  extra_key.encoded = extra_key_obj.cast<std::string>();
+  if (extra_key.encoded.size() > UINT32_MAX) {
+    throw std::out_of_range("extra_key UTF-8 encoding exceeds uint32 length");
+  }
+  const auto length = static_cast<std::uint32_t>(extra_key.encoded.size());
+  extra_key.length_bytes = {
+      static_cast<unsigned char>(length),
+      static_cast<unsigned char>(length >> 8),
+      static_cast<unsigned char>(length >> 16),
+      static_cast<unsigned char>(length >> 24),
+  };
+  return extra_key;
+}
+
 inline void hash_page(const unsigned char *data, std::size_t len,
                       bool &has_prior_digest,
-                      std::array<unsigned char, kDigestLen> &prior_digest) {
+                      std::array<unsigned char, kDigestLen> &prior_digest,
+                      const ExtraKey &extra_key) {
   SHA256_CTX ctx;
   SHA256_Init(&ctx);
+  if (extra_key.present) {
+    SHA256_Update(&ctx, extra_key.length_bytes.data(),
+                  extra_key.length_bytes.size());
+    if (!extra_key.encoded.empty()) {
+      SHA256_Update(&ctx, extra_key.encoded.data(), extra_key.encoded.size());
+    }
+  }
   if (has_prior_digest) {
     SHA256_Update(&ctx, prior_digest.data(), prior_digest.size());
   }
@@ -185,7 +220,7 @@ void hash_pages_to_hex_blob(const RawToken *raw, std::size_t logical_len,
                             std::size_t page_size, std::size_t unit_width,
                             bool is_bigram, bool has_prior_digest,
                             std::array<unsigned char, kDigestLen> prior_digest,
-                            std::string &hex_blob) {
+                            const ExtraKey &extra_key, std::string &hex_blob) {
   if (page_size == 0) {
     throw std::invalid_argument("page_size must be positive");
   }
@@ -219,7 +254,7 @@ void hash_pages_to_hex_blob(const RawToken *raw, std::size_t logical_len,
       bytes = reinterpret_cast<const unsigned char *>(page_words.data());
     }
 
-    hash_page(bytes, page_bytes, has_prior_digest, prior_digest);
+    hash_page(bytes, page_bytes, has_prior_digest, prior_digest, extra_key);
     digest_to_hex_chars(prior_digest.data(),
                         hex_blob.data() + page_idx * kHexLen);
   }
@@ -229,7 +264,8 @@ template <typename RawToken>
 std::string hash_all(const RawToken *raw, std::size_t logical_len,
                      std::size_t unit_width, bool is_bigram,
                      bool has_prior_digest,
-                     std::array<unsigned char, kDigestLen> prior_digest) {
+                     std::array<unsigned char, kDigestLen> prior_digest,
+                     const ExtraKey &extra_key) {
   if (is_bigram) {
     unit_width = 2;
   }
@@ -253,7 +289,7 @@ std::string hash_all(const RawToken *raw, std::size_t logical_len,
     bytes = reinterpret_cast<const unsigned char *>(words.data());
   }
 
-  hash_page(bytes, num_bytes, has_prior_digest, prior_digest);
+  hash_page(bytes, num_bytes, has_prior_digest, prior_digest, extra_key);
   return digest_to_hex_string(prior_digest.data());
 }
 
@@ -284,32 +320,35 @@ py::object hex_blob_to_pylist(const std::string &hex_blob) {
 
 std::string hash_str(const py::buffer &raw_tokens, std::size_t logical_len,
                      std::size_t unit_width, bool is_bigram,
-                     py::object prior_digest_obj) {
+                     py::object prior_digest_obj, py::object extra_key_obj) {
   RawTokenBuffer buffer =
       get_raw_token_buffer(raw_tokens, logical_len, unit_width, is_bigram);
   bool has_prior_digest = false;
   auto prior_digest = parse_prior_digest(prior_digest_obj, &has_prior_digest);
+  auto extra_key = parse_extra_key(extra_key_obj);
 
   py::gil_scoped_release release;
   if (buffer.info.itemsize == 4) {
     return hash_all(static_cast<const std::uint32_t *>(buffer.info.ptr),
                     logical_len, unit_width, is_bigram, has_prior_digest,
-                    prior_digest);
+                    prior_digest, extra_key);
   }
   return hash_all(static_cast<const std::uint64_t *>(buffer.info.ptr),
                   logical_len, unit_width, is_bigram, has_prior_digest,
-                  prior_digest);
+                  prior_digest, extra_key);
 }
 
 py::object pages_hashes(const py::buffer &raw_tokens, std::size_t logical_len,
                         std::size_t page_size, std::size_t unit_width,
-                        bool is_bigram, py::object prior_digest_obj) {
+                        bool is_bigram, py::object prior_digest_obj,
+                        py::object extra_key_obj) {
   RawTokenBuffer buffer =
       get_raw_token_buffer(raw_tokens, logical_len, unit_width, is_bigram);
   const std::size_t num_pages =
       page_size == 0 ? 0 : (logical_len + page_size - 1) / page_size;
   bool has_prior_digest = false;
   auto prior_digest = parse_prior_digest(prior_digest_obj, &has_prior_digest);
+  auto extra_key = parse_extra_key(extra_key_obj);
   std::string hex_blob(num_pages * kHexLen, '\0');
 
   {
@@ -318,12 +357,12 @@ py::object pages_hashes(const py::buffer &raw_tokens, std::size_t logical_len,
       hash_pages_to_hex_blob(
           static_cast<const std::uint32_t *>(buffer.info.ptr), logical_len,
           page_size, unit_width, is_bigram, has_prior_digest, prior_digest,
-          hex_blob);
+          extra_key, hex_blob);
     } else {
       hash_pages_to_hex_blob(
           static_cast<const std::uint64_t *>(buffer.info.ptr), logical_len,
           page_size, unit_width, is_bigram, has_prior_digest, prior_digest,
-          hex_blob);
+          extra_key, hex_blob);
     }
   }
 
@@ -332,14 +371,15 @@ py::object pages_hashes(const py::buffer &raw_tokens, std::size_t logical_len,
 
 py::object get_hash(const py::buffer &raw_tokens, std::size_t logical_len,
                     std::size_t unit_width, bool is_bigram,
-                    py::object prior_digest_obj, py::object page_size_obj) {
+                    py::object prior_digest_obj, py::object extra_key_obj,
+                    py::object page_size_obj) {
   if (page_size_obj.is_none()) {
     return py::cast(hash_str(raw_tokens, logical_len, unit_width, is_bigram,
-                             prior_digest_obj));
+                             prior_digest_obj, extra_key_obj));
   }
   return pages_hashes(raw_tokens, logical_len,
                       page_size_obj.cast<std::size_t>(), unit_width, is_bigram,
-                      prior_digest_obj);
+                      prior_digest_obj, extra_key_obj);
 }
 
 } // namespace
@@ -347,5 +387,5 @@ py::object get_hash(const py::buffer &raw_tokens, std::size_t logical_len,
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("get_hash", &get_hash, py::arg("raw_tokens"), py::arg("logical_len"),
         py::arg("unit_width"), py::arg("is_bigram"), py::arg("prior_digest"),
-        py::arg("page_size") = py::none());
+        py::arg("extra_key"), py::arg("page_size") = py::none());
 }

--- a/python/sglang/srt/mem_cache/cpp_utils/native_hash.py
+++ b/python/sglang/srt/mem_cache/cpp_utils/native_hash.py
@@ -78,9 +78,18 @@ def _native_hash_input(token_ids: Any) -> tuple[array, int, int, bool]:
 
 
 def get_native_hash(
-    token_ids: Any, prior_digest: Optional[bytes], page_size: Optional[int] = None
+    token_ids: Any,
+    prior_digest: Optional[bytes],
+    page_size: Optional[int] = None,
+    extra_key: Optional[str] = None,
 ) -> str | list[str]:
     raw, logical_len, unit_width, is_bigram = _native_hash_input(token_ids)
     return _load_native_hash_module().get_hash(
-        raw, logical_len, unit_width, is_bigram, prior_digest, page_size
+        raw,
+        logical_len,
+        unit_width,
+        is_bigram,
+        prior_digest,
+        extra_key,
+        page_size,
     )

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -1801,11 +1801,14 @@ class HiMambaRadixCache(MambaRadixCache):
         new_input_tokens: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        extra_key: Optional[str] = None,
     ):
-        prefetch_length = len(new_input_tokens) - (
-            len(new_input_tokens) % self.page_size
+        cache_extra_key = (
+            extra_key if extra_key is not None else last_host_node.key.extra_key
         )
-        new_input_tokens = new_input_tokens[:prefetch_length]
+        prefetch_key = RadixKey(new_input_tokens, extra_key=cache_extra_key)
+        prefetch_key = prefetch_key.page_aligned(self.page_size)
+        prefetch_length = len(prefetch_key)
         if (
             not self.enable_storage
             or prefetch_length < self.prefetch_threshold
@@ -1816,7 +1819,7 @@ class HiMambaRadixCache(MambaRadixCache):
         self._protect_host_node(last_host_node, protect_mamba=False)
 
         # Allocate host mamba slot
-        extra_pools = self.mamba_prefetch_alloc(new_input_tokens, last_hash)
+        extra_pools = self.mamba_prefetch_alloc(prefetch_key.token_ids, last_hash)
         if extra_pools is None:
             self._release_host_node(last_host_node, release_mamba=False)
             return
@@ -1828,24 +1831,24 @@ class HiMambaRadixCache(MambaRadixCache):
 
         operation = self.cache_controller.prefetch(
             req_id,
-            new_input_tokens,
+            prefetch_key,
             last_hash,
             prefix_keys,
             extra_pools=extra_pools,
         )
         self.ongoing_prefetch[req_id] = (
             last_host_node,
-            new_input_tokens,
+            prefetch_key,
             None,
             operation,
         )
-        self.cache_controller.prefetch_tokens_occupied += len(new_input_tokens)
+        self.cache_controller.prefetch_tokens_occupied += len(prefetch_key)
 
     def check_prefetch_progress(self, req_id: str) -> bool:
         if req_id not in self.ongoing_prefetch:
             return True
 
-        last_host_node, token_ids, host_indices, operation = self.ongoing_prefetch[
+        last_host_node, prefetch_key, host_indices, operation = self.ongoing_prefetch[
             req_id
         ]
 
@@ -1889,14 +1892,11 @@ class HiMambaRadixCache(MambaRadixCache):
                 )
                 break
 
-        fetched_token_ids = token_ids[:min_completed_tokens]
+        fetched_key = prefetch_key[:min_completed_tokens]
         written_indices = host_indices[:min_completed_tokens]
         matched_length = self._insert_helper_host(
             last_host_node,
-            RadixKey(
-                token_ids=fetched_token_ids,
-                extra_key=last_host_node.key.extra_key,
-            ),
+            fetched_key,
             written_indices,
             hash_value[: min_completed_tokens // self.page_size],
             mamba_host_indices,
@@ -1917,7 +1917,7 @@ class HiMambaRadixCache(MambaRadixCache):
 
         self._release_host_node(last_host_node)
         del self.ongoing_prefetch[req_id]
-        self.cache_controller.prefetch_tokens_occupied -= len(token_ids)
+        self.cache_controller.prefetch_tokens_occupied -= len(prefetch_key)
 
         loaded_from_storage = min_completed_tokens - matched_length
         self.prefetch_loaded_tokens_by_reqid[req_id] = loaded_from_storage

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1395,13 +1395,17 @@ class HiRadixCache(RadixCache):
         new_input_tokens: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        extra_key: Optional[str] = None,
     ) -> int:
         if not self.enable_storage or self.cache_controller.prefetch_rate_limited():
             return 0
 
+        cache_extra_key = (
+            extra_key if extra_key is not None else last_host_node.key.extra_key
+        )
         prefetch_key = RadixKey(
             new_input_tokens,
-            extra_key=last_host_node.key.extra_key,
+            extra_key=cache_extra_key,
             is_bigram=self.is_eagle,
         ).page_aligned(self.page_size)
         if len(prefetch_key) < self.prefetch_threshold:
@@ -1683,10 +1687,14 @@ class HiRadixCache(RadixCache):
         new_input_tokens: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        extra_key: Optional[str] = None,
     ):
+        cache_extra_key = (
+            extra_key if extra_key is not None else last_host_node.key.extra_key
+        )
         prefetch_key = RadixKey(
             new_input_tokens,
-            extra_key=last_host_node.key.extra_key,
+            extra_key=cache_extra_key,
             is_bigram=self.is_eagle,
         )
         # align the number of fetching tokens to the page size

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1118,14 +1118,16 @@ class UnifiedRadixCache(BasePrefixCache):
         new_input_tokens: list[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[list[str]] = None,
+        extra_key: Optional[str] = None,
     ) -> None:
         if not self.enable_storage or self.cache_controller is None:
             return
 
-        extra_key = self.tree_core.prefetch_anchor_info(last_host_node_id)
+        anchor_extra_key = self.tree_core.prefetch_anchor_info(last_host_node_id)
+        cache_extra_key = extra_key if extra_key is not None else anchor_extra_key
         prefetch_key = RadixKey(
             new_input_tokens,
-            extra_key=extra_key,
+            extra_key=cache_extra_key,
             is_bigram=self.tree_core.is_eagle,
         ).page_aligned(self.page_size)
         prefetch_length = len(prefetch_key)

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -107,9 +107,13 @@ def get_hash_str(
     token_ids: List[int],
     prior_hash: Optional[str] = None,
     page_size: Optional[int] = None,
+    extra_key: Optional[str] = None,
 ) -> str | List[str]:
     prior_digest = bytes.fromhex(prior_hash) if prior_hash else None
-    return get_native_hash(token_ids, prior_digest, page_size)
+    cache_extra_key = (
+        extra_key if extra_key is not None else getattr(token_ids, "extra_key", None)
+    )
+    return get_native_hash(token_ids, prior_digest, page_size, cache_extra_key)
 
 
 def hash_str_to_int64(hash_str: str) -> int:

--- a/test/registered/unit/mem_cache/test_mem_cache_utils.py
+++ b/test/registered/unit/mem_cache/test_mem_cache_utils.py
@@ -29,8 +29,15 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
 
 
-def _legacy_get_hash_str(token_ids, prior_hash=None):
+def _legacy_get_hash_str(token_ids, prior_hash=None, extra_key=None):
     hasher = hashlib.sha256()
+    cache_extra_key = (
+        extra_key if extra_key is not None else getattr(token_ids, "extra_key", None)
+    )
+    if cache_extra_key is not None:
+        encoded_extra_key = cache_extra_key.encode("utf-8")
+        hasher.update(len(encoded_extra_key).to_bytes(4, byteorder="little"))
+        hasher.update(encoded_extra_key)
     if prior_hash:
         hasher.update(bytes.fromhex(prior_hash))
     for t in token_ids:
@@ -54,9 +61,10 @@ def _legacy_page_hashes(key, page_size, prior_hash=None):
 
 
 class _HashKey:
-    def __init__(self, token_ids, is_bigram=False):
+    def __init__(self, token_ids, is_bigram=False, extra_key=None):
         self.token_ids = token_ids
         self.is_bigram = is_bigram
+        self.extra_key = extra_key
 
     def __len__(self):
         if self.is_bigram:
@@ -68,8 +76,12 @@ class _HashKey:
             start = index.start or 0
             stop = index.stop if index.stop is not None else len(self)
             if self.is_bigram:
-                return _HashKey(self.token_ids[start : stop + 1], is_bigram=True)
-            return _HashKey(self.token_ids[start:stop])
+                return _HashKey(
+                    self.token_ids[start : stop + 1],
+                    is_bigram=True,
+                    extra_key=self.extra_key,
+                )
+            return _HashKey(self.token_ids[start:stop], extra_key=self.extra_key)
         if self.is_bigram:
             return (self.token_ids[index], self.token_ids[index + 1])
         return self.token_ids[index]
@@ -246,9 +258,42 @@ class TestGetHashStr(unittest.TestCase):
         self.assertNotEqual(
             chained, get_hash_str([3, 4], prior_hash=get_hash_str([9, 9]))
         )
+
         for tokens in [[], [1], [1, 2, 3], [(1, 2)], [1, 2, 3, 4, 5]]:
             with self.subTest(tokens=tokens):
                 self.assertRegex(get_hash_str(tokens), r"^[0-9a-f]{64}$")
+
+    def test_extra_key_namespaces_first_step(self):
+        salted_a = get_hash_str([1, 2, 3, 4], extra_key="salt-A")
+        salted_b = get_hash_str([1, 2, 3, 4], extra_key="salt-B")
+        unsalted = get_hash_str([1, 2, 3, 4])
+
+        self.assertEqual(
+            salted_a, _legacy_get_hash_str([1, 2, 3, 4], extra_key="salt-A")
+        )
+        self.assertNotEqual(salted_a, salted_b)
+        self.assertNotEqual(salted_a, unsalted)
+        self.assertNotEqual(get_hash_str([1, 2, 3, 4], extra_key=""), unsalted)
+
+    def test_extra_key_is_carried_by_token_view_slices(self):
+        token_view = _HashKey(array("q", [1, 2, 3, 4, 5]), extra_key="salt-A")
+
+        first_hash = get_hash_str(token_view[:4])
+        self.assertEqual(first_hash, get_hash_str([1, 2, 3, 4], extra_key="salt-A"))
+
+        second_hash = get_hash_str(token_view[4:5], prior_hash=first_hash)
+        self.assertEqual(
+            second_hash, get_hash_str([5], prior_hash=first_hash, extra_key="salt-A")
+        )
+
+    def test_page_hashes_apply_extra_key_to_each_page(self):
+        token_view = _HashKey(array("q", [1, 2, 3, 4, 5]), extra_key="salt-A")
+        page_hashes = get_hash_str(token_view, page_size=4)
+
+        first_hash = get_hash_str(token_view[:4])
+        second_hash = get_hash_str(token_view[4:5], prior_hash=first_hash)
+        self.assertEqual(page_hashes, [first_hash, second_hash])
+        self.assertEqual(page_hashes, _legacy_page_hashes(token_view, page_size=4))
 
     def test_hash_key_hash_page_matches_get_hash_str(self):
         key = _HashKey(array("q", [1, 2, 3, 4, 5, 6]), is_bigram=True)

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -39,6 +39,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
 )
 from sglang.srt.mem_cache.mamba_radix_cache import TreeNode as MambaTreeNode
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
+from sglang.srt.mem_cache.utils import get_hash_str
 from sglang.srt.utils import get_device
 
 # Test constants
@@ -104,6 +105,24 @@ class TestRadixKey(unittest.TestCase):
         key = RadixKey(array("q", [1, 2, 3]))
         with self.assertRaises(IndexError):
             _ = key[10]  # Out of bounds
+
+    def test_hash_page_includes_extra_key_namespace(self):
+        """hash_page uses the same extra_key namespace as child_key."""
+        tokens = array("q", [1, 2, 3, 4, 5])
+        key_a = RadixKey(tokens, "salt-A")
+        key_b = RadixKey(tokens, "salt-B")
+        key_empty = RadixKey(tokens, "")
+        key_none = RadixKey(tokens, None)
+
+        first_a = key_a.hash_page(0, 4)
+        first_b = key_b.hash_page(0, 4)
+        self.assertNotEqual(first_a, first_b)
+        self.assertNotEqual(key_empty.hash_page(0, 4), key_none.hash_page(0, 4))
+
+        # Storage-hit queries recompute the same chain from RadixKey slices.
+        self.assertEqual(first_a, get_hash_str(key_a[:4]))
+        second_a = key_a.hash_page(4, 5, first_a)
+        self.assertEqual(second_a, get_hash_str(key_a[4:5], first_a))
 
     def _assert_match(self, a, b, page_size, expected, is_bigram=False):
         key_a = RadixKey(array("q", a), is_bigram=is_bigram)
@@ -469,6 +488,36 @@ class TestRadixCache(unittest.TestCase):
         remove_events = [e for e in events if isinstance(e, BlockRemoved)]
         self.assertEqual(len(remove_events), 1)
         self.assertEqual(remove_events[0].block_hashes, stored_hashes)
+
+    def test_block_hashes_are_isolated_by_extra_key(self):
+        """KV event block hashes differ across extra_key namespaces."""
+        cache = RadixCache.create_simulated(
+            page_size=4,
+            enable_kv_cache_events=True,
+        )
+        tokens = array("q", [1, 2, 3, 4])
+
+        cache.insert(InsertParams(key=RadixKey(tokens, "salt-A"), value=None))
+        events_a = [
+            event for event in cache.take_events() if isinstance(event, BlockStored)
+        ]
+
+        match_other_namespace = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(tokens, "salt-B"))
+        )
+        self.assertEqual(len(match_other_namespace.device_indices), 0)
+
+        cache.insert(InsertParams(key=RadixKey(tokens, "salt-B"), value=None))
+        events_b = [
+            event for event in cache.take_events() if isinstance(event, BlockStored)
+        ]
+
+        self.assertEqual(len(events_a), 1)
+        self.assertEqual(len(events_b), 1)
+        self.assertNotEqual(
+            events_a[0].block_hashes[0],
+            events_b[0].block_hashes[0],
+        )
 
     def test_extra_key_isolation(self):
         """Test that keys with different extra_key values are isolated."""


### PR DESCRIPTION
## Motivation

Related to #24568.

This PR documents and tests the broader KV-cache hash contract around `RadixKey.extra_key` / OpenAI `cache_salt`. It is intentionally not presented as an independent replacement for the existing work:

- #24579 fixes the immediate `RadixKey.hash_page()` event-hash collision.
- #25351 rebuilds prefix-cache namespace composition for `cache_salt`, `extra_key`, and `lora_id`.

The remaining contract this PR exercises is that all hash mirrors that consume the final radix-cache namespace must agree with the worker-side block hash semantics. In particular, storage-hit queries, decode/offload prefetch paths, and the experimental router's KV-event hash mirror should not remain namespace-blind after `hash_page()` becomes namespace-aware.

This branch currently mirrors #24579's per-page hash ordering: `extra_key` bytes are fed before the parent digest and token bytes.

If #25351 lands first, the router-side request namespace derivation in this PR should be rebased onto the structured namespace semantics from that PR rather than preserving the current `main` concatenation behavior. The Python storage paths consume `Req.extra_key` after request construction and should continue to apply to the composed namespace.

## Modifications

- Add shared Python hash helper support for `extra_key` in `python/sglang/srt/mem_cache/utils.py`.
- Make `RadixKey.hash_page()` and `get_hash_str()` agree on namespaced page hashes.
- Thread `req.extra_key` through storage/offload query and prefetch paths, including root-L3 cases where the matched host node has no namespace.
- Preserve `RadixKey` namespace information in HiCache, Mamba, and unified-cache storage paths.
- Update the experimental router hash mirror to compute namespace-aware block hashes for unigram and bigram/EAGLE modes.
- Update router parity fixtures and route-selection coverage for `cache_salt`.
- Add focused unit coverage for storage-query mirrors and KV-event block hash isolation.

## Related PRs / overlap

- #24579: covers the immediate worker-side `hash_page()` salt. This PR extends the same semantics to storage/query and router mirrors.
- #25351: changes how the final namespace is composed before it becomes `Req.extra_key`. This PR should be rebased if that PR lands first, especially in the router request-body mirror.

This is ready for review after rebasing onto current `main`; maintainers can still decide whether they want this as a follow-up, a split patch, or folded into one of the existing PRs.

## Accuracy Tests

Revalidated after rebasing onto current `main` on 2026-06-27 UTC:

- `git diff --check upstream/main...HEAD`
- Python compile + `uvx ruff check --select E9,F --ignore F841,F541` on changed Python/test files
- Focused Python hash namespace tests — 4 passed
- `cargo fmt --manifest-path experimental/sgl-router/Cargo.toml --check`
- `cargo test --manifest-path experimental/sgl-router/Cargo.toml kv_events::hash` — 20 passed
- `cargo test --manifest-path experimental/sgl-router/Cargo.toml kv_events_hash_parity` — 2 passed
- `cargo test --manifest-path experimental/sgl-router/Cargo.toml cache_salt_participates_in_route_hashes_with_precomputed_tokens` — 1 passed
- `TORCHDYNAMO_DISABLE=1 PYTHONPATH=python .venv/bin/python experimental/sgl-router/tests/scripts/generate_kv_events_hash_parity.py --validate-against-sglang` — 10 cases agreed

Earlier local validation before rebase:

Validated locally on macOS / CPU-oriented environment:

- `git diff --check`
- `python -m py_compile` on changed Python files
- `uvx ruff check --select E9,F --ignore F841,F541 ...` on changed Python files
- `TORCHDYNAMO_DISABLE=1 PYTHONPATH=python .venv/bin/python -m pytest test/registered/unit/mem_cache/test_mem_cache_utils.py::TestGetHashStr::test_extra_key_namespaces_first_step test/registered/unit/mem_cache/test_mem_cache_utils.py::TestGetHashStr::test_extra_key_is_carried_by_token_view_slices test/registered/unit/mem_cache/test_radix_cache_unit.py::TestRadixKey::test_hash_page_includes_extra_key_namespace test/registered/unit/mem_cache/test_radix_cache_unit.py::TestRadixCache::test_block_hashes_are_isolated_by_extra_key -q` — 4 passed
- `cargo fmt --manifest-path experimental/sgl-router/Cargo.toml --check`
- `cargo test --manifest-path experimental/sgl-router/Cargo.toml kv_events::hash` — 20 passed
- `cargo test --manifest-path experimental/sgl-router/Cargo.toml kv_events_hash_parity` — 2 passed
- `cargo test --manifest-path experimental/sgl-router/Cargo.toml cache_salt_participates_in_route_hashes_with_precomputed_tokens` — 1 passed
- `TORCHDYNAMO_DISABLE=1 PYTHONPATH=python .venv/bin/python experimental/sgl-router/tests/scripts/generate_kv_events_hash_parity.py --validate-against-sglang` — 10 cases agreed

Additional local checks:

- Full `test/registered/unit/mem_cache/test_radix_cache_unit.py`: 42 passed, 1 failed because local PyTorch is CPU-only and `test_memory_allocated` requires CUDA.
- Full `test/registered/unit/mem_cache/test_mem_cache_utils.py`: 44 passed, 1 failed due local optional Mooncake module/mock resolution (`sglang.srt.disaggregation.mooncake`), unrelated to this hash change.

Full CI was not run locally.

## Speed Tests and Profiling

Not run. This changes hash-key construction and routing/storage lookup parity, not inference kernels. Unsalted hashes remain unchanged; salted namespaces intentionally produce different block/storage/router hashes.

## Checklist

- [x] Added focused unit/parity tests for the changed behavior.
- [x] Ran targeted Python and Rust validation listed above.
- [x] Ran `git diff --check`.
- [ ] Full pre-commit / full CI not run locally.
- [ ] Documentation not updated; this is internal cache identity behavior.

## Review and Merge Process

This overlaps active namespace/hash work in #24579 and #25351. Please treat it as a proposed follow-up/split point rather than a request to supersede either PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30245847181](https://github.com/sgl-project/sglang/actions/runs/30245847181)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30245845674](https://github.com/sgl-project/sglang/actions/runs/30245845674)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

