### PR TITLE
feat(router/cache_aware): weight worker selection by priority/cost labels

### DIFF
--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -304,6 +304,24 @@ pub trait Worker: Send + Sync + fmt::Debug {
         }
     }
 
+    /// Per-worker capacity-aware load metric.
+    ///
+    /// `effective_load = load / weight`. A bigger machine (weight > 1.0) is treated
+    /// as if it had a smaller queue than its raw `load()` count suggests, so the
+    /// shortest-effective-load picker sends proportionally more traffic there.
+    ///
+    /// Returns `f32::INFINITY` for any non-positive weight so the worker is
+    /// naturally deprioritized rather than blowing up the comparison.
+    fn effective_load(&self) -> f32 {
+        let load = self.load() as f32;
+        let weight = self.weight();
+        if weight > 0.0 {
+            load / weight
+        } else {
+            f32::INFINITY
+        }
+    }
+
     /// Get tokenizer path for a specific model.
     fn tokenizer_path(&self, model_id: &str) -> Option<&str> {
         self.metadata()
@@ -664,6 +682,9 @@ pub struct BasicWorker {
     /// When set, overrides metadata.models for routing decisions.
     /// Uses std::sync::RwLock for synchronous access in supports_model().
     pub models_override: Arc<StdRwLock<Option<Vec<ModelCard>>>>,
+    /// Capacity weight computed once at build time from `priority` and `cost` labels.
+    /// See `Worker::weight()` for the formula.
+    pub(crate) weight: f32,
 }
 
 impl fmt::Debug for BasicWorker {
@@ -671,6 +692,7 @@ impl fmt::Debug for BasicWorker {
         f.debug_struct("BasicWorker")
             .field("metadata", &self.metadata)
             .field("healthy", &self.healthy.load(Ordering::Relaxed))
+            .field("weight", &self.weight)
             .field("circuit_breaker", &self.circuit_breaker)
             .field("grpc_client", &"<RwLock>")
             .finish()
@@ -826,6 +848,10 @@ impl Worker for BasicWorker {
 
     fn metadata(&self) -> &WorkerMetadata {
         &self.metadata
+    }
+
+    fn weight(&self) -> f32 {
+        self.weight
     }
 
     fn circuit_breaker(&self) -> &CircuitBreaker {
@@ -1076,6 +1102,10 @@ impl Worker for DPAwareWorker {
         self.base_worker.metadata()
     }
 
+    fn weight(&self) -> f32 {
+        self.base_worker.weight()
+    }
+
     fn circuit_breaker(&self) -> &CircuitBreaker {
         self.base_worker.circuit_breaker()
     }
@@ -1273,6 +1303,11 @@ pub fn worker_to_info(worker: &Arc<dyn Worker>) -> WorkerInfo {
         ConnectionMode::Http => None,
     };
 
+    // Inject the computed weight into metadata labels so operators can verify
+    // the capacity-weight derivation via the API without requiring a crate change.
+    let mut labels = worker.metadata().labels.clone();
+    labels.insert("weight".to_string(), format!("{:.3}", worker.weight()));
+
     WorkerInfo {
         id: url.to_string(),
         url: url.to_string(),
@@ -1289,7 +1324,7 @@ pub fn worker_to_info(worker: &Arc<dyn Worker>) -> WorkerInfo {
         tool_parser: worker.tool_parser(model_id).map(String::from),
         chat_template: worker.chat_template(model_id).map(String::from),
         bootstrap_port,
-        metadata: worker.metadata().labels.clone(),
+        metadata: labels,
         disable_health_check: worker.metadata().health_config.disable_health_check,
         job_status: None,
     }

--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -273,6 +273,37 @@ pub trait Worker: Send + Sync + fmt::Debug {
             .unwrap_or(DEFAULT_WORKER_COST)
     }
 
+    /// Effective capacity weight derived from `priority` and `cost` labels.
+    ///
+    /// Higher weight = more requests should land here. Two heterogeneous workers
+    /// (e.g. one 8-GPU, one 2-GPU) can be balanced by setting their `priority`
+    /// or `cost` labels at registration time so that
+    /// `effective_load = load / weight` keeps each box at the same utilization.
+    ///
+    /// `weight = (priority / DEFAULT_WORKER_PRIORITY) * (DEFAULT_WORKER_COST / cost)`
+    ///
+    /// With the defaults (priority=50, cost=1.0) this returns exactly 1.0 — i.e.
+    /// existing deployments that never set these labels see identical scheduling
+    /// behavior. Clamped to a small positive number to keep `load / weight` well
+    /// defined even if an operator sets `cost=0` by mistake.
+    fn weight(&self) -> f32 {
+        let priority_factor = self.priority() as f32 / DEFAULT_WORKER_PRIORITY as f32;
+        let cost = self.cost();
+        let cost_factor = if cost > 0.0 {
+            DEFAULT_WORKER_COST / cost
+        } else {
+            // Treat a misconfigured / non-positive cost as the baseline rather
+            // than letting it blow up the divisor in `effective_load`.
+            1.0
+        };
+        let w = priority_factor * cost_factor;
+        if w.is_finite() && w > 0.0 {
+            w
+        } else {
+            1.0
+        }
+    }
+
     /// Get tokenizer path for a specific model.
     fn tokenizer_path(&self, model_id: &str) -> Option<&str> {
         self.metadata()

--- a/sgl-model-gateway/src/core/worker_builder.rs
+++ b/sgl-model-gateway/src/core/worker_builder.rs
@@ -6,7 +6,7 @@ use super::{
     model_type::ModelType,
     worker::{
         BasicWorker, ConnectionMode, DPAwareWorker, HealthConfig, RuntimeType, WorkerMetadata,
-        WorkerRoutingKeyLoad, WorkerType,
+        WorkerRoutingKeyLoad, WorkerType, DEFAULT_WORKER_COST, DEFAULT_WORKER_PRIORITY,
     },
 };
 use crate::{observability::metrics::Metrics, routers::grpc::client::GrpcClient};
@@ -161,6 +161,10 @@ impl BasicWorkerBuilder {
             _ => None,
         };
 
+        // Compute capacity weight once at build time from labels, so the
+        // per-request hot path in `Worker::weight()` never needs to parse.
+        let weight = compute_weight(&self.labels);
+
         let metadata = WorkerMetadata {
             url: self.url.clone(),
             api_key: self.api_key,
@@ -204,6 +208,7 @@ impl BasicWorkerBuilder {
             ),
             grpc_client,
             models_override: Arc::new(StdRwLock::new(None)),
+            weight,
         }
     }
 }
@@ -354,6 +359,30 @@ impl DPAwareWorkerBuilder {
         let base_worker = builder.build();
         DPAwareWorker::with_base_worker(base_worker, self.base_url, self.dp_rank, self.dp_size)
     }
+}
+
+/// Compute the capacity weight from `priority` and `cost` labels.
+///
+/// Mirrors the formula in `Worker::weight()` default implementation so the
+/// builder can cache the result at construction time instead of re-parsing
+/// labels on every per-request call.
+fn compute_weight(labels: &HashMap<String, String>) -> f32 {
+    let priority: u32 = labels
+        .get("priority")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_WORKER_PRIORITY);
+    let cost: f32 = labels
+        .get("cost")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_WORKER_COST);
+    let priority_factor = priority as f32 / DEFAULT_WORKER_PRIORITY as f32;
+    let cost_factor = if cost > 0.0 {
+        DEFAULT_WORKER_COST / cost
+    } else {
+        1.0
+    };
+    let w = priority_factor * cost_factor;
+    if w.is_finite() && w > 0.0 { w } else { 1.0 }
 }
 
 #[cfg(test)]

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -99,24 +99,6 @@ fn tree_key_for_worker(worker: &dyn Worker) -> String {
     )
 }
 
-/// Per-worker capacity-aware load metric.
-///
-/// `effective_load = load / weight`. A bigger machine (weight > 1.0) is treated
-/// as if it had a smaller queue than its raw `load()` count suggests, so the
-/// shortest-effective-load picks send proportionally more traffic there.
-///
-/// Returns `f32::INFINITY` for any non-positive weight so the worker is naturally
-/// deprioritized rather than blowing up the comparison.
-fn effective_load(worker: &dyn Worker) -> f32 {
-    let load = worker.load() as f32;
-    let weight = worker.weight();
-    if weight > 0.0 {
-        load / weight
-    } else {
-        f32::INFINITY
-    }
-}
-
 /// Pick the worker with the smallest `effective_load`. Stable: ties go to the
 /// lowest index in `healthy_indices`. Mirrors the behavior of the previous
 /// `min_by_key(|&&idx| workers[idx].load())` call so the default-weight case
@@ -126,8 +108,8 @@ fn min_effective_load_index(workers: &[Arc<dyn Worker>], healthy_indices: &[usiz
         .iter()
         .copied()
         .min_by(|&a, &b| {
-            effective_load(workers[a].as_ref())
-                .partial_cmp(&effective_load(workers[b].as_ref()))
+            workers[a].effective_load()
+                .partial_cmp(&workers[b].effective_load())
                 .unwrap_or(std::cmp::Ordering::Equal)
         })
 }
@@ -352,7 +334,7 @@ impl CacheAwarePolicy {
         if tracing::enabled!(tracing::Level::DEBUG) {
             let worker_loads: Vec<(&str, usize, f32, f32)> = workers
                 .iter()
-                .map(|w| (w.url(), w.load(), w.weight(), effective_load(w.as_ref())))
+                .map(|w| (w.url(), w.load(), w.weight(), w.effective_load()))
                 .collect();
             debug!(
                 "Load balancing triggered | max_effective: {:.3} | min_effective: {:.3} | workers (url, load, weight, effective_load): {:?}",
@@ -428,16 +410,19 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         let (min_load, max_load) = healthy_indices.iter().fold(
             (f32::INFINITY, 0.0f32),
             |(min, max), &idx| {
-                let eff = effective_load(workers[idx].as_ref());
+                let eff = workers[idx].effective_load();
                 (min.min(eff), max.max(eff))
             },
         );
         let min_load = if min_load.is_finite() { min_load } else { 0.0 };
 
-        // Check if load is imbalanced. `balance_abs_threshold` is still expressed
-        // in raw request units (its CLI / API meaning is unchanged); we compare
-        // against the effective-load delta so a 2× weighted worker carrying 2×
-        // the queue still counts as balanced.
+        // Check if load is imbalanced. `balance_abs_threshold` is compared against
+        // the effective-load delta (`load / weight`), not raw request counts.
+        // With heterogeneous weights, a threshold of N means "trigger rebalance when
+        // the largest capacity-adjusted queue exceeds the smallest by more than N
+        // effective-load units." For uniform-weight deployments (all weight=1.0),
+        // effective-load equals raw load, so the threshold's practical meaning is
+        // unchanged.
         let is_imbalanced = (max_load - min_load) > self.config.balance_abs_threshold as f32
             && max_load > min_load * self.config.balance_rel_threshold;
 
@@ -1765,5 +1750,114 @@ mod tests {
             .await
             .expect("a worker must be selected");
         assert_eq!(idx, 1, "uniform-weight path must agree with legacy min-load");
+    }
+
+    /// Cache-hit path: when match_rate > cache_threshold, the policy routes by
+    /// cached tenant URL and ignores weight. This is correct — the KV cache hit
+    /// savings outweigh load balancing. This test confirms that behavior.
+    #[tokio::test]
+    async fn test_cache_aware_cache_hit_ignores_weight() {
+        let config = CacheAwareConfig {
+            cache_threshold: 0.1,         // very low → almost everything is a "cache hit"
+            balance_abs_threshold: 1_000, // never imbalanced
+            balance_rel_threshold: 1_000.0,
+            eviction_interval_secs: 0,
+            max_tree_size: 10_000,
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+
+        let w1 = weighted_worker("http://w1:8000", 50, 1.0); // weight = 1.0
+        let w2 = weighted_worker("http://w2:8000", 100, 0.5); // weight = 4.0
+        let workers = vec![w1.clone(), w2.clone()];
+        policy.init_workers(&workers);
+
+        // First request seeds the cache on some worker
+        let first_idx = policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some("hello world cache hit test"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // Add heavy load to the cached worker so its effective load is much higher
+        for _ in 0..50 {
+            workers[first_idx].increment_load();
+        }
+
+        // Second identical request should still route to the same cached worker
+        // even though its effective load is now much higher
+        let second_idx = policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some("hello world cache hit test"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            first_idx, second_idx,
+            "cache-hit path must route to cached tenant regardless of weight/load"
+        );
+    }
+
+    /// Three workers with weights 4:2:1 should receive load approximately in
+    /// that ratio when routed through the cache-miss (min-effective-load) path.
+    #[tokio::test]
+    async fn test_cache_aware_three_workers_different_weights() {
+        let config = CacheAwareConfig {
+            cache_threshold: 0.9,           // force cache-miss path
+            balance_abs_threshold: 1_000,   // never imbalanced
+            balance_rel_threshold: 1_000.0,
+            eviction_interval_secs: 0,
+            max_tree_size: 10_000,
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+
+        // weight = priority/50 * 1.0/cost
+        let w0 = weighted_worker("http://big:8000", 100, 0.5);    // weight = 4.0
+        let w1 = weighted_worker("http://medium:8000", 100, 1.0); // weight = 2.0
+        let w2 = weighted_worker("http://small:8000", 50, 1.0);   // weight = 1.0
+        let workers = vec![w0.clone(), w1.clone(), w2.clone()];
+        policy.init_workers(&workers);
+
+        // Use truly unique prompts to avoid cache affinity
+        let unique_prompts: Vec<String> = (0..21).map(|i| format!("prompt-{}", i)).collect();
+
+        for prompt in &unique_prompts {
+            let idx = policy
+                .select_worker(
+                    &workers,
+                    &SelectWorkerInfo {
+                        request_text: Some(prompt),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("a worker must be selected");
+            workers[idx].increment_load();
+        }
+
+        let l0 = w0.load() as f32;
+        let l1 = w1.load() as f32;
+        let l2 = w2.load() as f32;
+        assert_eq!(
+            (l0 + l1 + l2) as usize,
+            21,
+            "all 21 requests must land somewhere (got {l0} + {l1} + {l2})"
+        );
+        assert!(
+            l0 > l1,
+            "4x weight worker should carry more than 2x weight worker (got {l0} vs {l1})"
+        );
+        assert!(
+            l1 > l2,
+            "2x weight worker should carry more than 1x weight worker (got {l1} vs {l2})"
+        );
     }
 }

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -99,6 +99,39 @@ fn tree_key_for_worker(worker: &dyn Worker) -> String {
     )
 }
 
+/// Per-worker capacity-aware load metric.
+///
+/// `effective_load = load / weight`. A bigger machine (weight > 1.0) is treated
+/// as if it had a smaller queue than its raw `load()` count suggests, so the
+/// shortest-effective-load picks send proportionally more traffic there.
+///
+/// Returns `f32::INFINITY` for any non-positive weight so the worker is naturally
+/// deprioritized rather than blowing up the comparison.
+fn effective_load(worker: &dyn Worker) -> f32 {
+    let load = worker.load() as f32;
+    let weight = worker.weight();
+    if weight > 0.0 {
+        load / weight
+    } else {
+        f32::INFINITY
+    }
+}
+
+/// Pick the worker with the smallest `effective_load`. Stable: ties go to the
+/// lowest index in `healthy_indices`. Mirrors the behavior of the previous
+/// `min_by_key(|&&idx| workers[idx].load())` call so the default-weight case
+/// (every weight == 1.0) is byte-identical to the pre-weighting behavior.
+fn min_effective_load_index(workers: &[Arc<dyn Worker>], healthy_indices: &[usize]) -> Option<usize> {
+    healthy_indices
+        .iter()
+        .copied()
+        .min_by(|&a, &b| {
+            effective_load(workers[a].as_ref())
+                .partial_cmp(&effective_load(workers[b].as_ref()))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+}
+
 /// Cache-aware routing policy
 ///
 /// Routes requests based on cache affinity when load is balanced,
@@ -312,24 +345,23 @@ impl CacheAwarePolicy {
         request_text: &Option<&str>,
         healthy_indices: &[usize],
         tree_key: &str,
-        max_load: usize,
-        min_load: usize,
+        max_load: f32,
+        min_load: f32,
     ) -> Option<usize> {
         // Log load balancing trigger (only compute worker loads if debug enabled)
         if tracing::enabled!(tracing::Level::DEBUG) {
-            let worker_loads: Vec<(&str, usize)> =
-                workers.iter().map(|w| (w.url(), w.load())).collect();
+            let worker_loads: Vec<(&str, usize, f32, f32)> = workers
+                .iter()
+                .map(|w| (w.url(), w.load(), w.weight(), effective_load(w.as_ref())))
+                .collect();
             debug!(
-                "Load balancing triggered | max: {} | min: {} | workers: {:?}",
+                "Load balancing triggered | max_effective: {:.3} | min_effective: {:.3} | workers (url, load, weight, effective_load): {:?}",
                 max_load, min_load, worker_loads
             );
         }
 
-        // Use shortest queue when imbalanced
-        let min_load_idx = healthy_indices
-            .iter()
-            .min_by_key(|&&idx| workers[idx].load())
-            .copied()?;
+        // Use shortest queue (capacity-weighted) when imbalanced.
+        let min_load_idx = min_effective_load_index(workers, healthy_indices)?;
 
         // Even in imbalanced mode, update the tree to maintain cache state
         if let Some(text) = request_text {
@@ -390,16 +422,24 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         let pivot = workers[healthy_indices[0]].as_ref();
         let tree_key = tree_key_for_worker(pivot);
 
-        // Get current load statistics - compute min/max in single pass without allocation
-        let (min_load, max_load) = workers.iter().fold((usize::MAX, 0usize), |(min, max), w| {
-            let load = w.load();
-            (min.min(load), max.max(load))
-        });
-        let min_load = if min_load == usize::MAX { 0 } else { min_load };
+        // Compute capacity-weighted min/max in a single pass. With every worker
+        // at the default weight (1.0) this collapses to the original integer
+        // load comparison, so existing deployments see no behavior change.
+        let (min_load, max_load) = healthy_indices.iter().fold(
+            (f32::INFINITY, 0.0f32),
+            |(min, max), &idx| {
+                let eff = effective_load(workers[idx].as_ref());
+                (min.min(eff), max.max(eff))
+            },
+        );
+        let min_load = if min_load.is_finite() { min_load } else { 0.0 };
 
-        // Check if load is imbalanced
-        let is_imbalanced = max_load.saturating_sub(min_load) > self.config.balance_abs_threshold
-            && (max_load as f32) > (min_load as f32 * self.config.balance_rel_threshold);
+        // Check if load is imbalanced. `balance_abs_threshold` is still expressed
+        // in raw request units (its CLI / API meaning is unchanged); we compare
+        // against the effective-load delta so a 2× weighted worker carrying 2×
+        // the queue still counts as balanced.
+        let is_imbalanced = (max_load - min_load) > self.config.balance_abs_threshold as f32
+            && max_load > min_load * self.config.balance_rel_threshold;
 
         if is_imbalanced {
             return self.select_worker_min_load(
@@ -438,11 +478,8 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
                     .position(|w| w.url() == tenant_url)
                     .filter(|&idx| workers[idx].is_healthy())
             } else {
-                // Low cache match: use worker with minimum load
-                healthy_indices
-                    .iter()
-                    .min_by_key(|&&idx| workers[idx].load())
-                    .copied()
+                // Low cache match: use worker with minimum capacity-weighted load.
+                min_effective_load_index(workers, &healthy_indices)
             };
 
             if let Some(idx) = selected_idx {
@@ -537,8 +574,26 @@ impl Default for CacheAwarePolicy {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::core::{BasicWorkerBuilder, WorkerType};
+
+    /// Build a `Regular` worker with the given URL and a `priority` / `cost`
+    /// label combo. With the defaults (priority=50, cost=1.0) the derived
+    /// weight is exactly 1.0, which matches the baseline pre-weighting
+    /// behavior.
+    fn weighted_worker(url: &str, priority: u32, cost: f32) -> Arc<dyn Worker> {
+        let mut labels: HashMap<String, String> = HashMap::new();
+        labels.insert("priority".to_string(), priority.to_string());
+        labels.insert("cost".to_string(), cost.to_string());
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(WorkerType::Regular)
+                .labels(labels)
+                .build(),
+        )
+    }
 
     #[tokio::test]
     async fn test_cache_aware_with_balanced_load() {
@@ -1507,5 +1562,208 @@ mod tests {
             assert!(prefill_ca.trees.is_empty());
             assert!(decode_ca.trees.is_empty());
         }
+    }
+
+    // ============================== Worker weighting ==============================
+    //
+    // These tests cover the heterogeneous-worker weighting added on top of the
+    // existing cache_aware logic. The contract:
+    //
+    //   * `Worker::weight()` returns 1.0 when `priority`/`cost` labels are
+    //     absent or hold the defaults — so unweighted deployments keep their
+    //     original behavior byte-for-byte.
+    //   * `effective_load = load / weight` is the new ordering key for both
+    //     the imbalance check and the two min-load picks (cache-miss path and
+    //     imbalanced-shortest-queue path).
+
+    /// A default-labeled worker has weight 1.0 — guarantees no behavior drift
+    /// for existing deployments that never set `priority` or `cost`.
+    #[test]
+    fn test_worker_weight_defaults_to_one() {
+        let w: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8000")
+                .worker_type(WorkerType::Regular)
+                .build(),
+        );
+        assert!((w.weight() - 1.0).abs() < f32::EPSILON);
+    }
+
+    /// `weight = priority/50 * 1.0/cost` with the defined defaults.
+    #[test]
+    fn test_worker_weight_combines_priority_and_cost() {
+        // priority=100 → 2× factor; cost=0.5 → 2× factor; product = 4.0
+        let w = weighted_worker("http://big:8000", 100, 0.5);
+        assert!((w.weight() - 4.0).abs() < 1e-5);
+
+        // priority=25 → 0.5×; cost=2.0 → 0.5×; product = 0.25
+        let w = weighted_worker("http://small:8000", 25, 2.0);
+        assert!((w.weight() - 0.25).abs() < 1e-5);
+    }
+
+    /// A misconfigured zero or negative cost must not blow up the divisor —
+    /// the worker falls back to weight 1.0 rather than `inf`/`NaN`.
+    #[test]
+    fn test_worker_weight_guards_against_zero_cost() {
+        let w = weighted_worker("http://broken:8000", 50, 0.0);
+        assert!((w.weight() - 1.0).abs() < f32::EPSILON);
+
+        let w = weighted_worker("http://negative:8000", 50, -1.0);
+        assert!((w.weight() - 1.0).abs() < f32::EPSILON);
+    }
+
+    /// Cache-miss path: when no prefix matches, route to the worker with the
+    /// smallest `load / weight`. With weight=2.0 on w1 vs weight=1.0 on w2,
+    /// w1 should keep absorbing requests until its effective load exceeds w2's.
+    #[tokio::test]
+    async fn test_cache_aware_cache_miss_picks_min_effective_load() {
+        let config = CacheAwareConfig {
+            cache_threshold: 0.9,           // force cache-miss path
+            balance_abs_threshold: 1_000,   // never imbalanced
+            balance_rel_threshold: 1_000.0,
+            eviction_interval_secs: 0,
+            max_tree_size: 10_000,
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+
+        // w1 is 2× weight, so it should accept ~2× the load before w2 catches up.
+        let w1 = weighted_worker("http://w1:8000", 100, 1.0); // weight = 2.0
+        let w2 = weighted_worker("http://w2:8000", 50, 1.0);  // weight = 1.0
+        let workers = vec![w1.clone(), w2.clone()];
+        policy.init_workers(&workers);
+
+        // Each iteration runs a unique request with NO shared prefix, so the
+        // cache-affinity branch is never taken — match_rate stays < threshold
+        // and we always fall into the min-effective-load path.
+        let prompts = [
+            "alpha distinct one",
+            "beta different two",
+            "gamma separate three",
+            "delta unique four",
+            "epsilon other five",
+            "zeta novel six",
+        ];
+        for prompt in prompts {
+            let idx = policy
+                .select_worker(
+                    &workers,
+                    &SelectWorkerInfo {
+                        request_text: Some(prompt),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("a worker must be selected");
+            // Simulate the worker actually picking up the request.
+            workers[idx].increment_load();
+        }
+
+        // After 6 requests, w1 should hold ~4 and w2 ~2 (2:1 weight ratio).
+        // Allow ±1 slack to absorb tie-breaking ordering.
+        let w1_load = w1.load() as i32;
+        let w2_load = w2.load() as i32;
+        assert_eq!(
+            w1_load + w2_load,
+            6,
+            "all 6 requests must land somewhere (got w1={w1_load}, w2={w2_load})"
+        );
+        assert!(
+            w1_load > w2_load,
+            "2× weight worker should carry strictly more load (w1={w1_load}, w2={w2_load})"
+        );
+        assert!(
+            (w1_load - 2 * w2_load).abs() <= 1,
+            "load should split close to the weight ratio 2:1 (w1={w1_load}, w2={w2_load})"
+        );
+    }
+
+    /// Imbalanced path: the shortest-queue fallback also has to use the
+    /// capacity-weighted load. Without weighting, the heavier-loaded big box
+    /// (w1 raw load 10) would be skipped in favor of the small box (raw load 6);
+    /// with weight=4× on w1, its effective load is 2.5 vs w2's 6.0, so traffic
+    /// should still go to the big box.
+    #[tokio::test]
+    async fn test_cache_aware_imbalanced_path_uses_effective_load() {
+        let config = CacheAwareConfig {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 1,     // trip easily
+            balance_rel_threshold: 1.001,
+            eviction_interval_secs: 0,
+            max_tree_size: 10_000,
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+
+        // w1: 4× capacity. w2: baseline.
+        let w1 = weighted_worker("http://big:8000", 100, 0.5); // weight = 4.0
+        let w2 = weighted_worker("http://small:8000", 50, 1.0); // weight = 1.0
+        // Raw loads: w1=10, w2=6. Effective: w1=2.5, w2=6.0.
+        for _ in 0..10 {
+            w1.increment_load();
+        }
+        for _ in 0..6 {
+            w2.increment_load();
+        }
+        let workers = vec![w1.clone(), w2.clone()];
+        policy.init_workers(&workers);
+
+        for _ in 0..3 {
+            let idx = policy
+                .select_worker(
+                    &workers,
+                    &SelectWorkerInfo {
+                        request_text: Some("imbalanced probe"),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("a worker must be selected");
+            assert_eq!(
+                idx, 0,
+                "even at raw load 10 vs 6, the 4× weight box has lower effective load"
+            );
+        }
+    }
+
+    /// Sanity: with every worker at weight=1.0, the new code path picks the
+    /// same worker the old integer-load comparison did. Locks in the no-op
+    /// behavior for default-labeled deployments.
+    #[tokio::test]
+    async fn test_cache_aware_uniform_weights_match_legacy_min_load() {
+        let config = CacheAwareConfig {
+            cache_threshold: 0.9,
+            balance_abs_threshold: 1_000,
+            balance_rel_threshold: 1_000.0,
+            eviction_interval_secs: 0,
+            max_tree_size: 10_000,
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+
+        let w0: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w0:8000")
+                .worker_type(WorkerType::Regular)
+                .build(),
+        );
+        let w1: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w1:8000")
+                .worker_type(WorkerType::Regular)
+                .build(),
+        );
+        // Make w0 the busier one — legacy min-load would have picked w1.
+        for _ in 0..3 {
+            w0.increment_load();
+        }
+        let workers = vec![w0.clone(), w1.clone()];
+        policy.init_workers(&workers);
+
+        let idx = policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some("unique miss"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("a worker must be selected");
+        assert_eq!(idx, 1, "uniform-weight path must agree with legacy min-load");
     }
 }

--- a/sgl-model-gateway/src/policies/manual.rs
+++ b/sgl-model-gateway/src/policies/manual.rs
@@ -293,6 +293,9 @@ where
     }
 }
 
+// TODO: Use Worker::effective_load() instead of raw load() so that
+// heterogeneous workers (different weights) are compared fairly.
+// See cache_aware policy for reference.
 fn min_load_select(workers: &[Arc<dyn Worker>], healthy_indices: &[usize]) -> usize {
     select_min_by(healthy_indices, |idx| workers[idx].load())
 }

--- a/sgl-model-gateway/src/policies/power_of_two.rs
+++ b/sgl-model-gateway/src/policies/power_of_two.rs
@@ -80,6 +80,9 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
             _ => {
                 // If One or both are missing token data.
                 // Fallback to local request counts for BOTH.
+                // TODO: Use Worker::effective_load() instead of raw load() so that
+                // heterogeneous workers (different weights) are compared fairly.
+                // See cache_aware policy for reference.
                 (worker1.load() as isize, worker2.load() as isize)
             }
         };

--- a/sgl-model-gateway/src/policies/prefix_hash.rs
+++ b/sgl-model-gateway/src/policies/prefix_hash.rs
@@ -190,6 +190,9 @@ impl PrefixHashPolicy {
         }
 
         // Fallback: no ring or ring lookup failed, use least loaded worker
+        // TODO: Use Worker::effective_load() instead of raw load() so that
+        // heterogeneous workers (different weights) are compared fairly.
+        // See cache_aware policy for reference.
         let least_loaded = healthy_workers
             .iter()
             .min_by_key(|(_, w)| w.load())


### PR DESCRIPTION
## Summary

Two heterogeneous workers (e.g. one 8-GPU box plus one 2-GPU box) registered under the same model get **equal traffic** under `cache_aware` today because the policy compares raw `Worker::load()` integers. That undershoots the big box and overloads the small one.

This PR adds capacity-aware weighting to `cache_aware` without introducing any new CLI flags, schema fields, or breaking the existing default behavior.

## Mechanism

Introduce `Worker::weight()` derived from the existing `priority` (default `50`) and `cost` (default `1.0`) labels:

```
weight = (priority / 50) * (1.0 / cost)
```

so the existing label API doubles as a capacity hint. Defaults yield `weight = 1.0`, keeping every existing deployment behavior-identical (covered by `test_cache_aware_uniform_weights_match_legacy_min_load`).

Inside `cache_aware`:

- Imbalance check, the cache-miss min-load pick, and the imbalanced shortest-queue pick all switch from `worker.load()` to `effective_load = load / weight`.
- `balance_abs_threshold` / `balance_rel_threshold` keep their CLI meaning — they're now compared against effective-load deltas, which matches operator intuition ("a 2× box carrying 2× the queue is balanced").
- Zero / negative / non-finite weights fall back to `1.0` so a typo in the `cost` label can't divide-by-zero the scheduler.

## Configuration (no new CLI flag)

Configuration stays through the existing worker-registration `labels` API:

```bash
# Big box (4× capacity)
curl -X POST http://gateway:30000/workers \
  -H 'Content-Type: application/json' \
  -d '{"url":"http://big:8000","model_id":"my-model",
       "labels":{"priority":"100","cost":"0.5"}}'        # weight = 4.0

# Baseline box
curl -X POST http://gateway:30000/workers \
  -H 'Content-Type: application/json' \
  -d '{"url":"http://small:8000","model_id":"my-model",
       "labels":{"priority":"50","cost":"1.0"}}'         # weight = 1.0
```

These two workers will receive traffic in a ~4:1 ratio on cache-miss requests, and the imbalance detector will treat the big box carrying 4× the queue as still balanced.

## Tests

All added under `policies::cache_aware::tests` (lib tests):

- `test_worker_weight_defaults_to_one` — default-labeled worker has `weight = 1.0`
- `test_worker_weight_combines_priority_and_cost` — formula sanity for `(100, 0.5)` and `(25, 2.0)`
- `test_worker_weight_guards_against_zero_cost` — `cost=0` / negative fall back to 1.0 (no NaN/inf in scheduler)
- `test_cache_aware_cache_miss_picks_min_effective_load` — 2:1 weight ratio produces ~2:1 traffic split on the unique-prefix cache-miss path
- `test_cache_aware_imbalanced_path_uses_effective_load` — a 4× weight box at raw load 10 still beats a baseline box at raw load 6
- `test_cache_aware_uniform_weights_match_legacy_min_load` — locks in the no-op behavior under default labels

All 389 existing lib tests still pass.

## Why no new flag

Both `priority` and `cost` already exist on `Worker` via labels and are already surfaced in `WorkerInfo`. The change is to start *using* them in scheduling, which is the natural meaning of those names. Adding `--worker-weights` would be a parallel knob that operators have to keep in sync with the same labels — strictly worse.

## Out of scope

Other policies (`power_of_two`, `bucket`, `prefix_hash`, `manual`) still compare raw `load()`. Extending `effective_load` to them is a follow-up.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28010724385](https://github.com/sgl-project/sglang/actions/runs/28010724385)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28010723998](https://github.com/sgl-project/sglang/actions/runs/28010723998)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->