### PR TITLE
[Bugfix] Register mla_kv_a_proj TP style in Transformers backend

### DIFF
--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -241,6 +241,9 @@ def _normalize_tp_style(style: str) -> Style:
         "local": "replicate",
         "replicated_with_grad_allreduce": "replicate",
         "moe_tp_experts": "replicate",
+        # MLA kv_a_proj: replicate (HF MlaKvAProjParallel replicates the weight;
+        # its rope-segment all_reduce_backward is backward-only).
+        "mla_kv_a_proj": "replicate",
     }.get(style, style)
     if style not in {"colwise", "colwise_rep", "rowwise", "rowwise_rep", "replicate"}:
         raise ValueError(f"Unsupported TP style '{style}' for Transformers backend.")


### PR DESCRIPTION
## Motivation

MLA attention models (DeepSeek-V2/V3, GLM-5.x) define `kv_a_proj_with_mqa` with the `mla_kv_a_proj` TP style in HuggingFace transformers' `base_model_tp_plan` (see `transformers/models/glm_moe_dsa/configuration_glm_moe_dsa.py` and `transformers/models/deepseek_v2/configuration_deepseek_v2.py`). When such a model is routed through SGLang's Transformers backend, `_normalize_tp_style` rejects the style and the server crashes at load:

```
File ".../srt/models/transformers.py", line 246, in _normalize_tp_style
    raise ValueError(f"Unsupported TP style '{style}' for Transformers backend.")
ValueError: Unsupported TP style 'mla_kv_a_proj' for Transformers backend.
```

## Changes

Map `mla_kv_a_proj → replicate` in `_normalize_tp_style`. HF's `MlaKvAProjParallel` (`transformers/integrations/tensor_parallel.py`) shards the weight via `param[...]` (i.e. replicated); the rope-segment `all_reduce_backward` it applies in `_prepare_output_fn` is backward-only. So `replicate` is forward-correct for inference — the gradient path is irrelevant at serve time.

The native MLA path (`DeepseekV2ForCausalLM` / `GlmMoeDsaForCausalLM` using `ColumnParallelLinear`) never goes through `_normalize_tp_style`, so this change is a no-op for it.

## Scope

Side fix. This unblocks the load stage for any MLA model that happens to route through the Transformers backend, but is not a standalone fix for full GLM-5.2 H200 serving — it's a small, independent correctness gap worth fixing on its own.

## Verification

On an 8×H200 devbox with a complete GLM-5.2-FP8 checkpoint (`zai-org/GLM-5.2-0610-Provider-FP8`, 79 shards), `--model-impl sglang --tp 8`:
- `mla_kv_a_proj` ValueError count across runs: **0** (previously intermittent at load).
- No load-stage crash; server proceeds to weight loading / capture.

Confirmed the style is forward-correct by reading HF's `MlaKvAProjParallel` implementation (weight replicate + backward-only rope all-reduce).

## Notes

- `mla_kv_a_proj` is shared across DeepSeek-V3 and GLM-5.x, so this benefits more than just GLM-5.2.
- One line of mapping + a 3-line comment explaining the forward-correctness reasoning.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27951945522](https://github.com/sgl-project/sglang/actions/runs/27951945522)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27951945473](https://github.com/sgl-project/sglang/actions/runs/27951945473)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->