### PR TITLE
[AMD] Fix nightly-8-gpu-mi35x-deepseek-v4-flash-rocm720 OOM issue

### DIFF
--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -578,29 +578,29 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 global_page_size=swa_page_size,
             )
 
-        c4_kv_pool_type = DeepSeekV4SingleKVPool
-        if enable_hisparse:
-            c4_kv_pool_type = HiSparseC4DevicePool
-        self.c4_kv_pool = self._make_kv_pool(
-            size=c4_size,
-            page_size=c4_page_size,
-            dtype=dtype,
-            layer_num=c4_layer_num,
-            device=device,
-            enable_memory_saver=enable_memory_saver,
-            global_page_size=page_size,
-            cls=c4_kv_pool_type,
-        )
+            c4_kv_pool_type = DeepSeekV4SingleKVPool
+            if enable_hisparse:
+                c4_kv_pool_type = HiSparseC4DevicePool
+            self.c4_kv_pool = self._make_kv_pool(
+                size=c4_size,
+                page_size=c4_page_size,
+                dtype=dtype,
+                layer_num=c4_layer_num,
+                device=device,
+                enable_memory_saver=enable_memory_saver,
+                global_page_size=page_size,
+                cls=c4_kv_pool_type,
+            )
 
-        self.c128_kv_pool = self._make_kv_pool(
-            size=c128_size,
-            page_size=c128_page_size,
-            dtype=dtype,
-            layer_num=c128_layer_num,
-            device=device,
-            enable_memory_saver=enable_memory_saver,
-            global_page_size=page_size,
-        )
+            self.c128_kv_pool = self._make_kv_pool(
+                size=c128_size,
+                page_size=c128_page_size,
+                dtype=dtype,
+                layer_num=c128_layer_num,
+                device=device,
+                enable_memory_saver=enable_memory_saver,
+                global_page_size=page_size,
+            )
 
         indexer_size = (
             self.c4_logical_size


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The `nightly-8-gpu-mi35x-deepseek-v4-flash-rocm720` suite has been failing since ~06/16: the server hits an OOM during launch procedure.

## Modifications

<!-- Detail the changes made in this pull request. -->

The regression was introduced in [#25144](https://github.com/sgl-project/sglang/pull/25144), which refactored the DSV4 KV pool creation in `deepseek_v4_memory_pool.py`. During the refactor, the `c4_kv_pool` / `c128_kv_pool` allocations were de-indented out of the non-unified else branch and into the common code path, so they are now allocated unconditionally.

Under unified-kv, the c4/c128 KV already lives inside `unified_kv_pool`, so this allocates a redundant copy of the c4/c128 KV and causes the startup OOM.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

CI cmd: 
```python
DEEPSEEK_V4_FP4_MODEL_PATH={MODEL_PATH} python test/registered/amd/test_deepseek_v4_flash_fp4.py
```

- Before PR: 
  ```text
  torch.OutOfMemoryError: HIP out of memory. Tried to allocate 5.76 GiB. GPU 3 has a total capacity of 287.98 GiB of which 2.33 GiB is free. Of the allocated memory 275.65 GiB is allocated by PyTorch, and 228.73 MiB is reserved by PyTorch but unallocated.
  ```
- After PR: 
  ```text
  Accuracy: 0.934
  Invalid: 0.000
  Latency: 60.846 s
  Output throughput: 2157.076 token/s
  ```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27954540759](https://github.com/sgl-project/sglang/actions/runs/27954540759)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #27954554342](https://github.com/sgl-project/sglang/actions/runs/27954554342)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->