### PR TITLE
DFLASH: support grammar-constrained decoding (JSON schema / regex / ebnf / structural_tag)

### DIFF
--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -780,15 +780,85 @@ def validate_dflash_request(req: Req, enable_overlap: bool) -> Optional[str]:
     if enable_overlap and req.return_hidden_states:
         return "DFLASH speculative decoding does not support return_hidden_states yet."
 
-    if (
-        req.sampling_params.json_schema is not None
-        or req.sampling_params.regex is not None
-        or req.sampling_params.ebnf is not None
-        or req.sampling_params.structural_tag is not None
-    ):
-        return (
-            "DFLASH speculative decoding does not support "
-            "grammar-constrained decoding yet."
-        )
-
+    # Grammar-constrained decoding (json_schema / regex / ebnf / structural_tag) IS
+    # supported: dflash_worker_v2 verify masks each block position's target logits
+    # along the draft path (apply_dflash_grammar_vocab_mask). No request rejection.
     return None
+
+
+def apply_dflash_grammar_vocab_mask(
+    *,
+    reqs,
+    candidates,
+    next_token_logits,
+    block_size: int,
+) -> None:
+    """Mask the DFlash verify block's target logits to grammar-legal tokens.
+
+    DFLASH verifies a linear block ``[c0, c1, ..., c_{T-1}]`` in one target forward;
+    ``logits[pos]`` predicts the token following ``c_pos``. A grammar FSM is
+    sequential (the legal set at ``pos`` depends on ``c1..c_pos``), so we build the
+    bitmask along the DRAFT path -- mirroring EAGLE's ``generate_token_bitmask``,
+    adapted from a tree to DFlash's linear block:
+
+      * fill position 0 from the request's current FSM state;
+      * for pos = 1..T-1, if the drafted token ``c_pos`` is legal under position
+        ``pos-1``'s mask, advance the FSM and fill position ``pos``; stop at the
+        first grammar-illegal draft (its mask at ``pos-1`` already forbids it,
+        forcing rejection + a legal bonus there).
+
+    Rows left unfilled (non-grammar reqs / positions past a violation or
+    termination) keep ``allocate_vocab_mask``'s all-allowed default, so mixed
+    batches and the non-grammar fast path are unaffected. The FSM is advanced and
+    rolled back here; the commit-time advance is handled generically by the
+    scheduler batch-result processor over the accepted run.
+    """
+    grammar_ref = next(
+        (getattr(r, "grammar", None) for r in reqs if getattr(r, "grammar", None) is not None),
+        None,
+    )
+    if grammar_ref is None:
+        return
+
+    vocab_size = int(next_token_logits.shape[-1])
+    T = int(block_size)
+    bitmask = grammar_ref.allocate_vocab_mask(
+        vocab_size=vocab_size, batch_size=len(reqs) * T, device="cpu"
+    )
+    cand_cpu = candidates.to("cpu")
+    filled = False
+
+    for i, req in enumerate(reqs):
+        g = getattr(req, "grammar", None)
+        # Skip reqs without a grammar AND reqs whose grammar has ALREADY terminated
+        # (e.g. the JSON closed in a prior block): xgrammar raises if you fill the
+        # mask after the stop token was accepted. Their rows stay all-allowed; the
+        # model emits EOS/trailing freely and the scheduler result processor handles
+        # the finished grammar.
+        if g is None or g.is_terminated():
+            continue
+        base = i * T
+        advanced = 0
+        try:
+            g.fill_vocab_mask(bitmask, base)
+            filled = True
+            for pos in range(1, T):
+                tok = int(cand_cpu[i, pos].item())
+                parent = bitmask[base + pos - 1]
+                if tok >= vocab_size or (
+                    int(parent[tok // 32].item()) & (1 << (tok % 32))
+                ) == 0:
+                    break  # draft diverges from grammar; rest stays all-allowed
+                g.accept_token(tok)
+                advanced += 1
+                if g.is_terminated():
+                    break
+                g.fill_vocab_mask(bitmask, base + pos)
+        finally:
+            if advanced:
+                g.rollback(advanced)
+
+    if not filled:
+        return
+    vocab_mask = grammar_ref.move_vocab_mask(bitmask, next_token_logits.device)
+    grammar_ref.apply_vocab_mask(logits=next_token_logits, vocab_mask=vocab_mask)

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -25,6 +25,7 @@ from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
 from sglang.srt.speculative.dflash_utils import (
     apply_dflash_verify_logits_adjustments,
+    apply_dflash_grammar_vocab_mask,
     can_dflash_use_fused_qkv_proj,
     compute_dflash_correct_drafts_and_bonus,
     compute_dflash_sampling_correct_drafts_and_bonus,
@@ -1601,6 +1602,16 @@ class DFlashWorkerV2(BaseSpecWorker):
                 draft_token_num=int(self.block_size),
             )
 
+        # Grammar-constrained decoding: mask each block position's target logits
+        # to the grammar-legal set along the draft path before accept/argmax, so
+        # accepted drafts and the bonus token are valid. No-op without grammar.
+        if getattr(model_worker_batch, "has_grammar", False):
+            apply_dflash_grammar_vocab_mask(
+                reqs=model_worker_batch.reqs,
+                candidates=draft_tokens,
+                next_token_logits=logits_output.next_token_logits,
+                block_size=int(self.block_size),
+            )
         candidates = draft_tokens
         new_seq_lens = None
         if (


### PR DESCRIPTION
## Motivation

DFLASH speculative decoding currently rejects any grammar-constrained request — `validate_dflash_request` returns "does not support grammar-constrained decoding yet" for `json_schema` / `regex` / `ebnf` / `structural_tag`. This PR implements support.

## Approach

The grammar FSM is sequential (the legal token set at position *i* depends on tokens 0..*i-1*), while DFLASH verifies a linear block of draft tokens in one target forward. We mask each block position's target logits **along the draft path** before accept/argmax — mirroring EAGLE's `generate_token_bitmask`, adapted from a tree to DFlash's linear block:

- fill the bitmask for position 0 from the request's current FSM state;
- for pos = 1..T-1, if the drafted token is grammar-legal under position pos-1's mask, advance the FSM through it and fill position pos; stop at the first grammar-illegal draft token (its mask at pos-1 already forbids it, forcing rejection there with a grammar-legal bonus token).

The FSM is advanced and rolled back during mask build; the **commit-time advance is handled by the existing scheduler batch-result processor** over the accepted run (no change needed there). Rows left unfilled (non-grammar requests, or positions past a violation/termination) keep `allocate_vocab_mask`'s all-allowed default, so **mixed batches and the non-grammar fast path are unaffected** (zero overhead when no request in the batch carries a grammar).

## Changes

- `speculative/dflash_utils.py`: add `apply_dflash_grammar_vocab_mask`; drop the grammar rejection in `validate_dflash_request` (`return_logprob` remains gated).
- `speculative/dflash_worker_v2.py`: build + apply the mask in verify before accept/argmax, gated on `batch.has_grammar`.

## Validation

Tested on Kimi-K2.7-Code (TP4, B300, sglang-kernel 0.4.4 cu130), DFLASH block size 8:

- json_schema (large `content` string), regex, and dense json_schema requests all return **valid, schema-conformant** output (previously hard-errored).
- Grammar applies only to the output, not the reasoning phase (correct interaction with thinking models).
- For thin JSON envelopes around large free-form bodies (e.g. coding CLIs returning whole files/diffs in a `content` field), acceptance is largely retained — only the rare structural tokens are masked while the dominant string body stays unconstrained.

## Notes / limitations

- Marked draft: validated on one model/config (above), not yet across CI matrix.
- Draft-side grammar awareness is not added; for densely-structured outputs the draft proposes off-grammar tokens that get rejected, lowering acceptance (correctness unaffected). Large free-form payloads are unaffected.
- `return_logprob` with DFLASH remains unsupported (separate).

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28549106415](https://github.com/sgl-project/sglang/actions/runs/28549106415)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28549106315](https://github.com/sgl-project/sglang/actions/runs/28549106315)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->