### PR TITLE
[DSV4][Perf] Fuse FP8 quantization with DSV4 scale layout write

### DIFF
--- a/python/sglang/jit_kernel/csrc/gemm/per_token_group_quant_8bit_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/per_token_group_quant_8bit_v2.cuh
@@ -536,4 +536,150 @@ struct PerTokenGroupQuant8bitV2Kernel {
   }
 };
 
+template <int GROUP_SIZE, int THREADS_PER_SUBWARP, typename T, typename DST_DTYPE, bool kUsePDL>
+__global__ void per_token_group_quant_fp8_dsv4_kernel(
+    const T* __restrict__ input,
+    DST_DTYPE* __restrict__ output_q,
+    float* __restrict__ output_s,
+    const int subwarps_per_block,
+    const int hidden_dim_num_groups,
+    const int num_dsv4_groups,
+    const int scale_token_stride,
+    const int scale_group_stride) {
+  using dst_dtype_info = DtypeInfo<DST_DTYPE>;
+  static_assert(std::is_same_v<DST_DTYPE, fp8_e4m3_t>);
+
+  device::PDLWaitPrimary<kUsePDL>();
+
+  NaiveScheduler::template execute<false, GROUP_SIZE, THREADS_PER_SUBWARP>(
+      subwarps_per_block,
+      hidden_dim_num_groups,
+      nullptr,
+      0,
+      [&](const int,
+          const int token_idx,
+          const int hidden_dim_group_idx,
+          const int lane_id,
+          const int64_t input_group_start_offset) {
+        constexpr uint32_t INPUT_PRIMARY_VEC_SIZE = INPUT_PRIMARY_VEC_NUM_BYTES / sizeof(T);
+        constexpr uint32_t INPUT_PRIMARY_INT4_SIZE = INPUT_PRIMARY_VEC_NUM_BYTES / sizeof(int4);
+
+        const int row_idx = token_idx;
+        const int dsv4_token_idx = row_idx / num_dsv4_groups;
+        const int dsv4_group_idx = row_idx - dsv4_token_idx * num_dsv4_groups;
+        const int64_t output_s_offset = static_cast<int64_t>(dsv4_token_idx) * scale_token_stride +
+                                        static_cast<int64_t>(dsv4_group_idx) * scale_group_stride +
+                                        hidden_dim_group_idx;
+        const int offset_num_groups = row_idx * hidden_dim_num_groups + hidden_dim_group_idx;
+
+        int4 input_primary_int4[INPUT_PRIMARY_INT4_SIZE];
+        T* input_primary_vec = reinterpret_cast<T*>(input_primary_int4);
+
+#pragma unroll
+        for (uint32_t j = 0; j < INPUT_PRIMARY_INT4_SIZE; ++j) {
+          input_primary_int4[j] =
+              reinterpret_cast<const int4*>(input + input_group_start_offset + lane_id * INPUT_PRIMARY_VEC_SIZE)[j];
+        }
+
+        float local_absmax = LOCAL_ABSMAX_ABS;
+#pragma unroll
+        for (uint32_t j = 0; j < INPUT_PRIMARY_VEC_SIZE; ++j) {
+          const float val = static_cast<float>(input_primary_vec[j]);
+          local_absmax = fmaxf(local_absmax, fabsf(val));
+        }
+
+        local_absmax = GroupReduceMax<THREADS_PER_SUBWARP>(local_absmax);
+
+        float y_scale, y_scale_inv;
+        calculate_fp8_scales<true, dst_dtype_info>(local_absmax, y_scale, y_scale_inv);
+        if (lane_id == 0) {
+          output_s[output_s_offset] = y_scale_inv;
+        }
+        float2 y_scale_repeated = {y_scale, y_scale};
+
+        int4 output_buf;
+        const auto output_buf_ptr = reinterpret_cast<__nv_fp8x2_storage_t*>(&output_buf);
+#pragma unroll
+        for (uint32_t j = 0; j < INPUT_PRIMARY_VEC_SIZE; j += 2) {
+          float2 inputx2 = {static_cast<float>(input_primary_vec[j]), static_cast<float>(input_primary_vec[j + 1])};
+          float2 outputx2 = fmul2_rn(inputx2, y_scale_repeated);
+          outputx2.x = fminf(fmaxf(outputx2.x, dst_dtype_info::MIN), dst_dtype_info::MAX);
+          outputx2.y = fminf(fmaxf(outputx2.y, dst_dtype_info::MIN), dst_dtype_info::MAX);
+          output_buf_ptr[j / 2] = __nv_cvt_float2_to_fp8x2(outputx2, __NV_SATFINITE, __NV_E4M3);
+        }
+
+        *reinterpret_cast<int4*>(output_q + offset_num_groups * GROUP_SIZE + lane_id * INPUT_PRIMARY_VEC_SIZE) =
+            output_buf;
+      });
+
+  device::PDLTriggerSecondary<kUsePDL>();
+}
+
+template <typename T, typename DST_DTYPE, bool kUsePDL>
+struct PerTokenGroupQuantFp8Dsv4Kernel {
+  template <int GROUP_SIZE>
+  static void launch(
+      const DLDevice& device,
+      int num_groups,
+      int hidden_dim_num_groups,
+      int num_dsv4_groups,
+      int scale_token_stride,
+      int scale_group_stride,
+      const void* input,
+      void* output_q,
+      void* output_s) {
+    constexpr int THREADS_PER_SUBWARP = GROUP_SIZE / 16;
+    static_assert((GROUP_SIZE / 16) * INPUT_PRIMARY_VEC_NUM_BYTES == GROUP_SIZE * static_cast<int>(sizeof(T)));
+    int subwarps_per_block;
+    dim3 grid, block;
+    NaiveScheduler::compute_exec_config(
+        THREADS_PER_SUBWARP, 1, hidden_dim_num_groups, num_groups, subwarps_per_block, grid, block);
+    auto kernel = per_token_group_quant_fp8_dsv4_kernel<GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, kUsePDL>;
+    host::LaunchKernel(grid, block, device)
+        .enable_pdl(kUsePDL)(
+            kernel,
+            static_cast<const T*>(input),
+            static_cast<DST_DTYPE*>(output_q),
+            static_cast<float*>(output_s),
+            subwarps_per_block,
+            hidden_dim_num_groups,
+            num_dsv4_groups,
+            scale_token_stride,
+            scale_group_stride);
+  }
+
+  static void
+  run(tvm::ffi::TensorView input,
+      tvm::ffi::TensorView output_q,
+      tvm::ffi::TensorView output_s,
+      int64_t group_size,
+      int64_t num_groups,
+      int64_t hidden_dim_num_groups,
+      int64_t num_dsv4_groups,
+      int64_t scale_token_stride,
+      int64_t scale_group_stride) {
+    const DLDevice dev = input.device();
+    const void* in = input.data_ptr();
+    void* oq = output_q.data_ptr();
+    void* os = output_s.data_ptr();
+
+    switch (group_size) {
+      case 128:
+        launch<128>(
+            dev,
+            static_cast<int>(num_groups),
+            static_cast<int>(hidden_dim_num_groups),
+            static_cast<int>(num_dsv4_groups),
+            static_cast<int>(scale_token_stride),
+            static_cast<int>(scale_group_stride),
+            in,
+            oq,
+            os);
+        break;
+      default:
+        host::Panic("Unsupported DSV4 group_size ", group_size);
+    }
+  }
+};
+
 }  // namespace

--- a/python/sglang/jit_kernel/per_token_group_quant_8bit_v2.py
+++ b/python/sglang/jit_kernel/per_token_group_quant_8bit_v2.py
@@ -36,6 +36,25 @@ def _jit_module(in_dtype: torch.dtype, out_dtype: torch.dtype, use_pdl: bool) ->
     )
 
 
+@cache_once
+def _jit_dsv4_module(
+    in_dtype: torch.dtype, out_dtype: torch.dtype, use_pdl: bool
+) -> Module:
+    args = make_cpp_args(in_dtype, out_dtype, use_pdl)
+    return load_jit(
+        "per_token_group_quant_8bit_v2_dsv4",
+        *args,
+        cuda_files=["gemm/per_token_group_quant_8bit_v2.cuh"],
+        cuda_wrappers=[
+            (
+                "per_token_group_quant_fp8_dsv4",
+                f"PerTokenGroupQuantFp8Dsv4Kernel<{args}>::run",
+            )
+        ],
+        extra_cuda_cflags=["--use_fast_math"],
+    )
+
+
 @register_custom_op(
     op_name="per_token_group_quant_8bit_v2",
     mutates_args=["output_q", "output_s"],
@@ -98,6 +117,37 @@ def _per_token_group_quant_8bit_v2_custom_op(
     )
 
 
+@register_custom_op(
+    op_name="per_token_group_quant_fp8_dsv4",
+    mutates_args=["output_q", "output_s"],
+)
+def _per_token_group_quant_fp8_dsv4_custom_op(
+    input: torch.Tensor,
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+    group_size: int,
+    num_dsv4_groups: int,
+) -> None:
+    """Quantize FP8 and write rounded FP32 scales in DSV4 fp8-einsum layout."""
+    if input.numel() == 0:
+        return
+
+    hidden_dim_num_groups = output_q.shape[-1] // group_size
+    num_groups = input.numel() // group_size
+    module = _jit_dsv4_module(input.dtype, output_q.dtype, is_arch_support_pdl())
+    module.per_token_group_quant_fp8_dsv4(
+        input,
+        output_q,
+        output_s,
+        int(group_size),
+        int(num_groups),
+        int(hidden_dim_num_groups),
+        int(num_dsv4_groups),
+        int(output_s.stride(0)),
+        int(output_s.stride(1)),
+    )
+
+
 @debug_kernel_api
 def per_token_group_quant_8bit_v2(
     input: torch.Tensor,
@@ -127,4 +177,27 @@ def per_token_group_quant_8bit_v2(
         scale_ue8m0=scale_ue8m0,
         fuse_silu_and_mul=fuse_silu_and_mul,
         masked_m=masked_m,
+    )
+
+
+@debug_kernel_api
+def per_token_group_quant_fp8_dsv4(
+    input: torch.Tensor,
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+    group_size: int,
+    num_dsv4_groups: int,
+) -> None:
+    """DSV4-specific JIT v2 quantization.
+
+    This uses the current v2 UE8M0 behavior: quantize with rounded power-of-two
+    scales and store those FP32 scales directly as ``(token, dsv4_group,
+    hidden_group)`` for ``deep_gemm.fp8_einsum``.
+    """
+    _per_token_group_quant_fp8_dsv4_custom_op(
+        input=input,
+        output_q=output_q,
+        output_s=output_s,
+        group_size=group_size,
+        num_dsv4_groups=num_dsv4_groups,
     )

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -77,6 +77,9 @@ if _is_cuda or _is_musa:
     from sglang.jit_kernel.per_token_group_quant_8bit_v2 import (
         per_token_group_quant_8bit_v2 as sgl_per_token_group_quant_8bit_jit_v2,
     )
+    from sglang.jit_kernel.per_token_group_quant_8bit_v2 import (
+        per_token_group_quant_fp8_dsv4 as sgl_per_token_group_quant_fp8_dsv4_jit,
+    )
 
 if _is_hip:
     _has_vllm = False
@@ -690,6 +693,54 @@ def sglang_per_token_group_quant_fp8_ue8m0(
             False,  # fuse_silu_and_mul
             None,  # masked_m
             enable_v2=True,
+        )
+
+    return x_q, x_s
+
+
+def sglang_per_token_group_quant_fp8_dsv4_ue8m0(
+    x: torch.Tensor,
+    num_dsv4_groups: int,
+    group_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert group_size == 128, "DSV4 deep_gemm fp8_einsum expects group_size=128"
+    assert x.dim() == 2, "x must be flattened as (num_tokens * num_dsv4_groups, hidden)"
+    assert (
+        x.shape[-1] % group_size == 0
+    ), f"hidden ({x.shape[-1]}) must be divisible by group_size ({group_size})"
+    assert (
+        x.shape[0] % num_dsv4_groups == 0
+    ), f"rows ({x.shape[0]}) must be divisible by num_dsv4_groups ({num_dsv4_groups})"
+    assert x.is_contiguous(), "x must be contiguous"
+    assert (
+        enable_sgl_per_token_group_quant_8bit
+    ), "DSV4 quant requires the v2 group quant kernel"
+
+    num_tokens = x.shape[0] // num_dsv4_groups
+    hidden_dim_num_groups = x.shape[-1] // group_size
+    x_q = torch.empty(x.shape, device=x.device, dtype=fp8_dtype)
+    if num_tokens <= 1:
+        x_s = torch.empty_strided(
+            (num_tokens, num_dsv4_groups, hidden_dim_num_groups),
+            (num_dsv4_groups * hidden_dim_num_groups, hidden_dim_num_groups, 1),
+            device=x.device,
+            dtype=torch.float32,
+        )
+    else:
+        x_s = torch.empty_strided(
+            (num_tokens, num_dsv4_groups, hidden_dim_num_groups),
+            (hidden_dim_num_groups, num_tokens * hidden_dim_num_groups, 1),
+            device=x.device,
+            dtype=torch.float32,
+        )
+
+    if x.shape[0] > 0:
+        sgl_per_token_group_quant_fp8_dsv4_jit(
+            x,
+            x_q,
+            x_s,
+            group_size=group_size,
+            num_dsv4_groups=num_dsv4_groups,
         )
 
     return x_q, x_s

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -70,7 +70,9 @@ from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.mhc import mhc_fused_post_pre, npu_hc_pre
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
-from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
+from sglang.srt.layers.quantization.fp8_kernel import (
+    sglang_per_token_group_quant_fp8_dsv4_ue8m0,
+)
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.utils.cp_utils import (
@@ -1063,15 +1065,14 @@ class MQALayer(nn.Module):
 
             T, G, D = o.shape
             R = self.o_lora_rank
-            o_fp8, o_s = sglang_per_token_group_quant_fp8(
+            o_fp8, o_s = sglang_per_token_group_quant_fp8_dsv4_ue8m0(
                 o.reshape(T * G, D).contiguous(),
-                group_size=128,
-                scale_ue8m0=True,
+                num_dsv4_groups=G,
             )
             output = torch.empty(T, G, R, device=o.device, dtype=torch.bfloat16)
             deep_gemm.fp8_einsum(
                 "bhr,hdr->bhd",
-                (o_fp8.view(T, G, D), o_s.view(T, G, -1)),
+                (o_fp8.view(T, G, D), o_s),
                 (self.wo_a.weight.view(G, R, D), self.wo_a.weight_scale_inv.data),
                 output,
                 recipe=(1, 1, 128),

--- a/test/registered/jit/test_per_token_group_quant_8bit_v2.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit_v2.py
@@ -11,6 +11,7 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     fp8_max,
     fp8_min,
     sglang_per_token_group_quant_fp8,
+    sglang_per_token_group_quant_fp8_dsv4_ue8m0,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -160,6 +161,44 @@ def test_v2_jit_masked_matches_aot(num_experts, hidden, tokens_pad):
         x_q.view(torch.int8), q_ref.view(torch.int8)
     ), "masked fp8 differ"
     assert torch.equal(x_s, s_ref), "masked scales differ"
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    ("num_tokens", "num_dsv4_groups", "hidden"),
+    [(1, 4, 128), (2, 4, 128), (7, 8, 256), (16, 8, 512), (0, 8, 128)],
+)
+def test_v2_jit_dsv4_ue8m0_matches_current_layout_reference(
+    dtype, num_tokens, num_dsv4_groups, hidden
+):
+    torch.manual_seed(7000 + num_tokens * 31 + num_dsv4_groups * 7 + hidden)
+    if num_tokens == 0:
+        x = torch.empty(
+            num_tokens * num_dsv4_groups, hidden, device="cuda", dtype=dtype
+        )
+    else:
+        x = torch.randn(
+            num_tokens * num_dsv4_groups, hidden, device="cuda", dtype=dtype
+        )
+
+    q_ref, s_ref = sglang_per_token_group_quant_fp8(x, G, scale_ue8m0=True)
+    s_ref = (
+        s_ref.view(num_tokens, num_dsv4_groups, hidden // G)
+        .transpose(0, 1)
+        .contiguous()
+        .transpose(0, 1)
+    )
+
+    x_q, x_s = sglang_per_token_group_quant_fp8_dsv4_ue8m0(
+        x, num_dsv4_groups=num_dsv4_groups
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(x_q.view(torch.int8), q_ref.view(torch.int8)), "fp8 differ"
+    assert x_s.shape == s_ref.shape
+    assert x_s.stride() == s_ref.stride()
+    if num_tokens > 0:
+        assert torch.equal(x_s, s_ref), "DSV4 UE8M0 scales differ"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This is the follow-up/rebase of my earlier DSV4 FP8 `wo_a` fusion work from #27818.

Since then, main already picked up part of the idea: UE8M0 scale rounding is now fused into the generic JIT v2 FP8 group quant path. So this PR is a smaller delta than #27818. It keeps the current main behavior for `scale_ue8m0=True`, but still removes the remaining DSV4-specific extra scale layout materialization.

The DSV4 `wo_a` path needs activation scales in the layout used by:

```python
deep_gemm.fp8_einsum("bhr,hdr->bhd", ...)
```

Before this PR, we quantized with the generic path and then reshaped/transposed the scale tensor into the final DSV4 layout. This PR writes that final layout directly from the quantization kernel.

## Changes

- Added a DSV4-specific JIT v2 entry: `PerTokenGroupQuantFp8Dsv4Kernel`.
- Added Python wrapper `per_token_group_quant_fp8_dsv4`.
- Added helper `sglang_per_token_group_quant_fp8_dsv4_ue8m0`.
- Routed the DeepSeek-V4 FP8 `wo_a` path through the new helper.
- Added a registered DSV4 test for BF16/FP16, empty/non-empty inputs, exact FP8 bytes, exact scale values, and final scale tensor shape/stride.

One detail compared with #27818: the old PR preserved the old FP8 bytes and rounded only the stored scale. This version follows current main: FP8 quantization itself uses the rounded power-of-two UE8M0 scale, so it is bit-exact with the current generic `scale_ue8m0=True` path plus the old DSV4 layout transform.

## Accuracy

### GSM8K

Server:

```bash
CUDA_VISIBLE_DEVICES=3 \
python -m sglang.launch_server \
  --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash \
  --moe-runner-backend flashinfer_mxfp4 \
  --disable-flashinfer-autotune \
  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 46}'
```

Benchmark:

```bash
sgl-eval run \
  --base-url http://127.0.0.1:30000/v1 \
  --num-threads 256 \
  gsm8k
```

Results:

| benchmark | examples | score | latency | output throughput |
|---|---:|---:|---:|---:|
| GSM8K | 1319 | 96.89% | 81.7s | 1766 tok/s |

## Perf

Benchmarks were run on one GPU from a GB300 node.

### Bench Serving, 8192 / 1024

Server:

```bash
CUDA_VISIBLE_DEVICES=3 \
python -m sglang.launch_server \
  --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash \
  --moe-runner-backend flashinfer_mxfp4 \
  --disable-flashinfer-autotune \
  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 46}'
```

Benchmark:

```bash
python -m sglang.bench_serving \
  --model deepseek-ai/DeepSeek-V4-Flash \
  --dataset-name random \
  --random-input-len 8192 \
  --random-output-len 1024 \
  --random-range-ratio 1.0 \
  --max-concurrency 16 \
  --num-prompts 64 \
  --flush-cache
```

Results:

| Metric | Baseline | This PR | Delta |
|---|---:|---:|---:|
| Output throughput | 620.55 tok/s | 748.96 tok/s | **+20.7%** |
| Mean TTFT | 3863.19 ms | 2643.26 ms | **31.6% faster** |
| Mean TPOT | 22.02 ms | 18.79 ms | **14.7% faster** |





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27960005882](https://github.com/sgl-project/sglang/actions/runs/27960005882)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #27960416907](https://github.com/sgl-project/sglang/actions/runs/27960416907)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->