### PR TITLE
[Anthropic] Skip mid-conv system hoist on inline-capable templates

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -379,64 +379,6 @@ class AnthropicMessagesRequest(BaseModel):
     output_config: Optional[AnthropicOutputConfig] = None
     betas: Optional[list[str]] = None
 
-    @model_validator(mode="before")
-    @classmethod
-    def move_mid_conversation_system_messages(cls, values: dict) -> dict:
-        """Fold mid-conversation ``role: "system"`` turns into the top-level
-        ``system`` field — some clients (e.g. Claude Code) emit them there."""
-        messages = values.get("messages", [])
-        if not messages:
-            return values
-
-        clean_messages = []
-        extracted_system_texts = []
-
-        for msg in messages:
-            # ``mode="before"`` sees raw dicts (HTTP path) but also already-
-            # constructed ``AnthropicMessage`` objects (programmatic path, e.g.
-            # ``handle_count_tokens``), so normalize to a dict first.
-            if isinstance(msg, BaseModel):
-                msg = msg.model_dump()
-            if msg.get("role") == "system":
-                content = msg.get("content", "")
-                if isinstance(content, str) and content.strip():
-                    extracted_system_texts.append(content.strip())
-                elif isinstance(content, list):
-                    for block in content:
-                        if isinstance(block, dict) and block.get("type") == "text":
-                            text = block.get("text", "").strip()
-                            if text:
-                                extracted_system_texts.append(text)
-            else:
-                clean_messages.append(msg)
-
-        if extracted_system_texts:
-            existing_system = values.get("system")
-            combined_system = []
-
-            if existing_system:
-                if isinstance(existing_system, str):
-                    if existing_system.strip():
-                        combined_system.append(existing_system.strip())
-                elif isinstance(existing_system, list):
-                    for block in existing_system:
-                        if isinstance(block, BaseModel):
-                            block = block.model_dump()
-                        if isinstance(block, dict) and block.get("type") == "text":
-                            text = block.get("text", "").strip()
-                            if text:
-                                combined_system.append(text)
-
-            combined_system.extend(extracted_system_texts)
-
-            # Join into a string — ``system`` is ``str | list[AnthropicContentBlock]``,
-            # so a ``list[str]`` would fail validation.
-            if combined_system:
-                values["system"] = "\n".join(combined_system)
-
-        values["messages"] = clean_messages
-        return values
-
     @field_validator("model")
     @classmethod
     def _validate_model(cls, v):

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -22,6 +22,7 @@ from sglang.srt.entrypoints.anthropic.protocol import (
     AnthropicCountTokensResponse,
     AnthropicError,
     AnthropicErrorResponse,
+    AnthropicMessage,
     AnthropicMessageEndDelta,
     AnthropicMessagesRequest,
     AnthropicMessagesResponse,
@@ -169,6 +170,97 @@ class AnthropicServing:
 
     def __init__(self, openai_serving_chat: OpenAIServingChat):
         self.openai_serving_chat = openai_serving_chat
+        self._inline_system_capable: Optional[bool] = None
+
+    _INLINE_SYSTEM_PROBE_MESSAGES = (
+        {"role": "system", "content": "a"},
+        {"role": "user", "content": "x"},
+        {"role": "system", "content": "b"},
+        {"role": "user", "content": "y"},
+    )
+
+    def _chat_template_supports_inline_system(self) -> bool:
+        """Cache whether the active chat template renders mid-conversation system turns without raising."""
+        if self._inline_system_capable is not None:
+            return self._inline_system_capable
+
+        try:
+            tokenizer = self.openai_serving_chat.tokenizer_manager.tokenizer
+        except AttributeError:
+            self._inline_system_capable = False
+            return False
+
+        apply = getattr(tokenizer, "apply_chat_template", None)
+        if apply is None:
+            self._inline_system_capable = False
+            return False
+
+        try:
+            apply(
+                list(self._INLINE_SYSTEM_PROBE_MESSAGES),
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        except Exception as e:
+            logger.debug(
+                "Chat template rejects mid-conversation system turns "
+                "(%s: %s); hoisting to top-level system field.",
+                type(e).__name__,
+                e,
+            )
+            self._inline_system_capable = False
+            return False
+
+        self._inline_system_capable = True
+        return True
+
+    def _maybe_hoist_mid_conversation_system(
+        self, request: AnthropicMessagesRequest
+    ) -> AnthropicMessagesRequest:
+        """Fold mid-conversation system turns into top-level system field when the template can't render them inline."""
+        if not any(m.role == "system" for m in request.messages):
+            return request
+
+        if self._chat_template_supports_inline_system():
+            return request
+
+        extracted: list[str] = []
+        clean_messages: list[AnthropicMessage] = []
+        for msg in request.messages:
+            if msg.role != "system":
+                clean_messages.append(msg)
+                continue
+            if isinstance(msg.content, str):
+                text = msg.content.strip()
+                if text:
+                    extracted.append(text)
+            else:
+                for block in msg.content:
+                    if getattr(block, "type", None) == "text":
+                        text = (getattr(block, "text", "") or "").strip()
+                        if text:
+                            extracted.append(text)
+
+        if not extracted:
+            request.messages = clean_messages
+            return request
+
+        combined: list[str] = []
+        existing = request.system
+        if isinstance(existing, str):
+            if existing.strip():
+                combined.append(existing.strip())
+        elif isinstance(existing, list):
+            for block in existing:
+                if getattr(block, "type", None) == "text":
+                    text = (getattr(block, "text", "") or "").strip()
+                    if text:
+                        combined.append(text)
+        combined.extend(extracted)
+
+        request.system = "\n".join(combined)
+        request.messages = clean_messages
+        return request
 
     async def handle_messages(
         self,
@@ -197,6 +289,8 @@ class AnthropicServing:
         self, anthropic_request: AnthropicMessagesRequest
     ) -> ChatCompletionRequest:
         """Convert an Anthropic Messages request to an OpenAI ChatCompletion request."""
+        anthropic_request = self._maybe_hoist_mid_conversation_system(anthropic_request)
+
         openai_messages = []
 
         def _convert_anthropic_image_source_to_openai_part(

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -242,8 +242,7 @@ class AnthropicServing:
                             extracted.append(text)
 
         if not extracted:
-            request.messages = clean_messages
-            return request
+            return request.model_copy(update={"messages": clean_messages})
 
         combined: list[str] = []
         existing = request.system
@@ -258,9 +257,9 @@ class AnthropicServing:
                         combined.append(text)
         combined.extend(extracted)
 
-        request.system = "\n".join(combined)
-        request.messages = clean_messages
-        return request
+        return request.model_copy(
+            update={"system": "\n".join(combined), "messages": clean_messages}
+        )
 
     async def handle_messages(
         self,

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -172,91 +172,74 @@ class AnthropicServing:
         self.openai_serving_chat = openai_serving_chat
         self._inline_system_capable: Optional[bool] = None
 
-    _INLINE_SYSTEM_PROBE_MESSAGES = (
-        {"role": "system", "content": "a"},
-        {"role": "user", "content": "x"},
-        {"role": "system", "content": "b"},
-        {"role": "user", "content": "y"},
-    )
-
     def _chat_template_supports_inline_system(self) -> bool:
-        """Cache whether the active chat template renders mid-conversation system turns without raising."""
+        """Cache whether the chat template renders mid-conversation system turns without raising."""
         if self._inline_system_capable is not None:
             return self._inline_system_capable
-
-        try:
-            tokenizer = self.openai_serving_chat.tokenizer_manager.tokenizer
-        except AttributeError:
-            self._inline_system_capable = False
-            return False
-
-        apply = getattr(tokenizer, "apply_chat_template", None)
+        apply = getattr(
+            getattr(
+                getattr(self.openai_serving_chat, "tokenizer_manager", None),
+                "tokenizer",
+                None,
+            ),
+            "apply_chat_template",
+            None,
+        )
         if apply is None:
             self._inline_system_capable = False
             return False
-
         try:
             apply(
-                list(self._INLINE_SYSTEM_PROBE_MESSAGES),
+                [
+                    {"role": "system", "content": "a"},
+                    {"role": "user", "content": "x"},
+                    {"role": "system", "content": "b"},
+                    {"role": "user", "content": "y"},
+                ],
                 tokenize=False,
                 add_generation_prompt=True,
             )
         except Exception as e:
-            logger.debug(
-                "Chat template rejects mid-conversation system turns "
-                "(%s: %s); hoisting to top-level system field.",
-                type(e).__name__,
-                e,
-            )
+            logger.debug("Chat template rejects mid-conv system (%s); hoisting.", e)
             self._inline_system_capable = False
             return False
-
         self._inline_system_capable = True
         return True
+
+    @staticmethod
+    def _extract_text(content: Any) -> list[str]:
+        if isinstance(content, str):
+            text = content.strip()
+            return [text] if text else []
+        out: list[str] = []
+        for block in content or []:
+            if getattr(block, "type", None) == "text":
+                text = (getattr(block, "text", "") or "").strip()
+                if text:
+                    out.append(text)
+        return out
 
     def _maybe_hoist_mid_conversation_system(
         self, request: AnthropicMessagesRequest
     ) -> AnthropicMessagesRequest:
-        """Fold mid-conversation system turns into top-level system field when the template can't render them inline."""
+        """Fold mid-conv system turns into top-level system when template can't render them inline."""
         if not any(m.role == "system" for m in request.messages):
             return request
-
         if self._chat_template_supports_inline_system():
             return request
 
         extracted: list[str] = []
         clean_messages: list[AnthropicMessage] = []
         for msg in request.messages:
-            if msg.role != "system":
-                clean_messages.append(msg)
-                continue
-            if isinstance(msg.content, str):
-                text = msg.content.strip()
-                if text:
-                    extracted.append(text)
+            if msg.role == "system":
+                extracted.extend(self._extract_text(msg.content))
             else:
-                for block in msg.content:
-                    if getattr(block, "type", None) == "text":
-                        text = (getattr(block, "text", "") or "").strip()
-                        if text:
-                            extracted.append(text)
+                clean_messages.append(msg)
 
         if not extracted:
             return request.model_copy(update={"messages": clean_messages})
 
-        combined: list[str] = []
-        existing = request.system
-        if isinstance(existing, str):
-            if existing.strip():
-                combined.append(existing.strip())
-        elif isinstance(existing, list):
-            for block in existing:
-                if getattr(block, "type", None) == "text":
-                    text = (getattr(block, "text", "") or "").strip()
-                    if text:
-                        combined.append(text)
-        combined.extend(extracted)
-
+        combined = self._extract_text(request.system) + extracted
         return request.model_copy(
             update={"system": "\n".join(combined), "messages": clean_messages}
         )

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -1303,37 +1303,29 @@ class TestAnthropicServing(unittest.TestCase):
         )
         self.assertIsNone(request.system)
 
+    def _serving_with_tokenizer(self, apply_fn):
+        tokenizer = type("_Tok", (), {"apply_chat_template": apply_fn})()
+        chat_cls = type(
+            "_ChatWithTM",
+            (_FakeOpenAIServingChat,),
+            {"tokenizer_manager": type("_TM", (), {"tokenizer": tokenizer})()},
+        )
+        return AnthropicServing(chat_cls())
+
     def test_chat_template_probe_caches_and_falls_back_when_render_raises(self):
-        class _StrictTokenizer:
-            calls = 0
+        calls = [0]
 
-            def apply_chat_template(self, messages, **kwargs):
-                _StrictTokenizer.calls += 1
-                raise ValueError("Conversation roles must alternate")
+        def apply(self, messages, **kwargs):
+            calls[0] += 1
+            raise ValueError("Conversation roles must alternate")
 
-        class _TM:
-            tokenizer = _StrictTokenizer()
-
-        class _ChatWithTM(_FakeOpenAIServingChat):
-            tokenizer_manager = _TM()
-
-        serving = AnthropicServing(_ChatWithTM())
+        serving = self._serving_with_tokenizer(apply)
         self.assertFalse(serving._chat_template_supports_inline_system())
         self.assertFalse(serving._chat_template_supports_inline_system())
-        self.assertEqual(_StrictTokenizer.calls, 1)
+        self.assertEqual(calls[0], 1)
 
     def test_chat_template_probe_detects_inline_capable_template(self):
-        class _InlineTokenizer:
-            def apply_chat_template(self, messages, **kwargs):
-                return "ok"
-
-        class _TM:
-            tokenizer = _InlineTokenizer()
-
-        class _ChatWithTM(_FakeOpenAIServingChat):
-            tokenizer_manager = _TM()
-
-        serving = AnthropicServing(_ChatWithTM())
+        serving = self._serving_with_tokenizer(lambda self, messages, **kw: "ok")
         self.assertTrue(serving._chat_template_supports_inline_system())
 
     def test_in_messages_system_role_merged_with_top_level(self):

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -1268,10 +1268,8 @@ class TestAnthropicServing(unittest.TestCase):
         self.assertEqual(roles, ["user", "assistant", "user"])
 
     def test_in_messages_system_role_folded_to_top_level(self):
-        """A mid-conversation ``role: "system"`` turn is folded into the
-        top-level ``system`` field by the request validator, so it does not
-        appear as a dialogue turn — matching the official Anthropic API."""
         serving = self._serving()
+        serving._inline_system_capable = False
         request = self._anthropic_request(
             stream=False,
             messages=[
@@ -1280,20 +1278,67 @@ class TestAnthropicServing(unittest.TestCase):
                 {"role": "user", "content": "go"},
             ],
         )
-        # The validator moved the system turn into the top-level system field.
-        self.assertEqual(request.system, "Reply with exactly: OK")
-        self.assertEqual([m.role for m in request.messages], ["user", "user"])
-        # And the converted OpenAI request has one leading system message.
+        self.assertIsNone(request.system)
+        self.assertEqual([m.role for m in request.messages], ["user", "system", "user"])
         chat_request = serving._convert_to_chat_completion_request(request)
         self.assertEqual(
             [m.role for m in chat_request.messages], ["system", "user", "user"]
         )
         self.assertEqual(chat_request.messages[0].content, "Reply with exactly: OK")
 
-    def test_in_messages_system_role_merged_with_top_level(self):
-        """A top-level ``system`` field and a mid-conversation system turn are
-        merged; top-level text comes first."""
+    def test_in_messages_system_role_passthrough_on_inline_capable_template(self):
         serving = self._serving()
+        serving._inline_system_capable = True
+        request = self._anthropic_request(
+            stream=False,
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "Reply with exactly: OK"},
+                {"role": "user", "content": "go"},
+            ],
+        )
+        chat_request = serving._convert_to_chat_completion_request(request)
+        self.assertEqual(
+            [m.role for m in chat_request.messages], ["user", "system", "user"]
+        )
+        self.assertIsNone(request.system)
+
+    def test_chat_template_probe_caches_and_falls_back_when_render_raises(self):
+        class _StrictTokenizer:
+            calls = 0
+
+            def apply_chat_template(self, messages, **kwargs):
+                _StrictTokenizer.calls += 1
+                raise ValueError("Conversation roles must alternate")
+
+        class _TM:
+            tokenizer = _StrictTokenizer()
+
+        class _ChatWithTM(_FakeOpenAIServingChat):
+            tokenizer_manager = _TM()
+
+        serving = AnthropicServing(_ChatWithTM())
+        self.assertFalse(serving._chat_template_supports_inline_system())
+        self.assertFalse(serving._chat_template_supports_inline_system())
+        self.assertEqual(_StrictTokenizer.calls, 1)
+
+    def test_chat_template_probe_detects_inline_capable_template(self):
+        class _InlineTokenizer:
+            def apply_chat_template(self, messages, **kwargs):
+                return "ok"
+
+        class _TM:
+            tokenizer = _InlineTokenizer()
+
+        class _ChatWithTM(_FakeOpenAIServingChat):
+            tokenizer_manager = _TM()
+
+        serving = AnthropicServing(_ChatWithTM())
+        self.assertTrue(serving._chat_template_supports_inline_system())
+
+    def test_in_messages_system_role_merged_with_top_level(self):
+        serving = self._serving()
+        serving._inline_system_capable = False
         request = self._anthropic_request(
             stream=False,
             system="You are terse.",
@@ -1303,10 +1348,14 @@ class TestAnthropicServing(unittest.TestCase):
                 {"role": "user", "content": "go"},
             ],
         )
-        # Validator combines top-level system first, then the in-messages turn,
-        # joined into a single string.
+        chat_request = serving._convert_to_chat_completion_request(request)
+        # After conversion: combined top-level system first, then the in-
+        # messages turn, joined into a single string.
         self.assertEqual(request.system, "You are terse.\nOne word only.")
         self.assertEqual([m.role for m in request.messages], ["user", "user"])
+        self.assertEqual(
+            chat_request.messages[0].content, "You are terse.\nOne word only."
+        )
 
     def test_top_level_system_only_is_unchanged(self):
         """A request with only the top-level ``system`` field (no in-messages
@@ -1336,10 +1385,7 @@ class TestAnthropicServing(unittest.TestCase):
             chat_request.messages[0].content, "You are a helpful assistant."
         )
 
-    def test_validator_handles_constructed_message_objects(self):
-        """The ``mode="before"`` validator must also handle requests built
-        programmatically with ``AnthropicMessage`` objects (not just raw dicts),
-        e.g. ``handle_count_tokens`` constructs the request this way."""
+    def test_validator_accepts_constructed_system_message_objects(self):
         request = AnthropicMessagesRequest(
             model="m",
             max_tokens=8,
@@ -1349,8 +1395,8 @@ class TestAnthropicServing(unittest.TestCase):
                 AnthropicMessage(role="user", content="go"),
             ],
         )
-        self.assertEqual(request.system, "be terse")
-        self.assertEqual([m.role for m in request.messages], ["user", "user"])
+        self.assertIsNone(request.system)
+        self.assertEqual([m.role for m in request.messages], ["user", "system", "user"])
 
     def test_thinking_history_drop_on_missing_detector(self):
         """Replaying a thinking block on a non-reasoning model should not 400."""

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -1278,13 +1278,13 @@ class TestAnthropicServing(unittest.TestCase):
                 {"role": "user", "content": "go"},
             ],
         )
-        self.assertIsNone(request.system)
-        self.assertEqual([m.role for m in request.messages], ["user", "system", "user"])
         chat_request = serving._convert_to_chat_completion_request(request)
         self.assertEqual(
             [m.role for m in chat_request.messages], ["system", "user", "user"]
         )
         self.assertEqual(chat_request.messages[0].content, "Reply with exactly: OK")
+        self.assertIsNone(request.system)
+        self.assertEqual([m.role for m in request.messages], ["user", "system", "user"])
 
     def test_in_messages_system_role_passthrough_on_inline_capable_template(self):
         serving = self._serving()
@@ -1349,10 +1349,11 @@ class TestAnthropicServing(unittest.TestCase):
             ],
         )
         chat_request = serving._convert_to_chat_completion_request(request)
-        # After conversion: combined top-level system first, then the in-
-        # messages turn, joined into a single string.
-        self.assertEqual(request.system, "You are terse.\nOne word only.")
-        self.assertEqual([m.role for m in request.messages], ["user", "user"])
+        self.assertEqual(request.system, "You are terse.")
+        self.assertEqual([m.role for m in request.messages], ["user", "system", "user"])
+        self.assertEqual(
+            [m.role for m in chat_request.messages], ["system", "user", "user"]
+        )
         self.assertEqual(
             chat_request.messages[0].content, "You are terse.\nOne word only."
         )


### PR DESCRIPTION
Fixes #28883

First time contributing. Hopefully useful!

#26773 unconditionally moves every mid-conversation role:"system" turn into the top-level system field. On templates that render inline system turns natively (GLM, Kimi, Qwen3) that pulls rotating per-turn content to the front and forks the prefix cache every turn.

This probes the active chat template once with a four-message payload, caches the result, and only hoists when the template raises (Llama, Mistral, Anthropic-strict). Same trick vLLM used in vllm-project/vllm#46025.

Tests cover both probe outcomes, the combined-with-top-level-system case, and a regression on inline-capable templates. No CLI, env, or protocol surface change.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27975892775](https://github.com/sgl-project/sglang/actions/runs/27975892775)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27975892463](https://github.com/sgl-project/sglang/actions/runs/27975892463)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->