### PR TITLE
[AMD] Register 24 JIT kernel unit tests for AMD CI

### DIFF
--- a/test/registered/jit/test_add_constant.py
+++ b/test/registered/jit/test_add_constant.py
@@ -4,10 +4,11 @@ import pytest
 import torch
 
 from sglang.jit_kernel.add_constant import add_constant
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=45, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=180, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=45, suite="jit-kernel-unit-test-amd")
 
 
 @pytest.mark.parametrize("size", [1, 2, 127, 128, 1024, 1025, 4096, 4097])

--- a/test/registered/jit/test_concat_mla.py
+++ b/test/registered/jit/test_concat_mla.py
@@ -5,10 +5,11 @@ import pytest
 import torch
 import triton
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=17, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=17, suite="jit-kernel-unit-test-amd")
 
 
 def torch_concat_mla_k(

--- a/test/registered/jit/test_fused_add_rmsnorm.py
+++ b/test/registered/jit/test_fused_add_rmsnorm.py
@@ -5,10 +5,11 @@ import pytest
 import torch
 
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=10, suite="jit-kernel-unit-test-amd")
 
 
 def sglang_jit_fused_add_rmsnorm(

--- a/test/registered/jit/test_fused_metadata_copy.py
+++ b/test/registered/jit/test_fused_metadata_copy.py
@@ -14,10 +14,11 @@ import time
 import pytest
 import torch
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=100, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=400, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=100, suite="jit-kernel-unit-test-amd")
 
 # =============================================================================
 # Helper Functions

--- a/test/registered/jit/test_fused_store_index_cache.py
+++ b/test/registered/jit/test_fused_store_index_cache.py
@@ -22,7 +22,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 try:
     from sglang.jit_kernel.fused_store_index_cache import (
@@ -50,6 +50,7 @@ except ImportError:
 
 register_cuda_ci(est_time=24, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=24, suite="jit-kernel-unit-test-amd")
 
 PAGE_SIZE = 64
 HEAD_DIM = 128

--- a/test/registered/jit/test_grouped_topk.py
+++ b/test/registered/jit/test_grouped_topk.py
@@ -7,10 +7,11 @@ import torch
 from sglang.jit_kernel.grouped_topk import grouped_topk as jit_grouped_topk
 from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.srt.layers.moe.topk import biased_grouped_topk_impl
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 
 CORRECTNESS_CASES = get_ci_test_range(

--- a/test/registered/jit/test_hicache.py
+++ b/test/registered/jit/test_hicache.py
@@ -14,10 +14,11 @@ from sglang.srt.mem_cache.pool_host.common import (
     alloc_with_pin_memory,
 )
 from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=10, suite="jit-kernel-unit-test-amd")
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available()

--- a/test/registered/jit/test_kpool_topk_transform.py
+++ b/test/registered/jit/test_kpool_topk_transform.py
@@ -15,9 +15,10 @@ import pytest
 import torch
 
 from sglang.jit_kernel.kpool_topk_transform import fast_kpool_topk_transform_fused
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=60, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=60, suite="jit-kernel-unit-test-amd")
 
 
 def _ref_torch_kpool_transform_impl(

--- a/test/registered/jit/test_kvcacheio_asymmetric.py
+++ b/test/registered/jit/test_kvcacheio_asymmetric.py
@@ -5,9 +5,10 @@ import pytest
 import torch
 
 from sglang.srt.mem_cache.memory_pool_host import AsymmetricMHATokenToKVPoolHost
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=10, suite="jit-kernel-unit-test-amd")
 
 # These tests use AsymmetricMHATokenToKVPoolHost methods and let that class call
 # the real sgl-kernel transfer ops.

--- a/test/registered/jit/test_mla_kv_pack_quantize_fp8.py
+++ b/test/registered/jit/test_mla_kv_pack_quantize_fp8.py
@@ -5,9 +5,10 @@ import torch
 
 from sglang.jit_kernel.mla_kv_pack_quantize_fp8 import mla_kv_pack_quantize_fp8
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=60, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=60, suite="jit-kernel-unit-test-amd")
 
 DEVICE = "cuda"
 

--- a/test/registered/jit/test_moe_align_block_size.py
+++ b/test/registered/jit/test_moe_align_block_size.py
@@ -7,10 +7,11 @@ import triton
 import triton.language as tl
 
 from sglang.jit_kernel.moe_align import moe_align_block_size
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=28, suite="jit-kernel-unit-test-amd")
 
 
 def ceil_div(a, b):

--- a/test/registered/jit/test_moe_lora_align_block_size.py
+++ b/test/registered/jit/test_moe_lora_align_block_size.py
@@ -9,10 +9,11 @@ import torch
 # IMPORT PREBUILT KERNEL
 # ---------------------------------------------------------
 from sglang.jit_kernel.moe_lora_align import moe_lora_align_block_size
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=28, suite="jit-kernel-unit-test-amd")
 
 
 def round_up(x, base):

--- a/test/registered/jit/test_ngram_embedding.py
+++ b/test/registered/jit/test_ngram_embedding.py
@@ -9,9 +9,10 @@ from sglang.jit_kernel.ngram_embedding import (
     update_token_table,
     update_token_table_decode,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 
 def _make_ngram_params(ne_n: int, ne_k: int, vocab_size: int):

--- a/test/registered/jit/test_per_tensor_quant_fp8.py
+++ b/test/registered/jit/test_per_tensor_quant_fp8.py
@@ -6,10 +6,11 @@ import pytest
 import torch
 
 from sglang.jit_kernel.per_tensor_quant_fp8 import per_tensor_quant_fp8
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=16, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=16, suite="jit-kernel-unit-test-amd")
 
 try:
     from sglang.srt.utils import is_hip

--- a/test/registered/jit/test_per_token_group_quant_8bit.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit.py
@@ -23,10 +23,11 @@ from sglang.srt.layers.quantization.fp8_kernel import (
 from sglang.srt.layers.quantization.fp8_kernel import (
     per_token_group_quant_8bit as triton_per_token_group_quant_8bit,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=16, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=16, suite="jit-kernel-unit-test-amd")
 
 configs = list(
     itertools.product(

--- a/test/registered/jit/test_per_token_group_quant_8bit_v2.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit_v2.py
@@ -12,9 +12,10 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     fp8_min,
     sglang_per_token_group_quant_fp8,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=90, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=90, suite="jit-kernel-unit-test-amd")
 
 G = 128
 

--- a/test/registered/jit/test_pos_enc.py
+++ b/test/registered/jit/test_pos_enc.py
@@ -8,10 +8,11 @@ import triton
 import triton.language as tl
 
 from sglang.jit_kernel.rope import rotary_embedding
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=18, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=18, suite="jit-kernel-unit-test-amd")
 
 
 @triton.jit

--- a/test/registered/jit/test_qknorm.py
+++ b/test/registered/jit/test_qknorm.py
@@ -6,10 +6,11 @@ import torch
 import triton
 
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=37, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=148, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=37, suite="jit-kernel-unit-test-amd")
 
 
 def sglang_aot_qknorm(

--- a/test/registered/jit/test_qknorm_across_heads.py
+++ b/test/registered/jit/test_qknorm_across_heads.py
@@ -6,10 +6,11 @@ import torch
 import triton
 
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=15, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=15, suite="jit-kernel-unit-test-amd")
 
 
 def sglang_jit_qknorm_across_heads(

--- a/test/registered/jit/test_renorm.py
+++ b/test/registered/jit/test_renorm.py
@@ -7,10 +7,11 @@ import pytest
 import sgl_kernel
 import torch
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=6, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=6, suite="jit-kernel-unit-test-amd")
 
 
 @pytest.mark.parametrize("batch_size", [1, 99, 989])

--- a/test/registered/jit/test_rmsnorm.py
+++ b/test/registered/jit/test_rmsnorm.py
@@ -5,10 +5,11 @@ import pytest
 import torch
 
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=45, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=240, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=45, suite="jit-kernel-unit-test-amd")
 
 
 EPS = 1e-6

--- a/test/registered/jit/test_rope.py
+++ b/test/registered/jit/test_rope.py
@@ -5,10 +5,11 @@ import torch
 import triton
 
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=64, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=256, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=64, suite="jit-kernel-unit-test-amd")
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16

--- a/test/registered/jit/test_set_mla_kv_buffer.py
+++ b/test/registered/jit/test_set_mla_kv_buffer.py
@@ -8,9 +8,10 @@ from sglang.jit_kernel.set_mla_kv_buffer import (
     set_mla_kv_buffer,
 )
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 DEVICE = "cuda"
 CACHE_SIZE = 4096

--- a/test/registered/jit/test_timestep_embedding.py
+++ b/test/registered/jit/test_timestep_embedding.py
@@ -14,10 +14,11 @@ from sglang.jit_kernel.timestep_embedding import (
     timestep_embedding as timestep_embedding_cuda,
 )
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=16, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=16, suite="jit-kernel-unit-test-amd")
 
 CORRECTNESS_BATCH_SIZES = get_ci_test_range(
     [1, 2, 8, 128, 256, 512, 1536, 2048, 4096, 11008, 16384],


### PR DESCRIPTION
## Summary

Add `register_amd_ci(suite="jit-kernel-unit-test-amd")` to **24** existing JIT-kernel correctness tests under `test/registered/jit/` that were migrated in #27644 but registered **CUDA-only**. This closes part of the AMD-vs-NVIDIA kernel coverage gap using the canonical new-API (`sglang.jit_kernel`) tests.

## Why these 24

They are generic norm / rope / qknorm / quant / index / moe-align kernels — the same family as the JIT tests already green on ROCm (`test_activation`, `test_rmsnorm_hf`, `test_clamp_position`, `test_sigmoid_gate_mul`, `test_hisparse`, `test_resolve_future_token_ids`, `test_store_cache`), so they're strong candidates to pass on AMD.

`test_rmsnorm`, `test_fused_add_rmsnorm`, `test_rope`, `test_pos_enc`, `test_qknorm`, `test_qknorm_across_heads`, `test_renorm`, `test_add_constant`, `test_timestep_embedding`, `test_grouped_topk`, `test_moe_align_block_size`, `test_moe_lora_align_block_size`, `test_per_token_group_quant_8bit`, `test_per_token_group_quant_8bit_v2`, `test_per_tensor_quant_fp8`, `test_ngram_embedding`, `test_concat_mla`, `test_set_mla_kv_buffer`, `test_fused_store_index_cache`, `test_fused_metadata_copy`, `test_kpool_topk_transform`, `test_mla_kv_pack_quantize_fp8`, `test_kvcacheio_asymmetric`, `test_hicache`.

## Approach — purely additive, AMD-only

- Each file keeps its existing `register_cuda_ci(...)`; we only add one `register_amd_ci(est_time=<same as the CUDA per-commit value>, suite="jit-kernel-unit-test-amd")` line.
- **No new files, no duplication, no moves.**
- **No workflow changes**: the AMD `jit-kernel-unit-test-amd` job already runs `run_suite.py --hw amd --suite jit-kernel-unit-test-amd` over `test/registered/jit/`, and that suite is already in `run_suite.py`'s AMD allowlist. The legacy `sgl-kernel/tests/` and the NV / MUSA jobs are untouched.

## Excluded

Multi-GPU JIT tests (e.g. `test_tp_qknorm`, 8-GPU) are intentionally left out of this 1-GPU suite, as are clearly NV-specific kernels (nvfp4, marlin/gptq, FA3/FA4, cutedsl, mxfp8, diffusion/minimax/deepseek_v4 suites).

## Verification

- `collect_tests(sanity_check=True)` over the full `test/registered/` tree passes; `jit-kernel-unit-test-amd` enabled count goes from 22 → **46** (+24).
- `ruff --select=F401,F821,UP037`, `isort`, `black` (pinned 26.1.0) all clean.

## Test plan

- [ ] AMD `jit-kernel-unit-test-amd` runs the +24 tests via `run_suite` and passes.
- [ ] Any test that fails on ROCm gets flipped to `disabled=...` and triaged in a follow-up.
- [ ] No change to NV / MUSA / ROCm-7.2 behavior.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #27989407574](https://github.com/sgl-project/sglang/actions/runs/27989407574)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27989407455](https://github.com/sgl-project/sglang/actions/runs/27989407455)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->