### PR TITLE
fix(sampling): validate sampling_seed is an int within int64 range

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -197,6 +197,17 @@ class SamplingParams:
                         f"logit_bias must has keys in [0, {vocab_size - 1}], got "
                         f"{token_id}."
                     )
+        if self.sampling_seed is not None:
+            if not isinstance(self.sampling_seed, int):
+                raise ValueError(
+                    "sampling_seed must be an integer, got "
+                    f"{type(self.sampling_seed).__name__}."
+                )
+            if not -(2**63) <= self.sampling_seed <= 2**63 - 1:
+                raise ValueError(
+                    "sampling_seed must be in [-2**63, 2**63 - 1], got "
+                    f"{self.sampling_seed}."
+                )
 
         grammars = [
             self.json_schema,

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -269,6 +269,31 @@ class TestSamplingParamsVerify(CustomTestCase):
         sp = self._make(logit_bias={"0": 1.0, "31999": -0.5})
         sp.verify(self.VOCAB_SIZE)
 
+    # --- sampling_seed ---
+    def test_sampling_seed_valid(self):
+        """Test that None (the default) and the int64 min/max boundaries are accepted."""
+        self._make(sampling_seed=None).verify(self.VOCAB_SIZE)
+        self._make(sampling_seed=2**63 - 1).verify(self.VOCAB_SIZE)
+        self._make(sampling_seed=-(2**63)).verify(self.VOCAB_SIZE)
+
+    def test_sampling_seed_out_of_range_raises(self):
+        """Test that verify() rejects a seed outside the int64 range.
+
+        With deterministic inference enabled the seed feeds a torch.int64
+        tensor; an out-of-range value raises "Overflow when unpacking long
+        long" inside the scheduler and crashes every rank, so it must be
+        rejected at admission instead.
+        """
+        with self.assertRaises(ValueError):
+            self._make(sampling_seed=2**63).verify(self.VOCAB_SIZE)
+        with self.assertRaises(ValueError):
+            self._make(sampling_seed=-(2**63) - 1).verify(self.VOCAB_SIZE)
+
+    def test_sampling_seed_non_int_raises(self):
+        """Test that verify() rejects a non-integer seed (e.g. a string)."""
+        with self.assertRaises(ValueError):
+            self._make(sampling_seed="100").verify(self.VOCAB_SIZE)
+
     def test_multiple_grammars_raises(self):
         """Test that verify() rejects setting both json_schema and regex (mutually exclusive)."""
         sp = self._make(json_schema='{"type":"object"}', regex="abc")


### PR DESCRIPTION

## Motivation

`sampling_seed` is a public sampling field on `/generate` (and the OpenAI `/v1/*` `seed`), but its type and range are never checked at admission. With `--enable-deterministic-inference`, the value is passed straight to `SamplingBatchInfo.from_schedule_batch`, which packs it into a `torch.int64` tensor in the scheduler thread:

- an integer beyond int64 (e.g. `10**20`) raises `ValueError: Overflow when unpacking long long`;
- a non-int (e.g. the string `"100"`) raises `ValueError: too many dimensions 'str'`.

Neither is caught: the scheduler receives `SIGQUIT`, `kill_process_tree` tears down the whole process group, and the server exits. A single request crashes a deterministic-inference server, after which `/health_generate` and normal `/generate` are all connection-refused. Both positive and negative overflow trigger it.

This follows the same pattern as #24874 (reject `repetition_penalty=0` in `verify()` to stop a scheduler-side crash): a user-controllable sampling field must be validated at admission rather than crashing the engine.

## Modifications

- In `SamplingParams.verify()`, validate `sampling_seed`: `None` stays valid (the default), otherwise it must be an `int` within `[-2**63, 2**63 - 1]`.
- An invalid value now raises `ValueError` at admission, which maps to HTTP 400, instead of reaching the `torch.int64` tensor construction in the scheduler.
- The `isinstance(int)` check also rejects non-int seeds (string, float) that would otherwise raise inside the scheduler.
- No change to sampling behavior for valid seeds.

## Testing

Real `launch_server` on a deterministic-inference server, single request, before and after the fix:

Server: `python -m sglang.launch_server --model-path <tinyllama-w4a16> --attention-backend triton --sampling-backend pytorch --disable-cuda-graph --disable-piecewise-cuda-graph --mem-fraction-static 0.5 --dtype float16 --max-running-requests 8 --enable-deterministic-inference`

| request `sampling_seed` | before fix | after fix |
| --- | --- | --- |
| `10**20` | server `RemoteDisconnected`, then health + normal connection-refused, process exit -9 | 400, server healthy |
| `-(10**20)` | same crash | 400, server healthy |
| `"100"` (string) | same crash | 400, server healthy |
| `2**63 - 1` (valid) | n/a | 200, normal generation |

<details>
<summary>Before fix (clean tree) — both probes crash the server</summary>

```
===== seed_overflow (10**20) =====
MARKER_BASELINE_OK
MARKER_ATTACK_RESULT seed_overflow status=None body=RemoteDisconnected: Remote end closed connection without response
MARKER_HEALTH_AFTER seed_overflow fail:None
MARKER_NORMAL_AFTER seed_overflow fail:None body=URLError: [Errno 111] Connection refused
MARKER_SERVER_EXIT seed_overflow -9
MARKER_DOS_CONFIRMED seed_overflow

===== seed_string ("100") =====
MARKER_BASELINE_OK
MARKER_ATTACK_RESULT seed_string status=None body=RemoteDisconnected: Remote end closed connection without response
MARKER_HEALTH_AFTER seed_string fail:None
MARKER_NORMAL_AFTER seed_string fail:None body=URLError: [Errno 111] Connection refused
MARKER_SERVER_EXIT seed_string -9
MARKER_DOS_CONFIRMED seed_string
```

Server log root cause: `ValueError: Overflow when unpacking long long` in `SamplingBatchInfo.from_schedule_batch`, then `Received sigquit from a child process` + `kill_process_tree`.
</details>

<details>
<summary>After fix (same server) — invalid seeds 400, server stays up, valid seed works</summary>

```
MARKER_ATTACK_RESULT seed_overflow status=400 body={"error":{"message":"sampling_seed must be in [-2**63, 2**63 - 1], got 100000000000000000000."}}
MARKER_HEALTH_AFTER seed_overflow ok / MARKER_NORMAL_AFTER seed_overflow ok / MARKER_SERVER_EXIT seed_overflow running
MARKER_ATTACK_RESULT seed_neg_overflow status=400 body={"error":{"message":"sampling_seed must be in [-2**63, 2**63 - 1], got -100000000000000000000."}}
MARKER_HEALTH_AFTER seed_neg_overflow ok / MARKER_SERVER_EXIT seed_neg_overflow running
MARKER_ATTACK_RESULT seed_string status=400 body={"error":{"message":"sampling_seed must be an integer, got str."}}
MARKER_HEALTH_AFTER seed_string ok / MARKER_SERVER_EXIT seed_string running
MARKER_ATTACK_RESULT seed_int64_ok status=200 body={"text":"! Hey Stick",...}
MARKER_HEALTH_AFTER seed_int64_ok ok / MARKER_SERVER_EXIT seed_int64_ok running
```
</details>

Unit tests added to `test/registered/unit/sampling/test_sampling_params.py` (`TestSamplingParamsVerify`): one accepts `None` and the int64 boundaries, one rejects out-of-range seeds (both directions), one rejects a non-int seed. The two reject tests fail on the unpatched tree and pass with the fix.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc @hnyls2002 @cctry

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #35522118118](https://github.com/sgl-project/sglang/actions/runs/35522118118)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35522117901](https://github.com/sgl-project/sglang/actions/runs/35522117901)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35522118087](https://github.com/sgl-project/sglang/actions/runs/35522118087)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->