### PR TITLE
[AMD] [GLM5] Add opt-in Triton fp8 sparse-MLA prefill kernel for gfx950

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/tilelang_kernel.py
+++ b/python/sglang/srt/layers/attention/dsa/tilelang_kernel.py
@@ -7,7 +7,7 @@ import tilelang.language as T
 import torch
 
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-from sglang.srt.utils import is_gfx95_supported, is_hip
+from sglang.srt.utils import get_bool_env_var, is_gfx95_supported, is_hip
 
 tilelang.set_log_level("WARNING")
 
@@ -46,6 +46,13 @@ elif hasattr(tilelang.PassConfigKey, "TL_ENABLE_FAST_MATH"):
 _is_hip = is_hip()
 _is_gfx95_supported = is_gfx95_supported()
 _is_fp8_fnuz = is_fp8_fnuz()
+
+# Opt-in (default off): route the fp8 sparse-MLA *prefill* path through the
+# Triton per-query flash kernel (~1.6x faster than the TileLang partial+combine
+# on gfx950 for the tiny M=16 attention tile; ~8-12% lower TTFT e2e, GSM8K
+# unchanged). Decode is left on TileLang. Validated on gfx950; enable with
+# SGLANG_DSA_TRITON_PREFILL=1.
+_DSA_TRITON_PREFILL = get_bool_env_var("SGLANG_DSA_TRITON_PREFILL")
 
 BF16 = "bfloat16"
 FP8 = "float8_e4m3fnuz" if _is_fp8_fnuz else "float8_e4m3fn"
@@ -1349,6 +1356,23 @@ def tilelang_sparse_fwd(
         if is_fp8_kv:
             if q.dtype != kv.dtype:
                 q = q.to(kv.dtype)
+            # Prefill (many query rows) -> Triton flash kernel. Detect prefill
+            # by a large query-row count; decode stays on TileLang.
+            #
+            # Restricted to the *validated* attention shape (GLM-5.1 @ TP4 and
+            # any DSA model presenting the same per-rank tile): 16 heads,
+            # d_v=512, tail=64 (topk==2048 asserted above). Other shapes — e.g.
+            # DeepSeek-V3.2 at TP4 (32 heads/rank), or any non-power-of-2 head
+            # count that would break tl.arange — fall back to TileLang.
+            triton_shape_ok = num_heads == 16 and d_v == 512 and tail_dim == 64
+            if _DSA_TRITON_PREFILL and triton_shape_ok and q.shape[0] >= 512:
+                from sglang.srt.layers.attention.dsa.triton_sparse_mla import (
+                    triton_sparse_mla_fwd,
+                )
+
+                return triton_sparse_mla_fwd(
+                    q=q, kv=kv, indices=indices, sm_scale=sm_scale, d_v=d_v
+                )
             if _is_gfx95_supported:
                 block_I, threads, block_per_cu, cu = 64, 256, 2, 256
             else:

--- a/python/sglang/srt/layers/attention/dsa/triton_sparse_mla.py
+++ b/python/sglang/srt/layers/attention/dsa/triton_sparse_mla.py
@@ -1,0 +1,144 @@
+"""Triton sparse-MLA forward for the DSA fp8 prefill path.
+
+A per-query flash-attention kernel over the indexer-selected topk KV. On
+gfx950 this is ~1.6x faster than the TileLang partial+combine kernel for the
+prefill regime (n_groups=1): the attention tile is tiny (M=16 heads = one
+16x16 MFMA), so a small-warp per-program kernel avoids the intra-block
+coordination overhead of the 256-thread TileLang block.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+
+_IS_FNUZ = is_fp8_fnuz()
+_FP8_MAX = 240.0 if _IS_FNUZ else 448.0
+
+
+def _prune_configs(configs, named_args, **kwargs):
+    """Drop configs whose KV tile exceeds topk (pure waste)."""
+    topk = named_args["topk"]
+    keep = [c for c in configs if c.kwargs["BLOCK_N"] <= topk]
+    return keep or [configs[0]]
+
+
+# The best (BLOCK_N, num_warps, num_stages) is shape- and arch-sensitive, so
+# autotune over a grid keyed on the attention shape. Benchmarked once per key
+# (a one-time stall on the first prefill of each new shape), then cached.
+_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": bn}, num_warps=w, num_stages=ns)
+    for bn in (32, 64, 128)
+    for w in (1, 2, 4)
+    for ns in (1, 2)
+]
+
+
+@triton.autotune(
+    configs=_AUTOTUNE_CONFIGS,
+    key=["topk", "H", "DIM"],
+    prune_configs_by={"early_config_prune": _prune_configs},
+)
+@triton.jit
+def _sparse_mla_fwd_kernel(
+    q_ptr,
+    kv_ptr,
+    idx_ptr,
+    o_ptr,
+    sm_scale,
+    fp8_max,
+    topk,
+    H: tl.constexpr,
+    DIM: tl.constexpr,
+    D_V: tl.constexpr,
+    D_TAIL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    s_i = tl.program_id(0)
+
+    h = tl.arange(0, H)
+    dv = tl.arange(0, D_V)
+    dt = tl.arange(0, D_TAIL)
+    qbase = q_ptr + s_i * H * DIM + h[:, None] * DIM
+    q_main = tl.load(qbase + dv[None, :]).to(q_ptr.dtype.element_ty)  # [H, D_V]
+    q_tail = tl.load(qbase + (D_V + dt)[None, :]).to(
+        q_ptr.dtype.element_ty
+    )  # [H, D_TAIL]
+
+    m_i = tl.full([H], -float("inf"), tl.float32)
+    l_i = tl.zeros([H], tl.float32)
+    acc = tl.zeros([H, D_V], tl.float32)
+
+    n = tl.arange(0, BLOCK_N)
+    for k0 in range(0, topk, BLOCK_N):
+        kmask = (k0 + n) < topk
+        idx = tl.load(idx_ptr + s_i * topk + k0 + n, mask=kmask, other=-1)
+        valid = (idx >= 0) & kmask
+        page = tl.where(valid, idx, 0)
+        kbase = kv_ptr + page[:, None] * DIM
+        kv_main = tl.load(kbase + dv[None, :], mask=valid[:, None], other=0.0).to(
+            q_ptr.dtype.element_ty
+        )  # [BLOCK_N, D_V] -- reused as V
+        kv_tail = tl.load(
+            kbase + (D_V + dt)[None, :], mask=valid[:, None], other=0.0
+        ).to(
+            q_ptr.dtype.element_ty
+        )  # [BLOCK_N, D_TAIL]
+
+        qk = tl.dot(q_main, tl.trans(kv_main)).to(tl.float32)
+        qk += tl.dot(q_tail, tl.trans(kv_tail)).to(tl.float32)
+        qk = qk * sm_scale
+        qk = tl.where(valid[None, :], qk, -float("inf"))
+
+        m_new = tl.maximum(m_i, tl.max(qk, axis=1))
+        # Guard an all-masked row (m_new == -inf): shift by 0 instead so that
+        # exp(-inf - 0) = 0 rather than exp(-inf + inf) = NaN. Identical to
+        # m_new whenever the row has >=1 valid key.
+        m_safe = tl.where(m_new == -float("inf"), 0.0, m_new)
+        alpha = tl.exp(m_i - m_safe)
+        p = tl.exp(qk - m_safe[:, None])  # [H, BLOCK_N]
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+
+        p_fp8 = (p * fp8_max).to(q_ptr.dtype.element_ty)
+        pv = tl.dot(p_fp8, kv_main).to(tl.float32) * (1.0 / fp8_max)
+        acc = acc * alpha[:, None] + pv
+        m_i = m_new
+
+    l_safe = tl.where(l_i == 0.0, 1.0, l_i)
+    acc = acc / l_safe[:, None]
+    tl.store(
+        o_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :],
+        acc.to(o_ptr.dtype.element_ty),
+    )
+
+
+def triton_sparse_mla_fwd(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    d_v: int = 512,
+) -> torch.Tensor:
+    """q: [seq, H, dim] fp8, kv: [num_pages, 1, dim] fp8, indices: [seq, 1, topk].
+
+    Returns [1, seq, H, d_v] bf16 to match tilelang_sparse_fwd's output shape.
+    """
+    seq, H, dim = q.shape
+    topk = indices.shape[-1]
+    out = torch.empty(seq, H, d_v, device=q.device, dtype=torch.bfloat16)
+    # BLOCK_N / num_warps / num_stages are chosen by @triton.autotune.
+    _sparse_mla_fwd_kernel[(seq,)](
+        q,
+        kv,
+        indices,
+        out,
+        sm_scale,
+        _FP8_MAX,
+        topk,
+        H=H,
+        DIM=dim,
+        D_V=d_v,
+        D_TAIL=dim - d_v,
+    )
+    return out.unsqueeze(0)


### PR DESCRIPTION
## Motivation

This affects HIP serving of DSA (DeepSeek Sparse Attention) models; it was found
and validated on **GLM-5.1-MXFP4** (which uses the DSA indexer) at long context.

On the HIP fp8 path, `tilelang_sparse_fwd` runs the *same* TileLang
partial+combine kernel for prefill as for decode. The sparse-MLA attention tile
is tiny — `M = 16` heads (one `16x16` MFMA) — so the 256-thread (4-warp)
TileLang block over-parallelizes it and spends most of its time on intra-block
coordination rather than the matmuls (profiling at `16x8192` on gfx950 shows the
kernel VALU-bound at ~42% with MFMA at ~12% and ~37% occupancy).

A per-query Triton flash kernel with a small `2-warp` / `BLOCK_N=32` tile fits
the problem shape and saturates the GPU on block count instead. It is ~1.6x
faster than the TileLang kernel in isolation and lowers median TTFT ~8-12% e2e,
with no change to decode (which stays on TileLang).

## Modifications

- New `python/sglang/srt/layers/attention/dsa/triton_sparse_mla.py`: a per-query
  Triton flash kernel over the indexer-selected topk KV. Autotuned over
  `BLOCK_N`/`num_warps`/`num_stages`; guards an all-masked query row against
  `NaN` (uses a finite softmax shift when the row has no valid key).
- `python/sglang/srt/layers/attention/dsa/tilelang_kernel.py`: route the fp8
  prefill path through the Triton kernel in `tilelang_sparse_fwd`.
  - **Opt-in, default off**: enable with `SGLANG_DSA_TRITON_PREFILL=1`.
  - Restricted to the validated shape (`num_heads==16`, `d_v==512`, `tail==64`;
    `topk==2048` is asserted); other shapes (e.g. a 32-heads/rank config) fall
    back to TileLang.
  - Only the prefill path (large query-row count) is routed; decode stays on
    TileLang.

## Accuracy Tests

GSM8K 5-shot, full 1319 questions, GLM-5.1-MXFP4, MI355X (gfx950), tp4,
fp8_e4m3 KV:

| | accuracy | invalid |
|---|---|---|
| TileLang prefill (default) | 0.938 | 0.000 |
| Triton prefill (`SGLANG_DSA_TRITON_PREFILL=1`) | 0.941 | 0.002 |

No regression (delta within run-to-run noise).

## Speed Benchmarks

E2E `sglang.bench_serving` (random, input 8192 / output 1024, median latencies),
GLM-5.1-MXFP4 / MI355X / tp4 / fp8_e4m3 KV:

Baseline (TileLang prefill):

| concurrency | total tok/s | TTFT (ms) | ITL (ms) | E2EL (ms) |
|---|---|---|---|---|
| 2 | 946 | 933 | 17.72 | 19467 |
| 4 | 1721 | 1751 | 18.56 | 21335 |
| 8 | 2860 | 2866 | 20.69 | 25764 |
| 16 | 4364 | 5090 | 24.19 | 33786 |
| 32 | 6188 | 9591 | 28.96 | 47623 |
| 64 | 8156 | 18603 | 35.45 | 72268 |

This PR (`SGLANG_DSA_TRITON_PREFILL=1`):

| concurrency | total tok/s | TTFT (ms) | TTFT delta | ITL (ms) | E2EL (ms) |
|---|---|---|---|---|---|
| 2 | 953 | 845 | -9.4% | 17.70 | 19312 |
| 4 | 1739 | 1597 | -8.8% | 18.55 | 21125 |
| 8 | 2887 | 2625 | -8.4% | 20.69 | 25513 |
| 16 | 4446 | 4659 | -8.5% | 24.22 | 33144 |
| 32 | 6423 | 8752 | -8.7% | 28.72 | 45849 |
| 64 | 8545 | 16935 | -9.0% | 35.37 | 69030 |

Median TTFT improves 8.4-9.4% across the sweep; median ITL is unchanged
(within +/-0.5%) and median E2EL is flat-to-better, confirming the change is
prefill-side with no decode regression. The benefit scales with how
prefill-heavy the workload is (short outputs / RAG / long context).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27982323069](https://github.com/sgl-project/sglang/actions/runs/27982323069)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27982322079](https://github.com/sgl-project/sglang/actions/runs/27982322079)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->