### PR TITLE
[AMD-miles] Make ROCm aiter fp8 weight pre-shuffle idempotent for RL weight reload

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -576,12 +576,17 @@ class Fp8LinearMethod(LinearMethodBase):
             and self.w8a8_block_fp8_linear is aiter_w8a8_block_fp8_linear
         ):
             n, k = layer.weight.shape
-            if not use_aiter_triton_gemm_w8a8_tuned_gfx950(n, k):
+            if not use_aiter_triton_gemm_w8a8_tuned_gfx950(n, k) and not getattr(
+                layer.weight, "is_shuffled", False
+            ):
                 # TODO(1am9trash), to deal with case that this branch chance
-                # drops as use_aiter_triton_gemm_w8a8_tuned_gfx950() expands
+                # drops as use_aiter_triton_gemm_w8a8_tuned_gfx950() expands.
+                # Guard on is_shuffled so RL rollout's repeated process_weights
+                # calls shuffle exactly once per fresh (plain) load.
                 t = shuffle_weight(layer.weight, (16, 16))
                 layer.weight.copy_(t)
                 del t
+                layer.weight.is_shuffled = True
 
     def _process_mxfp8_linear_weight_scale(self, layer: Module) -> None:
         if not self.use_mxfp8:
@@ -660,6 +665,14 @@ class Fp8LinearMethod(LinearMethodBase):
         layer.weight_scale_inv.format_ue8m0 = True
         self._process_mxfp8_linear_weight_scale(layer)
         layer.input_scale = None
+
+    def restore_weights_before_loading(self, layer: Module) -> None:
+        # See Fp8MoEMethod.restore_weights_before_loading: aiter shuffle is
+        # shape-preserving and the RL weight update overwrites the buffer with
+        # fresh plain bytes, so clearing the idempotency flag is enough.
+        w = getattr(layer, "weight", None)
+        if w is not None and getattr(w, "is_shuffled", False):
+            w.is_shuffled = False
 
     def process_weights_after_loading(self, layer: Module) -> None:
         if self.block_quant:
@@ -1305,13 +1318,18 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     layer.w2_weight.contiguous(), (16, 16)
                 )
         elif _use_aiter:
-            # Pre-shuffle weights
-            t = shuffle_weight(layer.w13_weight, (16, 16))
-            layer.w13_weight.copy_(t)
-            del t
-            t = shuffle_weight(layer.w2_weight, (16, 16))
-            layer.w2_weight.copy_(t)
-            del t
+            # Pre-shuffle weights. shuffle_weight((16, 16)) is NOT idempotent and
+            # RL rollout re-runs process_weights after every weight update, so guard
+            # on is_shuffled to shuffle exactly once per fresh (plain) load.
+            if not getattr(layer.w13_weight, "is_shuffled", False):
+                t = shuffle_weight(layer.w13_weight, (16, 16))
+                layer.w13_weight.copy_(t)
+                del t
+                t = shuffle_weight(layer.w2_weight, (16, 16))
+                layer.w2_weight.copy_(t)
+                del t
+                layer.w13_weight.is_shuffled = True
+                layer.w2_weight.is_shuffled = True
         elif _is_cpu:
             assert (
                 _is_cpu_amx_available
@@ -1570,6 +1588,16 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             )
 
             align_mxfp8_moe_weights_for_flashinfer_trtllm(layer)
+
+    def restore_weights_before_loading(self, layer: Module) -> None:
+        # aiter shuffle_weight((16, 16)) is shape-preserving and the RL weight
+        # update overwrites the weight buffer with fresh plain bytes, so we only
+        # need to clear the idempotency flag here; process_weights_after_loading
+        # re-shuffles the freshly loaded plain weights exactly once.
+        for name in ("w13_weight", "w2_weight"):
+            w = getattr(layer, name, None)
+            if w is not None and getattr(w, "is_shuffled", False):
+                w.is_shuffled = False
 
     def process_weights_after_loading(self, layer: Module) -> None:
         if _is_hip and _use_hip_int4:


### PR DESCRIPTION
Co-authored-with: @XinyuJiangCMU

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

On ROCm, the aiter FP8 path pre-shuffles weights in `process_weights_after_loading` via `shuffle_weight(..., (16, 16))`, which is not idempotent. In RL training the policy weights are reloaded into the running engine every step, so `process_weights_after_loading` runs again on already-shuffled weights and shuffles them a second time, corrupting the rollout. This PR makes the shuffle idempotent across reloads.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Guard the aiter shuffle on a per-tensor `is_shuffled` flag (set right after shuffling) so repeated `process_weights_after_loading` calls shuffle each weight exactly once. Covers `Fp8LinearMethod` (dense block-quant) and `Fp8MoEMethod` (aiter block-quant).
- Implement `restore_weights_before_loading` on both methods to clear the flag. `ModelRunner` already invokes this hook on every quant method before a weight reload (the same hook compressed-tensors uses); the aiter shuffle is shape-preserving and the reload overwrites the buffer with fresh plain weights, so clearing the flag lets the next `process_weights_after_loading` re-shuffle exactly once.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Validated end-to-end on Qwen3-30B-A3B (8x MI350X): fp8 blockwise train + rollout matches the bf16 reference to ~0.04 relerr, and stays on-policy (per-step train-vs-rollout logprob abs-diff ~0.04), including under TP2 + sequence parallel (fwd/dgrad/wgrad).

<p float="left">
  <img width="49%" alt="eval:aime" src="https://github.com/user-attachments/assets/1f865c84-83bd-4292-b56b-6678e1c32abb" />
  <img width="49%" alt="rollout:raw_reward" src="https://github.com/user-attachments/assets/d0f2628e-1e89-4853-b3a4-390fbeadf45b" />
</p>

<img width="979" height="492" alt="train:train_rollout_logprob_abs_diff" src="https://github.com/user-attachments/assets/a3e7d132-8c42-4f42-8c8f-67d3a3f22b15" />

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27984409774](https://github.com/sgl-project/sglang/actions/runs/27984409774)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27984408425](https://github.com/sgl-project/sglang/actions/runs/27984408425)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->