### PR TITLE
[AMD] Register 7 JIT kernel unit tests for AMD nightly CI

### DIFF
--- a/test/registered/jit/minimax/test_minimax_decode_topk.py
+++ b/test/registered/jit/minimax/test_minimax_decode_topk.py
@@ -10,10 +10,11 @@ import pytest
 import torch
 
 from sglang.jit_kernel.minimax_decode_topk import minimax_decode_topk
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=40, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=40, suite="base-b-kernel-unit-1-gpu-b200")
+register_amd_ci(est_time=15, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 
 def _ref(score, seq_lens, block_size, topk):

--- a/test/registered/jit/minimax/test_minimax_store_kv_index.py
+++ b/test/registered/jit/minimax/test_minimax_store_kv_index.py
@@ -9,10 +9,11 @@ import pytest
 import torch
 
 from sglang.jit_kernel.minimax_store_kv_index import store_kv_index
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-b200")
+register_amd_ci(est_time=10, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 dev = "cuda"
 HEAD_DIM = 128

--- a/test/registered/jit/test_deepseek_v4_compress_state_runtime_shapes.py
+++ b/test/registered/jit/test_deepseek_v4_compress_state_runtime_shapes.py
@@ -98,10 +98,11 @@ from sglang.jit_kernel.tests.deepseek_v4.common import (
     make_legacy_context,
     to_seq_extend,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.utils import is_in_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=25, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 Mode = Literal["decode", "prefill"]
 ShapeTier = Literal["ci", "smoke", "full"]

--- a/test/registered/jit/test_fused_store_index_cache.py
+++ b/test/registered/jit/test_fused_store_index_cache.py
@@ -22,7 +22,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 try:
     from sglang.jit_kernel.fused_store_index_cache import (
@@ -50,6 +50,7 @@ except ImportError:
 
 register_cuda_ci(est_time=24, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=24, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 PAGE_SIZE = 64
 HEAD_DIM = 128

--- a/test/registered/jit/test_fused_verify_triton_gdn.py
+++ b/test/registered/jit/test_fused_verify_triton_gdn.py
@@ -11,7 +11,7 @@ import sys
 import pytest
 import torch
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 try:
     from sglang.srt.layers.attention.fla.fused_gdn_gating import fused_gdn_gating
@@ -28,6 +28,7 @@ except ImportError:
 
 register_cuda_ci(est_time=6, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=10, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 
 def _make_tensors(N, T, H, HV, K, V, device="cuda", seed=2025):

--- a/test/registered/jit/test_kvcacheio_asymmetric.py
+++ b/test/registered/jit/test_kvcacheio_asymmetric.py
@@ -5,9 +5,10 @@ import pytest
 import torch
 
 from sglang.srt.mem_cache.memory_pool_host import AsymmetricMHATokenToKVPoolHost
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=10, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 # These tests use AsymmetricMHATokenToKVPoolHost methods and let that class call
 # the real sgl-kernel transfer ops.

--- a/test/registered/jit/test_mla_kv_pack_quantize_fp8.py
+++ b/test/registered/jit/test_mla_kv_pack_quantize_fp8.py
@@ -5,9 +5,10 @@ import torch
 
 from sglang.jit_kernel.mla_kv_pack_quantize_fp8 import mla_kv_pack_quantize_fp8
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=60, suite="base-b-kernel-unit-1-gpu-large")
+register_amd_ci(est_time=60, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"
 


### PR DESCRIPTION
## Summary

Add `register_amd_ci(suite="nightly-amd-kernel-1-gpu", nightly=True)` to **7** JIT-kernel correctness tests (previously CUDA-only) that are **validated to pass on both ROCm 7.0 and ROCm 7.2** (MI35x / gfx950).

**Batch 1 (3 tests):**
- `test_fused_store_index_cache`
- `test_mla_kv_pack_quantize_fp8`
- `test_kvcacheio_asymmetric`

**Batch 2 (4 tests):**
- `test_fused_verify_triton_gdn`
- `minimax/test_minimax_store_kv_index`
- `minimax/test_minimax_decode_topk`
- `test_deepseek_v4_compress_state_runtime_shapes`

## ✅ Verified on real MI35x via `run_suite` (per-file runtime)

`run_suite.py --hw amd --suite nightly-amd-kernel-1-gpu --nightly` — dedicated runs of the kernel suite on both stacks, **both jobs green (11/11 files passed)**:

| Test | ROCm 7.0 | ROCm 7.2 |
| --- | --- | --- |
| `test_mla_kv_pack_quantize_fp8` | ✅ 6s | ✅ 6s |
| `test_fused_store_index_cache` | ✅ 12s | ✅ 12s |
| `test_kvcacheio_asymmetric` | ✅ 11s | ✅ 11s |
| `test_fused_verify_triton_gdn` | ✅ 9s | ✅ 9s |
| `test_minimax_store_kv_index` | ✅ 7s | ✅ 8s |
| `test_minimax_decode_topk` (118 cases) | ✅ 11s | ✅ 13s |
| `test_deepseek_v4_compress_state_runtime_shapes` (90 cases) | ✅ 37s | ✅ 30s |

Latest dispatched runs (kernel job only):
- ROCm 7.0: https://github.com/sgl-project/sglang/actions/runs/28066360661
- ROCm 7.2: https://github.com/sgl-project/sglang/actions/runs/28066361479

## Placement

Mirrors NV's nightly tier (NV dual-registers each JIT kernel test to `base-b-kernel-unit-1-gpu-large` + `nightly-kernel-1-gpu`). AMD's `nightly-amd-kernel-1-gpu` suite is already wired in `nightly-test-amd.yml` / `nightly-test-amd-rocm720.yml`, so **no workflow changes** are needed.

## Approach — purely additive, AMD-only

- Each file keeps its existing `register_cuda_ci(...)`; we only add one `register_amd_ci(..., nightly=True)` line.
- No new files, no moves, no workflow changes. Legacy `sgl-kernel/tests/` and NV / MUSA jobs untouched.

## Scope note (why these and not the rest)

Candidates were trial-registered and run on both ROCm stacks; only the ones green on **both** are kept. The remainder were dropped — their failures are **environment / portability gaps, not registration issues** (confirmed from run logs):
- Missing dep on ROCm (`flashinfer`) → norm / rope family (`test_rmsnorm`, `test_qknorm`, `test_rope`, ...).
- JIT sources `#include` raw CUDA headers not hipified on ROCm (`cuda_runtime.h`, `cuda_fp16.h`, `cuda/ptx`, `cub/cub.cuh`, `cooperative_groups/reduce.h`) → `ninja` compile failures.
- AOT `sgl_kernel` ops not built on the ROCm images (e.g. `concat_mla_*`, `sgl_per_token_group_quant_8bit_v2`); `renorm` op not registered.
- wave64 portability: 32-bit `__shfl_sync` mask static-assert (`test_grouped_topk`).
- JIT runtime `Tensor match failed` on ROCm device (`test_add_constant`, `test_ngram_embedding`; incl. fp8 `e4m3fnuz` vs `e4m3fn`).
- `diffusers` dep (`test_timestep_embedding`).
- `test_moe_align_block_size`: 4392-case matrix all fail + 900s timeout.

These can be revisited once the ROCm jit-build / deps gaps are addressed (separate effort).

## Verification

- `collect_tests(sanity_check=True)` passes; all 7 register to `nightly-amd-kernel-1-gpu` (each has a `__main__` entry).
- `ruff`, `isort`, `black` clean.

## Test plan

- [x] AMD nightly `nightly-amd-kernel-1-gpu` runs all 7 on ROCm 7.0 and 7.2 (validated green on both — see runtime table).
- [x] No change to NV / MUSA / per-commit AMD behavior (CUDA registrations untouched).
