### PR TITLE
[AMD] [GLM5] Add opt-in Triton fp8 sparse-MLA prefill kernel for gfx950

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/triton_sparse_mla.py
+++ b/python/sglang/srt/layers/attention/dsa/triton_sparse_mla.py
@@ -1,0 +1,160 @@
+"""Triton sparse-MLA forward for the DSA fp8 prefill path.
+
+A per-query flash-attention kernel over the indexer-selected topk KV. On
+gfx950 this is ~1.6x faster than the TileLang partial+combine kernel for the
+prefill regime (n_groups=1): the attention tile is tiny (M=16 heads = one
+16x16 MFMA), so a small-warp per-program kernel avoids the intra-block
+coordination overhead of the 256-thread TileLang block.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+
+_IS_FNUZ = is_fp8_fnuz()
+_FP8_MAX = 240.0 if _IS_FNUZ else 448.0
+
+
+def _prune_configs(configs, named_args, **kwargs):
+    """Drop configs whose KV tile exceeds topk (pure waste)."""
+    topk = named_args["topk"]
+    keep = [c for c in configs if c.kwargs["BLOCK_N"] <= topk]
+    return keep or [configs[0]]
+
+
+# The best (BLOCK_N, num_warps, num_stages) is shape- and arch-sensitive, so
+# autotune over a grid keyed on the attention shape. Benchmarked once per key
+# (a one-time stall on the first prefill of each new shape), then cached.
+_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": bn}, num_warps=w, num_stages=ns)
+    for bn in (32, 64, 128)
+    for w in (1, 2, 4)
+    for ns in (1, 2)
+]
+
+
+@triton.autotune(
+    configs=_AUTOTUNE_CONFIGS,
+    key=["topk", "H", "DIM"],
+    prune_configs_by={"early_config_prune": _prune_configs},
+)
+@triton.jit
+def _sparse_mla_fwd_kernel(
+    q_nope_ptr,
+    q_rope_ptr,
+    kv_ptr,
+    idx_ptr,
+    o_ptr,
+    sm_scale,
+    fp8_max,
+    topk,
+    H: tl.constexpr,
+    DIM: tl.constexpr,
+    D_V: tl.constexpr,
+    D_TAIL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    s_i = tl.program_id(0)
+
+    h = tl.arange(0, H)
+    dv = tl.arange(0, D_V)
+    dt = tl.arange(0, D_TAIL)
+    # q is read as two separate tensors (q_nope width D_V, q_rope width D_TAIL):
+    # the upstream concat into a single [.., DIM] tensor is skipped since this
+    # kernel splits q into main/tail anyway.
+    q_main = tl.load(q_nope_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :]).to(
+        q_nope_ptr.dtype.element_ty
+    )  # [H, D_V]
+    q_tail = tl.load(
+        q_rope_ptr + s_i * H * D_TAIL + h[:, None] * D_TAIL + dt[None, :]
+    ).to(
+        q_nope_ptr.dtype.element_ty
+    )  # [H, D_TAIL]
+
+    m_i = tl.full([H], -float("inf"), tl.float32)
+    l_i = tl.zeros([H], tl.float32)
+    acc = tl.zeros([H, D_V], tl.float32)
+
+    n = tl.arange(0, BLOCK_N)
+    for k0 in range(0, topk, BLOCK_N):
+        kmask = (k0 + n) < topk
+        idx = tl.load(idx_ptr + s_i * topk + k0 + n, mask=kmask, other=-1)
+        valid = (idx >= 0) & kmask
+        page = tl.where(valid, idx, 0)
+        kbase = kv_ptr + page[:, None] * DIM
+        kv_main = tl.load(kbase + dv[None, :], mask=valid[:, None], other=0.0).to(
+            q_nope_ptr.dtype.element_ty
+        )  # [BLOCK_N, D_V] -- reused as V
+        kv_tail = tl.load(
+            kbase + (D_V + dt)[None, :], mask=valid[:, None], other=0.0
+        ).to(
+            q_nope_ptr.dtype.element_ty
+        )  # [BLOCK_N, D_TAIL]
+
+        qk = tl.dot(q_main, tl.trans(kv_main)).to(tl.float32)
+        qk += tl.dot(q_tail, tl.trans(kv_tail)).to(tl.float32)
+        qk = qk * sm_scale
+        qk = tl.where(valid[None, :], qk, -float("inf"))
+
+        m_new = tl.maximum(m_i, tl.max(qk, axis=1))
+        # Guard an all-masked row (m_new == -inf): shift by 0 instead so that
+        # exp(-inf - 0) = 0 rather than exp(-inf + inf) = NaN. Identical to
+        # m_new whenever the row has >=1 valid key.
+        m_safe = tl.where(m_new == -float("inf"), 0.0, m_new)
+        alpha = tl.exp(m_i - m_safe)
+        p = tl.exp(qk - m_safe[:, None])  # [H, BLOCK_N]
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+
+        p_fp8 = (p * fp8_max).to(q_nope_ptr.dtype.element_ty)
+        pv = tl.dot(p_fp8, kv_main).to(tl.float32) * (1.0 / fp8_max)
+        acc = acc * alpha[:, None] + pv
+        m_i = m_new
+
+    l_safe = tl.where(l_i == 0.0, 1.0, l_i)
+    acc = acc / l_safe[:, None]
+    tl.store(
+        o_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :],
+        acc.to(o_ptr.dtype.element_ty),
+    )
+
+
+def triton_sparse_mla_fwd(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    d_v: int = 512,
+) -> torch.Tensor:
+    """q_nope: [seq, H, d_v] fp8, q_rope: [seq, H, dim-d_v] fp8,
+    kv: [num_pages, 1, dim] fp8, indices: [seq, 1, topk].
+
+    Reads q from the two un-concatenated tensors directly (no q_nope/q_rope
+    concat). Returns [1, seq, H, d_v] bf16 to match tilelang_sparse_fwd.
+    """
+    seq, H, d_v_in = q_nope.shape
+    assert d_v_in == d_v
+    d_tail = q_rope.shape[-1]
+    dim = kv.shape[-1]
+    topk = indices.shape[-1]
+    q_nope = q_nope.contiguous()
+    q_rope = q_rope.contiguous()
+    out = torch.empty(seq, H, d_v, device=q_nope.device, dtype=torch.bfloat16)
+    # BLOCK_N / num_warps / num_stages are chosen by @triton.autotune.
+    _sparse_mla_fwd_kernel[(seq,)](
+        q_nope,
+        q_rope,
+        kv,
+        indices,
+        out,
+        sm_scale,
+        _FP8_MAX,
+        topk,
+        H=H,
+        DIM=dim,
+        D_V=d_v,
+        D_TAIL=d_tail,
+    )
+    return out.unsqueeze(0)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -50,7 +50,20 @@ from sglang.srt.layers.attention.utils import (
     seqlens_expand_triton,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.utils import is_cuda, is_hip, is_sm100_supported
+from sglang.srt.utils import (
+    get_bool_env_var,
+    is_cuda,
+    is_gfx95_supported,
+    is_hip,
+    is_sm100_supported,
+)
+
+# Opt-in (default off): route the fp8 sparse-MLA prefill path through the Triton
+# per-query flash kernel instead of TileLang. Validated on gfx950 (GLM-5.1 @
+# TP4: 16 heads, d_v=512, tail=64). Reads q_nope/q_rope directly (skips the
+# concat). Enable with SGLANG_DSA_TRITON_PREFILL=1. Decode stays on TileLang.
+_DSA_TRITON_PREFILL = get_bool_env_var("SGLANG_DSA_TRITON_PREFILL")
+_IS_GFX95 = is_gfx95_supported()
 
 if is_cuda():
     import deep_gemm
@@ -1648,6 +1661,32 @@ class DeepseekSparseAttnBackend(
 
         if dsa_impl == "tilelang":
             if q_rope is not None:
+                # Triton prefill kernel reads q_nope/q_rope directly, skipping
+                # the concat (it splits q into main/tail internally anyway).
+                # Gated to gfx950 + the validated shape (16 heads, d_v=512,
+                # tail=64, topk=2048); everything else uses TileLang.
+                if (
+                    _DSA_TRITON_PREFILL
+                    and _IS_GFX95
+                    and kv_cache.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+                    and layer.tp_q_head_num == 16
+                    and layer.v_head_dim == 512
+                    and (layer.head_dim - layer.v_head_dim) == 64
+                    and page_table_1.shape[-1] == 2048
+                    and q_nope.shape[0] >= 512
+                ):
+                    from sglang.srt.layers.attention.dsa.triton_sparse_mla import (
+                        triton_sparse_mla_fwd,
+                    )
+
+                    return triton_sparse_mla_fwd(
+                        q_nope=q_nope,
+                        q_rope=q_rope,
+                        kv=kv_cache,
+                        indices=page_table_1.unsqueeze(1),
+                        sm_scale=layer.scaling,
+                        d_v=layer.v_head_dim,
+                    )
                 q_all = concat_mla_absorb_q_general(q_nope, q_rope)
             return self._forward_tilelang(
                 q_all=q_all,


### PR DESCRIPTION
## Motivation

This affects HIP serving of DSA (DeepSeek Sparse Attention) models; it was found
and validated on **GLM-5.1-MXFP4** (which uses the DSA indexer) on MI350X.

On the HIP fp8 path, `tilelang_sparse_fwd` runs the *same* TileLang
partial+combine kernel for prefill as for decode. The sparse-MLA attention tile
is tiny — `M = 16` heads (one `16x16` MFMA) — so the 256-thread (4-warp)
TileLang block over-parallelizes it and spends most of its time on intra-block
coordination rather than the matmuls (profiling at the prefill config on gfx950
shows the kernel VALU-bound at ~42% with MFMA at ~12% and ~37% occupancy).

A per-query Triton flash kernel with a small `2-warp` / `BLOCK_N=32` tile fits
the problem shape and saturates the GPU on block count instead. It also reads
`q_nope`/`q_rope` directly, skipping the per-layer concat (the kernel splits q
into main/tail internally anyway, so combining them first is wasted work — and
the HIP path uses a plain `torch.cat`, not the fused CUDA concat). Decode is
left on TileLang.

## Modifications

- New `python/sglang/srt/layers/attention/dsa/triton_sparse_mla.py`: a per-query
  Triton flash kernel over the indexer-selected topk KV. Autotuned over
  `BLOCK_N`/`num_warps`/`num_stages`; guards an all-masked query row against
  `NaN` (finite softmax shift when the row has no valid key). Reads `q_nope`
  (width `d_v`) and `q_rope` (width `dim-d_v`) as two separate tensors.
- `python/sglang/srt/layers/attention/dsa_backend.py`: in `forward_extend`, route
  the fp8 prefill path to the Triton kernel and pass `q_nope`/`q_rope` directly,
  skipping `concat_mla_absorb_q_general`.
  - **Opt-in, default off**: enable with `SGLANG_DSA_TRITON_PREFILL=1`.
  - Gated to gfx950 + the validated shape (`num_heads==16`, `d_v==512`,
    `tail==64`, `topk==2048`); other archs/shapes use TileLang.
  - Prefill only; decode stays on TileLang.

## Accuracy Tests

GSM8K 5-shot, full 1319 questions, GLM-5.1-MXFP4, MI350X (gfx950), tp4,
fp8_e4m3 KV:

| | accuracy |
|---|---|
| TileLang prefill (default) | 0.938 |
| Triton prefill (`SGLANG_DSA_TRITON_PREFILL=1`) | 0.941 |

No regression.

## Speed Benchmarks

E2E `sglang.bench_serving` (random, input 8192 / output 1024, median latencies),
GLM-5.1-MXFP4 / MI350X / tp4 / fp8_e4m3 KV.

Baseline (TileLang prefill):

| concurrency | total tok/s | TTFT (ms) | ITL (ms) | E2EL (ms) |
|---|---|---|---|---|
| 2 | 944 | 920 | 17.74 | 19491 |
| 4 | 1717 | 1752 | 18.56 | 21436 |
| 8 | 2847 | 2887 | 20.66 | 25895 |
| 16 | 4343 | 5116 | 24.23 | 33946 |
| 32 | 6233 | 9588 | 28.68 | 47438 |
| 64 | 8158 | 18558 | 35.54 | 72308 |

This PR (`SGLANG_DSA_TRITON_PREFILL=1`):

| concurrency | total tok/s | TTFT (ms) | TTFT delta | ITL (ms) | E2EL (ms) |
|---|---|---|---|---|---|
| 2 | 957 | 798 | -13.3% | 17.71 | 19228 |
| 4 | 1738 | 1511 | -13.8% | 18.58 | 21126 |
| 8 | 2922 | 2486 | -13.9% | 20.73 | 25217 |
| 16 | 4515 | 4410 | -13.8% | 24.22 | 32655 |
| 32 | 6574 | 8276 | -13.7% | 28.56 | 44814 |
| 64 | 8750 | 16051 | -13.5% | 35.36 | 67431 |

Median TTFT improves 13.3-13.9% across the sweep; median ITL is unchanged
(within +/-0.5%) and median E2EL is flat-to-better, confirming the change is
prefill-side with no decode regression.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27994768455](https://github.com/sgl-project/sglang/actions/runs/27994768455)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #27994768350](https://github.com/sgl-project/sglang/actions/runs/27994768350)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->