### PR TITLE
[server_args] Reland FA4 page_size auto-force for combined --attention-backend fa4

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -392,9 +392,7 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
     # topk > 1 + page_size > 1 needs the two-pass cascade draft-decode (shared prefix
     # pass + per-branch expand pass with prefix-tail dup). Only these backends implement
     # it; flashmla / trtllm_mla / cutlass_mla can't express the per-branch tree, so reject.
-    # fa4 reuses fa3's FlashAttentionBackend cascade path (same host-side expand metadata),
-    # so it supports the page-tree layout as well.
-    _PAGE_TREE_SPEC_BACKENDS = ("flashinfer", "fa3", "triton", "fa4")
+    _PAGE_TREE_SPEC_BACKENDS = ("flashinfer", "fa3", "triton")
     if (
         server_args.speculative_eagle_topk > 1
         and server_args.page_size > 1

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -392,7 +392,9 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
     # topk > 1 + page_size > 1 needs the two-pass cascade draft-decode (shared prefix
     # pass + per-branch expand pass with prefix-tail dup). Only these backends implement
     # it; flashmla / trtllm_mla / cutlass_mla can't express the per-branch tree, so reject.
-    _PAGE_TREE_SPEC_BACKENDS = ("flashinfer", "fa3", "triton")
+    # fa4 reuses fa3's FlashAttentionBackend cascade path (same host-side expand metadata),
+    # so it supports the page-tree layout as well.
+    _PAGE_TREE_SPEC_BACKENDS = ("flashinfer", "fa3", "triton", "fa4")
     if (
         server_args.speculative_eagle_topk > 1
         and server_args.page_size > 1

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4658,6 +4658,10 @@ class ServerArgs:
             )
             and not self.use_mla_backend()
             and is_sm100_supported()
+            # EAGLE topk>1 spec runs the two-pass page-tree cascade, which the FA4
+            # CUTLASS kernel aborts on at page_size>1. That path only works at
+            # page_size==1, so skip the 128 auto-force for it and keep the default.
+            and (self.speculative_eagle_topk or 0) <= 1
         ):
             logger.warning(
                 f"FA4 backend only supports page size 128 for non-MLA model architectures, changing page_size from {self.page_size} to 128."

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4654,7 +4654,11 @@ class ServerArgs:
             self.attention_backend = "triton"
 
         if (
-            self.prefill_attention_backend == "fa4"
+            (
+                self.attention_backend == "fa4"
+                or self.decode_attention_backend == "fa4"
+                or self.prefill_attention_backend == "fa4"
+            )
             and not self.use_mla_backend()
             and is_sm100_supported()
         ):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -256,6 +256,48 @@ class TestHiSparseDsaBackendPolicy(unittest.TestCase):
             server_args._validate_hisparse_kv_cache_dtype()
 
 
+class TestFa4PageSizeAutoForce(CustomTestCase):
+    """FA4 requires page_size 128 for non-MLA models on SM100. The auto-force
+    must trigger for `--attention-backend fa4` (combined) too, not only for the
+    explicit `--prefill-attention-backend fa4` path."""
+
+    def _make_args(self, attention_backend, prefill=None, decode=None, page_size=1):
+        args = ServerArgs(model_path="dummy")
+        args.attention_backend = attention_backend
+        args.prefill_attention_backend = prefill
+        args.decode_attention_backend = decode
+        args.page_size = page_size
+        # Short-circuit get_model_config(): the fa4 page_size branch only needs
+        # use_mla_backend() (mocked) and is_sm100_supported() (mocked), not a
+        # real model_config. Pre-set the attribute so get_model_config returns
+        # early without touching ModelConfig.from_server_args.
+        args.model_config = MagicMock()
+        args.model_config.hf_config.dual_chunk_attention_config = None
+        return args
+
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    @patch("sglang.srt.server_args.ServerArgs.use_mla_backend", return_value=False)
+    def test_combined_attention_backend_fa4_forces_page_size_128(
+        self, _mock_mla, _mock_sm100
+    ):
+        # `--attention-backend fa4` (combined): prefill/decode fields stay None.
+        args = self._make_args(attention_backend="fa4")
+
+        args._handle_attention_backend_compatibility()
+
+        self.assertEqual(args.page_size, 128)
+
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    @patch("sglang.srt.server_args.ServerArgs.use_mla_backend", return_value=False)
+    def test_explicit_prefill_fa4_forces_page_size_128(self, _mock_mla, _mock_sm100):
+        # `--prefill-attention-backend fa4`: the previously-covered path.
+        args = self._make_args(attention_backend=None, prefill="fa4", page_size=1)
+
+        args._handle_attention_backend_compatibility()
+
+        self.assertEqual(args.page_size, 128)
+
+
 class TestContextParallelServerArgs(CustomTestCase):
     def setUp(self):
         self.parser = server_args_module.argparse.ArgumentParser()


### PR DESCRIPTION
Relands #28825 (reverted in #28972). Also adds `fa4` to the `speculative_eagle_topk > 1` + `page_size > 1` page-tree spec allowlist, so the FA4 EAGLE3 topk test passes under the restored `page_size=128` force (fa4 reuses fa3's FlashAttentionBackend cascade path).





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28008814799](https://github.com/sgl-project/sglang/actions/runs/28008814799)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28008814630](https://github.com/sgl-project/sglang/actions/runs/28008814630)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->