### PR TITLE
[deepep] auto-tune num_max_dispatch_tokens_per_rank from free memory

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -347,13 +347,11 @@ class _DeepEPDispatcherImplBase:
         self.deepep_mode = deepep_mode
 
         self.params_bytes = 2
-        # A large value will lead to large memory occupation, thus users should change it accordingly
-        self.num_max_dispatch_tokens_per_rank = (
-            envs.SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
-        )
-        # DeepEP internode_ll dispatch uses FINISHED_SUM_TAG=1024
-        # and the logic requires num-tokens-sent-from-one-rank-to-another-rank less than it
-        assert self.num_max_dispatch_tokens_per_rank <= 1024
+        # Resolved lazily on first use rather than cached here: model_runner may
+        # auto-tune SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK from post-KV
+        # free memory after this dispatcher is constructed but before the first
+        # forward (ModelRunner._maybe_auto_tune_deepep_num_max_dispatch_tokens).
+        self._num_max_dispatch_tokens_per_rank: Optional[int] = None
 
         self.handle = None
 
@@ -363,6 +361,18 @@ class _DeepEPDispatcherImplBase:
         self.meta_overlap_args: Optional[dict] = None
 
         self.set_deepep_dispatcher_dtype()
+
+    @property
+    def num_max_dispatch_tokens_per_rank(self) -> int:
+        # Cache on first read so the per-dispatch path stays free of env lookups,
+        # while still honoring a value auto-tuned after construction.
+        if self._num_max_dispatch_tokens_per_rank is None:
+            value = envs.SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
+            # DeepEP internode_ll dispatch uses FINISHED_SUM_TAG=1024 and requires
+            # num-tokens-sent-from-one-rank-to-another-rank below it.
+            assert value <= 1024
+            self._num_max_dispatch_tokens_per_rank = value
+        return self._num_max_dispatch_tokens_per_rank
 
     def dispatch_a(
         self,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -890,6 +890,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         because they capture their own decode-style graphs separately.
         """
 
+        # Pick the DeepEP low_latency dispatch cap before any DeepEP buffer is
+        # created or the capture list is built — both read the env downstream.
+        self._maybe_auto_tune_deepep_num_max_dispatch_tokens()
+
         # The eager (no-cuda-graph) phase runner, built AFTER the attention
         # backend so its __init__ can warm up kernels (run-once) and allocate the
         # fixed-max static buffer — both before the cuda-graph runners, so that
@@ -929,6 +933,52 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         if self.canary_manager is not None and not self.is_draft_worker:
             self.canary_manager.mark_init_finished()
+
+    def _maybe_auto_tune_deepep_num_max_dispatch_tokens(self):
+        """Auto-pick SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK for the
+        DeepEP low_latency path from post-KV free memory.
+
+        DeepEP caps per-rank dispatch tokens at this value; the default (128)
+        forces DP+DeepEP high-throughput serving to hand-set it just to avoid
+        the dispatch assertion (deep_ep.cpp) at high concurrency, and the same
+        value bounds the cuda-graph capture list (get_batch_sizes_to_capture).
+        Raising it costs cuda-graph capture-activation memory, which is what
+        OOMs on smaller GPUs (e.g. H200) — so the cap is chosen from free GPU
+        memory measured after the KV pool is allocated. An explicit user env
+        always wins, and the value is only ever raised above the default.
+        """
+        env = envs.SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK
+        if env.is_set():
+            return
+        if (
+            self.server_args.moe_a2a_backend != "deepep"
+            or self.server_args.deepep_mode == "normal"
+        ):
+            return
+
+        # Min across ranks so every rank picks the same cap (the DeepEP buffer
+        # is collective and must be sized identically on all ranks).
+        free_gb = get_available_gpu_memory(
+            self.device,
+            self.gpu_id,
+            distributed=get_world_group().world_size > 1,
+            cpu_group=get_world_group().cpu_group,
+        )
+
+        if free_gb >= 32:
+            num_max = 512
+        elif free_gb >= 20:
+            num_max = 256
+        else:
+            num_max = 128
+
+        if num_max > env.get():
+            env.set(num_max)
+        log_info_on_rank0(
+            logger,
+            f"Auto-tuned SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK="
+            f"{num_max} (post-KV free mem={free_gb:.1f} GB).",
+        )
 
     def adjust_hybrid_swa_layers_for_pp(self):
         if not self.is_hybrid_swa:

--- a/python/sglang/srt/model_executor/runner/base_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_cuda_graph_runner.py
@@ -22,6 +22,7 @@ from abc import abstractmethod
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, List, Sequence, Tuple
 
+from sglang.srt.environ import envs
 from sglang.srt.model_executor.runner.base_runner import BaseRunner
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import require_gathered_buffer
@@ -90,6 +91,17 @@ def get_batch_sizes_to_capture(
     capture_bs = [bs for bs in capture_bs if bs * num_tokens_per_bs % mul_base == 0]
     capture_bs = [bs for bs in capture_bs if bs <= num_max_requests]
     capture_bs = list(sorted(set(capture_bs)))
+
+    # DeepEP low_latency dispatch caps per-rank dispatch tokens at
+    # num_max_dispatch_tokens_per_rank (default 128). When the MoE A2A backend is
+    # DeepEP and the mode runs the low_latency path (auto/low_latency, not normal),
+    # a decode capture bs above that cap overflows the dispatch buffer and trips an
+    # assertion during graph capture. Clamp the list so the default capture list
+    # works without forcing the user to set --max-running-requests just to dodge it.
+    if server_args.moe_a2a_backend == "deepep" and server_args.deepep_mode != "normal":
+        deepep_cap = envs.SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
+        if max(capture_bs) > deepep_cap:
+            capture_bs = [bs for bs in capture_bs if bs <= deepep_cap]
 
     assert len(capture_bs) > 0 and capture_bs[0] > 0, f"{capture_bs=}"
     compile_bs = (

--- a/test/registered/unit/model_executor/test_deepep_auto_tune.py
+++ b/test/registered/unit/model_executor/test_deepep_auto_tune.py
@@ -1,0 +1,154 @@
+"""Unit tests for DeepEP num_max_dispatch_tokens_per_rank auto-tuning.
+
+Two pieces, both CPU-only and fully mocked:
+  - The dispatcher resolves SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK
+    lazily (honoring a value auto-tuned after construction) and caches it.
+  - ModelRunner._maybe_auto_tune_deepep_num_max_dispatch_tokens picks the cap
+    from post-KV free memory, only for the DeepEP low_latency path, and never
+    overrides an explicit user env.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+_ENV = envs.SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK
+
+try:
+    from sglang.srt.layers.moe.token_dispatcher.deepep import _DeepEPDispatcherImplBase
+
+    _HAS_DEEPEP_MODULE = True
+except Exception:
+    _HAS_DEEPEP_MODULE = False
+
+try:
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+    _HAS_MODEL_RUNNER = True
+except Exception:
+    _HAS_MODEL_RUNNER = False
+
+
+@contextlib.contextmanager
+def _env_unset():
+    """Run with the env cleared, restoring whatever was there afterward."""
+    was_set = _ENV.is_set()
+    old = _ENV.get() if was_set else None
+    _ENV.clear()
+    try:
+        yield
+    finally:
+        if was_set:
+            _ENV.set(old)
+        else:
+            _ENV.clear()
+
+
+@unittest.skipUnless(_HAS_DEEPEP_MODULE, "deepep token dispatcher not importable")
+class TestDeepEPNumMaxDispatchTokensProperty(unittest.TestCase):
+    """The dispatcher field resolves from the env lazily, then caches."""
+
+    def _stub(self):
+        # Skip __init__ (needs DeepEP + a process group); only the lazy field matters.
+        stub = _DeepEPDispatcherImplBase.__new__(_DeepEPDispatcherImplBase)
+        stub._num_max_dispatch_tokens_per_rank = None
+        return stub
+
+    def test_resolves_default_when_unset(self):
+        with _env_unset():
+            self.assertEqual(self._stub().num_max_dispatch_tokens_per_rank, 128)
+
+    def test_resolves_value_set_after_construction(self):
+        stub = self._stub()
+        with _ENV.override(512):
+            self.assertEqual(stub.num_max_dispatch_tokens_per_rank, 512)
+
+    def test_caches_first_read(self):
+        stub = self._stub()
+        with _ENV.override(256):
+            self.assertEqual(stub.num_max_dispatch_tokens_per_rank, 256)
+        # Env moved after the first read; the cached value must not follow it.
+        with _ENV.override(512):
+            self.assertEqual(stub.num_max_dispatch_tokens_per_rank, 256)
+
+    def test_rejects_above_hard_cap(self):
+        stub = self._stub()
+        with _ENV.override(2048):
+            with self.assertRaises(AssertionError):
+                _ = stub.num_max_dispatch_tokens_per_rank
+
+
+@unittest.skipUnless(_HAS_MODEL_RUNNER, "model_runner not importable")
+class TestDeepEPAutoTune(unittest.TestCase):
+    """ModelRunner._maybe_auto_tune_deepep_num_max_dispatch_tokens behavior."""
+
+    def _runner(self, backend="deepep", mode="auto"):
+        return SimpleNamespace(
+            server_args=SimpleNamespace(moe_a2a_backend=backend, deepep_mode=mode),
+            device="cuda",
+            gpu_id=0,
+        )
+
+    def _run(self, runner, free_gb):
+        with patch(
+            "sglang.srt.model_executor.model_runner.get_available_gpu_memory",
+            return_value=free_gb,
+        ), patch(
+            "sglang.srt.model_executor.model_runner.get_world_group",
+            return_value=SimpleNamespace(world_size=1, cpu_group=None),
+        ):
+            ModelRunner._maybe_auto_tune_deepep_num_max_dispatch_tokens(runner)
+
+    def test_user_env_always_wins(self):
+        with _ENV.override(700):
+            self._run(self._runner(), free_gb=200)
+            self.assertEqual(_ENV.get(), 700)
+
+    def test_no_op_for_non_deepep_backend(self):
+        with _env_unset():
+            self._run(self._runner(backend="none"), free_gb=200)
+            self.assertFalse(_ENV.is_set())
+
+    def test_no_op_for_normal_mode(self):
+        with _env_unset():
+            self._run(self._runner(mode="normal"), free_gb=200)
+            self.assertFalse(_ENV.is_set())
+
+    def test_picks_512_with_ample_free_mem(self):
+        with _env_unset():
+            self._run(self._runner(), free_gb=40)
+            self.assertEqual(_ENV.get(), 512)
+
+    def test_picks_512_at_threshold(self):
+        with _env_unset():
+            self._run(self._runner(), free_gb=32)
+            self.assertEqual(_ENV.get(), 512)
+
+    def test_picks_256_in_mid_band(self):
+        with _env_unset():
+            self._run(self._runner(mode="low_latency"), free_gb=25)
+            self.assertEqual(_ENV.get(), 256)
+
+    def test_picks_256_at_threshold(self):
+        with _env_unset():
+            self._run(self._runner(), free_gb=20)
+            self.assertEqual(_ENV.get(), 256)
+
+    def test_keeps_default_128_when_low(self):
+        with _env_unset():
+            self._run(self._runner(), free_gb=15)
+            # 128 == default: never written, so the env stays unset.
+            self.assertFalse(_ENV.is_set())
+            self.assertEqual(_ENV.get(), 128)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1154,5 +1154,97 @@ class TestSamplingBackendTokenOracleEnvGate(CustomTestCase):
         self.assertEqual(parsed.sampling_backend, "token_oracle")
 
 
+class TestDeepEPCaptureBsClamp(unittest.TestCase):
+    """get_batch_sizes_to_capture clamps the decode capture list to the
+    DeepEP low_latency dispatch buffer when deepep runs the low_latency path,
+    so HT can drop --max-running-requests without tripping the dispatch
+    assertion during graph capture.
+    """
+
+    def _make_runner(self, deepep_mode, max_running_requests=None):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="deepep",
+            deepep_mode=deepep_mode,
+        )
+        server_args.deepep_mode = deepep_mode
+        server_args.enable_torch_compile = False
+        # Default decode capture list (max_bs=512): includes 256 and 512.
+        server_args.cuda_graph_config.decode.bs = (
+            server_args._generate_decode_cuda_graph_batch_sizes(512)
+        )
+        runner = MagicMock()
+        runner.server_args = server_args
+        # req_to_token_pool.size large enough not to clamp before the DeepEP gate.
+        runner.req_to_token_pool.size = 2048
+        return runner
+
+    @patch(
+        "sglang.srt.model_executor.runner.base_cuda_graph_runner.require_gathered_buffer",
+        return_value=False,
+    )
+    @patch("sglang.srt.model_executor.runner.base_cuda_graph_runner.get_parallel")
+    def test_clamps_to_deepep_buffer_in_auto_mode(self, mock_get_parallel, _):
+        from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+            get_batch_sizes_to_capture,
+        )
+
+        mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
+        runner = self._make_runner("auto")
+        capture_bs, _ = get_batch_sizes_to_capture(runner)
+        self.assertGreater(max(capture_bs), 0)
+        # DeepEP low_latency buffer default is 128; capture list must not exceed it.
+        self.assertLessEqual(max(capture_bs), 128)
+        self.assertIn(128, capture_bs)
+
+    @patch(
+        "sglang.srt.model_executor.runner.base_cuda_graph_runner.require_gathered_buffer",
+        return_value=False,
+    )
+    @patch("sglang.srt.model_executor.runner.base_cuda_graph_runner.get_parallel")
+    def test_clamps_to_deepep_buffer_in_low_latency_mode(self, mock_get_parallel, _):
+        from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+            get_batch_sizes_to_capture,
+        )
+
+        mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
+        runner = self._make_runner("low_latency")
+        capture_bs, _ = get_batch_sizes_to_capture(runner)
+        self.assertLessEqual(max(capture_bs), 128)
+
+    @patch(
+        "sglang.srt.model_executor.runner.base_cuda_graph_runner.require_gathered_buffer",
+        return_value=False,
+    )
+    @patch("sglang.srt.model_executor.runner.base_cuda_graph_runner.get_parallel")
+    def test_does_not_clamp_in_normal_mode(self, mock_get_parallel, _):
+        # normal mode disables cuda graph; the clamp must not fire.
+        from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+            get_batch_sizes_to_capture,
+        )
+
+        mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
+        runner = self._make_runner("normal")
+        capture_bs, _ = get_batch_sizes_to_capture(runner)
+        # 512 is in the default list and normal mode must NOT clamp it away.
+        self.assertIn(512, capture_bs)
+
+    @patch(
+        "sglang.srt.model_executor.runner.base_cuda_graph_runner.require_gathered_buffer",
+        return_value=False,
+    )
+    @patch("sglang.srt.model_executor.runner.base_cuda_graph_runner.get_parallel")
+    def test_does_not_clamp_non_deepep_backend(self, mock_get_parallel, _):
+        from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+            get_batch_sizes_to_capture,
+        )
+
+        mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
+        runner = self._make_runner("auto")
+        runner.server_args.moe_a2a_backend = "none"
+        capture_bs, _ = get_batch_sizes_to_capture(runner)
+        self.assertIn(512, capture_bs)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1161,17 +1161,24 @@ class TestDeepEPCaptureBsClamp(unittest.TestCase):
     assertion during graph capture.
     """
 
-    def _make_runner(self, deepep_mode, max_running_requests=None):
-        server_args = ServerArgs(
-            model_path="dummy",
-            moe_a2a_backend="deepep",
-            deepep_mode=deepep_mode,
+    def _make_runner(self, moe_a2a_backend="deepep", deepep_mode="auto"):
+        # The non-spec decode capture list for max_bs=512 (see
+        # _generate_decode_cuda_graph_batch_sizes): includes 256 and 512.
+        decode_bs = (
+            [1, 2, 4, 8, 12]
+            + list(range(16, 257, 8))
+            + list(range(272, 512, 16))
+            + [512]
         )
-        server_args.deepep_mode = deepep_mode
-        server_args.enable_torch_compile = False
-        # Default decode capture list (max_bs=512): includes 256 and 512.
-        server_args.cuda_graph_config.decode.bs = (
-            server_args._generate_decode_cuda_graph_batch_sizes(512)
+        server_args = SimpleNamespace(
+            moe_a2a_backend=moe_a2a_backend,
+            deepep_mode=deepep_mode,
+            enable_two_batch_overlap=False,
+            enable_torch_compile=False,
+            torch_compile_max_bs=32,
+            cuda_graph_config=SimpleNamespace(
+                decode=SimpleNamespace(bs=list(decode_bs)),
+            ),
         )
         runner = MagicMock()
         runner.server_args = server_args
@@ -1190,7 +1197,7 @@ class TestDeepEPCaptureBsClamp(unittest.TestCase):
         )
 
         mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
-        runner = self._make_runner("auto")
+        runner = self._make_runner("deepep", "auto")
         capture_bs, _ = get_batch_sizes_to_capture(runner)
         self.assertGreater(max(capture_bs), 0)
         # DeepEP low_latency buffer default is 128; capture list must not exceed it.
@@ -1208,7 +1215,7 @@ class TestDeepEPCaptureBsClamp(unittest.TestCase):
         )
 
         mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
-        runner = self._make_runner("low_latency")
+        runner = self._make_runner("deepep", "low_latency")
         capture_bs, _ = get_batch_sizes_to_capture(runner)
         self.assertLessEqual(max(capture_bs), 128)
 
@@ -1224,7 +1231,7 @@ class TestDeepEPCaptureBsClamp(unittest.TestCase):
         )
 
         mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
-        runner = self._make_runner("normal")
+        runner = self._make_runner("deepep", "normal")
         capture_bs, _ = get_batch_sizes_to_capture(runner)
         # 512 is in the default list and normal mode must NOT clamp it away.
         self.assertIn(512, capture_bs)
@@ -1240,8 +1247,7 @@ class TestDeepEPCaptureBsClamp(unittest.TestCase):
         )
 
         mock_get_parallel.return_value = SimpleNamespace(attn_tp_size=1, attn_cp_size=1)
-        runner = self._make_runner("auto")
-        runner.server_args.moe_a2a_backend = "none"
+        runner = self._make_runner("none", "auto")
         capture_bs, _ = get_batch_sizes_to_capture(runner)
         self.assertIn(512, capture_bs)
 


### PR DESCRIPTION
> **Stacked on #28914 — merge that first.** This branch builds on the capture-list clamp from #28914; until it lands, the first two commits in this PR's diff belong to #28914 (they vanish once #28914 merges and this rebases onto `main`). Review/merge order: #28914 → this.

## Motivation

DeepEP's `low_latency` dispatch caps per-rank tokens at `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK` (default `128`). For DP + DeepEP high-throughput serving this bites in two places:

1. **runtime decode** — at high concurrency the per-rank decode batch exceeds 128 and trips the DeepEP dispatch assertion (`deep_ep.cpp`).
2. **cuda-graph capture** — the same value bounds the capture list (#28914), and raising it costs capture-activation memory, which OOMs on smaller GPUs.

Today recipes hand-tune this per hardware (raise the value / cap `--max-running-requests`) just to dodge the assertion. This PR makes the default work.

## What it does

When the user has **not** set the env and DeepEP runs the low_latency path (`moe_a2a_backend == "deepep"` and `deepep_mode != "normal"`), `ModelRunner._maybe_auto_tune_deepep_num_max_dispatch_tokens()` picks the cap from **post-KV free GPU memory** (min across ranks, so the collective DeepEP buffer is sized identically everywhere):

| post-KV free mem | cap |
|---|---|
| ≥ 32 GB | 512 |
| ≥ 20 GB | 256 |
| < 20 GB | 128 (default) |

It runs at the top of `init_cuda_graphs` — after the KV pool is allocated, before any DeepEP buffer is created and before the capture list is built — so the chosen value flows into both the capture-list clamp (#28914 reads the env) and the buffer. An explicit user/env value always wins, and the value is only ever raised above the default.

Because the dispatcher caches the env value at construction (model load, before the budget exists), `_DeepEPDispatcherImplBase.num_max_dispatch_tokens_per_rank` becomes a lazily-resolved cached property: the first read happens at the first forward (capture/warmup), after the auto-tune `.set()`, so the buffer and the runtime dispatch cap both pick up the tuned value. The cuda-graph decode path replays without running the Python dispatch, so this adds no per-token env lookup.

This is a buffer-**sizing** change only — it does not touch any forward / kernel / quant / attention math, so a 512 vs 128 buffer produces identical outputs.

## Testing

**Unit** (`test/registered/unit/model_executor/test_deepep_auto_tune.py`, CPU): property lazy-resolve/cache/`≤1024` cap, and the method's gate (user-env-wins, non-deepep no-op, `normal`-mode no-op) and tiering (512/256/128 at thresholds). 12/12 pass.

**e2e** — GLM-5.2-FP8, identical serve flags on both (`--tp N --dp N --enable-dp-attention --moe-a2a-backend deepep --mem-fraction-static 0.85 --cuda-graph-max-bs 512`, no env, no `--max-running-requests`):

- **GB300 (TP4/DP4):** `Auto-tuned …=512 (post-KV free mem=39.5 GB)`; bs→512 captured with no OOM; c1024 bench (2048 prompts, peak concurrent 1221 → per-DP-rank ≈ 253 > 128) → **2048/2048 success, zero dispatch assertion**, 23.9k tok/s total, healthy generation (no runaway/early-stop).
- **H200 (TP8/DP8):** same flags → `Auto-tuned …=128 (post-KV free mem=12.5 GB)`. The capture clamp keeps the list ≤ 128, so capture fits (used 9.97 GB) where bs=512 would OOM; server fires up, `/health` + `/generate` OK.

Same command, GB300 uses the headroom (512) and H200 stays safe (128) — no manual lever on either.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27998716859](https://github.com/sgl-project/sglang/actions/runs/27998716859)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27998716758](https://github.com/sgl-project/sglang/actions/runs/27998716758)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->