### PR TITLE
[CI] Fix AMD extra scheduled runs cancelling each other

### DIFF
--- a/.github/workflows/pr-test-amd-extra.yml
+++ b/.github/workflows/pr-test-amd-extra.yml
@@ -83,8 +83,12 @@ env:
   DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
 
 concurrency:
-  group: pr-test-amd-extra-${{ github.event_name }}-${{ github.head_ref || github.ref_name || 'default' }}-${{ inputs.ref || 'all' }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
+  # Mirror pr-test-amd.yml: schedule/dispatch runs key on run_id (unique group,
+  # never cancel each other); PR runs share a per-branch group so pushes cancel
+  # stale runs. (In a reusable workflow github.event_name is the originating
+  # event, never workflow_call, so the guard keys off the real events.)
+  group: pr-test-amd-extra-${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && format('full-{0}', github.run_id) || github.head_ref || github.ref_name || inputs.ref || 'default' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   actions: write


### PR DESCRIPTION
## Motivation

Scheduled runs of the chained AMD extra suite keep getting cancelled mid-run, e.g. [this job](https://github.com/sgl-project/sglang/actions/runs/27977371862/job/82798476988) failed during *Install dependencies* with:

> `Canceling since a higher priority waiting request for pr-test-amd-extra-schedule-main-all exists`

### Root cause

`pr-test-amd-extra.yml` is invoked via `workflow_call` from the scheduled `pr-test-amd.yml` (cron every 6h). Its concurrency block was:

```yaml
group: pr-test-amd-extra-${{ github.event_name }}-${{ github.head_ref || github.ref_name || 'default' }}-${{ inputs.ref || 'all' }}
cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
```

Two problems for scheduled runs:

1. **The group omits `github.run_id`.** Every 6-hourly scheduled invocation resolves to the *same* string `pr-test-amd-extra-schedule-main-all`, so all scheduled runs land in one concurrency group and compete.
2. **The cancel guard is a no-op.** Inside a reusable workflow, `github.event_name` is the *originating* event (`schedule`), never `workflow_call`, so `cancel-in-progress` is always `true`.

Together, each new scheduled run cancels the still-running previous one.

## Fix

Mirror the parent `pr-test-amd.yml` concurrency pattern:

- Key scheduled / `workflow_dispatch` runs on `github.run_id` so each gets a unique group and they never cancel each other.
- Limit `cancel-in-progress` to `pull_request`, preserving the desired behaviour where a new push supersedes a stale PR run.

```yaml
group: pr-test-amd-extra-${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && format('full-{0}', github.run_id) || github.head_ref || github.ref_name || inputs.ref || 'default' }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Test

- `yaml.safe_load` parses the workflow; pre-commit `check yaml` passes.
- PR runs still share a per-branch group (new push cancels stale run); scheduled/dispatch runs now isolate per `run_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28000070494](https://github.com/sgl-project/sglang/actions/runs/28000070494)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28000070385](https://github.com/sgl-project/sglang/actions/runs/28000070385)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->