### PR TITLE
Revert "[server_args] compute mem_fraction_static after dp chunked-prefill division"

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3266,12 +3266,9 @@ class ServerArgs:
         if self.mem_fraction_static is None:
             # Constant meta data (e.g., from attention backend)
             reserved_mem = 512
-            effective_chunked_prefill_size = self.chunked_prefill_size // (
-                self.dp_size if self.enable_dp_attention and self.dp_size > 1 else 1
-            )
             # For activation during large prefill
             if self.chunked_prefill_size > 0:
-                reserved_mem += max(effective_chunked_prefill_size, 2048) * 1.5
+                reserved_mem += max(self.chunked_prefill_size, 2048) * 1.5
             else:
                 reserved_mem += max(self.max_prefill_tokens, 2048) * 1.5
             # For cuda graphs


### PR DESCRIPTION
Reverts sgl-project/sglang#28884

This breaks the DeepEP-related tests...









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28000732886](https://github.com/sgl-project/sglang/actions/runs/28000732886)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28000732791](https://github.com/sgl-project/sglang/actions/runs/28000732791)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->