### PR TITLE
Fix flaky optimistic prefill retry test

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -361,7 +361,10 @@ class PrefillBootstrapQueue:
                     indices_to_remove.add(i)
                     req.time_stats.set_wait_queue_entry_time()
             elif poll == KVPoll.WaitingForInput:
-                if not self.finalize_bootstrap(req):
+                if should_force_retry(req):  # skip checking for testing
+                    if not self.ensure_metadata_buffer(req):
+                        continue  # no more metadata buffer
+                elif not self.finalize_bootstrap(req):
                     continue
                 bootstrapped_reqs.append(req)
                 indices_to_remove.add(i)


### PR DESCRIPTION
`pop_bootstrapped` finalized a `WaitingForInput` request unconditionally, so a `should_force_retry` request whose bootstrap had already completed skipped the optimistic-retry path entirely — making `test_disaggregation_optimistic_prefill` flaky (e.g. `test_logprob`: retry counter didn't increase).

Now honor `should_force_retry` in that branch (pop optimistically, keep `pending_bootstrap`) so the forced request always reaches `handle_pending_bootstrap` and retries, regardless of bootstrap timing. Matches the existing handling in `resolve_waiting_queue_bootstrap`. Test-hook only — no production behavior change.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28004630870](https://github.com/sgl-project/sglang/actions/runs/28004630870)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28004630695](https://github.com/sgl-project/sglang/actions/runs/28004630695)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->