### PR TITLE
[misc] Add bench_serving compatibility shim

### DIFF
--- a/python/sglang/bench_offline_throughput.py
+++ b/python/sglang/bench_offline_throughput.py
@@ -15,7 +15,7 @@ warnings.warn(
     "`sglang.bench_offline_throughput` is deprecated and will be removed in a "
     "future release; use `sglang.benchmark.offline_throughput` instead "
     "(e.g. `python -m sglang.benchmark.offline_throughput`).",
-    DeprecationWarning,
+    FutureWarning,
     stacklevel=1,
 )
 

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -14,7 +14,7 @@ warnings.warn(
     "`sglang.bench_one_batch` is deprecated and will be removed in a future "
     "release; use `sglang.benchmark.one_batch` instead "
     "(e.g. `python -m sglang.benchmark.one_batch`).",
-    DeprecationWarning,
+    FutureWarning,
     stacklevel=1,
 )
 

--- a/python/sglang/bench_one_batch_server.py
+++ b/python/sglang/bench_one_batch_server.py
@@ -4,8 +4,18 @@
 ``from sglang.bench_one_batch_server import ...`` imports.
 """
 
+import warnings
+
 from sglang.benchmark.one_batch_server import *  # noqa: F401,F403
 from sglang.benchmark.one_batch_server import main
+
+warnings.warn(
+    "`sglang.bench_one_batch_server` is deprecated and will be removed in a "
+    "future release; use `sglang.benchmark.one_batch_server` instead "
+    "(e.g. `python -m sglang.benchmark.one_batch_server`).",
+    DeprecationWarning,
+    stacklevel=1,
+)
 
 if __name__ == "__main__":
     main()

--- a/python/sglang/bench_one_batch_server.py
+++ b/python/sglang/bench_one_batch_server.py
@@ -13,7 +13,7 @@ warnings.warn(
     "`sglang.bench_one_batch_server` is deprecated and will be removed in a "
     "future release; use `sglang.benchmark.one_batch_server` instead "
     "(e.g. `python -m sglang.benchmark.one_batch_server`).",
-    DeprecationWarning,
+    FutureWarning,
     stacklevel=1,
 )
 

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -11,7 +11,7 @@ from sglang.benchmark.serving import (  # noqa: F401
 
 warnings.warn(
     "sglang.bench_serving is deprecated; use sglang.benchmark.serving instead.",
-    DeprecationWarning,
+    FutureWarning,
     stacklevel=1,
 )
 

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility shim for the relocated serving benchmark entrypoint."""
+
+import warnings
+
+from sglang.benchmark.serving import *  # noqa: F403
+from sglang.benchmark.serving import (  # noqa: F401
+    _create_bench_client_session,
+    cli_main,
+)
+
+warnings.warn(
+    "sglang.bench_serving is deprecated; use sglang.benchmark.serving instead.",
+    DeprecationWarning,
+    stacklevel=1,
+)
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -7,9 +7,9 @@
 Benchmark online serving with dynamic requests.
 
 Usage:
-python3 -m sglang.bench_serving --backend sglang --num-prompt 10
+python3 -m sglang.benchmark.serving --backend sglang --num-prompt 10
 
-python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompts 3000 --random-input 1024 --random-output 1024 --random-range-ratio 0.5
+python3 -m sglang.benchmark.serving --backend sglang --dataset-name random --num-prompts 3000 --random-input 1024 --random-output 1024 --random-range-ratio 0.5
 """
 
 import argparse
@@ -2124,7 +2124,7 @@ class LoRAPathAction(argparse.Action):
             getattr(namespace, self.dest).append(lora_name)
 
 
-if __name__ == "__main__":
+def cli_main():
     parser = ArgumentParser(description="Benchmark the online serving throughput.")
     parser.add_argument(
         "--backend",
@@ -2651,3 +2651,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     _validate_parsed_gsp_args(parser, args)
     run_benchmark(args)
+
+
+if __name__ == "__main__":
+    cli_main()


### PR DESCRIPTION
## Motivation

Part of #28969. Stacked on #28996.

This is intentionally opened as a draft until #28996 lands. Before #28996 is merged, GitHub may show the pure rename commit in this PR's diff as well; after #28996 lands, this PR should collapse to the compatibility shim and `cli_main()` extraction.

The previous PR moves in-repo usage to `sglang.benchmark.serving` and intentionally leaves no module at `sglang.bench_serving` so the rename is preserved. This follow-up restores external compatibility for users and scripts that still run `python -m sglang.bench_serving` or import from `sglang.bench_serving`, while nudging migration to the new module path.

## Modifications

- Add `python/sglang/bench_serving.py` as a thin compatibility shim.
- Re-export the serving benchmark module contents, including the helper names used by existing callers.
- Emit a `DeprecationWarning` for the old `sglang.bench_serving` module path.
- Extract `cli_main()` from `sglang.benchmark.serving` so both module paths invoke the same CLI entrypoint.

## Accuracy Tests

N/A -- compatibility entrypoint only; no model output path changed.

## Speed Tests and Profiling

N/A -- benchmark execution logic is unchanged.

## Validation

Verified compile, shim import, and CLI `--help` smoke via Docker using `lmsysorg/sglang:dev`.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28071598117](https://github.com/sgl-project/sglang/actions/runs/28071598117)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28071598022](https://github.com/sgl-project/sglang/actions/runs/28071598022)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
