### PR TITLE
[Spec] Add Domino projector support to DFlash speculative decoding (V2)

### DIFF
--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -30,6 +30,7 @@ from sglang.srt.speculative.dflash_utils import (
     can_dflash_slice_qkv_weight,
     get_dflash_attention_sliding_window_size,
     get_dflash_layer_types,
+    is_dflash_domino_projector,
     parse_dflash_draft_config,
 )
 from sglang.srt.utils import is_npu
@@ -349,6 +350,43 @@ class DFlashDraftModel(nn.Module):
 
         self.block_size = draft_config.resolve_block_size(default=16)
 
+        # Optional Domino projector (GRU prefix encoder + MLP that emits a per-step
+        # bias on top of the target lm_head logits). Older checkpoints used
+        # projector_type=causal_v5; public checkpoints use projector_type=domino.
+        self.projector_type: Optional[str] = draft_config.projector_type
+        self.pure_draft_prefix_len: int = int(draft_config.pure_draft_prefix_len)
+        self.shift_label: bool = bool(draft_config.shift_label)
+        self.gru_hidden_dim: Optional[int] = draft_config.gru_hidden_dim
+        self.emb_dim: Optional[int] = draft_config.emb_dim
+
+        if is_dflash_domino_projector(self.projector_type):
+            if self.gru_hidden_dim is None or self.emb_dim is None:
+                raise ValueError(
+                    "DFLASH Domino requires gru_hidden_dim and emb_dim. "
+                    f"gru_hidden_dim={self.gru_hidden_dim}, emb_dim={self.emb_dim}."
+                )
+            vocab_size = int(getattr(config, "vocab_size", 0))
+            if vocab_size <= 0:
+                raise ValueError(
+                    f"DFLASH Domino requires positive vocab_size, got {vocab_size}."
+                )
+            self.prefix_gru = nn.GRU(
+                input_size=hidden_size,
+                hidden_size=int(self.gru_hidden_dim),
+                num_layers=1,
+                batch_first=True,
+                bias=False,
+            )
+            self.embed_proj = nn.Sequential(
+                nn.Linear(
+                    hidden_size + int(self.gru_hidden_dim),
+                    int(self.emb_dim),
+                    bias=False,
+                ),
+                nn.SiLU(),
+                nn.Linear(int(self.emb_dim), vocab_size, bias=False),
+            )
+
     def get_attention_sliding_window_size(self) -> Optional[int]:
         return get_dflash_attention_sliding_window_size(self.config)
 
@@ -454,6 +492,9 @@ class DFlashDraftModel(nn.Module):
                     )
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+        if hasattr(self, "prefix_gru") and self.prefix_gru is not None:
+            self.prefix_gru.flatten_parameters()
 
 
 EntryClass = DFlashDraftModel

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from dataclasses import dataclass
 from numbers import Integral
 from typing import Any, List, Optional, Tuple
 
+import msgspec
 import torch
 import torch.nn.functional as F
 
@@ -17,7 +17,20 @@ from sglang.srt.utils import is_cuda, is_musa
 
 DEFAULT_DFLASH_MASK_TOKEN = "<|MASK|>"
 
+# Projectors supported by the SGLang DFlash inference path. The public Domino
+# checkpoints use projector_type="domino" for the GRU-prefix + MLP bias path.
+# Keep causal_v5 as a backward-compatible alias for older internal checkpoints.
+_DFLASH_DOMINO_PROJECTORS = frozenset({"domino", "causal_v5"})
+_DFLASH_SUPPORTED_PROJECTORS: frozenset[Optional[str]] = frozenset(
+    {None, *_DFLASH_DOMINO_PROJECTORS}
+)
+
 logger = logging.getLogger(__name__)
+
+
+def is_dflash_domino_projector(projector_type: Optional[str]) -> bool:
+    return projector_type in _DFLASH_DOMINO_PROJECTORS
+
 
 _DFLASH_SAMPLING_VERIFY_AVAILABLE = False
 _DFLASH_CHAIN_VERIFY_BUFFERS: dict[tuple[Optional[int], int], dict[str, Any]] = {}
@@ -415,14 +428,18 @@ def _parse_optional_int(
     return parsed
 
 
-@dataclass(frozen=True)
-class DFlashDraftConfig:
+class DFlashDraftConfig(msgspec.Struct, frozen=True):
     num_hidden_layers: Optional[int]
     num_target_layers: Optional[int]
     block_size: Optional[int]
     target_layer_ids: Optional[List[int]]
     mask_token: str
     mask_token_id: Optional[int]
+    projector_type: Optional[str] = None
+    gru_hidden_dim: Optional[int] = None
+    emb_dim: Optional[int] = None
+    pure_draft_prefix_len: int = 0
+    shift_label: bool = False
 
     def require_num_layers(self) -> int:
         if self.num_hidden_layers is None:
@@ -541,6 +558,68 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
                 f"got {mask_token_id}."
             )
 
+    projector_type = dflash_cfg.get("projector_type", None)
+    if projector_type is not None:
+        if not isinstance(projector_type, str) or not projector_type:
+            raise ValueError(
+                "DFLASH dflash_config.projector_type must be a non-empty string, "
+                f"got {projector_type!r}."
+            )
+        if projector_type not in _DFLASH_SUPPORTED_PROJECTORS:
+            raise ValueError(
+                "DFLASH dflash_config.projector_type is not supported by SGLang yet. "
+                f"Got projector_type={projector_type!r}, "
+                f"supported={sorted(p for p in _DFLASH_SUPPORTED_PROJECTORS if p is not None)}."
+            )
+
+    # Domino fields. emb_dim is top-level on the HF config (not inside dflash_config).
+    gru_hidden_dim = _parse_optional_int(
+        dflash_cfg.get("gru_hidden_dim", None),
+        field_name="DFLASH dflash_config.gru_hidden_dim",
+        min_value=1,
+    )
+    emb_dim = _parse_optional_int(
+        _cfg_get(draft_text_config, "emb_dim", None),
+        field_name="DFLASH emb_dim",
+        min_value=1,
+    )
+
+    pure_draft_prefix_len_raw = dflash_cfg.get("pure_draft_prefix_len", 0)
+    parsed_pure_draft_prefix_len = _parse_optional_int(
+        pure_draft_prefix_len_raw,
+        field_name="DFLASH dflash_config.pure_draft_prefix_len",
+        min_value=0,
+    )
+    pure_draft_prefix_len = (
+        0 if parsed_pure_draft_prefix_len is None else int(parsed_pure_draft_prefix_len)
+    )
+
+    shift_label_raw = dflash_cfg.get("shift_label", False)
+    if not isinstance(shift_label_raw, bool):
+        raise ValueError(
+            "DFLASH dflash_config.shift_label must be a bool, "
+            f"got {shift_label_raw!r} (type={type(shift_label_raw).__name__})."
+        )
+    shift_label = bool(shift_label_raw)
+
+    if is_dflash_domino_projector(projector_type):
+        if gru_hidden_dim is None:
+            raise ValueError(
+                "DFLASH Domino requires dflash_config.gru_hidden_dim to be set."
+            )
+        if emb_dim is None:
+            raise ValueError(
+                "DFLASH Domino requires top-level config.emb_dim to be set."
+            )
+        # The current SGLang adapter supports both shift_label=True and
+        # shift_label=False Domino/causal_v5 alignment, while still assuming the
+        # single pure-draft prefix token.
+        if pure_draft_prefix_len != 1:
+            raise NotImplementedError(
+                "DFLASH Domino currently requires dflash_config.pure_draft_prefix_len=1, "
+                f"got {pure_draft_prefix_len}."
+            )
+
     return DFlashDraftConfig(
         num_hidden_layers=num_hidden_layers,
         num_target_layers=num_target_layers,
@@ -548,6 +627,11 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
         target_layer_ids=parsed_target_layer_ids,
         mask_token=mask_token,
         mask_token_id=mask_token_id,
+        projector_type=projector_type,
+        gru_hidden_dim=gru_hidden_dim,
+        emb_dim=emb_dim,
+        pure_draft_prefix_len=pure_draft_prefix_len,
+        shift_label=shift_label,
     )
 
 

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -28,9 +28,12 @@ from sglang.srt.speculative.dflash_utils import (
     can_dflash_use_fused_qkv_proj,
     compute_dflash_correct_drafts_and_bonus,
     compute_dflash_sampling_correct_drafts_and_bonus,
+    is_dflash_domino_projector,
     is_dflash_sampling_verify_available,
     parse_dflash_draft_config,
 )
+from sglang.srt.speculative.domino_helper import DFlashDominoHelper
+from sglang.srt.speculative.domino_rollout import DFlashDominoRollout
 from sglang.srt.speculative.eagle_info_v2 import assign_extend_cache_locs_func
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
@@ -183,6 +186,39 @@ class DFlashWorkerV2(BaseSpecWorker):
                     model_block_size,
                 )
         self.speculative_num_draft_tokens = int(self.block_size)
+
+        # Optional Domino projector rollout. Only created when the draft model
+        # carries a Domino projector; ordinary DFLASH draft selection is left
+        # untouched. The rollout owns the Domino-specific draft-token generation
+        # and currently supports CUDA + TP=1 only.
+        self.domino_helper: Optional[DFlashDominoHelper] = (
+            DFlashDominoHelper(self.draft_model)
+            if is_dflash_domino_projector(
+                getattr(self.draft_model, "projector_type", None)
+            )
+            else None
+        )
+        if self.domino_helper is not None:
+            # Fail early (at server init) for unsupported parallelism instead of
+            # raising deep inside the first decode step. The selected draft token
+            # feeds the next GRU step, so TP>1 would need per-step cross-rank
+            # synchronization that this first port does not implement.
+            domino_tp_size = int(get_tp_group().world_size)
+            if domino_tp_size != 1:
+                raise NotImplementedError(
+                    "DFLASH Domino projector currently supports TP=1 only, got "
+                    f"tp_size={domino_tp_size}. Launch with --tp-size 1 "
+                    "(alias --tensor-parallel-size 1), or use a non-Domino DFLASH "
+                    "draft model for TP>1."
+                )
+        self.domino_rollout: Optional[DFlashDominoRollout] = (
+            DFlashDominoRollout(
+                domino_helper=self.domino_helper,
+                block_size=self.block_size,
+            )
+            if self.domino_helper is not None
+            else None
+        )
 
         self._mask_token = draft_config.mask_token
         self._mask_token_id_override = draft_config.mask_token_id
@@ -1490,10 +1526,27 @@ class DFlashWorkerV2(BaseSpecWorker):
         if draft_hidden is None:
             raise RuntimeError("DFLASH draft model returned no hidden states.")
         draft_hidden = draft_hidden.view(bs, int(self.block_size), -1)
-        draft_next = self._greedy_sample_from_vocab_parallel_head(
-            hidden_states=draft_hidden[:, 1:, :].reshape(-1, draft_hidden.shape[-1]),
-            lm_head=lm_head,
-        ).view(bs, int(self.block_size) - 1)
+
+        if is_dflash_domino_projector(
+            getattr(self.draft_model, "projector_type", None)
+        ):
+            if self.domino_rollout is None:
+                raise RuntimeError(
+                    "DFLASH Domino projector requires an initialized Domino rollout."
+                )
+            draft_next = self.domino_rollout.rollout_draft_block(
+                draft_hidden=draft_hidden,
+                verified_id=block_ids[:, 0],
+                target_model=target_model,
+                lm_head=lm_head,
+            )
+        else:
+            draft_next = self._greedy_sample_from_vocab_parallel_head(
+                hidden_states=draft_hidden[:, 1:, :].reshape(
+                    -1, draft_hidden.shape[-1]
+                ),
+                lm_head=lm_head,
+            ).view(bs, int(self.block_size) - 1)
 
         draft_tokens = self._draft_block_tokens_buf[:bs]
         draft_tokens[:, 0].copy_(block_ids[:, 0])

--- a/python/sglang/srt/speculative/domino_helper.py
+++ b/python/sglang/srt/speculative/domino_helper.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.speculative.dflash_utils import is_dflash_domino_projector
+
+
+class DFlashDominoHelper:
+    """Helper for Domino projector rollout state and GRU utilities.
+
+    The draft model owns ``prefix_gru`` and ``embed_proj`` directly so checkpoint
+    parameter names remain unchanged. This helper keeps Domino-specific rollout
+    logic out of the base DFLASH model file.
+    """
+
+    def __init__(self, draft_model) -> None:
+        self.draft_model = draft_model
+        self._rollout_state_cache = None
+        self._gru_input_table_cache = None
+
+    def _check_projector(self) -> None:
+        if not is_dflash_domino_projector(
+            getattr(self.draft_model, "projector_type", None)
+        ):
+            raise RuntimeError("Domino helper called on a non-Domino draft model.")
+        if not hasattr(self.draft_model, "prefix_gru") or not hasattr(
+            self.draft_model, "embed_proj"
+        ):
+            raise RuntimeError("Domino draft model is missing prefix_gru/embed_proj.")
+
+    def init_gru_hidden(self, prefix_embeds: torch.Tensor) -> torch.Tensor:
+        """Run the Domino prefix GRU over ``prefix_embeds``."""
+
+        self._check_projector()
+        prefix_embeds = prefix_embeds.contiguous()
+        gru = self.draft_model.prefix_gru
+        hidden_size = int(gru.hidden_size)
+        h = torch.zeros(
+            (prefix_embeds.shape[0], hidden_size),
+            dtype=prefix_embeds.dtype,
+            device=prefix_embeds.device,
+        )
+        w_ih = gru.weight_ih_l0.to(dtype=prefix_embeds.dtype)
+        w_hh = gru.weight_hh_l0.to(dtype=prefix_embeds.dtype)
+        b_ih = gru.bias_ih_l0.to(dtype=prefix_embeds.dtype) if gru.bias else None
+        b_hh = gru.bias_hh_l0.to(dtype=prefix_embeds.dtype) if gru.bias else None
+
+        for step in range(prefix_embeds.shape[1]):
+            gi = torch.nn.functional.linear(prefix_embeds[:, step, :], w_ih, b_ih)
+            gh = torch.nn.functional.linear(h, w_hh, b_hh)
+            r = torch.sigmoid(gi[:, :hidden_size] + gh[:, :hidden_size])
+            z = torch.sigmoid(
+                gi[:, hidden_size : 2 * hidden_size]
+                + gh[:, hidden_size : 2 * hidden_size]
+            )
+            n = torch.tanh(gi[:, 2 * hidden_size :] + r * gh[:, 2 * hidden_size :])
+            h = (1.0 - z) * n + z * h
+        return h
+
+    def get_rollout_state(self) -> dict:
+        """Return cached weight views used by the optimized Domino rollout loop."""
+
+        if self._rollout_state_cache is not None:
+            return self._rollout_state_cache
+
+        self._check_projector()
+        fc1 = self.draft_model.embed_proj[0]
+        fc2 = self.draft_model.embed_proj[2]
+        hidden_dim = int(self.draft_model.config.hidden_size)
+
+        w_z = fc1.weight[:, :hidden_dim].detach()
+        w_s = fc1.weight[:, hidden_dim:].detach()
+        b1 = fc1.bias.detach() if fc1.bias is not None else None
+
+        gru = self.draft_model.prefix_gru
+        w_ih = gru.weight_ih_l0.detach()
+        w_hh = gru.weight_hh_l0.detach()
+        b_ih = gru.bias_ih_l0.detach() if gru.bias else None
+        b_hh = gru.bias_hh_l0.detach() if gru.bias else None
+
+        self._rollout_state_cache = {
+            "w_z": w_z,
+            "w_s": w_s,
+            "w_s_hh_T": torch.cat([w_s.T, w_hh.T], dim=1).contiguous(),
+            "b1": b1,
+            "fc2_weight": fc2.weight.detach(),
+            "fc2_bias": fc2.bias.detach() if fc2.bias is not None else None,
+            "w_ih": w_ih,
+            "w_hh": w_hh,
+            "b_ih": b_ih,
+            "b_hh": b_hh,
+            "gru_hidden_size": int(gru.hidden_size),
+        }
+        return self._rollout_state_cache
+
+    def get_gru_input_proj_table(self, embed_weight: torch.Tensor) -> torch.Tensor:
+        """Return [vocab, 3*gru_hidden] table: embed_weight @ W_ih.T + b_ih."""
+
+        cached = self._gru_input_table_cache
+        if cached is not None and cached["weight_ptr"] == embed_weight.data_ptr():
+            return cached["table"]
+
+        state = self.get_rollout_state()
+        table = torch.nn.functional.linear(
+            embed_weight, state["w_ih"], state["b_ih"]
+        ).contiguous()
+        self._gru_input_table_cache = {
+            "weight_ptr": embed_weight.data_ptr(),
+            "table": table,
+        }
+        return table

--- a/python/sglang/srt/speculative/domino_kernels.py
+++ b/python/sglang/srt/speculative/domino_kernels.py
@@ -1,0 +1,387 @@
+"""Triton kernels for the DFLASH Domino sequential rollout.
+
+The per-step body of Domino rollout is dominated by tiny ops at bs=1. Even with a
+CUDA graph capturing the loop, the per-step work is fundamentally limited by
+fc2 ([B,256] @ [256, V=152K]) bandwidth and a handful of elementwise/reduce
+launches. These kernels collapse the small ops:
+
+  1. ``fused_silu_fc2_argmax`` — fuses ``SiLU(z+s) @ fc2.T + fc2_bias +
+     base_logits`` into a single per-step matmul that emits per-block
+     (val, idx) pairs, followed by a reduction kernel that produces the global
+     argmax token. Avoids materializing the full [B, V] bias tensor.
+  2. ``fused_gru_cell_from_table`` — fuses GRU input-table lookup and the
+     sigmoid/tanh/gate update into one kernel.
+
+Both kernels are CUDA-graph friendly (no host-driven sync, fixed shapes).
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _domino_fused_silu_fc2_argmax_kernel(
+    z_ptr,
+    s_ptr,
+    fc2_ptr,
+    base_ptr,
+    fc2_bias_ptr,
+    out_val_ptr,
+    out_idx_ptr,
+    M,
+    V,
+    stride_z_b,
+    stride_z_m,
+    stride_s_b,
+    stride_s_m,
+    stride_f2_v,
+    stride_f2_m,
+    stride_base_b,
+    stride_base_v,
+    stride_outv_b,
+    stride_outv_n,
+    stride_outi_b,
+    stride_outi_n,
+    BLOCK_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    HAS_FC2_BIAS: tl.constexpr,
+):
+    pid_v = tl.program_id(0)
+    pid_b = tl.program_id(1)
+
+    offs_v = pid_v * BLOCK_V + tl.arange(0, BLOCK_V)
+    mask_v = offs_v < V
+
+    acc = tl.zeros([BLOCK_V], dtype=tl.float32)
+
+    for m_start in range(0, M, BLOCK_M):
+        offs_m = m_start + tl.arange(0, BLOCK_M)
+        mask_m = offs_m < M
+
+        z_block = tl.load(
+            z_ptr + pid_b * stride_z_b + offs_m * stride_z_m,
+            mask=mask_m,
+            other=0.0,
+        ).to(tl.float32)
+        s_block = tl.load(
+            s_ptr + pid_b * stride_s_b + offs_m * stride_s_m,
+            mask=mask_m,
+            other=0.0,
+        ).to(tl.float32)
+        preact = z_block + s_block
+        mid_block = preact * tl.sigmoid(preact)
+
+        fc2_ptrs = (
+            fc2_ptr + offs_v[:, None] * stride_f2_v + offs_m[None, :] * stride_f2_m
+        )
+        fc2_block = tl.load(
+            fc2_ptrs,
+            mask=mask_v[:, None] & mask_m[None, :],
+            other=0.0,
+            cache_modifier=".cg",
+        ).to(tl.float32)
+
+        acc += tl.sum(fc2_block * mid_block[None, :], axis=1)
+
+    if HAS_FC2_BIAS:
+        bias_block = tl.load(fc2_bias_ptr + offs_v, mask=mask_v, other=0.0).to(
+            tl.float32
+        )
+        acc += bias_block
+
+    base_block = tl.load(
+        base_ptr + pid_b * stride_base_b + offs_v * stride_base_v,
+        mask=mask_v,
+        other=-float("inf"),
+        cache_modifier=".cg",
+    ).to(tl.float32)
+    acc += base_block
+
+    acc = tl.where(mask_v, acc, -float("inf"))
+
+    local_max_val = tl.max(acc, axis=0)
+    local_max_idx = tl.argmax(acc, axis=0)
+    global_max_idx = pid_v * BLOCK_V + local_max_idx
+
+    out_val_offs = pid_b * stride_outv_b + pid_v * stride_outv_n
+    out_idx_offs = pid_b * stride_outi_b + pid_v * stride_outi_n
+    tl.store(out_val_ptr + out_val_offs, local_max_val)
+    tl.store(out_idx_ptr + out_idx_offs, global_max_idx)
+
+
+@triton.jit
+def _domino_reduce_argmax_kernel(
+    out_val_ptr,
+    out_idx_ptr,
+    final_token_ptr,
+    N,
+    stride_val_b,
+    stride_val_n,
+    stride_idx_b,
+    stride_idx_n,
+    stride_final_b,
+    BLOCK_N: tl.constexpr,
+):
+    pid_b = tl.program_id(0)
+    best_val = -float("inf")
+    best_idx = 0
+
+    for start_n in range(0, N, BLOCK_N):
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        mask_n = offs_n < N
+
+        vals = tl.load(
+            out_val_ptr + pid_b * stride_val_b + offs_n * stride_val_n,
+            mask=mask_n,
+            other=-float("inf"),
+        )
+        local_pos = tl.argmax(vals, axis=0)
+        local_val = tl.max(vals, axis=0)
+        local_idx = tl.load(
+            out_idx_ptr + pid_b * stride_idx_b + (start_n + local_pos) * stride_idx_n
+        )
+
+        take = local_val > best_val
+        best_val = tl.where(take, local_val, best_val)
+        best_idx = tl.where(take, local_idx, best_idx)
+
+    tl.store(final_token_ptr + pid_b * stride_final_b, best_idx)
+
+
+def fused_silu_fc2_argmax(
+    *,
+    z_proj: torch.Tensor,  # [B, M]
+    s_proj: torch.Tensor,  # [B, M]
+    fc2_weight: torch.Tensor,  # [V, M]
+    fc2_bias: torch.Tensor | None,  # [V] or None
+    base_logits: torch.Tensor,  # [B, V]
+    out_val: torch.Tensor,  # [B, num_v_blocks] fp32 scratch
+    out_idx: torch.Tensor,  # [B, num_v_blocks] int32 scratch
+    final_token: torch.Tensor,  # [B] int64 destination
+    block_v: int = 512,
+    block_m: int = 32,
+    num_warps: int = 4,
+    num_stages: int = 3,
+) -> None:
+    """Single-step fused: SiLU(z+s) @ fc2.T + bias + base_logits -> argmax.
+
+    Writes the per-batch global argmax into ``final_token`` in-place.
+    """
+    B, M = z_proj.shape
+    V = base_logits.shape[1]
+    num_v_blocks = (V + block_v - 1) // block_v
+    has_fc2_bias = fc2_bias is not None
+    fc2_bias_arg = fc2_bias if has_fc2_bias else out_val  # placeholder ptr
+
+    grid_main = (num_v_blocks, B)
+    _domino_fused_silu_fc2_argmax_kernel[grid_main](
+        z_proj,
+        s_proj,
+        fc2_weight,
+        base_logits,
+        fc2_bias_arg,
+        out_val,
+        out_idx,
+        M,
+        V,
+        z_proj.stride(0),
+        z_proj.stride(1),
+        s_proj.stride(0),
+        s_proj.stride(1),
+        fc2_weight.stride(0),
+        fc2_weight.stride(1),
+        base_logits.stride(0),
+        base_logits.stride(1),
+        out_val.stride(0),
+        out_val.stride(1),
+        out_idx.stride(0),
+        out_idx.stride(1),
+        BLOCK_V=block_v,
+        BLOCK_M=block_m,
+        HAS_FC2_BIAS=has_fc2_bias,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    _domino_reduce_argmax_kernel[(B,)](
+        out_val,
+        out_idx,
+        final_token,
+        num_v_blocks,
+        out_val.stride(0),
+        out_val.stride(1),
+        out_idx.stride(0),
+        out_idx.stride(1),
+        final_token.stride(0),
+        BLOCK_N=512,
+        num_warps=1,
+    )
+
+
+@triton.jit
+def _domino_fused_gru_cell_from_table_kernel(
+    tok_ptr,
+    table_ptr,
+    gh_ptr,
+    gh_bias_ptr,
+    h_ptr,
+    h_out_ptr,
+    G,
+    V,
+    stride_table_v,
+    stride_table_g,
+    stride_gh_b,
+    stride_gh_g,
+    stride_gh_bias_g,
+    stride_h_b,
+    stride_h_g,
+    stride_hout_b,
+    stride_hout_g,
+    BLOCK_G: tl.constexpr,
+    HAS_GH_BIAS: tl.constexpr,
+):
+    pid_b = tl.program_id(0)
+    pid_g = tl.program_id(1)
+
+    offs_g = pid_g * BLOCK_G + tl.arange(0, BLOCK_G)
+    mask_g = offs_g < G
+
+    tok_id_raw = tl.load(tok_ptr + pid_b)
+    tok_in_range = (tok_id_raw >= 0) & (tok_id_raw < V)
+    tok_id = tl.where(tok_in_range, tok_id_raw, 0)
+    mask_tok = mask_g & tok_in_range
+
+    h_state = tl.load(
+        h_ptr + pid_b * stride_h_b + offs_g * stride_h_g,
+        mask=mask_g,
+        other=0.0,
+    ).to(tl.float32)
+
+    row_base = tok_id * stride_table_v
+    gi_r = tl.load(
+        table_ptr + row_base + offs_g * stride_table_g,
+        mask=mask_tok,
+        other=0.0,
+    ).to(tl.float32)
+    gi_z = tl.load(
+        table_ptr + row_base + (G + offs_g) * stride_table_g,
+        mask=mask_tok,
+        other=0.0,
+    ).to(tl.float32)
+    gi_n = tl.load(
+        table_ptr + row_base + (2 * G + offs_g) * stride_table_g,
+        mask=mask_tok,
+        other=0.0,
+    ).to(tl.float32)
+
+    gh_r = tl.load(
+        gh_ptr + pid_b * stride_gh_b + offs_g * stride_gh_g,
+        mask=mask_g,
+        other=0.0,
+    ).to(tl.float32)
+    gh_z = tl.load(
+        gh_ptr + pid_b * stride_gh_b + (G + offs_g) * stride_gh_g,
+        mask=mask_g,
+        other=0.0,
+    ).to(tl.float32)
+    gh_n = tl.load(
+        gh_ptr + pid_b * stride_gh_b + (2 * G + offs_g) * stride_gh_g,
+        mask=mask_g,
+        other=0.0,
+    ).to(tl.float32)
+
+    if HAS_GH_BIAS:
+        gh_r = (
+            (
+                gh_r
+                + tl.load(
+                    gh_bias_ptr + offs_g * stride_gh_bias_g,
+                    mask=mask_g,
+                    other=0.0,
+                ).to(tl.float32)
+            )
+            .to(gh_ptr.dtype.element_ty)
+            .to(tl.float32)
+        )
+        gh_z = (
+            (
+                gh_z
+                + tl.load(
+                    gh_bias_ptr + (G + offs_g) * stride_gh_bias_g,
+                    mask=mask_g,
+                    other=0.0,
+                ).to(tl.float32)
+            )
+            .to(gh_ptr.dtype.element_ty)
+            .to(tl.float32)
+        )
+        gh_n = (
+            (
+                gh_n
+                + tl.load(
+                    gh_bias_ptr + (2 * G + offs_g) * stride_gh_bias_g,
+                    mask=mask_g,
+                    other=0.0,
+                ).to(tl.float32)
+            )
+            .to(gh_ptr.dtype.element_ty)
+            .to(tl.float32)
+        )
+
+    r = tl.sigmoid(gi_r + gh_r)
+    z = tl.sigmoid(gi_z + gh_z)
+    n = 2.0 * tl.sigmoid(2.0 * (gi_n + r * gh_n)) - 1.0
+    h_new = (1.0 - z) * n + z * h_state
+
+    tl.store(
+        h_out_ptr + pid_b * stride_hout_b + offs_g * stride_hout_g,
+        h_new.to(h_ptr.dtype.element_ty),
+        mask=mask_g,
+    )
+
+
+def fused_gru_cell_from_table(
+    *,
+    tok_full: torch.Tensor,  # [B] int64 token ids (already shifted by org_vocab_start)
+    gru_input_table: torch.Tensor,  # [V, 3*G] precomputed embed @ W_ih.T + b_ih
+    gh: torch.Tensor,  # [B, 3*G] h_state @ W_hh.T (+ b_hh)
+    gh_bias: torch.Tensor | None = None,  # [3*G] or None
+    h_state: torch.Tensor,  # [B, G]
+    h_out: torch.Tensor,  # [B, G] destination
+    block_g: int = 256,
+) -> None:
+    """Fused: gi = gru_input_table[tok_full]; then GRU cell update.
+
+    Replaces the index_select + fused_gru_cell pair with a single kernel that
+    reads gi directly from the table by tok id, skipping the gi_buf materialize.
+    """
+    B = tok_full.shape[0]
+    G = h_state.shape[1]
+    V = gru_input_table.shape[0]
+    has_gh_bias = gh_bias is not None
+    gh_bias_arg = gh_bias if has_gh_bias else gh  # placeholder ptr
+    gh_bias_stride = gh_bias_arg.stride(0) if has_gh_bias else 0
+    grid = (B, (G + block_g - 1) // block_g)
+    _domino_fused_gru_cell_from_table_kernel[grid](
+        tok_full,
+        gru_input_table,
+        gh,
+        gh_bias_arg,
+        h_state,
+        h_out,
+        G,
+        V,
+        gru_input_table.stride(0),
+        gru_input_table.stride(1),
+        gh.stride(0),
+        gh.stride(1),
+        gh_bias_stride,
+        h_state.stride(0),
+        h_state.stride(1),
+        h_out.stride(0),
+        h_out.stride(1),
+        BLOCK_G=block_g,
+        HAS_GH_BIAS=has_gh_bias,
+    )

--- a/python/sglang/srt/speculative/domino_rollout.py
+++ b/python/sglang/srt/speculative/domino_rollout.py
@@ -1,0 +1,355 @@
+import logging
+from typing import Optional
+
+import torch
+
+from sglang.srt.speculative.domino_helper import DFlashDominoHelper
+from sglang.srt.speculative.domino_kernels import (
+    fused_gru_cell_from_table,
+    fused_silu_fc2_argmax,
+)
+
+logger = logging.getLogger(__name__)
+
+_DOMINO_BLOCK_V = 512
+_DOMINO_BLOCK_M = 32
+_DOMINO_SCORE_NUM_WARPS = 4
+_DOMINO_SCORE_NUM_STAGES = 3
+
+
+class DFlashDominoRollout:
+    """Domino-specific draft-token rollout for DFLASH speculative decoding.
+
+    This first port supports CUDA + TP=1 only. The draft-token selection at each
+    step feeds the next GRU state, so TP>1 needs per-step cross-rank
+    synchronization; that combination is rejected early during worker init
+    (`DFlashWorkerV2.__init__`). The rollout keeps a defensive CUDA-only guard
+    because it relies on `torch.cuda.CUDAGraph()` and Triton kernels.
+
+    Scoring is full-vocab: each step computes the true argmax of
+    `base_logits + domino_bias` over the whole vocabulary, so the result matches
+    a dense reference implementation exactly (no candidate-pool approximation).
+    """
+
+    def __init__(
+        self,
+        *,
+        domino_helper: DFlashDominoHelper,
+        block_size: int,
+    ) -> None:
+        self.domino_helper = domino_helper
+        self.block_size = int(block_size)
+
+    def _slice_domino_fc2(
+        self,
+        *,
+        state: dict,
+        start: int,
+        length: int,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        end = int(start) + int(length)
+        fc2_w = state["fc2_weight"][int(start) : end].contiguous()
+        fc2_b = (
+            state["fc2_bias"][int(start) : end].contiguous()
+            if state["fc2_bias"] is not None
+            else None
+        )
+        return fc2_w, fc2_b
+
+    def _init_domino_prefix_gru_hidden(
+        self,
+        *,
+        prefix_ids: torch.Tensor,
+        z_dtype: torch.dtype,
+        embed_module,
+    ) -> torch.Tensor:
+        """Initialize the Domino prefix GRU state from [verified, first draft]."""
+
+        if embed_module is None:
+            raise RuntimeError(
+                "DFLASH Domino prefix init requires the target embedding module."
+            )
+        prefix_embeds = embed_module(prefix_ids).to(z_dtype)
+        return self.domino_helper.init_gru_hidden(prefix_embeds)
+
+    def _get_or_capture_domino_loop_graph(
+        self,
+        *,
+        bs: int,
+        num_draft: int,
+        emb_dim: int,
+        gru_hidden: int,
+        num_org: int,
+        org_vocab_start: int,
+        z_dtype: torch.dtype,
+        logits_dtype: torch.dtype,
+        device: torch.device,
+        state: dict,
+        gru_input_table: torch.Tensor,
+    ):
+        """Capture or return the CUDA graph for the full-vocab Domino rollout loop."""
+
+        pool = getattr(self, "_domino_loop_graph_pool", None)
+        if pool is None:
+            pool = {}
+            self._domino_loop_graph_pool = pool
+
+        pool_key = (
+            bs,
+            num_draft,
+            emb_dim,
+            gru_hidden,
+            num_org,
+            org_vocab_start,
+            z_dtype,
+            logits_dtype,
+        )
+        entry = pool.get(pool_key)
+        if entry is not None:
+            return entry
+
+        G = gru_hidden
+        z_proj_buf = torch.empty((bs, num_draft, emb_dim), dtype=z_dtype, device=device)
+        base_logits_buf = torch.empty(
+            (bs, num_draft, num_org), dtype=logits_dtype, device=device
+        )
+        gru_h_buf = torch.empty((bs, G), dtype=z_dtype, device=device)
+        out_buf = torch.empty((bs, num_draft), dtype=torch.long, device=device)
+
+        block_v = _DOMINO_BLOCK_V
+        block_m = _DOMINO_BLOCK_M
+        score_num_warps = _DOMINO_SCORE_NUM_WARPS
+        score_num_stages = _DOMINO_SCORE_NUM_STAGES
+        num_score_blocks = (num_org + block_v - 1) // block_v
+
+        w_sh_T = torch.cat(
+            [state["w_s"].T.contiguous(), state["w_hh"].T.contiguous()],
+            dim=1,
+        ).contiguous()
+        sh_buf = torch.empty((bs, emb_dim + 3 * G), dtype=z_dtype, device=device)
+        s_proj_buf = sh_buf[:, :emb_dim]
+        gh_buf = sh_buf[:, emb_dim:]
+        h_new_buf = torch.empty((bs, G), dtype=z_dtype, device=device)
+        argmax_val_buf = torch.empty(
+            (bs, num_score_blocks), dtype=torch.float32, device=device
+        )
+        argmax_idx_buf = torch.empty(
+            (bs, num_score_blocks), dtype=torch.int32, device=device
+        )
+        local_tok_buf = torch.empty((bs,), dtype=torch.long, device=device)
+        fc2_w_shard, fc2_b_shard = self._slice_domino_fc2(
+            state=state,
+            start=org_vocab_start,
+            length=num_org,
+        )
+        b_hh_static = state["b_hh"]
+
+        static_refs = [
+            z_proj_buf,
+            base_logits_buf,
+            gru_h_buf,
+            out_buf,
+            sh_buf,
+            h_new_buf,
+            argmax_val_buf,
+            argmax_idx_buf,
+            local_tok_buf,
+            fc2_w_shard,
+            w_sh_T,
+            gru_input_table,
+        ]
+        if fc2_b_shard is not None:
+            static_refs.append(fc2_b_shard)
+        if b_hh_static is not None:
+            static_refs.append(b_hh_static)
+
+        def run_loop(out_target):
+            h_state = gru_h_buf
+            for k in range(1, num_draft):
+                torch.matmul(h_state, w_sh_T, out=sh_buf)
+                fused_silu_fc2_argmax(
+                    z_proj=z_proj_buf[:, k, :],
+                    s_proj=s_proj_buf,
+                    fc2_weight=fc2_w_shard,
+                    fc2_bias=fc2_b_shard,
+                    base_logits=base_logits_buf[:, k, :],
+                    out_val=argmax_val_buf,
+                    out_idx=argmax_idx_buf,
+                    final_token=local_tok_buf,
+                    block_v=block_v,
+                    block_m=block_m,
+                    num_warps=score_num_warps,
+                    num_stages=score_num_stages,
+                )
+                tok_full = local_tok_buf + org_vocab_start
+                out_target[:, k] = tok_full
+                if k + 1 < num_draft:
+                    fused_gru_cell_from_table(
+                        tok_full=tok_full,
+                        gru_input_table=gru_input_table,
+                        gh=gh_buf,
+                        gh_bias=b_hh_static,
+                        h_state=h_state,
+                        h_out=h_new_buf,
+                    )
+                    h_state = h_new_buf
+            return None
+
+        warmup_out = torch.empty((bs, num_draft), dtype=torch.long, device=device)
+        for _ in range(2):
+            run_loop(warmup_out)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            run_loop(out_buf)
+
+        entry = {
+            "graph": graph,
+            "z_proj_buf": z_proj_buf,
+            "base_logits_buf": base_logits_buf,
+            "gru_h_buf": gru_h_buf,
+            "out_buf": out_buf,
+            "_static_refs": static_refs,
+        }
+        pool[pool_key] = entry
+        logger.info(
+            "[DFLASH Domino] captured CUDA graph (Triton full-vocab) for rollout "
+            "loop bs=%d num_draft=%d",
+            bs,
+            num_draft,
+        )
+        return entry
+
+    def rollout_draft_block(
+        self,
+        *,
+        draft_hidden: torch.Tensor,
+        verified_id: torch.Tensor,
+        target_model,
+        lm_head,
+    ) -> torch.Tensor:
+        """Sequential Domino rollout to produce `block_size - 1` draft tokens.
+
+        Algorithm mirrors the reference Domino rollout for both shift_label=True
+        and shift_label=False. SGLang's draft block reserves slot 0 for the
+        current verified token and emits slots 1..block_size-1:
+          1. Select z so z[:, 0] predicts slot_1 under the checkpoint's label
+             alignment.
+          2. slot_1 = argmax(base_logits[0]).
+          3. Initialize prefix_gru on embeddings of [verified_id, slot_1] to get gru_h.
+          4. For k = 1..block_size-2:
+                 bias = embed_proj(cat(z_k, gru_h))
+                 slot_{k+1} = argmax(base_logits[k] + bias)   # full vocab
+                 gru_h = prefix_gru_step(embed(slot_{k+1}))
+
+        Implementation note: the per-step embed_proj/GRU calls have non-trivial
+        Python + cuDNN launch overhead.  We pre-split fc1.weight along its input
+        axis so z @ W_z (the part that doesn't depend on the GRU state) is
+        batched outside the loop, and we replace nn.GRU(seq_len=1) with a manual
+        GRU cell to skip cuDNN setup.
+
+        Args:
+            draft_hidden: [B, block_size, hidden_size] draft model output (post-norm).
+            verified_id: [B] current verified token per request (int64).
+            target_model: the SGLang target model (for embed_tokens).
+            lm_head: vocab-parallel lm_head (used to compute dense base logits).
+
+        Returns:
+            [B, block_size - 1] int64 tensor of sampled draft tokens.
+        """
+        bs, total_slots, hidden_size = draft_hidden.shape
+        if total_slots != self.block_size:
+            raise RuntimeError(
+                f"DFLASH Domino expected draft_hidden block dim={self.block_size}, "
+                f"got {total_slots}."
+            )
+        num_draft = self.block_size - 1  # 15 for block_size=16
+        if num_draft <= 0:
+            raise RuntimeError(
+                f"DFLASH Domino requires block_size > 1, got {self.block_size}."
+            )
+
+        device = draft_hidden.device
+        # Defensive: TP>1 is rejected at worker init, but the CUDA-graph + Triton
+        # path also requires a CUDA device. Fail clearly instead of silently
+        # falling back on CPU/other backends.
+        if device.type != "cuda":
+            raise NotImplementedError(
+                "DFLASH Domino rollout requires a CUDA device (uses CUDA graphs and "
+                f"Triton kernels), got device.type={device.type!r}."
+            )
+
+        weight = lm_head.weight
+        shard = lm_head.shard_indices
+        num_added = int(shard.num_added_elements)
+        if num_added != 0:
+            raise NotImplementedError(
+                "DFLASH Domino rollout does not yet handle added-vocab lm_head shards."
+            )
+        org_vocab_start = int(shard.org_vocab_start_index)
+        num_org = int(shard.num_org_elements)
+        if num_org <= 0:
+            raise RuntimeError("DFLASH lm_head has empty base vocab shard.")
+
+        draft_model = self.domino_helper.draft_model
+        embed_module = target_model.get_input_embeddings()
+        domino_helper = self.domino_helper
+        if domino_helper is None:
+            raise RuntimeError("DFLASH Domino rollout called without a Domino helper.")
+
+        # shift_label=True: draft_hidden[:, i, :] predicts token at position i+1.
+        # shift_label=False: draft_hidden[:, i, :] predicts token at position i.
+        # For the draft block, position 0 is verified_id; positions 1..block_size-1
+        # are the draft slots.  With shift_label we need draft_hidden[:, 0, :]
+        # to predict slot_1, so we slice [:num_draft]; otherwise we slice [1:].
+        if getattr(draft_model, "shift_label", False):
+            z = draft_hidden[:, :num_draft, :].contiguous()  # [B, num_draft, hidden]
+        else:
+            z = draft_hidden[:, 1:, :].contiguous()  # [B, num_draft, hidden]
+
+        state = domino_helper.get_rollout_state()
+
+        G = state["gru_hidden_size"]
+        emb_dim = int(state["w_z"].shape[0])
+        z_for_dtype = z.to(weight.dtype) if z.dtype != weight.dtype else z
+        gru_input_table = domino_helper.get_gru_input_proj_table(embed_module.weight)
+
+        # Dense base logits over the full (org) vocab shard. Full-vocab scoring
+        # guarantees the per-step argmax of (base_logits + domino_bias) is exact.
+        z_flat = z_for_dtype.reshape(bs * num_draft, hidden_size)
+        base_logits = torch.matmul(z_flat, weight[:num_org].T).view(
+            bs, num_draft, num_org
+        )
+
+        slot_local_arg = torch.argmax(base_logits[:, 0, :], dim=-1)
+        slot_1 = (slot_local_arg + org_vocab_start).to(torch.long)
+
+        gru_h = self._init_domino_prefix_gru_hidden(
+            prefix_ids=torch.stack([verified_id.to(torch.long), slot_1], dim=1),
+            z_dtype=z.dtype,
+            embed_module=embed_module,
+        )
+
+        z_proj_all = torch.nn.functional.linear(z, state["w_z"], state["b1"])
+
+        graph_entry = self._get_or_capture_domino_loop_graph(
+            bs=bs,
+            num_draft=num_draft,
+            emb_dim=emb_dim,
+            gru_hidden=G,
+            num_org=num_org,
+            org_vocab_start=org_vocab_start,
+            z_dtype=z.dtype,
+            logits_dtype=base_logits.dtype,
+            device=device,
+            state=state,
+            gru_input_table=gru_input_table,
+        )
+        graph_entry["z_proj_buf"].copy_(z_proj_all)
+        graph_entry["base_logits_buf"].copy_(base_logits)
+        graph_entry["gru_h_buf"].copy_(gru_h)
+        graph_entry["out_buf"][:, 0].copy_(slot_1)
+        graph_entry["graph"].replay()
+        out = graph_entry["out_buf"]
+        return out

--- a/test/registered/unit/spec/test_dflash_domino_config.py
+++ b/test/registered/unit/spec/test_dflash_domino_config.py
@@ -1,0 +1,107 @@
+"""Unit tests for DFLASH Domino projector config parsing in srt/speculative/dflash_utils.
+
+These cover the Domino-specific fields added to ``DFlashDraftConfig`` and the
+validation in ``parse_dflash_draft_config``. No server / GPU is required: the
+parser operates on plain HF-style config dicts.
+"""
+
+import unittest
+
+from sglang.srt.speculative.dflash_utils import (
+    is_dflash_domino_projector,
+    parse_dflash_draft_config,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _ordinary_dflash_config() -> dict:
+    """A plain (non-Domino) DFLASH draft config dict."""
+    return {
+        "vocab_size": 151936,
+        "hidden_size": 4096,
+        "num_hidden_layers": 1,
+        "block_size": 16,
+        "dflash_config": {
+            "num_target_layers": 36,
+            "target_layer_ids": [1, 9, 17, 25, 33],
+        },
+    }
+
+
+def _domino_dflash_config() -> dict:
+    """A Domino DFLASH draft config dict matching the public b16 checkpoint."""
+    cfg = _ordinary_dflash_config()
+    cfg["emb_dim"] = 256
+    cfg["dflash_config"].update(
+        {
+            "projector_type": "domino",
+            "gru_hidden_dim": 1024,
+            "pure_draft_prefix_len": 1,
+            "shift_label": True,
+        }
+    )
+    return cfg
+
+
+class TestDFlashDominoConfigParsing(CustomTestCase):
+    def test_ordinary_config_still_parses(self):
+        parsed = parse_dflash_draft_config(draft_hf_config=_ordinary_dflash_config())
+        self.assertIsNone(parsed.projector_type)
+        self.assertIsNone(parsed.gru_hidden_dim)
+        self.assertIsNone(parsed.emb_dim)
+        self.assertEqual(parsed.pure_draft_prefix_len, 0)
+        self.assertFalse(parsed.shift_label)
+        self.assertFalse(is_dflash_domino_projector(parsed.projector_type))
+
+    def test_domino_config_parses(self):
+        parsed = parse_dflash_draft_config(draft_hf_config=_domino_dflash_config())
+        self.assertEqual(parsed.projector_type, "domino")
+        self.assertEqual(parsed.gru_hidden_dim, 1024)
+        self.assertEqual(parsed.emb_dim, 256)
+        self.assertEqual(parsed.pure_draft_prefix_len, 1)
+        self.assertTrue(parsed.shift_label)
+        self.assertTrue(is_dflash_domino_projector(parsed.projector_type))
+
+    def test_causal_v5_alias_recognized(self):
+        cfg = _domino_dflash_config()
+        cfg["dflash_config"]["projector_type"] = "causal_v5"
+        parsed = parse_dflash_draft_config(draft_hf_config=cfg)
+        self.assertEqual(parsed.projector_type, "causal_v5")
+        self.assertTrue(is_dflash_domino_projector(parsed.projector_type))
+
+    def test_unsupported_projector_type_fails(self):
+        cfg = _domino_dflash_config()
+        cfg["dflash_config"]["projector_type"] = "totally_unsupported"
+        with self.assertRaises(ValueError):
+            parse_dflash_draft_config(draft_hf_config=cfg)
+
+    def test_missing_gru_hidden_dim_fails(self):
+        cfg = _domino_dflash_config()
+        del cfg["dflash_config"]["gru_hidden_dim"]
+        with self.assertRaises(ValueError):
+            parse_dflash_draft_config(draft_hf_config=cfg)
+
+    def test_missing_emb_dim_fails(self):
+        cfg = _domino_dflash_config()
+        del cfg["emb_dim"]
+        with self.assertRaises(ValueError):
+            parse_dflash_draft_config(draft_hf_config=cfg)
+
+    def test_unsupported_pure_draft_prefix_len_fails(self):
+        cfg = _domino_dflash_config()
+        cfg["dflash_config"]["pure_draft_prefix_len"] = 2
+        with self.assertRaises(NotImplementedError):
+            parse_dflash_draft_config(draft_hf_config=cfg)
+
+    def test_non_bool_shift_label_fails(self):
+        cfg = _domino_dflash_config()
+        cfg["dflash_config"]["shift_label"] = 1
+        with self.assertRaises(ValueError):
+            parse_dflash_draft_config(draft_hf_config=cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dflash_domino_kernel.py
+++ b/test/registered/unit/spec/test_dflash_domino_kernel.py
@@ -1,0 +1,102 @@
+"""Correctness test for the DFLASH Domino full-vocab fused scoring kernel.
+
+The Domino rollout selects each draft token as the argmax of
+``base_logits + domino_bias`` over the whole vocabulary, where
+``domino_bias = SiLU(z_proj + s_proj) @ fc2.T + fc2_bias``. ``fused_silu_fc2_argmax``
+fuses that into one Triton matmul + reduction. This test pins the fused result
+to a dense ``torch`` reference so the first PR's "full-vocab, no candidate-pool
+approximation" claim is verified, not assumed.
+
+A mutation check perturbs ``base_logits`` at the reference-selected token and
+asserts the fused argmax moves, so the equivalence is not vacuous.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.speculative.domino_kernels import fused_silu_fc2_argmax
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Domino kernel requires CUDA")
+class TestDominoFusedScoringKernel(CustomTestCase):
+    def _make_inputs(self, B, M, V, has_bias, dtype, seed):
+        torch.manual_seed(seed)
+        dev = "cuda"
+        z = torch.randn(B, M, device=dev, dtype=dtype)
+        s = torch.randn(B, M, device=dev, dtype=dtype)
+        fc2_w = torch.randn(V, M, device=dev, dtype=dtype) * 0.1
+        fc2_b = torch.randn(V, device=dev, dtype=dtype) * 0.1 if has_bias else None
+        base = torch.randn(B, V, device=dev, dtype=dtype)
+        return z, s, fc2_w, fc2_b, base
+
+    def _run_fused(self, z, s, fc2_w, fc2_b, base, block_v=512):
+        B = z.shape[0]
+        V = base.shape[1]
+        num_v_blocks = (V + block_v - 1) // block_v
+        out_val = torch.empty(B, num_v_blocks, dtype=torch.float32, device=z.device)
+        out_idx = torch.empty(B, num_v_blocks, dtype=torch.int32, device=z.device)
+        final_token = torch.empty(B, dtype=torch.long, device=z.device)
+        fused_silu_fc2_argmax(
+            z_proj=z,
+            s_proj=s,
+            fc2_weight=fc2_w,
+            fc2_bias=fc2_b,
+            base_logits=base,
+            out_val=out_val,
+            out_idx=out_idx,
+            final_token=final_token,
+            block_v=block_v,
+        )
+        torch.cuda.synchronize()
+        return final_token
+
+    def test_matches_dense_reference(self):
+        # Qwen3-class vocab + a couple of smaller shapes, across dtypes.
+        cases = [
+            (1, 256, 151936, True, torch.bfloat16, 0),
+            (1, 256, 151936, False, torch.bfloat16, 1),
+            (4, 256, 151936, True, torch.bfloat16, 2),
+            (1, 256, 151936, True, torch.float16, 3),
+            (2, 256, 4096, True, torch.float32, 4),
+            (1, 256, 50000, False, torch.float32, 5),
+        ]
+        for B, M, V, has_bias, dtype, seed in cases:
+            with self.subTest(B=B, V=V, has_bias=has_bias, dtype=dtype):
+                z, s, fc2_w, fc2_b, base = self._make_inputs(
+                    B, M, V, has_bias, dtype, seed
+                )
+                # Dense reference: SiLU(z+s) @ fc2.T + fc2_bias + base_logits,
+                # then full-vocab argmax.
+                mid = torch.nn.functional.silu(z + s)
+                bias = torch.nn.functional.linear(mid, fc2_w, fc2_b)
+                logits = (base + bias.to(base.dtype)).float()
+                ref = torch.argmax(logits, dim=-1).to(torch.long)
+                got = self._run_fused(z, s, fc2_w, fc2_b, base)
+                # Argmax must match where there is no tie; if it differs, the two
+                # tokens must carry the same (max) logit value within tolerance.
+                ref_val = logits.gather(1, ref.view(-1, 1)).squeeze(1)
+                got_val = logits.gather(1, got.view(-1, 1)).squeeze(1)
+                self.assertTrue(
+                    torch.allclose(ref_val, got_val, atol=1e-3, rtol=0),
+                    f"fused argmax logit value diverged: ref={ref_val} got={got_val}",
+                )
+
+    def test_mutation_changes_argmax(self):
+        # Make the fused selection sensitive: spike base_logits at a fixed token
+        # for batch row 0 and assert the fused argmax follows it.
+        z, s, fc2_w, fc2_b, base = self._make_inputs(
+            1, 256, 4096, True, torch.float32, 7
+        )
+        spiked = 1234
+        base[0, spiked] += 1e4
+        got = self._run_fused(z, s, fc2_w, fc2_b, base)
+        self.assertEqual(int(got[0].item()), spiked)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Add **Domino** projector support to DFlash speculative decoding so the public Domino draft checkpoints (e.g. `Qwen3-8B-Domino-b16`) can run on SGLang. Closes the request in #28977.

Domino augments the ordinary DFlash draft model with a GRU prefix encoder (`prefix_gru`) and an MLP (`embed_proj`) that emits a per-step bias on top of the target `lm_head` logits. Draft tokens for the block are then produced by a short sequential rollout (each selected token feeds the next GRU step). The verify / accept / bonus-token / draft-KV paths are the existing DFlash V2 paths, unchanged.

## Scope of this PR: CUDA + TP=1 only

This first PR intentionally supports **single-GPU (TP=1) on CUDA only**. The Domino rollout is sequential — the token selected at step *k* is the input to the GRU at step *k+1* — so TP>1 would require a cross-rank synchronization after **every** drafted token. That is non-trivial and is deliberately deferred to a follow-up commit/PR.

Behavior for unsupported configurations (clear errors, no silent fallback):
- **TP>1**: rejected early at `DFlashWorkerV2.__init__` as soon as a Domino projector is detected (`--tp-size 1` required).
- **Non-CUDA device**: the rollout raises `NotImplementedError` before touching CUDA graphs / Triton kernels.
- **Added-vocab `lm_head` shards**: explicit `NotImplementedError`.

Other DFlash limitations are unchanged and still apply (DP attention, PP>1, grammar-constrained decoding, `return_logprob`, `return_hidden_states` with overlap).

## Implementation

- **`dflash_utils.py`**: recognize `projector_type in {"domino", "causal_v5"}`; add Domino fields to `DFlashDraftConfig` (`gru_hidden_dim`, `emb_dim`, `pure_draft_prefix_len`, `shift_label`) with validation. `DFlashDraftConfig` is migrated from `@dataclass` to `msgspec.Struct` to follow the repo container convention.
- **`models/dflash.py`**: instantiate `prefix_gru` + `embed_proj` only for Domino projectors; `flatten_parameters()` after weight load.
- **`domino_helper.py` / `domino_kernels.py` / `domino_rollout.py`** (new): Domino rollout state, Triton kernels (fused `SiLU(z+s) @ fc2.T + bias + base_logits` full-vocab argmax, fused GRU cell), and the sequential draft-block rollout with a CUDA-graph-captured loop.
- **`dflash_worker_v2.py`**: create the Domino helper/rollout only for Domino draft models, reject TP>1 early, and branch to the Domino rollout at the existing draft-token selection hook. Ordinary DFlash draft selection is untouched.

**Scoring is full-vocab**: each step computes the exact argmax of `base_logits + domino_bias` over the entire vocabulary (no candidate-pool approximation), so the result matches a dense reference exactly. **No new environment variables** are introduced.

## Tests

- `test/registered/unit/spec/test_dflash_domino_config.py` (CPU, `base-a-test-cpu`): config parsing + validation (Domino fields, unsupported projector, missing required fields, `pure_draft_prefix_len != 1`, non-bool `shift_label`).
- `test/registered/unit/spec/test_dflash_domino_kernel.py` (CUDA, `base-b` 1-gpu-small): the fused full-vocab scoring kernel matches a dense `torch` reference across bf16/fp16/fp32 and multiple vocab sizes, plus a mutation check.

## Local validation (RTX A6000, single GPU)

| Setup | accept_length | tok/s |
|---|---|---|
| Ordinary DFlash (`Qwen3-8B-DFlash-b16`), baseline | 3.066 | 98.1 |
| Ordinary DFlash, after this change | 3.066 | 98.1 |
| **Domino** (`Qwen3-8B-Domino-b16`), V2 overlap | 3.737 | 111.7 |
| **Domino**, non-overlap (`--disable-overlap-schedule`) | 3.66 | 106.9 |

Target model: `Qwen3-8B`. Prompt: one GSM8K sample, `temperature=0`, `max_new_tokens=512`. Ordinary DFlash numbers are unchanged by this PR; Domino output text is identical between overlap and non-overlap.

## Follow-ups

- TP>1 support (per-step cross-rank sync for the GRU rollout).
- Optional perf work (e.g. candidate-pool scoring) only if it can be shown not to change the selected tokens.

Closes #28977







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28005093292](https://github.com/sgl-project/sglang/actions/runs/28005093292)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28005093197](https://github.com/sgl-project/sglang/actions/runs/28005093197)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->