### PR TITLE
[Fix] Remove misleading echo+logprobs warning in OpenAI completions

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import time
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Union
@@ -37,8 +36,6 @@ if TYPE_CHECKING:
     from sglang.srt.managers.template_manager import TemplateManager
     from sglang.srt.managers.tokenizer_manager import TokenizerManager
 
-logger = logging.getLogger(__name__)
-
 
 class OpenAIServingCompletion(OpenAIServingBase):
     """Handler for /v1/completion requests"""
@@ -68,12 +65,9 @@ class OpenAIServingCompletion(OpenAIServingBase):
         raw_request: Request = None,
     ) -> tuple[GenerateReqInput, CompletionRequest]:
         """Convert OpenAI completion request to internal format"""
-        # NOTE: with openai API, the prompt's logprobs are always not computed
-        if request.echo and request.logprobs:
-            logger.warning(
-                "Echo is not compatible with logprobs. "
-                "To compute logprobs of input prompt, please use the native /generate API."
-            )
+        # When echo + logprobs are both requested, compute logprobs for the
+        # prompt too (logprob_start_len=0); otherwise only output logprobs
+        # are computed (logprob_start_len=-1).
         # Process prompt
         prompt = request.prompt
         if self.template_manager.completion_template_name is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The OpenAI `/v1/completions` path emitted a misleading `logger.warning` and NOTE when a request set both `echo` and `logprobs`:

```python
# NOTE: with openai API, the prompt's logprobs are always not computed
if request.echo and request.logprobs:
    logger.warning(
        "Echo is not compatible with logprobs. "
        "To compute logprobs of input prompt, please use the native /generate API."
    )
```

Both statements contradicted the code directly below them, which sets `logprob_start_len = 0` in exactly that case:

```python
# Set logprob start length based on echo and logprobs
if request.echo and request.logprobs:
    logprob_start_len = 0
else:
    logprob_start_len = -1
```

With `logprob_start_len = 0`, the prompt's logprobs **are** computed — `logprob_result_processor.py` slices `req.origin_input_ids[req.logprob_start_len:]` (i.e. the whole prompt). So `echo + logprobs` is fully supported and works, yet the code told users it was "not compatible" and pushed them to a different API. A caller using the OpenAI completions API with `echo=true, logprobs=5` gets the prompt logprobs they wanted *and* a spurious warning telling them to go use `/generate`.

## Modifications

`python/sglang/srt/entrypoints/openai/serving_completions.py`:
- Removed the false `logger.warning(...)` that claimed echo is "not compatible with logprobs".
- Replaced the inaccurate NOTE (`"the prompt's logprobs are always not computed"`) with a NOTE describing the real behavior: echo + logprobs ⇒ `logprob_start_len=0` (prompt logprobs computed); otherwise `-1` (output logprobs only).
- Removed the now-unused `import logging` and `logger = logging.getLogger(__name__)` (the warning was the only `logger` usage in the file).

No behavioral change — only a comment correction and removal of a misleading warning. The actual `logprob_start_len` logic is untouched.

## Accuracy Tests

This change does not affect model outputs or sampling — it removes a log warning and corrects a comment, with no change to the request-handling code path. Existing coverage already asserts the real behavior:

`test/registered/openai_server/basic/test_openai_server.py` documents that with `echo=True` and `logprobs>0`, `logprob_start_len` is 0 and prompt logprobs are returned (the first token's logprob is `None` because nothing precedes it, matching OpenAI semantics):

```python
# when echo=True and request.logprobs>0, logprob_start_len is 0, so the first token's logprob would be None.
if not echo:
    assert response.choices[0].logprobs.token_logprobs[0]
```

No new test is needed because behavior is unchanged and already asserted. All project pre-commit hooks pass on the changed file (`ruff` F401/F821/UP037, `isort`, `black-jupyter`, `codespell`, `check-ast`, trailing-whitespace, end-of-file-fixer).

## Speed Tests and Profiling

Not applicable. The change removes a `logger.warning` call and an unused import; it has no effect on the inference hot path or speed. (If anything, it removes a branch+warning-log in the request-conversion path for the `echo and logprobs` case.)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). _(all pre-commit hooks pass on the changed file)_
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). _(no new test needed — behavior unchanged; existing `test_openai_server.py` covers the echo+logprobs case)_
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). _(n/a — internal comment/warning, no user-facing docs)_
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). _(n/a — no impact on outputs or speed; see sections above)_
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). _(no new code; unused import removed; pre-commit clean)_

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #28006278752](https://github.com/sgl-project/sglang/actions/runs/28006278752)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #28006278618](https://github.com/sgl-project/sglang/actions/runs/28006278618)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->