### PR TITLE
Sync EAGLE verify results across TP ranks

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -532,17 +532,15 @@ def eagle_sample(
             deterministic=True,
         )
 
-        # Sync sampling results across TP ranks: different GPUs may
-        # produce slightly different target_probs due to floating-point
-        # non-determinism in softmax/top_k/top_p, causing different
-        # sampled tokens. Broadcast from rank 0 to ensure consistency.
-        tp_group = (
-            get_attention_tp_group() if is_dp_attention_enabled() else get_tp_group()
-        )
-        if tp_group.world_size > 1:
-            tp_group.broadcast(predict, src=0)
-            tp_group.broadcast(accept_index, src=0)
-            tp_group.broadcast(num_correct_drafts, src=0)
+    # Sync verify results across TP ranks: different GPUs may produce slightly
+    # different logits/probs due to floating-point non-determinism, causing
+    # different accepted tokens. Broadcast from rank 0 to keep running-batch
+    # composition consistent before the next collective.
+    tp_group = get_attention_tp_group() if is_dp_attention_enabled() else get_tp_group()
+    if tp_group.world_size > 1:
+        tp_group.broadcast(predict, src=0)
+        tp_group.broadcast(accept_index, src=0)
+        tp_group.broadcast(num_correct_drafts, src=0)
 
     if SIMULATE_ACC_LEN > 0:
         # Do simulation. The helper builds (and returns) a replacement

--- a/test/registered/unit/spec/test_eagle_verify_tp_sync.py
+++ b/test/registered/unit/spec/test_eagle_verify_tp_sync.py
@@ -1,0 +1,108 @@
+"""Regression test for synchronizing EAGLE verify results across TP ranks."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.speculative.eagle_utils as eagle_utils
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class _FakeForwardMode:
+    def is_idle(self):
+        return False
+
+
+class _FakeTpGroup:
+    world_size = 2
+
+    def __init__(self):
+        self.broadcasts = []
+
+    def broadcast(self, tensor, src):
+        self.broadcasts.append((tensor, src))
+
+
+class TestEagleVerifyTpSync(unittest.TestCase):
+    def test_hip_greedy_verify_results_are_broadcast(self):
+        tp_group = _FakeTpGroup()
+        logits = torch.tensor(
+            [
+                [1.0, 3.0, 2.0],
+                [5.0, 4.0, 1.0],
+                [0.0, 2.0, 6.0],
+            ],
+            dtype=torch.float32,
+        )
+        batch = SimpleNamespace(
+            device=torch.device("cpu"),
+            forward_mode=_FakeForwardMode(),
+            seq_lens=torch.tensor([3], dtype=torch.int32),
+            sampling_info=SimpleNamespace(
+                is_all_greedy=False,
+                acc_additive_penalties=None,
+                acc_scaling_penalties=None,
+                logit_bias=None,
+            ),
+        )
+        verify_input = SimpleNamespace(
+            draft_token=torch.tensor([10, 11, 12], dtype=torch.int64),
+            draft_token_num=3,
+            max_tree_depth=3,
+            retrieve_index=torch.zeros((1, 3), dtype=torch.int32),
+            retrieve_next_token=torch.full((3,), -1, dtype=torch.int32),
+            retrieve_next_sibling=torch.full((3,), -1, dtype=torch.int32),
+            tree_topk=1,
+            grammar=None,
+        )
+        logits_output = SimpleNamespace(next_token_logits=logits)
+
+        def fake_verify_tree_greedy_func(
+            predicts,
+            accept_index,
+            accept_token_num,
+            candidates,
+            retrieve_index,
+            retrieve_next_token,
+            retrieve_next_sibling,
+            target_predict,
+            topk,
+        ):
+            predicts.copy_(target_predict.flatten().to(torch.int32))
+            accept_index[0, 0] = 0
+            accept_token_num.fill_(1)
+            return predicts, accept_index, accept_token_num
+
+        with (
+            patch.object(eagle_utils, "_is_cuda", False),
+            patch.object(eagle_utils, "_is_hip", True),
+            patch.object(eagle_utils, "_is_musa", False),
+            patch.object(eagle_utils, "_is_npu", False),
+            patch.object(
+                eagle_utils, "verify_tree_greedy_func", fake_verify_tree_greedy_func
+            ),
+            patch(
+                "sglang.srt.layers.dp_attention.is_dp_attention_enabled",
+                return_value=False,
+            ),
+            patch("sglang.srt.distributed.get_tp_group", return_value=tp_group),
+        ):
+            predict, num_correct_tokens, accept_index = eagle_utils.eagle_sample(
+                verify_input, batch, logits_output
+            )
+
+        self.assertEqual(num_correct_tokens.tolist(), [2])
+        self.assertEqual(predict.tolist(), [1, 0, 2])
+        self.assertEqual(accept_index.tolist(), [[0, -1, -1]])
+        self.assertEqual([src for _, src in tp_group.broadcasts], [0, 0, 0])
+        self.assertIs(tp_group.broadcasts[0][0], predict)
+        self.assertIs(tp_group.broadcasts[1][0], accept_index)
+        self.assertEqual(tp_group.broadcasts[2][0].tolist(), [1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Move EAGLE verify result synchronization out of the sampling-only branch so greedy/HIP verify results are also broadcast across TP ranks.
- Keep `predict`, `accept_index`, and `num_correct_drafts` aligned before later running-batch updates and collectives.
- Add a CPU regression test that exercises the HIP-forced greedy path with a mocked TP group.

Fixes #28815.

## Motivation
On ROCm, EAGLE/NEXTN verify enters the greedy path via `_is_hip`. The sampling path already broadcasts verify outputs across TP ranks, but the greedy/HIP path returned local verify results. If ranks accept different numbers of draft tokens, later shape-dependent collectives can diverge and hang.

The fix treats TP synchronization as a verify-output invariant rather than a sampling-only behavior.

## Testing
- `python3 -m pytest test/registered/unit/spec/test_eagle_verify_tp_sync.py -q`
- `pre-commit run --files python/sglang/srt/speculative/eagle_utils.py test/registered/unit/spec/test_eagle_verify_tp_sync.py`
- MI300X/gfx942 ROCm container synthetic 2-rank validation: `python3 repro_issue_28815_tp_divergence.py --mode repo-fixed --master-port 29622 --join-timeout-seconds 30`















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28007911393](https://github.com/sgl-project/sglang/actions/runs/28007911393)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28007911148](https://github.com/sgl-project/sglang/actions/runs/28007911148)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->