### PR TITLE
[Misc] Use logger instead of print() in utils/common.py

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -566,9 +566,11 @@ def get_available_gpu_memory(
         assert gpu_id < num_gpus
 
         if torch.cuda.current_device() != gpu_id:
-            print(
-                f"WARNING: current device is not {gpu_id}, but {torch.cuda.current_device()}, ",
-                "which may cause useless memory allocation for torch CUDA context.",
+            logger.warning(
+                "current device is not %s, but %s, which may cause useless "
+                "memory allocation for torch CUDA context.",
+                gpu_id,
+                torch.cuda.current_device(),
             )
 
         if empty_cache:
@@ -588,9 +590,11 @@ def get_available_gpu_memory(
         assert gpu_id < num_gpus
 
         if torch.xpu.current_device() != gpu_id:
-            print(
-                f"WARNING: current device is not {gpu_id}, but {torch.xpu.current_device()}, ",
-                "which may cause useless memory allocation for torch XPU context.",
+            logger.warning(
+                "current device is not %s, but %s, which may cause useless "
+                "memory allocation for torch XPU context.",
+                gpu_id,
+                torch.xpu.current_device(),
             )
 
         if empty_cache:
@@ -604,9 +608,11 @@ def get_available_gpu_memory(
         assert gpu_id < num_gpus
 
         if torch.hpu.current_device() != gpu_id:
-            print(
-                f"WARNING: current device is not {gpu_id}, but {torch.hpu.current_device()}, ",
-                "which may cause useless memory allocation for torch HPU context.",
+            logger.warning(
+                "current device is not %s, but %s, which may cause useless "
+                "memory allocation for torch HPU context.",
+                gpu_id,
+                torch.hpu.current_device(),
             )
 
         free_gpu_memory, total_gpu_memory = torch.hpu.mem_get_info()
@@ -621,9 +627,11 @@ def get_available_gpu_memory(
         assert gpu_id < num_gpus
 
         if torch.npu.current_device() != gpu_id:
-            print(
-                f"WARNING: current device is not {gpu_id}, but {torch.npu.current_device()}, ",
-                "which may cause useless memory allocation for torch NPU context.",
+            logger.warning(
+                "current device is not %s, but %s, which may cause useless "
+                "memory allocation for torch NPU context.",
+                gpu_id,
+                torch.npu.current_device(),
             )
         if empty_cache:
             empty_device_cache(torch.npu)
@@ -642,9 +650,11 @@ def get_available_gpu_memory(
         assert gpu_id < num_gpus
 
         if torch.musa.current_device() != gpu_id:
-            print(
-                f"WARNING: current device is not {gpu_id}, but {torch.musa.current_device()}, ",
-                "which may cause useless memory allocation for torch MUSA context.",
+            logger.warning(
+                "current device is not %s, but %s, which may cause useless "
+                "memory allocation for torch MUSA context.",
+                gpu_id,
+                torch.musa.current_device(),
             )
         if empty_cache:
             empty_device_cache(torch.musa)
@@ -1539,7 +1549,7 @@ def delete_directory(dirpath):
         # This will remove the directory and all its contents
         shutil.rmtree(dirpath)
     except OSError as e:
-        print(f"Warning: {dirpath} : {e.strerror}")
+        logger.warning("Failed to delete directory %s: %s", dirpath, e.strerror)
 
 
 # Temporary directory for prometheus multiprocess mode
@@ -3848,7 +3858,7 @@ def get_nvidia_driver_version() -> tuple:
 
 
 @lru_cache(maxsize=1)
-def get_nvidia_driver_version_str() -> str:
+def get_nvidia_driver_version_str() -> str | None:
     """Return the NVIDIA driver version string, e.g. '595.58.03'.
     Returns None on failure."""
     try:
@@ -3930,7 +3940,7 @@ def get_device_sm_nvidia_smi():
 
     except (subprocess.CalledProcessError, FileNotFoundError, ValueError) as e:
         # Handle cases where nvidia-smi isn't available or output is unexpected
-        print(f"Error getting compute capability: {e}")
+        logger.error("Error getting compute capability: %s", e)
         return (0, 0)  # Default/fallback value
 
 

--- a/test/registered/unit/utils/test_common.py
+++ b/test/registered/unit/utils/test_common.py
@@ -3,7 +3,11 @@ from array import array
 
 import torch
 
-from sglang.srt.utils.common import flatten_arrays_to_int64_tensor
+from sglang.srt.utils.common import (
+    flatten_arrays_to_int64_tensor,
+    get_device_sm_nvidia_smi,
+    get_nvidia_driver_version_str,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -44,6 +48,99 @@ class TestFlattenArraysToInt64Tensor(CustomTestCase):
             array("q", [1000]),
         ]
         self._check(parts, [10, 20, 30, 100, 200, 1000])
+
+
+class TestNvidiaDriverVersionStr(CustomTestCase):
+    """`get_nvidia_driver_version_str` is typed as `str | None`: it returns
+    `None` when nvidia-smi is missing, fails, or emits an empty string. These
+    tests exercise both the success and the None-return paths by monkey-
+    patching `subprocess.run`, so they don't require a GPU. The function is
+    `@lru_cache`d, so the cache is cleared around each test to make the patch
+    observable.
+    """
+
+    def setUp(self):
+        get_nvidia_driver_version_str.cache_clear()
+
+    def tearDown(self):
+        get_nvidia_driver_version_str.cache_clear()
+
+    def test_returns_version_string(self):
+        import subprocess
+
+        class _R:
+            stdout = "595.58.03\n"
+
+        original = subprocess.run
+        subprocess.run = lambda *a, **k: _R()
+        try:
+            self.assertEqual(get_nvidia_driver_version_str(), "595.58.03")
+        finally:
+            subprocess.run = original
+
+    def test_returns_none_on_empty_output(self):
+        import subprocess
+
+        class _R:
+            stdout = "\n"
+
+        original = subprocess.run
+        subprocess.run = lambda *a, **k: _R()
+        try:
+            self.assertIsNone(get_nvidia_driver_version_str())
+        finally:
+            subprocess.run = original
+
+    def test_returns_none_on_called_process_error(self):
+        import subprocess
+
+        original = subprocess.run
+
+        def boom(*a, **k):
+            raise subprocess.CalledProcessError(1, "nvidia-smi")
+
+        subprocess.run = boom
+        try:
+            self.assertIsNone(get_nvidia_driver_version_str())
+        finally:
+            subprocess.run = original
+
+    def test_returns_none_on_file_not_found(self):
+        import subprocess
+
+        original = subprocess.run
+
+        def boom(*a, **k):
+            raise FileNotFoundError("nvidia-smi")
+
+        subprocess.run = boom
+        try:
+            self.assertIsNone(get_nvidia_driver_version_str())
+        finally:
+            subprocess.run = original
+
+
+class TestGetDeviceSmNvidiaSmi(CustomTestCase):
+    """`get_device_sm_nvidia_smi` parses nvidia-smi output into a (major,
+    minor) tuple and falls back to (0, 0) -- logging via `logger.error` --
+    when nvidia-smi fails. The success path needs a GPU; the fallback path is
+    covered here by forcing a failure and asserting the (0, 0) return. The
+    fallback path needs no GPU, so this test runs on CPU.
+    """
+
+    def test_fallback_on_failure_returns_zero_zero(self):
+        import subprocess
+
+        original = subprocess.run
+
+        def boom(*a, **k):
+            raise subprocess.CalledProcessError(1, "nvidia-smi")
+
+        subprocess.run = boom
+        try:
+            self.assertEqual(get_device_sm_nvidia_smi(), (0, 0))
+        finally:
+            subprocess.run = original
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`python/sglang/srt/utils/common.py` emits several warnings and errors via `print()` to **stdout**. Warnings/errors belong on stderr, and a logging logger (with the right level) is the idiomatic way to emit them in the runtime. This PR converts those `print()` calls to the module's existing `logger`, and fixes a return-type annotation that did not match the function's actual behavior. The touched file has no CODEOWNERS entry, so this is low-churn cleanup in an unowned utility module.

## Modifications

In `python/sglang/srt/utils/common.py`:

1. **`get_available_gpu_memory`** — the 5 device branches (`cuda`/`xpu`/`hpu`/`npu`/`musa`) now use `logger.warning(...)` instead of `print()`. This matches the existing pattern already used for the identical message in `multimodal_gen/runtime/platforms/xpu.py`, and also removes the double-space artifact produced by the old two-argument `print()`.
2. **`delete_directory`** — the `OSError` message now uses `logger.warning`.
3. **`get_device_sm_nvidia_smi`** — the fallback error now uses `logger.error`.
4. **`get_nvidia_driver_version_str`** — return annotation corrected from `-> str` to `-> str | None`. The function already returns `None` on two failure paths (empty `nvidia-smi` output, or `nvidia-smi` unavailable), as its docstring documents. Both existing callers (`get_nvidia_driver_version` in `common.py`, and `check_env.py`) already handle `None`.

Observable change: these messages move from **stdout → stderr**. The default log level is `WARNING`, so they remain visible by default. No return values or control flow change. Nothing parses these stdout strings (the only sibling is the `xpu.py` message, already a `logger.warning`).

## Accuracy Tests

This change does not affect model outputs — it only changes where helper-warning messages are emitted and corrects a type annotation. No model/forward/kernel code is touched.

## Speed Tests and Profiling

No inference-speed impact. The changes are in non-hot-path device-query/error helpers; the annotation is a no-op at runtime.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) — all pre-commit hooks pass locally (isort, ruff, black-jupyter, codespell, check-registered-tests).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) — added tests in `test/registered/unit/utils/test_common.py` covering the `str | None` paths of `get_nvidia_driver_version_str` and the `(0, 0)` fallback of `get_device_sm_nvidia_smi` (CPU-runnable, monkeypatch `subprocess.run`).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — N/A (no user-facing API change).
- [x] Provide accuracy and speed benchmark results — N/A (no model-output or speed impact).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28007750716](https://github.com/sgl-project/sglang/actions/runs/28007750716)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28007750595](https://github.com/sgl-project/sglang/actions/runs/28007750595)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->