### PR TITLE
[AMD] Enable pa_decode_gluon for Qwen3.5-MoE and fix decode split count

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_utils.py
+++ b/python/sglang/srt/layers/attention/aiter_utils.py
@@ -24,14 +24,10 @@ try:
     # `from aiter.mha import ...` does NOT work — that module path only
     # exists as `aiter.ops.mha`.
     from aiter import mha_batch_prefill_func
-    from aiter.ops.triton.gluon.pa_decode_gluon import (
-        get_recommended_splits,
-        pa_decode_gluon,
-    )
+    from aiter.ops.triton.gluon.pa_decode_gluon import pa_decode_gluon
 except ImportError:  # pragma: no cover - import-time guard mirrors aiter_backend
     mha_batch_prefill_func = None
     pa_decode_gluon = None
-    get_recommended_splits = None
 
 from sglang.srt.layers.attention.utils import launch_gather_shuffle_5d_to_linear
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
@@ -139,8 +135,17 @@ def forward_extend_vectorized_5d(
     # SWA→sub-pool mapping when applicable).
     pool = backend.token_to_kv_pool
     if hasattr(pool, "layers_mapping"):
+        # SWAKVPool: full / SWA sub-pool split keyed by layer id.
         sub_layer_id, sub_is_swa = pool.layers_mapping[layer.layer_id]
         sub_pool = pool.swa_kv_pool if sub_is_swa else pool.full_kv_pool
+    elif hasattr(pool, "full_kv_pool") and hasattr(pool, "_transfer_full_attention_id"):
+        # HybridLinearKVPool (GDN/linear + full-attn, e.g. Qwen3.5-MoE):
+        # the 5D K/V buffers live on the inner full_kv_pool, and full-attn
+        # layer ids are remapped into a dense [0, num_full_layers) range
+        # (full_kv_pool.start_layer == 0). The wrapper itself has no
+        # `.k_buffer` / `layers_mapping`, so resolve through full_kv_pool.
+        sub_pool = pool.full_kv_pool
+        sub_layer_id = pool._transfer_full_attention_id(layer.layer_id)
     else:
         sub_pool = pool
         sub_layer_id = layer.layer_id
@@ -258,7 +263,39 @@ def forward_decode_vectorized_5d(
     else:
         block_tables_pa = backend.forward_metadata.kv_indices
         ctx_part = 256
-        max_part_num = get_recommended_splits(bs, num_kv_heads)
+        # Each gluon decode CTA covers exactly `ctx_part` (256) context
+        # The launch grid is (bs, num_kv_heads, max_context_partition_num).
+        # The gluon decode kernel grid-strides over the 256-token context
+        # partitions, so `max_part_num` is purely a PARALLELISM knob — any
+        # value is numerically correct, but too few splits serialize the
+        # per-CTA partition loop. aiter's get_recommended_splits() caps the
+        # count at min(...,8), which starves occupancy for low-KV-head models
+        # (Qwen3.5-MoE has 1 KV head/rank under TP=2, vs gpt-oss's 8): with
+        # only bs*1*8 CTAs the MI355X is <25% utilized and the SAME kernel
+        # that ATOM runs in ~22us takes ~126us. Profiled at conc4/IL8k:
+        # SGLang gluon 125.7us vs ATOM 22.1us for the identical kernel.
+        #
+        # Choose the split count from THREE bounds, all graph-safe (constant
+        # per CUDA-graph bucket):
+        #   1. parts_needed  — partitions to cover the context. Derived from
+        #      the decode page-table WIDTH (kv_indices is
+        #      [bs, max_num_blocks_per_seq]); fixed at capture, mirrors the
+        #      unified_attention path's `page_table.shape[1] * page_size`.
+        #   2. sm_splits     — splits to fill the GPU given bs*num_kv_heads
+        #      CTAs already in flight (scales DOWN at high bs so we don't
+        #      over-split / blow up the per-call temp buffers).
+        #   3. FLYDSL_WARP_SIZE (64) — HARD cap: the flydsl ps-reduce kernel
+        #      only compiles for max_context_partition_num <= 64 (the >64
+        #      else-branch hits an arith.constant std::bad_cast at capture).
+        FLYDSL_REDUCE_MAX_PARTS = 64
+        max_ctx_tokens = block_tables_pa.shape[1] * backend.page_size
+        parts_needed = (int(max_ctx_tokens) + ctx_part - 1) // ctx_part
+        props = torch.cuda.get_device_properties(q.device)
+        # occupancy factor 2 mirrors aiter get_recommended_splits/get_occupancy
+        num_sm = props.multi_processor_count * 2
+        denom = max(1, bs * num_kv_heads)
+        sm_splits = (num_sm + denom - 1) // denom
+        max_part_num = max(1, min(FLYDSL_REDUCE_MAX_PARTS, parts_needed, sm_splits))
         sliding_window_arg = 0
 
     q_in = q.view(-1, num_q_heads, layer.qk_head_dim)

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1961,6 +1961,18 @@ class HybridLinearKVPool(KVCache):
             k_size, v_size = self.get_kv_size_bytes()
             self.mem_usage = (k_size + v_size) / GB
 
+    @property
+    def kv_cache_layout(self):
+        # Expose the inner full-attention sub-pool's physical layout so the
+        # AITER backend's `_pool_is_vec5d` detection (and any other
+        # layout-aware caller) sees the SHUFFLE 5D layout through the hybrid
+        # wrapper. The full_kv_pool (MHATokenToKVPool) picks the layout up
+        # from SGLANG_AITER_KV_CACHE_LAYOUT in its own ctor; without this
+        # delegation the wrapper would always report the default "nhd" and
+        # pa_decode_gluon would never be enabled for hybrid (GDN + full-attn)
+        # models such as Qwen3.5-MoE.
+        return getattr(self.full_kv_pool, "kv_cache_layout", "nhd")
+
     def get_kv_size_bytes(self):
         return self.full_kv_pool.get_kv_size_bytes()
 


### PR DESCRIPTION
## Motivation

PR #27063 integrated aiter's `pa_decode_gluon` paged-attention decode kernel
behind the SHUFFLE 5D KV layout (`SGLANG_AITER_KV_CACHE_LAYOUT=vectorized_5d`)
for **gpt-oss-120B**. That work is model-agnostic at the attention-backend /
memory-pool layer, but it does **not** light up for **Qwen3.5-MoE**
(`Qwen3_5MoeForConditionalGeneration`, e.g. Qwen3.5-397B-A17B-MXFP4), and the
decode wrapper drove the kernel with a split count that crashed CUDA-graph
capture and badly under-utilized the GPU at low concurrency.

This PR is an **enablement + correctness** change: it makes the
`vectorized_5d` / `pa_decode_gluon` decode path usable for Qwen3.5-MoE and
brings the SGLang decode kernel to **ATOM parity**. It is **not** a perf win
over `unified_attention` for this model — see the honest comparison below.

Problems fixed:

1. **Hybrid pool wiring.** Qwen3.5 is a hybrid model (GDN linear-attention +
   periodic full-attention, `full_attention_interval=4`). Its full-attention KV
   lives inside `HybridLinearKVPool`, which wraps an inner `MHATokenToKVPool`.
   The AITER backend's 5D detection and the chunked-prefill gather path only
   understood `MHATokenToKVPool` / `SWAKVPool`, so the SHUFFLE 5D layout was
   never detected through the hybrid wrapper and gluon stayed disabled.

2. **CUDA-graph capture crash.** `forward_decode_vectorized_5d` could pass a
   `max_context_partition_num > 64` (e.g. derived from the capture-time
   page-table width). The flydsl `pa_decode_ps_reduce` kernel only compiles for
   `<= FLYDSL_WARP_SIZE (64)`; the `> 64` branch hits an `arith.constant`
   `std::bad_cast` and aborts graph capture.

3. **Low-concurrency occupancy.** The previous split count
   (`get_recommended_splits`, hard-capped at `min(..., 8)`) starved GPU
   occupancy for low-KV-head decode. Under TP=2 Qwen3.5 has **1 KV head per
   rank**, so the launch grid `bs × 1 × 8` left the MI355X largely idle: the
   same gluon kernel that ATOM runs in ~22 µs took ~126 µs in SGLang at the
   larger decode batch.

## Modifications

- **`mem_cache/memory_pool.py`** — add a `kv_cache_layout` property on
  `HybridLinearKVPool` that delegates to its inner `full_kv_pool`, so the AITER
  backend's `_pool_is_vec5d` detection sees the SHUFFLE 5D layout through the
  hybrid wrapper (writes already flow through
  `set_kv_buffer(layer_id_override=…)` into the existing 5D writer).

- **`layers/attention/aiter_utils.py` — `forward_extend_vectorized_5d`** — add a
  `HybridLinearKVPool` branch to the sub-pool resolution. The wrapper has no
  `layers_mapping` / `.k_buffer`; resolve the 5D buffers through
  `pool.full_kv_pool` with `pool._transfer_full_attention_id(layer.layer_id)`.

- **`layers/attention/aiter_utils.py` — `forward_decode_vectorized_5d`** —
  replace `get_recommended_splits()` with
  `max_part_num = max(1, min(64, parts_needed, sm_splits))`, where
  - `parts_needed = cdiv(block_tables_pa.shape[1] * page_size, 256)` — partitions
    to cover the context, from the decode page-table **width** (fixed at
    CUDA-graph capture → grid is static across replays),
  - `sm_splits = cdiv(num_sm * 2, bs * num_kv_heads)` — occupancy-based split
    count that scales **down** at high batch (this mirrors the occupancy
    heuristic `unified_attention` itself uses for `NUM_SEGMENTS_PER_SEQ`),
  - **64 = `FLYDSL_WARP_SIZE`** — hard cap required by the flydsl reduce kernel
    (see crash above).

All three changes are gated behind `SGLANG_AITER_KV_CACHE_LAYOUT=vectorized_5d`;
with the default `nhd` layout every code path is byte-for-byte unchanged.

### Effect on gpt-oss-120B

- The two hybrid-pool changes are **inert** for gpt-oss: it uses
  `SWAKVPool` / `MHATokenToKVPool`, never `HybridLinearKVPool`. `SWAKVPool` is
  caught by the existing `layers_mapping` branch, so the new hybrid branch is
  never reached.
- The decode `max_part_num` change applies to gpt-oss only under `vectorized_5d`,
  and only improves it: `sm_splits` is the same occupancy formula
  `get_recommended_splits` used internally, with the artificial cap raised from
  8 → `min(64, parts_needed)`. More splits for long-context / low-batch decode,
  `parts_needed`-bounded for short context; correctness unchanged (the kernel
  grid-strides over the full context), value stays `≤ 64` (graph-safe, no flydsl
  crash).
- With the default `nhd` layout, gpt-oss is completely untouched.

## Accuracy Tests

Pending — will add GSM8K (lm_eval, chat template) for Qwen3.5-MoE on the
`vectorized_5d` path vs the `nhd` baseline before merge.

## Benchmarking and Profiling

Decode attention kernel, **Qwen3.5-397B-A17B-MXFP4, MI355X, TP=2, IL8k/OL1k**.
`bs` is the decode batch. Gluon attention is
`paged_attention_decode_sliding_window_head_1`; the `unified_attention`
baseline is `kernel_unified_attention_3d` (`NUM_SEGMENTS_PER_SEQ` shown — it is
occupancy-scaled by batch, exactly like this PR's `sm_splits`).

**What this PR fixes — gluon reaches ATOM parity:**

| Config | bs | gluon kernel time (µs) |
|---|---|---|
| gluon before this PR (`max_part=8`) | 4 | 37.6 |
| **gluon after this PR (`max_part=64`)** | 4 | **22.8** |
| ATOM reference (same gluon kernel) | 4 | 22.1 |
| gluon before this PR (`max_part=8`) | 64 | 125.7 |
| gluon after this PR (`max_part=8`\*) | 64 | 120.8 |

\* At `bs=64` the 64 sequences already saturate the GPU, so `sm_splits` correctly
keeps the split count at 8; more splits would only add reduce overhead. The
gluon kernel is compute-bound here, so this PR leaves it ~unchanged (the fix
targets the low-batch occupancy hole and the capture crash).

**Honest comparison vs `unified_attention` (the default decode path):**

| bs | `unified_attention` | gluon (after this PR) |
|---|---|---|
| 4  | **11.3** (`SEGMENTS=128`) | 22.8 |
| 64 | **88.0** (`SEGMENTS=16`) | 120.8 |

`unified_attention` is faster than gluon at **both** batch sizes for this model.
The remaining gap is structural, not a tuning bug:

- **Split ceiling.** `unified_attention` may split context into up to **128**
  segments; the gluon path is capped at **64** by the flydsl reduce kernel, so
  at low batch it gets half the context parallelism.
- **Two-pass.** gluon runs a compute kernel + a separate reduce kernel; unified
  fuses both into one launch.
- **Shape.** `pa_decode_gluon` is tuned for gpt-oss (head_dim 64, 8 KV heads);
  Qwen3.5 is head_dim 256 with 1 KV head/rank under TP=2, which is unfavorable
  for its tiling. ATOM (the reference gluon impl) hits the same ~22 µs, so
  22 µs is the gluon kernel's ceiling for this shape — not an SGLang issue.

**Bottom line:** this PR makes the gluon decode path correct, crash-free, and
ATOM-equivalent for Qwen3.5-MoE, so it can be evaluated fairly. For the shapes
measured here `unified_attention` remains the faster choice; closing the gap is
an aiter kernel-level task (lift the flydsl 64-split cap / retune gluon for
head_dim 256), outside this PR. Per-decode-layer totals are within noise
(unified layer 76.1 µs vs gluon-after layer 77.5 µs) since attention is ~20% of
a full-attention decode layer and only 15 of 60 layers are full-attention.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.