### PR TITLE
Fix EAGLE hidden-state sizing and text prefill CUDA graphs

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -239,6 +239,7 @@ from sglang.srt.speculative.dflash_utils import (
     should_delay_dflash_prefill_for_batching,
     validate_dflash_request,
 )
+from sglang.srt.speculative.eagle_utils import get_draft_input_from_target_hidden_dim
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
     DynamicGradMode,
@@ -1098,6 +1099,17 @@ class Scheduler(
         if model_config is None:
             model_config = self.model_config
 
+        if self.spec_algorithm.carries_draft_hidden_states():
+            if self.server_args.enable_multi_layer_eagle:
+                draft_runner = self.draft_worker.draft_worker.draft_runner_list[0]
+            else:
+                draft_runner = self.draft_worker.draft_worker.draft_runner
+            disagg_hidden_size = get_draft_input_from_target_hidden_dim(draft_runner)
+            disagg_hidden_states_dtype = model_config.dtype
+        else:
+            disagg_hidden_size = 16  # minimal padding size for RDMA
+            disagg_hidden_states_dtype = torch.float32
+
         if (
             self.disaggregation_mode == DisaggregationMode.DECODE
         ):  # *2 for the headroom.
@@ -1107,16 +1119,8 @@ class Scheduler(
             )
             self.disagg_metadata_buffers = MetadataBuffers(
                 buffer_size,
-                hidden_size=(
-                    model_config.spec_hidden_size
-                    if self.spec_algorithm.carries_draft_hidden_states()
-                    else 16  # minimal padding size for RDMA
-                ),
-                hidden_states_dtype=(
-                    model_config.dtype
-                    if self.spec_algorithm.carries_draft_hidden_states()
-                    else torch.float32
-                ),
+                hidden_size=disagg_hidden_size,
+                hidden_states_dtype=disagg_hidden_states_dtype,
                 custom_mem_pool=self.token_to_kv_pool_allocator.get_kvcache().maybe_get_custom_mem_pool(),
             )
 
@@ -1160,16 +1164,8 @@ class Scheduler(
             )
             self.disagg_metadata_buffers = MetadataBuffers(
                 buffer_size,
-                hidden_size=(
-                    model_config.spec_hidden_size
-                    if self.spec_algorithm.carries_draft_hidden_states()
-                    else 16  # minimal padding size for RDMA
-                ),
-                hidden_states_dtype=(
-                    model_config.dtype
-                    if self.spec_algorithm.carries_draft_hidden_states()
-                    else torch.float32
-                ),
+                hidden_size=disagg_hidden_size,
+                hidden_states_dtype=disagg_hidden_states_dtype,
                 custom_mem_pool=self.token_to_kv_pool_allocator.get_kvcache().maybe_get_custom_mem_pool(),
             )
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -235,7 +235,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         if model_runner.spec_algorithm.is_speculative():
             if self.model_runner.is_draft_worker:
                 # Draft workers can use TARGET_VERIFY mode.
-                if not self.model_runner.spec_algorithm.is_dflash():
+                if (
+                    not self.model_runner.spec_algorithm.supports_target_verify_for_draft()
+                ):
                     raise RuntimeError("This should not happen")
             self.capture_forward_mode = ForwardMode.TARGET_VERIFY
             self.num_tokens_per_bs = (

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -176,6 +176,9 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             hidden_size=self.model_runner.model_config.hidden_size,
             embed_dtype=self.model_runner.dtype,
             enable_mamba_track=self.mamba_track_enabled,
+            # Graph replay must preserve input_embeds=None for text-only requests.
+            # A zero static tensor makes multimodal models skip token embeddings.
+            register_input_embeds=False,
             source=self.buffers,
         )
 
@@ -336,15 +339,18 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         )
         set_is_extend_in_batch(False)
 
-        with forward_context(
-            ForwardContext(attn_backend=self.model_runner.attn_backend)
-        ), set_tc_piecewise_forward_context(
-            forward_batch,
-            self.attention_layers,
-            self.quant_config,
-            self.moe_layers,
-            self.moe_fusions,
-            dsa_indexers=self.dsa_indexers,
+        with (
+            forward_context(
+                ForwardContext(attn_backend=self.model_runner.attn_backend)
+            ),
+            set_tc_piecewise_forward_context(
+                forward_batch,
+                self.attention_layers,
+                self.quant_config,
+                self.moe_layers,
+                self.moe_fusions,
+                dsa_indexers=self.dsa_indexers,
+            ),
         ):
             if self.layer_model is not None:
                 return self.layer_model.forward(
@@ -811,17 +817,20 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 original_layer_forward = self.layer_model.forward
                 self.layer_model.forward = replay_layer_forward
                 try:
-                    with forward_context(
-                        ForwardContext(attn_backend=self.model_runner.attn_backend)
-                    ), set_tc_piecewise_forward_context(
-                        static_forward_batch,
-                        self.attention_layers,
-                        self.quant_config,
-                        self.moe_layers,
-                        self.moe_fusions,
-                        dsa_indexers=self.dsa_indexers,
-                        num_tokens=static_num_tokens,
-                        raw_num_tokens=raw_num_tokens,
+                    with (
+                        forward_context(
+                            ForwardContext(attn_backend=self.model_runner.attn_backend)
+                        ),
+                        set_tc_piecewise_forward_context(
+                            static_forward_batch,
+                            self.attention_layers,
+                            self.quant_config,
+                            self.moe_layers,
+                            self.moe_fusions,
+                            dsa_indexers=self.dsa_indexers,
+                            num_tokens=static_num_tokens,
+                            raw_num_tokens=raw_num_tokens,
+                        ),
                     ):
                         output = self.model_runner.model.forward(
                             static_forward_batch.input_ids,
@@ -835,17 +844,20 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 # TC_PIECEWISE path. backend.replay calls the compiled
                 # outer model.forward directly (torch.compile handles
                 # multi-req via bs-invariant FX-traced kernels).
-                with forward_context(
-                    ForwardContext(attn_backend=self.model_runner.attn_backend)
-                ), set_tc_piecewise_forward_context(
-                    static_forward_batch,
-                    self.attention_layers,
-                    self.quant_config,
-                    self.moe_layers,
-                    self.moe_fusions,
-                    dsa_indexers=self.dsa_indexers,
-                    num_tokens=static_num_tokens,
-                    raw_num_tokens=raw_num_tokens,
+                with (
+                    forward_context(
+                        ForwardContext(attn_backend=self.model_runner.attn_backend)
+                    ),
+                    set_tc_piecewise_forward_context(
+                        static_forward_batch,
+                        self.attention_layers,
+                        self.quant_config,
+                        self.moe_layers,
+                        self.moe_fusions,
+                        dsa_indexers=self.dsa_indexers,
+                        num_tokens=static_num_tokens,
+                        raw_num_tokens=raw_num_tokens,
+                    ),
                 ):
                     output = self.backend.replay(
                         self._static_num_tokens, static_forward_batch, **kwargs

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -33,6 +33,7 @@ from sglang.srt.model_executor.runner_backend_utils import (
     CUDA_GRAPH_CAPTURE_FAILED_MSG,
 )
 from sglang.srt.speculative.eagle_info import EagleDraftInput
+from sglang.srt.speculative.eagle_utils import get_draft_recurrent_hidden_state_spec
 from sglang.srt.utils import (
     require_attn_tp_gather,
     require_gathered_buffer,
@@ -177,11 +178,13 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             extend_seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
             topk_p = torch.zeros((self.max_bs, self.topk), dtype=torch.float32)
             topk_index = torch.zeros((self.max_bs, self.topk), dtype=torch.int64)
-            _hidden_size = EagleDraftInput.hidden_size_for(self.eagle_worker)
+            _hidden_size, _hidden_dtype = get_draft_recurrent_hidden_state_spec(
+                model_runner
+            )
             hidden_states = (
                 torch.zeros(
                     (self.max_bs, _hidden_size),
-                    dtype=EagleDraftInput.dtype_for(self.eagle_worker),
+                    dtype=_hidden_dtype,
                 )
                 if _hidden_size is not None
                 else None

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -33,6 +33,7 @@ from sglang.srt.model_executor.runner_backend_utils import (
     CUDA_GRAPH_CAPTURE_FAILED_MSG,
 )
 from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
+from sglang.srt.speculative.eagle_utils import get_draft_input_from_target_hidden_dim
 from sglang.srt.speculative.spec_utils import fast_topk
 from sglang.srt.utils import (
     is_hip,
@@ -152,11 +153,18 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
             mrope_positions = torch.zeros((3, self.max_num_token), dtype=torch.int64)
 
-            _hidden_size = EagleDraftExtendInput.hidden_size_for(self.eagle_worker)
+            target_dtype = (
+                self.eagle_worker.target_worker.model_runner.model_config.dtype
+            )
+            _hidden_size = (
+                None
+                if self.eagle_worker.speculative_algorithm.is_standalone()
+                else get_draft_input_from_target_hidden_dim(model_runner)
+            )
             hidden_states = (
                 torch.zeros(
                     (self.max_num_token, _hidden_size),
-                    dtype=EagleDraftExtendInput.dtype_for(self.eagle_worker),
+                    dtype=target_dtype,
                 )
                 if _hidden_size is not None
                 else None

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -14,18 +14,6 @@ from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 logger = logging.getLogger(__name__)
 
 
-def _draft_runner_of(worker):
-    """Draft model_runner accessor across worker shapes.
-
-    v2 draft workers (`EagleDraftWorker` and subclasses) expose the draft
-    model_runner as `draft_runner`; fall back to `model_runner` for workers
-    that run the draft model directly.
-    """
-    return (
-        worker.draft_runner if hasattr(worker, "draft_runner") else worker.model_runner
-    )
-
-
 @dataclass
 class EagleVerifyInput(SpecInput):
     draft_token: torch.Tensor
@@ -186,22 +174,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
         return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
 
     @classmethod
-    def hidden_size_for(cls, worker) -> Optional[int]:
-        """Decode-phase `hidden_states` width: draft self-chain output
-        (draft model writes its own last hidden back via `capture_for_decode`
-        and the draft loop). Returns None when the draft architecture doesn't
-        consume the field (e.g., STANDALONE)."""
-        if worker.speculative_algorithm.is_standalone():
-            return None
-        return _draft_runner_of(worker).model_config.spec_hidden_size
-
-    @classmethod
-    def dtype_for(cls, worker) -> Optional[torch.dtype]:
-        if worker.speculative_algorithm.is_standalone():
-            return None
-        return _draft_runner_of(worker).model_config.dtype
-
-    @classmethod
     def create_idle_input(
         cls,
         device: torch.device,
@@ -331,39 +303,6 @@ class EagleDraftExtendInput(SpecInput):
 
     def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
         return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
-
-    @classmethod
-    def hidden_size_for(cls, worker) -> Optional[int]:
-        """Extend-phase `hidden_states` width: target's `spec_hidden_size`,
-        widened to `num_aux * target_hidden` for EAGLE-3 aux mode. Returns
-        None when the draft architecture doesn't consume the field
-        (e.g., STANDALONE)."""
-        if worker.speculative_algorithm.is_standalone():
-            return None
-        target_cfg = worker.target_worker.model_runner.model_config
-        if not (
-            worker.speculative_algorithm.is_eagle3()
-            and worker.eagle_use_aux_hidden_state
-        ):
-            return target_cfg.spec_hidden_size
-
-        hf_config = target_cfg.hf_config
-
-        # `num_aux` resolution: explicit attr > eagle_config layer_ids > default 3.
-        num_aux = getattr(hf_config, "num_aux_hidden_states", None)
-        if num_aux is None:
-            eagle_config = getattr(hf_config, "eagle_config", None) or {}
-            layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids")
-            num_aux = len(layer_ids) if layer_ids else 3
-
-        target_hidden = getattr(hf_config, "target_hidden_size", target_cfg.hidden_size)
-        return target_hidden * num_aux
-
-    @classmethod
-    def dtype_for(cls, worker) -> Optional[torch.dtype]:
-        if worker.speculative_algorithm.is_standalone():
-            return None
-        return worker.target_worker.model_runner.model_config.dtype
 
     @classmethod
     def create_idle_input(

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -261,21 +261,47 @@ def verify_tree_greedy_func(
     return predicts, accept_index, accept_token_num
 
 
-def get_draft_hidden_dim(model_runner: ModelRunner) -> int:
+def get_draft_input_from_target_hidden_dim(model_runner: ModelRunner) -> int:
     """Derive the hidden dimension of target hidden states fed to the draft model."""
     hf_config = model_runner.model_config.hf_config
-    eagle_config = getattr(hf_config, "eagle_config", {})
-    use_aux = eagle_config.get("use_aux_hidden_state", False)
+    eagle_config = getattr(hf_config, "eagle_config", None) or {}
+    get_eagle_config = (
+        eagle_config.get
+        if isinstance(eagle_config, dict)
+        else lambda key, default=None: getattr(eagle_config, key, default)
+    )
+    use_aux = get_eagle_config("use_aux_hidden_state", True)
     spec_algorithm = model_runner.spec_algorithm
 
     if spec_algorithm is not None and spec_algorithm.is_eagle3() and use_aux:
+        model = getattr(model_runner, "model", None)
+        if model is not None:
+            inner = getattr(model, "model", model)
+            for projection_name in ("fc_cat_hidden", "fc"):
+                projection = getattr(inner, projection_name, None)
+                if projection is not None and hasattr(projection, "in_features"):
+                    return projection.in_features
+
         base = getattr(hf_config, "target_hidden_size", None)
         if base is None:
             base = model_runner.model_config.hidden_size
-        layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids", [])
-        num_aux = max(len(layer_ids), 1)
+        num_aux = getattr(hf_config, "num_aux_hidden_states", None)
+        if num_aux is None:
+            layer_ids = get_eagle_config("eagle_aux_hidden_state_layer_ids", None)
+            if layer_ids is None:
+                layer_ids = getattr(hf_config, "eagle_aux_hidden_state_layer_ids", None)
+            num_aux = len(layer_ids) if layer_ids else 3
         return base * num_aux
     return model_runner.model_config.spec_hidden_size
+
+
+def get_draft_recurrent_hidden_state_spec(
+    model_runner: ModelRunner,
+) -> tuple[Optional[int], Optional[torch.dtype]]:
+    """Return hidden_states width/dtype carried between draft decode steps."""
+    if model_runner.spec_algorithm.is_standalone():
+        return None, None
+    return model_runner.model_config.spec_hidden_size, model_runner.model_config.dtype
 
 
 def eagle_prepare_for_verify(

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -67,6 +67,7 @@ from sglang.srt.speculative.eagle_utils import (
     build_tree_kernel_efficient,
     eagle_prepare_for_verify,
     eagle_sample,
+    get_draft_recurrent_hidden_state_spec,
     organize_draft_results,
     per_step_draft_out_cache_loc,
 )
@@ -180,14 +181,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
         # Alias for better readability
         self.draft_runner = self.draft_worker.model_runner
-        self.eagle_use_aux_hidden_state = False
-        if self.speculative_algorithm.is_eagle3():
-            eagle_config = getattr(
-                self.draft_runner.model_config.hf_config, "eagle_config", {}
-            )
-            self.eagle_use_aux_hidden_state = eagle_config.get(
-                "use_aux_hidden_state", True
-            )
         # Reuse the first draft step's NSA/DSA indexer topk across the rest;
         # topk == 1 only (select_top_k_tokens reorders rows, desyncing indices).
         self.index_share_for_mtp_iteration = (
@@ -223,9 +216,11 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.init_lm_head()
 
     def init_backends(self):
-        with self.draft_tp_context(
-            self.draft_runner.tp_group
-        ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
+        with (
+            self.draft_tp_context(self.draft_runner.tp_group),
+            speculative_moe_backend_context(),
+            speculative_moe_a2a_backend_context(),
+        ):
             self.draft_worker.init_backends(disable_cuda_graph=True)
             self.init_attention_backend()
             if check_cuda_graph_backend(Phase.PREFILL, Backend.BREAKABLE):
@@ -1004,10 +999,13 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     if self.speculative_algorithm.is_standalone()
                     else CaptureHiddenMode.LAST
                 )
+                hidden_size, hidden_dtype = get_draft_recurrent_hidden_state_spec(
+                    self.draft_worker.draft_runner
+                )
                 batch.spec_info = EagleDraftInput.create_idle_input(
                     device=self.device,
-                    hidden_size=EagleDraftInput.hidden_size_for(self.draft_worker),
-                    dtype=EagleDraftInput.dtype_for(self.draft_worker),
+                    hidden_size=hidden_size,
+                    dtype=hidden_dtype,
                     topk=self.topk,
                     capture_hidden_mode=capture_mode,
                 )
@@ -1126,11 +1124,13 @@ class EAGLEWorkerV2(BaseSpecWorker):
         next_draft_input.topk_index = torch.zeros(
             (bs, self.topk), dtype=torch.int64, device=device
         )
-        hidden_size = EagleDraftInput.hidden_size_for(self.draft_worker)
+        hidden_size, hidden_dtype = get_draft_recurrent_hidden_state_spec(
+            self.draft_worker.draft_runner
+        )
         if hidden_size is not None:
             next_draft_input.hidden_states = torch.zeros(
                 (bs, hidden_size),
-                dtype=EagleDraftInput.dtype_for(self.draft_worker),
+                dtype=hidden_dtype,
                 device=device,
             )
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -56,6 +56,7 @@ from sglang.srt.model_executor.runner_backend_utils import (
     CUDA_GRAPH_CAPTURE_FAILED_MSG,
 )
 from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
+from sglang.srt.speculative.eagle_utils import get_draft_input_from_target_hidden_dim
 from sglang.srt.speculative.multi_layer_eagle_utils import assign_new_state_triton
 from sglang.srt.speculative.spec_utils import fast_topk
 from sglang.srt.utils import (
@@ -206,12 +207,15 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
 
             mrope_positions = torch.zeros((3, self.max_num_token), dtype=torch.int64)
 
+            target_dtype = (
+                self.eagle_worker.target_worker.model_runner.model_config.dtype
+            )
             hidden_states = torch.zeros(
                 (
                     self.max_num_token,
-                    EagleDraftExtendInput.hidden_size_for(self.eagle_worker),
+                    get_draft_input_from_target_hidden_dim(self.model_runner),
                 ),
-                dtype=EagleDraftExtendInput.dtype_for(self.eagle_worker),
+                dtype=target_dtype,
             )
 
             if self.require_gathered_buffer:

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -54,6 +54,7 @@ from sglang.srt.speculative.eagle_utils import (
     build_tree_kernel_efficient,
     eagle_prepare_for_verify,
     eagle_sample,
+    get_draft_recurrent_hidden_state_spec,
 )
 from sglang.srt.speculative.multi_layer_eagle_draft_extend_cuda_graph_runner import (
     MultiLayerEagleMultiStepDraftExtendCudaGraphRunner,
@@ -158,8 +159,7 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
 
         # Alias for better readability
         self.draft_runner_list: List[ModelRunner] = self.draft_worker.model_runner_list
-        # Match `EagleDraftWorker.draft_runner` so `_draft_runner_of(self)` works
-        # for the EagleDraftInput shape classmethods.
+        # Match `EagleDraftWorker.draft_runner` for generic draft-runner access.
         self.draft_runner: ModelRunner = self.draft_runner_list[0]
 
         # Chain-style MTP: each step propagates its own output hidden states to the
@@ -201,9 +201,10 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         )
 
     def init_backends(self):
-        with self.draft_tp_context(
-            self.draft_runner_list[0].tp_group
-        ), speculative_moe_backend_context():
+        with (
+            self.draft_tp_context(self.draft_runner_list[0].tp_group),
+            speculative_moe_backend_context(),
+        ):
             super().init_backends()
 
     def mtp_model_runner(self, step: int):
@@ -782,10 +783,13 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                     if self.speculative_algorithm.is_standalone()
                     else CaptureHiddenMode.LAST
                 )
+                hidden_size, hidden_dtype = get_draft_recurrent_hidden_state_spec(
+                    self.draft_worker.draft_runner
+                )
                 batch.spec_info = EagleDraftInput.create_idle_input(
                     device=self.device,
-                    hidden_size=EagleDraftInput.hidden_size_for(self.draft_worker),
-                    dtype=EagleDraftInput.dtype_for(self.draft_worker),
+                    hidden_size=hidden_size,
+                    dtype=hidden_dtype,
                     topk=self.topk * self.speculative_num_steps,
                     capture_hidden_mode=capture_mode,
                 )

--- a/test/registered/unit/spec/test_eagle_utils.py
+++ b/test/registered/unit/spec/test_eagle_utils.py
@@ -1,0 +1,209 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.speculative.eagle_utils import (
+    get_draft_input_from_target_hidden_dim,
+    get_draft_recurrent_hidden_state_spec,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _eagle_config_get(eagle_config, key, default=None):
+    if isinstance(eagle_config, dict):
+        return eagle_config.get(key, default)
+    return getattr(eagle_config, key, default)
+
+
+def _old_draft_extend_hidden_size(model_runner):
+    model_config = model_runner.model_config
+    if not model_runner.spec_algorithm.is_eagle3():
+        return model_config.spec_hidden_size
+
+    hf_config = model_config.hf_config
+    eagle_config = getattr(hf_config, "eagle_config", None) or {}
+    if not _eagle_config_get(eagle_config, "use_aux_hidden_state", True):
+        return model_config.spec_hidden_size
+
+    num_aux = getattr(hf_config, "num_aux_hidden_states", None)
+    if num_aux is None:
+        layer_ids = _eagle_config_get(eagle_config, "eagle_aux_hidden_state_layer_ids")
+        if layer_ids is None:
+            layer_ids = getattr(hf_config, "eagle_aux_hidden_state_layer_ids", None)
+        num_aux = len(layer_ids) if layer_ids else 3
+
+    target_hidden = getattr(hf_config, "target_hidden_size", model_config.hidden_size)
+    return target_hidden * num_aux
+
+
+def _runner(
+    *,
+    spec_algorithm,
+    hidden_size,
+    spec_hidden_size,
+    hf_config,
+    fc_in_features=None,
+    dtype=torch.bfloat16,
+):
+    inner = SimpleNamespace()
+    if fc_in_features is not None:
+        inner.fc = SimpleNamespace(in_features=fc_in_features)
+
+    return SimpleNamespace(
+        model=SimpleNamespace(model=inner),
+        model_config=SimpleNamespace(
+            hidden_size=hidden_size,
+            spec_hidden_size=spec_hidden_size,
+            hf_config=hf_config,
+            dtype=dtype,
+        ),
+        spec_algorithm=spec_algorithm,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_runner",
+    [
+        _runner(
+            spec_algorithm=SpeculativeAlgorithm.EAGLE3,
+            hidden_size=8192,
+            spec_hidden_size=8192,
+            hf_config=SimpleNamespace(
+                target_hidden_size=8192,
+                eagle_config={
+                    "use_aux_hidden_state": True,
+                    "eagle_aux_hidden_state_layer_ids": [2, 23, 43],
+                },
+            ),
+            fc_in_features=24576,
+        ),
+        _runner(
+            spec_algorithm=SpeculativeAlgorithm.EAGLE3,
+            hidden_size=5120,
+            spec_hidden_size=5120,
+            hf_config=SimpleNamespace(
+                target_hidden_size=5120,
+                num_aux_hidden_states=4,
+                eagle_config={"use_aux_hidden_state": True},
+            ),
+            fc_in_features=20480,
+        ),
+        _runner(
+            spec_algorithm=SpeculativeAlgorithm.EAGLE3,
+            hidden_size=4096,
+            spec_hidden_size=4096,
+            hf_config=SimpleNamespace(
+                target_hidden_size=4096,
+                eagle_aux_hidden_state_layer_ids=[1, 7],
+                eagle_config={"use_aux_hidden_state": True},
+            ),
+            fc_in_features=8192,
+        ),
+        _runner(
+            spec_algorithm=SpeculativeAlgorithm.EAGLE3,
+            hidden_size=4096,
+            spec_hidden_size=4096,
+            hf_config=SimpleNamespace(
+                eagle_config={"use_aux_hidden_state": False},
+            ),
+        ),
+        _runner(
+            spec_algorithm=SpeculativeAlgorithm.EAGLE,
+            hidden_size=4096,
+            spec_hidden_size=4096,
+            hf_config=SimpleNamespace(),
+            fc_in_features=8192,
+        ),
+    ],
+)
+def test_get_draft_input_from_target_hidden_dim_matches_old_oss_draft_extend_rules(
+    model_runner,
+):
+    assert get_draft_input_from_target_hidden_dim(
+        model_runner
+    ) == _old_draft_extend_hidden_size(model_runner)
+
+
+@pytest.mark.parametrize(
+    "model_runner",
+    [
+        _runner(
+            spec_algorithm=SpeculativeAlgorithm.EAGLE3,
+            hidden_size=8192,
+            spec_hidden_size=8192,
+            hf_config=SimpleNamespace(
+                target_hidden_size=8192,
+                eagle_config={
+                    "use_aux_hidden_state": True,
+                    "eagle_aux_hidden_state_layer_ids": [2, 23, 43],
+                },
+            ),
+            fc_in_features=24576,
+        ),
+        _runner(
+            spec_algorithm=SpeculativeAlgorithm.EAGLE3,
+            hidden_size=5120,
+            spec_hidden_size=5120,
+            hf_config=SimpleNamespace(
+                target_hidden_size=5120,
+                num_aux_hidden_states=4,
+                eagle_config={"use_aux_hidden_state": True},
+            ),
+            fc_in_features=20480,
+        ),
+        _runner(
+            spec_algorithm=SpeculativeAlgorithm.EAGLE3,
+            hidden_size=4096,
+            spec_hidden_size=4096,
+            hf_config=SimpleNamespace(
+                target_hidden_size=4096,
+                eagle_aux_hidden_state_layer_ids=[1, 7],
+                eagle_config={"use_aux_hidden_state": True},
+            ),
+            fc_in_features=8192,
+        ),
+        _runner(
+            spec_algorithm=SpeculativeAlgorithm.EAGLE3,
+            hidden_size=4096,
+            spec_hidden_size=4096,
+            hf_config=SimpleNamespace(
+                target_hidden_size=4096,
+                eagle_config={
+                    "use_aux_hidden_state": True,
+                    "eagle_aux_hidden_state_layer_ids": [2, 18, 30],
+                },
+            ),
+            fc_in_features=16384,
+        ),
+    ],
+)
+def test_get_draft_input_from_target_hidden_dim_matches_oss_eagle3_projection_width(
+    model_runner,
+):
+    assert (
+        get_draft_input_from_target_hidden_dim(model_runner)
+        == model_runner.model.model.fc.in_features
+    )
+
+
+@pytest.mark.parametrize(
+    ("spec_algorithm", "expected"),
+    [
+        (SpeculativeAlgorithm.STANDALONE, (None, None)),
+        (SpeculativeAlgorithm.EAGLE, (4096, torch.bfloat16)),
+        (SpeculativeAlgorithm.EAGLE3, (4096, torch.bfloat16)),
+    ],
+)
+def test_get_draft_recurrent_hidden_state_spec(spec_algorithm, expected):
+    model_runner = _runner(
+        spec_algorithm=spec_algorithm,
+        hidden_size=8192,
+        spec_hidden_size=4096,
+        hf_config=SimpleNamespace(),
+    )
+
+    assert get_draft_recurrent_hidden_state_spec(model_runner) == expected


### PR DESCRIPTION
## Summary

- Centralize EAGLE hidden-state sizing so draft-extend uses the target-hidden input width while recurrent draft decode keeps the draft hidden width.
- Update single and multi-layer EAGLE CUDA graph buffer sizing and disaggregation metadata sizing to use the shared helpers.
- Preserve `input_embeds=None` for text-only prefill CUDA graph replay and add unit coverage for EAGLE sizing helpers.

## Testing

- `uv run --no-sync pre-commit run --files <changed files>`
- `LD_PRELOAD=/usr/lib64/libnuma.so.1 uv run --no-sync python -m pytest test/registered/unit/spec/test_eagle_utils.py`

## Original commits

- `090fc0e4a`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->