### PR TITLE
fix(models): clean up weight-load error logging (print→logger, drop dead except)

### DIFF
--- a/python/sglang/srt/models/glm4v.py
+++ b/python/sglang/srt/models/glm4v.py
@@ -777,18 +777,14 @@ class Glm4vForConditionalGeneration(nn.Module):
                     # adapt to VisionAttention
                     name = name.replace(r"attn.qkv.", r"attn.qkv_proj.")
 
-                try:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
 
-                    if name not in params_dict:
-                        continue
+                if name not in params_dict:
+                    continue
 
-                    param = params_dict[name]
-                except KeyError:
-                    print(params_dict.keys())
-                    raise
+                param = params_dict[name]
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 if "visual" in name:

--- a/python/sglang/srt/models/glm_ocr.py
+++ b/python/sglang/srt/models/glm_ocr.py
@@ -414,18 +414,14 @@ class GlmOcrForConditionalGeneration(Glm4vForConditionalGeneration):
                     # adapt to VisionAttention
                     name = name.replace(r"attn.qkv.", r"attn.qkv_proj.")
 
-                try:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
 
-                    if name not in params_dict:
-                        continue
+                if name not in params_dict:
+                    continue
 
-                    param = params_dict[name]
-                except KeyError:
-                    print(params_dict.keys())
-                    raise
+                param = params_dict[name]
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 if "visual" in name:

--- a/python/sglang/srt/models/glmasr.py
+++ b/python/sglang/srt/models/glmasr.py
@@ -161,7 +161,10 @@ class GlmAsrForConditionalGeneration(nn.Module):
                         continue
                     param = params_dict[name]
                 except KeyError:
-                    print(params_dict.keys())
+                    logger.error(
+                        f"Weight '{name}' not found in params_dict "
+                        f"({len(params_dict)} params; sample: {list(params_dict)[:10]})"
+                    )
                     raise
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)

--- a/python/sglang/srt/models/points_v15_chat.py
+++ b/python/sglang/srt/models/points_v15_chat.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 from typing import Iterable, List, Optional, Set, Tuple
 
 import torch
@@ -21,6 +22,8 @@ from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen2 import Qwen2ForCausalLM
 from sglang.srt.models.qwen2_vl import Qwen2VisionPatchMerger, Qwen2VisionTransformer
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class Qwen2VisionTransformerForNavitPOINTS(Qwen2VisionTransformer):
@@ -176,7 +179,10 @@ class POINTSV15ChatModel(nn.Module):
                         continue
                     param = params_dict[name]
                 except KeyError:
-                    print(params_dict.keys())
+                    logger.error(
+                        f"Weight '{name}' not found in params_dict "
+                        f"({len(params_dict)} params; sample: {list(params_dict)[:10]})"
+                    )
                     raise
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -847,18 +847,13 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module):
                     # adapt to VisionAttention
                     name = name.replace(r"attn.qkv.", r"attn.qkv_proj.")
 
-                try:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
-                    if name in params_dict.keys():
-                        param = params_dict[name]
-                    else:
-                        continue
-
-                except KeyError:
-                    print(params_dict.keys())
-                    raise
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name in params_dict.keys():
+                    param = params_dict[name]
+                else:
+                    continue
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)

--- a/python/sglang/srt/models/qwen2_audio.py
+++ b/python/sglang/srt/models/qwen2_audio.py
@@ -179,7 +179,10 @@ class Qwen2AudioForConditionalGeneration(nn.Module):
                         continue
                     param = params_dict[name]
                 except KeyError:
-                    print(params_dict.keys())
+                    logger.error(
+                        f"Weight '{name}' not found in params_dict "
+                        f"({len(params_dict)} params; sample: {list(params_dict)[:10]})"
+                    )
                     raise
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)

--- a/python/sglang/srt/models/qwen2_vl.py
+++ b/python/sglang/srt/models/qwen2_vl.py
@@ -609,7 +609,10 @@ class Qwen2VLForConditionalGeneration(nn.Module):
                         continue
                     param = params_dict[name]
                 except KeyError:
-                    print(params_dict.keys())
+                    logger.error(
+                        f"Weight '{name}' not found in params_dict "
+                        f"({len(params_dict)} params; sample: {list(params_dict)[:10]})"
+                    )
                     raise
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1377,18 +1377,13 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                     name = name.replace(r"attn.qkv.", r"attn.qkv_proj.")
                     name = name.replace(r"model.visual.", r"visual.")
 
-                try:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
-                    if name in params_dict.keys():
-                        param = params_dict[name]
-                    else:
-                        continue
-
-                except KeyError:
-                    print(params_dict.keys())
-                    raise
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name in params_dict.keys():
+                    param = params_dict[name]
+                else:
+                    continue
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)


### PR DESCRIPTION
## Motivation

On a weight-name mismatch during `load_weights`, several VLM loaders called `print(params_dict.keys())`, which dumps the model's entire weight-key set (thousands of entries on large models) to **stdout** while omitting the one useful detail — *which* weight was missing. In some of those loaders the surrounding `except KeyError` was also dead code, so the print could never even run there.

This path is reachable at runtime via the weight-update APIs (e.g. `/update_weights_from_disk`, `/update_weights_from_tensor`), not only at startup.

## Modifications

- **print → logger** (loaders that can actually raise the `KeyError`: `qwen2_vl`, `qwen2_audio`, `glmasr`, `points_v15_chat`): replace `print(params_dict.keys())` with `logger.error(...)` that names the missing weight and logs only a bounded sample of available keys. Add a module logger to `points_v15_chat.py`.
- **drop dead except** (loaders where a preceding `if name [not] in params_dict: continue` guard means `params_dict[name]` never raises: `qwen2_5_vl`, `qwen3_vl`, `glm4v`, `glm_ocr`): remove the unreachable `try/except` instead of keeping unreachable logging.

No runtime behavior change — the removed `except` blocks could not execute.

## Accuracy Tests

N/A — logging-only change on an error path, no effect on model output.

## Checklist

- [x] Format your code according to the Format code with pre-commit.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28013995992](https://github.com/sgl-project/sglang/actions/runs/28013995992)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28013995254](https://github.com/sgl-project/sglang/actions/runs/28013995254)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->