### PR TITLE
[HiSparse] Fix host-backed max request length

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -546,8 +546,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         return decode_req
 
     def _check_if_req_exceed_kv_capacity(self, req: Req) -> bool:
-        if len(req.origin_input_ids) > self.max_total_num_tokens:
-            message = f"Request {req.rid} exceeds the maximum number of tokens: {len(req.origin_input_ids)} > {self.max_total_num_tokens}"
+        capacity = (
+            self.scheduler.tp_worker.model_runner.max_token_pool_size
+            if self.scheduler.enable_hisparse
+            else self.max_total_num_tokens
+        )
+        if len(req.origin_input_ids) > capacity:
+            message = (
+                f"Request {req.rid} exceeds the maximum number of tokens: "
+                f"{len(req.origin_input_ids)} > {capacity}"
+            )
             logger.error(message)
             prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)
             self.scheduler.output_streamer.stream_output([req], req.return_logprob)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -966,7 +966,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 enable=get_global_server_args().enable_return_routed_experts,
                 model_config=self.model_config,
                 num_fused_shared_experts=num_fused_shared_experts,
-                num_tokens=self.max_total_num_tokens + self.page_size,
+                num_tokens=self.max_token_pool_size + self.page_size,
                 max_running_requests=self.max_running_requests,
                 device=self.device,
             )
@@ -993,7 +993,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 enable=enable,
                 num_indexer_layers=num_indexer_layers,
                 index_topk=index_topk,
-                num_tokens=self.max_total_num_tokens + self.page_size,
+                num_tokens=self.max_token_pool_size + self.page_size,
                 max_running_requests=self.max_running_requests,
                 device=self.device,
             )
@@ -2296,7 +2296,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
     @property
     def max_token_pool_size(self):
-        """Return the max token pool size considering hybrid swa settings."""
+        """Return the max token pool size considering hybrid swa and hisparse settings."""
+        if self.enable_hisparse:
+            size_full = getattr(self.token_to_kv_pool_allocator, "size_full", None)
+            if size_full is not None:
+                return size_full
         if self.is_hybrid_swa:
             return self.full_max_total_num_tokens
         else:

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -29,6 +29,76 @@ class FakeReceiver:
 
 
 class TestDecodeQueueCleanup(CustomTestCase):
+    def test_hisparse_request_length_uses_full_token_pool_capacity(self):
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue.max_total_num_tokens = 10
+        queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
+
+        scheduler = MagicMock()
+        scheduler.enable_hisparse = True
+        scheduler.tp_worker.model_runner.max_token_pool_size = 20
+        scheduler.output_streamer = MagicMock()
+        queue.scheduler = scheduler
+
+        req = SimpleNamespace(
+            rid="hisparse-host-backed",
+            origin_input_ids=list(range(15)),
+            return_logprob=False,
+        )
+
+        self.assertFalse(queue._check_if_req_exceed_kv_capacity(req))
+        scheduler.output_streamer.stream_output.assert_not_called()
+
+    @patch("sglang.srt.disaggregation.decode.prepare_abort")
+    def test_hisparse_request_length_rejects_above_full_token_pool_capacity(
+        self, mock_prepare_abort
+    ):
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue.max_total_num_tokens = 10
+        queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
+
+        scheduler = MagicMock()
+        scheduler.enable_hisparse = True
+        scheduler.tp_worker.model_runner.max_token_pool_size = 20
+        scheduler.output_streamer = MagicMock()
+        queue.scheduler = scheduler
+
+        req = SimpleNamespace(
+            rid="hisparse-too-long",
+            origin_input_ids=list(range(21)),
+            return_logprob=False,
+        )
+
+        self.assertTrue(queue._check_if_req_exceed_kv_capacity(req))
+        mock_prepare_abort.assert_called_once()
+        message = mock_prepare_abort.call_args.args[1]
+        self.assertIn("21 > 20", message)
+        scheduler.output_streamer.stream_output.assert_called_once_with(
+            [req], req.return_logprob
+        )
+
+    def test_non_hisparse_request_length_keeps_max_total_num_tokens_capacity(self):
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue.max_total_num_tokens = 10
+        queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
+
+        scheduler = MagicMock()
+        scheduler.enable_hisparse = False
+        scheduler.tp_worker.model_runner.max_token_pool_size = 20
+        scheduler.output_streamer = MagicMock()
+        queue.scheduler = scheduler
+
+        req = SimpleNamespace(
+            rid="normal-too-long",
+            origin_input_ids=list(range(15)),
+            return_logprob=False,
+        )
+
+        with patch("sglang.srt.disaggregation.decode.prepare_abort") as mock_abort:
+            self.assertTrue(queue._check_if_req_exceed_kv_capacity(req))
+            message = mock_abort.call_args.args[1]
+            self.assertIn("15 > 10", message)
+
     def test_prealloc_abort_clears_receiver_before_removing_request(self):
         receiver = FakeReceiver()
         req = SimpleNamespace(

--- a/test/registered/unit/model_executor/test_model_runner_token_pool_size.py
+++ b/test/registered/unit/model_executor/test_model_runner_token_pool_size.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestModelRunnerTokenPoolSize(CustomTestCase):
+    def _make_runner(
+        self,
+        *,
+        enable_hisparse=False,
+        is_hybrid_swa=False,
+        size_full=None,
+    ):
+        runner = object.__new__(ModelRunner)
+        runner.enable_hisparse = enable_hisparse
+        runner.is_hybrid_swa = is_hybrid_swa
+        runner.max_total_num_tokens = 1024
+        runner.full_max_total_num_tokens = 2048
+
+        allocator = SimpleNamespace()
+        if size_full is not None:
+            allocator.size_full = size_full
+        runner.token_to_kv_pool_allocator = allocator
+        return runner
+
+    def test_hisparse_uses_allocator_size_full_when_available(self):
+        runner = self._make_runner(enable_hisparse=True, size_full=4096)
+
+        self.assertEqual(runner.max_token_pool_size, 4096)
+
+    def test_hisparse_without_size_full_keeps_non_hybrid_fallback(self):
+        runner = self._make_runner(enable_hisparse=True)
+
+        self.assertEqual(runner.max_token_pool_size, 1024)
+
+    def test_hisparse_without_size_full_preserves_hybrid_swa_fallback(self):
+        runner = self._make_runner(enable_hisparse=True, is_hybrid_swa=True)
+
+        self.assertEqual(runner.max_token_pool_size, 2048)
+
+    def test_non_hisparse_preserves_hybrid_swa_behavior(self):
+        runner = self._make_runner(enable_hisparse=False, is_hybrid_swa=True)
+
+        self.assertEqual(runner.max_token_pool_size, 2048)
+
+    def test_non_hisparse_preserves_default_behavior(self):
+        runner = self._make_runner()
+
+        self.assertEqual(runner.max_token_pool_size, 1024)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

HiSparse can expose a larger host-backed logical KV capacity than max_total_num_tokens. The decode request length check and related capture buffers should use the actual token pool capacity, otherwise valid HiSparse requests may be rejected or under-sized.

## Modifications

- Use ModelRunner.max_token_pool_size for HiSparse decode request length validation.
- Extend max_token_pool_size to prefer allocator size_full when HiSparse exposes it.
- Size routed experts and indexer capturers from max_token_pool_size + page_size.
- Preserve existing non-HiSparse and hybrid-SWA behavior.
- Add unit coverage for HiSparse and fallback capacity selection.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28014874922](https://github.com/sgl-project/sglang/actions/runs/28014874922)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28014874482](https://github.com/sgl-project/sglang/actions/runs/28014874482)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->