### PR TITLE
[NPU][Bugfix] Fix a ModelSlim loading failure

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -179,15 +179,6 @@ class LinearBase(torch.nn.Module):
             self.quant_method: Optional[QuantizeMethodBase] = UnquantizedLinearMethod()
         else:
             self.quant_method = quant_config.get_quant_method(self, prefix=prefix)
-            print(
-                "[DEBUG LinearBase.get_quant_method] "
-                f"prefix={prefix} "
-                f"layer_cls={self.__class__.__name__} "
-                f"quant_config_cls={quant_config.__class__.__name__} "
-                f"quant_method={self.quant_method} "
-                f"quant_method_cls={type(self.quant_method).__name__ if self.quant_method is not None else 'None'}",
-                flush=True,
-            )
 
         if self.quant_method is not None:
             wrap_method_with_debug_kernel_once(

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -179,6 +179,15 @@ class LinearBase(torch.nn.Module):
             self.quant_method: Optional[QuantizeMethodBase] = UnquantizedLinearMethod()
         else:
             self.quant_method = quant_config.get_quant_method(self, prefix=prefix)
+            print(
+                "[DEBUG LinearBase.get_quant_method] "
+                f"prefix={prefix} "
+                f"layer_cls={self.__class__.__name__} "
+                f"quant_config_cls={quant_config.__class__.__name__} "
+                f"quant_method={self.quant_method} "
+                f"quant_method_cls={type(self.quant_method).__name__ if self.quant_method is not None else 'None'}",
+                flush=True,
+            )
 
         if self.quant_method is not None:
             wrap_method_with_debug_kernel_once(

--- a/python/sglang/srt/layers/quantization/modelslim/modelslim.py
+++ b/python/sglang/srt/layers/quantization/modelslim/modelslim.py
@@ -181,7 +181,7 @@ class ModelSlimConfig(QuantizationConfig):
         elif isinstance(layer, FusedMoE):
             layer.scheme = self.get_moe_scheme(layer, prefix)
             return ModelSlimFusedMoEMethod(self)
-        return UnquantizedLinearMethod()
+        return None
 
     def get_linear_scheme(
         self, layer: torch.nn.Module, prefix: Optional[str] = None
@@ -209,7 +209,7 @@ class ModelSlimConfig(QuantizationConfig):
             f"Unsupported Linear modelslim scheme: "
             f"{quant_schemes} in layer: {prefix}"
         )
-        return None
+        return UnquantizedLinearMethod()
 
     def get_moe_scheme(
         self,

--- a/python/sglang/srt/layers/quantization/modelslim/modelslim.py
+++ b/python/sglang/srt/layers/quantization/modelslim/modelslim.py
@@ -181,7 +181,7 @@ class ModelSlimConfig(QuantizationConfig):
         elif isinstance(layer, FusedMoE):
             layer.scheme = self.get_moe_scheme(layer, prefix)
             return ModelSlimFusedMoEMethod(self)
-        return None
+        return UnquantizedLinearMethod()
 
     def get_linear_scheme(
         self, layer: torch.nn.Module, prefix: Optional[str] = None

--- a/python/sglang/srt/layers/quantization/modelslim/modelslim.py
+++ b/python/sglang/srt/layers/quantization/modelslim/modelslim.py
@@ -177,6 +177,8 @@ class ModelSlimConfig(QuantizationConfig):
             ) or self.is_layer_skipped(prefix, self.packed_modules_mapping):
                 return UnquantizedLinearMethod()
             layer.scheme = self.get_linear_scheme(layer, prefix_in_quant_config)
+            if layer.scheme is None:
+                return UnquantizedLinearMethod()
             return ModelSlimLinearMethod(self)
         elif isinstance(layer, FusedMoE):
             layer.scheme = self.get_moe_scheme(layer, prefix)
@@ -209,7 +211,7 @@ class ModelSlimConfig(QuantizationConfig):
             f"Unsupported Linear modelslim scheme: "
             f"{quant_schemes} in layer: {prefix}"
         )
-        return UnquantizedLinearMethod()
+        return None
 
     def get_moe_scheme(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix a ModelSlim loading failure on Ascend NPU for GLM-5.2 / DSA-style models.

Previously, `ModelSlimConfig.get_linear_scheme()` returned `None` for these layers, but `get_quant_method()` still returned `ModelSlimLinearMethod`. This caused model initialization to fail when `ModelSlimLinearMethod.create_weights()` attempted to call `layer.scheme.create_weights()`:


```text
AttributeError: 'NoneType' object has no attribute 'create_weights'
```

## Modifications

If `get_linear_scheme()` returns `None`, `get_quant_method()` now returns `UnquantizedLinearMethod()` instead of `ModelSlimLinearMethod`. This keeps `get_linear_scheme()` responsible only for resolving ModelSlim schemes, while unsupported or unquantized linear layers use the standard unquantized linear path.

## Accuracy Tests

This change only affects ModelSlim initialization fallback for linear layers without a supported quantization scheme. Quantized layers with valid ModelSlim scheme entries continue to use the existing ModelSlim path.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
The change may make unsupported/unquantized linear layers use the standard unquantized linear path, but does not change kernels or execution paths for layers with valid ModelSlim quantization schemes.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28018163843](https://github.com/sgl-project/sglang/actions/runs/28018163843)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28018165011](https://github.com/sgl-project/sglang/actions/runs/28018165011)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->