### PR TITLE
[DeepSeek-V4][HiSparse] Enable online C128 MTP for EAGLE

### DIFF
--- a/python/sglang/srt/arg_groups/hisparse_hook.py
+++ b/python/sglang/srt/arg_groups/hisparse_hook.py
@@ -91,6 +91,57 @@ def validate_hisparse_kv_cache_dtype(server_args: ServerArgs) -> None:
     )
 
 
+def _validate_dsv4_hisparse_online_c128_mtp(server_args: ServerArgs) -> None:
+    """Validate the DSV4 HiSparse + online C128 MTP combination early."""
+    from sglang.srt.environ import envs
+
+    if not envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+        return
+
+    if server_args.speculative_algorithm is None:
+        return
+
+    if not envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.get():
+        raise ValueError(
+            "DSV4 HiSparse online C128 with speculative decode requires "
+            "SGLANG_EXPERIMENTAL_ONLINE_C128_MTP=1."
+        )
+
+    if server_args.speculative_algorithm != "EAGLE":
+        raise ValueError(
+            "DSV4 HiSparse online C128 MTP supports "
+            f"EAGLE, got {server_args.speculative_algorithm!r}."
+        )
+
+    if server_args.speculative_eagle_topk not in (None, 1):
+        raise ValueError(
+            "DSV4 HiSparse online C128 MTP requires "
+            f"--speculative-eagle-topk 1, got {server_args.speculative_eagle_topk}."
+        )
+
+    speculative_num_steps = int(server_args.speculative_num_steps or 0)
+    if speculative_num_steps > 2:
+        raise ValueError(
+            "DSV4 HiSparse online C128 MTP supports "
+            f"EAGLE step1/step2, got speculative_num_steps={speculative_num_steps}."
+        )
+
+    if not envs.SGLANG_OPT_USE_COMPRESSOR_V2.get():
+        raise ValueError(
+            "DSV4 HiSparse online C128 MTP requires "
+            "SGLANG_OPT_USE_COMPRESSOR_V2=1 because the v2 compressor carries "
+            "online state-slot metadata."
+        )
+
+    logger.warning(
+        "DSV4 HiSparse online C128 MTP enabled: C4 stays on the HiSparse "
+        "host mirror; C128 uses online EAGLE state banks; eagle_steps=%d, "
+        "draft_tokens=%s.",
+        speculative_num_steps,
+        server_args.speculative_num_draft_tokens,
+    )
+
+
 def validate_hisparse(server_args: ServerArgs) -> None:
     """Validate --enable-hisparse constraints (model class, radix cache, DSA backend)."""
     if not server_args.enable_hisparse:
@@ -115,6 +166,9 @@ def validate_hisparse(server_args: ServerArgs) -> None:
 
     # DSv4 hisparse handles its own dtype/backend pairing elsewhere; the dtype-
     # aware checks below only apply to the DSA hisparse path.
+    if is_v4_hisparse:
+        _validate_dsv4_hisparse_online_c128_mtp(server_args)
+
     if is_hip and is_v4_hisparse:
         # TEMPORARY GUARD: DSv4 HiSparse is not supported on the unified-KV path.
         # In unified-KV mode c4_kv_pool is None, so DeepSeekV4HiSparseTokenToKVPoolAllocator

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -516,10 +516,62 @@ class DeepseekV4AttnBackend(
             DSV4RawDecodeMetadata,
         ] = None
         self.online_c128_mtp = OnlineC128MTPController(self)
+        self._log_hisparse_online_c128_mtp_state(model_runner)
 
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
         return pin_tensor.to(self.device, non_blocking=True)
+
+    def _log_hisparse_online_c128_mtp_state(self, model_runner: ModelRunner) -> None:
+        if not model_runner.enable_hisparse or not self.online_c128_mtp.enabled():
+            return
+
+        c128_state_layers = sum(
+            1
+            for pool in self.token_to_kv_pool.compress_state_pools
+            if pool is not None and pool.ratio == 128
+        )
+        state_slot_offset = (
+            self.token_to_kv_pool.get_online_c128_mtp_state_slot_offset()
+        )
+        max_draft_tokens = self.token_to_kv_pool.get_online_c128_mtp_max_draft_tokens()
+
+        if getattr(model_runner, "is_draft_worker", False):
+            logger.info(
+                "DSV4 HiSparse online C128 MTP draft runner initialized: "
+                "c128_state_layers=%d, draft_banks=%d.",
+                c128_state_layers,
+                max_draft_tokens,
+            )
+            return
+
+        if c128_state_layers > 0 and state_slot_offset <= 0:
+            raise RuntimeError(
+                "DSV4 HiSparse online C128 MTP target runner has C128 state "
+                "layers but no pending state-bank offset."
+            )
+        if max_draft_tokens <= 0:
+            raise RuntimeError(
+                "DSV4 HiSparse online C128 MTP target runner has no draft banks."
+            )
+
+        logger.warning(
+            "DSV4 HiSparse online C128 MTP target runner initialized: "
+            "c128_state_layers=%d, state_slot_offset=%d, draft_banks=%d. "
+            "C4 host mirror remains handled by HiSparseCoordinator.",
+            c128_state_layers,
+            state_slot_offset,
+            max_draft_tokens,
+        )
+
+    @staticmethod
+    def _active_batch_size(
+        forward_batch: ForwardBatch,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> int:
+        raw_bs = _get_target_verify_bs(forward_batch)
+        return min(raw_bs, int(req_pool_indices.shape[0]), int(seq_lens.shape[0]))
 
     def _make_target_verify_c128_metadata(
         self,
@@ -1011,7 +1063,9 @@ class DeepseekV4AttnBackend(
                 out_cache_loc=out_cache_loc_padded,
             )
         elif bucket == _GraphBucket.TARGET_VERIFY:
-            verify_bs = _get_target_verify_bs(forward_batch)
+            verify_bs = self._active_batch_size(
+                forward_batch, req_pool_indices, seq_lens
+            )
             if self.online_c128_mtp.enabled() and verify_bs == 0:
                 self.online_c128_mtp.clear()
                 self.forward_metadata = self.cuda_graph_metadata_of_bucket_and_bs[
@@ -1117,7 +1171,7 @@ class DeepseekV4AttnBackend(
             if max_seq_len_override is None
             else max_seq_len_override
         )
-        verify_bs = _get_target_verify_bs(forward_batch)
+        verify_bs = self._active_batch_size(forward_batch, req_pool_indices, seq_lens)
         online_c128_state_slot_offset = self.online_c128_mtp.prepare_forward(
             logical_forward_mode,
             req_pool_indices,

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -32,11 +32,13 @@ def get_compress_state_ring_size(
 ) -> int:
     assert compress_ratio in [4, 128], f"Unsupported {compress_ratio = }"
     # Online c128 keeps a single (max, sum, kv) state per index instead of a
-    # 128-slot ring buffer of raw tokens, so ring_size collapses to 1. Online
-    # is incompatible with speculative decode for now.
+    # 128-slot ring buffer of raw tokens, so ring_size collapses to 1. The
+    # experimental MTP path uses online C128 state banks for EAGLE.
     if compress_ratio == 128 and ONLINE_C128:
         if is_speculative and not envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.get():
-            raise AssertionError("online c128 does not support MTP")
+            raise AssertionError(
+                "online c128 MTP requires SGLANG_EXPERIMENTAL_ONLINE_C128_MTP=1"
+            )
         return 1
     if is_speculative:
         return 16 if compress_ratio == 4 else 256

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -502,19 +502,18 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             target_layers = self.num_layers_total
             self.bytes_per_full_token *= (target_layers + draft_layers) / target_layers
 
-        # Online c128 keeps a single in-progress (max, sum, kv) state per index
-        # and assumes a strict forward-only schedule. Speculative decode (MTP)
-        # would need rollback / replay across draft and verify, which the
-        # online path doesn't support yet.
+        # Online c128 keeps a single in-progress (max, sum, kv) state per index.
+        # Speculative decode is only supported for the experimental EAGLE path
+        # that uses online state banks for draft/verify replay.
         if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
             allow_experimental_online_c128_mtp = (
                 envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.get()
                 and mr.spec_algorithm.is_eagle()
             )
             assert mr.spec_algorithm.is_none() or allow_experimental_online_c128_mtp, (
-                "SGLANG_OPT_USE_ONLINE_COMPRESS does not support speculative decode "
-                "(MTP) yet, except the experimental EAGLE topk=1 path gated by "
-                "SGLANG_EXPERIMENTAL_ONLINE_C128_MTP=1"
+                "SGLANG_OPT_USE_ONLINE_COMPRESS with speculative decode requires "
+                "the experimental EAGLE topk=1 path gated by "
+                "SGLANG_EXPERIMENTAL_ONLINE_C128_MTP=1."
             )
             if allow_experimental_online_c128_mtp:
                 assert self.online_c128_mtp_max_draft_tokens > 0, (

--- a/test/registered/unit/managers/test_hisparse_online_c128_mtp.py
+++ b/test/registered/unit/managers/test_hisparse_online_c128_mtp.py
@@ -1,0 +1,96 @@
+import unittest
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.arg_groups.hisparse_hook import validate_hisparse
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _make_server_args(**overrides):
+    args = SimpleNamespace(
+        enable_hisparse=True,
+        disable_radix_cache=True,
+        kv_cache_dtype="auto",
+        dsa_prefill_backend=None,
+        dsa_decode_backend=None,
+        speculative_algorithm="EAGLE",
+        speculative_eagle_topk=1,
+        speculative_num_steps=2,
+        speculative_num_draft_tokens=3,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    args.get_model_config = lambda: SimpleNamespace(hf_config=object())
+    return args
+
+
+class TestHiSparseOnlineC128MTPSupport(CustomTestCase):
+    def _validate(self, args, *, online=True, experimental=True, compressor_v2=True):
+        with ExitStack() as stack:
+            stack.enter_context(envs.SGLANG_OPT_USE_ONLINE_COMPRESS.override(online))
+            stack.enter_context(
+                envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.override(experimental)
+            )
+            stack.enter_context(
+                envs.SGLANG_OPT_USE_COMPRESSOR_V2.override(compressor_v2)
+            )
+            stack.enter_context(
+                patch("sglang.srt.arg_groups.hisparse_hook._is_hip", return_value=False)
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.configs.model_config.is_deepseek_v4",
+                    return_value=True,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.configs.model_config.is_deepseek_dsa",
+                    return_value=False,
+                )
+            )
+            validate_hisparse(args)
+
+    def test_accepts_dsv4_hisparse_online_c128_eagle(self):
+        self._validate(_make_server_args())
+
+    def test_requires_experimental_online_c128_mtp_for_speculative(self):
+        with self.assertRaisesRegex(ValueError, "SGLANG_EXPERIMENTAL_ONLINE_C128_MTP"):
+            self._validate(_make_server_args(), experimental=False)
+
+    def test_rejects_non_eagle_speculative_algorithm(self):
+        with self.assertRaisesRegex(ValueError, "supports EAGLE"):
+            self._validate(_make_server_args(speculative_algorithm="NGRAM"))
+
+    def test_rejects_eagle_topk_greater_than_one(self):
+        with self.assertRaisesRegex(ValueError, "speculative-eagle-topk 1"):
+            self._validate(_make_server_args(speculative_eagle_topk=2))
+
+    def test_rejects_eagle_step3(self):
+        with self.assertRaisesRegex(ValueError, "supports EAGLE step1/step2"):
+            self._validate(_make_server_args(speculative_num_steps=3))
+
+    def test_requires_compressor_v2(self):
+        with self.assertRaisesRegex(ValueError, "SGLANG_OPT_USE_COMPRESSOR_V2=1"):
+            self._validate(_make_server_args(), compressor_v2=False)
+
+    def test_non_speculative_online_c128_keeps_existing_hisparse_path(self):
+        self._validate(
+            _make_server_args(
+                speculative_algorithm=None,
+                speculative_eagle_topk=None,
+                speculative_num_steps=None,
+                speculative_num_draft_tokens=None,
+            ),
+            experimental=False,
+            compressor_v2=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DeepSeek-V4 HiSparse should be able to use online C128 compression together with EAGLE speculative decoding. This PR adds the minimal validation and state-bank plumbing needed for the EAGLE topk=1 step1/step2 path while keeping C4 on the existing HiSparse host mirror.

## Modifications

Allow the experimental online C128 MTP path for DSV4 HiSparse when EAGLE topk=1 and compressor v2 are enabled. Add early fail-fast checks for unsupported speculative settings, use active verify batch size for online state-bank preparation, validate target runner state-bank setup, and account for draft banks in C128 state sizing. C4 host mirror, SWA, radix cache, and PD transfer semantics are unchanged.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28016298073](https://github.com/sgl-project/sglang/actions/runs/28016298073)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28016297930](https://github.com/sgl-project/sglang/actions/runs/28016297930)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->