### PR TITLE
Fix manual chunked-prefill test to use req.fill_len after fill_ids refactor

### DIFF
--- a/test/manual/chunked_prefill/test_scripted_special_case.py
+++ b/test/manual/chunked_prefill/test_scripted_special_case.py
@@ -476,9 +476,7 @@ class TestSpecialCaseBasic(ScriptedTestCase):
                 and req.extend_input_len is not None
             ):
                 saw_mid_chunk = True
-                assert (
-                    req.fill_len == len(req.prefix_indices) + req.extend_input_len
-                ), (
+                assert req.fill_len == len(req.prefix_indices) + req.extend_input_len, (
                     f"init_next_round_input must rebuild fill_ids to the committed "
                     f"prefix plus the in-flight chunk; "
                     f"fill_ids_len={req.fill_len}, "

--- a/test/manual/chunked_prefill/test_scripted_special_case.py
+++ b/test/manual/chunked_prefill/test_scripted_special_case.py
@@ -477,11 +477,11 @@ class TestSpecialCaseBasic(ScriptedTestCase):
             ):
                 saw_mid_chunk = True
                 assert (
-                    len(req.fill_ids) == len(req.prefix_indices) + req.extend_input_len
+                    req.fill_len == len(req.prefix_indices) + req.extend_input_len
                 ), (
                     f"init_next_round_input must rebuild fill_ids to the committed "
                     f"prefix plus the in-flight chunk; "
-                    f"fill_ids_len={len(req.fill_ids)}, "
+                    f"fill_ids_len={req.fill_len}, "
                     f"prefix_indices_len={len(req.prefix_indices)}, "
                     f"extend_input_len={req.extend_input_len}, "
                     f"chunks_done={r.chunks_done}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
PR #26637 replaced `Req.fill_ids` with `full_untruncated_fill_ids` + `fill_len`, and PR #26659 pinned `fill_len` to the truncated/committed length. Most call sites were migrated in those PRs, but one manual test still referenced the removed `req.fill_ids` field.
This PR updates the remaining assertion in `test/manual/chunked_prefill/test_scripted_special_case.py` so the test runs correctly on current main.
## Modifications
- In `test_init_next_round_input_resets_chunk_state`, replace `len(req.fill_ids)` with `req.fill_len` in both the assertion and its error message.
- The checked invariant is unchanged: `fill_len == len(prefix_indices) + extend_input_len`, matching the admission logic in `schedule_policy.py`.


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
Manual test, not needed.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28017024586](https://github.com/sgl-project/sglang/actions/runs/28017024586)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28017024184](https://github.com/sgl-project/sglang/actions/runs/28017024184)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->