### PR TITLE
feat: support session radix cache in HiCache

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4064,7 +4064,7 @@ class Scheduler(
         if self.server_args.enable_session_radix_cache:
             # Radix-native: open is implicit; explicit open only permits id reuse.
             session_id = recv_req.session_id
-            self.tree_cache.register_session(session_id)
+            self.tree_cache.register_radix_session(session_id)
             output = OpenSessionReqOutput(session_id, session_id is not None)
         else:
             output = self.session_controller.open(recv_req)
@@ -4075,7 +4075,7 @@ class Scheduler(
     def close_session(self, recv_req: CloseSessionReqInput):
         if self.server_args.enable_session_radix_cache:
             # "Close" just triggers eviction of the session's tagged KV.
-            self.tree_cache.release_session(recv_req.session_id)
+            self.tree_cache.release_radix_session(recv_req.session_id)
         else:
             self.session_controller.close(recv_req)
 

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -337,6 +337,12 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def release_session(self, session_id: str) -> None:
         pass
 
+    def register_radix_session(self, session_id: str) -> None:
+        pass
+
+    def release_radix_session(self, session_id: str) -> int:
+        return 0
+
     def session_held_tokens(self, active_pool_idxs: Optional[set] = None) -> int:
         return 0
 

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -708,6 +708,7 @@ class HiRadixCache(RadixCache):
         # Clear per-request tracking dicts
         self.prefetch_loaded_tokens_by_reqid.clear()
         self.evictable_host_leaves.clear()
+        self._pending_session_releases = set()
         super().reset()
 
     def get_height(self, node: TreeNode):
@@ -1132,6 +1133,7 @@ class HiRadixCache(RadixCache):
             key = x.key.child_key(self.page_size)
             v = x.parent.children.pop(key, None)
             assert v == x, f"parent does not have child key, {key}"
+            self._discard_session_leaf(x)
             if x in self.evictable_host_leaves:
                 self.evictable_host_leaves.remove(x)
             self._update_host_leaf_status(x.parent)
@@ -1211,6 +1213,79 @@ class HiRadixCache(RadixCache):
             self.metrics_collector.increment_load_back_num_tokens(len(device_indices))
 
         return device_indices
+
+    def register_session(self, session_id: str) -> None:
+        self._pending_session_releases.discard(session_id)
+        super().register_session(session_id)
+
+    def release_session(self, session_id: str) -> int:
+        """Free a session's last-holder nodes from both device and host."""
+        self._ensure_session_radix_state()
+        self._remember_closed_session(session_id)
+        self._pending_session_releases.discard(session_id)
+        indexed = self._session_leaves.pop(session_id, set())
+        deferred = set()
+        freed = 0
+
+        for leaf in sorted(indexed, key=lambda node: node.id, reverse=True):
+            if session_id not in getattr(leaf, "session_ids", ()):
+                continue
+            node = leaf
+            while True:
+                if node is self.root_node:
+                    break
+                if node.lock_ref != 0 or node.host_ref_counter != 0:
+                    if session_id in getattr(leaf, "session_ids", ()):
+                        deferred.add(leaf)
+                    break
+                session_ids = getattr(node, "session_ids", None)
+                if session_ids is not None:
+                    session_ids.discard(session_id)
+                    if not session_ids:
+                        delattr(node, "session_ids")
+                if (
+                    len(node.children) != 0
+                    or getattr(node, "session_ids", None)
+                    or (
+                        node not in self.evictable_leaves
+                        and node not in self.evictable_host_leaves
+                    )
+                ):
+                    break
+
+                parent = node.parent
+                if node.host_value is not None:
+                    self._record_remove_event(node, medium=StorageMedium.CPU)
+                    self.cache_controller.evict_host(node.host_value)
+                    node.host_value = None
+                    self.evictable_host_leaves.discard(node)
+
+                if node.value is not None:
+                    self._record_remove_event(node, medium=StorageMedium.GPU)
+                    self.cache_controller.mem_pool_device_allocator.free(node.value)
+                    self._delete_leaf(node)
+                else:
+                    key = node.key.child_key(self.page_size)
+                    popped = parent.children.pop(key, None)
+                    assert popped is node, "release_session: parent missing child"
+                    self._discard_session_leaf(node)
+                    self.evictable_host_leaves.discard(node)
+                    self._update_leaf_status(parent)
+                    self._update_host_leaf_status(parent)
+                freed += 1
+                node = parent
+
+        if deferred:
+            self._session_leaves[session_id].update(deferred)
+            self._pending_session_releases.add(session_id)
+        logger.info(
+            "release_session %s: indexed %d leaves, freed %d nodes, deferred %d",
+            session_id,
+            len(indexed),
+            freed,
+            len(deferred),
+        )
+        return freed
 
     def init_load_back(
         self,
@@ -1296,6 +1371,8 @@ class HiRadixCache(RadixCache):
         self.loading_check()
         if self.enable_storage:
             self.drain_storage_control_queues()
+        for session_id in tuple(self._pending_session_releases):
+            self.release_session(session_id)
         if self.enable_storage_metrics:
             self.storage_metrics_collector.log_storage_metrics(
                 self.cache_controller.storage_backend.get_stats()
@@ -1721,7 +1798,11 @@ class HiRadixCache(RadixCache):
 
             if self.cache_controller.write_policy != "write_back":
                 self._inc_hit_count(new_node, chunked)
-        return InsertResult(prefix_len=total_prefix_length)
+            node = new_node
+        return InsertResult(
+            prefix_len=total_prefix_length,
+            last_device_node=node,
+        )
 
     def release_aborted_request(self, rid: str):
         # Clean up storage hit tracking for aborted request

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1264,6 +1264,7 @@ class HiRadixCache(RadixCache):
                     self._record_remove_event(node, medium=StorageMedium.GPU)
                     self.cache_controller.mem_pool_device_allocator.free(node.value)
                     self._delete_leaf(node)
+                    self._update_host_leaf_status(parent)
                 else:
                     key = node.key.child_key(self.page_size)
                     popped = parent.children.pop(key, None)

--- a/python/sglang/srt/mem_cache/session_radix_cache.py
+++ b/python/sglang/srt/mem_cache/session_radix_cache.py
@@ -41,6 +41,9 @@ class SessionRadixCacheMixin:
         self._closed_session_ids.pop(session_id, None)
         self._session_leaves.setdefault(session_id, set())
 
+    def register_radix_session(self, session_id: str) -> None:
+        self.register_session(session_id)
+
     def _remember_closed_session(self, session_id: str) -> None:
         self._closed_session_ids[session_id] = None
         self._closed_session_ids.move_to_end(session_id)
@@ -124,3 +127,6 @@ class SessionRadixCacheMixin:
             freed,
         )
         return freed
+
+    def release_radix_session(self, session_id: str) -> int:
+        return self.release_session(session_id)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -37,6 +37,7 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
 )
 from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.session_radix_cache import SessionRadixCacheMixin
 from sglang.srt.mem_cache.unified_cache_components import (
     _NUM_COMPONENT_TYPES,
     BASE_COMPONENT_TYPE,
@@ -302,7 +303,7 @@ class _OngoingPrefetch(NamedTuple):
     comp_xfers: dict[ComponentType, list[PoolTransfer]]
 
 
-class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
+class UnifiedRadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
     def __init__(
         self,
         params: CacheInitParams,
@@ -456,6 +457,8 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             ct: UnifiedLRUList(ct, self.tree_components) for ct in self.tree_components
         }
         self.session.slots.clear()
+        self._reset_session_radix_state()
+        self._pending_radix_session_releases = set()
 
         self.evictable_device_leaves: set[UnifiedTreeNode] = set()
         self.evictable_host_leaves: set[UnifiedTreeNode] = set()
@@ -723,6 +726,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
         result = None
         insert_params = None
+        session_leaf = None
 
         if is_insert:
             insert_params = InsertParams(
@@ -758,11 +762,17 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             insert_params.key = radix_key
             insert_params.value = values
             result = self.insert(insert_params)
+            session_leaf = result.last_device_node
 
             # Free unaligned tail
             self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:])
         else:
             self.token_to_kv_pool_allocator.free(kv_indices[req.cache_protected_len :])
+            radix_key = RadixKey(
+                token_ids, req.extra_key, is_bigram=self.is_eagle
+            ).page_aligned(self.page_size)
+
+        self._tag_session_leaf(req, radix_key, node=session_leaf)
 
         self.dec_lock_ref(
             req.last_node,
@@ -870,6 +880,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         req.cache_protected_len = len(new_indices)
         req.last_node = new_last_node
         req.swa_uuid_for_lock = lock_result.swa_uuid_for_lock
+        self._tag_session_leaf(req, radix_key, node=new_last_node)
 
         # cleanup
         for comp in self._components_tuple:
@@ -1105,7 +1116,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         self._touch_node(node)
         node.priority = max(node.priority, priority)
         if len(key) == 0:
-            return InsertResult(prefix_len=0, mamba_exist=True)
+            return InsertResult(prefix_len=0, last_device_node=node, mamba_exist=True)
 
         child_key = key.child_key(self.page_size)
         total_prefix_length = 0
@@ -1173,7 +1184,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 # resources here or propagate a flag so that
                 # cleanup_after_caching_req can free them properly.
                 self.token_to_kv_pool_allocator.free(value)
-                return InsertResult(prefix_len=total_prefix_length)
+                return InsertResult(
+                    prefix_len=total_prefix_length, last_device_node=node
+                )
             target_node = self._add_new_node(node, key, value, priority=priority)
             is_new_leaf = True
         else:
@@ -1181,7 +1194,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
         # Finalize: let each component attach its data to the target node.
         # e.g. Mamba attaches mamba_value to the leaf node
-        result = InsertResult(prefix_len=total_prefix_length)
+        result = InsertResult(
+            prefix_len=total_prefix_length, last_device_node=target_node
+        )
         for component in self._components_tuple:
             component.commit_insert_component_data(
                 node=target_node,
@@ -1310,6 +1325,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         key = node.key.child_key(self.page_size)
         v = node.parent.children.pop(key, None)
         assert v == node
+        self._discard_session_leaf(node)
 
     def _evict_component_and_detach_lru(
         self,
@@ -2468,6 +2484,8 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         self.loading_check()
         if self.enable_storage:
             self.drain_storage_control_queues()
+        for session_id in tuple(self._pending_radix_session_releases):
+            self.release_radix_session(session_id)
         if self.enable_storage_metrics and self.storage_metrics_collector is not None:
             self.storage_metrics_collector.log_storage_metrics(
                 self.cache_controller.storage_backend.get_stats()
@@ -2497,6 +2515,81 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
     def supports_mamba(self) -> bool:
         return ComponentType.MAMBA in self.components
+
+    # ---- Radix-native session API ----
+
+    def register_radix_session(self, session_id: str) -> None:
+        self._pending_radix_session_releases.discard(session_id)
+        super().register_radix_session(session_id)
+
+    def release_radix_session(self, session_id: str) -> int:
+        """Free a session's last-holder nodes across all cache components."""
+        self._ensure_session_radix_state()
+        self._remember_closed_session(session_id)
+        self._pending_radix_session_releases.discard(session_id)
+        indexed = self._session_leaves.pop(session_id, set())
+        deferred = set()
+        freed = 0
+
+        for leaf in sorted(indexed, key=lambda node: node.id, reverse=True):
+            if session_id not in getattr(leaf, "session_ids", ()):
+                continue
+            node = leaf
+            while True:
+                if node is self.root_node:
+                    break
+                if any(
+                    data.lock_ref != 0 or data.host_lock_ref != 0
+                    for data in node.component_data
+                ):
+                    if session_id in getattr(node, "session_ids", ()):
+                        deferred.add(node)
+                    break
+
+                session_ids = getattr(node, "session_ids", None)
+                if session_ids is not None:
+                    session_ids.discard(session_id)
+                    if not session_ids:
+                        delattr(node, "session_ids")
+                if (
+                    node.children
+                    or getattr(node, "session_ids", None)
+                    or (
+                        node not in self.evictable_device_leaves
+                        and node not in self.evictable_host_leaves
+                    )
+                ):
+                    break
+
+                parent = node.parent
+                full_data = node.component_data[BASE_COMPONENT_TYPE]
+                if full_data.value is not None:
+                    self._record_remove_event(node, medium=StorageMedium.GPU)
+                if full_data.host_value is not None:
+                    self._record_remove_event(node, medium=StorageMedium.CPU)
+                for component in self._components_tuple:
+                    self._evict_component_and_detach_lru(
+                        node, component, target=EvictLayer.ALL
+                    )
+                full_data.value = None
+                self.evictable_device_leaves.discard(node)
+                self.evictable_host_leaves.discard(node)
+                self._remove_leaf_from_parent(node)
+                self._update_evictable_leaf_sets(parent)
+                freed += 1
+                node = parent
+
+        if deferred:
+            self._session_leaves[session_id].update(deferred)
+            self._pending_radix_session_releases.add(session_id)
+        logger.info(
+            "release_radix_session %s: indexed %d leaves, freed %d nodes, deferred %d",
+            session_id,
+            len(indexed),
+            freed,
+            len(deferred),
+        )
+        return freed
 
     # ---- Streaming session API (delegates to composed StreamingSession) ----
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -984,7 +984,7 @@ class ServerArgs:
     ] = False
     enable_session_radix_cache: A[
         bool,
-        "Hold per-session KV as ordinary evictable radix entries, tagged by session id and bulk-evicted on close. Requires --radix-eviction-policy priority.",
+        "Hold per-session KV as ordinary evictable radix entries, tagged by session id and bulk-evicted on close.",
     ] = False
 
     # -------------------------------------------------------------------------
@@ -2537,11 +2537,6 @@ class ServerArgs:
         )
 
         handle_pd_disaggregation(self)
-        if self.enable_session_radix_cache and self.radix_eviction_policy != "priority":
-            raise ValueError(
-                "--enable-session-radix-cache requires --radix-eviction-policy priority"
-            )
-
         # Normalize deprecated CP aliases before validations or model-specific
         # defaults inspect enable_prefill_cp/cp_strategy.
         self._handle_legacy_cp_arguments()

--- a/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
@@ -3,12 +3,17 @@
 import os
 import unittest
 from array import array
+from types import SimpleNamespace
 
 import torch
 
 from sglang.srt.disaggregation.kv_events import BlockStored, StorageMedium
 from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
-from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+    MatchPrefixParams,
+)
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
@@ -88,6 +93,15 @@ class TestHiRadixCacheKVEvents(CustomTestCase):
         self.assertIsNot(match.last_device_node, cache.root_node)
         return match.last_device_node
 
+    def _tag(self, cache, tokens, session_id):
+        leaf = self._leaf_for(cache, tokens)
+        cache._tag_session_leaf(
+            SimpleNamespace(session_id=session_id),
+            RadixKey(array("q", tokens)),
+            node=leaf,
+        )
+        return leaf
+
     def _stored_cpu_events(self, cache):
         return [
             e
@@ -118,6 +132,89 @@ class TestHiRadixCacheKVEvents(CustomTestCase):
         )
         self.assertIsNone(stored_cpu[0].parent_block_hash)
         self.assertEqual(stored_cpu[1].parent_block_hash, stored_cpu[0].block_hashes[0])
+
+    def test_session_survives_hicache_eviction_and_release(self):
+        cache, allocator = self._build_cache()
+        first_turn = list(range(12))
+        second_turn = list(range(24))
+        result = self._insert(cache, allocator, first_turn)
+        self.assertIs(result.last_device_node, self._leaf_for(cache, first_turn))
+        self._tag(cache, first_turn, "S")
+        self._insert(cache, allocator, second_turn)
+        leaf = self._tag(cache, second_turn, "S")
+
+        cache.cache_controller.write_policy = "write_back"
+        self.assertEqual(
+            cache.evict(EvictParams(num_tokens=len(second_turn))).num_tokens_evicted,
+            len(second_turn),
+        )
+        self.assertTrue(leaf.evicted)
+        self.assertTrue(leaf.backuped)
+
+        device_indices = cache.load_back(leaf)
+        self.assertEqual(len(device_indices), len(second_turn))
+        consumer = cache.ready_to_load_host_cache()
+        cache.cache_controller.layer_done_counter.events[
+            consumer
+        ].finish_event.synchronize()
+        cache.loading_check()
+        self.assertFalse(leaf.evicted)
+        self.assertEqual(cache.release_session("S"), 2)
+        self.assertNotIn("S", cache._session_leaves)
+
+    def test_session_shared_leaf_kept_until_last_holder(self):
+        cache, allocator = self._build_cache()
+        tokens = list(range(12))
+        self._insert(cache, allocator, tokens)
+        leaf = self._tag(cache, tokens, "A")
+        self._tag(cache, tokens, "B")
+
+        cache.cache_controller.write_policy = "write_back"
+        cache.evict(EvictParams(num_tokens=len(tokens)))
+        self.assertEqual(cache.release_session("A"), 0)
+        self.assertEqual(leaf.session_ids, {"B"})
+        self.assertEqual(cache.release_session("B"), 1)
+        self.assertNotIn(leaf, cache.evictable_host_leaves)
+
+    def test_locked_session_release_retries_after_unlock(self):
+        cache, allocator = self._build_cache()
+        tokens = list(range(12))
+        self._insert(cache, allocator, tokens)
+        leaf = self._tag(cache, tokens, "S")
+        cache.inc_lock_ref(leaf)
+
+        self.assertEqual(cache.release_session("S"), 0)
+        self.assertIn("S", cache._pending_session_releases)
+        cache.dec_lock_ref(leaf)
+        cache.check_hicache_events()
+        self.assertNotIn("S", cache._pending_session_releases)
+        self.assertNotIn("S", cache._session_leaves)
+
+    def test_reopen_cancels_pending_release(self):
+        cache, allocator = self._build_cache()
+        tokens = list(range(12))
+        self._insert(cache, allocator, tokens)
+        leaf = self._tag(cache, tokens, "S")
+        cache.inc_lock_ref(leaf)
+        cache.release_session("S")
+
+        cache.register_session("S")
+        cache.dec_lock_ref(leaf)
+        cache.check_hicache_events()
+        self.assertNotIn("S", cache._pending_session_releases)
+        self.assertIn(leaf, cache._session_leaves["S"])
+
+    def test_host_eviction_discards_session_index(self):
+        cache, allocator = self._build_cache()
+        tokens = list(range(12))
+        self._insert(cache, allocator, tokens)
+        leaf = self._tag(cache, tokens, "S")
+        cache.cache_controller.write_policy = "write_back"
+        cache.evict(EvictParams(num_tokens=len(tokens)))
+
+        cache.evict_host(len(tokens))
+        self.assertNotIn("S", cache._session_leaves)
+        self.assertFalse(hasattr(leaf, "session_ids"))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -7,6 +7,7 @@ import time
 import unittest
 from array import array
 from dataclasses import dataclass, replace
+from types import SimpleNamespace
 from typing import Optional
 from unittest import mock
 
@@ -627,9 +628,74 @@ class TestUnifiedRadixCacheKVEvents(CustomTestCase):
         self.assertFalse(node.evicted)
         self.assertCountEqual([e.block_hashes[0] for e in restored_gpu], stored_hashes)
 
+    def test_radix_session_release_frees_device_and_host_copies(self):
+        tree, allocator, _ = build_fixture(self.cfg, enable_kv_cache_events=True)
+        self._init_hicache(tree)
+        tree.take_events()
+
+        session_id = "session-a"
+        seq = [1, 2, 3, 4]
+        result = self._insert(tree, allocator, seq)
+        node = result.last_device_node
+        tree.register_radix_session(session_id)
+        tree._tag_session_leaf(
+            SimpleNamespace(session_id=session_id),
+            RadixKey(array("q", seq)),
+            node=node,
+        )
+        self._backup_node(tree, node)
+        tree.take_events()
+
+        self.assertGreater(tree.release_radix_session(session_id), 0)
+        self.assertNotIn(node, tree.evictable_device_leaves)
+        self.assertNotIn(node, tree.evictable_host_leaves)
+        self.assertNotIn(session_id, tree._session_leaves)
+        self.assertEqual(
+            len(
+                tree.match_prefix(
+                    MatchPrefixParams(key=RadixKey(array("q", seq)))
+                ).device_indices
+            ),
+            0,
+        )
+        removed = [
+            event for event in tree.take_events() if isinstance(event, BlockRemoved)
+        ]
+        self.assertTrue(any(event.medium == StorageMedium.GPU for event in removed))
+        self.assertTrue(any(event.medium == StorageMedium.CPU for event in removed))
+
+    def test_radix_session_release_retries_after_unlock(self):
+        tree, allocator, _ = build_fixture(self.cfg)
+        self._init_hicache(tree)
+
+        session_id = "session-a"
+        seq = [1, 2, 3, 4]
+        node = self._insert(tree, allocator, seq).last_device_node
+        tree.register_radix_session(session_id)
+        tree._tag_session_leaf(
+            SimpleNamespace(session_id=session_id),
+            RadixKey(array("q", seq)),
+            node=node,
+        )
+        tree.inc_lock_ref(node)
+
+        self.assertEqual(tree.release_radix_session(session_id), 0)
+        self.assertIn(session_id, tree._pending_radix_session_releases)
+
+        tree.dec_lock_ref(node)
+        tree.check_hicache_events()
+        self.assertNotIn(session_id, tree._pending_radix_session_releases)
+        self.assertEqual(
+            len(
+                tree.match_prefix(
+                    MatchPrefixParams(key=RadixKey(array("q", seq)))
+                ).device_indices
+            ),
+            0,
+        )
+
 
 class UnifiedRadixCacheSuite:
-
     cfg: CacheConfig
     _rid: int = 0
 
@@ -711,6 +777,28 @@ class UnifiedRadixCacheSuite:
         )
         self.assertEqual(len(m.device_indices), 0)
 
+        tree.sanity_check()
+
+    def test_radix_session_release_frees_all_components(self):
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        seq = self._make_seq(1, 2)
+        result = self._insert(tree, allocator, req_to_token_pool, seq)
+        session_id = "session-a"
+        tree.register_radix_session(session_id)
+        tree._tag_session_leaf(
+            SimpleNamespace(session_id=session_id),
+            RadixKey(array("q", seq)),
+            node=result.last_device_node,
+        )
+
+        self.assertGreater(tree.release_radix_session(session_id), 0)
+        match = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
+        self.assertEqual(len(match.device_indices), 0)
+        self.assertEqual(tree.full_evictable_size(), 0)
+        if self.cfg.has_swa:
+            self.assertEqual(tree.swa_evictable_size(), 0)
+        if self.cfg.has_mamba:
+            self.assertEqual(tree.mamba_evictable_size(), 0)
         tree.sanity_check()
 
     def test_shared_prefix_split(self):
@@ -885,6 +973,8 @@ class UnifiedRadixCacheSuite:
         ps = self.cfg.page_size
 
         req = self._make_req(req_to_token_pool)
+        req.session_id = "session-a"
+        tree.register_radix_session(req.session_id)
         input_ids = self._make_seq(1, 3)
         output_ids = self._make_seq(2000, 1)
         req.origin_input_ids = array("q", input_ids)
@@ -910,6 +1000,7 @@ class UnifiedRadixCacheSuite:
             MatchPrefixParams(key=RadixKey(array("q", all_ids[:aligned_len])))
         )
         self.assertEqual(len(m.device_indices), aligned_len)
+        self.assertIn(m.last_device_node, tree._session_leaves[req.session_id])
         tree.sanity_check()
 
     def test_cache_finished_req_strips_thinking(self):
@@ -4151,7 +4242,6 @@ class UnifiedRadixCacheSuite:
 
 
 class UnifiedLRUListBoundedRefreshTest(CustomTestCase):
-
     components = (ComponentType.FULL, ComponentType.SWA)
 
     def _make_node(self, key_len: int) -> UnifiedTreeNode:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1145,13 +1145,13 @@ class TestPrefillOnlyDisableKvCache(unittest.TestCase):
 
 
 class TestSessionRadixCacheServerArgs(unittest.TestCase):
-    def test_requires_priority_radix_eviction_policy(self):
-        with self.assertRaisesRegex(ValueError, "--radix-eviction-policy priority"):
-            ServerArgs(
-                model_path="dummy",
-                enable_session_radix_cache=True,
-                radix_eviction_policy="lru",
-            )
+    def test_supports_lru_radix_eviction_policy(self):
+        args = ServerArgs(
+            model_path="dummy",
+            enable_session_radix_cache=True,
+            radix_eviction_policy="lru",
+        )
+        self.assertEqual(args.radix_eviction_policy, "lru")
 
 
 class TestCudaGraphConfigDataclassAccess(CustomTestCase):


### PR DESCRIPTION
Follow-up to #27058, this extends the existing session radix-cache ownership model into HiCache and UnifiedRadixCache. Session close can now free tagged Full, SWA, and Mamba KV across GPU and host tiers without requiring priority eviction or changing streaming-session behavior.

### How This Was Implemented
- Keep the established Radix session traversal unchanged and add explicit radix-session lifecycle hooks to avoid colliding with streaming sessions.
- Reuse `SessionRadixCacheMixin` for UnifiedRadixCache ownership bookkeeping and request tagging.
- Free last-holder Unified nodes directly across device and host components, with locked releases deferred until the next HiCache event poll.
- Remove stale ownership indexes during normal Unified eviction and refresh HiRadix host-leaf state after device deletion.
- Keep session tags eviction-policy neutral; LRU and priority are both supported.

<details>
<summary>Walkthrough</summary>

- `scheduler.py` / `base_prefix_cache.py`: route native session open and close through distinct radix-session APIs.
- `session_radix_cache.py`: expose the existing Radix implementation through those adapter methods.
- `unified_radix_cache.py`: add tagging, component-aware release, lock retry, and eviction-index cleanup.
- `hiradix_cache.py`: apply the parent host-leaf status fix from review.
- Unit tests cover Full, SWA, Mamba, mixed Unified layouts, GPU+host copies, locked retry, and LRU configuration.

</details>

### Validation
- `PYTHONPATH=$PWD/python /ephemeral/sglang/.venv/bin/python -m pytest -q test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py` (1,071 passed, 711 skipped, 44 subtests passed)
- `PYTHONPATH=$PWD/python /ephemeral/sglang/.venv/bin/python -m pytest -q test/manual/core/test_session_radix_cache.py test/registered/unit/mem_cache/test_hiradix_cache_unit.py test/registered/unit/mem_cache/test_hiradix_pp_sync_drain.py` (14 passed)
- `PYTHONPATH=$PWD/python /ephemeral/sglang/.venv/bin/python -m pytest -q test/registered/unit/server_args/test_server_args.py::TestSessionRadixCacheServerArgs` (1 passed)
- `pre-commit run --files <changed files>`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28094652788](https://github.com/sgl-project/sglang/actions/runs/28094652788)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28094652659](https://github.com/sgl-project/sglang/actions/runs/28094652659)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
