### PR TITLE
fix: graceful degradation when EAGLE draft pool fails to register with Mooncake standalone storage

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -847,9 +847,17 @@ class HiCacheController:
                     "supported on the mooncake v2 path."
                 )
                 return
-            self.storage_backend.register_mem_host_pool_v2(
-                self.mem_pool_host_draft, PoolName.DRAFT
-            )
+            try:
+                self.storage_backend.register_mem_host_pool_v2(
+                    self.mem_pool_host_draft, PoolName.DRAFT
+                )
+            except RuntimeError as e:
+                logger.warning(
+                    "HiCache draft L3 disabled: failed to register draft buffer "
+                    "to Mooncake Store. Draft KV cache will use L2 (host DRAM) only. "
+                    "Error: %s", e
+                )
+                return
             self.draft_page_get_func = self._draft_page_get_v2
             self.draft_page_set_func = self._draft_page_set_v2
             return

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -851,7 +851,7 @@ class HiCacheController:
                 self.storage_backend.register_mem_host_pool_v2(
                     self.mem_pool_host_draft, PoolName.DRAFT
                 )
-            except RuntimeError as e:
+            except Exception as e:
                 logger.warning(
                     "HiCache draft L3 disabled: failed to register draft buffer "
                     "to Mooncake Store. Draft KV cache will use L2 (host DRAM) only. "

--- a/test/registered/unit/mem_cache/test_draft_l3_graceful_degradation.py
+++ b/test/registered/unit/mem_cache/test_draft_l3_graceful_degradation.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDraftL3GracefulDegradation(CustomTestCase):
+    """When register_mem_host_pool_v2 fails for the draft pool (e.g.
+    standalone Mooncake mode where the draft buffer is outside the shared
+    memory segment), the controller must keep draft_page_get_func /
+    draft_page_set_func as None instead of crashing.
+    """
+
+    def _make_controller(self, backend="mooncake"):
+        from sglang.srt.managers.cache_controller import HiCacheController
+
+        ctrl = HiCacheController.__new__(HiCacheController)
+        ctrl.has_draft = True
+        ctrl.enable_storage = True
+        ctrl.storage_backend_type = backend
+        ctrl.storage_config = MagicMock()
+        ctrl.storage_config.should_split_heads = False
+        ctrl.storage_backend = MagicMock()
+        ctrl.mem_pool_host_draft = MagicMock()
+        ctrl.draft_page_get_func = None
+        ctrl.draft_page_set_func = None
+        return ctrl
+
+    def test_mooncake_register_failure_keeps_funcs_none(self):
+        """register_mem_host_pool_v2 raising RuntimeError must not crash."""
+        ctrl = self._make_controller("mooncake")
+        ctrl.storage_backend.register_mem_host_pool_v2.side_effect = RuntimeError(
+            "Failed to register buffer to Mooncake Store, error code: -1"
+        )
+
+        ctrl._maybe_register_draft_with_storage()
+
+        self.assertIsNone(ctrl.draft_page_get_func)
+        self.assertIsNone(ctrl.draft_page_set_func)
+
+    def test_mooncake_register_failure_any_exception(self):
+        """Any exception type (not just RuntimeError) must be caught."""
+        ctrl = self._make_controller("mooncake")
+        ctrl.storage_backend.register_mem_host_pool_v2.side_effect = OSError("boom")
+
+        ctrl._maybe_register_draft_with_storage()
+
+        self.assertIsNone(ctrl.draft_page_get_func)
+        self.assertIsNone(ctrl.draft_page_set_func)
+
+    def test_mooncake_register_success_sets_funcs(self):
+        """When registration succeeds, v2 funcs must be set."""
+        ctrl = self._make_controller("mooncake")
+
+        ctrl._maybe_register_draft_with_storage()
+
+        self.assertIsNotNone(ctrl.draft_page_get_func)
+        self.assertIsNotNone(ctrl.draft_page_set_func)
+
+    def test_non_mooncake_backend_unaffected(self):
+        """Generic backends must still set generic funcs."""
+        ctrl = self._make_controller("file")
+
+        ctrl._maybe_register_draft_with_storage()
+
+        self.assertIsNotNone(ctrl.draft_page_get_func)
+        self.assertIsNotNone(ctrl.draft_page_set_func)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Motivation
Fixes #28873

When using EAGLE speculative decoding with Mooncake L3 storage in standalone (dummy client) mode, the server crashes during startup. The draft host pool is allocated with the default allocator (mmap) instead of MooncakeHostTensorAllocator, causing `register_buffer()` to fail with error code -1 because the buffer is outside Mooncake's shared memory segment.

## Modifications

Wrap the `register_mem_host_pool_v2()` call in `_maybe_register_draft_with_storage()` with a try/except. On failure, log a warning and return early so that `draft_page_get_func` and `draft_page_set_func` remain None.

This disables draft L3 (SSD offload) while keeping:
- Draft L2 (host DRAM): fully functional (uses mem_pool_host_draft directly, independent of storage backend)
- Target model L2/L3: fully functional (target pool uses MooncakeHostTensorAllocator correctly)

## Accuracy Tests

Not applicable — no changes to model forward code.

## Speed Tests and Profiling

Not applicable — no changes to inference kernels. The fix only affects startup behavior.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28023230096](https://github.com/sgl-project/sglang/actions/runs/28023230096)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28023229767](https://github.com/sgl-project/sglang/actions/runs/28023229767)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->