### PR TITLE
[Bugfix] Fix DeepSeek-V4 FP8 wo_a scale layout for DeepGEMM

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -70,7 +70,11 @@ from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.mhc import mhc_fused_post_pre, npu_hc_pre
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
-from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
+from sglang.srt.layers.quantization.fp8_kernel import (
+    fp8_dtype,
+    fp8_max,
+    fp8_min,
+)
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.utils.cp_utils import (
@@ -127,6 +131,7 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
+    ceil_align,
     get_bool_env_var,
     is_gfx95_supported,
     log_info_on_rank0,
@@ -144,6 +149,53 @@ logger = logging.getLogger(__name__)
 
 _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
 _MHC_POST_MULT_VALUE = 2.0
+
+
+def _fp8_wo_a_group_major_quant_ue8m0_for_deep_gemm(
+    o_group_major: torch.Tensor,
+    group_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize DeepSeek-V4 wo_a input for DeepGEMM FP8 einsum.
+
+    The input is logical [G, T, D]. The returned scale tensor is logical
+    [G, T, ceil(D / group_size, 4) / 4] with four UE8M0 scales packed per int32,
+    backed by the TMA-aligned layout expected by DeepGEMM on SM100. Do not make
+    the scale tensor contiguous.
+    """
+    from sglang.srt.layers.quantization.fp8_kernel import (
+        sgl_per_token_group_quant_8bit,
+    )
+
+    G, T, D = o_group_major.shape
+    scale_inner = ceil_align(D // group_size, 4) // 4
+    aligned_t = ceil_align(T, 4)
+    o_fp8 = torch.empty(
+        o_group_major.shape, device=o_group_major.device, dtype=fp8_dtype
+    )
+    o_s = torch.empty(
+        (G, scale_inner, aligned_t),
+        device=o_group_major.device,
+        dtype=torch.int,
+    ).transpose(-1, -2)[:, :T, :]
+
+    # The generic wrapper cannot express this preallocated group-major scale
+    # buffer. Write each group's [T, D] rows into the DeepGEMM TMA layout.
+    for g in range(G):
+        sgl_per_token_group_quant_8bit(
+            o_group_major[g],
+            o_fp8[g],
+            o_s[g],
+            group_size,
+            1e-10,
+            fp8_min,
+            fp8_max,
+            True,
+            False,
+            None,
+            enable_v2=True,
+        )
+
+    return o_fp8, o_s
 
 
 def _is_fused_mhc_post_pre_enabled() -> bool:
@@ -1067,15 +1119,14 @@ class MQALayer(nn.Module):
 
             T, G, D = o.shape
             R = self.o_lora_rank
-            o_fp8, o_s = sglang_per_token_group_quant_fp8(
-                o.reshape(T * G, D).contiguous(),
+            o_fp8, o_s = _fp8_wo_a_group_major_quant_ue8m0_for_deep_gemm(
+                o.transpose(0, 1).contiguous(),
                 group_size=128,
-                scale_ue8m0=True,
             )
             output = torch.empty(T, G, R, device=o.device, dtype=torch.bfloat16)
             deep_gemm.fp8_einsum(
                 "bhr,hdr->bhd",
-                (o_fp8.view(T, G, D), o_s.view(T, G, -1)),
+                (o_fp8.transpose(0, 1), o_s.transpose(0, 1)),
                 (self.wo_a.weight.view(G, R, D), self.wo_a.weight_scale_inv.data),
                 output,
                 recipe=(1, 1, 128),

--- a/test/registered/jit/test_deepseek_v4_fp8_wo_a.py
+++ b/test/registered/jit/test_deepseek_v4_fp8_wo_a.py
@@ -1,0 +1,128 @@
+import importlib
+import unittest
+
+import torch
+
+from sglang.srt.utils import get_device_sm
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-b200")
+
+
+def _ceil_to_ue8m0(x: torch.Tensor) -> torch.Tensor:
+    return torch.pow(2.0, torch.ceil(torch.log2(x.abs())))
+
+
+def _per_token_group_quant_dequant_ref(
+    x_q: torch.Tensor,
+    x: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """Dequantize FP8 per-token-group activations with logical UE8M0 scales."""
+    *prefix, hidden_size = x.shape
+    x_view = x.float().view(*prefix, hidden_size // group_size, group_size)
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    scale = _ceil_to_ue8m0(x_view.abs().amax(dim=-1).clamp(min=1e-10) / fp8_max)
+    x_q_view = x_q.float().view(*prefix, hidden_size // group_size, group_size)
+    return (x_q_view * scale.unsqueeze(-1)).view_as(x).float()
+
+
+class TestDeepSeekV4FP8WoA(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
+        if get_device_sm() < 100:
+            raise unittest.SkipTest("Test requires CUDA SM 100 or higher")
+
+        try:
+            cls.deep_gemm = importlib.import_module("deep_gemm")
+        except ImportError as exc:
+            raise unittest.SkipTest("deep_gemm is required") from exc
+
+        try:
+            cls.deepseek_v4 = importlib.import_module("sglang.srt.models.deepseek_v4")
+        except ImportError as exc:
+            raise unittest.SkipTest(
+                "DeepSeek-V4 model dependencies are required"
+            ) from exc
+
+        if not hasattr(
+            cls.deepseek_v4, "_fp8_wo_a_group_major_quant_ue8m0_for_deep_gemm"
+        ):
+            raise AssertionError(
+                "DeepSeek-V4 FP8 wo_a DeepGEMM quant helper is missing"
+            )
+
+        try:
+            fp8_utils = importlib.import_module(
+                "sglang.srt.layers.quantization.fp8_utils"
+            )
+        except ImportError as exc:
+            raise unittest.SkipTest("FP8 quantization utilities are required") from exc
+
+        cls.quant_helper = staticmethod(
+            cls.deepseek_v4._fp8_wo_a_group_major_quant_ue8m0_for_deep_gemm
+        )
+        cls.quant_weight_ue8m0 = staticmethod(fp8_utils.quant_weight_ue8m0)
+        cls.transform_scale_ue8m0 = staticmethod(fp8_utils.transform_scale_ue8m0)
+        cls.block_quant_dequant = staticmethod(fp8_utils.block_quant_dequant)
+
+    def test_fp8_wo_a_einsum_uses_group_major_activation_scales(self):
+        torch.manual_seed(0)
+        torch.cuda.manual_seed_all(0)
+
+        T, G, D, R = 5, 2, 256, 256
+        group_size = 128
+        device = torch.device("cuda")
+
+        token_scale = torch.linspace(0.5, 1.5, T, device=device).view(T, 1, 1)
+        group_scale = torch.tensor([0.25, 2.0], device=device).view(1, G, 1)
+        o = (
+            torch.randn(T, G, D, device=device, dtype=torch.float32)
+            * token_scale
+            * group_scale
+            * 0.2
+        ).to(torch.bfloat16)
+        weight = (torch.randn(G, R, D, device=device, dtype=torch.float32) * 0.2).to(
+            torch.bfloat16
+        )
+
+        o_group_major = o.transpose(0, 1).contiguous()
+        o_fp8, o_s = self.quant_helper(o_group_major, group_size=group_size)
+
+        self.assertEqual(o_fp8.shape, (G, T, D))
+        self.assertEqual(o_s.shape, (G, T, 1))
+        self.assertFalse(o_s.is_contiguous())
+
+        weight_fp8, weight_s_raw = self.quant_weight_ue8m0(
+            weight, weight_block_size=[128, 128]
+        )
+        weight_s = self.transform_scale_ue8m0(weight_s_raw, mn=R)
+
+        output = torch.empty(T, G, R, device=device, dtype=torch.bfloat16)
+        self.deep_gemm.fp8_einsum(
+            "bhr,hdr->bhd",
+            (o_fp8.transpose(0, 1), o_s.transpose(0, 1)),
+            (weight_fp8, weight_s),
+            output,
+            recipe=(1, 1, 128),
+        )
+
+        o_dequant = _per_token_group_quant_dequant_ref(
+            o_fp8, o_group_major, group_size=group_size
+        ).transpose(0, 1)
+        weight_dequant = self.block_quant_dequant(
+            weight_fp8,
+            weight_s_raw,
+            block_size=[128, 128],
+            dtype=torch.float32,
+        )
+        ref = torch.einsum("tgd,grd->tgr", o_dequant, weight_dequant).to(torch.bfloat16)
+
+        torch.testing.assert_close(output, ref, atol=1e-1, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the DeepSeek-V4 FP8 `wo_a` DeepGEMM path by quantizing the activation in group-major `[G, T, D]` order and preserving the TMA-aligned packed UE8M0 scale layout consumed by DeepGEMM on SM100.

## Problem

The existing path quantizes `o: [T, G, D]` as a flat `[T * G, D]` tensor and then views the scales back as `[T, G, -1]`. For the SM100 DeepGEMM FP8 einsum path, the activation scale buffer needs group-major, TMA-aligned layout semantics. Flattening across `T * G` can associate scales with the wrong group.

## Fix

- Add a private DeepSeek-V4 `wo_a` helper that accepts `[G, T, D]` activation input.
- Write each group's `[T, D]` activation quantization into a preallocated TMA-aligned packed UE8M0 scale buffer.
- Pass the logical `[T, G, ...]` activation/scale views to `deep_gemm.fp8_einsum` without making the scale tensor contiguous.

This only changes the existing `SGLANG_OPT_FP8_WO_A_GEMM` path. No new runtime flag is added.

## Tests

The GPU tests below were run locally on a Blackwell GPU.

```text
PYTHONPATH=python python -m pytest test/registered/jit/test_deepseek_v4_fp8_wo_a.py -q -s
# 1 passed

PYTHONPATH=python python -m pytest test/registered/quant/test_fp8_kernel.py -q -s
# 2 passed

PYTHONPATH=python python -m pytest test/registered/quant/test_fused_rms_fp8_group_quant.py -q -s
# 1 skipped in this environment

python -m py_compile python/sglang/srt/models/deepseek_v4.py test/registered/jit/test_deepseek_v4_fp8_wo_a.py
python -m isort --check-only python/sglang/srt/models/deepseek_v4.py test/registered/jit/test_deepseek_v4_fp8_wo_a.py
python -m black --check python/sglang/srt/models/deepseek_v4.py test/registered/jit/test_deepseek_v4_fp8_wo_a.py
git diff --check
```

I also verified the new regression test fails against current `origin/main` when importing the old DeepSeek-V4 implementation, while it passes on this branch.

## Risk

Low. The change is scoped to the DeepSeek-V4 FP8 `wo_a` DeepGEMM path on SM100+.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28024903795](https://github.com/sgl-project/sglang/actions/runs/28024903795)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #28542390805](https://github.com/sgl-project/sglang/actions/runs/28542390805)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->