### PR TITLE
fix: scale mamba host pool proportionally when --hicache-size is set

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -510,10 +510,24 @@ def build_hybrid_mamba_stack(
         server_args=server_args,
         use_mla=use_mla,
     )
+    mamba_hicache_size = server_args.hicache_size
+    if (
+        server_args.hicache_size > 0
+        and kv_pool.mem_usage > 0
+        and mamba_pool.mem_usage > 0
+    ):
+        scaled_size = int(
+            server_args.hicache_size * mamba_pool.mem_usage / kv_pool.mem_usage
+        )
+        mamba_device_size_gb = mamba_pool.mem_usage * 1.073741824
+        if scaled_size > mamba_device_size_gb:
+            mamba_hicache_size = scaled_size
+        else:
+            mamba_hicache_size = 0
     mamba_host_pool = MambaPoolHost(
         mamba_pool,
         server_args.hicache_ratio,
-        server_args.hicache_size,
+        mamba_hicache_size,
         allocator_type=server_args.hicache_storage_backend,
         layout=server_args.hicache_mem_layout,
     )


### PR DESCRIPTION
## Motivation

Fixes #29034

When `--hicache-size N` is set for hybrid Mamba models (e.g., Qwen3.5 with GatedDeltaNet layers), the same absolute size N is passed to both the KV host pool and the Mamba host pool in `build_hybrid_mamba_stack()`. This causes the Mamba host pool to be vastly over-allocated, because the Mamba device pool is typically only ~10% of the KV device pool (controlled by `--mamba-full-memory-ratio`).

For example, with `--hicache-size 20` on Qwen3.5-397B-A17B-FP8 (TP=8, `--mamba-full-memory-ratio 0.1`):

| Pool | Device pool (per rank) | Host pool before fix | Host pool after fix |
|------|----------------------|---------------------|---------------------|
| KV cache | 13.42 GB | 20.00 GB | 20.00 GB |
| Mamba cache | 1.34 GB | 20.02 GB | 2.86 GB |
| **Total per rank** | 14.76 GB | **40.02 GB** | **22.86 GB** |
| **Total 8 ranks** | 118.08 GB | **320.16 GB** | **182.88 GB** |

The Mamba host pool was ~15x larger than its device pool, wasting ~18.7 GB/rank of DRAM. On memory-constrained hosts, this can cause unexpected OOM or leave insufficient DRAM for other processes.

`--hicache-ratio` does not have this issue because it scales each host pool by its own device pool size (`device_pool.size * ratio`). The bug only manifests with `--hicache-size`, which bypasses the ratio-based path and uses a fixed absolute value for both pools.

## Modifications

In `build_hybrid_mamba_stack()` (`hybrid_pool_assembler.py`), scale the Mamba host pool size proportionally based on the ratio of Mamba device pool `mem_usage` to KV device pool `mem_usage`:

```python
mamba_hicache_size = server_args.hicache_size
if (
    server_args.hicache_size > 0
    and kv_pool.mem_usage > 0
    and mamba_pool.mem_usage > 0
):
    scaled_size = int(
        server_args.hicache_size
        * mamba_pool.mem_usage
        / kv_pool.mem_usage
    )
    if scaled_size > mamba_pool.mem_usage:
        mamba_hicache_size = scaled_size
    else:
        mamba_hicache_size = 0
```

The scaled value must be larger than the Mamba device pool (in GB) to satisfy the protocol requirement that host pool > device pool (`assert self.size > device_pool.size` in `MambaPoolHost.__init__`). If the scaled value is too small (e.g., `--hicache-size 1` with a 1.34 GB Mamba device pool), fall back to ratio-based sizing by setting `host_size=0`, which lets `MambaPoolHost` compute `device_pool.size * hicache_ratio` internally — the same path `--hicache-ratio` takes.

This change only affects hybrid Mamba models. Non-hybrid models (standard transformers) are unaffected because `build_hybrid_mamba_stack()` is not called.

## Accuracy Tests


## Speed Tests and Profiling


No inference speed impact. The change only affects DRAM allocation at startup.

Server log before fix:
```
[TP0] Allocating 20.00 GB host memory for hierarchical KV cache.
[TP0] Allocating 20.02 GB host memory for hierarchical Mamba cache (layout=page_first_direct).
```

Server log after fix:
```
[TP0] Allocating 20.00 GB host memory for hierarchical KV cache.
[TP0] Allocating 2.86 GB host memory for hierarchical Mamba cache (layout=page_first_direct).
```

DRAM usage reduced from 320 GB to 183 GB (43% reduction) across 8 ranks, with no functional impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28067330127](https://github.com/sgl-project/sglang/actions/runs/28067330127)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28067330040](https://github.com/sgl-project/sglang/actions/runs/28067330040)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->