### PR TITLE
[NPU] Fix the DeepSeek-V2-Coder model accuracy issue

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/moe/topk.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/topk.py
@@ -81,9 +81,7 @@ def fused_topk_npu(
             group_select_mode=(1 if use_grouped_topk else 0),
             renorm=0,
             # 1 for sigmoid, 0 for softmax
-            norm_type=(
-                0 if topk_config.scoring_func == "softmax" else 1
-            ),
+            norm_type=(0 if topk_config.scoring_func == "softmax" else 1),
             routed_scaling_factor=(
                 1 if renormalize else topk_config.routed_scaling_factor
             ),

--- a/python/sglang/srt/hardware_backend/npu/moe/topk.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/topk.py
@@ -82,7 +82,7 @@ def fused_topk_npu(
             renorm=0,
             # 1 for sigmoid, 0 for softmax
             norm_type=(
-                0 if topk_config.scoring_func == "softmax" else 1,
+                0 if topk_config.scoring_func == "softmax" else 1
             ),
             routed_scaling_factor=(
                 1 if renormalize else topk_config.routed_scaling_factor

--- a/python/sglang/srt/hardware_backend/npu/moe/topk.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/topk.py
@@ -80,7 +80,10 @@ def fused_topk_npu(
             group_count=topk_config.num_expert_group if use_grouped_topk else 1,
             group_select_mode=(1 if use_grouped_topk else 0),
             renorm=0,
-            norm_type=1,  # 1 for sigmoid, 0 for softmax
+            # 1 for sigmoid, 0 for softmax
+            norm_type=(
+                0 if topk_config.scoring_func == "softmax" else 1,
+            ),
             routed_scaling_factor=(
                 1 if renormalize else topk_config.routed_scaling_factor
             ),

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -647,6 +647,7 @@ class DeepseekV2MoE(nn.Module):
                 num_expert_group=config.n_group,
                 num_fused_shared_experts=self.num_fused_shared_experts,
                 topk_group=config.topk_group,
+                scoring_func=config.scoring_func,
                 correction_bias=self.gate.e_score_correction_bias,
                 quant_config=quant_config,
                 routed_scaling_factor=self.routed_scaling_factor,

--- a/python/sglang/srt/models/llada2.py
+++ b/python/sglang/srt/models/llada2.py
@@ -262,6 +262,7 @@ class LLaDA2MoeSparseMoeBlock(nn.Module):
             # num_fused_shared_experts=self.num_fused_shared_experts,
             topk_group=self.topk_group,
             correction_bias=self.correction_bias,
+            scoring_func=self.score_function,
             routed_scaling_factor=self.routed_scaling_factor,
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix the DeepSeek-V2-Coder model accuracy issue.

## Modifications

1. In `fused_topk_npu()`, determine whether `norm_type` is sigmoid or softmax based on the value of `topk_config.scoring_func`.
2. In `DeepseekV2MoE::__init__()`, pass `config.scoring_func` into `topk_kwargs` so that `self.topk` correctly determines the scoring function based on its construction-time value.

## Accuracy Tests

```
#!/bin/bash

export HCCL_BUFFSIZE="1024"
export PYTHONPATH=/root/RemoteDev/sglang/python:$PYTHONPATH
export SGLANG_LOG_PATH=/root/run_scripts/granite/sglang.log
rm -rf $SGLANG_LOG_PATH

python -m sglang.launch_server \
    --model-path /home/weights/DeepSeek-Coder-V2-Lite-Instruct \
    --trust-remote-code \
    --attention-backend ascend \
    --disable-cuda-graph \
    --mem-fraction-static 0.5 \
    --tp-size 2 \
    --moe-dense-tp-size 1 \
    --device npu \
    --host 127.0.0.1 \
    --port 9090
```
<img width="1665" height="270" alt="DeepSeek-Coder-V2-Lite-Instruct精度" src="https://github.com/user-attachments/assets/65cf9c89-c0ca-4c0f-b3d6-072b7d8bf43c" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28089354692](https://github.com/sgl-project/sglang/actions/runs/28089354692)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28089354534](https://github.com/sgl-project/sglang/actions/runs/28089354534)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->