### PR TITLE
Fix PP grammar preprocessing hang

### DIFF
--- a/python/sglang/srt/constrained/grammar_manager.py
+++ b/python/sglang/srt/constrained/grammar_manager.py
@@ -115,7 +115,30 @@ class GrammarManager:
 
                 if not cache_hit:
                     req.grammar_key = key
-                    add_to_grammar_queue = True
+                    if self.server_args.pp_size > 1:
+                        assert isinstance(value, futures.Future)
+                        try:
+                            req.grammar = value.result()
+                        except Exception as e:
+                            logger.error(
+                                f"Grammar compilation raised an exception: {e}, "
+                                f"grammar_key={req.grammar_key}"
+                            )
+                            req.grammar = InvalidGrammarObject(
+                                f"Grammar compilation failed: {e}"
+                            )
+                        self.grammar_backend.set_cache(
+                            req.grammar_key, req.grammar.copy()
+                        )
+                        self._apply_request_reasoning_budget(req)
+                        if isinstance(req.grammar, InvalidGrammarObject):
+                            error_msg = (
+                                f"Failed to compile {req.grammar_key[0]} grammar: "
+                                f"{req.grammar.error_message}"
+                            )
+                            req.set_finish_with_abort(error_msg)
+                    else:
+                        add_to_grammar_queue = True
                 else:
                     if isinstance(
                         value, InvalidGrammarObject


### PR DESCRIPTION
## Motivation

  Structured output / grammar requests can hang when pipeline parallelism is enabled.

  In the PP path, grammar preprocessing receives a grammar compilation `Future`, but the request was still added to the normal grammar queue. That queue is not the
  right place to make progress for this PP preprocessing path, so the request can remain stuck before scheduling.

  ## Modifications

  - Resolve the grammar compilation `Future` directly in the PP preprocessing path.
  - Cache the compiled grammar in the grammar backend.
  - Apply the request reasoning budget after the grammar is available.
  - If grammar compilation fails, convert the failure to an `InvalidGrammarObject` and abort the request with a clear error message.
  - Keep the existing non-PP behavior unchanged.

  ## Accuracy Tests

  This PR does not change model forward logic, logits, sampling, kernels, or generated token semantics.

  It only changes grammar preprocessing control flow for PP mode, so no model accuracy impact is expected.

  ## Speed Tests and Profiling

  No inference speed regression is expected.

  The change only avoids a PP-only hang by resolving grammar compilation in the preprocessing path. Non-PP behavior is unchanged.

  ## Checklist

  - [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy)
  and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28027387878](https://github.com/sgl-project/sglang/actions/runs/28027387878)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28027387349](https://github.com/sgl-project/sglang/actions/runs/28027387349)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->