### PR TITLE
Fix KV event publisher bind conflict under PP

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -447,6 +447,7 @@ class Scheduler(
             enable_metrics=self.server_args.enable_metrics,
             enable_kv_cache_events=bool(
                 self.server_args.kv_events_config
+                and self.ps.pp_rank == 0
                 and self.ps.attn_tp_rank == 0
                 and self.ps.attn_cp_rank == 0
             ),

--- a/python/sglang/srt/managers/scheduler_components/kv_events_publisher.py
+++ b/python/sglang/srt/managers/scheduler_components/kv_events_publisher.py
@@ -58,7 +58,10 @@ class SchedulerKvEventsPublisher:
 
     def init_kv_events(self, kv_events_config: Optional[str]):
         self.enable_kv_cache_events = bool(
-            kv_events_config and self.ps.attn_tp_rank == 0 and self.ps.attn_cp_rank == 0
+            kv_events_config
+            and self.ps.pp_rank == 0
+            and self.ps.attn_tp_rank == 0
+            and self.ps.attn_cp_rank == 0
         )
 
         if self.enable_kv_cache_events:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1044,6 +1044,7 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         )
         enable_kv_cache_events = bool(
             server_args.kv_events_config
+            and ps.pp_rank == 0
             and ps.attn_tp_rank == 0
             and ps.attn_cp_rank == 0
         )


### PR DESCRIPTION
## Motivation

  When KV cache events are enabled together with pipeline parallelism, multiple PP stages can try to start a KV event publisher on the same endpoint.

  Only one process can bind to the configured publisher endpoint. If multiple PP stages start publishers independently, server startup can fail with an address/port
  bind conflict.

  ## Modifications

  - Restrict KV event publisher initialization to `pp_rank == 0`.
  - Keep the existing restrictions that only `attn_tp_rank == 0` and `attn_cp_rank == 0` publish KV events.
  - This makes exactly one scheduler process own the KV event publisher in PP + TP/CP deployments.

  ## Accuracy Tests

  This PR does not change model forward logic, logits, sampling, kernels, or KV cache contents.

  It only changes which scheduler process starts the KV event publisher, so no model accuracy impact is expected.

  ## Speed Tests and Profiling

  No inference speed impact is expected.

  The change only prevents duplicate publisher initialization under PP. Normal request scheduling and model execution are unchanged.

  ## Checklist

  - [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy)
  and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28147322880](https://github.com/sgl-project/sglang/actions/runs/28147322880)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28147322743](https://github.com/sgl-project/sglang/actions/runs/28147322743)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->