### PR TITLE
[NPU] W4A4 MoE: optional fused mega_moe_w4a4 kernel dispatch (default-off)

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -485,6 +485,7 @@ class Envs:
     SGLANG_MLX_CLEAR_CACHE_STEPS = EnvInt(256)
 
     # NPU
+    SGLANG_NPU_USE_MEGA_MOE_W4A4 = EnvBool(False)
     SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT = EnvBool(False)
     SGLANG_NPU_USE_MULTI_STREAM = EnvBool(False)
     SGLANG_NPU_USE_MLAPO = EnvBool(False)

--- a/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
@@ -496,6 +496,11 @@ class _NPUFusedMoEMethodBase(FusedMoEMethodBase):
 class NPUW4A4Int4DynamicMoEMethod(_NPUFusedMoEMethodBase):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_NPU_USE_MEGA_MOE_W4A4.get():
+            return self._process_weights_mega(layer)
+
         layer.w13_weight.data = npu_format_cast(
             layer.w13_weight.data.transpose(1, 2).contiguous()
         )
@@ -545,12 +550,85 @@ class NPUW4A4Int4DynamicMoEMethod(_NPUFusedMoEMethodBase):
         new_weight = new_weight.view(weight.shape[0], weight.shape[1], -1)
         return new_weight
 
+    def _process_weights_mega(self, layer: torch.nn.Module) -> None:
+        """Prepare weights for the fused mega kernel: FRACTAL-NZ int4 pack + uint64 scales.
+        Loaded layout: w13_weight [E, 2I, H] int8, scale [E, 2I, 1]; w2_weight [E, H, I] int8,
+        scale [E, H, 1]. The mega kernel applies the block-diagonal Hadamard in-kernel, so the
+        weights are passed un-rotated (the matching rotation is baked into w13 offline).
+        """
+        from sgl_kernel_npu.moe.mega_moe_w4a4 import pack_nz_int4, pack_scale_uint64
+
+        w13 = layer.w13_weight.data
+        w2 = layer.w2_weight.data
+        E = w13.shape[0]
+        device = w13.device
+
+        w13_kn = w13.transpose(1, 2).contiguous()  # [E, H, 2I]
+        w2_kn = w2.transpose(1, 2).contiguous()  # [E, I, H]
+        layer.w13_nz = pack_nz_int4(w13_kn)
+        layer.w2_nz = pack_nz_int4(w2_kn)
+        layer.w13_scale_mega = pack_scale_uint64(
+            layer.w13_weight_scale.data.squeeze(-1)
+        )
+        layer.w2_scale_mega = pack_scale_uint64(layer.w2_weight_scale.data.squeeze(-1))
+        # (E, H, I, 2I) — mega_moe_forward needs H/I/2I; kernel is compiled for H=2048, I=128.
+        layer.mega_dims = (E, w13_kn.shape[1], w2_kn.shape[1], w13_kn.shape[2])
+
+        # Free the original int8 weights (mega path uses the packed copies above).
+        layer.w13_weight.data = torch.empty(E, 1, 1, dtype=torch.int8, device=device)
+        layer.w2_weight.data = torch.empty(E, 1, 1, dtype=torch.int8, device=device)
+
+    def _apply_mega(self, layer, dispatch_output):
+        from sgl_kernel_npu.moe.mega_moe_w4a4 import mega_moe_forward, routing_prep
+
+        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+        x = dispatch_output.hidden_states
+        topk_weights, topk_ids, _ = dispatch_output.topk_output
+
+        T = x.shape[0]
+        H = x.shape[-1]
+        x_2d = x.view(T, H) if x.dim() > 2 else x
+        outer_dtype = x_2d.dtype
+        # The INT4 expert path is fp16-only on 910B; cast at the MoE boundary and back.
+        if outer_dtype == torch.bfloat16:
+            x_2d = x_2d.to(torch.float16)
+
+        E, kgu, kdn, n_gu = layer.mega_dims
+        group_list, expanded_row_idx, sort_idx = routing_prep(
+            topk_ids.to(torch.int32), E
+        )
+        out = mega_moe_forward(
+            x_2d,
+            layer.w13_nz,
+            layer.w13_scale_mega,
+            layer.w2_nz,
+            layer.w2_scale_mega,
+            group_list,
+            expanded_row_idx,
+            sort_idx,
+            topk_weights.to(torch.float16),
+            top_k=topk_ids.shape[1],
+            H=kgu,
+            i_dim=kdn,
+            n_gu=n_gu,
+        )
+        # Detach from the reused workspace: .to(bfloat16) already allocates a fresh tensor,
+        # so only the non-cast (fp16) path needs an explicit .clone().
+        out = out.to(torch.bfloat16) if outer_dtype == torch.bfloat16 else out.clone()
+        out = out.view_as(x) if x.dim() > 2 else out
+        return StandardCombineInput(hidden_states=out)
+
     def apply(
         self,
         layer,
         dispatch_output: "DispatchOutput",
     ) -> "CombineInput":
+        from sglang.srt.environ import envs
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+        if envs.SGLANG_NPU_USE_MEGA_MOE_W4A4.get():
+            return self._apply_mega(layer, dispatch_output)
 
         combine_input = self._maybe_apply_deepep(layer, dispatch_output)
         if combine_input is not None:


### PR DESCRIPTION
> **Status: Draft / RFC** — opening to discuss upstreaming the NPU W4A4 fused mega-MoE path. Depends on the kernel in **[sgl-project/sgl-kernel-npu#563](https://github.com/sgl-project/sgl-kernel-npu/pull/563)**.

## Motivation

The NPU W4A4 MoE currently runs as a chain of `torch_npu` ops (`npu_fused_experts_w4a4`: init-routing → dynamic-quant → grouped-matmul → swiglu → grouped-matmul → finalize). This PR adds an **optional, default-off** path that routes the whole routed-expert chain through a single fused **`mega_moe_w4a4`** kernel (block-diag Hadamard → INT4 quant → INT4×INT4 gate_up → SwiGLU+requant → INT4×INT4 down → unpermute/combine) in **one launch**, for lower decode launch/glue overhead on Qwen3.x-MoE. The kernel ships in sgl-kernel-npu #563.

## Modifications

Two files, +80 lines, **additive and default-off**:
- `python/sglang/srt/environ.py` — adds `SGLANG_NPU_USE_MEGA_MOE_W4A4` (`EnvBool`, default **False**), in the `# NPU` section.
- `python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py` — `NPUW4A4Int4DynamicMoEMethod` gains `_process_weights_mega` (FRACTAL-NZ int4 + uint64-scale repack at load) and `_apply_mega` (`routing_prep` + `mega_moe_forward` at forward); `process_weights_after_loading` / `apply` branch on the flag.

With the flag unset/`0`, behavior is unchanged (the existing `npu_fused_experts_w4a4` path). The kernel is reached via its host wrapper `sgl_kernel_npu.moe.mega_moe_w4a4` (built from sgl-kernel-npu #563).

<details><summary><b>Build → link → serve → eval (how to run)</b></summary>

## Checkpoint

Download the ready-made W4A4-hadamard64 checkpoint from HuggingFace (public, no login). This step needs
the HF CLI — `pip install -U huggingface_hub` (required **only** to download this checkpoint; skip it if
you build the checkpoint yourself with the quantizer below):

```bash
# Pick any directory; reuse that SAME path for every --model-path / model= below.
hf download Mocchibird/Qwen3.6-35B-A3B-W4A4-Hadamard64 \
  --local-dir /path/to/Qwen3.6-35B-A3B-W4A4-Hadamard64     # ~37 GB, a few minutes
```

The **bf16 baseline** (for the comparison at the end) is the public `Qwen/Qwen3.6-35B-A3B` release.

<details><summary>Or reproduce the W4A4 checkpoint yourself from the bf16 base</summary>

A calibration-free RTN quantizer (no dataset needed),
[`quantize_qwen3_moe_w4a4_hadamard.py`](https://github.com/Mocchibird/vllm-ascend/blob/feat/w4a4-mega-moe-kernel/examples/quantization/quantize_qwen3_moe_w4a4_hadamard.py)
(Mocchibird `vllm-ascend`, branch `feat/w4a4-mega-moe-kernel`):

```bash
python examples/quantization/quantize_qwen3_moe_w4a4_hadamard.py \
  --src /path/to/Qwen3.6-35B-A3B \
  --dst /path/to/Qwen3.6-35B-A3B-w4a4-hadamard64 \
  --hadamard-block-size 64        # MUST be 64 — matches the compiled kernel shape; other sizes silently break accuracy
```

The result is **functionally equivalent but not byte-identical** to the HF download: the Hadamard-rotated
`gate/up` experts have tiny per-channel scales, so small bf16-source/precision differences flip many INT4
levels (the dequantized weights stay ~equal; `down_proj` is untouched). Both serve coherently at matched
accuracy — but if you need the exact bytes, use the HF download above.
</details>

## Layout — linking `sgl-kernel-npu` ↔ `sglang`

The two repos plug together purely in Python: this sglang branch `import`s the kernel's host
wrapper `sgl_kernel_npu.moe.mega_moe_w4a4`, which calls the compiled op
`torch.ops.npu.mega_moe_w4a4` from `libsgl_kernel_npu.so`. **The only "link" is putting
`sgl-kernel-npu/python/sgl_kernel_npu` on `PYTHONPATH` for the env that runs sglang** — no files
are copied between the repos, and the Run command below already does this (so there is no separate
install-into-sglang step). Clone both side-by-side under one root:

```bash
export ROOT=~/repos                              # any parent dir; both repos live directly under it
cd "$ROOT"
git clone -b feature/w4a4-mega-moe https://github.com/Mocchibird/sgl-kernel-npu.git
git clone -b feat/npu-w4a4-mega-moe-rfc https://github.com/Mocchibird/sglang.git   # large repos; if a clone aborts with "early EOF / invalid index-pack output", just re-run it
source /usr/local/Ascend/ascend-toolkit/set_env.sh

# 1) Build the kernel -> $ROOT/sgl-kernel-npu/python/sgl_kernel_npu/sgl_kernel_npu/lib/libsgl_kernel_npu.so
cd "$ROOT/sgl-kernel-npu" && git submodule update --init third_party/pto-isa && ./build.sh -a kernels
ASCEND_RT_VISIBLE_DEVICES=0 python tests/python/sgl_kernel_npu/test_mega_moe_w4a4_npu.py   # any one free NPU; expect cos=0.999x

# 2) Install sglang (this branch) into the Python env that has torch_npu. On NPU you MUST use the NPU
#    pyproject — the default pyproject.toml
#    pulls CUDA-only deps (cuda-python, flashinfer, nvidia-cutlass-dsl, sglang-kernel, torch==2.11)
#    that don't build on aarch64 and would override the pre-installed torch_npu; pyproject_npu.toml
#    drops all of those.
cd "$ROOT/sglang" && mv python/pyproject_npu.toml python/pyproject.toml && pip install -e "python[all_npu]"

# sanity: the kernel imports once its dir is on PYTHONPATH (the Run command below sets this for you)
PYTHONPATH="$ROOT/sgl-kernel-npu/python/sgl_kernel_npu:$PYTHONPATH" \
  python -c "import sgl_kernel_npu.moe.mega_moe_w4a4; print('linked OK')"
```

> **PYTHONPATH gotcha:** keep CANN's python on the path — always append `:$PYTHONPATH` after
> sourcing `set_env.sh`. Dropping it removes CANN's `tbe`, and the JIT op-compiler then fails with
> `AclSetCompileopt … 500001`.

## Run (one command, both repos under `$ROOT`)

```bash
source /usr/local/Ascend/ascend-toolkit/set_env.sh
cd "$ROOT/sglang"
ASCEND_RT_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_NPU_USE_MEGA_MOE_W4A4=1 \
PYTHONPATH="$ROOT/sgl-kernel-npu/python/sgl_kernel_npu:$PWD/python:$PYTHONPATH" \
python -m sglang.launch_server \
  --model-path /path/to/Qwen3.6-35B-A3B-W4A4-Hadamard64 \
  --attention-backend ascend --device npu --tp-size 4 --trust-remote-code \
  --mem-fraction-static 0.9 --disable-cuda-graph --disable-radix-cache
```

- `SGLANG_NPU_USE_MEGA_MOE_W4A4=1` selects the fused kernel; unset/`0` uses the torch_npu path.
- `--disable-radix-cache` is required for Qwen3.x hybrid (GDN) decode correctness on NPU.
- The `PYTHONPATH=` line both links the kernel **and** preserves CANN's `tbe` via `:$PYTHONPATH`.
- `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3` is an **example** — set it to any 4 free NPUs (`npu-smi info` to check); TP=4 needs exactly 4. Re-export `ROOT` if you opened a new shell.

## End-to-end model eval

Two steps: (1) **serve** with the command above (mega on), then (2) point any OpenAI-compatible
harness at the endpoint (`http://127.0.0.1:30000/v1`).

**MMLU** (stable, teacher-forced) via `lm-eval`.

> **MMLU needs a different server than the Run block above.** Do **not** reuse the
> `--mem-fraction-static 0.9` server — it OOMs in the logits processor (see note below). Kill it and
> re-serve with the same command but these two flags swapped in:
> `--chunked-prefill-size 2048 --mem-fraction-static 0.8` (everything else, including
> `SGLANG_NPU_USE_MEGA_MOE_W4A4=1` and the `PYTHONPATH=` line, stays identical).

Then run the eval:

```bash
pip install "lm-eval[api]"   # the [api] extra (tenacity/aiohttp) is required for the local-completions model
lm_eval --model local-completions \
  --model_args base_url=http://127.0.0.1:30000/v1/completions,model=/path/to/Qwen3.6-35B-A3B-W4A4-Hadamard64,num_concurrent=32,max_length=2048,tokenized_requests=False \
  --tasks mmlu --batch_size 32
```

> MMLU is loglikelihood-scored: `lm-eval` asks for logprobs over every prompt position, and on
> Qwen3.6's ~248K-token vocab the per-position `[positions, vocab]` fp32 logits tensor is large. With
> many requests in flight (`num_concurrent`), an uncapped prefill batch at the default
> `--mem-fraction-static 0.9` OOMs in the logits processor. **For this eval, serve with
> `--chunked-prefill-size 2048 --mem-fraction-static 0.8`**: the cap bounds the prefill batch — and thus
> the logits tensor — regardless of `num_concurrent` (the batch stays ≤2048 tokens even with dozens of
> requests running), and `0.8` leaves activation headroom. Verified here at `num_concurrent=32`.
> Generation-based evals (GPQA below) don't hit this path.

**GPQA-Diamond** (thinking mode) — same endpoint, sample with the Qwen3.6 recipe
(`temperature=1.0 top_p=0.95 top_k=20 presence_penalty=1.5`, `max_tokens=8192`), parse the CoT for
the answer letter, and fall back to a single-token A/B/C/D logprob when it runs over budget. No
packaged harness for this exact recipe ships in this branch (stock `lm_eval --tasks gpqa_diamond`
does **not** do thinking-mode CoT + logprob fallback) — drive it from your own OpenAI-client script
hitting `http://127.0.0.1:30000/v1` with the params above.

**Comparing bf16 ↔ W4A4-mega ↔ torch_npu-W4A4.** The flag selects the *expert kernel*, not the precision.
On the **W4A4** checkpoint: `SGLANG_NPU_USE_MEGA_MOE_W4A4=1` runs the fused mega kernel, `unset`/`0` runs the
torch_npu W4A4 path (both 4-bit, same weights). For the **bf16** baseline, re-serve with the bf16 checkpoint
(`--model-path …/Qwen3.6-35B-A3B`; the flag is then irrelevant). Same eval command in all three cases.

Validated on Qwen3.6-35B-A3B (910B2, TP=4, eager, matched batch, GPQA-Diamond, 7 seeds):
**bf16 70.6 / W4A4-mega 67.7**, **mega decode 1.14× bf16**. The −2.9pp sits within the run-to-run seed
spread (per-seed std ≈ 1.8 bf16 / 2.9 mega; NPU TP=4 is non-deterministic), and mega tracks the torch_npu
W4A4 path (same checkpoint) — so the kernel's contribution is throughput at accuracy parity.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28049798121](https://github.com/sgl-project/sglang/actions/runs/28049798121)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28049797953](https://github.com/sgl-project/sglang/actions/runs/28049797953)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

</details>

## Accuracy Tests

Ascend **910B2 / CANN 9.0.0**, TP=4, Qwen3.6-35B-A3B-W4A4-Hadamard64:
- Kernel correctness: **cos 0.999** vs a pure-torch W4A4+Hadamard oracle (sgl-kernel-npu #563 test).
- GPQA-Diamond (thinking mode, matched batch, 7 seeds): **bf16 70.6 / W4A4-mega 67.7** — the −2.9pp is within the run-to-run seed spread (per-seed std ≈ 1.8 / 2.9; NPU TP=4 is non-deterministic), and mega tracks the `torch_npu` W4A4 path on the same checkpoint. Accuracy parity.
- Re-validated end-to-end on **current `main`** (this branch): serves + generates coherently with `SGLANG_NPU_USE_MEGA_MOE_W4A4=1`.

## Speed Tests and Profiling

**mega decode ≈ 1.14× bf16** on the matched-batch GPQA run (910B2, TP=4, eager). The win is launch/glue reduction (one fused launch vs the per-op chain), HBM-bound at this shape.

## Checklist

- [x] Code formatted with pre-commit.
- [ ] Unit tests — the kernel's cosine test lives in sgl-kernel-npu #563; a sglang-side Ascend-CI test needs the W4A4 checkpoint registered on ModelScope + `test_ascend_utils.py` (RFC follow-up; happy to add with maintainer help on the CI model cache).
- [x] Documentation — the build→serve→eval guide is in this PR description (intentionally no doc file added to the repo).
- [x] Accuracy and speed benchmark results — provided above.
- [x] Follows the SGLang code style (pre-commit).
