### PR TITLE
Fix Responses API structured output and thinking controls

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1294,7 +1294,7 @@ OpenAIServingRequest = Union[
 class ResponseReasoningParam(BaseModel):
     """Reasoning parameters for responses."""
 
-    effort: Optional[Literal["low", "medium", "high"]] = Field(
+    effort: Optional[Literal["none", "low", "medium", "high", "max"]] = Field(
         default="medium",
         description="Constrains effort on reasoning for reasoning models.",
     )
@@ -1379,6 +1379,7 @@ class ResponsesRequest(BaseModel):
     store: Optional[bool] = True
     stream: Optional[bool] = False
     temperature: Optional[float] = None
+    text: Optional[Dict[str, Any]] = None
     tool_choice: Literal["auto", "required", "none"] = "auto"
     tools: List[ResponseTool] = Field(default_factory=list)
     top_logprobs: Optional[int] = 0
@@ -1407,6 +1408,8 @@ class ResponsesRequest(BaseModel):
     top_k: Optional[int] = None
     min_p: Optional[float] = None
     repetition_penalty: Optional[float] = None
+    reasoning_effort: Optional[Literal["none", "low", "medium", "high", "max"]] = None
+    chat_template_kwargs: Optional[Dict] = None
 
     # Default sampling parameters
     _DEFAULT_SAMPLING_PARAMS = {
@@ -1416,6 +1419,43 @@ class ResponsesRequest(BaseModel):
         "min_p": 0.0,
         "repetition_penalty": 1.0,
     }
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_reasoning_inputs(cls, values: Dict):
+        if not isinstance(values, dict):
+            return values
+
+        r = values.get("reasoning")
+        if r is not None and isinstance(r, dict):
+            effort = r.get("effort") or r.get("reasoning_effort")
+            if effort in {"none", "low", "medium", "high", "max"}:
+                values["reasoning_effort"] = effort
+
+            enabled = (
+                r.get("enabled")
+                if r.get("enabled") is not None
+                else r.get("enable", False)
+            )
+            if isinstance(enabled, str):
+                enabled = enabled.strip().lower() in {"1", "true", "yes", "y", "on"}
+            if enabled:
+                ctk = values.get("chat_template_kwargs")
+                if not isinstance(ctk, dict):
+                    ctk = {}
+                ctk.setdefault("thinking", True)
+                ctk.setdefault("enable_thinking", True)
+                values["chat_template_kwargs"] = ctk
+
+        if values.get("reasoning_effort") == "none":
+            ctk = values.get("chat_template_kwargs")
+            if not isinstance(ctk, dict):
+                ctk = {}
+            ctk.setdefault("thinking", False)
+            ctk.setdefault("enable_thinking", False)
+            values["chat_template_kwargs"] = ctk
+
+        return values
 
     @model_validator(mode="before")
     @classmethod
@@ -1513,6 +1553,23 @@ class ResponsesRequest(BaseModel):
         for key, value in default_params.items():
             if key not in params or params[key] is None:
                 params[key] = value
+
+        text_format = (self.text or {}).get("format") if self.text else None
+        if isinstance(text_format, dict):
+            format_type = text_format.get("type")
+            if format_type == "json_schema":
+                schema = text_format.get("schema")
+                if schema is None and isinstance(text_format.get("json_schema"), dict):
+                    schema = text_format["json_schema"].get("schema")
+                if schema is None:
+                    raise ValueError(
+                        "schema is required for json_schema text format request."
+                    )
+                params["json_schema"] = convert_json_schema_to_str(schema)
+            elif format_type == "json_object":
+                params["json_schema"] = '{"type": "object"}'
+            elif format_type == "structural_tag":
+                params["structural_tag"] = convert_json_schema_to_str(text_format)
 
         has_existing_constraints = (
             params.get("regex")

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -449,10 +449,16 @@ class OpenAIServingResponses(OpenAIServingChat):
         messages = self._construct_input_messages(request, prev_response)
 
         chat_tools = self._response_tools_to_chat_tools(request)
+        response_format = None
+        text_format = (request.text or {}).get("format") if request.text else None
+        if isinstance(text_format, dict):
+            response_format = text_format
+
         chat_request = ChatCompletionRequest(
             model=request.model,
             messages=messages,
             stream=request.stream,
+            response_format=response_format,
             tools=chat_tools or None,
             tool_choice=request.tool_choice if chat_tools else "none",
             parallel_tool_calls=(
@@ -461,6 +467,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                 else True
             ),
             stop=request.stop,
+            reasoning_effort=request.reasoning_effort,
+            chat_template_kwargs=request.chat_template_kwargs,
         )
 
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal

--- a/test/registered/reasoning/test_reasoning.py
+++ b/test/registered/reasoning/test_reasoning.py
@@ -141,6 +141,106 @@ class TestEnableThinking(
             has_content, "The stream response does not contain normal content"
         )
 
+    @staticmethod
+    def _responses_output_text(data):
+        return "".join(
+            content["text"]
+            for item in data["output"]
+            if item.get("type") == "message"
+            for content in item.get("content", [])
+            if content.get("type") == "output_text"
+        )
+
+    def assert_responses_has_no_reasoning_item(self, data):
+        self.assertFalse(
+            any(item.get("type") == "reasoning" for item in data["output"]),
+            data["output"],
+        )
+
+    def test_responses_chat_template_kwargs_disable_reasoning(self):
+        response = requests.post(
+            f"{self.base_url}/v1/responses",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            json={
+                "model": self.model,
+                "input": "What is 123 + 456? Explain briefly.",
+                "temperature": 0,
+                "max_output_tokens": 64,
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+        )
+        self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
+        data = response.json()
+        self.assert_responses_has_no_reasoning_item(data)
+        self.assertTrue(self._responses_output_text(data))
+
+    def test_responses_structured_output_matches_chat_and_disables_reasoning(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name", "age"],
+            "additionalProperties": False,
+        }
+        prompt = "Invent a random fictional character and tell me a little about them."
+
+        chat_resp = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "temperature": 0,
+                "max_tokens": 128,
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "person",
+                        "strict": True,
+                        "schema": schema,
+                    },
+                },
+                "chat_template_kwargs": {"enable_thinking": False},
+                **self.additional_chat_kwargs,
+            },
+        )
+        self.assertEqual(chat_resp.status_code, 200, f"Failed with: {chat_resp.text}")
+        chat_text = chat_resp.json()["choices"][0]["message"]["content"]
+        chat_obj = json.loads(chat_text)
+        self.assertIsInstance(chat_obj["name"], str)
+        self.assertIsInstance(chat_obj["age"], int)
+
+        responses_resp = requests.post(
+            f"{self.base_url}/v1/responses",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            json={
+                "model": self.model,
+                "input": prompt,
+                "temperature": 0,
+                "max_output_tokens": 128,
+                "text": {
+                    "format": {
+                        "type": "json_schema",
+                        "name": "person",
+                        "strict": True,
+                        "schema": schema,
+                    }
+                },
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+        )
+        self.assertEqual(
+            responses_resp.status_code, 200, f"Failed with: {responses_resp.text}"
+        )
+        data = responses_resp.json()
+        self.assert_responses_has_no_reasoning_item(data)
+        output_text = self._responses_output_text(data)
+        responses_obj = json.loads(output_text)
+        self.assertIsInstance(responses_obj["name"], str)
+        self.assertIsInstance(responses_obj["age"], int)
+
     def test_stream_chat_completion_without_reasoning(self):
         # Test streaming with "enable_thinking": False, reasoning_content should be empty
         response = requests.post(

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 from utils import make_serving  # noqa: F401 — bootstrap import
@@ -108,6 +109,69 @@ class ResponsesSamplingParamsTestCase(unittest.TestCase):
                 default_params={"json_schema": '{"type": "object"}'},
                 tool_call_constraint=("json_schema", {"type": "object"}),
             )
+
+    def test_structured_text_format_maps_to_json_schema_sampling_param(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name", "age"],
+            "additionalProperties": False,
+        }
+        request = ResponsesRequest(
+            model="x",
+            input="Invent a random fictional character.",
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "person",
+                    "strict": True,
+                    "schema": schema,
+                }
+            },
+            store=False,
+        )
+
+        params = request.to_sampling_params(default_max_tokens=128, default_params={})
+
+        self.assertEqual(json.loads(params["json_schema"]), schema)
+
+    def test_text_json_object_maps_to_json_schema_sampling_param(self):
+        request = ResponsesRequest(
+            model="x",
+            input="hi",
+            text={"format": {"type": "json_object"}},
+            store=False,
+        )
+        params = request.to_sampling_params(default_max_tokens=128, default_params={})
+        self.assertEqual(params["json_schema"], '{"type": "object"}')
+
+    def test_text_format_conflicts_with_tool_constraint(self):
+        request = ResponsesRequest(
+            model="x",
+            input="call the tool",
+            text={"format": {"type": "json_object"}},
+            store=False,
+        )
+        with self.assertRaises(ValueError):
+            request.to_sampling_params(
+                default_max_tokens=128,
+                default_params={},
+                tool_call_constraint=("json_schema", {"type": "object"}),
+            )
+
+    def test_responses_reasoning_effort_none_disables_thinking(self):
+        request = ResponsesRequest(
+            model="x",
+            input="hi",
+            reasoning={"effort": "none"},
+            store=False,
+        )
+        self.assertEqual(request.reasoning_effort, "none")
+        self.assertFalse(request.chat_template_kwargs.get("thinking"))
+        self.assertFalse(request.chat_template_kwargs.get("enable_thinking"))
 
     def test_structural_tag_with_model_dump(self):
         class _FakeStructuralTag:

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -193,6 +193,55 @@ class ChatToolForwardingTestCase(unittest.TestCase):
         self.assertFalse(seen["parallel_tool_calls"])
         self.assertEqual(processed.tool_call_constraint[0], "json_schema")
 
+    def test_make_request_forwards_structured_output_and_thinking_controls(self):
+        serving = make_serving()
+        seen = {}
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+
+        def fake_process(chat_request, is_multimodal):
+            seen["response_format"] = chat_request.response_format
+            seen["chat_template_kwargs"] = chat_request.chat_template_kwargs
+            seen["reasoning_effort"] = chat_request.reasoning_effort
+            return MessageProcessingResult(
+                prompt="prompt",
+                prompt_ids=[1, 2, 3],
+                image_data=None,
+                audio_data=None,
+                video_data=None,
+                modalities=[],
+                stop=[],
+                tool_call_constraint=None,
+            )
+
+        serving._process_messages = Mock(side_effect=fake_process)
+        request = ResponsesRequest(
+            model="x",
+            input="Invent a random fictional character.",
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "person",
+                    "strict": True,
+                    "schema": schema,
+                }
+            },
+            chat_template_kwargs={"enable_thinking": False},
+            store=False,
+        )
+
+        asyncio.run(
+            serving._make_request(request, None, serving.tokenizer_manager.tokenizer)
+        )
+
+        self.assertEqual(seen["response_format"].type, "json_schema")
+        self.assertEqual(seen["response_format"].json_schema.schema_, schema)
+        self.assertFalse(seen["chat_template_kwargs"]["enable_thinking"])
+        self.assertIsNone(seen["reasoning_effort"])
+
     def test_required_tool_choice_without_function_tool_returns_400(self):
         serving = make_serving()
         request = ResponsesRequest(


### PR DESCRIPTION
## Summary
- map Responses API `text.format` (`json_schema` / `json_object` / `structural_tag`) into constrained decoding sampling params
- forward `text.format`, `chat_template_kwargs`, and reasoning effort from `/v1/responses` into the internal chat request used for prompt rendering
- add unit coverage plus a reasoning-model regression that checks chat/responses structured parity and no reasoning item when `enable_thinking=false`

## Tests
- `PYTHONPATH=python:test/registered/unit/entrypoints/openai python/.venv/bin/python -m pytest test/registered/unit/entrypoints/openai/test_responses_protocol.py test/registered/unit/entrypoints/openai/test_serving_responses.py -q`
- `python/.venv/bin/python -m py_compile python/sglang/srt/entrypoints/openai/protocol.py python/sglang/srt/entrypoints/openai/serving_responses.py test/registered/reasoning/test_reasoning.py test/registered/unit/entrypoints/openai/test_responses_protocol.py test/registered/unit/entrypoints/openai/test_serving_responses.py`













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28029377120](https://github.com/sgl-project/sglang/actions/runs/28029377120)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28029376652](https://github.com/sgl-project/sglang/actions/runs/28029376652)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->