### PR TITLE
[feat]: add comp-comm overlap kernel generation and integration skills

### DIFF
--- a/.claude/skills/sglang-overlap-integration/SKILL.md
+++ b/.claude/skills/sglang-overlap-integration/SKILL.md
@@ -2,19 +2,17 @@
 name: sglang-overlap-integration
 description: >
   Integrate an existing overlap kernel (compute-communication fusion) into the SGLang serving
-  framework. This skill starts from a user-provided profiling trace and overlap kernel,
-  automatically locates the corresponding operators in the trace via profiler analysis, maps
-  them to source code, validates semantic equivalence, and then performs the framework-layer
-  plumbing — kernel code placement, communicator setup, environment-variable-controlled
-  dispatch, and model code replacement. Use this skill when the user provides a profiling
-  file and wants to merge a pre-written overlap kernel into SGLang's distributed inference
-  pipeline, wants to wire up symmetric-memory-based communication for a custom kernel, or
-  needs to add an overlap kernel as a drop-in replacement for existing compute+communication
-  operators. Also trigger when the user mentions: "integrate overlap kernel into SGLang",
-  "add overlap layer to SGLang", "hook overlap kernel into model_runner",
-  "SGLang overlap kernel integration", "wire up overlap kernel with nvshmem/torch_symm_mem
-  in SGLang", or describes a step-by-step plan to add a fused compute-comm kernel to the
-  SGLang model execution flow.
+  framework. Requires a profiling trace file path and the overlap kernel source code from the
+  user — ask for them if not provided. This skill locates target operators via profiler analysis,
+  validates semantic equivalence, and performs framework-level plumbing — kernel placement,
+  communicator setup, env-var dispatch, and model code replacement. Use this skill when the
+  user wants to merge a pre-written overlap kernel into SGLang's distributed inference pipeline,
+  wire up symmetric-memory-based communication for a custom kernel, or add an overlap kernel
+  as a drop-in replacement for existing compute+communication operators. Also trigger when the
+  user mentions: "integrate overlap kernel into SGLang", "add overlap layer to SGLang",
+  "hook overlap kernel into model_runner", "SGLang overlap kernel integration",
+  "wire up overlap kernel with nvshmem/torch_symm_mem in SGLang", or describes a step-by-step
+  plan to add a fused compute-comm kernel to the SGLang model execution flow.
 ---
 
 # SGLang Overlap Kernel Integration
@@ -24,6 +22,21 @@ description: >
 This skill guides the integration of an existing overlap kernel (compute-communication fusion)
 into the SGLang LLM serving framework. It does NOT generate kernel code — it assumes the
 overlap kernel already exists and handles identification, validation, and framework-level plumbing.
+
+## Prerequisites — Required User Inputs
+
+This skill requires two mandatory inputs. **If either is missing, stop and ask the user — do not proceed with guesswork or code inspection alone.**
+
+| # | Input | Format | Used By |
+|---|-------|--------|---------|
+| 1 | **Profiling trace file path** | `.json` or `.json.gz` from `torch.profiler.profile(with_stack=True, record_shapes=True)` on a distributed run (TP≥2) | Pattern 0 — locates target compute/communication operators and maps them to source code |
+| 2 | **Overlap kernel source code** | File path or pasted code | Pattern 1 — determines compute op, communication collective, symm-mem mechanism, I/O shapes, and context state |
+
+When asking the user, request:
+1. The absolute path to the profiling trace (must include CUDA kernel events and communication collectives).
+2. The overlap kernel source — file path or pasted code.
+
+Do not skip Pattern 0, fabricate operator chains from code inspection, or begin code changes (Patterns 2–6) before both inputs are provided.
 
 ## Minimal-Invasion Principle
 

--- a/.claude/skills/sglang-overlap-integration/SKILL.md
+++ b/.claude/skills/sglang-overlap-integration/SKILL.md
@@ -1,0 +1,495 @@
+---
+name: sglang-overlap-integration
+description: >
+  Integrate an existing overlap kernel (compute-communication fusion) into the SGLang serving
+  framework. This skill starts from a user-provided profiling trace and overlap kernel,
+  automatically locates the corresponding operators in the trace via profiler analysis, maps
+  them to source code, validates semantic equivalence, and then performs the framework-layer
+  plumbing — kernel code placement, communicator setup, environment-variable-controlled
+  dispatch, and model code replacement. Use this skill when the user provides a profiling
+  file and wants to merge a pre-written overlap kernel into SGLang's distributed inference
+  pipeline, wants to wire up symmetric-memory-based communication for a custom kernel, or
+  needs to add an overlap kernel as a drop-in replacement for existing compute+communication
+  operators. Also trigger when the user mentions: "integrate overlap kernel into SGLang",
+  "add overlap layer to SGLang", "hook overlap kernel into model_runner",
+  "SGLang overlap kernel integration", "wire up overlap kernel with nvshmem/torch_symm_mem
+  in SGLang", or describes a step-by-step plan to add a fused compute-comm kernel to the
+  SGLang model execution flow.
+---
+
+# SGLang Overlap Kernel Integration
+
+## Overview
+
+This skill guides the integration of an existing overlap kernel (compute-communication fusion)
+into the SGLang LLM serving framework. It does NOT generate kernel code — it assumes the
+overlap kernel already exists and handles identification, validation, and framework-level plumbing.
+
+## Minimal-Invasion Principle
+
+All integration changes must obey these four rules:
+
+1. **Do not touch unrelated kernels.** Only modify the code path that the overlap kernel
+   directly replaces. Other kernels' computation logic and input parameters should remain
+   completely unchanged.
+
+2. **Do not introduce unnecessary computation.** The fused path should replace existing
+   work, not add new work. If the overlap kernel subsumes a step, skip that step — do not
+   compute it redundantly "just in case."
+
+3. **Use communicator per-iteration state to control bypass.** 
+   Add a flag (e.g., `comm.enable_<kernel_name>_fused_kernel`) in the communicator instance to control
+   whether the fused kernel is enabled in the current iteration or not. Its value is usually 
+   decided before the beginning of the model's decoder layer loop.
+   When you need to tell a downstream function "skip this step because the fused kernel is 
+   enabled and already handled it," try to get the communication group and check the communicator 
+   instance's per-iteration decided flag (e.g., `comm.enable_<kernel_name>_fused_kernel`) at the bypass site 
+   directly. This avoids redundant checks in the fused path.
+
+These rules exist because SGLang's model code is shared across many configurations.
+Spreading overlap-specific logic into unrelated code paths creates maintenance burden
+and subtle correctness risks for non-overlap users.
+
+---
+
+## Core Integration Patterns
+
+The integration consists of **seven patterns**, each building on the previous one:
+
+| # | Pattern | Purpose |
+|---|---------|---------|
+| 0 | Profile-driven identification + semantic gate | Locate target operators via profiling, validate equivalence; **stop if mismatched** |
+| 1 | Kernel understanding | Identify compute/communication/symm-mem mechanism in the kernel |
+| 2 | Self-contained placement | Place kernel under `symm_mem_kernels/` with no external deps |
+| 3 | Communicator setup | Extend existing communicator or create new one; lazy-init context helpers with shape-key caching |
+| 4 | Env-var gating | Add `SGLANG_OPT_USE_*` env var via `environ.py` for opt-in control |
+| 5 | Fused fast-path + fallback | Add `_maybe_fused_*()` with `None`-return fallback; upstream bypass if needed |
+| 6 | Redundant communication bypass | Skip model-layer collective when fused kernel handles it internally |
+
+---
+
+## Pattern 0: Profile-Driven Identification + Semantic Gate
+
+This pattern is a **hard gate** — if semantic validation fails, STOP immediately.
+
+Use the profiler analysis script to locate target operators in the trace, build an
+operator chain with source mapping, and validate semantic equivalence between the
+overlap kernel and the original sequential operators.
+
+**Read [`references/pattern0-profiler-analysis.md`](references/pattern0-profiler-analysis.md)**
+for the full step-by-step procedure (script commands, flags, operator chain format,
+semantic validation checklist, and source-mapping target level heuristic).
+
+Key points:
+- Run `trace_kernel_stack.py` in two steps: `--list-kernels` first, then `--format chain`
+- Map to **model-level** replacement points (not low-level primitives) — see Pattern 0f in the reference
+- If semantic validation fails → output mismatch reason and **STOP**
+
+---
+
+## Pattern 1: Kernel Understanding
+
+Before touching SGLang code, understand the overlap kernel:
+
+- **Compute operator**: GEMM / attention / normalization / reduction / ...
+- **Communication collective**: all-reduce / reduce-scatter / all-gather / ...
+- **Symmetric memory mechanism**:
+  - `torch.distributed._symmetric_memory` → `torch_symm_mem.empty()`, `multimem_all_reduce_`, etc.
+  - `nvshmem4py` → `nvshmem.core.tensor()`, `nvshmem.bindings.mc_ptr()`, etc.
+- **I/O shapes and dtypes**
+- **Context/state needed at launch** (buffers, barriers, handles)
+- **Target call sites** in SGLang model code (from Pattern 0 source mapping)
+
+---
+
+## Pattern 2: Self-Contained Kernel Placement
+
+**Rule: overlap kernel code must be self-contained — no external third-party dependency.**
+
+Place kernel files under `symm_mem_kernels/<kernel_name>_symm_mem.py`. Each kernel
+exposes: a Context class (with `finalize()`), a context factory, and an op function.
+
+**Read [`references/pattern2-kernel-placement.md`](references/pattern2-kernel-placement.md)**
+for placement conventions, context class patterns, and op function conventions.
+
+---
+
+## Pattern 3: Communicator Setup
+
+**Principle: symmetric memory initialization does NOT happen in `parallel_state.py`.**
+Context objects are created lazily on first use inside communicator methods.
+
+This pattern has two branches depending on whether a matching communicator already exists.
+
+### Branch A: Extend existing communicator
+
+If the overlap kernel uses a symmetric memory mechanism that already has a communicator
+(e.g., `torch.distributed._symmetric_memory` → `TorchSymmMemCommunicator`):
+
+#### Communicator creation condition (static, at startup)
+
+In `parallel_state.py`, extend the communicator's creation condition to include the new
+fused kernel env var (OR with existing conditions). This ensures that **as long as the
+fused kernel env var is enabled**, the communicator must be guaranteed to be instantiated 
+if the fused kernel env var is on — regardless of whether the fused kernel will actually 
+run in every iteration.
+
+Do NOT initialize any symm-mem buffers or contexts here — only ensure the communicator
+object itself is created. The ctx is lazy-initialized on first use (see below).
+
+#### Lazy-init context helper
+
+Add `get_or_create_<name>_ctx()` to the existing communicator class:
+
+- Store `self._<name>_ctx` and `self._<name>_key` as instance attributes
+- Build a **shape key** tuple from model-structure parameters only (dims fixed
+  after model init, dtype, world_size, etc.) — **do NOT include per-batch
+  parameters (num_tokens, etc.)** in the key
+- If key matches and context exists → return cached context immediately
+- If key differs → call `finalize()` on stale context, then create new one via factory
+- Derive the buffer's max token budget from `server_args` — allocate at the
+  **theoretical maximum** so the buffer accommodates any batch size without
+  reallocation
+- Return `None` when the relevant signal variable indicates the path is unavailable
+
+The ctx is created lazily on first actual invocation of the fused kernel path
+(i.e., when `enable_fused_kernel` is `True` for the first time), not at startup.
+
+**Critical: allocate once, reuse forever.** Never include per-batch values in the
+shape key. Allocate at the theoretical maximum from `server_args`. The shape key
+should only contain values fixed after model initialization.
+
+```python
+def _get_max_forward_tokens(self) -> int:
+    server_args = get_global_server_args()
+    chunked = server_args.chunked_prefill_size
+    if chunked is not None and chunked > 0:
+        return chunked
+    return server_args.max_prefill_tokens
+```
+
+### Branch B: Create new communicator
+
+If the overlap kernel uses a symmetric memory mechanism that does NOT yet have a communicator
+in SGLang (e.g., `nvshmem4py`, `cuda.core.experimental`), a new communicator class must
+be created and registered.
+
+#### New communicator class
+
+Create a new communicator file under `device_communicators/` (e.g., `<mechanism>_communicator.py`).
+Follow the existing communicator interface conventions:
+
+1. **Constructor** — validate device capability and world size; set `self.unavailable = True`
+   on failure and return early; on success, allocate symmetric memory buffers, perform
+   rendezvous, then set `self.unavailable = False`
+2. **Signal variables** — env-var-driven booleans to gate different execution paths:
+   - One env var → one signal variable (e.g., `self.fused_kernel_enabled`)
+   - Only when multiple env vars control different paths within the same communicator,
+     introduce additional signal variables (e.g., `self.allreduce_enabled` for the base
+     allreduce env var, `self.fused_kernel_enabled` for the fused kernel env var)
+   - All path gating should use these signal booleans, NOT raw env var reads at call sites
+3. **Lazy-init context helpers** — same shape-key-cached pattern as Branch A
+4. **Runtime mode flags** — add as needed (e.g., `use_cp`)
+5. **Cleanup** — release symmetric memory resources on destruction
+
+#### Register in GroupCoordinator
+
+In `parallel_state.py`, `GroupCoordinator`:
+
+1. Add a class-level type annotation: `<name>_comm: Optional[<CommunicatorClass>]`
+2. In `__init__`, add the creation condition gated by env var and `world_size > 1`
+3. Do NOT initialize any symm-mem buffers here — only instantiate the communicator
+
+### Communicator access from model code (both branches)
+
+Access via `get_tp_group().<name>_comm`. Add a model-class helper that checks all
+prerequisites (comm not None, not unavailable, signal variables enabled, `enable_fused_kernel`
+active, runtime mode active) and returns `None` otherwise.
+
+### Signal variable pattern (both branches)
+
+Communicator availability is determined by env-var-driven signal booleans:
+
+- `self.unavailable` — communicator is not usable (device/hardware prerequisites not met)
+- Additional signal variables are added **only** when multiple env vars control different
+  execution paths within the same communicator (e.g., one env var for allreduce, another
+  for fused kernel — then use two separate signals instead of a single `unavailable`)
+
+Do NOT hardcode fixed flag pairs (like `disabled`/`allreduce_disabled`) as a universal
+pattern. Instead, add signal variables that correspond one-to-one with the env vars that
+gate each path.
+
+### Per-iteration `enable_fused_kernel` flag (both branches)
+
+The integration uses **two-level gating**:
+
+| Level | Controls | Determined when | Location |
+|-------|----------|----------------|----------|
+| **Static** (env var) | Fused path *available* — communicator instantiated | Server startup | `environ.py` + `parallel_state.py` |
+| **Dynamic** (flag) | Fused path *active* for current batch | Each forward pass | `comm.enable_fused_kernel` |
+
+#### Design
+
+1. **Define** on communicator: `self.enable_fused_kernel: bool = False`
+
+2. **Set per-iteration** before the layer loop — **all conditions evaluated here**:
+   ```python
+   comm = get_tp_group().<name>_comm
+   if comm is not None and not comm.disabled:
+       comm.enable_fused_kernel = (
+           <phase_condition>(forward_batch.forward_mode)
+           and <runtime_mode_condition>  # e.g., CP mode active, a2a backend check
+       )
+   ```
+   This is the **single point of truth** for whether the fused path runs. Incorporate
+   every relevant condition here:
+   - Forward mode (prefill/decode/both)
+   - Runtime mode (CP mode, TP mode, a2a backend, etc.)
+   - Any other prerequisite that the original code path checks
+
+   **Do NOT** leave conditions to be checked later by reusing existing variables
+   (like `use_reduce_scatter`, `_use_cp`) at the fused-path entry site. All conditions
+   are folded into this one flag assignment.
+
+3. **Reset** after the layer loop: `comm.enable_fused_kernel = False`
+
+4. **Check** in `_maybe_fused_*()` — only the per-iteration flag, nothing else:
+   ```python
+   def _maybe_fused_<name>(self, ...):
+       comm = get_tp_group().<name>_comm
+       if comm is None or comm.disabled or not comm.enable_fused_kernel:
+           return None
+       ctx = comm.get_or_create_<name>_ctx(...)  # lazy-init on first actual use
+       if ctx is None:
+           return None
+       # ... proceed with fused kernel
+   ```
+
+#### Two-level interaction flow
+
+```
+Env var OFF → communicator not created → fused path never entered
+Env var ON  → communicator created (ctx deferred)
+  └─ Each iteration:
+       ForwardMode matches → enable_fused_kernel = True → ctx lazy-created/reused
+       ForwardMode mismatches → enable_fused_kernel = False → original path runs
+```
+
+The `enable_fused_kernel` flag is independent of `change_state()` — it is managed
+exclusively by model-level forward dispatch code.
+
+---
+
+## Pattern 4: Env-Var Gating
+
+Follow the `env-var-conventions` skill strictly.
+
+### Definition
+
+In `environ.py`, add to `Envs` class:
+- `SGLANG_OPT_` prefix for optimization toggles
+- `EnvBool(False)` — default off, opt-in
+- Do NOT use `os.getenv`, `get_bool_env_var`, or `SGL_` prefix
+
+### Access at call sites
+
+Use `envs.SGLANG_OPT_USE_*_FUSED_KERNEL.get()` — never read the env var directly.
+
+### Runtime mode flag (optional)
+
+If the kernel only runs under specific conditions (e.g., CP mode prefill):
+- Add a runtime flag on the communicator
+- Set it `True` before the layer loop when condition is active, reset `False` after
+- Check it in the model's comm accessor helper
+
+---
+
+## Pattern 5: Fused Fast-Path + Fallback
+
+The core integration pattern — replace sequential compute+communication with the fused kernel.
+
+### Find target call sites
+
+Use source mapping from Pattern 0. Compute steps live in kernel launch functions;
+auxiliary steps are typically elementwise PyTorch ops in combine/output paths;
+collective steps are called via `get_tp_group()` methods.
+
+### Add `_maybe_fused_*()` method
+
+Add to the relevant model class (MoE, MLP, attention). This method:
+
+1. Checks all prerequisites (including `comm.enable_fused_kernel`) → returns `None` if any unmet
+2. Calls comm's lazy-init context helper → returns `None` if context unavailable
+3. Calls the overlap op function
+4. Returns result on success, `None` on failure
+
+The prerequisite check must include the per-iteration phase flag:
+```python
+comm = get_tp_group().<name>_comm
+if comm is None or comm.disabled or not comm.enable_fused_kernel:
+    return None
+```
+
+### Insert with transparent fallback
+
+In the model's forward method, call `_maybe_fused_*()` **before** the original code:
+
+```
+fused_out = self._maybe_fused_*(...)
+if fused_out is not None:
+    return fused_out
+# Original sequential path — unchanged, serves as fallback
+```
+
+**The entry condition for the fused path must ONLY depend on `comm.enable_fused_kernel`**
+(checked inside `_maybe_fused_*()`). Do NOT gate the call with existing variables like
+`use_reduce_scatter`, `_use_cp`, or any other original-path variable. Those conditions
+are already folded into the per-iteration flag at the Model-level set point.
+
+This guarantees:
+- Zero overhead when env var is off
+- Graceful fallback on any failure
+- Original code path never deleted
+- No coupling between fused-path routing and original-path variables
+
+### Upstream bypass (when kernel subsumes an upstream step)
+
+If the overlap kernel handles a step that upstream normally does, the bypass site
+must query the communicator's per-iteration state directly — **never add a new
+parameter to the function signature** to thread bypass intent through the call chain.
+
+Correct pattern:
+```python
+# Inside the function that normally performs the step:
+comm = get_tp_group().<name>_comm
+if comm is not None and comm.enable_fused_kernel:
+    pass  # fused kernel already handled this step
+else:
+    <original_step>
+```
+
+Forbidden pattern:
+```python
+# DO NOT do this — pollutes function signatures with overlap-specific flags
+def some_upstream_fn(x, ..., skip_because_fused=False):
+    if not skip_because_fused:
+        <original_step>
+```
+
+This keeps function signatures stable and ensures unrelated callers are never
+affected by overlap integration.
+
+### Branch enforcement (when fused path requires a specific downstream branch)
+
+When the fused fast-path depends on the downstream execution taking a
+particular branch (e.g., outplace mode instead of inplace, skip-reduce
+instead of reduce), the fused-path code **must actively force that branch**
+rather than assuming the default configuration happens to match.
+
+Relying on an `assert` is insufficient — it only crashes at runtime and
+provides no recovery.  Instead:
+
+1. **Before entering the fused path**, override the relevant config fields
+   to the values the fused path requires.
+2. **Always restore** the original values afterward, even on exception
+   (`try/finally`).
+3. **In the downstream dispatch logic**, unsupported combinations should
+   gracefully fall through to the correct branch (e.g., force outplace
+   when incompatible flags are set) rather than assert.
+
+This makes the fused path self-contained — it works regardless of the
+user's default runner configuration.
+
+---
+
+## Pattern 6: Redundant Communication Bypass
+
+When the fused kernel handles a collective internally, the surrounding model code must
+skip its own collective step.
+
+### Bypass pattern
+
+Query the communicator's per-iteration state at the bypass site — do NOT pass a flag
+through the call chain:
+
+```python
+if <condition_for_collective>:
+    comm = get_tp_group().<name>_comm
+    if comm is None or not comm.enable_fused_kernel:
+        result = <collective_op>(result)
+    # else: fused kernel already performed the collective internally
+```
+
+**Critical**: the bypass condition must be exactly correct. If the collective is skipped
+when the fused kernel is NOT handling it, correctness breaks. Add a comment explaining
+why the bypass is safe.
+
+**Do NOT** add helper functions that thread bypass flags through multiple call layers.
+The communicator instance is globally accessible via `get_tp_group()` — read it directly
+at the point where the decision is made.
+
+---
+
+## Verification
+
+After all patterns are applied:
+
+1. **Import check** — all new imports resolve
+2. **Env var off** — original path taken, no behavior change
+3. **Env var on** — fused kernel called, correct output
+4. **Fallback** — comm unavailable → graceful fallback to original
+5. **Runtime mode** — flag set/cleared correctly if applicable
+6. **Shape key caching** — context reused across same-shape calls; shape key does NOT include per-batch parameters
+7. **Context allocation** — symm-mem context allocated once at max token budget (from `server_args`), never recreated on varying batch sizes
+8. **Branch enforcement** — fused path actively forces required downstream branches (no asserts); original config always restored on exit
+9. **Communicator initialization check** — when fused kernel env var is on:
+   comm must not be `None` and `comm.disabled` must be `False`; if not,
+   emit `logger.warning(...)` at startup explaining why the fused path is unavailable
+10. **Per-iteration phase gating** — `enable_fused_kernel` set/reset correctly per
+    `ForwardMode`; fused path never invoked in unsupported phase
+11. **Minimal-invasion check** — confirm:
+    - No computation added that didn't exist before (only replaced or skipped)
+    - Bypass decisions read `comm.enable_fused_kernel` at the bypass site, not threaded flags
+    - No existing variables (e.g., `use_reduce_scatter`, `_use_cp`, `no_combine`) reused
+      to gate the fused path — only the per-iteration flag is consulted
+    - No other kernel's config/mode temporarily modified to produce intermediate results
+      for the overlap kernel (e.g., forcing `no_combine=True` on experts is forbidden)
+
+---
+
+## Reference Files
+
+| File | Purpose |
+|------|---------|
+| `python/sglang/srt/environ.py` | Env var definitions (`Envs` class) |
+| `python/sglang/srt/distributed/parallel_state.py` | Communicator creation (`GroupCoordinator`) |
+| `python/sglang/srt/distributed/device_communicators/torch_symm_mem.py` | `TorchSymmMemCommunicator` — reference for communicator interface patterns |
+| `python/sglang/srt/distributed/device_communicators/symm_mem_kernels/` | Self-contained overlap kernel directory |
+| `python/sglang/srt/model_executor/forward_batch_info.py` | `ForwardMode` enum — `is_extend()`, `is_decode()` for phase detection |
+| `python/sglang/srt/layers/communicator.py` | `LayerCommunicator` — reference for per-iteration context and scatter mode patterns |
+| `.claude/skills/sglang-overlap-integration/scripts/trace_kernel_stack.py` | Targeted kernel stack extraction — filter by kernel name, unlimited stack depth |
+| `.claude/skills/llm-torch-profiler-analysis/scripts/analyze_llm_torch_profile.py` | General-purpose profiler triage (all kernels, overlap, fuse) |
+| `.claude/skills/env-var-conventions/SKILL.md` | Env var naming conventions |
+
+---
+
+## Integration Checklist
+
+- [ ] **P0**: Run profiler analysis, locate operators, build chain + source mapping (map to **model-level** replacement points, not low-level primitives — see Pattern 0f)
+- [ ] **P0**: Validate semantic equivalence; if mismatched → STOP
+- [ ] **P1**: Understand kernel (compute/comm/symm-mem/call sites)
+- [ ] **P2**: Migrate kernel to `symm_mem_kernels/` (self-contained, no external deps)
+- [ ] **P2**: Add exports to `__init__.py`; implement context class with `finalize()`
+- [ ] **P3**: If matching communicator exists → extend with `get_or_create_*_ctx()` lazy-init helper; else → create new communicator class and register in `GroupCoordinator`
+- [ ] **P3**: Extend communicator creation condition in `parallel_state.py` (or add new comm registration)
+- [ ] **P3**: Set up signal variables (one per env var gating a distinct path)
+- [ ] **P3**: Define `enable_fused_kernel` flag on communicator; confirm user-specified target phase(s) (prefill/decode/both); implement per-iteration set/reset logic in model forward; **fold ALL conditions (forward mode, runtime mode, CP/TP) into the single flag assignment**
+- [ ] **P4**: Define `SGLANG_OPT_USE_*` env var in `environ.py`
+- [ ] **P5**: Add `_maybe_fused_*()` fast-path + fallback in model forward; entry condition ONLY checks `comm.enable_fused_kernel` — no existing variables reused
+- [ ] **P5**: Add upstream bypass using communicator per-iteration state (NOT function parameter propagation)
+- [ ] **P5**: Force required downstream branches when entering fused path (override config, try/finally restore); downstream dispatch must fall through gracefully instead of asserting
+- [ ] **P6**: Bypass redundant collective by reading communicator state at bypass site (NOT call-chain flags)
+- [ ] Verify: env-var-off path, env-var-on path, fallback, runtime mode, shape caching, no-per-batch key, max-budget allocation, branch enforcement
+- [ ] Verify: minimal-invasion — no unrelated kernel signatures changed, no unnecessary computation added, no call-chain parameter pollution, no existing variables reused for fused-path routing, no other kernel's config temporarily modified
+- [ ] Verify: communicator initialization check — env var on but comm unavailable → warning log emitted at startup
+- [ ] Verify: per-iteration phase gating — `enable_fused_kernel` set/reset correctly per `ForwardMode`; fused path never invoked in unsupported phase

--- a/.claude/skills/sglang-overlap-integration/references/pattern0-profiler-analysis.md
+++ b/.claude/skills/sglang-overlap-integration/references/pattern0-profiler-analysis.md
@@ -1,0 +1,133 @@
+# Pattern 0: Profile-Driven Identification + Semantic Gate (Detail)
+
+This pattern is a **hard gate** — if semantic validation fails, STOP immediately.
+
+## 0a. Run kernel stack analysis
+
+Given the user provides a profiling trace path and an overlap kernel description,
+use the dedicated stack analysis script in **two steps**: first discover actual
+kernel names, then extract full Python call stacks.
+
+### Step 1: Discover actual kernel names
+
+User-provided kernel names (e.g. `reduce_scatter`, `add_`) often don't
+exactly match the canonical names in the trace. Use `--list-kernels` to
+discover the real names first:
+
+```bash
+python3 .claude/skills/sglang-overlap-integration/scripts/trace_kernel_stack.py \
+  --input <trace_path> \
+  --list-kernels \
+  --kernel-filter <keyword1> <keyword2> ...
+```
+
+This outputs:
+- All GPU kernels sorted by GPU time, with `[MATCH]` tags on those matching
+  any filter substring
+- Matching CPU op names (important for ops that appear only at the CPU op
+  level)
+- Suggested `--kernel-filter` values for Step 2
+
+### Step 2: Extract full Python call stacks
+
+Use the discovered kernel name substrings from Step 1:
+
+```bash
+python3 .claude/skills/sglang-overlap-integration/scripts/trace_kernel_stack.py \
+  --input <trace_path> \
+  --kernel-filter <discovered_substring1> <discovered_substring2> ... \
+  --stack-depth 0 \
+  --format chain
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--list-kernels` | List all GPU kernel names sorted by GPU time; with `--kernel-filter`, mark matches with `[MATCH]` and show matching CPU ops |
+| `--kernel-filter` | One or more case-insensitive substrings; matches both GPU kernel names **and** CPU op names |
+| `--stack-depth` | Max Python stack frames to display. `0` = unlimited (full call stack). Default: `0`. |
+| `--format table` | Per-kernel stack report with GPU time, location, and full call stack. |
+| `--format chain` | Operator-chain summary for Pattern 0c (grouped by source location). |
+| `--format json` | Machine-readable JSON output for downstream tooling. |
+| `--output <path>` | Write to file instead of stdout. |
+
+This script is self-contained (does not depend on the general-purpose triage
+scripts) and provides **unlimited stack depth** by default, unlike the
+4-frame cap in the general triage output.
+
+For a full triage report (all kernels, overlap opportunities, fuse opportunities),
+use the general-purpose script instead:
+
+```bash
+python3 .claude/skills/llm-torch-profiler-analysis/scripts/analyze_llm_torch_profile.py \
+  --input <trace_path>
+```
+
+## 0b. Locate target operators
+
+From the overlap kernel description, identify each operator in the trace:
+- Match GPU kernels (`cat=kernel` events) by name substring
+- Match CPU ops (`cat=cpu_op` events) by op name
+- Use `python_function` events for source scope
+- Confirm: non-trivial GPU time, same CUDA stream (sequential), temporal ordering
+
+## 0c. Build operator chain + source mapping
+
+For each operator, record: GPU kernel name, CPU op name, Python source location,
+input tensor shapes, stream, temporal order, per-layer GPU time.
+
+Output the chain in temporal order and the source mapping for each step.
+
+## 0d. Semantic equivalence validation
+
+Must verify all of the following:
+
+1. **Compute equivalence** — same math operation (reduction type, scaling application, dtype handling)
+2. **Communication equivalence** — same collective type, data partitioning, reduction operation
+3. **Shape invariance** — same input/output/intermediate shapes
+4. **Semantic ordering** — same operation order (order matters when inputs differ across ranks)
+5. **Scaling factor compatibility** — same timing and mechanism of scaling
+
+**If any check fails**: output the mismatch reason and **STOP**. Do not proceed.
+
+## 0e. Summary output
+
+```
+=== Operator Chain to Replace ===
+Chain: <op1> → <op2> → <op3>
+Total GPU time / Per-layer / Stream / Source mapping
+Semantics: VALIDATED or MISMATCH (with reason)
+```
+
+## 0f. Source-mapping target level
+
+When building the source mapping in Step 0c, the target location must be the
+**model-level replacement point** — the highest-level function in the model
+code that orchestrates the entire compute+communication chain — not the
+low-level communication primitive.
+
+**Rule**: Walk up the Python call stack from each GPU kernel until you reach
+the model layer (typically a `forward()` method or similar orchestrator on an
+`nn.Module` subclass in the model files, or a model-layer helper function in
+the layer modules). That model-level function is the insertion point where
+Pattern 5 and Pattern 6 will inject the `_maybe_fused_*()` fast-path and
+bypass redundant collectives.
+
+**Why**: Pattern 5 needs to intercept the full operator chain (compute +
+elementwise + communication) at a level where all inputs and the fused
+output are accessible, and Pattern 6 needs to skip the surrounding
+collective call. Low-level wrappers in communication modules cannot serve as
+insertion points because they lack access to the compute inputs needed by
+the fused kernel.
+
+**Stack-level heuristic** — classify each frame in the call stack:
+
+| Stack level | How to identify | Use as target? |
+|---|---|---|
+| **Low** | Communication primitive wrappers (e.g., `reduce_scatter_tensor`, `all_reduce`) in distributed/parallel modules | No — no access to compute inputs |
+| **Mid** | Layer-internal helpers (e.g., elementwise fuse functions, quantization helpers) that handle only one step of the chain | Partial — only covers part of the chain |
+| **High** | Model-layer orchestrator functions (e.g., `forward()` or a helper called from it) that invoke the full compute→elementwise→communication sequence | **Yes** — all inputs and the collective call are in scope |
+
+The low-level primitive is still useful for confirming the GPU kernel
+identity (e.g., verifying the exact NCCL/CUDA kernel name), but the source
+mapping for the operator chain should point to the model-level function that
+will be modified.

--- a/.claude/skills/sglang-overlap-integration/references/pattern2-kernel-placement.md
+++ b/.claude/skills/sglang-overlap-integration/references/pattern2-kernel-placement.md
@@ -1,0 +1,42 @@
+# Pattern 2: Self-Contained Kernel Placement (Detail)
+
+**Rule: overlap kernel code must be self-contained — no external third-party dependency.**
+
+## Placement
+
+Kernel files go under:
+```
+python/sglang/srt/distributed/device_communicators/symm_mem_kernels/<kernel_name>_symm_mem.py
+```
+
+Add public API exports to `symm_mem_kernels/__init__.py`.
+
+## Context object pattern
+
+Each kernel exposes three items:
+
+| Item | Role |
+|------|------|
+| Context class | Holds symm-mem buffers, signals, config; **must implement `finalize()`** for cleanup |
+| Context factory | Creates the context; called by communicator lazy-init |
+| Op function | Executes the kernel given context + input tensors |
+
+The context class holds all persistent state (symmetric memory buffers, rendezvous handles,
+signal buffers). `finalize()` is called when shape parameters change and the context must
+be rebuilt.
+
+## Context class conventions
+
+- Use `@dataclass` for the context class
+- All symm-mem buffers and signal tensors are instance attributes
+- `__post_init__` performs the actual symm-mem allocation and rendezvous
+- Expose pointer arrays (`buf_ptrs`, `signal_pad_ptrs`) as `torch.Tensor` of dtype `int64`
+  for GPU-side peer indexing (e.g., `tl.load(ptrs + peer)` in Triton kernels)
+- `finalize()` releases all symm-mem resources and resets handles to `None`
+
+## Op function conventions
+
+- Takes `ctx` as first argument, followed by input tensors and runtime parameters
+- Resets synchronization state before launch (e.g., `ctx.grid_barrier.zero_()`)
+- Returns the output tensor(s) — same shape/dtype as the original sequential path would produce
+- Does NOT modify the context's persistent buffers in a way that would break reuse

--- a/.claude/skills/sglang-overlap-integration/scripts/trace_kernel_stack.py
+++ b/.claude/skills/sglang-overlap-integration/scripts/trace_kernel_stack.py
@@ -1,0 +1,1223 @@
+"""Trace kernel stack analyzer for overlap integration.
+
+Self-contained script that extracts full Python call stacks for specific GPU
+kernels from a torch profiler trace.  Designed for Pattern 0 of the
+sglang-overlap-integration skill: identify which source code is responsible
+for launching the kernels you want to overlap.
+
+Compared to the general-purpose triage script this tool:
+  * Accepts ``--kernel-filter`` to restrict output to kernels whose name
+    contains any of the given substrings (case-insensitive).
+  * Provides ``--list-kernels`` mode to discover actual kernel names before
+    running a full stack analysis — essential when user-provided names
+    don't exactly match the canonical kernel names in the trace.
+  * Shows **unlimited** call-stack depth instead of the default 4-frame
+    cap, controlled by ``--stack-depth``.
+  * Outputs a compact, goal-oriented table keyed by (kernel,
+    python-location, stack) instead of a full triage report.
+
+Typical two-step workflow:
+    # Step 1: Discover actual kernel names matching your keywords
+    python3 trace_kernel_stack.py --input <trace.json> \\
+        --list-kernels --kernel-filter <keyword1> <keyword2> ...
+
+    # Step 2: Use the discovered names for full stack analysis
+    python3 trace_kernel_stack.py --input <trace.json> \\
+        --kernel-filter <discovered_substring1> <discovered_substring2> ... \\
+        --stack-depth 0 --format chain
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import re
+import sys
+from bisect import bisect_right
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+# ---------------------------------------------------------------------------
+# Text / path helpers (inlined from profile_common to stay self-contained)
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=65536)
+def _normalize_text_cached(text: str) -> str:
+    text = text.strip()
+    if not text:
+        return ""
+    for token in (" ", "\t", "\n", "\r", "\v", "\f"):
+        if token in text:
+            return " ".join(text.split())
+    return text
+
+
+def normalize_text(value: object) -> str:
+    return _normalize_text_cached(value if isinstance(value, str) else str(value))
+
+
+@lru_cache(maxsize=65536)
+def _normalize_repo_relative_path_cached(text: str) -> str:
+    text = text.replace("\\", "/")
+    lowered = text.lower()
+    for marker, normalized_marker in (
+        ("python/sglang/", "python/sglang/"),
+        ("sgl_kernel/", "sgl_kernel/"),
+        ("vllm/", "vllm/"),
+        ("tensorrt_llm/", "tensorrt_llm/"),
+        ("tensorrt-llm/", "tensorrt_llm/"),
+    ):
+        idx = lowered.find(marker)
+        if idx != -1:
+            suffix = text[idx + len(marker) :].lstrip("/")
+            return f"{normalized_marker}{suffix}".lstrip("/")
+    idx = lowered.find("sglang/")
+    if idx != -1:
+        return ("python/" + text[idx:]).lstrip("/")
+    return text.lstrip("/")
+
+
+def normalize_repo_relative_path(path: object) -> str:
+    return _normalize_repo_relative_path_cached(normalize_text(path))
+
+
+def coerce_optional_int(value: object) -> Optional[int]:
+    if value in (None, "", "None"):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else None
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_trace_events(trace: object) -> Sequence[dict]:
+    if isinstance(trace, dict):
+        events = trace.get("traceEvents", [])
+        return events if isinstance(events, list) else []
+    if isinstance(trace, list):
+        return trace
+    return []
+
+
+def contains_any_keyword(text: str, keywords: Sequence[str]) -> bool:
+    return any(keyword in text for keyword in keywords)
+
+
+def _normalize_for_match(text: str) -> str:
+    """Lowercase and strip underscores so that snake_case and camelCase names
+    can match each other.  For example, ``reduce_scatter`` and ``ReduceScatter``
+    both become ``reducescatter``."""
+    return text.lower().replace("_", "")
+
+
+def _keyword_matches_text(keyword: str, text: str) -> bool:
+    """Check whether *keyword* appears in *text*, trying both the raw
+    case-insensitive match and the underscore-normalised match.
+
+    This bridges the naming gap between user-facing snake_case names
+    (``reduce_scatter``, ``all_reduce``) and camelCase / PascalCase kernel
+    names (``ReduceScatter``, ``AllReduce``) commonly found in NCCL / CUDA
+    profiler events.
+    """
+    kw_lower = keyword.lower()
+    text_lower = text.lower()
+    if kw_lower in text_lower:
+        return True
+    # Strip underscores from both sides so reduce_scatter matches ReduceScatter
+    kw_norm = _normalize_for_match(keyword)
+    text_norm = _normalize_for_match(text)
+    return kw_norm in text_norm
+
+
+TRACE_METADATA_NAMES = {
+    "process_name",
+    "thread_name",
+    "process_sort_index",
+    "thread_sort_index",
+}
+
+NON_KERNEL_TRACE_CATEGORIES = ("python_function", "cpu_op", "trace")
+
+PYTHON_SCOPE_NAME_PREFIXES = ("python/", "nn.module:")
+
+
+def is_trace_metadata_name(name: object) -> bool:
+    return str(name) in TRACE_METADATA_NAMES
+
+
+def is_complete_duration_event(event: dict) -> bool:
+    if event.get("ph") != "X":
+        return False
+    dur = event.get("dur")
+    ts = event.get("ts")
+    if dur is None or ts is None:
+        return False
+    try:
+        return float(dur) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def is_annotation_event(name: object, category: object) -> bool:
+    lowered_name = normalize_text(name).lower()
+    lowered_category = normalize_text(category).lower()
+    return "annotation" in lowered_category or lowered_name.startswith("## call ")
+
+
+def is_non_kernel_trace_category(category: object) -> bool:
+    lowered_category = normalize_text(category).lower()
+    return any(token in lowered_category for token in NON_KERNEL_TRACE_CATEGORIES)
+
+
+def looks_like_python_scope_name(name: object) -> bool:
+    lowered_name = normalize_text(name).lower()
+    return ".py(" in lowered_name or lowered_name.startswith(PYTHON_SCOPE_NAME_PREFIXES)
+
+
+def has_stream_marker(args: Optional[dict]) -> bool:
+    trace_args = args or {}
+    return "stream" in trace_args or "cuda_stream" in trace_args
+
+
+def is_gpu_kernel_event(event: dict) -> bool:
+    if not is_complete_duration_event(event):
+        return False
+    name = normalize_text(event.get("name", ""))
+    if is_trace_metadata_name(name):
+        return False
+    cat = normalize_text(event.get("cat", "")).lower()
+    args = event.get("args") or {}
+    if is_non_kernel_trace_category(cat):
+        return False
+    if is_annotation_event(name, cat):
+        return False
+    if "kernel" in cat or cat.startswith("gpu_"):
+        return True
+    if looks_like_python_scope_name(name):
+        return False
+    return has_stream_marker(args)
+
+
+def is_cuda_launch_event(name: str, cat: str) -> bool:
+    lowered_name = normalize_text(name).lower()
+    lowered_cat = normalize_text(cat).lower()
+    if lowered_cat not in {"cuda_runtime", "cuda_driver"}:
+        return False
+    return "launch" in lowered_name
+
+
+def select_heaviest_pid(
+    events: Sequence[dict],
+    event_filter,
+    preferred_substrings: Sequence[str] = (),
+) -> Optional[str]:
+    durations: Counter = Counter()
+    for event in events:
+        if not event_filter(event):
+            continue
+        pid = str(event.get("pid"))
+        durations[pid] += float(event["dur"])
+    if not durations:
+        return None
+    for substring in preferred_substrings:
+        preferred = [pid for pid in durations if substring in pid]
+        if preferred:
+            return max(preferred, key=lambda pid: durations[pid])
+    return max(durations, key=lambda pid: durations[pid])
+
+
+def load_trace_json(path: Path) -> dict:
+    if path.suffix == ".gz":
+        with gzip.open(path, "rt", encoding="utf-8") as handle:
+            return json.load(handle)
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+# ---------------------------------------------------------------------------
+# Kernel name canonicalization & classification
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=65536)
+def normalize_source_location(name: str) -> str:
+    text = normalize_text(name)
+    match = re.match(r"(?P<path>.+?)\((?P<line>\d+)\): (?P<func>.+)$", text)
+    if not match:
+        return text
+    path = normalize_repo_relative_path(match.group("path"))
+    return f"{path}:{match.group('line')} {match.group('func')}"
+
+
+@lru_cache(maxsize=65536)
+def canonicalize_name(name: str) -> str:
+    text = normalize_text(name)
+    text = re.sub(r"0x[0-9a-fA-F]+", "0xADDR", text)
+    if text.startswith("void ") and text.endswith(")"):
+        depth = 0
+        split_idx: Optional[int] = None
+        for idx in range(len(text) - 1, -1, -1):
+            char = text[idx]
+            if char == ")":
+                depth += 1
+            elif char == "(":
+                depth -= 1
+                if depth == 0:
+                    split_idx = idx
+                    break
+        if split_idx is not None:
+            text = text[:split_idx]
+    return text
+
+
+COMMUNICATION_STRONG_KEYWORDS = (
+    "nccl",
+    "allreduce",
+    "all_reduce",
+    "reduce_scatter",
+    "allgather",
+    "all_gather",
+    "alltoall",
+    "all_to_all",
+    "cross_device_reduce",
+    "deepep",
+    "mooncake",
+)
+
+CATEGORY_PATTERNS: List[Tuple[str, Tuple[str, ...]]] = [
+    ("hybrid_linear", ("gdn", "gated_delta", "mamba", "selective_scan", "ssd", "causal_conv", "ssm")),
+    ("attention", ("flash_attn", "flashattention", "flash_attention", "fmha", "attention", "mla", "paged_attention", "decode_attention")),
+    ("moe", ("fused_moe", "grouped_mm", "groupgemm", "group_gemm", "moe", "expert", "groupproblemshape")),
+    ("gemm", ("gemm", "gemv", "matmul", "cublas", "cutlass", "wgmma", "mma", "bmm", "nvjet")),
+    ("norm", ("rmsnorm", "layernorm", "_norm_", " norm", "normkernel")),
+    ("rope", ("rotary", "rope", "mrope")),
+    ("softmax", ("softmax",)),
+    ("activation", ("silu", "gelu", "relu", "act_and_mul", "sigmoid")),
+    ("quantize", ("quant", "fp8", "mxfp", "nvfp4", "dequant", "cvt")),
+    ("reduce_topk", ("topk", "reduce", "argmax", "argtopk", "sampling", "multinomial")),
+    ("communication", ("broadcast", "dispatch", "combine")),
+    ("memory", ("memcpy", "memset", "dma", "prefetch", "copy", "fill")),
+]
+
+
+@lru_cache(maxsize=65536)
+def classify_kernel(name: str) -> str:
+    lowered = name.lower()
+    if contains_any_keyword(lowered, COMMUNICATION_STRONG_KEYWORDS):
+        return "communication"
+    if contains_any_keyword(lowered, ("memcpy", "memset", "dma", "prefetch")):
+        return "memory"
+    looks_compute_like = contains_any_keyword(
+        lowered, ("gemm", "gemv", "matmul", "cublas", "cutlass", "wgmma", "mma", "bmm", "nvjet", "fmha", "attention", "flash_attn", "flashattention", "flash_attention", "grouped_mm", "groupgemm", "moe", "expert")
+    )
+    if contains_any_keyword(lowered, ("copy", "fill")) and not looks_compute_like:
+        return "memory"
+    for category, keywords in CATEGORY_PATTERNS:
+        if contains_any_keyword(lowered, keywords):
+            return category
+    if contains_any_keyword(lowered, ("broadcast", "dispatch", "combine")) and not looks_compute_like:
+        return "communication"
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Python frame priority & stack display
+# ---------------------------------------------------------------------------
+
+NOISE_FRAME_PREFIXES = (
+    "threading.py(",
+    "multiprocessing/",
+    "contextlib.py(",
+    "torch/utils/_contextlib.py(",
+    "runpy.py(",
+    "asyncio/",
+    "selectors.py(",
+    "queue.py(",
+    "socket.py(",
+    "tqdm/_monitor.py(",
+    "<string>(",
+    "<built-in method ",
+)
+
+LOW_LEVEL_FRAME_PREFIXES = (
+    "triton/runtime/",
+    "triton/backends/",
+    "torch/_ops.py",
+    "torch/nn/modules/module.py",
+)
+
+LOW_SIGNAL_FUNCTION_TOKENS = (
+    "__torch_function__",
+    "__torch_dispatch__",
+    "__call__",
+    "_call_impl",
+    "_wrapped_call_impl",
+)
+
+LOW_SIGNAL_PATH_TOKENS = (
+    "model_executor/parameter.py:",
+    "model_executor/cuda_graph_runner.py:",
+    "compilation/cuda_graph.py:",
+    "pyexecutor/cuda_graph_runner.py:",
+    "pyexecutor/py_executor.py:",
+    "_torch/utils.py:",
+    "torch/fx/graph_module.py:",
+)
+
+
+def is_low_signal_source_location(location: str) -> bool:
+    lowered = str(location).strip().lower()
+    if not lowered:
+        return False
+    return any(token in lowered for token in LOW_SIGNAL_FUNCTION_TOKENS) or any(
+        token in lowered for token in LOW_SIGNAL_PATH_TOKENS
+    )
+
+
+@lru_cache(maxsize=65536)
+def frame_priority(frame_name: str) -> int:
+    raw_text = str(frame_name).strip()
+    normalized_text = normalize_source_location(raw_text)
+    penalty = 80 if is_low_signal_source_location(normalized_text) else 0
+    if raw_text.startswith(NOISE_FRAME_PREFIXES):
+        return -20
+    if normalized_text.startswith("python/sglang/"):
+        return 300 - penalty
+    if normalized_text.startswith("sglang/"):
+        return 290 - penalty
+    if normalized_text.startswith("vllm/"):
+        return 285 - penalty
+    if normalized_text.startswith("tensorrt_llm/"):
+        return 280 - penalty
+    if normalized_text.startswith("sgl_kernel/"):
+        return 260 - penalty
+    if normalized_text.startswith("triton_kernels/"):
+        return 220 - penalty
+    if normalized_text.startswith(LOW_LEVEL_FRAME_PREFIXES):
+        return 0
+    if raw_text.startswith("/data/") or raw_text.startswith("/Users/"):
+        if "/sglang/" in raw_text:
+            return 120
+        if "/vllm/" in raw_text:
+            return 118
+        if "/TensorRT-LLM/" in raw_text or "/tensorrt_llm/" in raw_text:
+            return 116
+        return 100
+    if ".py(" in raw_text and "/sglang/" in raw_text:
+        return 110
+    if ".py(" in raw_text and "/vllm/" in raw_text:
+        return 108
+    if ".py(" in raw_text and ("/TensorRT-LLM/" in raw_text or "/tensorrt_llm/" in raw_text):
+        return 106
+    if ".py:" in normalized_text and ("site-packages" in raw_text or normalized_text.startswith("torch/")):
+        return 45
+    if ".py:" in normalized_text:
+        return 35
+    if raw_text.startswith("<built-in method "):
+        return -10
+    return 0
+
+
+def build_stack_display(active_frames: Sequence["PythonFrame"], max_depth: int = 0) -> str:
+    """Build a multi-layer stack string from active Python frames.
+
+    Args:
+        active_frames: Frames sorted by (ts, end_ts).
+        max_depth: Maximum number of frames to show.  0 means unlimited.
+    """
+    if not active_frames:
+        return ""
+    filtered = [item.normalized_name for item in active_frames if item.priority > 0]
+    if not filtered:
+        filtered = [active_frames[-1].normalized_name]
+    if max_depth > 0:
+        filtered = filtered[-max_depth:]
+    return " -> ".join(filtered)
+
+
+def choose_mapping_frame(active_frames: Sequence["PythonFrame"]) -> Optional["PythonFrame"]:
+    if not active_frames:
+        return None
+    best = active_frames[0]
+    best_key = (best.priority, best.ts, -best.dur)
+    for item in active_frames[1:]:
+        key = (item.priority, item.ts, -item.dur)
+        if key > best_key:
+            best = item
+            best_key = key
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class KernelEvent:
+    name: str
+    canonical_name: str
+    category: str
+    pid: str
+    tid: str
+    ts: float
+    dur: float
+    external_id: Optional[int]
+    correlation: Optional[int] = None
+
+
+@dataclass
+class CpuOpEvent:
+    name: str
+    pid: str
+    tid: str
+    ts: float
+    dur: float
+    external_id: int
+
+
+@dataclass
+class LaunchEvent:
+    name: str
+    pid: str
+    tid: str
+    ts: float
+    dur: float
+    correlation: int
+
+
+@dataclass
+class PythonFrame:
+    name: str
+    normalized_name: str
+    pid: str
+    tid: str
+    ts: float
+    dur: float
+    python_id: Optional[int]
+    parent_id: Optional[int]
+    end_ts: float
+    priority: int
+
+
+@dataclass
+class TimedEventIndex:
+    events: List[object]
+    start_ts: List[float]
+
+
+@dataclass
+class StackInfo:
+    """Per-kernel stack attribution result."""
+    kernel_name: str
+    canonical_name: str
+    category: str
+    gpu_time_us: float
+    location: str
+    stack: str
+    cpu_op: str
+    stream: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# Trace extraction
+# ---------------------------------------------------------------------------
+
+def build_correlation_external_lookup(raw_events: Sequence[dict]) -> Dict[int, int]:
+    lookup: Dict[int, int] = {}
+    for event in raw_events:
+        args = event.get("args", {}) or {}
+        correlation = coerce_optional_int(args.get("correlation"))
+        external_id = coerce_optional_int(args.get("External id"))
+        if correlation is not None and external_id is not None:
+            lookup[correlation] = external_id
+    return lookup
+
+
+def build_timed_event_index(events: Sequence[object]) -> TimedEventIndex:
+    ordered = list(events)
+    ordered.sort(key=lambda item: item.ts)
+    return TimedEventIndex(
+        events=ordered,
+        start_ts=[float(item.ts) for item in ordered],
+    )
+
+
+def build_cpu_op_index(cpu_ops: Sequence[CpuOpEvent]) -> Dict[int, TimedEventIndex]:
+    output: Dict[int, List[CpuOpEvent]] = defaultdict(list)
+    for cpu_op in cpu_ops:
+        output[cpu_op.external_id].append(cpu_op)
+    return {
+        external_id: build_timed_event_index(items)
+        for external_id, items in output.items()
+    }
+
+
+def build_launch_index(launch_events: Sequence[LaunchEvent]) -> Dict[int, TimedEventIndex]:
+    output: Dict[int, List[LaunchEvent]] = defaultdict(list)
+    for launch in launch_events:
+        output[launch.correlation].append(launch)
+    return {
+        correlation: build_timed_event_index(items)
+        for correlation, items in output.items()
+    }
+
+
+def match_timed_event(index, probe_ts: float):
+    if not index:
+        return None
+    if isinstance(index, TimedEventIndex):
+        events = index.events
+        if not events:
+            return None
+        right = bisect_right(index.start_ts, probe_ts + 1e-3)
+        candidates: List[object] = []
+        if right > 0:
+            candidates.extend(events[max(0, right - 4) : right])
+        if right < len(events):
+            candidates.extend(events[right : min(len(events), right + 2)])
+        if not candidates:
+            return None
+        earlier = [item for item in candidates if item.ts <= probe_ts + 1e-3]
+        if earlier:
+            return min(earlier, key=lambda item: abs((item.ts + item.dur) - probe_ts))
+        return min(candidates, key=lambda item: abs(item.ts - probe_ts))
+    events = list(index)
+    if not events:
+        return None
+    earlier = [item for item in events if item.ts <= probe_ts + 1e-3]
+    if earlier:
+        return min(earlier, key=lambda item: abs((item.ts + item.dur) - probe_ts))
+    return min(events, key=lambda item: abs(item.ts - probe_ts))
+
+
+def match_cpu_op(kernel: KernelEvent, cpu_ops_by_external_id: Dict[int, TimedEventIndex]) -> Optional[CpuOpEvent]:
+    if kernel.external_id is None:
+        return None
+    return match_timed_event(cpu_ops_by_external_id.get(kernel.external_id, []), kernel.ts)
+
+
+def match_launch_event(kernel: KernelEvent, launches_by_correlation: Dict[int, TimedEventIndex]) -> Optional[LaunchEvent]:
+    if kernel.correlation is None:
+        return None
+    return match_timed_event(launches_by_correlation.get(kernel.correlation, []), kernel.ts)
+
+
+# ---------------------------------------------------------------------------
+# Frame resolution
+# ---------------------------------------------------------------------------
+
+def resolve_active_frames_linear(frames: Sequence[PythonFrame], probe_ts: float) -> List[PythonFrame]:
+    active = [item for item in frames if item.ts <= probe_ts <= item.end_ts]
+    active.sort(key=lambda item: (item.ts, item.end_ts))
+    return active
+
+
+def find_active_python_frames(cpu_op: CpuOpEvent, python_frames: Dict[Tuple[str, str], List[PythonFrame]]) -> List[PythonFrame]:
+    frames = python_frames.get((cpu_op.pid, cpu_op.tid), [])
+    if not frames:
+        return []
+    probe_ts = cpu_op.ts + min(cpu_op.dur * 0.5, 1.0)
+    return resolve_active_frames_linear(frames, probe_ts)
+
+
+def find_active_python_frames_at_ts(*, pid: str, tid: str, ts: float, python_frames: Dict[Tuple[str, str], List[PythonFrame]]) -> List[PythonFrame]:
+    frames = python_frames.get((pid, tid), [])
+    if not frames:
+        return []
+    return resolve_active_frames_linear(frames, ts)
+
+
+def resolve_kernel_site_context(
+    kernel: KernelEvent,
+    cpu_ops_by_external_id: Dict[int, TimedEventIndex],
+    python_frames: Dict[Tuple[str, str], List[PythonFrame]],
+    launches_by_correlation: Dict[int, TimedEventIndex],
+    max_stack_depth: int = 0,
+) -> Tuple[str, str, str]:
+    """Resolve the Python source location, full stack, and CPU op for a kernel.
+
+    Args:
+        max_stack_depth: Maximum stack frames to show. 0 = unlimited.
+    """
+    cpu_op = match_cpu_op(kernel, cpu_ops_by_external_id)
+    if cpu_op is not None:
+        active_frames = find_active_python_frames(cpu_op, python_frames)
+        if active_frames:
+            chosen = choose_mapping_frame(active_frames)
+            location = chosen.normalized_name if chosen else "unresolved"
+            stack = build_stack_display(active_frames, max_depth=max_stack_depth)
+            return location, stack, cpu_op.name
+
+    launch_event = match_launch_event(kernel, launches_by_correlation)
+    if launch_event is not None:
+        active_frames = find_active_python_frames_at_ts(
+            pid=launch_event.pid, tid=launch_event.tid, ts=launch_event.ts,
+            python_frames=python_frames,
+        )
+        if active_frames:
+            chosen = choose_mapping_frame(active_frames)
+            location = chosen.normalized_name if chosen else "unresolved"
+            stack = build_stack_display(active_frames, max_depth=max_stack_depth)
+            cpu_op_name = cpu_op.name if cpu_op is not None else launch_event.name
+            return location, stack, cpu_op_name
+        return "unresolved", "", launch_event.name
+
+    cpu_op_name = cpu_op.name if cpu_op is not None else ""
+    return "unresolved", "", cpu_op_name
+
+
+# ---------------------------------------------------------------------------
+# Main extraction pipeline
+# ---------------------------------------------------------------------------
+
+def extract_trace_data(trace: dict):
+    """Extract kernel events, CPU ops, Python frames, and launch events from a trace."""
+    raw_events = extract_trace_events(trace)
+    correlation_external = build_correlation_external_lookup(raw_events)
+    chosen_pid = select_heaviest_pid(
+        raw_events,
+        is_gpu_kernel_event,
+        preferred_substrings=("TP00", "TP-0"),
+    )
+
+    kernels: List[KernelEvent] = []
+    cpu_ops: List[CpuOpEvent] = []
+    launches: List[LaunchEvent] = []
+    python_frames: Dict[Tuple[str, str], List[PythonFrame]] = defaultdict(list)
+
+    for event in raw_events:
+        if event.get("ph") != "X":
+            continue
+
+        pid = str(event.get("pid"))
+        tid = str(event.get("tid"))
+        ts = float(event.get("ts", 0.0))
+        dur = float(event.get("dur", 0.0))
+        cat = str(event.get("cat", ""))
+        args = event.get("args") or {}
+        name = str(event.get("name", ""))
+
+        if cat == "python_function":
+            python_frames[(pid, tid)].append(
+                PythonFrame(
+                    name=name,
+                    normalized_name=normalize_source_location(name),
+                    pid=pid,
+                    tid=tid,
+                    ts=ts,
+                    dur=dur,
+                    python_id=coerce_optional_int(args.get("Python id")),
+                    parent_id=coerce_optional_int(args.get("Python parent id")),
+                    end_ts=ts + dur,
+                    priority=frame_priority(name),
+                )
+            )
+
+        correlation = coerce_optional_int(args.get("correlation"))
+        external_id = coerce_optional_int(args.get("External id"))
+        if external_id is None and correlation is not None:
+            external_id = correlation_external.get(correlation)
+        if cat == "cpu_op" and external_id is not None:
+            cpu_ops.append(
+                CpuOpEvent(name=name, pid=pid, tid=tid, ts=ts, dur=dur, external_id=external_id)
+            )
+        if is_cuda_launch_event(name, cat) and correlation is not None:
+            launches.append(
+                LaunchEvent(name=name, pid=pid, tid=tid, ts=ts, dur=dur, correlation=correlation)
+            )
+
+        if chosen_pid is None or not is_gpu_kernel_event(event) or pid != chosen_pid:
+            continue
+
+        stream = None
+        if args:
+            raw_stream = args.get("stream") or args.get("cuda_stream")
+            if raw_stream is not None:
+                try:
+                    stream = int(str(raw_stream), 0)
+                except (ValueError, TypeError):
+                    pass
+
+        kernels.append(
+            KernelEvent(
+                name=name,
+                canonical_name=canonicalize_name(name),
+                category=classify_kernel(name),
+                pid=pid,
+                tid=tid,
+                ts=ts,
+                dur=dur,
+                external_id=external_id,
+                correlation=correlation,
+            )
+        )
+
+    for frames in python_frames.values():
+        frames.sort(key=lambda item: (item.ts, item.end_ts))
+
+    return kernels, cpu_ops, dict(python_frames), launches, chosen_pid
+
+
+def filter_kernels(
+    kernels: Sequence[KernelEvent],
+    cpu_ops: Sequence["CpuOpEvent"],
+    kernel_filters: Sequence[str],
+) -> List[KernelEvent]:
+    """Keep kernels whose canonical name or associated CPU op name contains any
+    filter substring.
+
+    Matching is case-insensitive and also **underscore-normalised**: a filter
+    like ``reduce_scatter`` will match kernel names containing ``ReduceScatter``
+    because both sides are lowercased *and* stripped of underscores before
+    comparison.
+
+    This also matches kernels via their CPU op names: if a kernel's GPU name
+    doesn't match but its associated CPU op name does, the kernel is included.
+    This is important because some ops like ``aten::add_`` appear as CPU op
+    names rather than GPU kernel names.
+    """
+    if not kernel_filters:
+        return list(kernels)
+
+    # Direct GPU kernel name match
+    direct_matches = set()
+    for k in kernels:
+        if any(_keyword_matches_text(f, k.canonical_name) for f in kernel_filters):
+            direct_matches.add(id(k))
+
+    # CPU-op-name-based match: find CPU ops that match, then find their kernels
+    cpu_op_names_matching: Dict[int, bool] = {}  # external_id -> True
+    for op in cpu_ops:
+        if any(_keyword_matches_text(f, op.name) for f in kernel_filters):
+            cpu_op_names_matching[op.external_id] = True
+
+    if cpu_op_names_matching:
+        cpu_ops_by_eid = build_cpu_op_index(cpu_ops)
+        for k in kernels:
+            if id(k) in direct_matches:
+                continue
+            cpu_op = match_cpu_op(k, cpu_ops_by_eid)
+            if cpu_op is not None and cpu_op_names_matching.get(cpu_op.external_id):
+                direct_matches.add(id(k))
+
+    return [k for k in kernels if id(k) in direct_matches]
+
+
+def resolve_stacks(
+    kernels: Sequence[KernelEvent],
+    cpu_ops: Sequence[CpuOpEvent],
+    python_frames: Dict[Tuple[str, str], List[PythonFrame]],
+    launches: Sequence[LaunchEvent],
+    max_stack_depth: int = 0,
+) -> List[StackInfo]:
+    """Resolve Python call stacks for each kernel event."""
+    cpu_ops_by_external_id = build_cpu_op_index(cpu_ops)
+    launches_by_correlation = build_launch_index(launches)
+
+    results: List[StackInfo] = []
+
+    # Batch-resolve query times for efficiency
+    query_times_by_thread: Dict[Tuple[str, str], List[float]] = defaultdict(list)
+    query_kernel_map: Dict[Tuple[str, str, float], KernelEvent] = {}
+
+    for kernel in kernels:
+        cpu_op = match_cpu_op(kernel, cpu_ops_by_external_id)
+        if cpu_op is not None:
+            qts = cpu_op.ts + min(cpu_op.dur * 0.5, 1.0)
+            query_times_by_thread[(cpu_op.pid, cpu_op.tid)].append(qts)
+            query_kernel_map[(cpu_op.pid, cpu_op.tid, qts)] = kernel
+        launch_event = match_launch_event(kernel, launches_by_correlation)
+        if launch_event is not None:
+            qts = launch_event.ts
+            if (launch_event.pid, launch_event.tid, qts) not in query_kernel_map:
+                query_times_by_thread[(launch_event.pid, launch_event.tid)].append(qts)
+                query_kernel_map[(launch_event.pid, launch_event.tid, qts)] = kernel
+
+    # Resolve each kernel individually for full control over stack depth
+    for kernel in kernels:
+        location, stack, cpu_op_name = resolve_kernel_site_context(
+            kernel, cpu_ops_by_external_id, python_frames, launches_by_correlation,
+            max_stack_depth=max_stack_depth,
+        )
+        results.append(
+            StackInfo(
+                kernel_name=kernel.name,
+                canonical_name=kernel.canonical_name,
+                category=kernel.category,
+                gpu_time_us=kernel.dur,
+                location=location,
+                stack=stack,
+                cpu_op=cpu_op_name,
+            )
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def format_stack_table(stacks: Sequence[StackInfo]) -> str:
+    """Format stack results as a human-readable table."""
+    if not stacks:
+        return "No matching kernels found."
+
+    lines = []
+    lines.append("=" * 80)
+    lines.append("KERNEL STACK TRACE REPORT")
+    lines.append("=" * 80)
+    lines.append("")
+
+    # Aggregate by (canonical_name, location, stack)
+    agg: Dict[Tuple[str, str, str, str], Dict] = {}
+    for s in stacks:
+        key = (s.canonical_name, s.category, s.location, s.stack)
+        if key not in agg:
+            agg[key] = {"count": 0, "total_us": 0.0, "cpu_ops": Counter(), "kernel_name": s.kernel_name}
+        agg[key]["count"] += 1
+        agg[key]["total_us"] += s.gpu_time_us
+        if s.cpu_op:
+            agg[key]["cpu_ops"][s.cpu_op] += 1
+
+    # Sort by total GPU time descending
+    sorted_items = sorted(agg.items(), key=lambda x: x[1]["total_us"], reverse=True)
+
+    for idx, (key, info) in enumerate(sorted_items, 1):
+        canonical_name, category, location, stack = key
+        lines.append(f"--- [{idx}] ---")
+        lines.append(f"  Kernel:     {canonical_name}")
+        lines.append(f"  Category:   {category}")
+        lines.append(f"  GPU time:   {info['total_us'] / 1000:.2f} ms  ({info['count']} launches)")
+        top_cpu_op = info["cpu_ops"].most_common(1)
+        if top_cpu_op:
+            lines.append(f"  CPU op:     {top_cpu_op[0][0]}  (x{top_cpu_op[0][1]})")
+        lines.append(f"  Location:   {location}")
+        if stack:
+            lines.append(f"  Call stack:")
+            for frame_idx, frame in enumerate(stack.split(" -> ")):
+                indent = "    " + "  " * frame_idx
+                lines.append(f"{indent}-> {frame}")
+        else:
+            lines.append(f"  Call stack: (unresolved)")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_operator_chain(stacks: Sequence[StackInfo]) -> str:
+    """Format results as an operator chain for Pattern 0c of the overlap integration skill."""
+    if not stacks:
+        return "No matching kernels found."
+
+    lines = []
+    lines.append("=== Operator Chain to Replace ===")
+
+    # Group by location, preserve temporal-like ordering by GPU time
+    by_location: Dict[str, List[StackInfo]] = defaultdict(list)
+    for s in stacks:
+        by_location[s.location].append(s)
+
+    # Sort locations by total GPU time
+    location_order = sorted(
+        by_location.keys(),
+        key=lambda loc: sum(s.gpu_time_us for s in by_location[loc]),
+        reverse=True,
+    )
+
+    total_gpu_us = sum(s.gpu_time_us for s in stacks)
+
+    for location in location_order:
+        group = by_location[location]
+        total_us = sum(s.gpu_time_us for s in group)
+        kernels_seen: Dict[str, int] = {}
+        for s in group:
+            kernels_seen[s.canonical_name] = kernels_seen.get(s.canonical_name, 0) + 1
+
+        kernel_summary = ", ".join(
+            f"{name} (x{count})" for name, count in kernels_seen.items()
+        )
+        lines.append(f"  {location}")
+        lines.append(f"    GPU time: {total_us / 1000:.2f} ms")
+        lines.append(f"    Kernels:  {kernel_summary}")
+        if group[0].stack:
+            lines.append(f"    Stack:    {group[0].stack}")
+
+    lines.append(f"")
+    lines.append(f"Total GPU time: {total_gpu_us / 1000:.2f} ms")
+    lines.append(f"Semantics: PENDING VALIDATION (see Pattern 0d)")
+    return "\n".join(lines)
+
+
+def list_kernels(
+    kernels: Sequence[KernelEvent],
+    cpu_ops: Sequence["CpuOpEvent"],
+    kernel_filters: Sequence[str],
+) -> str:
+    """List all GPU kernel names (and matching CPU op names) in the trace.
+
+    When ``kernel_filters`` is non-empty, kernels/CPU ops whose name contains
+    any filter substring (case-insensitive) are marked with ``[MATCH]``; all
+    others are still listed but unmarked so the user can discover nearby names.
+
+    Output is sorted by total GPU time descending.
+    """
+    lines: List[str] = []
+    lines.append("=" * 80)
+    lines.append("KERNEL NAME DISCOVERY")
+    lines.append("=" * 80)
+    lines.append("")
+
+    # --- GPU kernels ---
+    gpu_agg: Dict[str, Dict] = {}  # canonical_name -> {count, total_us, category, sample_name}
+    for k in kernels:
+        if k.canonical_name not in gpu_agg:
+            gpu_agg[k.canonical_name] = {
+                "count": 0, "total_us": 0.0,
+                "category": k.category,
+                "sample_name": k.name,
+            }
+        gpu_agg[k.canonical_name]["count"] += 1
+        gpu_agg[k.canonical_name]["total_us"] += k.dur
+
+    lowered_filters = [f.lower() for f in kernel_filters] if kernel_filters else []
+
+    def _matches(text: str) -> bool:
+        if not lowered_filters:
+            return True
+        return any(_keyword_matches_text(f, text) for f in kernel_filters)
+
+    gpu_sorted = sorted(gpu_agg.items(), key=lambda x: x[1]["total_us"], reverse=True)
+    matched_gpu = [(name, info) for name, info in gpu_sorted if _matches(name)]
+    unmatched_gpu = [(name, info) for name, info in gpu_sorted if not _matches(name)]
+
+    if kernel_filters:
+        lines.append(f"GPU kernels matching filter {list(kernel_filters)}:")
+        lines.append("")
+        if matched_gpu:
+            for name, info in matched_gpu:
+                tag = "[MATCH]"
+                sample = info["sample_name"]
+                display = sample if len(sample) <= 96 else sample[:93] + "..."
+                lines.append(
+                    f"  {tag} {info['total_us']/1000:10.2f} ms  "
+                    f"({info['count']:5d} launches)  [{info['category']}]  {display}"
+                )
+                # Also show canonical if different from sample
+                if info["sample_name"] != name:
+                    lines.append(f"       canonical: {name}")
+        else:
+            lines.append("  (no match)")
+        lines.append("")
+        lines.append(f"Other GPU kernels ({len(unmatched_gpu)}):")
+        lines.append("")
+        for name, info in unmatched_gpu:
+            sample = info["sample_name"]
+            display = sample if len(sample) <= 96 else sample[:93] + "..."
+            lines.append(
+                f"        {info['total_us']/1000:10.2f} ms  "
+                f"({info['count']:5d} launches)  [{info['category']}]  {display}"
+            )
+    else:
+        lines.append(f"All GPU kernels ({len(gpu_sorted)}):")
+        lines.append("")
+        for name, info in gpu_sorted:
+            sample = info["sample_name"]
+            display = sample if len(sample) <= 96 else sample[:93] + "..."
+            lines.append(
+                f"  {info['total_us']/1000:10.2f} ms  "
+                f"({info['count']:5d} launches)  [{info['category']}]  {display}"
+            )
+
+    # --- CPU ops (only show matches when filters are given) ---
+    if kernel_filters:
+        cpu_agg: Dict[str, Dict] = {}
+        for op in cpu_ops:
+            if op.name not in cpu_agg:
+                cpu_agg[op.name] = {"count": 0, "total_us": 0.0}
+            cpu_agg[op.name]["count"] += 1
+            cpu_agg[op.name]["total_us"] += op.dur
+
+        matched_cpu = [(n, i) for n, i in cpu_agg.items() if _matches(n)]
+        if matched_cpu:
+            matched_cpu.sort(key=lambda x: x[1]["total_us"], reverse=True)
+            lines.append("")
+            lines.append(f"CPU ops matching filter {list(kernel_filters)}:")
+            lines.append("")
+            for name, info in matched_cpu:
+                lines.append(
+                    f"  [MATCH] {info['total_us']/1000:10.2f} ms  "
+                    f"({info['count']:5d} launches)  {name}"
+                )
+
+    lines.append("")
+    lines.append(
+        "TIP: Use the matched kernel name substrings with --kernel-filter "
+        "to run stack analysis."
+    )
+    if matched_gpu and kernel_filters:
+        # Generate short, distinctive filter suggestions from matched canonical names.
+        # For each matched kernel, extract a short keyword that is likely unique.
+        suggested = []
+        for name, _ in matched_gpu:
+            lowered = name.lower()
+            # Try each user filter as base, extend to next word boundary
+            for f in lowered_filters:
+                idx = lowered.find(f)
+                if idx != -1:
+                    # Extend forward to next non-alnum/underscore char or +20 chars
+                    end = idx + len(f)
+                    while end < len(name) and (name[end].isalnum() or name[end] == '_'):
+                        end += 1
+                    end = min(end, idx + len(f) + 25)
+                    seg = name[idx:end].rstrip("_(").strip()
+                    if seg and len(seg) >= len(f) and seg not in suggested:
+                        suggested.append(seg)
+                    break
+        if suggested:
+            lines.append(
+                f"Suggested --kernel-filter values: "
+                + " ".join(repr(s) for s in suggested[:8])
+            )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="trace_kernel_stack.py",
+        description=(
+            "Extract full Python call stacks for specific GPU kernels from a "
+            "torch profiler trace. Designed for overlap-kernel integration: "
+            "identify which source code launches the kernels you want to overlap."
+        ),
+    )
+    parser.add_argument(
+        "--input", type=str, required=True,
+        help="Path to the torch profiler trace file (.json or .json.gz).",
+    )
+    parser.add_argument(
+        "--kernel-filter", nargs="+", default=[],
+        help=(
+            "One or more case-insensitive substrings. Only kernels whose "
+            "canonical name contains any of these substrings will be included. "
+            "Omit to include all kernels.  Use --list-kernels first to discover "
+            "the actual kernel names in the trace."
+        ),
+    )
+    parser.add_argument(
+        "--list-kernels", action="store_true", default=False,
+        help=(
+            "List all GPU kernel names (and matching CPU op names) found in the "
+            "trace, sorted by total GPU time.  When combined with --kernel-filter, "
+            "matching entries are marked with [MATCH].  Use this to discover exact "
+            "kernel names before running a full stack analysis."
+        ),
+    )
+    parser.add_argument(
+        "--stack-depth", type=int, default=0,
+        help=(
+            "Maximum number of Python stack frames to display per kernel. "
+            "0 means unlimited (show the full call stack). Default: 0."
+        ),
+    )
+    parser.add_argument(
+        "--format", choices=["table", "chain", "json"], default="table",
+        help=(
+            "Output format. 'table': human-readable per-kernel stack report; "
+            "'chain': operator-chain summary for Pattern 0c; "
+            "'json': machine-readable JSON. Default: table."
+        ),
+    )
+    parser.add_argument(
+        "--output", type=str, default=None,
+        help="Output file path. Omit to write to stdout.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    trace_path = Path(args.input)
+    if not trace_path.exists():
+        print(f"Error: trace file not found: {trace_path}", file=sys.stderr)
+        return 1
+
+    print(f"Loading trace: {trace_path} ...", file=sys.stderr)
+    trace = load_trace_json(trace_path)
+    print(f"Extracting events ...", file=sys.stderr)
+    kernels, cpu_ops, python_frames, launches, chosen_pid = extract_trace_data(trace)
+    print(f"Found {len(kernels)} GPU kernels on PID {chosen_pid}, "
+          f"{len(cpu_ops)} CPU ops, {sum(len(v) for v in python_frames.values())} Python frames",
+          file=sys.stderr)
+
+    # --- List-kernels mode: just print kernel names and exit ---
+    if args.list_kernels:
+        output = list_kernels(kernels, cpu_ops, args.kernel_filter)
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as f:
+                f.write(output)
+            print(f"Output written to: {args.output}", file=sys.stderr)
+        else:
+            print(output)
+        return 0
+
+    # Filter kernels if requested
+    original_count = len(kernels)
+    filtered = filter_kernels(kernels, cpu_ops, args.kernel_filter)
+    if args.kernel_filter:
+        print(f"Kernel filter {args.kernel_filter}: {original_count} -> {len(filtered)} kernels",
+              file=sys.stderr)
+
+    if not filtered:
+        print("No matching kernels found after filtering.", file=sys.stderr)
+        return 0
+
+    # Resolve stacks
+    print(f"Resolving Python call stacks (max_depth={args.stack_depth}) ...", file=sys.stderr)
+    stacks = resolve_stacks(filtered, cpu_ops, python_frames, launches, max_stack_depth=args.stack_depth)
+
+    # Format output
+    if args.format == "table":
+        output = format_stack_table(stacks)
+    elif args.format == "chain":
+        output = format_operator_chain(stacks)
+    elif args.format == "json":
+        output = json.dumps(
+            [{"kernel": s.canonical_name,
+              "category": s.category,
+              "gpu_time_us": s.gpu_time_us,
+              "location": s.location,
+              "stack": s.stack.split(" -> ") if s.stack else [],
+              "cpu_op": s.cpu_op}
+             for s in stacks],
+            indent=2,
+        )
+    else:
+        output = format_stack_table(stacks)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(output)
+        print(f"Output written to: {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
@@ -231,6 +231,12 @@ The performance test must separately benchmark:
 
 This enables calculating **speedup** = `(compute_time + comm_time) / overlap_time` and **overlap efficiency** = `max(compute_time, comm_time) / overlap_time` (how close to the ideal of fully overlapping compute and comm).
 
+**Compute kernel selection for benchmark (important):** The compute-only and non-overlap benchmarks **must prefer the user-provided compute kernel implementation** for timing, not a PyTorch reference implementation. The overlap kernel internally uses the custom compute kernel (e.g., a Triton kernel), so the non-overlap baseline must use the same compute path to ensure a fair comparison. If the benchmark measures compute-only with PyTorch ops while the overlap uses Triton, the speedup metric becomes misleading. Implementation pattern:
+
+1. If the user provides a compute kernel (path or function), import it from the overlap kernel file and use it directly in `compute_only()` and `non_overlap()`.
+2. Keep a separate PyTorch reference implementation for **correctness verification only** (comparing overlap output against ground truth).
+3. Only fall back to PyTorch ops for performance benchmarking when no user-provided compute kernel is available.
+
 Read `references/benchmark_template.md` for the complete test file structure, argument conventions, and output format.
 
 ---

--- a/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
@@ -211,10 +211,10 @@ These checks prevent `CUDA error: an illegal memory access was encountered`. Thi
 | **tl.constexpr strides** | Stride parameters are declared as `tl.constexpr` so the compiler can optimize address calculations at compile time |
 | **Incremental pointer update** | topk/reduction loops use `tl.static_range` + `ptr + j * stride` instead of recomputing full addresses each iteration |
 | **Input layout flattening** | 3D inputs like `[M, topk, N]` are flattened to `[M*topk, N]` for contiguous memory access in the topk dimension |
-| **Master CTA barrier** | `barrier_on_this_grid` uses the master CTA pattern (bid==0 spins, others wait for high bit) with a single `tl.debug_barrier()`, not the naive 3-barrier pattern (see `primitives.md` §6.2) |
-| **Multi-threaded CAS barrier** | `barrier_all_intra_node_atomic_cas_block` uses `flat_tid < world_size` for parallel peer signaling, not single-threaded serial iteration (see `primitives.md` §6.3) |
-| **Cross-rank barrier placement** | In-kernel `barrier_all_intra_node_atomic_cas_block` is only needed when the kernel has a subsequent phase after communication (intra-sm). For inter-sm and without-sm, use host-side `symm_mem_hdl.barrier()` around `signal.zero_()` instead — the comm kernel exits once communication is done, so no in-kernel cross-rank sync is required. See `primitives.md` §6.3 for the in-kernel barrier and §6.4 for the host-side barrier |
-| **PTX-level CAS spin-loop** | `_cas_sys_release`/`_cas_sys_acquire` have the spin-loop inside PTX (`@!%p0 bra cas_loop`), not in Python-level `while` loops (see `primitives.md` §4) |
+| **Master CTA barrier** | `barrier_on_this_grid` uses the master CTA pattern (bid==0 spins, others wait for high bit) with a single `tl.debug_barrier()`, not the naive 3-barrier pattern (see `primitives.md` §5.2) |
+| **Multi-threaded CAS barrier** | `barrier_all_intra_node_atomic_cas_block` uses `flat_tid < world_size` for parallel peer signaling, not single-threaded serial iteration (see `primitives.md` §5.3) |
+| **Cross-rank barrier placement** | In-kernel `barrier_all_intra_node_atomic_cas_block` is only needed when the kernel has a subsequent phase after communication (intra-sm). For inter-sm and without-sm, use the host-side `barrier() → signal.zero_() → barrier()` pattern (two barriers flanking the reset, not just one) instead — the comm kernel exits once communication is done, so no in-kernel cross-rank sync is required. See `primitives.md` §5.3 for the in-kernel barrier and §5.4 for the host-side barrier |
+| **PTX-level CAS spin-loop** | `_cas_sys_release`/`_cas_sys_acquire` have the spin-loop inside PTX (`@!%p0 bra cas_loop`), not in Python-level `while` loops (see `primitives.md` §3) |
 | **Auto block size** | `BLOCK_M`/`BLOCK_N` default to `None` and are auto-computed based on problem size: `BLOCK_N = next_power_of_2(N_per_chunk)`, `BLOCK_M = next_power_of_2(16K / BLOCK_N / element_size)` |
 
 If any check fails, fix the generated kernel before proceeding.
@@ -226,9 +226,10 @@ Generate a test file with four modes: `correctness`, `performance`, `multi_size`
 The performance test must separately benchmark:
 1. **Compute-only**: the compute kernel in isolation
 2. **Comm-only**: the collective (NCCL) in isolation
-3. **Overlap**: the fused overlap kernel
+3. **Non-overlap**: compute + comm sequentially (no overlap)
+4. **Overlap**: the fused overlap kernel
 
-This enables calculating **overlap efficiency** = `max(compute_time, comm_time) / overlap_time`.
+This enables calculating **speedup** = `(compute_time + comm_time) / overlap_time` and **overlap efficiency** = `max(compute_time, comm_time) / overlap_time` (how close to the ideal of fully overlapping compute and comm).
 
 Read `references/benchmark_template.md` for the complete test file structure, argument conventions, and output format.
 

--- a/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
@@ -26,7 +26,7 @@ When presenting options to the user via `AskUserQuestion`, put the full explanat
 3. **Communication mechanism**: which hardware path for the collective? *(default: register)*
    - `register` — load/store via symmetric memory (SM-driven)
    - `copy_engine` — DMA copy on a background stream (zero SM cost)
-   - `tma` — Tensor Memory Accelerator async bulk copy
+   - `tma` — Tensor Memory Accelerator async bulk copy **(not yet supported)**
    - `nvswitch` — multimem via NVSwitch hardware (NVLS)
 4. **Overlap mode**: how compute and comm are scheduled: *(default: inter-sm)*
    - `inter-sm` — two separate kernels, two streams
@@ -35,7 +35,9 @@ When presenting options to the user via `AskUserQuestion`, put the full explanat
 5. **Execution order**: compute-first or comm-first
 6. **Overlap triton kernel type**: **persistent** (one CTA loops over multiple tiles) or **non-persistent** (one CTA handles one tile)? *(default: persistent)*
 
-**Constraint**: if communication mechanism = `copy_engine`, overlap mode is forced to `without-sm` (copy engine runs on DMA, not SMs) — inform the user and skip the overlap mode question.
+**Constraint 1**: if communication mechanism = `copy_engine`, overlap mode is forced to `without-sm` (copy engine runs on DMA, not SMs) — inform the user and skip the overlap mode question.
+
+**Constraint 2**: if communication mechanism = `tma`, inform the user that TMA (Tensor Memory Accelerator) async bulk copy is **not yet supported** and ask them to choose a different mechanism (`register`, `copy_engine`, or `nvswitch`). Do not proceed with TMA.
 
 ## Mode Overview
 
@@ -53,7 +55,7 @@ Read `references/intra_sm.md` for barrier primitives, A2A push pattern, kernel s
 
 ### Without-SM — copy engine (DMA)
 
-Communication is offloaded to the **copy engine**, consuming zero SM resources. A background stream performs `copy_()` on symmetric memory (routed through DMA). A `progress` tensor, updated via `cuStreamWriteValue32` after each chunk copy, lets the compute kernel or the collectives (on the other stream) poll and process data as it arrives — local data first (no wait), then remote chunks as they become ready.
+Communication is offloaded to the **copy engine**, consuming zero SM resources. A background stream performs `copy_()` on symmetric memory (routed through DMA). A **signal tensor** (written either via PtoP signal pull or `cuStreamWriteValue32`) lets the compute kernel poll and process data as it arrives — local data first (no wait), then remote chunks as they become ready. The signal tensor shape is `[world_size * splits_per_rank]`, where `splits_per_rank=1` gives per-rank granularity and `splits_per_rank>1` gives finer per-chunk granularity. Both signaling approaches support any granularity.
 
 Read `references/without_sm.md` for copy engine setup, progress tracking, compute kernel polling pattern, and full implementation guide.
 
@@ -128,7 +130,7 @@ When triggered:
 1. Read `references/multimem.md` in addition to the selected mode file.
 2. **Inline the implementation source from `multimem.md` §D** (helpers + `multimem_st` + `multimem_ld_reduce` + their `_v*` impls) into the generated kernel file's PTX Primitives section.
 3. On the host side: extend the context dataclass with `mc_ptr`, access `hdl.multicast_ptr` (stock PyTorch symm_mem property, no extra import) after `symm_mem.rendezvous`, and guard against unsupported hardware (`mc_ptr == 0`).
-4. In the kernel: replace the per-peer `tl.store` push loop with `multimem_st(...)`, and replace the hand-written `acc += tl.load(peer_buf, ...)` reduction loop with `multimem_ld_reduce(..., op="sum", acc_dtype=tl.float32)`. Keep all existing grid-level and cross-rank barriers — multimem swaps out only the bulk data movement, not the synchronization.
+4. In the kernel: replace the per-peer `tl.store` push loop with `multimem_st(...)`, and replace the hand-written `acc += tl.load(peer_buf, ...)` reduction loop with `multimem_ld_reduce(..., OP="sum", ACC_DTYPE=tl.float32)`. Keep all existing grid-level and cross-rank barriers — multimem swaps out only the bulk data movement, not the synchronization.
 
 When **not** triggered: stay on the default path (per-peer `tl.store` for the push phase, hand-written reduction for the reduce phase) and do **not** load `references/multimem.md`.
 

--- a/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
@@ -55,7 +55,7 @@ Read `references/intra_sm.md` for barrier primitives, A2A push pattern, kernel s
 
 ### Without-SM — copy engine (DMA)
 
-Communication is offloaded to the **copy engine**, consuming zero SM resources. A background stream performs `copy_()` on symmetric memory (routed through DMA). A **signal tensor** (written either via PtoP signal pull or `cuStreamWriteValue32`) lets the compute kernel poll and process data as it arrives — local data first (no wait), then remote chunks as they become ready. The signal tensor shape is `[world_size * splits_per_rank]`, where `splits_per_rank=1` gives per-rank granularity and `splits_per_rank>1` gives finer per-chunk granularity. Both signaling approaches support any granularity.
+Communication is offloaded to the **copy engine**, consuming zero SM resources. A background stream performs `copy_()` on symmetric memory (routed through DMA). A **signal tensor** (written via `cuStreamWriteValue32` / polled via `ld_sys`) lets the compute kernel poll and process data as it arrives — local data first (no wait), then remote chunks as they become ready. The signal tensor shape is `[world_size * splits_per_rank]`, where `splits_per_rank=1` gives per-rank granularity and `splits_per_rank>1` gives finer per-chunk granularity.
 
 Read `references/without_sm.md` for copy engine setup, progress tracking, compute kernel polling pattern, and full implementation guide.
 
@@ -211,9 +211,9 @@ These checks prevent `CUDA error: an illegal memory access was encountered`. Thi
 | **tl.constexpr strides** | Stride parameters are declared as `tl.constexpr` so the compiler can optimize address calculations at compile time |
 | **Incremental pointer update** | topk/reduction loops use `tl.static_range` + `ptr + j * stride` instead of recomputing full addresses each iteration |
 | **Input layout flattening** | 3D inputs like `[M, topk, N]` are flattened to `[M*topk, N]` for contiguous memory access in the topk dimension |
-| **Master CTA barrier** | `barrier_on_this_grid` uses the master CTA pattern (bid==0 spins, others wait for high bit) with a single `tl.debug_barrier()`, not the naive 3-barrier pattern (see `primitives.md` §5.2) |
-| **Multi-threaded CAS barrier** | `barrier_all_intra_node_atomic_cas_block` uses `flat_tid < world_size` for parallel peer signaling, not single-threaded serial iteration (see `primitives.md` §5.3) |
-| **Cross-rank barrier placement** | In-kernel `barrier_all_intra_node_atomic_cas_block` is only needed when the kernel has a subsequent phase after communication (intra-sm). For inter-sm and without-sm, use host-side `symm_mem_hdl.barrier()` around `signal.zero_()` instead — the comm kernel exits once communication is done, so no in-kernel cross-rank sync is required. See `primitives.md` §5.3 for the in-kernel barrier and §5.4 for the host-side barrier |
+| **Master CTA barrier** | `barrier_on_this_grid` uses the master CTA pattern (bid==0 spins, others wait for high bit) with a single `tl.debug_barrier()`, not the naive 3-barrier pattern (see `primitives.md` §6.2) |
+| **Multi-threaded CAS barrier** | `barrier_all_intra_node_atomic_cas_block` uses `flat_tid < world_size` for parallel peer signaling, not single-threaded serial iteration (see `primitives.md` §6.3) |
+| **Cross-rank barrier placement** | In-kernel `barrier_all_intra_node_atomic_cas_block` is only needed when the kernel has a subsequent phase after communication (intra-sm). For inter-sm and without-sm, use host-side `symm_mem_hdl.barrier()` around `signal.zero_()` instead — the comm kernel exits once communication is done, so no in-kernel cross-rank sync is required. See `primitives.md` §6.3 for the in-kernel barrier and §6.4 for the host-side barrier |
 | **PTX-level CAS spin-loop** | `_cas_sys_release`/`_cas_sys_acquire` have the spin-loop inside PTX (`@!%p0 bra cas_loop`), not in Python-level `while` loops (see `primitives.md` §4) |
 | **Auto block size** | `BLOCK_M`/`BLOCK_N` default to `None` and are auto-computed based on problem size: `BLOCK_N = next_power_of_2(N_per_chunk)`, `BLOCK_M = next_power_of_2(16K / BLOCK_N / element_size)` |
 

--- a/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
@@ -13,7 +13,7 @@ description: |
 ---
 # Compute-Communication Overlap Kernel Generator
 
-> **Platform limitation**: Currently only NVIDIA GPUs are supported (tested on SM90).
+> **Platform limitation**: Currently only NVIDIA GPUs are supported.
 
 ## Input
 
@@ -21,8 +21,7 @@ The user's request may only partially specify the configuration. For any item be
 
 When presenting options to the user via `AskUserQuestion`, put the full explanation directly into each option's **label** field (not just the description field, which may be hidden behind a tooltip in the UI). For example, use `"label": "inter-sm — two kernels, two streams"` rather than a bare `"label": "inter-sm"`. This ensures the user sees the explanation directly without needing to hover or click.
 
-1. **Compute kernel**: what kernel to overlap (e.g., GEMM, topk-reduce). Also clarify:
-   - **persistent** (one CTA loops over multiple tiles) or **non-persistent** (one CTA handles one tile)? *(default: persistent)*
+1. **Compute kernel**: what kernel to overlap (e.g., GEMM, topk-reduce).
 2. **Collective operation**: all-gather, reduce-scatter, all-reduce, etc.
 3. **Communication mechanism**: which hardware path for the collective? *(default: register)*
    - `register` — load/store via symmetric memory (SM-driven)
@@ -30,10 +29,11 @@ When presenting options to the user via `AskUserQuestion`, put the full explanat
    - `tma` — Tensor Memory Accelerator async bulk copy
    - `nvswitch` — multimem via NVSwitch hardware (NVLS)
 4. **Overlap mode**: how compute and comm are scheduled: *(default: inter-sm)*
-   - `inter-sm` — two kernels, two streams
+   - `inter-sm` — two separate kernels, two streams
    - `intra-sm` — fused single kernel, single stream
    - `without-sm` — copy engine (DMA), two streams
 5. **Execution order**: compute-first or comm-first
+6. **Overlap triton kernel type**: **persistent** (one CTA loops over multiple tiles) or **non-persistent** (one CTA handles one tile)? *(default: persistent)*
 
 **Constraint**: if communication mechanism = `copy_engine`, overlap mode is forced to `without-sm` (copy engine runs on DMA, not SMs) — inform the user and skip the overlap mode question.
 
@@ -47,13 +47,13 @@ Read `references/inter_sm.md` for signal primitives, cross-device barrier, host-
 
 ### Intra-SM — fused single kernel
 
-Compute and communication are **fused into one kernel**. Each CTA computes a tile, then directly writes results to peer symmetric memory buffers via load/store (or multimem load/store). Synchronization uses GPU-scope atomics (`atomic_add_release` / `load_acquire`) for intra-node CTA barriers and `symm_mem_sync` for cross-rank barriers. If the collective requires reduction (e.g., reduce-scatter), a final local-reduce phase sums contributions from all peers.
+Compute and communication are **fused into one kernel**. Each CTA computes a tile, then directly writes results to peer symmetric memory buffers via load/store (or multimem load/store). Synchronization uses GPU-scope atomics (`atomic_add_release` / `load_acquire`) for intra-node CTA barriers and `barrier_all_intra_node_atomic_cas_block` for cross-rank barriers. If the collective requires reduction (e.g., reduce-scatter), a final local-reduce phase sums contributions from all peers.
 
 Read `references/intra_sm.md` for barrier primitives, A2A push pattern, kernel structure template, and full implementation guide. The default push/reduce path uses `tl.store` / hand-written reduction; if the user wants the collective communication portion to use hardware multicast (NVLS) — i.e. `multimem.st` for the push phase and `multimem.ld_reduce` for the reduce phase — additionally read `references/multimem.md`.
 
 ### Without-SM — copy engine (DMA)
 
-Communication is offloaded to the **copy engine**, consuming zero SM resources. A background stream performs `copy_()` on symmetric memory (routed through DMA). A `progress` tensor, updated via `cuStreamWriteValue32` after each chunk copy, lets the compute kernel (on the main stream) poll and process data as it arrives — local data first (no wait), then remote chunks as they become ready.
+Communication is offloaded to the **copy engine**, consuming zero SM resources. A background stream performs `copy_()` on symmetric memory (routed through DMA). A `progress` tensor, updated via `cuStreamWriteValue32` after each chunk copy, lets the compute kernel or the collectives (on the other stream) poll and process data as it arrives — local data first (no wait), then remote chunks as they become ready.
 
 Read `references/without_sm.md` for copy engine setup, progress tracking, compute kernel polling pattern, and full implementation guide.
 
@@ -122,14 +122,11 @@ Read the appropriate reference file for the selected mode, then generate a compl
 
 **Multimem (NVLS) trigger — load `references/multimem.md` on demand.**
 
-Additionally read `references/multimem.md` **before** generating the kernel when **either** of the following holds:
-
-- **Keyword trigger** — the user's request literally mentions any of: `multimem`, `NVLS`, `multicast`, `硬件广播` / `硬件 multicast`, `multimem.st`, `multimem.ld_reduce`, `NVSwitch reduce` / `in-network reduce`, `multicast_ptr`.
-- **Intent trigger** — the user expresses a semantically equivalent goal even without those keywords, e.g. "用一条指令对所有 rank 广播 / 规约", "让交换机帮我做 reduce", "利用 NVSwitch 做 in-network reduction", "把 push 阶段从 N 次写降到 1 次", "让通信不占 SM 周期 / 走硬件路径".
+Additionally read `references/multimem.md` **before** generating the kernel when the user select the Communication mechanism as `nvswitch`.
 
 When triggered:
 1. Read `references/multimem.md` in addition to the selected mode file.
-2. **Inline the implementation source from `multimem.md` §D** (helpers + `multimem_st` + `multimem_ld_reduce` + their `_v*` impls) into the generated kernel file's PTX Primitives section. Do **not** import from `triton_dist.kernels.nvidia.multimem_api` — the generated file must remain self-contained per the "Self-contained kernel files" constraint below.
+2. **Inline the implementation source from `multimem.md` §D** (helpers + `multimem_st` + `multimem_ld_reduce` + their `_v*` impls) into the generated kernel file's PTX Primitives section.
 3. On the host side: extend the context dataclass with `mc_ptr`, access `hdl.multicast_ptr` (stock PyTorch symm_mem property, no extra import) after `symm_mem.rendezvous`, and guard against unsupported hardware (`mc_ptr == 0`).
 4. In the kernel: replace the per-peer `tl.store` push loop with `multimem_st(...)`, and replace the hand-written `acc += tl.load(peer_buf, ...)` reduction loop with `multimem_ld_reduce(..., op="sum", acc_dtype=tl.float32)`. Keep all existing grid-level and cross-rank barriers — multimem swaps out only the bulk data movement, not the synchronization.
 
@@ -144,7 +141,7 @@ Additionally read `references/triton_fp8_gemm.md` **before** generating the kern
 
 When triggered:
 1. Read `references/triton_fp8_gemm.md` in addition to the selected mode file and `references/primitives.md`.
-2. Inline the `_w8a8_block_fp8_matmul` kernel code from the reference into the generated file. The generated file must remain self-contained (no imports from `triton_dist` or `sglang`).
+2. Inline the `_w8a8_block_fp8_matmul` kernel code from the reference into the generated file. The generated file must remain self-contained.
 3. Choose the activation quantization strategy based on the overlap pattern (see `references/triton_fp8_gemm.md` §C.1):
    - **Separate quantize kernel + pre-quantized `_w8a8_block_fp8_matmul`**: run a `per_token_group_quant_fp8` kernel to produce `A_fp8` and `A_scale` first, then feed them into the standard kernel. Use this when exact per-`group_k` quantization granularity is required, or when A is already available in fp8 format.
    - **On-the-fly quantization inside the GEMM kernel**: modify the K-loop to load bf16 A, compute per-row `absmax`, cast to fp8 inline, then `tl.dot(fp8_A, fp8_B) * scale * B_scale`. Use this when A arrives as bf16 from symmetric memory and you want to save one kernel launch + one global memory round-trip. This is the recommended default for overlap kernels. When `BLOCK_SIZE_K == group_k == 128` (standard setting), numerical accuracy is equivalent to the separate-kernel approach.
@@ -160,7 +157,7 @@ After generating the kernel, produce a **verification checklist** and verify eac
 | Check | What to verify |
 |-------|---------------|
 | **Grid barrier correctness** | `barrier_on_this_grid` is called by ALL CTAs before cross-rank sync; the barrier counter is reset to 0 before each kernel launch |
-| **Cross-rank barrier single-CTA** | `barrier_all_intra_node_atomic_cas_block` is called by exactly ONE CTA per rank (guarded by `if pid == 0:`). The signal pad slots are binary (0↔1) and can only track one barrier invocation per rank pair; multiple CTAs calling it concurrently will CAS-contend on the same slots and **deadlock** |
+| **Cross-rank barrier single-CTA** | In-kernel `barrier_all_intra_node_atomic_cas_block` is called by **exactly ONE CTA per rank** (guarded by `if pid == 0:`). The signal pad slots are binary (0↔1) and can only track one barrier invocation per rank pair; multiple CTAs calling it concurrently will CAS-contend on the same slots and **deadlock**. For inter-sm and without-sm modes, do NOT use this in-kernel barrier — use host-side `symm_mem_hdl.barrier()` instead (see `primitives.md` §5.4) |
 | **Cross-rank barrier symmetry** | Every rank executes the same number of barrier calls; no conditional paths that skip barriers on some ranks. The `if pid == 0:` guard does NOT violate this — all ranks have a pid==0 CTA |
 | **Signal reset** | Signal tensor is reset by host `.zero_()` before each launch; `_send_signal` stores 1, `_wait_signal` spins until 1 — no in-kernel reset needed |
 | **No deadlock ordering** | If multiple barriers exist, all ranks execute them in the same order; no circular dependencies between barrier phases |
@@ -207,14 +204,14 @@ These checks prevent `CUDA error: an illegal memory access was encountered`. Thi
 |-------|---------------|
 | **num_warps=32** | The kernel launch specifies `num_warps=32` (not the default 4). These kernels are memory-bound; 32 warps (1024 threads/CTA) is needed to saturate memory bandwidth. Using default 4 warps causes 50%+ performance loss |
 | **num_stages=1** | Explicitly set `num_stages=1`. No software pipelining is needed for simple load/store patterns |
-| **N_CHUNKS splitting** | The N dimension is split into chunks (default 2) via an outer `tl.range` loop to reduce register pressure and improve SM occupancy |
+| **N_CHUNKS splitting** | The N dimension is split into chunks (default N dimension // 1024) via an outer `tl.range` loop to reduce register pressure and improve SM occupancy |
 | **tl.multiple_of hints** | `tl.multiple_of(N_per_chunk, 16)` and `tl.multiple_of(peer_buf, 16)` are used to enable vectorized 128-bit loads/stores |
 | **tl.constexpr strides** | Stride parameters are declared as `tl.constexpr` so the compiler can optimize address calculations at compile time |
 | **Incremental pointer update** | topk/reduction loops use `tl.static_range` + `ptr + j * stride` instead of recomputing full addresses each iteration |
 | **Input layout flattening** | 3D inputs like `[M, topk, N]` are flattened to `[M*topk, N]` for contiguous memory access in the topk dimension |
 | **Master CTA barrier** | `barrier_on_this_grid` uses the master CTA pattern (bid==0 spins, others wait for high bit) with a single `tl.debug_barrier()`, not the naive 3-barrier pattern (see `primitives.md` §5.2) |
 | **Multi-threaded CAS barrier** | `barrier_all_intra_node_atomic_cas_block` uses `flat_tid < world_size` for parallel peer signaling, not single-threaded serial iteration (see `primitives.md` §5.3) |
-| **Cross-rank barrier placement** | In-kernel `barrier_all_intra_node_atomic_cas_block` is only needed when the kernel has a subsequent phase after communication (intra-sm). For inter-sm and without-sm, use host-side `symm_mem_hdl.barrier()` around `signal.zero_()` instead — the comm kernel exits once communication is done, so no in-kernel cross-rank sync is required |
+| **Cross-rank barrier placement** | In-kernel `barrier_all_intra_node_atomic_cas_block` is only needed when the kernel has a subsequent phase after communication (intra-sm). For inter-sm and without-sm, use host-side `symm_mem_hdl.barrier()` around `signal.zero_()` instead — the comm kernel exits once communication is done, so no in-kernel cross-rank sync is required. See `primitives.md` §5.3 for the in-kernel barrier and §5.4 for the host-side barrier |
 | **PTX-level CAS spin-loop** | `_cas_sys_release`/`_cas_sys_acquire` have the spin-loop inside PTX (`@!%p0 bra cas_loop`), not in Python-level `while` loops (see `primitives.md` §4) |
 | **Auto block size** | `BLOCK_M`/`BLOCK_N` default to `None` and are auto-computed based on problem size: `BLOCK_N = next_power_of_2(N_per_chunk)`, `BLOCK_M = next_power_of_2(16K / BLOCK_N / element_size)` |
 
@@ -238,7 +235,7 @@ Read `references/benchmark_template.md` for the complete test file structure, ar
 ## Important Constraints
 
 - **No hardcoded paths**: all file paths, module imports, and resource locations must be relative or derived from runtime context (e.g., `os.path.dirname(__file__)`). The skill must work regardless of where the repo is cloned.
-- **Self-contained kernel files**: each generated kernel file imports only from standard packages (`torch`, `triton`, `triton.language`, `torch.distributed`) and the project's public APIs (`triton_dist.utils`, `triton_dist.profiler_utils`). No cross-imports between overlap kernel implementations.
+- **Self-contained kernel files**: each generated kernel file imports only from standard packages (`torch`, `triton`, `triton.language`, `torch.distributed`). No cross-imports between overlap kernel implementations.
 - **Reusable context**: the context dataclass must support repeated kernel launches without re-allocation. Only `grid_barrier.zero_()` and similar resets are needed between calls.
 
 ## References

--- a/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
@@ -1,0 +1,255 @@
+---
+ name: sglang-overlap-kernel-generation
+description: |
+  Generate compute-communication overlap kernels for distributed GPU workloads (currently NVIDIA GPU only).
+  Given a compute kernel, a collective communication operation, their execution order,
+  and an overlap mode (inter-sm / intra-sm / without-sm), produce a complete overlap
+  implementation based on PyTorch symmetric memory. Use this skill whenever the user
+  wants to overlap compute with communication, fuse a collective into a kernel, hide
+  communication latency, or mentions "overlap", "fused collective", "compute-comm",
+  "persistent kernel", "copy engine", "symmetric memory", "signal/wait", "inter-sm",
+  "intra-sm", "fp8", "block-wise fp8", "w8a8", "fp8 gemm", "fp8 matmul" in the context
+  of multi-GPU kernel development.
+---
+# Compute-Communication Overlap Kernel Generator
+
+> **Platform limitation**: Currently only NVIDIA GPUs are supported (tested on SM90).
+
+## Input
+
+The user's request may only partially specify the configuration. For any item below that the user has **not** explicitly provided, ask them about it before generating code. Ask each missing item **one by one in order** (do not bundle multiple questions into one message, and do not skip any). If the user skips a question (e.g., replies "skip", or similar), use the default value for that item and move on to the next.
+
+When presenting options to the user via `AskUserQuestion`, put the full explanation directly into each option's **label** field (not just the description field, which may be hidden behind a tooltip in the UI). For example, use `"label": "inter-sm — two kernels, two streams"` rather than a bare `"label": "inter-sm"`. This ensures the user sees the explanation directly without needing to hover or click.
+
+1. **Compute kernel**: what kernel to overlap (e.g., GEMM, topk-reduce). Also clarify:
+   - **persistent** (one CTA loops over multiple tiles) or **non-persistent** (one CTA handles one tile)? *(default: persistent)*
+2. **Collective operation**: all-gather, reduce-scatter, all-reduce, etc.
+3. **Communication mechanism**: which hardware path for the collective? *(default: register)*
+   - `register` — load/store via symmetric memory (SM-driven)
+   - `copy_engine` — DMA copy on a background stream (zero SM cost)
+   - `tma` — Tensor Memory Accelerator async bulk copy
+   - `nvswitch` — multimem via NVSwitch hardware (NVLS)
+4. **Overlap mode**: how compute and comm are scheduled: *(default: inter-sm)*
+   - `inter-sm` — two kernels, two streams
+   - `intra-sm` — fused single kernel, single stream
+   - `without-sm` — copy engine (DMA), two streams
+5. **Execution order**: compute-first or comm-first
+
+**Constraint**: if communication mechanism = `copy_engine`, overlap mode is forced to `without-sm` (copy engine runs on DMA, not SMs) — inform the user and skip the overlap mode question.
+
+## Mode Overview
+
+### Inter-SM — two kernels, two streams
+
+Compute and communication run as **separate kernels on separate CUDA streams**. The first-to-execute kernel writes per-tile signals as blocks complete; the second is a **persistent kernel** that polls signals and processes data as it becomes ready. Coarse ordering via `torch.cuda.Event`, fine-grained overlap via store/load PTX signals on the signal tensor (host `.zero_()` reset before each launch). Barrier level (thread / CTA / rank) is chosen based on the collective.
+
+Read `references/inter_sm.md` for signal primitives, cross-device barrier, host-side launch pattern, and full implementation guide. If the user wants the collective communication portion to use hardware multicast (NVLS), additionally read `references/multimem.md`.
+
+### Intra-SM — fused single kernel
+
+Compute and communication are **fused into one kernel**. Each CTA computes a tile, then directly writes results to peer symmetric memory buffers via load/store (or multimem load/store). Synchronization uses GPU-scope atomics (`atomic_add_release` / `load_acquire`) for intra-node CTA barriers and `symm_mem_sync` for cross-rank barriers. If the collective requires reduction (e.g., reduce-scatter), a final local-reduce phase sums contributions from all peers.
+
+Read `references/intra_sm.md` for barrier primitives, A2A push pattern, kernel structure template, and full implementation guide. The default push/reduce path uses `tl.store` / hand-written reduction; if the user wants the collective communication portion to use hardware multicast (NVLS) — i.e. `multimem.st` for the push phase and `multimem.ld_reduce` for the reduce phase — additionally read `references/multimem.md`.
+
+### Without-SM — copy engine (DMA)
+
+Communication is offloaded to the **copy engine**, consuming zero SM resources. A background stream performs `copy_()` on symmetric memory (routed through DMA). A `progress` tensor, updated via `cuStreamWriteValue32` after each chunk copy, lets the compute kernel (on the main stream) poll and process data as it arrives — local data first (no wait), then remote chunks as they become ready.
+
+Read `references/without_sm.md` for copy engine setup, progress tracking, compute kernel polling pattern, and full implementation guide.
+
+## Common Dependencies
+
+All three modes use PyTorch symmetric memory:
+
+```python
+import torch.distributed._symmetric_memory as symm_mem
+
+buf = symm_mem.empty(shape, dtype=dtype, device=device)       # allocate
+hdl = symm_mem.rendezvous(buf, group=dist.group.WORLD)        # rendezvous
+peer_buf = hdl.get_buffer(peer_rank, sizes=shape, dtype=dtype,
+                        storage_offset=offset)               # peer access
+signal_pad_ptrs = torch.tensor(                                    # cross-rank sync
+    [hdl.get_signal_pad(i, (world_size,), torch.int32).data_ptr()
+     for i in range(world_size)],
+    dtype=torch.int64, device=device,
+)
+```
+
+### Symmetric Memory Shape Selection Principle
+
+The symmetric memory buffer (`symm_mem.empty(shape, ...)`) is primarily used for the **communication** phase — it is the medium through which data is exchanged between ranks. Therefore, its shape should match the shape required by the collective communication operation, not the compute kernel's input/output shape. This avoids unnecessary memory waste and offset misalignment.
+
+Choose the shape based on the collective:
+
+| Collective | symm_mem shape per rank | Rationale |
+|-----------|------------------------|-----------|
+| **All-Gather** | `[M_per_rank, N]` (each rank's local contribution) | Each rank writes its local data into its own symm_mem buffer; peers read from it. The gathered output `[M, N]` is assembled from all ranks' buffers. |
+| **Reduce-Scatter** | `[M, N]` (i.e., `[world_size * M_per_rank, N]`) | Each rank's buffer receives partial results from all peers (one `M_per_rank`-row segment per source rank), then reduces locally. The buffer layout is logically `[world_size, M_per_rank, N]`. |
+| **All-Reduce** | `[M, N]` (full data shape) | Each rank's buffer holds the full tensor; peers write their contributions and a reduction is performed in-place or into a separate output. |
+
+The key insight: symm_mem shape = the shape that the communication pattern needs to read/write across ranks. The compute kernel's input/output may have a different shape (e.g., the compute input might be `[M, K]` while the symm_mem buffer for reduce-scatter is `[M, N]` where N is the output dimension after compute).
+
+## Selection Guide
+
+| Mode | When to use | Pros | Cons |
+|------|------------|------|------|
+| **inter-sm** | Compute and comm have different granularity; need flexibility | Clear separation, easier to debug | Two kernels, stream overhead |
+| **intra-sm** | Tile-aligned data, same CTA can do both | Zero extra SM cost, tightest overlap | Complex kernel, register pressure |
+| **without-sm** | Large contiguous transfers, want zero SM overhead for comm | Copy engine is free, simple compute kernel | Coarser granularity, needs large transfers |
+
+---
+
+## Output Format Convention
+
+The generated overlap kernel file is organized into **four sections** in order, each separated by comment banners:
+
+1. **PTX Primitives** — `@triton.jit` inline-asm helpers (signal, barrier, memory ordering)
+2. **Context Dataclass** — `@dataclass` + `create_*_context()` factory for symmetric memory setup
+3. **Triton Kernel** — the `@triton.jit` kernel function(s) implementing the overlap logic
+4. **Python Entry Point** — host-side launcher that resets barriers and calls the kernel
+
+Read `references/kernel_format.md` for the complete code templates, design rules, and available PTX primitives catalog.
+
+---
+
+## Workflow Steps
+
+After gathering user input and selecting the overlap mode, execute these steps **in order**:
+
+### Step 1: Generate Overlap Kernel
+
+Read the appropriate reference file for the selected mode, then generate a complete kernel file following the four-section format above. **Before emitting any PTX primitives or barrier calls, read `references/primitives.md`** to use the canonical implementations — do not re-derive them from the mode files. The file should be self-contained (no imports from other overlap implementations in this repo except standard libraries: `torch`, `torch.distributed`, `triton`, `triton.language`).
+
+**Multimem (NVLS) trigger — load `references/multimem.md` on demand.**
+
+Additionally read `references/multimem.md` **before** generating the kernel when **either** of the following holds:
+
+- **Keyword trigger** — the user's request literally mentions any of: `multimem`, `NVLS`, `multicast`, `硬件广播` / `硬件 multicast`, `multimem.st`, `multimem.ld_reduce`, `NVSwitch reduce` / `in-network reduce`, `multicast_ptr`.
+- **Intent trigger** — the user expresses a semantically equivalent goal even without those keywords, e.g. "用一条指令对所有 rank 广播 / 规约", "让交换机帮我做 reduce", "利用 NVSwitch 做 in-network reduction", "把 push 阶段从 N 次写降到 1 次", "让通信不占 SM 周期 / 走硬件路径".
+
+When triggered:
+1. Read `references/multimem.md` in addition to the selected mode file.
+2. **Inline the implementation source from `multimem.md` §D** (helpers + `multimem_st` + `multimem_ld_reduce` + their `_v*` impls) into the generated kernel file's PTX Primitives section. Do **not** import from `triton_dist.kernels.nvidia.multimem_api` — the generated file must remain self-contained per the "Self-contained kernel files" constraint below.
+3. On the host side: extend the context dataclass with `mc_ptr`, access `hdl.multicast_ptr` (stock PyTorch symm_mem property, no extra import) after `symm_mem.rendezvous`, and guard against unsupported hardware (`mc_ptr == 0`).
+4. In the kernel: replace the per-peer `tl.store` push loop with `multimem_st(...)`, and replace the hand-written `acc += tl.load(peer_buf, ...)` reduction loop with `multimem_ld_reduce(..., op="sum", acc_dtype=tl.float32)`. Keep all existing grid-level and cross-rank barriers — multimem swaps out only the bulk data movement, not the synchronization.
+
+When **not** triggered: stay on the default path (per-peer `tl.store` for the push phase, hand-written reduction for the reduce phase) and do **not** load `references/multimem.md`.
+
+**FP8 GEMM trigger — load `references/triton_fp8_gemm.md` on demand.**
+
+Additionally read `references/triton_fp8_gemm.md` **before** generating the kernel when the compute kernel in the overlap is a **GEMM / matmul that operates on FP8 quantized inputs** (e.g., AllGather + FP8 GEMM, reduce-scatter + FP8 GEMM, linear layers with FP8 weight). This covers:
+
+- **Keyword trigger** — the user's request mentions any of: `fp8`, `block-wise fp8`, `w8a8`, `fp8 gemm`, `fp8 matmul`, `block fp8`.
+- **Intent trigger** — the user describes a quantized GEMM workload (e.g., "weight is in fp8", "block-wise quantized matmul", "fp8 weight and activation with per-block scaling", "quantize activation on the fly inside GEMM", "fuse bf16 to fp8 quantization into the matmul kernel").
+
+When triggered:
+1. Read `references/triton_fp8_gemm.md` in addition to the selected mode file and `references/primitives.md`.
+2. Inline the `_w8a8_block_fp8_matmul` kernel code from the reference into the generated file. The generated file must remain self-contained (no imports from `triton_dist` or `sglang`).
+3. Choose the activation quantization strategy based on the overlap pattern (see `references/triton_fp8_gemm.md` §C.1):
+   - **Separate quantize kernel + pre-quantized `_w8a8_block_fp8_matmul`**: run a `per_token_group_quant_fp8` kernel to produce `A_fp8` and `A_scale` first, then feed them into the standard kernel. Use this when exact per-`group_k` quantization granularity is required, or when A is already available in fp8 format.
+   - **On-the-fly quantization inside the GEMM kernel**: modify the K-loop to load bf16 A, compute per-row `absmax`, cast to fp8 inline, then `tl.dot(fp8_A, fp8_B) * scale * B_scale`. Use this when A arrives as bf16 from symmetric memory and you want to save one kernel launch + one global memory round-trip. This is the recommended default for overlap kernels. When `BLOCK_SIZE_K == group_k == 128` (standard setting), numerical accuracy is equivalent to the separate-kernel approach.
+
+When **not** triggered: if the compute kernel uses bf16/fp16 natively (not block-wise FP8), do **not** load `references/triton_fp8_gemm.md`.
+
+### Step 2: Overlap Kernel Correctness & Hang Check
+
+After generating the kernel, produce a **verification checklist** and verify each item:
+
+#### Hang Prevention Checks
+
+| Check | What to verify |
+|-------|---------------|
+| **Grid barrier correctness** | `barrier_on_this_grid` is called by ALL CTAs before cross-rank sync; the barrier counter is reset to 0 before each kernel launch |
+| **Cross-rank barrier single-CTA** | `barrier_all_intra_node_atomic_cas_block` is called by exactly ONE CTA per rank (guarded by `if pid == 0:`). The signal pad slots are binary (0↔1) and can only track one barrier invocation per rank pair; multiple CTAs calling it concurrently will CAS-contend on the same slots and **deadlock** |
+| **Cross-rank barrier symmetry** | Every rank executes the same number of barrier calls; no conditional paths that skip barriers on some ranks. The `if pid == 0:` guard does NOT violate this — all ranks have a pid==0 CTA |
+| **Signal reset** | Signal tensor is reset by host `.zero_()` before each launch; `_send_signal` stores 1, `_wait_signal` spins until 1 — no in-kernel reset needed |
+| **No deadlock ordering** | If multiple barriers exist, all ranks execute them in the same order; no circular dependencies between barrier phases |
+| **Persistent kernel termination** | For inter-SM persistent kernels: the polling loop has a bounded exit condition (tile counter reaches total_tiles) |
+| **Thread convergence** | `tl.debug_barrier()` is called after any warp-divergent section to re-converge threads before shared operations |
+| **Triton AST compatibility** | Triton JIT does NOT support `break`, `continue`, or `return` inside `@triton.jit` functions. Replace `while True: ... if cond: break` with `while not cond:` pattern. All loop exits must be expressed as `while <condition>` |
+
+#### Precision Checks
+
+| Check | What to verify |
+|-------|---------------|
+| **Accumulator dtype** | Reductions (sum, mean) use `tl.float32` accumulator even if input is fp16/bf16 |
+| **Cast placement** | Cast to native dtype happens AFTER all arithmetic, immediately before `tl.store` |
+| **Scaling factor** | Multiplicative scaling (e.g., `1/topk`) is applied in float32 before final cast |
+| **Overflow in offsets** | All pointer offset calculations use int64 when `M * stride` could exceed int32 range (~2B elements). For Triton tensors (e.g., `tl.arange`, `tl.load` results), use `.to(tl.int64)`. For values that may be Python `int` at compile time (e.g., results of `//` or `%` on `tl.constexpr` args, loop variables from `tl.static_range` or `range`), use `tl.cast(val, tl.int64)` instead — Python `int` has no `.to()` method and will raise `AttributeError` |
+| **tl.cast vs .to() usage** | `.to(tl.int64)` is only valid on Triton tensor values (results of `tl.load`, `tl.arange`, tensor arithmetic). For scalar values that may be Python `int` at JIT time, always use `tl.cast(val, tl.int64)`. Mixing these up causes `AttributeError: 'int' object has no attribute 'to'` at kernel compile time |
+| **Mask correctness** | Boundary masks cover both M and N dimensions; `other=0.0` is used for masked loads in reductions |
+| **Output copy shape** | Ensure output shape matches collective semantics: <br>- **AllReduce**: same as input (full data, reduced) <br>- **AllGather**: concatenated across ranks <br>- **ReduceScatter**: local portion only |
+
+#### Memory Safety Checks (Illegal Memory Access Prevention)
+
+These checks prevent `CUDA error: an illegal memory access was encountered`. This is the most common runtime crash in Triton kernels and almost always means some thread/lane is dereferencing a pointer outside allocated memory.
+
+| Check | What to verify |
+|-------|---------------|
+| **Power-of-2 lane overflow** | `tl.arange(0, BLOCK_X)` always produces a power-of-2-length tensor. When `BLOCK_X > actual_size` (which is the norm — `BLOCK_X = next_power_of_2(actual_size)`), excess lanes exist. For standard `tl.load`/`tl.store` this is handled by the `mask` parameter. But **any operation that bypasses Triton's mask mechanism — PTX `inline_asm_elementwise`, raw pointer arithmetic passed to inline asm, manual `tl.store` without mask — will execute on ALL lanes including out-of-bounds ones**. Every pointer derived from `tl.arange` that feeds into an unmasked operation must be guarded |
+| **Unmasked PTX inline_asm** | PTX inline assembly (`tl.inline_asm_elementwise`) has no built-in mask support. If it receives a tensor of addresses, ALL addresses are dereferenced unconditionally. Two valid fix patterns: (1) **Address clamping** — `addr = tl.where(mask, real_addr, safe_addr)` before calling the asm, where `safe_addr` is a known-valid address (e.g., element 0). (2) **Predicated execution** — pass mask as an integer arg and use `setp + @%p` guard inside the PTX asm so the instruction only fires for valid lanes |
+| **Tile boundary overflow** | When tiling a dimension (M or N), the last tile often extends past the real extent. Verify: (a) loads from input use `mask` + `other=0.0`, (b) stores to output use `mask`, (c) pointer offsets for the last tile don't produce negative values or wrap around due to unsigned arithmetic. (d) For compact layout where each rank occupies exactly `M_local` rows (no padding to `BLOCK_SIZE_M`), tile row offsets must account for the real per-rank size, not assume uniform tile-aligned strides across ranks |
+| **Cross-buffer pointer confusion** | Kernels with multiple buffers (input, output, symm_mem, signal pads) must not mix up strides or base pointers. Verify each pointer offset expression uses the stride that matches its target buffer. Common bug: applying `stride_in_m` to `symm_buffer` offsets when `stride_buf_m` is different |
+| **Byte-level pointer arithmetic** | When computing byte offsets for raw pointers (common with multicast/DMA), verify: (a) multiplication by `ELEM_BYTES` is applied consistently, (b) division back to element-level (e.g., `// 4` for int32 reinterpret) is correct, (c) alignment requirements (16B for v4 ops) are satisfied by the computed addresses |
+| **Pointer array bounds** | Arrays like `buf_ptrs[world_size]` or `signal_pad_ptrs[world_size]` have fixed length. Any index used to load from them must be provably `< array_length`. Verify loop bounds and conditional indices |
+| **Chunk/split divisibility** | When splitting a dimension into chunks (`N_per_chunk = N // N_CHUNKS`), the division must be exact. Non-exact division causes: the last chunk to be short (missing mask → OOB reads), or `BLOCK_X = next_power_of_2(N_per_chunk)` to overshoot into the next chunk's address space. Enforce `assert dim % num_chunks == 0` on the host side |
+| **Dynamic vs allocated size mismatch** | If a buffer is pre-allocated for `max_M` rows but the kernel is called with `M < max_M`, this is safe (under-utilization). But if `M > max_M` at runtime, stores will exceed the buffer. Enforce `assert M <= ctx.max_M` on the host side. Same applies to N dimension |
+| **Grid-stride loop with raw pointers** | In persistent kernel patterns (`for tile_id in range(pid, total, npid)`), each iteration computes new pointer offsets. Verify that `total` is correctly derived from the actual tensor shape, not from an unrelated `BLOCK` constant. Off-by-one in `total` means the last CTA accesses memory one tile beyond the allocation |
+
+**Fix patterns:**
+- **Address clamping for inline asm**: `safe_addr = tl.where(mask, real_addr, base_addr)` — redirect OOB lanes to element 0
+- **Predicated PTX**: Add `setp.ne.s32 %p0, $mask_arg, 0; @%p0 <instruction>` inside the asm string; pass `mask.to(tl.int32)` as an extra arg
+- **Host-side guards**: `assert N % n_chunks == 0`, `assert M <= ctx.max_M`, `assert input.shape[-1] == ctx.N`
+
+#### Performance Checks
+
+| Check | What to verify |
+|-------|---------------|
+| **num_warps=32** | The kernel launch specifies `num_warps=32` (not the default 4). These kernels are memory-bound; 32 warps (1024 threads/CTA) is needed to saturate memory bandwidth. Using default 4 warps causes 50%+ performance loss |
+| **num_stages=1** | Explicitly set `num_stages=1`. No software pipelining is needed for simple load/store patterns |
+| **N_CHUNKS splitting** | The N dimension is split into chunks (default 2) via an outer `tl.range` loop to reduce register pressure and improve SM occupancy |
+| **tl.multiple_of hints** | `tl.multiple_of(N_per_chunk, 16)` and `tl.multiple_of(peer_buf, 16)` are used to enable vectorized 128-bit loads/stores |
+| **tl.constexpr strides** | Stride parameters are declared as `tl.constexpr` so the compiler can optimize address calculations at compile time |
+| **Incremental pointer update** | topk/reduction loops use `tl.static_range` + `ptr + j * stride` instead of recomputing full addresses each iteration |
+| **Input layout flattening** | 3D inputs like `[M, topk, N]` are flattened to `[M*topk, N]` for contiguous memory access in the topk dimension |
+| **Master CTA barrier** | `barrier_on_this_grid` uses the master CTA pattern (bid==0 spins, others wait for high bit) with a single `tl.debug_barrier()`, not the naive 3-barrier pattern (see `primitives.md` §5.2) |
+| **Multi-threaded CAS barrier** | `barrier_all_intra_node_atomic_cas_block` uses `flat_tid < world_size` for parallel peer signaling, not single-threaded serial iteration (see `primitives.md` §5.3) |
+| **Cross-rank barrier placement** | In-kernel `barrier_all_intra_node_atomic_cas_block` is only needed when the kernel has a subsequent phase after communication (intra-sm). For inter-sm and without-sm, use host-side `symm_mem_hdl.barrier()` around `signal.zero_()` instead — the comm kernel exits once communication is done, so no in-kernel cross-rank sync is required |
+| **PTX-level CAS spin-loop** | `_cas_sys_release`/`_cas_sys_acquire` have the spin-loop inside PTX (`@!%p0 bra cas_loop`), not in Python-level `while` loops (see `primitives.md` §4) |
+| **Auto block size** | `BLOCK_M`/`BLOCK_N` default to `None` and are auto-computed based on problem size: `BLOCK_N = next_power_of_2(N_per_chunk)`, `BLOCK_M = next_power_of_2(16K / BLOCK_N / element_size)` |
+
+If any check fails, fix the generated kernel before proceeding.
+
+### Step 3: Generate Benchmark Test File
+
+Generate a test file with four modes: `correctness`, `performance`, `multi_size`, `stability`.
+
+The performance test must separately benchmark:
+1. **Compute-only**: the compute kernel in isolation
+2. **Comm-only**: the collective (NCCL) in isolation
+3. **Overlap**: the fused overlap kernel
+
+This enables calculating **overlap efficiency** = `max(compute_time, comm_time) / overlap_time`.
+
+Read `references/benchmark_template.md` for the complete test file structure, argument conventions, and output format.
+
+---
+
+## Important Constraints
+
+- **No hardcoded paths**: all file paths, module imports, and resource locations must be relative or derived from runtime context (e.g., `os.path.dirname(__file__)`). The skill must work regardless of where the repo is cloned.
+- **Self-contained kernel files**: each generated kernel file imports only from standard packages (`torch`, `triton`, `triton.language`, `torch.distributed`) and the project's public APIs (`triton_dist.utils`, `triton_dist.profiler_utils`). No cross-imports between overlap kernel implementations.
+- **Reusable context**: the context dataclass must support repeated kernel launches without re-allocation. Only `grid_barrier.zero_()` and similar resets are needed between calls.
+
+## References
+
+| File | When to read |
+|------|-------------|
+| `references/primitives.md` | Always — before emitting any PTX helpers, barriers, or signals into the kernel |
+| `references/kernel_format.md` | Step 1 — generating the kernel file (4-section code templates) |
+| `references/benchmark_template.md` | Step 3 — generating the benchmark test file |
+| `references/inter_sm.md` | User selects inter-sm mode |
+| `references/intra_sm.md` | User selects intra-sm mode |
+| `references/without_sm.md` | User selects without-sm mode |
+| `references/multimem.md` | On-demand — only when the user asks the collective communication portion to use multimem / NVLS / hardware multicast (see Step 1 trigger conditions) |
+| `references/triton_fp8_gemm.md` | On-demand — only when the compute kernel is a GEMM with FP8 quantized inputs (block-wise W8A8), e.g. AllGather + FP8 GEMM overlap (see Step 1 trigger conditions) |

--- a/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/SKILL.md
@@ -21,7 +21,7 @@ The user's request may only partially specify the configuration. For any item be
 
 When presenting options to the user via `AskUserQuestion`, put the full explanation directly into each option's **label** field (not just the description field, which may be hidden behind a tooltip in the UI). For example, use `"label": "inter-sm — two kernels, two streams"` rather than a bare `"label": "inter-sm"`. This ensures the user sees the explanation directly without needing to hover or click.
 
-1. **Compute kernel**: what kernel to overlap (e.g., GEMM, topk-reduce).
+1. **Compute kernel**: what kernel to overlap (e.g., GEMM, topk-reduce), users can provide the path to the target compute kernel.
 2. **Collective operation**: all-gather, reduce-scatter, all-reduce, etc.
 3. **Communication mechanism**: which hardware path for the collective? *(default: register)*
    - `register` — load/store via symmetric memory (SM-driven)

--- a/.claude/skills/sglang-overlap-kernel-generation/references/benchmark_template.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/benchmark_template.md
@@ -186,7 +186,45 @@ The performance test **must** include all four components separately:
 3. **Non-overlap**: run compute + comm sequentially (no overlap)
 4. **Overlap**: run the fused overlap kernel
 
-This allows calculating **speedup** = `(compute_time + comm_time) / overlap_time`.
+This allows calculating **speedup** = `(compute_time + comm_time) / overlap_time` and **overlap efficiency** = `max(compute_time, comm_time) / overlap_time`.
+
+### Compute Kernel Selection for Benchmark
+
+The **compute-only** and **non-overlap** benchmarks **must prefer the user-provided compute kernel implementation** for timing measurement, not a PyTorch reference implementation. This ensures a fair apples-to-apples comparison with the overlap kernel, which also uses the same compute kernel internally.
+
+**Priority order for compute kernel selection:**
+
+1. **User-provided compute kernel** (highest priority): If the user supplies a path to a custom compute kernel (e.g., a Triton kernel function), import and call it directly for the compute-only and non-overlap measurements. This is the same compute path that the overlap kernel uses internally, so the comparison is authoritative.
+
+2. **PyTorch reference implementation** (fallback): Only use PyTorch built-in ops (e.g., `torch.sum`, `torch.matmul`, `.mul_()`) when no user-provided compute kernel is available. The reference implementation is primarily used for **correctness verification** (comparing overlap output against ground truth), not for performance benchmarking.
+
+**Implementation pattern when user provides a compute kernel:**
+
+```python
+# Import the user-provided compute kernel from the overlap kernel file
+from <overlap_kernel_file> import (
+    <user_compute_kernel>,        # e.g., topk_sum_reduce_kernel (Triton kernel launcher)
+    <overlap_kernel_entry>,       # e.g., topk_sum_reduce_rs_overlap
+    create_<op>_overlap_context,
+)
+
+def compute_only(x, out, *args, **kwargs):
+    """Compute-only: user-provided compute kernel in isolation."""
+    <user_compute_kernel>(x, out, *args, **kwargs)
+    return out
+
+def comm_only(x, output, tp_group):
+    """Comm-only: NCCL collective in isolation."""
+    ...
+
+def non_overlap(x, out, output, *args, tp_group, **kwargs):
+    """Non-overlap: user-provided compute kernel + NCCL comm sequentially."""
+    compute_only(x, out, *args, **kwargs)
+    comm_only(out, output, tp_group)
+    return output
+```
+
+**Why this matters:** If the overlap kernel uses a Triton compute path but the benchmark measures the compute-only baseline with PyTorch ops, the speedup metric becomes misleading — PyTorch ops may be faster or slower than the custom kernel, distorting the overlap efficiency calculation. Using the same compute kernel in both overlap and non-overlap ensures the speedup metric reflects the genuine benefit of overlapping compute and communication.
 
 ## Output Table Format
 

--- a/.claude/skills/sglang-overlap-kernel-generation/references/benchmark_template.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/benchmark_template.md
@@ -1,0 +1,211 @@
+# Benchmark Test File Template
+
+Generate a test file that exercises the overlap kernel with four test modes. The structure follows this pattern:
+
+```python
+"""
+Test for <Op> Overlap Kernel using PyTorch Symmetric Memory.
+
+Usage:
+    # Correctness test
+    <NVSHMEM_DISABLE_CUDA_VMM=0 if multimem else "">torchrun --nproc_per_node=<world_size> <test_file>.py --case correctness
+
+    # Performance benchmark
+    <NVSHMEM_DISABLE_CUDA_VMM=0 if multimem else "">torchrun --nproc_per_node=<world_size> <test_file>.py --case performance
+
+    # Multi-size sweep
+    <NVSHMEM_DISABLE_CUDA_VMM=0 if multimem else "">torchrun --nproc_per_node=<world_size> <test_file>.py --case multi_size
+
+    # Stability (hang detection)
+    <NVSHMEM_DISABLE_CUDA_VMM=0 if multimem else "">torchrun --nproc_per_node=<world_size> <test_file>.py --case stability
+
+Note: <Add NVSHMEM_DISABLE_CUDA_VMM=0 prefix when using multimem/NVLS communication mechanism>
+"""
+
+import argparse
+import os
+import torch
+import torch.distributed as dist
+
+
+def initialize_distributed():
+    """Initialize distributed environment."""
+    RANK = int(os.environ.get("RANK", 0))
+    LOCAL_RANK = int(os.environ.get("LOCAL_RANK", 0))
+    WORLD_SIZE = int(os.environ.get("WORLD_SIZE", 1))
+    LOCAL_WORLD_SIZE = int(os.environ.get("LOCAL_WORLD_SIZE", 1))
+
+    torch.cuda.set_device(LOCAL_RANK)
+
+    dist.init_process_group(
+        backend="nccl",
+        world_size=WORLD_SIZE,
+        rank=RANK,
+        device_id=torch.device(f"cuda:{LOCAL_RANK}"),
+    )
+    assert dist.is_initialized()
+
+    tp_group = dist.new_group(ranks=list(range(WORLD_SIZE)), backend="nccl")
+    dist.barrier(tp_group)
+
+    return RANK, LOCAL_RANK, WORLD_SIZE, LOCAL_WORLD_SIZE, tp_group
+
+# Block size for FP8 GEMM kernels: [block_m, block_n, block_k]
+BLOCK_SIZE = [64, 128, 128]
+
+# Precision check (cosine-similarity based, from DeepGEMM)
+def calc_diff(x: torch.Tensor, y: torch.Tensor):
+    """Cosine-similarity based diff metric. Threshold: < 0.001."""
+    x, y = x.double(), y.double()
+    denominator = (x * x + y * y).sum()
+    sim = 2 * (x * y).sum() / denominator
+    return 1 - sim
+
+# ---------------------------------------------------------------------------
+# Reference Implementation
+# ---------------------------------------------------------------------------
+
+def <op>_reference(input_tensor, ..., pg):
+    """
+    Reference implementation using standard PyTorch/NCCL ops.
+    This is the ground truth for correctness verification.
+    """
+    ...
+
+# ---------------------------------------------------------------------------
+# Performance Measurement
+# ---------------------------------------------------------------------------
+
+def perf_func(func, warmup_iters=10, iters=100, *args, **kwargs):
+    """Performance measurement: warmup then timed iterations."""
+    # Warmup
+    for _ in range(warmup_iters):
+        output = func(*args, **kwargs)
+
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+
+    for _ in range(iters):
+        output = func(*args, **kwargs)
+
+    torch.cuda.synchronize()
+    end = time.perf_counter()
+
+    duration_ms = (end - start) / iters * 1000
+    return output, duration_ms
+
+# ---------------------------------------------------------------------------
+# Test Cases
+# ---------------------------------------------------------------------------
+
+def test_correctness(args):
+    """
+    Verify overlap kernel output matches reference implementation.
+    Tests: overlap kernel vs NCCL reference.
+    """
+    ...
+    # 1. Create context
+    # 2. Generate random input (seeded with 42 + rank)
+    # 3. Run overlap kernel
+    # 4. Run reference implementation
+    # 5. torch.testing.assert_close(overlap_out, ref_out, rtol=rtol, atol=atol)
+    # 6. Print PASSED/FAILED with max_diff and mean_diff on failure
+
+def test_performance(args):
+    """
+    Benchmark three implementations:
+    1. Standalone compute kernel
+    2. Standalone comm kernel (NCCL)
+    3. Overlap kernel (compute + comm overlap)
+
+    Reports latency (us), bandwidth (GB/s), and speedup.
+    """
+    ...
+    # For each implementation, use perf_func(func, args.warmup, args.iters, ...):
+    # 1. Standalone compute: _, compute_time = perf_func(compute_only, args.warmup, args.iters, ...)
+    # 2. Standalone comm: _, comm_time = perf_func(comm_only, args.warmup, args.iters, ...)
+    # 3. Overlap kernel: _, overlap_time = perf_func(overlap_kernel, args.warmup, args.iters, ...)
+    # 4. Print comparison table
+    # 5. Calculate speedup = (compute_time + comm_time) / overlap_time
+
+def test_multi_size(args):
+    """Correctness across multiple problem shapes and dtypes."""
+    ...
+    # Sweep over representative (M, N, ...) configurations
+    # Each config must satisfy divisibility constraints
+
+def test_stability(args, n_iters=50):
+    """Repeated correctness checks to catch non-deterministic hang/failures."""
+    ...
+    # Run overlap kernel n_iters times with different random inputs
+    # Detects intermittent hangs (timeout) and precision drift
+
+# ---------------------------------------------------------------------------
+# Argument Parsing
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Test <Op> Overlap Kernel")
+    parser.add_argument("--case", type=str, default="correctness",
+                        choices=["correctness", "performance", "multi_size", "stability"])
+    # Shape parameters (with sensible defaults)
+    # For GEMM-based kernels, DEFAULT values are: M=1024, N=7168, K=2048
+    # These defaults represent realistic LLM inference workloads
+    parser.add_argument("--M", type=int, default=1024, help="M dimension")
+    parser.add_argument("--N", type=int, default=7168, help="N dimension")
+    parser.add_argument("--K", type=int, default=2048, help="K dimension")
+    # Kernel tuning parameters (block_size defined as module-level constant BLOCK_SIZE)
+    parser.add_argument("--num_comm_sms", type=int, default=8, help="Number of SMs for communication")
+    # Benchmark parameters
+    parser.add_argument("--warmup", type=int, default=10, help="Warmup iterations")
+    parser.add_argument("--iters", type=int, default=100, help="Benchmark iterations")
+    # Misc (--profile, --dtype)
+    return parser.parse_args()
+
+# ---------------------------------------------------------------------------
+# Entry Point
+# ---------------------------------------------------------------------------
+
+def main():
+    rank, local_rank, world_size, local_world_size, tp_group = initialize_distributed()
+    args = parse_args()
+    # Validate constraints (divisibility, etc.)
+    # Dispatch to test case
+    ...
+
+if __name__ == "__main__":
+    main()
+```
+
+## Performance Test Requirements
+
+The performance test **must** include all four components separately:
+
+1. **Compute-only**: run just the compute kernel in isolation
+2. **Comm-only**: run just the collective (e.g., via NCCL) in isolation
+3. **Non-overlap**: run compute + comm sequentially (no overlap)
+4. **Overlap**: run the fused overlap kernel
+
+This allows calculating **speedup** = `(compute_time + comm_time) / overlap_time`.
+
+## Output Table Format
+
+```
+  Implementation           Latency (us)    BW (GB/s)    Speedup
+  -----------------------------------------------------------------------
+  Compute-only             xxx.xx          xx.xx        -
+  Comm-only (NCCL)         xxx.xx          xx.xx        -
+  Non-overlap              xxx.xx          xx.xx        -
+  Overlap kernel           xxx.xx          xx.xx        x.xxx
+  -----------------------------------------------------------------------
+  Speedup = (compute_time + comm_time) / overlap_time
+```
+
+## Key Conventions
+
+- Use `torch.manual_seed(42 + rank)` for reproducible inputs
+- Use CUDA events (`torch.cuda.Event(enable_timing=True)`) for timing
+- Always call `torch.cuda.synchronize()` before/after timed sections
+- Print results only on rank 0
+- Call `ctx.finalize()` in cleanup to release symmetric memory
+- Support `--profile` flag for optional torch profiler trace export

--- a/.claude/skills/sglang-overlap-kernel-generation/references/inter_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/inter_sm.md
@@ -113,11 +113,16 @@ def launch_inter_sm_overlap(ctx, compute_fn, comm_fn, data, ...):
     # Ensure comm_stream sees signal reset
     comm_stream.wait_stream(current_stream)
 
-    # Launch compute kernel on current_stream (producer of signals)
+    # Launch compute kernel on current_stream (producer of signals).
+    # Compute kernel uses ctx.num_gemm_sms (= total SMs - num_comm_sms).
+    # This leaves num_comm_sms SMs free for the concurrent comm kernel.
+    compute_grid = (ctx.num_gemm_sms,)
     compute_fn[compute_grid](data, ctx.symm_buffer, ctx.signal, ...)
 
     # Launch persistent comm kernel on comm_stream.
-    # Comm kernel polls signal[] per-tile — no need to wait for GEMM to finish.
+    # Comm kernel uses ctx.num_comm_sms SMs — a small subset of total SMs.
+    # This kernel is persistent: CTAs loop over all tiles, polling signals.
+    # Grid size must not exceed num_comm_sms to avoid scheduling deadlock.
     with torch.cuda.stream(comm_stream):
         comm_fn[(ctx.num_comm_sms,)](
             ctx.symm_buffer,

--- a/.claude/skills/sglang-overlap-kernel-generation/references/inter_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/inter_sm.md
@@ -1,0 +1,149 @@
+# Inter-SM Overlap: Two Kernels on Separate Streams
+
+Compute and communication run as separate kernels on two CUDA streams, synchronized via
+per-tile signals for fine-grained overlap.
+
+> **Primitives**: all PTX helpers (`_send_signal`, `_wait_signal`, `_get_flat_tid`, etc.)
+> are defined in `references/primitives.md`. Read that file first for the canonical
+> implementations.
+
+## Architecture
+
+```
+Stream A (compute)          Stream B (comm)
+┌──────────────────┐        ┌──────────────────────────┐
+│ compute_kernel   │        │ persistent_comm_kernel   │
+│  tile 0 → signal │──────▶ │  poll signal → comm tile │
+│  tile 1 → signal │──────▶ │  poll signal → comm tile │
+│  ...             │        │  ...                     │
+└──────────────────┘        └──────────────────────────┘
+                            ↓ wait_stream
+                            symm_mem_hdl.barrier()  (host-side rank sync)
+```
+
+## Step 1: Add Signals to Compute Kernel
+
+After each CTA finishes computing a tile, it writes a signal to indicate the output data
+is ready. Use `_send_signal` (see `primitives.md` §6) with `"release"` semantics so that
+preceding data stores are visible to the consumer.
+
+### Signal Insertion Pattern
+
+In the compute kernel, after writing the output tile:
+
+```python
+@triton.jit
+def compute_kernel_with_signal(out_ptr, signal_ptr, ...):
+    pid = tl.program_id(0)
+    # ... compute tile ...
+    tl.store(out_ptr + offsets, result, mask=mask)
+    # Signal this tile is ready (only thread 0)
+    flat_tid = _get_flat_tid()
+    if flat_tid == 0:
+        _send_signal(signal_ptr + pid, "release")
+```
+
+## Step 2: Implement Persistent Communication Kernel
+
+The comm kernel is **persistent** — it stays alive and polls signals, processing tiles
+as they become available. It uses `symm_mem` pointer arrays for peer buffer access.
+
+```python
+@triton.jit
+def persistent_comm_kernel(
+    data_ptr, peer_ptrs, signal_ptr,
+    tiles_per_rank, rank: tl.constexpr, world_size: tl.constexpr, ...
+):
+    pid = tl.program_id(0)
+
+    # Each CTA handles one or more tiles
+    for tile_id in range(pid, total_tiles, tl.num_programs(0)):
+        # Wait for compute to finish this tile
+        flat_tid = _get_flat_tid()
+        if flat_tid == 0:
+            _wait_signal(signal_ptr + tile_id, "acquire")
+        tl.debug_barrier()  # broadcast readiness to all threads in CTA
+
+        # Load tile data from local output
+        tile_data = tl.load(data_ptr + tile_offsets)
+
+        # Push to peer(s) via symmetric memory
+        for peer in range(world_size):
+            if peer != rank:
+                peer_buf = tl.load(peer_ptrs + peer).to(tl.pointer_type(out_dtype))
+                tl.store(peer_buf + dest_offsets, tile_data)
+
+    # No in-kernel cross-rank barrier needed — host-side barrier handles it
+    tl.debug_barrier()
+```
+
+**Key points about the persistent kernel:**
+- The `for tile_id in range(pid, total_tiles, tl.num_programs(0))` loop distributes tiles
+  across CTAs in a round-robin fashion. The loop terminates when all tiles are processed —
+  this is the bounded exit condition that prevents hangs.
+- `_wait_signal` + `tl.debug_barrier()` ensures all threads in the CTA see the data before
+  loading it.
+- No in-kernel cross-rank barrier is needed. Since the comm kernel has no subsequent phase
+  after communication, the host-side `symm_mem_hdl.barrier()` (around `signal.zero_()`) provides
+  the same rank-level synchronization with less kernel complexity.
+
+## Step 3: Host-Side Launch
+
+Use a two-stream pattern where compute runs on the **current stream** and
+communication runs on a **separate stream**. This avoids creating unnecessary
+extra streams and follows standard PyTorch stream management conventions.
+
+```python
+import torch
+import torch.distributed._symmetric_memory as symm_mem
+
+def launch_inter_sm_overlap(ctx, compute_fn, comm_fn, data, ...):
+    # --- Stream setup ---
+    # Compute on current stream; comm on a separate stream (from ctx).
+    current_stream = torch.cuda.current_stream()
+    comm_stream = ctx.comm_stream
+
+    # Host-side barrier: ensure all ranks finished previous iteration
+    ctx.symm_mem_hdl.barrier()
+    # Reset signal tensor (safe now — all ranks' comm kernels have exited)
+    ctx.signal.zero_()
+    # Host-side barrier: ensure all ranks see the reset before launching
+    ctx.symm_mem_hdl.barrier()
+
+    # Ensure comm_stream sees signal reset
+    comm_stream.wait_stream(current_stream)
+
+    # Launch compute kernel on current_stream (producer of signals)
+    compute_fn[compute_grid](data, ctx.symm_buffer, ctx.signal, ...)
+
+    # Launch persistent comm kernel on comm_stream.
+    # Comm kernel polls signal[] per-tile — no need to wait for GEMM to finish.
+    with torch.cuda.stream(comm_stream):
+        comm_fn[(ctx.num_comm_sms,)](
+            ctx.symm_buffer,
+            ctx.mc_ptr,
+            ctx.signal,
+            ...
+        )
+
+    # Wait for comm stream to finish (needed for correctness of next iteration's barrier)
+    current_stream.wait_stream(comm_stream)
+```
+
+## Barrier Level Selection
+
+Choose the barrier granularity based on the collective and data dependencies.
+See `primitives.md` §5 for the full barrier hierarchy and implementations.
+
+| Barrier level | When to use | Mechanism |
+|---------------|------------|-----------|
+| **Thread** | Independent per-element operations | `tl.debug_barrier()` within CTA |
+| **CTA** | All CTAs on this device must finish | `barrier_on_this_grid()` (primitives.md §5.2) |
+| **Rank (host-side)** | All ranks must finish, no in-kernel follow-up | `symm_mem_hdl.barrier()` around `signal.zero_()` |
+| **Rank (in-kernel)** | All ranks must finish, kernel has a subsequent phase (e.g. reduce) | `barrier_all_intra_node_atomic_cas_block()` (primitives.md §5.3) |
+
+**Inter-sm** and **without-sm** use host-side rank barrier: the comm kernel (or copy-engine)
+completes communication and exits, then `barrier()` → `signal.zero_()` → `barrier()` ensures all ranks
+have finished and see the reset before the next iteration launches. **Intra-sm** uses
+in-kernel rank barrier: the same kernel must continue to a reduce/read phase after all
+ranks push, so it cannot exit first.

--- a/.claude/skills/sglang-overlap-kernel-generation/references/inter_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/inter_sm.md
@@ -114,9 +114,9 @@ def launch_inter_sm_overlap(ctx, compute_fn, comm_fn, data, ...):
     comm_stream.wait_stream(current_stream)
 
     # Launch compute kernel on current_stream (producer of signals).
-    # Compute kernel uses ctx.num_gemm_sms (= total SMs - num_comm_sms).
+    # Compute kernel uses ctx.num_comp_sms (= total SMs - num_comm_sms).
     # This leaves num_comm_sms SMs free for the concurrent comm kernel.
-    compute_grid = (ctx.num_gemm_sms,)
+    compute_grid = (ctx.num_comp_sms,)
     compute_fn[compute_grid](data, ctx.symm_buffer, ctx.signal, ...)
 
     # Launch persistent comm kernel on comm_stream.

--- a/.claude/skills/sglang-overlap-kernel-generation/references/intra_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/intra_sm.md
@@ -1,0 +1,230 @@
+# Intra-SM Overlap: Fused Single Kernel
+
+Compute and communication are fused into one kernel. Each CTA computes a tile, then
+immediately performs communication via load/store to peer symmetric memory — no extra
+streams or separate kernels needed.
+
+> **Primitives**: all PTX helpers (`_get_flat_tid`, `_get_flat_bid`,
+> `_atomic_add_release`, `_load_acquire`, `_cas_sys_release`, `_cas_sys_acquire`,
+> `barrier_on_this_grid`, `barrier_all_intra_node_atomic_cas_block`, etc.) are defined
+> in `references/primitives.md`. Read that file first for the canonical implementations.
+
+## Architecture
+
+```
+Single Kernel (one CTA per tile)
+┌──────────────────────────────────────┐
+│ Phase 1: Compute tile                │
+│ Phase 2: Push result to peer buffers │  ← A2A via symm_mem pointers
+│ Phase 3: CTA barrier + rank barrier  │
+│ Phase 4: Local reduce (if needed)    │  ← e.g., reduce-scatter
+└──────────────────────────────────────┘
+```
+
+## Synchronization Overview
+
+Intra-SM overlap needs two levels of synchronization (both defined in `primitives.md`):
+
+1. **CTA-Grid barrier** (`barrier_on_this_grid`, primitives.md §5.2) — GPU-scope atomics
+   ensure all CTAs on this device finish pushing before any CTA starts reducing.
+2. **Cross-rank barrier** (`barrier_all_intra_node_atomic_cas_block`, primitives.md §5.3) —
+   system-scope CAS ensures all ranks have completed their pushes.
+
+See `primitives.md` §7 for memory ordering rules (release/acquire/relaxed).
+
+## Step 1: Peer Access via Pointer Arrays
+
+Symmetric memory provides a pointer array where `peer_ptrs[i]` points to rank `i`'s
+buffer. In Triton, load the pointer and cast to the appropriate type:
+
+```python
+# In kernel arguments: peer_ptrs is a tensor of uint64 pointers, one per rank
+peer_buf_addr = tl.load(peer_ptrs + peer_rank).to(tl.pointer_type(tl.float16))
+
+# Use tl.multiple_of hint for aligned pointers to enable vectorized loads/stores
+peer_buf_addr = tl.multiple_of(peer_buf_addr, 16)
+
+# Write to peer's buffer at the appropriate offset
+tl.store(peer_buf_addr + write_offset, tile_data, mask=mask)
+```
+
+## Step 2: Fused Kernel Template
+
+### Reduce-Scatter Pattern
+
+Each CTA computes a tile, pushes partial results to peer buffers (A2A), waits for all
+ranks to finish pushing, then reduces contributions from all peers locally.
+
+**Key performance optimizations** applied in this template:
+1. **N_CHUNKS loop**: Split the N dimension into chunks to reduce register pressure and improve data locality
+2. **Incremental pointer update**: Use `tl.static_range` + `ptr + j * stride` instead of recomputing full addresses each iteration
+3. **`tl.multiple_of` hints**: Enable vectorized 128-bit loads/stores for aligned pointers
+4. **`tl.constexpr` strides**: Let the compiler optimize address calculations at compile time
+5. **Input layout as `[M * topk, N]`**: Flatten the topk dimension for contiguous memory access
+
+```python
+@triton.jit
+def fused_compute_reduce_scatter(
+    input_ptr, output_ptr,
+    peer_ptrs,          # symm_mem buffer pointers (one per rank)
+    barrier_ptr,        # grid-level barrier counter
+    signal_pad_ptrs,    # cross-rank signal pad
+    M, N, K,
+    stride_xm: tl.constexpr,    # strides as constexpr for compiler optimization
+    stride_xn: tl.constexpr,
+    stride_buf_m: tl.constexpr,
+    stride_buf_n: tl.constexpr,
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    N_CHUNKS: tl.constexpr,     # number of chunks along N dimension
+    TOPK: tl.constexpr,         # compile-time topk for full unrolling
+    DTYPE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    npid = tl.num_programs(0)
+
+    M_per_rank = M // world_size
+    N_per_chunk = N // N_CHUNKS
+    N_per_chunk = tl.multiple_of(N_per_chunk, 16)  # alignment hint
+
+    num_tiles_m = tl.cdiv(M_per_rank, BLOCK_M)
+    num_tiles_n = tl.cdiv(N_per_chunk, BLOCK_N)
+    blocks_per_rank = num_tiles_m * num_tiles_n
+
+    # Pre-compute destination segment offset (int64 to avoid overflow)
+    dst_segment_offset = M_per_rank.to(tl.int64) * stride_buf_m * rank
+
+    # === Phase 1: Compute + A2A push (with N_CHUNKS loop) ===
+    for n_chunk in tl.range(0, N_CHUNKS, step=1, loop_unroll_factor=1):
+        offs_n_chunk = n_chunk * N_per_chunk * stride_xn
+
+        total_tiles = world_size * blocks_per_rank
+
+        for tile_id in range(pid, total_tiles, npid):
+            peer = tile_id // blocks_per_rank
+            bid = tile_id % blocks_per_rank
+            bid_m = bid // num_tiles_n
+            bid_n = bid % num_tiles_n
+
+            offs_m = bid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+            offs_n = bid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+            mask_m = offs_m < M_per_rank
+            mask_n = offs_n < N_per_chunk
+            mask = mask_m[:, None] & mask_n[None, :]
+
+            # Incremental pointer update for topk reduce:
+            # Input layout: [M * topk, N], compute base pointer once,
+            # then use ptr + j * stride_xm for each topk iteration
+            offs_in = (offs_m[:, None].to(tl.int64) * stride_xm * TOPK
+                       + offs_n[None, :].to(tl.int64) * stride_xn)
+            src_segment_offset = peer.to(tl.int64) * M_per_rank * TOPK * stride_xm
+            input_ptrs = input_ptr + offs_n_chunk + src_segment_offset + offs_in
+
+            # Accumulate in float32 for numerical stability
+            accum = tl.load(input_ptrs, mask=mask, other=0.0).to(tl.float32)
+            for j in tl.static_range(1, TOPK):
+                accum += tl.load(input_ptrs + j * stride_xm, mask=mask, other=0.0).to(tl.float32)
+
+            # Apply scaling (scalar or per-token)
+            accum *= scaling_factor
+
+            # Push to peer's buffer with alignment hint
+            peer_buf = tl.load(peer_ptrs + peer).to(tl.pointer_type(DTYPE))
+            peer_buf = tl.multiple_of(peer_buf, 16)  # enable vectorized stores
+            dst_ptrs = (peer_buf
+                        + offs_n_chunk
+                        + dst_segment_offset
+                        + offs_m[:, None].to(tl.int64) * stride_buf_m
+                        + offs_n[None, :].to(tl.int64) * stride_buf_n)
+            tl.store(dst_ptrs, accum, mask=mask)
+
+    # === Phase 2: Synchronize ===
+    # Grid barrier: all CTAs on this device must finish pushing (primitives.md §5.2)
+    barrier_on_this_grid(barrier_ptr)
+    # Cross-rank barrier: only CTA 0 participates — the signal pad slots are
+    # binary (0↔1) and can only track one barrier invocation per rank pair.
+    # ALL CTAs must NOT call this; only pid == 0 does the cross-rank sync.
+    # (primitives.md §5.3)
+    if pid == 0:
+        barrier_all_intra_node_atomic_cas_block(rank, rank, world_size, signal_pad_ptrs)
+
+    # === Phase 3: Local reduce (can also be done host-side via torch.sum) ===
+    # Host-side torch.sum is often simpler and equally fast:
+    #   torch.sum(symm_buffer[:M].view(world_size, M_per_rank, N), dim=0, out=output)
+```
+
+**Performance notes on the template above:**
+- `tl.static_range(1, TOPK)` enables full compile-time unrolling of the topk loop
+- `offs_n_chunk` is added to both input and output pointers to handle N-dimension chunking
+- The `N_CHUNKS` outer loop processes the N dimension in smaller pieces, reducing the
+  register footprint of each tile and improving SM occupancy
+
+### All-Gather Pattern
+
+Simpler — each CTA pushes its local tile to all peers, barrier, then reads the full
+gathered result.
+
+```python
+@triton.jit
+def fused_compute_allgather(input_ptr, output_ptr, peer_ptrs, ...):
+    pid = tl.program_id(0)
+
+    # Phase 1: Compute
+    result = compute_tile(input_ptr, pid, ...)
+
+    # Phase 2: Push local result to all peers
+    for peer in range(world_size):
+        peer_buf = tl.load(peer_ptrs + peer).to(tl.pointer_type(result.dtype))
+        tl.store(peer_buf + rank * chunk_size + local_offset, result)
+
+    # Phase 3: Barrier (primitives.md §5.2 + §5.3)
+    barrier_on_this_grid(barrier_ptr)
+    # Only CTA 0 does cross-rank sync — signal pad slots are single-use binary flags
+    if pid == 0:
+        barrier_all_intra_node_atomic_cas_block(rank, rank, world_size, signal_pad_ptrs)
+
+    # Phase 4: Read full gathered tensor (optional — may just use the buffer directly)
+```
+
+## Step 3: Host-Side Launch
+
+Single kernel launch, no stream management needed:
+
+```python
+def launch_intra_sm_overlap(kernel_fn, input_tensor, ...):
+    # Symmetric buffer shape should match the collective's communication layout:
+    #   - Reduce-Scatter: [M, N] = [world_size * M_per_rank, N]
+    #     (each rank's buffer receives one M_per_rank segment from every peer)
+    #   - All-Gather: [M_per_rank, N]
+    #     (each rank's buffer holds its local contribution for peers to read)
+    #   - All-Reduce: [M, N]
+    #     (full data shape for in-place reduction)
+    buf = symm_mem.empty(buffer_shape, dtype=input_tensor.dtype, device=device)
+    hdl = symm_mem.rendezvous(buf, group=dist.group.WORLD)
+
+    # Collect peer buffer pointers
+    peer_ptrs = torch.tensor(
+        [hdl.get_buffer(r, sizes=buf[r].shape, dtype=buf.dtype,
+                         storage_offset=0).data_ptr()
+         for r in range(world_size)],
+        dtype=torch.int64, device=device,
+    )
+
+    # Collect signal pad pointers (for cross-rank barrier)
+    signal_pad_ptrs_device = torch.tensor(
+        [hdl.get_signal_pad(i, (world_size,), torch.int32).data_ptr() for i in range(world_size)],
+        dtype=torch.int64, device=device,
+    )
+
+    barrier = torch.zeros(1, dtype=torch.int32, device=device)
+    output = torch.empty(output_shape, dtype=input_tensor.dtype, device=device)
+
+    grid = (num_tiles,)
+    kernel_fn[grid](
+        input_tensor, output, peer_ptrs, barrier,
+        signal_pad_ptrs_device,
+        M, N, K, rank, world_size,
+        BLOCK_M=128, BLOCK_N=128,
+    )
+```

--- a/.claude/skills/sglang-overlap-kernel-generation/references/intra_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/intra_sm.md
@@ -189,7 +189,8 @@ def fused_compute_allgather(input_ptr, output_ptr, peer_ptrs, ...):
 
 ## Step 3: Host-Side Launch
 
-Single kernel launch, no stream management needed:
+Single kernel launch, no stream management needed. The fused kernel handles both
+compute and communication, so it uses **all SMs** on the device.
 
 ```python
 def launch_intra_sm_overlap(kernel_fn, input_tensor, ...):
@@ -220,7 +221,12 @@ def launch_intra_sm_overlap(kernel_fn, input_tensor, ...):
     barrier = torch.zeros(1, dtype=torch.int32, device=device)
     output = torch.empty(output_shape, dtype=input_tensor.dtype, device=device)
 
-    grid = (num_tiles,)
+    # Intra-SM: single kernel uses ALL SMs (compute + communication are fused).
+    # num_ctas must not exceed SM count — this is a persistent kernel with a grid barrier,
+    # so all CTAs must be concurrently schedulable to avoid deadlock.
+    num_sm = torch.cuda.get_device_properties(device).multi_processor_count
+    num_ctas = min(num_tiles, num_sm)
+    grid = (num_ctas,)
     kernel_fn[grid](
         input_tensor, output, peer_ptrs, barrier,
         signal_pad_ptrs_device,

--- a/.claude/skills/sglang-overlap-kernel-generation/references/intra_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/intra_sm.md
@@ -231,6 +231,6 @@ def launch_intra_sm_overlap(kernel_fn, input_tensor, ...):
         input_tensor, output, peer_ptrs, barrier,
         signal_pad_ptrs_device,
         M, N, K, rank, world_size,
-        BLOCK_M=128, BLOCK_N=128,
+        BLOCK_M=64, BLOCK_N=128,
     )
 ```

--- a/.claude/skills/sglang-overlap-kernel-generation/references/kernel_format.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/kernel_format.md
@@ -8,21 +8,7 @@ All low-level PTX inline assembly helpers needed by the kernel. These are self-c
 
 **The canonical implementations live in `references/primitives.md`.** Read that file to get the exact code for each helper. Copy only the primitives the kernel actually uses into this section.
 
-Available primitives (choose based on mode):
-
-| Category | Primitives | Used by |
-|----------|-----------|---------|
-| Thread/block ID | `_get_flat_tid`, `_get_flat_bid` | all in-kernel modes |
-| GPU-scope atomics | `_atomic_add_release`, `_load_acquire`, `_store_release_with_highbit` | intra-sm (grid barrier) |
-| System-scope CAS | `_cas_sys_release`, `_cas_sys_acquire` | intra-sm only |
-| Per-tile signals | `_send_signal`, `_wait_signal` | inter-sm only |
-| CTA-Grid barrier | `barrier_on_this_grid` | intra-sm |
-| Cross-rank barrier (in-kernel) | `barrier_all_intra_node_atomic_cas_block` | intra-sm only |
-| Cross-rank barrier (host-side) | `symm_mem_hdl.barrier()` | inter-sm, without-sm (around `signal.zero_()`) |
-| Signal polling/writing (without-sm) | `ld_sys`, `st_sys`, `__syncthreads`, `tid` | without-sm only (defined in `without_sm.md`) |
-| CE-side signal ops (without-sm) | `stream_write_value32`, `cuStreamWaitValue32` | without-sm only (host-side, in `without_sm.md`) |
-
-See `primitives.md` §8 for the full mode-to-primitive mapping.
+See `primitives.md` §8 for the authoritative mode-to-primitive mapping. Copy only the primitives the kernel actually uses into this section.
 
 ## Section 2: Context Dataclass & Initialization
 
@@ -82,7 +68,8 @@ class <Op>OverlapContext:
         # Allocate signal tensor for two-stream tile-level sync (one slot per tile, reused across calls)
         # Size based on max possible tiles: cdiv(max_M, block_m) * cdiv(N, block_n)
         # Reset to 0 before each kernel launch via signal.zero_()
-        # self.signal = torch.zeros(max_total_tiles, dtype=torch.int32, device=device)
+        # self.signal = torch.zeros(max_total_tiles, dtype=torch.uint32, device=device)
+        # Note: without-sm mode MUST use uint32 for cuStreamWriteValue32 compatibility;
         # 1. Allocate symmetric buffer via symm_mem.empty()
         #    IMPORTANT: The symm_mem buffer shape must match the collective communication's
         #    data layout, NOT the compute kernel's input/output shape. The buffer is the

--- a/.claude/skills/sglang-overlap-kernel-generation/references/kernel_format.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/kernel_format.md
@@ -19,6 +19,8 @@ Available primitives (choose based on mode):
 | CTA-Grid barrier | `barrier_on_this_grid` | intra-sm |
 | Cross-rank barrier (in-kernel) | `barrier_all_intra_node_atomic_cas_block` | intra-sm only |
 | Cross-rank barrier (host-side) | `symm_mem_hdl.barrier()` | inter-sm, without-sm (around `signal.zero_()`) |
+| Signal polling/writing (without-sm) | `ld_sys`, `st_sys`, `__syncthreads`, `tid` | without-sm only (defined in `without_sm.md`) |
+| CE-side signal ops (without-sm) | `stream_write_value32`, `cuStreamWaitValue32` | without-sm only (host-side, in `without_sm.md`) |
 
 See `primitives.md` §8 for the full mode-to-primitive mapping.
 

--- a/.claude/skills/sglang-overlap-kernel-generation/references/kernel_format.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/kernel_format.md
@@ -49,13 +49,13 @@ class <Op>OverlapContext:
 
     # SM allocation — semantics differ by overlap mode:
     #   intra-sm:   num_comm_sms = total SMs (single kernel uses all SMs);
-    #               num_gemm_sms is unused (0).
+    #               num_comp_sms is unused (0).
     #   inter-sm:   num_comm_sms = small set of SMs for persistent comm kernel;
-    #               num_gemm_sms = remaining SMs for compute kernel.
+    #               num_comp_sms = remaining SMs for compute kernel.
     #   without-sm: comm is on copy engine (zero SMs); compute kernel uses all SMs;
-    #               num_comm_sms = 0, num_gemm_sms = total SMs.
+    #               num_comm_sms = 0, num_comp_sms = total SMs.
     num_comm_sms: int
-    num_gemm_sms: int = field(default=0, init=False)  # computed in __post_init__
+    num_comp_sms: int = field(default=0, init=False)  # computed in __post_init__
 
     # Local sync primitives (non-symmetric, device tensors)
     grid_barrier: torch.Tensor       # [1], int32 — intra-kernel CTA barrier
@@ -74,7 +74,7 @@ class <Op>OverlapContext:
         device = torch.cuda.current_device()
         # Calculate SM allocation: total SMs minus communication SMs
         num_sms = torch.cuda.get_device_properties(device).multi_processor_count
-        self.num_gemm_sms = num_sms - self.num_comm_sms
+        self.num_comp_sms = num_sms - self.num_comm_sms
         # Create communication stream (for two-stream overlap: inter-SM or without-SM/copy-engine)
         self.comm_stream = torch.cuda.Stream(device=device)
         # Allocate signal tensor for two-stream tile-level sync (one slot per tile, reused across calls)
@@ -179,7 +179,7 @@ The host-side function that prepares arguments, resets barriers, and launches th
 **Critical performance settings:**
 - `num_warps=32`: These kernels are memory-bound; 32 warps (1024 threads) per CTA maximizes memory bandwidth utilization. Using the default (4 warps / 128 threads) can cause 50%+ performance loss.
 - `num_stages=1`: No software pipelining needed for these simple load/store patterns.
-- `n_chunks=2`: Split the N dimension into chunks to reduce register pressure.
+- `n_chunks=N dimension // 1024`: Split the N dimension into chunks to reduce register pressure.
 - Auto-compute `BLOCK_M`/`BLOCK_N` based on problem size to balance register usage.
 
 ```python
@@ -201,7 +201,7 @@ def <op>_overlap(
     Host-side launcher for the overlap kernel.
 
     Args:
-        ctx: pre-allocated overlap context (contains num_comm_sms, num_gemm_sms, comm_stream)
+        ctx: pre-allocated overlap context (contains num_comm_sms, num_comp_sms, comm_stream)
         input_tensor: input data
         output: pre-allocated output tensor
         block_size: [block_m, block_n, block_k] tile dimensions, e.g. [64, 128, 128]
@@ -234,7 +234,7 @@ def <op>_overlap(
     # Compute grid dimensions
     # SM allocation differs by overlap mode:
     #   intra-sm:   single kernel uses ALL SMs — num_ctas = min(total_tiles, num_sms)
-    #   inter-sm:   comm kernel uses num_comm_sms; compute kernel uses num_gemm_sms
+    #   inter-sm:   comm kernel uses num_comm_sms; compute kernel uses num_comp_sms
     #   without-sm: compute kernel uses all SMs; comm is on copy engine (zero SMs)
     n_blocks_m = triton.cdiv(M_per_rank, block_m)
     n_blocks_n = triton.cdiv(N_per_chunk, block_n)
@@ -270,13 +270,6 @@ def <op>_overlap(
         DTYPE=tl.bfloat16 if input_tensor.dtype == torch.bfloat16 else tl.float16,
         num_warps=num_warps,
         num_stages=num_stages,
-    )
-
-    # Local reduce via torch.sum (simpler and equally fast as in-kernel reduce)
-    torch.sum(
-        ctx.symm_buffer[:M].view(world_size, M_per_rank, N),
-        dim=0,
-        out=output,
     )
     return output
 ```

--- a/.claude/skills/sglang-overlap-kernel-generation/references/kernel_format.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/kernel_format.md
@@ -1,0 +1,265 @@
+# Output Format Convention
+
+The generated overlap kernel file **must** be organized into the following four sections, in order. Each section is clearly separated by comment banners. This structure ensures consistency, readability, and testability.
+
+## Section 1: PTX Instruction Primitives (Dependencies)
+
+All low-level PTX inline assembly helpers needed by the kernel. These are self-contained `@triton.jit` functions with no external dependencies beyond `triton` and `tl`.
+
+**The canonical implementations live in `references/primitives.md`.** Read that file to get the exact code for each helper. Copy only the primitives the kernel actually uses into this section.
+
+Available primitives (choose based on mode):
+
+| Category | Primitives | Used by |
+|----------|-----------|---------|
+| Thread/block ID | `_get_flat_tid`, `_get_flat_bid` | all in-kernel modes |
+| GPU-scope atomics | `_atomic_add_release`, `_load_acquire`, `_store_release_with_highbit` | intra-sm (grid barrier) |
+| System-scope CAS | `_cas_sys_release`, `_cas_sys_acquire` | intra-sm only |
+| Per-tile signals | `_send_signal`, `_wait_signal` | inter-sm only |
+| CTA-Grid barrier | `barrier_on_this_grid` | intra-sm |
+| Cross-rank barrier (in-kernel) | `barrier_all_intra_node_atomic_cas_block` | intra-sm only |
+| Cross-rank barrier (host-side) | `symm_mem_hdl.barrier()` | inter-sm, without-sm (around `signal.zero_()`) |
+
+See `primitives.md` §8 for the full mode-to-primitive mapping.
+
+## Section 2: Context Dataclass & Initialization
+
+A `@dataclass` holding all pre-allocated buffers, symmetric memory handles, and synchronization state. Followed by a factory function `create_*_context()` that performs allocation and rendezvous.
+
+```python
+# ---------------------------------------------------------------------------
+# Context Dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class <Op>OverlapContext:
+    """
+    Pre-allocated state for the overlap kernel.
+    Holds symmetric memory buffers, signal pads, and local sync primitives.
+    """
+    # Problem dimensions
+    max_M: int
+    N: int
+    dtype: torch.dtype
+
+    # Distributed info
+    rank: int
+    num_ranks: int
+    num_local_ranks: int
+
+    # SM allocation
+    num_comm_sms: int
+    num_gemm_sms: int = field(default=0, init=False)  # computed in __post_init__
+
+    # Local sync primitives (non-symmetric, device tensors)
+    grid_barrier: torch.Tensor       # [1], int32 — intra-kernel CTA barrier
+    # ... additional counters/flags as needed ...
+
+    # Symmetric memory (set in __post_init__)
+    symm_mem_hdl: Optional[object] = field(default=None, init=False)
+    symm_buffer: Optional[torch.Tensor] = field(default=None, init=False)
+    buf_ptrs: Optional[torch.Tensor] = field(default=None, init=False)       # [num_ranks], int64
+    signal_pad_ptrs: Optional[torch.Tensor] = field(default=None, init=False) # [num_ranks], int64
+
+    # Communication stream (created once, reused across calls; used by both inter-SM and without-SM overlap)
+    comm_stream: Optional[torch.cuda.Stream] = field(default=None, init=False)
+
+    def __post_init__(self):
+        device = torch.cuda.current_device()
+        # Calculate SM allocation: total SMs minus communication SMs
+        num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+        self.num_gemm_sms = num_sms - self.num_comm_sms
+        # Create communication stream (for two-stream overlap: inter-SM or without-SM/copy-engine)
+        self.comm_stream = torch.cuda.Stream(device=device)
+        # Allocate signal tensor for two-stream tile-level sync (one slot per tile, reused across calls)
+        # Size based on max possible tiles: cdiv(max_M, block_m) * cdiv(N, block_n)
+        # Reset to 0 before each kernel launch via signal.zero_()
+        # self.signal = torch.zeros(max_total_tiles, dtype=torch.int32, device=device)
+        # 1. Allocate symmetric buffer via symm_mem.empty()
+        #    IMPORTANT: The symm_mem buffer shape must match the collective communication's
+        #    data layout, NOT the compute kernel's input/output shape. The buffer is the
+        #    medium for cross-rank data exchange, so its shape should reflect what the
+        #    communication pattern needs:
+        #      - All-Gather:      [M_per_rank, N]  (each rank's local contribution)
+        #      - Reduce-Scatter:  [M, N] = [world_size * M_per_rank, N]  (receives from all peers)
+        #      - All-Reduce:      [M, N]  (full data shape)
+        # 2. Rendezvous across ranks via symm_mem.rendezvous()
+        # 3. Build per-rank buffer pointer array (int64) for Triton dynamic indexing
+        # 4. Build per-rank signal pad pointer array (int64)
+        # 5. dist.barrier() to ensure all ranks complete setup
+        ...
+
+    def finalize(self):
+        """Release symmetric memory resources."""
+        dist.barrier()
+        # Set all handles/buffers to None (freed by GC)
+        ...
+
+
+def create_<op>_overlap_context(...) -> <Op>OverlapContext:
+    """Factory: allocate local tensors, construct and return context."""
+    device = torch.cuda.current_device()
+    grid_barrier = torch.zeros((1,), dtype=torch.int32, device=device)
+    # ... allocate other local sync tensors ...
+    return <Op>OverlapContext(...)
+```
+
+Key principles:
+- Triton cannot index Python tuples dynamically — always expose pointer arrays (`buf_ptrs`, `signal_pad_ptrs`) as int64 tensors for `tl.load(ptrs + index)`
+- Keep `max_M`, `N` etc. as the **logical** problem dimensions (not multiplied by topk/world_size) to avoid confusion
+- The context is **reusable** across multiple kernel invocations with different actual sizes ≤ max
+
+## Section 3: Triton Kernel Implementation
+
+The `@triton.jit` kernel function(s). For intra-SM mode this is a single kernel; for inter-SM mode there may be two (compute kernel + persistent comm kernel).
+
+```python
+# ---------------------------------------------------------------------------
+# Triton Kernel
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def <op>_overlap_kernel(
+    # ---- input/output pointers ----
+    input_ptr,
+    output_ptr,
+    # ---- symmetric buffer pointer arrays ----
+    buf_ptrs,
+    # ---- sync ----
+    signal_ptr,
+    signal_pad_ptrs,
+    grid_barrier_ptr,
+    # ---- problem sizes (runtime) ----
+    M, N,
+    # ---- strides (constexpr where possible) ----
+    stride_im: tl.constexpr,
+    stride_in: tl.constexpr,
+    # ---- distributed (constexpr) ----
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+    # ---- tile sizes (constexpr) ----
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    # ---- dtype ----
+    DTYPE: tl.constexpr,
+):
+    """
+    Overlap kernel: <describe compute> + <describe communication>.
+    """
+    # Phase 1: Compute + push to peer symmetric buffers
+    ...
+
+    # Grid barrier: ensure all CTAs complete before cross-rank sync
+    barrier_on_this_grid(grid_barrier_ptr)
+
+    # Cross-rank barrier
+    barrier_all_intra_node_atomic_cas_block(rank, rank, world_size, signal_pad_ptrs)
+
+    # Phase 2: Local reduction (if needed, e.g., reduce-scatter)
+    ...
+```
+
+Design rules:
+- Use `tl.constexpr` only for values fixed across calls (strides, rank, world_size, tile sizes). Frequently-changing quantities (`M`, `M_per_rank`, `n_chunks`, etc.) must be regular parameters or computed inside the kernel — each unique constexpr combination triggers a recompilation.
+- Use `tl.multiple_of` hints for aligned pointers/offsets to enable vectorized loads
+- Accumulate in `tl.float32` for numerical stability, cast to native dtype before store
+- Use `int64` arithmetic for offset calculations to avoid overflow with large tensors
+- Include `N_CHUNKS` loop if the N dimension exceeds what a single tile can cover
+
+## Section 4: Python Entry Point
+
+The host-side function that prepares arguments, resets barriers, and launches the kernel.
+
+**Critical performance settings:**
+- `num_warps=32`: These kernels are memory-bound; 32 warps (1024 threads) per CTA maximizes memory bandwidth utilization. Using the default (4 warps / 128 threads) can cause 50%+ performance loss.
+- `num_stages=1`: No software pipelining needed for these simple load/store patterns.
+- `n_chunks=2`: Split the N dimension into chunks to reduce register pressure.
+- Auto-compute `BLOCK_M`/`BLOCK_N` based on problem size to balance register usage.
+
+```python
+# ---------------------------------------------------------------------------
+# Python Entry Point
+# ---------------------------------------------------------------------------
+
+def <op>_overlap(
+    ctx: <Op>OverlapContext,
+    input_tensor: torch.Tensor,
+    # ... problem-specific args ...
+    output: torch.Tensor,
+    block_size: list,           # [block_m, block_n, block_k], e.g. [64, 128, 128]
+    num_warps: int = 32,        # 32 warps for memory-bound workloads
+    num_stages: int = 1,        # No software pipeline needed
+    n_chunks: int = 2,          # N-dimension chunks
+) -> torch.Tensor:
+    """
+    Host-side launcher for the overlap kernel.
+
+    Args:
+        ctx: pre-allocated overlap context (contains num_comm_sms, num_gemm_sms, comm_stream)
+        input_tensor: input data
+        output: pre-allocated output tensor
+        block_size: [block_m, block_n, block_k] tile dimensions, e.g. [64, 128, 128]
+        num_warps: warps per CTA (default: 32 for memory-bound workload)
+        num_stages: pipeline stages (default: 1)
+        n_chunks: number of chunks along N dimension (default: 2)
+
+    Returns:
+        output tensor (same as input `output` argument)
+    """
+    assert len(block_size) == 3
+    block_m, block_n, block_k = block_size[0], block_size[1], block_size[2]
+
+    # Handle both [M, topk, N] and [M*topk, N] input layouts
+    if input_tensor.ndim == 3:
+        M, topk, N = input_tensor.shape
+        x_flat = input_tensor.view(M * topk, N)
+    elif input_tensor.ndim == 2:
+        M_topk, N = input_tensor.shape
+        topk = ctx.topk
+        M = M_topk // topk
+        x_flat = input_tensor
+
+    N_per_chunk = N // n_chunks
+
+    # Reset sync tensors (must be 0 before each launch)
+    ctx.signal.zero_()
+    ctx.grid_barrier.zero_()
+
+    # Compute grid dimensions (use ctx.num_comm_sms for persistent comm grid)
+    n_blocks_m = triton.cdiv(M_per_rank, block_m)
+    n_blocks_n = triton.cdiv(N_per_chunk, block_n)
+    total_tiles = world_size * n_blocks_m * n_blocks_n
+    num_ctas = min(total_tiles, ctx.num_comm_sms)
+
+    grid = (num_ctas,)
+
+    # Launch kernel with explicit num_warps and num_stages
+    <op>_overlap_kernel[grid](
+        x_flat,
+        output,
+        ctx.buf_ptrs,
+        ctx.signal,
+        ctx.signal_pad_ptrs,
+        ctx.grid_barrier,
+        M, N,
+        x_flat.stride(0), x_flat.stride(1),  # strides from flattened input
+        ctx.symm_buffer.stride(0), ctx.symm_buffer.stride(1),
+        rank=ctx.rank,
+        world_size=ctx.num_ranks,
+        BLOCK_SIZE_M=block_m,
+        BLOCK_SIZE_N=block_n,
+        TOPK=topk,
+        N_CHUNKS=n_chunks,
+        DTYPE=tl.bfloat16 if input_tensor.dtype == torch.bfloat16 else tl.float16,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+    # Local reduce via torch.sum (simpler and equally fast as in-kernel reduce)
+    torch.sum(
+        ctx.symm_buffer[:M].view(world_size, M_per_rank, N),
+        dim=0,
+        out=output,
+    )
+    return output
+```

--- a/.claude/skills/sglang-overlap-kernel-generation/references/kernel_format.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/kernel_format.md
@@ -47,7 +47,13 @@ class <Op>OverlapContext:
     num_ranks: int
     num_local_ranks: int
 
-    # SM allocation
+    # SM allocation — semantics differ by overlap mode:
+    #   intra-sm:   num_comm_sms = total SMs (single kernel uses all SMs);
+    #               num_gemm_sms is unused (0).
+    #   inter-sm:   num_comm_sms = small set of SMs for persistent comm kernel;
+    #               num_gemm_sms = remaining SMs for compute kernel.
+    #   without-sm: comm is on copy engine (zero SMs); compute kernel uses all SMs;
+    #               num_comm_sms = 0, num_gemm_sms = total SMs.
     num_comm_sms: int
     num_gemm_sms: int = field(default=0, init=False)  # computed in __post_init__
 
@@ -225,11 +231,22 @@ def <op>_overlap(
     ctx.signal.zero_()
     ctx.grid_barrier.zero_()
 
-    # Compute grid dimensions (use ctx.num_comm_sms for persistent comm grid)
+    # Compute grid dimensions
+    # SM allocation differs by overlap mode:
+    #   intra-sm:   single kernel uses ALL SMs — num_ctas = min(total_tiles, num_sms)
+    #   inter-sm:   comm kernel uses num_comm_sms; compute kernel uses num_gemm_sms
+    #   without-sm: compute kernel uses all SMs; comm is on copy engine (zero SMs)
     n_blocks_m = triton.cdiv(M_per_rank, block_m)
     n_blocks_n = triton.cdiv(N_per_chunk, block_n)
     total_tiles = world_size * n_blocks_m * n_blocks_n
-    num_ctas = min(total_tiles, ctx.num_comm_sms)
+
+    # For intra-sm: the single fused kernel handles both compute and communication,
+    # so it should use all SMs on the device. The kernel contains a grid barrier,
+    # so num_ctas must not exceed the number of SMs (otherwise scheduling deadlock).
+    num_sm = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).multi_processor_count
+    num_ctas = min(total_tiles, num_sm)
 
     grid = (num_ctas,)
 

--- a/.claude/skills/sglang-overlap-kernel-generation/references/multimem.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/multimem.md
@@ -82,7 +82,7 @@ One instruction → NVSwitch reads the value at this offset from every rank, sum
 - **Zero SM occupancy for the comm itself.** Compute can keep using the same warps; the switch does the broadcast / reduction.
 - **Bandwidth-optimal.** `multimem.st` consumes 1× NVLink BW for an N-rank broadcast (vs. N-1×). `multimem.ld_reduce` returns reduced data, saving (N-1)/N of the ingress BW.
 - **Alignment-sensitive.** Misaligned `ptr` produces undefined behaviour; the v4 path requires 16 B alignment of both `ptr` and the multicast region's base.
-- **Visibility model.** Multimem is a memory operation, not a barrier. Producer/consumer ordering across ranks **still requires** the same cross-rank barriers you would use with `tl.store` (see §C.5).
+- **Visibility model.** Multimem is a memory operation, not a barrier — cross-rank barriers are still required. See §C.6 for details.
 
 ---
 

--- a/.claude/skills/sglang-overlap-kernel-generation/references/multimem.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/multimem.md
@@ -8,7 +8,7 @@ This reference covers the three operations that drive NVSwitch in-network comput
 
 - `hdl.multicast_ptr` — host-side, extract the multicast (MC) pointer from a symmetric-memory handle (it is a PyTorch symm_mem property, no extra import needed).
 - `multimem_st(ptr, val0[, val1, val2, val3], dtype=...)` — kernel-side, one PTX instruction broadcasts a value to **all** ranks. **Paste the implementation from §D into the generated file.**
-- `multimem_ld_reduce(ptr, op="sum", dtype=..., acc_dtype=tl.float32)` — kernel-side, one PTX instruction loads + reduces values **from all ranks** inside the NVSwitch fabric. **Paste the implementation from §D into the generated file.**
+- `multimem_ld_reduce(ptr, OP, DTYPE, ACC_DTYPE)` — kernel-side, one PTX instruction loads + reduces values **from all ranks** inside the NVSwitch fabric. **Paste the implementation from §D into the generated file.**
 
 The semantics are exactly equivalent to "N peer stores" / "N peer loads + sum" but cost **one** instruction and **zero** extra SM cycles on the issuer; the data movement and the reduction happen inside the switch.
 
@@ -56,19 +56,21 @@ Supported `dtype` (drives the PTX suffix):
 
 Semantics: one instruction → the value lands at the same byte offset in **every** rank's symmetric-memory region. There is no per-rank loop, no `for peer in range(world_size)`. This is the key reason intra-sm push phases shrink from `O(world_size)` stores to `O(1)`.
 
-### A.4 `multimem_ld_reduce(ptr, op="sum", dtype=..., acc_dtype=tl.float32)`
+### A.4 `multimem_ld_reduce(ptr, OP, DTYPE, ACC_DTYPE)`
 
-- `op`: **only `"sum"` is supported by hardware today** (`tl.static_assert` enforces this in the inlined source).
-- `dtype`: `tl.float32 | tl.bfloat16 | tl.float16` (integer reduce is not exposed here).
-- `acc_dtype`: `tl.float32` (recommended for bf16/fp16) or `tl.float16`. Adds the PTX `.acc::f32` / `.acc::f16` modifier so the in-switch accumulator runs in the requested precision regardless of payload dtype.
-- The default variant emitted is **v4**: returns a tuple `(v0, v1, v2, v3)` of the reduced values (16 B worth). For 4 B scalar loads use the lower-level `_multimem_ld_reduce_impl` (also inlined in §D).
+All three parameters are `tl.constexpr` (compile-time constants), matching Triton's convention for dispatch parameters.
+
+- `OP`: **only `"sum"` is supported by hardware today** (`tl.static_assert` enforces this in the inlined source).
+- `DTYPE`: `tl.float32 | tl.bfloat16 | tl.float16` — selects the PTX operand suffix (integer reduce is not exposed here).
+- `ACC_DTYPE`: `tl.float32` — in-switch accumulator precision. Currently only `tl.float32` is supported (`tl.static_assert` enforces this in the inlined source). The `.acc::f32` PTX modifier is used for bf16/fp16 to preserve reduction precision. Ignored for `DTYPE == tl.float32` (no `.acc::` modifier needed).
+- The default variant emitted is **v4**: returns a tuple `(v0, v1, v2, v3)` of the reduced values (16 B worth).
 
 ```python
 v0, v1, v2, v3 = multimem_ld_reduce(
     mc_ptr + byte_off,            # pointer arithmetic in element units; see §C.4
-    op="sum",
-    dtype=tl.bfloat16,
-    acc_dtype=tl.float32,         # IMPORTANT for bf16/fp16
+    OP="sum",
+    DTYPE=tl.bfloat16,
+    ACC_DTYPE=tl.float32,         # .acc::f32 for bf16/fp16
 )
 ```
 
@@ -189,8 +191,8 @@ import triton.language as tl
 def my_overlap_kernel(...):
     ...
     multimem_st(mc_addr, v0, v1, v2, v3, dtype=tl.bfloat16)
-    a, b, c, d = multimem_ld_reduce(mc_addr, op="sum",
-                                     dtype=tl.bfloat16, acc_dtype=tl.float32)
+    a, b, c, d = multimem_ld_reduce(mc_addr, OP="sum",
+                                     DTYPE=tl.bfloat16, ACC_DTYPE=tl.float32)
 ```
 
 ### C.2 Replacing the intra-sm "push" phase
@@ -240,7 +242,7 @@ Multimem-equivalent — one instruction loads + sums in the switch:
 mc_addr = mc_ptr + (src_off + cols_base) * tl.constexpr(2)
 tl.multiple_of(mc_addr, 16)
 v0, v1, v2, v3 = multimem_ld_reduce(
-    mc_addr, op="sum", dtype=tl.bfloat16, acc_dtype=tl.float32,
+    mc_addr, OP="sum", DTYPE=tl.bfloat16, ACC_DTYPE=tl.float32,
 )
 # v0..v3 are bf16 values (returned as 4 × int32 holding 8 bf16 elements).
 # Either store them back to the local output via 4 × tl.store, or repack
@@ -249,8 +251,8 @@ v0, v1, v2, v3 = multimem_ld_reduce(
 
 Notes:
 
-- `acc_dtype=tl.float32` is required for bf16/fp16 to match the precision rules already enforced by the SKILL.md "Accumulator dtype" check.
-- `op="sum"` is the only operation currently supported by hardware. For mean/scaling, do the divide **after** `multimem_ld_reduce` returns (in fp32, then cast).
+- `ACC_DTYPE=tl.float32` is required for bf16/fp16 to match the precision rules already enforced by the SKILL.md "Accumulator dtype" check.
+- `OP="sum"` is the only operation currently supported by hardware. For mean/scaling, do the divide **after** `multimem_ld_reduce` returns (in fp32, then cast).
 
 ### C.4 Data packing rules (the 16-byte unit)
 
@@ -490,7 +492,7 @@ def _multimem_ld_reduce_v4_f32(ptr):
 
 
 @triton.jit
-def multimem_ld_reduce(ptr, DTYPE: tl.constexpr):
+def multimem_ld_reduce(ptr, OP: tl.constexpr, DTYPE: tl.constexpr, ACC_DTYPE: tl.constexpr):
     """Load + in-switch reduce from all ranks (v4 variant, one PTX instruction).
 
     NVSwitch reads 16 B at `ptr` from every rank, sums them in network, and
@@ -498,14 +500,19 @@ def multimem_ld_reduce(ptr, DTYPE: tl.constexpr):
 
     Args:
         ptr: multicast pointer (byte address, 16 B aligned).
+        OP: reduction operation. Only "sum" is supported by hardware.
         DTYPE: tl.bfloat16 / tl.float16 / tl.float32 — selects the PTX suffix.
-               For bf16/fp16, .acc::f32 is always used for precision.
+        ACC_DTYPE: in-switch accumulator precision. Only tl.float32 is
+                   supported currently. The .acc::f32 PTX modifier is used
+                   for bf16/fp16 to preserve reduction precision.
 
     Returns:
         Tuple (v0, v1, v2, v3):
           - bf16/fp16: 4 × int32, each holding 2 packed reduced elements.
           - fp32: 4 × fp32 reduced values.
     """
+    tl.static_assert(OP == "sum", "multimem_ld_reduce: only OP='sum' is supported by hardware")
+    tl.static_assert(ACC_DTYPE == tl.float32, "multimem_ld_reduce: only ACC_DTYPE=tl.float32 is supported currently")
     if DTYPE == tl.bfloat16:
         return _multimem_ld_reduce_v4_bf16_acc32(ptr)
     elif DTYPE == tl.float16:
@@ -514,7 +521,7 @@ def multimem_ld_reduce(ptr, DTYPE: tl.constexpr):
         return _multimem_ld_reduce_v4_f32(ptr)
 ```
 
-After pasting, the rest of the kernel file uses `multimem_st(ptr, v0, v1, v2, v3, DTYPE)` / `multimem_ld_reduce(ptr, DTYPE)` directly. 
+After pasting, the rest of the kernel file uses `multimem_st(ptr, v0, v1, v2, v3, DTYPE)` / `multimem_ld_reduce(ptr, OP, DTYPE, ACC_DTYPE)` directly. 
 
 ---
 
@@ -526,7 +533,7 @@ After pasting, the rest of the kernel file uses `multimem_st(ptr, v0, v1, v2, v3
 - [ ] Kernel signature: `mc_ptr` declared as a plain scalar (Triton treats it as int64).
 - [ ] Inside kernel: `tl.multiple_of(mc_ptr, 16)` and offset alignment hints in place.
 - [ ] Push path: replaced the `for peer in range(world_size): tl.store(peer_buf, ...)` loop with a single `multimem_st(...)`.
-- [ ] Reduce path: replaced the hand-written `acc += tl.load(peer_buf, ...)` loop with `multimem_ld_reduce(..., op="sum", acc_dtype=tl.float32)`.
+- [ ] Reduce path: replaced the hand-written `acc += tl.load(peer_buf, ...)` loop with `multimem_ld_reduce(..., OP="sum", ACC_DTYPE=tl.float32)`.
 - [ ] Packing: bf16/fp16 v4 loads reinterpreted as 4 × int32; fp32 v4 passes 4 fp32 directly.
 - [ ] Barriers: grid-level + cross-rank barriers are still present around the multimem ops.
-- [ ] Dtype: `acc_dtype=tl.float32` used for bf16/fp16 reductions to preserve precision.
+- [ ] Dtype: `ACC_DTYPE=tl.float32` used for bf16/fp16 reductions to preserve precision.

--- a/.claude/skills/sglang-overlap-kernel-generation/references/multimem.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/multimem.md
@@ -1,0 +1,540 @@
+# Multimem (NVLS Hardware Multicast) Reference
+
+> **On-demand reference.** Load this file **only when** the user explicitly asks the collective communication portion (the "comm" half of intra-sm / inter-sm overlap) to use **multimem / NVLS / hardware multicast / in-network reduction**. Otherwise stay on the default `tl.store` + hand-written reduce path.
+
+> **Self-contained: do NOT import from `triton_dist`.** The generated kernel file must paste the implementations from §D directly. The only project-external dependencies remain `torch`, `torch.distributed`, `triton`, `triton.language`.
+
+This reference covers the three operations that drive NVSwitch in-network compute:
+
+- `hdl.multicast_ptr` — host-side, extract the multicast (MC) pointer from a symmetric-memory handle (it is a PyTorch symm_mem property, no extra import needed).
+- `multimem_st(ptr, val0[, val1, val2, val3], dtype=...)` — kernel-side, one PTX instruction broadcasts a value to **all** ranks. **Paste the implementation from §D into the generated file.**
+- `multimem_ld_reduce(ptr, op="sum", dtype=..., acc_dtype=tl.float32)` — kernel-side, one PTX instruction loads + reduces values **from all ranks** inside the NVSwitch fabric. **Paste the implementation from §D into the generated file.**
+
+The semantics are exactly equivalent to "N peer stores" / "N peer loads + sum" but cost **one** instruction and **zero** extra SM cycles on the issuer; the data movement and the reduction happen inside the switch.
+
+---
+
+## (A) API Quick Reference
+
+### A.1 Hardware / software prerequisites
+
+| Requirement | Minimum |
+|-------------|---------|
+| GPU | NVIDIA H100 or newer (SM 9.0+) |
+| Interconnect | NVSwitch V3+ with NVLink 4.0 Switch (NVLS-capable) |
+| CUDA | 12.3+ |
+| PyTorch | 2.11+ (symm_mem must expose `multicast_ptr`) |
+| Triton | 3.0+ |
+
+If any of the above is missing, `hdl.multicast_ptr` returns `0`. The host code **must** check for this and fall back to the default path (or raise a clear error). See §B.3.
+
+### A.2 Multicast pointer from symm_mem
+
+```python
+import torch.distributed._symmetric_memory as symm_mem
+
+buf = symm_mem.empty(M, N, dtype=dtype, device=device)
+hdl = symm_mem.rendezvous(buf, group=group.group_name)
+mc_ptr = hdl.multicast_ptr   # int64; 0 means "unsupported"
+```
+
+- Returns a Python `int` (already an `int64` device address). Pass it directly into a Triton kernel; Triton will treat it as an `int64` scalar — the kernel side should reinterpret it as `*` of the element dtype via `tl.cast(mc_ptr, tl.pointer_type(dtype))` (or just use pointer arithmetic on the `int64` and cast at the store/load site).
+- The pointer covers the **same logical region** as `hdl.get_buffer(...)`, i.e. byte offsets line up with the local symm_mem buffer.
+- This is a stock PyTorch API on the symm_mem handle. **Do not import any wrapper from triton_dist.**
+
+### A.3 `multimem_st(ptr, val0[, val1, val2, val3], dtype=...)`
+
+Three variants are selected by how many `val*` arguments you pass:
+
+| Variant | Args | PTX | Bytes written | Alignment of `ptr` |
+|---------|------|-----|---------------|--------------------|
+| scalar  | `val0`                         | `multimem.st.global.{suffix}`     | 4   | 4 B  |
+| v2      | `val0, val1`                   | `multimem.st.global.v2.{suffix}`  | 8   | 8 B  |
+| v4      | `val0, val1, val2, val3`       | `multimem.st.global.v4.{suffix}`  | 16  | **16 B** |
+
+Supported `dtype` (drives the PTX suffix):
+
+| `dtype`                  | PTX suffix | Per-register payload          |
+|--------------------------|------------|-------------------------------|
+| `tl.float32`             | `f32`      | 1 fp32 per reg → v4 = 4×fp32 (16 B) |
+| `tl.bfloat16`            | `bf16x2`   | 2 bf16 packed in 1 int32 reg → v4 = 8×bf16 (16 B) |
+| `tl.float16`             | `f16x2`    | 2 fp16 packed in 1 int32 reg → v4 = 8×fp16 (16 B) |
+| `tl.int32` / `tl.uint32` | `b32`      | 1 int32 per reg → v4 = 4×int32 (16 B) |
+| `tl.int64` / `tl.uint64` | `b64`      | 1 int64 per reg (scalar/v2 only) |
+
+Semantics: one instruction → the value lands at the same byte offset in **every** rank's symmetric-memory region. There is no per-rank loop, no `for peer in range(world_size)`. This is the key reason intra-sm push phases shrink from `O(world_size)` stores to `O(1)`.
+
+### A.4 `multimem_ld_reduce(ptr, op="sum", dtype=..., acc_dtype=tl.float32)`
+
+- `op`: **only `"sum"` is supported by hardware today** (`tl.static_assert` enforces this in the inlined source).
+- `dtype`: `tl.float32 | tl.bfloat16 | tl.float16` (integer reduce is not exposed here).
+- `acc_dtype`: `tl.float32` (recommended for bf16/fp16) or `tl.float16`. Adds the PTX `.acc::f32` / `.acc::f16` modifier so the in-switch accumulator runs in the requested precision regardless of payload dtype.
+- The default variant emitted is **v4**: returns a tuple `(v0, v1, v2, v3)` of the reduced values (16 B worth). For 4 B scalar loads use the lower-level `_multimem_ld_reduce_impl` (also inlined in §D).
+
+```python
+v0, v1, v2, v3 = multimem_ld_reduce(
+    mc_ptr + byte_off,            # pointer arithmetic in element units; see §C.4
+    op="sum",
+    dtype=tl.bfloat16,
+    acc_dtype=tl.float32,         # IMPORTANT for bf16/fp16
+)
+```
+
+One instruction → NVSwitch reads the value at this offset from every rank, sums them in network, returns the reduced result to the issuing thread. The N-1 cross-rank bandwidth that a naïve hand-written reduce would burn is saved.
+
+### A.5 Key performance properties
+
+- **1 instruction, all ranks.** No peer loop on the issuer side.
+- **Zero SM occupancy for the comm itself.** Compute can keep using the same warps; the switch does the broadcast / reduction.
+- **Bandwidth-optimal.** `multimem.st` consumes 1× NVLink BW for an N-rank broadcast (vs. N-1×). `multimem.ld_reduce` returns reduced data, saving (N-1)/N of the ingress BW.
+- **Alignment-sensitive.** Misaligned `ptr` produces undefined behaviour; the v4 path requires 16 B alignment of both `ptr` and the multicast region's base.
+- **Visibility model.** Multimem is a memory operation, not a barrier. Producer/consumer ordering across ranks **still requires** the same cross-rank barriers you would use with `tl.store` (see §C.5).
+
+---
+
+## (B) Host-side Setup
+
+### B.1 Extend the existing context dataclass
+
+Add `mc_ptr` next to the existing symm_mem fields. Do **not** remove the regular `peer_buf` / `signal_pad_ptrs` plumbing — multimem replaces only the bulk data movement, not the signaling.
+
+```python
+from dataclasses import dataclass
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+
+@dataclass
+class OverlapCtx:
+    # ... existing fields ...
+    symm_buf: torch.Tensor
+    hdl: object
+    signal_pad_ptrs: torch.Tensor
+    grid_barrier: torch.Tensor
+    # NEW: multicast pointer (int64 device address; 0 if unsupported)
+    mc_ptr: int
+```
+
+### B.2 Rendezvous + extract `mc_ptr`
+
+The order is fixed: `symm_mem.empty` → `symm_mem.rendezvous` → `hdl.multicast_ptr`. Accessing `multicast_ptr` before rendezvous is undefined.
+
+```python
+def create_overlap_context(M, N, dtype, group, device):
+    world_size = dist.get_world_size(group)
+
+    # 1. Allocate symmetric memory (shape selection per SKILL.md table)
+    symm_buf = symm_mem.empty(M, N, dtype=dtype, device=device)
+
+    # 2. Rendezvous across the group
+    hdl = symm_mem.rendezvous(symm_buf, group=group.group_name)
+
+    # 3. Extract multicast pointer (must come AFTER rendezvous)
+    mc_ptr = hdl.multicast_ptr      # stock PyTorch API; no triton_dist import
+
+    # 4. Same signal-pad / grid-barrier plumbing as the default path
+    signal_pad_ptrs = torch.tensor(
+        [hdl.get_signal_pad(i, (world_size,), torch.int32).data_ptr()
+         for i in range(world_size)],
+        dtype=torch.int64, device=device,
+    )
+    grid_barrier = torch.zeros(1, dtype=torch.int32, device=device)
+
+    return OverlapCtx(
+        symm_buf=symm_buf,
+        hdl=hdl,
+        signal_pad_ptrs=signal_pad_ptrs,
+        grid_barrier=grid_barrier,
+        mc_ptr=mc_ptr,
+    )
+```
+
+### B.3 Runtime support check
+
+```python
+ctx = create_overlap_context(...)
+if ctx.mc_ptr == 0:
+    raise RuntimeError(
+        "Multimem (NVLS) is not supported on this system: "
+        "requires H100+ GPU, NVSwitch V3+, CUDA 12.3+, and PyTorch 2.11+. "
+        "Re-run without the --multimem flag to use the default tl.store path."
+    )
+```
+
+For a richer pre-flight diagnostic you may probe `torch.cuda.get_device_capability()[0] >= 9` and `torch.version.cuda` before allocating anything. Keep the check inline; do not import any helper from triton_dist.
+
+### B.4 Passing `mc_ptr` into the kernel
+
+```python
+kernel[grid](
+    # ... regular tensor args ...
+    ctx.signal_pad_ptrs,
+    ctx.grid_barrier,
+    ctx.mc_ptr,           # plain int64; Triton accepts it as a scalar arg
+    M, N,
+    num_warps=32,
+    num_stages=1,
+)
+```
+
+The kernel signature simply declares it as a regular argument (no special annotation). Inside the kernel, treat `mc_ptr` as an `int64` device address and apply byte-offset arithmetic, then cast to the appropriate pointer type at the store/load site (see §C).
+
+---
+
+## (C) Kernel-side Usage
+
+### C.1 Where the implementations come from
+
+**Do not import `multimem_st` / `multimem_ld_reduce` from any external module.** Paste the source from §D verbatim into the generated kernel file's "PTX Primitives" section (the first of the four sections defined in `references/kernel_format.md`). After that, just use the names:
+
+```python
+import triton
+import triton.language as tl
+# (Paste the helpers + multimem_st + multimem_ld_reduce from §D here.)
+
+@triton.jit
+def my_overlap_kernel(...):
+    ...
+    multimem_st(mc_addr, v0, v1, v2, v3, dtype=tl.bfloat16)
+    a, b, c, d = multimem_ld_reduce(mc_addr, op="sum",
+                                     dtype=tl.bfloat16, acc_dtype=tl.float32)
+```
+
+### C.2 Replacing the intra-sm "push" phase
+
+Default intra-sm pattern — one store per peer (`O(world_size)` traffic on the issuer):
+
+```python
+# BEFORE: hand-written push to every peer
+for peer in tl.static_range(WORLD_SIZE):
+    peer_ptr = tl.load(peer_buf_ptrs + peer).to(tl.pointer_type(tl.bfloat16))
+    tl.store(peer_ptr + dst_off + cols, vals, mask=mask)
+```
+
+Multimem-equivalent — one instruction broadcasts to every peer:
+
+```python
+# AFTER: single multimem store, switch broadcasts to all ranks
+# vals must be already packed into 4 registers (16 B). For bf16, that's 8 bf16
+# elements packed as 4 × int32 (see §C.4).
+mc_addr = mc_ptr + (dst_off + cols_base) * tl.constexpr(2)  # byte offset for bf16
+tl.multiple_of(mc_addr, 16)
+multimem_st(mc_addr, v0, v1, v2, v3, dtype=tl.bfloat16)
+```
+
+Behavioural consequences:
+
+- The per-CTA push cost drops from `world_size × store` to `1 × store`.
+- The cross-rank barrier you used after the push loop is still needed (see §C.5).
+- If the local rank also needs the value, multimem already wrote it to the local symm_mem region — no extra `tl.store` to the local buffer.
+
+### C.3 Replacing the reduce phase (reduce-scatter / all-reduce)
+
+Default pattern — load from every peer, sum in registers:
+
+```python
+acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+for peer in tl.static_range(WORLD_SIZE):
+    peer_ptr = tl.load(peer_buf_ptrs + peer).to(tl.pointer_type(tl.bfloat16))
+    acc += tl.load(peer_ptr + src_off + cols, mask=mask, other=0.0).to(tl.float32)
+out = acc.to(tl.bfloat16)
+tl.store(out_ptr + ..., out, mask=mask)
+```
+
+Multimem-equivalent — one instruction loads + sums in the switch:
+
+```python
+mc_addr = mc_ptr + (src_off + cols_base) * tl.constexpr(2)
+tl.multiple_of(mc_addr, 16)
+v0, v1, v2, v3 = multimem_ld_reduce(
+    mc_addr, op="sum", dtype=tl.bfloat16, acc_dtype=tl.float32,
+)
+# v0..v3 are bf16 values (returned as 4 × int32 holding 8 bf16 elements).
+# Either store them back to the local output via 4 × tl.store, or repack
+# into a vector and store once (preferred).
+```
+
+Notes:
+
+- `acc_dtype=tl.float32` is required for bf16/fp16 to match the precision rules already enforced by the SKILL.md "Accumulator dtype" check.
+- `op="sum"` is the only operation currently supported by hardware. For mean/scaling, do the divide **after** `multimem_ld_reduce` returns (in fp32, then cast).
+
+### C.4 Data packing rules (the 16-byte unit)
+
+`multimem_st` / `multimem_ld_reduce` always operate on 4 registers in the v4 path. The mapping from "elements" to "registers" depends on dtype:
+
+| dtype          | Elements per `multimem_*_v4` call | How to obtain the 4 values |
+|----------------|------------------------------------|----------------------------|
+| `tl.float32`   | 4                                  | Load 4 fp32 elements as a 4-vector, unpack into `v0..v3`. |
+| `tl.bfloat16`  | 8                                  | Reinterpret 8 bf16 as 4 × int32, pass the 4 int32 values. The PTX suffix `bf16x2` tells the switch to treat each int32 as 2 bf16. |
+| `tl.float16`   | 8                                  | Same as bf16 but with `dtype=tl.float16` → PTX suffix `f16x2`. |
+
+Practical loading pattern for bf16:
+
+```python
+# Load 8 bf16 values as 4 packed int32s
+data_i32 = tl.load(
+    (input_ptr + src_off + cols_base).to(tl.pointer_type(tl.int32)),
+    mask=mask_i32,
+    other=0,
+)  # shape [..., 4], dtype int32, each int32 = 2 bf16
+
+multimem_st(mc_addr, data_i32[..., 0], data_i32[..., 1],
+            data_i32[..., 2], data_i32[..., 3], dtype=tl.bfloat16)
+```
+
+For fp32 you skip the packing and pass the 4 fp32 values directly.
+
+#### Scalar (per-row) loading: use `ld.global.v4` instead of 4× `tl.load`
+
+When the multimem push is done in a serial per-row loop (e.g., inter-SM comm kernel iterating `tl.static_range(0, BLOCK_M)` rows × `tl.static_range(0, N_I32_PER_ROW, 4)` groups), each iteration loads 4 scalar int32 values and passes them to `multimem_st`. **Do NOT use 4 separate `tl.load` calls** — this generates 4 independent load instructions and wastes memory bandwidth.
+
+Instead, use a single `ld.global.v4.b32` inline-asm helper that loads 16 bytes in one instruction:
+
+```python
+@triton.jit
+def _load_v4_b32(ptr):
+    """ld.global.v4.b32 — load 4 × int32 (16 bytes) in one instruction."""
+    return tl.inline_asm_elementwise(
+        asm="ld.global.v4.b32 {$0,$1,$2,$3}, [$4];",
+        constraints="=r,=r,=r,=r,l",
+        args=[ptr],
+        dtype=(tl.int32, tl.int32, tl.int32, tl.int32),
+        is_pure=True, pack=1)
+```
+
+Usage:
+
+```python
+# GOOD: one v4 load → one multimem_st (16 B load + 16 B broadcast)
+load_addr = buf_i32_ptr + row_i32_off + g
+v0, v1, v2, v3 = _load_v4_b32(load_addr)
+multimem_st(mc_addr, v0, v1, v2, v3, DTYPE)
+
+# BAD: 4 × scalar tl.load (generates 4 separate ld.global.b32 instructions)
+v0 = tl.load(buf_i32_ptr + row_i32_off + g)
+v1 = tl.load(buf_i32_ptr + row_i32_off + g + 1)
+v2 = tl.load(buf_i32_ptr + row_i32_off + g + 2)
+v3 = tl.load(buf_i32_ptr + row_i32_off + g + 3)
+```
+
+This pairs the 16 B vectorized load with the 16 B `multimem_st`, maximizing memory bandwidth utilization. The `_load_v4_b32` helper should be included in the PTX Primitives section of the generated kernel file whenever the multimem push uses scalar per-row iteration.
+
+### C.5 Alignment hints & offset rules
+
+These hints are **mandatory** for the v4 variant — the PTX instruction is UB on misaligned addresses.
+
+```python
+tl.multiple_of(mc_ptr, 16)              # base pointer is 16 B aligned
+tl.multiple_of(byte_offset, 16)         # the offset added to it is also 16 B aligned
+tl.max_contiguous(cols_base, 16)        # helps the compiler vectorize the surrounding loads
+```
+
+Rules of thumb when computing offsets:
+
+- Keep `BLOCK_N` such that one tile row spans an integer number of 16 B groups (i.e. multiple of 8 for bf16/fp16, multiple of 4 for fp32).
+- Compute offsets in elements, then multiply by `element_size` when adding to `mc_ptr` (which is in bytes). Use `tl.cast(off, tl.int64)` when the multiplication could overflow int32 (see SKILL.md "Overflow in offsets" check).
+- Place the `tl.multiple_of` hint immediately before the `multimem_st` / `multimem_ld_reduce` call so the compiler does not lose it through intermediate ops.
+
+### C.6 Synchronization is still required
+
+`multimem_st` is a memory store, not a release. `multimem_ld_reduce` is a memory load, not an acquire. Cross-rank visibility is not free.
+
+Keep the existing primitives from `primitives.md`:
+
+- After a multimem push, run the **cross-rank barrier** (`barrier_all_intra_node_atomic_cas_block` or equivalent) before any consumer issues `multimem_ld_reduce` / peer loads.
+- After a producer CTA finishes its tile, still do the **grid-level barrier** (`barrier_on_this_grid`) before the consumer phase begins on the same rank.
+- The signal-pad / CAS protocol is unchanged; multimem only swaps out the bulk data ops.
+
+A correct intra-sm reduce-scatter sequence with multimem becomes:
+
+```
+1. compute tile → results in regs
+2. multimem_st  (push results to all ranks' symm_buf at this tile offset)
+3. barrier_on_this_grid                     # local CTAs synced
+4. barrier_all_intra_node_atomic_cas_block  # cross-rank synced
+5. multimem_ld_reduce on the rows assigned to this rank
+6. cast + tl.store to the final output tensor
+```
+
+Skipping step 3 or step 4 is the most common cause of intermittent wrong results when migrating from the default path to multimem.
+
+---
+
+## (D) Inlined Implementation Source (paste into the generated kernel file)
+
+Copy the block below verbatim into the **PTX Primitives** section of the generated file. It only depends on `triton` and `triton.language` — no triton_dist, no nvshmem, no other project module.
+
+```python
+import triton
+import triton.language as tl
+
+
+# ---------------------------------------------------------------------------
+# multimem.st — v4 variants (16 B broadcast to all ranks)
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def _multimem_st_v4_bf16(ptr, val0, val1, val2, val3):
+    """multimem.st.global.v4.bf16x2 [ptr], {val0, val1, val2, val3};
+    Each val is an int32 holding 2 packed bf16 values. Total: 8 bf16 = 16 B.
+    """
+    tl.inline_asm_elementwise(
+        asm="""
+        multimem.st.global.v4.bf16x2 [$1], {$2, $3, $4, $5};
+        mov.u32 $0, 0;
+        """,
+        constraints="=r,l,r,r,r,r",
+        args=[ptr, val0, val1, val2, val3],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _multimem_st_v4_f16(ptr, val0, val1, val2, val3):
+    """multimem.st.global.v4.f16x2 [ptr], {val0, val1, val2, val3};
+    Each val is an int32 holding 2 packed fp16 values. Total: 8 fp16 = 16 B.
+    """
+    tl.inline_asm_elementwise(
+        asm="""
+        multimem.st.global.v4.f16x2 [$1], {$2, $3, $4, $5};
+        mov.u32 $0, 0;
+        """,
+        constraints="=r,l,r,r,r,r",
+        args=[ptr, val0, val1, val2, val3],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _multimem_st_v4_f32(ptr, val0, val1, val2, val3):
+    """multimem.st.global.v4.f32 [ptr], {val0, val1, val2, val3};
+    Each val is one fp32. Total: 4 fp32 = 16 B.
+    """
+    tl.inline_asm_elementwise(
+        asm="""
+        multimem.st.global.v4.f32 [$1], {$2, $3, $4, $5};
+        mov.u32 $0, 0;
+        """,
+        constraints="=r,l,f,f,f,f",
+        args=[ptr, val0, val1, val2, val3],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def multimem_st(ptr, val0, val1, val2, val3, DTYPE: tl.constexpr):
+    """Store 16B to all ranks via NVLS multicast (v4 variant, one PTX instruction).
+
+    Args:
+        ptr: multicast pointer (byte address, 16 B aligned).
+        val0-val3: 4 register values. For bf16/fp16: each is int32 holding 2 packed elements.
+                   For fp32: each is one fp32 value.
+        DTYPE: tl.bfloat16 / tl.float16 / tl.float32 — selects the PTX suffix.
+    """
+    if DTYPE == tl.bfloat16:
+        _multimem_st_v4_bf16(ptr, val0, val1, val2, val3)
+    elif DTYPE == tl.float16:
+        _multimem_st_v4_f16(ptr, val0, val1, val2, val3)
+    elif DTYPE == tl.float32:
+        _multimem_st_v4_f32(ptr, val0, val1, val2, val3)
+
+
+# ---------------------------------------------------------------------------
+# multimem.ld_reduce — v4 variants (16 B in-switch reduction from all ranks)
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def _multimem_ld_reduce_v4_bf16_acc32(ptr):
+    """multimem.ld_reduce.global.add.acc::f32.v4.bf16x2 {r0,r1,r2,r3}, [ptr];
+    Returns 4 × int32, each holding 2 reduced bf16 values (8 bf16 total = 16 B).
+    The .acc::f32 modifier ensures the in-switch accumulator runs in fp32.
+    """
+    return tl.inline_asm_elementwise(
+        asm="multimem.ld_reduce.global.add.acc::f32.v4.bf16x2 {$0,$1,$2,$3}, [$4];",
+        constraints="=r,=r,=r,=r,l",
+        args=[ptr],
+        dtype=(tl.int32, tl.int32, tl.int32, tl.int32),
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _multimem_ld_reduce_v4_f16_acc32(ptr):
+    """multimem.ld_reduce.global.add.acc::f32.v4.f16x2 {r0,r1,r2,r3}, [ptr];
+    Returns 4 × int32, each holding 2 reduced fp16 values (8 fp16 total = 16 B).
+    """
+    return tl.inline_asm_elementwise(
+        asm="multimem.ld_reduce.global.add.acc::f32.v4.f16x2 {$0,$1,$2,$3}, [$4];",
+        constraints="=r,=r,=r,=r,l",
+        args=[ptr],
+        dtype=(tl.int32, tl.int32, tl.int32, tl.int32),
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _multimem_ld_reduce_v4_f32(ptr):
+    """multimem.ld_reduce.global.add.v4.f32 {r0,r1,r2,r3}, [ptr];
+    Returns 4 × fp32 reduced values (16 B total).
+    """
+    return tl.inline_asm_elementwise(
+        asm="multimem.ld_reduce.global.add.v4.f32 {$0,$1,$2,$3}, [$4];",
+        constraints="=f,=f,=f,=f,l",
+        args=[ptr],
+        dtype=(tl.float32, tl.float32, tl.float32, tl.float32),
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def multimem_ld_reduce(ptr, DTYPE: tl.constexpr):
+    """Load + in-switch reduce from all ranks (v4 variant, one PTX instruction).
+
+    NVSwitch reads 16 B at `ptr` from every rank, sums them in network, and
+    returns the reduced 16 B to the issuing thread.
+
+    Args:
+        ptr: multicast pointer (byte address, 16 B aligned).
+        DTYPE: tl.bfloat16 / tl.float16 / tl.float32 — selects the PTX suffix.
+               For bf16/fp16, .acc::f32 is always used for precision.
+
+    Returns:
+        Tuple (v0, v1, v2, v3):
+          - bf16/fp16: 4 × int32, each holding 2 packed reduced elements.
+          - fp32: 4 × fp32 reduced values.
+    """
+    if DTYPE == tl.bfloat16:
+        return _multimem_ld_reduce_v4_bf16_acc32(ptr)
+    elif DTYPE == tl.float16:
+        return _multimem_ld_reduce_v4_f16_acc32(ptr)
+    elif DTYPE == tl.float32:
+        return _multimem_ld_reduce_v4_f32(ptr)
+```
+
+After pasting, the rest of the kernel file uses `multimem_st(ptr, v0, v1, v2, v3, DTYPE)` / `multimem_ld_reduce(ptr, DTYPE)` directly. No imports from `triton_dist.kernels.nvidia.multimem_api` should appear anywhere in the generated file.
+
+---
+
+## Checklist when generating a multimem-enabled overlap kernel
+
+- [ ] Source from §D is pasted into the file's PTX Primitives section; **no** `from triton_dist...multimem_api import ...` statement is present.
+- [ ] Host: accessed `hdl.multicast_ptr` **after** `symm_mem.rendezvous`, stored in `ctx.mc_ptr`.
+- [ ] Host: runtime check `ctx.mc_ptr != 0` with a clear error message.
+- [ ] Kernel signature: `mc_ptr` declared as a plain scalar (Triton treats it as int64).
+- [ ] Inside kernel: `tl.multiple_of(mc_ptr, 16)` and offset alignment hints in place.
+- [ ] Push path: replaced the `for peer in range(world_size): tl.store(peer_buf, ...)` loop with a single `multimem_st(...)`.
+- [ ] Reduce path: replaced the hand-written `acc += tl.load(peer_buf, ...)` loop with `multimem_ld_reduce(..., op="sum", acc_dtype=tl.float32)`.
+- [ ] Packing: bf16/fp16 v4 loads reinterpreted as 4 × int32; fp32 v4 passes 4 fp32 directly.
+- [ ] Barriers: grid-level + cross-rank barriers are still present around the multimem ops.
+- [ ] Dtype: `acc_dtype=tl.float32` used for bf16/fp16 reductions to preserve precision.

--- a/.claude/skills/sglang-overlap-kernel-generation/references/multimem.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/multimem.md
@@ -2,7 +2,7 @@
 
 > **On-demand reference.** Load this file **only when** the user explicitly asks the collective communication portion (the "comm" half of intra-sm / inter-sm overlap) to use **multimem / NVLS / hardware multicast / in-network reduction**. Otherwise stay on the default `tl.store` + hand-written reduce path.
 
-> **Self-contained: do NOT import from `triton_dist`.** The generated kernel file must paste the implementations from §D directly. The only project-external dependencies remain `torch`, `torch.distributed`, `triton`, `triton.language`.
+> **Self-contained** The generated kernel file must paste the implementations from §D directly. The only project-external dependencies remain `torch`, `torch.distributed`, `triton`, `triton.language`.
 
 This reference covers the three operations that drive NVSwitch in-network compute:
 
@@ -16,17 +16,9 @@ The semantics are exactly equivalent to "N peer stores" / "N peer loads + sum" b
 
 ## (A) API Quick Reference
 
-### A.1 Hardware / software prerequisites
+### A.1 Prerequisites
 
-| Requirement | Minimum |
-|-------------|---------|
-| GPU | NVIDIA H100 or newer (SM 9.0+) |
-| Interconnect | NVSwitch V3+ with NVLink 4.0 Switch (NVLS-capable) |
-| CUDA | 12.3+ |
-| PyTorch | 2.11+ (symm_mem must expose `multicast_ptr`) |
-| Triton | 3.0+ |
-
-If any of the above is missing, `hdl.multicast_ptr` returns `0`. The host code **must** check for this and fall back to the default path (or raise a clear error). See §B.3.
+If `hdl.multicast_ptr` returns `0`. The host code **must** check for this and fall back to the default path (or raise a clear error). See §B.3.
 
 ### A.2 Multicast pointer from symm_mem
 
@@ -40,7 +32,7 @@ mc_ptr = hdl.multicast_ptr   # int64; 0 means "unsupported"
 
 - Returns a Python `int` (already an `int64` device address). Pass it directly into a Triton kernel; Triton will treat it as an `int64` scalar — the kernel side should reinterpret it as `*` of the element dtype via `tl.cast(mc_ptr, tl.pointer_type(dtype))` (or just use pointer arithmetic on the `int64` and cast at the store/load site).
 - The pointer covers the **same logical region** as `hdl.get_buffer(...)`, i.e. byte offsets line up with the local symm_mem buffer.
-- This is a stock PyTorch API on the symm_mem handle. **Do not import any wrapper from triton_dist.**
+- This is a stock PyTorch API on the symm_mem handle. 
 
 ### A.3 `multimem_st(ptr, val0[, val1, val2, val3], dtype=...)`
 
@@ -131,7 +123,7 @@ def create_overlap_context(M, N, dtype, group, device):
     hdl = symm_mem.rendezvous(symm_buf, group=group.group_name)
 
     # 3. Extract multicast pointer (must come AFTER rendezvous)
-    mc_ptr = hdl.multicast_ptr      # stock PyTorch API; no triton_dist import
+    mc_ptr = hdl.multicast_ptr      # stock PyTorch API
 
     # 4. Same signal-pad / grid-barrier plumbing as the default path
     signal_pad_ptrs = torch.tensor(
@@ -162,7 +154,7 @@ if ctx.mc_ptr == 0:
     )
 ```
 
-For a richer pre-flight diagnostic you may probe `torch.cuda.get_device_capability()[0] >= 9` and `torch.version.cuda` before allocating anything. Keep the check inline; do not import any helper from triton_dist.
+For a richer pre-flight diagnostic you may probe `torch.cuda.get_device_capability()[0] >= 9` and `torch.version.cuda` before allocating anything.
 
 ### B.4 Passing `mc_ptr` into the kernel
 
@@ -364,7 +356,7 @@ Skipping step 3 or step 4 is the most common cause of intermittent wrong results
 
 ## (D) Inlined Implementation Source (paste into the generated kernel file)
 
-Copy the block below verbatim into the **PTX Primitives** section of the generated file. It only depends on `triton` and `triton.language` — no triton_dist, no nvshmem, no other project module.
+Copy the block below verbatim into the **PTX Primitives** section of the generated file. It only depends on `triton` and `triton.language` — no nvshmem, no other project module.
 
 ```python
 import triton
@@ -522,13 +514,13 @@ def multimem_ld_reduce(ptr, DTYPE: tl.constexpr):
         return _multimem_ld_reduce_v4_f32(ptr)
 ```
 
-After pasting, the rest of the kernel file uses `multimem_st(ptr, v0, v1, v2, v3, DTYPE)` / `multimem_ld_reduce(ptr, DTYPE)` directly. No imports from `triton_dist.kernels.nvidia.multimem_api` should appear anywhere in the generated file.
+After pasting, the rest of the kernel file uses `multimem_st(ptr, v0, v1, v2, v3, DTYPE)` / `multimem_ld_reduce(ptr, DTYPE)` directly. 
 
 ---
 
 ## Checklist when generating a multimem-enabled overlap kernel
 
-- [ ] Source from §D is pasted into the file's PTX Primitives section; **no** `from triton_dist...multimem_api import ...` statement is present.
+- [ ] Source from §D is pasted into the file's PTX Primitives section; 
 - [ ] Host: accessed `hdl.multicast_ptr` **after** `symm_mem.rendezvous`, stored in `ctx.mc_ptr`.
 - [ ] Host: runtime check `ctx.mc_ptr != 0` with a clear error message.
 - [ ] Kernel signature: `mc_ptr` declared as a plain scalar (Triton treats it as int64).

--- a/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
@@ -523,7 +523,12 @@ Rule of thumb: any flag whose **point** is to advertise "data is ready" pairs **
 | `barrier_all_intra_node_atomic_cas_block` | ❌ (use host-side `symm_mem_hdl.barrier()`) | ✅ (after grid barrier) | — |
 | `symm_mem_hdl.barrier()` (host-side) | ✅ (around `signal.zero_()`) | ❌ (use in-kernel rank barrier) | ✅ (between iterations) |
 | `tl.debug_barrier()` | ✅ | ✅ | — |
+| `ld_sys` / `st_sys` / `__syncthreads` | — | — | ✅ (signal polling & writing) |
+| `stream_write_value32` / `cuStreamWaitValue32` | — | — | ✅ (CE-side signal ops) |
 
-Without-sm relies on `hdl.barrier()` on the host side and copy-engine `cuStreamWriteValue32` progress polling instead of in-kernel barriers, so it does not pull from this catalog.
+Without-sm does NOT pull from the inter-sm/intra-sm primitives in this catalog. Instead, it uses:
+- **Kernel-side**: `ld_sys` (`ld.global.acquire.sys.b32`) for signal polling, `st_sys` (`st.global.release.sys.b32`) for signal writing, and `__syncthreads` / `tid` helpers — all defined directly in `references/without_sm.md`.
+- **CE-side (host)**: `symm_mem_hdl.stream_write_value32` (comm-first) or `cuda.bindings.driver.cuStreamWaitValue32` (comp-first) for CPU-side CE signal operations.
+- **Cross-rank sync**: `symm_mem_hdl.barrier()` (host-side) around `signal.zero_()` / `progress.fill_(0)` between iterations.
 
 Both inter-sm and without-sm use host-side `symm_mem_hdl.barrier()` (around `signal.zero_()`) for cross-rank synchronization between iterations, since neither has a subsequent in-kernel phase after communication completes.

--- a/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
@@ -1,6 +1,6 @@
 # Shared Primitives Library
 
-This file is the **single source of truth** for all low-level synchronization helpers used by `inter-sm` and `intra-sm` overlap kernels — thread/block ID helpers, PTX inline-asm atomics, signals, and the three-level barrier hierarchy.
+This file is the **single source of truth** for all low-level synchronization helpers used by `inter-sm`, `intra-sm`, and `without-sm` overlap kernels — thread/block ID helpers, PTX inline-asm atomics, signals, system-scope load/store, and the three-level barrier hierarchy.
 
 Read this file whenever you are about to emit any of these helpers into a generated kernel, regardless of which mode you picked. The mode files (`inter_sm.md`, `intra_sm.md`) reference primitives by name and only describe *how* they are composed.
 
@@ -10,13 +10,14 @@ Read this file whenever you are about to emit any of these helpers into a genera
 2. [Thread/Block ID helpers](#2-threadblock-id-helpers)
 3. [GPU-scope memory ordering atomics](#3-gpu-scope-memory-ordering-atomics)
 4. [System-scope CAS (cross-rank)](#4-system-scope-cas-cross-rank)
-5. [Three-level barrier hierarchy](#5-three-level-barrier-hierarchy)
-   - 5.1 Thread-level (intra-CTA)
-   - 5.2 CTA-Grid level: `barrier_on_this_grid`
-   - 5.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
-6. [Per-tile signal pattern (inter-sm only)](#6-per-tile-signal-pattern-inter-sm-only)
-7. [Memory order rules — when to use release / acquire / relaxed](#7-memory-order-rules)
-8. [Which primitives each mode needs (quick reference)](#8-which-primitives-each-mode-needs)
+5. [System-scope load/store (without-sm)](#5-system-scope-loadstore-without-sm)
+6. [Three-level barrier hierarchy](#6-three-level-barrier-hierarchy)
+   - 6.1 Thread-level (intra-CTA)
+   - 6.2 CTA-Grid level: `barrier_on_this_grid`
+   - 6.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
+7. [Per-tile signal pattern (inter-sm only)](#7-per-tile-signal-pattern-inter-sm-only)
+8. [Memory order rules — when to use release / acquire / relaxed](#8-memory-order-rules)
+9. [Which primitives each mode needs (quick reference)](#9-which-primitives-each-mode-needs)
 
 ---
 
@@ -56,6 +57,61 @@ def _get_flat_bid():
         tl.program_id(2) * tl.num_programs(1) * tl.num_programs(0)
         + tl.program_id(1) * tl.num_programs(0)
         + tl.program_id(0)
+    )
+```
+
+### `tid`
+
+Lightweight per-axis thread index accessor. Used in without-sm mode where only a single axis tid is needed (e.g., `tid(0) == 0` to gate signal polling to one thread).
+
+```python
+@triton.jit
+def tid(axis: tl.constexpr = 0):
+    """PTX threadIdx.x/y/z."""
+    if axis == 0:
+        return tl.inline_asm_elementwise(
+            asm="mov.u32 $0, %tid.x;",
+            constraints=("=r"),
+            args=[],
+            dtype=tl.int32,
+            is_pure=True,
+            pack=1,
+        )
+    elif axis == 1:
+        return tl.inline_asm_elementwise(
+            asm="mov.u32 $0, %tid.y;",
+            constraints=("=r"),
+            args=[],
+            dtype=tl.int32,
+            is_pure=True,
+            pack=1,
+        )
+    else:
+        return tl.inline_asm_elementwise(
+            asm="mov.u32 $0, %tid.z;",
+            constraints=("=r"),
+            args=[],
+            dtype=tl.int32,
+            is_pure=True,
+            pack=1,
+        )
+```
+
+### `__syncthreads`
+
+PTX `bar.sync` — block-level `__syncthreads`. Used in without-sm mode to broadcast a signal poll result from one thread to all threads in the CTA.
+
+```python
+@triton.jit
+def __syncthreads():
+    """PTX bar.sync (block-level __syncthreads)."""
+    tl.inline_asm_elementwise(
+        asm="bar.sync 0;",
+        constraints="=r",
+        args=[],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
     )
 ```
 
@@ -202,11 +258,70 @@ while old != 0:
 
 ---
 
-## 5. Three-level barrier hierarchy
+## 5. System-scope load/store (without-sm)
+
+These helpers are used by without-sm (copy engine) overlap kernels. The compute kernel needs `ld_sys` to poll signals written by the CE (cross-GPU PtoP copy or `cuStreamWriteValue32`), and `st_sys` to write per-tile completion signals that the CE waits on via `cuStreamWaitValue32`.
+
+Plain `tl.load` / `tl.store` lack cross-device visibility guarantees — the L2 cache may return stale data when the writer is on a different GPU. System-scope acquire/release is required.
+
+### `ld_sys`
+
+```python
+@triton.jit
+def ld_sys(ptr):
+    """ld.global.acquire.sys.b32 — system-scope acquire load.
+
+    Required for reading signals written by the CE (cross-GPU PtoP copy or
+    cuStreamWriteValue32). Plain tl.load does NOT guarantee visibility of
+    writes that arrived over NVLink — the L2 cache may return stale data.
+    """
+    return tl.inline_asm_elementwise(
+        asm="ld.global.acquire.sys.b32 $0, [$1];",
+        constraints="=r,l",
+        args=[ptr],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+```
+
+### `st_sys`
+
+```python
+@triton.jit
+def st_sys(ptr, val):
+    """st.global.release.sys.b32 — system-scope release store.
+
+    Used by the compute kernel (comp-first path) to write a per-tile signal
+    that the CE waits on via cuStreamWaitValue32. Release semantics ensure
+    all prior tl.store (tile data) are visible before the signal write.
+    """
+    tl.inline_asm_elementwise(
+        asm="""
+        st.global.release.sys.b32 [$1], $2;
+        mov.u32 $0, 0;
+        """,
+        constraints="=r,l,r",
+        args=[ptr, val],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+```
+
+**Memory ordering rationale:**
+- `ld_sys` → `ld.global.acquire.sys`: the CE's `stream_write_value32` or PtoP `copy_()` is a release operation; the compute kernel's acquire load ensures it sees the data that was copied before the signal was written.
+- `st_sys` → `st.global.release.sys`: the compute kernel's release store ensures all prior tile data stores are visible before the signal `1` becomes observable by the CE's `cuStreamWaitValue32`.
+
+**Why `st_sys` instead of `_send_signal` (CAS)?** In without-sm comp-first mode, each tile has exactly one writer (the CTA that computed it), and the signal tensor is reset to 0 before each launch. So there is no contention — a simple store suffices. The CAS spin-loop in `_send_signal` is overkill and adds latency.
+
+---
+
+## 6. Three-level barrier hierarchy
 
 A kernel that synchronizes "everyone" must say *which* "everyone": threads in this CTA, CTAs on this device, or ranks across devices. Pick the smallest scope that covers your data dependency.
 
-### 5.1 Thread-level (intra-CTA)
+### 6.1 Thread-level (intra-CTA)
 
 Built-in. Use `tl.debug_barrier()` to re-converge threads after warp-divergent control flow, or to broadcast a value written by `if flat_tid == 0` to the rest of the CTA. No custom helper needed.
 
@@ -216,7 +331,7 @@ if flat_tid == 0:
 tl.debug_barrier()  # broadcast readiness to all threads in CTA
 ```
 
-### 5.2 CTA-Grid level: `barrier_on_this_grid`
+### 6.2 CTA-Grid level: `barrier_on_this_grid`
 
 Synchronizes all CTAs in a single kernel launch **without** requiring `cooperative_groups`. Uses a split-counter pattern: each CTA atomically increments a global counter; the master CTA (`bid == 0`) spins until all arrive, then flips the high bit to release everyone.
 
@@ -252,7 +367,7 @@ num_ctas = min(total_tiles, num_sm)  # conservative: assume 1 CTA/SM
 # or query actual occupancy and use: min(total_tiles, num_sm * occupancy)
 ```
 
-### 5.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
+### 6.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
 
 The single canonical cross-rank barrier used by both `inter-sm` and `intra-sm` kernels. Each CTA independently participates: thread `i` (where `i < local_world_size`) signals peer `i` by CAS(0→1) on the peer's barrier slot for our rank, then waits for the peer to signal us back by CAS(1→0) on our own slot.
 
@@ -327,7 +442,7 @@ if flat_tid == 0:
 
 > **Note on naming**: an older variant `barrier_all_intra_node_atomic_cas_block_symm_mem` (with `(rank, num_ranks, symm_flag_ptr, peer_barrier_ptrs)` signature, using Python-level `while atomic_cas(...) != 0` spin-loops) appeared in earlier drafts. It is superseded by the function above — same semantics, faster spin-loop, fewer arguments. Always emit the canonical form.
 
-### 5.4 Host-side cross-rank barrier: `symm_mem_hdl.barrier()`
+### 6.4 Host-side cross-rank barrier: `symm_mem_hdl.barrier()`
 
 When a kernel does **not** have a subsequent in-kernel phase after communication (i.e., the kernel exits once the communication phase is done), use **host-side** `symm_mem_hdl.barrier()` instead of the in-kernel `barrier_all_intra_node_atomic_cas_block`. This is the standard PyTorch symmetric memory barrier and is the correct choice for **inter-sm** and **without-sm** modes.
 
@@ -414,7 +529,7 @@ For overlap kernels, `channel=0` is typically sufficient. The number of channels
 
 ---
 
-## 6. Per-tile signal pattern (inter-sm only)
+## 7. Per-tile signal pattern (inter-sm only)
 
 The inter-sm mode uses an additional **per-tile** signal protocol on top of the rank barrier: the producer kernel stores 1 to a signal slot as each tile completes, the consumer kernel spins on it before consuming. This is what enables fine-grained pipelining between two kernels on different streams.
 
@@ -495,7 +610,7 @@ The signal tensor is reset by the host via `.zero_()` before each launch. `_send
 
 ---
 
-## 7. Memory order rules
+## 8. Memory order rules
 
 | Operation | Order | Why |
 |---|---|---|
@@ -510,25 +625,22 @@ Rule of thumb: any flag whose **point** is to advertise "data is ready" pairs **
 
 ---
 
-## 8. Which primitives each mode needs
+## 9. Which primitives each mode needs
 
 | Primitive | inter-sm | intra-sm | without-sm |
 |---|:---:|:---:|:---:|
 | `_get_flat_tid` | ✅ | ✅ | — |
 | `_get_flat_bid` | (optional) | ✅ | — |
+| `tid` | — | — | ✅ (single-axis thread index for signal gating) |
+| `__syncthreads` | — | — | ✅ (broadcast signal poll to CTA) |
 | `_atomic_add_release` / `_load_acquire` / `_store_release_with_highbit` | (only if you add a grid barrier) | ✅ | — |
 | `_cas_sys_release` / `_cas_sys_acquire` | — | ✅ (backs rank barrier) | — |
+| `ld_sys` / `st_sys` | — | — | ✅ (signal polling & writing for CE sync) |
 | `_send_signal` / `_wait_signal` | ✅ (core mechanism) | — | — |
 | `barrier_on_this_grid` | usually ❌ (per-tile signal replaces it) | ✅ (separates compute/push from reduce) | — |
 | `barrier_all_intra_node_atomic_cas_block` | ❌ (use host-side `symm_mem_hdl.barrier()`) | ✅ (after grid barrier) | — |
 | `symm_mem_hdl.barrier()` (host-side) | ✅ (around `signal.zero_()`) | ❌ (use in-kernel rank barrier) | ✅ (between iterations) |
 | `tl.debug_barrier()` | ✅ | ✅ | — |
-| `ld_sys` / `st_sys` / `__syncthreads` | — | — | ✅ (signal polling & writing) |
 | `stream_write_value32` / `cuStreamWaitValue32` | — | — | ✅ (CE-side signal ops) |
 
-Without-sm does NOT pull from the inter-sm/intra-sm primitives in this catalog. Instead, it uses:
-- **Kernel-side**: `ld_sys` (`ld.global.acquire.sys.b32`) for signal polling, `st_sys` (`st.global.release.sys.b32`) for signal writing, and `__syncthreads` / `tid` helpers — all defined directly in `references/without_sm.md`.
-- **CE-side (host)**: `symm_mem_hdl.stream_write_value32` (comm-first) or `cuda.bindings.driver.cuStreamWaitValue32` (comp-first) for CPU-side CE signal operations.
-- **Cross-rank sync**: `symm_mem_hdl.barrier()` (host-side) around `signal.zero_()` / `progress.fill_(0)` between iterations.
-
-Both inter-sm and without-sm use host-side `symm_mem_hdl.barrier()` (around `signal.zero_()`) for cross-rank synchronization between iterations, since neither has a subsequent in-kernel phase after communication completes.
+Without-sm uses: **kernel-side** `ld_sys`/`st_sys`/`tid`/`__syncthreads` from this catalog for signal polling and writing; **CE-side (host)** `symm_mem_hdl.stream_write_value32` (comm-first) or `cuda.bindings.driver.cuStreamWaitValue32` (comp-first) for CPU-side CE signal operations; and **cross-rank sync** `symm_mem_hdl.barrier()` (host-side) around `progress.fill_(0)` between iterations.

--- a/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
@@ -1,37 +1,27 @@
 # Shared Primitives Library
 
-This file is the **single source of truth** for all low-level synchronization helpers used by `inter-sm`, `intra-sm`, and `without-sm` overlap kernels — thread/block ID helpers, PTX inline-asm atomics, signals, system-scope load/store, and the three-level barrier hierarchy.
+This file is the **single source of truth** for all low-level synchronization helpers used by overlap kernels — thread/block ID helpers, PTX inline-asm atomics, signals, system-scope load/store, and the three-level barrier hierarchy.
 
-Read this file whenever you are about to emit any of these helpers into a generated kernel, regardless of which mode you picked. The mode files (`inter_sm.md`, `intra_sm.md`) reference primitives by name and only describe *how* they are composed.
+Read this file whenever you are about to emit any of these helpers into a generated kernel. The mode files reference primitives by name and only describe *how* they are composed. When emitting a kernel, include only the primitives that mode actually uses (see [§9](#9-which-primitives-each-mode-needs)) — do not paste this whole catalog into the output file.
 
 ## Table of Contents
 
-1. [Why factor primitives out](#1-why-factor-primitives-out)
-2. [Thread/Block ID helpers](#2-threadblock-id-helpers)
-3. [GPU-scope memory ordering atomics](#3-gpu-scope-memory-ordering-atomics)
-4. [System-scope CAS (cross-rank)](#4-system-scope-cas-cross-rank)
-5. [System-scope load/store (without-sm)](#5-system-scope-loadstore-without-sm)
-6. [Three-level barrier hierarchy](#6-three-level-barrier-hierarchy)
-   - 6.1 Thread-level (intra-CTA)
-   - 6.2 CTA-Grid level: `barrier_on_this_grid`
-   - 6.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
-7. [Per-tile signal pattern (inter-sm only)](#7-per-tile-signal-pattern-inter-sm-only)
-8. [Memory order rules — when to use release / acquire / relaxed](#8-memory-order-rules)
-9. [Which primitives each mode needs (quick reference)](#9-which-primitives-each-mode-needs)
+1. [Thread/Block ID helpers](#1-threadblock-id-helpers)
+2. [GPU-scope memory ordering atomics](#2-gpu-scope-memory-ordering-atomics)
+3. [System-scope CAS (cross-rank)](#3-system-scope-cas-cross-rank)
+4. [System-scope load/store (without-sm)](#4-system-scope-loadstore-without-sm)
+5. [Three-level barrier hierarchy](#5-three-level-barrier-hierarchy)
+   - 5.1 Thread-level (intra-CTA)
+   - 5.2 CTA-Grid level: `barrier_on_this_grid`
+   - 5.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
+   - 5.4 Host-side cross-rank barrier: `symm_mem_hdl.barrier()`
+6. [Per-tile signal pattern (inter-sm only)](#6-per-tile-signal-pattern-inter-sm-only)
+7. [Memory order rules](#7-memory-order-rules)
+8. [Which primitives each mode needs](#8-which-primitives-each-mode-needs)
 
 ---
 
-## 1. Why factor primitives out
-
-These helpers (store/load spin-loops, grid barriers, signal pads) are mode-agnostic: the same `barrier_on_this_grid` works in any fused kernel; CAS primitives back `barrier_all_intra_node_atomic_cas_block` (cross-rank sync), while `_send_signal`/`_wait_signal` use simple store/load spin (inter-sm). Defining them once here avoids signature drift and ensures the generated kernel uses the fastest known implementation of each primitive.
-
-When emitting a kernel, include only the primitives that mode actually uses (see [section 8](#8-which-primitives-each-mode-needs)) — do not paste this whole catalog into the output file.
-
----
-
-## 2. Thread/Block ID helpers
-
-Both `_get_flat_tid` and `_get_flat_bid` are needed whenever a kernel must restrict an action to "one thread per CTA" (signals) or "one CTA per grid" (master CTA in grid barrier).
+## 1. Thread/Block ID helpers
 
 ```python
 @triton.jit
@@ -58,78 +48,26 @@ def _get_flat_bid():
         + tl.program_id(1) * tl.num_programs(0)
         + tl.program_id(0)
     )
-```
 
-### `tid`
 
-Lightweight per-axis thread index accessor. Used in without-sm mode where only a single axis tid is needed (e.g., `tid(0) == 0` to gate signal polling to one thread).
-
-```python
-@triton.jit
-def tid(axis: tl.constexpr = 0):
-    """PTX threadIdx.x/y/z."""
-    if axis == 0:
-        return tl.inline_asm_elementwise(
-            asm="mov.u32 $0, %tid.x;",
-            constraints=("=r"),
-            args=[],
-            dtype=tl.int32,
-            is_pure=True,
-            pack=1,
-        )
-    elif axis == 1:
-        return tl.inline_asm_elementwise(
-            asm="mov.u32 $0, %tid.y;",
-            constraints=("=r"),
-            args=[],
-            dtype=tl.int32,
-            is_pure=True,
-            pack=1,
-        )
-    else:
-        return tl.inline_asm_elementwise(
-            asm="mov.u32 $0, %tid.z;",
-            constraints=("=r"),
-            args=[],
-            dtype=tl.int32,
-            is_pure=True,
-            pack=1,
-        )
-```
-
-### `__syncthreads`
-
-PTX `bar.sync` — block-level `__syncthreads`. Used in without-sm mode to broadcast a signal poll result from one thread to all threads in the CTA.
-
-```python
 @triton.jit
 def __syncthreads():
-    """PTX bar.sync (block-level __syncthreads)."""
-    tl.inline_asm_elementwise(
-        asm="bar.sync 0;",
-        constraints="=r",
-        args=[],
-        dtype=tl.int32,
-        is_pure=False,
-        pack=1,
-    )
+    """PTX bar.sync — broadcasts signal poll result from one thread to all in CTA."""
+    tl.inline_asm_elementwise(asm="bar.sync 0;", constraints="=r", args=[], dtype=tl.int32, is_pure=False, pack=1)
 ```
 
-**Signedness pitfall:** `_get_flat_tid()` returns `tl.uint32`. Triton forbids `//`, `%` between `uint32` and `int32`. When using `flat_tid` in arithmetic (e.g., `flat_tid // vec_per_row`), cast first: `flat_tid = _get_flat_tid().to(tl.int32)`. Same applies to `%ntid.x` if read via inline asm as a loop stride. Simple comparisons (`== 0`, `< N`) work without casting.
+**Signedness pitfall:** `_get_flat_tid()` returns `tl.uint32`. Triton forbids `//`, `%` between `uint32` and `int32`. Cast first: `flat_tid = _get_flat_tid().to(tl.int32)`. Simple comparisons (`== 0`, `< N`) work without casting.
 
 ---
 
-## 3. GPU-scope memory ordering atomics
+## 2. GPU-scope memory ordering atomics
 
-Used to build the CTA-grid barrier. **GPU scope** is correct here because all participating CTAs run on the same device.
-
-### `_atomic_add_release`
-
-Used to count arrivals at a barrier point. The `release` semantics ensure all preceding stores are visible to other CTAs that observe the counter increment.
+Used to build the CTA-grid barrier. GPU scope is correct because all participating CTAs run on the same device.
 
 ```python
 @triton.jit
 def _atomic_add_release(ptr, val):
+    """Release-semantics atomic add — counts arrivals at a barrier point."""
     tl.inline_asm_elementwise(
         """
         {
@@ -143,15 +81,11 @@ def _atomic_add_release(ptr, val):
         is_pure=False,
         pack=1,
     )
-```
 
-### `_load_acquire`
 
-Spin-wait on a barrier counter. The `acquire` semantics ensure that reads after this load see all stores that happened before the corresponding `release`.
-
-```python
 @triton.jit
 def _load_acquire(ptr):
+    """Acquire-semantics load — spin-wait on a barrier counter."""
     return tl.inline_asm_elementwise(
         """
         {
@@ -166,15 +100,11 @@ def _load_acquire(ptr):
         is_pure=False,
         pack=1,
     )
-```
 
-### `_store_release_with_highbit`
 
-Master CTA broadcasts "release all waiters" by storing `expected | 0x80000000` (high-bit flag pattern).
-
-```python
 @triton.jit
 def _store_release_with_highbit(ptr, expected):
+    """Master CTA broadcasts 'release all waiters' by storing expected | 0x80000000."""
     tl.inline_asm_elementwise(
         """
         {
@@ -194,11 +124,9 @@ def _store_release_with_highbit(ptr, expected):
 
 ---
 
-## 4. System-scope CAS (cross-rank)
+## 3. System-scope CAS (cross-rank)
 
-These back the **cross-rank barrier** (`barrier_all_intra_node_atomic_cas_block`). **System scope** is required because the target memory lives in another GPU's symmetric memory.
-
-The spin-loop is kept **inside PTX** (`@!%p0 bra cas_loop`). A Python-level `while` around a single-shot CAS incurs significant Triton control-flow overhead and is measurably slower.
+Backs the **cross-rank barrier** (`barrier_all_intra_node_atomic_cas_block`). System scope is required because the target memory lives in another GPU's symmetric memory. The spin-loop is kept **inside PTX** (`@!%p0 bra cas_loop`) — a Python-level `while` around a single-shot CAS incurs significant Triton control-flow overhead.
 
 ```python
 @triton.jit
@@ -247,34 +175,16 @@ def _cas_sys_acquire(addrs, expected, desired):
     )
 ```
 
-**Anti-pattern** — do NOT use a Python-level spin-loop with a single-shot CAS:
-
-```python
-# BAD: Python-level spin-loop is slow
-old = tl.cast(1, tl.uint32)
-while old != 0:
-    old = _cas_single_shot(peer_signal_addr, 0, 1)  # single CAS, no internal loop
-```
-
 ---
 
-## 5. System-scope load/store (without-sm)
+## 4. System-scope load/store (without-sm)
 
-These helpers are used by without-sm (copy engine) overlap kernels. The compute kernel needs `ld_sys` to poll signals written by the CE (cross-GPU PtoP copy or `cuStreamWriteValue32`), and `st_sys` to write per-tile completion signals that the CE waits on via `cuStreamWaitValue32`.
-
-Plain `tl.load` / `tl.store` lack cross-device visibility guarantees — the L2 cache may return stale data when the writer is on a different GPU. System-scope acquire/release is required.
-
-### `ld_sys`
+Without-sm (copy engine) overlap kernels use these for CE ↔ compute kernel synchronization. Plain `tl.load`/`tl.store` lack cross-device visibility — the L2 cache may return stale data when the writer is on a different GPU. System-scope acquire/release is required.
 
 ```python
 @triton.jit
 def ld_sys(ptr):
-    """ld.global.acquire.sys.b32 — system-scope acquire load.
-
-    Required for reading signals written by the CE (cross-GPU PtoP copy or
-    cuStreamWriteValue32). Plain tl.load does NOT guarantee visibility of
-    writes that arrived over NVLink — the L2 cache may return stale data.
-    """
+    """ld.global.acquire.sys.b32 — poll signal written by CE (cuStreamWriteValue32 or PtoP copy)."""
     return tl.inline_asm_elementwise(
         asm="ld.global.acquire.sys.b32 $0, [$1];",
         constraints="=r,l",
@@ -283,19 +193,14 @@ def ld_sys(ptr):
         is_pure=False,
         pack=1,
     )
-```
 
-### `st_sys`
 
-```python
 @triton.jit
 def st_sys(ptr, val):
-    """st.global.release.sys.b32 — system-scope release store.
+    """st.global.release.sys.b32 — write per-tile completion signal for CE cuStreamWaitValue32.
 
-    Used by the compute kernel (comp-first path) to write a per-tile signal
-    that the CE waits on via cuStreamWaitValue32. Release semantics ensure
-    all prior tl.store (tile data) are visible before the signal write.
-    """
+    No contention (each tile has exactly one writer, signal reset to 0 before launch),
+    so a simple store suffices — the CAS spin-loop in `_send_signal` is overkill here."""
     tl.inline_asm_elementwise(
         asm="""
         st.global.release.sys.b32 [$1], $2;
@@ -309,21 +214,15 @@ def st_sys(ptr, val):
     )
 ```
 
-**Memory ordering rationale:**
-- `ld_sys` → `ld.global.acquire.sys`: the CE's `stream_write_value32` or PtoP `copy_()` is a release operation; the compute kernel's acquire load ensures it sees the data that was copied before the signal was written.
-- `st_sys` → `st.global.release.sys`: the compute kernel's release store ensures all prior tile data stores are visible before the signal `1` becomes observable by the CE's `cuStreamWaitValue32`.
-
-**Why `st_sys` instead of `_send_signal` (CAS)?** In without-sm comp-first mode, each tile has exactly one writer (the CTA that computed it), and the signal tensor is reset to 0 before each launch. So there is no contention — a simple store suffices. The CAS spin-loop in `_send_signal` is overkill and adds latency.
-
 ---
 
-## 6. Three-level barrier hierarchy
+## 5. Three-level barrier hierarchy
 
-A kernel that synchronizes "everyone" must say *which* "everyone": threads in this CTA, CTAs on this device, or ranks across devices. Pick the smallest scope that covers your data dependency.
+Pick the smallest scope that covers your data dependency.
 
-### 6.1 Thread-level (intra-CTA)
+### 5.1 Thread-level (intra-CTA)
 
-Built-in. Use `tl.debug_barrier()` to re-converge threads after warp-divergent control flow, or to broadcast a value written by `if flat_tid == 0` to the rest of the CTA. No custom helper needed.
+Built-in. Use `tl.debug_barrier()` to re-converge threads after warp-divergent control flow, or to broadcast a value written by `if flat_tid == 0` to the rest of the CTA.
 
 ```python
 if flat_tid == 0:
@@ -331,11 +230,9 @@ if flat_tid == 0:
 tl.debug_barrier()  # broadcast readiness to all threads in CTA
 ```
 
-### 6.2 CTA-Grid level: `barrier_on_this_grid`
+### 5.2 CTA-Grid level: `barrier_on_this_grid`
 
-Synchronizes all CTAs in a single kernel launch **without** requiring `cooperative_groups`. Uses a split-counter pattern: each CTA atomically increments a global counter; the master CTA (`bid == 0`) spins until all arrive, then flips the high bit to release everyone.
-
-**Performance note**: This implementation uses the *master CTA pattern* (only `bid==0` does the spin-wait, others just check the high bit) with a single `tl.debug_barrier()` at the end. Avoid the naive variant where every CTA checks if it's the last to arrive — that requires 3 separate `tl.debug_barrier()` calls and is significantly slower.
+Synchronizes all CTAs in a single kernel launch **without** requiring `cooperative_groups`. Uses a split-counter pattern: each CTA atomically increments a global counter; the master CTA (`bid == 0`) spins until all arrive, then flips the high bit to release everyone. Uses the *master CTA pattern* (only `bid==0` spins, others check the high bit) with a single `tl.debug_barrier()` at the end.
 
 ```python
 @triton.jit
@@ -357,39 +254,15 @@ def barrier_on_this_grid(barrier_ptr):
     tl.debug_barrier()  # single sync point at the end
 ```
 
-**Host-side requirement**: the counter must be reset to 0 between kernel launches (`ctx.grid_barrier.zero_()`).
+**Host-side**: reset counter to 0 between launches (`ctx.grid_barrier.zero_()`).
 
-**⚠️ CRITICAL: `num_ctas` must not exceed SM for persistent kernels.** This barrier requires ALL CTAs to arrive before any can proceed. If `num_ctas > SMs`, some CTAs cannot be scheduled (SMs are fully occupied by earlier CTAs that are already spinning at the barrier) and the kernel deadlocks. Always cap the grid size:
+**⚠️ CRITICAL: `num_ctas` must not exceed SM for persistent kernels.** If `num_ctas > SMs`, some CTAs cannot be scheduled (SMs occupied by earlier CTAs already spinning at the barrier) and the kernel deadlocks. Cap: `num_ctas = min(total_tiles, num_sm)`.
 
-```python
-num_sm = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
-num_ctas = min(total_tiles, num_sm)  # conservative: assume 1 CTA/SM
-# or query actual occupancy and use: min(total_tiles, num_sm * occupancy)
-```
+### 5.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
 
-### 6.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
+Cross-rank barrier for `inter-sm` and `intra-sm` kernels. Thread `i` (where `i < local_world_size`) signals peer `i` by CAS(0→1), then waits for the peer to signal us back by CAS(1→0). Self-resetting (CAS 1→0 returns slot to 0), reusable across iterations.
 
-The single canonical cross-rank barrier used by both `inter-sm` and `intra-sm` kernels. Each CTA independently participates: thread `i` (where `i < local_world_size`) signals peer `i` by CAS(0→1) on the peer's barrier slot for our rank, then waits for the peer to signal us back by CAS(1→0) on our own slot.
-
-The barrier is **self-resetting** (CAS 1→0 in phase 2 returns the slot to 0), so it is reusable across iterations with no host-side reset.
-
-**⚠️ CRITICAL: Only ONE CTA per rank must call this function.** The signal pad slots are binary (0↔1) and can only track a single barrier invocation per rank pair. If multiple CTAs call this function concurrently, their threads will CAS-contend on the same slots:
-1. CTA 0's thread CAS(0→1) succeeds (slot → 1)
-2. CTA 1's thread CAS(0→1) fails (slot already 1) → spins waiting for reset
-3. Peer's phase-2 CAS(1→0) resets the slot → CTA 1's CAS succeeds (slot → 1 again)
-4. But the peer will NOT reset the slot a second time → **CTA 2+ deadlock**
-
-Always guard the call with `if pid == 0:` (or equivalent single-CTA condition) after `barrier_on_this_grid`:
-
-```python
-barrier_on_this_grid(barrier_ptr)  # ALL CTAs participate
-if pid == 0:                        # Only CTA 0 does cross-rank sync
-    barrier_all_intra_node_atomic_cas_block(rank, rank, world_size, signal_pad_ptrs)
-```
-
-**Performance**: uses **multiple threads in parallel** (one per peer rank), not a single thread serially iterating over all peers. With 8 ranks, the parallel version is ~8× faster than the serial variant.
-
-Parameters `local_rank`, `rank`, and `local_world_size` are declared `tl.constexpr` so the compiler can fully unroll the thread-to-peer mapping.
+**⚠️ CRITICAL: Only ONE CTA per rank must call this.** Signal pad slots are binary (0↔1) — multiple CTAs calling concurrently will CAS-contend and **deadlock**. Guard with `if pid == 0:` after `barrier_on_this_grid`.
 
 ```python
 @triton.jit
@@ -407,7 +280,6 @@ def barrier_all_intra_node_atomic_cas_block(
              for i in range(world_size)],
             dtype=torch.int64, device=device,
         )
-    Each rank's signal pad needs `local_world_size` int32 slots (one per remote rank).
     """
     flat_tid = _get_flat_tid()
     local_rank_offset = rank - local_rank
@@ -430,121 +302,39 @@ def barrier_all_intra_node_atomic_cas_block(
     tl.debug_barrier()
 ```
 
-**Anti-pattern** — do NOT use single-threaded serial iteration:
+### 5.4 Host-side cross-rank barrier: `symm_mem_hdl.barrier()`
 
-```python
-# BAD: single thread (flat_tid == 0) serially loops over all peers
-if flat_tid == 0:
-    for peer in range(local_world_size):
-        if peer != local_rank:
-            ...  # signal peer one by one (serial, slow)
-```
+Use when the kernel has **no** subsequent in-kernel phase after communication (inter-sm, without-sm). It launches a small CUDA kernel (1 block, `world_size` threads) that performs pairwise signal/wait on symmetric memory signal pads — a host-side API that launches + synchronizes internally. Self-resetting; supports `barrier(channel=N)` for multi-phase pipelines (typically `channel=0` is sufficient for overlap kernels).
 
-> **Note on naming**: an older variant `barrier_all_intra_node_atomic_cas_block_symm_mem` (with `(rank, num_ranks, symm_flag_ptr, peer_barrier_ptrs)` signature, using Python-level `while atomic_cas(...) != 0` spin-loops) appeared in earlier drafts. It is superseded by the function above — same semantics, faster spin-loop, fewer arguments. Always emit the canonical form.
-
-### 6.4 Host-side cross-rank barrier: `symm_mem_hdl.barrier()`
-
-When a kernel does **not** have a subsequent in-kernel phase after communication (i.e., the kernel exits once the communication phase is done), use **host-side** `symm_mem_hdl.barrier()` instead of the in-kernel `barrier_all_intra_node_atomic_cas_block`. This is the standard PyTorch symmetric memory barrier and is the correct choice for **inter-sm** and **without-sm** modes.
-
-`symm_mem_hdl` is obtained via `symm_mem.rendezvous(<symm_mem_tensor>, group=<communication_group>)`:
-
-```python
-import torch.distributed._symmetric_memory as symm_mem
-
-buf = symm_mem.empty(shape, dtype=dtype, device=device)       # allocate symmetric memory
-symm_mem_hdl = symm_mem.rendezvous(buf, group=dist.group.WORLD)  # get the handler
-```
-
-The handler provides `barrier()`, `get_buffer()`, `get_signal_pad()`, and other symmetric memory APIs.
-
-**Underlying implementation** (from PyTorch's `CUDASymmetricMemory.cu`):
-
-```cuda
-static __global__ void barrier_kernel(
-    uint32_t** signal_pads, int channel, int rank, int world_size, size_t timeout_ms) {
-    if (threadIdx.x < world_size) {
-        auto target_rank = threadIdx.x;
-        if (target_rank == rank) return;
-        // Signal target_rank (release)
-        try_put_signal<memory_order_release>(
-            signal_pads[target_rank] + world_size * channel + rank, timeout_ms);
-        // Wait for target_rank's signal (acquire)
-        try_wait_signal<memory_order_acquire>(
-            signal_pads[rank] + world_size * channel + target_rank, timeout_ms);
-    }
-}
-```
-
-It launches a small CUDA kernel (1 block, `world_size` threads) that performs pairwise signal/wait on the symmetric memory signal pads. This is a **host-side API** — you call it from Python, and it launches + synchronizes internally.
-
-**Key characteristics:**
+`symm_mem_hdl` is obtained via `symm_mem.rendezvous(buf, group=dist.group.WORLD)`. The handler provides `barrier()`, `get_buffer()`, `get_signal_pad()`, etc.
 
 | Property | `symm_mem_hdl.barrier()` | `barrier_all_intra_node_atomic_cas_block` |
 |---|---|---|
-| **Where it runs** | Host side (launches a CUDA kernel) | Inside a Triton kernel |
-| **Channel support** | Yes — `barrier(channel=N)` for multi-phase pipelines | No — uses CAS on dedicated signal pad slots |
-| **Self-resetting** | Yes — signal pads are toggled and reset by the barrier kernel itself | Yes — CAS(1→0) in phase 2 returns the slot to 0 |
-| **Overhead** | Extra kernel launch + stream sync | Zero extra kernel launches (runs inside existing kernel) |
-| **Best for** | inter-sm, without-sm (kernel exits after comm) | intra-sm (kernel has post-comm compute phase) |
+| **Where** | Host side (launches CUDA kernel) | Inside a Triton kernel |
+| **Overhead** | Extra kernel launch + stream sync | Zero extra launches |
+| **Best for** | inter-sm, without-sm | intra-sm (has post-comm compute) |
 
 **Usage pattern:**
 
 ```python
-# Host side: use symm_mem_hdl.barrier() around signal.zero_() for cross-rank sync
-# between iterations when the kernel itself has no post-comm compute phase.
+# Reset + barrier before launch
+hdl.barrier()              # all ranks finished previous iteration
+progress.fill_(0)          # or signal.zero_()
+hdl.barrier()              # all ranks see reset before launching
 
-# Reset per-tile signals (must happen after all ranks finished consuming)
-ctx.signal_tensor.zero_()
-ctx.symm_mem_hdl.barrier()  # ensure all ranks see zeroed signals
-
-# Launch kernel — it exits when communication is done
-kernel[grid](...)
+# Launch kernels ...
 ```
-
-**Channel usage for multi-phase pipelines:**
-
-The `barrier(channel=N)` parameter supports multiple independent barrier channels within the same signal pad. This is used by PyTorch's `_pipelined_produce_and_all2all` and `_pipelined_all_gather_and_consume` to manage multi-phase pipelines:
-
-```python
-symm_mem.barrier(channel=0)  # phase 0: ensure workspace is ready
-# ... copy local shard ...
-symm_mem.barrier(channel=1)  # phase 1: all local shards copied
-# ... consume remote shards ...
-symm_mem.barrier(channel=0)  # final sync
-```
-
-For overlap kernels, `channel=0` is typically sufficient. The number of channels is bounded by `signal_pad_size / (sizeof(uint32_t) * world_size)`.
-
-**Signal pad size requirement:** Each channel uses `world_size * world_size` uint32 slots in the signal pad. The default signal pad size is typically sufficient for a few channels. If more channels are needed, call `symm_mem.set_signal_pad_size()` before any allocations.
-
-**Memory ordering:** The barrier kernel uses `memory_order_release` for puts and `memory_order_acquire` for waits. This establishes a full happens-before relationship: all stores before the barrier on any rank are visible to all loads after the barrier on every other rank. This is equivalent to the ordering guarantees of the in-kernel `barrier_all_intra_node_atomic_cas_block`.
-
-**Decision rule:**
-
-| Scenario | Use |
-|---|---|
-| Kernel has a post-comm compute phase (intra-sm) | In-kernel `barrier_all_intra_node_atomic_cas_block` (single CTA) |
-| Kernel exits after communication (inter-sm, without-sm) | Host-side `symm_mem_hdl.barrier()` |
-| Multi-phase pipelined host-side communication | Host-side `symm_mem_hdl.barrier(channel=N)` |
 
 ---
 
-## 7. Per-tile signal pattern (inter-sm only)
+## 6. Per-tile signal pattern (inter-sm only)
 
-The inter-sm mode uses an additional **per-tile** signal protocol on top of the rank barrier: the producer kernel stores 1 to a signal slot as each tile completes, the consumer kernel spins on it before consuming. This is what enables fine-grained pipelining between two kernels on different streams.
-
-`_send_signal` and `_wait_signal` use system-scope store/load (not CAS). They are not needed by intra-sm or without-sm kernels.
+Inter-sm uses a per-tile signal protocol: producer stores 1 as each tile completes, consumer spins on it before consuming. `_send_signal`/`_wait_signal` use system-scope store/load (not CAS). Not needed by intra-sm or without-sm.
 
 ```python
 @triton.jit
 def _send_signal(addrs, sem: tl.constexpr):
-    """Store 1 to signal slot. System-scope.
-
-    Valid sem values:
-      - "release"  — flush prior writes before signal (use after producing data)
-      - "relaxed"  — no ordering guarantee (use for pure event signaling)
-      "acquire" is NOT valid for send.
-    """
+    """Store 1 to signal slot. System-scope. sem: "release" (after data) or "relaxed" (pure event)."""
     if sem == "release":
         tl.inline_asm_elementwise(
             "st.global.release.sys.b32 [$1], 1;",
@@ -559,13 +349,7 @@ def _send_signal(addrs, sem: tl.constexpr):
 
 @triton.jit
 def _wait_signal(addrs, sem: tl.constexpr):
-    """Spin until signal slot becomes 1 (ld spin). System-scope.
-
-    Valid sem values:
-      - "acquire"  — ensure subsequent loads see remote writes (use before consuming data)
-      - "relaxed"  — no ordering guarantee
-      "release" is NOT valid for wait.
-    """
+    """Spin until signal slot becomes 1. System-scope. sem: "acquire" (before data) or "relaxed"."""
     if sem == "acquire":
         tl.inline_asm_elementwise(
             """
@@ -588,59 +372,38 @@ def _wait_signal(addrs, sem: tl.constexpr):
         )
 ```
 
-### Usage pattern
-
-```python
-# Producer (compute kernel): one thread signals per tile, after the store
-tl.store(out_ptr + offsets, result, mask=mask)
-flat_tid = _get_flat_tid()
-if flat_tid == 0:
-    _send_signal(signal_ptr + pid, "release")
-
-# Consumer (persistent comm kernel): one thread waits, then broadcasts to CTA
-for tile_id in range(pid, total_tiles, tl.num_programs(0)):
-    flat_tid = _get_flat_tid()
-    if flat_tid == 0:
-        _wait_signal(signal_ptr + tile_id, "acquire")
-    tl.debug_barrier()  # broadcast readiness to all threads in CTA
-    # ... consume tile ...
-```
-
-The signal tensor is reset by the host via `.zero_()` before each launch. `_send_signal` stores 1, `_wait_signal` spins until it sees 1. No in-kernel reset is needed.
+Signal tensor is reset by host `.zero_()` before each launch. No in-kernel reset needed.
 
 ---
 
-## 8. Memory order rules
+## 7. Memory order rules
 
 | Operation | Order | Why |
 |---|---|---|
-| Plain `tl.store` of data | (none) | Visibility is established by the subsequent signal/barrier |
-| Barrier counter increment (`_atomic_add_release`) | release | Make preceding data stores visible to observers of the counter |
-| Barrier counter read (`_load_acquire`) | acquire | Subsequent loads must see remote stores released before the counter |
-| Cross-rank signal **send** after data store | release | Same reason — flush data before raising the flag |
+| Plain `tl.store` of data | (none) | Visibility established by subsequent signal/barrier |
+| Barrier counter increment (`_atomic_add_release`) | release | Make preceding data stores visible to counter observers |
+| Barrier counter read (`_load_acquire`) | acquire | Subsequent loads must see stores released before the counter |
+| Cross-rank signal **send** after data store | release | Flush data before raising the flag |
 | Cross-rank signal **wait** before data load | acquire | Reads after wait must see the producer's data |
 | Cross-rank signal for pure ordering (no data) | relaxed | Cheaper; only the happens-before edge is needed |
 
-Rule of thumb: any flag whose **point** is to advertise "data is ready" pairs **release** (writer) with **acquire** (reader). Use **relaxed** only when you've already proven there's no data dependency through that flag.
+Rule of thumb: any flag whose **point** is to advertise "data is ready" pairs **release** (writer) with **acquire** (reader). Use **relaxed** only when there's no data dependency through that flag.
 
 ---
 
-## 9. Which primitives each mode needs
+## 8. Which primitives each mode needs
 
 | Primitive | inter-sm | intra-sm | without-sm |
 |---|:---:|:---:|:---:|
-| `_get_flat_tid` | ✅ | ✅ | — |
+| `_get_flat_tid` | ✅ | ✅ | ✅ |
 | `_get_flat_bid` | (optional) | ✅ | — |
-| `tid` | — | — | ✅ (single-axis thread index for signal gating) |
 | `__syncthreads` | — | — | ✅ (broadcast signal poll to CTA) |
-| `_atomic_add_release` / `_load_acquire` / `_store_release_with_highbit` | (only if you add a grid barrier) | ✅ | — |
-| `_cas_sys_release` / `_cas_sys_acquire` | — | ✅ (backs rank barrier) | — |
-| `ld_sys` / `st_sys` | — | — | ✅ (signal polling & writing for CE sync) |
-| `_send_signal` / `_wait_signal` | ✅ (core mechanism) | — | — |
-| `barrier_on_this_grid` | usually ❌ (per-tile signal replaces it) | ✅ (separates compute/push from reduce) | — |
-| `barrier_all_intra_node_atomic_cas_block` | ❌ (use host-side `symm_mem_hdl.barrier()`) | ✅ (after grid barrier) | — |
-| `symm_mem_hdl.barrier()` (host-side) | ✅ (around `signal.zero_()`) | ❌ (use in-kernel rank barrier) | ✅ (between iterations) |
+| `_atomic_add_release` / `_load_acquire` / `_store_release_with_highbit` | (grid barrier only) | ✅ | — |
+| `_cas_sys_release` / `_cas_sys_acquire` | — | ✅ (rank barrier) | — |
+| `ld_sys` / `st_sys` | — | — | ✅ (CE signal poll/write) |
+| `_send_signal` / `_wait_signal` | ✅ (core) | — | — |
+| `barrier_on_this_grid` | usually ❌ | ✅ | — |
+| `barrier_all_intra_node_atomic_cas_block` | ❌ (host barrier) | ✅ | ❌ (host barrier) |
+| `symm_mem_hdl.barrier()` | ✅ | ❌ (in-kernel) | ✅ |
 | `tl.debug_barrier()` | ✅ | ✅ | — |
-| `stream_write_value32` / `cuStreamWaitValue32` | — | — | ✅ (CE-side signal ops) |
-
-Without-sm uses: **kernel-side** `ld_sys`/`st_sys`/`tid`/`__syncthreads` from this catalog for signal polling and writing; **CE-side (host)** `symm_mem_hdl.stream_write_value32` (comm-first) or `cuda.bindings.driver.cuStreamWaitValue32` (comp-first) for CPU-side CE signal operations; and **cross-rank sync** `symm_mem_hdl.barrier()` (host-side) around `progress.fill_(0)` between iterations.
+| `stream_write_value32` / `cuStreamWaitValue32` | — | — | ✅ (CE-side) |

--- a/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
@@ -1,0 +1,435 @@
+# Shared Primitives Library
+
+This file is the **single source of truth** for all low-level synchronization helpers used by `inter-sm` and `intra-sm` overlap kernels — thread/block ID helpers, PTX inline-asm atomics, signals, and the three-level barrier hierarchy.
+
+Read this file whenever you are about to emit any of these helpers into a generated kernel, regardless of which mode you picked. The mode files (`inter_sm.md`, `intra_sm.md`) reference primitives by name and only describe *how* they are composed.
+
+## Table of Contents
+
+1. [Why factor primitives out](#1-why-factor-primitives-out)
+2. [Thread/Block ID helpers](#2-threadblock-id-helpers)
+3. [GPU-scope memory ordering atomics](#3-gpu-scope-memory-ordering-atomics)
+4. [System-scope CAS (cross-rank)](#4-system-scope-cas-cross-rank)
+5. [Three-level barrier hierarchy](#5-three-level-barrier-hierarchy)
+   - 5.1 Thread-level (intra-CTA)
+   - 5.2 CTA-Grid level: `barrier_on_this_grid`
+   - 5.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
+6. [Per-tile signal pattern (inter-sm only)](#6-per-tile-signal-pattern-inter-sm-only)
+7. [Memory order rules — when to use release / acquire / relaxed](#7-memory-order-rules)
+8. [Which primitives each mode needs (quick reference)](#8-which-primitives-each-mode-needs)
+
+---
+
+## 1. Why factor primitives out
+
+These helpers (store/load spin-loops, grid barriers, signal pads) are mode-agnostic: the same `barrier_on_this_grid` works in any fused kernel; CAS primitives back `barrier_all_intra_node_atomic_cas_block` (cross-rank sync), while `_send_signal`/`_wait_signal` use simple store/load spin (inter-sm). Defining them once here avoids signature drift and ensures the generated kernel uses the fastest known implementation of each primitive.
+
+When emitting a kernel, include only the primitives that mode actually uses (see [section 8](#8-which-primitives-each-mode-needs)) — do not paste this whole catalog into the output file.
+
+---
+
+## 2. Thread/Block ID helpers
+
+Both `_get_flat_tid` and `_get_flat_bid` are needed whenever a kernel must restrict an action to "one thread per CTA" (signals) or "one CTA per grid" (master CTA in grid barrier).
+
+```python
+@triton.jit
+def _get_flat_tid():
+    """Flattened thread index within the CTA: tid.z * ntid.y * ntid.x + tid.y * ntid.x + tid.x."""
+    tid_x, tid_y, tid_z = tl.inline_asm_elementwise(
+        "mov.u32 $0, %tid.x; mov.u32 $1, %tid.y; mov.u32 $2, %tid.z;",
+        "=r,=r,=r", [], dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True, pack=1,
+    )
+    ntid_x, ntid_y, _ = tl.inline_asm_elementwise(
+        "mov.u32 $0, %ntid.x; mov.u32 $1, %ntid.y; mov.u32 $2, %ntid.z;",
+        "=r,=r,=r", [], dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True, pack=1,
+    )
+    return tid_z * ntid_y * ntid_x + tid_y * ntid_x + tid_x
+
+
+@triton.jit
+def _get_flat_bid():
+    """Flattened CTA index within the grid."""
+    return (
+        tl.program_id(2) * tl.num_programs(1) * tl.num_programs(0)
+        + tl.program_id(1) * tl.num_programs(0)
+        + tl.program_id(0)
+    )
+```
+
+**Signedness pitfall:** `_get_flat_tid()` returns `tl.uint32`. Triton forbids `//`, `%` between `uint32` and `int32`. When using `flat_tid` in arithmetic (e.g., `flat_tid // vec_per_row`), cast first: `flat_tid = _get_flat_tid().to(tl.int32)`. Same applies to `%ntid.x` if read via inline asm as a loop stride. Simple comparisons (`== 0`, `< N`) work without casting.
+
+---
+
+## 3. GPU-scope memory ordering atomics
+
+Used to build the CTA-grid barrier. **GPU scope** is correct here because all participating CTAs run on the same device.
+
+### `_atomic_add_release`
+
+Used to count arrivals at a barrier point. The `release` semantics ensure all preceding stores are visible to other CTAs that observe the counter increment.
+
+```python
+@triton.jit
+def _atomic_add_release(ptr, val):
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32 %inc;
+            atom.global.release.gpu.add.u32 %inc, [$1], $2;
+        }
+        """,
+        "=r, l, r",
+        [ptr, tl.cast(val, tl.uint32)],
+        dtype=tl.uint32,
+        is_pure=False,
+        pack=1,
+    )
+```
+
+### `_load_acquire`
+
+Spin-wait on a barrier counter. The `acquire` semantics ensure that reads after this load see all stores that happened before the corresponding `release`.
+
+```python
+@triton.jit
+def _load_acquire(ptr):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32 %val;
+            ld.global.acquire.gpu.u32 %val, [$1];
+            mov.u32 $0, %val;
+        }
+        """,
+        "=r, l",
+        [ptr],
+        dtype=tl.uint32,
+        is_pure=True,
+        pack=1,
+    )
+```
+
+### `_store_release_with_highbit`
+
+Master CTA broadcasts "release all waiters" by storing `expected | 0x80000000` (high-bit flag pattern).
+
+```python
+@triton.jit
+def _store_release_with_highbit(ptr, expected):
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32 %mask, %val;
+            mov.u32  %mask, 0x80000000;
+            or.b32   %val, %mask, $2;
+            st.global.release.gpu.u32 [$1], %val;
+        }
+        """,
+        "=r, l, r",
+        [ptr, tl.cast(expected, tl.uint32)],
+        dtype=tl.uint32,
+        is_pure=False,
+        pack=1,
+    )
+```
+
+---
+
+## 4. System-scope CAS (cross-rank)
+
+These back the **cross-rank barrier** (`barrier_all_intra_node_atomic_cas_block`). **System scope** is required because the target memory lives in another GPU's symmetric memory.
+
+The spin-loop is kept **inside PTX** (`@!%p0 bra cas_loop`). A Python-level `while` around a single-shot CAS incurs significant Triton control-flow overhead and is measurably slower.
+
+```python
+@triton.jit
+def _cas_sys_release(addrs, expected, desired):
+    """atom.global.release.sys.cas.b32 with PTX-level spin-loop."""
+    return tl.inline_asm_elementwise(
+        f"""
+        {{
+            .reg .u32   %tmp32_<1>;
+            .reg .pred  %p<1>;
+            cas_loop:
+                atom.global.release.sys.cas.b32 %tmp32_0, [$1], {expected}, {desired};
+                setp.eq.u32 %p0, %tmp32_0, {expected};
+                @!%p0 bra cas_loop;
+            mov.u32 $0, %tmp32_0;
+        }}
+        """,
+        "=r, l",
+        [addrs],
+        dtype=addrs.dtype,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _cas_sys_acquire(addrs, expected, desired):
+    """atom.global.acquire.sys.cas.b32 with PTX-level spin-loop."""
+    return tl.inline_asm_elementwise(
+        f"""
+        {{
+            .reg .u32   %tmp32_<1>;
+            .reg .pred  %p<1>;
+            cas_loop:
+                atom.global.acquire.sys.cas.b32 %tmp32_0, [$1], {expected}, {desired};
+                setp.eq.u32 %p0, %tmp32_0, {expected};
+                @!%p0 bra cas_loop;
+            mov.u32 $0, %tmp32_0;
+        }}
+        """,
+        "=r, l",
+        [addrs],
+        dtype=addrs.dtype,
+        is_pure=False,
+        pack=1,
+    )
+```
+
+**Anti-pattern** — do NOT use a Python-level spin-loop with a single-shot CAS:
+
+```python
+# BAD: Python-level spin-loop is slow
+old = tl.cast(1, tl.uint32)
+while old != 0:
+    old = _cas_single_shot(peer_signal_addr, 0, 1)  # single CAS, no internal loop
+```
+
+---
+
+## 5. Three-level barrier hierarchy
+
+A kernel that synchronizes "everyone" must say *which* "everyone": threads in this CTA, CTAs on this device, or ranks across devices. Pick the smallest scope that covers your data dependency.
+
+### 5.1 Thread-level (intra-CTA)
+
+Built-in. Use `tl.debug_barrier()` to re-converge threads after warp-divergent control flow, or to broadcast a value written by `if flat_tid == 0` to the rest of the CTA. No custom helper needed.
+
+```python
+if flat_tid == 0:
+    _wait_signal(signal_ptr + tile_id, "acquire")
+tl.debug_barrier()  # broadcast readiness to all threads in CTA
+```
+
+### 5.2 CTA-Grid level: `barrier_on_this_grid`
+
+Synchronizes all CTAs in a single kernel launch **without** requiring `cooperative_groups`. Uses a split-counter pattern: each CTA atomically increments a global counter; the master CTA (`bid == 0`) spins until all arrive, then flips the high bit to release everyone.
+
+**Performance note**: This implementation uses the *master CTA pattern* (only `bid==0` does the spin-wait, others just check the high bit) with a single `tl.debug_barrier()` at the end. Avoid the naive variant where every CTA checks if it's the last to arrive — that requires 3 separate `tl.debug_barrier()` calls and is significantly slower.
+
+```python
+@triton.jit
+def barrier_on_this_grid(barrier_ptr):
+    expected = tl.num_programs(0) * tl.num_programs(1) * tl.num_programs(2)
+
+    if _get_flat_tid() == 0:
+        _atomic_add_release(barrier_ptr, 1)
+        if _get_flat_bid() == 0:
+            # Master CTA: spin until all CTAs have arrived
+            while _load_acquire(barrier_ptr) != expected:
+                pass
+            _store_release_with_highbit(barrier_ptr, expected)
+        else:
+            # Other CTAs: spin until the high bit is set
+            while (_load_acquire(barrier_ptr) & 0x80000000) == 0:
+                pass
+
+    tl.debug_barrier()  # single sync point at the end
+```
+
+**Host-side requirement**: the counter must be reset to 0 between kernel launches (`ctx.grid_barrier.zero_()`).
+
+### 5.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
+
+The single canonical cross-rank barrier used by both `inter-sm` and `intra-sm` kernels. Each CTA independently participates: thread `i` (where `i < local_world_size`) signals peer `i` by CAS(0→1) on the peer's barrier slot for our rank, then waits for the peer to signal us back by CAS(1→0) on our own slot.
+
+The barrier is **self-resetting** (CAS 1→0 in phase 2 returns the slot to 0), so it is reusable across iterations with no host-side reset.
+
+**⚠️ CRITICAL: Only ONE CTA per rank must call this function.** The signal pad slots are binary (0↔1) and can only track a single barrier invocation per rank pair. If multiple CTAs call this function concurrently, their threads will CAS-contend on the same slots:
+1. CTA 0's thread CAS(0→1) succeeds (slot → 1)
+2. CTA 1's thread CAS(0→1) fails (slot already 1) → spins waiting for reset
+3. Peer's phase-2 CAS(1→0) resets the slot → CTA 1's CAS succeeds (slot → 1 again)
+4. But the peer will NOT reset the slot a second time → **CTA 2+ deadlock**
+
+Always guard the call with `if pid == 0:` (or equivalent single-CTA condition) after `barrier_on_this_grid`:
+
+```python
+barrier_on_this_grid(barrier_ptr)  # ALL CTAs participate
+if pid == 0:                        # Only CTA 0 does cross-rank sync
+    barrier_all_intra_node_atomic_cas_block(rank, rank, world_size, signal_pad_ptrs)
+```
+
+**Performance**: uses **multiple threads in parallel** (one per peer rank), not a single thread serially iterating over all peers. With 8 ranks, the parallel version is ~8× faster than the serial variant.
+
+Parameters `local_rank`, `rank`, and `local_world_size` are declared `tl.constexpr` so the compiler can fully unroll the thread-to-peer mapping.
+
+```python
+@triton.jit
+def barrier_all_intra_node_atomic_cas_block(
+    local_rank: tl.constexpr,
+    rank: tl.constexpr,
+    local_world_size: tl.constexpr,
+    symm_flag_ptr,                  # tensor of int64 ptrs → each peer's barrier base
+):
+    """Cross-rank barrier via system-scope CAS on symmetric-memory signal pads.
+
+    `symm_flag_ptr` is the pointer array built by:
+        symm_flag_ptr = torch.tensor(
+            [hdl.get_signal_pad(i, (world_size,), torch.int32).data_ptr()
+             for i in range(world_size)],
+            dtype=torch.int64, device=device,
+        )
+    Each rank's signal pad needs `local_world_size` int32 slots (one per remote rank).
+    """
+    flat_tid = _get_flat_tid()
+    local_rank_offset = rank - local_rank
+
+    ptrs = symm_flag_ptr.to(tl.pointer_type(tl.uint64))
+
+    # Phase 1: each thread with tid < world_size signals one peer (parallel)
+    if flat_tid < local_world_size:
+        peer = flat_tid + local_rank_offset
+        remote_base = tl.load(ptrs + peer).to(tl.pointer_type(tl.uint32))
+        remote_addr = remote_base + local_rank
+        _cas_sys_release(remote_addr, 0, 1)
+
+    # Phase 2: each thread waits for its corresponding peer's signal (parallel)
+    if flat_tid < local_world_size:
+        local_base = tl.load(ptrs + rank).to(tl.pointer_type(tl.uint32))
+        local_addr = local_base + flat_tid
+        _cas_sys_acquire(local_addr, 1, 0)
+
+    tl.debug_barrier()
+```
+
+**Anti-pattern** — do NOT use single-threaded serial iteration:
+
+```python
+# BAD: single thread (flat_tid == 0) serially loops over all peers
+if flat_tid == 0:
+    for peer in range(local_world_size):
+        if peer != local_rank:
+            ...  # signal peer one by one (serial, slow)
+```
+
+> **Note on naming**: an older variant `barrier_all_intra_node_atomic_cas_block_symm_mem` (with `(rank, num_ranks, symm_flag_ptr, peer_barrier_ptrs)` signature, using Python-level `while atomic_cas(...) != 0` spin-loops) appeared in earlier drafts. It is superseded by the function above — same semantics, faster spin-loop, fewer arguments. Always emit the canonical form.
+
+---
+
+## 6. Per-tile signal pattern (inter-sm only)
+
+The inter-sm mode uses an additional **per-tile** signal protocol on top of the rank barrier: the producer kernel stores 1 to a signal slot as each tile completes, the consumer kernel spins on it before consuming. This is what enables fine-grained pipelining between two kernels on different streams.
+
+`_send_signal` and `_wait_signal` use system-scope store/load (not CAS). They are not needed by intra-sm or without-sm kernels.
+
+```python
+@triton.jit
+def _send_signal(addrs, sem: tl.constexpr):
+    """Store 1 to signal slot. System-scope.
+
+    Valid sem values:
+      - "release"  — flush prior writes before signal (use after producing data)
+      - "relaxed"  — no ordering guarantee (use for pure event signaling)
+      "acquire" is NOT valid for send.
+    """
+    if sem == "release":
+        tl.inline_asm_elementwise(
+            "st.global.release.sys.b32 [$1], 1;",
+            "=r, l", [addrs], dtype=addrs.dtype, is_pure=False, pack=1,
+        )
+    else:  # relaxed
+        tl.inline_asm_elementwise(
+            "st.global.relaxed.sys.b32 [$1], 1;",
+            "=r, l", [addrs], dtype=addrs.dtype, is_pure=False, pack=1,
+        )
+
+
+@triton.jit
+def _wait_signal(addrs, sem: tl.constexpr):
+    """Spin until signal slot becomes 1 (ld spin). System-scope.
+
+    Valid sem values:
+      - "acquire"  — ensure subsequent loads see remote writes (use before consuming data)
+      - "relaxed"  — no ordering guarantee
+      "release" is NOT valid for wait.
+    """
+    if sem == "acquire":
+        tl.inline_asm_elementwise(
+            """
+            {
+                .reg .u32 %tmp; .reg .pred %p;
+                wait: ld.global.acquire.sys.b32 %tmp, [$1];
+                setp.eq.u32 %p, %tmp, 1; @!%p bra wait;
+            }
+            """, "=r, l", [addrs], dtype=tl.int32, is_pure=False, pack=1,
+        )
+    else:  # relaxed
+        tl.inline_asm_elementwise(
+            """
+            {
+                .reg .u32 %tmp; .reg .pred %p;
+                wait: ld.global.relaxed.sys.b32 %tmp, [$1];
+                setp.eq.u32 %p, %tmp, 1; @!%p bra wait;
+            }
+            """, "=r, l", [addrs], dtype=tl.int32, is_pure=False, pack=1,
+        )
+```
+
+### Usage pattern
+
+```python
+# Producer (compute kernel): one thread signals per tile, after the store
+tl.store(out_ptr + offsets, result, mask=mask)
+flat_tid = _get_flat_tid()
+if flat_tid == 0:
+    _send_signal(signal_ptr + pid, "release")
+
+# Consumer (persistent comm kernel): one thread waits, then broadcasts to CTA
+for tile_id in range(pid, total_tiles, tl.num_programs(0)):
+    flat_tid = _get_flat_tid()
+    if flat_tid == 0:
+        _wait_signal(signal_ptr + tile_id, "acquire")
+    tl.debug_barrier()  # broadcast readiness to all threads in CTA
+    # ... consume tile ...
+```
+
+The signal tensor is reset by the host via `.zero_()` before each launch. `_send_signal` stores 1, `_wait_signal` spins until it sees 1. No in-kernel reset is needed.
+
+---
+
+## 7. Memory order rules
+
+| Operation | Order | Why |
+|---|---|---|
+| Plain `tl.store` of data | (none) | Visibility is established by the subsequent signal/barrier |
+| Barrier counter increment (`_atomic_add_release`) | release | Make preceding data stores visible to observers of the counter |
+| Barrier counter read (`_load_acquire`) | acquire | Subsequent loads must see remote stores released before the counter |
+| Cross-rank signal **send** after data store | release | Same reason — flush data before raising the flag |
+| Cross-rank signal **wait** before data load | acquire | Reads after wait must see the producer's data |
+| Cross-rank signal for pure ordering (no data) | relaxed | Cheaper; only the happens-before edge is needed |
+
+Rule of thumb: any flag whose **point** is to advertise "data is ready" pairs **release** (writer) with **acquire** (reader). Use **relaxed** only when you've already proven there's no data dependency through that flag.
+
+---
+
+## 8. Which primitives each mode needs
+
+| Primitive | inter-sm | intra-sm | without-sm |
+|---|:---:|:---:|:---:|
+| `_get_flat_tid` | ✅ | ✅ | — |
+| `_get_flat_bid` | (optional) | ✅ | — |
+| `_atomic_add_release` / `_load_acquire` / `_store_release_with_highbit` | (only if you add a grid barrier) | ✅ | — |
+| `_cas_sys_release` / `_cas_sys_acquire` | — | ✅ (backs rank barrier) | — |
+| `_send_signal` / `_wait_signal` | ✅ (core mechanism) | — | — |
+| `barrier_on_this_grid` | usually ❌ (per-tile signal replaces it) | ✅ (separates compute/push from reduce) | — |
+| `barrier_all_intra_node_atomic_cas_block` | ❌ (use host-side `hdl.barrier()`) | ✅ (after grid barrier) | — |
+| `tl.debug_barrier()` | ✅ | ✅ | — |
+
+Without-sm relies on `hdl.barrier()` on the host side and copy-engine `cuStreamWriteValue32` progress polling instead of in-kernel barriers, so it does not pull from this catalog.
+
+Both inter-sm and without-sm use host-side `symm_mem_hdl.barrier()` (around `signal.zero_()`) for cross-rank synchronization between iterations, since neither has a subsequent in-kernel phase after communication completes.

--- a/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
@@ -327,6 +327,91 @@ if flat_tid == 0:
 
 > **Note on naming**: an older variant `barrier_all_intra_node_atomic_cas_block_symm_mem` (with `(rank, num_ranks, symm_flag_ptr, peer_barrier_ptrs)` signature, using Python-level `while atomic_cas(...) != 0` spin-loops) appeared in earlier drafts. It is superseded by the function above — same semantics, faster spin-loop, fewer arguments. Always emit the canonical form.
 
+### 5.4 Host-side cross-rank barrier: `symm_mem_hdl.barrier()`
+
+When a kernel does **not** have a subsequent in-kernel phase after communication (i.e., the kernel exits once the communication phase is done), use **host-side** `symm_mem_hdl.barrier()` instead of the in-kernel `barrier_all_intra_node_atomic_cas_block`. This is the standard PyTorch symmetric memory barrier and is the correct choice for **inter-sm** and **without-sm** modes.
+
+`symm_mem_hdl` is obtained via `symm_mem.rendezvous(<symm_mem_tensor>, group=<communication_group>)`:
+
+```python
+import torch.distributed._symmetric_memory as symm_mem
+
+buf = symm_mem.empty(shape, dtype=dtype, device=device)       # allocate symmetric memory
+symm_mem_hdl = symm_mem.rendezvous(buf, group=dist.group.WORLD)  # get the handler
+```
+
+The handler provides `barrier()`, `get_buffer()`, `get_signal_pad()`, and other symmetric memory APIs.
+
+**Underlying implementation** (from PyTorch's `CUDASymmetricMemory.cu`):
+
+```cuda
+static __global__ void barrier_kernel(
+    uint32_t** signal_pads, int channel, int rank, int world_size, size_t timeout_ms) {
+    if (threadIdx.x < world_size) {
+        auto target_rank = threadIdx.x;
+        if (target_rank == rank) return;
+        // Signal target_rank (release)
+        try_put_signal<memory_order_release>(
+            signal_pads[target_rank] + world_size * channel + rank, timeout_ms);
+        // Wait for target_rank's signal (acquire)
+        try_wait_signal<memory_order_acquire>(
+            signal_pads[rank] + world_size * channel + target_rank, timeout_ms);
+    }
+}
+```
+
+It launches a small CUDA kernel (1 block, `world_size` threads) that performs pairwise signal/wait on the symmetric memory signal pads. This is a **host-side API** — you call it from Python, and it launches + synchronizes internally.
+
+**Key characteristics:**
+
+| Property | `symm_mem_hdl.barrier()` | `barrier_all_intra_node_atomic_cas_block` |
+|---|---|---|
+| **Where it runs** | Host side (launches a CUDA kernel) | Inside a Triton kernel |
+| **Channel support** | Yes — `barrier(channel=N)` for multi-phase pipelines | No — uses CAS on dedicated signal pad slots |
+| **Self-resetting** | Yes — signal pads are toggled and reset by the barrier kernel itself | Yes — CAS(1→0) in phase 2 returns the slot to 0 |
+| **Overhead** | Extra kernel launch + stream sync | Zero extra kernel launches (runs inside existing kernel) |
+| **Best for** | inter-sm, without-sm (kernel exits after comm) | intra-sm (kernel has post-comm compute phase) |
+
+**Usage pattern:**
+
+```python
+# Host side: use symm_mem_hdl.barrier() around signal.zero_() for cross-rank sync
+# between iterations when the kernel itself has no post-comm compute phase.
+
+# Reset per-tile signals (must happen after all ranks finished consuming)
+ctx.signal_tensor.zero_()
+ctx.symm_mem_hdl.barrier()  # ensure all ranks see zeroed signals
+
+# Launch kernel — it exits when communication is done
+kernel[grid](...)
+```
+
+**Channel usage for multi-phase pipelines:**
+
+The `barrier(channel=N)` parameter supports multiple independent barrier channels within the same signal pad. This is used by PyTorch's `_pipelined_produce_and_all2all` and `_pipelined_all_gather_and_consume` to manage multi-phase pipelines:
+
+```python
+symm_mem.barrier(channel=0)  # phase 0: ensure workspace is ready
+# ... copy local shard ...
+symm_mem.barrier(channel=1)  # phase 1: all local shards copied
+# ... consume remote shards ...
+symm_mem.barrier(channel=0)  # final sync
+```
+
+For overlap kernels, `channel=0` is typically sufficient. The number of channels is bounded by `signal_pad_size / (sizeof(uint32_t) * world_size)`.
+
+**Signal pad size requirement:** Each channel uses `world_size * world_size` uint32 slots in the signal pad. The default signal pad size is typically sufficient for a few channels. If more channels are needed, call `symm_mem.set_signal_pad_size()` before any allocations.
+
+**Memory ordering:** The barrier kernel uses `memory_order_release` for puts and `memory_order_acquire` for waits. This establishes a full happens-before relationship: all stores before the barrier on any rank are visible to all loads after the barrier on every other rank. This is equivalent to the ordering guarantees of the in-kernel `barrier_all_intra_node_atomic_cas_block`.
+
+**Decision rule:**
+
+| Scenario | Use |
+|---|---|
+| Kernel has a post-comm compute phase (intra-sm) | In-kernel `barrier_all_intra_node_atomic_cas_block` (single CTA) |
+| Kernel exits after communication (inter-sm, without-sm) | Host-side `symm_mem_hdl.barrier()` |
+| Multi-phase pipelined host-side communication | Host-side `symm_mem_hdl.barrier(channel=N)` |
+
 ---
 
 ## 6. Per-tile signal pattern (inter-sm only)
@@ -435,7 +520,8 @@ Rule of thumb: any flag whose **point** is to advertise "data is ready" pairs **
 | `_cas_sys_release` / `_cas_sys_acquire` | — | ✅ (backs rank barrier) | — |
 | `_send_signal` / `_wait_signal` | ✅ (core mechanism) | — | — |
 | `barrier_on_this_grid` | usually ❌ (per-tile signal replaces it) | ✅ (separates compute/push from reduce) | — |
-| `barrier_all_intra_node_atomic_cas_block` | ❌ (use host-side `hdl.barrier()`) | ✅ (after grid barrier) | — |
+| `barrier_all_intra_node_atomic_cas_block` | ❌ (use host-side `symm_mem_hdl.barrier()`) | ✅ (after grid barrier) | — |
+| `symm_mem_hdl.barrier()` (host-side) | ✅ (around `signal.zero_()`) | ❌ (use in-kernel rank barrier) | ✅ (between iterations) |
 | `tl.debug_barrier()` | ✅ | ✅ | — |
 
 Without-sm relies on `hdl.barrier()` on the host side and copy-engine `cuStreamWriteValue32` progress polling instead of in-kernel barriers, so it does not pull from this catalog.

--- a/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/primitives.md
@@ -107,7 +107,7 @@ def _load_acquire(ptr):
         "=r, l",
         [ptr],
         dtype=tl.uint32,
-        is_pure=True,
+        is_pure=False,
         pack=1,
     )
 ```
@@ -243,6 +243,14 @@ def barrier_on_this_grid(barrier_ptr):
 ```
 
 **Host-side requirement**: the counter must be reset to 0 between kernel launches (`ctx.grid_barrier.zero_()`).
+
+**⚠️ CRITICAL: `num_ctas` must not exceed SM for persistent kernels.** This barrier requires ALL CTAs to arrive before any can proceed. If `num_ctas > SMs`, some CTAs cannot be scheduled (SMs are fully occupied by earlier CTAs that are already spinning at the barrier) and the kernel deadlocks. Always cap the grid size:
+
+```python
+num_sm = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+num_ctas = min(total_tiles, num_sm)  # conservative: assume 1 CTA/SM
+# or query actual occupancy and use: min(total_tiles, num_sm * occupancy)
+```
 
 ### 5.3 Rank level: `barrier_all_intra_node_atomic_cas_block`
 

--- a/.claude/skills/sglang-overlap-kernel-generation/references/triton_fp8_gemm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/triton_fp8_gemm.md
@@ -221,8 +221,8 @@ def w8a8_block_fp8_matmul_triton(
 | `BLOCK_SIZE_N` | 128 | Match `group_n` for clean B-scale indexing |
 | `BLOCK_SIZE_K` | 128 | Match `group_k` for clean A-scale stepping |
 | `GROUP_SIZE_M` | 32 | L2 swizzle group; 32 is a good default |
-| `num_warps` | 4 | Standard for matmul kernels |
-| `num_stages` | 3 | Software pipelining for memory latency hiding |
+| `num_warps` | 4 | Standard for **standalone** matmul kernels (compute-bound). When the FP8 GEMM is embedded **inside an overlap kernel** (intra-sm, without-sm), the outer kernel is memory-bound and should use `num_warps=32` per the SKILL.md Performance Checks. The two settings apply at different levels: the matmul inner loop benefits from 4 warps (more SM occupancy for tensor cores), while the overlap wrapper needs 32 warps (hide memory latency for signal polling / barriers). |
+| `num_stages` | 3 | Standard for standalone matmul (software pipelining). When embedded in an overlap kernel, `num_stages=1` is used for the outer wrapper (simple load/store patterns, no pipelining). |
 
 When `BLOCK_SIZE_K == group_k`, the scale stepping logic simplifies: scales advance every K-tile, and `n_tiles_k_per_group_k == 1`.
 

--- a/.claude/skills/sglang-overlap-kernel-generation/references/triton_fp8_gemm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/triton_fp8_gemm.md
@@ -1,0 +1,359 @@
+# Block-wise FP8 GEMM Reference
+
+> **On-demand reference.** Load this file when the user's compute kernel is a **GEMM / matmul** that operates on **FP8 quantized** inputs (e.g. batched GEMM, linear layers with FP8 weight, AllGather + FP8 GEMM overlap). If the compute kernel uses bf16/fp16 natively (not block-wise FP8), this reference is not needed.
+
+> **Self-contained: do NOT import from `triton_dist` or `sglang`.** The generated kernel file must include the matmul kernel inline. Only standard imports (`torch`, `torch.distributed`, `triton`, `triton.language`) are allowed.
+
+This reference documents the block-wise FP8 (W8A8) GEMM kernel used in production inference frameworks (SGLang, vLLM) and adapted for overlap kernels in triton_dist. It covers:
+
+- §A — Block-wise FP8 matmul kernel (`_w8a8_block_fp8_matmul`)
+- §B — Host-side launch helpers and configuration
+- §C — Integration into overlap kernels: activation quantization strategies (separate kernel vs. on-the-fly), code patterns, and stride conventions
+
+---
+
+## (A) Block-wise FP8 Matmul Kernel
+
+### A.1 Core algorithm
+
+The kernel computes `C = (A_fp8 * A_scale) @ (B_fp8 * B_scale)` where scales are applied per-block after `tl.dot`:
+
+```
+for each K-tile:
+    a_tile = load A_fp8[M_tile, K_tile]       # fp8
+    b_tile = load B_fp8[K_tile, N_tile]       # fp8
+    a_s    = load A_scale[M_tile, K_tile // group_k]   # float32
+    b_s    = load B_scale[N_tile // group_n, K_tile // group_k]  # float32
+    acc   += tl.dot(a_tile, b_tile) * a_s * b_s
+```
+
+Key insight: `tl.dot(fp8, fp8)` produces an `int32` result on SM90+ hardware (HMMAInstructions), which is implicitly cast to `float32` in Triton. The scale multiplication happens in `float32` after the dot product.
+
+### A.2 Tensor layout
+
+| Tensor | Dtype | Shape | Scale shape | Scale granularity |
+|--------|-------|-------|-------------|-------------------|
+| A (activation) | `float8_e4m3fn` | `[M, K]` | `[M, K // group_k]` | Per-token, per-`group_k` columns |
+| B (weight) | `float8_e4m3fn` | `[N, K]` (column-major) | `[N // group_n, K // group_k]` | Per-`group_n` rows, per-`group_k` columns |
+
+Typical block sizes: `group_n = 128`, `group_k = 128`.
+
+### A.3 Full kernel
+
+```python
+@triton.jit
+def _w8a8_block_fp8_matmul(
+    # Pointers
+    A, B, C, As, Bs,
+    # Dimensions
+    M, N, K,
+    M_local,         # rows per rank (for compact AG layout row addressing)
+    # Block quantization sizes
+    group_n, group_k,
+    # Strides
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
+    stride_As_m, stride_As_k,
+    stride_Bs_k, stride_Bs_n,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    needs_k_masking: tl.constexpr,
+    needs_m_masking: tl.constexpr,
+    M_per_rank_tiles: tl.constexpr,  # cdiv(M_local, BLOCK_SIZE_M)
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+):
+    # Swizzled PID for L2 locality
+    pid = tl.program_id(axis=0)
+    num_pid_m = M_per_rank_tiles * world_size
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # Rank-aware tile rotation (match AG signal arrival order)
+    logical_src_rank = min(pid_m // M_per_rank_tiles, world_size - 1)
+    tile_in_rank = pid_m - logical_src_rank * M_per_rank_tiles
+    src_rank = (rank + logical_src_rank) % world_size
+
+    # Row offsets — compact layout: src_rank * M_local + tile_in_rank * BLOCK_SIZE_M
+    offs_am = src_rank * M_local + tile_in_rank * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # M-dimension row mask (tail tiles)
+    if needs_m_masking:
+        shard_end = (src_rank + 1) * M_local
+        row_mask = (offs_am < M) & (offs_am < shard_end)
+
+    a_ptrs = A + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = B + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    # Scale pointer offsets
+    As_ptrs = As + offs_am * stride_As_m
+    offs_bsn = offs_bn // group_n
+    Bs_ptrs = Bs + offs_bsn * stride_Bs_n
+    n_tiles_k_per_group_k = group_k // BLOCK_SIZE_K
+
+    # Main loop
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        if needs_k_masking:
+            k_mask = offs_k < K - k * BLOCK_SIZE_K
+            if needs_m_masking:
+                a = tl.load(a_ptrs, mask=row_mask[:, None] & k_mask[None, :], other=0.0)
+            else:
+                a = tl.load(a_ptrs, mask=k_mask[None, :], other=0.0)
+            b = tl.load(b_ptrs, mask=k_mask[:, None], other=0.0)
+        else:
+            if needs_m_masking:
+                a = tl.load(a_ptrs, mask=row_mask[:, None], other=0.0)
+            else:
+                a = tl.load(a_ptrs)
+            b = tl.load(b_ptrs)
+
+        a_s = tl.load(As_ptrs)
+        b_s = tl.load(Bs_ptrs)
+
+        scale_step_k = tl.where((k + 1) % n_tiles_k_per_group_k == 0, 1, 0)
+        accumulator += tl.dot(a, b) * a_s[:, None] * b_s[None, :]
+
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+        As_ptrs += scale_step_k * stride_As_k
+        Bs_ptrs += scale_step_k * stride_Bs_k
+
+    # Epilogue: cast and store
+    c = accumulator.to(tl.bfloat16)
+
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C + stride_cm * offs_am[:, None] + stride_cn * offs_cn[None, :]
+    if needs_m_masking:
+        c_mask = row_mask[:, None] & (offs_cn[None, :] < N)
+    else:
+        c_mask = (offs_am[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+```
+
+### A.4 Critical details
+
+1. **Scale stepping**: The scale tensors have lower resolution than the data (one scale per `group_k` elements along K). The pointer only advances when we cross a scale-group boundary: `scale_step_k = tl.where((k + 1) % n_tiles_k_per_group_k == 0, 1, 0)`. This means `BLOCK_SIZE_K` must divide `group_k` (typically `BLOCK_SIZE_K = group_k = 128`).
+
+2. **`BLOCK_SIZE_N` alignment with `group_n`**: `offs_bsn = offs_bn // group_n` computes which B-scale row to load. If `BLOCK_SIZE_N < group_n`, threads within a CTA load duplicate scale values — this is harmless but wastes bandwidth. Recommended: `BLOCK_SIZE_N = group_n` or `BLOCK_SIZE_N` is a multiple of `group_n`.
+
+3. **B is column-major (transposed)**: The weight matrix B has shape `[N, K]` with `stride_bk` (row stride in the `[N, K]` view) being the fast dimension. This matches FP8 weight-quantized models in vLLM/SGLang where weights are stored transposed for column-major access.
+
+4. **Swizzled PID**: The `GROUP_SIZE_M` swizzling pattern reorders CTAs for better L2 cache locality. `GROUP_SIZE_M = 32` is a good default.
+
+5. **`needs_k_masking` / `needs_m_masking`**: Two `tl.constexpr` flags for fast/slow-path compilation. `needs_k_masking = K % BLOCK_SIZE_K != 0` (K-tail mask). `needs_m_masking = M_local % BLOCK_SIZE_M != 0` (M-tail row mask). Any overlap pattern where the GEMM's M dimension is partitioned across ranks (AG→GEMM, GEMM→AG, etc.) must handle tail tiles when `M_local` is not a multiple of `BLOCK_SIZE_M`. For example in AG→GEMM (compact layout): grid = `cdiv(M_local, BLOCK_SIZE_M) * world_size * num_pid_n`; row offset = `src_rank * M_local + tile_in_rank * BLOCK_SIZE_M`; row mask = `(offs_row < M) & (offs_row < (src_rank+1)*M_local)` to stay within the current rank's shard.
+
+6. **Avoid `tl.constexpr` for frequently-changing values.** Triton JIT compiles a separate kernel binary for each unique combination of `tl.constexpr` arguments. Quantities derived from dynamic problem size (`M`, `M_per_rank`, `n_chunks`, etc.) should be regular (non-constexpr) parameters, or computed inside the kernel from other arguments:
+
+   ```python
+   # BAD — recompiles every time ntokens changes:
+   #   M_per_rank: tl.constexpr,
+
+   # GOOD (option A) — pass as regular (non-constexpr) parameter:
+   #   M_per_rank,   # no tl.constexpr annotation
+
+   # GOOD (option B) — compute inside kernel from runtime M:
+   M_per_rank = M // world_size
+   ```
+
+---
+
+## (B) Host-side Launch Helpers
+
+### B.1 Launching the kernel
+
+```python
+def w8a8_block_fp8_matmul_triton(
+    A: torch.Tensor,       # fp8 [M_local * world_size, K] (gathered A, compact layout)
+    B: torch.Tensor,       # fp8 [N, K], column-major
+    As: torch.Tensor,      # float32 scale for A
+    Bs: torch.Tensor,      # float32 scale for B [N // group_n, K // group_k]
+    block_size: list,       # [BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K]
+    M_local: int,           # rows per rank
+    rank: int,
+    world_size: int,
+    output_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    assert len(block_size) == 3
+    block_m, block_n, block_k = block_size
+
+    M = A.numel() // A.shape[-1]
+    N, K = B.shape
+    C = A.new_empty(*A.shape[:-1], N, dtype=output_dtype)
+
+    needs_k_masking = bool(K % block_k != 0)
+    needs_m_masking = bool(M_local % block_m != 0)
+    M_per_rank_tiles = triton.cdiv(M_local, block_m)
+    num_pid_m = M_per_rank_tiles * world_size
+    num_pid_n = triton.cdiv(N, block_n)
+    num_tiles = num_pid_m * num_pid_n
+
+    _w8a8_block_fp8_matmul[(num_tiles,)](
+        A, B, C, As, Bs,
+        M, N, K,
+        M_local,
+        block_n, block_k,
+        A.stride(-2), A.stride(-1),
+        B.stride(1), B.stride(0),
+        C.stride(-2), C.stride(-1),
+        As.stride(-2), As.stride(-1),
+        Bs.stride(1), Bs.stride(0),
+        BLOCK_SIZE_M=block_m,
+        BLOCK_SIZE_N=block_n,
+        BLOCK_SIZE_K=block_k,
+        GROUP_SIZE_M=32,
+        needs_k_masking=needs_k_masking,
+        needs_m_masking=needs_m_masking,
+        M_per_rank_tiles=M_per_rank_tiles,
+        rank=rank,
+        world_size=world_size,
+        num_warps=4,
+        num_stages=3,
+    )
+    return C
+```
+
+### B.2 Default tuning configuration
+
+| Parameter | Default | Reason |
+|-----------|---------|--------|
+| `BLOCK_SIZE_M` | 64 | Balance SM occupancy vs. register pressure |
+| `BLOCK_SIZE_N` | 128 | Match `group_n` for clean B-scale indexing |
+| `BLOCK_SIZE_K` | 128 | Match `group_k` for clean A-scale stepping |
+| `GROUP_SIZE_M` | 32 | L2 swizzle group; 32 is a good default |
+| `num_warps` | 4 | Standard for matmul kernels |
+| `num_stages` | 3 | Software pipelining for memory latency hiding |
+
+When `BLOCK_SIZE_K == group_k`, the scale stepping logic simplifies: scales advance every K-tile, and `n_tiles_k_per_group_k == 1`.
+
+---
+
+## (C) Integration into Overlap Kernels
+
+### C.1 Activation quantization strategies
+
+B (weight) and Bs (weight scale) are always quantized offline before the overlap begins — they are static and do not change across iterations.
+
+A (activation) may arrive as either **fp8** (pre-quantized) or **bf16** (raw from communication). There are two strategies:
+
+| Strategy | When to use | How it works | Pros | Cons |
+|----------|-------------|--------------|------|------|
+| **Separate quantize kernel** | A is pre-quantized, or you need exact per-`group_k` granularity | Run a `per_token_group_quant_fp8` kernel to produce `A_fp8` and `A_scale`, then feed them into `_w8a8_block_fp8_matmul` | Exact per-`group_k` quantization granularity; clean separation of concerns | Extra kernel launch + one global memory round-trip for `A_fp8` and `A_scale` |
+| **On-the-fly quantization inside GEMM** | A arrives as bf16 from symmetric memory and you want to save the extra kernel launch | Inside the GEMM K-loop, load bf16 A tile → compute per-row `absmax` → `scale = absmax / fp8_max` → `A_fp8 = clamp(A_bf16 / scale, -fp8_max, fp8_max)` → `tl.dot(A_fp8, B_fp8) * scale * B_scale` | Saves one kernel launch and one global memory round-trip (no separate `A_fp8` / `A_scale` buffers) | Quantization granularity is per-`BLOCK_SIZE_K`-tile per M-tile-row; matches per-`group_k` only when `BLOCK_SIZE_K == group_k` |
+
+When `BLOCK_SIZE_K == group_k == 128` (the standard setting), both strategies produce equivalent numerical results.
+
+### C.2 On-the-fly quantization code pattern
+
+To add on-the-fly A quantization inside the `_w8a8_block_fp8_matmul` K-loop, replace the A loading and scaling logic:
+
+**Before** (pre-quantized A_fp8 + A_scale):
+```python
+# Load pre-quantized fp8 A and its scale
+a = tl.load(a_ptrs, ...)           # fp8
+a_s = tl.load(As_ptrs)             # float32 scale
+accumulator += tl.dot(a, b) * a_s[:, None] * b_s[None, :]
+```
+
+**After** (on-the-fly bf16→fp8 quantization inside GEMM):
+```python
+# Load bf16 A tile and quantize on the fly
+fp8_max = 448.0  # float(torch.finfo(torch.float8_e4m3fn).max)
+a_bf16 = tl.load(a_ptrs, ...)                           # bf16
+a_absmax = tl.max(tl.abs(a_bf16), axis=1)              # [BLOCK_SIZE_M]
+a_s = tl.maximum(a_absmax, 1e-12) / fp8_max             # [BLOCK_SIZE_M], per-row scale
+a_rcp_s = fp8_max / tl.maximum(a_absmax, 1e-12)         # [BLOCK_SIZE_M], reciprocal for cast
+a_fp8 = (a_bf16 * a_rcp_s[:, None]).to(B.dtype.element_ty)  # FMUL + saturating cast to fp8
+accumulator += tl.dot(a_fp8, b) * a_s[:, None] * b_s[None, :]
+```
+
+Key differences when using on-the-fly quantization:
+- The `As` pointer and stride parameters are removed from the kernel signature.
+- A is loaded as bf16 instead of fp8, so `A.dtype` should be `torch.bfloat16`.
+- The `a_s` scale is computed inline per K-tile instead of loaded from a separate tensor.
+- The `fp8_max = 448.0` constant should be defined at the top of the kernel.
+
+### C.3 Pattern: signal poll → GEMM
+
+In the overlap scenario (e.g. AllGather → GEMM), the consumer GEMM kernel:
+
+1. **Polls** a signal (e.g., `ld_sys(ag_signal_ptr + src_rank)`) to confirm that the corresponding A shard has arrived in symmetric memory.
+2. **Loads** A from symmetric memory (either as pre-quantized fp8 or as bf16 for on-the-fly quantization).
+3. **Performs** `tl.dot(A_fp8, B_fp8) * A_scale * B_scale`.
+4. **Stores** the result to the output tensor.
+
+### C.4 Stride conventions for overlap kernels
+
+When A comes from symmetric memory, be especially careful with strides:
+
+- `symm_ag_a` shape: `[M * world_size, K]`, contiguous row-major.
+- Strides: `stride_am = K`, `stride_ak = 1`.
+- B is pre-quantized fp8 with shape `[N, K]`, column-major (transposed): `B.stride(0) = K, B.stride(1) = 1`. In the kernel, `stride_bk` is the stride along K (fast dim = 1) and `stride_bn` is the stride along N (slow dim = K). So `stride_bk = B.stride(1) = 1, stride_bn = B.stride(0) = K`.
+- Bs for B-scale is `[N // group_n, K // group_k]` with `Bs.stride(0) = K // group_k, Bs.stride(1) = 1`. So `stride_Bs_k = Bs.stride(1) = 1, stride_Bs_n = Bs.stride(0) = K // group_k`.
+
+**CRITICAL: stride parameter ordering pitfall.** The kernel signature declares `stride_Bs_k, stride_Bs_n` (K-dim first, N-dim second), but `Bs` tensor shape is `[N // group_n, K // group_k]` (N-dim first, K-dim second). You must pass `Bs.stride(1), Bs.stride(0)` — NOT `Bs.stride(0), Bs.stride(1)`. Getting this wrong silently produces garbage results with large numerical errors.
+
+### C.5 Signal tile_id mapping with swizzled PID
+
+When the GEMM kernel uses `GROUP_SIZE_M` swizzling (§A.4 point 4), the `pid` (program_id) does NOT correspond to a linear `(tile_m, tile_n)` mapping. If a communication kernel (e.g., AllGather comm kernel) polls signals by linear tile_id (`tile_m * num_tiles_n + tile_n`), the GEMM kernel must signal using the **linear tile_id**, not the raw `pid`:
+
+```python
+# WRONG: signal with swizzled pid
+_send_signal(signal_ptr + pid, "release")
+
+# CORRECT: signal with linear tile_id derived from swizzled (pid_m, pid_n)
+linear_tile_id = pid_m * num_pid_n + pid_n
+_send_signal(signal_ptr + linear_tile_id, "release")
+```
+
+If the GEMM signals `signal_ptr + pid` but the comm kernel waits on `signal_ptr + tile_id` (linear), the comm kernel will read stale/wrong tile data, causing either a hang (waiting for a signal that never fires) or silent data corruption.
+
+---
+
+## (D) When to Use On-the-fly Quantization vs. Pre-quantized FP8
+
+### D.1 Decision rule
+
+| Overlap pattern | A input to GEMM | Quantization strategy |
+|-----------------|-----------------|----------------------|
+| **GEMM → AllGather** | A is pre-quantized fp8 (quantized before GEMM) | Use `_w8a8_block_fp8_matmul` directly with fp8 A + A_scale. **No on-the-fly quant.** |
+| **AllGather → GEMM** | A arrives as bf16 from AllGather (symmetric memory) | Use on-the-fly quantization (§C.2) inside the GEMM kernel. A is loaded as bf16 and quantized per K-tile. |
+
+**Key principle:** On-the-fly quantization is ONLY needed when the GEMM kernel's A input is bf16 (because it came from a communication collective that operates on bf16). If A is already fp8 (pre-quantized before the overlap begins), the GEMM kernel should directly load fp8 and use the pre-computed scale — do NOT re-quantize.
+
+### D.2 Constructing FP8 test data
+
+Use `deep_gemm.utils` to produce correctly-shaped FP8 tensors and scales for testing:
+
+```python
+from deep_gemm.utils import per_token_cast_to_fp8, per_block_cast_to_fp8
+
+# Activation: per-token-group quantization (group_k=128 fixed)
+# Input: a_bf16 [M, K], dtype=torch.bfloat16
+# Output: a_fp8 [M, K], dtype=torch.float8_e4m3fn
+#         a_scale [M, K // 128], dtype=torch.float32
+a_fp8, a_scale = per_token_cast_to_fp8(a_bf16, use_ue8m0=False)
+
+# Weight: per-block quantization (group_n=128, group_k=128)
+# Input: weight_bf16 [N, K], dtype=torch.bfloat16
+# Output: b_fp8 [N, K], dtype=torch.float8_e4m3fn
+#         b_scale [N // 128, K // 128], dtype=torch.float32
+b_fp8, b_scale = per_block_cast_to_fp8(weight_bf16, use_ue8m0=False)
+```
+
+**Important notes:**
+- `per_token_cast_to_fp8` always uses group_k=128 internally (hardcoded). The returned `a_scale` shape is `[M, K // 128]`.
+- `per_block_cast_to_fp8` uses 128×128 blocks. The returned `b_scale` shape is `[N // 128, K // 128]`.
+- Both functions require `use_ue8m0=False` parameter (mandatory positional arg in current version).
+- `per_block_cast_to_fp8` does NOT take `group_n`/`group_k` parameters — it always uses 128×128 blocks.

--- a/.claude/skills/sglang-overlap-kernel-generation/references/triton_fp8_gemm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/triton_fp8_gemm.md
@@ -63,7 +63,6 @@ def _w8a8_block_fp8_matmul(
     BLOCK_SIZE_K: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
     needs_k_masking: tl.constexpr,
-    needs_m_masking: tl.constexpr,
     rank: tl.constexpr,
     world_size: tl.constexpr,
 ):
@@ -84,19 +83,17 @@ def _w8a8_block_fp8_matmul(
     src_rank = (rank + logical_src_rank) % world_size
 
     # Row offsets — compact layout: src_rank * M_local + tile_in_rank * BLOCK_SIZE_M
-    offs_am = src_rank * M_local + tile_in_rank * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    # Use % M to handle M not divisible by BLOCK_SIZE_M: tail tile rows wrap
+    # around to valid indices; store mask prevents overwriting wrong rows.
+    tile_row_start = src_rank * M_local + tile_in_rank * BLOCK_SIZE_M
+    offs_am = (tile_row_start + tl.arange(0, BLOCK_SIZE_M)) % M
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-
-    # M-dimension row mask (tail tiles)
-    if needs_m_masking:
-        shard_end = (src_rank + 1) * M_local
-        row_mask = (offs_am < M) & (offs_am < shard_end)
 
     a_ptrs = A + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
     b_ptrs = B + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
 
-    # Scale pointer offsets
+    # Scale pointer offsets (use % M for tail tiles)
     As_ptrs = As + offs_am * stride_As_m
     offs_bsn = offs_bn // group_n
     Bs_ptrs = Bs + offs_bsn * stride_Bs_n
@@ -107,16 +104,10 @@ def _w8a8_block_fp8_matmul(
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         if needs_k_masking:
             k_mask = offs_k < K - k * BLOCK_SIZE_K
-            if needs_m_masking:
-                a = tl.load(a_ptrs, mask=row_mask[:, None] & k_mask[None, :], other=0.0)
-            else:
-                a = tl.load(a_ptrs, mask=k_mask[None, :], other=0.0)
+            a = tl.load(a_ptrs, mask=k_mask[None, :], other=0.0)
             b = tl.load(b_ptrs, mask=k_mask[:, None], other=0.0)
         else:
-            if needs_m_masking:
-                a = tl.load(a_ptrs, mask=row_mask[:, None], other=0.0)
-            else:
-                a = tl.load(a_ptrs)
+            a = tl.load(a_ptrs)
             b = tl.load(b_ptrs)
 
         a_s = tl.load(As_ptrs)
@@ -135,10 +126,10 @@ def _w8a8_block_fp8_matmul(
 
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     c_ptrs = C + stride_cm * offs_am[:, None] + stride_cn * offs_cn[None, :]
-    if needs_m_masking:
-        c_mask = row_mask[:, None] & (offs_cn[None, :] < N)
-    else:
-        c_mask = (offs_am[:, None] < M) & (offs_cn[None, :] < N)
+    # offs_am used % M wrapping, so re-compute raw row indices for the store mask
+    offs_cm = tile_row_start + tl.arange(0, BLOCK_SIZE_M)
+    rank_row_end = (src_rank + 1) * M_local
+    c_mask = (offs_cm[:, None] < M) & (offs_cm[:, None] < rank_row_end) & (offs_cn[None, :] < N)
     tl.store(c_ptrs, c, mask=c_mask)
 ```
 
@@ -152,7 +143,7 @@ def _w8a8_block_fp8_matmul(
 
 4. **Swizzled PID**: The `GROUP_SIZE_M` swizzling pattern reorders CTAs for better L2 cache locality. `GROUP_SIZE_M = 32` is a good default.
 
-5. **`needs_k_masking` / `needs_m_masking`**: Two `tl.constexpr` flags for fast/slow-path compilation. `needs_k_masking = K % BLOCK_SIZE_K != 0` (K-tail mask). `needs_m_masking = M_local % BLOCK_SIZE_M != 0` (M-tail row mask). Any overlap pattern where the GEMM's M dimension is partitioned across ranks (AG→GEMM, GEMM→AG, etc.) must handle tail tiles when `M_local` is not a multiple of `BLOCK_SIZE_M`. For example in AG→GEMM (compact layout): grid = `cdiv(M_local, BLOCK_SIZE_M) * world_size * num_pid_n`; row offset = `src_rank * M_local + tile_in_rank * BLOCK_SIZE_M`; row mask = `(offs_row < M) & (offs_row < (src_rank+1)*M_local)` to stay within the current rank's shard.
+5. **`needs_k_masking`**: A `tl.constexpr` flag for K-tail compilation fast/slow-path. `needs_k_masking = K % BLOCK_SIZE_K != 0`. For M-dimension tail tiles (when `M_local % BLOCK_SIZE_M != 0`), the kernel uses `% M` wrapping on row offsets instead of a separate compilation flag — the raw `tile_row_start` is stored separately for the store mask, while `offs_am = (tile_row_start + tl.arange(...)) % M` ensures A loads never go out of bounds. The store mask `(offs_cm[:, None] < M) & (offs_cm[:, None] < rank_row_end)` protects tail tiles from writing outside the current rank's shard. This follows the SGLang `consumer_bf16_a_block_fp8_matmul` pattern and avoids an extra JIT compilation path.
 
 6. **Avoid `tl.constexpr` for frequently-changing values.** Triton JIT compiles a separate kernel binary for each unique combination of `tl.constexpr` arguments. Quantities derived from dynamic problem size (`M`, `M_per_rank`, `n_chunks`, etc.) should be regular (non-constexpr) parameters, or computed inside the kernel from other arguments:
 
@@ -193,7 +184,6 @@ def w8a8_block_fp8_matmul_triton(
     C = A.new_empty(*A.shape[:-1], N, dtype=output_dtype)
 
     needs_k_masking = bool(K % block_k != 0)
-    needs_m_masking = bool(M_local % block_m != 0)
     M_local_tiles = triton.cdiv(M_local, block_m)
     num_pid_m = M_local_tiles * world_size
     num_pid_n = triton.cdiv(N, block_n)
@@ -215,7 +205,6 @@ def w8a8_block_fp8_matmul_triton(
         BLOCK_SIZE_K=block_k,
         GROUP_SIZE_M=32,
         needs_k_masking=needs_k_masking,
-        needs_m_masking=needs_m_masking,
         rank=rank,
         world_size=world_size,
         num_warps=4,

--- a/.claude/skills/sglang-overlap-kernel-generation/references/triton_fp8_gemm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/triton_fp8_gemm.md
@@ -48,6 +48,7 @@ def _w8a8_block_fp8_matmul(
     # Dimensions
     M, N, K,
     M_local,         # rows per rank (for compact AG layout row addressing)
+    M_local_tiles,   # cdiv(M_local, BLOCK_SIZE_M)
     # Block quantization sizes
     group_n, group_k,
     # Strides
@@ -63,13 +64,12 @@ def _w8a8_block_fp8_matmul(
     GROUP_SIZE_M: tl.constexpr,
     needs_k_masking: tl.constexpr,
     needs_m_masking: tl.constexpr,
-    M_per_rank_tiles: tl.constexpr,  # cdiv(M_local, BLOCK_SIZE_M)
     rank: tl.constexpr,
     world_size: tl.constexpr,
 ):
     # Swizzled PID for L2 locality
     pid = tl.program_id(axis=0)
-    num_pid_m = M_per_rank_tiles * world_size
+    num_pid_m = M_local_tiles * world_size
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
     group_id = pid // num_pid_in_group
@@ -79,8 +79,8 @@ def _w8a8_block_fp8_matmul(
     pid_n = (pid % num_pid_in_group) // group_size_m
 
     # Rank-aware tile rotation (match AG signal arrival order)
-    logical_src_rank = min(pid_m // M_per_rank_tiles, world_size - 1)
-    tile_in_rank = pid_m - logical_src_rank * M_per_rank_tiles
+    logical_src_rank = min(pid_m // M_local_tiles, world_size - 1)
+    tile_in_rank = pid_m - logical_src_rank * M_local_tiles
     src_rank = (rank + logical_src_rank) % world_size
 
     # Row offsets — compact layout: src_rank * M_local + tile_in_rank * BLOCK_SIZE_M
@@ -194,8 +194,8 @@ def w8a8_block_fp8_matmul_triton(
 
     needs_k_masking = bool(K % block_k != 0)
     needs_m_masking = bool(M_local % block_m != 0)
-    M_per_rank_tiles = triton.cdiv(M_local, block_m)
-    num_pid_m = M_per_rank_tiles * world_size
+    M_local_tiles = triton.cdiv(M_local, block_m)
+    num_pid_m = M_local_tiles * world_size
     num_pid_n = triton.cdiv(N, block_n)
     num_tiles = num_pid_m * num_pid_n
 
@@ -203,6 +203,7 @@ def w8a8_block_fp8_matmul_triton(
         A, B, C, As, Bs,
         M, N, K,
         M_local,
+        M_local_tiles,
         block_n, block_k,
         A.stride(-2), A.stride(-1),
         B.stride(1), B.stride(0),
@@ -215,7 +216,6 @@ def w8a8_block_fp8_matmul_triton(
         GROUP_SIZE_M=32,
         needs_k_masking=needs_k_masking,
         needs_m_masking=needs_m_masking,
-        M_per_rank_tiles=M_per_rank_tiles,
         rank=rank,
         world_size=world_size,
         num_warps=4,

--- a/.claude/skills/sglang-overlap-kernel-generation/references/triton_fp8_gemm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/triton_fp8_gemm.md
@@ -2,7 +2,7 @@
 
 > **On-demand reference.** Load this file when the user's compute kernel is a **GEMM / matmul** that operates on **FP8 quantized** inputs (e.g. batched GEMM, linear layers with FP8 weight, AllGather + FP8 GEMM overlap). If the compute kernel uses bf16/fp16 natively (not block-wise FP8), this reference is not needed.
 
-> **Self-contained: do NOT import from `triton_dist` or `sglang`.** The generated kernel file must include the matmul kernel inline. Only standard imports (`torch`, `torch.distributed`, `triton`, `triton.language`) are allowed.
+> **Self-contained: do NOT import from `sglang`.** The generated kernel file must include the matmul kernel inline. Only standard imports (`torch`, `torch.distributed`, `triton`, `triton.language`) are allowed.
 
 This reference documents the block-wise FP8 (W8A8) GEMM kernel used in production inference frameworks (SGLang, vLLM) and adapted for overlap kernels in triton_dist. It covers:
 

--- a/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
@@ -3,10 +3,11 @@
 Communication is offloaded to the **copy engine** (CE), consuming zero SM resources. A
 background stream performs `copy_()` on symmetric memory (routed through DMA), while the
 compute kernel runs simultaneously on the main stream. Synchronization between the two
-streams is achieved through **signal tensors** — written by either PtoP signal pulls or
-CPU-side CE operations (`cuStreamWriteValue32` / `cuStreamWaitValue32`). Signal tensor
-shape determines granularity: `[world_size * splits_per_rank]` where `splits_per_rank=1`
-gives one signal per rank and `splits_per_rank>1` gives finer-grained chunk signaling.
+streams is achieved through **signal tensors** — written by `cuStreamWriteValue32` on the
+CE stream and polled by the compute kernel via `ld_sys` (system-scope acquire load).
+Signal tensor shape determines granularity: `[world_size * splits_per_rank]` where
+`splits_per_rank=1` gives one signal per rank and `splits_per_rank>1` gives finer-grained
+chunk signaling.
 
 ## Architecture
 
@@ -19,9 +20,8 @@ Main Stream (SM)                         Backend Stream (Copy Engine)
 ┌──────────────────────────────┐         ┌─────────────────────────────────────────┐
 │ compute_kernel               │         │ for each peer in rotated order:         │
 │   process local (no wait)    │         │   copy_(peer_symm_buf → local_dst)      │
-│   poll signal[chunk_idx]     │ ◄────── │   write signal[chunk_idx] = 1           │
-│   process remote chunk       │         │     (Approach A: PtoP signal pull)      │
-│                              │         │     (Approach B: stream_write_value32)  │
+│   poll signal[chunk_idx]     │ ◄────── │   stream_write_value32(progress, 1)     │
+│   process remote chunk       │         │                                         │
 └──────────────────────────────┘         └─────────────────────────────────────────┘
 ```
 
@@ -37,425 +37,108 @@ Main Stream (SM)                         Backend Stream (Copy Engine)
 └──────────────────────────────┘         └─────────────────────────────────────────┘
 ```
 
-## Signal Mechanisms for Copy Engine
+## Signal Mechanism: `stream_write_value32`
 
-Because the copy engine operates on a separate CUDA stream and consumes no SMs,
-synchronization between the CE stream and the compute stream must use **CPU-side CE
-operations** or **PtoP copies** — NOT GPU-side atomics or in-kernel barriers.
+The compute kernel and CE stream synchronize via `stream_write_value32` (which wraps
+`cuStreamWriteValue32`) — a 32-bit write on the CE stream with a **system-level fence**
+before the write, guaranteeing that all prior `copy_()` operations on that stream are
+visible before the signal value becomes `1`.
 
-### Comm-First: CE writes signal → Compute kernel polls signal
+**Comm-First**: After the CE copies data from a peer, it writes `1` to the progress tensor
+via `hdl.stream_write_value32`. The compute kernel polls via `ld_sys`.
 
-After the CE copies data from a peer, it must signal the compute kernel that the data
-is ready. There are **two approaches** for writing the signal:
-
-#### Approach A: PtoP Signal Pull via `signal_one_buf`
-
-Create an extra all-ones symmetric memory tensor (`signal_one_buf`). After the data
-`copy_()`, issue a second `copy_()` that pulls a pre-filled `1` from the `signal_one_buf` 
-into the local `ag_signal_buf`:
-
-```python
-# After data copy from src_rank:
-ag_signal[src_rank:src_rank + 1].copy_(
-    peer_signal_one_bufs[src_rank][src_rank:src_rank + 1]
-)
-```
-
-**Pros:**
-- Both data and signal writes stay on the **same PtoP CE channel**, preserving strict
-  ordering without fences — the signal `copy_()` is enqueued after the data `copy_()`
-  on the same stream, and both go through NVLink PtoP.
-- No extra CUDA driver API calls needed.
-
-**Cons:**
-- Requires allocating `signal_one_buf` in symmetric memory and its rendezvous handle
-  (`signal_one_hdl`), plus `peer_signal_one_bufs` for cross-rank access.
-- The `ag_signal_buf` must also be in symmetric memory (as the PtoP destination).
-- Signal granularity should be the same with the granularity of the data tensor.
-
-**Buffers required (in addition to data buffers):**
-
-| Field | Shape / Type | Description |
-|-------|-------------|-------------|
-| `ag_signal_buf` | `[world_size * splits_per_rank]` int32, **symmetric** | Signal tensor. Must be symmetric — CE writes into it via PtoP pull. `splits_per_rank=1` gives `[world_size]`, `splits_per_rank>1` gives finer chunk granularity. |
-| `signal_one_buf` | `[world_size * splits_per_rank]` int32, **symmetric** | All-ones symmetric buffer, pre-filled with `1`. PtoP signal source. Shape matches `ag_signal_buf`. |
-
-#### Approach B: `stream_write_value32` / `hdl.stream_write_value32`
-
-Use the symmetric memory handle's `stream_write_value32` method (which wraps
-`cuStreamWriteValue32`) to write a `1` to a progress tensor after each chunk copy:
-
-```python
-# After data copy from src_rank (or each split within src_rank):
-hdl.stream_write_value32(
-    progress,
-    offset=src_rank * splits_per_rank + split_id,
-    val=1,
-)
-```
-
-Under the hood, `cuStreamWriteValue32` issues a 32-bit write on the CE stream with a
-**system-level fence** before the write, guaranteeing that all prior `copy_()` operations
-on that stream are visible before the signal value becomes `1`.
+**Comp-First**: The compute kernel writes `1` to a signal slot via `st_sys` after each
+tile's stores complete. The CE stream enqueues `cuStreamWaitValue32` — a GPU-side hardware
+wait that stalls the CE channel until the signal equals the expected value.
 
 **⚠️ CRITICAL: The `progress` tensor MUST use `dtype=torch.uint32`, NOT `torch.int32`.**
 `cuStreamWriteValue32` writes an unsigned 32-bit value, and PyTorch's `symm_mem` binding
 validates that the input tensor is a flat, contiguous `uint32` tensor. Passing an `int32`
 tensor raises: `RuntimeError: symm_mem::stream_write_value32_: input must be a flat,
-contiguous uint32 tensor.` This is the most common mistake when using Approach B — always
-double-check that the signal tensor is `uint32`.
-
-**Pros:**
-- Much simpler — no extra symmetric memory allocation for `signal_one_buf`.
-- The `progress` tensor can be a **regular local device tensor** (`torch.zeros(...)`,
-  not `symm_mem.empty()`).
-- Single API call per signal write.
-- Signal tensor shape is `[world_size * splits_per_rank]` — set `splits_per_rank=1` for
-  one signal per rank, or `>1` for finer chunk-level overlap.
-
-**Cons:**
-- `cuStreamWriteValue32` routes the signal write through a **local DtoD write** CE
-  command rather than the PtoP channel used for data copies. This means the signal
-  write goes through a different hardware path than the data copy.
-- In practice this is still correct — the CE stream enforces ordering (the
-  `stream_write_value32` is ordered after the `copy_()` on the same stream), and the
-  system-level fence ensures the data is visible before the signal. However, on some
-  topologies the extra CE command may add slight latency compared to the PtoP pull
-  approach where both data and signal share the same NVLink transfer.
+contiguous uint32 tensor.` Always double-check that the signal tensor is `uint32`.
 
 **Buffers required (in addition to data buffers):**
 
 | Field | Shape / Type | Description |
 |-------|-------------|-------------|
-| `progress` | `[world_size * splits_per_rank]` uint32, **local** | Progress/signal tensor on the local device. No symmetric memory needed. **Must be `uint32` — `int32` causes a RuntimeError in `stream_write_value32`.** |
+| `progress` | `[world_size * splits_per_rank]` uint32, **local** | Progress/signal tensor on the local device. No symmetric memory needed. **Must be `uint32` — `int32` causes a RuntimeError in `stream_write_value32`.** Reset via `progress.fill_(0)` between iterations. |
 
-**How to choose:**
-- For **maximum overlap performance**: Approach A (PtoP pull)
-  keeps all CE traffic on the same PtoP channel. Both approaches support
-  `splits_per_rank>1` for finer chunk-level overlap.
-- For **simplicity**: Approach B (`stream_write_value32`)
-  is the recommended default — simpler code (no extra symmetric memory allocation
-  for `signal_one_buf`), and the slight latency difference is negligible in most
-  workloads.
+## Primitives Used
 
-### Comp-First: Compute kernel writes signal → CE waits for signal
+Without-sm does NOT use `_send_signal` / `_wait_signal` / `barrier_all_intra_node_atomic_cas_block`.
+Instead, it uses the following from `primitives.md`:
 
-The compute kernel writes `1` to a signal slot (via `st.global.release.sys.b32`) after
-each tile's stores complete. The CE stream enqueues `cuStreamWaitValue32` — a **GPU-side
-hardware wait** that stalls the CE channel until the signal equals the expected value.
-
-See [Path B: Compute → CE (Comp-First)](#path-b-compute--ce-comp-first) for the full
-implementation.
-
-## PTX Primitives for Signal Polling and Writing
-
-The following PTX helpers are needed for the compute kernel to read/write signals with
-correct memory ordering across GPU boundaries.
-
-**⚠️ IMPORTANT:** Unlike inter-sm and intra-sm modes, without-sm does NOT use
-`_send_signal` / `_wait_signal` / `barrier_all_intra_node_atomic_cas_block` from
-`primitives.md`. Instead, it uses simpler `ld_sys` / `st_sys` for kernel-side signal
-access, and host-side `stream_write_value32` / `cuStreamWaitValue32` for CE-side
-signal operations.
-
-Paste these into the kernel file's PTX Primitives section:
-
-```python
-@triton.jit
-def ld_sys(ptr):
-    """ld.global.acquire.sys.b32 — system-scope acquire load.
-
-    Required for reading signals written by the CE (cross-GPU PtoP copy or
-    cuStreamWriteValue32). Plain tl.load does NOT guarantee visibility of
-    writes that arrived over NVLink — the L2 cache may return stale data.
-    """
-    return tl.inline_asm_elementwise(
-        asm="ld.global.acquire.sys.b32 $0, [$1];",
-        constraints="=r,l",
-        args=[ptr],
-        dtype=tl.int32,
-        is_pure=False,
-        pack=1,
-    )
-
-
-@triton.jit
-def st_sys(ptr, val):
-    """st.global.release.sys.b32 — system-scope release store.
-
-    Used by the compute kernel (comp-first path) to write a per-tile signal
-    that the CE waits on via cuStreamWaitValue32. Release semantics ensure
-    all prior tl.store (tile data) are visible before the signal write.
-    """
-    tl.inline_asm_elementwise(
-        asm="""
-        st.global.release.sys.b32 [$1], $2;
-        mov.u32 $0, 0;
-        """,
-        constraints="=r,l,r",
-        args=[ptr, val],
-        dtype=tl.int32,
-        is_pure=False,
-        pack=1,
-    )
-
-
-@triton.jit
-def __syncthreads():
-    """PTX bar.sync (block-level __syncthreads).
-
-    Broadcasts signal poll result from tid(0) to all threads in the CTA.
-    """
-    tl.inline_asm_elementwise(
-        asm="bar.sync 0;",
-        constraints="=r",
-        args=[],
-        dtype=tl.int32,
-        is_pure=False,
-        pack=1,
-    )
-
-
-@triton.jit
-def tid(axis: tl.constexpr = 0):
-    """PTX threadIdx.x/y/z."""
-    if axis == 0:
-        return tl.inline_asm_elementwise(
-            asm="mov.u32 $0, %tid.x;",
-            constraints=("=r"),
-            args=[],
-            dtype=tl.int32,
-            is_pure=True,
-            pack=1,
-        )
-    elif axis == 1:
-        return tl.inline_asm_elementwise(
-            asm="mov.u32 $0, %tid.y;",
-            constraints=("=r"),
-            args=[],
-            dtype=tl.int32,
-            is_pure=True,
-            pack=1,
-        )
-    else:
-        return tl.inline_asm_elementwise(
-            asm="mov.u32 $0, %tid.z;",
-            constraints=("=r"),
-            args=[],
-            dtype=tl.int32,
-            is_pure=True,
-            pack=1,
-        )
-```
-
-**Memory ordering rationale:**
-- `ld_sys` → `ld.global.acquire.sys`: the CE's `stream_write_value32` or PtoP `copy_()`
-  is a release operation; the compute kernel's acquire load ensures it sees the data
-  that was copied before the signal was written.
-- `st_sys` → `st.global.release.sys`: the compute kernel's release store ensures all
-  prior tile data stores are visible before the signal `1` becomes observable by the
-  CE's `cuStreamWaitValue32`.
+- **Kernel-side**: `ld_sys`, `st_sys`, `tid(axis)`, `__syncthreads` (§2 & §5)
+- **CE-side (host)**: `hdl.stream_write_value32` (comm-first) or `cuda.bindings.driver.cuStreamWaitValue32` (comp-first)
+- **Cross-rank sync**: `symm_mem_hdl.barrier()` (§6.4) between iterations
 
 ---
 
 ## Path A: CE → Compute (Comm-First)
 
 Example: AllGather (CE) → GEMM (compute). The CE pulls data from peers and writes
-signals; the compute kernel polls signals and processes chunks as they arrive.
+signals via `stream_write_value32`; the compute kernel polls signals and processes chunks
+as they arrive.
 
 ### Step 1: Context (Buffers Required)
-
-Each approach requires different context fields:
-
-#### Approach A (PtoP Signal Pull) — Context Fields
-
-| Field | Shape / Type | Description |
-|-------|-------------|-------------|
-| `symm_input_buf` | `[world_size, M_local, K]` symmetric | Input shards. Each rank writes into `[rank, :, :]`. |
-| `symm_ag_a_buf` | `[M_local * world_size, K]` symmetric | Compact gathered output. CE PtoP writes into it. |
-| `ag_signal_buf` | `[world_size * splits_per_rank]` int32, **symmetric** | Signal tensor. Must be symmetric — CE writes into it via PtoP pull. `splits_per_rank=1` gives `[world_size]`, `splits_per_rank>1` gives finer chunk granularity. |
-| `signal_one_buf` | `[world_size * splits_per_rank]` int32, **symmetric** | All-ones symm buffer. PtoP signal source. Shape matches `ag_signal_buf`. Pre-filled with `fill_(1)`. |
-| `splits_per_rank` | `int` | Number of chunk splits per rank (≥1). `=1` means one signal per rank; `>1` splits each rank further for finer overlap. |
-| `peer_symm_input_bufs` | `List[Tensor]` | `input_hdl.get_buffer(i, ...)` views. |
-| `peer_signal_one_bufs` | `List[Tensor]` | `signal_one_hdl.get_buffer(i, ...)` views. |
-| `ag_stream` | `torch.cuda.Stream` | Dedicated stream for CE copies. |
-| `input_hdl` | handle | `rendezvous(symm_input_buf)`. |
-| `ag_hdl` | handle | `rendezvous(symm_ag_a_buf)`. |
-| `signal_hdl` | handle | `rendezvous(ag_signal_buf)`. |
-| `signal_one_hdl` | handle | `rendezvous(signal_one_buf)`. |
-
-**Why `peer_signal_one_bufs`?** Signal writes must stay on the same Memcpy PtoP CE
-channel as data copies. Pulling a pre-filled `1` from a peer's symmetric buffer keeps
-both data and signal on the same NVLink PtoP path. Using `fill_()` or
-`stream_write_value32` routes through a different hardware path (DtoD write), which
-may introduce serialization on some topologies.
-
-**Why must `ag_signal_buf` be symmetric?** The CE enqueues
-`ag_signal[idx:idx+1].copy_(peer_signal_one_bufs[rank][idx:idx+1])` — this is a
-PtoP copy from a peer's symmetric buffer into the local `ag_signal_buf`. The
-destination must be in symmetric memory for the PtoP channel to address it correctly.
-
-**Chunk-level splitting:** When `splits_per_rank > 1`, each rank's shard is split into
-smaller chunks, and `ag_signal_buf` / `signal_one_buf` have `world_size * splits_per_rank`
-slots. The CE loop issues one PtoP data copy + one PtoP signal pull per chunk. The compute
-kernel polls the corresponding slot. When `splits_per_rank=1`, this degrades to one signal
-per rank — the only difference is the signal tensor shape and the loop structure.
-
-#### Approach B (`stream_write_value32`) — Context Fields
 
 | Field | Shape / Type | Description |
 |-------|-------------|-------------|
 | `symm_input_buf` | `[world_size, M_local, K]` symmetric | Input shards. Each rank writes into `[rank, :, :]`. |
 | `symm_ag_a_buf` | `[M_local * world_size, K]` symmetric | Compact gathered output. |
-| `progress` | `[world_size * splits_per_rank]` uint32, **local** | Progress/signal tensor. **No symmetric memory needed. Must be `uint32` — `int32` causes a RuntimeError in `stream_write_value32`.** |
+| `progress` | `[world_size * splits_per_rank]` uint32, **local** | Progress/signal tensor. **No symmetric memory needed. Must be `uint32`.** |
 | `peer_symm_input_bufs` | `List[Tensor]` | `input_hdl.get_buffer(i, ...)` views. |
 | `ag_stream` | `torch.cuda.Stream` | Dedicated stream for CE copies. |
 | `input_hdl` | handle | `rendezvous(symm_input_buf)`. |
 | `ag_hdl` | handle | `rendezvous(symm_ag_a_buf)`. |
 | `splits_per_rank` | `int` | Number of chunk splits per rank (≥1). Higher = finer overlap. |
 
-Note: `signal_one_buf`, `signal_one_hdl`, and `peer_signal_one_bufs` are **not needed**
-with Approach B. The `progress` tensor is a regular local device tensor — it does not
-need to be in symmetric memory because it is only written by the local CE and read by
-the local compute kernel.
+The `progress` tensor is a regular local device tensor — it does not need to be in
+symmetric memory because it is only written by the local CE (via `stream_write_value32`)
+and read by the local compute kernel (via `ld_sys`).
 
 ### Step 2: CE Communication Helper
 
-#### Approach A: Full-Mesh Pull AG with PtoP Signal
-
 ```python
+from torch._C._distributed_c10d import _SymmetricMemory
 def cp_engine_full_mesh_pull_ag(
     rank: int,
     world_size: int,
     M_local: int,
     K: int,
-    splits_per_rank: int,
-    symm_input: torch.Tensor,                  # this rank's [M_local, K] shard
-    symm_ag_output: torch.Tensor,              # [M_local * world_size, K] gathered buffer
-    peer_symm_input_bufs: List[torch.Tensor],  # peer views into symm_input_buf
-    ag_signal: torch.Tensor,                   # [world_size * splits_per_rank] int32, symmetric
-    peer_signal_one_bufs: List[torch.Tensor],  # peer views of all-ones symm int32
-    ag_stream: torch.cuda.Stream,
+    symm_input: torch.Tensor,              # this rank's [M_local, K] shard (view into symm_input_buf[rank])
+    symm_ag_output: torch.Tensor,          # local [M_local * world_size, K] gathered buffer
+    peer_symm_input_bufs: List[torch.Tensor],  # peer views: peer_symm_input_bufs[i] is rank i's symm_input_buf
+    ag_signal: torch.Tensor,               # local ag_signal [world_size] int32
 ):
     """
-    AllGather via Copy Engine (full-mesh pull) with PtoP signal writes.
-
-    For each peer rank src_rank in rotated order, for each split within that rank:
-      1. PtoP data copy:  peer_symm_input_bufs[src_rank] → symm_ag_output chunk
-      2. PtoP signal pull: peer_signal_one_bufs[src_rank] → ag_signal[chunk_idx]
-
-    CRITICAL: Both data and signal writes are routed through the PtoP channel
-    by sourcing them from peer symmetric memory. This keeps all ops on the
-    same CE channel, preserving ordering without explicit fences.
-
-    When splits_per_rank=1, each rank has one chunk (one signal per rank);
-    when splits_per_rank>1, each rank's shard is split into smaller chunks
-    for finer-grained overlap. The signal tensor shape must match the total
-    number of chunks (world_size * splits_per_rank).
-
-    Caller must wrap in `with torch.cuda.stream(ag_stream):`.
+    AllGather via Copy Engine (full-mesh pull).
+    For each peer rank src_rank in rotated order:
+      - PtoP data copy from peer_symm_input_bufs[src_rank][src_rank, :, :]
+        into symm_ag_output[src_rank * M_local : (src_rank+1) * M_local, :]
+      - Signal write via _SymmetricMemory.stream_write_value32
+    Signal writes use cuStreamWriteValue32, which issues a system-scope fence
+    before the write. This ensures all prior data copies are visible to all GPUs
+    before the signal value becomes visible, correctly pairing with ld.sys in
+    the consumer kernel.
+    NOTE: caller must wrap this call in `with torch.cuda.stream(ag_stream):`
+    so that all enqueued copy_ ops land on ag_stream.
     """
-    M_split = M_local // splits_per_rank
-    assert M_local % splits_per_rank == 0, "M_local must be divisible by splits_per_rank"
-
-    # Self-shard: local copy + PtoP signal (chunk by chunk)
-    for split_id in range(splits_per_rank):
-        chunk = symm_ag_output[
-            rank * M_local + split_id * M_split :
-            rank * M_local + (split_id + 1) * M_split, :
-        ]
-        chunk.copy_(symm_input[split_id * M_split : (split_id + 1) * M_split, :])
-        idx = rank * splits_per_rank + split_id
-        ag_signal[idx:idx + 1].copy_(peer_signal_one_bufs[rank][idx:idx + 1])
-
+    # Self-shard: local copy + signal via stream_write_value32
+    local_dst = symm_ag_output[rank * M_local : (rank + 1) * M_local, :]
+    local_dst.copy_(symm_input)
+    _SymmetricMemory.stream_write_value32(ag_signal, rank, 1)
     # Remote shards in rotated order
     for offset in range(1, world_size):
         src_rank = (rank + offset) % world_size
-        for split_id in range(splits_per_rank):
-            remote_src = peer_symm_input_bufs[src_rank][
-                src_rank, split_id * M_split : (split_id + 1) * M_split, :
-            ]
-            chunk = symm_ag_output[
-                src_rank * M_local + split_id * M_split :
-                src_rank * M_local + (split_id + 1) * M_split, :
-            ]
-            chunk.copy_(remote_src)
-            idx = src_rank * splits_per_rank + split_id
-            ag_signal[idx:idx + 1].copy_(peer_signal_one_bufs[src_rank][idx:idx + 1])
+        remote_src = peer_symm_input_bufs[src_rank][src_rank, :M_local, :]
+        local_dst = symm_ag_output[src_rank * M_local : (src_rank + 1) * M_local, :]
+        local_dst.copy_(remote_src)
+        # cuStreamWriteValue32 issues a system level fence before the write
+        _SymmetricMemory.stream_write_value32(ag_signal, src_rank, 1)
 ```
 
-#### Approach B: Full-Mesh Pull AG with `stream_write_value32`
-
-```python
-import torch.distributed._symmetric_memory as symm_mem
-
-def cp_engine_full_mesh_pull_ag_v2(
-    rank: int,
-    world_size: int,
-    M_local: int,
-    K: int,
-    splits_per_rank: int,
-    symm_input: torch.Tensor,                  # this rank's [M_local, K] shard
-    output: torch.Tensor,                      # [M_local * world_size, K] gathered output
-    peer_symm_input_bufs: List[torch.Tensor],  # peer views into symm_input_buf
-    progress: torch.Tensor,                    # [world_size * splits_per_rank] uint32 (NOT int32!)
-    hdl: object,                               # symm_mem handle (for stream_write_value32)
-    ag_stream: torch.cuda.Stream,
-):
-    """
-    AllGather via Copy Engine (full-mesh pull) with stream_write_value32 signals.
-
-    For each peer rank src_rank, for each split within that rank:
-      1. PtoP data copy:  peer_symm_input_bufs[src_rank] → output chunk
-      2. Write progress:  hdl.stream_write_value32(progress, offset, 1)
-
-    stream_write_value32 wraps cuStreamWriteValue32, which issues a 32-bit
-    write with a system-level fence on the CE stream. This guarantees that
-    the preceding copy_() data is visible before the signal value becomes 1.
-
-    Advantages over Approach A:
-      - No signal_one_buf allocation or rendezvous needed.
-      - progress tensor is a local device tensor (not symmetric memory).
-      - Simpler API: single hdl.stream_write_value32() call per signal write.
-
-    Caller must wrap in `with torch.cuda.stream(ag_stream):`.
-    """
-    M_split = M_local // splits_per_rank
-    assert M_local % splits_per_rank == 0, "M_local must be divisible by splits_per_rank"
-
-    # Self-shard: local copy + signal
-    for split_id in range(splits_per_rank):
-        chunk = output[
-            rank * M_local + split_id * M_split :
-            rank * M_local + (split_id + 1) * M_split, :
-        ]
-        chunk.copy_(symm_input[split_id * M_split : (split_id + 1) * M_split, :])
-        hdl.stream_write_value32(
-            progress,
-            offset=rank * splits_per_rank + split_id,
-            val=1,
-        )
-
-    # Remote shards in rotated order
-    for step in range(1, world_size):
-        src_rank = (rank + step) % world_size
-        for split_id in range(splits_per_rank):
-            src_buf = peer_symm_input_bufs[src_rank][
-                src_rank, split_id * M_split : (split_id + 1) * M_split, :
-            ]
-            chunk = output[
-                src_rank * M_local + split_id * M_split :
-                src_rank * M_local + (split_id + 1) * M_split, :
-            ]
-            chunk.copy_(src_buf)
-            hdl.stream_write_value32(
-                progress,
-                offset=src_rank * splits_per_rank + split_id,
-                val=1,
-            )
-```
-
-**Key details (both approaches):**
+**Key details:**
 - `copy_()` from a peer symmetric tensor routes through the **Memcpy PtoP** CE channel
   (DMA, zero SM cost).
 - Rotated iteration order `(rank + offset) % world_size` spreads NVLink traffic across
@@ -463,36 +146,24 @@ def cp_engine_full_mesh_pull_ag_v2(
 - Signal granularity: controlled by `splits_per_rank`. Signal tensor shape is always
   `[world_size * splits_per_rank]`. `splits_per_rank=1` gives one signal per rank;
   `splits_per_rank>1` splits each rank's shard into finer chunks for earlier compute
-  overlap. Both Approach A (PtoP pull) and Approach B (`stream_write_value32`) support
-  any `splits_per_rank` value.
-- `splits_per_rank > 1` splits each rank's shard into smaller chunks, allowing the
-  compute kernel to start processing earlier (finer-grained overlap).
-- **Signal tensor dtype**: Approach A (PtoP pull) uses `int32` for `ag_signal_buf` and
-  `signal_one_buf` (standard symmetric memory signal pads). Approach B
-  (`stream_write_value32`) **must** use `uint32` for `progress` — `cuStreamWriteValue32`
+  overlap.
+- **Signal tensor dtype**: **must** use `uint32` for `progress` — `cuStreamWriteValue32`
   writes an unsigned 32-bit value and PyTorch's binding validates the dtype; `int32`
   raises `RuntimeError`. The compute kernel's `ld_sys` (PTX `ld.global.acquire.sys.b32`)
-  reads 32 bits regardless of signedness, so it works with both `int32` and `uint32`
-  signal tensors — but the host-side `stream_write_value32` call requires `uint32`.
+  reads 32 bits regardless of signedness, so it works with `uint32`.
 
 ### Step 3: Compute Kernel with Signal Polling
 
 The compute kernel polls the signal tensor before touching remote data. Signal granularity
 is controlled by `splits_per_rank`: `=1` means one signal per rank (per-rank), `>1` means
-one signal per chunk within each rank (per-chunk). The signal tensor shape is always
-`[world_size * splits_per_rank]`, which equals `[world_size]` when `splits_per_rank=1`.
+one signal per chunk within each rank (per-chunk). Local data (this rank's own shard) needs
+no waiting — the signal is already set to 1 for all local chunks.
 
-Local data (this rank's own shard) needs no waiting — the signal is already set to 1 for
-all local chunks.
-
-**Critical**: Only **one thread** (threadIdx.x == 0) polls the signal. After the poll
-exits, `__syncthreads()` ensures all threads in the CTA see the signal before proceeding.
-If all threads poll independently, each thread issues its own `ld.global.acquire.sys` —
-wasting memory bandwidth and adding unnecessary synchronization traffic.
-
-#### Unified chunk-based polling kernel
-
-Works with **both** Approach A (PtoP pull) and Approach B (`stream_write_value32`).
+**Critical**: Only **one thread** (threadIdx.x == 0) polls the signal via `ld_sys`. After
+the poll exits, `__syncthreads()` ensures all threads in the CTA see the signal before
+proceeding. If all threads poll independently, each thread issues its own
+`ld.global.acquire.sys` — wasting memory bandwidth and adding unnecessary synchronization
+traffic.
 
 ```python
 @triton.jit
@@ -500,7 +171,7 @@ def consumer_gemm_kernel(
     A_ptr,              # symm_ag_a_buf: [M, K] gathered A (compact layout)
     B_ptr,              # weight [N, K]
     C_ptr,              # output [M, N]
-    signal_ptr,         # signal tensor [world_size * splits_per_rank] — uint32 for Approach B, int32 for Approach A
+    signal_ptr,         # signal tensor [world_size * splits_per_rank] — uint32
     M, N, K,
     M_local,            # rows per rank
     M_split,            # rows per split = M_local // splits_per_rank
@@ -520,7 +191,6 @@ def consumer_gemm_kernel(
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
 
     # Chunk-aware tile rotation: local chunks first, then peers in rotated order.
-    # When splits_per_rank=1, each chunk is an entire rank shard (per-rank mode).
     total_chunks = world_size * splits_per_rank
     num_pid_m = M_split_tiles * total_chunks
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
@@ -552,15 +222,15 @@ def consumer_gemm_kernel(
     # ... standard GEMM tile computation using A[tile_row_start:, :] x B ...
 ```
 
-**Key points (both approaches):**
+**Key points:**
 - **`splits_per_rank=1`** is the per-rank case: `M_split = M_local`, `total_chunks = world_size`,
   each CTA polls `signal_ptr + src_rank`. This is the simplest default.
 - **`splits_per_rank>1`** is the per-chunk case: each rank's shard is split into finer chunks,
   allowing the compute kernel to start processing earlier as each chunk's copy completes.
 - Signal poll uses `ld_sys(...)` = `ld.global.acquire.sys.b32` — not `tl.load(...)`.
-  System-scope acquire is required because the signal was written by the CE (either
-  via PtoP copy or `cuStreamWriteValue32`); plain `tl.load` has no cross-device
-  visibility guarantee and may read stale L2 cache data.
+  System-scope acquire is required because the signal was written by the CE
+  (`cuStreamWriteValue32`); plain `tl.load` has no cross-device visibility guarantee
+  and may read stale L2 cache data.
 - Only `tid(0) == 0` polls to reduce `ld.global.acquire.sys` traffic to 1-per-CTA.
 - Chunk-aware rotation ensures CTAs for the local shard process first (signal
   already set), then peers in the same rotated order as the CE AG helper — minimizing
@@ -588,42 +258,24 @@ def ag_gemm_overlap(ctx, a_input, compute_kernel, block_size):
     # ---- Barrier + signal reset pattern ----
     # Must happen on the default stream BEFORE enqueuing anything on ag_stream.
     ctx.input_hdl.barrier()          # ensure all ranks finished previous iteration
-    if hasattr(ctx, 'ag_signal_buf'):  # Approach A
-        ctx.ag_signal_buf.fill_(0)
-    else:                                # Approach B
-        ctx.progress.fill_(0)
+    ctx.progress.fill_(0)
     ctx.input_hdl.barrier()          # ensure all ranks see the reset before launching
 
     ag_stream.wait_stream(current_stream)
 
     # Step 1: enqueue full-mesh pull AG on ag_stream
     with torch.cuda.stream(ag_stream):
-        if hasattr(ctx, 'ag_signal_buf'):
-            # Approach A: PtoP signal pull
-            cp_engine_full_mesh_pull_ag(
-                rank=rank, world_size=world_size,
-                M_local=M_local, K=K,
-                splits_per_rank=ctx.splits_per_rank,
-                symm_input=symm_input,
-                symm_ag_output=ctx.symm_ag_a_buf,
-                peer_symm_input_bufs=ctx.peer_symm_input_bufs,
-                ag_signal=ctx.ag_signal_buf,
-                peer_signal_one_bufs=ctx.peer_signal_one_bufs,
-                ag_stream=ag_stream,
-            )
-        else:
-            # Approach B: stream_write_value32
-            cp_engine_full_mesh_pull_ag_v2(
-                rank=rank, world_size=world_size,
-                M_local=M_local, K=K,
-                splits_per_rank=ctx.splits_per_rank,
-                symm_input=symm_input,
-                output=ctx.symm_ag_a_buf,
-                peer_symm_input_bufs=ctx.peer_symm_input_bufs,
-                progress=ctx.progress,
-                hdl=ctx.ag_hdl,
-                ag_stream=ag_stream,
-            )
+        cp_engine_full_mesh_pull_ag(
+            rank=rank, world_size=world_size,
+            M_local=M_local, K=K,
+            splits_per_rank=ctx.splits_per_rank,
+            symm_input=symm_input,
+            output=ctx.symm_ag_a_buf,
+            peer_symm_input_bufs=ctx.peer_symm_input_bufs,
+            progress=ctx.progress,
+            hdl=ctx.ag_hdl,
+            ag_stream=ag_stream,
+        )
 
     # Step 2: launch consumer compute kernel on current_stream
     # Without-SM: communication is on copy engine (zero SMs), compute uses ALL SMs.
@@ -634,7 +286,7 @@ def ag_gemm_overlap(ctx, a_input, compute_kernel, block_size):
     c = torch.empty((M, N), dtype=a_input.dtype, device=a_input.device)
     compute_kernel[(num_tiles,)](
         ctx.symm_ag_a_buf, ctx.weight, c,
-        ctx.ag_signal_buf if hasattr(ctx, 'ag_signal_buf') else ctx.progress,
+        ctx.progress,
         M, N, K, M_local, M_local_tiles,
         # ... strides, block sizes, etc.
         rank=rank, world_size=world_size,
@@ -696,11 +348,6 @@ def compute_kernel_with_push_signal(
     if tid(0) == 0:
         st_sys(signal_pad_ptr + pid, 1)
 ```
-
-**Why `st_sys` instead of `_send_signal` (CAS)?** In without-sm comp-first mode, each
-tile has exactly one writer (the CTA that computed it), and the signal tensor is reset
-to 0 before each launch. So there is no contention — a simple store suffices. The CAS
-spin-loop in `_send_signal` (from `primitives.md`) is overkill and adds latency.
 
 #### Step B: CE push — `cuStreamWaitValue32` per tile
 
@@ -783,8 +430,7 @@ tile's copy as soon as the compute kernel's signal lands in memory.
 
 **Key details:**
 - `st_sys` uses `st.global.release.sys.b32` — system-scope release ensures data stores
-  are visible before the signal. This is simpler and faster than `_send_signal`'s CAS
-  spin-loop because there is no contention (each tile has exactly one writer).
+  are visible before the signal.
 - `cuStreamWaitValue32` is a **GPU-side hardware wait** — the CE stream's DMAs are gated
   by the memory-mapped value. No CPU involvement, no D2H transfers.
 - Signal granularity is **per-tile** (fine-grained), giving the CE stream maximum overlap
@@ -853,7 +499,7 @@ Both paths require host-side `symm_mem_hdl.barrier()` calls to synchronize acros
 ```python
 # Reset pattern (before each iteration):
 hdl.barrier()              # all ranks finished previous iteration
-signal.zero_()             # or progress.fill_(0) for Approach B
+progress.fill_(0)          # or signal_pad.zero_() for comp-first
 hdl.barrier()              # all ranks see reset before launching
 
 # Sync pattern (after each iteration):
@@ -864,4 +510,5 @@ current_stream.wait_stream(ce_stream)   # wait for CE to finish
 run as separate entities with no shared in-kernel phase after communication. The
 barrier needs to happen on the host side between iterations. Using in-kernel
 `barrier_all_intra_node_atomic_cas_block` is incorrect here — there is no single
-kernel that encompasses both compute and communication.
+kernel that encompasses both compute and communication. Use host-side
+`symm_mem_hdl.barrier()` instead (see `primitives.md` §6.4).

--- a/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
@@ -45,7 +45,7 @@ before the write, guaranteeing that all prior `copy_()` operations on that strea
 visible before the signal value becomes `1`.
 
 **Comm-First**: After the CE copies data from a peer, it writes `1` to the progress tensor
-via `hdl.stream_write_value32`. The compute kernel polls via `ld_sys`.
+via `hdl.stream_write_value32` or `from torch._C._distributed_c10d import _SymmetricMemory _SymmetricMemory.stream_write_value32`. The compute kernel polls via `ld_sys`.
 
 **Comp-First**: The compute kernel writes `1` to a signal slot via `st_sys` after each
 tile's stores complete. The CE stream enqueues `cuStreamWaitValue32` — a GPU-side hardware
@@ -68,9 +68,9 @@ contiguous uint32 tensor.` Always double-check that the signal tensor is `uint32
 Without-sm does NOT use `_send_signal` / `_wait_signal` / `barrier_all_intra_node_atomic_cas_block`.
 Instead, it uses the following from `primitives.md`:
 
-- **Kernel-side**: `ld_sys`, `st_sys`, `tid(axis)`, `__syncthreads` (§2 & §5)
-- **CE-side (host)**: `hdl.stream_write_value32` (comm-first) or `cuda.bindings.driver.cuStreamWaitValue32` (comp-first)
-- **Cross-rank sync**: `symm_mem_hdl.barrier()` (§6.4) between iterations
+- **Kernel-side**: `ld_sys`, `st_sys`, `_get_flat_tid`, `__syncthreads` (§1 & §4)
+- **CE-side (host)**: `_SymmetricMemory.stream_write_value32` (comm-first) or `cuda.bindings.driver.cuStreamWaitValue32` (comp-first)
+- **Cross-rank sync**: `symm_mem_hdl.barrier()` (§5.4) between iterations
 
 ---
 
@@ -93,7 +93,7 @@ as they arrive.
 | `ag_hdl` | handle | `rendezvous(symm_ag_a_buf)`. |
 | `splits_per_rank` | `int` | Number of chunk splits per rank (≥1). Higher = finer overlap. |
 
-The `progress` tensor is a regular local device tensor — it does not need to be in
+The `progress` tensor can be a regular local device tensor — it does not need to be in
 symmetric memory because it is only written by the local CE (via `stream_write_value32`)
 and read by the local compute kernel (via `ld_sys`).
 
@@ -109,7 +109,7 @@ def cp_engine_full_mesh_pull_ag(
     symm_input: torch.Tensor,              # this rank's [M_local, K] shard (view into symm_input_buf[rank])
     symm_ag_output: torch.Tensor,          # local [M_local * world_size, K] gathered buffer
     peer_symm_input_bufs: List[torch.Tensor],  # peer views: peer_symm_input_bufs[i] is rank i's symm_input_buf
-    ag_signal: torch.Tensor,               # local ag_signal [world_size] int32
+    ag_signal: torch.Tensor,               # local ag_signal [world_size] uint32
 ):
     """
     AllGather via Copy Engine (full-mesh pull).
@@ -159,7 +159,7 @@ is controlled by `splits_per_rank`: `=1` means one signal per rank (per-rank), `
 one signal per chunk within each rank (per-chunk). Local data (this rank's own shard) needs
 no waiting — the signal is already set to 1 for all local chunks.
 
-**Critical**: Only **one thread** (threadIdx.x == 0) polls the signal via `ld_sys`. After
+**Critical**: Only **one thread** (`_get_flat_tid() == 0`) polls the signal via `ld_sys`. After
 the poll exits, `__syncthreads()` ensures all threads in the CTA see the signal before
 proceeding. If all threads poll independently, each thread issues its own
 `ld.global.acquire.sys` — wasting memory bandwidth and adding unnecessary synchronization
@@ -209,9 +209,9 @@ def consumer_gemm_kernel(
     pid_m = (src_rank * splits_per_rank + split_id) * M_split_tiles + tile_in_chunk
 
     # Poll signal for this chunk (system-scope acquire load).
-    # Only tid(0) polls; __syncthreads() broadcasts the result.
+    # Only _get_flat_tid()==0 polls; __syncthreads() broadcasts the result.
     signal_idx = src_rank * splits_per_rank + split_id
-    if tid(0) == 0:
+    if _get_flat_tid() == 0:
         while ld_sys(signal_ptr + signal_idx) != 1:
             pass
     __syncthreads()
@@ -231,7 +231,7 @@ def consumer_gemm_kernel(
   System-scope acquire is required because the signal was written by the CE
   (`cuStreamWriteValue32`); plain `tl.load` has no cross-device visibility guarantee
   and may read stale L2 cache data.
-- Only `tid(0) == 0` polls to reduce `ld.global.acquire.sys` traffic to 1-per-CTA.
+- Only `_get_flat_tid() == 0` polls to reduce `ld.global.acquire.sys` traffic to 1-per-CTA.
 - Chunk-aware rotation ensures CTAs for the local shard process first (signal
   already set), then peers in the same rotated order as the CE AG helper — minimizing
   spin-wait time.
@@ -305,22 +305,6 @@ Example: GEMM (compute) → ReduceScatter (CE). The compute kernel writes per-ti
 as tiles complete; the CE stream enqueues `cuStreamWaitValue32` + `copy_()` per tile to
 pipeline copies behind computation.
 
-### Anti-patterns
-
-❌ **Host-side CPU spin-wait** — each `.item()` call triggers GPU→CPU sync (~5–50 μs),
-and `pass` in the loop burns a CPU core at 100%:
-```python
-# ❌ BAD: CPU spin-wait — D2H latency × num_tiles
-for tile_id in range(num_tiles):
-    while signal_pad[tile_id].item() != 1:
-        pass
-    issue_ce_copy(tile_id)
-```
-
-❌ **Chunked kernel launch + CUDA event** — per-chunk kernel launch overhead is
-prohibitively expensive for fine-grained tile-level overlap. The whole point of
-without-sm is a single compute kernel launch with CE pipelining behind it.
-
 ### Recommended: GPU-side signal + `cuStreamWaitValue32`
 
 Single compute kernel launch. Each CTA writes a per-tile signal via `st_sys`
@@ -345,7 +329,7 @@ def compute_kernel_with_push_signal(
     # After all tile stores are done, signal this tile's completion.
     # st_sys = st.global.release.sys.b32 — ensures tile data is visible before signal.
     # Only one thread per CTA needs to write the signal.
-    if tid(0) == 0:
+    if _get_flat_tid() == 0:
         st_sys(signal_pad_ptr + pid, 1)
 ```
 
@@ -505,10 +489,3 @@ hdl.barrier()              # all ranks see reset before launching
 # Sync pattern (after each iteration):
 current_stream.wait_stream(ce_stream)   # wait for CE to finish
 ```
-
-**Why not in-kernel barriers?** In without-sm mode, the compute kernel and CE stream
-run as separate entities with no shared in-kernel phase after communication. The
-barrier needs to happen on the host side between iterations. Using in-kernel
-`barrier_all_intra_node_atomic_cas_block` is incorrect here — there is no single
-kernel that encompasses both compute and communication. Use host-side
-`symm_mem_hdl.barrier()` instead (see `primitives.md` §6.4).

--- a/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
@@ -1,48 +1,327 @@
 # Without-SM Overlap: Copy Engine (DMA) Based
 
-Communication is offloaded to the copy engine, consuming zero SM resources. The compute
-kernel on the main stream polls a signal tensor to process data as it arrives.
+Communication is offloaded to the **copy engine** (CE), consuming zero SM resources. A
+background stream performs `copy_()` on symmetric memory (routed through DMA), while the
+compute kernel runs simultaneously on the main stream. Synchronization between the two
+streams is achieved through **signal tensors** — written by either PtoP signal pulls or
+CPU-side CE operations (`cuStreamWriteValue32` / `cuStreamWaitValue32`). Signal tensor
+shape determines granularity: `[world_size * splits_per_rank]` where `splits_per_rank=1`
+gives one signal per rank and `splits_per_rank>1` gives finer-grained chunk signaling.
 
 ## Architecture
 
+The without-sm mode supports two execution orders:
+
+### Comm-First: CE → Compute (e.g., AllGather → GEMM)
+
 ```
-Main Stream (SM)                      Backend Stream (Copy Engine / DMA)
-┌──────────────────────────┐          ┌──────────────────────────────────────┐
-│ compute_kernel           │          │ for each peer in rotated order:      │
-│  process local (no wait) │          │   copy_(peer_symm_buf → local_dst)   │
-│  poll signal[src_rank]   │◄──────── │   signal[src_rank].copy_(peer_one)   │
-│  process remote chunk    │          │     (PtoP pull — same CE channel)    │
-└──────────────────────────┘          └──────────────────────────────────────┘
+Main Stream (SM)                         Backend Stream (Copy Engine)
+┌──────────────────────────────┐         ┌─────────────────────────────────────────┐
+│ compute_kernel               │         │ for each peer in rotated order:         │
+│   process local (no wait)    │         │   copy_(peer_symm_buf → local_dst)      │
+│   poll signal[chunk_idx]     │ ◄────── │   write signal[chunk_idx] = 1           │
+│   process remote chunk       │         │     (Approach A: PtoP signal pull)      │
+│                              │         │     (Approach B: stream_write_value32)  │
+└──────────────────────────────┘         └─────────────────────────────────────────┘
 ```
 
-## Step 1: Buffers Required (ctx)
+### Comp-First: Compute → CE (e.g., GEMM → ReduceScatter)
 
-The orchestration function (Step 4) assumes a pre-initialized context `ctx` with:
+```
+Main Stream (SM)                         Backend Stream (Copy Engine)
+┌──────────────────────────────┐         ┌─────────────────────────────────────────┐
+│ compute_kernel               │         │ for each tile:                          │
+│   compute tile               │         │   cuStreamWaitValue32(signal[tile]==1)  │
+│   st_sys signal[tile] = 1    │ ──────► │   copy_(local_tile → peer_symm_buf)     │
+│                              │         │                                         │
+└──────────────────────────────┘         └─────────────────────────────────────────┘
+```
+
+## Signal Mechanisms for Copy Engine
+
+Because the copy engine operates on a separate CUDA stream and consumes no SMs,
+synchronization between the CE stream and the compute stream must use **CPU-side CE
+operations** or **PtoP copies** — NOT GPU-side atomics or in-kernel barriers.
+
+### Comm-First: CE writes signal → Compute kernel polls signal
+
+After the CE copies data from a peer, it must signal the compute kernel that the data
+is ready. There are **two approaches** for writing the signal:
+
+#### Approach A: PtoP Signal Pull via `signal_one_buf`
+
+Create an extra all-ones symmetric memory tensor (`signal_one_buf`). After the data
+`copy_()`, issue a second `copy_()` that pulls a pre-filled `1` from the `signal_one_buf` 
+into the local `ag_signal_buf`:
+
+```python
+# After data copy from src_rank:
+ag_signal[src_rank:src_rank + 1].copy_(
+    peer_signal_one_bufs[src_rank][src_rank:src_rank + 1]
+)
+```
+
+**Pros:**
+- Both data and signal writes stay on the **same PtoP CE channel**, preserving strict
+  ordering without fences — the signal `copy_()` is enqueued after the data `copy_()`
+  on the same stream, and both go through NVLink PtoP.
+- No extra CUDA driver API calls needed.
+
+**Cons:**
+- Requires allocating `signal_one_buf` in symmetric memory and its rendezvous handle
+  (`signal_one_hdl`), plus `peer_signal_one_bufs` for cross-rank access.
+- The `ag_signal_buf` must also be in symmetric memory (as the PtoP destination).
+- Signal granularity should be the same with the granularity of the data tensor.
+
+**Buffers required (in addition to data buffers):**
 
 | Field | Shape / Type | Description |
 |-------|-------------|-------------|
-| `symm_input_buf` | `[world_size, M_local, K]` symmetric | Allocated via `symm_mem.empty()` + `rendezvous()`. Each rank writes its shard into `[rank, :, :]`. |
-| `symm_ag_output` | `[M_local * world_size, K]` local | Compact gathered output buffer. |
-| `ag_signal` | `[world_size]` int32, local | Per-rank-shard signal (consumer polls for `== 1`). |
-| `peer_symm_input_bufs` | `List[Tensor]` (len = world_size) | `hdl.get_buffer(i, ...)` views into each peer's `symm_input_buf`. |
-| `peer_signal_one_bufs` | `List[Tensor]` (len = world_size) | Views into a **symmetric all-ones int32 buffer** — used as PtoP source for signal writes. Allocate a separate symmetric buffer filled with `1`, rendezvous it, then `get_buffer(i, ...)` for each peer. |
+| `ag_signal_buf` | `[world_size * splits_per_rank]` int32, **symmetric** | Signal tensor. Must be symmetric — CE writes into it via PtoP pull. `splits_per_rank=1` gives `[world_size]`, `splits_per_rank>1` gives finer chunk granularity. |
+| `signal_one_buf` | `[world_size * splits_per_rank]` int32, **symmetric** | All-ones symmetric buffer, pre-filled with `1`. PtoP signal source. Shape matches `ag_signal_buf`. |
+
+#### Approach B: `stream_write_value32` / `hdl.stream_write_value32`
+
+Use the symmetric memory handle's `stream_write_value32` method (which wraps
+`cuStreamWriteValue32`) to write a `1` to a progress tensor after each chunk copy:
+
+```python
+# After data copy from src_rank (or each split within src_rank):
+hdl.stream_write_value32(
+    progress,
+    offset=src_rank * splits_per_rank + split_id,
+    val=1,
+)
+```
+
+Under the hood, `cuStreamWriteValue32` issues a 32-bit write on the CE stream with a
+**system-level fence** before the write, guaranteeing that all prior `copy_()` operations
+on that stream are visible before the signal value becomes `1`.
+
+**⚠️ CRITICAL: The `progress` tensor MUST use `dtype=torch.uint32`, NOT `torch.int32`.**
+`cuStreamWriteValue32` writes an unsigned 32-bit value, and PyTorch's `symm_mem` binding
+validates that the input tensor is a flat, contiguous `uint32` tensor. Passing an `int32`
+tensor raises: `RuntimeError: symm_mem::stream_write_value32_: input must be a flat,
+contiguous uint32 tensor.` This is the most common mistake when using Approach B — always
+double-check that the signal tensor is `uint32`.
+
+**Pros:**
+- Much simpler — no extra symmetric memory allocation for `signal_one_buf`.
+- The `progress` tensor can be a **regular local device tensor** (`torch.zeros(...)`,
+  not `symm_mem.empty()`).
+- Single API call per signal write.
+- Signal tensor shape is `[world_size * splits_per_rank]` — set `splits_per_rank=1` for
+  one signal per rank, or `>1` for finer chunk-level overlap.
+
+**Cons:**
+- `cuStreamWriteValue32` routes the signal write through a **local DtoD write** CE
+  command rather than the PtoP channel used for data copies. This means the signal
+  write goes through a different hardware path than the data copy.
+- In practice this is still correct — the CE stream enforces ordering (the
+  `stream_write_value32` is ordered after the `copy_()` on the same stream), and the
+  system-level fence ensures the data is visible before the signal. However, on some
+  topologies the extra CE command may add slight latency compared to the PtoP pull
+  approach where both data and signal share the same NVLink transfer.
+
+**Buffers required (in addition to data buffers):**
+
+| Field | Shape / Type | Description |
+|-------|-------------|-------------|
+| `progress` | `[world_size * splits_per_rank]` uint32, **local** | Progress/signal tensor on the local device. No symmetric memory needed. **Must be `uint32` — `int32` causes a RuntimeError in `stream_write_value32`.** |
+
+**How to choose:**
+- For **maximum overlap performance**: Approach A (PtoP pull)
+  keeps all CE traffic on the same PtoP channel. Both approaches support
+  `splits_per_rank>1` for finer chunk-level overlap.
+- For **simplicity**: Approach B (`stream_write_value32`)
+  is the recommended default — simpler code (no extra symmetric memory allocation
+  for `signal_one_buf`), and the slight latency difference is negligible in most
+  workloads.
+
+### Comp-First: Compute kernel writes signal → CE waits for signal
+
+The compute kernel writes `1` to a signal slot (via `st.global.release.sys.b32`) after
+each tile's stores complete. The CE stream enqueues `cuStreamWaitValue32` — a **GPU-side
+hardware wait** that stalls the CE channel until the signal equals the expected value.
+
+See [Path B: Compute → CE (Comp-First)](#path-b-compute--ce-comp-first) for the full
+implementation.
+
+## PTX Primitives for Signal Polling and Writing
+
+The following PTX helpers are needed for the compute kernel to read/write signals with
+correct memory ordering across GPU boundaries.
+
+**⚠️ IMPORTANT:** Unlike inter-sm and intra-sm modes, without-sm does NOT use
+`_send_signal` / `_wait_signal` / `barrier_all_intra_node_atomic_cas_block` from
+`primitives.md`. Instead, it uses simpler `ld_sys` / `st_sys` for kernel-side signal
+access, and host-side `stream_write_value32` / `cuStreamWaitValue32` for CE-side
+signal operations.
+
+Paste these into the kernel file's PTX Primitives section:
+
+```python
+@triton.jit
+def ld_sys(ptr):
+    """ld.global.acquire.sys.b32 — system-scope acquire load.
+
+    Required for reading signals written by the CE (cross-GPU PtoP copy or
+    cuStreamWriteValue32). Plain tl.load does NOT guarantee visibility of
+    writes that arrived over NVLink — the L2 cache may return stale data.
+    """
+    return tl.inline_asm_elementwise(
+        asm="ld.global.acquire.sys.b32 $0, [$1];",
+        constraints="=r,l",
+        args=[ptr],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def st_sys(ptr, val):
+    """st.global.release.sys.b32 — system-scope release store.
+
+    Used by the compute kernel (comp-first path) to write a per-tile signal
+    that the CE waits on via cuStreamWaitValue32. Release semantics ensure
+    all prior tl.store (tile data) are visible before the signal write.
+    """
+    tl.inline_asm_elementwise(
+        asm="""
+        st.global.release.sys.b32 [$1], $2;
+        mov.u32 $0, 0;
+        """,
+        constraints="=r,l,r",
+        args=[ptr, val],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def __syncthreads():
+    """PTX bar.sync (block-level __syncthreads).
+
+    Broadcasts signal poll result from tid(0) to all threads in the CTA.
+    """
+    tl.inline_asm_elementwise(
+        asm="bar.sync 0;",
+        constraints="=r",
+        args=[],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def tid(axis: tl.constexpr = 0):
+    """PTX threadIdx.x/y/z."""
+    if axis == 0:
+        return tl.inline_asm_elementwise(
+            asm="mov.u32 $0, %tid.x;",
+            constraints=("=r"),
+            args=[],
+            dtype=tl.int32,
+            is_pure=True,
+            pack=1,
+        )
+    elif axis == 1:
+        return tl.inline_asm_elementwise(
+            asm="mov.u32 $0, %tid.y;",
+            constraints=("=r"),
+            args=[],
+            dtype=tl.int32,
+            is_pure=True,
+            pack=1,
+        )
+    else:
+        return tl.inline_asm_elementwise(
+            asm="mov.u32 $0, %tid.z;",
+            constraints=("=r"),
+            args=[],
+            dtype=tl.int32,
+            is_pure=True,
+            pack=1,
+        )
+```
+
+**Memory ordering rationale:**
+- `ld_sys` → `ld.global.acquire.sys`: the CE's `stream_write_value32` or PtoP `copy_()`
+  is a release operation; the compute kernel's acquire load ensures it sees the data
+  that was copied before the signal was written.
+- `st_sys` → `st.global.release.sys`: the compute kernel's release store ensures all
+  prior tile data stores are visible before the signal `1` becomes observable by the
+  CE's `cuStreamWaitValue32`.
+
+---
+
+## Path A: CE → Compute (Comm-First)
+
+Example: AllGather (CE) → GEMM (compute). The CE pulls data from peers and writes
+signals; the compute kernel polls signals and processes chunks as they arrive.
+
+### Step 1: Context (Buffers Required)
+
+Each approach requires different context fields:
+
+#### Approach A (PtoP Signal Pull) — Context Fields
+
+| Field | Shape / Type | Description |
+|-------|-------------|-------------|
+| `symm_input_buf` | `[world_size, M_local, K]` symmetric | Input shards. Each rank writes into `[rank, :, :]`. |
+| `symm_ag_a_buf` | `[M_local * world_size, K]` symmetric | Compact gathered output. CE PtoP writes into it. |
+| `ag_signal_buf` | `[world_size * splits_per_rank]` int32, **symmetric** | Signal tensor. Must be symmetric — CE writes into it via PtoP pull. `splits_per_rank=1` gives `[world_size]`, `splits_per_rank>1` gives finer chunk granularity. |
+| `signal_one_buf` | `[world_size * splits_per_rank]` int32, **symmetric** | All-ones symm buffer. PtoP signal source. Shape matches `ag_signal_buf`. Pre-filled with `fill_(1)`. |
+| `splits_per_rank` | `int` | Number of chunk splits per rank (≥1). `=1` means one signal per rank; `>1` splits each rank further for finer overlap. |
+| `peer_symm_input_bufs` | `List[Tensor]` | `input_hdl.get_buffer(i, ...)` views. |
+| `peer_signal_one_bufs` | `List[Tensor]` | `signal_one_hdl.get_buffer(i, ...)` views. |
 | `ag_stream` | `torch.cuda.Stream` | Dedicated stream for CE copies. |
-| `symm_mem_hdl` | handle | The symmetric memory handle from `rendezvous(symm_input_buf)`. |
+| `input_hdl` | handle | `rendezvous(symm_input_buf)`. |
+| `ag_hdl` | handle | `rendezvous(symm_ag_a_buf)`. |
+| `signal_hdl` | handle | `rendezvous(ag_signal_buf)`. |
+| `signal_one_hdl` | handle | `rendezvous(signal_one_buf)`. |
 
 **Why `peer_signal_one_bufs`?** Signal writes must stay on the same Memcpy PtoP CE
-channel as data copies. Pulling a pre-filled `1` from a peer's symmetric buffer
-achieves this — using `fill_()` or `stream_write_value32` would route through a
-different channel (DtoD) and introduce a serialization point that breaks overlap.
+channel as data copies. Pulling a pre-filled `1` from a peer's symmetric buffer keeps
+both data and signal on the same NVLink PtoP path. Using `fill_()` or
+`stream_write_value32` routes through a different hardware path (DtoD write), which
+may introduce serialization on some topologies.
 
-## Step 2: Copy Engine Communication Helper (Full-Mesh Pull)
+**Why must `ag_signal_buf` be symmetric?** The CE enqueues
+`ag_signal[idx:idx+1].copy_(peer_signal_one_bufs[rank][idx:idx+1])` — this is a
+PtoP copy from a peer's symmetric buffer into the local `ag_signal_buf`. The
+destination must be in symmetric memory for the PtoP channel to address it correctly.
 
-Enqueues PtoP (Peer-to-Peer) DMA copies on the **current stream** (caller is responsible
-for stream context). Both data and signal writes are sourced from **peer symmetric
-memory**, keeping all operations on the same CE (Memcpy PtoP) channel. This avoids the
-DtoD serialization point that `fill_()` or local `copy_()` would introduce — which
-empirically prevents overlap with the consumer compute kernel.
+**Chunk-level splitting:** When `splits_per_rank > 1`, each rank's shard is split into
+smaller chunks, and `ag_signal_buf` / `signal_one_buf` have `world_size * splits_per_rank`
+slots. The CE loop issues one PtoP data copy + one PtoP signal pull per chunk. The compute
+kernel polls the corresponding slot. When `splits_per_rank=1`, this degrades to one signal
+per rank — the only difference is the signal tensor shape and the loop structure.
 
-Below is a Full-Mesh Pull AllGather example:
+#### Approach B (`stream_write_value32`) — Context Fields
+
+| Field | Shape / Type | Description |
+|-------|-------------|-------------|
+| `symm_input_buf` | `[world_size, M_local, K]` symmetric | Input shards. Each rank writes into `[rank, :, :]`. |
+| `symm_ag_a_buf` | `[M_local * world_size, K]` symmetric | Compact gathered output. |
+| `progress` | `[world_size * splits_per_rank]` uint32, **local** | Progress/signal tensor. **No symmetric memory needed. Must be `uint32` — `int32` causes a RuntimeError in `stream_write_value32`.** |
+| `peer_symm_input_bufs` | `List[Tensor]` | `input_hdl.get_buffer(i, ...)` views. |
+| `ag_stream` | `torch.cuda.Stream` | Dedicated stream for CE copies. |
+| `input_hdl` | handle | `rendezvous(symm_input_buf)`. |
+| `ag_hdl` | handle | `rendezvous(symm_ag_a_buf)`. |
+| `splits_per_rank` | `int` | Number of chunk splits per rank (≥1). Higher = finer overlap. |
+
+Note: `signal_one_buf`, `signal_one_hdl`, and `peer_signal_one_bufs` are **not needed**
+with Approach B. The `progress` tensor is a regular local device tensor — it does not
+need to be in symmetric memory because it is only written by the local CE and read by
+the local compute kernel.
+
+### Step 2: CE Communication Helper
+
+#### Approach A: Full-Mesh Pull AG with PtoP Signal
 
 ```python
 def cp_engine_full_mesh_pull_ag(
@@ -50,239 +329,539 @@ def cp_engine_full_mesh_pull_ag(
     world_size: int,
     M_local: int,
     K: int,
-    symm_input: torch.Tensor,              # this rank's [M_local, K] shard (view into symm_input_buf[rank])
-    symm_ag_output: torch.Tensor,          # local [M_local * world_size, K] gathered buffer
-    peer_symm_input_bufs: List[torch.Tensor],  # peer views: peer_symm_input_bufs[i] is rank i's symm_input_buf
-    ag_signal: torch.Tensor,               # local ag_signal [world_size] int32
-    peer_signal_one_bufs: List[torch.Tensor],  # peer views of symmetric all-ones int32 [world_size]
-    ag_stream: torch.cuda.Stream = None,   # dedicated stream for CE copies (optional, caller sets stream context)
+    splits_per_rank: int,
+    symm_input: torch.Tensor,                  # this rank's [M_local, K] shard
+    symm_ag_output: torch.Tensor,              # [M_local * world_size, K] gathered buffer
+    peer_symm_input_bufs: List[torch.Tensor],  # peer views into symm_input_buf
+    ag_signal: torch.Tensor,                   # [world_size * splits_per_rank] int32, symmetric
+    peer_signal_one_bufs: List[torch.Tensor],  # peer views of all-ones symm int32
+    ag_stream: torch.cuda.Stream,
 ):
     """
-    AllGather via Copy Engine (full-mesh pull).
+    AllGather via Copy Engine (full-mesh pull) with PtoP signal writes.
 
-    For each peer rank src_rank in rotated order:
-      - PtoP data copy from peer_symm_input_bufs[src_rank][src_rank, :, :]
-        into symm_ag_output[src_rank * M_local : (src_rank+1) * M_local, :]
-      - PtoP signal pull of 4B from peer_signal_one_bufs[src_rank]
+    For each peer rank src_rank in rotated order, for each split within that rank:
+      1. PtoP data copy:  peer_symm_input_bufs[src_rank] → symm_ag_output chunk
+      2. PtoP signal pull: peer_signal_one_bufs[src_rank] → ag_signal[chunk_idx]
 
-    CRITICAL: Both data and signal writes are routed through PtoP (Memcpy PtoP
-    channel) by sourcing them from peer symmetric memory. This keeps all ops
-    on the same CE channel and avoids DtoD serialization.
+    CRITICAL: Both data and signal writes are routed through the PtoP channel
+    by sourcing them from peer symmetric memory. This keeps all ops on the
+    same CE channel, preserving ordering without explicit fences.
 
-    NOTE: caller must wrap this call in `with torch.cuda.stream(ag_stream):`
-    so that all enqueued copy_ ops land on ag_stream.
+    When splits_per_rank=1, each rank has one chunk (one signal per rank);
+    when splits_per_rank>1, each rank's shard is split into smaller chunks
+    for finer-grained overlap. The signal tensor shape must match the total
+    number of chunks (world_size * splits_per_rank).
+
+    Caller must wrap in `with torch.cuda.stream(ag_stream):`.
     """
-    # Self-shard: local copy + PtoP signal
-    local_dst = symm_ag_output[rank * M_local : (rank + 1) * M_local, :]
-    local_dst.copy_(symm_input)
-    ag_signal[rank:rank + 1].copy_(peer_signal_one_bufs[rank][rank:rank + 1])
+    M_split = M_local // splits_per_rank
+    assert M_local % splits_per_rank == 0, "M_local must be divisible by splits_per_rank"
+
+    # Self-shard: local copy + PtoP signal (chunk by chunk)
+    for split_id in range(splits_per_rank):
+        chunk = symm_ag_output[
+            rank * M_local + split_id * M_split :
+            rank * M_local + (split_id + 1) * M_split, :
+        ]
+        chunk.copy_(symm_input[split_id * M_split : (split_id + 1) * M_split, :])
+        idx = rank * splits_per_rank + split_id
+        ag_signal[idx:idx + 1].copy_(peer_signal_one_bufs[rank][idx:idx + 1])
 
     # Remote shards in rotated order
     for offset in range(1, world_size):
         src_rank = (rank + offset) % world_size
-        remote_src = peer_symm_input_bufs[src_rank][src_rank, :M_local, :]
-        local_dst = symm_ag_output[src_rank * M_local : (src_rank + 1) * M_local, :]
-        local_dst.copy_(remote_src)
-        ag_signal[src_rank:src_rank + 1].copy_(
-            peer_signal_one_bufs[src_rank][src_rank:src_rank + 1]
-        )
+        for split_id in range(splits_per_rank):
+            remote_src = peer_symm_input_bufs[src_rank][
+                src_rank, split_id * M_split : (split_id + 1) * M_split, :
+            ]
+            chunk = symm_ag_output[
+                src_rank * M_local + split_id * M_split :
+                src_rank * M_local + (split_id + 1) * M_split, :
+            ]
+            chunk.copy_(remote_src)
+            idx = src_rank * splits_per_rank + split_id
+            ag_signal[idx:idx + 1].copy_(peer_signal_one_bufs[src_rank][idx:idx + 1])
 ```
 
-**Key details:**
+#### Approach B: Full-Mesh Pull AG with `stream_write_value32`
+
+```python
+import torch.distributed._symmetric_memory as symm_mem
+
+def cp_engine_full_mesh_pull_ag_v2(
+    rank: int,
+    world_size: int,
+    M_local: int,
+    K: int,
+    splits_per_rank: int,
+    symm_input: torch.Tensor,                  # this rank's [M_local, K] shard
+    output: torch.Tensor,                      # [M_local * world_size, K] gathered output
+    peer_symm_input_bufs: List[torch.Tensor],  # peer views into symm_input_buf
+    progress: torch.Tensor,                    # [world_size * splits_per_rank] uint32 (NOT int32!)
+    hdl: object,                               # symm_mem handle (for stream_write_value32)
+    ag_stream: torch.cuda.Stream,
+):
+    """
+    AllGather via Copy Engine (full-mesh pull) with stream_write_value32 signals.
+
+    For each peer rank src_rank, for each split within that rank:
+      1. PtoP data copy:  peer_symm_input_bufs[src_rank] → output chunk
+      2. Write progress:  hdl.stream_write_value32(progress, offset, 1)
+
+    stream_write_value32 wraps cuStreamWriteValue32, which issues a 32-bit
+    write with a system-level fence on the CE stream. This guarantees that
+    the preceding copy_() data is visible before the signal value becomes 1.
+
+    Advantages over Approach A:
+      - No signal_one_buf allocation or rendezvous needed.
+      - progress tensor is a local device tensor (not symmetric memory).
+      - Simpler API: single hdl.stream_write_value32() call per signal write.
+
+    Caller must wrap in `with torch.cuda.stream(ag_stream):`.
+    """
+    M_split = M_local // splits_per_rank
+    assert M_local % splits_per_rank == 0, "M_local must be divisible by splits_per_rank"
+
+    # Self-shard: local copy + signal
+    for split_id in range(splits_per_rank):
+        chunk = output[
+            rank * M_local + split_id * M_split :
+            rank * M_local + (split_id + 1) * M_split, :
+        ]
+        chunk.copy_(symm_input[split_id * M_split : (split_id + 1) * M_split, :])
+        hdl.stream_write_value32(
+            progress,
+            offset=rank * splits_per_rank + split_id,
+            val=1,
+        )
+
+    # Remote shards in rotated order
+    for step in range(1, world_size):
+        src_rank = (rank + step) % world_size
+        for split_id in range(splits_per_rank):
+            src_buf = peer_symm_input_bufs[src_rank][
+                src_rank, split_id * M_split : (split_id + 1) * M_split, :
+            ]
+            chunk = output[
+                src_rank * M_local + split_id * M_split :
+                src_rank * M_local + (split_id + 1) * M_split, :
+            ]
+            chunk.copy_(src_buf)
+            hdl.stream_write_value32(
+                progress,
+                offset=src_rank * splits_per_rank + split_id,
+                val=1,
+            )
+```
+
+**Key details (both approaches):**
 - `copy_()` from a peer symmetric tensor routes through the **Memcpy PtoP** CE channel
-  (DMA, zero SM cost)
-- Signal is written by pulling a pre-filled `1` from the peer's symmetric `signal_one_buf`
-  — this stays on the same PtoP channel as data, preserving ordering without explicit
-  fences. The consumer kernel sees `ag_signal[src_rank] == 1` only after the preceding
-  data copy completes on the same channel.
+  (DMA, zero SM cost).
 - Rotated iteration order `(rank + offset) % world_size` spreads NVLink traffic across
-  links, reducing hot-spots
-- Signal granularity is **per-rank-shard** (one slot per peer), not per-chunk. The
-  consumer kernel polls `ag_signal[src_rank]` before processing that rank's rows.
+  links, reducing hot-spots.
+- Signal granularity: controlled by `splits_per_rank`. Signal tensor shape is always
+  `[world_size * splits_per_rank]`. `splits_per_rank=1` gives one signal per rank;
+  `splits_per_rank>1` splits each rank's shard into finer chunks for earlier compute
+  overlap. Both Approach A (PtoP pull) and Approach B (`stream_write_value32`) support
+  any `splits_per_rank` value.
+- `splits_per_rank > 1` splits each rank's shard into smaller chunks, allowing the
+  compute kernel to start processing earlier (finer-grained overlap).
+- **Signal tensor dtype**: Approach A (PtoP pull) uses `int32` for `ag_signal_buf` and
+  `signal_one_buf` (standard symmetric memory signal pads). Approach B
+  (`stream_write_value32`) **must** use `uint32` for `progress` — `cuStreamWriteValue32`
+  writes an unsigned 32-bit value and PyTorch's binding validates the dtype; `int32`
+  raises `RuntimeError`. The compute kernel's `ld_sys` (PTX `ld.global.acquire.sys.b32`)
+  reads 32 bits regardless of signedness, so it works with both `int32` and `uint32`
+  signal tensors — but the host-side `stream_write_value32` call requires `uint32`.
 
-## Step 3: Compute Kernel with Signal Polling
+### Step 3: Compute Kernel with Signal Polling
 
-The compute kernel polls the **per-rank-shard** signal tensor before touching remote
-data. Signal granularity matches the AG helper: one slot per peer rank. Local data
-(this rank's own shard) needs no waiting.
+The compute kernel polls the signal tensor before touching remote data. Signal granularity
+is controlled by `splits_per_rank`: `=1` means one signal per rank (per-rank), `>1` means
+one signal per chunk within each rank (per-chunk). The signal tensor shape is always
+`[world_size * splits_per_rank]`, which equals `[world_size]` when `splits_per_rank=1`.
 
-The example below shows a non-persistent GEMM consumer (one CTA per output tile) with
-rank-aware tile rotation so that tiles targeting the local shard launch first (signaled
-immediately), then tiles for peers in rotated order — matching the AG signal-arrival
-order and minimizing spin-wait.
+Local data (this rank's own shard) needs no waiting — the signal is already set to 1 for
+all local chunks.
+
+**Critical**: Only **one thread** (threadIdx.x == 0) polls the signal. After the poll
+exits, `__syncthreads()` ensures all threads in the CTA see the signal before proceeding.
+If all threads poll independently, each thread issues its own `ld.global.acquire.sys` —
+wasting memory bandwidth and adding unnecessary synchronization traffic.
+
+#### Unified chunk-based polling kernel
+
+Works with **both** Approach A (PtoP pull) and Approach B (`stream_write_value32`).
 
 ```python
 @triton.jit
-def consumer_gemm_compute_kernel(
-    A_ptr,              # symm_ag_output: [M, K] gathered A (compact layout)
+def consumer_gemm_kernel(
+    A_ptr,              # symm_ag_a_buf: [M, K] gathered A (compact layout)
     B_ptr,              # weight [N, K]
     C_ptr,              # output [M, N]
-    ag_signal_ptr,      # signal from AG [world_size] int32 (per-rank-shard)
+    signal_ptr,         # signal tensor [world_size * splits_per_rank] — uint32 for Approach B, int32 for Approach A
     M, N, K,
     M_local,            # rows per rank
-    M_local_tiles,      # = cdiv(M_local, BLOCK_SIZE_M)
+    M_split,            # rows per split = M_local // splits_per_rank
+    M_split_tiles,      # = cdiv(M_split, BLOCK_SIZE_M)
+    splits_per_rank,    # number of splits per rank (1 = per-rank, >1 = per-chunk)
     stride_am, stride_ak,
     stride_bk, stride_bn,
     stride_cm, stride_cn,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
     rank: tl.constexpr,
     world_size: tl.constexpr,
 ):
     pid = tl.program_id(0)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
-    pid_m = pid // num_pid_n
-    pid_n = pid % num_pid_n
 
-    # Rank-aware tile rotation: remap pid_m so local tiles come first
-    tile_in_rank = pid_m % M_local_tiles
-    rank_offset = pid_m // M_local_tiles
-    src_rank = (rank + rank_offset) % world_size
+    # Chunk-aware tile rotation: local chunks first, then peers in rotated order.
+    # When splits_per_rank=1, each chunk is an entire rank shard (per-rank mode).
+    total_chunks = world_size * splits_per_rank
+    num_pid_m = M_split_tiles * total_chunks
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
 
-    # Poll AG signal for this rank's shard (skip for local)
-    if rank_offset != 0:
-        while tl.load(ag_signal_ptr + src_rank, volatile=True) == 0:
-            pass  # spin-wait until src_rank's shard is gathered
+    # Map from logical tile to (src_rank, split_id)
+    chunk_id = min(pid_m // M_split_tiles, total_chunks - 1)
+    tile_in_chunk = pid_m - chunk_id * M_split_tiles
+    logical_rank = chunk_id // splits_per_rank
+    split_id = chunk_id % splits_per_rank
+    src_rank = (rank + logical_rank) % world_size
+    pid_m = (src_rank * splits_per_rank + split_id) * M_split_tiles + tile_in_chunk
 
-    # Compute row offset in compact layout
-    row_start = src_rank * M_local + tile_in_rank * BLOCK_SIZE_M
+    # Poll signal for this chunk (system-scope acquire load).
+    # Only tid(0) polls; __syncthreads() broadcasts the result.
+    signal_idx = src_rank * splits_per_rank + split_id
+    if tid(0) == 0:
+        while ld_sys(signal_ptr + signal_idx) != 1:
+            pass
+    __syncthreads()
 
-    # ... standard GEMM tile computation using A[row_start:, :] x B ...
+    # Compute row offset
+    tile_row_start = src_rank * M_local + split_id * M_split + tile_in_chunk * BLOCK_SIZE_M
+
+    # ... standard GEMM tile computation using A[tile_row_start:, :] x B ...
 ```
 
-**Key points:**
-- Signal poll is `ag_signal_ptr + src_rank` (per-rank-shard granularity)
-- Rank-aware rotation ensures CTAs for the local shard (rank_offset == 0) skip the poll
-  entirely, and subsequent CTAs target peers in the same rotated order as the AG helper
-- For a simpler (non-GEMM) persistent kernel, the same pattern applies: determine which
-  rank owns the chunk, poll `ag_signal[src_rank]`, then process
+**Key points (both approaches):**
+- **`splits_per_rank=1`** is the per-rank case: `M_split = M_local`, `total_chunks = world_size`,
+  each CTA polls `signal_ptr + src_rank`. This is the simplest default.
+- **`splits_per_rank>1`** is the per-chunk case: each rank's shard is split into finer chunks,
+  allowing the compute kernel to start processing earlier as each chunk's copy completes.
+- Signal poll uses `ld_sys(...)` = `ld.global.acquire.sys.b32` — not `tl.load(...)`.
+  System-scope acquire is required because the signal was written by the CE (either
+  via PtoP copy or `cuStreamWriteValue32`); plain `tl.load` has no cross-device
+  visibility guarantee and may read stale L2 cache data.
+- Only `tid(0) == 0` polls to reduce `ld.global.acquire.sys` traffic to 1-per-CTA.
+- Chunk-aware rotation ensures CTAs for the local shard process first (signal
+  already set), then peers in the same rotated order as the CE AG helper — minimizing
+  spin-wait time.
 
-## Step 4: Host-Side Orchestration
-
-Launch both communication and compute in a single host function. The
-`barrier() → signal.fill_(0) → barrier()` pattern ensures all ranks have finished
-the previous iteration's communication before resetting, and all ranks see the reset
-before launching the next iteration.
-
-Below is an example implementation of AG-GEMM overlap with Copy Engine:
+### Step 4: Host-Side Orchestration
 
 ```python
-def ag_gemm_overlap(ctx, a_input, compute_kernel):
+def ag_gemm_overlap(ctx, a_input, compute_kernel, block_size):
     """Launch copy-engine AG and consumer compute kernel with overlap."""
     rank, world_size = ctx.rank, ctx.num_ranks
-    hdl = ctx.symm_mem_hdl
     M_local, K = a_input.shape[0], a_input.shape[1]
+    N = ctx.weight.shape[0]
+    M = M_local * world_size
 
-    symm_input = ctx.symm_input_buf          # symmetric [world_size, M_local, K]
-    symm_ag_output = ctx.symm_ag_output      # local [M_local * world_size, K]
-    ag_signal = ctx.ag_signal                 # local [world_size] int32
-    peer_symm_input_bufs = ctx.peer_symm_input_bufs
-    peer_signal_one_bufs = ctx.peer_signal_one_bufs
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = block_size
+
+    # Copy input shard into symmetric buffer (so peers can pull it)
+    symm_input = ctx.get_input_buf(M_local, K)
+    symm_input.copy_(a_input)
 
     current_stream = torch.cuda.current_stream()
     ag_stream = ctx.ag_stream
 
-    # Copy input shard into symmetric buffer (so peers can pull it)
-    symm_input[rank, :M_local, :].copy_(a_input)
+    # ---- Barrier + signal reset pattern ----
+    # Must happen on the default stream BEFORE enqueuing anything on ag_stream.
+    ctx.input_hdl.barrier()          # ensure all ranks finished previous iteration
+    if hasattr(ctx, 'ag_signal_buf'):  # Approach A
+        ctx.ag_signal_buf.fill_(0)
+    else:                                # Approach B
+        ctx.progress.fill_(0)
+    ctx.input_hdl.barrier()          # ensure all ranks see the reset before launching
 
-    # Host-side cross-rank barrier: ensure all ranks finished previous iteration
-    hdl.barrier()
-    # Reset signal (safe now — all ranks' CE copies have completed)
-    ag_signal.fill_(0)
-    # Host-side barrier: ensure all ranks see the reset before launching
-    hdl.barrier()
-
-    # Ensure ag_stream waits for signal reset and input copy
     ag_stream.wait_stream(current_stream)
 
     # Step 1: enqueue full-mesh pull AG on ag_stream
     with torch.cuda.stream(ag_stream):
-        cp_engine_full_mesh_pull_ag(
-            rank=rank,
-            world_size=world_size,
-            M_local=M_local,
-            K=K,
-            symm_input=symm_input[rank, :M_local, :],
-            symm_ag_output=symm_ag_output,
-            peer_symm_input_bufs=peer_symm_input_bufs,
-            ag_signal=ag_signal,
-            peer_signal_one_bufs=peer_signal_one_bufs,
-        )
+        if hasattr(ctx, 'ag_signal_buf'):
+            # Approach A: PtoP signal pull
+            cp_engine_full_mesh_pull_ag(
+                rank=rank, world_size=world_size,
+                M_local=M_local, K=K,
+                splits_per_rank=ctx.splits_per_rank,
+                symm_input=symm_input,
+                symm_ag_output=ctx.symm_ag_a_buf,
+                peer_symm_input_bufs=ctx.peer_symm_input_bufs,
+                ag_signal=ctx.ag_signal_buf,
+                peer_signal_one_bufs=ctx.peer_signal_one_bufs,
+                ag_stream=ag_stream,
+            )
+        else:
+            # Approach B: stream_write_value32
+            cp_engine_full_mesh_pull_ag_v2(
+                rank=rank, world_size=world_size,
+                M_local=M_local, K=K,
+                splits_per_rank=ctx.splits_per_rank,
+                symm_input=symm_input,
+                output=ctx.symm_ag_a_buf,
+                peer_symm_input_bufs=ctx.peer_symm_input_bufs,
+                progress=ctx.progress,
+                hdl=ctx.ag_hdl,
+                ag_stream=ag_stream,
+            )
 
-    # Step 2: launch consumer compute kernel on current_stream (polls ag_signal)
-    # Without-SM mode: communication is on copy engine (zero SM cost), so the
-    # compute kernel can use ALL SMs. This kernel is non-persistent (one CTA per tile,
-    # no grid barrier), so num_tiles > SMs is safe — CUDA scheduler handles it.
-    M = M_local * world_size
-    N = ctx.N
+    # Step 2: launch consumer compute kernel on current_stream
+    # Without-SM: communication is on copy engine (zero SMs), compute uses ALL SMs.
+    # Non-persistent kernel (one CTA per tile), so num_tiles > SMs is safe.
     M_local_tiles = triton.cdiv(M_local, BLOCK_SIZE_M)
     num_tiles = M_local_tiles * world_size * triton.cdiv(N, BLOCK_SIZE_N)
 
-    c = torch.empty((M, N), dtype=ctx.output_dtype, device=a_input.device)
+    c = torch.empty((M, N), dtype=a_input.dtype, device=a_input.device)
     compute_kernel[(num_tiles,)](
-        symm_ag_output, ctx.weight, c, ag_signal,
+        ctx.symm_ag_a_buf, ctx.weight, c,
+        ctx.ag_signal_buf if hasattr(ctx, 'ag_signal_buf') else ctx.progress,
         M, N, K, M_local, M_local_tiles,
         # ... strides, block sizes, etc.
-        rank=rank,
-        world_size=world_size,
+        rank=rank, world_size=world_size,
+        num_warps=32, num_stages=1,
     )
 
-    # Wait for AG stream to complete before returning
     current_stream.wait_stream(ag_stream)
-    return c
+    return ctx.symm_ag_a_buf[:M_local * world_size, :], c
 ```
 
-## Signal Variant: Compute-First
+---
 
-If compute runs first and communication follows (e.g., GEMM → reduce-scatter / all-gather
-via DMA), the direction reverses: the compute kernel signals tile completion, and the
-CE stream waits for each signal before issuing the corresponding `copy_()`.
+## Path B: Compute → CE (Comp-First)
+
+Example: GEMM (compute) → ReduceScatter (CE). The compute kernel writes per-tile signals
+as tiles complete; the CE stream enqueues `cuStreamWaitValue32` + `copy_()` per tile to
+pipeline copies behind computation.
+
+### Anti-patterns
+
+❌ **Host-side CPU spin-wait** — each `.item()` call triggers GPU→CPU sync (~5–50 μs),
+and `pass` in the loop burns a CPU core at 100%:
+```python
+# ❌ BAD: CPU spin-wait — D2H latency × num_tiles
+for tile_id in range(num_tiles):
+    while signal_pad[tile_id].item() != 1:
+        pass
+    issue_ce_copy(tile_id)
+```
+
+❌ **Chunked kernel launch + CUDA event** — per-chunk kernel launch overhead is
+prohibitively expensive for fine-grained tile-level overlap. The whole point of
+without-sm is a single compute kernel launch with CE pipelining behind it.
+
+### Recommended: GPU-side signal + `cuStreamWaitValue32`
+
+Single compute kernel launch. Each CTA writes a per-tile signal via `st_sys`
+(after the tile's `tl.store` completes). The CE stream enqueues
+`cuStreamWaitValue32` per tile — a **GPU-side hardware wait** that blocks the CE
+channel until the memory-mapped signal equals the expected value. The host call
+returns immediately; no CPU spinning, no extra kernel launches.
+
+#### Step A: Compute kernel — write signal per tile
+
+```python
+@triton.jit
+def compute_kernel_with_push_signal(
+    # ... existing args (input, output, weight pointers, dimensions, strides, etc.) ...
+    signal_pad_ptr,    # [num_tiles] int32 — one slot per tile
+    # ... dimensions, block sizes, etc. ...
+):
+    pid = tl.program_id(0)
+
+    # ... compute tile, tl.store results to symm_output ...
+
+    # After all tile stores are done, signal this tile's completion.
+    # st_sys = st.global.release.sys.b32 — ensures tile data is visible before signal.
+    # Only one thread per CTA needs to write the signal.
+    if tid(0) == 0:
+        st_sys(signal_pad_ptr + pid, 1)
+```
+
+**Why `st_sys` instead of `_send_signal` (CAS)?** In without-sm comp-first mode, each
+tile has exactly one writer (the CTA that computed it), and the signal tensor is reset
+to 0 before each launch. So there is no contention — a simple store suffices. The CAS
+spin-loop in `_send_signal` (from `primitives.md`) is overkill and adds latency.
+
+#### Step B: CE push — `cuStreamWaitValue32` per tile
 
 ```python
 from typing import List
+from cuda.bindings import driver
 
 def cp_engine_full_mesh_push(
     rank: int,
     world_size: int,
     M_local: int,
     K: int,
-    symm_output: torch.Tensor,             # this rank's computed [M_local, K] in symmetric memory
+    symm_output: torch.Tensor,                 # this rank's computed [M_local, K] in symmetric memory
     peer_symm_output_bufs: List[torch.Tensor],  # peer views of symm_output
-    signal_pad: torch.Tensor,              # [num_tiles] int32 — compute kernel writes 1 per tile
-    ce_stream: torch.cuda.Stream,          # the backend CE stream (caller sets stream context)
+    signal_pad: torch.Tensor,                  # [num_tiles] int32 — compute kernel writes 1 per tile
+    ce_stream: torch.cuda.Stream,              # dedicated stream for CE copies
 ):
     """
-    Push computed tiles to all peers via Copy Engine, waiting for each tile's
-    compute signal before issuing the copy.
+    Push computed tiles to all peers via Copy Engine.
 
-    Host-side while loop polls signal_pad until the compute kernel writes 1,
-    then issues PtoP push via copy_(). No external dependencies required.
-
-    NOTE: caller must wrap this call in `with torch.cuda.stream(ce_stream):`
+    The compute kernel (running on current_stream) writes signal_pad[tile_id] = 1
+    via st_sys after each tile's stores complete. This function enqueues
+    per-tile cuStreamWaitValue32 + copy_() on ce_stream so the CE channel
+    pipelines naturally behind the compute kernel — zero CPU spin, zero extra
+    kernel launches.
     """
     num_tiles = signal_pad.numel()
-    tile_numel = (M_local * K) // num_tiles  # elements per tile
+    tile_numel = (M_local * K) // num_tiles
+    assert (M_local * K) % num_tiles == 0, "Output must be evenly divisible by num_tiles"
+    ce_stream_handle = driver.CUstream(ce_stream.cuda_stream)
 
-    for tile_id in range(num_tiles):
-        # Host-side poll: wait for compute kernel to signal this tile
-        while signal_pad[tile_id].item() != 1:
-            pass
+    with torch.cuda.stream(ce_stream):
+        for tile_id in range(num_tiles):
+            # GPU-side hardware wait: CE channel stalls until signal_pad[tile_id] == 1.
+            # Host call returns immediately — no CPU blocking.
+            wait_addr = driver.CUdeviceptr(signal_pad[tile_id].data_ptr())
+            driver.cuStreamWaitValue32(
+                ce_stream_handle,
+                wait_addr,
+                1,
+                driver.CUstreamWaitValue_flags.CU_STREAM_WAIT_VALUE_EQ,
+            )
 
-        # PtoP push: copy this tile to every peer's symmetric buffer
-        tile_offset = tile_id * tile_numel
-        local_tile = symm_output.flatten()[tile_offset : tile_offset + tile_numel]
+            # PtoP push: copy this tile to every peer's symmetric buffer
+            tile_offset = tile_id * tile_numel
+            local_tile = symm_output.flatten()[tile_offset : tile_offset + tile_numel]
 
-        for offset in range(1, world_size):
-            dst_rank = (rank + offset) % world_size
-            remote_dst = peer_symm_output_bufs[dst_rank].flatten()[tile_offset : tile_offset + tile_numel]
-            remote_dst.copy_(local_tile)  # PtoP CE push
+            for offset in range(1, world_size):
+                dst_rank = (rank + offset) % world_size
+                remote_dst = peer_symm_output_bufs[dst_rank].flatten()[
+                    tile_offset : tile_offset + tile_numel
+                ]
+                remote_dst.copy_(local_tile)  # PtoP CE push
+
+    # Cleanup: current stream waits for all CE copies to finish
+    current_stream = torch.cuda.current_stream()
+    current_stream.wait_stream(ce_stream)
 ```
 
+**End-to-end timeline:**
+
+```
+current_stream (SM)                ce_stream (Copy Engine)
+─────────────────────              ─────────────────────
+kernel launches →
+  CTA-0: compute tile 0
+         st_sys(pad[0], 1)  ───►  cuStreamWaitValue32(pad[0], ==1)  ← fires!
+                                      copy_(tile_0 → peer_1, peer_2, …)
+  CTA-1: compute tile 1
+         st_sys(pad[1], 1)  ───►  cuStreamWaitValue32(pad[1], ==1)  ← fires!
+                                      copy_(tile_1 → peer_1, peer_2, …)
+  ...                               ...
+kernel exits                       all copies complete
+```
+
+The CE channel pipelines naturally: `cuStreamWaitValue32` is a hardware wait that gates
+the subsequent `copy_()` on the CE stream. The host thread enqueues all `num_tiles`
+wait+copy pairs up front (returns immediately), and the GPU scheduler progresses each
+tile's copy as soon as the compute kernel's signal lands in memory.
+
 **Key details:**
-- Host-side `while signal_pad[tile_id].item() != 1: pass` polls the compute kernel's
-  per-tile signal
-- `copy_()` into a peer symmetric tensor routes through the **Memcpy PtoP** CE channel,
-  same as the pull direction in `cp_engine_full_mesh_pull_ag`
-- Reset `signal_pad.zero_()` between iterations (protected by the same
-  `barrier() → zero_() → barrier()` pattern as the pull variant)
+- `st_sys` uses `st.global.release.sys.b32` — system-scope release ensures data stores
+  are visible before the signal. This is simpler and faster than `_send_signal`'s CAS
+  spin-loop because there is no contention (each tile has exactly one writer).
+- `cuStreamWaitValue32` is a **GPU-side hardware wait** — the CE stream's DMAs are gated
+  by the memory-mapped value. No CPU involvement, no D2H transfers.
+- Signal granularity is **per-tile** (fine-grained), giving the CE stream maximum overlap
+  opportunity — each tile's copy starts as soon as that tile's signal fires.
+- `copy_()` into a peer symmetric tensor routes through the **Memcpy PtoP** CE channel.
+- Reset `signal_pad.zero_()` between iterations (protected by the
+  `barrier() → zero_() → barrier()` pattern). If the reset is missing, the CE will
+  see stale `1` values and issue copies before the compute kernel has finished — a
+  correctness bug.
+
+#### Step C: Host-Side Orchestration (Comp-First)
+
+```python
+def gemm_rs_overlap(ctx, a_input, b_weight, compute_kernel, signal_pad, block_size):
+    """Launch compute kernel (GEMM) and CE push (reduce-scatter) with overlap."""
+    rank, world_size = ctx.rank, ctx.num_ranks
+    M_local, K = a_input.shape
+    N = b_weight.shape[0]
+
+    current_stream = torch.cuda.current_stream()
+    ce_stream = ctx.ce_stream
+
+    # Barrier + signal reset
+    ctx.output_hdl.barrier()
+    signal_pad.zero_()
+    ctx.output_hdl.barrier()
+
+    # Step 1: launch compute kernel on current_stream (writes per-tile signals)
+    num_tiles = triton.cdiv(M_local, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)
+    symm_output = ctx.get_output_buf(M_local, K)
+
+    compute_kernel[(num_tiles,)](
+        a_input, b_weight, symm_output, signal_pad,
+        M_local, N, K,
+        # ... strides, block sizes, etc.
+        num_warps=32, num_stages=1,
+    )
+
+    # Step 2: enqueue CE push on ce_stream (per-tile wait + copy)
+    ce_stream.wait_stream(current_stream)
+    cp_engine_full_mesh_push(
+        rank=rank, world_size=world_size,
+        M_local=M_local, K=K,
+        symm_output=symm_output,
+        peer_symm_output_bufs=ctx.peer_symm_output_bufs,
+        signal_pad=signal_pad,
+        ce_stream=ce_stream,
+    )
+
+    current_stream.wait_stream(ce_stream)
+```
+
+---
+
+## Host-Side Cross-Rank Barrier Pattern
+
+Both paths require host-side `symm_mem_hdl.barrier()` calls to synchronize across ranks:
+
+1. **Before launching**: `barrier() → signal_reset → barrier()` ensures all ranks have
+   finished the previous iteration before resetting signals, and all ranks see the reset
+   before launching new kernels.
+
+2. **After completion**: `current_stream.wait_stream(ce_stream)` ensures the host thread
+   does not return until both streams complete.
+
+```python
+# Reset pattern (before each iteration):
+hdl.barrier()              # all ranks finished previous iteration
+signal.zero_()             # or progress.fill_(0) for Approach B
+hdl.barrier()              # all ranks see reset before launching
+
+# Sync pattern (after each iteration):
+current_stream.wait_stream(ce_stream)   # wait for CE to finish
+```
+
+**Why not in-kernel barriers?** In without-sm mode, the compute kernel and CE stream
+run as separate entities with no shared in-kernel phase after communication. The
+barrier needs to happen on the host side between iterations. Using in-kernel
+`barrier_all_intra_node_atomic_cas_block` is incorrect here — there is no single
+kernel that encompasses both compute and communication.

--- a/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
@@ -42,6 +42,8 @@ memory**, keeping all operations on the same CE (Memcpy PtoP) channel. This avoi
 DtoD serialization point that `fill_()` or local `copy_()` would introduce — which
 empirically prevents overlap with the consumer compute kernel.
 
+Below is a Full-Mesh Pull AllGather example:
+
 ```python
 def cp_engine_full_mesh_pull_ag(
     rank: int,
@@ -53,6 +55,7 @@ def cp_engine_full_mesh_pull_ag(
     peer_symm_input_bufs: List[torch.Tensor],  # peer views: peer_symm_input_bufs[i] is rank i's symm_input_buf
     ag_signal: torch.Tensor,               # local ag_signal [world_size] int32
     peer_signal_one_bufs: List[torch.Tensor],  # peer views of symmetric all-ones int32 [world_size]
+    ag_stream: torch.cuda.Stream = None,   # dedicated stream for CE copies (optional, caller sets stream context)
 ):
     """
     AllGather via Copy Engine (full-mesh pull).
@@ -69,21 +72,17 @@ def cp_engine_full_mesh_pull_ag(
     NOTE: caller must wrap this call in `with torch.cuda.stream(ag_stream):`
     so that all enqueued copy_ ops land on ag_stream.
     """
-    # Self-shard: data is already local, just signal via PtoP pull.
+    # Self-shard: local copy + PtoP signal
     local_dst = symm_ag_output[rank * M_local : (rank + 1) * M_local, :]
     local_dst.copy_(symm_input)
     ag_signal[rank:rank + 1].copy_(peer_signal_one_bufs[rank][rank:rank + 1])
 
-    # Pull remote shards in rotated order: (rank+1, rank+2, ..., rank-1) % world_size
-    # Rotated order spreads NVLink traffic: not all ranks pull from rank 0 first.
+    # Remote shards in rotated order
     for offset in range(1, world_size):
         src_rank = (rank + offset) % world_size
-        # Remote source: rank src_rank's own shard at peer's symm_input_buf[src_rank, :, :]
         remote_src = peer_symm_input_bufs[src_rank][src_rank, :M_local, :]
         local_dst = symm_ag_output[src_rank * M_local : (src_rank + 1) * M_local, :]
-        local_dst.copy_(remote_src)  # PtoP CE data copy
-
-        # Signal: PtoP pull 4B from peer's signal_one_buf — same channel as data.
+        local_dst.copy_(remote_src)
         ag_signal[src_rank:src_rank + 1].copy_(
             peer_signal_one_bufs[src_rank][src_rank:src_rank + 1]
         )
@@ -165,6 +164,8 @@ Launch both communication and compute in a single host function. The
 `barrier() → signal.fill_(0) → barrier()` pattern ensures all ranks have finished
 the previous iteration's communication before resetting, and all ranks see the reset
 before launching the next iteration.
+
+Below is an example implementation of AG-GEMM overlap with Copy Engine:
 
 ```python
 def ag_gemm_overlap(ctx, a_input, compute_kernel):

--- a/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
@@ -1,0 +1,288 @@
+# Without-SM Overlap: Copy Engine (DMA) Based
+
+Communication is offloaded to the copy engine, consuming zero SM resources. The compute
+kernel on the main stream polls a signal tensor to process data as it arrives.
+
+## Architecture
+
+```
+Main Stream (SM)                      Backend Stream (Copy Engine / DMA)
+┌──────────────────────────┐          ┌──────────────────────────────────────┐
+│ compute_kernel           │          │ for each peer in rotated order:      │
+│  process local (no wait) │          │   copy_(peer_symm_buf → local_dst)   │
+│  poll signal[src_rank]   │◄──────── │   signal[src_rank].copy_(peer_one)   │
+│  process remote chunk    │          │     (PtoP pull — same CE channel)    │
+└──────────────────────────┘          └──────────────────────────────────────┘
+```
+
+## Step 1: Buffers Required (ctx)
+
+The orchestration function (Step 4) assumes a pre-initialized context `ctx` with:
+
+| Field | Shape / Type | Description |
+|-------|-------------|-------------|
+| `symm_input_buf` | `[world_size, M_local, K]` symmetric | Allocated via `symm_mem.empty()` + `rendezvous()`. Each rank writes its shard into `[rank, :, :]`. |
+| `symm_ag_output` | `[M_local * world_size, K]` local | Compact gathered output buffer. |
+| `ag_signal` | `[world_size]` int32, local | Per-rank-shard signal (consumer polls for `== 1`). |
+| `peer_symm_input_bufs` | `List[Tensor]` (len = world_size) | `hdl.get_buffer(i, ...)` views into each peer's `symm_input_buf`. |
+| `peer_signal_one_bufs` | `List[Tensor]` (len = world_size) | Views into a **symmetric all-ones int32 buffer** — used as PtoP source for signal writes. Allocate a separate symmetric buffer filled with `1`, rendezvous it, then `get_buffer(i, ...)` for each peer. |
+| `ag_stream` | `torch.cuda.Stream` | Dedicated stream for CE copies. |
+| `symm_mem_hdl` | handle | The symmetric memory handle from `rendezvous(symm_input_buf)`. |
+
+**Why `peer_signal_one_bufs`?** Signal writes must stay on the same Memcpy PtoP CE
+channel as data copies. Pulling a pre-filled `1` from a peer's symmetric buffer
+achieves this — using `fill_()` or `stream_write_value32` would route through a
+different channel (DtoD) and introduce a serialization point that breaks overlap.
+
+## Step 2: Copy Engine Communication Helper (Full-Mesh Pull)
+
+Enqueues PtoP (Peer-to-Peer) DMA copies on the **current stream** (caller is responsible
+for stream context). Both data and signal writes are sourced from **peer symmetric
+memory**, keeping all operations on the same CE (Memcpy PtoP) channel. This avoids the
+DtoD serialization point that `fill_()` or local `copy_()` would introduce — which
+empirically prevents overlap with the consumer compute kernel.
+
+```python
+def cp_engine_full_mesh_pull_ag(
+    rank: int,
+    world_size: int,
+    M_local: int,
+    K: int,
+    symm_input: torch.Tensor,              # this rank's [M_local, K] shard (view into symm_input_buf[rank])
+    symm_ag_output: torch.Tensor,          # local [M_local * world_size, K] gathered buffer
+    peer_symm_input_bufs: List[torch.Tensor],  # peer views: peer_symm_input_bufs[i] is rank i's symm_input_buf
+    ag_signal: torch.Tensor,               # local ag_signal [world_size] int32
+    peer_signal_one_bufs: List[torch.Tensor],  # peer views of symmetric all-ones int32 [world_size]
+):
+    """
+    AllGather via Copy Engine (full-mesh pull).
+
+    For each peer rank src_rank in rotated order:
+      - PtoP data copy from peer_symm_input_bufs[src_rank][src_rank, :, :]
+        into symm_ag_output[src_rank * M_local : (src_rank+1) * M_local, :]
+      - PtoP signal pull of 4B from peer_signal_one_bufs[src_rank]
+
+    CRITICAL: Both data and signal writes are routed through PtoP (Memcpy PtoP
+    channel) by sourcing them from peer symmetric memory. This keeps all ops
+    on the same CE channel and avoids DtoD serialization.
+
+    NOTE: caller must wrap this call in `with torch.cuda.stream(ag_stream):`
+    so that all enqueued copy_ ops land on ag_stream.
+    """
+    # Self-shard: data is already local, just signal via PtoP pull.
+    local_dst = symm_ag_output[rank * M_local : (rank + 1) * M_local, :]
+    local_dst.copy_(symm_input)
+    ag_signal[rank:rank + 1].copy_(peer_signal_one_bufs[rank][rank:rank + 1])
+
+    # Pull remote shards in rotated order: (rank+1, rank+2, ..., rank-1) % world_size
+    # Rotated order spreads NVLink traffic: not all ranks pull from rank 0 first.
+    for offset in range(1, world_size):
+        src_rank = (rank + offset) % world_size
+        # Remote source: rank src_rank's own shard at peer's symm_input_buf[src_rank, :, :]
+        remote_src = peer_symm_input_bufs[src_rank][src_rank, :M_local, :]
+        local_dst = symm_ag_output[src_rank * M_local : (src_rank + 1) * M_local, :]
+        local_dst.copy_(remote_src)  # PtoP CE data copy
+
+        # Signal: PtoP pull 4B from peer's signal_one_buf — same channel as data.
+        ag_signal[src_rank:src_rank + 1].copy_(
+            peer_signal_one_bufs[src_rank][src_rank:src_rank + 1]
+        )
+```
+
+**Key details:**
+- `copy_()` from a peer symmetric tensor routes through the **Memcpy PtoP** CE channel
+  (DMA, zero SM cost)
+- Signal is written by pulling a pre-filled `1` from the peer's symmetric `signal_one_buf`
+  — this stays on the same PtoP channel as data, preserving ordering without explicit
+  fences. The consumer kernel sees `ag_signal[src_rank] == 1` only after the preceding
+  data copy completes on the same channel.
+- Rotated iteration order `(rank + offset) % world_size` spreads NVLink traffic across
+  links, reducing hot-spots
+- Signal granularity is **per-rank-shard** (one slot per peer), not per-chunk. The
+  consumer kernel polls `ag_signal[src_rank]` before processing that rank's rows.
+
+## Step 3: Compute Kernel with Signal Polling
+
+The compute kernel polls the **per-rank-shard** signal tensor before touching remote
+data. Signal granularity matches the AG helper: one slot per peer rank. Local data
+(this rank's own shard) needs no waiting.
+
+The example below shows a non-persistent GEMM consumer (one CTA per output tile) with
+rank-aware tile rotation so that tiles targeting the local shard launch first (signaled
+immediately), then tiles for peers in rotated order — matching the AG signal-arrival
+order and minimizing spin-wait.
+
+```python
+@triton.jit
+def consumer_gemm_compute_kernel(
+    A_ptr,              # symm_ag_output: [M, K] gathered A (compact layout)
+    B_ptr,              # weight [N, K]
+    C_ptr,              # output [M, N]
+    ag_signal_ptr,      # signal from AG [world_size] int32 (per-rank-shard)
+    M, N, K,
+    M_local,            # rows per rank
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    M_per_rank_tiles: tl.constexpr,  # = cdiv(M_local, BLOCK_SIZE_M)
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+
+    # Rank-aware tile rotation: remap pid_m so local tiles come first
+    # tile_in_rank = pid_m % M_per_rank_tiles
+    # rank_offset = pid_m // M_per_rank_tiles
+    # src_rank = (rank + rank_offset) % world_size
+    tile_in_rank = pid_m % M_per_rank_tiles
+    rank_offset = pid_m // M_per_rank_tiles
+    src_rank = (rank + rank_offset) % world_size
+
+    # Poll AG signal for this rank's shard (skip for local)
+    if rank_offset != 0:
+        while tl.load(ag_signal_ptr + src_rank, volatile=True) == 0:
+            pass  # spin-wait until src_rank's shard is gathered
+
+    # Compute row offset in compact layout
+    row_start = src_rank * M_local + tile_in_rank * BLOCK_SIZE_M
+
+    # ... standard GEMM tile computation using A[row_start:, :] x B ...
+```
+
+**Key points:**
+- Signal poll is `ag_signal_ptr + src_rank` (per-rank-shard granularity)
+- Rank-aware rotation ensures CTAs for the local shard (rank_offset == 0) skip the poll
+  entirely, and subsequent CTAs target peers in the same rotated order as the AG helper
+- For a simpler (non-GEMM) persistent kernel, the same pattern applies: determine which
+  rank owns the chunk, poll `ag_signal[src_rank]`, then process
+
+## Step 4: Host-Side Orchestration
+
+Launch both communication and compute in a single host function. The
+`barrier() → signal.fill_(0) → barrier()` pattern ensures all ranks have finished
+the previous iteration's communication before resetting, and all ranks see the reset
+before launching the next iteration.
+
+```python
+def ag_gemm_overlap(ctx, a_input, compute_kernel):
+    """Launch copy-engine AG and consumer compute kernel with overlap."""
+    rank, world_size = ctx.rank, ctx.num_ranks
+    hdl = ctx.symm_mem_hdl
+    M_local, K = a_input.shape[0], a_input.shape[1]
+
+    symm_input = ctx.symm_input_buf          # symmetric [world_size, M_local, K]
+    symm_ag_output = ctx.symm_ag_output      # local [M_local * world_size, K]
+    ag_signal = ctx.ag_signal                 # local [world_size] int32
+    peer_symm_input_bufs = ctx.peer_symm_input_bufs
+    peer_signal_one_bufs = ctx.peer_signal_one_bufs
+
+    current_stream = torch.cuda.current_stream()
+    ag_stream = ctx.ag_stream
+
+    # Copy input shard into symmetric buffer (so peers can pull it)
+    symm_input[rank, :M_local, :].copy_(a_input)
+
+    # Host-side cross-rank barrier: ensure all ranks finished previous iteration
+    hdl.barrier()
+    # Reset signal (safe now — all ranks' CE copies have completed)
+    ag_signal.fill_(0)
+    # Host-side barrier: ensure all ranks see the reset before launching
+    hdl.barrier()
+
+    # Ensure ag_stream waits for signal reset and input copy
+    ag_stream.wait_stream(current_stream)
+
+    # Step 1: enqueue full-mesh pull AG on ag_stream
+    with torch.cuda.stream(ag_stream):
+        cp_engine_full_mesh_pull_ag(
+            rank=rank,
+            world_size=world_size,
+            M_local=M_local,
+            K=K,
+            symm_input=symm_input[rank, :M_local, :],
+            symm_ag_output=symm_ag_output,
+            peer_symm_input_bufs=peer_symm_input_bufs,
+            ag_signal=ag_signal,
+            peer_signal_one_bufs=peer_signal_one_bufs,
+        )
+
+    # Step 2: launch consumer compute kernel on current_stream (polls ag_signal)
+    M = M_local * world_size
+    N = ctx.N
+    M_per_rank_tiles = triton.cdiv(M_local, BLOCK_SIZE_M)
+    num_tiles = M_per_rank_tiles * world_size * triton.cdiv(N, BLOCK_SIZE_N)
+
+    c = torch.empty((M, N), dtype=ctx.output_dtype, device=a_input.device)
+    compute_kernel[(num_tiles,)](
+        symm_ag_output, ctx.weight, c, ag_signal,
+        M, N, K, M_local,
+        # ... strides, block sizes, etc.
+        M_per_rank_tiles=M_per_rank_tiles,
+        rank=rank,
+        world_size=world_size,
+    )
+
+    # Wait for AG stream to complete before returning
+    current_stream.wait_stream(ag_stream)
+    return c
+```
+
+## Signal Variant: Compute-First
+
+If compute runs first and communication follows (e.g., GEMM → reduce-scatter / all-gather
+via DMA), the direction reverses: the compute kernel signals tile completion, and the
+CE stream waits for each signal before issuing the corresponding `copy_()`.
+
+```python
+from typing import List
+
+def cp_engine_full_mesh_push(
+    rank: int,
+    world_size: int,
+    M_local: int,
+    K: int,
+    symm_output: torch.Tensor,             # this rank's computed [M_local, K] in symmetric memory
+    peer_symm_output_bufs: List[torch.Tensor],  # peer views of symm_output
+    signal_pad: torch.Tensor,              # [num_tiles] int32 — compute kernel writes 1 per tile
+    ce_stream: torch.cuda.Stream,          # the backend CE stream (caller sets stream context)
+):
+    """
+    Push computed tiles to all peers via Copy Engine, waiting for each tile's
+    compute signal before issuing the copy.
+
+    Host-side while loop polls signal_pad until the compute kernel writes 1,
+    then issues PtoP push via copy_(). No external dependencies required.
+
+    NOTE: caller must wrap this call in `with torch.cuda.stream(ce_stream):`
+    """
+    num_tiles = signal_pad.numel()
+    tile_numel = (M_local * K) // num_tiles  # elements per tile
+
+    for tile_id in range(num_tiles):
+        # Host-side poll: wait for compute kernel to signal this tile
+        while signal_pad[tile_id].item() != 1:
+            pass
+
+        # PtoP push: copy this tile to every peer's symmetric buffer
+        tile_offset = tile_id * tile_numel
+        local_tile = symm_output.flatten()[tile_offset : tile_offset + tile_numel]
+
+        for offset in range(1, world_size):
+            dst_rank = (rank + offset) % world_size
+            remote_dst = peer_symm_output_bufs[dst_rank].flatten()[tile_offset : tile_offset + tile_numel]
+            remote_dst.copy_(local_tile)  # PtoP CE push
+```
+
+**Key details:**
+- Host-side `while signal_pad[tile_id].item() != 1: pass` polls the compute kernel's
+  per-tile signal
+- `copy_()` into a peer symmetric tensor routes through the **Memcpy PtoP** CE channel,
+  same as the pull direction in `cp_engine_full_mesh_pull_ag`
+- Reset `signal_pad.zero_()` between iterations (protected by the same
+  `barrier() → zero_() → barrier()` pattern as the pull variant)

--- a/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
+++ b/.claude/skills/sglang-overlap-kernel-generation/references/without_sm.md
@@ -121,13 +121,13 @@ def consumer_gemm_compute_kernel(
     ag_signal_ptr,      # signal from AG [world_size] int32 (per-rank-shard)
     M, N, K,
     M_local,            # rows per rank
+    M_local_tiles,      # = cdiv(M_local, BLOCK_SIZE_M)
     stride_am, stride_ak,
     stride_bk, stride_bn,
     stride_cm, stride_cn,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
-    M_per_rank_tiles: tl.constexpr,  # = cdiv(M_local, BLOCK_SIZE_M)
     rank: tl.constexpr,
     world_size: tl.constexpr,
 ):
@@ -137,11 +137,8 @@ def consumer_gemm_compute_kernel(
     pid_n = pid % num_pid_n
 
     # Rank-aware tile rotation: remap pid_m so local tiles come first
-    # tile_in_rank = pid_m % M_per_rank_tiles
-    # rank_offset = pid_m // M_per_rank_tiles
-    # src_rank = (rank + rank_offset) % world_size
-    tile_in_rank = pid_m % M_per_rank_tiles
-    rank_offset = pid_m // M_per_rank_tiles
+    tile_in_rank = pid_m % M_local_tiles
+    rank_offset = pid_m // M_local_tiles
     src_rank = (rank + rank_offset) % world_size
 
     # Poll AG signal for this rank's shard (skip for local)
@@ -213,17 +210,19 @@ def ag_gemm_overlap(ctx, a_input, compute_kernel):
         )
 
     # Step 2: launch consumer compute kernel on current_stream (polls ag_signal)
+    # Without-SM mode: communication is on copy engine (zero SM cost), so the
+    # compute kernel can use ALL SMs. This kernel is non-persistent (one CTA per tile,
+    # no grid barrier), so num_tiles > SMs is safe — CUDA scheduler handles it.
     M = M_local * world_size
     N = ctx.N
-    M_per_rank_tiles = triton.cdiv(M_local, BLOCK_SIZE_M)
-    num_tiles = M_per_rank_tiles * world_size * triton.cdiv(N, BLOCK_SIZE_N)
+    M_local_tiles = triton.cdiv(M_local, BLOCK_SIZE_M)
+    num_tiles = M_local_tiles * world_size * triton.cdiv(N, BLOCK_SIZE_N)
 
     c = torch.empty((M, N), dtype=ctx.output_dtype, device=a_input.device)
     compute_kernel[(num_tiles,)](
         symm_ag_output, ctx.weight, c, ag_signal,
-        M, N, K, M_local,
+        M, N, K, M_local, M_local_tiles,
         # ... strides, block sizes, etc.
-        M_per_rank_tiles=M_per_rank_tiles,
         rank=rank,
         world_size=world_size,
     )

--- a/.claude/skills/sglang-overlap-kernel-optimize/SKILL.md
+++ b/.claude/skills/sglang-overlap-kernel-optimize/SKILL.md
@@ -1,0 +1,417 @@
+# SGLang Overlap Kernel Optimize — Multi-Agent Orchestration Skill
+
+## Overview
+
+This skill orchestrates an iterative overlap kernel optimization loop using **four sequential sub-agents**. It is a **lead agent** that never directly generates kernel code, runs benchmarks, or performs integration — all work is delegated to specialized sub-agents that invoke existing skills.
+
+The optimization loop:
+1. **Generate** an overlap kernel and benchmark(via `sglang-overlap-kernel-generation` skill)
+2. **Benchmark** the kernel on a remote pod (via kubectl exec)
+3. **Optimize** the kernel based on benchmark results / error info (tune parameters, optimize kernel code, fix errors)
+4. **Repeat** steps 2–3 for the user-specified number of iterations
+5. **Integrate** the best-performing version into SGLang (via `sglang-overlap-kernel-integration` skill)
+
+---
+
+## Architecture
+
+### Lead Agent Responsibilities
+
+The lead agent (this skill) is responsible for:
+- **Orchestrating the loop**: dispatching sub-agents in the correct sequence
+- **Tracking progress**: maintaining the performance progress table across iterations
+- **Version management**: ensuring each optimization creates a new versioned file (never overwriting)
+- **Best-version selection**: selecting the highest-speedup correctness-passing version after all iterations
+- **Handoff preparation**: assembling the integration context package for the final sub-agent
+- **User communication**: presenting iteration results and final recommendation
+
+The lead agent **never** writes kernel code, runs benchmarks, or modifies SGLang framework code directly.
+
+### Sub-Agent Sequence
+
+Sub-agents are dispatched **sequentially** (not parallel) because each step depends on the output of the previous step:
+
+| Step | Sub-Agent | Invoked Skill / Action | Input | Output |
+|------|-----------|----------------------|-------|--------|
+| 1 | **Generation** | `sglang-overlap-kernel-generation` | User requirements (mode, ops, shapes) | Kernel file `v1.py` + benchmark file `v1_benchmark.py` |
+| 2 | **Benchmark** | kubectl exec + run benchmark on remote pod | Kernel + benchmark files, pod info | `<kernel_name>_result_v1.json` (unified: perf + errors in one file) |
+| 3 | **Optimize** | Error analysis + parameter tuning + code fixes | Result JSON file + current kernel source | New kernel `v<N+1>.py` + updated benchmark file |
+| 4 | **Benchmark** | Same as Step 2 | New kernel version files | `<kernel_name>_result_v<N+1>.json` |
+| ... | **Loop** Steps 3–4 | Until max iterations reached or target speedup achieved | ... | ... |
+| Final | **Integration** | `sglang-overlap-kernel-integration` | Best kernel file + integration context package | SGLang framework changes |
+
+---
+
+## Required User Inputs
+
+Before starting, the lead agent must collect these inputs from the user:
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| **Overlap mode** | Yes | — | `inter-sm`, `intra-sm`, or `without-sm` (passed to generation skill) |
+| **Compute operator** | Yes | — | GEMM, attention, etc. (passed to generation skill) |
+| **Communication collective** | Yes | — | all-gather, reduce-scatter, all-reduce (passed to generation skill) |
+| **Problem shape (M, N, K)** | Yes | — | Tensor dimensions for the overlap kernel |
+| **Data type** | Yes | bf16 | bf16, fp16, fp8, etc. |
+| **Pod name or namespace+selector** | Yes | — | Kubernetes pod for benchmark execution |
+| **World size** | Yes | 2 | Number of GPUs / ranks for distributed benchmark |
+| **Max optimization iterations** | Yes | 5 | Number of optimize→benchmark loops to run |
+| **Comm time savings target** | No | 50% | Overlap kernel must save > this % of pure communication time for early termination. Formula: `(non_overlap_us - overlap_us) > target * comm_only_us` |
+| **Multimem / NVLS** | No | false | Whether to use NVLS for communication |
+| **FP8 GEMM** | No | false | Whether compute kernel uses block-wise FP8 |
+
+---
+
+## Workflow
+
+### Step 0: Input Collection & Planning
+
+Collect all required user inputs listed above. If any required input is missing, ask the user before proceeding.
+
+Then output the **Optimization Plan** to the user:
+
+```
+=== Overlap Kernel Optimization Plan ===
+Mode: <overlap_mode>
+Compute: <compute_op>  Comm: <comm_collective>
+Shape: M=<M>, N=<N>, K=<K>  Dtype: <dtype>
+Pod: <pod_name>  World size: <world_size>
+Max iterations: <max_iterations>  Comm savings target: ><target>% of comm_only time
+Multimem: <yes/no>  FP8 GEMM: <yes/no>
+
+Sub-agent sequence:
+  1. Generation (sglang-overlap-kernel-generation) → v1 kernel
+  2. Benchmark (kubectl exec on <pod>) → v1 result JSON
+  3. Optimize (error analysis + tuning) → v2 kernel
+  4. Benchmark → v2 result JSON
+  ... (repeat until <max_iterations> or comm_savings > <target>%)
+  Final. Integration (sglang-overlap-kernel-integration) → SGLang changes
+```
+
+Wait for user confirmation before proceeding.
+
+---
+
+### Step 1: Generation Sub-Agent
+
+Dispatch a sub-agent to invoke the **`sglang-overlap-kernel-generation`** skill.
+
+#### Dispatch Prompt
+
+```
+You are the Generation sub-agent. Your task is to generate an overlap kernel using the sglang-overlap-kernel-generation skill.
+
+Requirements:
+- Overlap mode: <overlap_mode>
+- Compute operator: <compute_op>
+- Communication collective: <comm_collective>
+- Problem shape: M=<M>, N=<N>, K=<K>
+- Data type: <dtype>
+- World size: <world_size>
+- Multimem/NVLS: <yes/no>
+- FP8 GEMM: <yes/no>
+
+Follow the sglang-overlap-kernel-generation SKILL.md exactly, including:
+1. Read the appropriate mode reference file
+2. Read references/primitives.md before emitting any PTX helpers
+3. Generate the kernel file following the four-section format
+4. Run the correctness & hang check verification
+5. Generate the benchmark test file
+
+Output files:
+- Kernel file: save as <kernel_name>_v1.py
+- Benchmark file: save as <kernel_name>_v1_benchmark.py
+
+These files will be sent to a remote pod for benchmark testing.
+```
+
+#### Expected Output
+
+- `<kernel_name>_v1.py` — the initial overlap kernel
+- `<kernel_name>_v1_benchmark.py` — the corresponding benchmark test
+
+The lead agent records these file paths for the benchmark sub-agent.
+
+---
+
+### Step 2: Benchmark Sub-Agent
+
+Dispatch a sub-agent to execute the benchmark on the remote pod using `kubectl exec`.
+
+#### Dispatch Prompt
+
+```
+You are the Benchmark sub-agent. Your task is to run the overlap kernel benchmark on a remote Kubernetes pod.
+
+Pod info:
+- Pod name: <pod_name>
+- Namespace: <namespace> (if provided)
+- World size: <world_size>
+
+Files to test:
+- Kernel: <kernel_name>_v<version>.py
+- Benchmark: <kernel_name>_v<version>_benchmark.py
+
+Remote work directory: /tmp/overlap_kernel_bench
+All files on the pod MUST be placed under this directory.
+
+Follow the benchmark execution protocol in references/benchmark-protocol.md exactly:
+1. Validate the pod environment (GPU, torch, triton, symm_mem)
+2. Create remote work directory: kubectl exec <pod> -- mkdir -p /tmp/overlap_kernel_bench/results
+3. Copy kernel and benchmark files to the pod:
+   kubectl cp <local_kernel> <pod>:/tmp/overlap_kernel_bench/<kernel_name>_v<version>.py
+   kubectl cp <local_benchmark> <pod>:/tmp/overlap_kernel_bench/<kernel_name>_v<version>_benchmark.py
+4. Run correctness test FIRST with 30s timeout:
+   kubectl exec <pod> -- bash -c 'cd /tmp/overlap_kernel_bench && timeout 30 env NVSHMEM_DISABLE_CUDA_VMM=0 torchrun --nproc_per_node=<world_size> <benchmark_file>.py --case correctness --M <M> --N <N> --K <K>'
+5. If correctness PASSES (exit code 0), run performance benchmark with 30s timeout:
+   kubectl exec <pod> -- bash -c 'cd /tmp/overlap_kernel_bench && timeout 30 env NVSHMEM_DISABLE_CUDA_VMM=0 torchrun --nproc_per_node=<world_size> <benchmark_file>.py --case performance --M <M> --N <N> --K <K> --warmup 10 --iters 100'
+6. Collect results back to local machine: kubectl cp <pod>:/tmp/overlap_kernel_bench/results/ <local_results_dir>/
+7. Clean up: kill lingering torchrun processes and remove version-specific files on the pod
+8. Write results to the unified result file: <kernel_name>_result_v<version>.json (use `scripts/record_benchmark_result.py`)
+
+HANG DETECTION (CRITICAL):
+- ALL benchmark commands MUST be wrapped with `timeout 30`. Exit code 124 = timeout = hang.
+- If exit code is 124, the kernel has hung/deadlocked. Record this as error_type "hang_deadlock".
+- On hang: capture partial log output, check GPU state (nvidia-smi), kill zombie processes, do NOT proceed to performance test.
+- Common hang causes in overlap kernels: signal polling spin-wait without timeout, barrier mismatch across ranks, missing signal reset between iterations, break/continue in Triton JIT loops.
+
+IMPORTANT:
+- Correctness is a hard gate. Do NOT run performance if correctness fails or times out.
+- Record FULL error output in the result file's `errors` field (including traceback, CUDA errors, environment info).
+- For hangs: record error_type as "hang_deadlock" with error_details explaining the timeout behavior.
+- Use `scripts/record_benchmark_result.py` to write the unified result JSON.
+- Timeout: 30s for BOTH correctness and performance. No exceptions.
+```
+
+#### Expected Output
+
+- **Unified result file**: `<kernel_name>_result_v<version>.json` — single file per version containing both performance data and error info (via `errors` field)
+
+After the benchmark sub-agent returns, the lead agent:
+1. Reads the result file
+2. Updates the **Performance Progress Table** (use `scripts/select_best_version.py` or see `references/performance-tracking.md`)
+3. Presents the current iteration results to the user
+4. Decides whether to continue the optimization loop or terminate early
+
+---
+
+### Step 3: Optimize Sub-Agent
+
+Dispatch a sub-agent to analyze errors / performance and produce an improved kernel version.
+
+#### Dispatch Prompt Template
+
+```
+You are the Optimize sub-agent. Your task is to analyze the benchmark results and produce an optimized version of the overlap kernel.
+
+Current state:
+- Current kernel: <kernel_name>_v<version>.py
+- Benchmark result: <result_file_path> (unified JSON with perf + errors)
+- Previous versions' performance: <summary of all prior iterations' speedup and key changes>
+
+Follow the error analysis and optimization guide in references/error-analysis.md exactly:
+1. Read the error/performance file to understand what needs to be fixed or improved
+2. Read the current kernel source to identify root causes
+3. Classify the error (if any) using the taxonomy
+4. Select the appropriate optimization strategy
+5. Create a NEW kernel file: <kernel_name>_v<next_version>.py (NEVER overwrite existing versions)
+6. Copy the current version's code as starting point, then apply targeted changes
+7. Update the benchmark file import to reference the new version: <kernel_name>_v<next_version>_benchmark.py
+8. Write an optimization note documenting what was changed and why
+
+VERSION MANAGEMENT RULES:
+- NEVER overwrite or delete existing kernel version files
+- Always create a new file with the next version number
+- The new version must be self-contained (no cross-imports between versions)
+
+Optimization strategies (prioritize in this order):
+- If kernel FAILED correctness: fix the root cause (memory safety, barriers, precision)
+- If kernel PASSED but below target speedup: tune parameters (BLOCK_M/N/K, num_warps, num_comm_sms, N_CHUNKS)
+- If kernel PASSED and near target: fine-tune for marginal gains (vectorization hints, barrier optimization)
+```
+
+#### Expected Output
+
+- `<kernel_name>_v<next_version>.py` — the optimized kernel
+- `<kernel_name>_v<next_version>_benchmark.py` — updated benchmark file
+- Optimization note (brief description of changes and rationale)
+
+After the optimize sub-agent returns, the lead agent dispatches the benchmark sub-agent again (Step 2) with the new version.
+
+---
+
+### Step 4: Loop Control
+
+After each benchmark sub-agent return, the lead agent evaluates the loop termination conditions:
+
+**Comm savings metric**: `comm_savings_pct = (non_overlap_us - overlap_us) / comm_only_us * 100%`
+
+This measures how much of the pure communication time the overlap kernel saves. The overlap kernel overlaps compute and comm, so the ideal overlap time ≈ `max(compute_only_us, comm_only_us)`. The time saved compared to sequential execution (`non_overlap_us`) is `non_overlap_us - overlap_us`, and we compare this savings against the communication cost (`comm_only_us`) to quantify overlap effectiveness.
+
+| Condition | Action |
+|-----------|--------|
+| **Comm savings target achieved** (`comm_savings_pct > target%`) | Stop loop; proceed to Step 5 (integration) |
+| **Max iterations reached** | Stop loop; proceed to Step 5 with best available version |
+| **All versions failed correctness** | Stop loop; report failure to user; do NOT proceed to integration |
+| **No progress for 3 iterations** (last 3 passing versions show < 5% improvement in `comm_savings_pct`) | Stop loop; proceed to Step 5 with best available version |
+| **Regression** (`comm_savings_pct` drops > 10% from best) | Note regression; continue loop but flag the regression |
+| **Otherwise** | Continue loop: dispatch optimize sub-agent → benchmark sub-agent |
+
+The lead agent presents the current **Performance Progress Table** to the user after each iteration (use `scripts/select_best_version.py` to generate):
+
+```
+Iteration | Version | Correctness | Speedup | Overlap (us) | Comm Savings (%) | Key Change
+---------------------------------------------------------------------------------------------------------
+    1     |   v1    |   PASSED    |  1.20   |    3456.7    |       25.0       | Initial generation
+    2     |   v2    |   FAILED    |   N/A   |     N/A      |        N/A       | Reduced BLOCK_M, clamping
+    3     |   v3    |   PASSED    |  1.80   |    2100.0    |       55.0       | Increased BLOCK_N, 32 warps
+---------------------------------------------------------------------------------------------------------
+Best so far: v3 (speedup=1.80, comm_savings=55.0%)
+Comm savings target: >50% — ACHIEVED ✓
+
+Proceeding to integration with v3.
+```
+
+---
+
+### Step 5: Best Version Selection
+
+After the loop terminates, the lead agent selects the best version for integration.
+
+**Selection procedure** (see `references/performance-tracking.md` §Best Version Selection):
+
+1. Filter out all versions that failed correctness
+2. Sort remaining versions by `comm_savings_pct` DESC, then speedup DESC, overlap_us ASC
+3. Select the first entry
+4. Report the selection to the user with rationale
+
+**Edge case handling**:
+- If NO version passed correctness → report failure, recommend manual debugging, do NOT integrate
+- If best `comm_savings_pct` < target → inform user, ask whether to proceed with integration anyway
+
+After selection, the lead agent prepares the **Integration Handoff Package**:
+
+```json
+{
+  "kernel_file": "<kernel_name>_v<best>.py",
+  "kernel_version": "v<best>",
+  "overlap_mode": "<mode>",
+  "compute_op": "<compute_op>",
+  "comm_op": "<comm_collective>",
+  "symm_mem_mechanism": "<mechanism>",
+  "target_model_layers": "<layers>",
+  "forward_mode": "<prefill|decode|both>",
+  "speedup": "<best_speedup>",
+  "overlap_efficiency": "<best_efficiency>",
+  "comm_savings_pct": "<best_comm_savings_pct>",
+  "config": {
+    "M": "<M>", "N": "<N>", "K": "<K>",
+    "dtype": "<dtype>",
+    "num_comm_sms": "<value>",
+    "world_size": "<world_size>"
+  }
+}
+```
+
+---
+
+### Step 6: Integration Sub-Agent
+
+Dispatch a sub-agent to invoke the **`sglang-overlap-kernel-integration`** skill with the best-performing kernel.
+
+#### Dispatch Prompt
+
+```
+You are the Integration sub-agent. Your task is to integrate the best-performing overlap kernel into the SGLang framework using the sglang-overlap-kernel-integration skill.
+
+Integration handoff package:
+<full JSON of the handoff package>
+
+Kernel file to integrate: <kernel_name>_v<best_version>.py
+Performance data: <kernel_name>_perf_summary.json (generated by `scripts/select_best_version.py --output_summary`)
+
+Follow the sglang-overlap-kernel-integration SKILL.md exactly, executing all 7 patterns in order:
+  P0: Profile-driven identification + semantic gate
+  P1: Kernel understanding
+  P2: Self-contained kernel placement (migrate to symm_mem_kernels/)
+  P3: Communicator setup
+  P4: Env-var gating
+  P5: Fused fast-path + fallback
+  P6: Redundant communication bypass
+
+IMPORTANT:
+- Use the BEST version (<best_version>) of the kernel for integration
+- The kernel must be self-contained — no cross-imports from versioned files
+- Follow the integration checklist at the end of the skill
+- Verify all patterns before declaring completion
+```
+
+#### Expected Output
+
+The integration sub-agent produces the full set of SGLang framework changes as described in the `sglang-overlap-kernel-integration` skill. The lead agent reviews the changes and presents a summary to the user.
+
+---
+
+## Final Output Format
+
+After all sub-agents have completed, the lead agent produces a summary report:
+
+```
+=== Overlap Kernel Optimization Complete ===
+
+Optimization Loop Summary:
+  Total iterations: <N>
+  Best version: v<best> (speedup=<speedup>x, comm_savings=<comm_savings_pct>%)
+  Comm savings target: ><target>% — ACHIEVED / NOT ACHIEVED
+
+Performance Progress:
+  <Full progress table generated by scripts/select_best_version.py>
+
+Best Kernel:
+  File: <kernel_name>_v<best>.py
+  Speedup: <speedup>x over sequential compute+comm
+  Overlap latency: <overlap_us> us
+  Comm savings: <comm_savings_pct>% of comm_only time overlapped away
+
+Integration Status:
+  <Summary of integration sub-agent's output — files modified, patterns applied>
+
+All Result Files:
+  v1: <path>/<kernel_name>_result_v1.json — speedup=<val>, comm_savings=<val>% / FAILED (errors: <error_type>)
+  v2: <path>/<kernel_name>_result_v2.json — speedup=<val>, comm_savings=<val>% / FAILED (errors: <error_type>)
+  ...
+  v<best>: <path>/<kernel_name>_result_v<best>.json — speedup=<val>, comm_savings=<val>% — SELECTED FOR INTEGRATION
+```
+
+---
+
+## References
+
+| File | When to Read |
+|------|-------------|
+| `references/benchmark-protocol.md` | Step 2 — benchmark sub-agent dispatch; defines pod execution protocol, file transfer, unified result file format |
+| `references/error-analysis.md` | Step 3 — optimize sub-agent dispatch; defines error taxonomy, optimization strategies, version management rules |
+| `references/performance-tracking.md` | Step 4–5 — loop control and best-version selection; defines unified result file schema, progress table, selection criteria |
+| `scripts/record_benchmark_result.py` | Step 2 — write unified result JSON files; used by benchmark sub-agent to record both perf and error data |
+| `scripts/select_best_version.py` | Step 4–5 — read all result files, print progress table, select best version, optionally generate summary JSON |
+| `../sglang-overlap-kernel-generation/SKILL.md` | Step 1 — generation sub-agent invokes this skill for initial kernel creation |
+| `../sglang-overlap-kernel-generation/references/primitives.md` | Step 1 — sub-agent reads for PTX primitives before generating kernel |
+| `../sglang-overlap-kernel-generation/references/benchmark_template.md` | Step 1 — sub-agent reads for benchmark test file format |
+| `../sglang-overlap-kernel-generation/references/<mode>.md` | Step 1 — sub-agent reads the selected overlap mode reference |
+| `../sglang-overlap-integration/SKILL.md` | Step 6 — integration sub-agent invokes this skill for SGLang framework integration |
+
+---
+
+## Constraints
+
+- **Lead agent never writes kernel code** — all kernel generation and optimization is done by sub-agents
+- **Lead agent never runs benchmarks** — all remote execution is done by benchmark sub-agents
+- **Lead agent never modifies SGLang framework** — all integration is done by integration sub-agent
+- **Never overwrite existing versions** — each optimization creates a new versioned file
+- **Correctness is a hard gate** — performance benchmark never runs on a kernel that failed correctness
+- **Self-contained kernels** — each kernel version file imports only from standard packages; no cross-imports between versions
+- **Pod access required** — the user must provide a valid Kubernetes pod for benchmark execution; the skill cannot proceed without it
+- **30-second timeout mandatory** — all benchmark commands on the pod MUST be wrapped with `timeout 30`; if a command does not return within 30 seconds, it is killed (exit code 124) and recorded as a hang/deadlock failure
+- **Hang = hard failure** — if any benchmark phase times out (exit code 124), the kernel is treated as FAILED regardless of whether it might eventually complete; do NOT retry without code fixes
+- **Remote work directory** — all files on the pod MUST be placed under `/tmp/overlap_kernel_bench/`; this path is fixed and must not be changed
+- **Cleanup after each run** — kill lingering torchrun processes and remove version-specific files on the pod after collecting results, to avoid stale state affecting subsequent runs

--- a/.claude/skills/sglang-overlap-kernel-optimize/references/benchmark-protocol.md
+++ b/.claude/skills/sglang-overlap-kernel-optimize/references/benchmark-protocol.md
@@ -1,0 +1,405 @@
+# Benchmark Execution Protocol
+
+This document defines the end-to-end protocol for executing overlap kernel benchmarks on a remote Kubernetes pod. The benchmark sub-agent MUST follow these steps exactly in order.
+
+---
+
+## Remote Work Directory Convention
+
+All kernel and benchmark files on the pod are placed under a fixed directory:
+
+```
+REMOTE_WORK_DIR=/tmp/overlap_kernel_bench
+```
+
+Files on the pod follow this layout:
+
+```
+/tmp/overlap_kernel_bench/
+├── <kernel_name>_v<version>.py
+├── <kernel_name>_v<version>_benchmark.py
+└── results/
+    └── <kernel_name>_result_v<version>.json
+```
+
+The benchmark sub-agent MUST use this path for all `kubectl cp` and `kubectl exec` operations. Create it if it does not exist.
+
+---
+
+## Step 1: Pod Environment Validation
+
+Before any benchmark, validate the pod has the required hardware and software:
+
+```bash
+kubectl exec <pod> -n <namespace> -- bash -c '
+  echo "=== GPU Check ===" && \
+  nvidia-smi --query-gpu=name,memory.total --format=csv,noheader && \
+  echo "=== GPU Count ===" && \
+  nvidia-smi --list-gpus | wc -l && \
+  echo "=== Python Check ===" && \
+  python3 -c "import torch; print(f\"torch={torch.__version__}, cuda={torch.cuda.is_available()}\")" && \
+  echo "=== Triton Check ===" && \
+  python3 -c "import triton; print(f\"triton={triton.__version__}\")" && \
+  echo "=== Symmetric Memory Check ===" && \
+  python3 -c "import torch.distributed._symmetric_memory as sm; print(\"symm_mem=OK\")" && \
+  echo "=== NVSHMEM Check ===" && \
+  python3 -c "import nvshmem; print(\"nvshmem=OK\")" 2>/dev/null || echo "nvshmem=NOT_AVAILABLE"
+'
+```
+
+**Validation gates** (must ALL pass before proceeding):
+
+| Check | Requirement | Failure Action |
+|-------|------------|----------------|
+| GPU available | `torch.cuda.is_available() == True` | Record env failure, STOP |
+| GPU count | `>= world_size` | Record env failure, STOP |
+| Triton | Version >= 3.0 | Record env failure, STOP |
+| Symmetric memory | `import` succeeds | Record env failure, STOP |
+| NVSHMEM | `import` succeeds (optional for without-sm mode) | Warning only; only required for inter-SM / intra-SM modes |
+
+If validation fails, record the error using the `environment_failure` error type and STOP. Do NOT proceed to benchmark.
+
+---
+
+## Step 2: File Transfer to Pod
+
+Copy kernel and benchmark files from the local machine to the pod.
+
+### 2.1 Create remote work directory
+
+```bash
+kubectl exec <pod> -n <namespace> -- mkdir -p /tmp/overlap_kernel_bench/results
+```
+
+### 2.2 Copy files
+
+```bash
+# Copy kernel file
+kubectl cp <local_kernel_path> <pod>:/tmp/overlap_kernel_bench/<kernel_name>_v<version>.py -n <namespace>
+
+# Copy benchmark file
+kubectl cp <local_benchmark_path> <pod>:/tmp/overlap_kernel_bench/<kernel_name>_v<version>_benchmark.py -n <namespace>
+```
+
+### 2.3 Verify file transfer
+
+```bash
+kubectl exec <pod> -n <namespace> -- ls -la /tmp/overlap_kernel_bench/<kernel_name>_v<version>*.py
+```
+
+Confirm both files exist and have non-zero size. If transfer fails, record error and STOP.
+
+---
+
+## Step 3: Run Correctness Test (with 30s Timeout)
+
+Correctness is a **hard gate** — performance benchmark MUST NOT run if correctness fails.
+
+### 3.1 Execute correctness test
+
+```bash
+kubectl exec <pod> -n <namespace> -- bash -c '
+  cd /tmp/overlap_kernel_bench && \
+  timeout 30 env NVSHMEM_DISABLE_CUDA_VMM=0 torchrun \
+    --nproc_per_node=<world_size> \
+    <kernel_name>_v<version>_benchmark.py \
+    --case correctness \
+    --M <M> --N <N> --K <K>
+' 2>&1 | tee /tmp/overlap_kernel_bench/results/correctness_v<version>.log
+```
+
+### 3.2 Timeout & hang detection
+
+**CRITICAL: 30-second timeout is mandatory.** The `timeout 30` wrapper ensures the process is killed if it does not return within 30 seconds. This is the primary mechanism for detecting kernel hangs.
+
+After the command completes, check the exit code:
+
+| Exit code | Meaning | Action |
+|-----------|---------|--------|
+| 0 | Correctness test passed | Proceed to Step 4 |
+| 1 (or non-zero, non-124) | Correctness test failed (logic error, CUDA error, etc.) | Parse error output, record as `FAILED`, STOP |
+| 124 | **Timeout — process killed after 30s** | This indicates a **kernel hang/deadlock**. Record as `HANG` error type, STOP |
+| 137 | Process killed by SIGKILL (OOM or similar) | Record as `environment_failure`, STOP |
+
+**HANG DETECTION PROTOCOL**: When exit code is 124 (timeout), the benchmark sub-agent MUST:
+
+1. Record the error as `error_type: "hang_deadlock"` in the unified result file
+2. Capture any partial output from the log file:
+   ```bash
+   kubectl exec <pod> -n <namespace> -- cat /tmp/overlap_kernel_bench/results/correctness_v<version>.log
+   ```
+3. Check for GPU state after hang (nvidia-smi may show GPU still occupied):
+   ```bash
+   kubectl exec <pod> -n <namespace> -- nvidia-smi
+   ```
+4. Attempt to clean up zombie processes:
+   ```bash
+   kubectl exec <pod> -n <namespace> -- bash -c "pkill -9 -f 'torchrun.*<kernel_name>'"
+   ```
+5. **Do NOT proceed to performance benchmark** — a hanging kernel is a hard failure
+6. Report the hang to the lead agent for the optimize sub-agent to diagnose root cause
+
+### 3.3 Parse correctness results
+
+If the correctness test passed (exit code 0), extract diff metrics from the output:
+
+```bash
+kubectl exec <pod> -n <namespace> -- grep -E "(PASSED|FAILED|max_diff|mean_diff|diff=)" /tmp/overlap_kernel_bench/results/correctness_v<version>.log
+```
+
+Record `max_diff` and `mean_diff` values for the unified result file.
+
+---
+
+## Step 4: Run Performance Benchmark (with 30s Timeout)
+
+Only execute if correctness test PASSED (exit code 0 in Step 3).
+
+### 4.1 Execute performance benchmark
+
+```bash
+kubectl exec <pod> -n <namespace> -- bash -c '
+  cd /tmp/overlap_kernel_bench && \
+  timeout 30 env NVSHMEM_DISABLE_CUDA_VMM=0 torchrun \
+    --nproc_per_node=<world_size> \
+    <kernel_name>_v<version>_benchmark.py \
+    --case performance \
+    --M <M> --N <N> --K <K> \
+    --warmup 10 --iters 100
+' 2>&1 | tee /tmp/overlap_kernel_bench/results/performance_v<version>.log
+```
+
+### 4.2 Timeout & hang detection (same as Step 3.2)
+
+The same 30-second timeout applies. Exit code 124 indicates a hang during the performance benchmark phase. This is less common than correctness-phase hangs (since correctness already verified the kernel can complete at least once), but can still occur due to:
+
+- Non-deterministic hangs (race conditions in signal polling)
+- GPU thermal throttling causing timing-dependent stalls
+- Memory pressure from multiple iterations causing OOM-triggered hangs
+
+If timeout occurs during performance benchmark:
+1. Record as `error_type: "hang_deadlock"` with `error_details: "Performance benchmark hung after correctness passed — possible race condition or resource exhaustion"`
+2. The correctness result still counts as PASSED, but performance data is unavailable
+3. Set `performance: null` in the result file
+4. Attempt cleanup (same as Step 3.2)
+
+### 4.3 Parse performance results
+
+If the performance benchmark completed (exit code 0), extract metrics:
+
+```bash
+kubectl exec <pod> -n <namespace> -- grep -E "(Compute-only|Comm-only|Non-overlap|Overlap kernel|Speedup|efficiency|savings)" /tmp/overlap_kernel_bench/results/performance_v<version>.log
+```
+
+Extract these values from the output:
+- `compute_only_us` — standalone GEMM latency
+- `comm_only_us` — NCCL AllGather latency
+- `non_overlap_us` — sequential compute+comm latency
+- `overlap_us` — overlap kernel latency
+- `speedup` — (compute_time + comm_time) / overlap_time
+- `comm_savings_pct` — (non_overlap - overlap) / comm_only * 100
+
+---
+
+## Step 5: Result Collection & Recording
+
+After benchmark execution, collect output files back to local machine:
+
+```bash
+# Copy result logs and any output files from the pod
+kubectl cp <pod>:/tmp/overlap_kernel_bench/results/ <local_results_dir>/ -n <namespace>
+```
+
+### Unified Result File Format
+
+All benchmark results (both successful and failed) are recorded in a **single unified JSON file** per version. There is no separate error log file — error information is embedded in the same JSON via the `errors` field.
+
+The file name convention is:
+
+```
+<kernel_name>_result_v<version>.json
+```
+
+Use the `scripts/record_benchmark_result.py` script to write result files:
+
+```bash
+# Successful benchmark
+python3 scripts/record_benchmark_result.py \
+    --kernel_name <kernel_name> \
+    --version v1 \
+    --pod <pod_name> \
+    --iteration 1 \
+    --status PASSED \
+    --max_diff 0.0001 --mean_diff 0.00005 \
+    --compute_only_us 1234.5 --comm_only_us 5678.9 \
+    --non_overlap_us 6913.4 --overlap_us 3456.7 \
+    --speedup 2.0 --overlap_efficiency 0.85 \
+    --config "M=1024,N=7168,K=2048,dtype=bf16,world_size=2,num_comm_sms=8" \
+    --tuning_changes "Initial generation" \
+    --output_dir ./results
+
+# Failed benchmark (correctness error)
+python3 scripts/record_benchmark_result.py \
+    --kernel_name <kernel_name> \
+    --version v2 \
+    --pod <pod_name> \
+    --iteration 2 \
+    --status FAILED \
+    --max_diff 0.5 --mean_diff 0.2 \
+    --error_type cuda_illegal_access \
+    --error_details "CUDA error: an illegal memory access was encountered at kernel line 89" \
+    --error_traceback "<full traceback string>" \
+    --error_env_info "<nvidia-smi + version info>" \
+    --config "M=1024,N=7168,K=2048,dtype=bf16,world_size=2,num_comm_sms=8" \
+    --tuning_changes "Reduced BLOCK_M, added address clamping" \
+    --output_dir ./results
+
+# Hang / timeout (exit code 124)
+python3 scripts/record_benchmark_result.py \
+    --kernel_name <kernel_name> \
+    --version v3 \
+    --pod <pod_name> \
+    --iteration 3 \
+    --status FAILED \
+    --error_type hang_deadlock \
+    --error_details "Correctness test hung — process killed after 30s timeout. Possible signal polling deadlock or barrier mismatch." \
+    --error_traceback "N/A — process timed out, no traceback available. Partial log captured in correctness_v3.log" \
+    --error_env_info "<nvidia-smi output showing GPU state after hang>" \
+    --config "M=1024,N=7168,K=2048,dtype=bf16,world_size=2,num_comm_sms=8" \
+    --tuning_changes "Added barrier, changed num_warps from 4 to 32" \
+    --output_dir ./results
+```
+
+### Unified Result JSON Schema
+
+```json
+{
+  "kernel_name": "<op>_overlap",
+  "version": "v1",
+  "timestamp": "2026-06-26T14:30:00Z",
+  "pod": "<pod_name>",
+  "iteration": 1,
+  "config": {
+    "M": 1024,
+    "N": 7168,
+    "K": 2048,
+    "dtype": "bf16",
+    "world_size": 2,
+    "num_comm_sms": 8,
+    "block_m": 64,
+    "block_n": 256,
+    "block_k": 128,
+    "num_warps": 32,
+    "n_chunks": 7
+  },
+  "correctness": {
+    "status": "PASSED",
+    "max_diff": 0.0001,
+    "mean_diff": 0.00005,
+    "rtol": 0.01,
+    "atol": 0.01
+  },
+  "performance": {
+    "compute_only_us": 1234.5,
+    "comm_only_us": 5678.9,
+    "non_overlap_us": 6913.4,
+    "overlap_us": 3456.7,
+    "speedup": 2.0,
+    "overlap_efficiency": 0.85
+  },
+  "errors": null,
+  "tuning_changes": "Initial generation — no tuning applied"
+}
+```
+
+When correctness **fails** (logic/CUDA error), the `performance` field is `null` and the `errors` field is populated:
+
+```json
+{
+  "kernel_name": "<op>_overlap",
+  "version": "v2",
+  "timestamp": "2026-06-26T14:35:00Z",
+  "pod": "<pod_name>",
+  "iteration": 2,
+  "config": { ... },
+  "correctness": {
+    "status": "FAILED",
+    "max_diff": 0.5,
+    "mean_diff": 0.2
+  },
+  "performance": null,
+  "errors": {
+    "error_type": "cuda_illegal_access",
+    "error_details": "CUDA error: an illegal memory access was encountered at kernel line 89",
+    "traceback": "<full Python/CUDA traceback>",
+    "env_info": "<nvidia-smi output, Python/Torch/Triton versions, GPU model>"
+  },
+  "tuning_changes": "Reduced BLOCK_M from 64 to 32, added address clamping"
+}
+```
+
+When the test **hangs** (30s timeout), the result file records it as a hang error:
+
+```json
+{
+  "kernel_name": "<op>_overlap",
+  "version": "v3",
+  "timestamp": "2026-06-26T14:40:00Z",
+  "pod": "<pod_name>",
+  "iteration": 3,
+  "config": { ... },
+  "correctness": {
+    "status": "FAILED",
+    "max_diff": null,
+    "mean_diff": null
+  },
+  "performance": null,
+  "errors": {
+    "error_type": "hang_deadlock",
+    "error_details": "Correctness test timed out after 30s — process killed by timeout (exit code 124). Indicates kernel hang/deadlock, likely caused by signal polling spin-wait, barrier mismatch across ranks, or missing signal reset between iterations.",
+    "traceback": "N/A — process timed out before producing traceback. Partial stdout captured in correctness_v3.log.",
+    "env_info": "<nvidia-smi output after hang showing GPU state>"
+  },
+  "tuning_changes": "Changed signal polling from infinite while loop to bounded spin"
+}
+```
+
+Key design principles:
+- **One file per version**: no separate `perf_*.json` and `errors_*.log` — everything goes into `<kernel_name>_result_v<version>.json`
+- **`errors` field**: `null` when normal (no errors), populated with structured error info when something went wrong
+- **`performance` field**: `null` when correctness failed or timed out, populated with all metrics when correctness passed
+- **Hang detection**: exit code 124 from the `timeout` command is the canonical hang indicator — it means the process did not complete within the 30-second budget
+- **Read via script**: use `scripts/select_best_version.py` to read all result files, print progress table, and select best version
+
+---
+
+## Step 6: Cleanup
+
+After collecting results, clean up remote artifacts to avoid stale state affecting subsequent runs:
+
+```bash
+# Kill any lingering torchrun processes
+kubectl exec <pod> -n <namespace> -- bash -c "pkill -9 -f 'torchrun.*overlap_kernel_bench' 2>/dev/null || true"
+
+# Remove version-specific files (keep the work directory for future runs)
+kubectl exec <pod> -n <namespace> -- rm -f /tmp/overlap_kernel_bench/<kernel_name>_v<version>.py
+kubectl exec <pod> -n <namespace> -- rm -f /tmp/overlap_kernel_bench/<kernel_name>_v<version>_benchmark.py
+kubectl exec <pod> -n <namespace> -- rm -f /tmp/overlap_kernel_bench/results/correctness_v<version>.log
+kubectl exec <pod> -n <namespace> -- rm -f /tmp/overlap_kernel_bench/results/performance_v<version>.log
+```
+
+This cleanup ensures that the next benchmark iteration starts from a clean state and avoids import conflicts if the kernel module name changes between versions.
+
+---
+
+## Summary: Timeout & Hang Detection Rules
+
+| Phase | Timeout | Hang indicator | On hang |
+|-------|---------|---------------|---------|
+| Pod validation | 30s | No response from kubectl exec | Record `environment_failure`, STOP |
+| File transfer | 30s per file | kubectl cp stalls | Retry once, then record error, STOP |
+| Correctness test | **30s** | Exit code 124 from `timeout 30` | Record `hang_deadlock`, cleanup, STOP |
+| Performance benchmark | **30s** | Exit code 124 from `timeout 30` | Record `hang_deadlock`, cleanup, STOP |
+| Result collection | 30s | kubectl cp stalls | Retry once, then warn and continue |
+
+**Why 30 seconds?** A correctly functioning overlap kernel correctness test should complete in 5-10 seconds on modern GPUs. A performance benchmark (10 warmup + 100 iterations) should complete in 15-25 seconds. The 30-second budget provides reasonable headroom while ensuring hangs are detected promptly. If a test cannot complete in 30 seconds, it almost certainly indicates a kernel bug (infinite spin-wait, barrier deadlock, missing signal) rather than a legitimate slow execution.

--- a/.claude/skills/sglang-overlap-kernel-optimize/references/error-analysis.md
+++ b/.claude/skills/sglang-overlap-kernel-optimize/references/error-analysis.md
@@ -1,0 +1,217 @@
+# Error Analysis & Optimization Guide
+
+This reference defines the protocol for the **optimize sub-agent** to analyze errors and plan optimizations for overlap kernels. It covers error diagnosis, optimization strategies, and version management.
+
+---
+
+## Error Diagnosis Taxonomy
+
+When the optimize sub-agent receives a result file from the benchmark sub-agent, it first reads the unified JSON and classifies the error (if any) into one of the following categories:
+
+| Category | Typical Symptoms | Root Cause Patterns | Fix Strategy |
+|----------|-----------------|--------------------|--------------|
+| **Compile Error** | Triton JIT compilation fails; `CompilationError`, `RuntimeError` during kernel import | Syntax errors, unsupported Triton ops, missing `tl.constexpr`, type mismatches | Fix code syntax; ensure all Triton constraints are met |
+| **CUDA Illegal Memory Access** | `CUDA error: an illegal memory access was encountered`; silent corruption or crash | Out-of-bounds pointer, unmasked PTX inline asm, power-of-2 lane overflow, incorrect stride calculation | Add address clamping, boundary masks, validate pointer offsets |
+| **CUDA Misaligned Address** | `CUDA error: a misaligned address was encountered` | Accessing `symm_mem` buffer at non-16B-aligned offset; `BLOCK_SIZE` not matching alignment requirements | Ensure 16B alignment for all buffer accesses; use `tl.multiple_of` hints |
+| **Hang / Deadlock** | `timeout 30` kills the process (exit code 124); no output after 30s; GPU shows 100% utilization on nvidia-smi but no progress; torchrun processes linger after timeout | **Most common overlap kernel hang causes:** (1) Signal polling spin-wait without timeout: `while ld_sys(signal_addr) != 1: pass` — if CE never writes the signal, the thread spins forever; (2) Barrier mismatch across ranks: one rank hits `dist.barrier()` but another rank is stuck in the kernel; (3) Missing signal reset between iterations: `progress.fill_(0)` not called before relaunching, so kernel reads stale `1` values and proceeds before data is ready, or CE reads stale `0` and signals are never written; (4) `break`/`continue` in Triton JIT loop body — Triton doesn't support these control flow constructs at the thread level, causing CTA divergence; (5) Circular barrier ordering: rank 0 waits for rank 1's signal, rank 1 waits for rank 0's signal; (6) Asymmetric CTA count: if num_tiles is not divisible across ranks, some CTAs never reach the barrier | **Fix by root cause:** (1) Add bounded spin-wait with timeout counter to signal polling loops; (2) Ensure all ranks call `dist.barrier()` symmetrically; (3) Always reset signal tensor to 0 before each kernel launch with a barrier before and after; (4) Replace `break`/`continue` with `while not cond` pattern; (5) Use rotated peer ordering so each rank pulls from different peers first; (6) Pad num_tiles to be divisible by world_size. **Also add host-side timeout** wrapping all torchrun commands with `timeout 30` to detect hangs automatically |
+| **Correctness Mismatch** | Output differs from reference beyond tolerance | Accumulator dtype (fp16 instead of fp32), wrong reduction order, incorrect scaling, wrong output shape | Use fp32 accumulator; verify cast placement; check output shape matches collective semantics |
+| **Environment Failure** | `torch.cuda.is_available() == False`, missing packages, wrong GPU count | Pod doesn't have required GPUs, missing symm_mem support, incompatible torch version | Cannot fix via kernel optimization — report to user |
+
+---
+
+## Diagnosis Procedure
+
+### Step 1: Read the Result File
+
+Read `<kernel_name>_result_v<version>.json` completely. This is a unified file containing both performance data and error info. Extract:
+- **Correctness status** (`correctness.status`: PASSED or FAILED)
+- **Error type** (from `errors.error_type` if `errors` is not null — using the taxonomy above)
+- **Error details** (from `errors.error_details` + `errors.traceback` if available)
+- **Environment info** (from `errors.env_info` if available)
+- **Performance data** (from `performance` if correctness passed — speedup, latency, efficiency)
+
+### Step 2: Read the Kernel Source
+
+Read the current version of the kernel file (`<kernel_name>_v<version>.py`). Cross-reference the error with specific code sections:
+- For compile errors: locate the exact line/operation that Triton rejected
+- For CUDA errors: locate pointer arithmetic, inline asm, mask logic
+- For hangs: locate barrier calls, signal patterns, loop structures
+- For correctness: locate accumulator types, reduction logic, output shapes
+
+### Step 2b: Hang-Specific Diagnosis (if error_type is "hang_deadlock")
+
+When the benchmark timed out with exit code 124, perform this additional structured diagnosis:
+
+1. **Locate signal polling loops**: Search for `while` loops that poll signal values (e.g., `while ld_sys(signal_addr) != 1: pass`). These are the #1 cause of hangs. Check:
+   - Is there a timeout/bound on the loop? If no, the thread will spin forever if CE never writes.
+   - Is the signal tensor reset to 0 before each kernel launch? (`progress.fill_(0)`)
+   - Is there a `dist.barrier()` after the reset to ensure all ranks see it?
+
+2. **Check barrier symmetry**: Ensure every `dist.barrier()` in the host code is reached by ALL ranks. An asymmetric barrier (one rank calls it, another doesn't) causes deadlock.
+
+3. **Check `break`/`continue` in Triton JIT**: Triton doesn't support Python `break` or `continue` in JIT-compiled loops at the thread level. Replace with conditional logic (`while not cond: pass` or flag variables).
+
+4. **Check CTA count vs world_size alignment**: If `num_tiles` is not evenly divisible by the chunk scheduling, some CTAs may be assigned to empty chunks and skip signal polling, causing other CTAs to wait forever.
+
+5. **Check peer ordering**: In full-mesh pull AllGather, each rank must pull from all peers. If the rotation order is wrong, a rank may wait for a signal that is only written after the rank itself completes, creating a circular dependency.
+
+6. **Examine the partial log**: Read `<kernel_name>_results/correctness_v<version>.log` from the pod for any partial output. Sometimes the kernel prints partial results before hanging, which can identify which rank/stage is stuck.
+
+### Step 3: Read the Performance Info (If Available)
+
+If the result file has `correctness.status == "PASSED"` and `performance` is not null, read the performance data from the same JSON to understand:
+- Which parts worked (compute-only passed? comm-only passed?)
+- Where the bottleneck is (compute-heavy? comm-heavy?)
+
+This helps the optimize sub-agent prioritize which dimension to optimize.
+
+---
+
+## Optimization Strategies
+
+### Strategy Selection Matrix
+
+Based on the error category and performance profile, select the optimization strategy:
+
+| Error Category | Performance Profile | Primary Strategy | Secondary Strategy |
+|---------------|--------------------|-----------------|--------------------|
+| Compile Error | N/A (can't run) | Fix syntax/compilation issues | N/A |
+| CUDA Illegal Access | N/A (crashes) | Fix memory safety (address clamping, masks) | Reduce grid size as safety measure |
+| CUDA Misaligned | N/A (crashes) | Fix alignment (16B boundaries, `tl.multiple_of`) | Adjust BLOCK_SIZE to power-of-2 aligned values |
+| Hang / Deadlock | N/A (timeout after 30s, exit code 124) | Fix the specific hang root cause (signal polling, barrier symmetry, signal reset, CTA divergence) | Add bounded spin-wait with timeout counter in kernel; verify `progress.fill_(0)` + barrier pattern before each launch |
+| Correctness Mismatch | Low speedup (< 1.5x) | Fix precision (fp32 accumulator, cast placement) | Adjust block sizes for better tiling |
+| Correctness Pass, Low Performance | Low speedup (< 1.5x) | Tune block sizes and SM allocation | Reduce register pressure via chunking |
+| Correctness Pass, Good Performance | Good speedup (> 1.5x) | Fine-tune for marginal gains | Try alternative overlap mode |
+
+### Parameter Tuning Parameters
+
+These are the tunable parameters the optimize sub-agent can adjust (do NOT change the overlap algorithm itself unless correctness is broken):
+
+| Parameter | Default | Range | Impact | How to Tune |
+|-----------|---------|-------|--------|-------------|
+| `BLOCK_M` | auto-computed | 16–128 | CTA tile size in M dimension; affects register pressure and occupancy | Increase for compute-heavy, decrease for memory-bound |
+| `BLOCK_N` | auto-computed | 32–512 | CTA tile size in N dimension; affects shared memory usage | Must be `next_power_of_2(N_per_chunk)`; increase chunk size to increase |
+| `BLOCK_K` | 128 (for GEMM) | 64–256 | Inner loop tile for GEMM kernels | Keep at 128 for fp8; 64 for bf16 with high register pressure |
+| `num_warps` | 32 | 4–32 | Threads per CTA; affects memory bandwidth saturation | Always try 32 first for memory-bound kernels; reduce to 16 if register pressure is high |
+| `num_stages` | 1 | 0–4 | Software pipelining depth | Keep at 1 for overlap kernels (compute and comm interleave naturally) |
+| `num_comm_sms` | 8 | 4–16 | SMs dedicated to communication in inter-SM mode | Increase if comm is bottleneck; decrease if compute needs more SMs |
+| `N_CHUNKS` | `N // 1024` | 2–16 | Number of chunks in N dimension; reduces register pressure | Increase if occupancy is low; decrease if chunk overhead dominates |
+
+### Code-Level Optimization Strategies
+
+When parameter tuning alone doesn't achieve the target speedup, the optimize sub-agent can apply code-level optimizations:
+
+| Strategy | When to Apply | How |
+|----------|--------------|-----|
+| **Reduce register pressure** | Occupancy < 50%; compiler reports high register count | Split K-dimension into chunks via `tl.range`; use `tl.constexpr` for strides; avoid large intermediate tensors |
+| **Vectorize memory access** | Kernel is memory-bound but BW utilization is low | Add `tl.multiple_of(ptr, 16)` hints; use `tl.load` with `eviction_policy=evict_last` for read-once data |
+| **Eliminate redundant computation** | Compute time > expected; repeated calculations in loop | Pre-compute offsets outside loops; use incremental pointer update (`ptr += stride` instead of `base + i * stride`) |
+| **Optimize barrier pattern** | Barrier overhead > 10% of total time | Replace 3-barrier pattern with master CTA barrier; use PTX-level CAS spin-loop instead of Python `while` |
+| **Switch overlap mode** | Current mode has fundamental limitations | Consider switching: intra-SM → inter-SM (if register pressure too high), inter-SM → without-SM (if SM cost dominates) |
+
+---
+
+## Version Management Rules
+
+### Naming Convention
+
+Each optimization iteration produces a **new kernel file** with a version suffix. The original kernel is `v1`, and each subsequent optimization is `v2`, `v3`, etc.
+
+```
+<kernel_name>_v1.py   ← initial generation (from sglang-overlap-kernel-generation)
+<kernel_name>_v2.py   ← first optimization iteration
+<kernel_name>_v3.py   ← second optimization iteration
+...
+```
+
+### File Organization
+
+All kernel versions coexist in the same directory. The optimize sub-agent:
+- **NEVER overwrites** an existing version file
+- **Always creates** a new file with the next version number
+- **Preserves** the original version for comparison and rollback
+
+### Benchmark File Correspondence
+
+Each kernel version has a corresponding benchmark file:
+
+```
+<kernel_name>_v1_benchmark.py
+<kernel_name>_v2_benchmark.py
+...
+```
+
+The benchmark file for each version imports from its corresponding kernel version. The optimize sub-agent updates the import path in the benchmark file when creating a new version.
+
+### Error and Performance File Correspondence
+
+All data is stored in **unified result files** (not separate perf/error files):
+
+```
+<kernel_name>_result_v1.json   ← v1 result: perf + errors in one file
+<kernel_name>_result_v2.json   ← v2 result: perf + errors in one file
+...
+```
+
+If v1 correctness passed: `errors` = null, `performance` populated.
+If v2 correctness failed: `errors` populated, `performance` = null.
+All data for a version is in one place — no separate log files to cross-reference.
+
+---
+
+## Optimization Iteration Protocol
+
+### Step 1: Read Current State
+
+1. Read the **result JSON file** from the latest benchmark run (`<kernel_name>_result_v<version>.json`) — this unified file contains both performance data and error info
+2. Read the **current kernel source** (the version that produced the result)
+4. Read **previous result files** for comparison (what changed, what was tried)
+
+### Step 2: Diagnose and Plan
+
+1. Classify the error using the taxonomy above
+2. Identify the root cause in the kernel source
+3. Select the optimization strategy from the strategy matrix
+4. Plan specific code changes (which parameters to tune, which code sections to modify)
+5. Document the planned changes in a brief optimization note
+
+### Step 3: Implement Optimization
+
+1. Create a **new kernel file** with the next version number (`v<N+1>.py`)
+2. Copy the current version's code as the starting point
+3. Apply the planned changes
+4. Update the benchmark file import to reference the new version
+5. Ensure the kernel remains self-contained (no cross-imports between versions)
+
+### Step 4: Generate Optimization Note
+
+Write a brief note documenting what was changed and why:
+
+```
+=== Optimization Note: <kernel_name> v<N+1> ===
+Based on: v<N> error/performance data
+Error type: <category or "none — performance optimization">
+Changes:
+  1. <specific change with line reference>
+  2. <specific change with line reference>
+Rationale: <why these changes should improve the issue>
+Expected impact: <predicted improvement in correctness or performance>
+```
+
+This note is saved alongside the kernel file for traceability.
+
+---
+
+## Optimization Stop Criteria
+
+The optimize loop terminates when any of these conditions is met:
+
+1. **Target speedup achieved**: overlap speedup ≥ user-specified target (default: 1.5x)
+2. **Max iterations reached**: user-specified number of optimization rounds completed
+3. **No progress detected**: last 3 iterations show no performance improvement (speedup delta < 0.05x)
+4. **Regression detected**: new version's performance is worse than the previous version by > 0.2x
+
+When the loop terminates due to stop criteria 3 or 4, the optimize sub-agent should:
+- Note the stop reason in its report
+- Recommend the best-performing version found so far
+- NOT attempt further optimization without user guidance

--- a/.claude/skills/sglang-overlap-kernel-optimize/references/performance-tracking.md
+++ b/.claude/skills/sglang-overlap-kernel-optimize/references/performance-tracking.md
@@ -1,0 +1,293 @@
+# Performance Tracking & Best Version Selection
+
+This reference defines the format for tracking performance across optimization iterations and the procedure for selecting the best-performing kernel version for integration. All benchmark data (both successful and failed) is stored in **unified result JSON files** — there is no separate error log file.
+
+---
+
+## Unified Result File Format
+
+Each benchmark iteration produces a **single unified JSON file** that contains both performance data and error info:
+
+```
+<kernel_name>_result_v<version>.json
+```
+
+Use the `scripts/record_benchmark_result.py` script to write result files, and `scripts/select_best_version.py` to read them and select the best version.
+
+### Schema — Successful Benchmark
+
+```json
+{
+  "kernel_name": "allgather_gemm_overlap",
+  "version": "v1",
+  "timestamp": "2026-06-26T14:30:00Z",
+  "pod": "sglang-test-pod-abc123",
+  "iteration": 1,
+  "config": {
+    "M": 1024,
+    "N": 7168,
+    "K": 2048,
+    "dtype": "bf16",
+    "world_size": 2,
+    "num_comm_sms": 8,
+    "block_m": 64,
+    "block_n": 256,
+    "block_k": 128,
+    "num_warps": 32,
+    "n_chunks": 7
+  },
+  "correctness": {
+    "status": "PASSED",
+    "max_diff": 0.0001,
+    "mean_diff": 0.00005,
+    "rtol": 0.01,
+    "atol": 0.01
+  },
+  "performance": {
+    "compute_only_us": 1234.5,
+    "comm_only_us": 5678.9,
+    "non_overlap_us": 6913.4,
+    "overlap_us": 3456.7,
+    "speedup": 2.0,
+    "overlap_efficiency": 0.85,
+    "compute_bw_gb_s": 120.5,
+    "overlap_bw_gb_s": 95.3
+  },
+  "errors": null,
+  "tuning_changes": "Initial generation — no tuning applied"
+}
+```
+
+### Schema — Failed Benchmark
+
+For versions that fail correctness, `performance` is `null` and `errors` is populated:
+
+```json
+{
+  "kernel_name": "allgather_gemm_overlap",
+  "version": "v2",
+  "timestamp": "2026-06-26T14:35:00Z",
+  "pod": "sglang-test-pod-abc123",
+  "iteration": 2,
+  "config": { ... },
+  "correctness": {
+    "status": "FAILED",
+    "max_diff": 0.5,
+    "mean_diff": 0.2
+  },
+  "performance": null,
+  "errors": {
+    "error_type": "cuda_illegal_access",
+    "error_details": "CUDA error: an illegal memory access was encountered at kernel line 89",
+    "traceback": "<full Python/CUDA traceback>",
+    "env_info": "<nvidia-smi output, Python/Torch/Triton versions>"
+  },
+  "tuning_changes": "Reduced BLOCK_M from 64 to 32, added address clamping for inline asm"
+}
+```
+
+**Key design**: `errors` field is `null` when everything is normal, and populated with structured error info when something went wrong. No separate error log file exists.
+
+---
+
+## Comm Savings Metric
+
+The primary optimization target is **comm savings percentage** — how much of the pure communication time the overlap kernel manages to "hide" behind compute:
+
+```
+comm_savings_pct = (non_overlap_us - overlap_us) / comm_only_us * 100%
+```
+
+- `non_overlap_us` = `compute_only_us + comm_only_us` (sequential compute + comm, no overlap)
+- `overlap_us` = latency of the overlap kernel (compute and comm running concurrently)
+- `comm_only_us` = pure communication time (NCCL collective alone)
+- The time saved by overlap = `non_overlap_us - overlap_us`
+- We compare this savings against the communication cost to quantify overlap effectiveness
+
+**Interpretation**:
+- `comm_savings_pct > 50%` means the overlap kernel hides more than half of the communication time → target achieved
+- `comm_savings_pct = 100%` means communication is fully hidden (ideal: overlap time ≈ compute_only time)
+- `comm_savings_pct ≈ 0%` means no overlap benefit at all (overlap time ≈ sequential time)
+
+The `speedup` metric is still recorded for reference: `speedup = (compute_only_us + comm_only_us) / overlap_us`, but the loop termination condition is based on `comm_savings_pct`.
+
+---
+
+## Performance Summary File
+
+After all optimization iterations complete, use `scripts/select_best_version.py` to consolidate all result files into a single summary:
+
+```bash
+python3 scripts/select_best_version.py \
+    --kernel_name <kernel_name> \
+    --results_dir ./results \
+    --comm_savings_target_pct <target_pct> \
+    --max_iterations <max_iterations> \
+    --output_summary
+```
+
+This produces `<kernel_name>_perf_summary.json` in the results directory:
+
+### Schema
+
+```json
+{
+  "kernel_name": "allgather_gemm_overlap",
+  "total_iterations": 5,
+  "comm_savings_target_pct": 50,
+  "target_iterations": 5,
+  "versions": [
+    {
+      "version": "v1",
+      "correctness": "PASSED",
+      "speedup": 1.2,
+      "overlap_us": 3456.7,
+      "overlap_efficiency": 0.6,
+      "comm_savings_pct": 25.0,
+      "tuning_changes": "Initial generation"
+    },
+    {
+      "version": "v2",
+      "correctness": "FAILED",
+      "speedup": null,
+      "overlap_us": null,
+      "overlap_efficiency": null,
+      "comm_savings_pct": null,
+      "tuning_changes": "Reduced BLOCK_M, added address clamping"
+    },
+    {
+      "version": "v3",
+      "correctness": "PASSED",
+      "speedup": 1.8,
+      "overlap_us": 2100.0,
+      "overlap_efficiency": 0.88,
+      "comm_savings_pct": 55.0,
+      "tuning_changes": "Increased BLOCK_N to 512, switched to 32 warps, added tl.multiple_of hints"
+    },
+    {
+      "version": "v4",
+      "correctness": "PASSED",
+      "speedup": 1.9,
+      "overlap_us": 1980.0,
+      "overlap_efficiency": 0.91,
+      "comm_savings_pct": 60.0,
+      "tuning_changes": "Optimized barrier pattern (master CTA), reduced N_CHUNKS to 4"
+    },
+    {
+      "version": "v5",
+      "correctness": "PASSED",
+      "speedup": 1.85,
+      "overlap_us": 2050.0,
+      "overlap_efficiency": 0.89,
+      "comm_savings_pct": 55.5,
+      "tuning_changes": "Tried num_comm_sms=12 (regression — too many SMs for comm)"
+    }
+  ],
+  "best_version": "v4",
+  "best_speedup": 1.9,
+  "best_overlap_efficiency": 0.91,
+  "best_comm_savings_pct": 60.0,
+  "convergence_status": "converged|no_progress|regression|max_iterations_reached|all_failed"
+}
+```
+
+---
+
+## Best Version Selection Procedure
+
+After all optimization iterations, the lead agent selects the best-performing version for integration.
+
+### Selection Criteria (Priority Order)
+
+1. **Correctness MUST pass** — any version that failed correctness is excluded from consideration
+2. **Highest comm_savings_pct** — among correctness-passing versions, select the one that saves the most communication time
+3. **Tiebreaker: highest speedup** — if two versions have the same `comm_savings_pct`, prefer the one with higher speedup
+4. **Tiebreaker: lowest overlap latency** — if still tied, prefer the one with lower `overlap_us`
+
+### Selection Algorithm
+
+```
+1. Filter: remove all versions where correctness.status != "PASSED" (read from result JSON files)
+2. Compute comm_savings_pct for each passing version: (non_overlap_us - overlap_us) / comm_only_us * 100
+3. Sort: by comm_savings_pct DESC, then speedup DESC, then overlap_us ASC
+4. Select: the first entry in the sorted list
+5. Report: the selected version, its comm_savings_pct, speedup, and the rationale
+```
+
+This algorithm is implemented in `scripts/select_best_version.py`.
+
+### Edge Cases
+
+| Case | Handling |
+|------|----------|
+| **All versions failed correctness** | Report failure; recommend manual intervention; do NOT proceed to integration |
+| **Only one version passed** | Select that version regardless of metrics; note in report that it's the only viable option |
+| **Best version regressed from previous** | Still select the highest comm_savings_pct; note the regression context in the report |
+| **Comm savings below target** | Select the best available; note that target was not met; proceed to integration only with user confirmation |
+
+---
+
+## Performance Progress Table
+
+During the optimization loop, the lead agent maintains a running progress table for the user. This is printed automatically by `scripts/select_best_version.py`:
+
+```bash
+python3 scripts/select_best_version.py \
+    --kernel_name <kernel_name> \
+    --results_dir ./results \
+    --comm_savings_target_pct <target_pct>
+```
+
+Example output:
+
+```
+Iteration | Version | Correctness | Speedup | Overlap (us) | Comm Savings (%) | Key Change
+---------------------------------------------------------------------------------------------------------
+    1     |   v1    |   PASSED    |  1.20   |    3456.7    |       25.0       | Initial generation
+    2     |   v2    |   FAILED    |   N/A   |     N/A      |        N/A       | Reduced BLOCK_M, clamping
+    3     |   v3    |   PASSED    |  1.80   |    2100.0    |       55.0       | Increased BLOCK_N, 32 warps
+    4     |   v4    |   PASSED    |  1.90   |    1980.0    |       60.0       | Master CTA barrier, N_CHUNKS=4
+    5     |   v5    |   PASSED    |  1.85   |    2050.0    |       55.5       | num_comm_sms=12 (regression)
+---------------------------------------------------------------------------------------------------------
+Best: v4 (speedup=1.90, comm_savings=60.0%)
+Comm savings target: >50% — ACHIEVED
+```
+
+This table is updated after each benchmark sub-agent returns results, and presented to the user at the end of each iteration.
+
+---
+
+## Integration Handoff Package
+
+When the best version is selected, the lead agent prepares an **integration handoff package** for the integration sub-agent. This package contains:
+
+1. **Best kernel file**: `<kernel_name>_v<best_version>.py` — the selected kernel
+2. **Best benchmark file**: `<kernel_name>_v<best_version>_benchmark.py` — the corresponding benchmark
+3. **Performance summary**: `<kernel_name>_perf_summary.json` — all iteration data
+4. **Integration context**: a JSON document describing:
+
+```json
+{
+  "kernel_file": "allgather_gemm_overlap_v4.py",
+  "kernel_version": "v4",
+  "overlap_mode": "inter-sm",
+  "compute_op": "GEMM",
+  "comm_op": "all-gather",
+  "symm_mem_mechanism": "torch.distributed._symmetric_memory",
+  "target_model_layers": ["model.layers.*.mlp"],
+  "forward_mode": "decode",
+  "speedup": 1.9,
+  "overlap_efficiency": 0.91,
+  "comm_savings_pct": 60.0,
+  "config": {
+    "M": 1024,
+    "N": 7168,
+    "K": 2048,
+    "dtype": "bf16",
+    "num_comm_sms": 8,
+    "world_size": 2
+  }
+}
+```
+
+The integration sub-agent uses this package to invoke the `sglang-overlap-integration` skill with all necessary context.

--- a/.claude/skills/sglang-overlap-kernel-optimize/scripts/record_benchmark_result.py
+++ b/.claude/skills/sglang-overlap-kernel-optimize/scripts/record_benchmark_result.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Record benchmark result for an overlap kernel version.
+
+Writes a unified JSON result file (<kernel_name>_result_v<version>.json) that
+contains both performance data (if correctness passed) and error info (if any).
+If the file already exists for that version, the new data overwrites it.
+
+Usage:
+    # Record a successful benchmark (correctness PASSED, with performance data)
+    python3 record_benchmark_result.py \
+        --kernel_name allgather_gemm_overlap \
+        --version v1 \
+        --pod sglang-test-pod-abc123 \
+        --iteration 1 \
+        --status PASSED \
+        --max_diff 0.0001 --mean_diff 0.00005 \
+        --compute_only_us 1234.5 \
+        --comm_only_us 5678.9 \
+        --non_overlap_us 6913.4 \
+        --overlap_us 3456.7 \
+        --speedup 2.0 \
+        --overlap_efficiency 0.85 \
+        --config M=1024,N=7168,K=2048,dtype=bf16,world_size=2,num_comm_sms=8 \
+        --tuning_changes "Initial generation"
+
+    # Record a failed benchmark (correctness FAILED, with error details)
+    python3 record_benchmark_result.py \
+        --kernel_name allgather_gemm_overlap \
+        --version v2 \
+        --pod sglang-test-pod-abc123 \
+        --iteration 2 \
+        --status FAILED \
+        --max_diff 0.5 --mean_diff 0.2 \
+        --error_type runtime_crash \
+        --error_details "CUDA error: an illegal memory access was encountered at kernel line 89" \
+        --config M=1024,N=7168,K=2048,dtype=bf16,world_size=2,num_comm_sms=8 \
+        --tuning_changes "Reduced BLOCK_M from 64 to 32, added address clamping"
+
+    # Record an environment failure (no benchmark ran at all)
+    python3 record_benchmark_result.py \
+        --kernel_name allgather_gemm_overlap \
+        --version v1 \
+        --pod sglang-test-pod-abc123 \
+        --iteration 1 \
+        --status FAILED \
+        --error_type environment_failure \
+        --error_details "torch.cuda.is_available() == False; pod has no GPU" \
+        --config M=1024,N=7168,K=2048,dtype=bf16,world_size=2,num_comm_sms=8
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+
+def parse_config_string(config_str: str) -> dict:
+    """Parse comma-separated key=value pairs into a dict with typed values."""
+    if not config_str:
+        return {}
+    result = {}
+    for pair in config_str.split(","):
+        key, value = pair.strip().split("=")
+        # Try to cast to int, then float, then keep as string
+        try:
+            result[key] = int(value)
+        except ValueError:
+            try:
+                result[key] = float(value)
+            except ValueError:
+                result[key] = value
+    return result
+
+
+def record_result(args: argparse.Namespace) -> None:
+    """Write the unified result JSON file."""
+    result = {
+        "kernel_name": args.kernel_name,
+        "version": args.version,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "pod": args.pod,
+        "iteration": args.iteration,
+        "config": parse_config_string(args.config),
+        "correctness": {
+            "status": args.status,
+            "max_diff": args.max_diff,
+            "mean_diff": args.mean_diff,
+        },
+        "performance": None,
+        "errors": None,
+        "tuning_changes": args.tuning_changes,
+    }
+
+    # Fill performance data if correctness passed
+    if args.status == "PASSED":
+        result["performance"] = {
+            "compute_only_us": args.compute_only_us,
+            "comm_only_us": args.comm_only_us,
+            "non_overlap_us": args.non_overlap_us,
+            "overlap_us": args.overlap_us,
+            "speedup": args.speedup,
+            "overlap_efficiency": args.overlap_efficiency,
+        }
+
+    # Fill error info if any (can coexist with PASSED for minor warnings,
+    # but typically only present when FAILED)
+    if args.error_type or args.error_details:
+        result["errors"] = {
+            "error_type": args.error_type or "unknown",
+            "error_details": args.error_details or "",
+        }
+        if args.error_traceback:
+            result["errors"]["traceback"] = args.error_traceback
+        if args.error_env_info:
+            result["errors"]["env_info"] = args.error_env_info
+
+    # Write to output directory
+    output_dir = args.output_dir
+    os.makedirs(output_dir, exist_ok=True)
+
+    filename = f"{args.kernel_name}_result_{args.version}.json"
+    filepath = os.path.join(output_dir, filename)
+
+    with open(filepath, "w") as f:
+        json.dump(result, f, indent=2)
+
+    print(f"Result written to: {filepath}")
+    print(f"  Status: {args.status}")
+    if args.status == "PASSED":
+        print(f"  Speedup: {args.speedup}x, Overlap: {args.overlap_us} us, Efficiency: {args.overlap_efficiency}")
+    else:
+        print(f"  Error type: {args.error_type}, Error: {args.error_details}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Record benchmark result for an overlap kernel version."
+    )
+
+    # Core fields
+    parser.add_argument("--kernel_name", required=True, help="Kernel name (e.g., allgather_gemm_overlap)")
+    parser.add_argument("--version", required=True, help="Version string (e.g., v1, v2)")
+    parser.add_argument("--pod", required=True, help="Pod name where benchmark ran")
+    parser.add_argument("--iteration", type=int, required=True, help="Iteration number in the optimization loop")
+    parser.add_argument("--status", required=True, choices=["PASSED", "FAILED"],
+                        help="Correctness test status")
+
+    # Correctness metrics
+    parser.add_argument("--max_diff", type=float, default=None, help="Max diff from correctness test")
+    parser.add_argument("--mean_diff", type=float, default=None, help="Mean diff from correctness test")
+
+    # Performance metrics (only used when status=PASSED)
+    parser.add_argument("--compute_only_us", type=float, default=None,
+                        help="Compute-only latency in microseconds")
+    parser.add_argument("--comm_only_us", type=float, default=None,
+                        help="Comm-only latency in microseconds")
+    parser.add_argument("--non_overlap_us", type=float, default=None,
+                        help="Non-overlap (sequential) latency in microseconds")
+    parser.add_argument("--overlap_us", type=float, default=None,
+                        help="Overlap kernel latency in microseconds")
+    parser.add_argument("--speedup", type=float, default=None,
+                        help="Speedup = (compute + comm) / overlap")
+    parser.add_argument("--overlap_efficiency", type=float, default=None,
+                        help="Overlap efficiency = max(compute, comm) / overlap")
+
+    # Error fields (only used when status=FAILED or when errors occurred)
+    parser.add_argument("--error_type", default=None,
+                        choices=["compile_error", "cuda_illegal_access", "cuda_misaligned",
+                                 "hang_deadlock", "correctness_mismatch", "environment_failure", "unknown"],
+                        help="Error category from taxonomy")
+    parser.add_argument("--error_details", default=None, help="Error description string")
+    parser.add_argument("--error_traceback", default=None, help="Full Python/CUDA traceback")
+    parser.add_argument("--error_env_info", default=None, help="Environment info (nvidia-smi, versions, etc.)")
+
+    # Config and metadata
+    parser.add_argument("--config", default=None,
+                        help="Comma-separated key=value config pairs (e.g., M=1024,N=7168,K=2048)")
+    parser.add_argument("--tuning_changes", default=None,
+                        help="Description of tuning changes for this version")
+    parser.add_argument("--output_dir", default="./results",
+                        help="Directory to write result files (default: ./results)")
+
+    args = parser.parse_args()
+    record_result(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/sglang-overlap-kernel-optimize/scripts/select_best_version.py
+++ b/.claude/skills/sglang-overlap-kernel-optimize/scripts/select_best_version.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+Select the best-performing overlap kernel version from all benchmark results.
+
+Reads all `<kernel_name>_result_v*.json` files from the results directory,
+filters out versions that failed correctness, and selects the one with the
+highest comm_savings_pct (how much of the pure communication time the overlap
+kernel manages to hide behind compute). Also generates a summary JSON file.
+
+Comm savings metric:
+    comm_savings_pct = (non_overlap_us - overlap_us) / comm_only_us * 100%
+
+The loop terminates when comm_savings_pct > target_pct (default 50%),
+meaning the overlap kernel saves more than 50% of the pure communication time.
+
+Usage:
+    # Select best version and print progress table
+    python3 select_best_version.py \
+        --kernel_name allgather_gemm_overlap \
+        --results_dir ./results \
+        --comm_savings_target_pct 50
+
+    # Also generate summary JSON file
+    python3 select_best_version.py \
+        --kernel_name allgather_gemm_overlap \
+        --results_dir ./results \
+        --comm_savings_target_pct 50 \
+        --output_summary
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+
+def compute_comm_savings_pct(perf: dict) -> float | None:
+    """
+    Compute how much of the pure communication time the overlap kernel saves.
+
+    comm_savings_pct = (non_overlap_us - overlap_us) / comm_only_us * 100%
+
+    Returns None if any required field is missing or comm_only_us is zero.
+    """
+    required = ["non_overlap_us", "overlap_us", "comm_only_us"]
+    for field in required:
+        if field not in perf or perf[field] is None:
+            return None
+    if perf["comm_only_us"] == 0:
+        return None
+    return (perf["non_overlap_us"] - perf["overlap_us"]) / perf["comm_only_us"] * 100.0
+
+
+def load_result_files(kernel_name: str, results_dir: str) -> list[dict]:
+    """Load all result JSON files for the given kernel name, sorted by version number."""
+    results = []
+    for filename in os.listdir(results_dir):
+        if filename.startswith(kernel_name) and filename.endswith(".json"):
+            filepath = os.path.join(results_dir, filename)
+            with open(filepath) as f:
+                data = json.load(f)
+            results.append(data)
+
+    # Sort by version number (extract numeric part from v1, v2, etc.)
+    def version_sort_key(result: dict) -> int:
+        version_str = result.get("version", "v0")
+        try:
+            return int(version_str.replace("v", ""))
+        except ValueError:
+            return 0
+
+    results.sort(key=version_sort_key)
+    return results
+
+
+def print_progress_table(results: list[dict], comm_target_pct: float) -> None:
+    """Print the performance progress table in human-readable format."""
+    print("\nIteration | Version | Correctness | Speedup | Overlap (us) | Comm Savings (%) | Key Change")
+    print("-" * 105)
+
+    best_savings_pct = -1.0
+    best_version = None
+
+    for result in results:
+        version = result["version"]
+        iteration = result.get("iteration", "?")
+        correctness = result["correctness"]["status"]
+        tuning = result.get("tuning_changes", "") or ""
+
+        if correctness == "PASSED" and result["performance"] is not None:
+            perf = result["performance"]
+            speedup = perf["speedup"]
+            overlap_us = perf["overlap_us"]
+            savings_pct = compute_comm_savings_pct(perf)
+            savings_display = f"{savings_pct:.1f}" if savings_pct is not None else "N/A"
+            tuning_display = tuning[:40] + ("..." if len(tuning) > 40 else "")
+            print(f"    {iteration}     |   {version}    |   {correctness}    |  {speedup:.2f}   |"
+                  f"    {overlap_us:.1f}    |       {savings_display}       | {tuning_display}")
+            if savings_pct is not None and savings_pct > best_savings_pct:
+                best_savings_pct = savings_pct
+                best_version = version
+        else:
+            errors = result.get("errors") or {}
+            error_type = errors.get("error_type", "unknown") if errors else "unknown"
+            tuning_display = tuning[:40] + ("..." if len(tuning) > 40 else "")
+            print(f"    {iteration}     |   {version}    |   {correctness}    |   N/A   |"
+                  f"     N/A      |        N/A       | {tuning_display} ({error_type})")
+
+    print("-" * 105)
+    if best_version:
+        print(f"Best: {best_version} (comm_savings={best_savings_pct:.1f}%)")
+        target_met = best_savings_pct >= comm_target_pct
+        print(f"Comm savings target: >{comm_target_pct}% — {'ACHIEVED ✓' if target_met else 'NOT ACHIEVED'}")
+    else:
+        print("Best: NONE (all versions failed correctness)")
+
+
+def select_best(results: list[dict]) -> dict | None:
+    """
+    Select the best version following the priority criteria:
+    1. Correctness MUST pass
+    2. Highest comm_savings_pct
+    3. Tiebreaker: highest speedup
+    4. Tiebreaker: lowest overlap latency
+    """
+    # Filter: only correctness-passing versions with performance data
+    passing = [r for r in results if r["correctness"]["status"] == "PASSED" and r["performance"] is not None]
+
+    if not passing:
+        return None
+
+    # Compute comm_savings_pct for each passing version
+    for r in passing:
+        r["_comm_savings_pct"] = compute_comm_savings_pct(r["performance"]) or -1.0
+
+    # Sort by: comm_savings_pct DESC, speedup DESC, overlap_us ASC
+    passing.sort(key=lambda r: (
+        -r["_comm_savings_pct"],
+        -r["performance"]["speedup"],
+        r["performance"]["overlap_us"],
+    ))
+
+    # Clean up temporary field
+    best = passing[0]
+    best.pop("_comm_savings_pct", None)
+    return best
+
+
+def generate_summary(results: list[dict], best: dict | None,
+                     comm_savings_target_pct: float, max_iterations: int,
+                     kernel_name: str, results_dir: str) -> dict:
+    """Generate the consolidated summary JSON."""
+    versions_summary = []
+    for result in results:
+        entry = {
+            "version": result["version"],
+            "correctness": result["correctness"]["status"],
+            "tuning_changes": result.get("tuning_changes", ""),
+        }
+        if result["correctness"]["status"] == "PASSED" and result["performance"] is not None:
+            perf = result["performance"]
+            entry["speedup"] = perf["speedup"]
+            entry["overlap_us"] = perf["overlap_us"]
+            entry["overlap_efficiency"] = perf["overlap_efficiency"]
+            entry["comm_savings_pct"] = compute_comm_savings_pct(perf)
+        else:
+            entry["speedup"] = None
+            entry["overlap_us"] = None
+            entry["overlap_efficiency"] = None
+            entry["comm_savings_pct"] = None
+            errors = result.get("errors") or {}
+            entry["error_type"] = errors.get("error_type", "unknown") if errors else "unknown"
+        versions_summary.append(entry)
+
+    # Determine convergence status
+    passing = [r for r in results if r["correctness"]["status"] == "PASSED" and r["performance"] is not None]
+    best_savings = compute_comm_savings_pct(best["performance"]) if best else None
+
+    if not passing:
+        convergence = "all_failed"
+    elif best_savings is not None and best_savings >= comm_savings_target_pct:
+        convergence = "converged"
+    elif len(passing) >= 3:
+        # Check no-progress: last 3 passing versions show < 5% improvement in comm_savings_pct
+        recent_savings = [compute_comm_savings_pct(r["performance"]) or 0.0 for r in passing[-3:]]
+        if max(recent_savings) - min(recent_savings) < 5.0:
+            convergence = "no_progress"
+        else:
+            convergence = "max_iterations_reached"
+    else:
+        convergence = "max_iterations_reached"
+
+    summary = {
+        "kernel_name": kernel_name,
+        "total_iterations": len(results),
+        "comm_savings_target_pct": comm_savings_target_pct,
+        "target_iterations": max_iterations,
+        "versions": versions_summary,
+        "best_version": best["version"] if best else None,
+        "best_speedup": best["performance"]["speedup"] if best else None,
+        "best_overlap_efficiency": best["performance"]["overlap_efficiency"] if best else None,
+        "best_comm_savings_pct": best_savings,
+        "convergence_status": convergence,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    return summary
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Select the best-performing overlap kernel version from benchmark results."
+    )
+    parser.add_argument("--kernel_name", required=True, help="Kernel name to filter results")
+    parser.add_argument("--results_dir", required=True, default="./results",
+                        help="Directory containing result JSON files")
+    parser.add_argument("--comm_savings_target_pct", type=float, default=50.0,
+                        help="Target comm savings percentage threshold (default: 50%%). "
+                             "Loop terminates when (non_overlap - overlap) / comm_only > this %%.")
+    parser.add_argument("--max_iterations", type=int, default=5,
+                        help="Maximum optimization iterations planned")
+    parser.add_argument("--output_summary", action="store_true",
+                        help="Also generate <kernel_name>_perf_summary.json in results_dir")
+
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.results_dir):
+        print(f"Error: results directory '{args.results_dir}' does not exist")
+        sys.exit(1)
+
+    results = load_result_files(args.kernel_name, args.results_dir)
+
+    if not results:
+        print(f"No result files found for kernel '{args.kernel_name}' in '{args.results_dir}'")
+        sys.exit(1)
+
+    # Print progress table
+    print_progress_table(results, args.comm_savings_target_pct)
+
+    # Select best version
+    best = select_best(results)
+
+    if best:
+        best_savings = compute_comm_savings_pct(best["performance"])
+        print(f"\nSelected best version: {best['version']}")
+        print(f"  Speedup: {best['performance']['speedup']:.2f}x")
+        print(f"  Overlap latency: {best['performance']['overlap_us']:.1f} us")
+        print(f"  Overlap efficiency: {best['performance']['overlap_efficiency']:.2f}")
+        if best_savings is not None:
+            print(f"  Comm savings: {best_savings:.1f}% of comm_only time overlapped away")
+            target_met = best_savings >= args.comm_savings_target_pct
+            print(f"  Comm savings target (>{args.comm_savings_target_pct}%): {'ACHIEVED ✓' if target_met else 'NOT ACHIEVED'}")
+    else:
+        print("\nNo passing version found — all versions failed correctness.")
+        print("Recommendation: manual debugging required; do NOT proceed to integration.")
+
+    # Generate summary file if requested
+    if args.output_summary:
+        summary = generate_summary(results, best, args.comm_savings_target_pct,
+                                   args.max_iterations, args.kernel_name, args.results_dir)
+        summary_path = os.path.join(args.results_dir, f"{args.kernel_name}_perf_summary.json")
+        with open(summary_path, "w") as f:
+            json.dump(summary, f, indent=2)
+        print(f"\nSummary written to: {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/overlap/fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py
+++ b/benchmark/kernels/overlap/fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py
@@ -4,8 +4,9 @@ Fused TopK Reduce-Sum + Add Shared Expert Output + Reduce-Scatter Overlap Kernel
 Intra-SM Mode: compute and communication are fused into a single kernel.
 
 Compute:
-  1. topk_reduce_sum: sum routed expert outputs across topk dimension (with optional
-     gating weights)
+  1. topk_reduce_sum: sum routed expert outputs across topk dimension
+     (gating weights have already been applied by the expert GEMM kernels,
+      so only a plain sum is needed here)
   2. add shared_expert_output: element-wise add the shared expert output
 
 Communication:
@@ -21,9 +22,8 @@ Architecture:
   +---------------------------------------------------+
 
 Input shapes (per rank):
-  - expert_outputs:      [M, TOPK, N] or [M * TOPK, N]  (routed expert outputs)
-  - topk_weights:        [M, TOPK]                       (gate weights, optional)
-  - shared_expert_output: [M, N]                         (shared expert output)
+  - expert_outputs:       [M, TOPK, N] or [M * TOPK, N]  (routed expert outputs)
+  - shared_expert_output: [M, N]                          (shared expert output)
 
 Output shape (per rank):
   - output: [M_per_rank, N]  where M_per_rank = M // world_size
@@ -105,7 +105,7 @@ def _load_acquire(ptr):
         "=r, l",
         [ptr],
         dtype=tl.uint32,
-        is_pure=True,
+        is_pure=False,
         pack=1,
     )
 
@@ -355,8 +355,8 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter_kernel(
     # ---- input/output pointers ----
     expert_outputs_ptr,       # [M * TOPK, N] — flattened routed expert outputs
     shared_expert_ptr,        # [M, N]        — shared expert output
-    topk_weights_ptr,         # [M, TOPK]     — gate weights (dummy if HAS_WEIGHTS=False)
     output_ptr,               # [M_per_rank, N] — reduce-scatter output (written by host-side torch.sum)
+    routed_scaling_factor,    # scalar float — applied after topk reduce-sum
     # ---- symmetric buffer pointer arrays ----
     buf_ptrs,                 # [world_size], int64
     # ---- sync ----
@@ -370,8 +370,6 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter_kernel(
     stride_xn: tl.constexpr,      # expert_outputs col stride
     stride_shared_m: tl.constexpr,  # shared_expert row stride
     stride_shared_n: tl.constexpr,  # shared_expert col stride
-    stride_wm: tl.constexpr,      # topk_weights row stride
-    stride_wk: tl.constexpr,      # topk_weights expert stride
     stride_buf_m: tl.constexpr,   # symm_buffer row stride
     stride_buf_n: tl.constexpr,   # symm_buffer col stride
     # ---- distributed (constexpr) ----
@@ -383,14 +381,14 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter_kernel(
     N_CHUNKS: tl.constexpr,       # number of chunks along N dimension
     TOPK: tl.constexpr,           # compile-time topk for full unrolling
     DTYPE: tl.constexpr,          # output dtype (tl.bfloat16 or tl.float16)
-    HAS_WEIGHTS: tl.constexpr,    # whether to use gating weights
 ):
     """
     Fused kernel: topk_reduce_sum + add shared_expert_output + reduce-scatter (A2A push).
 
     Phase 1: Each CTA (persistent) iterates over tiles for all destination peers.
              For each tile:
-               a) Load expert_outputs, reduce across TOPK dimension (weighted or unweighted)
+               a) Load expert_outputs, reduce across TOPK dimension (plain sum),
+                  then multiply by routed_scaling_factor
                b) Load and add shared_expert_output
                c) Push the result to the destination peer's symmetric buffer
     Phase 2: Grid barrier + cross-rank barrier
@@ -442,25 +440,12 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter_kernel(
                             + offs_n[None, :].to(tl.int64) * stride_xn)
             expert_ptrs = expert_outputs_ptr + n_chunk_off_x + base_row_off
 
-            if HAS_WEIGHTS:
-                # Weighted accumulation: accum += weight_k * expert_k
-                accum = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-                for k in tl.static_range(0, TOPK):
-                    expert_val = tl.load(expert_ptrs + k * stride_xm,
-                                         mask=mask, other=0.0).to(tl.float32)
-                    weight_k = tl.load(
-                        topk_weights_ptr
-                        + global_row.to(tl.int64)[:, None] * stride_wm
-                        + k * stride_wk,
-                        mask=mask_m[:, None], other=0.0,
-                    ).to(tl.float32)
-                    accum += weight_k * expert_val
-            else:
-                # Unweighted sum: accum = sum over experts
-                accum = tl.load(expert_ptrs, mask=mask, other=0.0).to(tl.float32)
-                for k in tl.static_range(1, TOPK):
-                    accum += tl.load(expert_ptrs + k * stride_xm,
-                                     mask=mask, other=0.0).to(tl.float32)
+            # Sum across TOPK dimension (gating weights already applied upstream)
+            accum = tl.load(expert_ptrs, mask=mask, other=0.0).to(tl.float32)
+            for k in tl.static_range(1, TOPK):
+                accum += tl.load(expert_ptrs + k * stride_xm,
+                                 mask=mask, other=0.0).to(tl.float32)
+            accum = accum * routed_scaling_factor
 
             # --- Add shared expert output ---
             shared_row_off = (global_row.to(tl.int64)[:, None] * stride_shared_m
@@ -509,7 +494,7 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter(
     ctx: TopkRsSOverlapContext,
     expert_outputs: torch.Tensor,
     shared_expert_output: torch.Tensor,
-    topk_weights: Optional[torch.Tensor] = None,
+    routed_scaling_factor: float = 1.0,
     output: Optional[torch.Tensor] = None,
     block_m: Optional[int] = None,
     block_n: Optional[int] = None,
@@ -525,7 +510,7 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter(
         ctx:           pre-allocated overlap context
         expert_outputs:  routed expert outputs, shape [M, TOPK, N] or [M*TOPK, N]
         shared_expert_output: shared expert output, shape [M, N]
-        topk_weights:    gate weights, shape [M, TOPK], or None for unweighted sum
+        routed_scaling_factor: scalar applied after topk reduce-sum (default 1.0)
         output:          pre-allocated output tensor [M_per_rank, N], or None
         block_m:         tile size in M dimension (auto-computed if None)
         block_n:         tile size in N dimension (auto-computed if None)
@@ -571,11 +556,6 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter(
 
     # Resolve dtype
     DTYPE = tl.bfloat16 if x_flat.dtype == torch.bfloat16 else tl.float16
-    HAS_WEIGHTS = topk_weights is not None
-
-    # If no weights provided, use a dummy (won't be accessed by the kernel)
-    if topk_weights is None:
-        topk_weights = x_flat  # dummy — HAS_WEIGHTS=False ensures it's never loaded
 
     # Allocate output
     if output is None:
@@ -591,7 +571,15 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter(
     num_tiles_n = triton.cdiv(N_per_chunk, block_n)
     blocks_per_rank = num_tiles_m * num_tiles_n
     total_tiles = ctx.num_ranks * blocks_per_rank
-    num_ctas = min(total_tiles, 256)  # cap CTAs to avoid launch overhead
+    # Cap CTAs to SM count — this is a persistent kernel with a grid barrier,
+    # so ALL CTAs must be concurrently resident on SMs to avoid scheduling
+    # deadlock.  is_pure=False on _load_acquire increases register pressure,
+    # which can reduce occupancy to 1 CTA/SM; if num_ctas > SMs, later CTAs
+    # cannot be scheduled and the barrier deadlocks.
+    num_sm = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).multi_processor_count
+    num_ctas = min(total_tiles, num_sm)
 
     grid = (num_ctas,)
 
@@ -599,8 +587,8 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter(
     fused_topk_reduce_sum_add_shared_reduce_scatter_kernel[grid](
         x_flat,
         shared_expert_output,
-        topk_weights,
         output,
+        routed_scaling_factor,
         ctx.buf_ptrs,
         ctx.grid_barrier,
         ctx.signal_pad_ptrs,
@@ -609,8 +597,6 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter(
         stride_xn=x_flat.stride(1),
         stride_shared_m=shared_expert_output.stride(0),
         stride_shared_n=shared_expert_output.stride(1),
-        stride_wm=topk_weights.stride(0),
-        stride_wk=topk_weights.stride(1),
         stride_buf_m=ctx.symm_buffer.stride(0),
         stride_buf_n=ctx.symm_buffer.stride(1),
         rank=ctx.rank,
@@ -620,7 +606,6 @@ def fused_topk_reduce_sum_add_shared_reduce_scatter(
         N_CHUNKS=n_chunks,
         TOPK=topk,
         DTYPE=DTYPE,
-        HAS_WEIGHTS=HAS_WEIGHTS,
         num_warps=num_warps,
         num_stages=num_stages,
     )

--- a/benchmark/kernels/overlap/fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py
+++ b/benchmark/kernels/overlap/fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py
@@ -1,0 +1,637 @@
+"""
+Fused TopK Reduce-Sum + Add Shared Expert Output + Reduce-Scatter Overlap Kernel
+================================================================================
+Intra-SM Mode: compute and communication are fused into a single kernel.
+
+Compute:
+  1. topk_reduce_sum: sum routed expert outputs across topk dimension (with optional
+     gating weights)
+  2. add shared_expert_output: element-wise add the shared expert output
+
+Communication:
+  reduce-scatter: distribute the combined result across ranks
+
+Architecture:
+  Single Kernel (one CTA per tile, persistent loop over all tiles)
+  +---------------------------------------------------+
+  | Phase 1: Compute (topk reduce-sum + add shared)   |
+  |          + A2A push to peer symmetric buffers      |
+  | Phase 2: CTA-grid barrier + cross-rank barrier    |
+  | Phase 3: Local reduce (host-side torch.sum)       |
+  +---------------------------------------------------+
+
+Input shapes (per rank):
+  - expert_outputs:      [M, TOPK, N] or [M * TOPK, N]  (routed expert outputs)
+  - topk_weights:        [M, TOPK]                       (gate weights, optional)
+  - shared_expert_output: [M, N]                         (shared expert output)
+
+Output shape (per rank):
+  - output: [M_per_rank, N]  where M_per_rank = M // world_size
+
+Symmetric memory layout (per rank):
+  - [M, N]  (= [world_size * M_per_rank, N])
+    Each source rank i writes its segment into rows
+    [i * M_per_rank : (i+1) * M_per_rank] of the destination rank's buffer.
+"""
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+import triton
+import triton.language as tl
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ===========================================================================
+# Section 1: PTX Instruction Primitives
+# ===========================================================================
+
+@triton.jit
+def _get_flat_tid():
+    """Flattened thread index within the CTA."""
+    tid_x, tid_y, tid_z = tl.inline_asm_elementwise(
+        "mov.u32 $0, %tid.x; mov.u32 $1, %tid.y; mov.u32 $2, %tid.z;",
+        "=r,=r,=r", [], dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True, pack=1,
+    )
+    ntid_x, ntid_y, _ = tl.inline_asm_elementwise(
+        "mov.u32 $0, %ntid.x; mov.u32 $1, %ntid.y; mov.u32 $2, %ntid.z;",
+        "=r,=r,=r", [], dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True, pack=1,
+    )
+    return tid_z * ntid_y * ntid_x + tid_y * ntid_x + tid_x
+
+
+@triton.jit
+def _get_flat_bid():
+    """Flattened CTA index within the grid."""
+    return (
+        tl.program_id(2) * tl.num_programs(1) * tl.num_programs(0)
+        + tl.program_id(1) * tl.num_programs(0)
+        + tl.program_id(0)
+    )
+
+
+@triton.jit
+def _atomic_add_release(ptr, val):
+    """GPU-scope release atomic add (u32)."""
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32 %inc;
+            atom.global.release.gpu.add.u32 %inc, [$1], $2;
+        }
+        """,
+        "=r, l, r",
+        [ptr, tl.cast(val, tl.uint32)],
+        dtype=tl.uint32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _load_acquire(ptr):
+    """GPU-scope acquire load (u32)."""
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32 %val;
+            ld.global.acquire.gpu.u32 %val, [$1];
+            mov.u32 $0, %val;
+        }
+        """,
+        "=r, l",
+        [ptr],
+        dtype=tl.uint32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _store_release_with_highbit(ptr, expected):
+    """Store expected | 0x80000000 with GPU-scope release."""
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32 %mask, %val;
+            mov.u32  %mask, 0x80000000;
+            or.b32   %val, %mask, $2;
+            st.global.release.gpu.u32 [$1], %val;
+        }
+        """,
+        "=r, l, r",
+        [ptr, tl.cast(expected, tl.uint32)],
+        dtype=tl.uint32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _cas_sys_release(addrs, expected, desired):
+    """System-scope release CAS with PTX-level spin-loop."""
+    return tl.inline_asm_elementwise(
+        f"""
+        {{
+            .reg .u32   %tmp32_<1>;
+            .reg .pred  %p<1>;
+            cas_loop:
+                atom.global.release.sys.cas.b32 %tmp32_0, [$1], {expected}, {desired};
+                setp.eq.u32 %p0, %tmp32_0, {expected};
+                @!%p0 bra cas_loop;
+            mov.u32 $0, %tmp32_0;
+        }}
+        """,
+        "=r, l",
+        [addrs],
+        dtype=addrs.dtype,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _cas_sys_acquire(addrs, expected, desired):
+    """System-scope acquire CAS with PTX-level spin-loop."""
+    return tl.inline_asm_elementwise(
+        f"""
+        {{
+            .reg .u32   %tmp32_<1>;
+            .reg .pred  %p<1>;
+            cas_loop:
+                atom.global.acquire.sys.cas.b32 %tmp32_0, [$1], {expected}, {desired};
+                setp.eq.u32 %p0, %tmp32_0, {expected};
+                @!%p0 bra cas_loop;
+            mov.u32 $0, %tmp32_0;
+        }}
+        """,
+        "=r, l",
+        [addrs],
+        dtype=addrs.dtype,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def barrier_on_this_grid(barrier_ptr):
+    """CTA-grid barrier using master-CTA pattern (primitives.md S5.2).
+
+    All CTAs increment a counter; bid==0 spins until all arrive,
+    then flips the high bit to release everyone.
+    Host must zero the counter before each kernel launch.
+    """
+    expected = tl.num_programs(0) * tl.num_programs(1) * tl.num_programs(2)
+
+    if _get_flat_tid() == 0:
+        _atomic_add_release(barrier_ptr, 1)
+        if _get_flat_bid() == 0:
+            # Master CTA: spin until all CTAs have arrived
+            while _load_acquire(barrier_ptr) != expected:
+                pass
+            _store_release_with_highbit(barrier_ptr, expected)
+        else:
+            # Other CTAs: spin until the high bit is set
+            while (_load_acquire(barrier_ptr) & 0x80000000) == 0:
+                pass
+
+    tl.debug_barrier()
+
+
+@triton.jit
+def barrier_all_intra_node_atomic_cas_block(
+    local_rank: tl.constexpr,
+    rank: tl.constexpr,
+    local_world_size: tl.constexpr,
+    symm_flag_ptr,
+):
+    """Cross-rank barrier via system-scope CAS on symmetric-memory signal pads.
+
+    Phase 1: each thread (tid < world_size) signals one peer with CAS(0->1).
+    Phase 2: each thread waits for its peer's signal with CAS(1->0).
+    Self-resetting: no host-side reset needed between iterations.
+    """
+    flat_tid = _get_flat_tid()
+    local_rank_offset = rank - local_rank
+
+    ptrs = symm_flag_ptr.to(tl.pointer_type(tl.uint64))
+
+    # Phase 1: each thread with tid < world_size signals one peer (parallel)
+    if flat_tid < local_world_size:
+        peer = flat_tid + local_rank_offset
+        remote_base = tl.load(ptrs + peer).to(tl.pointer_type(tl.uint32))
+        remote_addr = remote_base + local_rank
+        _cas_sys_release(remote_addr, 0, 1)
+
+    # Phase 2: each thread waits for its corresponding peer's signal (parallel)
+    if flat_tid < local_world_size:
+        local_base = tl.load(ptrs + rank).to(tl.pointer_type(tl.uint32))
+        local_addr = local_base + flat_tid
+        _cas_sys_acquire(local_addr, 1, 0)
+
+    tl.debug_barrier()
+
+
+# ===========================================================================
+# Section 2: Context Dataclass & Initialization
+# ===========================================================================
+
+@dataclass
+class TopkRsSOverlapContext:
+    """
+    Pre-allocated state for the TopK Reduce-Sum + Add Shared + Reduce-Scatter
+    overlap kernel.
+
+    Holds symmetric memory buffers, signal pads, and local sync primitives.
+    Reusable across multiple kernel invocations (only barrier zero-out needed
+    between calls).
+    """
+    # Problem dimensions
+    max_M: int
+    N: int
+    topk: int
+    dtype: torch.dtype
+
+    # Distributed info
+    rank: int
+    num_ranks: int
+    num_local_ranks: int
+
+    # Local sync primitives
+    grid_barrier: torch.Tensor  # [1], int32
+
+    # Symmetric memory (set in __post_init__)
+    symm_mem_hdl: Optional[object] = field(default=None, init=False)
+    symm_buffer: Optional[torch.Tensor] = field(default=None, init=False)
+    buf_ptrs: Optional[torch.Tensor] = field(default=None, init=False)          # [num_ranks], int64
+    signal_pad_ptrs: Optional[torch.Tensor] = field(default=None, init=False)   # [num_ranks], int64
+
+    def __post_init__(self):
+        device = torch.cuda.current_device()
+        world_size = self.num_ranks
+
+        # Allocate symmetric buffer: [M, N] per rank for reduce-scatter
+        # Each rank's buffer receives one M_per_rank-row segment from each source rank
+        buf = symm_mem.empty(
+            (self.max_M, self.N),
+            dtype=self.dtype,
+            device=device,
+        )
+        hdl = symm_mem.rendezvous(buf, group=dist.group.WORLD)
+        self.symm_mem_hdl = hdl
+        self.symm_buffer = buf
+
+        # Build per-rank buffer pointer array (int64) for Triton dynamic indexing
+        self.buf_ptrs = torch.tensor(
+            [hdl.get_buffer(r, sizes=(self.max_M, self.N), dtype=self.dtype,
+                            storage_offset=0).data_ptr()
+             for r in range(world_size)],
+            dtype=torch.int64, device=device,
+        )
+
+        # Build per-rank signal pad pointer array (int64)
+        self.signal_pad_ptrs = torch.tensor(
+            [hdl.get_signal_pad(r, (world_size,), torch.int32).data_ptr()
+             for r in range(world_size)],
+            dtype=torch.int64, device=device,
+        )
+
+        dist.barrier()
+
+    def finalize(self):
+        """Release symmetric memory resources."""
+        dist.barrier()
+        self.symm_mem_hdl = None
+        self.symm_buffer = None
+        self.buf_ptrs = None
+        self.signal_pad_ptrs = None
+
+
+def create_topk_rss_overlap_context(
+    max_M: int,
+    N: int,
+    topk: int,
+    dtype: torch.dtype = torch.bfloat16,
+) -> TopkRsSOverlapContext:
+    """Factory: allocate local tensors, construct and return context.
+
+    Must be called after ``dist.init_process_group``.
+    ``max_M`` is the maximum total token count (same across all ranks).
+    Must be divisible by ``world_size``.
+    ``N`` is the hidden dimension and must be divisible by ``n_chunks`` (default 2).
+    """
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_world_size = world_size  # assuming single-node
+
+    assert max_M % world_size == 0, (
+        f"max_M ({max_M}) must be divisible by world_size ({world_size})"
+    )
+
+    device = torch.cuda.current_device()
+    grid_barrier = torch.zeros((1,), dtype=torch.int32, device=device)
+
+    return TopkRsSOverlapContext(
+        max_M=max_M,
+        N=N,
+        topk=topk,
+        dtype=dtype,
+        rank=rank,
+        num_ranks=world_size,
+        num_local_ranks=local_world_size,
+        grid_barrier=grid_barrier,
+    )
+
+
+# ===========================================================================
+# Section 3: Triton Kernel Implementation
+# ===========================================================================
+
+@triton.jit
+def fused_topk_reduce_sum_add_shared_reduce_scatter_kernel(
+    # ---- input/output pointers ----
+    expert_outputs_ptr,       # [M * TOPK, N] — flattened routed expert outputs
+    shared_expert_ptr,        # [M, N]        — shared expert output
+    topk_weights_ptr,         # [M, TOPK]     — gate weights (dummy if HAS_WEIGHTS=False)
+    output_ptr,               # [M_per_rank, N] — reduce-scatter output (written by host-side torch.sum)
+    # ---- symmetric buffer pointer arrays ----
+    buf_ptrs,                 # [world_size], int64
+    # ---- sync ----
+    grid_barrier_ptr,         # [1], int32
+    signal_pad_ptrs,          # [world_size], int64
+    # ---- problem sizes (runtime) ----
+    M,                        # total token count (same across all ranks)
+    N,
+    # ---- strides (constexpr) ----
+    stride_xm: tl.constexpr,      # expert_outputs row stride (in [M*TOPK, N] layout)
+    stride_xn: tl.constexpr,      # expert_outputs col stride
+    stride_shared_m: tl.constexpr,  # shared_expert row stride
+    stride_shared_n: tl.constexpr,  # shared_expert col stride
+    stride_wm: tl.constexpr,      # topk_weights row stride
+    stride_wk: tl.constexpr,      # topk_weights expert stride
+    stride_buf_m: tl.constexpr,   # symm_buffer row stride
+    stride_buf_n: tl.constexpr,   # symm_buffer col stride
+    # ---- distributed (constexpr) ----
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+    # ---- tile sizes (constexpr) ----
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    N_CHUNKS: tl.constexpr,       # number of chunks along N dimension
+    TOPK: tl.constexpr,           # compile-time topk for full unrolling
+    DTYPE: tl.constexpr,          # output dtype (tl.bfloat16 or tl.float16)
+    HAS_WEIGHTS: tl.constexpr,    # whether to use gating weights
+):
+    """
+    Fused kernel: topk_reduce_sum + add shared_expert_output + reduce-scatter (A2A push).
+
+    Phase 1: Each CTA (persistent) iterates over tiles for all destination peers.
+             For each tile:
+               a) Load expert_outputs, reduce across TOPK dimension (weighted or unweighted)
+               b) Load and add shared_expert_output
+               c) Push the result to the destination peer's symmetric buffer
+    Phase 2: Grid barrier + cross-rank barrier
+    Phase 3: Local reduce is done on the host side via torch.sum
+    """
+    pid = tl.program_id(0)
+    npid = tl.num_programs(0)
+
+    M_per_rank = M // world_size
+    N_per_chunk = N // N_CHUNKS
+    N_per_chunk = tl.multiple_of(N_per_chunk, 16)  # alignment hint for vectorized loads
+
+    num_tiles_m = tl.cdiv(M_per_rank, BLOCK_M)
+    num_tiles_n = tl.cdiv(N_per_chunk, BLOCK_N)
+    blocks_per_rank = num_tiles_m * num_tiles_n
+
+    # Pre-compute destination segment offset: this rank writes at
+    # offset rank * M_per_rank in the peer's buffer (int64 for overflow safety)
+    dst_segment_offset = tl.cast(M_per_rank, tl.int64) * stride_buf_m * rank
+
+    # === Phase 1: Compute (topk reduce-sum + add shared) + A2A push ===
+    for n_chunk in tl.range(0, N_CHUNKS, step=1, loop_unroll_factor=1):
+        n_chunk_off_x = n_chunk * N_per_chunk * stride_xn
+        n_chunk_off_shared = n_chunk * N_per_chunk * stride_shared_n
+        n_chunk_off_buf = n_chunk * N_per_chunk * stride_buf_n
+
+        total_tiles = world_size * blocks_per_rank
+
+        for tile_id in range(pid, total_tiles, npid):
+            peer = tile_id // blocks_per_rank
+            bid = tile_id % blocks_per_rank
+            bid_m = bid // num_tiles_n
+            bid_n = bid % num_tiles_n
+
+            offs_m = bid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+            offs_n = bid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+            mask_m = offs_m < M_per_rank
+            mask_n = offs_n < N_per_chunk
+            mask = mask_m[:, None] & mask_n[None, :]
+
+            # Global row index: peer p's segment starts at peer * M_per_rank
+            global_row = peer * M_per_rank + offs_m  # [BLOCK_M]
+
+            # --- Load expert outputs and reduce across TOPK ---
+            # Input layout: [M * TOPK, N]
+            # For token at global_row r, expert k: row = r * TOPK + k
+            # Base pointer for the first expert of each token in this tile:
+            base_row_off = (global_row.to(tl.int64)[:, None] * TOPK * stride_xm
+                            + offs_n[None, :].to(tl.int64) * stride_xn)
+            expert_ptrs = expert_outputs_ptr + n_chunk_off_x + base_row_off
+
+            if HAS_WEIGHTS:
+                # Weighted accumulation: accum += weight_k * expert_k
+                accum = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+                for k in tl.static_range(0, TOPK):
+                    expert_val = tl.load(expert_ptrs + k * stride_xm,
+                                         mask=mask, other=0.0).to(tl.float32)
+                    weight_k = tl.load(
+                        topk_weights_ptr
+                        + global_row.to(tl.int64)[:, None] * stride_wm
+                        + k * stride_wk,
+                        mask=mask_m[:, None], other=0.0,
+                    ).to(tl.float32)
+                    accum += weight_k * expert_val
+            else:
+                # Unweighted sum: accum = sum over experts
+                accum = tl.load(expert_ptrs, mask=mask, other=0.0).to(tl.float32)
+                for k in tl.static_range(1, TOPK):
+                    accum += tl.load(expert_ptrs + k * stride_xm,
+                                     mask=mask, other=0.0).to(tl.float32)
+
+            # --- Add shared expert output ---
+            shared_row_off = (global_row.to(tl.int64)[:, None] * stride_shared_m
+                              + offs_n[None, :].to(tl.int64) * stride_shared_n)
+            shared_ptrs = shared_expert_ptr + n_chunk_off_shared + shared_row_off
+            shared_val = tl.load(shared_ptrs, mask=mask, other=0.0).to(tl.float32)
+            accum += shared_val
+
+            # --- Push to peer's symmetric buffer ---
+            # In peer's buffer, this rank (source) writes at offset
+            # rank * M_per_rank (the segment belonging to this source)
+            peer_buf = tl.load(buf_ptrs + peer).to(tl.pointer_type(DTYPE))
+            peer_buf = tl.multiple_of(peer_buf, 16)  # enable vectorized stores
+            dst_ptrs = (peer_buf
+                        + n_chunk_off_buf
+                        + dst_segment_offset
+                        + offs_m[:, None].to(tl.int64) * stride_buf_m
+                        + offs_n[None, :].to(tl.int64) * stride_buf_n)
+            tl.store(dst_ptrs, accum.to(DTYPE), mask=mask)
+
+    # === Phase 2: Synchronize ===
+    # Grid barrier: all CTAs on this device must finish pushing (primitives.md S5.2)
+    barrier_on_this_grid(grid_barrier_ptr)
+    # Cross-rank barrier: only CTA 0 participates -- the signal pad slots are
+    # binary (0<->1) and can only track one barrier invocation per rank pair.
+    # If all CTAs called this, multiple CTAs' threads would CAS-contend on the
+    # same slot, causing deadlock (primitives.md S5.3).
+    if pid == 0:
+        barrier_all_intra_node_atomic_cas_block(
+            rank, rank, world_size, signal_pad_ptrs,
+        )
+
+
+# ===========================================================================
+# Section 4: Python Entry Point
+# ===========================================================================
+
+def _next_power_of_2(n: int) -> int:
+    """Return the smallest power of 2 >= n."""
+    if n <= 0:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+def fused_topk_reduce_sum_add_shared_reduce_scatter(
+    ctx: TopkRsSOverlapContext,
+    expert_outputs: torch.Tensor,
+    shared_expert_output: torch.Tensor,
+    topk_weights: Optional[torch.Tensor] = None,
+    output: Optional[torch.Tensor] = None,
+    block_m: Optional[int] = None,
+    block_n: Optional[int] = None,
+    num_warps: int = 32,
+    num_stages: int = 1,
+    n_chunks: int = 2,
+) -> torch.Tensor:
+    """
+    Host-side launcher for the fused topk_reduce_sum + add_shared + reduce_scatter
+    overlap kernel (intra-SM mode).
+
+    Args:
+        ctx:           pre-allocated overlap context
+        expert_outputs:  routed expert outputs, shape [M, TOPK, N] or [M*TOPK, N]
+        shared_expert_output: shared expert output, shape [M, N]
+        topk_weights:    gate weights, shape [M, TOPK], or None for unweighted sum
+        output:          pre-allocated output tensor [M_per_rank, N], or None
+        block_m:         tile size in M dimension (auto-computed if None)
+        block_n:         tile size in N dimension (auto-computed if None)
+        num_warps:       warps per CTA (default: 32 for memory-bound workload)
+        num_stages:      pipeline stages (default: 1)
+        n_chunks:        number of chunks along N dimension (default: 2)
+
+    Returns:
+        output tensor of shape [M_per_rank, N]
+    """
+    # Flatten input if 3D
+    if expert_outputs.ndim == 3:
+        M, topk, N = expert_outputs.shape
+        x_flat = expert_outputs.view(M * topk, N)
+    elif expert_outputs.ndim == 2:
+        M_topk, N = expert_outputs.shape
+        topk = ctx.topk
+        M = M_topk // topk
+        x_flat = expert_outputs
+    else:
+        raise ValueError(f"expert_outputs must be 2D or 3D, got {expert_outputs.ndim}D")
+
+    assert topk == ctx.topk, f"topk mismatch: got {topk}, expected {ctx.topk}"
+    assert M % ctx.num_ranks == 0, (
+        f"M ({M}) must be divisible by world_size ({ctx.num_ranks})"
+    )
+    assert N == ctx.N, f"N mismatch: got {N}, expected {ctx.N}"
+    assert M <= ctx.max_M, f"M ({M}) exceeds max_M ({ctx.max_M})"
+    assert N % n_chunks == 0, f"N ({N}) must be divisible by n_chunks ({n_chunks})"
+
+    M_per_rank = M // ctx.num_ranks
+    N_per_chunk = N // n_chunks
+
+    # Auto-compute block sizes
+    elem_size = x_flat.element_size()
+    if block_n is None:
+        block_n = _next_power_of_2(N_per_chunk)
+    if block_m is None:
+        block_m = _next_power_of_2(16 * 1024 // block_n // elem_size)
+    # Cap block sizes to avoid excessive register pressure
+    block_m = min(block_m, 128)
+    block_n = min(block_n, 512)
+
+    # Resolve dtype
+    DTYPE = tl.bfloat16 if x_flat.dtype == torch.bfloat16 else tl.float16
+    HAS_WEIGHTS = topk_weights is not None
+
+    # If no weights provided, use a dummy (won't be accessed by the kernel)
+    if topk_weights is None:
+        topk_weights = x_flat  # dummy — HAS_WEIGHTS=False ensures it's never loaded
+
+    # Allocate output
+    if output is None:
+        output = torch.empty(
+            (M_per_rank, N), dtype=x_flat.dtype, device=x_flat.device,
+        )
+
+    # Reset sync tensors (must be 0 before each launch)
+    ctx.grid_barrier.zero_()
+
+    # Compute grid dimensions
+    num_tiles_m = triton.cdiv(M_per_rank, block_m)
+    num_tiles_n = triton.cdiv(N_per_chunk, block_n)
+    blocks_per_rank = num_tiles_m * num_tiles_n
+    total_tiles = ctx.num_ranks * blocks_per_rank
+    num_ctas = min(total_tiles, 256)  # cap CTAs to avoid launch overhead
+
+    grid = (num_ctas,)
+
+    # Launch kernel
+    fused_topk_reduce_sum_add_shared_reduce_scatter_kernel[grid](
+        x_flat,
+        shared_expert_output,
+        topk_weights,
+        output,
+        ctx.buf_ptrs,
+        ctx.grid_barrier,
+        ctx.signal_pad_ptrs,
+        M, N,
+        stride_xm=x_flat.stride(0),
+        stride_xn=x_flat.stride(1),
+        stride_shared_m=shared_expert_output.stride(0),
+        stride_shared_n=shared_expert_output.stride(1),
+        stride_wm=topk_weights.stride(0),
+        stride_wk=topk_weights.stride(1),
+        stride_buf_m=ctx.symm_buffer.stride(0),
+        stride_buf_n=ctx.symm_buffer.stride(1),
+        rank=ctx.rank,
+        world_size=ctx.num_ranks,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        N_CHUNKS=n_chunks,
+        TOPK=topk,
+        DTYPE=DTYPE,
+        HAS_WEIGHTS=HAS_WEIGHTS,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+    # Phase 3: Local reduce — sum across source ranks in symmetric buffer
+    # Buffer layout: [M, N] = [world_size * M_per_rank, N]
+    # Rows [i * M_per_rank : (i+1) * M_per_rank] contain source rank i's contribution
+    torch.sum(
+        ctx.symm_buffer[:M].view(ctx.num_ranks, M_per_rank, N),
+        dim=0,
+        out=output,
+    )
+
+    return output

--- a/benchmark/kernels/overlap/test_fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py
+++ b/benchmark/kernels/overlap/test_fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py
@@ -1,0 +1,504 @@
+"""
+Test & Benchmark for Fused TopK Reduce-Sum + Add Shared + Reduce-Scatter Overlap Kernel
+========================================================================================
+
+Four test modes:
+  1. correctness  — verify overlap kernel output matches reference (PyTorch + NCCL)
+  2. performance  — benchmark compute-only, comm-only, non-overlap, and overlap
+  3. multi_size   — correctness sweep across problem shapes and dtypes
+  4. stability    — repeated correctness checks to catch intermittent hang/failures
+
+Usage:
+    # Correctness test (2 GPUs)
+    torchrun --nproc_per_node=2 test_fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py --case correctness
+
+    # Performance benchmark
+    torchrun --nproc_per_node=2 test_fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py --case performance
+
+    # Multi-size sweep
+    torchrun --nproc_per_node=2 test_fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py --case multi_size
+
+    # Stability (hang detection)
+    torchrun --nproc_per_node=2 test_fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py --case stability
+"""
+
+import argparse
+import os
+import time
+import torch
+import torch.distributed as dist
+
+from fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm import (
+    TopkRsSOverlapContext,
+    create_topk_rss_overlap_context,
+    fused_topk_reduce_sum_add_shared_reduce_scatter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Distributed Initialization
+# ---------------------------------------------------------------------------
+
+def initialize_distributed():
+    """Initialize distributed environment."""
+    RANK = int(os.environ.get("RANK", 0))
+    LOCAL_RANK = int(os.environ.get("LOCAL_RANK", 0))
+    WORLD_SIZE = int(os.environ.get("WORLD_SIZE", 1))
+    LOCAL_WORLD_SIZE = int(os.environ.get("LOCAL_WORLD_SIZE", 1))
+
+    torch.cuda.set_device(LOCAL_RANK)
+
+    dist.init_process_group(
+        backend="nccl",
+        world_size=WORLD_SIZE,
+        rank=RANK,
+        device_id=torch.device(f"cuda:{LOCAL_RANK}"),
+    )
+    assert dist.is_initialized()
+
+    tp_group = dist.new_group(ranks=list(range(WORLD_SIZE)), backend="nccl")
+    dist.barrier(tp_group)
+
+    return RANK, LOCAL_RANK, WORLD_SIZE, LOCAL_WORLD_SIZE, tp_group
+
+
+# ---------------------------------------------------------------------------
+# Precision Check
+# ---------------------------------------------------------------------------
+
+def calc_diff(x: torch.Tensor, y: torch.Tensor) -> float:
+    """Cosine-similarity based diff metric. Threshold: < 0.001."""
+    x, y = x.double(), y.double()
+    denominator = (x * x + y * y).sum()
+    if denominator == 0:
+        return 0.0
+    sim = 2 * (x * y).sum() / denominator
+    return (1 - sim).item()
+
+
+# ---------------------------------------------------------------------------
+# Reference Implementation
+# ---------------------------------------------------------------------------
+
+def reference_topk_rss(
+    expert_outputs: torch.Tensor,
+    shared_expert_output: torch.Tensor,
+    topk_weights: torch.Tensor | None,
+    pg,
+) -> torch.Tensor:
+    """
+    Reference implementation using standard PyTorch ops + NCCL reduce-scatter.
+
+    Args:
+        expert_outputs: [M, TOPK, N] routed expert outputs
+        shared_expert_output: [M, N] shared expert output
+        topk_weights: [M, TOPK] gate weights, or None (unweighted sum)
+        pg: process group for reduce-scatter
+
+    Returns:
+        [M_per_rank, N] reduced and scattered output
+    """
+    M, topk, N = expert_outputs.shape
+
+    # topk reduce-sum
+    if topk_weights is not None:
+        result = (expert_outputs * topk_weights[:, :, None]).sum(dim=1)
+    else:
+        result = expert_outputs.sum(dim=1)
+
+    # add shared expert output
+    result = result + shared_expert_output
+
+    # reduce-scatter
+    world_size = dist.get_world_size(pg)
+    M_per_rank = M // world_size
+    output = torch.empty(
+        (M_per_rank, N), dtype=result.dtype, device=result.device,
+    )
+    dist.reduce_scatter_tensor(output, result, op=dist.ReduceOp.SUM, group=pg)
+
+    return output
+
+
+def compute_only(
+    expert_outputs: torch.Tensor,
+    shared_expert_output: torch.Tensor,
+    topk_weights: torch.Tensor | None,
+) -> torch.Tensor:
+    """Standalone compute: topk_reduce_sum + add shared expert output (no comm)."""
+    if topk_weights is not None:
+        result = (expert_outputs * topk_weights[:, :, None]).sum(dim=1)
+    else:
+        result = expert_outputs.sum(dim=1)
+    return result + shared_expert_output
+
+
+def comm_only(tensor: torch.Tensor, output: torch.Tensor, pg) -> torch.Tensor:
+    """Standalone communication: NCCL reduce-scatter only."""
+    dist.reduce_scatter_tensor(output, tensor, op=dist.ReduceOp.SUM, group=pg)
+    return output
+
+
+def non_overlap(
+    expert_outputs: torch.Tensor,
+    shared_expert_output: torch.Tensor,
+    topk_weights: torch.Tensor | None,
+    output: torch.Tensor,
+    pg,
+) -> torch.Tensor:
+    """Non-overlap: compute + comm sequentially (no overlap)."""
+    result = compute_only(expert_outputs, shared_expert_output, topk_weights)
+    dist.reduce_scatter_tensor(output, result, op=dist.ReduceOp.SUM, group=pg)
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Performance Measurement
+# ---------------------------------------------------------------------------
+
+def perf_func(func, warmup_iters=10, iters=100, *args, **kwargs):
+    """Performance measurement: warmup then timed iterations."""
+    # Warmup
+    for _ in range(warmup_iters):
+        output = func(*args, **kwargs)
+
+    torch.cuda.synchronize()
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start_event.record()
+    for _ in range(iters):
+        output = func(*args, **kwargs)
+    end_event.record()
+
+    torch.cuda.synchronize()
+    duration_ms = start_event.elapsed_time(end_event) / iters
+
+    return output, duration_ms
+
+
+# ---------------------------------------------------------------------------
+# Test Cases
+# ---------------------------------------------------------------------------
+
+def test_correctness(args):
+    """
+    Verify overlap kernel output matches reference implementation.
+    Tests: overlap kernel vs NCCL reference.
+    """
+    rank, local_rank, world_size, local_world_size, pg = initialize_distributed()
+    torch.manual_seed(42 + rank)
+
+    M = args.M
+    N = args.N
+    topk = args.topk
+    dtype = getattr(torch, args.dtype)
+    has_weights = not args.no_weights
+
+    assert M % world_size == 0, f"M ({M}) must be divisible by world_size ({world_size})"
+
+    # Create context
+    ctx = create_topk_rss_overlap_context(
+        max_M=M, N=N, topk=topk, dtype=dtype,
+    )
+
+    # Generate random inputs
+    expert_outputs = torch.randn(M, topk, N, dtype=dtype, device=f"cuda:{local_rank}")
+    shared_expert_output = torch.randn(M, N, dtype=dtype, device=f"cuda:{local_rank}")
+    topk_weights = None
+    if has_weights:
+        topk_weights = torch.randn(M, topk, dtype=dtype, device=f"cuda:{local_rank}")
+
+    # Run overlap kernel
+    overlap_out = fused_topk_reduce_sum_add_shared_reduce_scatter(
+        ctx, expert_outputs, shared_expert_output, topk_weights,
+    )
+
+    # Run reference
+    ref_out = reference_topk_rss(expert_outputs, shared_expert_output, topk_weights, pg)
+
+    # Compare
+    torch.cuda.synchronize()
+    diff = calc_diff(overlap_out, ref_out)
+    max_diff = (overlap_out - ref_out).abs().max().item()
+    mean_diff = (overlap_out - ref_out).abs().mean().item()
+
+    if rank == 0:
+        rtol = 1e-2 if dtype == torch.bfloat16 else 1e-3
+        atol = 1e-2 if dtype == torch.bfloat16 else 1e-3
+        passed = diff < 0.001
+        status = "PASSED" if passed else "FAILED"
+        print(f"[Correctness] {status}")
+        print(f"  Config: M={M}, N={N}, topk={topk}, dtype={args.dtype}, "
+              f"world_size={world_size}, has_weights={has_weights}")
+        print(f"  cosine_diff={diff:.6f}, max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}")
+        if not passed:
+            print(f"  Expected (first row): {ref_out[0, :8]}")
+            print(f"  Got      (first row): {overlap_out[0, :8]}")
+
+    ctx.finalize()
+    dist.destroy_process_group()
+
+
+def test_performance(args):
+    """
+    Benchmark four implementations:
+    1. Compute-only: topk_reduce_sum + add shared (no comm)
+    2. Comm-only: NCCL reduce-scatter
+    3. Non-overlap: compute + comm sequentially
+    4. Overlap kernel: fused compute + comm
+
+    Reports latency (us) and speedup.
+    """
+    rank, local_rank, world_size, local_world_size, pg = initialize_distributed()
+    torch.manual_seed(42 + rank)
+
+    M = args.M
+    N = args.N
+    topk = args.topk
+    dtype = getattr(torch, args.dtype)
+    has_weights = not args.no_weights
+    warmup = args.warmup
+    iters = args.iters
+
+    assert M % world_size == 0, f"M ({M}) must be divisible by world_size ({world_size})"
+    M_per_rank = M // world_size
+
+    # Create context
+    ctx = create_topk_rss_overlap_context(
+        max_M=M, N=N, topk=topk, dtype=dtype,
+    )
+
+    # Generate inputs
+    expert_outputs = torch.randn(M, topk, N, dtype=dtype, device=f"cuda:{local_rank}")
+    shared_expert_output = torch.randn(M, N, dtype=dtype, device=f"cuda:{local_rank}")
+    topk_weights = None
+    if has_weights:
+        topk_weights = torch.randn(M, topk, dtype=dtype, device=f"cuda:{local_rank}")
+
+    # Pre-allocate comm-only tensors
+    compute_result = torch.randn(M, N, dtype=dtype, device=f"cuda:{local_rank}")
+    comm_output = torch.randn(M_per_rank, N, dtype=dtype, device=f"cuda:{local_rank}")
+    non_overlap_output = torch.randn(M_per_rank, N, dtype=dtype, device=f"cuda:{local_rank}")
+
+    # Data volume for bandwidth calculation
+    elem_bytes = expert_outputs.element_size()
+    input_bytes = M * topk * N * elem_bytes + M * N * elem_bytes  # expert_outputs + shared
+    output_bytes = M_per_rank * N * elem_bytes
+    comm_bytes = M * N * elem_bytes  # reduce-scatter input size
+
+    # 1. Compute-only
+    _, compute_ms = perf_func(
+        compute_only, warmup, iters,
+        expert_outputs, shared_expert_output, topk_weights,
+    )
+
+    # 2. Comm-only (NCCL reduce-scatter)
+    # Need a fresh compute_result for comm input
+    fresh_result = compute_only(expert_outputs, shared_expert_output, topk_weights)
+    _, comm_ms = perf_func(
+        comm_only, warmup, iters,
+        fresh_result, comm_output, pg,
+    )
+
+    # 3. Non-overlap (compute + comm sequential)
+    _, non_overlap_ms = perf_func(
+        non_overlap, warmup, iters,
+        expert_outputs, shared_expert_output, topk_weights,
+        non_overlap_output, pg,
+    )
+
+    # 4. Overlap kernel
+    _, overlap_ms = perf_func(
+        fused_topk_reduce_sum_add_shared_reduce_scatter, warmup, iters,
+        ctx, expert_outputs, shared_expert_output, topk_weights,
+    )
+
+    if rank == 0:
+        compute_us = compute_ms * 1000
+        comm_us = comm_ms * 1000
+        non_overlap_us = non_overlap_ms * 1000
+        overlap_us = overlap_ms * 1000
+
+        compute_bw = input_bytes / (compute_ms * 1e-3) / 1e9  # GB/s
+        comm_bw = comm_bytes / (comm_ms * 1e-3) / 1e9
+        non_overlap_bw = (input_bytes + output_bytes) / (non_overlap_ms * 1e-3) / 1e9
+        overlap_bw = (input_bytes + output_bytes) / (overlap_ms * 1e-3) / 1e9
+
+        speedup_vs_seq = non_overlap_us / overlap_us
+        overlap_efficiency = max(compute_us, comm_us) / overlap_us
+
+        print(f"\n{'Implementation':<25} {'Latency (us)':>14} {'BW (GB/s)':>12} {'Speedup':>10}")
+        print("-" * 65)
+        print(f"{'Compute-only':<25} {compute_us:>14.2f} {compute_bw:>12.2f} {'-':>10}")
+        print(f"{'Comm-only (NCCL)':<25} {comm_us:>14.2f} {comm_bw:>12.2f} {'-':>10}")
+        print(f"{'Non-overlap':<25} {non_overlap_us:>14.2f} {non_overlap_bw:>12.2f} {1.0:>10.3f}")
+        print(f"{'Overlap kernel':<25} {overlap_us:>14.2f} {overlap_bw:>12.2f} {speedup_vs_seq:>10.3f}")
+        print("-" * 65)
+        print(f"  Overlap efficiency = max(compute, comm) / overlap = "
+              f"{overlap_efficiency:.3f}")
+        print(f"  Config: M={M}, N={N}, topk={topk}, dtype={args.dtype}, "
+              f"world_size={world_size}, has_weights={has_weights}")
+
+    ctx.finalize()
+    dist.destroy_process_group()
+
+
+def test_multi_size(args):
+    """Correctness across multiple problem shapes and dtypes."""
+    rank, local_rank, world_size, local_world_size, pg = initialize_distributed()
+
+    configs = [
+        # (M, N, topk, dtype)
+        (1024, 4096, 8, "bfloat16"),
+        (2048, 7168, 8, "bfloat16"),
+        (4096, 7168, 6, "bfloat16"),
+        (1024, 4096, 4, "float16"),
+        (2048, 3584, 8, "float16"),
+        (512,  2048, 4, "bfloat16"),
+    ]
+
+    all_passed = True
+    for M, N, topk, dtype_name in configs:
+        if M % world_size != 0:
+            if rank == 0:
+                print(f"  SKIP M={M}, N={N}, topk={topk}, dtype={dtype_name} "
+                      f"(M not divisible by world_size={world_size})")
+            continue
+
+        dtype = getattr(torch, dtype_name)
+        torch.manual_seed(42 + rank)
+
+        ctx = create_topk_rss_overlap_context(
+            max_M=M, N=N, topk=topk, dtype=dtype,
+        )
+
+        expert_outputs = torch.randn(M, topk, N, dtype=dtype, device=f"cuda:{local_rank}")
+        shared_expert_output = torch.randn(M, N, dtype=dtype, device=f"cuda:{local_rank}")
+        topk_weights = torch.randn(M, topk, dtype=dtype, device=f"cuda:{local_rank}")
+
+        overlap_out = fused_topk_reduce_sum_add_shared_reduce_scatter(
+            ctx, expert_outputs, shared_expert_output, topk_weights,
+        )
+        ref_out = reference_topk_rss(expert_outputs, shared_expert_output, topk_weights, pg)
+
+        torch.cuda.synchronize()
+        diff = calc_diff(overlap_out, ref_out)
+        passed = diff < 0.001
+
+        if rank == 0:
+            status = "PASS" if passed else "FAIL"
+            print(f"  [{status}] M={M}, N={N}, topk={topk}, dtype={dtype_name}, "
+                  f"diff={diff:.6f}")
+
+        if not passed:
+            all_passed = False
+
+        ctx.finalize()
+
+    if rank == 0:
+        print(f"\n[Multi-size] Overall: {'PASSED' if all_passed else 'FAILED'}")
+
+    dist.destroy_process_group()
+
+
+def test_stability(args, n_iters=50):
+    """Repeated correctness checks to catch non-deterministic hangs/failures."""
+    rank, local_rank, world_size, local_world_size, pg = initialize_distributed()
+    torch.manual_seed(42 + rank)
+
+    M = args.M
+    N = args.N
+    topk = args.topk
+    dtype = getattr(torch, args.dtype)
+    has_weights = not args.no_weights
+
+    assert M % world_size == 0, f"M ({M}) must be divisible by world_size ({world_size})"
+
+    ctx = create_topk_rss_overlap_context(
+        max_M=M, N=N, topk=topk, dtype=dtype,
+    )
+
+    n_fail = 0
+    max_diff_overall = 0.0
+
+    for i in range(n_iters):
+        torch.manual_seed(100 + i + rank)
+        expert_outputs = torch.randn(M, topk, N, dtype=dtype, device=f"cuda:{local_rank}")
+        shared_expert_output = torch.randn(M, N, dtype=dtype, device=f"cuda:{local_rank}")
+        topk_weights = None
+        if has_weights:
+            topk_weights = torch.randn(M, topk, dtype=dtype, device=f"cuda:{local_rank}")
+
+        overlap_out = fused_topk_reduce_sum_add_shared_reduce_scatter(
+            ctx, expert_outputs, shared_expert_output, topk_weights,
+        )
+        ref_out = reference_topk_rss(expert_outputs, shared_expert_output, topk_weights, pg)
+
+        torch.cuda.synchronize()
+        diff = calc_diff(overlap_out, ref_out)
+        max_diff_overall = max(max_diff_overall, diff)
+
+        if diff >= 0.001:
+            n_fail += 1
+            if rank == 0 and n_fail <= 3:
+                print(f"  [iter {i}] FAIL diff={diff:.6f}")
+
+    if rank == 0:
+        status = "PASSED" if n_fail == 0 else "FAILED"
+        print(f"[Stability] {status}: {n_iters - n_fail}/{n_iters} passed, "
+              f"max_diff={max_diff_overall:.6f}")
+
+    ctx.finalize()
+    dist.destroy_process_group()
+
+
+# ---------------------------------------------------------------------------
+# Argument Parsing
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Test Fused TopK Reduce-Sum + Add Shared + Reduce-Scatter Overlap Kernel",
+    )
+    parser.add_argument(
+        "--case", type=str, default="correctness",
+        choices=["correctness", "performance", "multi_size", "stability"],
+        help="Test mode",
+    )
+    # Shape parameters
+    parser.add_argument("--M", type=int, default=4096, help="Total token count (must be divisible by world_size)")
+    parser.add_argument("--N", type=int, default=7168, help="Hidden dimension")
+    parser.add_argument("--topk", type=int, default=8, help="Number of selected experts")
+    # Benchmark parameters
+    parser.add_argument("--warmup", type=int, default=10, help="Warmup iterations")
+    parser.add_argument("--iters", type=int, default=100, help="Benchmark iterations")
+    # Misc
+    parser.add_argument("--dtype", type=str, default="bfloat16",
+                        choices=["bfloat16", "float16"], help="Data type")
+    parser.add_argument("--no-weights", action="store_true",
+                        help="Disable gating weights (unweighted sum)")
+    parser.add_argument("--profile", action="store_true",
+                        help="Export torch profiler trace")
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Entry Point
+# ---------------------------------------------------------------------------
+
+def main():
+    args = parse_args()
+
+    if args.case == "correctness":
+        test_correctness(args)
+    elif args.case == "performance":
+        test_performance(args)
+    elif args.case == "multi_size":
+        test_multi_size(args)
+    elif args.case == "stability":
+        test_stability(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/overlap/test_fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py
+++ b/benchmark/kernels/overlap/test_fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py
@@ -83,8 +83,8 @@ def calc_diff(x: torch.Tensor, y: torch.Tensor) -> float:
 def reference_topk_rss(
     expert_outputs: torch.Tensor,
     shared_expert_output: torch.Tensor,
-    topk_weights: torch.Tensor | None,
     pg,
+    routed_scaling_factor: float = 1.0,
 ) -> torch.Tensor:
     """
     Reference implementation using standard PyTorch ops + NCCL reduce-scatter.
@@ -92,19 +92,16 @@ def reference_topk_rss(
     Args:
         expert_outputs: [M, TOPK, N] routed expert outputs
         shared_expert_output: [M, N] shared expert output
-        topk_weights: [M, TOPK] gate weights, or None (unweighted sum)
         pg: process group for reduce-scatter
+        routed_scaling_factor: scalar applied after topk reduce-sum (default 1.0)
 
     Returns:
         [M_per_rank, N] reduced and scattered output
     """
     M, topk, N = expert_outputs.shape
 
-    # topk reduce-sum
-    if topk_weights is not None:
-        result = (expert_outputs * topk_weights[:, :, None]).sum(dim=1)
-    else:
-        result = expert_outputs.sum(dim=1)
+    # topk reduce-sum, then apply routed_scaling_factor
+    result = expert_outputs.sum(dim=1) * routed_scaling_factor
 
     # add shared expert output
     result = result + shared_expert_output
@@ -123,13 +120,10 @@ def reference_topk_rss(
 def compute_only(
     expert_outputs: torch.Tensor,
     shared_expert_output: torch.Tensor,
-    topk_weights: torch.Tensor | None,
 ) -> torch.Tensor:
     """Standalone compute: topk_reduce_sum + add shared expert output (no comm)."""
-    if topk_weights is not None:
-        result = (expert_outputs * topk_weights[:, :, None]).sum(dim=1)
-    else:
-        result = expert_outputs.sum(dim=1)
+    result = expert_outputs.sum(dim=1)
+    result = result * 2.5
     return result + shared_expert_output
 
 
@@ -142,12 +136,11 @@ def comm_only(tensor: torch.Tensor, output: torch.Tensor, pg) -> torch.Tensor:
 def non_overlap(
     expert_outputs: torch.Tensor,
     shared_expert_output: torch.Tensor,
-    topk_weights: torch.Tensor | None,
     output: torch.Tensor,
     pg,
 ) -> torch.Tensor:
     """Non-overlap: compute + comm sequentially (no overlap)."""
-    result = compute_only(expert_outputs, shared_expert_output, topk_weights)
+    result = compute_only(expert_outputs, shared_expert_output)
     dist.reduce_scatter_tensor(output, result, op=dist.ReduceOp.SUM, group=pg)
     return output
 
@@ -193,7 +186,6 @@ def test_correctness(args):
     N = args.N
     topk = args.topk
     dtype = getattr(torch, args.dtype)
-    has_weights = not args.no_weights
 
     assert M % world_size == 0, f"M ({M}) must be divisible by world_size ({world_size})"
 
@@ -205,17 +197,18 @@ def test_correctness(args):
     # Generate random inputs
     expert_outputs = torch.randn(M, topk, N, dtype=dtype, device=f"cuda:{local_rank}")
     shared_expert_output = torch.randn(M, N, dtype=dtype, device=f"cuda:{local_rank}")
-    topk_weights = None
-    if has_weights:
-        topk_weights = torch.randn(M, topk, dtype=dtype, device=f"cuda:{local_rank}")
 
     # Run overlap kernel
     overlap_out = fused_topk_reduce_sum_add_shared_reduce_scatter(
-        ctx, expert_outputs, shared_expert_output, topk_weights,
+        ctx, expert_outputs, shared_expert_output,
+        routed_scaling_factor=1.0,
     )
 
     # Run reference
-    ref_out = reference_topk_rss(expert_outputs, shared_expert_output, topk_weights, pg)
+    ref_out = reference_topk_rss(
+        expert_outputs, shared_expert_output, pg,
+        routed_scaling_factor=1.0,
+    )
 
     # Compare
     torch.cuda.synchronize()
@@ -230,7 +223,7 @@ def test_correctness(args):
         status = "PASSED" if passed else "FAILED"
         print(f"[Correctness] {status}")
         print(f"  Config: M={M}, N={N}, topk={topk}, dtype={args.dtype}, "
-              f"world_size={world_size}, has_weights={has_weights}")
+              f"world_size={world_size}")
         print(f"  cosine_diff={diff:.6f}, max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}")
         if not passed:
             print(f"  Expected (first row): {ref_out[0, :8]}")
@@ -257,7 +250,6 @@ def test_performance(args):
     N = args.N
     topk = args.topk
     dtype = getattr(torch, args.dtype)
-    has_weights = not args.no_weights
     warmup = args.warmup
     iters = args.iters
 
@@ -272,9 +264,6 @@ def test_performance(args):
     # Generate inputs
     expert_outputs = torch.randn(M, topk, N, dtype=dtype, device=f"cuda:{local_rank}")
     shared_expert_output = torch.randn(M, N, dtype=dtype, device=f"cuda:{local_rank}")
-    topk_weights = None
-    if has_weights:
-        topk_weights = torch.randn(M, topk, dtype=dtype, device=f"cuda:{local_rank}")
 
     # Pre-allocate comm-only tensors
     compute_result = torch.randn(M, N, dtype=dtype, device=f"cuda:{local_rank}")
@@ -290,12 +279,12 @@ def test_performance(args):
     # 1. Compute-only
     _, compute_ms = perf_func(
         compute_only, warmup, iters,
-        expert_outputs, shared_expert_output, topk_weights,
+        expert_outputs, shared_expert_output,
     )
 
     # 2. Comm-only (NCCL reduce-scatter)
     # Need a fresh compute_result for comm input
-    fresh_result = compute_only(expert_outputs, shared_expert_output, topk_weights)
+    fresh_result = compute_only(expert_outputs, shared_expert_output)
     _, comm_ms = perf_func(
         comm_only, warmup, iters,
         fresh_result, comm_output, pg,
@@ -304,14 +293,39 @@ def test_performance(args):
     # 3. Non-overlap (compute + comm sequential)
     _, non_overlap_ms = perf_func(
         non_overlap, warmup, iters,
-        expert_outputs, shared_expert_output, topk_weights,
+        expert_outputs, shared_expert_output,
         non_overlap_output, pg,
     )
 
     # 4. Overlap kernel
     _, overlap_ms = perf_func(
         fused_topk_reduce_sum_add_shared_reduce_scatter, warmup, iters,
-        ctx, expert_outputs, shared_expert_output, topk_weights,
+        ctx, expert_outputs, shared_expert_output, 1.0,
+    )
+
+    from moe_reduce_rs import (
+        MoEReduceRSSymmMemContext,
+        create_moe_rs_symm_mem_context,
+        reduce_topk_reduce_scatter_a2a_intra_node_with_shared_expert_symm_mem,
+    )
+
+    ctx = create_moe_rs_symm_mem_context(
+        rank=rank,
+        world_size=world_size,
+        local_world_size=local_world_size,
+        max_token_num=M,
+        hidden_dim=N,
+        num_experts=0,
+        topk=topk,
+        input_dtype=dtype,
+        group=pg,
+    )
+    output = torch.empty(
+        (M_per_rank, N), dtype=expert_outputs.dtype, device=expert_outputs.device,
+    )
+    _, overlap_ms = perf_func(
+        reduce_topk_reduce_scatter_a2a_intra_node_with_shared_expert_symm_mem, warmup, iters,
+        expert_outputs, shared_expert_output, ctx, M, 7, output, 1.0,
     )
 
     if rank == 0:
@@ -338,7 +352,7 @@ def test_performance(args):
         print(f"  Overlap efficiency = max(compute, comm) / overlap = "
               f"{overlap_efficiency:.3f}")
         print(f"  Config: M={M}, N={N}, topk={topk}, dtype={args.dtype}, "
-              f"world_size={world_size}, has_weights={has_weights}")
+              f"world_size={world_size}")
 
     ctx.finalize()
     dist.destroy_process_group()
@@ -375,12 +389,12 @@ def test_multi_size(args):
 
         expert_outputs = torch.randn(M, topk, N, dtype=dtype, device=f"cuda:{local_rank}")
         shared_expert_output = torch.randn(M, N, dtype=dtype, device=f"cuda:{local_rank}")
-        topk_weights = torch.randn(M, topk, dtype=dtype, device=f"cuda:{local_rank}")
 
         overlap_out = fused_topk_reduce_sum_add_shared_reduce_scatter(
-            ctx, expert_outputs, shared_expert_output, topk_weights,
+            ctx, expert_outputs, shared_expert_output,
+            routed_scaling_factor=1.0,
         )
-        ref_out = reference_topk_rss(expert_outputs, shared_expert_output, topk_weights, pg)
+        ref_out = reference_topk_rss(expert_outputs, shared_expert_output, pg)
 
         torch.cuda.synchronize()
         diff = calc_diff(overlap_out, ref_out)
@@ -411,7 +425,6 @@ def test_stability(args, n_iters=50):
     N = args.N
     topk = args.topk
     dtype = getattr(torch, args.dtype)
-    has_weights = not args.no_weights
 
     assert M % world_size == 0, f"M ({M}) must be divisible by world_size ({world_size})"
 
@@ -426,14 +439,12 @@ def test_stability(args, n_iters=50):
         torch.manual_seed(100 + i + rank)
         expert_outputs = torch.randn(M, topk, N, dtype=dtype, device=f"cuda:{local_rank}")
         shared_expert_output = torch.randn(M, N, dtype=dtype, device=f"cuda:{local_rank}")
-        topk_weights = None
-        if has_weights:
-            topk_weights = torch.randn(M, topk, dtype=dtype, device=f"cuda:{local_rank}")
 
         overlap_out = fused_topk_reduce_sum_add_shared_reduce_scatter(
-            ctx, expert_outputs, shared_expert_output, topk_weights,
+            ctx, expert_outputs, shared_expert_output,
+            routed_scaling_factor=1.0,
         )
-        ref_out = reference_topk_rss(expert_outputs, shared_expert_output, topk_weights, pg)
+        ref_out = reference_topk_rss(expert_outputs, shared_expert_output, pg)
 
         torch.cuda.synchronize()
         diff = calc_diff(overlap_out, ref_out)
@@ -467,7 +478,7 @@ def parse_args():
         help="Test mode",
     )
     # Shape parameters
-    parser.add_argument("--M", type=int, default=4096, help="Total token count (must be divisible by world_size)")
+    parser.add_argument("--M", type=int, default=8192, help="Total token count (must be divisible by world_size)")
     parser.add_argument("--N", type=int, default=7168, help="Hidden dimension")
     parser.add_argument("--topk", type=int, default=8, help="Number of selected experts")
     # Benchmark parameters
@@ -476,8 +487,6 @@ def parse_args():
     # Misc
     parser.add_argument("--dtype", type=str, default="bfloat16",
                         choices=["bfloat16", "float16"], help="Data type")
-    parser.add_argument("--no-weights", action="store_true",
-                        help="Disable gating weights (unweighted sum)")
     parser.add_argument("--profile", action="store_true",
                         help="Export torch profiler trace")
     return parser.parse_args()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Recently, agent skills have shown great potential in analyzing profiling data, generating and optimizing computation kernels, and integrating them into inference frameworks such as SGLang and vLLM. To further reducing the communication cost, we explored the ability of skills to generate computation-communication overlap kernels and integrate them into SGLang, developing two skills --- overlap kernel generation skill and integration skill.

Co-auther: @Zqy11 

## Modifications

<!-- Detail the changes made in this pull request. -->
We added two skills for automatically generating overlap kernel code and integrating the overlap kernel into sglang based on the stack trace shown in profiling data.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
This PR should not affect the accuracy.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
We have applied the skill to generate several overlap kernels for testing before, such as moe_sum_reduce + reduce_scatter fused kernel(using intra-sm overlap method) and allgather + fp8 quant gemm (using copy-engine + multi-stream, without sm occupation).  
Some of the detailed performance/profiling data can be seen in PR #28639. Note that currently we still need minor manual modifications for optimizing the performance of overlap kernel~(param configuration, etc.) and fixing some bugs in kernel integration process.


## sglang-overlap-kernel-generation skill

This skill aims to overlap collective communication with existing computation kernels. Users provide two key inputs to the agent: (1) the target computation kernel and the collective operation to be overlapped, and (2) the preferred overlap mechanism, including whether to use intra-SM or inter-SM mode, and whether to leverage the copy engine or registers for inter-rank communication, etc.. Based on the collected inputs, the skill follows the provided instructions (see reference markdown files) to generate the overlap kernel, validates the output against pre-defined constraints, and finally produces a benchmark to evaluate the correctness and performance of the generated kernel.


Usage：

> `/sglang-overlap-kernel-generation
> 
> we want to generate a triton overlap kernel that fused topk_reduce_sum, shared_experts_output add and reduce_scatter using intra-sm method.`

We include a generated kernel (benchmark/kernels/overlap/fused_topk_reduce_sum_add_shared_reduce_scatter_intra_sm.py) as a concrete example to demonstrate the effectiveness of this skill.


## sglang-overlap-kernel-integration skill

This skill attempts to automatically integrate overlap kernels (e.g., those generated by the kernel-generation skill) into the SGLang framework. It first analyzes the profiling data to extract the stack trace of the original kernels targeted for replacement. Based on this call stack information, the skill seamlessly replaces the sequential computation and communication operations with the fused overlap kernel, enabling automatic integration.

> `=== Operator Chain to Replace ===
> Chain: moe_sum_reduce → add_ → reduce_scatter
> Total GPU time: 82.00 ms (120 layer)
> 
> 1. moe_sum_reduce (29.97ms)
>    Kernel: moe_sum_reduce_warp_per_token_vec_kernel<8>
>    Source: fused_moe.py:738 → sgl_kernel/moe.py:83
>    
> 2. add_ (11.68ms)
>    Kernel: CUDAFunctor_add<c10::BFloat16>
>    Source: mxfp4_flashinfer_trtllm_moe.py:442 maybe_fuse_routed_scale_and_shared_add
> 
> 3. reduce_scatter (40.35ms)  
>    Kernel: ncclDevKernel_ReduceScatter_Sum_bf16_RING_LL
>    Source: communicator_dsa_cp.py:67 dsa_cp_reduce_scatter_hidden_states
> 
> Model-level replacement point: deepseek_v4.py:1342 MoEBlock.forward (lines 1497-1505)`

Here is the output of the profiling analysis step. We can see that the skill can accurately locate the func stack of the kernel to be replaced.

Usage:

> /sglang-overlap-integration
> 
> we want to integrate the overlap kernel in moe_reduce_rs_symm_mem.py under the folder of /path/to/overlap/kernel. currently we have a profiling file located in /path/to/profiling/baseline_profiling.json. We want to replace moe_reduce_sum+add_+reduce_scatter with the overlap kernel provided above. Note that the overlap kernel only work in prefill phase.
> 







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28231224289](https://github.com/sgl-project/sglang/actions/runs/28231224289)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28231223935](https://github.com/sgl-project/sglang/actions/runs/28231223935)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->