### PR TITLE
Fix NVFP4 Cutlass MoE fallback for local experts

### DIFF
--- a/python/sglang/jit_kernel/csrc/gemm/nvfp4/nvfp4_expert_quant.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/nvfp4/nvfp4_expert_quant.cuh
@@ -342,9 +342,8 @@ cvt_fp16_to_fp4(
   static_assert(sizeof(PackedVec) == sizeof(Type) * CVT_FP4_ELTS_PER_THREAD, "Vec size is not matched.");
   extern __shared__ uint32_t shared_input_offsets[];
 
-  // Load input offsets into shared memory.
-  // If n_experts is larger than 4, use vectorized int4 to save instructions.
-  // If n_experts is smaller than 4, read directly.
+  // Load input offsets into shared memory. The vectorized int4 path reads
+  // chunks of 16 experts, so it is only selected for 16-aligned expert counts.
   if constexpr (SMALL_NUM_EXPERTS) {
     for (int i = threadIdx.x; i < n_experts + 1; i += blockDim.x) {
       shared_input_offsets[i] = input_offset_by_experts[i];
@@ -477,7 +476,7 @@ void quant_impl(
   int const blockRepeat = (totalWorkSize + block.x * grid.x - 1) / (block.x * grid.x);
   if (blockRepeat > 1) {
     size_t shared_mem_size = (n_experts + 1) * sizeof(uint32_t);
-    if (n_experts >= 4) {
+    if (n_experts % 16 == 0) {
       cvt_fp16_to_fp4<T, false, false><<<grid, block, shared_mem_size, stream>>>(
           m_topk,
           k,
@@ -503,7 +502,7 @@ void quant_impl(
           n_experts);
     }
   } else {
-    if (n_experts >= 16) {
+    if (n_experts % 16 == 0) {
       cvt_fp16_to_fp4<T, false, false><<<grid, block, 0, stream>>>(
           m_topk,
           k,

--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -345,6 +345,75 @@ FLOAT4_E2M1_MAX = 6.0
 FLOAT8_E4M3_MAX = 448.0
 
 
+def _prepare_fp4_moe_input(
+    topk_ids: torch.Tensor,
+    params: CutlassMoEParams,
+    num_topk: int,
+) -> tuple[torch.Tensor, torch.Tensor, Optional[dict]]:
+    flat_topk_ids = topk_ids.reshape(-1)
+    invalid_topk_ids = (flat_topk_ids < 0) | (flat_topk_ids >= params.num_experts)
+    has_invalid = bool(invalid_topk_ids.any().item())
+    device = topk_ids.device
+
+    if not has_invalid:
+        a_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
+        c_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
+        prepare_moe_input(
+            topk_ids,
+            params.expert_offsets,
+            params.problem_sizes1,
+            params.problem_sizes2,
+            a_map,
+            c_map,
+            params.num_experts,
+            params.intermediate_size_per_partition,
+            params.hidden_size,
+            params.blockscale_offsets,
+        )
+        return a_map, c_map, None
+
+    valid_topk_ids = ~invalid_topk_ids
+    valid_route_indices = torch.nonzero(valid_topk_ids, as_tuple=False).flatten()
+    c_map = torch.zeros((topk_ids.numel(),), dtype=torch.int32, device=device)
+    active = {
+        "compact_source_rows": torch.div(
+            valid_route_indices, num_topk, rounding_mode="floor"
+        ),
+        "valid_route_indices": valid_route_indices,
+        "valid_topk_ids": valid_topk_ids.view_as(topk_ids),
+    }
+
+    if valid_route_indices.numel() == 0:
+        params.expert_offsets.zero_()
+        params.problem_sizes1.zero_()
+        params.problem_sizes2.zero_()
+        if params.blockscale_offsets is not None:
+            params.blockscale_offsets.zero_()
+        a_map = torch.empty((0,), dtype=torch.int32, device=device)
+        return a_map, c_map, active
+
+    compact_topk_ids = flat_topk_ids.index_select(0, valid_route_indices).view(-1, 1)
+    a_map = torch.empty((valid_route_indices.numel(),), dtype=torch.int32, device=device)
+    compact_c_map = torch.empty(
+        (valid_route_indices.numel(),), dtype=torch.int32, device=device
+    )
+    prepare_moe_input(
+        compact_topk_ids,
+        params.expert_offsets,
+        params.problem_sizes1,
+        params.problem_sizes2,
+        a_map,
+        compact_c_map,
+        params.num_experts,
+        params.intermediate_size_per_partition,
+        params.hidden_size,
+        params.blockscale_offsets,
+    )
+    c_map.scatter_(0, valid_route_indices, compact_c_map)
+
+    return a_map, c_map, active
+
+
 def cutlass_moe_fp4(
     a: torch.Tensor,
     a1_gscale: torch.Tensor,
@@ -434,69 +503,107 @@ def cutlass_moe_fp4(
     out_dtype = a.dtype
     num_topk = topk_ids.shape[1]
     device = a.device
-    a_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
-    c_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
-    prepare_moe_input(
-        topk_ids,
-        params.expert_offsets,
-        params.problem_sizes1,
-        params.problem_sizes2,
-        a_map,
-        c_map,
-        params.num_experts,
-        params.intermediate_size_per_partition,
-        params.hidden_size,
-        params.blockscale_offsets,
-    )
+    a_map, c_map, active = _prepare_fp4_moe_input(topk_ids, params, num_topk)
 
-    rep_a_fp4, rep_a_blockscale = scaled_fp4_experts_quant(
-        a,
-        a1_gscale,
-        params.expert_offsets,
-        params.blockscale_offsets,
-        num_topk,
-        expert_map=a_map,
-    )
-    c1 = cutlass_fp4_group_mm(
-        rep_a_fp4,
-        w1_fp4,
-        rep_a_blockscale,
-        w1_blockscale,
-        w1_alphas,
-        out_dtype,
-        params.to_gemm1_args(),
-    )
-    del rep_a_fp4, rep_a_blockscale
+    if active is None:
+        rep_a_fp4, rep_a_blockscale = scaled_fp4_experts_quant(
+            a,
+            a1_gscale,
+            params.expert_offsets,
+            params.blockscale_offsets,
+            num_topk,
+            expert_map=a_map,
+        )
+    elif active["valid_route_indices"].numel() == 0:
+        rep_a_fp4 = torch.empty(
+            (0, params.hidden_size // 2), device=device, dtype=torch.uint8
+        )
+        rep_a_blockscale = None
+    else:
+        compact_a = a.index_select(0, active["compact_source_rows"].to(torch.int64))
+        compact_a = compact_a.index_select(0, a_map.to(torch.int64))
+        rep_a_fp4, rep_a_blockscale = scaled_fp4_experts_quant(
+            compact_a,
+            a1_gscale,
+            params.expert_offsets,
+            params.blockscale_offsets,
+            num_topk,
+        )
 
-    # hidden size dimension is split to one half sized tensor.
-    intermediate = torch.empty(
-        (m_a * num_topk, w1_fp4.shape[1] // 2), device=device, dtype=out_dtype
-    )
-    silu_and_mul(c1, intermediate)
+    if rep_a_fp4.shape[0] == 0:
+        c2 = torch.zeros((1, params.hidden_size), device=device, dtype=out_dtype)
+    else:
+        c1 = cutlass_fp4_group_mm(
+            rep_a_fp4,
+            w1_fp4,
+            rep_a_blockscale,
+            w1_blockscale,
+            w1_alphas,
+            out_dtype,
+            params.to_gemm1_args(),
+        )
+        del rep_a_fp4, rep_a_blockscale
 
-    int_fp4, int_blockscale = scaled_fp4_experts_quant(
-        intermediate,
-        a2_gscale,
-        params.expert_offsets,
-        params.blockscale_offsets,
-        num_topk,
-    )
-    c2 = cutlass_fp4_group_mm(
-        int_fp4,
-        w2_fp4,
-        int_blockscale,
-        w2_blockscale,
-        w2_alphas,
-        out_dtype,
-        params.to_gemm2_args(),
-    )
-    del int_fp4, int_blockscale
+        # hidden size dimension is split to one half sized tensor.
+        intermediate = torch.empty(
+            (c1.shape[0], w1_fp4.shape[1] // 2), device=device, dtype=out_dtype
+        )
+        silu_and_mul(c1, intermediate)
+
+        int_fp4, int_blockscale = scaled_fp4_experts_quant(
+            intermediate,
+            a2_gscale,
+            params.expert_offsets,
+            params.blockscale_offsets,
+            num_topk,
+        )
+        c2 = cutlass_fp4_group_mm(
+            int_fp4,
+            w2_fp4,
+            int_blockscale,
+            w2_blockscale,
+            w2_alphas,
+            out_dtype,
+            params.to_gemm2_args(),
+        )
+        del int_fp4, int_blockscale
 
     if no_combine:
-        c2 = shuffle_rows(c2, c_map, (m_a * num_topk, params.hidden_size))
+        if active is None:
+            c2 = shuffle_rows(c2, c_map, (m_a * num_topk, params.hidden_size))
+        else:
+            c2_full = torch.zeros(
+                (m_a * num_topk, params.hidden_size),
+                device=device,
+                dtype=out_dtype,
+            )
+            if active["valid_route_indices"].numel() > 0:
+                c2_full[active["valid_route_indices"].to(torch.int64)] = (
+                    c2.index_select(
+                        0,
+                        c_map.index_select(0, active["valid_route_indices"]).to(
+                            torch.int64
+                        ),
+                    )
+                )
+            c2 = c2_full
         c2 = c2.view(m_a, num_topk, params.hidden_size)
         return c2.to(out_dtype)
     output = torch.empty((m_a, k_a), device=device, dtype=out_dtype)
-    weights = topk_weights.to(out_dtype) if not apply_router_weight_on_input else None
+    weights = topk_weights
+    if active is not None and not apply_router_weight_on_input:
+        weights = weights.masked_fill(~active["valid_topk_ids"], 0)
+    if active is not None and apply_router_weight_on_input:
+        c2_full = torch.zeros(
+            (m_a * num_topk, params.hidden_size), device=device, dtype=out_dtype
+        )
+        if active["valid_route_indices"].numel() > 0:
+            c2_full[active["valid_route_indices"].to(torch.int64)] = c2.index_select(
+                0,
+                c_map.index_select(0, active["valid_route_indices"]).to(torch.int64),
+            )
+        c2 = c2_full
+        c_map = torch.arange(m_a * num_topk, dtype=torch.int32, device=device)
+    weights = weights.to(out_dtype) if not apply_router_weight_on_input else None
     apply_shuffle_mul_sum(c2, output, c_map, weights)
     return output

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1055,8 +1055,6 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
             )
             from sglang.srt.layers.moe.utils import RoutingMethodType
 
-            topk_config = topk_output.topk_config
-
             from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
                 get_activation_type,
             )
@@ -1320,9 +1318,9 @@ class ModelOptFp4Config(ModelOptQuantConfig):
                     "Expected either flat format (config.json) or nested format (hf_quant_config.json)."
                 )
 
-        if not quant_method in ["FP8", "NVFP4"]:
+        if quant_method not in ["FP8", "NVFP4"]:
             raise ValueError(
-                f"ModelOpt currently only supports: FP8, NVFP4"
+                "ModelOpt currently only supports: FP8, NVFP4"
                 " quantizations in sglang. Please check the "
                 "quantization config for your model's configuration."
             )
@@ -1756,6 +1754,24 @@ def _compute_gemm1_alphas(
     return g1_alphas, g1_alphas_up
 
 
+def _slice_nvfp4_moe_input_scales_for_local_experts(
+    layer: torch.nn.Module,
+    w13_input_scale: torch.Tensor,
+    w2_input_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if layer.num_local_experts == layer.num_experts:
+        return w13_input_scale, w2_input_scale
+
+    local_start = layer.moe_ep_rank * layer.num_local_experts
+    local_end = local_start + layer.num_local_experts
+
+    if w13_input_scale.dim() > 0 and w13_input_scale.shape[0] == layer.num_experts:
+        w13_input_scale = w13_input_scale[local_start:local_end]
+    if w2_input_scale.dim() > 0 and w2_input_scale.shape[0] == layer.num_experts:
+        w2_input_scale = w2_input_scale[local_start:local_end]
+    return w13_input_scale, w2_input_scale
+
+
 class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
     """
        MoE Method for FP4 Quantization with Blockscales and PerTensorScales
@@ -2061,6 +2077,11 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         else:
             w13_input_scale = layer.w13_input_scale.max(dim=-1).values.to(torch.float32)
             w2_input_scale = layer.w2_input_scale
+            w13_input_scale, w2_input_scale = (
+                _slice_nvfp4_moe_input_scales_for_local_experts(
+                    layer, w13_input_scale, w2_input_scale
+                )
+            )
 
         if self.quant_config.use_per_token_activation:
             # FlashInfer computes activation scales dynamically per token, so
@@ -2284,10 +2305,11 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             inter_size = layer.w2_weight.shape[2] * 2
             hidden_size = layer.w13_weight.shape[2] * 2
             existing_params = getattr(layer, "cutlass_moe_params", None)
+            num_cutlass_experts = layer.w13_weight.shape[0]
             if (
                 existing_params is None
                 or existing_params.cutlass_moe_type != CutlassMoEType.BlockscaledFP4
-                or existing_params.num_experts != layer.num_experts
+                or existing_params.num_experts != num_cutlass_experts
                 or existing_params.intermediate_size_per_partition != inter_size
                 or existing_params.hidden_size != hidden_size
                 or existing_params.device != device
@@ -2295,7 +2317,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 layer.cutlass_moe_params = CutlassMoEParams(
                     CutlassMoEType.BlockscaledFP4,
                     device,
-                    num_experts=layer.num_experts,  # global num experts
+                    num_experts=num_cutlass_experts,
                     intermediate_size_per_partition=inter_size,  # n
                     hidden_size=hidden_size,
                 )  # k

--- a/test/registered/kernels/test_fp4_moe.py
+++ b/test/registered/kernels/test_fp4_moe.py
@@ -257,7 +257,10 @@ def check_moe(
     a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
     w1 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 10
     quant_blocksize = 16
-    round_up = lambda x, y: (x + y - 1) // y * y
+
+    def round_up(x, y):
+        return (x + y - 1) // y * y
+
     sf_w1_2n = round_up(2 * n, 128)
     sf_w1_k = round_up(k // quant_blocksize, 4)
     w1_blockscale = torch.empty(
@@ -410,6 +413,95 @@ def test_cutlass_fp4_moe_no_graph(
         )
 
     check_moe(m, n, k, e, topk, dtype, cutlass_moe_impl, flip_w13=False)
+
+
+@torch.inference_mode()
+def test_cutlass_fp4_moe_ignores_invalid_routes():
+    torch.manual_seed(7)
+    m, n, k, e, topk = 17, 1024, 1024, 36, 8
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    a = torch.randn((m, k), device=device, dtype=dtype) / 10
+    quant_blocksize = 16
+
+    def round_up(x, y):
+        return (x + y - 1) // y * y
+
+    w1 = torch.randn((e, 2 * n, k), device=device, dtype=dtype) / 10
+    w1_q = torch.empty((e, 2 * n, k // 2), device=device, dtype=torch.uint8)
+    w1_blockscale = torch.empty(
+        (e, round_up(2 * n, 128), round_up(k // quant_blocksize, 4)),
+        device=device,
+        dtype=torch.float8_e4m3fn,
+    )
+    w1_gs = torch.empty((e,), device=device, dtype=torch.float32)
+
+    w2 = torch.randn((e, k, n), device=device, dtype=dtype) / 10
+    w2_q = torch.empty((e, k, n // 2), device=device, dtype=torch.uint8)
+    w2_blockscale = torch.empty(
+        (e, round_up(k, 128), round_up(n // quant_blocksize, 4)),
+        device=device,
+        dtype=torch.float8_e4m3fn,
+    )
+    w2_gs = torch.empty((e,), device=device, dtype=torch.float32)
+
+    for expert in range(e):
+        w1_gs[expert] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(
+            w1[expert]
+        ).max().to(torch.float32)
+        w2_gs[expert] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(
+            w2[expert]
+        ).max().to(torch.float32)
+        w1_q[expert], w1_blockscale[expert] = scaled_fp4_quant(
+            w1[expert], w1_gs[expert]
+        )
+        w2_q[expert], w2_blockscale[expert] = scaled_fp4_quant(
+            w2[expert], w2_gs[expert]
+        )
+
+    topk_ids = torch.randint(0, e, (m, topk), device=device, dtype=torch.int32)
+    topk_weights = torch.softmax(
+        torch.randn((m, topk), device=device, dtype=torch.float32), dim=-1
+    )
+    invalid_mask = torch.zeros_like(topk_ids, dtype=torch.bool)
+    invalid_mask[::2, -1] = True
+    invalid_mask[1::3, 0] = True
+
+    invalid_topk_ids = topk_ids.masked_fill(invalid_mask, -1)
+    expected_topk_ids = invalid_topk_ids.clamp_min(0)
+    expected_topk_weights = topk_weights.masked_fill(invalid_mask, 0)
+
+    def run_moe(ids, weights):
+        params = CutlassMoEParams(
+            CutlassMoEType.BlockscaledFP4,
+            device=a.device,
+            num_experts=e,
+            intermediate_size_per_partition=n,
+            hidden_size=k,
+        )
+        return cutlass_moe_fp4(
+            a=a,
+            a1_gscale=torch.ones((e,), device=device, dtype=torch.float32),
+            w1_fp4=w1_q,
+            w1_blockscale=w1_blockscale,
+            w1_alphas=(1 / w1_gs),
+            a2_gscale=torch.ones((e,), device=device, dtype=torch.float32),
+            w2_fp4=w2_q,
+            w2_blockscale=w2_blockscale,
+            w2_alphas=(1 / w2_gs),
+            topk_weights=weights,
+            topk_ids=ids,
+            params=params,
+            apply_router_weight_on_input=False,
+        )
+
+    torch.testing.assert_close(
+        run_moe(invalid_topk_ids, topk_weights),
+        run_moe(expected_topk_ids, expected_topk_weights),
+        atol=1e-1,
+        rtol=1e-1,
+    )
 
 
 @pytest.mark.parametrize("m,n,k", MNK_FACTORS)


### PR DESCRIPTION
## Summary

This PR fixes the ModelOpt NVFP4 Cutlass MoE fallback path used by `Step-3.7-Flash-NVFP4` with expert parallelism and `--moe-runner-backend triton`.

Main changes:

- Slice ModelOpt NVFP4 MoE input scales to the local expert shard when EP stores local experts.
- Build `CutlassMoEParams` from the local expert count instead of the global expert count in the fallback path.
- Filter compact `-1` expert routes before calling `prepare_moe_input`, then scatter the compact MoE output back to the original token/top-k layout with invalid routes masked out.
- Avoid the vectorized NVFP4 expert-offset load path when the local expert count is not 16-aligned.
- Add a regression test covering `e=36`, `topk=8`, and `-1` expert routes.

## Error / Root Cause

Repro setup:

```bash
python3 -m sglang.launch_server \
  --model-path stepfun-ai/Step-3.7-Flash-NVFP4 \
  --tp-size 8 \
  --ep 8 \
  --quantization modelopt_fp4 \
  --kv-cache-dtype auto \
  --moe-runner-backend triton \
  --attention-backend flashinfer \
  --reasoning-parser step3p5 \
  --tool-call-parser step3p5
```

With EP enabled, the model has 288 global experts but each rank owns 36 local experts. The existing fallback path mixed these two layouts:

1. The loaded MoE weights/scales were local expert tensors, but fallback scale handling and `CutlassMoEParams.num_experts` still used the global expert count.
2. Runtime routing for this backend contains local expert IDs plus `-1` placeholders for routes owned by other EP ranks. Example from B200 debug logs:

```text
[FP4_MOE_DEBUG] shape=(188, 8) num_experts=36 topk_min=-1 topk_max=35 neg=1278 oor=0
```

`prepare_moe_input` expects valid expert IDs and cannot consume the `-1` placeholders. The fallback path therefore needs to compact valid routes before preparing the Cutlass grouped GEMM metadata, while preserving the original route layout for the final combine.

There is also a separate local-expert-count issue in the NVFP4 expert quant helper: `n_experts=36` is not 16-aligned, so the vectorized expert-offset load path can read a partial tail chunk incorrectly. This PR keeps that path only for 16-aligned expert counts.

## Fix Principle

For ModelOpt NVFP4 fallback MoE under EP, treat the Cutlass fallback as a local-expert operator:

- Use local weights and local input scales consistently.
- Convert `topk_ids` into compact valid-route metadata before `prepare_moe_input`.
- Zero invalid-route weights so they do not contribute to the final output.
- Scatter compact output rows back to the original route layout when the caller needs top-k layout output.

This keeps the fallback semantics aligned with the Triton MoE routing convention without changing the global routing behavior.

## Validation

Local checks:

```bash
python3 -m py_compile python/sglang/srt/layers/moe/cutlass_moe.py python/sglang/srt/layers/quantization/modelopt_quant.py test/registered/kernels/test_fp4_moe.py
python3 -m ruff check python/sglang/srt/layers/moe/cutlass_moe.py python/sglang/srt/layers/quantization/modelopt_quant.py test/registered/kernels/test_fp4_moe.py
```

B200 kernel regression:

```bash
pytest -q test/registered/kernels/test_fp4_moe.py::test_cutlass_fp4_moe_ignores_invalid_routes -q
```

B200 Step-3.7-Flash-NVFP4 smoke tests:

| Config | Result |
| --- | --- |
| `--moe-runner-backend triton --attention-backend flashinfer` | 512-token Chinese chat request finished with `finish_reason=stop`; final content was normal text, not garbled. |
| `--moe-runner-backend triton --attention-backend triton` | 512-token Chinese chat request finished with `finish_reason=stop`; final content was normal text, not garbled. |

## GSM8K Accuracy Command

The command below is the Step-3.7 NVFP4 accuracy command that produces normal GSM8K results. It follows the cookbook-recommended NVFP4 backend (`flashinfer_trtllm` MoE + `trtllm_mha` attention). The `triton` MoE command above is the fallback bug repro path for this PR, not the recommended accuracy path for this checkpoint.

Server:

```bash
python3 -m sglang.launch_server \
  --model-path stepfun-ai/Step-3.7-Flash-NVFP4 \
  --tp-size 8 \
  --ep 8 \
  --quantization modelopt_fp4 \
  --kv-cache-dtype fp8_e4m3 \
  --moe-runner-backend flashinfer_trtllm \
  --attention-backend trtllm_mha \
  --trust-remote-code \
  --port 31033
```

Eval:

```bash
python3 -m sglang.test.run_eval \
  --base-url http://127.0.0.1:31033 \
  --model stepfun-ai/Step-3.7-Flash-NVFP4 \
  --eval-name gsm8k \
  --api chat \
  --num-examples 1319 \
  --num-threads 128 \
  --max-tokens 512 \
  --num-shots 5 \
  --temperature 0.0 \
  --top-p 1.0 \
  --reasoning-effort low
```

Result on single-node 8x B200, PR commit `150de35bd`:

| Check | Effective samples | Score | Latency | Output throughput |
| --- | ---: | ---: | ---: | ---: |
| GSM8K full, 5-shot | 1314 | 0.943683 | 97.594 s | 2874.872 token/s |

A 20-sample sanity run with the same server/eval settings scored `0.950` before the full run.

## Triton MoE GSM8K Status

The first GSM8K attempts used `--moe-runner-backend triton` with `--attention-backend flashinfer` / `triton`. Those runs should not be treated as valid accuracy measurements for this PR:

- `run_eval --api completion` bypassed the Step chat template and produced token-soup outputs, reporting `Score: 0.000`.
- `run_eval --api chat --reasoning-effort low` with `--moe-runner-backend triton --attention-backend flashinfer` also produced token-soup outputs on the long few-shot GSM8K prompt; a 20-sample check reported `Score: 0.000`.
- The earlier `--attention-backend triton` full run reached about `209/1311` samples and then the server hit `kvcache.cuh:110 ... Assertion index >= 0 && index < size_limit failed`.

The triton MoE smoke tests and the targeted kernel regression above are the functional validation for this fallback fix. Full Step-3.7 NVFP4 GSM8K accuracy should use the cookbook backend shown in the accuracy command section.
