### PR TITLE
[AMD] Register scripted-core chunked-prefill test for AMD extra-a CI

### DIFF
--- a/test/registered/chunked_prefill/test_scripted_core_1gpu.py
+++ b/test/registered/chunked_prefill/test_scripted_core_1gpu.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.scripted_runtime.context import ScriptedContext
 from sglang.test.scripted_runtime.test_case import ScriptedTestCase
 from sglang.test.scripted_runtime_chunked_helpers import (
@@ -11,6 +11,7 @@ from sglang.test.scripted_runtime_chunked_helpers import (
 )
 
 register_cuda_ci(est_time=300, stage="extra-a", runner_config="1-gpu-small")
+register_amd_ci(est_time=300, stage="extra-a", runner_config="1-gpu-small-amd")
 
 
 _CHUNK_SIZE = 64

--- a/test/registered/chunked_prefill/test_scripted_core_1gpu.py
+++ b/test/registered/chunked_prefill/test_scripted_core_1gpu.py
@@ -11,7 +11,7 @@ from sglang.test.scripted_runtime_chunked_helpers import (
 )
 
 register_cuda_ci(est_time=300, stage="extra-a", runner_config="1-gpu-small")
-register_amd_ci(est_time=300, stage="extra-a", runner_config="1-gpu-small-amd")
+register_amd_ci(est_time=198, stage="extra-a", runner_config="1-gpu-small-amd")
 
 
 _CHUNK_SIZE = 64


### PR DESCRIPTION
## Summary

Registers one CPU/scheduler-bound `extra-a` test for AMD per-PR CI, mirroring its CUDA `stage="extra-a"` placement into the matching AMD `extra-a-test-1-gpu-small-amd` suite.

`test/registered/chunked_prefill/test_scripted_core_1gpu.py` drives the scripted-runtime scheduler harness (chunked-prefill lifecycle, pause/retract/abort, radix prefill/decode hit-count invariants) against `Qwen/Qwen3-0.6B` with the default attention backend — no FA3/FlashInfer/fa4, no fp8/mxfp4 quant, no CUDA-only kernels. The sibling scripted-runtime unit tests already run CPU-only, so the harness itself is hardware-agnostic; this just exercises it on a single GPU.

```python
register_cuda_ci(est_time=300, stage="extra-a", runner_config="1-gpu-small")
register_amd_ci(est_time=198, stage="extra-a", runner_config="1-gpu-small-amd")
```

This follows the extra-a AMD onboarding established in #28850 (mirror the CUDA stage; do not promote into per-commit `stage-b-*-amd`). The `extra-a-test-1-gpu-small-amd` suite and its `pr-test-amd-extra.yml` job already exist, so this is a pure registration — no workflow/run_suite changes. The AMD `est_time` is set to **198s** — the max measured per-file elapsed across the two AMD lanes (mi325 110s / rocm720 198s) — so the LPT auto-partitioner balances on real AMD timing. `register_cuda_ci` is unchanged.

After this change, AMD `extra-a-test-1-gpu-small-amd` grows **30 → 31** tests (local AST collector via the registered-test parser).

### Why the rest of the `extra-a` sweep stays CUDA-only (audited, not registered)

The remaining unregistered CUDA `extra-a` files each hit a real ROCm gap, not just a missing registration: `gpt-oss-20b` mxfp4 on gfx942 (session-latency, scripted-swa), FlashInfer/FA3/fa4 (hybrid-attn, lora-qwen3-8b, spec-ngram, lora-moe-tp, gemma4-dflash draft backend), DeepGEMM (moe-ep), already `@skipIf(is_hip())` (hicache spec file/mooncake), and hardware-tuned throughput / large-model accuracy gates (w8a8 throughput thresholds, ministral4 119B, gemma4-mtp-31b which dips below the gsm8k floor on ROCm). These need real ROCm work, not registration.

## Test plan

Verified green on **both** AMD lanes (the file is confirmed running, not skipped — `"passed": true` in each log):

- [x] AMD mi325 (`extra-a-test-1-gpu-small-amd`) passes — [PR Test Extra (AMD) run #28049639292](https://github.com/sgl-project/sglang/actions/runs/28049639292/job/83036638203) (`elapsed=110s`).
- [x] ROCm 7.2 / rocm720 (`extra-a-test-1-gpu-small-amd-rocm720`) passes — [targeted dispatch run #28043848812](https://github.com/sgl-project/sglang/actions/runs/28043848812/job/83016794551) (`elapsed=198s`).
- [x] NVIDIA CI unchanged (`register_cuda_ci` untouched; the AMD marker is a runtime no-op on CUDA).



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28049641454](https://github.com/sgl-project/sglang/actions/runs/28049641454)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28049640092](https://github.com/sgl-project/sglang/actions/runs/28049640092)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
