### PR TITLE
[Bugfix][Hardware][AMD] Fix fused shared-expert topk weight on aiter (HIP) path

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1486,7 +1486,7 @@ def _remap_topk_for_deepep(
 
     Routed IDs:  e -> e + e // num_local_routed
     Shared IDs:  ep_rank * num_local_experts + num_local_routed
-    Shared weight: 1 / routed_scaling_factor (compensates post-MoE scaling)
+    Shared weight: 1.0 on the aiter path, else 1/routed_scaling_factor (see below).
     """
     if topk_ids.shape[0] == 0:
         return topk_ids, topk_weights
@@ -1510,9 +1510,33 @@ def _remap_topk_for_deepep(
         + torch.arange(num_fused_shared_experts, device=topk_ids.device)
     )
 
-    # Override shared weight: 1/routed_scaling_factor so net contribution = 1.0
+    # Override the fused shared expert's weight so its net contribution is 1.0x.
+    #
+    # The correct value depends on whether routed_scaling_factor is applied to
+    # the MoE output AFTER the experts run, or already folded into the routed
+    # topk weights BEFORE dispatch:
+    #
+    #   * Post-MoE scaling path (default): DeepseekV2MoE.forward_deepep later
+    #     multiplies the whole MoE output by routed_scaling_factor, so the shared
+    #     weight must be 1/routed_scaling_factor for (1/rsf) * rsf = 1.0.
+    #   * aiter (HIP) path: aiter_biased_grouped_topk folds routed_scaling_factor
+    #     into each routed topk weight, and forward_deepep SKIPS the post-MoE
+    #     multiply for _use_aiter (see its `not (... or _use_aiter)` guard). The
+    #     shared weight must therefore be 1.0 -- applying 1/rsf here would
+    #     under-weight the always-on shared expert by routed_scaling_factor and
+    #     corrupt every MoE layer.
+    #
+    # NOTE: forward_deepep also skips the post-MoE multiply for the non-aiter
+    # families where routed_scaling_factor is pre-folded in topk
+    # (should_fuse_routed_scaling_factor_in_topk / apply_routed_scaling_factor_on_output:
+    # ModelOpt NVFP4, cutlass/trtllm-routed fp8), so those would likewise need a
+    # 1.0 shared weight. This fix is deliberately scoped to the aiter path (the
+    # one validated on AMD MI355X); those other backends are left at their
+    # existing behavior and can be addressed by their maintainers.
     routed_scaling_factor = topk_config.routed_scaling_factor
-    if routed_scaling_factor is not None and routed_scaling_factor != 0:
+    if _use_aiter:
+        topk_weights[:, -num_fused_shared_experts:] = 1.0
+    elif routed_scaling_factor is not None and routed_scaling_factor != 0:
         topk_weights[:, -num_fused_shared_experts:] = 1.0 / routed_scaling_factor
 
     return topk_ids, topk_weights


### PR DESCRIPTION
## Motivation

The fused shared-expert weight override in `_fuse_shared_experts_topk` (`python/sglang/srt/layers/moe/topk.py`) unconditionally set the shared-expert weight to `1/routed_scaling_factor` so that the post-MoE multiply by `routed_scaling_factor` would net out to a `1.0x` contribution.

This assumption is wrong on the aiter (HIP) path:

- `aiter_biased_grouped_topk` already folds `routed_scaling_factor` into each routed topk weight **before** dispatch.
- `DeepseekV2MoE.forward_deepep` **skips** the post-MoE multiply when `_use_aiter` is set (see its `not (... or _use_aiter)` guard).

Because there is no post-MoE multiply on the aiter path, applying `1/routed_scaling_factor` to the always-on shared expert under-weights it by a factor of `routed_scaling_factor`, corrupting the output of every MoE layer on AMD ROCm.

## Modifications

- In `_fuse_shared_experts_topk`, branch the shared-expert weight override:
  - **aiter (HIP) path** (`_use_aiter`): set the fused shared-expert weight to `1.0` (net contribution `1.0x`, since no post-MoE multiply is applied).
  - **Default post-MoE scaling path**: keep `1.0 / routed_scaling_factor` (so `(1/rsf) * rsf = 1.0`).
- Expanded the inline documentation to explain both paths and to explicitly note that other pre-folded backends (ModelOpt NVFP4, cutlass/trtllm-routed fp8) would also need a `1.0` shared weight, but are intentionally left unchanged in this PR and deferred to their maintainers.
- No kernel source changes; this is a pure dispatch-logic fix.

This is part of a series:
- PR 2 (test): Add CPU unit tests pinning the fused shared-expert scaling contract (to be opened).

## Accuracy Tests

This PR changes MoE outputs on the aiter (HIP) path, so a GSM8K few-shot sanity check is required. Use `benchmark_aiter_shared_expert_gsm8k.py` on AMD ROCm (e.g. MI355X) to compare:

| Configuration | GSM8K accuracy |
|---|---|
| (a) aiter + fusion ON, pre-fix (path broken before PR) | TBD — to be filled after benchmarking |
| (b) aiter + fusion ON, post-fix (this PR) | TBD — to be filled after benchmarking |
| (c) control: non-aiter path (unaffected by this PR) | TBD — to be filled after benchmarking |

Reproduction:

```
python3 -m sglang.launch_server --model Qwen/Qwen2-7B-Instruct
python3 -m sglang.test.few_shot_gsm8k --num-questions 200
```

Note: the pre-fix (a) numbers are expected to be degraded because the shared expert is under-weighted by `routed_scaling_factor`; the post-fix (b) numbers should match the intended `1.0x` shared-expert contribution. The non-aiter control (c) must be unchanged relative to main.

## Speed Tests and Profiling

This change only alters a scalar weight assignment on an existing code path and does not add or remove kernels or device syncs; no measurable performance impact is expected. TBD — to be filled after benchmarking if reviewers request confirmation.

## Review and Merge Process

- Ping Merge Oncalls to start the review process (see PR Merge Process in MAINTAINER.md).
- Request approvals from CODEOWNERS for `python/sglang/srt/layers/moe/`.
- An authorized user should comment `/tag-and-rerun-ci` to enable CI; the author can use `/rerun-failed-ci` for reruns.
- After green CI and required approvals, ask Merge Oncalls or a user with Write permission to merge.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28043856229](https://github.com/sgl-project/sglang/actions/runs/28043856229)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28043856512](https://github.com/sgl-project/sglang/actions/runs/28043856512)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->