### PR TITLE
Sync the changes in #23402

### DIFF
--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -59,6 +59,8 @@ def _resolve_backend(backend: str, is_multi_node: bool = False) -> str:
                 "FlashInfer allreduce fusion does not support multi-node on "
                 "non-Blackwell systems."
             )
+        if is_sm100_supported():
+            return "mnnvl"
         return "trtllm"
 
     if backend == "trtllm" and is_multi_node:

--- a/test/registered/unit/layers/test_flashinfer_comm_fusion.py
+++ b/test/registered/unit/layers/test_flashinfer_comm_fusion.py
@@ -80,11 +80,11 @@ class TestFlashInferCommFusion(unittest.TestCase):
             flashinfer_allreduce_fusion_backend="auto", nnodes=2
         )
 
-        # Blackwell: trtllm on single-node, mnnvl on multi-node.
+        # Blackwell: mnnvl on both single-node and multi-node.
         with patch.object(fusion, "is_sm100_supported", return_value=True):
             self.assertEqual(
                 fusion.resolve_flashinfer_allreduce_fusion_backend(single_node),
-                "trtllm",
+                "mnnvl",
             )
             self.assertEqual(
                 fusion.resolve_flashinfer_allreduce_fusion_backend(multi_node), "mnnvl"


### PR DESCRIPTION
These changes were partly reverted. 
We need the single-node + SM10X to be MNNVL.
Reland, since it's confirmed by CUPTI data across all message sizes, and @wenscarl https://github.com/sgl-project/sglang/pull/23402





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28044483348](https://github.com/sgl-project/sglang/actions/runs/28044483348)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #28056341149](https://github.com/sgl-project/sglang/actions/runs/28056341149)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->