### PR TITLE
[DO NOT MERGE] 0.5.14 CI checking

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -249,6 +249,42 @@ if is_blackwell_supported() and is_flashinfer_available():
 
     from sglang.srt.utils.custom_op import register_custom_op
 
+    def _patch_flashinfer_cudnn_fp8_libcudart_guard() -> None:
+        import functools
+
+        import flashinfer.gemm.gemm_base as fi_gemm
+
+        factory = getattr(fi_gemm, "_cudnn_gemm_fp8_runner", None)
+        if factory is None or getattr(factory, "_sgl_libcudart_guard", False):
+            return
+
+        @functools.wraps(factory)
+        def patched_factory(*args, **kwargs):
+            runner = factory(*args, **kwargs)
+            orig_get_valid_tactics = runner.get_valid_tactics
+
+            def get_valid_tactics(*a, **k):
+                try:
+                    return orig_get_valid_tactics(*a, **k)
+                except RuntimeError as e:
+                    if "Multiple libcudart libraries" not in str(e):
+                        raise
+                    logger.warning_once(
+                        "FlashInfer cuDNN FP8 GEMM tactic disabled: cuDNN's "
+                        "libcudart guard tripped (%s). Falling back to "
+                        "cutlass/cublas tactics.",
+                        e,
+                    )
+                    return []
+
+            runner.get_valid_tactics = get_valid_tactics
+            return runner
+
+        patched_factory._sgl_libcudart_guard = True
+        fi_gemm._cudnn_gemm_fp8_runner = patched_factory
+
+    _patch_flashinfer_cudnn_fp8_libcudart_guard()
+
     @register_custom_op(
         op_name="flashinfer_bmm_fp8",
         mutates_args=[],

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -249,42 +249,6 @@ if is_blackwell_supported() and is_flashinfer_available():
 
     from sglang.srt.utils.custom_op import register_custom_op
 
-    def _patch_flashinfer_cudnn_fp8_libcudart_guard() -> None:
-        import functools
-
-        import flashinfer.gemm.gemm_base as fi_gemm
-
-        factory = getattr(fi_gemm, "_cudnn_gemm_fp8_runner", None)
-        if factory is None or getattr(factory, "_sgl_libcudart_guard", False):
-            return
-
-        @functools.wraps(factory)
-        def patched_factory(*args, **kwargs):
-            runner = factory(*args, **kwargs)
-            orig_get_valid_tactics = runner.get_valid_tactics
-
-            def get_valid_tactics(*a, **k):
-                try:
-                    return orig_get_valid_tactics(*a, **k)
-                except RuntimeError as e:
-                    if "Multiple libcudart libraries" not in str(e):
-                        raise
-                    logger.warning_once(
-                        "FlashInfer cuDNN FP8 GEMM tactic disabled: cuDNN's "
-                        "libcudart guard tripped (%s). Falling back to "
-                        "cutlass/cublas tactics.",
-                        e,
-                    )
-                    return []
-
-            runner.get_valid_tactics = get_valid_tactics
-            return runner
-
-        patched_factory._sgl_libcudart_guard = True
-        fi_gemm._cudnn_gemm_fp8_runner = patched_factory
-
-    _patch_flashinfer_cudnn_fp8_libcudart_guard()
-
     @register_custom_op(
         op_name="flashinfer_bmm_fp8",
         mutates_args=[],

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -725,7 +725,7 @@ _LEGACY_SUITE_TO_RUNNER_CONFIG = {
     "nightly-perf-vlm-2-gpu": "2-gpu-large",
     "nightly-4-gpu": "4-gpu-h100",
     "nightly-4-gpu-b200": "4-gpu-b200",
-    "nightly-8-gpu-common": "8-gpu-h200",
+    "nightly-8-gpu-common": ["8-gpu-h200", "8-gpu-b200"],
     "nightly-8-gpu-h200": "8-gpu-h200",
     "nightly-kernel-8-gpu-h200": "8-gpu-h200",
     "nightly-precision-8-gpu-h200": "8-gpu-h200",
@@ -830,10 +830,14 @@ def detect_suite(file_path_from_test):
     legacy_suites = _extract_legacy_suites(content)
     mappable = [s for s in legacy_suites if s in _LEGACY_SUITE_TO_RUNNER_CONFIG]
     if mappable:
-        return [
-            _resolve_runner_config(_LEGACY_SUITE_TO_RUNNER_CONFIG[s], full_path, s)
-            for s in mappable
-        ]
+        results = []
+        for s in mappable:
+            rcs = _LEGACY_SUITE_TO_RUNNER_CONFIG[s]
+            if isinstance(rcs, str):
+                rcs = [rcs]
+            for rc in rcs:
+                results.append(_resolve_runner_config(rc, full_path, s))
+        return results
 
     if re.search(r"^[^#\n]*register_cpu_ci\s*\(", content, re.MULTILINE):
         return [


### PR DESCRIPTION
**DO NOT MERGE.** Opened solely to exercise CI on the `release/v0.5.14` branch.

Contains only the `scripts/ci/utils/slash_command_handler.py` change that maps `nightly-8-gpu-common` to both `8-gpu-h200` and `8-gpu-b200`, and teaches `detect_suite` to resolve a list of runner configs per legacy suite.













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28048986506](https://github.com/sgl-project/sglang/actions/runs/28048986506)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28048984072](https://github.com/sgl-project/sglang/actions/runs/28048984072)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->