### PR TITLE
[Cherry-pick to release/v0.5.14] Skip Flashinfer cuDNN FP8 GEMM tactic when cuDNN's libcudart guard trips (#29071)

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -249,6 +249,42 @@ if is_blackwell_supported() and is_flashinfer_available():
 
     from sglang.srt.utils.custom_op import register_custom_op
 
+    def _patch_flashinfer_cudnn_fp8_libcudart_guard() -> None:
+        import functools
+
+        import flashinfer.gemm.gemm_base as fi_gemm
+
+        factory = getattr(fi_gemm, "_cudnn_gemm_fp8_runner", None)
+        if factory is None or getattr(factory, "_sgl_libcudart_guard", False):
+            return
+
+        @functools.wraps(factory)
+        def patched_factory(*args, **kwargs):
+            runner = factory(*args, **kwargs)
+            orig_get_valid_tactics = runner.get_valid_tactics
+
+            def get_valid_tactics(*a, **k):
+                try:
+                    return orig_get_valid_tactics(*a, **k)
+                except RuntimeError as e:
+                    if "Multiple libcudart libraries" not in str(e):
+                        raise
+                    logger.warning_once(
+                        "FlashInfer cuDNN FP8 GEMM tactic disabled: cuDNN's "
+                        "libcudart guard tripped (%s). Falling back to "
+                        "cutlass/cublas tactics.",
+                        e,
+                    )
+                    return []
+
+            runner.get_valid_tactics = get_valid_tactics
+            return runner
+
+        patched_factory._sgl_libcudart_guard = True
+        fi_gemm._cudnn_gemm_fp8_runner = patched_factory
+
+    _patch_flashinfer_cudnn_fp8_libcudart_guard()
+
     @register_custom_op(
         op_name="flashinfer_bmm_fp8",
         mutates_args=[],


### PR DESCRIPTION
Cherry-pick of #29071 to `release/v0.5.14`.

The fix is confirmed in the following run: https://github.com/sgl-project/sglang/pull/29064#issuecomment-4782398791

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

On Blackwell, ModelOpt FP8 linear goes through `bmm_fp8(backend="auto")`, so the Flashinfer autotuner probes the cuDNN FP8 GEMM tactic during warmup. When the image has both a CUDA 12 (torch) and CUDA 13 (cuda-tile) runtime mapped, cuDNN-frontend's shim throws while dlopen-ing libcudart:

```
RuntimeError: Multiple libcudart libraries found: libcudart.so.12 and libcudart.so.13
```

It's raised inside `CudnnFp8GemmRunner.get_valid_tactics`, which `AutoTuner.choose_one` doesn't guard, so it kills the scheduler during warmup. Nemotron-3-Super (`test_nvidia_nemotron_3_super_nvfp4` / `_nightly`) dies this way in nightly.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Wrap Flashinfer's `_cudnn_gemm_fp8_runner` so tactic enumeration returns `[]` on that specific error → autotuner skips cuDNN and falls back to cutlass/cublas instead of crashing. Other errors re-raise, and healthy hosts (one libcudart) are untouched and still pick cuDNN.

The dual libcudart should really be fixed in the image — while both are mapped cuDNN can't resolve cudart at all (the failed scan isn't cached), so the tactic can't run there regardless.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

No model output change — falls back to the existing cutlass/cublas FP8 path. Covered by the Nemotron-3-Super nightly tests.

## Speed Tests and Profiling

N/A, crash fix.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28048752452](https://github.com/sgl-project/sglang/actions/runs/28048752452)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28048748776](https://github.com/sgl-project/sglang/actions/runs/28048748776)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->