### PR TITLE
[Perf] Overlap result D2H copy with the next forward step

### DIFF
--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -53,8 +53,8 @@ class ExpertDistributionMetrics:
     eplb_balancedness: torch.Tensor
 
     def map_device_tensors(self, fn):
-        # Only declare device-tensor fields; the caller injects the single
-        # copy+safety primitive. See GenerationBatchResult.copy_to_cpu.
+        # Device-tensor fields only; caller injects the copy+safety primitive
+        # (see GenerationBatchResult.copy_to_cpu).
         self.eplb_balancedness = fn(self.eplb_balancedness)
 
 

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -53,7 +53,13 @@ class ExpertDistributionMetrics:
     eplb_balancedness: torch.Tensor
 
     def copy_to_cpu(self):
-        self.eplb_balancedness = self.eplb_balancedness.to("cpu", non_blocking=True)
+        # May run on a dedicated copy stream (overlap scheduling); record_stream
+        # keeps the GPU source alive until that stream drains the D2H so the
+        # allocator can't recycle it mid-copy.
+        src = self.eplb_balancedness
+        self.eplb_balancedness = src.to("cpu", non_blocking=True)
+        if src.is_cuda:
+            src.record_stream(torch.cuda.current_stream(src.device))
 
 
 class ExpertDistributionRecorder(ABC):

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -52,14 +52,10 @@ _OutputMode = Literal["file", "object"]
 class ExpertDistributionMetrics:
     eplb_balancedness: torch.Tensor
 
-    def copy_to_cpu(self):
-        # May run on a dedicated copy stream (overlap scheduling); record_stream
-        # keeps the GPU source alive until that stream drains the D2H so the
-        # allocator can't recycle it mid-copy.
-        src = self.eplb_balancedness
-        self.eplb_balancedness = src.to("cpu", non_blocking=True)
-        if src.is_cuda:
-            src.record_stream(torch.cuda.current_stream(src.device))
+    def map_device_tensors(self, fn):
+        # Only declare device-tensor fields; the caller injects the single
+        # copy+safety primitive. See GenerationBatchResult.copy_to_cpu.
+        self.eplb_balancedness = fn(self.eplb_balancedness)
 
 
 class ExpertDistributionRecorder(ABC):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3223,7 +3223,9 @@ class Scheduler(
                             # copy is a leaf: nothing on forward_stream waits on
                             # it; the output processor gates on copy_done.
                             self.copy_stream.wait_stream(self.forward_stream)
-                            with self.copy_stream_ctx:
+                            with self.copy_stream_ctx, torch.profiler.record_function(
+                                "copy_result_to_cpu"
+                            ):
                                 batch_result.copy_to_cpu(
                                     return_logprob=batch.return_logprob,
                                     return_hidden_states=batch.return_hidden_states,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3217,11 +3217,9 @@ class Scheduler(
                                 else batch_result.next_token_ids
                             )
                             self.future_map.stash(future_indices, stash_payload)
-                            # Run the result D2H on the dedicated copy_stream so
-                            # it overlaps the next iter's forward (copy engine vs
-                            # SMs) instead of serializing on forward_stream. The
-                            # copy is a leaf: nothing on forward_stream waits on
-                            # it; the output processor gates on copy_done.
+                            # Result D2H on copy_stream overlaps the next forward
+                            # instead of serializing on forward_stream; it's a leaf
+                            # gated by copy_done, so nothing on forward_stream waits.
                             self.copy_stream.wait_stream(self.forward_stream)
                             with self.copy_stream_ctx, torch.profiler.record_function(
                                 "copy_result_to_cpu"

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3221,9 +3221,7 @@ class Scheduler(
                             # instead of serializing on forward_stream; it's a leaf
                             # gated by copy_done, so nothing on forward_stream waits.
                             self.copy_stream.wait_stream(self.forward_stream)
-                            with self.copy_stream_ctx, torch.profiler.record_function(
-                                "copy_result_to_cpu"
-                            ):
+                            with self.copy_stream_ctx:
                                 batch_result.copy_to_cpu(
                                     return_logprob=batch.return_logprob,
                                     return_hidden_states=batch.return_hidden_states,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3217,10 +3217,17 @@ class Scheduler(
                                 else batch_result.next_token_ids
                             )
                             self.future_map.stash(future_indices, stash_payload)
-                            batch_result.copy_to_cpu(
-                                return_logprob=batch.return_logprob,
-                                return_hidden_states=batch.return_hidden_states,
-                            )
+                            # Run the result D2H on the dedicated copy_stream so
+                            # it overlaps the next iter's forward (copy engine vs
+                            # SMs) instead of serializing on forward_stream. The
+                            # copy is a leaf: nothing on forward_stream waits on
+                            # it; the output processor gates on copy_done.
+                            self.copy_stream.wait_stream(self.forward_stream)
+                            with self.copy_stream_ctx:
+                                batch_result.copy_to_cpu(
+                                    return_logprob=batch.return_logprob,
+                                    return_hidden_states=batch.return_hidden_states,
+                                )
                         else:
                             batch_result.future_indices = future_indices
 

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -22,6 +22,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _async_d2h(t: torch.Tensor) -> torch.Tensor:
+    """Async device-to-host copy for overlap scheduling.
+
+    On CUDA the destination is pinned so the copy is genuinely async: a D2H to
+    pageable host memory blocks the calling (scheduler) thread until it
+    completes. The source is kept alive on the current stream via record_stream
+    so the caching allocator does not recycle it before this copy (which may run
+    on a separate copy stream) has drained. Non-CUDA falls back to a plain copy.
+    """
+    if not t.is_cuda:
+        return t.to("cpu", non_blocking=True)
+    cpu_t = torch.empty(t.shape, dtype=t.dtype, pin_memory=True)
+    cpu_t.copy_(t, non_blocking=True)
+    t.record_stream(torch.cuda.current_stream(t.device))
+    return cpu_t
+
+
 @dataclasses.dataclass
 class GenerationBatchResult:
     logits_output: Optional[LogitsProcessorOutput] = None
@@ -79,36 +96,36 @@ class GenerationBatchResult:
         """
         if return_logprob:
             if self.logits_output.next_token_logprobs is not None:
-                self.logits_output.next_token_logprobs = (
-                    self.logits_output.next_token_logprobs.to("cpu", non_blocking=True)
+                self.logits_output.next_token_logprobs = _async_d2h(
+                    self.logits_output.next_token_logprobs
                 )
             if self.logits_output.input_token_logprobs is not None:
-                self.logits_output.input_token_logprobs = (
-                    self.logits_output.input_token_logprobs.to("cpu", non_blocking=True)
+                self.logits_output.input_token_logprobs = _async_d2h(
+                    self.logits_output.input_token_logprobs
                 )
             if self.logits_output.next_token_top_logprobs_val is not None:
                 self.logits_output.next_token_top_logprobs_val = [
-                    v.to("cpu", non_blocking=True) if torch.is_tensor(v) else v
+                    _async_d2h(v) if torch.is_tensor(v) else v
                     for v in self.logits_output.next_token_top_logprobs_val
                 ]
             if self.logits_output.next_token_top_logprobs_idx is not None:
                 self.logits_output.next_token_top_logprobs_idx = [
-                    x.to("cpu", non_blocking=True) if torch.is_tensor(x) else x
+                    _async_d2h(x) if torch.is_tensor(x) else x
                     for x in self.logits_output.next_token_top_logprobs_idx
                 ]
             if self.logits_output.next_token_token_ids_logprobs_val is not None:
                 self.logits_output.next_token_token_ids_logprobs_val = [
-                    v.to("cpu", non_blocking=True) if torch.is_tensor(v) else v
+                    _async_d2h(v) if torch.is_tensor(v) else v
                     for v in self.logits_output.next_token_token_ids_logprobs_val
                 ]
         if return_hidden_states and self.logits_output.hidden_states is not None:
-            self.logits_output.hidden_states = self.logits_output.hidden_states.to(
-                "cpu", non_blocking=True
+            self.logits_output.hidden_states = _async_d2h(
+                self.logits_output.hidden_states
             )
-        self.next_token_ids = self.next_token_ids.to("cpu", non_blocking=True)
+        self.next_token_ids = _async_d2h(self.next_token_ids)
 
         if self.accept_lens is not None:
-            self.accept_lens = self.accept_lens.to("cpu", non_blocking=True)
+            self.accept_lens = _async_d2h(self.accept_lens)
 
         if self.routed_experts_output is not None:
             self.routed_experts_output.copy_to_cpu()

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -123,14 +123,16 @@ class GenerationBatchResult:
         if self.accept_lens is not None:
             self.accept_lens = _async_d2h(self.accept_lens)
 
-        if self.routed_experts_output is not None:
-            self.routed_experts_output.copy_to_cpu()
-
-        if self.indexer_topk_output is not None:
-            self.indexer_topk_output.copy_to_cpu()
-
-        if (x := self.expert_distribution_metrics) is not None:
-            x.copy_to_cpu()
+        # Sub-objects only declare their device fields; the single copy+safety
+        # primitive (_async_d2h: pinned D2H + record_stream) is injected here so
+        # all device->host copying and lifetime safety lives in one place.
+        for holder in (
+            self.routed_experts_output,
+            self.indexer_topk_output,
+            self.expert_distribution_metrics,
+        ):
+            if holder is not None:
+                holder.map_device_tensors(_async_d2h)
 
         self.copy_done.record()
 

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -23,14 +23,10 @@ logger = logging.getLogger(__name__)
 
 
 def _async_d2h(t: torch.Tensor) -> torch.Tensor:
-    """Async device-to-host copy for overlap scheduling.
-
-    On CUDA the destination is pinned so the copy is genuinely async: a D2H to
-    pageable host memory blocks the calling (scheduler) thread until it
-    completes. The source is kept alive on the current stream via record_stream
-    so the caching allocator does not recycle it before this copy (which may run
-    on a separate copy stream) has drained. Non-CUDA falls back to a plain copy.
-    """
+    """Async D2H copy for overlap scheduling. On CUDA the dest is pinned (a D2H
+    to pageable host memory blocks the caller until done) and record_stream keeps
+    the source alive until the copy stream drains, so the caching allocator can't
+    recycle it early. Non-CUDA falls back to a plain copy."""
     if not t.is_cuda:
         return t.to("cpu", non_blocking=True)
     cpu_t = torch.empty(t.shape, dtype=t.dtype, pin_memory=True)

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -85,6 +85,7 @@ class GenerationBatchResult:
     fpm_start_event: Optional[torch.cuda.Event] = None
     fpm_end_event: Optional[torch.cuda.Event] = None
 
+    @torch.profiler.record_function("copy_result_to_cpu")
     def copy_to_cpu(self, return_logprob: bool, return_hidden_states: bool = True):
         """Copy tensors to CPU in overlap scheduling.
         Only the tensors which are needed for processing results are copied,
@@ -258,6 +259,7 @@ class EmbeddingBatchResult:
     def can_run_cuda_graph(self) -> bool:
         return False
 
+    @torch.profiler.record_function("copy_embedding_to_cpu")
     def copy_to_cpu(self):
         """Copy embeddings and pooled hidden states to CPU for overlap scheduling."""
         if isinstance(self.embeddings, torch.Tensor):

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -262,26 +262,22 @@ class EmbeddingBatchResult:
         """Copy embeddings and pooled hidden states to CPU for overlap scheduling."""
         if isinstance(self.embeddings, torch.Tensor):
             self.copy_done = torch.get_device_module(self.embeddings.device).Event()
-            self.embeddings = self.embeddings.to("cpu", non_blocking=True)
+            self.embeddings = _async_d2h(self.embeddings)
         else:
             assert isinstance(self.embeddings, list)
             if len(self.embeddings) == 0:
                 return
 
             self.copy_done = torch.get_device_module(self.embeddings[0].device).Event()
-            self.embeddings = [
-                emb.to("cpu", non_blocking=True) for emb in self.embeddings
-            ]
+            self.embeddings = [_async_d2h(emb) for emb in self.embeddings]
 
         if self.pooled_hidden_states is not None:
             if isinstance(self.pooled_hidden_states, list):
                 self.pooled_hidden_states = [
-                    t.to("cpu", non_blocking=True) for t in self.pooled_hidden_states
+                    _async_d2h(t) for t in self.pooled_hidden_states
                 ]
             else:
-                self.pooled_hidden_states = self.pooled_hidden_states.to(
-                    "cpu", non_blocking=True
-                )
+                self.pooled_hidden_states = _async_d2h(self.pooled_hidden_states)
 
         self.copy_done.record()
 

--- a/python/sglang/srt/state_capturer/base.py
+++ b/python/sglang/srt/state_capturer/base.py
@@ -79,27 +79,20 @@ class BaseHostCache:
 @dataclasses.dataclass
 class TopkCaptureOutput:
     """Holds GPU tensors captured during forward for overlap scheduling.
-    Call copy_to_cpu() before copy_done.record() (it may run on the dedicated
-    result-copy stream), then finalize() after copy_done.synchronize().
+    map_device_tensors() D2H-copies them before copy_done.record() (may run on
+    the dedicated result-copy stream); finalize() runs after copy_done.synchronize().
     """
 
     out_cache_loc: torch.Tensor
     topk: torch.Tensor
     host_cache: BaseHostCache
 
-    def copy_to_cpu(self):
-        # May run on a dedicated copy stream (overlap scheduling); record_stream
-        # keeps each GPU source alive until that stream drains the D2H so the
-        # allocator can't recycle it mid-copy. The copy stream must already wait
-        # on the producer stream (Scheduler.run_batch).
-        src = self.out_cache_loc
-        self.out_cache_loc = src.to("cpu", non_blocking=True)
-        if src.is_cuda:
-            src.record_stream(torch.cuda.current_stream(src.device))
-        src = self.topk
-        self.topk = src.to("cpu", non_blocking=True)
-        if src.is_cuda:
-            src.record_stream(torch.cuda.current_stream(src.device))
+    def map_device_tensors(self, fn):
+        # Only declare this struct's device-tensor fields; the caller injects the
+        # single copy+safety primitive (D2H + record_stream). See
+        # GenerationBatchResult.copy_to_cpu.
+        self.out_cache_loc = fn(self.out_cache_loc)
+        self.topk = fn(self.topk)
 
     def finalize(self):
         self.host_cache.buffer[self.out_cache_loc] = self.topk

--- a/python/sglang/srt/state_capturer/base.py
+++ b/python/sglang/srt/state_capturer/base.py
@@ -88,9 +88,8 @@ class TopkCaptureOutput:
     host_cache: BaseHostCache
 
     def map_device_tensors(self, fn):
-        # Only declare this struct's device-tensor fields; the caller injects the
-        # single copy+safety primitive (D2H + record_stream). See
-        # GenerationBatchResult.copy_to_cpu.
+        # Device-tensor fields only; caller injects the copy+safety primitive
+        # (see GenerationBatchResult.copy_to_cpu).
         self.out_cache_loc = fn(self.out_cache_loc)
         self.topk = fn(self.topk)
 

--- a/python/sglang/srt/state_capturer/base.py
+++ b/python/sglang/srt/state_capturer/base.py
@@ -79,8 +79,8 @@ class BaseHostCache:
 @dataclasses.dataclass
 class TopkCaptureOutput:
     """Holds GPU tensors captured during forward for overlap scheduling.
-    Call copy_to_cpu() inside forward stream (before copy_done.record()),
-    then finalize() after copy_done.synchronize().
+    Call copy_to_cpu() before copy_done.record() (it may run on the dedicated
+    result-copy stream), then finalize() after copy_done.synchronize().
     """
 
     out_cache_loc: torch.Tensor
@@ -88,8 +88,18 @@ class TopkCaptureOutput:
     host_cache: BaseHostCache
 
     def copy_to_cpu(self):
-        self.out_cache_loc = self.out_cache_loc.to("cpu", non_blocking=True)
-        self.topk = self.topk.to("cpu", non_blocking=True)
+        # May run on a dedicated copy stream (overlap scheduling); record_stream
+        # keeps each GPU source alive until that stream drains the D2H so the
+        # allocator can't recycle it mid-copy. The copy stream must already wait
+        # on the producer stream (Scheduler.run_batch).
+        src = self.out_cache_loc
+        self.out_cache_loc = src.to("cpu", non_blocking=True)
+        if src.is_cuda:
+            src.record_stream(torch.cuda.current_stream(src.device))
+        src = self.topk
+        self.topk = src.to("cpu", non_blocking=True)
+        if src.is_cuda:
+            src.record_stream(torch.cuda.current_stream(src.device))
 
     def finalize(self):
         self.host_cache.buffer[self.out_cache_loc] = self.topk


### PR DESCRIPTION
## Summary
- Run the per-step result D2H (`next_token_ids`, logprobs, hidden states, spec `accept_lens`) on the dedicated `copy_stream` so it overlaps the next forward instead of serializing on `forward_stream`.
- Route every result-side device->host copy through a single `_async_d2h` primitive (pinned dst + `record_stream`), so the copy and its cross-stream lifetime safety live in one place.

## Background
- `copy_to_cpu` issued the D2H on `forward_stream` into pageable host memory. A D2H to pageable memory is synchronous on the host, so it blocked the scheduler thread and serialized ahead of the next forward.
- The sub-result copies (`TopkCaptureOutput`, `ExpertDistributionMetrics`) each hand-rolled their own `.to("cpu", non_blocking=True)`, duplicating the copy across modules.

## Changes
**Overlap**
- Issue the result D2H on `copy_stream` with `copy_stream.wait_stream(forward_stream)` for ordering. The copy is a leaf gated by `copy_done`, so nothing on `forward_stream` waits on it.
- `_async_d2h` writes into a pinned host buffer so the copy is genuinely async and no longer stalls the scheduler thread; `record_stream` keeps each GPU source alive until `copy_stream` drains.

**Single copy primitive**
- `_async_d2h(t)` is the only place a result-side D2H + `record_stream` happens.
- `TopkCaptureOutput` / `ExpertDistributionMetrics` now expose `map_device_tensors(fn)` (declare their device fields only); `GenerationBatchResult.copy_to_cpu` injects `_async_d2h`, so a new tensor holder cannot miss the safety step.
- `EmbeddingBatchResult.copy_to_cpu` routes through `_async_d2h` too.

**Observability**
- Annotate `copy_to_cpu` with `@torch.profiler.record_function` so the copy is identifiable in traces and projects onto the `copy_stream` GPU track.

## Notes
- CUDA-only; non-CUDA falls back to the previous plain `.to("cpu")` path.
- The next-iteration seq_lens relay D2H is intentionally left separate (different consumer, timing, and stream).









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28058041539](https://github.com/sgl-project/sglang/actions/runs/28058041539)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #28058041383](https://github.com/sgl-project/sglang/actions/runs/28058041383)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
