### PR TITLE
[deepseek/mla] Cache dequantized absorbed MLA weights (w_kc/w_vc) to skip per-step dequant

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -371,14 +371,18 @@ class DeepseekMLAForwardMixin:
                 else:
                     q_nope_out = torch.bmm(
                         q_nope.to(torch.bfloat16).transpose(0, 1),
-                        self.w_kc.to(torch.bfloat16) * self.w_scale,
+                        self.w_kc_dequant
+                        if self.w_kc_dequant is not None
+                        else self.w_kc.to(torch.bfloat16) * self.w_scale,
                     )
 
         elif self.w_kc.dtype == torch.float8_e4m3fn:
             if _is_cpu:
                 q_nope_out = torch.bmm(
                     q_nope.to(torch.bfloat16).transpose(0, 1),
-                    self.w_kc.to(torch.bfloat16) * self.w_scale,
+                    self.w_kc_dequant
+                    if self.w_kc_dequant is not None
+                    else self.w_kc.to(torch.bfloat16) * self.w_scale,
                 )
             else:
                 # fix bmm_fp8 error under cublas12.9 caused by bumpallocator, detail in pr#11612
@@ -655,7 +659,9 @@ class DeepseekMLAForwardMixin:
                 else:
                     attn_bmm_output = torch.bmm(
                         attn_output.to(torch.bfloat16).transpose(0, 1),
-                        self.w_vc.to(torch.bfloat16) * self.w_scale,
+                        self.w_vc_dequant
+                        if self.w_vc_dequant is not None
+                        else self.w_vc.to(torch.bfloat16) * self.w_scale,
                     )
 
             if _bmm_buf is not None:
@@ -689,7 +695,9 @@ class DeepseekMLAForwardMixin:
             if _is_cpu:
                 attn_bmm_output = torch.bmm(
                     attn_output.to(torch.bfloat16).transpose(0, 1),
-                    self.w_vc.to(torch.bfloat16) * self.w_scale,
+                    self.w_vc_dequant
+                    if self.w_vc_dequant is not None
+                    else self.w_vc.to(torch.bfloat16) * self.w_scale,
                 )
                 attn_bmm_output = attn_bmm_output.transpose(0, 1).flatten(1, 2)
             else:

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -588,6 +588,15 @@ class DeepseekV2WeightLoaderMixin:
                 if _is_npu:
                     w_vc = w_vc.contiguous()
                 self_attn.w_vc = bind_or_assign(self_attn.w_vc, w_vc)
+                # Cache the dequantized absorbed weights once; forward_absorb
+                # otherwise recomputes w.to(bf16) * w_scale every decode step.
+                if self_attn.w_kc.dtype in (torch.bfloat16, torch.float16):
+                    self_attn.w_kc_dequant = (
+                        self_attn.w_kc.to(torch.bfloat16) * self_attn.w_scale
+                    )
+                    self_attn.w_vc_dequant = (
+                        self_attn.w_vc.to(torch.bfloat16) * self_attn.w_scale
+                    )
                 if (
                     hasattr(self_attn.kv_b_proj, "weight_scale")
                     and self_attn.w_scale is None

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1687,6 +1687,10 @@ class DeepseekV2AttentionMLA(
 
         self.w_kc = None
         self.w_vc = None
+        # Dequantized (bf16) absorbed weights, cached once at load time to
+        # avoid recomputing w.to(bf16) * w_scale every decode step.
+        self.w_kc_dequant = None
+        self.w_vc_dequant = None
         self.w_scale = 1.0
 
         self.w_scale_k = None


### PR DESCRIPTION
## Motivation

In the absorbed MLA forward (`forward_absorb`), `q_nope @ w_kc` and `attn @ w_vc` recompute `w.to(torch.bfloat16) * w_scale` **on every decode step**:

```python
q_nope_out = torch.bmm(q_nope.to(torch.bfloat16).transpose(0, 1),
                       self.w_kc.to(torch.bfloat16) * self.w_scale)   # and w_vc
```

For models whose absorbed weights are **bf16** with a scalar `w_scale` — e.g. `amd/GLM-5.1-MXFP4`, where the checkpoint deliberately keeps attention in bf16 — this is a *static*, per-step-invariant cast + elementwise multiply. It shows up in decode traces as ~2 `vectorized_elementwise_kernel` (`MulFunctor`) launches per layer, pure redundant work since the result is identical every step.

## Change

Pre-dequantize `w_kc`/`w_vc` **once at weight-load time** (`deepseek_weight_loader.py`) into `w_kc_dequant` / `w_vc_dequant`, and use the cached tensors in `forward_absorb`.

- Populated at **load time, not lazily** — the CUDA-graph capture is the first forward, so a lazy cache would bake the multiply into the graph; load-time population avoids that.
- Guarded to `bf16`/`fp16` absorbed weights; **fp8/quantized paths fall back to the original on-the-fly compute** and are unchanged.

## Correctness

Numerically **identical** — it's the exact same computation, just cached once instead of recomputed per step. No change to fp8 paths. Output verified coherent on GLM-5.1-MXFP4.

## Performance

`amd/GLM-5.1-MXFP4`, MI355X (gfx950), tp=4, ISL/OSL 1024/1024, `benchmark_serving` (random dataset, `num-prompts = concurrency × 10`). Same server build, baseline vs this patch:

| concurrency | baseline (tok/s) | patched (tok/s) | Δ throughput | baseline TPOT (ms) | patched TPOT (ms) |
|---|---|---|---|---|---|
| 4   | 243.0  | 246.4  | **+1.4%** | 16.18 | 15.96 |
| 8   | 431.8  | 444.0  | **+2.8%** | 17.92 | 17.61 |
| 32  | 1245.5 | 1266.4 | **+1.7%** | 24.52 | 24.04 |
| 64  | 1937.2 | 1977.0 | **+2.1%** | 30.81 | 30.33 |
| 128 | 2939.8 | 2950.3 | **+0.4%** | 39.88 | 39.73 |

Average **+2.0% (c4–c64)**, **+1.7% (c4–c128)** output-token throughput; per-token latency (TPOT) improves correspondingly. The gain tapers at very high concurrency where the MoE/dense GEMMs dominate the step. Benefits any DeepseekV2-derived model with bf16 absorbed MLA weights (DeepSeek / GLM / Kimi MXFP4 family).

## Checklist
- [x] Format with `ruff`
- [x] `py_compile` clean
- [ ] CI
