### PR TITLE
[misc] Add sglang.bench_one_batch deprecation shim

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -1,0 +1,22 @@
+"""Deprecated import path for ``sglang.benchmark.one_batch``.
+
+``python -m sglang.bench_one_batch`` and ``from sglang.bench_one_batch import ...``
+still work, but the implementation now lives in ``sglang.benchmark.one_batch``.
+Update references to the new path.
+"""
+
+import warnings
+
+from sglang.benchmark.one_batch import *  # noqa: F401,F403
+from sglang.benchmark.one_batch import cli_main
+
+warnings.warn(
+    "`sglang.bench_one_batch` is deprecated and will be removed in a future "
+    "release; use `sglang.benchmark.one_batch` instead "
+    "(e.g. `python -m sglang.benchmark.one_batch`).",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+if __name__ == "__main__":
+    cli_main()

--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -1000,7 +1000,7 @@ def main(server_args, bench_args):
         proc.terminate()
 
 
-if __name__ == "__main__":
+def cli_main():
     parser = argparse.ArgumentParser()
     ServerArgs.add_cli_args(parser)
     BenchArgs.add_cli_args(parser)
@@ -1018,3 +1018,7 @@ if __name__ == "__main__":
     finally:
         if server_args.tp_size != 1:
             kill_process_tree(os.getpid(), include_parent=False)
+
+
+if __name__ == "__main__":
+    cli_main()


### PR DESCRIPTION
Stacks on #28687. Re-adds `sglang.bench_one_batch` as a thin CLI shim that forwards to `sglang.benchmark.one_batch` (extracting `cli_main`) and emits a `DeprecationWarning`, keeping `python -m sglang.bench_one_batch` and `from sglang.bench_one_batch import ...` working.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28059827475](https://github.com/sgl-project/sglang/actions/runs/28059827475)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28059827339](https://github.com/sgl-project/sglang/actions/runs/28059827339)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->