### PR TITLE
[Bugfix] Anthropic /v1/messages: keep tool_result adjacent to tool_use

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -412,22 +412,6 @@ class AnthropicServing:
                 {"role": "system", "content": "\n".join(system_parts)}
             )
 
-        def _emit_user_message(parts: list[dict]) -> None:
-            """Append accumulated parts as a user message, then clear them.
-
-            Used to flush content collected BEFORE a tool_result so the
-            wire order stays user(pre) → tool → user(post). Without this
-            flush, text/image parts that appeared before a tool_result
-            block would be moved AFTER the tool message at end of loop.
-            """
-            if not parts:
-                return
-            if len(parts) == 1 and parts[0]["type"] == "text":
-                openai_messages.append({"role": "user", "content": parts[0]["text"]})
-            else:
-                openai_messages.append({"role": "user", "content": list(parts)})
-            parts.clear()
-
         # Convert messages
         for msg in anthropic_request.messages:
             if msg.role == "system" and self._merge_inline_system:
@@ -491,12 +475,11 @@ class AnthropicServing:
                     # Use tool_use_id (per spec) with fallback to id
                     tool_call_id = block.tool_use_id or block.id or ""
 
-                    # Tool results from user become separate tool messages.
-                    # Flush any pending text/image first so the wire order
-                    # is preserved (a tool_result that arrived AFTER a text
-                    # block must come AFTER that text in OpenAI form too).
+                    # Emit the tool message immediately so the result stays
+                    # adjacent to the assistant tool_call it answers (same-turn
+                    # text flushes after). A user message between a tool_call
+                    # and its result is out-of-distribution for tool models.
                     if msg.role == "user":
-                        _emit_user_message(content_parts)
                         openai_messages.append(
                             {
                                 "role": "tool",

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -424,22 +424,6 @@ class AnthropicServing:
                 {"role": "system", "content": "\n".join(system_parts)}
             )
 
-        def _emit_user_message(parts: list[dict]) -> None:
-            """Append accumulated parts as a user message, then clear them.
-
-            Used to flush content collected BEFORE a tool_result so the
-            wire order stays user(pre) → tool → user(post). Without this
-            flush, text/image parts that appeared before a tool_result
-            block would be moved AFTER the tool message at end of loop.
-            """
-            if not parts:
-                return
-            if len(parts) == 1 and parts[0]["type"] == "text":
-                openai_messages.append({"role": "user", "content": parts[0]["text"]})
-            else:
-                openai_messages.append({"role": "user", "content": list(parts)})
-            parts.clear()
-
         # Convert messages
         for msg in anthropic_request.messages:
             if msg.role == "system" and self._merge_inline_system:
@@ -503,12 +487,9 @@ class AnthropicServing:
                     # Use tool_use_id (per spec) with fallback to id
                     tool_call_id = block.tool_use_id or block.id or ""
 
-                    # Tool results from user become separate tool messages.
-                    # Flush any pending text/image first so the wire order
-                    # is preserved (a tool_result that arrived AFTER a text
-                    # block must come AFTER that text in OpenAI form too).
+                    # Anthropic requires tool results before any same-turn text.
+                    # Emit all tool messages now; content_parts flushes afterward.
                     if msg.role == "user":
-                        _emit_user_message(content_parts)
                         for tool_content in tool_contents:
                             openai_messages.append(
                                 {

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -1341,12 +1341,23 @@ class TestAnthropicServing(unittest.TestCase):
         body = json.loads(bytes(response.body).decode())
         self.assertEqual(body["error"]["type"], "api_error")
 
-    def test_user_message_text_tool_text_preserves_order(self):
-        """User message [text, tool_result, text] must stay user→tool→user on the wire."""
+    def test_user_message_text_tool_text_keeps_tool_adjacent(self):
+        """User text around a tool_result flushes after the adjacent tool message."""
         serving = self._serving()
         request = self._anthropic_request(
             stream=False,
             messages=[
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_x",
+                            "name": "lookup",
+                            "input": {},
+                        }
+                    ],
+                },
                 {
                     "role": "user",
                     "content": [
@@ -1365,9 +1376,16 @@ class TestAnthropicServing(unittest.TestCase):
         # chat_request.messages items are Pydantic ChatCompletionMessage*Param
         # variants — use attribute access, not subscripts.
         roles = [m.role for m in chat_request.messages]
-        self.assertEqual(roles, ["user", "tool", "user"])
-        self.assertEqual(chat_request.messages[0].content, "first")
-        self.assertEqual(chat_request.messages[2].content, "second")
+        self.assertEqual(roles, ["assistant", "tool", "user"])
+        self.assertEqual(chat_request.messages[1].tool_call_id, "call_x")
+        self.assertEqual(chat_request.messages[1].content, "ok")
+        self.assertEqual(
+            [part.model_dump() for part in chat_request.messages[2].content],
+            [
+                {"type": "text", "text": "first"},
+                {"type": "text", "text": "second"},
+            ],
+        )
 
     def test_empty_text_assistant_turn_preserves_role_alternation(self):
         """Assistant turn with only empty text must NOT vanish from the wire."""

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -1369,7 +1369,7 @@ class TestAnthropicServing(unittest.TestCase):
                         },
                         {"type": "text", "text": "second"},
                     ],
-                }
+                },
             ],
         )
         chat_request = serving._convert_to_chat_completion_request(request)

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -383,6 +383,102 @@ class TestAnthropicServing(unittest.TestCase):
         self.assertIn("https://docs.sglang.ai", tool_message["content"])
         self.assertIn("Anthropic API notes", tool_message["content"])
 
+    def test_text_before_tool_result_keeps_tool_adjacent(self):
+        # Adjacency is the in-distribution layout: expect [assistant, tool, user].
+        request = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "test-model",
+                "max_tokens": 16,
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "call_1",
+                                "name": "read_file",
+                                "input": {"path": "/tmp/f"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "summarize the log below"},
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "call_1",
+                                "content": "ERROR: disk full",
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+
+        messages = (
+            self._serving()
+            ._convert_to_chat_completion_request(request)
+            .model_dump()["messages"]
+        )
+
+        self.assertEqual([m["role"] for m in messages], ["assistant", "tool", "user"])
+        self.assertEqual(messages[1]["tool_call_id"], "call_1")
+        self.assertEqual(messages[1]["content"], "ERROR: disk full")
+        self.assertEqual(messages[2]["content"], "summarize the log below")
+
+    def test_image_before_tool_result_keeps_tool_adjacent(self):
+        # Multimodal: an image before the tool_result also flushes after the
+        # tool (the list-content branch), keeping tool result and call adjacent.
+        request = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "test-model",
+                "max_tokens": 16,
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "call_1",
+                                "name": "screenshot",
+                                "input": {},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/png",
+                                    "data": "aGk=",
+                                },
+                            },
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "call_1",
+                                "content": "captured",
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+
+        messages = (
+            self._serving()
+            ._convert_to_chat_completion_request(request)
+            .model_dump()["messages"]
+        )
+
+        self.assertEqual([m["role"] for m in messages], ["assistant", "tool", "user"])
+        self.assertEqual(messages[1]["content"], "captured")
+        self.assertIsInstance(messages[2]["content"], list)
+        self.assertEqual(messages[2]["content"][0]["type"], "image_url")
+
     def test_builtin_web_search_tool_without_schema_is_skipped(self):
         request = AnthropicMessagesRequest.model_validate(
             {

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -1298,12 +1298,23 @@ class TestAnthropicServing(unittest.TestCase):
         body = json.loads(bytes(response.body).decode())
         self.assertEqual(body["error"]["type"], "api_error")
 
-    def test_user_message_text_tool_text_preserves_order(self):
-        """User message [text, tool_result, text] must stay user→tool→user on the wire."""
+    def test_user_message_text_tool_text_keeps_tool_adjacent(self):
+        """User text around a tool_result flushes after the adjacent tool message."""
         serving = self._serving()
         request = self._anthropic_request(
             stream=False,
             messages=[
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_x",
+                            "name": "lookup",
+                            "input": {},
+                        }
+                    ],
+                },
                 {
                     "role": "user",
                     "content": [
@@ -1315,16 +1326,23 @@ class TestAnthropicServing(unittest.TestCase):
                         },
                         {"type": "text", "text": "second"},
                     ],
-                }
+                },
             ],
         )
         chat_request = serving._convert_to_chat_completion_request(request)
         # chat_request.messages items are Pydantic ChatCompletionMessage*Param
         # variants — use attribute access, not subscripts.
         roles = [m.role for m in chat_request.messages]
-        self.assertEqual(roles, ["user", "tool", "user"])
-        self.assertEqual(chat_request.messages[0].content, "first")
-        self.assertEqual(chat_request.messages[2].content, "second")
+        self.assertEqual(roles, ["assistant", "tool", "user"])
+        self.assertEqual(chat_request.messages[1].tool_call_id, "call_x")
+        self.assertEqual(chat_request.messages[1].content, "ok")
+        self.assertEqual(
+            [part.model_dump() for part in chat_request.messages[2].content],
+            [
+                {"type": "text", "text": "first"},
+                {"type": "text", "text": "second"},
+            ],
+        )
 
     def test_empty_text_assistant_turn_preserves_role_alternation(self):
         """Assistant turn with only empty text must NOT vanish from the wire."""


### PR DESCRIPTION
## Motivation

Anthropic `user` messages can contain both `tool_result` blocks and text or images. The protocol requires tool results to come first so they immediately follow the preceding assistant `tool_use` turn.

When text appeared before a `tool_result`, the converter instead emitted:

```text
assistant(tool_calls) -> user(text) -> tool(result)
```

That detaches the tool result from the call it answers and produces an invalid model-facing sequence for common tool-calling templates.

## Changes

- Emit `tool` messages before any non-tool content from the same Anthropic user turn.
- Preserve the relative order and representation of trailing text, image, search-result, and mixed `tool_reference` content.
- Remove the redundant early-flush helper; the existing end-of-turn path remains the single owner of user-content serialization.

This intentionally revises the wire-order behavior introduced in #25876 in favor of Anthropic protocol compliance and tool-call adjacency. The mixed `tool_reference` grouping added by #32522 is preserved.

## Verification

- Focused CPU harness: 59 Anthropic conversion tests passed using the actual protocol and serving modules.
- Regression coverage asserts `assistant -> tool -> user` for text and image content around `tool_result`, including correct `tool_call_id` pairing.
- Existing mixed `tool_reference` composition remains covered.
- Full file-scoped `pre-commit`, Python compilation, and `git diff --check` passed.
- Rebased onto current `main`; the reviewed patch remained byte-for-byte identical.

## Accuracy Tests

N/A. This changes request conversion only; it does not alter model execution or numeric output.

## Speed Tests and Profiling

N/A. The change removes an intermediate flush and has no inference-path impact.

## Checklist

- [x] Format code with pre-commit.
- [x] Add focused unit coverage.
- [ ] Update documentation - not required for this conversion fix.
- [ ] Provide accuracy and speed benchmarks - not applicable; see above.
- [x] Follow SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31547774869](https://github.com/sgl-project/sglang/actions/runs/31547774869)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31547774578](https://github.com/sgl-project/sglang/actions/runs/31547774578)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->