### PR TITLE
[misc] Add sglang.bench_offline_throughput deprecation shim

### DIFF
--- a/python/sglang/bench_offline_throughput.py
+++ b/python/sglang/bench_offline_throughput.py
@@ -1,0 +1,23 @@
+"""Deprecated import path for ``sglang.benchmark.offline_throughput``.
+
+``python -m sglang.bench_offline_throughput`` and
+``from sglang.bench_offline_throughput import ...`` still work, but the
+implementation now lives in ``sglang.benchmark.offline_throughput``.
+Update references to the new path.
+"""
+
+import warnings
+
+from sglang.benchmark.offline_throughput import *  # noqa: F401,F403
+from sglang.benchmark.offline_throughput import cli_main
+
+warnings.warn(
+    "`sglang.bench_offline_throughput` is deprecated and will be removed in a "
+    "future release; use `sglang.benchmark.offline_throughput` instead "
+    "(e.g. `python -m sglang.benchmark.offline_throughput`).",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+if __name__ == "__main__":
+    cli_main()

--- a/python/sglang/bench_offline_throughput.py
+++ b/python/sglang/bench_offline_throughput.py
@@ -16,7 +16,7 @@ warnings.warn(
     "future release; use `sglang.benchmark.offline_throughput` instead "
     "(e.g. `python -m sglang.benchmark.offline_throughput`).",
     DeprecationWarning,
-    stacklevel=2,
+    stacklevel=1,
 )
 
 if __name__ == "__main__":

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -15,7 +15,7 @@ warnings.warn(
     "release; use `sglang.benchmark.one_batch` instead "
     "(e.g. `python -m sglang.benchmark.one_batch`).",
     DeprecationWarning,
-    stacklevel=2,
+    stacklevel=1,
 )
 
 if __name__ == "__main__":

--- a/python/sglang/benchmark/offline_throughput.py
+++ b/python/sglang/benchmark/offline_throughput.py
@@ -418,7 +418,7 @@ def throughput_test(
     # Parse args
     extra_request_body = {}
     if bench_args.extra_request_body:
-        extra_request_body = json.loads(args.extra_request_body)
+        extra_request_body = json.loads(bench_args.extra_request_body)
 
     # Read dataset
     input_requests = get_dataset(bench_args, tokenizer)
@@ -504,7 +504,7 @@ def throughput_test(
     return result
 
 
-if __name__ == "__main__":
+def cli_main():
     parser = argparse.ArgumentParser()
     ServerArgs.add_cli_args(parser)
     BenchArgs.add_cli_args(parser)
@@ -541,3 +541,7 @@ if __name__ == "__main__":
 
     while bench_args.do_not_exit:
         pass
+
+
+if __name__ == "__main__":
+    cli_main()


### PR DESCRIPTION
Stacks on #28747. Re-adds `sglang.bench_offline_throughput` as a thin CLI shim forwarding to `sglang.benchmark.offline_throughput` (extracting `cli_main`) with a `DeprecationWarning`, keeping `python -m sglang.bench_offline_throughput` and `from sglang.bench_offline_throughput import ...` working.

Extracting `cli_main` moves the argparse `args` out of module scope, surfacing a pre-existing bug: `throughput_test` referenced `args.extra_request_body` (undefined in that scope) instead of `bench_args.extra_request_body`. Fixed here since the extraction is what makes it a hard `NameError` (and ruff F821).

Also bumps the deprecation-warning `stacklevel` from 2 to 1 in both this shim and the already-merged `sglang.bench_one_batch` shim (#29082). At module top level, `stacklevel=2` attributed the warning to `runpy` instead of `__main__`, so Python's default filter (which shows `DeprecationWarning` only in `__main__`) silently dropped it and `python -m sglang.bench_*` printed nothing. `stacklevel=1` makes the warning surface as intended.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28069214201](https://github.com/sgl-project/sglang/actions/runs/28069214201)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28069214032](https://github.com/sgl-project/sglang/actions/runs/28069214032)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
