### PR TITLE
[AMD] ci: register lora qwen3.5-4b logprob diff on extra-a 1-gpu-large-amd

### DIFF
--- a/test/registered/lora/test_lora_qwen3_5_4b_logprob_diff.py
+++ b/test/registered/lora/test_lora_qwen3_5_4b_logprob_diff.py
@@ -31,10 +31,11 @@ import torch
 from huggingface_hub import snapshot_download
 
 import sglang as sgl
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=90, stage="extra-a", runner_config="1-gpu-large")
+register_amd_ci(est_time=90, suite="extra-a-test-1-gpu-large-amd")
 
 BASE_MODEL = "Qwen/Qwen3.5-4B"
 LORA_HF_REPO = "opherlie/lora-test-case-Qwen3.5-4B"


### PR DESCRIPTION
## Summary

Adds `register_amd_ci(est_time=90, suite="extra-a-test-1-gpu-large-amd")` to `test/registered/lora/test_lora_qwen3_5_4b_logprob_diff.py`, filling the thin AMD `1-gpu-large` extra coverage (was 3/26 vs the CUDA counterpart).

**Why this test is ROCm-safe:** it uses `lora_backend="triton"` with the **default** attention backend — no `flashinfer` / `fa4` — unlike its 8B sibling `test_lora_qwen3_8b_logprob_diff.py`, which hardcodes `attention_backend="flashinfer"` + `prefill/decode="fa4"` and stays CUDA-only. LoRA core is already AMD-proven per-commit (`lora/test_lora_drainer.py`, `test_lora_eviction.py`), and the lane's plumbing is validated by existing neighbors (`quant/test_fp8kv_triton.py`, `spec/test_spec_standalone_extra.py`).

**Sole gate:** `KL(sglang, trainer) <= 4e-3` against precomputed trainer logprobs. ROCm bf16 numerics could drift; verifying on both AMD lanes (mi325 + rocm720) before keeping. If the KL trips, the `register_amd_ci` line is dropped (no register-and-skip).

| Test | Suite | est_time |
|---|---|---|
| `test_lora_qwen3_5_4b_logprob_diff.py` | `extra-a-test-1-gpu-large-amd` | 90s (initial; refine from measured AMD runtime) |

No production code changes; registration only.

## Test plan

- [ ] `pr-test-amd-extra.yml` (mi325) green on `extra-a-test-1-gpu-large-amd`
- [ ] `pr-test-amd-extra.yml` (rocm720) green
- [ ] KL gate holds within `4e-3` on both lanes











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28062280684](https://github.com/sgl-project/sglang/actions/runs/28062280684)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28062280646](https://github.com/sgl-project/sglang/actions/runs/28062280646)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->