### PR TITLE
[Perf] optimize mla_kv_pack_quantize_fp8 flat kernel and dispatch

### DIFF
--- a/python/sglang/jit_kernel/mla_kv_pack_quantize_fp8.py
+++ b/python/sglang/jit_kernel/mla_kv_pack_quantize_fp8.py
@@ -164,7 +164,10 @@ def _pick_kernel(s: int, num_heads: int) -> Tuple[str, dict]:
 
     Memory bound. The flat kernel (1D grid over contiguous (token, head) pairs)
     wins everywhere except tiny ``s``, where ``v0``'s 2D grid trims launch
-    overhead.
+    overhead. For the flat path, ``num_warps`` tracks the total work
+    ``s * num_heads``: 4 warps keep more CTAs resident through the mid range
+    (including L2-resident prefix chunks), 8 warps win once the launch is large
+    enough to saturate HBM.
     """
     if s <= 2:
         # Launch-overhead-bound: minimal warps avoid setup cost.
@@ -174,7 +177,8 @@ def _pick_kernel(s: int, num_heads: int) -> Tuple[str, dict]:
     if s <= 32:
         # Still launch-bound: a smaller BLOCK keeps more CTAs in flight.
         return "v1_flat", {"BLOCK": 8, "num_warps": 8, "num_stages": 2}
-    return "v1_flat", {"BLOCK": 16, "num_warps": 8, "num_stages": 2}
+    num_warps = 8 if s * num_heads >= 200_000 else 4
+    return "v1_flat", {"BLOCK": 16, "num_warps": num_warps, "num_stages": 3}
 
 
 _FP8_DTYPE_MAP = {

--- a/python/sglang/jit_kernel/mla_kv_pack_quantize_fp8.py
+++ b/python/sglang/jit_kernel/mla_kv_pack_quantize_fp8.py
@@ -103,6 +103,7 @@ def _v1_flat_kernel(
     FP8_DTYPE: tl.constexpr,
     BLOCK: tl.constexpr,
     ENABLE_PDL: tl.constexpr,
+    CONTIGUOUS: tl.constexpr,
 ):
     if ENABLE_PDL:
         tl.extra.cuda.gdc_wait()
@@ -110,35 +111,48 @@ def _v1_flat_kernel(
     pair_idx = pid * BLOCK + tl.arange(0, BLOCK)
     total = s_total * num_heads
     mask = pair_idx < total
+    # k_pe is shared across heads, so it always needs the token index.
     t_idx = pair_idx // num_heads
-    h_idx = pair_idx % num_heads
     nope_idx = tl.arange(0, QK_NOPE)
     rope_idx = tl.arange(0, QK_ROPE)
-    v_idx_ = tl.arange(0, V_HEAD)
-    nope_off = (
-        t_idx[:, None] * k_nope_stride_t
-        + h_idx[:, None] * k_nope_stride_h
-        + nope_idx[None, :]
-    )
+    v_idx = tl.arange(0, V_HEAD)
+
+    if CONTIGUOUS:
+        # Packed layout: each (token, head) pair is one flat row, so index by
+        # `pair_idx` directly (drops `% num_heads` + strided math). Bit-identical.
+        nope_off = pair_idx[:, None] * QK_NOPE + nope_idx[None, :]
+        v_off = pair_idx[:, None] * V_HEAD + v_idx[None, :]
+        k_out_base = pair_idx[:, None] * (QK_NOPE + QK_ROPE)
+        v_out_off = v_off
+    else:
+        h_idx = pair_idx % num_heads
+        nope_off = (
+            t_idx[:, None] * k_nope_stride_t
+            + h_idx[:, None] * k_nope_stride_h
+            + nope_idx[None, :]
+        )
+        v_off = (
+            t_idx[:, None] * v_stride_t + h_idx[:, None] * v_stride_h + v_idx[None, :]
+        )
+        k_out_base = t_idx[:, None] * k_out_stride_t + h_idx[:, None] * k_out_stride_h
+        v_out_off = (
+            t_idx[:, None] * v_out_stride_t
+            + h_idx[:, None] * v_out_stride_h
+            + v_idx[None, :]
+        )
+
     k_nope = tl.load(k_nope_ptr + nope_off, mask=mask[:, None])
     pe_off = t_idx[:, None] * k_pe_stride_t + rope_idx[None, :]
     k_pe = tl.load(k_pe_ptr + pe_off, mask=mask[:, None])
-    v_off = t_idx[:, None] * v_stride_t + h_idx[:, None] * v_stride_h + v_idx_[None, :]
     v = tl.load(v_ptr + v_off, mask=mask[:, None])
     k_nope_fp8 = (k_nope.to(tl.float32) * k_scale_inv).to(FP8_DTYPE)
     k_pe_fp8 = (k_pe.to(tl.float32) * k_scale_inv).to(FP8_DTYPE)
     v_fp8 = (v.to(tl.float32) * v_scale_inv).to(FP8_DTYPE)
-    k_out_base = t_idx[:, None] * k_out_stride_t + h_idx[:, None] * k_out_stride_h
     tl.store(k_out_ptr + k_out_base + nope_idx[None, :], k_nope_fp8, mask=mask[:, None])
     tl.store(
         k_out_ptr + k_out_base + QK_NOPE + rope_idx[None, :],
         k_pe_fp8,
         mask=mask[:, None],
-    )
-    v_out_off = (
-        t_idx[:, None] * v_out_stride_t
-        + h_idx[:, None] * v_out_stride_h
-        + v_idx_[None, :]
     )
     tl.store(v_out_ptr + v_out_off, v_fp8, mask=mask[:, None])
     if ENABLE_PDL:
@@ -146,20 +160,21 @@ def _v1_flat_kernel(
 
 
 def _pick_kernel(s: int, num_heads: int) -> Tuple[str, dict]:
-    """Tuned on GB300, DSv3 dims, BF16 -> FP8 e4m3."""
+    """Pick kernel + launch config. Tuned on B200 (sm100), DSv3 dims, BF16 -> FP8 e4m3.
+
+    Memory bound. The flat kernel (1D grid over contiguous (token, head) pairs)
+    wins everywhere except tiny ``s``, where ``v0``'s 2D grid trims launch
+    overhead.
+    """
     if s <= 2:
-        # Launch-overhead-bound; tighter (BLOCK_S, num_warps) just adds warp
-        # setup cost without paying back in per-CTA work.
+        # Launch-overhead-bound: minimal warps avoid setup cost.
         return "v0", {"BLOCK_S": 1, "num_warps": 1, "num_stages": 2}
     if s <= 16:
         return "v0", {"BLOCK_S": 4, "num_warps": 2, "num_stages": 3}
     if s <= 32:
+        # Still launch-bound: a smaller BLOCK keeps more CTAs in flight.
         return "v1_flat", {"BLOCK": 8, "num_warps": 8, "num_stages": 2}
-    if s <= 192:
-        return "v1_flat", {"BLOCK": 16, "num_warps": 8, "num_stages": 3}
-    if s <= 1536:
-        return "v0", {"BLOCK_S": 16, "num_warps": 4, "num_stages": 3}
-    return "v1_flat", {"BLOCK": 16, "num_warps": 8, "num_stages": 3}
+    return "v1_flat", {"BLOCK": 16, "num_warps": 8, "num_stages": 2}
 
 
 _FP8_DTYPE_MAP = {
@@ -179,11 +194,11 @@ def mla_kv_pack_quantize_fp8(
     fp8_dtype: torch.dtype = torch.float8_e4m3fn,
     enable_pdl: Optional[bool] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Fused ``cat(k_nope, broadcast k_pe) + FP8 quantize`` for K and ``FP8 quantize`` for V.
+    """Fused ``cat(k_nope, broadcast k_pe)`` + FP8 quantize for K, FP8 quantize for V.
 
     Shapes: ``k_nope [s, h, qk_nope]``, ``k_pe [s, 1, qk_rope]`` or ``[s, qk_rope]``,
-    ``v [s, h, v_head]``. Returns ``(k_fp8 [s, h, qk_nope + qk_rope], v_fp8 [s, h, v_head])``.
-    Strided views are supported as long as the inner dim is contiguous.
+    ``v [s, h, v_head]`` -> ``(k_fp8 [s, h, qk_nope + qk_rope], v_fp8 [s, h, v_head])``.
+    Strided views are fine if the inner dim is contiguous.
     """
     assert k_nope.dtype in (
         torch.bfloat16,
@@ -261,8 +276,14 @@ def mla_kv_pack_quantize_fp8(
         )
     else:
         block = cfg["BLOCK"]
-        total = s * num_heads
-        grid = (triton.cdiv(total, block),)
+        grid = (triton.cdiv(s * num_heads, block),)
+        # Fast path only when all packed tensors are dense; else strided fallback.
+        flat_contiguous = (
+            k_nope.is_contiguous()
+            and v.is_contiguous()
+            and k_out.is_contiguous()
+            and v_out.is_contiguous()
+        )
         _v1_flat_kernel[grid](
             k_nope,
             k_pe_2d,
@@ -288,6 +309,7 @@ def mla_kv_pack_quantize_fp8(
             FP8_DTYPE=fp8_tl_dtype,
             BLOCK=block,
             ENABLE_PDL=enable_pdl,
+            CONTIGUOUS=flat_contiguous,
             num_warps=cfg["num_warps"],
             num_stages=cfg["num_stages"],
             **extra,

--- a/test/registered/jit/benchmark/bench_mla_kv_pack_quantize_fp8.py
+++ b/test/registered/jit/benchmark/bench_mla_kv_pack_quantize_fp8.py
@@ -1,4 +1,7 @@
-"""Bench the hybrid ``mla_kv_pack_quantize_fp8`` against an inlined naive Triton baseline."""
+"""Bench ``mla_kv_pack_quantize_fp8`` vs a naive Triton baseline.
+
+Dispatch keys on ``s * num_heads``, so sweep both ``batch_size`` and ``num_heads``.
+"""
 
 import itertools
 from typing import Tuple
@@ -20,7 +23,7 @@ from sglang.jit_kernel.mla_kv_pack_quantize_fp8 import (
 from sglang.jit_kernel.utils import is_arch_support_pdl
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=15, suite="base-b-kernel-benchmark-1-gpu-large")
+register_cuda_ci(est_time=20, suite="base-b-kernel-benchmark-1-gpu-large")
 
 
 @triton.jit
@@ -133,36 +136,29 @@ def _triton_pack(k_nope, k_pe, v, k_out, v_out):
 QK_NOPE = 128
 QK_ROPE = 64
 V_HEAD = 128
-NUM_HEADS = 32
 NUM_LAYERS = 8
+
+# Fixed axes used by each sweep.
+FIXED_NUM_HEADS = 32
+FIXED_BATCH_SIZE = 2048
 
 BS_RANGE = get_benchmark_range(
     full_range=[1, 4, 16, 64, 256, 1024, 4096, 8192, 16384],
     ci_range=[1, 64, 1024, 4096, 16384],
 )
+NH_RANGE = get_benchmark_range(
+    full_range=[8, 16, 32, 64, 128],
+    ci_range=[16, 128],
+)
 
 LINE_VALS = ["hybrid", "triton"]
 LINE_NAMES = ["hybrid (v0+v1_flat)", "naive Triton"]
 STYLES = [("green", "-"), ("red", "--")]
-CONFIGS = list(itertools.product(BS_RANGE))
 
 
-@triton.testing.perf_report(
-    triton.testing.Benchmark(
-        x_names=["batch_size"],
-        x_vals=CONFIGS,
-        line_arg="provider",
-        line_vals=LINE_VALS,
-        line_names=LINE_NAMES,
-        styles=STYLES,
-        ylabel="us",
-        plot_name="mla-kv-pack-quantize-fp8-performance",
-        args={},
-    )
-)
-def benchmark(batch_size: int, provider: str) -> Tuple[float, float, float]:
+def _make_inputs(batch_size: int, num_heads: int):
     k_nope = torch.randn(
-        (NUM_LAYERS, batch_size, NUM_HEADS, QK_NOPE),
+        (NUM_LAYERS, batch_size, num_heads, QK_NOPE),
         dtype=DEFAULT_DTYPE,
         device=DEFAULT_DEVICE,
     )
@@ -172,21 +168,26 @@ def benchmark(batch_size: int, provider: str) -> Tuple[float, float, float]:
         device=DEFAULT_DEVICE,
     )
     v = torch.randn(
-        (NUM_LAYERS, batch_size, NUM_HEADS, V_HEAD),
+        (NUM_LAYERS, batch_size, num_heads, V_HEAD),
         dtype=DEFAULT_DTYPE,
         device=DEFAULT_DEVICE,
     )
     k_out = torch.empty(
-        (NUM_LAYERS, batch_size, NUM_HEADS, QK_NOPE + QK_ROPE),
+        (NUM_LAYERS, batch_size, num_heads, QK_NOPE + QK_ROPE),
         dtype=torch.float8_e4m3fn,
         device=DEFAULT_DEVICE,
     )
     v_out = torch.empty(
-        (NUM_LAYERS, batch_size, NUM_HEADS, V_HEAD),
+        (NUM_LAYERS, batch_size, num_heads, V_HEAD),
         dtype=torch.float8_e4m3fn,
         device=DEFAULT_DEVICE,
     )
     torch.cuda.synchronize()
+    return k_nope, k_pe, v, k_out, v_out
+
+
+def _run(batch_size: int, num_heads: int, provider: str) -> Tuple[float, float, float]:
+    k_nope, k_pe, v, k_out, v_out = _make_inputs(batch_size, num_heads)
 
     if provider == "hybrid":
 
@@ -210,5 +211,44 @@ def benchmark(batch_size: int, provider: str) -> Tuple[float, float, float]:
     )
 
 
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size"],
+        x_vals=list(itertools.product(BS_RANGE)),
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=STYLES,
+        ylabel="us",
+        plot_name=f"mla-kv-pack-quantize-fp8-batch-size (num_heads={FIXED_NUM_HEADS})",
+        args={"num_heads": FIXED_NUM_HEADS},
+    )
+)
+def benchmark_batch_size(
+    batch_size: int, num_heads: int, provider: str
+) -> Tuple[float, float, float]:
+    return _run(batch_size, num_heads, provider)
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["num_heads"],
+        x_vals=list(itertools.product(NH_RANGE)),
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=STYLES,
+        ylabel="us",
+        plot_name=f"mla-kv-pack-quantize-fp8-num-heads (batch_size={FIXED_BATCH_SIZE})",
+        args={"batch_size": FIXED_BATCH_SIZE},
+    )
+)
+def benchmark_num_heads(
+    num_heads: int, batch_size: int, provider: str
+) -> Tuple[float, float, float]:
+    return _run(batch_size, num_heads, provider)
+
+
 if __name__ == "__main__":
-    benchmark.run(print_data=True)
+    benchmark_batch_size.run(print_data=True)
+    benchmark_num_heads.run(print_data=True)


### PR DESCRIPTION
## Motivation

`mla_kv_pack_quantize_fp8` is a purely memory-bound op (fused `cat(k_nope, broadcast k_pe)` + FP8 quantize for K, FP8 quantize for V). The `_v1_flat_kernel` path spent a meaningful fraction of its time on per-element address arithmetic (`// num_heads`, `% num_heads`, two-term strided offsets) rather than HBM traffic, and the `_pick_kernel` heuristic was tuned on GB300 and keyed only on `s`, so it mis-dispatched at higher head counts. This PR speeds up the common packed-tensor case and re-tunes dispatch for B200 (sm100).

## Modifications

- **`_v1_flat_kernel` contiguous fast path:** add a `CONTIGUOUS: tl.constexpr` branch that addresses each `(token, head)` pair as a single flat row (`pair_idx`-based offsets), dropping the per-element `% num_heads` and the two-term strided address math. This is what bounds throughput once the kernel is occupancy-limited. The strided path is kept as a fallback for non-contiguous views, and the fast path is selected only when `k_nope`/`v`/`k_out`/`v_out` are all dense. Output is bit-identical to the strided path.
- **`_pick_kernel` retune (B200), keyed on total work `s * num_heads`:**
  - The flat kernel wins for all but tiny `s`; `v0`'s 2D `(s, head)` grid is kept only for tiny `s`, where it trims launch overhead.
  - For the flat path, `num_warps` tracks total work: **4 warps** through the mid range (moderate / L2-resident prefix chunks) and **8 warps** only once the launch is large enough to saturate HBM (`>= 200k` pairs).
  - `num_stages = 3` (strictly `>=` `num_stages=2` across sizes: better mid-range, identical at large).
- **Benchmark:** `bench_mla_kv_pack_quantize_fp8.py` now sweeps `num_heads` in addition to `batch_size` (dispatch depends on both axes), refactored to share input/runner helpers.

## Accuracy Tests

The contiguous fast path is bit-identical to the existing strided path. The registered correctness test `test/registered/jit/test_mla_kv_pack_quantize_fp8.py` passes (130 cases) across the `(s, num_heads)` grid.

## Speed Tests and Profiling

Measured on NVIDIA B200 (DSv3 dims, BF16 -> FP8 e4m3), us/layer.

### vs naive Triton baseline (`num_heads=32`, contiguous)

batch_size sweep:

| batch_size | hybrid (us) | naive (us) |
| ---: | ---: | ---: |
| 64 | 1.12 | 2.98 |
| 256 | 1.53 | 9.31 |
| 1024 | 5.53 | 10.45 |
| 4096 | 17.00 | 18.45 |
| 16384 | 62.85 | 72.06 |

### Real serving shapes (TP8 DSv3, `num_heads=16`, strided kv-slice inputs)

Validated against a TP8 prefill profile where `pack_prefix_chunk_kv` feeds `k_nope = kv[..., :128]` / `v = kv[..., 128:]` (non-contiguous slices, so the kernel takes the strided path). Comparison vs the tokenspeed 2D-grid kernel (`num_warps=4, num_stages=3`):

| s | sglang (this PR) | sglang prior config | tokenspeed v0 | PR vs tokenspeed |
| ---: | ---: | ---: | ---: | ---: |
| 4800 | 6.19 us | 6.91 | 6.18 | 1.00x |
| 8192 | 14.95 us | 16.20 | 15.39 | 1.03x |
| 16384 (dominant) | 32.93 us | 32.96 | 36.22 | 1.10x |
| 32768 | 63.5 us | - | 75.1 | 1.18x |

The dispatch retune recovers ~8-11% at the moderate prefix-chunk sizes (s~4800-8192) that the prior `num_warps=8/num_stages=2` config gave up, while leaving the dominant `s=16384` case (already optimal, ~88% of pack time in the profile) untouched. It is a strict improvement over the previous sglang config at every measured size.

Note: the pack kernel is a small fraction of end-to-end GPU time (~1.4% in the profile) and at the largest chunks is HBM-bandwidth-bound (in-trace ~5.6 TB/s under contention vs ~7.7 TB/s isolated), so this is a kernel-level cleanup/win rather than a large end-to-end mover.

## Checklist

- [x] Format your code according to pre-commit.
- [x] Add unit tests / verify existing correctness tests.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.
