### PR TITLE
[CI] Temporarily disable openbmb MiniCPM tests

### DIFF
--- a/test/registered/eval/test_vlms_mmmu_eval.py
+++ b/test/registered/eval/test_vlms_mmmu_eval.py
@@ -44,8 +44,9 @@ MODEL_THRESHOLDS = {
     ModelLaunchSettings("moonshotai/Kimi-VL-A3B-Instruct"): ModelEvalMetrics(
         0.330, 23.5
     ),
-    ModelLaunchSettings("openbmb/MiniCPM-o-2_6"): ModelEvalMetrics(0.330, 29.5),
-    ModelLaunchSettings("openbmb/MiniCPM-v-2_6"): ModelEvalMetrics(0.259, 36.3),
+    # temporarily disabled: NaN in next_token_logits
+    # ModelLaunchSettings("openbmb/MiniCPM-o-2_6"): ModelEvalMetrics(0.330, 29.5),
+    # ModelLaunchSettings("openbmb/MiniCPM-v-2_6"): ModelEvalMetrics(0.259, 36.3),
     ModelLaunchSettings("OpenGVLab/InternVL2_5-2B"): ModelEvalMetrics(0.300, 18.0),
     ModelLaunchSettings("Qwen/Qwen2-VL-7B-Instruct"): ModelEvalMetrics(0.310, 83.3),
     ModelLaunchSettings("Qwen/Qwen2.5-VL-7B-Instruct"): ModelEvalMetrics(0.330, 31.9),

--- a/test/registered/models/test_vlm_models.py
+++ b/test/registered/models/test_vlm_models.py
@@ -19,12 +19,15 @@ register_amd_ci(est_time=850, suite="stage-b-test-1-gpu-small-amd-nondeterminist
 _is_hip = is_hip()
 # VLM models for testing
 if _is_hip:
-    MODELS = [SimpleNamespace(model="openbmb/MiniCPM-V-2_6", mmmu_accuracy=0.4)]
+    MODELS = [
+        # SimpleNamespace(model="openbmb/MiniCPM-V-2_6", mmmu_accuracy=0.4),  # temporarily disabled: NaN in next_token_logits
+        SimpleNamespace(model="Qwen/Qwen2.5-VL-3B-Instruct", mmmu_accuracy=0.4),
+    ]
 else:
     MODELS = [
         SimpleNamespace(model="google/gemma-3-4b-it", mmmu_accuracy=0.38),
         SimpleNamespace(model="Qwen/Qwen2.5-VL-3B-Instruct", mmmu_accuracy=0.4),
-        SimpleNamespace(model="openbmb/MiniCPM-V-2_6", mmmu_accuracy=0.4),
+        # SimpleNamespace(model="openbmb/MiniCPM-V-2_6", mmmu_accuracy=0.4),  # temporarily disabled: NaN in next_token_logits
     ]
 
 

--- a/test/registered/vlm/test_vision_openai_server_a.py
+++ b/test/registered/vlm/test_vision_openai_server_a.py
@@ -120,6 +120,7 @@ class TestInternVL25Server(ImageOpenAITestMixin):
     ]
 
 
+@unittest.skip("temporarily disabled: NaN in next_token_logits")
 class TestMiniCPMV4Server(ImageOpenAITestMixin):
     model = "openbmb/MiniCPM-V-4"
     extra_args = [
@@ -127,6 +128,7 @@ class TestMiniCPMV4Server(ImageOpenAITestMixin):
     ]
 
 
+@unittest.skip("temporarily disabled: NaN in next_token_logits")
 class TestMiniCPMo26Server(ImageOpenAITestMixin, AudioOpenAITestMixin):
     model = "openbmb/MiniCPM-o-2_6"
     extra_args = [

--- a/test/registered/vlm/test_vlm_input_format.py
+++ b/test/registered/vlm/test_vlm_input_format.py
@@ -590,6 +590,7 @@ class TestInternVLUnderstandsImage(VLMInputTestBase, unittest.IsolatedAsyncioTes
         return dict(processor_output, format="processor_output")
 
 
+@unittest.skip("temporarily disabled: NaN in next_token_logits")
 class TestMiniCPMVUnderstandsImage(VLMInputTestBase, unittest.IsolatedAsyncioTestCase):
     model_path = "openbmb/MiniCPM-V-4"
     chat_template = "minicpmv"


### PR DESCRIPTION
## Summary
- Disable all openbmb MiniCPM model tests in CI due to reproducible NaN in `next_token_logits` causing server crashes (CUDA assertion + SIGABRT).
- Affected models: `MiniCPM-V-2_6`, `MiniCPM-V-4`, `MiniCPM-o-2_6`.
- Ref: https://github.com/sgl-project/sglang/actions/runs/28064026314/job/83084369246



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28066511848](https://github.com/sgl-project/sglang/actions/runs/28066511848)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28066511755](https://github.com/sgl-project/sglang/actions/runs/28066511755)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->