### PR TITLE
[server_args] Make MoRI per-rank dispatch-token requirement overridable

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5450,8 +5450,16 @@ class ServerArgs:
             # Skip validation if disaggregation mode is decode.
             if self.chunked_prefill_size > 0 and self.disaggregation_mode != "decode":
                 assert (
-                    self.chunked_prefill_size
-                ) <= envs.SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get(), "SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK (default 4096) must be larger or equal to chunked_prefill_size"
+                    self._required_mori_dispatch_tokens_per_rank()
+                ) <= envs.SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get(), (
+                    "SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK (default 4096) "
+                    "must be >= the per-rank MoRI dispatch tokens "
+                    "(chunked_prefill_size by default)"
+                )
+
+    def _required_mori_dispatch_tokens_per_rank(self) -> int:
+        """Max tokens a single rank dispatches through MoRI in one forward."""
+        return self.chunked_prefill_size
 
     def _handle_eplb_and_dispatch(self):
         if self.enable_eplb and (self.expert_distribution_recorder_mode is None):


### PR DESCRIPTION
## Summary

The MoRI chunked-prefill check asserts the dispatch buffer
(`SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK`) covers a full
`chunked_prefill_size`. Setups that shard the sequence across ranks
(sequence parallelism) only dispatch a per-rank shard through MoRI -- fewer
than `chunked_prefill_size` tokens -- so a correctly-sized smaller buffer is
rejected at startup.

This extracts the required per-rank dispatch tokens into an overridable method
`ServerArgs._required_mori_dispatch_tokens_per_rank()` (default
`chunked_prefill_size`) and asserts against it. Default behavior is unchanged;
subclasses that shard the sequence can override it to return the smaller
per-rank value.

## Original commit

- `a836259bd`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28066715349](https://github.com/sgl-project/sglang/actions/runs/28066715349)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28066715225](https://github.com/sgl-project/sglang/actions/runs/28066715225)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->