### PR TITLE
fix(spec): track current_token in ReasonerGrammarObject

### DIFF
--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -109,6 +109,14 @@ class ReasonerGrammarObject(BaseGrammarObject):
                 self.tokens_after_end -= 1
 
     def accept_token(self, token: int):
+        # Track the last accepted token on the wrapper itself (mirroring
+        # XGrammarGrammar.accept_token). Disaggregation's process_prebuilt uses
+        # `grammar.current_token is None` to detect a retracted request whose
+        # token was already accepted and must not be re-accepted. Without this,
+        # a ReasonerGrammarObject's current_token stays None forever (the inner
+        # grammar's is updated, not the wrapper's), so the guard never fires and
+        # the token is accepted twice -> "Tokens not accepted" -> FINISH_ABORT.
+        self.current_token = token
         if self._is_generation() and self.grammar is not None:
             self.grammar.accept_token(token)
         self.transfer_state(token)

--- a/test/registered/unit/constrained/test_reasoner_grammar_backend.py
+++ b/test/registered/unit/constrained/test_reasoner_grammar_backend.py
@@ -451,5 +451,65 @@ class TestReasonerGrammarObjectFillVocabMask(unittest.TestCase):
         self.assertTrue(torch.all(mask == 0))
 
 
+class TestReasonerGrammarObjectCurrentToken(unittest.TestCase):
+    """`current_token` must be tracked on the wrapper so that disaggregation's
+    process_prebuilt dedup guard (`grammar.current_token is None`) works for
+    reasoning requests. Without it the guard never fires and a retracted/
+    re-prebuilt request re-accepts an already-accepted token -> grammar raises
+    "Tokens not accepted" -> FINISH_ABORT (the disagg tool_choice abort)."""
+
+    def _make_object_with_mock_grammar(self):
+        inner_grammar = MagicMock()
+        inner_grammar.is_terminated.return_value = False
+        obj = ReasonerGrammarObject(
+            grammar=inner_grammar,
+            think_end_id=7,
+            think_excluded_token_ids=None,
+            max_think_tokens=-1,
+            enable_token_filter=False,
+            token_filter_fn=None,
+        )
+        return obj, inner_grammar
+
+    def test_current_token_none_before_any_accept(self):
+        obj, _ = self._make_object_with_mock_grammar()
+        # Fresh grammar: the dedup guard must treat it as "not yet accepted".
+        self.assertIsNone(obj.current_token)
+
+    def test_current_token_tracked_in_generation_phase(self):
+        obj, inner_grammar = self._make_object_with_mock_grammar()
+        obj.maybe_init_reasoning(True)
+        obj.accept_token(10)  # thinking token
+        obj.accept_token(7)  # think_end_id -> GENERATION
+        obj.accept_token(58)  # generation token "["
+        self.assertEqual(obj.current_token, 58)
+
+    def test_current_token_tracked_in_thinking_phase(self):
+        obj, _ = self._make_object_with_mock_grammar()
+        obj.maybe_init_reasoning(True)
+        obj.accept_token(10)  # thinking token (inner grammar untouched)
+        # Even in the thinking phase the wrapper records progress, so a
+        # re-prebuilt request is not mistaken for a fresh one.
+        self.assertEqual(obj.current_token, 10)
+
+    def test_dedup_guard_skips_reaccept_after_generation(self):
+        """Reproduces the disagg double-accept: a generation token accepted once
+        must not be re-accepted; with current_token tracked, the guard skips."""
+        obj, inner_grammar = self._make_object_with_mock_grammar()
+        obj.maybe_init_reasoning(True)
+        obj.accept_token(7)  # think_end_id -> GENERATION
+        obj.accept_token(58)  # "[" accepted into inner grammar
+        obj.accept_token(4913)  # '{"' accepted into inner grammar
+        inner_grammar.accept_token.reset_mock()
+
+        # Mirror disaggregation/decode_schedule_batch_mixin.py:process_prebuilt
+        last_token = 4913
+        if obj.current_token is None:  # guard
+            obj.accept_token(last_token)
+
+        # Guard must have fired -> no second accept of 4913 into the inner grammar.
+        inner_grammar.accept_token.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
ReasonerGrammarObject.accept_token forwarded the token only to the inner grammar and never set its own `current_token`. Disaggregation's process_prebuilt uses `req.grammar.current_token is None` to detect a retracted/re-prebuilt request whose last token was already accepted and must not be re-accepted. With a reasoning parser enabled (so req.grammar is a ReasonerGrammarObject), current_token stayed None forever, defeating that guard and risking a double accept_token -> "Tokens not accepted". Set current_token at the top of accept_token, mirroring XGrammarGrammar.accept_token. Adds unit tests covering generation/thinking phases and the dedup-guard scenario.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28070964880](https://github.com/sgl-project/sglang/actions/runs/28070964880)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28070964752](https://github.com/sgl-project/sglang/actions/runs/28070964752)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->