### PR TITLE
[router] Add opt-in request-count admission control / backpressure

### DIFF
--- a/experimental/sgl-router/Cargo.toml
+++ b/experimental/sgl-router/Cargo.toml
@@ -81,6 +81,10 @@ zeromq = { version = "0.6", default-features = false, features = ["tokio-runtime
 [dev-dependencies]
 dirs = "5"
 http-body-util = "0.1"
+# Capture the router's `tracing` access log in tests (assert every request
+# outcome is logged exactly once). Also a runtime dep, but integration tests
+# are a separate crate and need it declared here too.
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/experimental/sgl-router/Cargo.toml
+++ b/experimental/sgl-router/Cargo.toml
@@ -31,7 +31,7 @@ dynamo-parsers = { git = "https://github.com/ai-dynamo/dynamo", rev = "1efdd4dcb
 tokio = { version = "1.42", features = ["full"] }
 axum = { version = "0.8", features = ["macros", "tracing"] }
 tower = { version = "0.5", features = ["full"] }
-tower-http = { version = "0.6", features = ["trace", "compression-gzip", "cors", "timeout", "request-id"] }
+tower-http = { version = "0.6", features = ["trace", "compression-gzip", "cors", "timeout", "request-id", "catch-panic"] }
 reqwest = { version = "0.12", features = ["stream", "json", "rustls-tls"], default-features = false }
 
 # Serialization

--- a/experimental/sgl-router/monitoring/README.md
+++ b/experimental/sgl-router/monitoring/README.md
@@ -20,7 +20,7 @@ The dashboard graphs every family the router emits:
 
 | Metric | Type | What it shows |
 |---|---|---|
-| `sgl_router_requests_total` | Counter | Dispatches by `worker_url`, `model_id`, `mode`, `outcome` |
+| `sgl_router_worker_requests_total` | Counter | Dispatches by `worker_url`, `model_id`, `mode`, `outcome` |
 | `sgl_router_request_duration_seconds` | Histogram | End-to-end request latency by `model_id` |
 | `sgl_router_ttft_seconds` | Histogram | Time to first token (streaming) by `model_id` |
 | `sgl_router_responses_total` | Counter | Client-visible HTTP `status_code` |

--- a/experimental/sgl-router/monitoring/grafana-dashboard.json
+++ b/experimental/sgl-router/monitoring/grafana-dashboard.json
@@ -89,7 +89,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(sgl_router_requests_total{model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval]))",
+          "expr": "sum(rate(sgl_router_worker_requests_total{model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval]))",
           "range": true,
           "refId": "A",
           "legendFormat": "__auto",
@@ -161,7 +161,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "100 * sum(rate(sgl_router_requests_total{outcome=\"error\",model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval])) / clamp_min(sum(rate(sgl_router_requests_total{model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval])), 1e-9)",
+          "expr": "100 * sum(rate(sgl_router_worker_requests_total{outcome=\"error\",model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval])) / clamp_min(sum(rate(sgl_router_worker_requests_total{model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval])), 1e-9)",
           "range": true,
           "refId": "A",
           "legendFormat": "__auto",
@@ -407,7 +407,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (outcome) (rate(sgl_router_requests_total{model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval]))",
+          "expr": "sum by (outcome) (rate(sgl_router_worker_requests_total{model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval]))",
           "range": true,
           "refId": "A",
           "legendFormat": "{{outcome}}",
@@ -500,7 +500,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (mode) (rate(sgl_router_requests_total{model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval]))",
+          "expr": "sum by (mode) (rate(sgl_router_worker_requests_total{model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval]))",
           "range": true,
           "refId": "A",
           "legendFormat": "{{mode}}",
@@ -686,7 +686,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (worker_url) (rate(sgl_router_requests_total{model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval]))",
+          "expr": "sum by (worker_url) (rate(sgl_router_worker_requests_total{model_id=~\"$model_id\",worker_url=~\"$worker_url\"}[$__rate_interval]))",
           "range": true,
           "refId": "A",
           "legendFormat": "{{worker_url}}",
@@ -2035,7 +2035,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(sgl_router_requests_total, model_id)",
+        "definition": "label_values(sgl_router_worker_requests_total, model_id)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -2044,7 +2044,7 @@
         "name": "model_id",
         "options": [],
         "query": {
-          "query": "label_values(sgl_router_requests_total, model_id)",
+          "query": "label_values(sgl_router_worker_requests_total, model_id)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2061,7 +2061,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(sgl_router_requests_total, worker_url)",
+        "definition": "label_values(sgl_router_worker_requests_total, worker_url)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -2070,7 +2070,7 @@
         "name": "worker_url",
         "options": [],
         "query": {
-          "query": "label_values(sgl_router_requests_total, worker_url)",
+          "query": "label_values(sgl_router_worker_requests_total, worker_url)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -7,13 +7,13 @@
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use crate::config::{
     default_cb_cool_down, default_proxy_request_timeout_secs, default_stale_request_timeout_secs,
-    resolve_mode, ActiveLoadConfig, CacheAwareConfig, CircuitBreakerConfig, Config,
-    DiscoveryBackend, K8sDiscoveryConfig, LogFormat, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig, StickyConfig,
+    resolve_mode, ActiveLoadConfig, AdmissionConfig, CacheAwareConfig, CircuitBreakerConfig,
+    Config, DiscoveryBackend, K8sDiscoveryConfig, LogFormat, ModelConfig, ObservabilityConfig,
+    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig, StickyConfig,
 };
 
 /// `sgl-router` — slim KV-aware OpenAI-compatible router for SGLang workers.
@@ -125,6 +125,19 @@ pub struct Cli {
     #[arg(long, default_value_t = default_stale_request_timeout_secs())]
     pub stale_request_timeout_secs: u64,
 
+    // ---- admission control ----
+    /// Maximum in-flight requests dispatched to a single worker. When set,
+    /// the router parks a request once every candidate worker is at this cap
+    /// and dispatches it when a slot frees. Must be > 0. Unset (default)
+    /// disables admission control: requests dispatch immediately as before.
+    #[arg(long)]
+    pub max_concurrent_requests_per_worker: Option<NonZeroUsize>,
+    /// Maximum requests parked in the admission wait queue before further
+    /// arrivals are shed with 503. Requires `--max-concurrent-requests-per-worker`.
+    /// Unset leaves the wait queue unbounded (park, never shed).
+    #[arg(long)]
+    pub max_queued_requests: Option<usize>,
+
     // ---- observability ----
     /// Default tracing level (overridden by `RUST_LOG`).
     #[arg(long, default_value = "info")]
@@ -226,6 +239,15 @@ impl Cli {
             None
         };
 
+        // A wait-queue depth is meaningless without a per-worker cap (nothing
+        // ever parks), so reject it rather than silently ignore it.
+        if self.max_queued_requests.is_some() && self.max_concurrent_requests_per_worker.is_none() {
+            return Err(anyhow!(
+                "--max-queued-requests requires --max-concurrent-requests-per-worker \
+                 (the wait queue only fills once workers hit their in-flight cap)"
+            ));
+        }
+
         let circuit_breaker = self.cb_threshold.map(|threshold| CircuitBreakerConfig {
             threshold,
             cool_down_secs: self.cb_cool_down_secs.unwrap_or_else(default_cb_cool_down),
@@ -274,6 +296,13 @@ impl Cli {
             },
             active_load: ActiveLoadConfig {
                 stale_request_timeout_secs: self.stale_request_timeout_secs,
+            },
+            admission: match self.max_concurrent_requests_per_worker {
+                Some(max_concurrent_per_worker) => AdmissionConfig::Enabled {
+                    max_concurrent_per_worker,
+                    max_queued_requests: self.max_queued_requests,
+                },
+                None => AdmissionConfig::Disabled,
             },
         };
         config.validate()?;
@@ -391,6 +420,68 @@ mod tests {
         assert_eq!(c.model.id, "qwen3-0.6b");
         assert_eq!(c.proxy.request_timeout_secs, 300);
         assert_eq!(c.active_load.stale_request_timeout_secs, 600);
+    }
+
+    #[test]
+    fn admission_control_disabled_by_default() {
+        let c = into_config_owned(with_model(&["--worker-urls", "http://10.0.0.1:30000"])).unwrap();
+        assert!(matches!(c.admission, AdmissionConfig::Disabled));
+    }
+
+    #[test]
+    fn admission_flags_map_into_config() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://10.0.0.1:30000",
+            "--max-concurrent-requests-per-worker",
+            "32",
+            "--max-queued-requests",
+            "8",
+        ]))
+        .unwrap();
+        match c.admission {
+            AdmissionConfig::Enabled {
+                max_concurrent_per_worker,
+                max_queued_requests,
+            } => {
+                assert_eq!(max_concurrent_per_worker.get(), 32);
+                assert_eq!(max_queued_requests, Some(8));
+            }
+            AdmissionConfig::Disabled => panic!("expected Enabled, got Disabled"),
+        }
+    }
+
+    #[test]
+    fn zero_per_worker_cap_is_rejected() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://10.0.0.1:30000",
+            "--max-concurrent-requests-per-worker",
+            "0",
+        ]))
+        .expect_err("a zero per-worker cap must be rejected");
+        // clap rejects `0` for a NonZeroUsize-typed flag at parse time.
+        assert!(
+            err.to_string()
+                .contains("max-concurrent-requests-per-worker")
+                || err.to_string().to_lowercase().contains("0"),
+            "got: {err}",
+        );
+    }
+
+    #[test]
+    fn max_queued_requests_requires_per_worker_cap() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://10.0.0.1:30000",
+            "--max-queued-requests",
+            "8",
+        ]))
+        .expect_err("--max-queued-requests without a per-worker cap must be rejected");
+        assert!(
+            err.to_string().contains("--max-queued-requests requires"),
+            "got: {err}",
+        );
     }
 
     /// With `--tokenizer-path` omitted, the tokenizer source defaults to the

--- a/experimental/sgl-router/src/config/mod.rs
+++ b/experimental/sgl-router/src/config/mod.rs
@@ -94,6 +94,7 @@ mod tests {
             }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
+            admission: AdmissionConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 /// In-memory router configuration, built from CLI flags by
 /// [`crate::config::cli::Cli::into_config`] and validated by
@@ -16,6 +16,7 @@ pub struct Config {
     pub discovery: DiscoveryBackend,
     pub proxy: ProxyConfig,
     pub active_load: ActiveLoadConfig,
+    pub admission: AdmissionConfig,
 }
 
 /// Outbound proxy tuning. Default mirrors SGLang's typical prefill /
@@ -62,6 +63,35 @@ impl Default for ActiveLoadConfig {
         Self {
             stale_request_timeout_secs: default_stale_request_timeout_secs(),
         }
+    }
+}
+
+/// Router-side admission control. Opt-in: [`AdmissionConfig::Disabled`] (the
+/// default) dispatches every request immediately, exactly as the router behaved
+/// before admission control existed.
+///
+/// Modelling this as an enum makes the illegal "wait-queue depth without a
+/// per-worker cap" state unrepresentable (the queue field only exists inside
+/// [`AdmissionConfig::Enabled`]), and `NonZeroUsize` rules out a `0` cap, which
+/// would wedge every worker as permanently full.
+#[derive(Debug, Clone, Copy)]
+pub enum AdmissionConfig {
+    /// No admission control: every request is dispatched immediately.
+    Disabled,
+    /// Cap in-flight requests per worker; park (and optionally shed) the rest.
+    Enabled {
+        /// Maximum in-flight requests the router dispatches to a single worker.
+        max_concurrent_per_worker: NonZeroUsize,
+        /// Maximum requests parked waiting for a slot before further arrivals
+        /// are shed with 503. `None` leaves the wait queue unbounded (park,
+        /// never shed).
+        max_queued_requests: Option<usize>,
+    },
+}
+
+impl Default for AdmissionConfig {
+    fn default() -> Self {
+        Self::Disabled
     }
 }
 

--- a/experimental/sgl-router/src/diag.rs
+++ b/experimental/sgl-router/src/diag.rs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lightweight process-global phase gauges for diagnosing where an admission
+//! slot's lifetime is spent. Each counter is the number of requests currently
+//! in a given phase between claiming a per-worker slot and releasing it. They
+//! are read (sampled) into the `phase_dispatch` log so a held-but-unconnected
+//! slot can be attributed to a concrete phase without per-request tracing.
+//!
+//! Diagnostic-only.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+/// Requests that hold an admission slot and are inside the synchronous handler
+/// body (post-`acquire` up to returning the response: build-body + dispatch +
+/// await-upstream-headers). High while requests are stuck before streaming.
+pub static HANDLER_INFLIGHT: AtomicI64 = AtomicI64::new(0);
+
+/// Requests currently blocked in the upstream `reqwest::send().await` (connect +
+/// write body + await response headers). High → stuck talking to the engine.
+pub static IN_SEND: AtomicI64 = AtomicI64::new(0);
+
+/// Active SSE pumps (post-headers streaming). ≈ live engine streams.
+pub static PUMP_INFLIGHT: AtomicI64 = AtomicI64::new(0);
+
+/// RAII: `+1` on construction, `-1` on drop, for the named gauge.
+pub struct PhaseGuard(&'static AtomicI64);
+
+impl PhaseGuard {
+    pub fn handler() -> Self {
+        HANDLER_INFLIGHT.fetch_add(1, Ordering::Relaxed);
+        Self(&HANDLER_INFLIGHT)
+    }
+    pub fn in_send() -> Self {
+        IN_SEND.fetch_add(1, Ordering::Relaxed);
+        Self(&IN_SEND)
+    }
+    pub fn pump() -> Self {
+        PUMP_INFLIGHT.fetch_add(1, Ordering::Relaxed);
+        Self(&PUMP_INFLIGHT)
+    }
+}
+
+impl Drop for PhaseGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Snapshot the three gauges as `(handler, in_send, pump)`.
+pub fn snapshot() -> (i64, i64, i64) {
+    (
+        HANDLER_INFLIGHT.load(Ordering::Relaxed),
+        IN_SEND.load(Ordering::Relaxed),
+        PUMP_INFLIGHT.load(Ordering::Relaxed),
+    )
+}

--- a/experimental/sgl-router/src/health/circuit_breaker.rs
+++ b/experimental/sgl-router/src/health/circuit_breaker.rs
@@ -172,6 +172,31 @@ impl CircuitBreaker {
             }
         }
     }
+
+    /// Record a backpressure response (HTTP 503 / 429): the worker answered, so
+    /// it is responsive — busy, not faulty.
+    ///
+    /// - **Closed:** no-op. A busy worker must not open the breaker, and —
+    ///   unlike [`record_success`](Self::record_success) — backpressure must
+    ///   NOT reset an in-progress failure streak, so a worker interleaving real
+    ///   5xx faults with 503s still trips.
+    /// - **HalfOpen:** resolve the probe by closing. The probe exists to test
+    ///   whether the worker is alive again; a 503 answer proves it is. Leaving
+    ///   the probe unresolved would wedge the breaker permanently — the probe
+    ///   slot is released only by a success or failure, and backpressure is
+    ///   neither — shutting a recovered-but-busy worker out forever (a worse
+    ///   false-shed than the one ignoring 503 removes).
+    /// - **Open:** unreachable on a response path; [`allow`](Self::allow) never
+    ///   admits a request while Open within cooldown (and moves it to HalfOpen
+    ///   once cooldown elapses), so no response is classified against an Open
+    ///   breaker.
+    pub fn record_backpressure(&self) {
+        let mut g = self.inner.lock().unwrap();
+        if matches!(g.state, State::HalfOpen { .. }) {
+            g.consecutive_failures = 0;
+            g.state = State::Closed;
+        }
+    }
 }
 
 impl Default for CircuitBreaker {
@@ -244,5 +269,68 @@ mod tests {
         let s = b.snapshot();
         assert!(s.admit, "open past cooldown admits a probe");
         assert_eq!(s.state_code, 1, "...but is still reported as open");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backpressure_resolves_half_open_probe() {
+        // Regression guard: a backpressure (503/429) answer to a half-open
+        // probe must RESOLVE the probe, not wedge the breaker. The probe slot
+        // is otherwise released only by success/failure; without
+        // record_backpressure handling HalfOpen, a recovered-but-busy worker
+        // would be shut out forever.
+        let b = cb(1, 10);
+        b.record_failure(); // Open
+        assert_eq!(b.snapshot().state_code, 1);
+        tokio::time::advance(Duration::from_secs(11)).await;
+        assert!(
+            b.allow(),
+            "cooldown elapsed → claims the probe slot (HalfOpen)"
+        );
+        assert_eq!(b.snapshot().state_code, 2);
+
+        b.record_backpressure();
+        assert_eq!(
+            b.snapshot().state_code,
+            0,
+            "a 503 probe answer must close the breaker, not leave it wedged half-open",
+        );
+        assert!(
+            b.would_allow(),
+            "worker must admit again after the probe resolves"
+        );
+    }
+
+    #[test]
+    fn backpressure_in_closed_state_preserves_failure_streak() {
+        // Unlike record_success, record_backpressure must NOT reset an
+        // in-progress streak: 2 faults + a 503 + 1 fault still hits threshold 3.
+        let b = cb(3, 30);
+        b.record_failure();
+        b.record_failure();
+        b.record_backpressure();
+        assert_eq!(
+            b.snapshot().state_code,
+            0,
+            "2 faults < threshold 3, still closed"
+        );
+        b.record_failure();
+        assert_eq!(
+            b.snapshot().state_code,
+            1,
+            "the 503 must not have reset the streak; the 3rd fault opens the breaker",
+        );
+    }
+
+    #[test]
+    fn backpressure_alone_never_opens_a_closed_breaker() {
+        let b = cb(3, 30);
+        for _ in 0..10 {
+            b.record_backpressure();
+        }
+        assert_eq!(
+            b.snapshot().state_code,
+            0,
+            "backpressure alone must never open the breaker, regardless of volume",
+        );
     }
 }

--- a/experimental/sgl-router/src/lib.rs
+++ b/experimental/sgl-router/src/lib.rs
@@ -9,6 +9,7 @@
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod config;
+pub mod diag;
 pub mod discovery;
 pub mod health;
 pub mod policies;

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -156,6 +156,16 @@ async fn main() -> Result<()> {
         Some(Arc::clone(&active_load)),
     ));
 
+    // Backstop the per-worker admission counter: reclaim any in-flight slot
+    // held past the TTL (a leaked guard whose request hung and never dropped).
+    // Complements the SSE idle timeout so the cap can never stay pinned and
+    // false-shed forever. Sweep every 60 s; a slot held > 10 min is leaked.
+    let _worker_load_janitor = sgl_router::workers::spawn_load_janitor(
+        registry.clone(),
+        std::time::Duration::from_secs(600),
+        std::time::Duration::from_secs(60),
+    );
+
     let proxy = Arc::new(
         sgl_router::proxy::Proxy::new(std::time::Duration::from_secs(
             cfg.proxy.request_timeout_secs,

--- a/experimental/sgl-router/src/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/src/policies/cache_aware_zmq.rs
@@ -308,6 +308,7 @@ mod tests {
             ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
+            admission: crate::config::AdmissionConfig::default(),
         };
         Arc::new(TokenizerRegistry::load_from_config(&cfg).expect("load tiny tokenizer"))
     }

--- a/experimental/sgl-router/src/policies/factory.rs
+++ b/experimental/sgl-router/src/policies/factory.rs
@@ -178,6 +178,7 @@ mod tests {
             }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
+            admission: crate::config::AdmissionConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -259,10 +259,16 @@ impl Proxy {
         req = req
             .header("content-type", "application/json")
             .header("accept", "text/event-stream");
-        let resp = req.send().await.map_err(|e| {
-            breaker.record_failure();
-            Self::classify_reqwest_error_for(worker_url.clone(), e, path)
-        })?;
+        // Diagnostic: count time blocked in upstream send (connect + write body +
+        // await response headers). Scoped so it decrements the instant send
+        // resolves, whether it returns headers or errors.
+        let resp = {
+            let _send_phase = crate::diag::PhaseGuard::in_send();
+            req.send().await.map_err(|e| {
+                breaker.record_failure();
+                Self::classify_reqwest_error_for(worker_url.clone(), e, path)
+            })?
+        };
         let status = resp.status();
         let upstream_ct = resp
             .headers()
@@ -313,9 +319,17 @@ impl Proxy {
         } else {
             None
         };
+        // Diagnostic: count this stream as an active SSE pump for its whole
+        // lifetime by packing a pump-phase guard into the stream guards (created
+        // post-headers, dropped when the pump task ends).
+        let pump_phase = crate::diag::PhaseGuard::pump();
+        let guards: Option<Box<dyn Send + 'static>> = match stream_guards {
+            Some(g) => Some(Box::new((g, pump_phase))),
+            None => Some(Box::new(pump_phase)),
+        };
         let body = sse::bytes_stream_to_body(
             sse::idle_timeout_stream(resp.bytes_stream(), STREAM_IDLE_TIMEOUT),
-            stream_guards,
+            guards,
             on_complete,
             first_byte_hook,
         );

--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -182,10 +182,15 @@ impl Proxy {
         let bytes = match resp.bytes().await {
             Ok(b) => b,
             Err(e) => {
+                // Walk the full source chain (`{:#}`) like the connect-error
+                // handler in `classify_reqwest_error_for` — a mid-body drop's
+                // real cause (incomplete message, connection reset) lives in the
+                // wrapped source, not the outer reqwest error.
+                let cause = anyhow::Error::new(e);
                 tracing::warn!(
                     upstream = %url,
                     status = %status,
-                    error = ?e,
+                    error = %format_args!("{cause:#}"),
                     "upstream dropped connection mid-body",
                 );
                 breaker.record_failure();
@@ -501,6 +506,43 @@ mod tests {
             breaker.would_allow(),
             "worker must admit traffic again after recovering from the probe",
         );
+    }
+
+    /// A worker's own response is forwarded with its status VERBATIM and carries
+    /// NO `x-router-error-code` header. The absence of that header is exactly how
+    /// a gateway tells "the engine said this" from "the router said this" — a
+    /// worker 2xx, 4xx, and 5xx (incl. a complete 500, distinct from a synthesized
+    /// 502 mid-body drop) all pass straight through, unannotated.
+    #[tokio::test]
+    async fn forwarded_worker_response_is_verbatim_with_no_router_error_code() {
+        for status in [200u16, 400, 500, 503] {
+            let (url, _shutdown) = spawn_status_worker(status).await;
+            let proxy = Proxy::new(Duration::from_secs(5)).unwrap();
+            let breaker = CircuitBreaker::new();
+            let resp = proxy
+                .forward_json_to(
+                    &url,
+                    &breaker,
+                    "/v1/chat/completions",
+                    &HeaderMap::new(),
+                    Bytes::from_static(b"{}"),
+                )
+                .await
+                .expect("dispatch should reach the worker");
+            assert_eq!(
+                resp.status().as_u16(),
+                status,
+                "worker status {status} must be forwarded verbatim",
+            );
+            assert!(
+                resp.headers().get("x-router-error-code").is_none(),
+                "a forwarded worker response must NOT carry x-router-error-code (status {status})",
+            );
+            assert!(
+                resp.headers().get("x-router-upstream-status").is_none(),
+                "a forwarded worker response must NOT carry x-router-upstream-status (status {status})",
+            );
+        }
     }
 
     /// Streaming path parity: the engine's 503 on the streaming arm must also

--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -30,6 +30,51 @@ fn parse_worker_url(worker_url: &str, breaker: &CircuitBreaker) -> Result<Url, A
     })
 }
 
+/// How an upstream HTTP response status should affect the worker's circuit
+/// breaker. Each variant maps to one `CircuitBreaker` call at the dispatch
+/// sites (`forward_json_to` / `forward_streaming_to`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BreakerOutcome {
+    /// Healthy completion → `record_success`: reset the failure streak and
+    /// close the breaker.
+    Success,
+    /// A real fault (5xx other than backpressure) → `record_failure`: count
+    /// toward opening.
+    Failure,
+    /// Backpressure (the worker is responsive but at capacity) →
+    /// `record_backpressure`: never opens the breaker and, while Closed, leaves
+    /// an in-progress failure streak intact — but still resolves a half-open
+    /// probe so a recovered-but-busy worker isn't wedged shut.
+    Neutral,
+}
+
+/// Classify an upstream status for circuit-breaker accounting.
+///
+/// A backpressure status — `503 Service Unavailable` or `429 Too Many
+/// Requests` — is the worker signalling "responsive but at capacity", not a
+/// fault. Counting it as a breaker failure is actively harmful: a saturated
+/// worker trips the breaker on its own queue-full 503s, and with a single
+/// worker the router then sheds *every* request for the whole cool-down —
+/// including after the engine has drained and gone idle. So backpressure is
+/// [`Neutral`](BreakerOutcome::Neutral) (see [`CircuitBreaker::record_backpressure`]
+/// for its exact effect per breaker state). Genuine 5xx faults (500 / 502 /
+/// 504 / …) still count as failures, and transport errors / timeouts /
+/// mid-body drops are recorded as failures at the call sites.
+///
+/// Tradeoff: because 503 never opens the breaker, a worker stuck returning 503
+/// indefinitely (a wedged engine, not transient load) is NOT detected here —
+/// HTTP status alone can't distinguish "busy" from "broken-and-saying-503", and
+/// counting it caused the worse fleet-wide false-shed above. Detecting a
+/// chronically-backpressuring worker is left to higher-level signals.
+fn breaker_outcome(status: reqwest::StatusCode) -> BreakerOutcome {
+    use reqwest::StatusCode;
+    match status {
+        StatusCode::SERVICE_UNAVAILABLE | StatusCode::TOO_MANY_REQUESTS => BreakerOutcome::Neutral,
+        s if s.is_server_error() => BreakerOutcome::Failure,
+        _ => BreakerOutcome::Success,
+    }
+}
+
 /// Idle (between-bytes) timeout for streaming upstream responses. A stream that
 /// delivers no bytes for this long is treated as hung and aborted, releasing the
 /// admission / active-load guards it holds. Distinct from `request_timeout` (the
@@ -147,10 +192,14 @@ impl Proxy {
                 return Err(ApiError::UpstreamStatus { status });
             }
         };
-        if status.is_server_error() {
-            breaker.record_failure();
-        } else {
-            breaker.record_success();
+        match breaker_outcome(status) {
+            BreakerOutcome::Failure => breaker.record_failure(),
+            BreakerOutcome::Success => breaker.record_success(),
+            // Backpressure (503/429): the engine is healthy but busy. This never
+            // opens the breaker and (in Closed) leaves the failure streak
+            // intact, but it DOES resolve a half-open probe so a recovered
+            // worker that answers a probe with 503 isn't wedged shut.
+            BreakerOutcome::Neutral => breaker.record_backpressure(),
         }
         let mut out = Response::new(Body::from(bytes));
         *out.status_mut() = status;
@@ -223,22 +272,33 @@ impl Proxy {
         };
         // Breaker recording is deferred to the pump's completion hook so
         // an upstream that returns 2xx headers and then drops mid-stream
-        // is recorded as a failure. For 5xx headers we record_failure
+        // is recorded as a failure. For a genuine 5xx fault we record_failure
         // up front and skip the pump hook (the body we surface is the
-        // error response — its stream completing is not a worker win).
+        // error response — its stream completing is not a worker win). For a
+        // backpressure status (503/429) we record_backpressure up front and
+        // skip the hook: a busy-but-healthy engine's queue-full responses can't
+        // open the breaker, but a half-open probe answered with 503 is still
+        // resolved rather than wedged (see `breaker_outcome` / `record_backpressure`).
         let on_complete: Option<Box<dyn FnOnce(bool) + Send + 'static>> =
-            if status.is_server_error() {
-                breaker.record_failure();
-                None
-            } else {
-                let breaker_for_hook = Arc::clone(breaker);
-                Some(Box::new(move |ok| {
-                    if ok {
-                        breaker_for_hook.record_success();
-                    } else {
-                        breaker_for_hook.record_failure();
-                    }
-                }))
+            match breaker_outcome(status) {
+                BreakerOutcome::Failure => {
+                    breaker.record_failure();
+                    None
+                }
+                BreakerOutcome::Neutral => {
+                    breaker.record_backpressure();
+                    None
+                }
+                BreakerOutcome::Success => {
+                    let breaker_for_hook = Arc::clone(breaker);
+                    Some(Box::new(move |ok| {
+                        if ok {
+                            breaker_for_hook.record_success();
+                        } else {
+                            breaker_for_hook.record_failure();
+                        }
+                    }))
+                }
             };
         // Only record TTFT for successful streams — a 4xx/5xx error body
         // streaming back is not a generated token, so drop the hook for
@@ -268,11 +328,214 @@ impl Proxy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::health::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
+    use axum::routing::post;
+    use axum::Router;
+    use reqwest::StatusCode;
+    use std::num::NonZeroU32;
     use std::time::Duration;
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
 
     #[tokio::test]
     async fn new_returns_result_not_panic() {
         let p = Proxy::new(Duration::from_secs(5)).unwrap();
         assert_eq!(p.request_timeout, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn breaker_outcome_treats_backpressure_as_neutral() {
+        // Backpressure: healthy but busy — must not touch the breaker.
+        assert_eq!(
+            breaker_outcome(StatusCode::SERVICE_UNAVAILABLE),
+            BreakerOutcome::Neutral,
+        );
+        assert_eq!(
+            breaker_outcome(StatusCode::TOO_MANY_REQUESTS),
+            BreakerOutcome::Neutral,
+        );
+        // Genuine faults: still failures.
+        for s in [
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::GATEWAY_TIMEOUT,
+        ] {
+            assert_eq!(breaker_outcome(s), BreakerOutcome::Failure, "{s}");
+        }
+        // Non-5xx (incl. 4xx client errors): treated as success.
+        for s in [
+            StatusCode::OK,
+            StatusCode::BAD_REQUEST,
+            StatusCode::NOT_FOUND,
+        ] {
+            assert_eq!(breaker_outcome(s), BreakerOutcome::Success, "{s}");
+        }
+    }
+
+    /// A fake upstream that answers every POST with a fixed status + tiny body.
+    async fn spawn_status_worker(status: u16) -> (String, oneshot::Sender<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let code = StatusCode::from_u16(status).unwrap();
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move || async move { (code, "{\"error\":\"x\"}") }),
+        );
+        let (tx, rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = rx.await;
+                })
+                .await;
+        });
+        (format!("http://127.0.0.1:{port}"), tx)
+    }
+
+    /// The bug this fixes: a saturated engine returning its own queue-full 503s
+    /// must NOT trip the router's circuit breaker. Dispatch well past the
+    /// default threshold (3) and assert the breaker stays Closed and admitting.
+    #[tokio::test]
+    async fn engine_503_does_not_trip_breaker() {
+        let (url, _shutdown) = spawn_status_worker(503).await;
+        let proxy = Proxy::new(Duration::from_secs(5)).unwrap();
+        let breaker = CircuitBreaker::new(); // default threshold = 3
+        let headers = HeaderMap::new();
+
+        for i in 0..6 {
+            let resp = proxy
+                .forward_json_to(
+                    &url,
+                    &breaker,
+                    "/v1/chat/completions",
+                    &headers,
+                    Bytes::from_static(b"{}"),
+                )
+                .await
+                .expect("dispatch should reach the worker (breaker must stay closed)");
+            assert_eq!(
+                resp.status(),
+                StatusCode::SERVICE_UNAVAILABLE,
+                "iter {i}: client must still see the engine's 503",
+            );
+            assert_eq!(
+                breaker.snapshot().state_code,
+                0,
+                "iter {i}: 503 backpressure must leave the breaker Closed",
+            );
+        }
+        assert!(
+            breaker.would_allow(),
+            "breaker must keep admitting after a burst of engine 503s",
+        );
+    }
+
+    /// Contrast / regression guard: a genuine 5xx fault (500) MUST still trip the
+    /// breaker after the threshold, so the backpressure carve-out didn't disable
+    /// fault detection.
+    #[tokio::test]
+    async fn engine_500_still_trips_breaker() {
+        let (url, _shutdown) = spawn_status_worker(500).await;
+        let proxy = Proxy::new(Duration::from_secs(5)).unwrap();
+        let breaker = CircuitBreaker::new(); // default threshold = 3
+        let headers = HeaderMap::new();
+
+        for _ in 0..3 {
+            let _ = proxy
+                .forward_json_to(
+                    &url,
+                    &breaker,
+                    "/v1/chat/completions",
+                    &headers,
+                    Bytes::from_static(b"{}"),
+                )
+                .await;
+        }
+        assert_eq!(
+            breaker.snapshot().state_code,
+            1,
+            "three 500s must open the breaker (fault detection still works)",
+        );
+    }
+
+    /// End-to-end wedge guard: a breaker that opened on real faults, then has
+    /// its half-open probe answered with a 503, must RECOVER — not stay shut
+    /// out forever. Exercises the `Neutral => record_backpressure` wiring in
+    /// `forward_json_to` through the half-open path.
+    #[tokio::test]
+    async fn engine_503_recovers_a_half_open_breaker() {
+        let (url, _shutdown) = spawn_status_worker(503).await;
+        let proxy = Proxy::new(Duration::from_secs(5)).unwrap();
+        // threshold=1 so one prior fault opens it; tiny cooldown so the probe
+        // is admitted almost immediately.
+        let breaker = CircuitBreaker::with_config(CircuitBreakerConfig {
+            threshold: NonZeroU32::new(1).unwrap(),
+            cool_down: Duration::from_millis(50),
+        });
+        let headers = HeaderMap::new();
+
+        // Simulate a prior genuine fault (e.g. a 500 / timeout) that tripped it.
+        breaker.record_failure();
+        assert_eq!(breaker.snapshot().state_code, 1, "breaker should be Open");
+
+        // Let the cooldown elapse so the next dispatch claims the half-open probe.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+
+        let resp = proxy
+            .forward_json_to(
+                &url,
+                &breaker,
+                "/v1/chat/completions",
+                &headers,
+                Bytes::from_static(b"{}"),
+            )
+            .await
+            .expect("the half-open probe must be admitted and reach the worker");
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            breaker.snapshot().state_code,
+            0,
+            "a 503 answer to the probe must close the breaker, not wedge it half-open",
+        );
+        assert!(
+            breaker.would_allow(),
+            "worker must admit traffic again after recovering from the probe",
+        );
+    }
+
+    /// Streaming path parity: the engine's 503 on the streaming arm must also
+    /// leave the breaker untouched (no up-front failure, no completion hook).
+    #[tokio::test]
+    async fn engine_503_does_not_trip_breaker_streaming() {
+        use http_body_util::BodyExt;
+
+        let (url, _shutdown) = spawn_status_worker(503).await;
+        let proxy = Proxy::new(Duration::from_secs(5)).unwrap();
+        let breaker = Arc::new(CircuitBreaker::new());
+        let headers = HeaderMap::new();
+
+        for i in 0..6 {
+            let resp = proxy
+                .forward_streaming_to(
+                    &url,
+                    &breaker,
+                    "/v1/chat/completions",
+                    &headers,
+                    Bytes::from_static(b"{}"),
+                    None,
+                    None,
+                )
+                .await
+                .expect("streaming dispatch should reach the worker");
+            assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE, "iter {i}");
+            // Drain the body so the pump task runs to completion (would fire any
+            // completion hook). For a 503 there is none, but draining proves it.
+            let _ = resp.into_body().collect().await;
+            assert_eq!(
+                breaker.snapshot().state_code,
+                0,
+                "iter {i}: streaming 503 must leave the breaker Closed",
+            );
+        }
     }
 }

--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -30,6 +30,15 @@ fn parse_worker_url(worker_url: &str, breaker: &CircuitBreaker) -> Result<Url, A
     })
 }
 
+/// Idle (between-bytes) timeout for streaming upstream responses. A stream that
+/// delivers no bytes for this long is treated as hung and aborted, releasing the
+/// admission / active-load guards it holds. Distinct from `request_timeout` (the
+/// total budget, which streaming deliberately skips so long generations can run):
+/// this fires only on a *stall*, not on slow-but-progressing generation. Without
+/// it, a half-open upstream (e.g. a worker killed mid-stream) pins the SSE pump
+/// and leaks the per-worker in-flight slot forever.
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+
 #[derive(Debug)]
 pub struct Proxy {
     pub client: Client,
@@ -240,7 +249,7 @@ impl Proxy {
             None
         };
         let body = sse::bytes_stream_to_body(
-            resp.bytes_stream(),
+            sse::idle_timeout_stream(resp.bytes_stream(), STREAM_IDLE_TIMEOUT),
             stream_guards,
             on_complete,
             first_byte_hook,

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -9,37 +9,73 @@ use std::sync::Arc;
 use axum::body::Body;
 use bytes::Bytes;
 use futures::{FutureExt, StreamExt};
-use tokio_stream::wrappers::ReceiverStream;
 
 /// Max time the pump waits to hand a chunk to the client before giving up.
 ///
 /// A client that reads the response headers, stops reading the body, but never
-/// closes the connection fills the bounded channel and parks the pump on
-/// `tx.send()`. The upstream idle timeout cannot rescue this: it is only armed
-/// while the pump polls `s.next()`, not while it blocks on `tx.send()`. Without
-/// this bound the pump parks forever, its `stream_guards` (the per-worker
-/// admission slot + active-load entry) never drop, and the in-flight counter
-/// leaks until every worker is pinned at its cap and all traffic is shed while
-/// the engines sit idle. 120 s mirrors the upstream idle timeout: a client that
-/// accepts no bytes for that long is treated as gone.
+/// closes the connection lets the read-ahead buffer fill and parks the pump
+/// acquiring read-ahead permits. The upstream idle timeout cannot rescue this:
+/// it is only armed while the pump polls `s.next()`, not while it blocks on the
+/// permit acquire. Without this bound the pump parks forever, its
+/// `stream_guards` (the per-worker admission slot + active-load entry) never
+/// drop, and the in-flight counter leaks until every worker is pinned at its cap
+/// and all traffic is shed while the engines sit idle. 120 s mirrors the
+/// upstream idle timeout: a client that accepts no bytes for that long is
+/// treated as gone.
 const STREAM_SEND_STALL: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Per-stream read-ahead budget, in bytes.
+///
+/// The pump reads engine→client through a byte-bounded read-ahead buffer: it may
+/// race ahead of a slow client by up to this many buffered bytes. This is what
+/// decouples the engine-read from the client-write so the `stream_guards` (the
+/// per-worker admission slot + active-load entry) release when the ENGINE
+/// finishes — not when the client finishes draining. With a per-worker cap, that
+/// difference is the whole game: if slots only freed at client-read speed, a fast
+/// engine would be paced by slow clients and the router would forward far below
+/// engine capacity while the engine sat idle.
+///
+/// Any completion whose total size is ≤ this cap reaches upstream-`None` at the
+/// engine's pace and drops its slot immediately (engine-done release), while the
+/// cap still bounds worst-case per-stream memory. A completion LARGER than this
+/// cap whose client has stalled re-engages backpressure: the pump blocks
+/// acquiring read-ahead permits (and, if the stall persists, trips
+/// `STREAM_SEND_STALL`).
+const STREAM_READAHEAD_MAX_BYTES: usize = 1 << 20; // 1 MiB
+
+// `acquire_many` takes a u32 and the per-chunk charge is `min(len, MAX)`, so the
+// cap must fit in u32 for the `as u32` cast in the pump to be lossless.
+const _: () = assert!(STREAM_READAHEAD_MAX_BYTES <= u32::MAX as usize);
 
 /// Bridge a byte stream into an axum Body that streams chunks unchanged.
 ///
 /// Spawns one tokio task per stream so the handler can return immediately.
-/// Uses a **bounded** 64-slot channel so `tx.send().await` naturally
-/// backpressures the upstream read when the client (axum Body consumer) falls
-/// behind — an unbounded channel would buffer hundreds of MB for a slow client
-/// receiving a long completion.
+/// Engine→client chunks flow through an **unbounded** channel paired with a
+/// byte-bounded read-ahead buffer (a [`tokio::sync::Semaphore`] seeded with
+/// `STREAM_READAHEAD_MAX_BYTES` permits): the pump acquires
+/// `min(chunk_len, STREAM_READAHEAD_MAX_BYTES)` permits before sending each
+/// chunk, and the client-facing stream returns the same count as it yields each
+/// chunk. Total buffered bytes therefore stay ≤ `STREAM_READAHEAD_MAX_BYTES`,
+/// plus at most one in-flight chunk that individually exceeds the cap (an
+/// oversized chunk is charged the full cap, never more, to avoid deadlock).
 ///
 /// # Backpressure note
-/// The channel bound of 64 absorbs short bursts while still limiting
-/// worst-case outstanding bytes to 64 × chunk_size (typically a few MB).
+/// The read-ahead buffer lets the pump race ahead of a slow client by up to
+/// `STREAM_READAHEAD_MAX_BYTES`. The point is the **engine-done release**: for
+/// any completion that fits within the read-ahead cap, the pump reaches the
+/// upstream `None` at the engine's pace and drops its `stream_guards`
+/// immediately, regardless of how slowly the client reads — so a per-worker
+/// admission slot frees as fast as the engine finishes, not as fast as clients
+/// drain. A completion that EXCEEDS the cap with a non-draining client still
+/// backpressures: the pump blocks acquiring permits until the client consumes
+/// (or `STREAM_SEND_STALL` trips), bounding worst-case per-stream memory.
 ///
 /// # Client disconnect
-/// When the axum Body is dropped the receiver is closed; `tx.send()` then
-/// returns `Err`, which breaks the loop — no upstream bytes are read after the
-/// client disconnects.
+/// When the axum Body is dropped the receiver is closed; the next `tx.send()` on
+/// the unbounded channel then returns `Err`, which breaks the loop. If the pump
+/// is instead blocked acquiring read-ahead permits when the client disconnects,
+/// a `tokio::select!` on `tx.closed()` wakes it so it breaks rather than holding
+/// the guards — no upstream bytes are read after the client disconnects.
 ///
 /// # Panic safety
 /// The pump future is wrapped in `AssertUnwindSafe(..).catch_unwind()`. If the
@@ -50,7 +86,8 @@ const STREAM_SEND_STALL: std::time::Duration = std::time::Duration::from_secs(12
 /// # Stream guards
 /// When `stream_guards` is `Some`, the value is **moved into the spawned task**
 /// and held for the entire body lifetime.  It is dropped only when the SSE
-/// pump finishes (stream exhausted, client disconnects, or upstream errors).
+/// pump finishes (stream exhausted, client disconnects, the client stalls past
+/// `STREAM_SEND_STALL` without draining, or upstream errors).
 /// The opaque `Box<dyn Send + 'static>` accepts any drop-only payload — most
 /// commonly a tuple of [`crate::workers::LoadGuard`] and
 /// [`crate::policies::active_load::ActiveLoadGuard`]. The proxy does not
@@ -62,8 +99,9 @@ const STREAM_SEND_STALL: std::time::Duration = std::time::Duration::from_secs(12
 /// # Completion hook
 /// When `on_complete` is `Some`, the closure runs exactly once when the
 /// pump task finishes. The bool argument is `true` on clean stream end
-/// (including a clean client disconnect after at least the headers
-/// landed cleanly), `false` on upstream stream error or pump panic.
+/// (including a clean client disconnect, or a non-draining client aborted by
+/// `STREAM_SEND_STALL`, after at least the headers landed cleanly), `false` on
+/// upstream stream error or pump panic.
 /// `forward_streaming_to` passes a closure that records the worker's
 /// circuit-breaker outcome — without this hook, a worker that returns
 /// 2xx headers and then drops the stream mid-flight would stay credited
@@ -85,7 +123,12 @@ where
     S: futures::Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
     E: std::fmt::Display + Send + Sync + 'static,
 {
-    let (tx, rx) = tokio::sync::mpsc::channel(64);
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();
+    // Byte-bounded read-ahead budget shared between the pump (acquires permits
+    // before sending) and the client-facing stream (returns them as it yields).
+    // Total buffered bytes stay ≤ STREAM_READAHEAD_MAX_BYTES; see the type doc.
+    let readahead = Arc::new(tokio::sync::Semaphore::new(STREAM_READAHEAD_MAX_BYTES));
+    let readahead_pump = Arc::clone(&readahead);
     tokio::spawn(async move {
         let tx_for_panic = tx.clone();
         // Capture the pump's outcome so we can report it through `on_complete`
@@ -108,6 +151,16 @@ where
                     std::io::Error::other(msg)
                 });
                 let is_err_chunk = item.is_err();
+                // An empty Ok chunk carries no bytes, so forwarding it is a
+                // client-visible no-op — but it charges zero read-ahead permits
+                // (the byte budget can't bound it) and would still occupy a slot
+                // on the unbounded channel. Skip it so an upstream emitting a
+                // flood of empty chunks can't grow the buffer without bound, and
+                // so the first-byte hook fires on the first chunk that actually
+                // carries a token.
+                if matches!(&item, Ok(b) if b.is_empty()) {
+                    continue;
+                }
                 // Fire the time-to-first-token hook on the first successful
                 // chunk from upstream. `take()` makes it fire at most once;
                 // an error-first stream never produced a token, so it's left
@@ -120,36 +173,95 @@ where
                 if is_err_chunk {
                     *outcome_setter.lock() = false;
                 }
-                // Bound the downstream send. A client that read headers, stopped
-                // reading, and never closed the connection leaves the receiver
-                // open but undrained; the bounded channel fills and this send
-                // parks. The upstream idle timeout cannot fire here (it is only
-                // armed while polling `s.next()`), so without this bound the pump
-                // parks forever and `_hold` (the admission slot + active-load
-                // entry) leaks — pinning the worker at its cap.
-                match tokio::time::timeout(STREAM_SEND_STALL, tx.send(item)).await {
-                    Ok(Ok(())) => {}
-                    Ok(Err(_)) => {
-                        // Receiver dropped. If we were about to ship an upstream
-                        // error there's nothing left to report; otherwise this is
-                        // a clean client-side disconnect — log at debug since it's
-                        // not a router-side fault.
-                        if !is_err_chunk {
+                // Reserve read-ahead budget before sending. We charge
+                // `min(chunk_len, MAX)` permits so a single chunk larger than the
+                // whole budget can still proceed (it would otherwise deadlock
+                // asking for more permits than exist); the client-facing stream
+                // returns exactly the same count, keeping the semaphore balanced.
+                // An error chunk carries no payload to buffer, so it bypasses the
+                // budget and is sent directly.
+                let want = item
+                    .as_ref()
+                    .map(|b| b.len().min(STREAM_READAHEAD_MAX_BYTES))
+                    .unwrap_or(0) as u32;
+                if want > 0 {
+                    // Acquire read-ahead permits. The pump may race ahead of a
+                    // slow client up to STREAM_READAHEAD_MAX_BYTES; only when the
+                    // buffer is full does this block. Two safety valves:
+                    //  - `tx.closed()` resolves when the receiver (client Body) is
+                    //    dropped, so a disconnect while blocked here wakes us
+                    //    rather than pinning the guards.
+                    //  - `STREAM_SEND_STALL` caps how long we wait on a client
+                    //    that stays connected but never drains (so it never frees
+                    //    permits); on elapse we abort and release the slot.
+                    let acquired = tokio::select! {
+                        biased;
+                        _ = tx.closed() => {
+                            // Client disconnected while we were blocked on the
+                            // budget — clean client-side cancel, not a fault.
                             tracing::debug!("SSE client disconnected mid-stream");
+                            break;
                         }
-                        break;
+                        res = tokio::time::timeout(
+                            STREAM_SEND_STALL,
+                            readahead_pump.acquire_many(want),
+                        ) => res,
+                    };
+                    match acquired {
+                        Ok(Ok(permit)) => {
+                            // Hand the bytes off to the client-facing stream,
+                            // which returns these permits as it yields the chunk.
+                            permit.forget();
+                        }
+                        Ok(Err(_)) => {
+                            // The semaphore is never closed while the pump holds a
+                            // clone, so this is unreachable. Log loudly rather than
+                            // break silently: if a future change ever closes it,
+                            // this surfaces the contract violation instead of
+                            // masquerading as a clean completion.
+                            tracing::error!(
+                                "SSE read-ahead semaphore closed unexpectedly; aborting pump"
+                            );
+                            break;
+                        }
+                        Err(_elapsed) => {
+                            // Client accepted no bytes for STREAM_SEND_STALL while
+                            // the connection stayed open. Stop pumping so `_hold`
+                            // drops and the slot is released. We leave `outcome` at
+                            // its `true` default, so `on_complete` records a breaker
+                            // SUCCESS — the worker was demonstrably delivering when
+                            // the client stalled, so it is not at fault and must not
+                            // be penalized. But the stream is being truncated
+                            // mid-completion, so we inject a loud `io::Error` (as the
+                            // panic path does) rather than letting the body EOF
+                            // cleanly: a client that resumes reading after the stall
+                            // must be able to tell its response was cut short, not
+                            // mistake a short body for a complete one.
+                            tracing::warn!(
+                                stall = ?STREAM_SEND_STALL,
+                                "SSE downstream not draining; aborting to release in-flight slot"
+                            );
+                            let _ = tx.send(Err(std::io::Error::other(
+                                "SSE downstream stalled; stream aborted before completion",
+                            )));
+                            break;
+                        }
                     }
-                    Err(_elapsed) => {
-                        // Client accepted no bytes for STREAM_SEND_STALL while the
-                        // connection stayed open. Treat it like a disconnect: stop
-                        // pumping so `_hold` drops and the slot is released. The
-                        // worker delivered fine, so this is not a breaker failure.
-                        tracing::warn!(
-                            stall = ?STREAM_SEND_STALL,
-                            "SSE downstream not draining; aborting to release in-flight slot"
-                        );
-                        break;
+                }
+                // Send on the unbounded channel. This only fails if the receiver
+                // (client Body) was dropped: a clean client-side disconnect (or
+                // nothing left to report if we were shipping an upstream error).
+                // The permits charged above are not returned on this break path,
+                // but that is harmless: the pump is the only acquirer and it is
+                // exiting, so nothing waits on the semaphore again — both Arc
+                // clones drop with the channel and the whole per-stream semaphore
+                // is freed. Permit balance only matters on the steady-state path,
+                // where the client stream returns each charge as it yields a chunk.
+                if tx.send(item).is_err() {
+                    if !is_err_chunk {
+                        tracing::debug!("SSE client disconnected mid-stream");
                     }
+                    break;
                 }
                 if is_err_chunk {
                     // Surfaced upstream error to client; stop reading.
@@ -166,18 +278,30 @@ where
                 .or_else(|| panic_payload.downcast_ref::<String>().cloned())
                 .unwrap_or_else(|| "<non-string panic payload>".to_string());
             tracing::error!(error = %msg, "SSE pump task panicked");
-            let _ = tx_for_panic
-                .send(Err(std::io::Error::other(format!(
-                    "SSE pump panicked: {msg}"
-                ))))
-                .await;
+            let _ = tx_for_panic.send(Err(std::io::Error::other(format!(
+                "SSE pump panicked: {msg}"
+            ))));
         }
         if let Some(hook) = on_complete {
             let ok = !panicked && *outcome_holder.lock();
             hook(ok);
         }
     });
-    Body::from_stream(ReceiverStream::new(rx))
+    // Client-facing stream: as each chunk is yielded to the client, return the
+    // read-ahead permits the pump charged for it (`min(len, MAX)`), freeing the
+    // pump to read further ahead. Error chunks carry no payload, so they
+    // returned nothing to release.
+    let body_stream = futures::stream::unfold((rx, readahead), |(mut rx, sem)| async move {
+        let item = rx.recv().await?;
+        if let Ok(bytes) = &item {
+            let release = bytes.len().min(STREAM_READAHEAD_MAX_BYTES);
+            if release > 0 {
+                sem.add_permits(release);
+            }
+        }
+        Some((item, (rx, sem)))
+    });
+    Body::from_stream(body_stream)
 }
 
 /// Wrap a byte stream with an idle (between-chunks) timeout. If the upstream
@@ -410,12 +534,14 @@ mod tests {
     /// Regression guard for the backpressure-via-disconnect invariant.
     ///
     /// The doc on `bytes_stream_to_body` claims "when the axum Body is dropped
-    /// the receiver is closed; `tx.send()` then returns `Err`, which breaks the
-    /// loop — no upstream bytes are read after the client disconnects." This
-    /// test pins that contract: a refactor that swaps the `if tx.send().await.
-    /// is_err() { break; }` for `let _ = tx.send().await;` would silently
-    /// regress (leaked upstream reads on every client cancel, visible only as
-    /// ops-side memory growth).
+    /// the receiver is closed; the next `tx.send()` returns `Err`, which breaks
+    /// the loop — no upstream bytes are read after the client disconnects." With
+    /// the byte-bounded read-ahead the pump can also be parked acquiring permits
+    /// when the disconnect lands, so the break may instead come from the
+    /// `tx.closed()` arm of the select. This test pins both: a refactor that
+    /// drops the `tx.send().is_err()` break OR the `tx.closed()` select arm would
+    /// silently regress (leaked upstream reads on every client cancel, visible
+    /// only as ops-side memory growth).
     #[tokio::test]
     async fn bytes_stream_to_body_breaks_on_client_disconnect() {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -423,7 +549,19 @@ mod tests {
 
         // A stream that yields N Ok chunks readily, counting polls via a shared
         // atomic. After we read 1 chunk and drop the body, the pump must hit
-        // tx.send-err and break — not drain all 1000 chunks.
+        // tx.send-err / tx.closed() and break — not drain all 1000 chunks.
+        //
+        // Chunk size is sized to the read-ahead budget on purpose: each chunk is
+        // 16 KiB, so 64 chunks (1 MiB) exactly fill STREAM_READAHEAD_MAX_BYTES.
+        // The pump reads ~64 chunks ahead, then blocks acquiring read-ahead
+        // permits for the 65th; the client never reads, so the only way it
+        // un-blocks is the `tx.closed()` arm of the select firing on our
+        // `drop(data_stream)`. That keeps the poll count tightly bounded
+        // (deterministic, not scheduler-dependent) AND exercises the new
+        // disconnect-while-blocked-on-permits path. Tiny chunks would instead
+        // let the pump read hundreds of thousands of chunks ahead before the
+        // budget bites, making the bound meaningless.
+        const CHUNK_LEN: usize = 16 * 1024; // 64 chunks fill the 1 MiB budget
         struct CountingStream {
             polls: Arc<AtomicUsize>,
             yielded: usize,
@@ -442,7 +580,7 @@ mod tests {
                     return std::task::Poll::Ready(None);
                 }
                 self.yielded += 1;
-                std::task::Poll::Ready(Some(Ok(Bytes::from_static(b"chunk"))))
+                std::task::Poll::Ready(Some(Ok(Bytes::from(vec![b'x'; CHUNK_LEN]))))
             }
         }
 
@@ -461,13 +599,14 @@ mod tests {
         drop(data_stream);
 
         // Give the pump generous time to make additional polls if its break is
-        // broken. Healthy code: pump fills the 64-slot channel, then on the
-        // next iteration tx.send().await detects receiver-drop and breaks.
+        // broken. Healthy code: pump reads ~64 chunks ahead (1 MiB), blocks on
+        // the permit acquire for the 65th, then `tx.closed()` fires on the drop
+        // and it breaks.
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         let final_polls = polls.load(Ordering::SeqCst);
         assert!(
             final_polls <= 70,
-            "pump kept polling upstream after client disconnect: {final_polls} polls (expected <=70, channel bound + slack)"
+            "pump kept polling upstream after client disconnect: {final_polls} polls (expected <=70, read-ahead budget + slack)"
         );
         // And: the pump must NOT have drained all 1000 chunks.
         assert!(
@@ -520,15 +659,68 @@ mod tests {
         );
     }
 
+    /// The engine-done release invariant: once the UPSTREAM stream ends (the
+    /// engine finished generating), the pump must drop its `stream_guards` (the
+    /// per-worker admission slot + active-load entry) at the engine's pace —
+    /// NOT wait for a slow client to finish reading the body. A completion whose
+    /// total size fits within the byte-bounded read-ahead buffer
+    /// (`STREAM_READAHEAD_MAX_BYTES`) must reach upstream-`None` even if the
+    /// client never reads a single byte. Without read-ahead the pump parks on a
+    /// full bounded channel and the slot is held for the whole client-facing
+    /// stream lifetime — starving a fast engine.
+    #[tokio::test(start_paused = true)]
+    async fn engine_done_releases_guards_before_client_drains() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        struct DropFlag(Arc<AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+        let dropped = Arc::new(AtomicBool::new(false));
+        let guard: Box<dyn Send + 'static> = Box::new(DropFlag(Arc::clone(&dropped)));
+
+        // ~200 small chunks, total well under STREAM_READAHEAD_MAX_BYTES, then
+        // the stream ends. The read-ahead buffer absorbs all of them so the pump
+        // can drain the upstream to completion without the client reading.
+        let chunks: Vec<Result<Bytes, std::io::Error>> = (0..200)
+            .map(|_| Ok(Bytes::from_static(b"small-chunk")))
+            .collect();
+        let s = stream::iter(chunks);
+
+        // Build the Body but DO NOT read it: the client never drains a byte.
+        let _body = bytes_stream_to_body(s, Some(guard), None, None);
+
+        // Let the pump run. It should race ahead of the (absent) client, reach
+        // upstream-`None`, and drop the guards — all well within STREAM_SEND_STALL.
+        for _ in 0..1000 {
+            if dropped.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "engine-done must release stream_guards at the engine's pace: a \
+             completion fitting in the read-ahead buffer reaches upstream-None \
+             and drops the slot even when the client never reads",
+        );
+    }
+
     /// A stalled *downstream* — the client reads response headers, then stops
     /// reading the body but never closes the connection — must not pin the SSE
-    /// pump forever. The bounded channel fills, the pump parks on `tx.send()`,
-    /// and the upstream idle timeout CANNOT fire there (it is only armed while we
-    /// poll `s.next()`). Without a send-stall timeout the pump blocks on the send
-    /// indefinitely and `stream_guards` (the per-worker admission slot +
-    /// active-load entry) leak — pinning every worker at its cap and shedding all
-    /// traffic while the engines sit idle (the exact production failure observed:
-    /// engine `num_running_reqs=0` while the router holds `inflight=cap`).
+    /// pump forever. With the byte-bounded read-ahead, a completion LARGER than
+    /// `STREAM_READAHEAD_MAX_BYTES` fills the buffer and the pump parks acquiring
+    /// read-ahead permits; the upstream idle timeout CANNOT fire there (it is
+    /// only armed while we poll `s.next()`), and the client never reads so it
+    /// never frees permits. Without the send-stall timeout the pump blocks on the
+    /// permit acquire indefinitely and `stream_guards` (the per-worker admission
+    /// slot + active-load entry) leak — pinning every worker at its cap and
+    /// shedding all traffic while the engines sit idle (the exact production
+    /// failure observed: engine `num_running_reqs=0` while the router holds
+    /// `inflight=cap`).
     #[tokio::test(start_paused = true)]
     async fn stalled_downstream_releases_stream_guards() {
         use std::sync::atomic::{AtomicBool, Ordering};
@@ -543,13 +735,21 @@ mod tests {
         let dropped = Arc::new(AtomicBool::new(false));
         let guard: Box<dyn Send + 'static> = Box::new(DropFlag(Arc::clone(&dropped)));
 
-        // Upstream readily yields far more chunks than the 64-slot channel holds.
-        let chunks: Vec<Result<Bytes, std::io::Error>> =
-            (0..256).map(|_| Ok(Bytes::from_static(b"x"))).collect();
+        // Upstream yields more bytes than the read-ahead buffer holds without
+        // ending: ~20 × 64 KiB = 1.25 MiB > STREAM_READAHEAD_MAX_BYTES (1 MiB).
+        // The buffer fills, so the pump parks acquiring permits for a chunk the
+        // (non-reading) client never makes room for — the path the send-stall
+        // timeout must rescue. (A completion small enough to fit the buffer would
+        // instead drain to upstream-`None` and release at engine-done; see
+        // `engine_done_releases_guards_before_client_drains`.)
+        let chunks: Vec<Result<Bytes, std::io::Error>> = (0..20)
+            .map(|_| Ok(Bytes::from(vec![b'x'; 64 * 1024])))
+            .collect();
         let s = stream::iter(chunks);
 
         // Hold the Body WITHOUT reading it: the receiver stays open (no clean
-        // disconnect) but undrained, so the pump parks on `tx.send()`.
+        // disconnect) but undrained, so the pump parks acquiring read-ahead
+        // permits once the buffer is full.
         let _body = bytes_stream_to_body(s, Some(guard), None, None);
 
         // Advance past the send-stall timeout. The pump must give up on the
@@ -558,8 +758,117 @@ mod tests {
         assert!(
             dropped.load(Ordering::SeqCst),
             "a client that stops reading (without disconnecting) must not pin \
-             stream_guards — the pump must time out the blocked send and release \
-             the admission slot",
+             stream_guards — the pump must time out the blocked permit acquire \
+             and release the admission slot",
+        );
+    }
+
+    /// The send-stall abort must record a breaker SUCCESS, not a failure: a
+    /// client that stops draining is not the worker's fault, and penalizing the
+    /// worker for it would trip the breaker on a healthy engine. Pins the
+    /// `outcome = true` default on the `STREAM_SEND_STALL` path (contrast the
+    /// failure path on a genuine mid-stream upstream error, which sets it false).
+    #[tokio::test(start_paused = true)]
+    async fn stalled_downstream_records_breaker_success() {
+        use std::sync::atomic::{AtomicU8, Ordering};
+        use std::sync::Arc;
+
+        // 0 = hook not yet called, 1 = called with `true`, 2 = called with `false`.
+        let outcome = Arc::new(AtomicU8::new(0));
+        let outcome_c = Arc::clone(&outcome);
+
+        // > 1 MiB so the buffer fills and the pump parks on the permit acquire
+        // (the send-stall path), with a client that never reads.
+        let chunks: Vec<Result<Bytes, std::io::Error>> = (0..20)
+            .map(|_| Ok(Bytes::from(vec![b'x'; 64 * 1024])))
+            .collect();
+        let s = stream::iter(chunks);
+        let _body = bytes_stream_to_body(
+            s,
+            None,
+            Some(Box::new(move |ok| {
+                outcome_c.store(if ok { 1 } else { 2 }, Ordering::SeqCst);
+            })),
+            None,
+        );
+
+        // Advance past the send-stall timeout, then let the on_complete hook run.
+        tokio::time::sleep(STREAM_SEND_STALL + std::time::Duration::from_secs(1)).await;
+        for _ in 0..1000 {
+            if outcome.load(Ordering::SeqCst) != 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            outcome.load(Ordering::SeqCst),
+            1,
+            "a client-stall abort must record breaker SUCCESS (the worker was \
+             delivering; the client stalled), not penalize a healthy worker",
+        );
+    }
+
+    /// Engine-done release must also hold for a single chunk LARGER than the
+    /// read-ahead budget. The pump charges `min(len, MAX)` permits (never more
+    /// than the semaphore holds), so an oversized chunk proceeds instead of
+    /// deadlocking on `acquire_many(len > MAX)`. This pins the acquire-side
+    /// `.min(MAX)`: dropping it would ask for more permits than exist, park the
+    /// pump forever, and leak the per-worker admission slot — the exact
+    /// production false-shedding bug.
+    #[tokio::test(start_paused = true)]
+    async fn oversized_single_chunk_releases_guards() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        struct DropFlag(Arc<AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+        let dropped = Arc::new(AtomicBool::new(false));
+        let guard: Box<dyn Send + 'static> = Box::new(DropFlag(Arc::clone(&dropped)));
+
+        // One chunk twice the read-ahead budget, then the stream ends. With a
+        // non-reading client the pump charges only MAX permits (not 2×MAX), sends
+        // the chunk onto the unbounded channel, reads upstream-None, and drops the
+        // guards — even though the client never read a byte.
+        let big = Bytes::from(vec![b'x'; 2 * STREAM_READAHEAD_MAX_BYTES]);
+        let s = stream::iter(vec![Ok::<Bytes, std::io::Error>(big)]);
+        let _body = bytes_stream_to_body(s, Some(guard), None, None);
+
+        for _ in 0..1000 {
+            if dropped.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "an oversized single chunk must still reach upstream-None and release \
+             the slot — the acquire charges min(len, MAX), never more than the \
+             semaphore holds, so it must not deadlock",
+        );
+    }
+
+    /// An oversized chunk (> read-ahead budget) must stream through intact when
+    /// the client reads — the `min(len, MAX)` charge/return on both sides keeps
+    /// the semaphore balanced rather than corrupting or truncating the payload.
+    #[tokio::test]
+    async fn oversized_single_chunk_streams_through_intact() {
+        let big = vec![b'x'; 2 * STREAM_READAHEAD_MAX_BYTES];
+        let s = stream::iter(vec![Ok::<Bytes, std::io::Error>(Bytes::from(big.clone()))]);
+        let body = bytes_stream_to_body(s, None, None, None);
+        let bytes = body.collect().await.unwrap().to_bytes();
+        assert_eq!(
+            bytes.len(),
+            big.len(),
+            "oversized chunk must stream through without truncation",
+        );
+        assert_eq!(
+            &bytes[..],
+            &big[..],
+            "oversized chunk payload must be intact"
         );
     }
 }

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -306,7 +306,7 @@ where
             if PUMP_LOG_COUNTER.fetch_add(1, Ordering::Relaxed) % PUMP_LOG_SAMPLE == 0 {
                 let first_byte_ms =
                     first_byte_at.map(|t| t.duration_since(task_start).as_millis() as u64);
-                tracing::info!(
+                tracing::debug!(
                     reason = exit_reason,
                     chunks = n_chunks,
                     bytes = n_bytes,

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -11,6 +11,19 @@ use bytes::Bytes;
 use futures::{FutureExt, StreamExt};
 use tokio_stream::wrappers::ReceiverStream;
 
+/// Max time the pump waits to hand a chunk to the client before giving up.
+///
+/// A client that reads the response headers, stops reading the body, but never
+/// closes the connection fills the bounded channel and parks the pump on
+/// `tx.send()`. The upstream idle timeout cannot rescue this: it is only armed
+/// while the pump polls `s.next()`, not while it blocks on `tx.send()`. Without
+/// this bound the pump parks forever, its `stream_guards` (the per-worker
+/// admission slot + active-load entry) never drop, and the in-flight counter
+/// leaks until every worker is pinned at its cap and all traffic is shed while
+/// the engines sit idle. 120 s mirrors the upstream idle timeout: a client that
+/// accepts no bytes for that long is treated as gone.
+const STREAM_SEND_STALL: std::time::Duration = std::time::Duration::from_secs(120);
+
 /// Bridge a byte stream into an axum Body that streams chunks unchanged.
 ///
 /// Spawns one tokio task per stream so the handler can return immediately.
@@ -107,15 +120,36 @@ where
                 if is_err_chunk {
                     *outcome_setter.lock() = false;
                 }
-                if tx.send(item).await.is_err() {
-                    // Receiver dropped. If we were about to ship an upstream
-                    // error there's nothing left to report; otherwise this is
-                    // a clean client-side disconnect — log at debug since it's
-                    // not a router-side fault.
-                    if !is_err_chunk {
-                        tracing::debug!("SSE client disconnected mid-stream");
+                // Bound the downstream send. A client that read headers, stopped
+                // reading, and never closed the connection leaves the receiver
+                // open but undrained; the bounded channel fills and this send
+                // parks. The upstream idle timeout cannot fire here (it is only
+                // armed while polling `s.next()`), so without this bound the pump
+                // parks forever and `_hold` (the admission slot + active-load
+                // entry) leaks — pinning the worker at its cap.
+                match tokio::time::timeout(STREAM_SEND_STALL, tx.send(item)).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(_)) => {
+                        // Receiver dropped. If we were about to ship an upstream
+                        // error there's nothing left to report; otherwise this is
+                        // a clean client-side disconnect — log at debug since it's
+                        // not a router-side fault.
+                        if !is_err_chunk {
+                            tracing::debug!("SSE client disconnected mid-stream");
+                        }
+                        break;
                     }
-                    break;
+                    Err(_elapsed) => {
+                        // Client accepted no bytes for STREAM_SEND_STALL while the
+                        // connection stayed open. Treat it like a disconnect: stop
+                        // pumping so `_hold` drops and the slot is released. The
+                        // worker delivered fine, so this is not a breaker failure.
+                        tracing::warn!(
+                            stall = ?STREAM_SEND_STALL,
+                            "SSE downstream not draining; aborting to release in-flight slot"
+                        );
+                        break;
+                    }
                 }
                 if is_err_chunk {
                     // Surfaced upstream error to client; stop reading.
@@ -483,6 +517,49 @@ mod tests {
         assert!(
             dropped.load(Ordering::SeqCst),
             "stalled upstream must release stream_guards via the idle timeout",
+        );
+    }
+
+    /// A stalled *downstream* — the client reads response headers, then stops
+    /// reading the body but never closes the connection — must not pin the SSE
+    /// pump forever. The bounded channel fills, the pump parks on `tx.send()`,
+    /// and the upstream idle timeout CANNOT fire there (it is only armed while we
+    /// poll `s.next()`). Without a send-stall timeout the pump blocks on the send
+    /// indefinitely and `stream_guards` (the per-worker admission slot +
+    /// active-load entry) leak — pinning every worker at its cap and shedding all
+    /// traffic while the engines sit idle (the exact production failure observed:
+    /// engine `num_running_reqs=0` while the router holds `inflight=cap`).
+    #[tokio::test(start_paused = true)]
+    async fn stalled_downstream_releases_stream_guards() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        struct DropFlag(Arc<AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+        let dropped = Arc::new(AtomicBool::new(false));
+        let guard: Box<dyn Send + 'static> = Box::new(DropFlag(Arc::clone(&dropped)));
+
+        // Upstream readily yields far more chunks than the 64-slot channel holds.
+        let chunks: Vec<Result<Bytes, std::io::Error>> =
+            (0..256).map(|_| Ok(Bytes::from_static(b"x"))).collect();
+        let s = stream::iter(chunks);
+
+        // Hold the Body WITHOUT reading it: the receiver stays open (no clean
+        // disconnect) but undrained, so the pump parks on `tx.send()`.
+        let _body = bytes_stream_to_body(s, Some(guard), None, None);
+
+        // Advance past the send-stall timeout. The pump must give up on the
+        // non-draining client and drop its guards.
+        tokio::time::sleep(STREAM_SEND_STALL + std::time::Duration::from_secs(1)).await;
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "a client that stops reading (without disconnecting) must not pin \
+             stream_guards — the pump must time out the blocked send and release \
+             the admission slot",
         );
     }
 }

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -4,11 +4,20 @@
 //! SSE passthrough — bridges a reqwest `bytes_stream()` into an axum Body.
 
 use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Instant;
 
 use axum::body::Body;
 use bytes::Bytes;
 use futures::{FutureExt, StreamExt};
+
+/// Sampling counter for the diagnostic `sse_pump_timing` log. ~1-in-`SAMPLE`
+/// pump completions are logged with their first-byte / drain / exit timing and
+/// exit reason, so we can see whether an admission slot lingers in the pump
+/// (engine streaming slowly, or the task not being polled) without flooding.
+static PUMP_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
+const PUMP_LOG_SAMPLE: u64 = 64;
 
 /// Max time the pump waits to hand a chunk to the client before giving up.
 ///
@@ -142,6 +151,15 @@ where
             // underscore suppresses the "unused variable" lint while
             // keeping intent explicit.
             let _hold = stream_guards;
+            // Diagnostic timing for this stream's lifetime. `task_start` ≈ when
+            // upstream headers landed (the task is spawned right after). These
+            // localize whether the admission slot (held by `_hold`) lingers
+            // because the engine streams slowly or the task isn't being polled.
+            let task_start = Instant::now();
+            let mut first_byte_at: Option<Instant> = None;
+            let mut n_chunks: u64 = 0;
+            let mut n_bytes: u64 = 0;
+            let mut exit_reason = "upstream_end";
             let mut on_first_byte = on_first_byte;
             let mut s = stream;
             while let Some(chunk) = s.next().await {
@@ -160,6 +178,13 @@ where
                 // carries a token.
                 if matches!(&item, Ok(b) if b.is_empty()) {
                     continue;
+                }
+                n_chunks += 1;
+                if let Ok(b) = &item {
+                    n_bytes += b.len() as u64;
+                    if first_byte_at.is_none() {
+                        first_byte_at = Some(Instant::now());
+                    }
                 }
                 // Fire the time-to-first-token hook on the first successful
                 // chunk from upstream. `take()` makes it fire at most once;
@@ -200,6 +225,7 @@ where
                             // Client disconnected while we were blocked on the
                             // budget — clean client-side cancel, not a fault.
                             tracing::debug!("SSE client disconnected mid-stream");
+                            exit_reason = "client_disconnect_blocked";
                             break;
                         }
                         res = tokio::time::timeout(
@@ -222,6 +248,7 @@ where
                             tracing::error!(
                                 "SSE read-ahead semaphore closed unexpectedly; aborting pump"
                             );
+                            exit_reason = "semaphore_closed";
                             break;
                         }
                         Err(_elapsed) => {
@@ -244,6 +271,7 @@ where
                             let _ = tx.send(Err(std::io::Error::other(
                                 "SSE downstream stalled; stream aborted before completion",
                             )));
+                            exit_reason = "downstream_stall";
                             break;
                         }
                     }
@@ -261,12 +289,31 @@ where
                     if !is_err_chunk {
                         tracing::debug!("SSE client disconnected mid-stream");
                     }
+                    exit_reason = "client_gone";
                     break;
                 }
                 if is_err_chunk {
                     // Surfaced upstream error to client; stop reading.
+                    exit_reason = "upstream_error";
                     break;
                 }
+            }
+            // Diagnostic: this stream's lifetime, sampled. `pump_exit_ms` is how
+            // long the admission slot (held by `_hold`, dropped when this block
+            // exits) was occupied by the pump; compare to the engine's own
+            // per-request latency to spot slots lingering long after the engine
+            // finished. `first_byte_ms` is headers→first token.
+            if PUMP_LOG_COUNTER.fetch_add(1, Ordering::Relaxed) % PUMP_LOG_SAMPLE == 0 {
+                let first_byte_ms =
+                    first_byte_at.map(|t| t.duration_since(task_start).as_millis() as u64);
+                tracing::info!(
+                    reason = exit_reason,
+                    chunks = n_chunks,
+                    bytes = n_bytes,
+                    first_byte_ms = ?first_byte_ms,
+                    pump_exit_ms = task_start.elapsed().as_millis() as u64,
+                    "sse_pump_timing",
+                );
             }
         });
         let pump_result = pump.catch_unwind().await;

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -146,6 +146,53 @@ where
     Body::from_stream(ReceiverStream::new(rx))
 }
 
+/// Wrap a byte stream with an idle (between-chunks) timeout. If the upstream
+/// delivers no chunk for `idle`, the wrapped stream yields one `io::Error` and
+/// ends — so a hung upstream (sends 200 headers then stalls without sending
+/// data or closing, e.g. a half-open TCP after a worker restart) can no longer
+/// block the SSE pump forever. Without this the pump's `stream_guards` (the
+/// per-worker admission slot + active-load entry) never drop and the router's
+/// in-flight counter leaks, eventually pinning every worker at its cap and
+/// shedding all traffic while the engines sit idle.
+///
+/// This is an *idle* timeout, not a total one: each delivered chunk resets it,
+/// so a slow-but-progressing long generation is unaffected — only a true stall
+/// trips it.
+pub fn idle_timeout_stream<S, E>(
+    stream: S,
+    idle: std::time::Duration,
+) -> futures::stream::BoxStream<'static, Result<Bytes, std::io::Error>>
+where
+    S: futures::Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
+    E: std::fmt::Display + Send + 'static,
+{
+    futures::stream::unfold((stream, false), move |(mut s, ended)| async move {
+        if ended {
+            return None;
+        }
+        match tokio::time::timeout(idle, s.next()).await {
+            // Chunk arrived in time: pass it through, keep going.
+            Ok(Some(Ok(chunk))) => Some((Ok(chunk), (s, false))),
+            // Upstream error: surface it and stop (the pump breaks on errors).
+            Ok(Some(Err(e))) => Some((
+                std::io::Result::Err(std::io::Error::other(e.to_string())),
+                (s, true),
+            )),
+            // Upstream ended cleanly.
+            Ok(None) => None,
+            // Idle timeout: surface a terminal error so the pump exits and drops
+            // its guards instead of blocking on `s.next()` forever.
+            Err(_elapsed) => Some((
+                std::io::Result::Err(std::io::Error::other(format!(
+                    "upstream stream idle for {idle:?}; aborting to release in-flight slot"
+                ))),
+                (s, true),
+            )),
+        }
+    })
+    .boxed()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -392,6 +439,50 @@ mod tests {
         assert!(
             final_polls < 1000,
             "pump drained the entire upstream after client disconnect ({final_polls} polls); the break-on-tx.send-err path is dead"
+        );
+    }
+
+    /// A stalled upstream — sends headers, then never delivers a byte and never
+    /// closes (a half-open TCP after a worker restart) — must not pin the SSE
+    /// pump forever. The pump must exit and DROP its `stream_guards` (the
+    /// per-worker admission slot + active-load entry). Without an idle timeout
+    /// the pump blocks on `s.next()` indefinitely and the guard leaks,
+    /// eventually pinning every worker at its cap (false shedding while engines
+    /// sit idle).
+    #[tokio::test]
+    async fn stalled_upstream_releases_stream_guards() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        struct DropFlag(Arc<AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+        let dropped = Arc::new(AtomicBool::new(false));
+        let guard: Box<dyn Send + 'static> = Box::new(DropFlag(Arc::clone(&dropped)));
+
+        // Upstream that never yields a byte and never ends, wrapped in the idle
+        // timeout so the pump aborts and releases the guard.
+        let stalled = idle_timeout_stream(
+            stream::pending::<Result<Bytes, std::io::Error>>(),
+            std::time::Duration::from_millis(50),
+        );
+        let body = bytes_stream_to_body(stalled, Some(guard), None, None);
+        tokio::spawn(async move {
+            let _ = body.collect().await;
+        });
+
+        for _ in 0..100 {
+            if dropped.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "stalled upstream must release stream_guards via the idle timeout",
         );
     }
 }

--- a/experimental/sgl-router/src/server/admission.rs
+++ b/experimental/sgl-router/src/server/admission.rs
@@ -342,6 +342,9 @@ impl AdmissionQueue {
         worker: Arc<Worker>,
         load_guard: LoadGuard,
     ) -> AdmissionGuard {
+        // Reset the slot's age: it's now held by a fresh request, so the TTL
+        // janitor must not treat a continuously handed-off slot as leaked.
+        load_guard.touch();
         AdmissionGuard::Armed(ArmedGuard {
             load_guard: Some(load_guard),
             worker,

--- a/experimental/sgl-router/src/server/admission.rs
+++ b/experimental/sgl-router/src/server/admission.rs
@@ -17,22 +17,55 @@
 //! (the default) makes the gate a pass-through and the router behaves exactly
 //! as before.
 //!
-//! **Fairness:** wakeups are unordered. A freed slot wakes every parked waiter
-//! and they race for it; losers re-park. There is no FIFO guarantee, so under
-//! sustained saturation an individual request can be repeatedly out-raced. The
-//! bounded queue caps how many wait, not how long any one waits;
-//! `sgl_router_admission_wait_seconds` makes the wait distribution observable.
+//! **Fairness:** parked requests are admitted in strict FIFO order. When a
+//! request completes, its freed per-worker slot is handed *directly* to the
+//! most-senior parked waiter eligible for that worker (the first one whose
+//! candidate set contains it) rather than decremented and re-contended. Because
+//! the slot is transferred — the worker's in-flight count never dips during the
+//! hand-off — a freshly arriving request that races for the same slot finds the
+//! worker still at capacity and parks *behind* the existing waiters instead of
+//! jumping ahead of them. A waiter is overtaken only by a later arrival that is
+//! ineligible for the freed worker (a different candidate pool), never by one
+//! competing for the same slot. `sgl_router_admission_wait_seconds` makes the
+//! resulting wait distribution observable.
 
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-use tokio::sync::{Notify, Semaphore};
+use parking_lot::Mutex;
+use tokio::sync::{oneshot, OwnedSemaphorePermit, Semaphore};
 
 use crate::config::AdmissionConfig;
+use crate::discovery::WorkerId;
 use crate::policies::{Policy, SelectionContext};
 use crate::server::error::ApiError;
 use crate::server::metrics::MetricsRegistry;
 use crate::workers::{LoadGuard, Worker};
+
+/// A slot handed to a parked waiter: the worker it was claimed on plus the live
+/// [`AdmissionGuard`] holding it. Sent over the waiter's oneshot on hand-off.
+type Grant = (Arc<Worker>, AdmissionGuard);
+
+/// One parked request. Shared (`Arc`) between the wait queue and the parking
+/// `acquire` frame's [`WaiterTicket`]. The hand-off path pops it from the queue
+/// and sends the freed slot through `grant_tx`; the `acquire` frame awaits the
+/// matching receiver.
+#[derive(Debug)]
+struct Waiter {
+    /// Monotonic id, used to find-and-remove this waiter from the queue on
+    /// cancellation without relying on `Arc` pointer identity.
+    id: u64,
+    /// Ids of the workers this request may run on. A freed slot is handed to a
+    /// waiter only when its worker is in this set, so a request is never woken
+    /// for a pool it cannot use.
+    candidate_ids: Vec<WorkerId>,
+    /// Sender for the granted slot. `take`n exactly once — by the hand-off that
+    /// delivers a slot, or by [`WaiterTicket::drop`] on cancellation, whichever
+    /// happens first — so a slot is never both delivered and abandoned.
+    grant_tx: Mutex<Option<oneshot::Sender<Grant>>>,
+}
 
 /// Bounded, count-based admission gate shared on the request hot path.
 #[derive(Debug)]
@@ -42,11 +75,17 @@ pub struct AdmissionQueue {
     /// matching the pre-admission behaviour.
     max_concurrent_per_worker: Option<usize>,
     /// Bounds how many requests may park waiting for a slot. `None` leaves the
-    /// wait queue unbounded (park indefinitely, never shed). `Some(n)` sheds
-    /// the request with 503 once `n` are already parked.
-    queue_slots: Option<Semaphore>,
-    /// Woken whenever a slot frees so parked requests re-attempt admission.
-    notify: Notify,
+    /// wait queue unbounded (park indefinitely, never shed). `Some(sem)` sheds
+    /// the request with 503 once all `sem` permits are taken.
+    queue_slots: Option<Arc<Semaphore>>,
+    /// Parked waiters in arrival (FIFO) order. Guarded by a sync mutex held only
+    /// for short, await-free critical sections: the enqueue decision and the
+    /// hand-off scan. Both the parking path's under-lock claim and the
+    /// hand-off's decrement happen here, which is what makes "a freed slot is
+    /// never lost between a waiter parking and a slot freeing" hold.
+    waiters: Mutex<VecDeque<Arc<Waiter>>>,
+    /// Source of monotonic [`Waiter::id`]s.
+    next_waiter_id: AtomicU64,
     metrics: Arc<MetricsRegistry>,
 }
 
@@ -61,29 +100,24 @@ impl AdmissionQueue {
         };
         Self {
             max_concurrent_per_worker,
-            queue_slots: max_queued.map(Semaphore::new),
-            notify: Notify::new(),
+            queue_slots: max_queued.map(|n| Arc::new(Semaphore::new(n))),
+            waiters: Mutex::new(VecDeque::new()),
+            next_waiter_id: AtomicU64::new(0),
             metrics,
         }
     }
 
-    /// Signal that a worker slot has freed so parked requests wake and
-    /// re-attempt admission. Wakes every parked waiter; each re-checks and only
-    /// those that can claim a slot proceed, the rest re-park (see the fairness
-    /// note in the module docs). A no-op when nothing is parked.
-    pub fn notify_slot_freed(&self) {
-        self.notify.notify_waiters();
-    }
-
     /// Select a worker and claim an in-flight slot, parking until one frees if
     /// every candidate is at capacity. Returns [`ApiError::ServiceOverloaded`]
-    /// (503) when the wait queue is already full, and
-    /// [`ApiError::PolicySelectionFailed`] when the policy declines (the full
-    /// candidate set when disabled, or the slot-having subset when enabled).
+    /// (503, retryable) when the request cannot be admitted — primarily when the
+    /// wait queue is already at its depth cap — and [`ApiError::PolicySelectionFailed`]
+    /// when the policy declines (the full candidate set when disabled, or the
+    /// slot-having subset when enabled).
     ///
-    /// The returned [`AdmissionGuard`] holds the claimed slot and wakes parked
-    /// requests when it drops; the caller keeps it alive for the request's
-    /// lifetime (stream end / client disconnect / error).
+    /// The returned [`AdmissionGuard`] holds the claimed slot and, when it
+    /// drops, hands the slot to the next FIFO waiter (or frees it); the caller
+    /// keeps it alive for the request's lifetime (stream end / client
+    /// disconnect / error).
     pub async fn acquire(
         self: &Arc<Self>,
         candidates: &[Arc<Worker>],
@@ -93,76 +127,113 @@ impl AdmissionQueue {
     ) -> Result<(Arc<Worker>, AdmissionGuard), ApiError> {
         let Some(cap) = self.max_concurrent_per_worker else {
             // Disabled: dispatch immediately with an unconditional guard and no
-            // wake obligation (nothing ever parks).
+            // hand-off obligation (nothing ever parks).
             let worker =
                 policy
                     .select(candidates, ctx)
                     .ok_or_else(|| ApiError::PolicySelectionFailed {
                         model: model.to_string(),
                     })?;
-            let guard = AdmissionGuard {
-                load_guard: Some(worker.load_guard()),
-                admission: None,
-            };
+            let guard = AdmissionGuard::pass_through(worker.load_guard());
             return Ok((worker, guard));
         };
 
-        // Fast path: a slot is free right now.
+        // Fast path: claim a free slot lock-free. This can only succeed on a
+        // genuinely free slot, which — because a freed slot is handed directly
+        // to a waiter while the count stays at `cap` — means no waiter was
+        // queued for that worker. So taking it here never jumps the FIFO queue.
         if let Some((worker, load_guard)) = self.try_claim(candidates, policy, ctx, cap, model)? {
-            return Ok((worker, self.admitted_guard(load_guard)));
+            return Ok((worker.clone(), self.handed_off_guard(worker, load_guard)));
         }
 
-        // All candidates full. Take a wait-queue slot, or shed with 503 if the
-        // queue is already at its depth cap.
-        let _queue_permit = match &self.queue_slots {
-            Some(sem) => match sem.try_acquire() {
-                Ok(permit) => Some(permit),
-                Err(_) => {
-                    self.metrics.record_backpressure_rejected(model);
-                    return Err(ApiError::ServiceOverloaded {
-                        model: model.to_string(),
-                    });
-                }
-            },
-            None => None,
-        };
-        let _parked = self.enter_queue();
-        let parked_since = Instant::now();
-
-        loop {
-            // Register the waiter BEFORE re-checking, so a `notify_slot_freed`
-            // racing between the check and the await is not lost.
-            let notified = self.notify.notified();
-            tokio::pin!(notified);
-            notified.as_mut().enable();
-
-            match self.try_claim(candidates, policy, ctx, cap, model) {
-                Ok(Some((worker, load_guard))) => {
-                    self.metrics
-                        .observe_admission_wait(model, parked_since.elapsed().as_secs_f64());
-                    return Ok((worker, self.admitted_guard(load_guard)));
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    // The policy declined a now-non-empty slot-having set after
-                    // the request had already parked (e.g. a sticky/cache-aware
-                    // key whose only available worker is ineligible). Log it so a
-                    // non-retryable error returned *after* a wait isn't silent to
-                    // operators.
-                    tracing::debug!(model = %model, "parked request declined by policy");
-                    return Err(e);
-                }
-            }
-            notified.await;
-        }
+        self.park(candidates, policy, ctx, cap, model).await
     }
 
-    /// Wrap a claimed [`LoadGuard`] in an [`AdmissionGuard`] that wakes parked
-    /// requests when the slot frees.
-    fn admitted_guard(self: &Arc<Self>, load_guard: LoadGuard) -> AdmissionGuard {
-        AdmissionGuard {
-            load_guard: Some(load_guard),
-            admission: Some(Arc::clone(self)),
+    /// Slow path: every candidate was full on the lock-free attempt. Re-check
+    /// under the lock (a slot may have freed), then either claim it, shed with
+    /// 503, or park in FIFO order until a slot is handed to us.
+    async fn park(
+        self: &Arc<Self>,
+        candidates: &[Arc<Worker>],
+        policy: &dyn Policy,
+        ctx: &SelectionContext<'_>,
+        cap: usize,
+        model: &str,
+    ) -> Result<(Arc<Worker>, AdmissionGuard), ApiError> {
+        let parked_since = Instant::now();
+
+        // Enqueue under the lock. The `_ticket` returned alongside the receiver
+        // owns the queue-depth gauge, the wait-queue permit, and removal of this
+        // waiter from the queue — all released when it drops (on admission or
+        // cancellation). It must outlive the `.await` below, so bind it.
+        let (rx, _ticket) = {
+            let mut waiters = self.waiters.lock();
+
+            // A slot may have freed between the lock-free attempt and acquiring
+            // this lock. Re-checking here, under the same lock the hand-off uses
+            // to decrement, serializes the two: a slot freed before we parked is
+            // claimed here, never lost.
+            if let Some((worker, load_guard)) =
+                self.try_claim(candidates, policy, ctx, cap, model)?
+            {
+                return Ok((worker.clone(), self.handed_off_guard(worker, load_guard)));
+            }
+
+            // Still full: reserve a wait-queue slot, or shed if the queue is at
+            // its depth cap.
+            let permit = match &self.queue_slots {
+                Some(sem) => match Arc::clone(sem).try_acquire_owned() {
+                    Ok(permit) => Some(permit),
+                    Err(_) => {
+                        self.metrics.record_backpressure_rejected(model);
+                        return Err(ApiError::ServiceOverloaded {
+                            model: model.to_string(),
+                        });
+                    }
+                },
+                None => None,
+            };
+
+            let (tx, rx) = oneshot::channel();
+            let waiter = Arc::new(Waiter {
+                id: self.next_waiter_id.fetch_add(1, Ordering::Relaxed),
+                candidate_ids: candidates.iter().map(|w| w.id.clone()).collect(),
+                grant_tx: Mutex::new(Some(tx)),
+            });
+            waiters.push_back(Arc::clone(&waiter));
+            self.metrics.add_queued_requests(1);
+
+            let ticket = WaiterTicket {
+                admission: Arc::clone(self),
+                waiter,
+                _permit: permit,
+            };
+            (rx, ticket)
+        };
+
+        match rx.await {
+            Ok((worker, guard)) => {
+                self.metrics
+                    .observe_admission_wait(model, parked_since.elapsed().as_secs_f64());
+                Ok((worker, guard))
+            }
+            // The sender was dropped without delivering a slot. In normal
+            // operation the sender is held alive by `_ticket` until either the
+            // hand-off sends through it or the ticket itself cancels — so this is
+            // only reachable if the queue is being torn down (or an internal
+            // invariant broke). Log it: a 503 here is NOT ordinary backpressure
+            // (no `record_backpressure_rejected`), and silently folding it into
+            // the shed path would hide a real bug behind a routine status.
+            Err(_) => {
+                tracing::error!(
+                    model = %model,
+                    "admission grant sender dropped without delivering a slot; \
+                     treating as overloaded (queue teardown or invariant violation)"
+                );
+                Err(ApiError::ServiceOverloaded {
+                    model: model.to_string(),
+                })
+            }
         }
     }
 
@@ -209,49 +280,193 @@ impl AdmissionQueue {
         }
     }
 
-    fn enter_queue(&self) -> QueuedGuard<'_> {
-        self.metrics.add_queued_requests(1);
-        QueuedGuard { queue: self }
+    /// Hand a freed `worker` slot (held by `load_guard`) to the most-senior
+    /// parked waiter eligible for it, or release the slot if none want it.
+    ///
+    /// Called from [`AdmissionGuard::drop`]. The pop-or-decrement decision is
+    /// made under the lock so it is atomic with the parking path's under-lock
+    /// claim — a slot freed while a waiter is queued is always handed off, and a
+    /// slot freed with no eligible waiter is decremented while a fresh parker
+    /// would still see it as taken (and so be handed it on the next free) or see
+    /// it freed (and claim it directly).
+    fn release_slot(self: &Arc<Self>, worker: Arc<Worker>, mut load_guard: LoadGuard) {
+        loop {
+            let waiter = {
+                let mut waiters = self.waiters.lock();
+                match waiters
+                    .iter()
+                    .position(|w| w.candidate_ids.contains(&worker.id))
+                {
+                    Some(pos) => waiters.remove(pos),
+                    None => {
+                        // No taker: free the slot (decrement) while holding the
+                        // lock, so the decision stays atomic with parkers.
+                        drop(load_guard);
+                        return;
+                    }
+                }
+            };
+            // `remove(pos)` cannot return `None` for an in-range index, but match
+            // defensively rather than unwrap.
+            let Some(waiter) = waiter else {
+                drop(load_guard);
+                return;
+            };
+
+            // Deliver outside the lock: the receiver may already be gone, in
+            // which case the guard we hand over drops and its `Drop` re-enters
+            // `release_slot` — so the lock must not be held here.
+            let Some(tx) = waiter.grant_tx.lock().take() else {
+                // The waiter was cancelled between our pop and now; the slot is
+                // still ours, so try the next eligible waiter.
+                continue;
+            };
+            let guard = self.handed_off_guard(Arc::clone(&worker), load_guard);
+            match tx.send((Arc::clone(&worker), guard)) {
+                Ok(()) => return,
+                Err((_worker, returned)) => {
+                    // Receiver gone (client disconnected before admission).
+                    // Reclaim the slot from the undelivered guard and hand it to
+                    // the next waiter. Disarming first makes the returned guard's
+                    // `Drop` a no-op, so we loop here instead of recursing.
+                    load_guard = returned.disarm();
+                }
+            }
+        }
+    }
+
+    /// Wrap a claimed [`LoadGuard`] in an [`AdmissionGuard`] that, on drop,
+    /// routes the freed slot through FIFO hand-off for `worker`.
+    fn handed_off_guard(
+        self: &Arc<Self>,
+        worker: Arc<Worker>,
+        load_guard: LoadGuard,
+    ) -> AdmissionGuard {
+        AdmissionGuard::Armed(ArmedGuard {
+            load_guard: Some(load_guard),
+            worker,
+            admission: Arc::clone(self),
+        })
+    }
+
+    /// Number of parked waiters. Test-only; production reads the
+    /// `sgl_router_queued_requests` gauge instead.
+    #[cfg(test)]
+    fn queued_len(&self) -> usize {
+        self.waiters.lock().len()
     }
 }
 
-/// Holds a claimed per-worker in-flight slot for the request's lifetime and,
-/// when it drops, wakes admission-parked requests so they re-attempt.
+/// Holds a claimed per-worker in-flight slot for the request's lifetime. The
+/// three variants make the only legal states exact, so there is no "armed but
+/// slotless" combination to guard against:
 ///
-/// The wake ordering lives in one place — this `Drop`: the inner [`LoadGuard`]
-/// is dropped (decrementing the worker's in-flight count) BEFORE
-/// `notify_slot_freed`, so a woken waiter re-checking capacity sees the freed
-/// slot. `admission` is `None` on the disabled pass-through path, where nothing
-/// ever parks and no wake is needed.
+/// * [`PassThrough`](Self::PassThrough) — disabled gate: holds a load slot for
+///   the request but has no wait queue to hand back to, so it just decrements on
+///   drop.
+/// * [`Armed`](Self::Armed) — enabled gate: on drop, the slot is routed through
+///   FIFO hand-off (see [`ArmedGuard`]) rather than decremented.
+/// * [`Spent`](Self::Spent) — holds nothing; the state left behind after
+///   [`disarm`](Self::disarm) moves the slot out for re-hand-off. Drop is a
+///   no-op.
+///
+/// The enum itself carries no `Drop`; the hand-off behaviour lives on the
+/// [`ArmedGuard`] payload, so the disabled and spent states drop trivially.
+#[must_use = "an AdmissionGuard must be held for the request's lifetime; \
+              dropping it releases the worker slot (and hands it to the next waiter)"]
 #[derive(Debug)]
-pub struct AdmissionGuard {
-    load_guard: Option<LoadGuard>,
-    admission: Option<Arc<AdmissionQueue>>,
+pub enum AdmissionGuard {
+    /// The slot has been moved out (reclaimed by [`disarm`](Self::disarm) for
+    /// re-hand-off). Drop is a no-op.
+    Spent,
+    /// Disabled gate: a plain load slot that decrements on drop.
+    PassThrough(LoadGuard),
+    /// Enabled gate: the claimed slot plus its FIFO hand-off target.
+    Armed(ArmedGuard),
 }
 
-impl Drop for AdmissionGuard {
-    fn drop(&mut self) {
-        // Decrement the slot first, THEN wake — a woken waiter must observe the
-        // freed slot. Taking the `Option` forces the `LoadGuard` drop here,
-        // before the notify, rather than at end-of-struct-drop.
-        drop(self.load_guard.take());
-        if let Some(admission) = &self.admission {
-            admission.notify_slot_freed();
+impl AdmissionGuard {
+    /// Guard for the disabled gate: holds the load slot for the request but has
+    /// no wait queue to hand back to, so it just decrements on drop.
+    fn pass_through(load_guard: LoadGuard) -> Self {
+        Self::PassThrough(load_guard)
+    }
+
+    /// Move the load slot out of an [`Armed`](Self::Armed) guard, leaving the
+    /// guard inert so its `Drop` is a no-op. The slot's in-flight count is
+    /// preserved (the [`LoadGuard`] is moved, not dropped), so
+    /// [`AdmissionQueue::release_slot`] can re-hand it to the next waiter without
+    /// re-entering hand-off. Only ever called on a freshly-built `Armed` guard
+    /// returned from a failed send, so the other arms are unreachable.
+    fn disarm(self) -> LoadGuard {
+        match self {
+            // `take` leaves the `ArmedGuard` with no slot, so when it drops at
+            // the end of this arm its `Drop` skips the hand-off.
+            Self::Armed(mut armed) => armed
+                .load_guard
+                .take()
+                .expect("armed guard reclaimed twice"),
+            _ => unreachable!("disarm called on a non-armed AdmissionGuard"),
         }
     }
 }
 
-/// Tracks one parked request: decrements the queued counter (and the gauge) on
-/// drop, whether the request was ultimately admitted or abandoned (the handler
-/// future dropped on client disconnect). Requests shed with 503 return before
-/// entering the queue, so they never construct this guard.
-struct QueuedGuard<'a> {
-    queue: &'a AdmissionQueue,
+/// Payload of an [`AdmissionGuard::Armed`]: the claimed slot plus the worker and
+/// queue needed to hand it off. The hand-off obligation lives here, in `Drop`,
+/// so it is impossible to forget and runs exactly once whether the request ends
+/// by stream completion, client disconnect, or error.
+///
+/// `load_guard` is an `Option` only so [`AdmissionGuard::disarm`] can move the
+/// slot out for re-hand-off, leaving this guard inert; it is `Some` in every
+/// other state.
+#[derive(Debug)]
+pub struct ArmedGuard {
+    load_guard: Option<LoadGuard>,
+    worker: Arc<Worker>,
+    admission: Arc<AdmissionQueue>,
 }
 
-impl Drop for QueuedGuard<'_> {
+impl Drop for ArmedGuard {
     fn drop(&mut self) {
-        self.queue.metrics.add_queued_requests(-1);
+        // The slot is *moved* into `release_slot` (which keeps the worker's
+        // in-flight count unchanged while it transfers, or decrements if no
+        // waiter wants it) — never dropped here. `None` means `disarm` already
+        // took it.
+        if let Some(load_guard) = self.load_guard.take() {
+            self.admission
+                .release_slot(Arc::clone(&self.worker), load_guard);
+        }
+    }
+}
+
+/// Tracks one parked request's wait-queue accounting: the depth gauge, the
+/// bounded-queue permit, and removal from the waiter list. Dropping it — on
+/// admission or on the handler future being dropped (client disconnect) —
+/// releases all three exactly once.
+///
+/// Taking `grant_tx` here ensures that if cancellation races an in-flight
+/// hand-off, the hand-off finds the sender gone and routes the slot to the next
+/// waiter instead of delivering it into a dropped receiver.
+struct WaiterTicket {
+    admission: Arc<AdmissionQueue>,
+    waiter: Arc<Waiter>,
+    _permit: Option<OwnedSemaphorePermit>,
+}
+
+impl Drop for WaiterTicket {
+    fn drop(&mut self) {
+        {
+            let mut waiters = self.admission.waiters.lock();
+            if let Some(pos) = waiters.iter().position(|w| w.id == self.waiter.id) {
+                waiters.remove(pos);
+            }
+        }
+        // Claim the sender so a concurrent hand-off returns the slot to the
+        // queue rather than delivering into our dropped receiver. No-op if the
+        // hand-off already delivered (normal admission).
+        let _ = self.waiter.grant_tx.lock().take();
+        self.admission.metrics.add_queued_requests(-1);
+        // `_permit` drops here, returning the wait-queue slot.
     }
 }
 
@@ -260,6 +475,7 @@ mod tests {
     use super::*;
     use crate::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
     use std::num::NonZeroUsize;
+    use std::sync::Mutex as StdMutex;
     use std::time::Duration;
 
     fn worker(id: &str) -> Arc<Worker> {
@@ -312,6 +528,22 @@ mod tests {
         ) -> Option<Arc<Worker>> {
             None
         }
+    }
+
+    /// Poll until the wait queue holds exactly `n` parked waiters, or panic.
+    /// Lets a test deterministically confirm waiters have parked (in a known
+    /// order) before it releases a slot.
+    async fn wait_until_queued(q: &Arc<AdmissionQueue>, n: usize) {
+        for _ in 0..200 {
+            if q.queued_len() == n {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!(
+            "queue never reached depth {n} (stuck at {})",
+            q.queued_len()
+        );
     }
 
     #[tokio::test]
@@ -418,7 +650,15 @@ mod tests {
     async fn parks_until_slot_frees_then_admits() {
         let q = queue(enabled(1, None));
         let w = worker("w");
-        let held = w.load_guard(); // w at cap=1 -> next acquire parks
+
+        // First acquire claims the only slot, via the gate (so dropping its
+        // guard triggers the hand-off path, not a bare decrement).
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+        let (_w0, held) = q
+            .acquire(&[Arc::clone(&w)], &PickFirst, &ctx, "m")
+            .await
+            .expect("first acquire claims the slot");
         assert_eq!(w.active_load(), 1);
 
         let q2 = Arc::clone(&q);
@@ -431,16 +671,14 @@ mod tests {
                 .map(|(w, _g)| w.id.clone())
         });
 
-        // Let the task reach the parked state.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        wait_until_queued(&q, 1).await;
         assert!(
             !handle.is_finished(),
             "acquire should park while worker is full"
         );
 
-        // Free the slot and wake the waiter.
+        // Drop the first guard: its slot is handed to the parked waiter.
         drop(held);
-        q.notify_slot_freed();
 
         let chosen = tokio::time::timeout(Duration::from_secs(1), handle)
             .await
@@ -451,14 +689,118 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn admits_parked_waiters_in_fifo_order() {
+        // cap=1: one slot, three waiters parked in order A, B, C. They must be
+        // admitted A, B, C regardless of scheduler wake order.
+        let q = queue(enabled(1, None));
+        let w = worker("w");
+
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+        let (_w0, held) = q
+            .acquire(&[Arc::clone(&w)], &PickFirst, &ctx, "m")
+            .await
+            .expect("seed acquire claims the slot");
+
+        let order: Arc<StdMutex<Vec<u32>>> = Arc::new(StdMutex::new(Vec::new()));
+        let mut handles = Vec::new();
+        // Park A, then B, then C — each confirmed parked before the next spawns,
+        // so the queue order is deterministic.
+        for label in 0..3u32 {
+            let q2 = Arc::clone(&q);
+            let cands = vec![Arc::clone(&w)];
+            let order2 = Arc::clone(&order);
+            handles.push(tokio::spawn(async move {
+                let model = ModelId("m".into());
+                let ctx = SelectionContext::new(&model, None);
+                let (_w, guard) = q2.acquire(&cands, &PickFirst, &ctx, "m").await.unwrap();
+                order2.lock().unwrap().push(label);
+                // Drop the slot so the next FIFO waiter is handed it.
+                drop(guard);
+            }));
+            wait_until_queued(&q, (label + 1) as usize).await;
+        }
+
+        // Release the seed slot; admissions cascade in FIFO order.
+        drop(held);
+        for h in handles {
+            tokio::time::timeout(Duration::from_secs(2), h)
+                .await
+                .expect("each waiter must admit")
+                .expect("task panicked");
+        }
+
+        assert_eq!(
+            *order.lock().unwrap(),
+            vec![0, 1, 2],
+            "waiters must be admitted in arrival order"
+        );
+        assert_eq!(q.queued_len(), 0, "queue should fully drain");
+    }
+
+    #[tokio::test]
+    async fn newcomer_parks_behind_existing_waiter() {
+        // A parks first; a later arrival N must not jump it. Freeing exactly one
+        // slot admits A, not N.
+        let q = queue(enabled(1, None));
+        let w = worker("w");
+
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+        let (_w0, held) = q
+            .acquire(&[Arc::clone(&w)], &PickFirst, &ctx, "m")
+            .await
+            .expect("seed acquire claims the slot");
+
+        let order: Arc<StdMutex<Vec<&'static str>>> = Arc::new(StdMutex::new(Vec::new()));
+
+        let spawn_waiter = |name: &'static str| {
+            let q2 = Arc::clone(&q);
+            let cands = vec![Arc::clone(&w)];
+            let order2 = Arc::clone(&order);
+            tokio::spawn(async move {
+                let model = ModelId("m".into());
+                let ctx = SelectionContext::new(&model, None);
+                let (_w, guard) = q2.acquire(&cands, &PickFirst, &ctx, "m").await.unwrap();
+                order2.lock().unwrap().push(name);
+                drop(guard);
+            })
+        };
+
+        let a = spawn_waiter("A");
+        wait_until_queued(&q, 1).await;
+        let n = spawn_waiter("N");
+        wait_until_queued(&q, 2).await;
+
+        drop(held);
+        for h in [a, n] {
+            tokio::time::timeout(Duration::from_secs(2), h)
+                .await
+                .expect("waiter must admit")
+                .expect("task panicked");
+        }
+        assert_eq!(
+            *order.lock().unwrap(),
+            vec!["A", "N"],
+            "the earlier waiter must be admitted before the later arrival"
+        );
+    }
+
+    #[tokio::test]
     async fn unbounded_queue_parks_many_then_admits_each_as_slots_free() {
         // cap=1 + unbounded queue: many waiters all park (none shed); freeing
         // the slot cascades admissions one at a time as each admitted request's
-        // guard drops and wakes the next.
+        // guard drops and hands the slot to the next.
         let m = metrics();
         let q = Arc::new(AdmissionQueue::new(enabled(1, None), Arc::clone(&m)));
         let w = worker("w");
-        let held = w.load_guard(); // occupies the only slot
+
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+        let (_w0, held) = q
+            .acquire(&[Arc::clone(&w)], &PickFirst, &ctx, "m")
+            .await
+            .expect("seed acquire claims the slot");
 
         let mut handles = Vec::new();
         for _ in 0..3 {
@@ -473,11 +815,7 @@ mod tests {
             }));
         }
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        assert!(
-            handles.iter().all(|h| !h.is_finished()),
-            "all three should park while the only slot is held"
-        );
+        wait_until_queued(&q, 3).await;
         // All three are parked; none was shed (unbounded queue).
         assert!(
             m.render().contains("sgl_router_queued_requests 3\n"),
@@ -487,7 +825,6 @@ mod tests {
 
         // Release the slot once; admissions cascade via each guard's drop.
         drop(held);
-        q.notify_slot_freed();
 
         for h in handles {
             tokio::time::timeout(Duration::from_secs(2), h)
@@ -502,6 +839,7 @@ mod tests {
             "{}",
             m.render(),
         );
+        assert_eq!(q.queued_len(), 0);
     }
 
     #[tokio::test]
@@ -512,7 +850,13 @@ mod tests {
         let m = metrics();
         let q = Arc::new(AdmissionQueue::new(enabled(1, Some(1)), Arc::clone(&m)));
         let w = worker("w");
-        let _held = w.load_guard(); // worker full for the whole test
+
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+        let (_w0, _held) = q
+            .acquire(&[Arc::clone(&w)], &PickFirst, &ctx, "m")
+            .await
+            .expect("seed acquire claims the slot"); // worker full for the whole test
         let cands = vec![Arc::clone(&w)];
 
         let qa = Arc::clone(&q);
@@ -522,7 +866,7 @@ mod tests {
             let ctx = SelectionContext::new(&model, None);
             qa.acquire(&ca, &PickFirst, &ctx, "m").await.map(|_| ())
         });
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        wait_until_queued(&q, 1).await;
         assert!(
             !a.is_finished(),
             "A should be parked holding the queue slot"
@@ -543,9 +887,10 @@ mod tests {
         );
 
         // A disconnects: aborting drops its `acquire` future, which releases the
-        // queue permit and (via QueuedGuard::drop) returns the gauge to 0.
+        // queue permit and (via WaiterTicket::drop) returns the gauge to 0.
         a.abort();
         let _ = a.await;
+        wait_until_queued(&q, 0).await;
         assert!(
             m.render().contains("sgl_router_queued_requests 0\n"),
             "A's abort must release its queue slot (gauge back to 0): {}",
@@ -560,7 +905,7 @@ mod tests {
             let ctx = SelectionContext::new(&model, None);
             qc.acquire(&cc, &PickFirst, &ctx, "m").await.map(|_| ())
         });
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        wait_until_queued(&q, 1).await;
         assert!(
             !c.is_finished(),
             "C should park (slot was freed by A's abort), not shed"
@@ -572,5 +917,173 @@ mod tests {
         );
         c.abort();
         let _ = c.await;
+    }
+
+    #[tokio::test]
+    async fn freed_worker_slot_skips_ineligible_senior_waiter() {
+        // Two single-slot worker pools. A parks first but is eligible only for
+        // `wy`; B parks later, eligible only for `wx`. Freeing `wx` must admit B
+        // (the only eligible waiter) even though A is more senior — a freed slot
+        // is handed by FIFO *within* the eligible set, never to a waiter that
+        // cannot use the worker. Freeing `wy` then admits A.
+        let q = queue(enabled(1, None));
+        let wx = worker("wx");
+        let wy = worker("wy");
+
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+        let (_x, held_x) = q
+            .acquire(&[Arc::clone(&wx)], &PickFirst, &ctx, "m")
+            .await
+            .expect("wx seed");
+        let (_y, held_y) = q
+            .acquire(&[Arc::clone(&wy)], &PickFirst, &ctx, "m")
+            .await
+            .expect("wy seed");
+
+        let order: Arc<StdMutex<Vec<&'static str>>> = Arc::new(StdMutex::new(Vec::new()));
+        let spawn_waiter = |name: &'static str, cands: Vec<Arc<Worker>>| {
+            let q2 = Arc::clone(&q);
+            let order2 = Arc::clone(&order);
+            tokio::spawn(async move {
+                let model = ModelId("m".into());
+                let ctx = SelectionContext::new(&model, None);
+                let (chosen, guard) = q2.acquire(&cands, &PickFirst, &ctx, "m").await.unwrap();
+                order2.lock().unwrap().push(name);
+                (chosen.id.clone(), guard)
+            })
+        };
+
+        // A: eligible only for wy (senior). B: eligible only for wx (junior).
+        let a = spawn_waiter("A", vec![Arc::clone(&wy)]);
+        wait_until_queued(&q, 1).await;
+        let b = spawn_waiter("B", vec![Arc::clone(&wx)]);
+        wait_until_queued(&q, 2).await;
+
+        // Free wx: only B is eligible -> B admits despite A being senior.
+        drop(held_x);
+        let (b_worker, _b_guard) = tokio::time::timeout(Duration::from_secs(2), b)
+            .await
+            .expect("B must admit when its eligible worker frees")
+            .expect("B task panicked");
+        assert_eq!(b_worker, wx.id, "B must be admitted on wx");
+        assert_eq!(order.lock().unwrap().as_slice(), &["B"]);
+        wait_until_queued(&q, 1).await; // only A still parked
+
+        // Free wy: now A (the only remaining, eligible) admits.
+        drop(held_y);
+        let (a_worker, _a_guard) = tokio::time::timeout(Duration::from_secs(2), a)
+            .await
+            .expect("A must admit when wy frees")
+            .expect("A task panicked");
+        assert_eq!(a_worker, wy.id, "A must be admitted on wy");
+        assert_eq!(order.lock().unwrap().as_slice(), &["B", "A"]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_acquires_never_exceed_cap_and_drain_to_zero() {
+        // The whole reason the gate exists: a hard per-worker bound under load.
+        // Hammer 3 workers (cap=2) with 200 concurrent acquires through the full
+        // fast-path / park / hand-off / cancel-free machinery and assert no
+        // worker ever exceeds cap, then everything drains to zero with no leak.
+        let cap = 2;
+        let q = queue(enabled(cap, None));
+        let workers: Vec<Arc<Worker>> = (0..3).map(|i| worker(&format!("w{i}"))).collect();
+
+        let mut handles = Vec::new();
+        for _ in 0..200 {
+            let q2 = Arc::clone(&q);
+            let cands = workers.clone();
+            handles.push(tokio::spawn(async move {
+                let model = ModelId("m".into());
+                let ctx = SelectionContext::new(&model, None);
+                let (chosen, guard) = q2.acquire(&cands, &PickFirst, &ctx, "m").await.unwrap();
+                // The hard bound must hold for every worker at all times.
+                assert!(
+                    chosen.active_load() <= cap,
+                    "worker {:?} exceeded cap: {} > {cap}",
+                    chosen.id,
+                    chosen.active_load(),
+                );
+                // Hold the slot briefly so claims genuinely overlap.
+                tokio::task::yield_now().await;
+                tokio::task::yield_now().await;
+                drop(guard);
+            }));
+        }
+        for h in handles {
+            tokio::time::timeout(Duration::from_secs(10), h)
+                .await
+                .expect("every acquire must complete")
+                .expect("task panicked");
+        }
+
+        for w in &workers {
+            assert_eq!(w.active_load(), 0, "worker {:?} leaked a slot", w.id);
+        }
+        assert_eq!(q.queued_len(), 0, "wait queue must drain to empty");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn granted_slot_to_cancelled_receiver_is_rehanded_to_next_waiter() {
+        // The riskiest path: a hand-off races a waiter's cancellation. A parks,
+        // then B; we abort A at the same instant we free the only slot, so the
+        // slot may be handed to A's already-dropped receiver. However that race
+        // resolves (A's ticket wins `grant_tx`, or the send fails, or A receives
+        // then its task is aborted and the grant's guard re-hands), the slot must
+        // never leak: B must always admit and the worker must drain to zero.
+        // Looped to exercise both interleavings.
+        for iter in 0..40 {
+            let q = queue(enabled(1, None));
+            let w = worker("w");
+            let model = ModelId("m".into());
+            let ctx = SelectionContext::new(&model, None);
+            let (_seed, held) = q
+                .acquire(&[Arc::clone(&w)], &PickFirst, &ctx, "m")
+                .await
+                .expect("seed acquire");
+
+            let qa = Arc::clone(&q);
+            let ca = vec![Arc::clone(&w)];
+            let a = tokio::spawn(async move {
+                let model = ModelId("m".into());
+                let ctx = SelectionContext::new(&model, None);
+                let _g = qa.acquire(&ca, &PickFirst, &ctx, "m").await;
+                // Hold briefly if admitted, to widen the race window.
+                tokio::task::yield_now().await;
+            });
+            wait_until_queued(&q, 1).await;
+
+            let qb = Arc::clone(&q);
+            let cb = vec![Arc::clone(&w)];
+            let b = tokio::spawn(async move {
+                let model = ModelId("m".into());
+                let ctx = SelectionContext::new(&model, None);
+                // Drop the guard immediately on admission so the slot frees.
+                let _ = qb.acquire(&cb, &PickFirst, &ctx, "m").await;
+            });
+            wait_until_queued(&q, 2).await;
+
+            // Race: cancel A as the slot frees.
+            a.abort();
+            drop(held);
+
+            // B must admit no matter how the race fell out.
+            tokio::time::timeout(Duration::from_secs(2), b)
+                .await
+                .unwrap_or_else(|_| panic!("iter {iter}: B never admitted (slot leaked)"))
+                .expect("B task panicked");
+            let _ = a.await;
+
+            // No leak: B has dropped its guard, the worker is idle, queue empty.
+            for _ in 0..200 {
+                if w.active_load() == 0 && q.queued_len() == 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            assert_eq!(w.active_load(), 0, "iter {iter}: worker leaked a slot");
+            assert_eq!(q.queued_len(), 0, "iter {iter}: queue did not drain");
+        }
     }
 }

--- a/experimental/sgl-router/src/server/admission.rs
+++ b/experimental/sgl-router/src/server/admission.rs
@@ -1,0 +1,576 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Request-count admission control for the router.
+//!
+//! Without this gate the router forwards every request to the selected worker
+//! the instant it arrives, so a saturated backend silently absorbs an unbounded
+//! pile of in-flight requests at its connection front door — latency that the
+//! client pays but the backend's own metrics never see. [`AdmissionQueue`]
+//! bounds that: each worker admits at most `max_concurrent_per_worker`
+//! in-flight requests, and when every candidate is full the request is parked
+//! in a wait queue until a slot frees. The queue itself is bounded — once
+//! `max_queued` requests are already waiting, further arrivals are shed with a
+//! 503 so the router never queues without limit.
+//!
+//! Admission is opt-in via [`AdmissionConfig`]: [`AdmissionConfig::Disabled`]
+//! (the default) makes the gate a pass-through and the router behaves exactly
+//! as before.
+//!
+//! **Fairness:** wakeups are unordered. A freed slot wakes every parked waiter
+//! and they race for it; losers re-park. There is no FIFO guarantee, so under
+//! sustained saturation an individual request can be repeatedly out-raced. The
+//! bounded queue caps how many wait, not how long any one waits;
+//! `sgl_router_admission_wait_seconds` makes the wait distribution observable.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::sync::{Notify, Semaphore};
+
+use crate::config::AdmissionConfig;
+use crate::policies::{Policy, SelectionContext};
+use crate::server::error::ApiError;
+use crate::server::metrics::MetricsRegistry;
+use crate::workers::{LoadGuard, Worker};
+
+/// Bounded, count-based admission gate shared on the request hot path.
+#[derive(Debug)]
+pub struct AdmissionQueue {
+    /// Per-worker in-flight cap. `None` disables admission control entirely:
+    /// `acquire` dispatches immediately with an unconditional load guard,
+    /// matching the pre-admission behaviour.
+    max_concurrent_per_worker: Option<usize>,
+    /// Bounds how many requests may park waiting for a slot. `None` leaves the
+    /// wait queue unbounded (park indefinitely, never shed). `Some(n)` sheds
+    /// the request with 503 once `n` are already parked.
+    queue_slots: Option<Semaphore>,
+    /// Woken whenever a slot frees so parked requests re-attempt admission.
+    notify: Notify,
+    metrics: Arc<MetricsRegistry>,
+}
+
+impl AdmissionQueue {
+    pub fn new(config: AdmissionConfig, metrics: Arc<MetricsRegistry>) -> Self {
+        let (max_concurrent_per_worker, max_queued) = match config {
+            AdmissionConfig::Disabled => (None, None),
+            AdmissionConfig::Enabled {
+                max_concurrent_per_worker,
+                max_queued_requests,
+            } => (Some(max_concurrent_per_worker.get()), max_queued_requests),
+        };
+        Self {
+            max_concurrent_per_worker,
+            queue_slots: max_queued.map(Semaphore::new),
+            notify: Notify::new(),
+            metrics,
+        }
+    }
+
+    /// Signal that a worker slot has freed so parked requests wake and
+    /// re-attempt admission. Wakes every parked waiter; each re-checks and only
+    /// those that can claim a slot proceed, the rest re-park (see the fairness
+    /// note in the module docs). A no-op when nothing is parked.
+    pub fn notify_slot_freed(&self) {
+        self.notify.notify_waiters();
+    }
+
+    /// Select a worker and claim an in-flight slot, parking until one frees if
+    /// every candidate is at capacity. Returns [`ApiError::ServiceOverloaded`]
+    /// (503) when the wait queue is already full, and
+    /// [`ApiError::PolicySelectionFailed`] when the policy declines (the full
+    /// candidate set when disabled, or the slot-having subset when enabled).
+    ///
+    /// The returned [`AdmissionGuard`] holds the claimed slot and wakes parked
+    /// requests when it drops; the caller keeps it alive for the request's
+    /// lifetime (stream end / client disconnect / error).
+    pub async fn acquire(
+        self: &Arc<Self>,
+        candidates: &[Arc<Worker>],
+        policy: &dyn Policy,
+        ctx: &SelectionContext<'_>,
+        model: &str,
+    ) -> Result<(Arc<Worker>, AdmissionGuard), ApiError> {
+        let Some(cap) = self.max_concurrent_per_worker else {
+            // Disabled: dispatch immediately with an unconditional guard and no
+            // wake obligation (nothing ever parks).
+            let worker =
+                policy
+                    .select(candidates, ctx)
+                    .ok_or_else(|| ApiError::PolicySelectionFailed {
+                        model: model.to_string(),
+                    })?;
+            let guard = AdmissionGuard {
+                load_guard: Some(worker.load_guard()),
+                admission: None,
+            };
+            return Ok((worker, guard));
+        };
+
+        // Fast path: a slot is free right now.
+        if let Some((worker, load_guard)) = self.try_claim(candidates, policy, ctx, cap, model)? {
+            return Ok((worker, self.admitted_guard(load_guard)));
+        }
+
+        // All candidates full. Take a wait-queue slot, or shed with 503 if the
+        // queue is already at its depth cap.
+        let _queue_permit = match &self.queue_slots {
+            Some(sem) => match sem.try_acquire() {
+                Ok(permit) => Some(permit),
+                Err(_) => {
+                    self.metrics.record_backpressure_rejected(model);
+                    return Err(ApiError::ServiceOverloaded {
+                        model: model.to_string(),
+                    });
+                }
+            },
+            None => None,
+        };
+        let _parked = self.enter_queue();
+        let parked_since = Instant::now();
+
+        loop {
+            // Register the waiter BEFORE re-checking, so a `notify_slot_freed`
+            // racing between the check and the await is not lost.
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            match self.try_claim(candidates, policy, ctx, cap, model) {
+                Ok(Some((worker, load_guard))) => {
+                    self.metrics
+                        .observe_admission_wait(model, parked_since.elapsed().as_secs_f64());
+                    return Ok((worker, self.admitted_guard(load_guard)));
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    // The policy declined a now-non-empty slot-having set after
+                    // the request had already parked (e.g. a sticky/cache-aware
+                    // key whose only available worker is ineligible). Log it so a
+                    // non-retryable error returned *after* a wait isn't silent to
+                    // operators.
+                    tracing::debug!(model = %model, "parked request declined by policy");
+                    return Err(e);
+                }
+            }
+            notified.await;
+        }
+    }
+
+    /// Wrap a claimed [`LoadGuard`] in an [`AdmissionGuard`] that wakes parked
+    /// requests when the slot frees.
+    fn admitted_guard(self: &Arc<Self>, load_guard: LoadGuard) -> AdmissionGuard {
+        AdmissionGuard {
+            load_guard: Some(load_guard),
+            admission: Some(Arc::clone(self)),
+        }
+    }
+
+    /// One admission attempt. Returns `Ok(Some(..))` on a claimed slot,
+    /// `Ok(None)` when every candidate is full (caller should park), and `Err`
+    /// only when the policy declines a non-empty set of slot-having workers.
+    fn try_claim(
+        &self,
+        candidates: &[Arc<Worker>],
+        policy: &dyn Policy,
+        ctx: &SelectionContext<'_>,
+        cap: usize,
+        model: &str,
+    ) -> Result<Option<(Arc<Worker>, LoadGuard)>, ApiError> {
+        // Each `continue` re-runs the filter; it is only reached when a
+        // competing claim consumed the slot we picked, i.e. global forward
+        // progress happened. With a finite candidate set and finite `cap` the
+        // loop is bounded by the number of concurrent claimers, so it cannot
+        // spin forever.
+        loop {
+            // Only offer the policy workers that currently have a free slot, so
+            // a cache-affinity or sticky decision never pins onto a worker
+            // that is already at capacity while another has room.
+            let available: Vec<Arc<Worker>> = candidates
+                .iter()
+                .filter(|w| w.active_load() < cap)
+                .cloned()
+                .collect();
+            if available.is_empty() {
+                return Ok(None);
+            }
+            let worker =
+                policy
+                    .select(&available, ctx)
+                    .ok_or_else(|| ApiError::PolicySelectionFailed {
+                        model: model.to_string(),
+                    })?;
+            match worker.try_load_guard(cap) {
+                Some(guard) => return Ok(Some((worker, guard))),
+                // Raced: the chosen worker filled between the filter and the
+                // claim. Recompute the available set and try again.
+                None => continue,
+            }
+        }
+    }
+
+    fn enter_queue(&self) -> QueuedGuard<'_> {
+        self.metrics.add_queued_requests(1);
+        QueuedGuard { queue: self }
+    }
+}
+
+/// Holds a claimed per-worker in-flight slot for the request's lifetime and,
+/// when it drops, wakes admission-parked requests so they re-attempt.
+///
+/// The wake ordering lives in one place — this `Drop`: the inner [`LoadGuard`]
+/// is dropped (decrementing the worker's in-flight count) BEFORE
+/// `notify_slot_freed`, so a woken waiter re-checking capacity sees the freed
+/// slot. `admission` is `None` on the disabled pass-through path, where nothing
+/// ever parks and no wake is needed.
+#[derive(Debug)]
+pub struct AdmissionGuard {
+    load_guard: Option<LoadGuard>,
+    admission: Option<Arc<AdmissionQueue>>,
+}
+
+impl Drop for AdmissionGuard {
+    fn drop(&mut self) {
+        // Decrement the slot first, THEN wake — a woken waiter must observe the
+        // freed slot. Taking the `Option` forces the `LoadGuard` drop here,
+        // before the notify, rather than at end-of-struct-drop.
+        drop(self.load_guard.take());
+        if let Some(admission) = &self.admission {
+            admission.notify_slot_freed();
+        }
+    }
+}
+
+/// Tracks one parked request: decrements the queued counter (and the gauge) on
+/// drop, whether the request was ultimately admitted or abandoned (the handler
+/// future dropped on client disconnect). Requests shed with 503 return before
+/// entering the queue, so they never construct this guard.
+struct QueuedGuard<'a> {
+    queue: &'a AdmissionQueue,
+}
+
+impl Drop for QueuedGuard<'_> {
+    fn drop(&mut self) {
+        self.queue.metrics.add_queued_requests(-1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
+    use std::num::NonZeroUsize;
+    use std::time::Duration;
+
+    fn worker(id: &str) -> Arc<Worker> {
+        Arc::new(Worker::new(WorkerSpec {
+            id: WorkerId(id.into()),
+            url: format!("http://{id}"),
+            mode: WorkerMode::Plain,
+            model_ids: vec![ModelId("m".into())],
+            bootstrap_port: None,
+        }))
+    }
+
+    fn metrics() -> Arc<MetricsRegistry> {
+        MetricsRegistry::new()
+    }
+
+    /// An `Enabled` admission config with the given per-worker cap.
+    fn enabled(cap: usize, max_queued: Option<usize>) -> AdmissionConfig {
+        AdmissionConfig::Enabled {
+            max_concurrent_per_worker: NonZeroUsize::new(cap).unwrap(),
+            max_queued_requests: max_queued,
+        }
+    }
+
+    fn queue(config: AdmissionConfig) -> Arc<AdmissionQueue> {
+        Arc::new(AdmissionQueue::new(config, metrics()))
+    }
+
+    /// Picks the first candidate offered — deterministic for tests.
+    #[derive(Debug)]
+    struct PickFirst;
+    impl Policy for PickFirst {
+        fn select(
+            &self,
+            workers: &[Arc<Worker>],
+            _ctx: &SelectionContext<'_>,
+        ) -> Option<Arc<Worker>> {
+            workers.first().cloned()
+        }
+    }
+
+    /// Never selects — models a policy that declines.
+    #[derive(Debug)]
+    struct PickNone;
+    impl Policy for PickNone {
+        fn select(
+            &self,
+            _workers: &[Arc<Worker>],
+            _ctx: &SelectionContext<'_>,
+        ) -> Option<Arc<Worker>> {
+            None
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_gate_admits_even_when_worker_is_loaded() {
+        let q = queue(AdmissionConfig::Disabled);
+        let w = worker("w");
+        // Pile on existing load; the disabled gate must not care.
+        let _h1 = w.load_guard();
+        let _h2 = w.load_guard();
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+
+        let (chosen, _g) = q
+            .acquire(&[Arc::clone(&w)], &PickFirst, &ctx, "m")
+            .await
+            .expect("disabled gate must always admit");
+        assert_eq!(chosen.id, w.id);
+        assert_eq!(w.active_load(), 3);
+    }
+
+    #[tokio::test]
+    async fn fast_path_admits_below_cap() {
+        let q = queue(enabled(2, None));
+        let w = worker("w");
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+
+        let (chosen, _g) = q
+            .acquire(&[Arc::clone(&w)], &PickFirst, &ctx, "m")
+            .await
+            .expect("under cap must admit");
+        assert_eq!(chosen.id, w.id);
+        assert_eq!(w.active_load(), 1);
+    }
+
+    #[tokio::test]
+    async fn skips_full_worker_for_one_with_a_free_slot() {
+        let q = queue(enabled(1, None));
+        let full = worker("full");
+        let free = worker("free");
+        let _hold = full.load_guard(); // full is at cap=1
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+
+        // PickFirst would choose `full` first, but it is filtered out as
+        // having no free slot, so `free` is admitted instead.
+        let (chosen, _g) = q
+            .acquire(
+                &[Arc::clone(&full), Arc::clone(&free)],
+                &PickFirst,
+                &ctx,
+                "m",
+            )
+            .await
+            .expect("must admit the worker with a free slot");
+        assert_eq!(chosen.id, free.id);
+    }
+
+    #[tokio::test]
+    async fn rejects_with_503_when_queue_full() {
+        // Depth cap of 0: never park, shed immediately once the worker is full.
+        let m = metrics();
+        let q = Arc::new(AdmissionQueue::new(enabled(1, Some(0)), Arc::clone(&m)));
+        let w = worker("w");
+        let _hold = w.load_guard(); // w at cap=1
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+
+        let err = q
+            .acquire(&[Arc::clone(&w)], &PickFirst, &ctx, "m")
+            .await
+            .expect_err("full worker + full queue must be shed");
+        assert!(
+            matches!(err, ApiError::ServiceOverloaded { .. }),
+            "expected ServiceOverloaded, got {err:?}",
+        );
+        let out = m.render();
+        assert!(
+            out.contains(r#"sgl_router_backpressure_rejected_total{model_id="m"} 1"#),
+            "rejection must be counted: {out}",
+        );
+        // A shed request never enters the queue, so the gauge stays at 0.
+        assert!(out.contains("sgl_router_queued_requests 0\n"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn policy_declining_nonempty_set_is_policy_selection_failed() {
+        let q = queue(enabled(2, None));
+        let w = worker("w");
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+
+        let err = q
+            .acquire(&[Arc::clone(&w)], &PickNone, &ctx, "m")
+            .await
+            .expect_err("declining policy must error");
+        assert!(
+            matches!(err, ApiError::PolicySelectionFailed { .. }),
+            "expected PolicySelectionFailed, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn parks_until_slot_frees_then_admits() {
+        let q = queue(enabled(1, None));
+        let w = worker("w");
+        let held = w.load_guard(); // w at cap=1 -> next acquire parks
+        assert_eq!(w.active_load(), 1);
+
+        let q2 = Arc::clone(&q);
+        let cands = vec![Arc::clone(&w)];
+        let handle = tokio::spawn(async move {
+            let model = ModelId("m".into());
+            let ctx = SelectionContext::new(&model, None);
+            q2.acquire(&cands, &PickFirst, &ctx, "m")
+                .await
+                .map(|(w, _g)| w.id.clone())
+        });
+
+        // Let the task reach the parked state.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !handle.is_finished(),
+            "acquire should park while worker is full"
+        );
+
+        // Free the slot and wake the waiter.
+        drop(held);
+        q.notify_slot_freed();
+
+        let chosen = tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("parked acquire must resolve once a slot frees")
+            .expect("task panicked")
+            .expect("acquire should succeed after slot frees");
+        assert_eq!(chosen, w.id);
+    }
+
+    #[tokio::test]
+    async fn unbounded_queue_parks_many_then_admits_each_as_slots_free() {
+        // cap=1 + unbounded queue: many waiters all park (none shed); freeing
+        // the slot cascades admissions one at a time as each admitted request's
+        // guard drops and wakes the next.
+        let m = metrics();
+        let q = Arc::new(AdmissionQueue::new(enabled(1, None), Arc::clone(&m)));
+        let w = worker("w");
+        let held = w.load_guard(); // occupies the only slot
+
+        let mut handles = Vec::new();
+        for _ in 0..3 {
+            let q2 = Arc::clone(&q);
+            let cands = vec![Arc::clone(&w)];
+            handles.push(tokio::spawn(async move {
+                let model = ModelId("m".into());
+                let ctx = SelectionContext::new(&model, None);
+                // Drop the guard immediately on admission so the slot frees and
+                // the next waiter can proceed.
+                q2.acquire(&cands, &PickFirst, &ctx, "m").await.map(|_| ())
+            }));
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            handles.iter().all(|h| !h.is_finished()),
+            "all three should park while the only slot is held"
+        );
+        // All three are parked; none was shed (unbounded queue).
+        assert!(
+            m.render().contains("sgl_router_queued_requests 3\n"),
+            "{}",
+            m.render(),
+        );
+
+        // Release the slot once; admissions cascade via each guard's drop.
+        drop(held);
+        q.notify_slot_freed();
+
+        for h in handles {
+            tokio::time::timeout(Duration::from_secs(2), h)
+                .await
+                .expect("each parked waiter must eventually admit")
+                .expect("task panicked")
+                .expect("acquire should succeed");
+        }
+        // Queue fully drained.
+        assert!(
+            m.render().contains("sgl_router_queued_requests 0\n"),
+            "{}",
+            m.render(),
+        );
+    }
+
+    #[tokio::test]
+    async fn abandoned_parked_request_releases_its_queue_slot() {
+        // Depth cap 1: A parks (taking the one queue slot), B is shed. Aborting
+        // A (client disconnect) must release the slot — observable via the
+        // gauge returning to 0 — so a later C can park instead of being shed.
+        let m = metrics();
+        let q = Arc::new(AdmissionQueue::new(enabled(1, Some(1)), Arc::clone(&m)));
+        let w = worker("w");
+        let _held = w.load_guard(); // worker full for the whole test
+        let cands = vec![Arc::clone(&w)];
+
+        let qa = Arc::clone(&q);
+        let ca = cands.clone();
+        let a = tokio::spawn(async move {
+            let model = ModelId("m".into());
+            let ctx = SelectionContext::new(&model, None);
+            qa.acquire(&ca, &PickFirst, &ctx, "m").await.map(|_| ())
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !a.is_finished(),
+            "A should be parked holding the queue slot"
+        );
+        assert!(
+            m.render().contains("sgl_router_queued_requests 1\n"),
+            "A parked -> gauge should read 1: {}",
+            m.render(),
+        );
+
+        // B finds the queue full -> shed.
+        let model = ModelId("m".into());
+        let ctx = SelectionContext::new(&model, None);
+        let b = q.acquire(&cands, &PickFirst, &ctx, "m").await;
+        assert!(
+            matches!(b, Err(ApiError::ServiceOverloaded { .. })),
+            "B must be shed while the single queue slot is taken: {b:?}",
+        );
+
+        // A disconnects: aborting drops its `acquire` future, which releases the
+        // queue permit and (via QueuedGuard::drop) returns the gauge to 0.
+        a.abort();
+        let _ = a.await;
+        assert!(
+            m.render().contains("sgl_router_queued_requests 0\n"),
+            "A's abort must release its queue slot (gauge back to 0): {}",
+            m.render(),
+        );
+
+        // C can now park (queue slot freed) rather than being shed.
+        let qc = Arc::clone(&q);
+        let cc = cands.clone();
+        let c = tokio::spawn(async move {
+            let model = ModelId("m".into());
+            let ctx = SelectionContext::new(&model, None);
+            qc.acquire(&cc, &PickFirst, &ctx, "m").await.map(|_| ())
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !c.is_finished(),
+            "C should park (slot was freed by A's abort), not shed"
+        );
+        assert!(
+            m.render().contains("sgl_router_queued_requests 1\n"),
+            "C parked -> gauge should read 1 again: {}",
+            m.render(),
+        );
+        c.abort();
+        let _ = c.await;
+    }
+}

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -11,6 +11,7 @@ use axum::response::Response;
 use axum::routing::{get, post};
 use axum::Router;
 use std::sync::Arc;
+use tower_http::catch_panic::CatchPanicLayer;
 
 /// Middleware: log 413 PAYLOAD_TOO_LARGE responses with the request method
 /// and URI so an operator investigating "client X gets 413s" has a
@@ -76,12 +77,78 @@ pub fn build_router(ctx: Arc<AppContext>) -> Router {
             "/flush_cache",
             post(crate::server::routes::cache::flush_cache),
         )
+        // Convert a handler panic into a 500 response. hyper otherwise catches
+        // the panic and drops the connection WITHOUT a Response, so the failure
+        // never reaches the `record_response_status` middleware below and is
+        // invisible to metrics and logs. Positioned INNER relative to that
+        // middleware (added before it, so it sits closer to the handlers) so the
+        // synthesized 500 is observed and counted.
+        .layer(CatchPanicLayer::new())
         // Outermost layer: count the final status of every response, so error
-        // short-circuits (admission 503s, 413s, …) land in
-        // `sgl_router_responses_total` alongside successes.
+        // short-circuits (admission 503s, 413s, …) and synthesized panic-500s
+        // land in `sgl_router_responses_total` alongside successes.
         .layer(middleware::from_fn_with_state(
             Arc::clone(&ctx.metrics),
             record_response_status,
         ))
         .with_state(ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    /// A handler panic must become a 500 that the `record_response_status`
+    /// middleware still observes. hyper catches a handler panic and drops the
+    /// connection WITHOUT producing a Response, so without `CatchPanicLayer`
+    /// the failure is invisible to the response-code metric. `CatchPanicLayer`
+    /// synthesizes a 500; the metrics layer must be OUTER (applied after) so it
+    /// counts that synthesized 500.
+    ///
+    /// This composes the SAME two layers in the SAME order as `build_router`
+    /// (metrics outer, catch-panic inner) over a panicking route — the real
+    /// `build_router` has no panicking route to exercise, so a minimal Router
+    /// pins the ordering contract directly.
+    #[tokio::test]
+    async fn handler_panic_becomes_500_and_is_counted() {
+        let metrics = MetricsRegistry::new();
+        let app = Router::new()
+            .route(
+                "/boom",
+                get(|| async {
+                    panic!("handler exploded");
+                    #[allow(unreachable_code)]
+                    StatusCode::OK
+                }),
+            )
+            // Inner: convert a handler panic into a 500 response.
+            .layer(CatchPanicLayer::new())
+            // Outer: count the final status — must observe the synthesized 500.
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&metrics),
+                record_response_status,
+            ));
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/boom")
+            .body(Body::empty())
+            .unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            res.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a handler panic must surface as 500, not a dropped connection",
+        );
+        assert!(
+            metrics
+                .render()
+                .contains(r#"sgl_router_responses_total{status_code="500"} 1"#),
+            "the metrics middleware must observe and count the panic-500; got:\n{}",
+            metrics.render(),
+        );
+    }
 }

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::server::app_context::AppContext;
+use crate::server::metrics::MetricsRegistry;
 use crate::server::routes::chat::MAX_CHAT_BODY_BYTES;
-use axum::extract::{DefaultBodyLimit, Request};
+use axum::extract::{DefaultBodyLimit, Request, State};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
 use axum::response::Response;
@@ -27,6 +28,24 @@ async fn log_413(req: Request, next: Next) -> Response {
             "request rejected with 413 PAYLOAD_TOO_LARGE (body exceeded route limit)",
         );
     }
+    resp
+}
+
+/// Middleware: record the final HTTP status of every response into
+/// `sgl_router_responses_total{status_code}`. Applied globally as the outermost
+/// layer so it observes the status of EVERY response — including errors produced
+/// before a handler runs (a 413 from the body-limit layer) and handler
+/// short-circuits that return via `?` before reaching their own bookkeeping
+/// (a 503 from the admission gate, or any other `ApiError`). Recording here is
+/// why handlers no longer count the status themselves: a single site means no
+/// outcome is missed and none is double-counted.
+async fn record_response_status(
+    State(metrics): State<Arc<MetricsRegistry>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let resp = next.run(req).await;
+    metrics.record_response(resp.status().as_u16());
     resp
 }
 
@@ -57,5 +76,12 @@ pub fn build_router(ctx: Arc<AppContext>) -> Router {
             "/flush_cache",
             post(crate::server::routes::cache::flush_cache),
         )
+        // Outermost layer: count the final status of every response, so error
+        // short-circuits (admission 503s, 413s, …) land in
+        // `sgl_router_responses_total` alongside successes.
+        .layer(middleware::from_fn_with_state(
+            Arc::clone(&ctx.metrics),
+            record_response_status,
+        ))
         .with_state(ctx)
 }

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::server::app_context::AppContext;
-use crate::server::metrics::MetricsRegistry;
+use crate::server::metrics::{
+    outcome_from_status, MetricsRegistry, RequestLogContext, RequestOutcome, WorkerModeLabel,
+};
 use crate::server::routes::chat::MAX_CHAT_BODY_BYTES;
 use axum::extract::{DefaultBodyLimit, Request, State};
 use axum::http::StatusCode;
@@ -32,21 +34,90 @@ async fn log_413(req: Request, next: Next) -> Response {
     resp
 }
 
-/// Middleware: record the final HTTP status of every response into
-/// `sgl_router_responses_total{status_code}`. Applied globally as the outermost
-/// layer so it observes the status of EVERY response — including errors produced
-/// before a handler runs (a 413 from the body-limit layer) and handler
-/// short-circuits that return via `?` before reaching their own bookkeeping
-/// (a 503 from the admission gate, or any other `ApiError`). Recording here is
-/// why handlers no longer count the status themselves: a single site means no
-/// outcome is missed and none is double-counted.
-async fn record_response_status(
+/// Infra endpoints excluded from the access log (logged at DEBUG instead) and
+/// from `requests_total`. They are polled constantly — Prometheus scrapes
+/// `/metrics`, the kubelet hits `/healthz` + `/readyz` every few seconds — so
+/// logging them at INFO would bury real API traffic and counting them in
+/// `requests_total` would swamp the by-outcome view with probe successes. They
+/// are still counted in `responses_total{status_code}`.
+fn is_infra_path(path: &str) -> bool {
+    matches!(path, "/healthz" | "/readyz" | "/metrics")
+}
+
+/// Outermost middleware: the single access-log and request/response metric site.
+///
+/// Runs for EVERY request — all routes, plus responses produced before any
+/// handler runs (a 413 from the body-limit layer; a 400 from the body extractor
+/// when a client drops the connection mid-upload; a `CatchPanicLayer` 500) and
+/// handler short-circuits that return via `?` (a 503 admission shed, a 400
+/// body-validation, a 404 model-not-found). For each request it:
+///   * counts `responses_total{status_code}` (every response, incl. infra);
+///   * for non-infra paths, counts
+///     `requests_total{worker_url,model_id,mode,outcome}` — reading the
+///     per-worker labels a routed handler attached via [`RequestLogContext`], or
+///     an empty `worker_url` when the request was rejected before routing — so
+///     the counter covers ALL ingress, not just dispatched traffic; and
+///   * emits one access-log line (INFO; DEBUG for infra).
+///
+/// Handlers therefore no longer log or count requests themselves: a single site
+/// means no outcome is missed and none is double-counted.
+async fn access_log_and_record(
     State(metrics): State<Arc<MetricsRegistry>>,
     req: Request,
     next: Next,
 ) -> Response {
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+    let request_id = req
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-")
+        .to_string();
+    let start = std::time::Instant::now();
+
     let resp = next.run(req).await;
-    metrics.record_response(resp.status().as_u16());
+
+    let status = resp.status();
+    let latency_ms = start.elapsed().as_millis() as u64;
+    metrics.record_response(status.as_u16());
+
+    if is_infra_path(&path) {
+        tracing::debug!(
+            method = %method,
+            path = %path,
+            status = status.as_u16(),
+            latency_ms,
+            "http_request",
+        );
+        return resp;
+    }
+
+    let outcome = outcome_from_status(status.as_u16());
+    let outcome_str = match outcome {
+        RequestOutcome::Success => "success",
+        RequestOutcome::Error => "error",
+        RequestOutcome::Cancelled => "cancelled",
+    };
+    // Per-worker labels are present only when a handler routed the request and
+    // attached them; pre-routing rejections record an empty worker_url.
+    let ctx = resp.extensions().get::<RequestLogContext>();
+    let worker = ctx.map(|c| c.worker_url.as_str()).unwrap_or("");
+    let model = ctx.map(|c| c.model_id.as_str()).unwrap_or("");
+    let mode = ctx.map(|c| c.mode).unwrap_or(WorkerModeLabel::Plain);
+
+    metrics.record_request(worker, model, mode, outcome);
+    tracing::info!(
+        request_id = %request_id,
+        method = %method,
+        path = %path,
+        status = status.as_u16(),
+        outcome = outcome_str,
+        worker = %worker,
+        model = %model,
+        latency_ms,
+        "http_request",
+    );
     resp
 }
 
@@ -79,17 +150,19 @@ pub fn build_router(ctx: Arc<AppContext>) -> Router {
         )
         // Convert a handler panic into a 500 response. hyper otherwise catches
         // the panic and drops the connection WITHOUT a Response, so the failure
-        // never reaches the `record_response_status` middleware below and is
+        // never reaches the `access_log_and_record` middleware below and is
         // invisible to metrics and logs. Positioned INNER relative to that
         // middleware (added before it, so it sits closer to the handlers) so the
         // synthesized 500 is observed and counted.
         .layer(CatchPanicLayer::new())
-        // Outermost layer: count the final status of every response, so error
-        // short-circuits (admission 503s, 413s, …) and synthesized panic-500s
-        // land in `sgl_router_responses_total` alongside successes.
+        // Outermost layer: the single access-log + metric site. Logs every
+        // request and counts both `responses_total{status_code}` and
+        // `requests_total{...,outcome}`, so error short-circuits (admission
+        // 503s, 413s, client-dropped-upload 400s, …) and synthesized panic-500s
+        // are logged and counted alongside successes.
         .layer(middleware::from_fn_with_state(
             Arc::clone(&ctx.metrics),
-            record_response_status,
+            access_log_and_record,
         ))
         .with_state(ctx)
 }
@@ -101,7 +174,7 @@ mod tests {
     use axum::http::Request;
     use tower::ServiceExt;
 
-    /// A handler panic must become a 500 that the `record_response_status`
+    /// A handler panic must become a 500 that the `access_log_and_record`
     /// middleware still observes. hyper catches a handler panic and drops the
     /// connection WITHOUT producing a Response, so without `CatchPanicLayer`
     /// the failure is invisible to the response-code metric. `CatchPanicLayer`
@@ -129,7 +202,7 @@ mod tests {
             // Outer: count the final status — must observe the synthesized 500.
             .layer(middleware::from_fn_with_state(
                 Arc::clone(&metrics),
-                record_response_status,
+                access_log_and_record,
             ));
 
         let req = Request::builder()

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -6,7 +6,7 @@ use crate::server::metrics::{
     outcome_from_status, MetricsRegistry, RequestLogContext, RequestOutcome, WorkerModeLabel,
 };
 use crate::server::routes::chat::MAX_CHAT_BODY_BYTES;
-use axum::extract::{DefaultBodyLimit, Request, State};
+use axum::extract::{DefaultBodyLimit, MatchedPath, Request, State};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
 use axum::response::Response;
@@ -44,22 +44,25 @@ fn is_infra_path(path: &str) -> bool {
     matches!(path, "/healthz" | "/readyz" | "/metrics")
 }
 
-/// Outermost middleware: the single access-log and request/response metric site.
+/// Outermost middleware: the single edge-counting + access-log site.
 ///
 /// Runs for EVERY request — all routes, plus responses produced before any
 /// handler runs (a 413 from the body-limit layer; a 400 from the body extractor
 /// when a client drops the connection mid-upload; a `CatchPanicLayer` 500) and
 /// handler short-circuits that return via `?` (a 503 admission shed, a 400
-/// body-validation, a 404 model-not-found). For each request it:
-///   * counts `responses_total{status_code}` (every response, incl. infra);
+/// body-validation, a 404 model-not-found).
+///
+/// At ENTRY (before the handler runs) it counts `intake_total{route,method}` —
+/// true intake, so a request parked/shed/cancelled/dropped before producing a
+/// response is still counted. `route` is the matched [`MatchedPath`] template
+/// (bounded cardinality), `unmatched` for a 404. At EXIT it:
+///   * counts `responses_total{route,method,status_code}` (every response, incl.
+///     infra); `intake_total - responses_total` is the received-but-not-answered
+///     gap;
 ///   * for non-infra paths, counts
 ///     `requests_total{worker_url,model_id,mode,outcome}` — reading the
 ///     per-worker labels a routed handler attached via [`RequestLogContext`], or
-///     an empty `worker_url` when the request was rejected before routing — so
-///     the counter covers ALL ingress, not just dispatched traffic. Non-chat API
-///     routes (`/v1/models`, `/v1/tokenize`, `/v1/detokenize`, `/flush_cache`)
-///     are intentionally included here (with an empty `worker_url`); only the
-///     infra paths below are excluded; and
+///     an empty `worker_url` when the request was rejected before routing; and
 ///   * emits one access-log line (INFO; DEBUG for infra).
 ///
 /// Handlers therefore no longer log or count requests themselves: a single site
@@ -71,6 +74,13 @@ async fn access_log_and_record(
 ) -> Response {
     let method = req.method().clone();
     let path = req.uri().path().to_string();
+    // Matched route template (e.g. `/v1/chat/completions`), not the raw URI, so
+    // `intake_total` / `responses_total` stay low-cardinality; `unmatched` for a 404.
+    let route = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|m| m.as_str().to_owned())
+        .unwrap_or_else(|| "unmatched".to_owned());
     let request_id = req
         .headers()
         .get("x-request-id")
@@ -79,11 +89,17 @@ async fn access_log_and_record(
         .to_string();
     let start = std::time::Instant::now();
 
+    // ENTRY: true intake — counted before the handler can park/shed/drop it, so
+    // a never-answered request still shows up (intake - responses = the gap).
+    metrics.record_intake(&route, method.as_str());
+
     let resp = next.run(req).await;
 
     let status = resp.status();
     let latency_ms = start.elapsed().as_millis() as u64;
-    metrics.record_response(status.as_u16());
+    // Edge responses count ALL routes (incl. infra) so the intake/response
+    // population matches; filter infra by `route` in PromQL.
+    metrics.record_response(&route, method.as_str(), status.as_u16());
 
     if is_infra_path(&path) {
         tracing::debug!(
@@ -114,6 +130,7 @@ async fn access_log_and_record(
         request_id = %request_id,
         method = %method,
         path = %path,
+        route = %route,
         status = status.as_u16(),
         outcome = outcome_str,
         worker = %worker,
@@ -220,11 +237,55 @@ mod tests {
             "a handler panic must surface as 500, not a dropped connection",
         );
         assert!(
-            metrics
-                .render()
-                .contains(r#"sgl_router_responses_total{status_code="500"} 1"#),
+            metrics.render().contains(
+                r#"sgl_router_responses_total{route="/boom",method="GET",status_code="500"} 1"#
+            ),
             "the metrics middleware must observe and count the panic-500; got:\n{}",
             metrics.render(),
+        );
+    }
+
+    /// The point of counting intake at ENTRY: a request that never produces a
+    /// response — client disconnect / cancellation drops the in-flight handler
+    /// future at its `.await` — is still counted in `intake_total`, while
+    /// `responses_total` stays empty. `intake_total - responses_total` is the
+    /// received-but-not-answered gap that exit-only counting can never show. A
+    /// handler that sleeps far past our abandon timeout models the dropped future.
+    #[tokio::test]
+    async fn intake_counted_at_entry_even_when_request_never_completes() {
+        let metrics = MetricsRegistry::new();
+        let app = Router::new()
+            .route(
+                "/v1/chat/completions",
+                post(|| async {
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    StatusCode::OK
+                }),
+            )
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&metrics),
+                access_log_and_record,
+            ));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .body(Body::empty())
+            .unwrap();
+        // Abandon before the handler completes — drops the middleware future at
+        // its `.await`, exactly like a client disconnect mid-request.
+        let abandoned =
+            tokio::time::timeout(std::time::Duration::from_millis(50), app.oneshot(req)).await;
+        assert!(abandoned.is_err(), "request must not complete within 50ms");
+
+        let m = metrics.render();
+        assert!(
+            m.contains(r#"sgl_router_intake_total{route="/v1/chat/completions",method="POST"} 1"#),
+            "intake must be counted at entry even when the request never completes; got:\n{m}",
+        );
+        assert!(
+            !m.contains(r#"sgl_router_responses_total{route="/v1/chat/completions""#),
+            "a never-answered request must NOT appear in responses_total; got:\n{m}",
         );
     }
 }

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -56,7 +56,10 @@ fn is_infra_path(path: &str) -> bool {
 ///     `requests_total{worker_url,model_id,mode,outcome}` — reading the
 ///     per-worker labels a routed handler attached via [`RequestLogContext`], or
 ///     an empty `worker_url` when the request was rejected before routing — so
-///     the counter covers ALL ingress, not just dispatched traffic; and
+///     the counter covers ALL ingress, not just dispatched traffic. Non-chat API
+///     routes (`/v1/models`, `/v1/tokenize`, `/v1/detokenize`, `/flush_cache`)
+///     are intentionally included here (with an empty `worker_url`); only the
+///     infra paths below are excluded; and
 ///   * emits one access-log line (INFO; DEBUG for infra).
 ///
 /// Handlers therefore no longer log or count requests themselves: a single site

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -44,6 +44,27 @@ fn is_infra_path(path: &str) -> bool {
     matches!(path, "/healthz" | "/readyz" | "/metrics")
 }
 
+/// Collapse an HTTP method to a bounded allow-list for use as a metric label.
+/// `http::Method` accepts any RFC-7230 extension token, and this middleware runs
+/// before axum's method-router rejects an unknown verb with 405 — so the raw
+/// method on `requests_total` / `responses_total` would be attacker-influenced
+/// unbounded-cardinality input. Unknown verbs collapse to `other`.
+fn normalize_method(method: &axum::http::Method) -> &'static str {
+    use axum::http::Method;
+    match *method {
+        Method::GET => "GET",
+        Method::POST => "POST",
+        Method::PUT => "PUT",
+        Method::DELETE => "DELETE",
+        Method::PATCH => "PATCH",
+        Method::HEAD => "HEAD",
+        Method::OPTIONS => "OPTIONS",
+        Method::TRACE => "TRACE",
+        Method::CONNECT => "CONNECT",
+        _ => "other",
+    }
+}
+
 /// Outermost middleware: the single edge-counting + access-log site.
 ///
 /// Runs for EVERY request — all routes, plus responses produced before any
@@ -74,13 +95,18 @@ async fn access_log_and_record(
 ) -> Response {
     let method = req.method().clone();
     let path = req.uri().path().to_string();
-    // Matched route template (e.g. `/v1/chat/completions`), not the raw URI, so
-    // `requests_total` / `responses_total` stay low-cardinality; `unmatched` for a 404.
+    // Metric labels must stay low-cardinality. `route` is the matched route
+    // template (`/v1/chat/completions`, …), not the raw URI — `unmatched` for a
+    // 404. `method` is collapsed to a known-verb allow-list (`normalize_method`):
+    // an arbitrary RFC-7230 extension token reaches this middleware before axum's
+    // method-router returns 405, so the raw method is untrusted unbounded input.
+    // The access log below keeps the real method.
     let route = req
         .extensions()
         .get::<MatchedPath>()
         .map(|m| m.as_str().to_owned())
         .unwrap_or_else(|| "unmatched".to_owned());
+    let method_label = normalize_method(&method);
     let request_id = req
         .headers()
         .get("x-request-id")
@@ -91,7 +117,7 @@ async fn access_log_and_record(
 
     // ENTRY: true intake — counted before the handler can park/shed/drop it, so
     // a never-answered request still shows up (intake - responses = the gap).
-    metrics.record_ingress(&route, method.as_str());
+    metrics.record_ingress(&route, method_label);
 
     let resp = next.run(req).await;
 
@@ -99,7 +125,7 @@ async fn access_log_and_record(
     let latency_ms = start.elapsed().as_millis() as u64;
     // Edge responses count ALL routes (incl. infra) so the intake/response
     // population matches; filter infra by `route` in PromQL.
-    metrics.record_response(&route, method.as_str(), status.as_u16());
+    metrics.record_response(&route, method_label, status.as_u16());
 
     if is_infra_path(&path) {
         tracing::debug!(
@@ -289,6 +315,22 @@ mod tests {
         assert!(
             !m.contains(r#"sgl_router_responses_total{route="/v1/chat/completions""#),
             "a never-answered request must NOT appear in responses_total; got:\n{m}",
+        );
+    }
+
+    /// Metric labels must stay bounded: standard verbs pass through, but an
+    /// arbitrary RFC-7230 extension token (which reaches this middleware before
+    /// axum's 405) collapses to `other` so it can't explode label cardinality.
+    #[test]
+    fn normalize_method_collapses_unknown_verbs() {
+        use axum::http::Method;
+        assert_eq!(normalize_method(&Method::GET), "GET");
+        assert_eq!(normalize_method(&Method::POST), "POST");
+        let exotic = Method::from_bytes(b"BREW").unwrap();
+        assert_eq!(
+            normalize_method(&exotic),
+            "other",
+            "an unknown verb must collapse to `other`, not mint a new label series",
         );
     }
 }

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -35,11 +35,11 @@ async fn log_413(req: Request, next: Next) -> Response {
 }
 
 /// Infra endpoints excluded from the access log (logged at DEBUG instead) and
-/// from `requests_total`. They are polled constantly — Prometheus scrapes
+/// from `worker_requests_total`. They are polled constantly — Prometheus scrapes
 /// `/metrics`, the kubelet hits `/healthz` + `/readyz` every few seconds — so
 /// logging them at INFO would bury real API traffic and counting them in
-/// `requests_total` would swamp the by-outcome view with probe successes. They
-/// are still counted in `responses_total{status_code}`.
+/// `worker_requests_total` would swamp the by-outcome view with probe successes. They
+/// are still counted in `responses_total{route,method,status_code}`.
 fn is_infra_path(path: &str) -> bool {
     matches!(path, "/healthz" | "/readyz" | "/metrics")
 }
@@ -52,15 +52,15 @@ fn is_infra_path(path: &str) -> bool {
 /// handler short-circuits that return via `?` (a 503 admission shed, a 400
 /// body-validation, a 404 model-not-found).
 ///
-/// At ENTRY (before the handler runs) it counts `intake_total{route,method}` —
+/// At ENTRY (before the handler runs) it counts `requests_total{route,method}` —
 /// true intake, so a request parked/shed/cancelled/dropped before producing a
 /// response is still counted. `route` is the matched [`MatchedPath`] template
 /// (bounded cardinality), `unmatched` for a 404. At EXIT it:
 ///   * counts `responses_total{route,method,status_code}` (every response, incl.
-///     infra); `intake_total - responses_total` is the received-but-not-answered
+///     infra); `requests_total - responses_total` is the received-but-not-answered
 ///     gap;
 ///   * for non-infra paths, counts
-///     `requests_total{worker_url,model_id,mode,outcome}` — reading the
+///     `worker_requests_total{worker_url,model_id,mode,outcome}` — reading the
 ///     per-worker labels a routed handler attached via [`RequestLogContext`], or
 ///     an empty `worker_url` when the request was rejected before routing; and
 ///   * emits one access-log line (INFO; DEBUG for infra).
@@ -75,7 +75,7 @@ async fn access_log_and_record(
     let method = req.method().clone();
     let path = req.uri().path().to_string();
     // Matched route template (e.g. `/v1/chat/completions`), not the raw URI, so
-    // `intake_total` / `responses_total` stay low-cardinality; `unmatched` for a 404.
+    // `requests_total` / `responses_total` stay low-cardinality; `unmatched` for a 404.
     let route = req
         .extensions()
         .get::<MatchedPath>()
@@ -91,7 +91,7 @@ async fn access_log_and_record(
 
     // ENTRY: true intake — counted before the handler can park/shed/drop it, so
     // a never-answered request still shows up (intake - responses = the gap).
-    metrics.record_intake(&route, method.as_str());
+    metrics.record_ingress(&route, method.as_str());
 
     let resp = next.run(req).await;
 
@@ -125,7 +125,7 @@ async fn access_log_and_record(
     let model = ctx.map(|c| c.model_id.as_str()).unwrap_or("");
     let mode = ctx.map(|c| c.mode).unwrap_or(WorkerModeLabel::Plain);
 
-    metrics.record_request(worker, model, mode, outcome);
+    metrics.record_worker_request(worker, model, mode, outcome);
     tracing::info!(
         request_id = %request_id,
         method = %method,
@@ -176,8 +176,9 @@ pub fn build_router(ctx: Arc<AppContext>) -> Router {
         // synthesized 500 is observed and counted.
         .layer(CatchPanicLayer::new())
         // Outermost layer: the single access-log + metric site. Logs every
-        // request and counts both `responses_total{status_code}` and
-        // `requests_total{...,outcome}`, so error short-circuits (admission
+        // request and counts `requests_total{route,method}` (intake),
+        // `responses_total{route,method,status_code}`, and
+        // `worker_requests_total{...,outcome}`, so error short-circuits (admission
         // 503s, 413s, client-dropped-upload 400s, …) and synthesized panic-500s
         // are logged and counted alongside successes.
         .layer(middleware::from_fn_with_state(
@@ -247,8 +248,8 @@ mod tests {
 
     /// The point of counting intake at ENTRY: a request that never produces a
     /// response — client disconnect / cancellation drops the in-flight handler
-    /// future at its `.await` — is still counted in `intake_total`, while
-    /// `responses_total` stays empty. `intake_total - responses_total` is the
+    /// future at its `.await` — is still counted in `requests_total`, while
+    /// `responses_total` stays empty. `requests_total - responses_total` is the
     /// received-but-not-answered gap that exit-only counting can never show. A
     /// handler that sleeps far past our abandon timeout models the dropped future.
     #[tokio::test]
@@ -280,7 +281,9 @@ mod tests {
 
         let m = metrics.render();
         assert!(
-            m.contains(r#"sgl_router_intake_total{route="/v1/chat/completions",method="POST"} 1"#),
+            m.contains(
+                r#"sgl_router_requests_total{route="/v1/chat/completions",method="POST"} 1"#
+            ),
             "intake must be counted at entry even when the request never completes; got:\n{m}",
         );
         assert!(

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -26,7 +26,7 @@ pub struct AppContext {
     /// the stale-request janitor (which sweeps expired entries).
     pub active_load: Arc<ActiveLoadRegistry>,
     /// Lightweight Prometheus-format metrics registry served via
-    /// `/metrics`. Shared with the chat handler (requests_total),
+    /// `/metrics`. Shared with the chat handler (worker_requests_total),
     /// cache-aware-zmq policy (overlap_blocks), active-load registry
     /// (active_load gauge + stale_requests_total), and PD resolver
     /// (decode_affinity_total).

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -6,6 +6,7 @@ use crate::config::Config;
 use crate::policies::active_load::ActiveLoadRegistry;
 use crate::policies::PolicyRegistry;
 use crate::proxy::Proxy;
+use crate::server::admission::AdmissionQueue;
 use crate::server::metrics::MetricsRegistry;
 use crate::tokenizer::TokenizerRegistry;
 use crate::workers::WorkerRegistry;
@@ -30,6 +31,10 @@ pub struct AppContext {
     /// (active_load gauge + stale_requests_total), and PD resolver
     /// (decode_affinity_total).
     pub metrics: Arc<MetricsRegistry>,
+    /// Router-side admission control. Gates the chat hot path: caps in-flight
+    /// requests per worker and parks (or sheds with 503) excess. A pass-through
+    /// when no per-worker cap is configured.
+    pub admission: Arc<AdmissionQueue>,
     ready: AtomicBool,
 }
 
@@ -74,6 +79,7 @@ impl AppContext {
         // after the policy registry, so inject it now. No-op for policies
         // that don't emit metrics.
         policies.attach_metrics(Arc::clone(&metrics));
+        let admission = Arc::new(AdmissionQueue::new(config.admission, Arc::clone(&metrics)));
         Self {
             config,
             tokenizers,
@@ -82,6 +88,7 @@ impl AppContext {
             policies,
             active_load,
             metrics,
+            admission,
             ready: AtomicBool::new(false),
         }
     }
@@ -98,6 +105,9 @@ impl AppContext {
 
     #[cfg(test)]
     pub fn stub() -> Self {
+        // Share one registry between `metrics` and `admission`, mirroring
+        // production, so admission metrics are visible via `ctx.metrics`.
+        let metrics = MetricsRegistry::new();
         Self {
             config: Config {
                 server: crate::config::ServerConfig {
@@ -120,13 +130,18 @@ impl AppContext {
                 ),
                 proxy: crate::config::ProxyConfig::default(),
                 active_load: crate::config::ActiveLoadConfig::default(),
+                admission: crate::config::AdmissionConfig::default(),
             },
             tokenizers: Arc::new(TokenizerRegistry::default()),
             proxy: Arc::new(Proxy::new(std::time::Duration::from_secs(60)).expect("stub proxy")),
             registry: Arc::new(WorkerRegistry::default()),
             policies: Arc::new(PolicyRegistry::default()),
             active_load: ActiveLoadRegistry::with_defaults(),
-            metrics: MetricsRegistry::new(),
+            admission: Arc::new(AdmissionQueue::new(
+                crate::config::AdmissionConfig::Disabled,
+                Arc::clone(&metrics),
+            )),
+            metrics,
             ready: AtomicBool::new(false),
         }
     }

--- a/experimental/sgl-router/src/server/error.rs
+++ b/experimental/sgl-router/src/server/error.rs
@@ -9,6 +9,55 @@ use thiserror::Error;
 
 pub const X_ROUTER_ERROR_CODE: HeaderName = HeaderName::from_static("x-router-error-code");
 
+/// Carries the worker's *own* HTTP status when the router had to synthesize a
+/// status of its own over a worker that did respond (today: a mid-body drop,
+/// where headers arrived but the body did not). Lets a gateway / operator
+/// recover what the engine actually said instead of seeing only the router's
+/// synthesized 502. Absent on every other response: a forwarded worker response
+/// already carries the worker's status in the status line, and a router-only
+/// condition (admission shed, no workers, …) has no upstream status to report.
+pub const X_ROUTER_UPSTREAM_STATUS: HeaderName =
+    HeaderName::from_static("x-router-upstream-status");
+
+/// Coarse failure class for a router-originated error. The router's HTTP status
+/// is a pure function of the class, so two conditions that mean the same thing
+/// — e.g. a per-request timeout and a stale-deadline cancel — can never drift to
+/// different status codes. The *precise* condition travels in
+/// `x-router-error-code` (see [`ApiError::error_code`]); since the router is
+/// always behind a gateway, that header is the authoritative signal the gateway
+/// converts on, and the status is only a self-sufficient HTTP-honest default for
+/// a direct caller. The class never contradicts the precise code — it only
+/// generalizes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ErrorClass {
+    /// 400 — request rejected at ingress as malformed / invalid.
+    BadRequest,
+    /// 404 — requested model / resource not found.
+    NotFound,
+    /// 502 — a selected worker failed to return a usable response (unreachable,
+    /// or started a response then dropped the body).
+    Upstream,
+    /// 503 — the router had no worker to dispatch to, or declined to.
+    NoTarget,
+    /// 504 — the router gave up waiting (any timeout / deadline).
+    Timeout,
+    /// 500 — internal router fault.
+    Internal,
+}
+
+impl ErrorClass {
+    fn status(self) -> StatusCode {
+        match self {
+            ErrorClass::BadRequest => StatusCode::BAD_REQUEST,
+            ErrorClass::NotFound => StatusCode::NOT_FOUND,
+            ErrorClass::Upstream => StatusCode::BAD_GATEWAY,
+            ErrorClass::NoTarget => StatusCode::SERVICE_UNAVAILABLE,
+            ErrorClass::Timeout => StatusCode::GATEWAY_TIMEOUT,
+            ErrorClass::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ApiError {
     #[error("bad request: {0}")]
@@ -74,10 +123,12 @@ pub enum ApiError {
     /// token wins, the handler returns this variant → HTTP 504 →
     /// client sees `stale_request_expired`.
     ///
-    /// Mapped to 504 (not 503) because the failure is a router-side
-    /// gateway timeout from the client's perspective: the upstream
-    /// worker is still potentially fine, the router gave up because
-    /// the per-request budget elapsed.
+    /// Classed as [`ErrorClass::Timeout`] (→ 504), the same class as
+    /// `UpstreamTimeout`: from the client's perspective both are a router-side
+    /// gateway timeout. Here the upstream worker is still potentially fine — the
+    /// router gave up because the per-request budget elapsed. The shared class
+    /// is what keeps the two timeouts on the same status; they stay tellable
+    /// apart only by `x-router-error-code`.
     #[error("stale request expired for model {model}")]
     StaleRequestExpired { model: String },
 
@@ -118,40 +169,53 @@ pub enum ApiError {
 }
 
 impl ApiError {
-    fn status_and_code(&self) -> (StatusCode, &'static str) {
+    /// The failure class — the sole determinant of the HTTP status. Grouping by
+    /// class is what makes the status non-divergent: every timeout is
+    /// [`ErrorClass::Timeout`], so a per-request timeout and a stale-deadline
+    /// cancel are guaranteed the same status, and no future variant can quietly
+    /// pick a different one.
+    fn class(&self) -> ErrorClass {
         match self {
-            ApiError::BadRequest(_) => (StatusCode::BAD_REQUEST, "bad_request"),
-            ApiError::ModelNotFound(_) => (StatusCode::NOT_FOUND, "model_not_found"),
-            ApiError::UpstreamUnreachable { .. } => {
-                (StatusCode::BAD_GATEWAY, "upstream_unreachable")
-            }
-            ApiError::UpstreamStatus { .. } => (StatusCode::BAD_GATEWAY, "upstream_status"),
-            ApiError::UpstreamTimeout { .. } => (StatusCode::BAD_GATEWAY, "upstream_timeout"),
-            ApiError::NoHealthyWorkers { .. } => {
-                (StatusCode::SERVICE_UNAVAILABLE, "no_healthy_workers")
-            }
-            ApiError::NoPrefillWorkersAvailable { .. } => (
-                StatusCode::SERVICE_UNAVAILABLE,
-                "no_prefill_workers_available",
-            ),
-            ApiError::NoDecodeWorkersAvailable { .. } => (
-                StatusCode::SERVICE_UNAVAILABLE,
-                "no_decode_workers_available",
-            ),
-            ApiError::StaleRequestExpired { .. } => {
-                (StatusCode::GATEWAY_TIMEOUT, "stale_request_expired")
-            }
-            ApiError::PolicySelectionFailed { .. } => {
-                (StatusCode::SERVICE_UNAVAILABLE, "policy_selection_failed")
-            }
-            ApiError::BreakerOpen { .. } => (StatusCode::SERVICE_UNAVAILABLE, "breaker_open"),
-            ApiError::WorkerMisconfigured { .. } => {
-                (StatusCode::SERVICE_UNAVAILABLE, "worker_misconfigured")
-            }
-            ApiError::ServiceOverloaded { .. } => {
-                (StatusCode::SERVICE_UNAVAILABLE, "service_overloaded")
-            }
-            ApiError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal_error"),
+            ApiError::BadRequest(_) => ErrorClass::BadRequest,
+            ApiError::ModelNotFound(_) => ErrorClass::NotFound,
+            ApiError::UpstreamUnreachable { .. } => ErrorClass::Upstream,
+            ApiError::UpstreamStatus { .. } => ErrorClass::Upstream,
+            ApiError::UpstreamTimeout { .. } => ErrorClass::Timeout,
+            ApiError::NoHealthyWorkers { .. } => ErrorClass::NoTarget,
+            ApiError::NoPrefillWorkersAvailable { .. } => ErrorClass::NoTarget,
+            ApiError::NoDecodeWorkersAvailable { .. } => ErrorClass::NoTarget,
+            ApiError::StaleRequestExpired { .. } => ErrorClass::Timeout,
+            ApiError::PolicySelectionFailed { .. } => ErrorClass::NoTarget,
+            ApiError::BreakerOpen { .. } => ErrorClass::NoTarget,
+            ApiError::WorkerMisconfigured { .. } => ErrorClass::NoTarget,
+            ApiError::ServiceOverloaded { .. } => ErrorClass::NoTarget,
+            ApiError::Internal(_) => ErrorClass::Internal,
+        }
+    }
+
+    /// Stable, machine-readable `x-router-error-code` — the authoritative signal
+    /// a gateway converts on. Distinct per condition even when two conditions
+    /// share a class (and thus a status): `upstream_timeout` and
+    /// `stale_request_expired` both map to 504 but stay tellable apart here.
+    fn error_code(&self) -> &'static str {
+        match self {
+            ApiError::BadRequest(_) => "bad_request",
+            ApiError::ModelNotFound(_) => "model_not_found",
+            ApiError::UpstreamUnreachable { .. } => "upstream_unreachable",
+            // Mid-body drop: headers (incl. a status) arrived, then the body
+            // didn't. We surface a 502 but echo the worker's status in
+            // `x-router-upstream-status` (see `into_response`).
+            ApiError::UpstreamStatus { .. } => "upstream_body_incomplete",
+            ApiError::UpstreamTimeout { .. } => "upstream_timeout",
+            ApiError::NoHealthyWorkers { .. } => "no_healthy_workers",
+            ApiError::NoPrefillWorkersAvailable { .. } => "no_prefill_workers_available",
+            ApiError::NoDecodeWorkersAvailable { .. } => "no_decode_workers_available",
+            ApiError::StaleRequestExpired { .. } => "stale_request_expired",
+            ApiError::PolicySelectionFailed { .. } => "policy_selection_failed",
+            ApiError::BreakerOpen { .. } => "breaker_open",
+            ApiError::WorkerMisconfigured { .. } => "worker_misconfigured",
+            ApiError::ServiceOverloaded { .. } => "service_overloaded",
+            ApiError::Internal(_) => "internal_error",
         }
     }
 
@@ -159,7 +223,7 @@ impl ApiError {
     /// `into_response`. Exposed so the access log records the real status
     /// (e.g. 502/503/504) instead of a sentinel.
     pub fn status_code(&self) -> StatusCode {
-        self.status_and_code().0
+        self.class().status()
     }
 }
 
@@ -178,7 +242,8 @@ struct ErrorBody<'a> {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        let (status, code) = self.status_and_code();
+        let status = self.class().status();
+        let code = self.error_code();
         let typ = match status.as_u16() {
             400..=499 => "invalid_request_error",
             _ => "server_error",
@@ -270,6 +335,15 @@ impl IntoResponse for ApiError {
             .into_response();
         resp.headers_mut()
             .insert(X_ROUTER_ERROR_CODE, HeaderValue::from_static(code));
+        // Preserve the worker's real status when we synthesized our own. Only
+        // the mid-body-drop case has one: the worker sent a status, then dropped
+        // the body, so we report a 502 but don't throw away what it said.
+        if let ApiError::UpstreamStatus { status: upstream } = &self {
+            resp.headers_mut().insert(
+                X_ROUTER_UPSTREAM_STATUS,
+                HeaderValue::from(upstream.as_u16()),
+            );
+        }
         resp
     }
 }
@@ -345,7 +419,10 @@ mod tests {
     }
 
     #[test]
-    fn upstream_status_envelope_has_code() {
+    fn upstream_body_incomplete_preserves_worker_status_in_header() {
+        // Mid-body drop: the worker sent a status (here 500) then dropped the
+        // body. The router synthesizes its own 502, but the worker's real status
+        // is preserved in `x-router-upstream-status` rather than silently lost.
         let err = ApiError::UpstreamStatus {
             status: StatusCode::INTERNAL_SERVER_ERROR,
         };
@@ -355,10 +432,20 @@ mod tests {
             resp.headers()
                 .get("x-router-error-code")
                 .and_then(|v| v.to_str().ok()),
-            Some("upstream_status"),
+            Some("upstream_body_incomplete"),
+        );
+        assert_eq!(
+            resp.headers()
+                .get("x-router-upstream-status")
+                .and_then(|v| v.to_str().ok()),
+            Some("500"),
+            "the worker's real status must be preserved, not discarded",
         );
         let body = collect_body(resp);
-        assert!(body.contains("\"code\":\"upstream_status\""), "{body}");
+        assert!(
+            body.contains("\"code\":\"upstream_body_incomplete\""),
+            "{body}"
+        );
     }
 
     #[test]
@@ -369,7 +456,10 @@ mod tests {
             worker: worker.clone(),
         };
         let resp = err.into_response();
-        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        // A timeout is a gateway timeout (504), not a bad gateway (502): same
+        // class — and same status — as the stale-deadline cancel, so the two
+        // can't drift apart.
+        assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
         assert_eq!(
             resp.headers()
                 .get("x-router-error-code")
@@ -455,5 +545,164 @@ mod tests {
             !body_str.contains(secret_msg),
             "ApiError::Internal must not leak anyhow chain to client; got: {body_str}"
         );
+    }
+
+    /// The three client-facing signals of the router status-code contract:
+    /// the HTTP status, `x-router-error-code`, and `x-router-upstream-status`.
+    fn signals(err: ApiError) -> (StatusCode, Option<String>, Option<String>) {
+        let resp = err.into_response();
+        let status = resp.status();
+        let header = |name: &str| {
+            resp.headers()
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned)
+        };
+        (
+            status,
+            header("x-router-error-code"),
+            header("x-router-upstream-status"),
+        )
+    }
+
+    /// Every router-*originated* condition maps to a fixed (status, error-code)
+    /// pair, and ONLY the mid-body-drop case echoes the worker's real status in
+    /// `x-router-upstream-status`. This pins the router half of the status-code
+    /// contract:
+    ///   * same condition class → same status — both timeouts are 504, so the
+    ///     per-request timeout and the stale-deadline cancel can never diverge
+    ///     to 502-vs-504 the way they used to;
+    ///   * a worker's real status is preserved, never silently rewritten.
+    #[test]
+    fn router_originated_scenarios_match_status_and_headers() {
+        let worker = reqwest::Url::parse("http://host:1/").unwrap();
+        // (label, error, expected status, expected x-router-error-code,
+        //  expected x-router-upstream-status)
+        let cases: Vec<(&str, ApiError, StatusCode, &str, Option<&str>)> = vec![
+            (
+                "mid-body drop preserves worker status",
+                ApiError::UpstreamStatus {
+                    status: StatusCode::OK,
+                },
+                StatusCode::BAD_GATEWAY,
+                "upstream_body_incomplete",
+                Some("200"),
+            ),
+            (
+                "unreachable",
+                ApiError::UpstreamUnreachable {
+                    worker: worker.clone(),
+                    source: anyhow::anyhow!("connect refused"),
+                },
+                StatusCode::BAD_GATEWAY,
+                "upstream_unreachable",
+                None,
+            ),
+            (
+                "request timeout",
+                ApiError::UpstreamTimeout {
+                    worker: worker.clone(),
+                },
+                StatusCode::GATEWAY_TIMEOUT,
+                "upstream_timeout",
+                None,
+            ),
+            (
+                "stale-deadline cancel",
+                ApiError::StaleRequestExpired { model: "m".into() },
+                StatusCode::GATEWAY_TIMEOUT,
+                "stale_request_expired",
+                None,
+            ),
+            (
+                "admission shed",
+                ApiError::ServiceOverloaded { model: "m".into() },
+                StatusCode::SERVICE_UNAVAILABLE,
+                "service_overloaded",
+                None,
+            ),
+            (
+                "no healthy workers",
+                ApiError::NoHealthyWorkers { model: "m".into() },
+                StatusCode::SERVICE_UNAVAILABLE,
+                "no_healthy_workers",
+                None,
+            ),
+            (
+                "bad request",
+                ApiError::BadRequest("bad".into()),
+                StatusCode::BAD_REQUEST,
+                "bad_request",
+                None,
+            ),
+            (
+                "model not found",
+                ApiError::ModelNotFound("ghost".into()),
+                StatusCode::NOT_FOUND,
+                "model_not_found",
+                None,
+            ),
+            (
+                "no prefill workers",
+                ApiError::NoPrefillWorkersAvailable { model: "m".into() },
+                StatusCode::SERVICE_UNAVAILABLE,
+                "no_prefill_workers_available",
+                None,
+            ),
+            (
+                "no decode workers",
+                ApiError::NoDecodeWorkersAvailable { model: "m".into() },
+                StatusCode::SERVICE_UNAVAILABLE,
+                "no_decode_workers_available",
+                None,
+            ),
+            (
+                "policy selection failed",
+                ApiError::PolicySelectionFailed { model: "m".into() },
+                StatusCode::SERVICE_UNAVAILABLE,
+                "policy_selection_failed",
+                None,
+            ),
+            (
+                "breaker open",
+                ApiError::BreakerOpen {
+                    worker: "http://w:1".into(),
+                },
+                StatusCode::SERVICE_UNAVAILABLE,
+                "breaker_open",
+                None,
+            ),
+            (
+                "worker misconfigured",
+                ApiError::WorkerMisconfigured {
+                    worker: "http://w:1".into(),
+                    source: anyhow::anyhow!("unparsable url"),
+                },
+                StatusCode::SERVICE_UNAVAILABLE,
+                "worker_misconfigured",
+                None,
+            ),
+            (
+                "internal",
+                ApiError::Internal(anyhow::anyhow!("boom")),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                None,
+            ),
+        ];
+        for (label, err, want_status, want_code, want_upstream) in cases {
+            let (status, code, upstream) = signals(err);
+            assert_eq!(status, want_status, "status mismatch for `{label}`");
+            assert_eq!(
+                code.as_deref(),
+                Some(want_code),
+                "x-router-error-code mismatch for `{label}`",
+            );
+            assert_eq!(
+                upstream.as_deref(),
+                want_upstream,
+                "x-router-upstream-status mismatch for `{label}`",
+            );
+        }
     }
 }

--- a/experimental/sgl-router/src/server/error.rs
+++ b/experimental/sgl-router/src/server/error.rs
@@ -106,6 +106,13 @@ pub enum ApiError {
         source: anyhow::Error,
     },
 
+    /// Every eligible worker is at its in-flight cap and the admission wait
+    /// queue is full, so the router sheds this request instead of piling more
+    /// onto saturated workers. Surfaced as 503 (retryable) so clients / the
+    /// upstream load balancer back off rather than fail-fast.
+    #[error("service overloaded for model {model}")]
+    ServiceOverloaded { model: String },
+
     #[error("internal: {0}")]
     Internal(#[from] anyhow::Error),
 }
@@ -140,6 +147,9 @@ impl ApiError {
             ApiError::BreakerOpen { .. } => (StatusCode::SERVICE_UNAVAILABLE, "breaker_open"),
             ApiError::WorkerMisconfigured { .. } => {
                 (StatusCode::SERVICE_UNAVAILABLE, "worker_misconfigured")
+            }
+            ApiError::ServiceOverloaded { .. } => {
+                (StatusCode::SERVICE_UNAVAILABLE, "service_overloaded")
             }
             ApiError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal_error"),
         }
@@ -244,6 +254,10 @@ impl IntoResponse for ApiError {
                     "worker URL emitted by discovery is malformed",
                 );
                 "service unavailable".to_string()
+            }
+            ApiError::ServiceOverloaded { model } => {
+                tracing::warn!(model = %model, reason = "service_overloaded", "shedding request: all workers at capacity and wait queue full");
+                "service overloaded".to_string()
             }
             ApiError::BadRequest(_) | ApiError::ModelNotFound(_) => self.to_string(),
         };
@@ -388,6 +402,18 @@ mod tests {
         );
         assert_ne!(env.error.code, "internal_error");
         assert_ne!(env.error.code, "model_not_found");
+    }
+
+    #[test]
+    fn service_overloaded_maps_to_503_with_code() {
+        let err = ApiError::ServiceOverloaded { model: "m".into() };
+        let resp = err.into_response();
+        let (status, code_header, env) = parse_envelope(resp);
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(code_header.as_deref(), Some("service_overloaded"));
+        assert_eq!(env.error.code, "service_overloaded");
+        assert_eq!(env.error.typ, "server_error");
     }
 
     #[test]

--- a/experimental/sgl-router/src/server/error.rs
+++ b/experimental/sgl-router/src/server/error.rs
@@ -225,6 +225,31 @@ impl ApiError {
     pub fn status_code(&self) -> StatusCode {
         self.class().status()
     }
+
+    /// The worker's *own* status to echo in `x-router-upstream-status`, for the
+    /// case where the router synthesized its own status over a worker that did
+    /// respond. Today only the mid-body-drop (`UpstreamStatus`) carries one. This
+    /// is an exhaustive, wildcard-free match (not an `if let` at the call site) so
+    /// a future "synthesized over a responding worker" variant is forced to decide
+    /// whether it echoes a status, rather than silently inheriting `None`.
+    fn upstream_status(&self) -> Option<StatusCode> {
+        match self {
+            ApiError::UpstreamStatus { status } => Some(*status),
+            ApiError::BadRequest(_)
+            | ApiError::ModelNotFound(_)
+            | ApiError::UpstreamUnreachable { .. }
+            | ApiError::UpstreamTimeout { .. }
+            | ApiError::NoHealthyWorkers { .. }
+            | ApiError::NoPrefillWorkersAvailable { .. }
+            | ApiError::NoDecodeWorkersAvailable { .. }
+            | ApiError::StaleRequestExpired { .. }
+            | ApiError::PolicySelectionFailed { .. }
+            | ApiError::BreakerOpen { .. }
+            | ApiError::WorkerMisconfigured { .. }
+            | ApiError::ServiceOverloaded { .. }
+            | ApiError::Internal(_) => None,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -335,10 +360,10 @@ impl IntoResponse for ApiError {
             .into_response();
         resp.headers_mut()
             .insert(X_ROUTER_ERROR_CODE, HeaderValue::from_static(code));
-        // Preserve the worker's real status when we synthesized our own. Only
-        // the mid-body-drop case has one: the worker sent a status, then dropped
-        // the body, so we report a 502 but don't throw away what it said.
-        if let ApiError::UpstreamStatus { status: upstream } = &self {
+        // Preserve the worker's real status when we synthesized our own (today,
+        // only the mid-body-drop case: the worker sent a status, then dropped the
+        // body, so we report a 502 but don't throw away what it said).
+        if let Some(upstream) = self.upstream_status() {
             resp.headers_mut().insert(
                 X_ROUTER_UPSTREAM_STATUS,
                 HeaderValue::from(upstream.as_u16()),

--- a/experimental/sgl-router/src/server/error.rs
+++ b/experimental/sgl-router/src/server/error.rs
@@ -23,11 +23,10 @@ pub const X_ROUTER_UPSTREAM_STATUS: HeaderName =
 /// is a pure function of the class, so two conditions that mean the same thing
 /// — e.g. a per-request timeout and a stale-deadline cancel — can never drift to
 /// different status codes. The *precise* condition travels in
-/// `x-router-error-code` (see [`ApiError::error_code`]); since the router is
-/// always behind a gateway, that header is the authoritative signal the gateway
-/// converts on, and the status is only a self-sufficient HTTP-honest default for
-/// a direct caller. The class never contradicts the precise code — it only
-/// generalizes it.
+/// `x-router-error-code` (see [`ApiError::error_code`]): a gateway in front
+/// converts on that header (the authoritative signal), while the status stays a
+/// self-sufficient HTTP-honest default for a direct caller. The class never
+/// contradicts the precise code — it only generalizes it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ErrorClass {
     /// 400 — request rejected at ingress as malformed / invalid.

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -138,6 +138,34 @@ impl WorkerModeLabel {
     }
 }
 
+/// Routing context a handler attaches to its `Response` (via response
+/// extensions) so the outermost access-log/metrics middleware can record the
+/// per-worker labels it otherwise cannot see. Present on every routed request
+/// (the request reached a worker); absent on requests rejected before routing
+/// (a body-validation 400, an admission 503 shed, model-not-found), which the
+/// middleware records with an empty `worker_url`. Recording in one place — the
+/// middleware — is what makes `requests_total` cover EVERY request, so
+/// `sum by (outcome)` reflects all ingress, not just dispatched traffic.
+#[derive(Debug, Clone)]
+pub struct RequestLogContext {
+    pub worker_url: String,
+    pub model_id: String,
+    pub mode: WorkerModeLabel,
+}
+
+/// Derive the bounded [`RequestOutcome`] label from the client-visible HTTP
+/// status: 2xx is success, 504 is the stale-request cancellation, everything
+/// else (incl. forwarded 4xx/5xx and proxy-side 5xx) is an error. Shared by the
+/// middleware so every request — routed or rejected pre-routing — is labelled
+/// the same way.
+pub fn outcome_from_status(status: u16) -> RequestOutcome {
+    match status {
+        200..=299 => RequestOutcome::Success,
+        504 => RequestOutcome::Cancelled,
+        _ => RequestOutcome::Error,
+    }
+}
+
 /// Decode-affinity outcome — see `select_decode_with_affinity` for the
 /// three reasons the affinity may not be honored.
 #[derive(Debug, Clone, Copy)]

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -641,7 +641,7 @@ impl MetricsRegistry {
         }
         drop(guard);
 
-        // requests_total
+        // worker_requests_total
         out.push_str(
             "# HELP sgl_router_worker_requests_total Total chat-completions requests dispatched to a worker.\n",
         );
@@ -1229,7 +1229,7 @@ mod tests {
     }
 
     #[test]
-    fn record_request_emits_labelled_counter_line() {
+    fn record_worker_request_emits_labelled_counter_line() {
         let reg = MetricsRegistry::new();
         reg.record_worker_request(
             "http://worker-a:30000",

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -18,8 +18,8 @@
 //!
 //! | Metric | Type | Labels |
 //! |---|---|---|
-//! | `sgl_router_intake_total` | Counter | `route`, `method` |
-//! | `sgl_router_requests_total` | Counter | `worker_url`, `model_id`, `mode`, `outcome` |
+//! | `sgl_router_requests_total` | Counter | `route`, `method` |
+//! | `sgl_router_worker_requests_total` | Counter | `worker_url`, `model_id`, `mode`, `outcome` |
 //! | `sgl_router_request_duration_seconds` | Histogram | `model_id` |
 //! | `sgl_router_ttft_seconds` | Histogram | `model_id` |
 //! | `sgl_router_responses_total` | Counter | `route`, `method`, `status_code` |
@@ -145,7 +145,7 @@ impl WorkerModeLabel {
 /// (the request reached a worker); absent on requests rejected before routing
 /// (a body-validation 400, an admission 503 shed, model-not-found), which the
 /// middleware records with an empty `worker_url`. Recording in one place — the
-/// middleware — is what makes `requests_total` cover EVERY request, so
+/// middleware — is what makes `worker_requests_total` cover EVERY request, so
 /// `sum by (outcome)` reflects all ingress, not just dispatched traffic.
 #[derive(Debug, Clone)]
 pub struct RequestLogContext {
@@ -252,17 +252,17 @@ impl ActiveLoadKind {
 pub struct MetricsRegistry {
     // Edge intake, counted at the `access_log_and_record` middleware BEFORE the
     // handler runs, so it includes requests parked/shed/cancelled/dropped before
-    // a response is produced. `intake_total - responses_total` (per route,method)
-    // = received but never answered, which the post-dispatch `requests_total`
+    // a response is produced. `requests_total - responses_total` (per route,method)
+    // = received but never answered, which the post-dispatch `worker_requests_total`
     // cannot see.
-    intake_total: Mutex<HashMap<EdgeKey, Arc<AtomicU64>>>,
+    requests_total: Mutex<HashMap<EdgeKey, Arc<AtomicU64>>>,
     // Per-worker dispatch outcomes. Recorded after a worker is picked, so blind
-    // to pre-dispatch drops (see `intake_total`).
-    requests_total: Mutex<HashMap<RequestKey, Arc<AtomicU64>>>,
+    // to pre-dispatch drops (see `requests_total`).
+    worker_requests_total: Mutex<HashMap<RequestKey, Arc<AtomicU64>>>,
     // Keyed by `model_id` only: a model's pool is either all-plain or all-PD
     // (the registry rejects mixed pools), so the worker `mode` would be a pure
     // function of `model_id` here — a redundant label. Per-worker `mode` lives
-    // on `requests_total` / the worker gauges instead.
+    // on `worker_requests_total` / the worker gauges instead.
     request_duration: Mutex<HashMap<String, Histogram>>,
     ttft_seconds: Mutex<HashMap<String, Histogram>>,
     // Edge responses by route/method/status (incl. early-exit 400/413/503 and the
@@ -292,7 +292,7 @@ struct RequestKey {
     outcome: &'static str,
 }
 
-/// Labels for the edge `intake_total` counter. `route` is the matched route
+/// Labels for the edge `requests_total` counter. `route` is the matched route
 /// template (a small fixed set), not the raw URI, so cardinality stays bounded.
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 struct EdgeKey {
@@ -384,8 +384,8 @@ impl MetricsRegistry {
         Arc::new(Self::default())
     }
 
-    /// Bump `sgl_router_requests_total` for the given worker / model / mode / outcome.
-    pub fn record_request(
+    /// Bump `sgl_router_worker_requests_total` for the given worker / model / mode / outcome.
+    pub fn record_worker_request(
         &self,
         worker_url: &str,
         model_id: &str,
@@ -398,7 +398,7 @@ impl MetricsRegistry {
             mode: mode.as_str(),
             outcome: outcome.as_str(),
         };
-        let mut guard = self.requests_total.lock();
+        let mut guard = self.worker_requests_total.lock();
         let counter = guard
             .entry(key)
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
@@ -455,17 +455,17 @@ impl MetricsRegistry {
         hist.observe(seconds);
     }
 
-    /// Bump `sgl_router_intake_total{route,method}` — true edge intake, counted
+    /// Bump `sgl_router_requests_total{route,method}` — true edge intake, counted
     /// by the `access_log_and_record` middleware BEFORE the handler runs, so a
     /// request that is parked/shed/cancelled/dropped before producing a response
-    /// is still counted. `intake_total - responses_total` is the
+    /// is still counted. `requests_total - responses_total` is the
     /// received-but-not-answered gap.
-    pub fn record_intake(&self, route: &str, method: &str) {
+    pub fn record_ingress(&self, route: &str, method: &str) {
         let key = EdgeKey {
             route: route.to_owned(),
             method: method.to_owned(),
         };
-        let mut guard = self.intake_total.lock();
+        let mut guard = self.requests_total.lock();
         let counter = guard
             .entry(key)
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
@@ -620,12 +620,12 @@ impl MetricsRegistry {
     pub fn render_with_workers(&self, workers: &[WorkerSnapshot]) -> String {
         let mut out = String::new();
 
-        // intake_total — true edge intake (every request, counted before the handler)
+        // requests_total — true edge intake (every request, counted before the handler)
         out.push_str(
-            "# HELP sgl_router_intake_total Requests received at the router HTTP edge, counted before the handler runs (true intake; includes requests dropped/shed/cancelled before a response).\n",
+            "# HELP sgl_router_requests_total Requests received at the router HTTP edge, counted before the handler runs (true intake; includes requests dropped/shed/cancelled before a response).\n",
         );
-        out.push_str("# TYPE sgl_router_intake_total counter\n");
-        let guard = self.intake_total.lock();
+        out.push_str("# TYPE sgl_router_requests_total counter\n");
+        let guard = self.requests_total.lock();
         let mut entries: Vec<(&EdgeKey, u64)> = guard
             .iter()
             .map(|(k, v)| (k, v.load(Ordering::Relaxed)))
@@ -633,7 +633,7 @@ impl MetricsRegistry {
         entries.sort_by(|a, b| (&a.0.route, &a.0.method).cmp(&(&b.0.route, &b.0.method)));
         for (key, value) in entries {
             out.push_str(&format!(
-                "sgl_router_intake_total{{route=\"{}\",method=\"{}\"}} {}\n",
+                "sgl_router_requests_total{{route=\"{}\",method=\"{}\"}} {}\n",
                 escape_label(&key.route),
                 escape_label(&key.method),
                 value,
@@ -643,10 +643,10 @@ impl MetricsRegistry {
 
         // requests_total
         out.push_str(
-            "# HELP sgl_router_requests_total Total chat-completions requests dispatched to a worker.\n",
+            "# HELP sgl_router_worker_requests_total Total chat-completions requests dispatched to a worker.\n",
         );
-        out.push_str("# TYPE sgl_router_requests_total counter\n");
-        let guard = self.requests_total.lock();
+        out.push_str("# TYPE sgl_router_worker_requests_total counter\n");
+        let guard = self.worker_requests_total.lock();
         // Sort for stable output — easier for tests.
         let mut entries: Vec<(&RequestKey, u64)> = guard
             .iter()
@@ -662,7 +662,7 @@ impl MetricsRegistry {
         });
         for (key, value) in entries {
             out.push_str(&format!(
-                "sgl_router_requests_total{{worker_url=\"{}\",model_id=\"{}\",mode=\"{}\",outcome=\"{}\"}} {}\n",
+                "sgl_router_worker_requests_total{{worker_url=\"{}\",model_id=\"{}\",mode=\"{}\",outcome=\"{}\"}} {}\n",
                 escape_label(&key.worker_url),
                 escape_label(&key.model_id),
                 key.mode,
@@ -1011,6 +1011,7 @@ mod tests {
         let out = reg.render();
         // Should at least carry HELP / TYPE for every metric family.
         assert!(out.contains("# TYPE sgl_router_requests_total counter"));
+        assert!(out.contains("# TYPE sgl_router_worker_requests_total counter"));
         assert!(out.contains("# TYPE sgl_router_request_duration_seconds histogram"));
         assert!(out.contains("# TYPE sgl_router_ttft_seconds histogram"));
         assert!(out.contains("# TYPE sgl_router_responses_total counter"));
@@ -1165,15 +1166,16 @@ mod tests {
     }
 
     #[test]
-    fn record_intake_counts_by_route_method() {
+    fn record_ingress_counts_by_route_method() {
         let reg = MetricsRegistry::new();
-        reg.record_intake("/v1/chat/completions", "POST");
-        reg.record_intake("/v1/chat/completions", "POST");
-        reg.record_intake("/v1/models", "GET");
+        reg.record_ingress("/v1/chat/completions", "POST");
+        reg.record_ingress("/v1/chat/completions", "POST");
+        reg.record_ingress("/v1/models", "GET");
         let out = reg.render();
-        assert!(out
-            .contains(r#"sgl_router_intake_total{route="/v1/chat/completions",method="POST"} 2"#));
-        assert!(out.contains(r#"sgl_router_intake_total{route="/v1/models",method="GET"} 1"#));
+        assert!(out.contains(
+            r#"sgl_router_requests_total{route="/v1/chat/completions",method="POST"} 2"#
+        ));
+        assert!(out.contains(r#"sgl_router_requests_total{route="/v1/models",method="GET"} 1"#));
     }
 
     #[test]
@@ -1229,13 +1231,13 @@ mod tests {
     #[test]
     fn record_request_emits_labelled_counter_line() {
         let reg = MetricsRegistry::new();
-        reg.record_request(
+        reg.record_worker_request(
             "http://worker-a:30000",
             "tiny",
             WorkerModeLabel::Prefill,
             RequestOutcome::Success,
         );
-        reg.record_request(
+        reg.record_worker_request(
             "http://worker-a:30000",
             "tiny",
             WorkerModeLabel::Prefill,
@@ -1243,7 +1245,7 @@ mod tests {
         );
         let out = reg.render();
         assert!(
-            out.contains(r#"sgl_router_requests_total{worker_url="http://worker-a:30000",model_id="tiny",mode="prefill",outcome="success"} 2"#),
+            out.contains(r#"sgl_router_worker_requests_total{worker_url="http://worker-a:30000",model_id="tiny",mode="prefill",outcome="success"} 2"#),
             "render did not include the expected counter line; got:\n{out}",
         );
     }
@@ -1404,7 +1406,7 @@ mod tests {
     #[test]
     fn label_values_escape_quotes_and_backslashes() {
         let reg = MetricsRegistry::new();
-        reg.record_request(
+        reg.record_worker_request(
             r#"http://"weird":30000"#,
             r"back\slash",
             WorkerModeLabel::Plain,

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -18,10 +18,11 @@
 //!
 //! | Metric | Type | Labels |
 //! |---|---|---|
+//! | `sgl_router_intake_total` | Counter | `route`, `method` |
 //! | `sgl_router_requests_total` | Counter | `worker_url`, `model_id`, `mode`, `outcome` |
 //! | `sgl_router_request_duration_seconds` | Histogram | `model_id` |
 //! | `sgl_router_ttft_seconds` | Histogram | `model_id` |
-//! | `sgl_router_responses_total` | Counter | `status_code` |
+//! | `sgl_router_responses_total` | Counter | `route`, `method`, `status_code` |
 //! | `sgl_router_overlap_blocks` | Histogram | `model_id` |
 //! | `sgl_router_active_load` | Gauge | `worker_url`, `kind` |
 //! | `sgl_router_workers` | Gauge | `mode` |
@@ -249,6 +250,14 @@ impl ActiveLoadKind {
 /// internal state is `Arc`/`Atomic`/`Mutex`-protected.
 #[derive(Debug, Default)]
 pub struct MetricsRegistry {
+    // Edge intake, counted at the `access_log_and_record` middleware BEFORE the
+    // handler runs, so it includes requests parked/shed/cancelled/dropped before
+    // a response is produced. `intake_total - responses_total` (per route,method)
+    // = received but never answered, which the post-dispatch `requests_total`
+    // cannot see.
+    intake_total: Mutex<HashMap<EdgeKey, Arc<AtomicU64>>>,
+    // Per-worker dispatch outcomes. Recorded after a worker is picked, so blind
+    // to pre-dispatch drops (see `intake_total`).
     requests_total: Mutex<HashMap<RequestKey, Arc<AtomicU64>>>,
     // Keyed by `model_id` only: a model's pool is either all-plain or all-PD
     // (the registry rejects mixed pools), so the worker `mode` would be a pure
@@ -256,7 +265,9 @@ pub struct MetricsRegistry {
     // on `requests_total` / the worker gauges instead.
     request_duration: Mutex<HashMap<String, Histogram>>,
     ttft_seconds: Mutex<HashMap<String, Histogram>>,
-    responses_total: Mutex<HashMap<u16, Arc<AtomicU64>>>,
+    // Edge responses by route/method/status (incl. early-exit 400/413/503 and the
+    // CatchPanicLayer-synthesized 500).
+    responses_total: Mutex<HashMap<EdgeResponseKey, Arc<AtomicU64>>>,
     overlap_blocks: Mutex<HashMap<String, Histogram>>,
     active_load: Mutex<HashMap<ActiveLoadKey, Arc<AtomicI64>>>,
     stale_requests_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
@@ -279,6 +290,23 @@ struct RequestKey {
     model_id: String,
     mode: &'static str,
     outcome: &'static str,
+}
+
+/// Labels for the edge `intake_total` counter. `route` is the matched route
+/// template (a small fixed set), not the raw URI, so cardinality stays bounded.
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+struct EdgeKey {
+    route: String,
+    method: String,
+}
+
+/// Labels for the edge `responses_total` counter: an [`EdgeKey`] plus the final
+/// client-visible HTTP status.
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+struct EdgeResponseKey {
+    route: String,
+    method: String,
+    status_code: u16,
 }
 
 /// Per-worker state sampled from the [`crate::workers::WorkerRegistry`] at
@@ -427,20 +455,43 @@ impl MetricsRegistry {
         hist.observe(seconds);
     }
 
-    /// Bump `sgl_router_responses_total{status_code}` for the HTTP status the
-    /// client ultimately saw. Driven by the `access_log_and_record` middleware,
-    /// so it counts EVERY response across all routes — including error
-    /// short-circuits that never reach a handler's own bookkeeping (an admission
-    /// 503, a body-limit 413). For streaming responses the status is the one sent
-    /// with the headers, so a stream that fails mid-body after a 200 header is
-    /// counted as 200 (the breaker / duration metrics capture mid-stream
-    /// failures). Cardinality is bounded by the small set of status codes the
-    /// router returns (2xx success, 4xx client, 5xx upstream/proxy, 504
-    /// stale-cancel).
-    pub fn record_response(&self, status_code: u16) {
+    /// Bump `sgl_router_intake_total{route,method}` — true edge intake, counted
+    /// by the `access_log_and_record` middleware BEFORE the handler runs, so a
+    /// request that is parked/shed/cancelled/dropped before producing a response
+    /// is still counted. `intake_total - responses_total` is the
+    /// received-but-not-answered gap.
+    pub fn record_intake(&self, route: &str, method: &str) {
+        let key = EdgeKey {
+            route: route.to_owned(),
+            method: method.to_owned(),
+        };
+        let mut guard = self.intake_total.lock();
+        let counter = guard
+            .entry(key)
+            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+            .clone();
+        drop(guard);
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Bump `sgl_router_responses_total{route,method,status_code}` for the HTTP
+    /// status the client ultimately saw. Driven by the `access_log_and_record`
+    /// middleware, so it counts EVERY response across all routes — including
+    /// error short-circuits that never reach a handler's own bookkeeping (an
+    /// admission 503, a body-limit 413). For streaming responses the status is
+    /// the one sent with the headers, so a stream that fails mid-body after a
+    /// 200 header is counted as 200 (the breaker / duration metrics capture
+    /// mid-stream failures). `route` is the matched template, so cardinality
+    /// stays bounded.
+    pub fn record_response(&self, route: &str, method: &str, status_code: u16) {
+        let key = EdgeResponseKey {
+            route: route.to_owned(),
+            method: method.to_owned(),
+            status_code,
+        };
         let mut guard = self.responses_total.lock();
         let counter = guard
-            .entry(status_code)
+            .entry(key)
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .clone();
         drop(guard);
@@ -569,6 +620,27 @@ impl MetricsRegistry {
     pub fn render_with_workers(&self, workers: &[WorkerSnapshot]) -> String {
         let mut out = String::new();
 
+        // intake_total — true edge intake (every request, counted before the handler)
+        out.push_str(
+            "# HELP sgl_router_intake_total Requests received at the router HTTP edge, counted before the handler runs (true intake; includes requests dropped/shed/cancelled before a response).\n",
+        );
+        out.push_str("# TYPE sgl_router_intake_total counter\n");
+        let guard = self.intake_total.lock();
+        let mut entries: Vec<(&EdgeKey, u64)> = guard
+            .iter()
+            .map(|(k, v)| (k, v.load(Ordering::Relaxed)))
+            .collect();
+        entries.sort_by(|a, b| (&a.0.route, &a.0.method).cmp(&(&b.0.route, &b.0.method)));
+        for (key, value) in entries {
+            out.push_str(&format!(
+                "sgl_router_intake_total{{route=\"{}\",method=\"{}\"}} {}\n",
+                escape_label(&key.route),
+                escape_label(&key.method),
+                value,
+            ));
+        }
+        drop(guard);
+
         // requests_total
         out.push_str(
             "# HELP sgl_router_requests_total Total chat-completions requests dispatched to a worker.\n",
@@ -635,21 +707,30 @@ impl MetricsRegistry {
         }
         drop(guard);
 
-        // responses_total
+        // responses_total — edge, by route/method/status (incl. early-exit 400/413/503)
         out.push_str(
-            "# HELP sgl_router_responses_total HTTP responses returned to clients across all routes, by status code (recorded at response-headers time, so a mid-stream failure after a 200 header counts as 200).\n",
+            "# HELP sgl_router_responses_total HTTP responses returned at the router edge, by route, method and status code (recorded at response-headers time, so a mid-stream failure after a 200 header counts as 200).\n",
         );
         out.push_str("# TYPE sgl_router_responses_total counter\n");
         let guard = self.responses_total.lock();
-        let mut entries: Vec<(u16, u64)> = guard
+        let mut entries: Vec<(&EdgeResponseKey, u64)> = guard
             .iter()
-            .map(|(k, v)| (*k, v.load(Ordering::Relaxed)))
+            .map(|(k, v)| (k, v.load(Ordering::Relaxed)))
             .collect();
-        entries.sort_by_key(|e| e.0);
-        for (status_code, value) in entries {
+        entries.sort_by(|a, b| {
+            (&a.0.route, &a.0.method, a.0.status_code).cmp(&(
+                &b.0.route,
+                &b.0.method,
+                b.0.status_code,
+            ))
+        });
+        for (key, value) in entries {
             out.push_str(&format!(
-                "sgl_router_responses_total{{status_code=\"{}\"}} {}\n",
-                status_code, value,
+                "sgl_router_responses_total{{route=\"{}\",method=\"{}\",status_code=\"{}\"}} {}\n",
+                escape_label(&key.route),
+                escape_label(&key.method),
+                key.status_code,
+                value,
             ));
         }
         drop(guard);
@@ -1065,16 +1146,34 @@ mod tests {
     }
 
     #[test]
-    fn record_response_counts_by_status_code() {
+    fn record_response_counts_by_route_method_status_code() {
         let reg = MetricsRegistry::new();
-        reg.record_response(200);
-        reg.record_response(200);
-        reg.record_response(502);
-        reg.record_response(504);
+        reg.record_response("/v1/chat/completions", "POST", 200);
+        reg.record_response("/v1/chat/completions", "POST", 200);
+        reg.record_response("/v1/chat/completions", "POST", 502);
+        reg.record_response("/v1/models", "GET", 200);
         let out = reg.render();
-        assert!(out.contains(r#"sgl_router_responses_total{status_code="200"} 2"#));
-        assert!(out.contains(r#"sgl_router_responses_total{status_code="502"} 1"#));
-        assert!(out.contains(r#"sgl_router_responses_total{status_code="504"} 1"#));
+        assert!(out.contains(
+            r#"sgl_router_responses_total{route="/v1/chat/completions",method="POST",status_code="200"} 2"#
+        ));
+        assert!(out.contains(
+            r#"sgl_router_responses_total{route="/v1/chat/completions",method="POST",status_code="502"} 1"#
+        ));
+        assert!(out.contains(
+            r#"sgl_router_responses_total{route="/v1/models",method="GET",status_code="200"} 1"#
+        ));
+    }
+
+    #[test]
+    fn record_intake_counts_by_route_method() {
+        let reg = MetricsRegistry::new();
+        reg.record_intake("/v1/chat/completions", "POST");
+        reg.record_intake("/v1/chat/completions", "POST");
+        reg.record_intake("/v1/models", "GET");
+        let out = reg.render();
+        assert!(out
+            .contains(r#"sgl_router_intake_total{route="/v1/chat/completions",method="POST"} 2"#));
+        assert!(out.contains(r#"sgl_router_intake_total{route="/v1/models",method="GET"} 1"#));
     }
 
     #[test]

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -158,6 +158,11 @@ pub struct RequestLogContext {
 /// else (incl. forwarded 4xx/5xx and proxy-side 5xx) is an error. Shared by the
 /// middleware so every request — routed or rejected pre-routing — is labelled
 /// the same way.
+///
+/// The 504→`Cancelled` mapping conflates the router's own stale-request cancel
+/// with a genuine upstream 504 forwarded unchanged; the unambiguous signal for a
+/// real stale-cancel is `stale_requests_total{outcome="expired"}`, which only
+/// the janitor increments.
 pub fn outcome_from_status(status: u16) -> RequestOutcome {
     match status {
         200..=299 => RequestOutcome::Success,
@@ -423,7 +428,7 @@ impl MetricsRegistry {
     }
 
     /// Bump `sgl_router_responses_total{status_code}` for the HTTP status the
-    /// client ultimately saw. Driven by the `record_response_status` middleware,
+    /// client ultimately saw. Driven by the `access_log_and_record` middleware,
     /// so it counts EVERY response across all routes — including error
     /// short-circuits that never reach a handler's own bookkeeping (an admission
     /// 503, a body-limit 413). For streaming responses the status is the one sent

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -395,9 +395,15 @@ impl MetricsRegistry {
     }
 
     /// Bump `sgl_router_responses_total{status_code}` for the HTTP status the
-    /// client ultimately saw. Cardinality is bounded by the small set of
-    /// status codes the router returns (2xx success, 4xx client, 5xx
-    /// upstream/proxy, 504 stale-cancel).
+    /// client ultimately saw. Driven by the `record_response_status` middleware,
+    /// so it counts EVERY response across all routes — including error
+    /// short-circuits that never reach a handler's own bookkeeping (an admission
+    /// 503, a body-limit 413). For streaming responses the status is the one sent
+    /// with the headers, so a stream that fails mid-body after a 200 header is
+    /// counted as 200 (the breaker / duration metrics capture mid-stream
+    /// failures). Cardinality is bounded by the small set of status codes the
+    /// router returns (2xx success, 4xx client, 5xx upstream/proxy, 504
+    /// stale-cancel).
     pub fn record_response(&self, status_code: u16) {
         let mut guard = self.responses_total.lock();
         let counter = guard
@@ -598,7 +604,7 @@ impl MetricsRegistry {
 
         // responses_total
         out.push_str(
-            "# HELP sgl_router_responses_total Chat-completions responses returned to clients, by HTTP status code (recorded after worker dispatch).\n",
+            "# HELP sgl_router_responses_total HTTP responses returned to clients across all routes, by status code (recorded at response-headers time, so a mid-stream failure after a 200 header counts as 200).\n",
         );
         out.push_str("# TYPE sgl_router_responses_total counter\n");
         let guard = self.responses_total.lock();

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -32,6 +32,9 @@
 //! | `sgl_router_decode_affinity_total` | Counter | `outcome` |
 //! | `sgl_router_sticky_total` | Counter | `outcome` |
 //! | `sgl_router_ingress_tokenize_errors_total` | Counter | `model_id` |
+//! | `sgl_router_backpressure_rejected_total` | Counter | `model_id` |
+//! | `sgl_router_queued_requests` | Gauge | (none) |
+//! | `sgl_router_admission_wait_seconds` | Histogram | `model_id` |
 //!
 //! The four `sgl_router_worker*` gauges and `sgl_router_workers` are sampled
 //! at scrape time from the live [`crate::workers::WorkerRegistry`] (passed to
@@ -85,6 +88,16 @@ const TTFT_BUCKETS: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, // router-only sub-100 ms head
     0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 20.0, 40.0, 60.0, 80.0, 100.0, 200.0,
     400.0,
+];
+
+/// Histogram bucket upper bounds (seconds) for
+/// `sgl_router_admission_wait_seconds` — time a request spends parked in the
+/// admission wait queue. Extends the standard latency ladder out to 120 s: the
+/// wait queue can park for a long time under sustained saturation, and the
+/// request-duration ladder (capped at 30 s) would dump those into `+Inf`,
+/// hiding them from `histogram_quantile`.
+const ADMISSION_WAIT_BUCKETS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0,
 ];
 
 /// Recordable outcome for a request — narrowed to a handful of variants so
@@ -217,6 +230,14 @@ pub struct MetricsRegistry {
     decode_affinity_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     sticky_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     ingress_tokenize_errors_total: Mutex<HashMap<String, Arc<AtomicU64>>>,
+    backpressure_rejected_total: Mutex<HashMap<String, Arc<AtomicU64>>>,
+    /// Current admission wait-queue depth (parked requests). A single
+    /// router-wide gauge — the queue is shared across the router, so this is a
+    /// global count, not per-model.
+    queued_requests: AtomicI64,
+    /// Time a parked request waited before admission (seconds), per model.
+    /// Only parked-then-admitted requests are recorded.
+    admission_wait_seconds: Mutex<HashMap<String, Histogram>>,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
@@ -455,6 +476,43 @@ impl MetricsRegistry {
             .clone();
         drop(guard);
         counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Bump `sgl_router_backpressure_rejected_total{model_id}` — a request the
+    /// admission gate shed with 503 because every worker was at its in-flight
+    /// cap and the wait queue was full.
+    pub fn record_backpressure_rejected(&self, model_id: &str) {
+        let mut guard = self.backpressure_rejected_total.lock();
+        let counter = guard
+            .entry(model_id.to_owned())
+            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+            .clone();
+        drop(guard);
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Adjust `sgl_router_queued_requests` by `delta` (+1 when a request parks,
+    /// -1 when it leaves the wait queue). The gauge atomic is the source of
+    /// truth: applying balanced deltas keeps it exact under concurrency and
+    /// converges to 0 at idle, unlike storing a separately-computed depth
+    /// (which can publish a stale value when two parks/unparks interleave).
+    pub fn add_queued_requests(&self, delta: i64) {
+        self.queued_requests.fetch_add(delta, Ordering::Relaxed);
+    }
+
+    /// Observe the time (seconds) a request spent parked in the admission wait
+    /// queue before being admitted, for `sgl_router_admission_wait_seconds`.
+    /// Recorded only for parked-then-admitted requests, so the histogram's
+    /// `_count` is the number of requests that had to wait at all.
+    pub fn observe_admission_wait(&self, model_id: &str, seconds: f64) {
+        if !seconds.is_finite() {
+            return;
+        }
+        let mut guard = self.admission_wait_seconds.lock();
+        let hist = guard
+            .entry(model_id.to_owned())
+            .or_insert_with(|| Histogram::new(ADMISSION_WAIT_BUCKETS));
+        hist.observe(seconds);
     }
 
     /// Render the registry as a Prometheus 0.0.4 exposition-format string
@@ -727,6 +785,56 @@ impl MetricsRegistry {
                 escape_label(model_id),
                 value,
             ));
+        }
+        drop(guard);
+
+        // backpressure_rejected_total
+        out.push_str(
+            "# HELP sgl_router_backpressure_rejected_total Requests rejected with 503 because every worker was at its in-flight cap and the admission wait queue was full.\n",
+        );
+        out.push_str("# TYPE sgl_router_backpressure_rejected_total counter\n");
+        let guard = self.backpressure_rejected_total.lock();
+        let mut entries: Vec<(&String, u64)> = guard
+            .iter()
+            .map(|(k, v)| (k, v.load(Ordering::Relaxed)))
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(b.0));
+        for (model_id, value) in entries {
+            out.push_str(&format!(
+                "sgl_router_backpressure_rejected_total{{model_id=\"{}\"}} {}\n",
+                escape_label(model_id),
+                value,
+            ));
+        }
+        drop(guard);
+
+        // queued_requests (router-wide gauge, no labels)
+        out.push_str(
+            "# HELP sgl_router_queued_requests Requests currently parked in the admission wait queue (router-wide).\n",
+        );
+        out.push_str("# TYPE sgl_router_queued_requests gauge\n");
+        out.push_str(&format!(
+            "sgl_router_queued_requests {}\n",
+            self.queued_requests.load(Ordering::Relaxed),
+        ));
+
+        // admission_wait_seconds histogram
+        out.push_str(
+            "# HELP sgl_router_admission_wait_seconds Time a request spent parked in the admission wait queue before admission, in seconds.\n",
+        );
+        out.push_str("# TYPE sgl_router_admission_wait_seconds histogram\n");
+        let guard = self.admission_wait_seconds.lock();
+        let mut models: Vec<&String> = guard.keys().collect();
+        models.sort();
+        for model_id in models {
+            let hist = guard.get(model_id).unwrap();
+            let label_body = format!("model_id=\"{}\"", escape_label(model_id));
+            render_histogram(
+                &mut out,
+                "sgl_router_admission_wait_seconds",
+                &label_body,
+                hist,
+            );
         }
         drop(guard);
 
@@ -1076,6 +1184,53 @@ mod tests {
         assert!(out.contains(r#"sgl_router_sticky_total{outcome="assigned"} 1"#));
         assert!(out.contains(r#"sgl_router_sticky_total{outcome="remap"} 1"#));
         assert!(out.contains(r#"sgl_router_sticky_total{outcome="no_routing_key"} 1"#));
+    }
+
+    #[test]
+    fn backpressure_rejected_counter_increments_per_model() {
+        let reg = MetricsRegistry::new();
+        reg.record_backpressure_rejected("tiny");
+        reg.record_backpressure_rejected("tiny");
+        reg.record_backpressure_rejected("other");
+        let out = reg.render();
+        assert!(
+            out.contains(r#"sgl_router_backpressure_rejected_total{model_id="tiny"} 2"#),
+            "{out}",
+        );
+        assert!(
+            out.contains(r#"sgl_router_backpressure_rejected_total{model_id="other"} 1"#),
+            "{out}",
+        );
+    }
+
+    #[test]
+    fn queued_requests_gauge_tracks_balanced_deltas() {
+        let reg = MetricsRegistry::new();
+        reg.add_queued_requests(1);
+        reg.add_queued_requests(1);
+        reg.add_queued_requests(-1);
+        let out = reg.render();
+        assert!(
+            out.contains("# TYPE sgl_router_queued_requests gauge"),
+            "{out}"
+        );
+        assert!(out.contains("sgl_router_queued_requests 1\n"), "{out}");
+    }
+
+    #[test]
+    fn admission_wait_histogram_writes_buckets_sum_and_count() {
+        let reg = MetricsRegistry::new();
+        reg.observe_admission_wait("tiny", 0.3);
+        reg.observe_admission_wait("tiny", 1.5);
+        let out = reg.render();
+        assert!(
+            out.contains("# TYPE sgl_router_admission_wait_seconds histogram"),
+            "{out}"
+        );
+        assert!(
+            out.contains(r#"sgl_router_admission_wait_seconds_count{model_id="tiny"} 2"#),
+            "{out}",
+        );
     }
 
     #[test]

--- a/experimental/sgl-router/src/server/mod.rs
+++ b/experimental/sgl-router/src/server/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod admission;
 pub mod app;
 pub mod app_context;
 pub mod error;

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -562,30 +562,6 @@ async fn chat_completions_inner(
         }
     };
 
-    // Record the dispatch outcome AFTER we know whether the upstream
-    // accepted the request. A 504 from the stale-request branch counts as
-    // `cancelled` — semantically distinct from upstream errors that bubble
-    // through as `error`. The metric is per-worker so convergence tests
-    // can scrape `/metrics` and assert that ≥N requests landed on a
-    // single prefill worker.
-    let outcome = match &result {
-        Ok(_) => RequestOutcome::Success,
-        Err(ApiError::StaleRequestExpired { .. }) => {
-            // The janitor fired the stale-cancel and we observed it
-            // user-side; record both the per-request `cancelled` outcome
-            // AND the global `expired` count. The two views are useful for
-            // different alerts: per-worker request_total{cancelled} flags a
-            // worker that's hanging, while stale_requests_total{expired}
-            // tracks the global health of the janitor.
-            ctx.metrics
-                .record_stale_request(StaleRequestOutcome::Expired);
-            RequestOutcome::Cancelled
-        }
-        Err(_) => RequestOutcome::Error,
-    };
-    ctx.metrics
-        .record_request(&metrics_worker_url, &metrics_model, metrics_mode, outcome);
-
     // Per-request access log — always on at INFO so incoming traffic and its
     // status are visible without DEBUG. `request_id` is the client/gateway
     // X-Request-Id (echoed end-to-end); `worker` is the engine the policy
@@ -599,6 +575,34 @@ async fn chat_completions_inner(
         Ok(resp) => resp.status().as_u16(),
         Err(e) => e.status_code().as_u16(),
     };
+
+    // Record the dispatch outcome AFTER we know the client-visible status.
+    // Derive `outcome` from the final HTTP status, NOT from `Result::Ok`/`Err`:
+    // a response the router FORWARDS from a worker with a 4xx/5xx status is an
+    // `Ok(Response)` here (only transport failures bubble up as `Err`), so
+    // keying off `Ok` would mislabel a forwarded engine error as a success.
+    //   * 2xx        → success
+    //   * 504        → cancelled (the stale-request branch; see below)
+    //   * everything → error (incl. forwarded 4xx/5xx and proxy-side 5xx)
+    // The metric is per-worker so convergence tests can scrape `/metrics` and
+    // assert that ≥N requests landed on a single prefill worker.
+    if matches!(&result, Err(ApiError::StaleRequestExpired { .. })) {
+        // The janitor fired the stale-cancel and we observed it user-side
+        // (surfaced as a 504). Record the global `expired` count in addition
+        // to the per-request `cancelled` outcome below. The two views are
+        // useful for different alerts: per-worker request_total{cancelled}
+        // flags a worker that's hanging, while stale_requests_total{expired}
+        // tracks the global health of the janitor.
+        ctx.metrics
+            .record_stale_request(StaleRequestOutcome::Expired);
+    }
+    let outcome = match http_status {
+        200..=299 => RequestOutcome::Success,
+        504 => RequestOutcome::Cancelled,
+        _ => RequestOutcome::Error,
+    };
+    ctx.metrics
+        .record_request(&metrics_worker_url, &metrics_model, metrics_mode, outcome);
 
     // Record end-to-end latency now that the outcome is known. For non-streaming
     // requests the body is already buffered here, so `start.elapsed()` is true

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -18,7 +18,14 @@ use bytes::Bytes;
 use serde::de::IgnoredAny;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+
+/// Sampling counter for the diagnostic `phase_*` timing logs below. Logs roughly
+/// 1-in-`PHASE_LOG_SAMPLE` requests so a steady flood doesn't drown the access
+/// log while still yielding a representative latency-phase breakdown.
+static PHASE_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
+const PHASE_LOG_SAMPLE: u64 = 64;
 
 /// Observability header carrying the decode-pool URL selected via host
 /// affinity for a PD-disaggregated request. The router fans the
@@ -173,6 +180,7 @@ async fn chat_completions_inner(
     // body. When parsed, this single value is reused for the routing
     // tokenization and the outgoing-body injection below (and PD bootstrap
     // injection). `parse_probe` already validated the object shape.
+    let at_pre_tokenize = start.elapsed();
     let want_tokens = ctx.tokenizers.has_chat_encoder(&model_str) || policy.needs_request_tokens();
     let request_value: Option<serde_json::Value> = if want_tokens {
         Some(serde_json::from_slice(&body).map_err(|_| {
@@ -190,6 +198,20 @@ async fn chat_completions_inner(
     let request_tokens = request_value
         .as_ref()
         .and_then(|v| request_tokens_for(&ctx.tokenizers, &model_id, v));
+    let at_post_tokenize = start.elapsed();
+    // Diagnostic: ingress-tokenize cost, sampled. Fires for EVERY request that
+    // reaches here — including those about to be shed at admission below — so a
+    // shed request's pre-admission time (the latency the access log shows on a
+    // 503) is attributable to tokenize vs. the rest.
+    if PHASE_LOG_COUNTER.fetch_add(1, Ordering::Relaxed) % PHASE_LOG_SAMPLE == 0 {
+        tracing::info!(
+            tokenize_ms = at_post_tokenize.saturating_sub(at_pre_tokenize).as_millis() as u64,
+            pre_admit_total_ms = at_post_tokenize.as_millis() as u64,
+            want_tokens,
+            model = %model_str,
+            "phase_pre_admit",
+        );
+    }
 
     // Sticky-session routing key. When the sticky policy is configured,
     // read the routing key from the operator-chosen header into the
@@ -213,6 +235,7 @@ async fn chat_completions_inner(
         .admission
         .acquire(&workers, policy.as_ref(), &selection_ctx, &model_str)
         .await?;
+    let at_post_admit = start.elapsed();
 
     // PD-mode decoder affinity. When the selected prefill worker is
     // part of a PD-disagg deployment, also resolve the matching decode
@@ -384,6 +407,7 @@ async fn chat_completions_inner(
     // untouched when neither applies.
     let outgoing_body =
         build_outgoing_body(&body, request_value, forward_input_ids, bootstrap.as_ref())?;
+    let at_post_build = start.elapsed();
 
     let result = if let Some(decode_worker) = decode_peer {
         // PD-disagg dispatch (Pattern B — spawn prefill, await decode).
@@ -547,6 +571,26 @@ async fn chat_completions_inner(
             _ = stale_token.cancelled() => Err(ApiError::StaleRequestExpired { model: model_str }),
         }
     };
+
+    // Diagnostic: phase breakdown up to response headers, for ADMITTED requests
+    // (those that got a slot). `dispatch_to_headers_ms` is connect + send-body +
+    // wait-for-upstream-headers; for streaming this is the whole synchronous cost
+    // before the SSE pump takes over. The pump's own first-byte/drain/exit timing
+    // is logged separately as `sse_pump_timing`.
+    let at_post_dispatch = start.elapsed();
+    if PHASE_LOG_COUNTER.fetch_add(1, Ordering::Relaxed) % PHASE_LOG_SAMPLE == 0 {
+        tracing::info!(
+            tokenize_ms = at_post_tokenize.saturating_sub(at_pre_tokenize).as_millis() as u64,
+            admit_ms = at_post_admit.saturating_sub(at_post_tokenize).as_millis() as u64,
+            build_ms = at_post_build.saturating_sub(at_post_admit).as_millis() as u64,
+            dispatch_to_headers_ms = at_post_dispatch.saturating_sub(at_post_build).as_millis() as u64,
+            to_headers_total_ms = at_post_dispatch.as_millis() as u64,
+            streaming,
+            worker = %metrics_worker_url,
+            model = %metrics_model,
+            "phase_dispatch",
+        );
+    }
 
     // The stale-request janitor fired and we observed it user-side (a 504).
     // Record the global `expired` count; the per-request `cancelled` outcome and

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -236,6 +236,11 @@ async fn chat_completions_inner(
         .acquire(&workers, policy.as_ref(), &selection_ctx, &model_str)
         .await?;
     let at_post_admit = start.elapsed();
+    // Diagnostic: count this request as holding a slot inside the synchronous
+    // handler (post-acquire → response returned). Drops when the function
+    // returns (headers time for streaming), so HANDLER_INFLIGHT reflects slots
+    // stuck before the SSE pump takes over.
+    let _handler_phase = crate::diag::PhaseGuard::handler();
 
     // PD-mode decoder affinity. When the selected prefill worker is
     // part of a PD-disagg deployment, also resolve the matching decode
@@ -579,12 +584,17 @@ async fn chat_completions_inner(
     // is logged separately as `sse_pump_timing`.
     let at_post_dispatch = start.elapsed();
     if PHASE_LOG_COUNTER.fetch_add(1, Ordering::Relaxed) % PHASE_LOG_SAMPLE == 0 {
+        let (handler_inflight, in_send, pump_inflight) = crate::diag::snapshot();
         tracing::info!(
             tokenize_ms = at_post_tokenize.saturating_sub(at_pre_tokenize).as_millis() as u64,
             admit_ms = at_post_admit.saturating_sub(at_post_tokenize).as_millis() as u64,
             build_ms = at_post_build.saturating_sub(at_post_admit).as_millis() as u64,
             dispatch_to_headers_ms = at_post_dispatch.saturating_sub(at_post_build).as_millis() as u64,
             to_headers_total_ms = at_post_dispatch.as_millis() as u64,
+            // process-wide phase gauges: where do held admission slots sit?
+            g_handler_inflight = handler_inflight,
+            g_in_send = in_send,
+            g_pump_inflight = pump_inflight,
             streaming,
             worker = %metrics_worker_url,
             model = %metrics_model,

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -7,7 +7,7 @@ use crate::policies::{request_tokens_for, RequestTokens, SelectionContext};
 use crate::server::app_context::AppContext;
 use crate::server::error::ApiError;
 use crate::server::metrics::{
-    MetricsRegistry, RequestOutcome, StaleRequestOutcome, WorkerModeLabel,
+    MetricsRegistry, RequestLogContext, StaleRequestOutcome, WorkerModeLabel,
 };
 use crate::workers::Worker;
 use axum::body::Body;
@@ -90,39 +90,21 @@ impl Drop for RecordDurationOnDrop {
     }
 }
 
-/// POST /v1/chat/completions handler. Thin wrapper over
-/// [`chat_completions_inner`] that surfaces early-error outcomes in the access
-/// log: a body-validation 400, an admission 503, a model-not-found, etc. return
-/// via `?` before the inner handler reaches its per-request access log, so
-/// without this they would be absent from the access log (visible only in the
-/// response-code metric, and for some variants a per-variant warning). The inner
-/// handler logs the success and post-dispatch outcomes — and returns its
-/// post-dispatch errors as a response rather than `Err`, so the wrapper logs
-/// each request exactly once (only the early `?` short-circuits land here).
+/// POST /v1/chat/completions handler. Thin delegator to
+/// [`chat_completions_inner`]. Per-request logging and `requests_total` /
+/// `responses_total` counting happen once, centrally, in the outermost
+/// `access_log_and_record` middleware (see [`crate::server::app`]) — including
+/// the early `?` short-circuits this returns as `Err` (a body-validation 400,
+/// an admission 503 shed, model-not-found), which the middleware records as a
+/// pre-routing rejection. Routed requests carry a
+/// [`RequestLogContext`](crate::server::metrics::RequestLogContext) so the
+/// middleware can attach their per-worker labels.
 pub async fn chat_completions(
     State(ctx): State<Arc<AppContext>>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response<Body>, ApiError> {
-    let start = std::time::Instant::now();
-    let request_id = headers
-        .get("x-request-id")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("-")
-        .to_string();
-    let result = chat_completions_inner(ctx, headers, body).await;
-    if let Err(e) = &result {
-        tracing::info!(
-            request_id = %request_id,
-            method = "POST",
-            path = "/v1/chat/completions",
-            outcome = "error",
-            http_status = e.status_code().as_u16(),
-            latency_ms = start.elapsed().as_millis() as u64,
-            "chat_completions",
-        );
-    }
-    result
+    chat_completions_inner(ctx, headers, body).await
 }
 
 /// Parse model from body, select a healthy worker via the per-model policy, then
@@ -562,79 +544,34 @@ async fn chat_completions_inner(
         }
     };
 
-    // Per-request access log — always on at INFO so incoming traffic and its
-    // status are visible without DEBUG. `request_id` is the client/gateway
-    // X-Request-Id (echoed end-to-end); `worker` is the engine the policy
-    // selected. The cache-aware routing rationale is logged separately at
-    // DEBUG by the policy.
-    let request_id = headers
-        .get("x-request-id")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("-");
-    let http_status = match &result {
-        Ok(resp) => resp.status().as_u16(),
-        Err(e) => e.status_code().as_u16(),
-    };
-
-    // Record the dispatch outcome AFTER we know the client-visible status.
-    // Derive `outcome` from the final HTTP status, NOT from `Result::Ok`/`Err`:
-    // a response the router FORWARDS from a worker with a 4xx/5xx status is an
-    // `Ok(Response)` here (only transport failures bubble up as `Err`), so
-    // keying off `Ok` would mislabel a forwarded engine error as a success.
-    //   * 2xx        → success
-    //   * 504        → cancelled (the stale-request branch; see below)
-    //   * everything → error (incl. forwarded 4xx/5xx and proxy-side 5xx)
-    // The metric is per-worker so convergence tests can scrape `/metrics` and
-    // assert that ≥N requests landed on a single prefill worker.
+    // The stale-request janitor fired and we observed it user-side (a 504).
+    // Record the global `expired` count; the per-request `cancelled` outcome and
+    // the access-log line are emitted centrally by the `access_log_and_record`
+    // middleware, derived from the final HTTP status.
     if matches!(&result, Err(ApiError::StaleRequestExpired { .. })) {
-        // The janitor fired the stale-cancel and we observed it user-side
-        // (surfaced as a 504). Record the global `expired` count in addition
-        // to the per-request `cancelled` outcome below. The two views are
-        // useful for different alerts: per-worker request_total{cancelled}
-        // flags a worker that's hanging, while stale_requests_total{expired}
-        // tracks the global health of the janitor.
         ctx.metrics
             .record_stale_request(StaleRequestOutcome::Expired);
     }
-    let outcome = match http_status {
-        200..=299 => RequestOutcome::Success,
-        504 => RequestOutcome::Cancelled,
-        _ => RequestOutcome::Error,
-    };
-    ctx.metrics
-        .record_request(&metrics_worker_url, &metrics_model, metrics_mode, outcome);
 
-    // Record end-to-end latency now that the outcome is known. For non-streaming
-    // requests the body is already buffered here, so `start.elapsed()` is true
-    // end-to-end latency — record it directly. For streaming, the body is still
-    // pending; the `RecordDurationOnDrop` guard packed into `stream_guards`
-    // records it at stream completion instead (so we don't capture only
-    // time-to-headers). `elapsed` still feeds the access-log `latency_ms` below
-    // for both. The client-visible HTTP status is counted centrally by the
-    // `record_response_status` middleware (so error short-circuits are counted
-    // too), not here.
-    let elapsed = start.elapsed();
+    // End-to-end latency for non-streaming requests: the body is already
+    // buffered here, so `start.elapsed()` is the true total. Streaming records
+    // at stream completion via the `RecordDurationOnDrop` guard packed into
+    // `stream_guards` (so it isn't just time-to-headers).
     if !streaming {
         ctx.metrics
-            .observe_request_duration(&metrics_model, elapsed.as_secs_f64());
+            .observe_request_duration(&metrics_model, start.elapsed().as_secs_f64());
     }
-    let outcome_str = match outcome {
-        RequestOutcome::Success => "success",
-        RequestOutcome::Error => "error",
-        RequestOutcome::Cancelled => "cancelled",
+
+    // Routing context for the outermost middleware: it records
+    // `requests_total{worker_url,model_id,mode,outcome}` and the access-log line
+    // for this request. Attaching it here (rather than recording directly) keeps
+    // all request accounting at one site that also covers pre-routing
+    // rejections, so the by-outcome view reflects ALL ingress.
+    let log_ctx = RequestLogContext {
+        worker_url: metrics_worker_url,
+        model_id: metrics_model,
+        mode: metrics_mode,
     };
-    tracing::info!(
-        request_id = %request_id,
-        method = "POST",
-        path = "/v1/chat/completions",
-        model = %metrics_model,
-        worker = %metrics_worker_url,
-        outcome = outcome_str,
-        http_status,
-        stream = streaming,
-        latency_ms = elapsed.as_millis() as u64,
-        "chat_completions",
-    );
 
     // Mirror the upstream `x-sgl-decode-url` hint onto the response so
     // external tests / sidecars can observe PD decode affinity without
@@ -644,7 +581,7 @@ async fn chat_completions_inner(
     // resolved). A malformed URL was already rejected at the
     // request-side parse — we only reach this branch when the URL was
     // header-valid, so the second parse is safe.
-    match (result, decode_hint_url) {
+    let mut response = match (result, decode_hint_url) {
         (Ok(mut response), Some(url)) => {
             match HeaderValue::from_str(&url) {
                 Ok(v) => {
@@ -659,15 +596,19 @@ async fn chat_completions_inner(
                     );
                 }
             }
-            Ok(response)
+            response
         }
-        (Ok(response), None) => Ok(response),
-        // Post-dispatch errors were already logged with full fields by the
-        // access-log call above; return them as a response (not `Err`) so the
-        // `chat_completions` wrapper does not log them a second time. The wrapper
-        // logs only the early `?` short-circuits, which never reached that log.
-        (Err(e), _) => Ok(e.into_response()),
-    }
+        (Ok(response), None) => response,
+        // Post-dispatch error (a worker was selected). Materialize it so it can
+        // be tagged with the routing context for the middleware, instead of
+        // returning `Err` — early `?` short-circuits return `Err` and the
+        // middleware records those as pre-routing rejections (empty worker_url).
+        (Err(e), _) => e.into_response(),
+    };
+    // Tag the routed response so the middleware records its per-worker labels
+    // and logs it with the worker/model it was dispatched to.
+    response.extensions_mut().insert(log_ctx);
+    Ok(response)
 }
 
 /// Estimate prefill-token count from the raw request body for use as
@@ -1314,13 +1255,19 @@ mod tests {
         }
     }
 
-    /// Early-error short-circuits (e.g. a malformed body → 400) must still be
-    /// surfaced in the `chat_completions` access log. Before the fix they
-    /// returned via `?` ahead of the in-handler log and were invisible in the
-    /// logs (only countable via the response-code metric).
+    /// A request rejected BEFORE routing — here a body that is valid JSON but not
+    /// an object, which `parse_probe` 400s before any worker is selected — must
+    /// still be (a) logged by the outermost access-log middleware and (b) counted
+    /// in `requests_total`. Both happen in `access_log_and_record`, NOT the
+    /// handler (which returns the 400 via `?`), so this drives the request
+    /// through `build_router` to exercise that middleware. Before request
+    /// accounting moved to the middleware, pre-routing rejections were invisible
+    /// to `requests_total` (so `sum by (outcome)` undercounted) and absent from
+    /// the access log.
     #[tokio::test]
-    async fn early_error_400_is_surfaced_in_access_log() {
+    async fn pre_routing_400_is_logged_and_counted() {
         use std::sync::Mutex;
+        use tower::ServiceExt;
         use tracing_subscriber::fmt::MakeWriter;
 
         #[derive(Clone)]
@@ -1348,24 +1295,36 @@ mod tests {
             .finish();
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        // Valid JSON but not an object → `parse_probe` rejects with 400, an early
-        // `?` return that bypasses the in-handler access log.
         let ctx = Arc::new(AppContext::stub());
-        let res = chat_completions(State(ctx), HeaderMap::new(), Bytes::from_static(b"[]")).await;
-        let status = match &res {
-            Ok(r) => r.status(),
-            Err(e) => e.status_code(),
-        };
-        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        let app = crate::server::app::build_router(ctx.clone());
+        // Valid JSON but not an object → `parse_probe` rejects with 400 via `?`
+        // before any worker is selected.
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from("[]"))
+            .unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), axum::http::StatusCode::BAD_REQUEST);
 
         let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
         assert!(
-            logs.contains("chat_completions"),
-            "the 400 outcome must be surfaced in the access log; captured:\n{logs}"
+            logs.contains("http_request"),
+            "every request must be logged by the middleware; captured:\n{logs}"
         );
         assert!(
-            logs.contains("http_status=400"),
-            "access log must record http_status=400; captured:\n{logs}"
+            logs.contains("path=/v1/chat/completions") && logs.contains("status=400"),
+            "access log must record the path and 400 status; captured:\n{logs}"
+        );
+
+        let metrics = ctx.metrics.render();
+        assert!(
+            metrics
+                .lines()
+                .any(|l| l.starts_with("sgl_router_requests_total")
+                    && l.contains(r#"outcome="error""#)),
+            "a pre-routing 400 must be counted in requests_total{{outcome=error}}; got:\n{metrics}"
         );
     }
 }

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -563,19 +563,20 @@ pub async fn chat_completions(
         Err(e) => e.status_code().as_u16(),
     };
 
-    // Record the client-visible HTTP status now that the outcome is known.
-    // For non-streaming requests the body is already buffered here, so
-    // `start.elapsed()` is true end-to-end latency — record it directly. For
-    // streaming, the body is still pending; the `RecordDurationOnDrop` guard
-    // packed into `stream_guards` records it at stream completion instead (so
-    // we don't capture only time-to-headers). `elapsed` still feeds the
-    // access-log `latency_ms` below for both.
+    // Record end-to-end latency now that the outcome is known. For non-streaming
+    // requests the body is already buffered here, so `start.elapsed()` is true
+    // end-to-end latency — record it directly. For streaming, the body is still
+    // pending; the `RecordDurationOnDrop` guard packed into `stream_guards`
+    // records it at stream completion instead (so we don't capture only
+    // time-to-headers). `elapsed` still feeds the access-log `latency_ms` below
+    // for both. The client-visible HTTP status is counted centrally by the
+    // `record_response_status` middleware (so error short-circuits are counted
+    // too), not here.
     let elapsed = start.elapsed();
     if !streaming {
         ctx.metrics
             .observe_request_duration(&metrics_model, elapsed.as_secs_f64());
     }
-    ctx.metrics.record_response(http_status);
     let outcome_str = match outcome {
         RequestOutcome::Success => "success",
         RequestOutcome::Error => "error",

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -1328,7 +1328,7 @@ mod tests {
                 .lines()
                 .any(|l| l.starts_with("sgl_router_worker_requests_total")
                     && l.contains(r#"outcome="error""#)),
-            "a pre-routing 400 must be counted in requests_total{{outcome=error}}; got:\n{metrics}"
+            "a pre-routing 400 must be counted in worker_requests_total{{outcome=error}}; got:\n{metrics}"
         );
     }
 }

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -204,7 +204,7 @@ async fn chat_completions_inner(
     // shed request's pre-admission time (the latency the access log shows on a
     // 503) is attributable to tokenize vs. the rest.
     if PHASE_LOG_COUNTER.fetch_add(1, Ordering::Relaxed) % PHASE_LOG_SAMPLE == 0 {
-        tracing::info!(
+        tracing::debug!(
             tokenize_ms = at_post_tokenize.saturating_sub(at_pre_tokenize).as_millis() as u64,
             pre_admit_total_ms = at_post_tokenize.as_millis() as u64,
             want_tokens,
@@ -585,7 +585,7 @@ async fn chat_completions_inner(
     let at_post_dispatch = start.elapsed();
     if PHASE_LOG_COUNTER.fetch_add(1, Ordering::Relaxed) % PHASE_LOG_SAMPLE == 0 {
         let (handler_inflight, in_send, pump_inflight) = crate::diag::snapshot();
-        tracing::info!(
+        tracing::debug!(
             tokenize_ms = at_post_tokenize.saturating_sub(at_pre_tokenize).as_millis() as u64,
             admit_ms = at_post_admit.saturating_sub(at_post_tokenize).as_millis() as u64,
             build_ms = at_post_build.saturating_sub(at_post_admit).as_millis() as u64,

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -13,6 +13,7 @@ use crate::workers::Worker;
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::{HeaderMap, HeaderName, HeaderValue, Response};
+use axum::response::IntoResponse;
 use bytes::Bytes;
 use serde::de::IgnoredAny;
 use serde::Deserialize;
@@ -89,12 +90,48 @@ impl Drop for RecordDurationOnDrop {
     }
 }
 
-/// POST /v1/chat/completions — parse model from body, select a healthy
-/// worker via the per-model policy, then proxy the request. If the
-/// request opts into streaming (`stream: true`), we pipe SSE bytes back;
-/// otherwise buffer.
+/// POST /v1/chat/completions handler. Thin wrapper over
+/// [`chat_completions_inner`] that surfaces early-error outcomes in the access
+/// log: a body-validation 400, an admission 503, a model-not-found, etc. return
+/// via `?` before the inner handler reaches its per-request access log, so
+/// without this they would be absent from the access log (visible only in the
+/// response-code metric, and for some variants a per-variant warning). The inner
+/// handler logs the success and post-dispatch outcomes — and returns its
+/// post-dispatch errors as a response rather than `Err`, so the wrapper logs
+/// each request exactly once (only the early `?` short-circuits land here).
 pub async fn chat_completions(
     State(ctx): State<Arc<AppContext>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response<Body>, ApiError> {
+    let start = std::time::Instant::now();
+    let request_id = headers
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-")
+        .to_string();
+    let result = chat_completions_inner(ctx, headers, body).await;
+    if let Err(e) = &result {
+        tracing::info!(
+            request_id = %request_id,
+            method = "POST",
+            path = "/v1/chat/completions",
+            outcome = "error",
+            http_status = e.status_code().as_u16(),
+            latency_ms = start.elapsed().as_millis() as u64,
+            "chat_completions",
+        );
+    }
+    result
+}
+
+/// Parse model from body, select a healthy worker via the per-model policy, then
+/// proxy the request. If the request opts into streaming (`stream: true`), we
+/// pipe SSE bytes back; otherwise buffer. Early errors returned here are logged
+/// by the [`chat_completions`] wrapper; the success / post-dispatch outcomes are
+/// logged at the end of this function.
+async fn chat_completions_inner(
+    ctx: Arc<AppContext>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response<Body>, ApiError> {
@@ -620,7 +657,12 @@ pub async fn chat_completions(
             }
             Ok(response)
         }
-        (other, _) => other,
+        (Ok(response), None) => Ok(response),
+        // Post-dispatch errors were already logged with full fields by the
+        // access-log call above; return them as a response (not `Err`) so the
+        // `chat_completions` wrapper does not log them a second time. The wrapper
+        // logs only the early `?` short-circuits, which never reached that log.
+        (Err(e), _) => Ok(e.into_response()),
     }
 }
 
@@ -1266,5 +1308,60 @@ mod tests {
             ),
             other => panic!("expected BadRequest, got {other:?}"),
         }
+    }
+
+    /// Early-error short-circuits (e.g. a malformed body → 400) must still be
+    /// surfaced in the `chat_completions` access log. Before the fix they
+    /// returned via `?` ahead of the in-handler log and were invisible in the
+    /// logs (only countable via the response-code metric).
+    #[tokio::test]
+    async fn early_error_400_is_surfaced_in_access_log() {
+        use std::sync::Mutex;
+        use tracing_subscriber::fmt::MakeWriter;
+
+        #[derive(Clone)]
+        struct VecWriter(Arc<Mutex<Vec<u8>>>);
+        impl std::io::Write for VecWriter {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for VecWriter {
+            type Writer = VecWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .with_writer(VecWriter(buf.clone()))
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        // Valid JSON but not an object → `parse_probe` rejects with 400, an early
+        // `?` return that bypasses the in-handler access log.
+        let ctx = Arc::new(AppContext::stub());
+        let res = chat_completions(State(ctx), HeaderMap::new(), Bytes::from_static(b"[]")).await;
+        let status = match &res {
+            Ok(r) => r.status(),
+            Err(e) => e.status_code(),
+        };
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+
+        let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(
+            logs.contains("chat_completions"),
+            "the 400 outcome must be surfaced in the access log; captured:\n{logs}"
+        );
+        assert!(
+            logs.contains("http_status=400"),
+            "access log must record http_status=400; captured:\n{logs}"
+        );
     }
 }

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -109,9 +109,13 @@ pub async fn chat_completions(
 
 /// Parse model from body, select a healthy worker via the per-model policy, then
 /// proxy the request. If the request opts into streaming (`stream: true`), we
-/// pipe SSE bytes back; otherwise buffer. Early errors returned here are logged
-/// by the [`chat_completions`] wrapper; the success / post-dispatch outcomes are
-/// logged at the end of this function.
+/// pipe SSE bytes back; otherwise buffer. This function does not emit the
+/// per-request access-log line and does not count `requests_total` /
+/// `responses_total`: it attaches a [`RequestLogContext`] to routed responses and
+/// returns early errors via `?`, leaving all access logging and request/response
+/// counting to the outermost `access_log_and_record` middleware (see
+/// [`crate::server::app`]). It still records auxiliary metrics (TTFT, request
+/// duration, stale-request, ingress-tokenize errors) and emits diagnostic logs.
 async fn chat_completions_inner(
     ctx: Arc<AppContext>,
     headers: HeaderMap,

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -567,7 +567,7 @@ async fn chat_completions_inner(
     }
 
     // Routing context for the outermost middleware: it records
-    // `requests_total{worker_url,model_id,mode,outcome}` and the access-log line
+    // `worker_requests_total{worker_url,model_id,mode,outcome}` and the access-log line
     // for this request. Attaching it here (rather than recording directly) keeps
     // all request accounting at one site that also covers pre-routing
     // rejections, so the by-outcome view reflects ALL ingress.
@@ -1326,7 +1326,7 @@ mod tests {
         assert!(
             metrics
                 .lines()
-                .any(|l| l.starts_with("sgl_router_requests_total")
+                .any(|l| l.starts_with("sgl_router_worker_requests_total")
                     && l.contains(r#"outcome="error""#)),
             "a pre-routing 400 must be counted in requests_total{{outcome=error}}; got:\n{metrics}"
         );

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -9,7 +9,7 @@ use crate::server::error::ApiError;
 use crate::server::metrics::{
     MetricsRegistry, RequestOutcome, StaleRequestOutcome, WorkerModeLabel,
 };
-use crate::workers::{LoadGuard, Worker};
+use crate::workers::Worker;
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::{HeaderMap, HeaderName, HeaderValue, Response};
@@ -182,12 +182,14 @@ pub async fn chat_completions(
         .filter(|s| !s.is_empty());
     let selection_ctx = SelectionContext::with_routing_key(&model_id, Some(&body), routing_key)
         .with_request_tokens(request_tokens.as_ref().map(|t| t.ids.as_slice()));
-    let worker =
-        policy
-            .select(&workers, &selection_ctx)
-            .ok_or_else(|| ApiError::PolicySelectionFailed {
-                model: model_str.clone(),
-            })?;
+    // Admission gate: pick a worker and claim an in-flight slot, parking until
+    // one frees if every candidate is at its cap. A pass-through (immediate
+    // dispatch, unconditional guard) when no per-worker cap is configured.
+    // Yields 503 `service_overloaded` when the wait queue is full.
+    let (worker, guard) = ctx
+        .admission
+        .acquire(&workers, policy.as_ref(), &selection_ctx, &model_str)
+        .await?;
 
     // PD-mode decoder affinity. When the selected prefill worker is
     // part of a PD-disagg deployment, also resolve the matching decode
@@ -260,7 +262,8 @@ pub async fn chat_completions(
     // 0 here: the active-load registry's decode axis is reserved for a
     // future decode-side scheduler — current decode selection is
     // host-affinity only.
-    let guard = worker.load_guard();
+    // `guard` (this request's per-worker in-flight slot) was claimed by the
+    // admission gate above; it is held until the dispatch guards below drop.
     // Use the exact token count from the ingress tokenization when available;
     // fall back to the byte-count heuristic for load-only policies that don't
     // tokenize. The exact count makes the cache-aware load-imbalance fast-path
@@ -403,7 +406,7 @@ pub async fn chat_completions(
         let prefill_headers = headers.clone();
         let prefill_body = outgoing_body.clone();
         let prefill_proxy = Arc::clone(&ctx.proxy);
-        let prefill_holds: (LoadGuard, _) = (guard, active_guard);
+        let prefill_holds = (guard, active_guard);
         tokio::spawn(async move {
             // The tuple binding extends both guards' lifetime to the
             // end of this async block, which lasts until the prefill
@@ -506,7 +509,7 @@ pub async fn chat_completions(
         // lifetime to the end of the function — the `forward_json_to`
         // future does not need them (it does not return until the
         // body is buffered).
-        let _holds: (LoadGuard, _) = (guard, active_guard);
+        let _holds = (guard, active_guard);
         let fetch = ctx.proxy.forward_json_to(
             &worker.url,
             &worker.breaker,

--- a/experimental/sgl-router/src/server/routes/metrics.rs
+++ b/experimental/sgl-router/src/server/routes/metrics.rs
@@ -94,7 +94,7 @@ mod tests {
         let body = res.into_body().collect().await.unwrap().to_bytes();
         let body = std::str::from_utf8(&body).unwrap();
         // Every metric family should at least carry its HELP/TYPE lines.
-        assert!(body.contains("# TYPE sgl_router_requests_total counter"));
+        assert!(body.contains("# TYPE sgl_router_worker_requests_total counter"));
         assert!(body.contains("# TYPE sgl_router_overlap_blocks histogram"));
         assert!(body.contains("# TYPE sgl_router_active_load gauge"));
     }
@@ -102,7 +102,7 @@ mod tests {
     #[tokio::test]
     async fn metrics_endpoint_reflects_recorded_counters() {
         let ctx = Arc::new(AppContext::stub());
-        ctx.metrics.record_request(
+        ctx.metrics.record_worker_request(
             "http://w-test:30000",
             "tiny",
             WorkerModeLabel::Prefill,

--- a/experimental/sgl-router/src/server/routes/tokenize.rs
+++ b/experimental/sgl-router/src/server/routes/tokenize.rs
@@ -129,6 +129,7 @@ mod tests {
             ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
+            admission: crate::config::AdmissionConfig::default(),
         };
         let registry = crate::tokenizer::TokenizerRegistry::load_from_config(&cfg).unwrap();
         let proxy = Arc::new(

--- a/experimental/sgl-router/src/tokenizer/mod.rs
+++ b/experimental/sgl-router/src/tokenizer/mod.rs
@@ -243,6 +243,7 @@ mod tests {
             ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
+            admission: crate::config::AdmissionConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/src/workers/manager.rs
+++ b/experimental/sgl-router/src/workers/manager.rs
@@ -487,6 +487,7 @@ mod tests {
             }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
+            admission: crate::config::AdmissionConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/src/workers/mod.rs
+++ b/experimental/sgl-router/src/workers/mod.rs
@@ -10,3 +10,45 @@ pub use introspect::{ServerInfo, WorkerIntrospector};
 pub use registry::WorkerRegistry;
 pub use worker::LoadGuard;
 pub use worker::Worker;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Spawn a background task that periodically reclaims in-flight admission slots
+/// held longer than `ttl` across every registered worker.
+///
+/// Defense-in-depth: the SSE idle timeout already bounds the common streaming
+/// leak path, but a slot held past `ttl` for any other reason (a future code
+/// path that forgets to drop a guard, an unforeseen hang) is force-released
+/// here, so the per-worker cap can never stay pinned and false-shed forever. A
+/// reclaim is logged at WARN — it means a guard leaked and is worth alerting on.
+pub fn spawn_load_janitor(
+    registry: Arc<WorkerRegistry>,
+    ttl: Duration,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            let now = Instant::now();
+            let mut total = 0usize;
+            for w in registry.all() {
+                let n = w.reclaim_stale_load(ttl, now);
+                if n > 0 {
+                    total += n;
+                    tracing::warn!(
+                        worker = %w.url,
+                        reclaimed = n,
+                        ttl_secs = ttl.as_secs(),
+                        "reclaimed leaked in-flight admission slot(s) past TTL",
+                    );
+                }
+            }
+            if total > 0 {
+                tracing::warn!(total, "worker-load janitor swept leaked admission slots");
+            }
+        }
+    })
+}

--- a/experimental/sgl-router/src/workers/worker.rs
+++ b/experimental/sgl-router/src/workers/worker.rs
@@ -3,8 +3,11 @@
 
 use crate::discovery::{ModelId, WorkerId, WorkerMode};
 use crate::health::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
-use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 /// Parse a host from a worker URL. Matches SMG's `worker_builder.rs`
 /// fallback chain: parse as-is, retry with `http://` prefix if missing,
@@ -31,53 +34,131 @@ fn parse_bootstrap_host(url: &str) -> String {
     "localhost".to_string()
 }
 
-/// RAII guard that increments `active_requests` on construction and
-/// decrements on drop.  Obtain via [`Worker::load_guard`].
-///
-/// `#[must_use]`: a statement-form call like `worker.load_guard();` would
-/// drop the guard on the same line, so the counter would never see the
-/// in-flight request.  The compile-time warning catches that misuse.
-#[must_use = "LoadGuard must be held for the request's lifetime; dropping it immediately decrements active_requests"]
+/// Tracks each in-flight slot with an acquisition timestamp so leaked slots —
+/// guards that are never dropped because their request hung (e.g. a half-open
+/// upstream after a worker restart) — can be reclaimed by a TTL sweep
+/// ([`reclaim_stale`](SlotRegistry::reclaim_stale)). The shared `count` is the
+/// same `Arc<AtomicUsize>` exposed as [`Worker::active_requests`], so the
+/// admission cap reads it lock-free; the per-slot map is only touched on
+/// claim / release / sweep, all off the read path.
 #[derive(Debug)]
-pub struct LoadGuard {
-    counter: Arc<AtomicUsize>,
+pub struct SlotRegistry {
+    count: Arc<AtomicUsize>,
+    slots: Mutex<HashMap<u64, Instant>>,
+    next_id: AtomicU64,
 }
 
-impl LoadGuard {
-    pub(crate) fn new(counter: Arc<AtomicUsize>) -> Self {
-        counter.fetch_add(1, Ordering::Relaxed);
-        Self { counter }
+impl SlotRegistry {
+    fn new(count: Arc<AtomicUsize>) -> Arc<Self> {
+        Arc::new(Self {
+            count,
+            slots: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(0),
+        })
     }
 
-    /// Claim a slot only while the counter is below `cap`, returning `None`
-    /// when the worker is already at capacity (counter left unchanged).
-    ///
-    /// Each claim is a compare-and-swap retried until it succeeds or the cap is
-    /// hit, so the cap holds *exactly* even when many callers race for the last
-    /// slot: at most `cap` guards can coexist. This is what makes the per-worker
-    /// admission limit a hard bound rather than a check-then-act race.
-    pub(crate) fn try_new(counter: Arc<AtomicUsize>, cap: usize) -> Option<Self> {
-        let mut current = counter.load(Ordering::Relaxed);
+    fn register(self: &Arc<Self>) -> LoadGuard {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        self.slots.lock().insert(id, Instant::now());
+        LoadGuard {
+            registry: Arc::clone(self),
+            id,
+        }
+    }
+
+    /// Unconditional claim (always increments).
+    fn claim(self: &Arc<Self>) -> LoadGuard {
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.register()
+    }
+
+    /// Claim a slot only while the count is below `cap`, returning `None` when
+    /// at capacity. The count is moved via a compare-and-swap retried until it
+    /// succeeds or the cap is hit, so the cap holds *exactly* under racing
+    /// callers — a hard bound, not a check-then-act race.
+    fn try_claim(self: &Arc<Self>, cap: usize) -> Option<LoadGuard> {
+        let mut current = self.count.load(Ordering::Relaxed);
         loop {
             if current >= cap {
                 return None;
             }
-            match counter.compare_exchange_weak(
+            match self.count.compare_exchange_weak(
                 current,
                 current + 1,
                 Ordering::AcqRel,
                 Ordering::Relaxed,
             ) {
-                Ok(_) => return Some(Self { counter }),
+                Ok(_) => return Some(self.register()),
                 Err(actual) => current = actual,
             }
         }
+    }
+
+    /// Release slot `id`. Decrements the count only if the slot is still
+    /// tracked, so a guard dropping *after* the janitor already reclaimed its
+    /// slot is a no-op (no double-decrement / underflow).
+    fn release(&self, id: u64) {
+        if self.slots.lock().remove(&id).is_some() {
+            self.count.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Reset slot `id`'s age — used when a slot is handed to a fresh request
+    /// (FIFO hand-off) so a continuously-cycled slot is never seen as stale.
+    fn touch(&self, id: u64) {
+        if let Some(t) = self.slots.lock().get_mut(&id) {
+            *t = Instant::now();
+        }
+    }
+
+    /// Force-release every slot older than `ttl` (defense-in-depth backstop for
+    /// a leaked in-flight guard). Returns the number reclaimed. A later drop of
+    /// a reclaimed slot's guard is a no-op (see [`release`](Self::release)).
+    pub fn reclaim_stale(&self, ttl: Duration, now: Instant) -> usize {
+        let mut slots = self.slots.lock();
+        let stale: Vec<u64> = slots
+            .iter()
+            .filter(|(_, &acquired)| now.saturating_duration_since(acquired) >= ttl)
+            .map(|(&id, _)| id)
+            .collect();
+        for id in &stale {
+            slots.remove(id);
+        }
+        drop(slots);
+        for _ in 0..stale.len() {
+            self.count.fetch_sub(1, Ordering::Relaxed);
+        }
+        stale.len()
+    }
+}
+
+/// RAII guard that increments `active_requests` on construction and decrements
+/// on drop. Obtain via [`Worker::load_guard`]. Each guard owns one timestamped
+/// slot in the worker's [`SlotRegistry`], so the TTL janitor can reclaim it if
+/// the guard is leaked (request hung and never dropped it).
+///
+/// `#[must_use]`: a statement-form call like `worker.load_guard();` would drop
+/// the guard on the same line, so the counter would never see the in-flight
+/// request.  The compile-time warning catches that misuse.
+#[must_use = "LoadGuard must be held for the request's lifetime; dropping it immediately decrements active_requests"]
+#[derive(Debug)]
+pub struct LoadGuard {
+    registry: Arc<SlotRegistry>,
+    id: u64,
+}
+
+impl LoadGuard {
+    /// Reset this slot's age in the registry. Called on FIFO hand-off so a slot
+    /// continuously transferred between live requests is not mistaken for a
+    /// leaked one by the janitor.
+    pub(crate) fn touch(&self) {
+        self.registry.touch(self.id);
     }
 }
 
 impl Drop for LoadGuard {
     fn drop(&mut self) {
-        self.counter.fetch_sub(1, Ordering::Relaxed);
+        self.registry.release(self.id);
     }
 }
 
@@ -114,6 +195,9 @@ pub struct Worker {
     pub model_ids: Vec<ModelId>,
     pub breaker: Arc<CircuitBreaker>,
     pub active_requests: Arc<AtomicUsize>,
+    /// Per-slot timestamps for the in-flight count, enabling the TTL janitor to
+    /// reclaim leaked guards. Shares `active_requests` as its count.
+    slots: Arc<SlotRegistry>,
     /// Hostname parsed from `url` at construction time and cached.
     /// Used as the `bootstrap_host` field on PD-disagg requests so the
     /// prefill engine can match incoming KV-transfer requests from
@@ -143,13 +227,16 @@ impl Worker {
             None => Arc::new(CircuitBreaker::new()),
         };
         let bootstrap_host = parse_bootstrap_host(&spec.url);
+        let active_requests = Arc::new(AtomicUsize::new(0));
+        let slots = SlotRegistry::new(Arc::clone(&active_requests));
         Self {
             id: spec.id,
             url: spec.url,
             mode: AtomicU8::new(spec.mode.as_u8()),
             model_ids: spec.model_ids,
             breaker,
-            active_requests: Arc::new(AtomicUsize::new(0)),
+            active_requests,
+            slots,
             bootstrap_host,
             bootstrap_port: spec.bootstrap_port,
         }
@@ -188,14 +275,22 @@ impl Worker {
     /// Returns a RAII guard that increments `active_requests` now and
     /// decrements when the guard is dropped.
     pub fn load_guard(&self) -> LoadGuard {
-        LoadGuard::new(self.active_requests.clone())
+        self.slots.claim()
     }
 
     /// Like [`Worker::load_guard`], but only admits while `active_requests` is
     /// below `cap`; returns `None` when the worker is already at capacity. Used
     /// by the admission gate to enforce a hard per-worker in-flight limit.
     pub fn try_load_guard(&self, cap: usize) -> Option<LoadGuard> {
-        LoadGuard::try_new(self.active_requests.clone(), cap)
+        self.slots.try_claim(cap)
+    }
+
+    /// Force-release in-flight slots whose guard has been held longer than
+    /// `ttl` — a defense-in-depth backstop against a leaked admission slot
+    /// (a guard whose request hung and never dropped). Returns the number
+    /// reclaimed. Driven by the worker janitor; `now` is injected for tests.
+    pub fn reclaim_stale_load(&self, ttl: Duration, now: Instant) -> usize {
+        self.slots.reclaim_stale(ttl, now)
     }
 }
 
@@ -392,5 +487,64 @@ mod tests {
             bootstrap_port: Some(8997),
         });
         assert_eq!(w.bootstrap_host(), "localhost");
+    }
+
+    fn test_worker() -> Worker {
+        Worker::new(WorkerSpec {
+            id: WorkerId("w".into()),
+            url: "http://x".into(),
+            mode: WorkerMode::Plain,
+            model_ids: vec![ModelId("m".into())],
+            bootstrap_port: None,
+        })
+    }
+
+    /// The TTL janitor force-releases a leaked slot, and the leaked guard's
+    /// eventual drop is a no-op — the counter must not underflow.
+    #[test]
+    fn reclaim_stale_load_force_releases_without_underflow() {
+        let w = test_worker();
+        let g = w.load_guard();
+        assert_eq!(w.active_load(), 1);
+
+        // ttl=0: the just-acquired slot counts as stale and is reclaimed.
+        let reclaimed = w.reclaim_stale_load(Duration::ZERO, Instant::now());
+        assert_eq!(reclaimed, 1);
+        assert_eq!(w.active_load(), 0, "stale slot must be force-released");
+
+        // The leaked guard finally drops after the sweep: must NOT decrement
+        // again (would underflow to usize::MAX and wedge the worker as "full").
+        drop(g);
+        assert_eq!(
+            w.active_load(),
+            0,
+            "post-reclaim drop must be a no-op (no double-decrement / underflow)",
+        );
+    }
+
+    /// A fresh slot (held less than the TTL) is left alone by the janitor.
+    #[test]
+    fn reclaim_stale_load_leaves_fresh_slots() {
+        let w = test_worker();
+        let _g = w.load_guard();
+        assert_eq!(w.active_load(), 1);
+
+        let reclaimed = w.reclaim_stale_load(Duration::from_secs(3600), Instant::now());
+        assert_eq!(reclaimed, 0, "a fresh slot must not be reclaimed");
+        assert_eq!(w.active_load(), 1);
+    }
+
+    /// `touch` resets a slot's age so a continuously handed-off slot is never
+    /// seen as stale by the janitor.
+    #[test]
+    fn touch_resets_slot_age() {
+        let w = test_worker();
+        let g = w.load_guard();
+        // Without touch, ttl=0 would reclaim it; touch keeps it "fresh" only
+        // against a positive ttl, so assert via the fresh-ttl path after touch.
+        g.touch();
+        let reclaimed = w.reclaim_stale_load(Duration::from_secs(3600), Instant::now());
+        assert_eq!(reclaimed, 0);
+        assert_eq!(w.active_load(), 1);
     }
 }

--- a/experimental/sgl-router/src/workers/worker.rs
+++ b/experimental/sgl-router/src/workers/worker.rs
@@ -38,6 +38,7 @@ fn parse_bootstrap_host(url: &str) -> String {
 /// drop the guard on the same line, so the counter would never see the
 /// in-flight request.  The compile-time warning catches that misuse.
 #[must_use = "LoadGuard must be held for the request's lifetime; dropping it immediately decrements active_requests"]
+#[derive(Debug)]
 pub struct LoadGuard {
     counter: Arc<AtomicUsize>,
 }
@@ -46,6 +47,31 @@ impl LoadGuard {
     pub(crate) fn new(counter: Arc<AtomicUsize>) -> Self {
         counter.fetch_add(1, Ordering::Relaxed);
         Self { counter }
+    }
+
+    /// Claim a slot only while the counter is below `cap`, returning `None`
+    /// when the worker is already at capacity (counter left unchanged).
+    ///
+    /// Each claim is a compare-and-swap retried until it succeeds or the cap is
+    /// hit, so the cap holds *exactly* even when many callers race for the last
+    /// slot: at most `cap` guards can coexist. This is what makes the per-worker
+    /// admission limit a hard bound rather than a check-then-act race.
+    pub(crate) fn try_new(counter: Arc<AtomicUsize>, cap: usize) -> Option<Self> {
+        let mut current = counter.load(Ordering::Relaxed);
+        loop {
+            if current >= cap {
+                return None;
+            }
+            match counter.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Some(Self { counter }),
+                Err(actual) => current = actual,
+            }
+        }
     }
 }
 
@@ -164,6 +190,13 @@ impl Worker {
     pub fn load_guard(&self) -> LoadGuard {
         LoadGuard::new(self.active_requests.clone())
     }
+
+    /// Like [`Worker::load_guard`], but only admits while `active_requests` is
+    /// below `cap`; returns `None` when the worker is already at capacity. Used
+    /// by the admission gate to enforce a hard per-worker in-flight limit.
+    pub fn try_load_guard(&self, cap: usize) -> Option<LoadGuard> {
+        LoadGuard::try_new(self.active_requests.clone(), cap)
+    }
 }
 
 impl std::fmt::Debug for Worker {
@@ -200,6 +233,71 @@ mod tests {
         assert_eq!(w.active_load(), 1);
         drop(g2);
         assert_eq!(w.active_load(), 0);
+    }
+
+    #[test]
+    fn try_load_guard_enforces_cap() {
+        let w = Worker::new(WorkerSpec {
+            id: WorkerId("w".into()),
+            url: "http://x".into(),
+            mode: WorkerMode::Plain,
+            model_ids: vec![ModelId("m".into())],
+            bootstrap_port: None,
+        });
+        let cap = 2;
+        let g1 = w.try_load_guard(cap);
+        assert!(g1.is_some());
+        assert_eq!(w.active_load(), 1);
+        let _g2 = w.try_load_guard(cap);
+        assert!(_g2.is_some());
+        assert_eq!(w.active_load(), 2);
+        // At cap: refused, counter unchanged.
+        assert!(w.try_load_guard(cap).is_none());
+        assert_eq!(w.active_load(), 2);
+        // Freeing a slot re-opens admission.
+        drop(g1);
+        assert_eq!(w.active_load(), 1);
+        let _g3 = w.try_load_guard(cap);
+        assert!(_g3.is_some());
+        assert_eq!(w.active_load(), 2);
+    }
+
+    #[test]
+    fn try_load_guard_never_exceeds_cap_under_concurrency() {
+        use std::sync::{Barrier, Mutex};
+        use std::thread;
+
+        let w = Arc::new(Worker::new(WorkerSpec {
+            id: WorkerId("w".into()),
+            url: "http://x".into(),
+            mode: WorkerMode::Plain,
+            model_ids: vec![ModelId("m".into())],
+            bootstrap_port: None,
+        }));
+        let cap = 8;
+        let n_threads = 64;
+        let barrier = Arc::new(Barrier::new(n_threads));
+        let granted: Arc<Mutex<Vec<LoadGuard>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let handles: Vec<_> = (0..n_threads)
+            .map(|_| {
+                let w = Arc::clone(&w);
+                let barrier = Arc::clone(&barrier);
+                let granted = Arc::clone(&granted);
+                thread::spawn(move || {
+                    barrier.wait();
+                    if let Some(guard) = w.try_load_guard(cap) {
+                        // Hold the guard so the claimed slot is never released.
+                        granted.lock().unwrap().push(guard);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(granted.lock().unwrap().len(), cap);
+        assert_eq!(w.active_load(), cap);
     }
 
     #[test]

--- a/experimental/sgl-router/tests/component/discovery/static_urls.rs
+++ b/experimental/sgl-router/tests/component/discovery/static_urls.rs
@@ -139,6 +139,7 @@ async fn static_urls_pd_role_resolved_end_to_end() {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     };
 
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
@@ -80,6 +80,7 @@ async fn zmq_indexer_routes_to_publishing_worker_e2e() {
         ),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
 

--- a/experimental/sgl-router/tests/e2e/chat_completions/test_load_based_policy.py
+++ b/experimental/sgl-router/tests/e2e/chat_completions/test_load_based_policy.py
@@ -19,7 +19,7 @@ _ACTIVE_RE = re.compile(
     r'^sgl_router_active_load\{worker_url="([^"]+)",kind="prefill_tokens"\}\s+(-?\d+)'
 )
 _REQ_TOTAL_RE = re.compile(
-    r"^sgl_router_requests_total\{([^}]*)\}\s+(\d+(?:\.\d+)?)\s*$"
+    r"^sgl_router_worker_requests_total\{([^}]*)\}\s+(\d+(?:\.\d+)?)\s*$"
 )
 _LABEL_RE = re.compile(r'(\w+)="([^"]*)"')
 

--- a/experimental/sgl-router/tests/e2e/chat_completions/test_two_router_convergence.py
+++ b/experimental/sgl-router/tests/e2e/chat_completions/test_two_router_convergence.py
@@ -74,7 +74,7 @@ PREFIX_Y = (_PREFIX_Y_BODY * 8).strip()
 
 
 _REQ_TOTAL_RE = re.compile(
-    r"^sgl_router_requests_total\{([^}]*)\}\s+(\d+(?:\.\d+)?)\s*$"
+    r"^sgl_router_worker_requests_total\{([^}]*)\}\s+(\d+(?:\.\d+)?)\s*$"
 )
 _LABEL_RE = re.compile(r'(\w+)="([^"]*)"')
 

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -60,6 +60,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -469,7 +469,7 @@ async fn non_streaming_upstream_500_preserved() {
 
 /// A response the router FORWARDS from a worker with a non-2xx status is an
 /// `Ok(Response)` at the router layer (only transport failures become `Err`).
-/// The per-worker `sgl_router_requests_total` outcome must be derived from the
+/// The per-worker `sgl_router_worker_requests_total` outcome must be derived from the
 /// client-visible HTTP status, not from `Result::Ok`/`Err` — so a forwarded 5xx
 /// is counted `outcome="error"`, NOT credited as a success.
 #[tokio::test]
@@ -501,7 +501,7 @@ async fn forwarded_5xx_records_outcome_error_not_success() {
 
     let m = ctx.metrics.render();
     let error_line = format!(
-        r#"sgl_router_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="error"}} 1"#,
+        r#"sgl_router_worker_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="error"}} 1"#,
         worker.url,
     );
     assert!(
@@ -509,7 +509,7 @@ async fn forwarded_5xx_records_outcome_error_not_success() {
         "a forwarded 5xx must be counted as outcome=\"error\"; got:\n{m}",
     );
     let success_line = format!(
-        r#"sgl_router_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="success"}}"#,
+        r#"sgl_router_worker_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="success"}}"#,
         worker.url,
     );
     assert!(
@@ -1465,7 +1465,7 @@ async fn janitor_expiry_returns_504_stale_request_expired() {
     let m = ctx.metrics.render();
     assert!(
         m.contains(&format!(
-            r#"sgl_router_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="cancelled"}}"#,
+            r#"sgl_router_worker_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="cancelled"}}"#,
             worker.url
         )),
         "stale 504 must be counted in requests_total as outcome=cancelled: {m}",
@@ -1609,7 +1609,7 @@ async fn admission_parks_second_request_until_first_stream_frees_the_slot() {
 /// A request shed by the admission gate (503 `service_overloaded`) must show up
 /// in the dedicated `sgl_router_backpressure_rejected_total` counter, the general
 /// `sgl_router_responses_total{status_code="503"}` series, AND
-/// `sgl_router_requests_total{outcome="error"}` with an empty `worker_url`. The
+/// `sgl_router_worker_requests_total{outcome="error"}` with an empty `worker_url`. The
 /// shed returns via `?` before reaching a worker, so only the outermost
 /// `access_log_and_record` middleware can count it — which is what makes
 /// `sum by (outcome)` include sheds instead of undercounting them.
@@ -1686,7 +1686,7 @@ async fn admission_shed_503_is_counted_in_responses_total() {
     // the line that makes `sum by (outcome)` include sheds.
     assert!(
         m.lines()
-            .any(|l| l.starts_with("sgl_router_requests_total{")
+            .any(|l| l.starts_with("sgl_router_worker_requests_total{")
                 && l.contains(r#"worker_url="""#)
                 && l.contains(r#"outcome="error""#)),
         "shed must be counted in requests_total with empty worker_url + outcome=error: {m}",
@@ -1736,7 +1736,7 @@ async fn success_200_counted_once_per_request_in_responses_total() {
     );
     // Both successes are also true intake (counted at entry, through build_router).
     assert!(
-        m.contains(r#"sgl_router_intake_total{route="/v1/chat/completions",method="POST"} 2"#),
+        m.contains(r#"sgl_router_requests_total{route="/v1/chat/completions",method="POST"} 2"#),
         "two successes must each be counted as intake: {m}",
     );
     // A routed success must carry its per-worker labels in requests_total — the
@@ -1745,7 +1745,7 @@ async fn success_200_counted_once_per_request_in_responses_total() {
     // empty worker_url (which would blank the per-worker convergence panels).
     assert!(
         ctx.metrics.render().contains(&format!(
-            r#"sgl_router_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="success"}} 2"#,
+            r#"sgl_router_worker_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="success"}} 2"#,
             worker.url
         )),
         "two routed successes must count to 2 with full per-worker labels: {}",
@@ -1784,7 +1784,7 @@ async fn infra_path_counted_in_responses_total_but_not_requests_total() {
     // name, so it is not matched here).
     assert!(
         !m.lines()
-            .any(|l| l.starts_with("sgl_router_requests_total{")),
+            .any(|l| l.starts_with("sgl_router_worker_requests_total{")),
         "infra path must NOT be counted in requests_total: {m}",
     );
 }

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -1652,3 +1652,329 @@ async fn success_200_counted_once_per_request_in_responses_total() {
         ctx.metrics.render(),
     );
 }
+
+/// Regression for the production false-shedding leak: with admission ENABLED, a
+/// streaming request whose client disconnects mid-stream must release its
+/// per-worker admission slot (`Worker.active_requests`), not just the
+/// active-load registry. A leaked slot pins the worker at its cap, so the gate
+/// then sheds later requests with 503 while the engine is actually idle.
+///
+/// `streaming_active_load_drops_on_client_disconnect` covers the active-load
+/// *registry* on this path; this covers the *admission* counter the gate reads.
+#[tokio::test]
+async fn admission_slot_released_on_streaming_client_disconnect() {
+    let chunks: Vec<&'static str> = vec![
+        "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"b\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"c\"}}]}\n\n",
+        "data: [DONE]\n\n",
+    ];
+    let worker = crate::common::mock_worker::MockWorker::start_slow_stream(
+        chunks,
+        Duration::from_millis(100),
+    )
+    .await;
+
+    // cap=1, depth 0: if the slot leaks on disconnect, the next request is shed.
+    let mut cfg = config_for(&worker.url);
+    cfg.admission = sgl_router::config::AdmissionConfig::Enabled {
+        max_concurrent_per_worker: std::num::NonZeroUsize::new(1).unwrap(),
+        max_queued_requests: Some(0),
+    };
+    let registry = Arc::new(WorkerRegistry::default());
+    let _ = registry.add(WorkerSpec {
+        id: WorkerId("w1".into()),
+        url: worker.url.clone(),
+        mode: WorkerMode::Plain,
+        model_ids: vec![ModelId("tiny".into())],
+        bootstrap_port: None,
+    });
+    let policies = Arc::new(build_policy_registry(&cfg).unwrap());
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
+    let ctx = Arc::new(AppContext::new(
+        cfg,
+        tokenizers,
+        proxy,
+        Arc::clone(&registry),
+        policies,
+    ));
+    let w = registry.get(&WorkerId("w1".into())).unwrap();
+
+    let make_req = || {
+        Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&serde_json::json!({
+                    "model": "tiny",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": true,
+                }))
+                .unwrap(),
+            ))
+            .unwrap()
+    };
+
+    // Request A claims the only slot; read one chunk so the stream is live.
+    let res_a = build_router(ctx.clone()).oneshot(make_req()).await.unwrap();
+    assert_eq!(res_a.status(), StatusCode::OK);
+    use futures::StreamExt;
+    let mut data_stream = res_a.into_body().into_data_stream();
+    let _first = data_stream.next().await;
+    assert_eq!(
+        w.active_load(),
+        1,
+        "slot must be held while the stream is live"
+    );
+
+    // Client disconnects mid-stream.
+    drop(data_stream);
+
+    // The SSE pump should notice the receiver-drop and release the admission slot.
+    for _ in 0..100 {
+        if w.active_load() == 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        w.active_load(),
+        0,
+        "admission slot must be released when the streaming client disconnects",
+    );
+
+    // Behavioral check: a fresh request must be admitted, not falsely shed.
+    let res_b = build_router(ctx.clone()).oneshot(make_req()).await.unwrap();
+    assert_eq!(
+        res_b.status(),
+        StatusCode::OK,
+        "next request must be admitted after the slot is released, not 503",
+    );
+    let _ = res_b.into_body().collect().await.unwrap();
+}
+
+/// Closer reproduction of the production false-shedding symptom: sustained
+/// CONCURRENT streaming load through the admission queue's hand-off path, with
+/// clients disconnecting mid-stream. Every slot claimed (directly or via
+/// hand-off to a parked waiter) must be released; if any leaks, the worker pins
+/// at its cap, later waiters never admit, and the gate sheds while the engine is
+/// idle. Asserts the worker drains to zero and all requests are admitted.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn admission_slots_not_leaked_under_concurrent_streaming_disconnects() {
+    let chunks: Vec<&'static str> = vec![
+        "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"b\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"c\"}}]}\n\n",
+        "data: [DONE]\n\n",
+    ];
+    let worker = crate::common::mock_worker::MockWorker::start_slow_stream(
+        chunks,
+        Duration::from_millis(40),
+    )
+    .await;
+
+    // cap=2 + a queue deep enough that all arrivals PARK (none shed) -> every
+    // admission after the first two goes through the FIFO hand-off path.
+    let mut cfg = config_for(&worker.url);
+    cfg.admission = sgl_router::config::AdmissionConfig::Enabled {
+        max_concurrent_per_worker: std::num::NonZeroUsize::new(2).unwrap(),
+        max_queued_requests: Some(64),
+    };
+    let registry = Arc::new(WorkerRegistry::default());
+    let _ = registry.add(WorkerSpec {
+        id: WorkerId("w1".into()),
+        url: worker.url.clone(),
+        mode: WorkerMode::Plain,
+        model_ids: vec![ModelId("tiny".into())],
+        bootstrap_port: None,
+    });
+    let policies = Arc::new(build_policy_registry(&cfg).unwrap());
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
+    let ctx = Arc::new(AppContext::new(
+        cfg,
+        tokenizers,
+        proxy,
+        Arc::clone(&registry),
+        policies,
+    ));
+    let w = registry.get(&WorkerId("w1".into())).unwrap();
+
+    let mut handles = Vec::new();
+    for _ in 0..24u32 {
+        let ctx2 = ctx.clone();
+        handles.push(tokio::spawn(async move {
+            let req = Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&serde_json::json!({
+                        "model": "tiny",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": true,
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap();
+            // Each request must be admitted (parked then handed a slot); a leak
+            // would make a later waiter hang here forever.
+            let res =
+                tokio::time::timeout(Duration::from_secs(10), build_router(ctx2).oneshot(req))
+                    .await
+                    .expect("request must admit within timeout (a leaked slot would hang it)")
+                    .unwrap();
+            let status = res.status();
+            // Read one chunk, then disconnect mid-stream.
+            use futures::StreamExt;
+            let mut ds = res.into_body().into_data_stream();
+            let _ = ds.next().await;
+            drop(ds);
+            status
+        }));
+    }
+    for h in handles {
+        let status = h.await.expect("task panicked");
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "every request must be admitted (no false shed)"
+        );
+    }
+
+    // All disconnected; every claimed/handed-off slot must have been released.
+    for _ in 0..200 {
+        if w.active_load() == 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        w.active_load(),
+        0,
+        "no admission slot may leak after concurrent streaming disconnects",
+    );
+    assert_eq!(
+        ctx.active_load.inflight_count(),
+        0,
+        "active-load registry must drain too"
+    );
+}
+
+/// Test-only `tracing` writer appending to a shared buffer.
+#[derive(Clone)]
+struct LogCapture(Arc<std::sync::Mutex<Vec<u8>>>);
+impl std::io::Write for LogCapture {
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(b);
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Process-wide capturing subscriber over a shared buffer. `set_global_default`
+/// can be installed only once, so a `OnceLock` guards it and the buffer
+/// accumulates every test's access log. Capture tests isolate their own lines by
+/// a unique `x-request-id` (see [`access_log_count`]), so concurrent tests
+/// writing to the shared buffer don't perturb the count. A *global* subscriber
+/// (vs a thread-local default) is required because under the parallel suite the
+/// handler's access-log events are not reliably emitted on the test's own thread.
+fn global_log_buf() -> Arc<std::sync::Mutex<Vec<u8>>> {
+    use tracing_subscriber::util::SubscriberInitExt;
+    static LOG_BUF: std::sync::OnceLock<Arc<std::sync::Mutex<Vec<u8>>>> =
+        std::sync::OnceLock::new();
+    LOG_BUF
+        .get_or_init(|| {
+            let buf = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+            let b = buf.clone();
+            let _ = tracing_subscriber::fmt()
+                .with_ansi(false)
+                .with_writer(move || LogCapture(b.clone()))
+                .finish()
+                .try_init();
+            buf
+        })
+        .clone()
+}
+
+fn make_chat_req(streaming: bool, request_id: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .header("x-request-id", request_id)
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "tiny",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": streaming,
+            }))
+            .unwrap(),
+        ))
+        .unwrap()
+}
+
+/// Count access-log lines for one specific request id. Tagging the request with
+/// a unique id and filtering on it isolates this test's log lines from any other
+/// test's `chat_completions` events that share the captured `tracing` default
+/// under parallel execution.
+fn access_log_count(logs: &str, request_id: &str) -> usize {
+    logs.lines()
+        .filter(|l| l.contains("chat_completions") && l.contains(request_id))
+        .count()
+}
+
+/// A post-dispatch error (unreachable upstream → 502) must be logged EXACTLY
+/// once in the access log: the inner handler logs the rich line, and the
+/// `chat_completions` wrapper must not re-log it (the wrapper logs only the
+/// early `?`-short-circuits, which never reach the inner log).
+#[tokio::test]
+async fn post_dispatch_error_logged_once_in_access_log() {
+    let buf = global_log_buf();
+    let rid = "rid-post-dispatch-once";
+
+    // Worker is registered (healthy on add) but unreachable → forward fails with
+    // UpstreamUnreachable (502), a post-dispatch error.
+    let ctx = build_ctx_with_worker("http://127.0.0.1:1");
+    let res = build_router(ctx)
+        .oneshot(make_chat_req(false, rid))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_GATEWAY);
+
+    let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    let n = access_log_count(&logs, rid);
+    assert_eq!(
+        n, 1,
+        "post-dispatch error must be logged exactly once (no wrapper double-log); got {n}:\n{logs}"
+    );
+}
+
+/// A successful (200) request must be logged exactly once — by the inner
+/// handler, never additionally by the wrapper. Guards against a regression that
+/// makes the wrapper log unconditionally.
+#[tokio::test]
+async fn success_logged_once_in_access_log() {
+    let buf = global_log_buf();
+    let rid = "rid-success-once";
+
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let res = build_router(ctx)
+        .oneshot(make_chat_req(false, rid))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let _ = res.into_body().collect().await.unwrap();
+
+    let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    let n = access_log_count(&logs, rid);
+    assert_eq!(
+        n, 1,
+        "a success must be logged exactly once; got {n}:\n{logs}"
+    );
+}

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -991,6 +991,60 @@ async fn forward_streaming_to_records_failure_on_mid_stream_drop() {
     );
 }
 
+/// Client-visible contract of a streaming mid-body drop, through `build_router`.
+/// This is the asymmetric half of the non-streaming case: headers were already
+/// sent as 200, so the client keeps a 200 (NOT the synthesized 502 of the
+/// non-streaming path), there is NO `x-router-error-code` / `x-router-upstream-status`,
+/// and `responses_total` counts it as a 200 (the breaker / duration metrics
+/// capture the mid-stream failure — see the breaker test above).
+#[tokio::test]
+async fn streaming_mid_body_drop_stays_200_with_no_router_headers() {
+    let worker = crate::common::mock_worker::MockWorker::start_returning_partial_body(
+        StatusCode::OK,
+        b"data: hi\n\n",
+    )
+    .await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx.clone());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "tiny",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": true
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "streaming mid-drop: headers were already sent as 200, so the client keeps 200",
+    );
+    assert!(
+        res.headers().get("x-router-error-code").is_none(),
+        "a 200-then-drop stream is not router-originated — no x-router-error-code",
+    );
+    assert!(
+        res.headers().get("x-router-upstream-status").is_none(),
+        "no status was synthesized over the worker, so no x-router-upstream-status",
+    );
+    let _ = res.into_body().collect().await;
+
+    let m = ctx.metrics.render();
+    assert!(
+        m.contains(
+            r#"sgl_router_responses_total{route="/v1/chat/completions",method="POST",status_code="200"} 1"#
+        ),
+        "a streaming mid-drop counts as a 200 at the edge: {m}",
+    );
+}
+
 #[tokio::test]
 async fn forward_json_to_records_failure_on_5xx() {
     use sgl_router::health::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -514,7 +514,7 @@ async fn oversized_request_body_returns_413() {
     // must NOT be forwarded to the upstream worker.
     let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
     let ctx = build_ctx_with_worker(&worker.url);
-    let app = build_router(ctx);
+    let app = build_router(ctx.clone());
 
     // One byte over the configured cap, so the test tracks the cap
     // (`MAX_CHAT_BODY_BYTES`) instead of a hardcoded size.
@@ -533,11 +533,22 @@ async fn oversized_request_body_returns_413() {
         res.status(),
     );
     // The worker must NOT have received the oversized payload.
-    let captured = worker.captured.lock().unwrap();
+    {
+        let captured = worker.captured.lock().unwrap();
+        assert!(
+            captured.last_body.is_none(),
+            "router must not forward oversized body to upstream; got body of {} bytes",
+            captured.last_body.as_ref().map(|b| b.len()).unwrap_or(0),
+        );
+    }
+    // The 413 is produced by the body-limit layer BEFORE the handler runs; the
+    // outermost `record_response_status` middleware must still count it.
     assert!(
-        captured.last_body.is_none(),
-        "router must not forward oversized body to upstream; got body of {} bytes",
-        captured.last_body.as_ref().map(|b| b.len()).unwrap_or(0),
+        ctx.metrics
+            .render()
+            .contains(r#"sgl_router_responses_total{status_code="413"} 1"#),
+        "body-limit 413 must be counted in responses_total: {}",
+        ctx.metrics.render(),
     );
 }
 
@@ -1521,6 +1532,123 @@ async fn admission_parks_second_request_until_first_stream_frees_the_slot() {
             .render()
             .contains("sgl_router_queued_requests 0\n"),
         "queue should drain to 0: {}",
+        ctx.metrics.render(),
+    );
+}
+
+/// A request shed by the admission gate (503 `service_overloaded`) must show up
+/// in BOTH the dedicated `sgl_router_backpressure_rejected_total` counter AND the
+/// general `sgl_router_responses_total{status_code="503"}` series. The latter is
+/// the point of the `record_response_status` middleware: the shed returns via `?`
+/// before the chat handler's own bookkeeping, so without the middleware it would
+/// be invisible in the response-code metric.
+#[tokio::test]
+async fn admission_shed_503_is_counted_in_responses_total() {
+    let chunks: Vec<&'static str> = vec![
+        "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\n",
+        "data: [DONE]\n\n",
+    ];
+    let worker = crate::common::mock_worker::MockWorker::start_slow_stream(
+        chunks,
+        Duration::from_millis(80),
+    )
+    .await;
+
+    // cap=1, depth cap 0: once the single slot is taken, the next request is
+    // shed immediately (never parks).
+    let mut cfg = config_for(&worker.url);
+    cfg.admission = sgl_router::config::AdmissionConfig::Enabled {
+        max_concurrent_per_worker: std::num::NonZeroUsize::new(1).unwrap(),
+        max_queued_requests: Some(0),
+    };
+    let registry = Arc::new(WorkerRegistry::default());
+    let _ = registry.add(WorkerSpec {
+        id: WorkerId("w1".into()),
+        url: worker.url.clone(),
+        mode: WorkerMode::Plain,
+        model_ids: vec![ModelId("tiny".into())],
+        bootstrap_port: None,
+    });
+    let policies = Arc::new(build_policy_registry(&cfg).unwrap());
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
+    let ctx = Arc::new(AppContext::new(cfg, tokenizers, proxy, registry, policies));
+
+    let make_req = || {
+        let body = serde_json::to_vec(&serde_json::json!({
+            "model": "tiny",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true,
+        }))
+        .unwrap();
+        Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap()
+    };
+
+    // A claims the only slot and holds it mid-stream (don't drain the body).
+    let res_a = build_router(ctx.clone()).oneshot(make_req()).await.unwrap();
+    assert_eq!(res_a.status(), StatusCode::OK);
+
+    // B is shed: worker at cap, wait queue depth 0 -> 503 service_overloaded.
+    let res_b = build_router(ctx.clone()).oneshot(make_req()).await.unwrap();
+    assert_eq!(res_b.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let m = ctx.metrics.render();
+    // The dedicated reject counter (was already wired).
+    assert!(
+        m.contains(r#"sgl_router_backpressure_rejected_total{model_id="tiny"} 1"#),
+        "shed must increment the dedicated reject counter: {m}",
+    );
+    // The general response-code series now sees the shed too (the fix).
+    assert!(
+        m.contains(r#"sgl_router_responses_total{status_code="503"} 1"#),
+        "shed 503 must be counted in responses_total: {m}",
+    );
+
+    // Drain A to release resources cleanly.
+    let _ = BodyExt::collect(res_a.into_body()).await.unwrap();
+}
+
+/// Guards the refactor that moved status counting into the global middleware:
+/// a successful (200) response must be counted in `sgl_router_responses_total`
+/// exactly once per request — not double-counted (a leftover handler call) nor
+/// dropped (the middleware skipping the success path). Two requests => exactly 2.
+#[tokio::test]
+async fn success_200_counted_once_per_request_in_responses_total() {
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+
+    let make_req = || {
+        Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&serde_json::json!({
+                    "model": "tiny",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": false
+                }))
+                .unwrap(),
+            ))
+            .unwrap()
+    };
+
+    for _ in 0..2 {
+        let res = build_router(ctx.clone()).oneshot(make_req()).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let _ = res.into_body().collect().await.unwrap();
+    }
+
+    assert!(
+        ctx.metrics
+            .render()
+            .contains(r#"sgl_router_responses_total{status_code="200"} 2"#),
+        "two successes must count to exactly 2 (no double- or under-count): {}",
         ctx.metrics.render(),
     );
 }

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -681,12 +681,13 @@ async fn chat_rejects_string_body_400() {
 }
 
 #[tokio::test]
-async fn non_streaming_mid_body_drop_classified_as_upstream_status() {
+async fn non_streaming_mid_body_drop_classified_as_upstream_body_incomplete() {
     // Regression: when the upstream replies with a status line and headers
     // but drops the connection mid-body, the failure is NOT
-    // "upstream_unreachable" (the upstream demonstrably DID reply). It must
-    // be classified as `upstream_status` so the operator-visible envelope
-    // reflects that the worker partially served the request.
+    // "upstream_unreachable" (the upstream demonstrably DID reply). It is
+    // classified as `upstream_body_incomplete`, and the worker's real status
+    // (200 here) is preserved in `x-router-upstream-status` rather than lost
+    // behind the synthesized 502.
     let worker = crate::common::mock_worker::MockWorker::start_returning_partial_body(
         StatusCode::OK,
         b"{\"partial\": ",
@@ -716,8 +717,13 @@ async fn non_streaming_mid_body_drop_classified_as_upstream_status() {
     );
     assert_eq!(
         res.headers().get("x-router-error-code").unwrap(),
-        "upstream_status",
-        "mid-body drop must be upstream_status (worker DID reply), not upstream_unreachable",
+        "upstream_body_incomplete",
+        "mid-body drop must be upstream_body_incomplete (worker DID reply), not upstream_unreachable",
+    );
+    assert_eq!(
+        res.headers().get("x-router-upstream-status").unwrap(),
+        "200",
+        "the worker's real status must be preserved end-to-end, not discarded",
     );
 }
 

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -1468,7 +1468,7 @@ async fn janitor_expiry_returns_504_stale_request_expired() {
             r#"sgl_router_worker_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="cancelled"}}"#,
             worker.url
         )),
-        "stale 504 must be counted in requests_total as outcome=cancelled: {m}",
+        "stale 504 must be counted in worker_requests_total as outcome=cancelled: {m}",
     );
 }
 
@@ -1689,7 +1689,7 @@ async fn admission_shed_503_is_counted_in_responses_total() {
             .any(|l| l.starts_with("sgl_router_worker_requests_total{")
                 && l.contains(r#"worker_url="""#)
                 && l.contains(r#"outcome="error""#)),
-        "shed must be counted in requests_total with empty worker_url + outcome=error: {m}",
+        "shed must be counted in worker_requests_total with empty worker_url + outcome=error: {m}",
     );
 
     // Drain A to release resources cleanly.
@@ -1753,13 +1753,15 @@ async fn success_200_counted_once_per_request_in_responses_total() {
     );
 }
 
-/// Infra paths (`/healthz`, `/readyz`, `/metrics`) are health/scrape probes, not
-/// API traffic: the middleware counts them in `responses_total{status_code}` (so
-/// a failing probe stays observable) but deliberately skips `requests_total` —
+/// Infra paths (`/healthz`, `/readyz`, `/metrics`) are health/scrape probes. The
+/// middleware counts them in the edge counters `requests_total{route,method}` and
+/// `responses_total{route,method,status_code}` (so a failing probe stays
+/// observable), but deliberately skips the per-worker `worker_requests_total` —
 /// otherwise probe successes would swamp the by-outcome view. A `/healthz` 200
-/// must therefore appear in `responses_total` yet leave `requests_total` empty.
+/// must therefore appear in the edge counters yet leave `worker_requests_total`
+/// empty.
 #[tokio::test]
-async fn infra_path_counted_in_responses_total_but_not_requests_total() {
+async fn infra_path_counted_in_edge_counters_but_not_worker_requests_total() {
     let ctx = build_ctx_with_worker("http://placeholder:0");
 
     let req = Request::builder()
@@ -1772,20 +1774,52 @@ async fn infra_path_counted_in_responses_total_but_not_requests_total() {
     let _ = res.into_body().collect().await.unwrap();
 
     let m = ctx.metrics.render();
-    // Counted in responses_total — a failing probe must stay observable there.
+    // Counted in the edge counters — a probe must stay observable there.
+    assert!(
+        m.contains(r#"sgl_router_requests_total{route="/healthz",method="GET"} 1"#),
+        "infra intake must be counted in requests_total: {m}",
+    );
     assert!(
         m.contains(
             r#"sgl_router_responses_total{route="/healthz",method="GET",status_code="200"} 1"#
         ),
         "infra 200 must be counted in responses_total: {m}",
     );
-    // ...but NOT in requests_total: when the only traffic is an infra probe, no
-    // request series may exist (the `# TYPE` line starts with `#`, not the metric
-    // name, so it is not matched here).
+    // ...but NOT in the per-worker counter: probe successes must not swamp the
+    // by-outcome view (the `# TYPE` line starts with `#`, not the metric name, so
+    // it is not matched here).
     assert!(
         !m.lines()
             .any(|l| l.starts_with("sgl_router_worker_requests_total{")),
-        "infra path must NOT be counted in requests_total: {m}",
+        "infra path must NOT be counted in worker_requests_total: {m}",
+    );
+}
+
+/// A request to a path the router does not serve (a true 404) collapses to the
+/// `route="unmatched"` label — NOT the raw URI — so scanner / fuzzer traffic
+/// can't explode the metric label cardinality. It is still counted at the edge.
+#[tokio::test]
+async fn unrouted_path_collapses_to_unmatched_label() {
+    let ctx = build_ctx_with_worker("http://placeholder:0");
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/no/such/route")
+        .body(Body::empty())
+        .unwrap();
+    let res = build_router(ctx.clone()).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    let _ = res.into_body().collect().await.unwrap();
+
+    let m = ctx.metrics.render();
+    assert!(
+        m.contains(r#"sgl_router_requests_total{route="unmatched",method="GET"} 1"#),
+        "an unrouted path must collapse to route=\"unmatched\": {m}",
+    );
+    // The raw URI must never become a metric label (cardinality safety).
+    assert!(
+        !m.contains("/no/such/route"),
+        "raw unrouted URI must not appear as a label: {m}",
     );
 }
 

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -465,6 +465,57 @@ async fn non_streaming_upstream_500_preserved() {
     assert_eq!(got, upstream_body);
 }
 
+/// A response the router FORWARDS from a worker with a non-2xx status is an
+/// `Ok(Response)` at the router layer (only transport failures become `Err`).
+/// The per-worker `sgl_router_requests_total` outcome must be derived from the
+/// client-visible HTTP status, not from `Result::Ok`/`Err` — so a forwarded 5xx
+/// is counted `outcome="error"`, NOT credited as a success.
+#[tokio::test]
+async fn forwarded_5xx_records_outcome_error_not_success() {
+    let worker = crate::common::mock_worker::MockWorker::start_returning_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        serde_json::json!({"error": {"type": "server_error", "message": "boom"}}),
+    )
+    .await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx.clone());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "tiny",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": false,
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let _ = res.into_body().collect().await.unwrap().to_bytes();
+
+    let m = ctx.metrics.render();
+    let error_line = format!(
+        r#"sgl_router_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="error"}} 1"#,
+        worker.url,
+    );
+    assert!(
+        m.contains(&error_line),
+        "a forwarded 5xx must be counted as outcome=\"error\"; got:\n{m}",
+    );
+    let success_line = format!(
+        r#"sgl_router_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="success"}}"#,
+        worker.url,
+    );
+    assert!(
+        !m.contains(&success_line),
+        "a forwarded 5xx must NOT be credited as a success; got:\n{m}",
+    );
+}
+
 #[tokio::test]
 async fn non_streaming_upstream_4xx_body_passthrough() {
     // Regression: the worker's response bytes must reach the client

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -1971,18 +1971,18 @@ fn make_chat_req(streaming: bool, request_id: &str) -> Request<Body> {
 
 /// Count access-log lines for one specific request id. Tagging the request with
 /// a unique id and filtering on it isolates this test's log lines from any other
-/// test's `chat_completions` events that share the captured `tracing` default
+/// test's `http_request` events that share the captured `tracing` default
 /// under parallel execution.
 fn access_log_count(logs: &str, request_id: &str) -> usize {
     logs.lines()
-        .filter(|l| l.contains("chat_completions") && l.contains(request_id))
+        .filter(|l| l.contains("http_request") && l.contains(request_id))
         .count()
 }
 
 /// A post-dispatch error (unreachable upstream → 502) must be logged EXACTLY
-/// once in the access log: the inner handler logs the rich line, and the
-/// `chat_completions` wrapper must not re-log it (the wrapper logs only the
-/// early `?`-short-circuits, which never reach the inner log).
+/// once in the access log. Logging happens once, centrally, in the
+/// `access_log_and_record` middleware (the handler no longer logs), so a routed
+/// error produces a single `http_request` line — not two.
 #[tokio::test]
 async fn post_dispatch_error_logged_once_in_access_log() {
     let buf = global_log_buf();
@@ -2005,9 +2005,9 @@ async fn post_dispatch_error_logged_once_in_access_log() {
     );
 }
 
-/// A successful (200) request must be logged exactly once — by the inner
-/// handler, never additionally by the wrapper. Guards against a regression that
-/// makes the wrapper log unconditionally.
+/// A successful (200) request must be logged exactly once — by the
+/// `access_log_and_record` middleware. Guards against a regression that
+/// re-introduces handler-side logging on top of the middleware.
 #[tokio::test]
 async fn success_logged_once_in_access_log() {
     let buf = global_log_buf();

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -593,7 +593,7 @@ async fn oversized_request_body_returns_413() {
         );
     }
     // The 413 is produced by the body-limit layer BEFORE the handler runs; the
-    // outermost `record_response_status` middleware must still count it.
+    // outermost `access_log_and_record` middleware must still count it.
     assert!(
         ctx.metrics
             .render()
@@ -1417,7 +1417,7 @@ async fn janitor_expiry_returns_504_stale_request_expired() {
         policies,
         active_load,
     ));
-    let app = build_router(ctx);
+    let app = build_router(ctx.clone());
 
     let req = Request::builder()
         .method("POST")
@@ -1450,6 +1450,17 @@ async fn janitor_expiry_returns_504_stale_request_expired() {
     assert!(
         body_str.contains("\"code\":\"stale_request_expired\""),
         "504 body must encode the same code in the JSON envelope: {body_str}",
+    );
+    // The stale-cancel is a routed request (a worker was selected), so it lands
+    // in requests_total with the worker's labels and outcome="cancelled" — the
+    // 504 → Cancelled mapping in `outcome_from_status`, distinct from "error".
+    let m = ctx.metrics.render();
+    assert!(
+        m.contains(&format!(
+            r#"sgl_router_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="cancelled"}}"#,
+            worker.url
+        )),
+        "stale 504 must be counted in requests_total as outcome=cancelled: {m}",
     );
 }
 
@@ -1588,11 +1599,12 @@ async fn admission_parks_second_request_until_first_stream_frees_the_slot() {
 }
 
 /// A request shed by the admission gate (503 `service_overloaded`) must show up
-/// in BOTH the dedicated `sgl_router_backpressure_rejected_total` counter AND the
-/// general `sgl_router_responses_total{status_code="503"}` series. The latter is
-/// the point of the `record_response_status` middleware: the shed returns via `?`
-/// before the chat handler's own bookkeeping, so without the middleware it would
-/// be invisible in the response-code metric.
+/// in the dedicated `sgl_router_backpressure_rejected_total` counter, the general
+/// `sgl_router_responses_total{status_code="503"}` series, AND
+/// `sgl_router_requests_total{outcome="error"}` with an empty `worker_url`. The
+/// shed returns via `?` before reaching a worker, so only the outermost
+/// `access_log_and_record` middleware can count it — which is what makes
+/// `sum by (outcome)` include sheds instead of undercounting them.
 #[tokio::test]
 async fn admission_shed_503_is_counted_in_responses_total() {
     let chunks: Vec<&'static str> = vec![
@@ -1659,6 +1671,16 @@ async fn admission_shed_503_is_counted_in_responses_total() {
         m.contains(r#"sgl_router_responses_total{status_code="503"} 1"#),
         "shed 503 must be counted in responses_total: {m}",
     );
+    // And the by-outcome request counter: the shed returns before routing, so the
+    // middleware records it with an empty worker_url and outcome="error". This is
+    // the line that makes `sum by (outcome)` include sheds.
+    assert!(
+        m.lines()
+            .any(|l| l.starts_with("sgl_router_requests_total{")
+                && l.contains(r#"worker_url="""#)
+                && l.contains(r#"outcome="error""#)),
+        "shed must be counted in requests_total with empty worker_url + outcome=error: {m}",
+    );
 
     // Drain A to release resources cleanly.
     let _ = BodyExt::collect(res_a.into_body()).await.unwrap();
@@ -1701,6 +1723,52 @@ async fn success_200_counted_once_per_request_in_responses_total() {
             .contains(r#"sgl_router_responses_total{status_code="200"} 2"#),
         "two successes must count to exactly 2 (no double- or under-count): {}",
         ctx.metrics.render(),
+    );
+    // A routed success must carry its per-worker labels in requests_total — the
+    // handler attaches them via RequestLogContext and the middleware records
+    // them. Guards the label migration against regressing routed traffic to an
+    // empty worker_url (which would blank the per-worker convergence panels).
+    assert!(
+        ctx.metrics.render().contains(&format!(
+            r#"sgl_router_requests_total{{worker_url="{}",model_id="tiny",mode="plain",outcome="success"}} 2"#,
+            worker.url
+        )),
+        "two routed successes must count to 2 with full per-worker labels: {}",
+        ctx.metrics.render(),
+    );
+}
+
+/// Infra paths (`/healthz`, `/readyz`, `/metrics`) are health/scrape probes, not
+/// API traffic: the middleware counts them in `responses_total{status_code}` (so
+/// a failing probe stays observable) but deliberately skips `requests_total` —
+/// otherwise probe successes would swamp the by-outcome view. A `/healthz` 200
+/// must therefore appear in `responses_total` yet leave `requests_total` empty.
+#[tokio::test]
+async fn infra_path_counted_in_responses_total_but_not_requests_total() {
+    let ctx = build_ctx_with_worker("http://placeholder:0");
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/healthz")
+        .body(Body::empty())
+        .unwrap();
+    let res = build_router(ctx.clone()).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let _ = res.into_body().collect().await.unwrap();
+
+    let m = ctx.metrics.render();
+    // Counted in responses_total — a failing probe must stay observable there.
+    assert!(
+        m.contains(r#"sgl_router_responses_total{status_code="200"} 1"#),
+        "infra 200 must be counted in responses_total: {m}",
+    );
+    // ...but NOT in requests_total: when the only traffic is an infra probe, no
+    // request series may exist (the `# TYPE` line starts with `#`, not the metric
+    // name, so it is not matched here).
+    assert!(
+        !m.lines()
+            .any(|l| l.starts_with("sgl_router_requests_total{")),
+        "infra path must NOT be counted in requests_total: {m}",
     );
 }
 

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -289,7 +289,9 @@ async fn streaming_5xx_request_records_duration_and_status_but_not_ttft() {
         "TTFT must NOT be recorded for a non-2xx streaming response; got:\n{m}",
     );
     assert!(
-        m.contains(r#"sgl_router_responses_total{status_code="500"} 1"#),
+        m.contains(
+            r#"sgl_router_responses_total{route="/v1/chat/completions",method="POST",status_code="500"} 1"#
+        ),
         "the 500 status must be counted; got:\n{m}",
     );
     assert!(
@@ -597,7 +599,7 @@ async fn oversized_request_body_returns_413() {
     assert!(
         ctx.metrics
             .render()
-            .contains(r#"sgl_router_responses_total{status_code="413"} 1"#),
+            .contains(r#"sgl_router_responses_total{route="/v1/chat/completions",method="POST",status_code="413"} 1"#),
         "body-limit 413 must be counted in responses_total: {}",
         ctx.metrics.render(),
     );
@@ -1674,7 +1676,9 @@ async fn admission_shed_503_is_counted_in_responses_total() {
     );
     // The general response-code series now sees the shed too (the fix).
     assert!(
-        m.contains(r#"sgl_router_responses_total{status_code="503"} 1"#),
+        m.contains(
+            r#"sgl_router_responses_total{route="/v1/chat/completions",method="POST",status_code="503"} 1"#
+        ),
         "shed 503 must be counted in responses_total: {m}",
     );
     // And the by-outcome request counter: the shed returns before routing, so the
@@ -1723,12 +1727,17 @@ async fn success_200_counted_once_per_request_in_responses_total() {
         let _ = res.into_body().collect().await.unwrap();
     }
 
+    let m = ctx.metrics.render();
     assert!(
-        ctx.metrics
-            .render()
-            .contains(r#"sgl_router_responses_total{status_code="200"} 2"#),
-        "two successes must count to exactly 2 (no double- or under-count): {}",
-        ctx.metrics.render(),
+        m.contains(
+            r#"sgl_router_responses_total{route="/v1/chat/completions",method="POST",status_code="200"} 2"#
+        ),
+        "two successes must count to exactly 2 (no double- or under-count): {m}",
+    );
+    // Both successes are also true intake (counted at entry, through build_router).
+    assert!(
+        m.contains(r#"sgl_router_intake_total{route="/v1/chat/completions",method="POST"} 2"#),
+        "two successes must each be counted as intake: {m}",
     );
     // A routed success must carry its per-worker labels in requests_total — the
     // handler attaches them via RequestLogContext and the middleware records
@@ -1765,7 +1774,9 @@ async fn infra_path_counted_in_responses_total_but_not_requests_total() {
     let m = ctx.metrics.render();
     // Counted in responses_total — a failing probe must stay observable there.
     assert!(
-        m.contains(r#"sgl_router_responses_total{status_code="200"} 1"#),
+        m.contains(
+            r#"sgl_router_responses_total{route="/healthz",method="GET",status_code="200"} 1"#
+        ),
         "infra 200 must be counted in responses_total: {m}",
     );
     // ...but NOT in requests_total: when the only traffic is an infra probe, no

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -43,6 +43,7 @@ fn config_for(_worker_url: &str) -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     }
 }
 
@@ -1426,5 +1427,100 @@ async fn non_streaming_error_path_drops_active_load_guard() {
         active_load.inflight_count(),
         0,
         "error path must drop the active-load guard",
+    );
+}
+
+/// End-to-end admission control: with a per-worker cap of 1, a second request
+/// parks at the router (does NOT 503) while the first holds the only slot
+/// mid-stream, and is admitted once the first stream completes and frees the
+/// slot. Exercises the real handler wiring (`acquire` + the `AdmissionGuard`
+/// firing on stream end), which the `AdmissionQueue` unit tests cannot reach.
+#[tokio::test]
+async fn admission_parks_second_request_until_first_stream_frees_the_slot() {
+    let chunks: Vec<&'static str> = vec![
+        "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\n",
+        "data: [DONE]\n\n",
+    ];
+    let worker = crate::common::mock_worker::MockWorker::start_slow_stream(
+        chunks,
+        Duration::from_millis(80),
+    )
+    .await;
+
+    // cap=1 per worker, bounded wait queue large enough that a parked request
+    // is not shed.
+    let mut cfg = config_for(&worker.url);
+    cfg.admission = sgl_router::config::AdmissionConfig::Enabled {
+        max_concurrent_per_worker: std::num::NonZeroUsize::new(1).unwrap(),
+        max_queued_requests: Some(4),
+    };
+    let registry = Arc::new(WorkerRegistry::default());
+    let _ = registry.add(WorkerSpec {
+        id: WorkerId("w1".into()),
+        url: worker.url.clone(),
+        mode: WorkerMode::Plain,
+        model_ids: vec![ModelId("tiny".into())],
+        bootstrap_port: None,
+    });
+    let policies = Arc::new(build_policy_registry(&cfg).unwrap());
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
+    let ctx = Arc::new(AppContext::new(cfg, tokenizers, proxy, registry, policies));
+
+    let make_req = || {
+        let body = serde_json::to_vec(&serde_json::json!({
+            "model": "tiny",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true,
+        }))
+        .unwrap();
+        Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap()
+    };
+
+    // Request A claims the only slot. Hold its response (don't drain) so the
+    // slot stays occupied for the stream's lifetime.
+    let res_a = build_router(ctx.clone()).oneshot(make_req()).await.unwrap();
+    assert_eq!(res_a.status(), StatusCode::OK);
+
+    // Request B must park (cap=1, A holds the slot). Spawn it and confirm it
+    // neither completes nor sheds while A is in flight.
+    let ctx_b = ctx.clone();
+    let b = tokio::spawn(async move { build_router(ctx_b).oneshot(make_req()).await.unwrap() });
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    assert!(
+        !b.is_finished(),
+        "B should park while A holds the only slot, not return"
+    );
+    assert!(
+        ctx.metrics
+            .render()
+            .contains("sgl_router_queued_requests 1\n"),
+        "B should be counted as parked: {}",
+        ctx.metrics.render(),
+    );
+
+    // Drain A: frees the slot and wakes B.
+    let _ = BodyExt::collect(res_a.into_body()).await.unwrap();
+
+    // B is now admitted and completes successfully.
+    let res_b = tokio::time::timeout(Duration::from_secs(2), b)
+        .await
+        .expect("B must be admitted once A frees the slot")
+        .expect("B task panicked");
+    assert_eq!(res_b.status(), StatusCode::OK);
+    let _ = BodyExt::collect(res_b.into_body()).await.unwrap();
+
+    // Wait queue fully drained.
+    assert!(
+        ctx.metrics
+            .render()
+            .contains("sgl_router_queued_requests 0\n"),
+        "queue should drain to 0: {}",
+        ctx.metrics.render(),
     );
 }

--- a/experimental/sgl-router/tests/proxy/failover.rs
+++ b/experimental/sgl-router/tests/proxy/failover.rs
@@ -47,6 +47,7 @@ async fn failover_when_one_worker_dies() {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: AdmissionConfig::default(),
     };
 
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());

--- a/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
+++ b/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
@@ -53,6 +53,7 @@ fn build_ctx_with_worker(worker_url: &str) -> Arc<AppContext> {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/proxy/header_forwarding.rs
+++ b/experimental/sgl-router/tests/proxy/header_forwarding.rs
@@ -40,6 +40,7 @@ async fn forwards_whitelisted_headers_strips_others() {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
+++ b/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
@@ -55,6 +55,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
+++ b/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
@@ -54,6 +54,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
@@ -51,6 +51,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
@@ -70,6 +70,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/sticky_routing.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_routing.rs
@@ -94,12 +94,12 @@ fn chat_request(header: Option<(&str, &str)>) -> Request<Body> {
         .unwrap()
 }
 
-/// Parse `sgl_router_requests_total{...,outcome="success"} N` lines into a
+/// Parse `sgl_router_worker_requests_total{...,outcome="success"} N` lines into a
 /// map of worker_url -> success count.
 fn success_counts(metrics: &str) -> std::collections::HashMap<String, u64> {
     let mut counts = std::collections::HashMap::new();
     for line in metrics.lines() {
-        let Some(rest) = line.strip_prefix("sgl_router_requests_total{") else {
+        let Some(rest) = line.strip_prefix("sgl_router_worker_requests_total{") else {
             continue;
         };
         if !rest.contains(r#"outcome="success""#) {

--- a/experimental/sgl-router/tests/proxy/sticky_routing.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_routing.rs
@@ -56,6 +56,7 @@ fn build_sticky_ctx(header_name: &str, worker_urls: &[String]) -> Arc<AppContext
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/proxy/timeout.rs
+++ b/experimental/sgl-router/tests/proxy/timeout.rs
@@ -47,6 +47,7 @@ fn config(_worker_url: &str) -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admission: sgl_router::config::AdmissionConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/timeout.rs
+++ b/experimental/sgl-router/tests/proxy/timeout.rs
@@ -7,7 +7,8 @@
 //! Without a configured `.timeout(...)` on the reqwest client, a stalled
 //! backend hangs the axum handler future forever and the test harness
 //! would just timeout. We assert here that the router returns a fast,
-//! clean 502 (`upstream_timeout`) instead.
+//! clean 504 (`upstream_timeout`) instead — a timeout is a gateway timeout,
+//! the same status class as the stale-deadline cancel.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -96,7 +97,7 @@ async fn non_streaming_request_times_out_when_worker_hangs() {
         elapsed < Duration::from_secs(1),
         "router must short-circuit on upstream timeout; elapsed {elapsed:?}"
     );
-    assert_eq!(res.status(), StatusCode::BAD_GATEWAY);
+    assert_eq!(res.status(), StatusCode::GATEWAY_TIMEOUT);
     assert_eq!(
         res.headers().get("x-router-error-code").unwrap(),
         "upstream_timeout"


### PR DESCRIPTION
## Motivation

Today the router forwards every request to the selected worker the instant it arrives. A saturated backend silently absorbs an unbounded pile of in-flight requests at its connection front door — latency the client pays but the backend's own metrics never see, and the router has no way to shed load or apply backpressure.

This PR adds **opt-in, request-count admission control** to the chat hot path.

## What it does

An `AdmissionQueue` gate sits in front of worker dispatch:

- **`--max-concurrent-requests-per-worker N`** — caps in-flight requests per worker. A request parks when every candidate worker is at its cap; when a slot frees it is handed to the **oldest** eligible parked waiter (strict FIFO — see Design notes). The cap is a *hard* bound: slots are claimed via a compare-and-swap `LoadGuard::try_new`, so at most `N` guards can coexist even when many callers race for the last slot.
- **`--max-queued-requests M`** — bounds the wait queue. Once `M` requests are parked, further arrivals are shed with `503 service_overloaded` (retryable, so clients / upstream LBs back off). Requires the per-worker cap. Unset → unbounded queue (park, never shed).

**Both flags default to unset**, in which case the gate is a pass-through and the router dispatches immediately, exactly as before — zero behavior change for existing deployments.

## Design notes

- Config is an `AdmissionConfig` enum (`Disabled` / `Enabled { max_concurrent_per_worker, max_queued_requests }`) so the illegal "wait-queue depth without a per-worker cap" state is unrepresentable. `NonZeroUsize` rules out a `0` cap that would wedge every worker as permanently full. CLI validation rejects `--max-queued-requests` without `--max-concurrent-requests-per-worker`.
- New `sgl_router_admission_*` metrics make the wait distribution (`sgl_router_admission_wait_seconds`) and shed rate observable.
- **Response-code coverage for sheds.** A global outermost middleware (`record_response_status`) now records the final status of every response into `sgl_router_responses_total{status_code}`, so an admission shed lands in **both** the dedicated `sgl_router_backpressure_rejected_total` (cause) and `sgl_router_responses_total{status_code="503"}` (outcome). Previously the response-code counter was recorded late in the chat handler and was bypassed by the early `?` return on a shed; the per-handler call is removed to avoid double-counting. (The counter is now router-wide and recorded at response-headers time — see the updated HELP text.)
- **Access-log coverage for all outcomes.** The chat access log fired only at the end of the handler, so early-error short-circuits — a 400 body-validation, a 503 admission shed, model-not-found, all `?` returns — never reached it and were invisible in the logs. `chat_completions` is now a thin wrapper over `chat_completions_inner`: the wrapper logs the early-error paths, the inner keeps the rich success / post-dispatch access line (model/worker/stream). The inner returns its post-dispatch errors (504 stale, 502 upstream) as a *response* (already logged) rather than `Err`, so every request is logged exactly once.
- **Fairness — strict FIFO via direct slot hand-off.** Parked requests are admitted in arrival order. When a request completes, `AdmissionGuard` drop hands its freed per-worker slot *directly* to the most-senior parked waiter eligible for that worker (transferring the live `LoadGuard` over a `oneshot`), rather than decrementing and letting waiters race for it. Because the worker's in-flight count never dips during the transfer, a freshly arriving request that races for the same slot finds the worker still at capacity and parks *behind* the existing waiters instead of jumping ahead. A waiter is overtaken only by a later arrival that is ineligible for the freed worker (a different candidate pool), never by one competing for the same slot — so no starvation. Cancellation (client disconnect) releases the wait-queue permit + depth gauge and re-routes any in-flight grant to the next waiter.
- `AdmissionGuard` is a 3-variant enum (`Spent` / `PassThrough` / `Armed`); the hand-off obligation lives in `Drop` and the guard is `#[must_use]`, so a slot can neither be silently dropped nor forgotten.

## Tests

- `try_load_guard` cap enforcement, including a 64-thread concurrency test asserting the cap is never exceeded.
- **FIFO admission order** of three parked waiters (independent of scheduler wake order), and **newcomer-parks-behind** an existing waiter.
- **Multi-worker eligibility:** a freed worker's slot skips an ineligible senior waiter and goes to the eligible one (FIFO *within* the eligible set).
- **Cancellation re-hand:** a granted slot whose receiver was cancelled mid-hand-off is re-routed to the next waiter (looped to exercise both race interleavings); the abandoned-parked-request case releases its wait-queue permit.
- **Concurrency stress:** 200 concurrent acquires over 3 workers never exceed the per-worker cap and the queue drains to zero (no slot leak).
- CLI flag mapping, default-disabled, zero-cap rejection, and the `--max-queued-requests` dependency check.
- `503 service_overloaded` envelope/status mapping.
- **Response-code metric:** a shed 503 is counted in `sgl_router_responses_total`; a 200 success is counted exactly once per request (two requests → 2); the body-limit 413 (produced before the handler) is counted by the outermost middleware.
- **Access log:** an early-error 400 is surfaced in the access log (was silent before); success and post-dispatch errors are each logged exactly once (no double-log).
- Admission integration in the chat-routing proxy tests (a second request parks at the router, then admits when the first stream frees the slot).

## Status

Draft — opening for early review / CI signal. Surface area is confined to `experimental/sgl-router/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


