### PR TITLE
 [NPU] perf: precompute mamba conv-state track indices once per batch

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
@@ -49,13 +49,11 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
 
     def _prepare_mamba_track_metadata(self, forward_batch: ForwardBatch):
         if self.forward_metadata.has_mamba_track_mask:
-            self.forward_metadata.mamba_track_mask_indices = (
-                forward_batch.mamba_track_mask.nonzero(as_tuple=True)[0]
-            )
+            mamba_track_mask_indices = forward_batch.mamba_track_mask.nonzero(
+                as_tuple=True
+            )[0]
             self.forward_metadata.conv_states_mask_indices = (
-                forward_batch.mamba_track_indices[
-                    self.forward_metadata.mamba_track_mask_indices
-                ]
+                forward_batch.mamba_track_indices[mamba_track_mask_indices]
             )
 
     def prepare_gdn_inputs(
@@ -234,6 +232,10 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
             ).view(seq_len, -1)
         else:
             mixed_qkv = mixed_qkv.transpose(0, 1)
+            # forward_extend runs eagerly (no CUDA-graph capture/replay), so
+            # has_mamba_track_mask / conv_states_mask_indices are always populated
+            # by init_forward_metadata{,_out_graph}. If extend is ever graph-replayed,
+            # _replay_metadata must precompute these too, otherwise tracking is skipped.
             if forward_metadata.has_mamba_track_mask:
                 mixed_qkv_to_track = mixed_qkv[
                     :, forward_metadata.track_conv_indices

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
@@ -47,6 +47,17 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
         prefill_backend = get_linear_attn_prefill_backend()
         self.kernel_dispatcher = GDNKernelDispatcher(decode_backend, prefill_backend)
 
+    def _prepare_mamba_track_metadata(self, forward_batch: ForwardBatch):
+        if self.forward_metadata.has_mamba_track_mask:
+            self.forward_metadata.mamba_track_mask_indices = (
+                forward_batch.mamba_track_mask.nonzero(as_tuple=True)[0]
+            )
+            self.forward_metadata.conv_states_mask_indices = (
+                forward_batch.mamba_track_indices[
+                    self.forward_metadata.mamba_track_mask_indices
+                ]
+            )
+
     def prepare_gdn_inputs(
         self,
         bs: int,
@@ -85,6 +96,7 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
             forward_batch.forward_mode,
             forward_batch.spec_info,
         )
+        self._prepare_mamba_track_metadata(forward_batch)
         self.graph_mode = True
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
@@ -96,6 +108,7 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
             forward_batch.forward_mode,
             forward_batch.spec_info,
         )
+        self._prepare_mamba_track_metadata(forward_batch)
         self.graph_mode = False
 
     def forward_decode(
@@ -221,16 +234,13 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
             ).view(seq_len, -1)
         else:
             mixed_qkv = mixed_qkv.transpose(0, 1)
-            if (
-                forward_batch.mamba_track_mask is not None
-                and forward_batch.mamba_track_mask.any()
-            ):
-                conv_dst = forward_batch.mamba_track_indices
+            if forward_metadata.has_mamba_track_mask:
                 mixed_qkv_to_track = mixed_qkv[
                     :, forward_metadata.track_conv_indices
                 ].transpose(0, 1)
-                mask_indices = forward_batch.mamba_track_mask.nonzero(as_tuple=True)[0]
-                conv_states.transpose(1, 2)[conv_dst[mask_indices]] = mixed_qkv_to_track
+                conv_states.transpose(1, 2)[
+                    forward_metadata.conv_states_mask_indices
+                ] = mixed_qkv_to_track
             kernel_size = layer.conv_weights.shape[-1]
             conv_states_for_prefill = conv_states[:, -(kernel_size - 1) :, :]
             conv_states_tmp = conv_states_for_prefill.transpose(1, 2).contiguous()

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
@@ -232,10 +232,6 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
             ).view(seq_len, -1)
         else:
             mixed_qkv = mixed_qkv.transpose(0, 1)
-            # forward_extend runs eagerly (no CUDA-graph capture/replay), so
-            # has_mamba_track_mask / conv_states_mask_indices are always populated
-            # by init_forward_metadata{,_out_graph}. If extend is ever graph-replayed,
-            # _replay_metadata must precompute these too, otherwise tracking is skipped.
             if forward_metadata.has_mamba_track_mask:
                 mixed_qkv_to_track = mixed_qkv[
                     :, forward_metadata.track_conv_indices


### PR DESCRIPTION
 ## Motivation

  In the Ascend GDN (Gated Delta Net) attention backend, the prefill/extend path  recomputed the mamba conv-state tracking indices **inside `forward_extend`,  once per linear-attention layer**. The index computation
  (`mamba_track_mask.nonzero()` plus a gather into `mamba_track_indices`) is  batch-level data — it does not change across layers — yet it was redone on  every layer. On NPU, `nonzero()` produces a data-dependent shape and forces a
  device→host sync, so repeating it per layer adds avoidable overhead on the  prefill critical path.
  This PR computes those indices **once per batch** and reuses them across all  layers, reducing time-to-first-token without changing any model output.
  ## Modifications

  - Add `_prepare_mamba_track_metadata()` to `AscendGDNAttnBackend`. When    `forward_metadata.has_mamba_track_mask` is set, it precomputes:
    - `mamba_track_mask_indices = mamba_track_mask.nonzero(as_tuple=True)[0]`
    - `conv_states_mask_indices = mamba_track_indices[mamba_track_mask_indices]`
    and stores them on `ForwardMetadata`. It is invoked from both  `init_forward_metadata` and `init_forward_metadata_out_graph`, i.e. once per   batch.
  - In `forward_extend`, replace the per-layer inline computation (`nonzero()` +   gather) and the inline `mamba_track_mask is not None and .any()` guard with a    read of the precomputed `forward_metadata.conv_states_mask_indices`, gated by    `forward_metadata.has_mamba_track_mask`.
  - Net effect: for a hybrid model with K linear-attention layers, the   dynamic-shape `nonzero()` runs **once per batch** instead of **K times per    prefill**. The decode path is untouched.

  This is a behavior-preserving change: `has_mamba_track_mask` is defined as  `bool(mamba_track_mask is not None and mamba_track_mask.any())`, identical to  the guard it replaces, and `conv_states_mask_indices` equals the previous
  `mamba_track_indices[mask_indices]`. A fresh `ForwardMetadata` is built per  batch, so no stale indices can leak across batches.

 ## Accuracy Tests

  The change is behavior-preserving, so accuracy is expected to match the  pre-change build. Verified with GPQA-Diamond on `Qwen3.6-27B`:

  | Model | Dataset | Metric | Num | Score |
  |---|---|---|---|---|
  | `Qwen3.6-27B` | gpqa_diamond | mean_acc | 198 | **0.8586** |

  Evaluated with evalscope; the score is within the expected range for this  model, confirming no regression from the refactor.

  <details>
  <summary>Raw evalscope report</summary>

  ┌──────────┬──────────────┬──────────┬─────────┬──────┬────────┬─────────┐
  │ Model    │ Dataset      │ Metric   │ Subset  │  Num │  Score │ Cat.0   │
  ├──────────┼──────────────┼──────────┼─────────┼──────┼────────┼─────────┤
  │ untitled │ gpqa_diamond │ mean_acc │ default │  198 │ 0.8586 │ default │
  └──────────┴──────────────┴──────────┴─────────┴──────┴────────┴─────────┘
  </details>

  ## Benchmarking and Profiling

  **Hardware:** `<Ascend 910x — confirm SKU>`
  **Command (confirm/replace):**

  ```bash
 python3 -m sglang.launch_server \
    --model-path /home/weight/Qwen3.6-27B \
    --attention-backend ascend \
    --device npu \
    --tp-size 2 --nnodes 1 --node-rank 0 \
    --chunked-prefill-size 32768 --max-prefill-tokens 32768 \
    --mamba-scheduler-strategy extra_buffer \
    --trust-remote-code \
    --host 127.0.0.1 --max-running-requests 20 --max-mamba-cache-size 108 \
    --mem-fraction-static 0.7 \
    --port 6688 \
    --cuda-graph-bs "1", "2", "4", "8", "12", "15","17", "19", "20" \
    --dtype bfloat16 --mamba-ssm-dtype bfloat16 \
    --speculative-algorithm NEXTN \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --enable-prefill-delayer \
    --prefill-delayer-queue-min-ratio 0.7 \
    --prefill-delayer-max-delay-ms 30000

  Same workload, 80 requests @ concurrency 20, MTP on (accept length ≈ 3.7).

  ┌─────────────────────────────────┬─────────────────┬──────────┬──────────────────────┐
  │             Metric              │ Baseline (main) │ This PR  │          Δ           │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ Benchmark duration (s)          │ 360.15          │ 343.59   │ −4.6%                │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ Total token throughput (tok/s)  │ 15776.60        │ 16537.05 │ +4.8%                │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ Output token throughput (tok/s) │ 227.46          │ 238.42   │ +4.8%                │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ Input token throughput (tok/s)  │ 15549.14        │ 16298.63 │ +4.8%                │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ Mean TTFT (ms)                  │ 31962.90        │ 30373.23 │ −5.0%                │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ Median TTFT (ms)                │ 27638.02        │ 27047.09 │ −2.1%                │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ P90 TTFT (ms)                   │ 55360.60        │ 47856.74 │ −13.6%               │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ P95 TTFT (ms)                   │ 55727.35        │ 47961.14 │ −13.9%               │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ P99 TTFT (ms)                   │ 64364.75        │ 58855.56 │ −8.6%                │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ Median E2E (ms)                 │ 82039.43        │ 77467.83 │ −5.6%                │
  ├─────────────────────────────────┼─────────────────┼──────────┼──────────────────────┤
  │ Mean TPOT (ms)                  │ 48.98           │ 49.57    │ +1.2% (within noise) │
  └─────────────────────────────────┴─────────────────┴──────────┴──────────────────────┘

  The gains concentrate on TTFT / prefill (P90–P95 down ~14%) and overall  throughput (+4.8%), consistent with removing the redundant per-layer  nonzero() from the prefill path. TPOT (decode) is flat, as expected since the  decode path is unchanged.

  <details>
  <summary>Raw bench_serving output — baseline</summary>

  ============ Serving Benchmark Result ============
  Backend:                                 sglang
  Max request concurrency:                 20
  Successful requests:                     80
  Benchmark duration (s):                  360.15
  Total token throughput (tok/s):          15776.60
  Accept length:                           3.66
  Mean TTFT (ms):                          31962.90
  Median TTFT (ms):                        27638.02
  P90 TTFT (ms):                           55360.60
  P95 TTFT (ms):                           55727.35
  P99 TTFT (ms):                           64364.75
  Mean TPOT (ms):                          48.98
  Median E2E Latency (ms):                 82039.43
  ==================================================
  </details>

  <details>
  <summary>Raw bench_serving output — this PR</summary>

  ============ Serving Benchmark Result ============
  Backend:                                 sglang
  Max request concurrency:                 20
  Successful requests:                     80
  Benchmark duration (s):                  343.59
  Total token throughput (tok/s):          16537.05
  Accept length:                           3.71
  Mean TTFT (ms):                          30373.23
  Median TTFT (ms):                        27047.09
  P90 TTFT (ms):                           47856.74
  P95 TTFT (ms):                           47961.14
  P99 TTFT (ms):                           58855.56
  Mean TPOT (ms):                          49.57
  Median E2E Latency (ms):                 77467.83
  ==================================================
  </details>
```
  Checklist

  - [ ] Format your code according to the Format code with pre-commit
  (https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [ ] Add unit tests according to the Run and add unit tests
  (https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to Write documentations
  (https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [ ] Provide accuracy and speed benchmark results according to Test the accuracy
  (https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and Benchmark the speed
  (https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [ ] Follow the SGLang code style guidance (https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

  ---

  A couple of review-pitfall flags worth knowing before you push:

  - **Accuracy section is a placeholder** — fill it (or, if you and the reviewer agree a behavior-preserving refactor doesn't need it, replace with
  `N/A — behavior-preserving, indices provably equal to prior path`).
  - **`mamba_track_mask_indices` is currently a write-only field** on `ForwardMetadata` — only used internally to compute
  `conv_states_mask_indices`, never read elsewhere. Not a blocker, but a reviewer may ask you to make it a local instead of a dataclass field. Cheap
  to address now.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28142594297](https://github.com/sgl-project/sglang/actions/runs/28142594297)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28142594209](https://github.com/sgl-project/sglang/actions/runs/28142594209)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->