### PR TITLE
Fix intermittent PP HiCache ack queue desync

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -920,18 +920,23 @@ class HiRadixCache(RadixCache):
         # host memory pressure), so a conditional skip desyncs the NCCL op
         # sequence and deadlocks under TP > 1. (Matches UnifiedRadixCache.)
         finish_count = 0
-        if self.pp_rank == 0:
+        has_local_work = len(self.ongoing_write_through) > 0
+        if self.pp_rank == 0 and has_local_work:
             for _, finish_event, ack_list in self.cache_controller.ack_write_queue:
                 if not finish_event.query():
                     break
                 finish_count += 1
+        elif self.pp_rank == 0:
+            finish_count = 2**30
         finish_count_tensor = torch.tensor(finish_count, dtype=torch.int, device="cpu")
         self._all_reduce(finish_count_tensor, torch.distributed.ReduceOp.MIN)
         finish_count = finish_count_tensor.item()
+        if finish_count == 2**30:
+            finish_count = 0
 
         if finish_count > 0:
             logger.debug(f"Process {finish_count} write back operations")
-        while finish_count > 0:
+        while finish_count > 0 and self.cache_controller.ack_write_queue:
             _, finish_event, ack_list = self.cache_controller.ack_write_queue.pop(0)
             finish_event.synchronize()
             for ack_id in ack_list:
@@ -940,18 +945,23 @@ class HiRadixCache(RadixCache):
 
     def loading_check(self):
         finish_count = 0
-        if self.pp_rank == 0:
+        has_local_work = len(self.ongoing_load_back) > 0
+        if self.pp_rank == 0 and has_local_work:
             for _, finish_event, ack_list in self.cache_controller.ack_load_queue:
                 if not finish_event.query():
                     break
                 finish_count += 1
+        elif self.pp_rank == 0:
+            finish_count = 2**30
         finish_count_tensor = torch.tensor(finish_count, dtype=torch.int, device="cpu")
         self._all_reduce(finish_count_tensor, torch.distributed.ReduceOp.MIN)
         finish_count = finish_count_tensor.item()
+        if finish_count == 2**30:
+            finish_count = 0
 
         if finish_count > 0:
             logger.debug(f"Process {finish_count} load operations")
-        while finish_count > 0:
+        while finish_count > 0 and self.cache_controller.ack_load_queue:
             _, finish_event, ack_list = self.cache_controller.ack_load_queue.pop(0)
             finish_event.synchronize()
             for ack_id in ack_list:

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2361,18 +2361,23 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         # Every rank must enter the all_reduce below; ongoing_write_through can
         # diverge across ranks (e.g. write_backup returning 0 on a subset).
         finish_count = 0
-        if self.pp_rank == 0:
+        has_local_work = len(self.ongoing_write_through) > 0
+        if self.pp_rank == 0 and has_local_work:
             for _, finish_event, ack_list in cc.ack_write_queue:
                 if not finish_event.query():
                     break
                 finish_count += 1
+        elif self.pp_rank == 0:
+            finish_count = 2**30
 
         finish_count_tensor = torch.tensor(finish_count, dtype=torch.int, device="cpu")
         self._all_reduce(finish_count_tensor, torch.distributed.ReduceOp.MIN)
         finish_count = finish_count_tensor.item()
+        if finish_count == 2**30:
+            finish_count = 0
 
         # Process completed acks
-        while finish_count > 0:
+        while finish_count > 0 and cc.ack_write_queue:
             _, finish_event, ack_list = cc.ack_write_queue.pop(0)
             finish_event.synchronize()
             for ack_id in ack_list:
@@ -2387,16 +2392,21 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         # Every rank must enter the all_reduce below; ongoing_load_back can
         # diverge across ranks.
         finish_count = 0
-        if self.pp_rank == 0:
+        has_local_work = len(self.ongoing_load_back) > 0
+        if self.pp_rank == 0 and has_local_work:
             for _, finish_event, ack_list in cc.ack_load_queue:
                 if not finish_event.query():
                     break
                 finish_count += 1
+        elif self.pp_rank == 0:
+            finish_count = 2**30
         finish_count_tensor = torch.tensor(finish_count, dtype=torch.int, device="cpu")
         self._all_reduce(finish_count_tensor, torch.distributed.ReduceOp.MIN)
         finish_count = finish_count_tensor.item()
+        if finish_count == 2**30:
+            finish_count = 0
 
-        while finish_count > 0:
+        while finish_count > 0 and cc.ack_load_queue:
             _, finish_event, ack_list = cc.ack_load_queue.pop(0)
             finish_event.synchronize()
             for ack_id in ack_list:


### PR DESCRIPTION
  ## Motivation

  Under long random-input pressure with PP + TP + HiCache enabled, some ranks can temporarily have no local HiCache write/load work while peer ranks still need to
  synchronize async completion counts.

  In that case, a rank with an empty local ack queue may receive a positive synchronized finish count and then try to consume `ack_write_queue` or `ack_load_queue`,
  which can crash with `pop from empty list`.

  This PR fixes the intermittent HiCache ack queue desynchronization and keeps completion synchronization safe across PP/TP ranks.

  ## Modifications

  - Keep all ranks participating in HiCache write/load completion synchronization to avoid collective desynchronization.
  - Ignore ranks with no local HiCache work when computing the ready completion count on the PP entry stage.
  - Only consume local ack queues when local ack entries exist.
  - Apply the fix to both `HiRadixCache` and `UnifiedRadixCache`.

  ## Accuracy Tests

  Not applicable. This PR only changes HiCache async completion bookkeeping and does not affect model forward computation, logits, sampling, or KV contents.

  ## Speed Tests and Profiling

  Not benchmarked. The change only affects HiCache ack queue polling under PP/TP synchronization and should not add overhead on the normal request path.

  ## Checklist

  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy)
  and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
