### PR TITLE
[deepseek/mla] Opt-in fp8 quant of absorbed MLA weights for fused a8w8 decode (ROCm)

### DIFF
--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -605,6 +605,35 @@ class DeepseekV2WeightLoaderMixin:
                     self_attn.w_vc = (
                         self_attn.w_vc.to(torch.bfloat16) * self_attn.w_scale
                     )
+                # Optional (opt-in): quantize bf16 absorbed MLA weights to fp8 so
+                # forward_absorb takes the fused batched a8w8 per-token-group-prequant
+                # kernel on ROCm/gfx95 instead of bmm(q, w.to(bf16)*w_scale). Off by
+                # default: MXFP4 checkpoints keep attention in bf16 on purpose, so this
+                # changes numerics -- validate accuracy (e.g. GSM8K) before enabling.
+                if (
+                    get_bool_env_var("SGLANG_FP8_MLA_ABSORB")
+                    and _is_hip
+                    and self_attn.w_kc.dtype == torch.bfloat16
+                    and self_attn.w_vc.dtype == torch.bfloat16
+                ):
+                    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+                    # per-head (per batched-tensor) scale, shared by w_kc and w_vc
+                    amax = torch.maximum(
+                        self_attn.w_kc.abs().amax(dim=(1, 2), keepdim=True),
+                        self_attn.w_vc.abs().amax(dim=(1, 2), keepdim=True),
+                    ).clamp(min=1e-4)
+                    w_scale = (amax / fp8_max).to(torch.float32)
+                    self_attn.w_kc = (
+                        (self_attn.w_kc.float() / w_scale)
+                        .clamp(-fp8_max, fp8_max)
+                        .to(torch.float8_e4m3fn)
+                    )
+                    self_attn.w_vc = (
+                        (self_attn.w_vc.float() / w_scale)
+                        .clamp(-fp8_max, fp8_max)
+                        .to(torch.float8_e4m3fn)
+                    )
+                    self_attn.w_scale = w_scale.view(-1)
             else:
                 num_tiles_k = self_attn.qk_nope_head_dim // weight_block_size[1]
                 num_tiles_n = self_attn.v_head_dim // weight_block_size[0]


### PR DESCRIPTION
## Motivation

For models whose **absorbed MLA weights are bf16** — e.g. `amd/GLM-5.1-MXFP4`, where the checkpoint deliberately keeps attention in bf16 while quantizing the MoE to MXFP4 — `forward_absorb` computes the bmm as:

```python
torch.bmm(q_nope.to(torch.bfloat16).transpose(0, 1),
          self.w_kc.to(torch.bfloat16) * self.w_scale)   # and attn @ w_vc
```

On ROCm/gfx95 there is a faster fused path that `forward_absorb` **already selects when `w_kc` is fp8** — `batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant` (activation quantized on-the-fly per-token-group; weight stays fp8 with a per-tensor scale). bf16 absorbed weights never reach it.

## Change

Add an **opt-in** env flag **`SGLANG_FP8_MLA_ABSORB`** that, at weight-load time, quantizes the bf16 `w_kc`/`w_vc` to fp8 (per-head amax scale shared by both), so `forward_absorb` takes the fused fp8 batched-a8w8 kernel.

- **Off by default** and **gated to ROCm** + bf16 `w_kc` only.
- fp8/quantized checkpoints and non-HIP backends are completely unaffected (existing fp8/uint8/deep-gemm paths untouched).
- One file (`deepseek_weight_loader.py`); no kernel changes — the fused kernel already exists and is already wired in `forward_absorb`.

## ⚠️ Accuracy caveat — fails on GLM-5.1 (reasoning), do not enable blindly

This **changes numerics**: MXFP4 checkpoints keep attention in bf16 on purpose (it's quant-sensitive). The flag is therefore **off by default and must be accuracy-validated per model before use**.

**GSM8K A/B on `amd/GLM-5.1-MXFP4` (50 questions, 5-shot, identical server build):**

| | strict-match | flexible-extract |
|---|---|---|
| baseline (bf16 absorb) | **0.98** | **0.98** |
| `SGLANG_FP8_MLA_ABSORB=1` | **0.00** | **0.02** |

On this **reasoning** model fp8 absorb is **catastrophic**: the per-head fp8 quant of `w_kc`/`w_vc` perturbs attention enough to send the reasoning trace into a degenerate loop — it never emits the final `#### N` answer (sampled responses ran to the full token cap with empty `content` and ~40k-char `reasoning_content`). The +2.7% throughput is real but worthless here.

So the flag stays **strictly opt-in / experimental**. It is **not safe for reasoning or quant-sensitive checkpoints**; any candidate model needs an accuracy A/B (non-reasoning, error-tolerant inference) before turning it on. Filing this for the mechanism + measurements; **not recommending it be enabled for GLM-5.1**.

## Performance

`amd/GLM-5.1-MXFP4`, MI355X (gfx950), tp=4, ISL/OSL 1024/1024, `benchmark_serving` (random, `num-prompts = concurrency × 10`). Same server build; baseline = bf16 absorbed weights, fp8 = this patch (`SGLANG_FP8_MLA_ABSORB=1`):

| concurrency | baseline bf16 (tok/s) | fp8 (tok/s) | Δ throughput | bf16 TPOT (ms) | fp8 TPOT (ms) |
|---|---|---|---|---|---|
| 4 | 243.0 | 253.7 | **+4.4%** | 16.18 | 15.45 |
| 8 | 431.8 | 449.8 | **+4.2%** | 17.92 | 17.16 |
| 32 | 1245.5 | 1275.4 | **+2.4%** | 24.52 | 23.84 |
| 64 | 1937.2 | 1965.7 | **+1.5%** | 30.81 | 30.41 |
| 128 | 2939.8 | 2966.4 | **+0.9%** | 39.88 | 39.31 |

Average **+3.1% (c4–c64)**, **+2.7% (c4–c128)** output-token throughput; per-token latency (TPOT) improves correspondingly. Larger gains at low/mid concurrency; tapers at high concurrency where MoE/dense GEMMs dominate the step.

Companion to #29081 (which caches the bf16 dequant for the same path); the two are mutually exclusive — with this flag on, `w_kc` is fp8 so the bf16 cache path is naturally skipped.

## Checklist
- [x] Format with `ruff` / `ruff check` clean
- [x] `py_compile` clean
- [x] benchmark_serving throughput (above)
- [x] Accuracy (GSM8K) A/B validation — **done: bf16 0.98 vs fp8 0.00 on GLM-5.1 (regression, documented above)**
- [ ] CI

