### PR TITLE
Strip unset tool-schema defaults before apply_chat_template (fixes #29061)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -156,6 +156,27 @@ def _extract_max_dynamic_patch(request: ChatCompletionRequest):
     return img_max_dynamic_patch, vid_max_dynamic_patch
 
 
+def _tool_to_chat_template_format(tool) -> Dict[str, Any]:
+    """Serialize a tool for ``apply_chat_template`` without leaking defaults.
+
+    ``model_dump()`` emits ``strict`` (defaults to ``False``) and a ``Tool``-level
+    ``defer_loading`` (defaults to ``None``) even when the caller never sent them.
+    Those extra keys land in the tool schema rendered into the prompt and change
+    the tokens, causing a train-serving mismatch. Drop them unless explicitly
+    provided, while leaving the general ``model_dump()`` output (used by the
+    function-call parser) untouched.
+    See https://github.com/sgl-project/sglang/issues/29061.
+    """
+    data = tool.model_dump()
+    # ``Tool`` has no model_serializer, so a null ``defer_loading`` leaks here.
+    if tool.defer_loading is None:
+        data.pop("defer_loading", None)
+    function = data.get("function")
+    if isinstance(function, dict) and "strict" not in tool.function.model_fields_set:
+        function.pop("strict", None)
+    return data
+
+
 class OpenAIServingChat(OpenAIServingBase):
     """Handler for /v1/chat/completions requests"""
 
@@ -646,12 +667,12 @@ class OpenAIServingChat(OpenAIServingBase):
             request.skip_special_tokens = False
             if not isinstance(request.tool_choice, str):
                 tools = [
-                    item.model_dump()
+                    _tool_to_chat_template_format(item)
                     for item in request.tools
                     if item.function.name == request.tool_choice.function.name
                 ]
             else:
-                tools = [item.model_dump() for item in request.tools]
+                tools = [_tool_to_chat_template_format(item) for item in request.tools]
             if self.tool_call_parser:
                 parser = FunctionCallParser(request.tools, self.tool_call_parser)
                 tool_call_constraint = parser.get_structure_constraint(
@@ -762,7 +783,9 @@ class OpenAIServingChat(OpenAIServingBase):
                 # insert an empty system prompt to help render tool system prompt
                 messages.insert(0, {"role": "system", "content": ""})
             if request.tools:
-                messages[0]["tools"] = [tool.model_dump() for tool in request.tools]
+                messages[0]["tools"] = [
+                    _tool_to_chat_template_format(tool) for tool in request.tools
+                ]
 
             # Default encoding (dsv4/dsv32)
             if self.chat_encoding_spec == "dsv4":

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -784,16 +784,19 @@ class OpenAIServingResponses(OpenAIServingChat):
         for tool in request.tools:
             if tool.type != "function":
                 continue
+            function_kwargs = dict(
+                name=tool.name,
+                description=tool.description,
+                parameters=tool.parameters,
+            )
+            # Only forward ``strict`` when the caller actually set it. Always
+            # passing it would bake it into ``model_fields_set`` and leak the
+            # default into the chat-template tool schema (train-serving
+            # mismatch). See https://github.com/sgl-project/sglang/issues/29061.
+            if "strict" in tool.model_fields_set:
+                function_kwargs["strict"] = tool.strict
             chat_tools.append(
-                Tool(
-                    type="function",
-                    function=Function(
-                        name=tool.name,
-                        description=tool.description,
-                        parameters=tool.parameters,
-                        strict=tool.strict,
-                    ),
-                )
+                Tool(type="function", function=Function(**function_kwargs))
             )
         return chat_tools
 

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -21,10 +21,13 @@ from fastapi import Request
 
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
+    Function,
     MessageProcessingResult,
+    Tool,
 )
 from sglang.srt.entrypoints.openai.serving_chat import (
     OpenAIServingChat,
+    _tool_to_chat_template_format,
     normalize_tool_content,
 )
 from sglang.srt.managers.io_struct import GenerateReqInput
@@ -460,9 +463,13 @@ class ServingChatTestCase(unittest.TestCase):
 
         self.chat._process_messages(req, is_multimodal=False)
 
-        expected_tools = [tool.model_dump() for tool in req.tools]
+        # Tools are passed through _tool_to_chat_template_format, which strips
+        # unset defaults (strict / defer_loading) that would otherwise change
+        # the rendered prompt. See #29061.
+        expected_tools = [_tool_to_chat_template_format(tool) for tool in req.tools]
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertEqual(kwargs["tools"], expected_tools)
+        self.assertNotIn("strict", kwargs["tools"][0]["function"])
 
     def test_jinja_tool_schema_fallback_to_flat_function(self):
         """Fallback to function-only schema when template rejects OpenAI wrapper."""
@@ -504,10 +511,10 @@ class ServingChatTestCase(unittest.TestCase):
         second_tools = self.tm.tokenizer.apply_chat_template.call_args_list[1].kwargs[
             "tools"
         ]
-        self.assertEqual(first_tools, [tool.model_dump() for tool in req.tools])
-        self.assertEqual(
-            second_tools, [tool.function.model_dump() for tool in req.tools]
-        )
+        expected = [_tool_to_chat_template_format(tool) for tool in req.tools]
+        self.assertEqual(first_tools, expected)
+        # Flat-function fallback reuses the same stripped tool dicts.
+        self.assertEqual(second_tools, [t["function"] for t in expected])
 
     def test_xgrammar_tag_omits_reasoning_when_parser_owns_it(self):
         """ReasonerGrammarBackend owns the thinking prefix when a parser is set."""
@@ -2316,6 +2323,48 @@ class TestNormalizeToolContent(unittest.TestCase):
             "tool", ["plain", {"type": "text", "text": "rich"}]
         )
         self.assertEqual(result, "plain rich")
+
+
+class ToolChatTemplateFormatTestCase(unittest.TestCase):
+    """`_tool_to_chat_template_format` must not leak unset defaults (`strict`,
+    `defer_loading`) into the tool schema rendered into the prompt. See #29061.
+    """
+
+    def _tool(self, **fn_kwargs):
+        return Tool(type="function", function=Function(name="get_weather", **fn_kwargs))
+
+    def test_unset_strict_and_defer_loading_dropped(self):
+        data = _tool_to_chat_template_format(self._tool())
+        self.assertEqual(data["function"]["name"], "get_weather")
+        self.assertNotIn("strict", data["function"])
+        self.assertNotIn("defer_loading", data["function"])
+        self.assertNotIn("defer_loading", data)
+
+    def test_explicit_strict_preserved(self):
+        data = _tool_to_chat_template_format(self._tool(strict=True))
+        self.assertEqual(data["function"]["strict"], True)
+
+    def test_explicit_strict_false_preserved(self):
+        # Explicitly sent strict=False must survive (caller's intent).
+        data = _tool_to_chat_template_format(self._tool(strict=False))
+        self.assertIn("strict", data["function"])
+        self.assertEqual(data["function"]["strict"], False)
+
+    def test_explicit_defer_loading_preserved_and_propagated(self):
+        tool = Tool(
+            type="function",
+            function=Function(name="get_weather"),
+            defer_loading=True,
+        )
+        data = _tool_to_chat_template_format(tool)
+        self.assertEqual(data["defer_loading"], True)
+        # _propagate_defer_loading copies it onto the function as well.
+        self.assertEqual(data["function"]["defer_loading"], True)
+
+    def test_general_model_dump_unchanged(self):
+        # The fix must be scoped to the chat-template path; the function-call
+        # parser still relies on strict being present in plain model_dump().
+        self.assertEqual(self._tool().function.model_dump()["strict"], False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #29061.

When building the tool schema for `apply_chat_template`, sglang does
`tools = [item.model_dump() for item in request.tools]`. `model_dump()`
serializes Pydantic **defaults the caller never sent**:

- `Function.strict` (defaults to `False`)
- the `Tool`-level `defer_loading` (defaults to `None`; `Tool` has no
  `model_serializer`, unlike `Function`)

Those extra keys (`"strict": false`, `"defer_loading": null`) land in the tool
schema rendered into the prompt and change the tokens. A pipeline that trains
and serves the *same* tool definitions then gets a **different prompt at
inference time** — a train-serving mismatch. Thanks @Maybewuss for the precise
root cause.

## Fix

`_tool_to_chat_template_format()` is added and used at the three chat-template
tool-dump sites in `serving_chat.py`. It drops `strict` / `defer_loading`
**unless the caller set them explicitly** (`model_fields_set`), so:

- the schema sent to `apply_chat_template` matches what the user actually sent;
- explicitly-provided `strict` / `defer_loading` (including `strict: false`) are
  preserved;
- the **global** `model_dump()` is untouched, so the function-call parser (which
  relies on `strict` being present) is unaffected.

The Responses→chat conversion (`_response_tools_to_chat_tools`) is also gated so
it doesn't bake the default `strict` into `model_fields_set` and re-leak it on
the `/v1/responses` path.

## Tests

- New `ToolChatTemplateFormatTestCase`: unset `strict`/`defer_loading` dropped;
  explicit `strict` (true *and* false) preserved; `Tool.defer_loading`
  propagated to the function; global `model_dump()` still keeps `strict`.
- The existing `test_jinja_uses_openai_tool_schema_first` /
  `test_jinja_tool_schema_fallback_to_flat_function` are updated to assert the
  cleaned shape (they previously encoded the leaking behaviour).

Verified locally: `test_serving_chat.py` (75), `test_protocol.py` (29),
`test_serving_responses.py` (16) all pass.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28074468875](https://github.com/sgl-project/sglang/actions/runs/28074468875)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28074468773](https://github.com/sgl-project/sglang/actions/runs/28074468773)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->