### PR TITLE
[sampling] feat: add Top-nσ logit truncation as built-in CustomLogitProcessor

### DIFF
--- a/python/sglang/srt/sampling/custom_logit_processor.py
+++ b/python/sglang/srt/sampling/custom_logit_processor.py
@@ -201,3 +201,65 @@ class DeepseekOCRNoRepeatNGramLogitProcessor(CustomLogitProcessor):
             logits[batch_idx, indices] = -float("inf")
 
         return logits
+
+
+class TopNSigmaLogitProcessor(CustomLogitProcessor):
+    """Top-n-sigma logit truncation processor.
+
+    Filters logits based on statistical outlier detection: tokens whose logit
+    value falls more than n standard deviations below the maximum logit are
+    masked to -inf before temperature scaling and softmax.
+
+    Ref: Tang et al., "Top-nσ: Not All Logits Are You Need", ACL 2025.
+         arXiv:2411.07641
+
+    Usage:
+        Set ``custom_params={"top_n_sigma": 2.0}`` on the request and pass the
+        serialized processor via ``custom_logit_processor``.
+    """
+
+    def __call__(self, logits, custom_param_list=None):
+        if not custom_param_list:
+            return logits
+
+        # Collect per-request n-sigma values and their batch indices.
+        n_sigmas = []
+        rows = []
+        for i, params in enumerate(custom_param_list):
+            if not params:
+                continue
+            n = params.get("top_n_sigma")
+            if n is None or not isinstance(n, (int, float)) or n <= 0:
+                continue
+            n_sigmas.append(n)
+            rows.append(i)
+
+        if not rows:
+            return logits
+
+        rows_t = torch.tensor(rows, device=logits.device, dtype=torch.long)
+        selected = logits[rows_t]
+
+        # Compute std once; reuse it both for the edge-case guard and for the
+        # threshold formula to avoid scanning the vocab twice.
+        n_sigmas_t = torch.tensor(
+            n_sigmas, device=logits.device, dtype=selected.dtype
+        )
+        std_all = selected.std(dim=-1, keepdim=True)
+
+        # Skip rows with NaN/Inf logits or all-equal logits (std == 0).
+        finite_mask = torch.isfinite(selected).all(dim=-1).unsqueeze(-1)
+        nonzero_std_mask = std_all != 0
+        process_mask = finite_mask & nonzero_std_mask
+
+        max_logits = selected.max(dim=-1, keepdim=True).values
+        thresholds = max_logits - n_sigmas_t.unsqueeze(-1) * std_all
+
+        # Mask tokens below threshold, only on rows that pass the guards.
+        below_threshold = selected < thresholds
+        selected.masked_fill_(below_threshold & process_mask, float("-inf"))
+        # Write back: advanced indexing produced a copy, so assign the
+        # modified rows back to the original logits tensor.
+        logits[rows_t] = selected
+
+        return logits

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -18,6 +18,7 @@ from sglang.srt.sampling.custom_logit_processor import (
     DeepSeekR1ThinkingBudgetLogitProcessor,
     DisallowedTokensLogitsProcessor,
     Qwen3ThinkingBudgetLogitProcessor,
+    TopNSigmaLogitProcessor,
     _cache_from_str,
 )
 from sglang.test.test_utils import CustomTestCase
@@ -441,6 +442,142 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
         # Batch 1: prefix is (5), no matching prefix in window → no bans
         self.assertEqual(result[1, 3].item(), 0.0)
         self.assertEqual(result[1, 4].item(), 0.0)
+
+
+# TopNSigmaLogitProcessor
+class TestTopNSigmaLogitProcessor(CustomTestCase):
+    VOCAB = 200
+
+    def setUp(self):
+        self.processor = TopNSigmaLogitProcessor()
+
+    def _sharp_logits(self, batch_size=1):
+        """A distribution with a clear peak at token 0."""
+        logits = torch.randn(batch_size, self.VOCAB) * 0.1
+        logits[:, 0] = 10.0  # sharp max
+        return logits
+
+    def test_serialization_round_trip(self):
+        s = TopNSigmaLogitProcessor.to_str()
+        processor = CustomLogitProcessor.from_str(s)
+        self.assertIsInstance(processor, TopNSigmaLogitProcessor)
+
+    def test_none_params_returns_unchanged(self):
+        logits = self._sharp_logits()
+        original = logits.clone()
+        result = self.processor(logits, None)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_empty_params_returns_unchanged(self):
+        logits = self._sharp_logits()
+        original = logits.clone()
+        result = self.processor(logits, [])
+        self.assertTrue(torch.equal(result, original))
+
+    def test_sharp_distribution_filters_tail(self):
+        """Sharp distribution should mask most tail tokens."""
+        logits = self._sharp_logits()
+        params = [{"top_n_sigma": 2.0}]
+        result = self.processor(logits.clone(), params)
+        num_masked = torch.isinf(result[0]).sum().item()
+        # std is small (~0.1), threshold ≈ 10 - 2*0.1 = 9.8, most tokens masked
+        self.assertGreater(num_masked, self.VOCAB * 0.8)
+        # The peak token (0) must survive
+        self.assertFalse(torch.isinf(result[0, 0]))
+
+    def test_argmax_is_invariant(self):
+        """The max-logit token must always survive the filter."""
+        logits = torch.randn(3, self.VOCAB)
+        logits[:, 5] = 100.0  # token 5 is argmax for all rows
+        params = [{"top_n_sigma": n} for n in (0.5, 2.0, 10.0)]
+        result = self.processor(logits.clone(), params)
+        for i in range(3):
+            self.assertFalse(
+                torch.isinf(result[i, 5]),
+                f"argmax token masked in row {i}",
+            )
+
+    def test_zero_std_no_filtering(self):
+        """All-equal logits (std==0) should be left unchanged."""
+        logits = torch.ones(1, self.VOCAB)
+        original = logits.clone()
+        params = [{"top_n_sigma": 2.0}]
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_nan_logits_skipped(self):
+        """Rows with NaN logits should not be modified."""
+        logits = self._sharp_logits(batch_size=2)
+        logits[1] = float("nan")  # row 1 has NaN
+        params = [{"top_n_sigma": 2.0}, {"top_n_sigma": 2.0}]
+        result = self.processor(logits.clone(), params)
+        # Row 0 should be filtered, row 1 left unchanged (NaN guard)
+        self.assertTrue(torch.isinf(result[0]).any())
+        # Row 1: not masked (all NaN → skipped by finite guard)
+        finite_row1 = result[1][torch.isfinite(result[1])]
+        self.assertEqual(finite_row1.numel(), 0)  # all NaN, nothing finite
+
+    def test_n_sigma_none_skipped(self):
+        """Requests with top_n_sigma=None should be skipped."""
+        logits = self._sharp_logits(batch_size=2)
+        original = logits.clone()
+        params = [{"top_n_sigma": None}, {"top_n_sigma": 2.0}]
+        result = self.processor(logits.clone(), params)
+        # Row 0 unchanged (None), row 1 filtered
+        self.assertTrue(torch.equal(result[0], original[0]))
+        self.assertTrue(torch.isinf(result[1]).any())
+
+    def test_n_sigma_negative_skipped(self):
+        """Negative top_n_sigma should be skipped."""
+        logits = self._sharp_logits()
+        original = logits.clone()
+        params = [{"top_n_sigma": -1.0}]
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_n_sigma_zero_skipped(self):
+        """top_n_sigma=0 should be skipped (must be positive)."""
+        logits = self._sharp_logits()
+        original = logits.clone()
+        params = [{"top_n_sigma": 0}]
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_mixed_batch(self):
+        """Some rows with valid params, some without."""
+        logits = self._sharp_logits(batch_size=3)
+        original = logits.clone()
+        params = [
+            {"top_n_sigma": 2.0},
+            None,  # skipped
+            {"top_n_sigma": 1.0},
+        ]
+        result = self.processor(logits.clone(), params)
+        # Row 0, 2 filtered; row 1 unchanged
+        self.assertTrue(torch.isinf(result[0]).any())
+        self.assertTrue(torch.equal(result[1], original[1]))
+        self.assertTrue(torch.isinf(result[2]).any())
+
+    def test_all_skipped_returns_unchanged(self):
+        """When no valid params, logits returned as-is."""
+        logits = self._sharp_logits(batch_size=2)
+        original = logits.clone()
+        params = [{"top_n_sigma": None}, {"top_n_sigma": -1}]
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_smaller_n_keeps_more(self):
+        """Smaller n → tighter threshold → fewer tokens survive."""
+        logits = torch.randn(2, self.VOCAB)
+        logits[:, 0] = 10.0
+        params_n5 = [{"top_n_sigma": 5.0}]
+        params_n1 = [{"top_n_sigma": 1.0}]
+        result_n5 = self.processor(logits.clone(), params_n5)
+        result_n1 = self.processor(logits.clone(), params_n1)
+        surviving_n5 = (~torch.isinf(result_n5[0])).sum().item()
+        surviving_n1 = (~torch.isinf(result_n1[0])).sum().item()
+        # n=5 (wider) keeps more than or equal to n=1 (tighter)
+        self.assertGreaterEqual(surviving_n5, surviving_n1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #29119

Adds `TopNSigmaLogitProcessor` as a **built-in** `CustomLogitProcessor`, following the same pattern as the existing `ThinkingBudgetLogitProcessor` and `DisallowedTokensLogitsProcessor`.

Based on: Tang et al., "Top-nσ: Not All Logits Are You Need", ACL 2025. [arXiv:2411.07641](https://arxiv.org/abs/2411.07641)

### What is Top-nσ?

Top-nσ is a logit-space dynamic truncation method that uses the standard deviation of the logit distribution to set a filtering threshold:

```
threshold = max_logit - n * std_logit
logits[logits < threshold] = -inf
```

Unlike probability-space filters (`top_p`, `min_p`), it operates **before softmax** — which is exactly where SGLang's custom logit processor pipeline runs (`_preprocess_logits` is called before temperature scaling) — and adapts to distribution "peakiness":
- **Sharp distribution** (model certain): small std → narrow threshold → fewer candidates
- **Flat distribution** (model uncertain): large std → wide threshold → more candidates

### How it compares to other truncation methods

| Method | Space | Truncation rule | Adaptive? |
|---|---|---|---|
| top_k | Probability | Keep top-k highest-probability tokens | ❌ Fixed count |
| top_p (nucleus) | Probability | Keep tokens until cumulative prob ≥ p | ✅ Adaptive count only |
| min_p | Probability | Keep tokens with prob ≥ max_prob × min_p | ✅ Relative threshold |
| top_nσ | **Logit** | threshold = max_logit − n × std | ✅ Dual-adaptive |

> Key distinction: top_k/top_p/min_p operate **after softmax** (probability space); top_nσ operates **before softmax** (logit space).

### Why Top-nσ?

- **Truncation before softmax** — filters in logit space first, then softmax only processes the surviving candidates.
- **Dual adaptivity** — the std-based threshold adjusts both *how many* and *how loosely* candidates are kept in one formula.
- **Temperature-stable** — candidate count stays consistent across temperature scaling (logit std scales proportionally).
- **Argmax-invariant** — the top-1 token always survives, so greedy decoding is unaffected.

## Changes

- **New processor**: `TopNSigmaLogitProcessor` in `python/sglang/srt/sampling/custom_logit_processor.py`
- **Unit tests**: `TestTopNSigmaLogitProcessor` in `test/registered/unit/sampling/test_custom_logit_processor.py` (13 test cases)

### Implementation details

- **Fully vectorized** across the batch (no Python per-row loop)
- **std computed once** and reused for both the `std==0` guard and the threshold formula, avoiding a duplicate vocab-wide reduction
- **Argmax-invariant** by construction (the peak token always survives)

### Edge cases handled

| Case | Behavior |
|------|----------|
| `top_n_sigma <= 0` | Request skipped |
| `top_n_sigma` is None / non-numeric | Request skipped |
| `std == 0` (all logits equal) | Row skipped (no filtering) |
| NaN/Inf logits | Row skipped (finite guard) |
| Empty / None param list | Logits returned unchanged |

### Usage

Server must be started with `--enable-custom-logit-processor`:

```python
import requests
from sglang.srt.sampling.custom_logit_processor import TopNSigmaLogitProcessor

response = requests.post("http://localhost:30000/generate", json={
    "text": "The capital of France is",
    "sampling_params": {
        "temperature": 0.8,
        "custom_params": {"top_n_sigma": 2.0},
    },
    "custom_logit_processor": TopNSigmaLogitProcessor.to_str(),
})
```

No changes to `SamplingParams`, `SamplingBatchInfo`, or the sampler — uses the existing custom processor framework as-is.

## Testing plan

- [x] Unit tests cover: sharp/flat distributions, argmax invariance, zero-std, NaN/Inf, negative/None/zero n, mixed batch, empty params
- [ ] Manual end-to-end test with `--enable-custom-logit-processor` on a small model
- [ ] CI passes

Co-authored-by: Boundless <ruihang_wu@163.com>







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28076812108](https://github.com/sgl-project/sglang/actions/runs/28076812108)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28076812084](https://github.com/sgl-project/sglang/actions/runs/28076812084)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->