### PR TITLE
[DEBUG] Isolate faulty RDMA NIC (rdma5) on MI35x disaggregation runner

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -1202,9 +1202,10 @@ jobs:
       - name: Run test_disaggregation
         timeout-minutes: 60
         run: |
+          set -o pipefail
           bash scripts/ci/amd/amd_ci_exec.sh \
             -e SGLANG_TEST_RDMA_DEVICE="${{ env.SGLANG_TEST_RDMA_DEVICE }}" \
-            -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-large-8-gpu-mi35x-disaggregation-amd --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+            -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-large-8-gpu-mi35x-disaggregation-amd --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }} 2>&1 | tee /tmp/disagg.out
 
       - name: DEBUG RDMA NIC diagnostic (post-test, isolate faulty NIC)
         if: ${{ always() }}
@@ -1217,57 +1218,38 @@ jobs:
           [ -d "$IB" ] || { echo "No $IB on host"; exit 0; }
 
           echo ""
-          echo "### 0. rdma<->netdev mapping ###"
-          for d in "$IB"/*; do
-            dev=$(basename "$d")
-            printf "  %-8s -> %s\n" "$dev" "$(cat /tmp/rdma_pre/${dev}.netdev 2>/dev/null)"
-          done
+          echo "### 1. PRIMARY EVIDENCE: failed RDMA transfers bucketed by local NIC ###"
+          echo "    (from the ionic provider's own errors in the test output)"
+          if [ -f /tmp/disagg.out ]; then
+            echo "-- 'transport retry counter exceeded' failures per local_nic --"
+            grep -oE "local_nic: rdma[0-9]+" /tmp/disagg.out | sort | uniq -c | sort -rn \
+              || echo "   (none found)"
+            echo ""
+            echo "-- peer nodes seen in those failures --"
+            grep -oE "peer_nic: [0-9.]+" /tmp/disagg.out | sort | uniq -c | sort -rn | head
+            echo ""
+            echo "-- KV-transfer timeouts / cqe errors (counts) --"
+            printf "   cqe with error            : %s\n" "$(grep -c 'cqe with error' /tmp/disagg.out)"
+            printf "   transport retry exceeded  : %s\n" "$(grep -c 'transport retry counter exceeded' /tmp/disagg.out)"
+            printf "   KVPoll WaitingForInput TO : %s\n" "$(grep -c 'timed out after .* in KVPoll.WaitingForInput' /tmp/disagg.out)"
+            echo ""
+            echo "-- sample raw error lines --"
+            grep -E "cqe with error|transport retry counter exceeded" /tmp/disagg.out | head -4 | sed 's/^/   /'
+          else
+            echo "/tmp/disagg.out not found (test step did not produce output)"
+          fi
 
           echo ""
-          echo "### 1. ionic hw_counters DELTA during this run (nonzero growth only) ###"
-          echo "    The NIC with large error/retry/drop growth is the faulty link."
-          printf "%-8s %-36s %14s %14s %14s\n" DEV COUNTER before after delta
-          for d in "$IB"/*; do
-            dev=$(basename "$d")
-            now="$d/ports/1/hw_counters"
-            [ -d "$now" ] || continue
-            for f in "$now"/*; do
-              [ -f "$f" ] || continue
-              key=$(basename "$f")
-              after=$(cat "$f" 2>/dev/null)
-              before=$(grep -E "^${key} " "/tmp/rdma_pre/${dev}.hw" 2>/dev/null | awk '{print $2}')
-              case "$after" in (''|*[!0-9]*) continue;; esac
-              case "$before" in (''|*[!0-9]*) before=0;; esac
-              delta=$((after-before))
-              [ "$delta" -ne 0 ] && printf "%-8s %-36s %14s %14s %14s\n" "$dev" "$key" "$before" "$after" "$delta"
-            done
-          done
-          echo "(no rows = no hw_counters changed; see section 2)"
+          echo "### 2. rdma statistic (netlink; bypasses pod sysfs mount limits) ###"
+          if docker ps --format '{{.Names}}' | grep -q '^ci_sglang$'; then
+            docker exec -u root ci_sglang bash -c 'rdma statistic show link 2>&1 || rdma statistic 2>&1 || echo "rdma statistic unavailable"' | head -80
+          else
+            echo "container ci_sglang not running"
+          fi
 
           echo ""
-          echo "### 2. ethtool -S DELTA, error/drop/retry/nak/seq/timeout counters ###"
-          printf "%-12s %-40s %14s\n" NETDEV COUNTER delta
-          for d in "$IB"/*; do
-            dev=$(basename "$d")
-            nd=$(cat /tmp/rdma_pre/${dev}.netdev 2>/dev/null)
-            [ -n "$nd" ] || continue
-            command -v ethtool >/dev/null 2>&1 || continue
-            ethtool -S "$nd" 2>/dev/null | sed 's/^ *//' > /tmp/${dev}.eth.now
-            while read -r line; do
-              key=$(echo "$line" | cut -d: -f1)
-              after=$(echo "$line" | cut -d: -f2 | tr -dc '0-9')
-              echo "$key" | grep -qiE "err|drop|nak|seq|timeout|retr|discard|miss|fail" || continue
-              before=$(grep -E "^${key}:" /tmp/rdma_pre/${dev}.eth 2>/dev/null | cut -d: -f2 | tr -dc '0-9')
-              [ -n "$after" ] || continue
-              [ -n "$before" ] || before=0
-              delta=$((after-before))
-              [ "$delta" -ne 0 ] && printf "%-12s %-40s %14s\n" "$nd" "$key" "$delta"
-            done < /tmp/${dev}.eth.now
-          done
-          echo "(no rows = no error/drop counters grew via ethtool)"
-
-          echo ""
-          echo "### 3. ibv_devinfo per device (port state/rate/link_layer) ###"
+          echo "### 3. ibv_devinfo per device (note: all show PORT_ACTIVE => ###"
+          echo "###    fault is transient transport, NOT a hard link-down)     ###"
           if docker ps --format '{{.Names}}' | grep -q '^ci_sglang$'; then
             docker exec -u root ci_sglang bash -c '
               for dev in $(ibv_devinfo -list 2>/dev/null | grep -oE "rdma[0-9]+" | sort); do
@@ -1277,6 +1259,13 @@ jobs:
           else
             echo "container ci_sglang not running; skipping ibv_devinfo"
           fi
+
+          echo ""
+          echo "NOTE: /sys/class/infiniband/*/ports/1/{counters,hw_counters} and"
+          echo "device/net are NOT populated inside the k8s runner pod (only the"
+          echo "infiniband class dir is bind-mounted), so sysfs/ethtool counter"
+          echo "deltas are unavailable here. Section 1 (provider errors) is the"
+          echo "authoritative per-NIC signal."
 
   pr-test-amd-finish:
     needs:

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -1165,12 +1165,100 @@ jobs:
             ci_sglang \
             python /sgl-workspace/aiter/op_tests/test_rmsnorm2d.py
 
+      # ---------------------------------------------------------------------
+      # DEBUG (bingxche): per-NIC RDMA health isolation. The disaggregation
+      # suite has failed on 3 consecutive scheduled runs with
+      # `transport retry counter exceeded` (ionic cqe error 12 /
+      # IBV_WC_RETRY_EXC_ERR); the failing local NIC is consistently rdma5
+      # while the peer node varies (10.42.20.122/.151/.195). These two steps
+      # capture per-NIC error-counter deltas across the test + kernel ionic
+      # errors so IT can confirm/repair the faulty NIC. Remove before merge.
+      - name: DEBUG RDMA NIC counters (pre-test baseline)
+        if: ${{ always() }}
+        run: |
+          set +e
+          IB=/sys/class/infiniband
+          mkdir -p /tmp/rdma_pre
+          echo "Runner host: $(hostname)"
+          [ -d "$IB" ] || { echo "No $IB on host"; exit 0; }
+          for d in "$IB"/*; do
+            dev=$(basename "$d"); p="$d/ports/1/counters"
+            for c in local_link_integrity_errors port_rcv_errors port_xmit_discards \
+                     symbol_error link_downed link_error_recovery \
+                     port_rcv_remote_physical_errors; do
+              cat "$p/$c" 2>/dev/null > "/tmp/rdma_pre/${dev}.${c}"
+            done
+          done
+          echo "Baseline captured for: $(ls $IB | paste -sd, -)"
+
       - name: Run test_disaggregation
         timeout-minutes: 60
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh \
             -e SGLANG_TEST_RDMA_DEVICE="${{ env.SGLANG_TEST_RDMA_DEVICE }}" \
             -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-large-8-gpu-mi35x-disaggregation-amd --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+
+      - name: DEBUG RDMA NIC diagnostic (post-test, isolate faulty NIC)
+        if: ${{ always() }}
+        run: |
+          set +e
+          IB=/sys/class/infiniband
+          echo "===================================================================="
+          echo "Runner host: $(hostname)   (failure peer IPs were 10.42.20.x)"
+          echo "===================================================================="
+          echo ""
+          echo "### 1. Per-NIC ERROR-COUNTER DELTA during this disaggregation run ###"
+          echo "    (the NIC with large growth is the faulty link)"
+          printf "%-8s %-34s %12s %12s %12s\n" DEV COUNTER before after delta
+          if [ -d "$IB" ]; then
+            for d in "$IB"/*; do
+              dev=$(basename "$d"); p="$d/ports/1/counters"
+              for c in local_link_integrity_errors port_rcv_errors port_xmit_discards \
+                       symbol_error link_downed link_error_recovery \
+                       port_rcv_remote_physical_errors; do
+                after=$(cat "$p/$c" 2>/dev/null)
+                before=$(cat "/tmp/rdma_pre/${dev}.${c}" 2>/dev/null)
+                [ -z "$after" ] && continue
+                if [ -n "$before" ] && [ "$before" != "$after" ]; then
+                  printf "%-8s %-34s %12s %12s %12s\n" "$dev" "$c" "$before" "$after" "$((after-before))"
+                fi
+              done
+            done
+            echo "(no rows above = no error counters changed during the test)"
+          else
+            echo "No $IB on host"
+          fi
+          echo ""
+          echo "### 2. Absolute per-NIC error counters (cumulative since boot) ###"
+          printf "%-8s %8s %12s %12s %12s %12s %12s\n" DEV state lnk_integ rcv_err xmit_disc sym_err lnk_down
+          if [ -d "$IB" ]; then
+            for d in "$IB"/*; do
+              dev=$(basename "$d"); pp="$d/ports/1"; p="$pp/counters"
+              printf "%-8s %8s %12s %12s %12s %12s %12s\n" "$dev" \
+                "$(cat $pp/state 2>/dev/null | grep -oE '[A-Z_]+' | head -1)" \
+                "$(cat $p/local_link_integrity_errors 2>/dev/null)" \
+                "$(cat $p/port_rcv_errors 2>/dev/null)" \
+                "$(cat $p/port_xmit_discards 2>/dev/null)" \
+                "$(cat $p/symbol_error 2>/dev/null)" \
+                "$(cat $p/link_downed 2>/dev/null)"
+            done
+          fi
+          echo ""
+          echo "### 3. Kernel ionic / RDMA errors (dmesg) ###"
+          (dmesg -T 2>/dev/null || dmesg 2>/dev/null || journalctl -k --no-pager 2>/dev/null) \
+            | grep -iE "ionic|cqe with error|retry counter|IBV_WC|qpid" | tail -120 \
+            || echo "no matching kernel lines / insufficient permission"
+          echo ""
+          echo "### 4. ibv_devinfo per device (port state/rate/link_layer) ###"
+          if docker ps --format '{{.Names}}' | grep -q '^ci_sglang$'; then
+            docker exec -u root ci_sglang bash -c '
+              for dev in $(ibv_devinfo -list 2>/dev/null | grep -oE "rdma[0-9]+"); do
+                echo "==== $dev ===="
+                ibv_devinfo -d "$dev" 2>&1 | grep -E "state|phys_state|rate|link_layer|fw_ver|active_width|active_speed"
+              done'
+          else
+            echo "container ci_sglang not running; skipping ibv_devinfo"
+          fi
 
   pr-test-amd-finish:
     needs:

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -1181,15 +1181,23 @@ jobs:
           mkdir -p /tmp/rdma_pre
           echo "Runner host: $(hostname)"
           [ -d "$IB" ] || { echo "No $IB on host"; exit 0; }
+          # ionic/RoCE NICs do NOT populate ports/1/counters; the real stats
+          # live in ports/1/hw_counters and in `ethtool -S <netdev>`.
           for d in "$IB"/*; do
-            dev=$(basename "$d"); p="$d/ports/1/counters"
-            for c in local_link_integrity_errors port_rcv_errors port_xmit_discards \
-                     symbol_error link_downed link_error_recovery \
-                     port_rcv_remote_physical_errors; do
-              cat "$p/$c" 2>/dev/null > "/tmp/rdma_pre/${dev}.${c}"
-            done
+            dev=$(basename "$d")
+            if [ -d "$d/ports/1/hw_counters" ]; then
+              for f in "$d/ports/1/hw_counters"/*; do
+                [ -f "$f" ] && printf "%s %s\n" "$(basename "$f")" "$(cat "$f" 2>/dev/null)"
+              done | sort > "/tmp/rdma_pre/${dev}.hw"
+            fi
+            nd=$(ls "$d/device/net" 2>/dev/null | head -1)
+            echo "$nd" > "/tmp/rdma_pre/${dev}.netdev"
+            if [ -n "$nd" ] && command -v ethtool >/dev/null 2>&1; then
+              ethtool -S "$nd" 2>/dev/null | sed 's/^ *//' > "/tmp/rdma_pre/${dev}.eth"
+            fi
           done
           echo "Baseline captured for: $(ls $IB | paste -sd, -)"
+          echo "Sample hw_counters keys (rdma5): $(cut -d' ' -f1 /tmp/rdma_pre/rdma5.hw 2>/dev/null | paste -sd, - | cut -c1-300)"
 
       - name: Run test_disaggregation
         timeout-minutes: 60
@@ -1206,53 +1214,63 @@ jobs:
           echo "===================================================================="
           echo "Runner host: $(hostname)   (failure peer IPs were 10.42.20.x)"
           echo "===================================================================="
+          [ -d "$IB" ] || { echo "No $IB on host"; exit 0; }
+
           echo ""
-          echo "### 1. Per-NIC ERROR-COUNTER DELTA during this disaggregation run ###"
-          echo "    (the NIC with large growth is the faulty link)"
-          printf "%-8s %-34s %12s %12s %12s\n" DEV COUNTER before after delta
-          if [ -d "$IB" ]; then
-            for d in "$IB"/*; do
-              dev=$(basename "$d"); p="$d/ports/1/counters"
-              for c in local_link_integrity_errors port_rcv_errors port_xmit_discards \
-                       symbol_error link_downed link_error_recovery \
-                       port_rcv_remote_physical_errors; do
-                after=$(cat "$p/$c" 2>/dev/null)
-                before=$(cat "/tmp/rdma_pre/${dev}.${c}" 2>/dev/null)
-                [ -z "$after" ] && continue
-                if [ -n "$before" ] && [ "$before" != "$after" ]; then
-                  printf "%-8s %-34s %12s %12s %12s\n" "$dev" "$c" "$before" "$after" "$((after-before))"
-                fi
-              done
+          echo "### 0. rdma<->netdev mapping ###"
+          for d in "$IB"/*; do
+            dev=$(basename "$d")
+            printf "  %-8s -> %s\n" "$dev" "$(cat /tmp/rdma_pre/${dev}.netdev 2>/dev/null)"
+          done
+
+          echo ""
+          echo "### 1. ionic hw_counters DELTA during this run (nonzero growth only) ###"
+          echo "    The NIC with large error/retry/drop growth is the faulty link."
+          printf "%-8s %-36s %14s %14s %14s\n" DEV COUNTER before after delta
+          for d in "$IB"/*; do
+            dev=$(basename "$d")
+            now="$d/ports/1/hw_counters"
+            [ -d "$now" ] || continue
+            for f in "$now"/*; do
+              [ -f "$f" ] || continue
+              key=$(basename "$f")
+              after=$(cat "$f" 2>/dev/null)
+              before=$(grep -E "^${key} " "/tmp/rdma_pre/${dev}.hw" 2>/dev/null | awk '{print $2}')
+              case "$after" in (''|*[!0-9]*) continue;; esac
+              case "$before" in (''|*[!0-9]*) before=0;; esac
+              delta=$((after-before))
+              [ "$delta" -ne 0 ] && printf "%-8s %-36s %14s %14s %14s\n" "$dev" "$key" "$before" "$after" "$delta"
             done
-            echo "(no rows above = no error counters changed during the test)"
-          else
-            echo "No $IB on host"
-          fi
+          done
+          echo "(no rows = no hw_counters changed; see section 2)"
+
           echo ""
-          echo "### 2. Absolute per-NIC error counters (cumulative since boot) ###"
-          printf "%-8s %8s %12s %12s %12s %12s %12s\n" DEV state lnk_integ rcv_err xmit_disc sym_err lnk_down
-          if [ -d "$IB" ]; then
-            for d in "$IB"/*; do
-              dev=$(basename "$d"); pp="$d/ports/1"; p="$pp/counters"
-              printf "%-8s %8s %12s %12s %12s %12s %12s\n" "$dev" \
-                "$(cat $pp/state 2>/dev/null | grep -oE '[A-Z_]+' | head -1)" \
-                "$(cat $p/local_link_integrity_errors 2>/dev/null)" \
-                "$(cat $p/port_rcv_errors 2>/dev/null)" \
-                "$(cat $p/port_xmit_discards 2>/dev/null)" \
-                "$(cat $p/symbol_error 2>/dev/null)" \
-                "$(cat $p/link_downed 2>/dev/null)"
-            done
-          fi
+          echo "### 2. ethtool -S DELTA, error/drop/retry/nak/seq/timeout counters ###"
+          printf "%-12s %-40s %14s\n" NETDEV COUNTER delta
+          for d in "$IB"/*; do
+            dev=$(basename "$d")
+            nd=$(cat /tmp/rdma_pre/${dev}.netdev 2>/dev/null)
+            [ -n "$nd" ] || continue
+            command -v ethtool >/dev/null 2>&1 || continue
+            ethtool -S "$nd" 2>/dev/null | sed 's/^ *//' > /tmp/${dev}.eth.now
+            while read -r line; do
+              key=$(echo "$line" | cut -d: -f1)
+              after=$(echo "$line" | cut -d: -f2 | tr -dc '0-9')
+              echo "$key" | grep -qiE "err|drop|nak|seq|timeout|retr|discard|miss|fail" || continue
+              before=$(grep -E "^${key}:" /tmp/rdma_pre/${dev}.eth 2>/dev/null | cut -d: -f2 | tr -dc '0-9')
+              [ -n "$after" ] || continue
+              [ -n "$before" ] || before=0
+              delta=$((after-before))
+              [ "$delta" -ne 0 ] && printf "%-12s %-40s %14s\n" "$nd" "$key" "$delta"
+            done < /tmp/${dev}.eth.now
+          done
+          echo "(no rows = no error/drop counters grew via ethtool)"
+
           echo ""
-          echo "### 3. Kernel ionic / RDMA errors (dmesg) ###"
-          (dmesg -T 2>/dev/null || dmesg 2>/dev/null || journalctl -k --no-pager 2>/dev/null) \
-            | grep -iE "ionic|cqe with error|retry counter|IBV_WC|qpid" | tail -120 \
-            || echo "no matching kernel lines / insufficient permission"
-          echo ""
-          echo "### 4. ibv_devinfo per device (port state/rate/link_layer) ###"
+          echo "### 3. ibv_devinfo per device (port state/rate/link_layer) ###"
           if docker ps --format '{{.Names}}' | grep -q '^ci_sglang$'; then
             docker exec -u root ci_sglang bash -c '
-              for dev in $(ibv_devinfo -list 2>/dev/null | grep -oE "rdma[0-9]+"); do
+              for dev in $(ibv_devinfo -list 2>/dev/null | grep -oE "rdma[0-9]+" | sort); do
                 echo "==== $dev ===="
                 ibv_devinfo -d "$dev" 2>&1 | grep -E "state|phys_state|rate|link_layer|fw_ver|active_width|active_speed"
               done'


### PR DESCRIPTION
> ⚠️ **DEBUG ONLY — do not merge.** This PR exists so IT/infra can reproduce a suspected NIC fault on the `linux-mi35x-gpu-8.fabric` runner.

## Problem
`stage-b-test-large-8-gpu-mi35x-disaggregation-amd` has failed on **3 consecutive scheduled runs**. Root cause looks like a **faulty RDMA NIC**, not a code regression: KV-cache transfer dies with

```
ionic_comp_msn:1277: cqe with error 12 for 0x1 (msn)
worker_pool.cpp:294] Worker: Process failed for slice (... local_nic: rdma5 ...
    retry_cnt: N): transport retry counter exceeded     # = IBV_WC_RETRY_EXC_ERR
KVTransferError: ... timed out after 300.0s in KVPoll.WaitingForInput
POST /generate -> 500  ->  test_disaggregation_basic: KeyError: 'answer'
```

Across all 3 runs the **peer node varies** but the failing **local NIC is consistently `rdma5`** → fault is local to that NIC/link:

| Run | failing `local_nic` | peer | result |
|-----|--------------------|------|--------|
| [83094386571](https://github.com/sgl-project/sglang/actions/runs/28067315750/job/83094386571) | **rdma5 (1541/1541, 100%)** | 10.42.20.151 | 1/3 pass |
| [82853564249](https://github.com/sgl-project/sglang/actions/runs/27994433780/job/82853564249) | **rdma5 (1522/1522, 100%)** | 10.42.20.195 | 1/3 pass |
| [82798487481](https://github.com/sgl-project/sglang/actions/runs/27977371862/job/82798487481) | **rdma5 (1260)** + 4/6/7 | 10.42.20.122 | 0/3 pass |

(`pp` / `mori` failures are a cascade: leftover procs after `basic` fails → `memory capacity is unbalanced` / HIP OOM / SIGKILL.)

## What this PR adds
Two debug steps inside the existing disaggregation job (no new workflow), so the evidence is collected in the **same job / container / node** that fails:
1. **pre-test baseline** — per-NIC sysfs error counters into `/tmp`.
2. **post-test (`if: always()`)** — per-NIC counter **delta** during the run + cumulative counters + kernel `ionic` errors (`dmesg`) + `ibv_devinfo` per device.

Expected signal: `rdma5` shows large growth in `local_link_integrity_errors` / `port_rcv_errors` / `port_xmit_discards` and dmesg `cqe with error 12`, while the other 7 NICs stay clean.

## Reproduction run (this branch)
- Run: https://github.com/sgl-project/sglang/actions/runs/28079402720
- Job (`stage-b-...-disaggregation-amd` on `linux-mi35x-gpu-8.fabric`): https://github.com/sgl-project/sglang/actions/runs/28079402720/job/83130723028
- See the **`DEBUG RDMA NIC diagnostic (post-test, isolate faulty NIC)`** step for the per-NIC breakdown.

## Ask for IT/infra
Inspect / repair NIC **`rdma5`** on `linux-mi35x-gpu-8.fabric` (link flap, fabric port/cabling, ionic firmware; `ibstat`, switch port counters). Drain the node from CI or drop `rdma5` from `--disaggregation-ib-device` until healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28094874458](https://github.com/sgl-project/sglang/actions/runs/28094874458)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28094874317](https://github.com/sgl-project/sglang/actions/runs/28094874317)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->