### PR TITLE
feat(seg_la): add [v,k] state layout option via linear_backend="seg_la_vk"

### DIFF
--- a/benchmark/lightning_cula/bench_state_layout.py
+++ b/benchmark/lightning_cula/bench_state_layout.py
@@ -1,0 +1,147 @@
+"""Operator-level benchmark: seg_la kv vs vk state layout.
+
+Compares ``seg_la_fwd(state_layout="kv")`` vs ``"vk"`` for PREFILL and
+DECODE paths on Ling-2.6-flash dims (H=HV=8, D=128).  Sweeps (B, S)
+configs and prints a per-path, per-config timing table.
+
+Columns:  path, B, S, H, D, layout, ms, ratio
+"""
+
+import argparse
+
+import torch
+
+from sglang.srt.layers.attention.linear.seg_la import SegLaMeta, seg_la_fwd
+
+
+def _bench(fn, iters=50, warmup=10):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters  # ms/iter
+
+
+def make_inputs(B, S, H, D):
+    total = B * S
+    q = torch.randn(total, H, D, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(total, H, D, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(total, H, D, device="cuda", dtype=torch.bfloat16)
+    decay = (0.3 * torch.arange(1, H + 1, device="cuda", dtype=torch.float32) / H).view(
+        H, 1, 1
+    )
+    return q, k, v, decay
+
+
+def make_closure(B, S, H, D, q, k, v, decay, scale, layout):
+    s = torch.zeros(B, H, D, D, device="cuda", dtype=torch.float32)
+    if layout == "vk":
+        s = s.transpose(-1, -2).contiguous()
+    q_offsets = torch.arange(0, B * S + 1, S, device="cuda", dtype=torch.int32)
+    meta = SegLaMeta(
+        batch_size=B,
+        max_q_length=S,
+        q_offsets=q_offsets,
+        s_offsets=torch.arange(B, device="cuda", dtype=torch.int32),
+        q_lengths=torch.full((B,), S, device="cuda", dtype=torch.int32),
+        s_scales=torch.zeros(B, device="cuda", dtype=torch.int32),
+    )
+
+    def run():
+        seg_la_fwd(q, k, v, s, decay, meta, softmax_scale=scale, state_layout=layout)
+
+    return run
+
+
+def make_decode_closure(B, H, D, q, k, v, decay, scale, layout):
+    s = torch.randn(B, H, D, D, device="cuda", dtype=torch.float32)
+    if layout == "vk":
+        s = s.transpose(-1, -2).contiguous()
+    q_offsets = torch.arange(0, B + 1, 1, device="cuda", dtype=torch.int32)
+    meta = SegLaMeta(
+        batch_size=B,
+        max_q_length=1,
+        q_offsets=q_offsets,
+        s_offsets=torch.arange(B, device="cuda", dtype=torch.int32),
+        q_lengths=torch.ones(B, device="cuda", dtype=torch.int32),
+        s_scales=torch.ones(B, device="cuda", dtype=torch.int32),
+    )
+
+    def run():
+        seg_la_fwd(q, k, v, s, decay, meta, softmax_scale=scale, state_layout=layout)
+
+    return run
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--H", type=int, default=8)
+    ap.add_argument("--D", type=int, default=128)
+    ap.add_argument("--iters", type=int, default=50)
+    args = ap.parse_args()
+    H, D = args.H, args.D
+    scale = D**-0.5
+
+    header = f"{'path':>8} {'B':>4} {'S':>6} {'tokens':>8} {'H':>3} {'D':>4} {'layout':>5} {'ms':>11} {'ratio':>8}"
+    print(
+        f"seg_la state_layout bench | H={H} D={D} | "
+        f"{torch.cuda.get_device_name(0)} "
+        f"sm_{torch.cuda.get_device_properties(0).major}"
+        f"{torch.cuda.get_device_properties(0).minor}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    # ------- PREFILL -------
+    for B, S in [
+        (1, 256),
+        (1, 1024),
+        (1, 4096),
+        (4, 512),
+        (8, 1024),
+        (16, 512),
+        (1, 8192),
+    ]:
+        torch.manual_seed(0)
+        q, k, v, decay = make_inputs(B, S, H, D)
+        t_kv = _bench(
+            make_closure(B, S, H, D, q, k, v, decay, scale, "kv"), iters=args.iters
+        )
+        t_vk = _bench(
+            make_closure(B, S, H, D, q, k, v, decay, scale, "vk"), iters=args.iters
+        )
+        ratio = t_vk / t_kv if t_kv > 0 else float("nan")
+        print(
+            f"{'PREFILL':>8} {B:>4} {S:>6} {B * S:>8} {H:>3} {D:>4} {'kv':>5} {t_kv:>11.4f} {'--':>8}"
+        )
+        print(
+            f"{'PREFILL':>8} {B:>4} {S:>6} {B * S:>8} {H:>3} {D:>4} {'vk':>5} {t_vk:>11.4f} {ratio:>7.2f}x"
+        )
+
+    # ------- DECODE -------
+    for B in [1, 32, 128, 256]:
+        torch.manual_seed(1)
+        q, k, v, decay = make_inputs(B, 1, H, D)
+        t_kv = _bench(
+            make_decode_closure(B, H, D, q, k, v, decay, scale, "kv"), iters=args.iters
+        )
+        t_vk = _bench(
+            make_decode_closure(B, H, D, q, k, v, decay, scale, "vk"), iters=args.iters
+        )
+        ratio = t_vk / t_kv if t_kv > 0 else float("nan")
+        print(
+            f"{'DECODE':>8} {B:>4} {1:>6} {B:>8} {H:>3} {D:>4} {'kv':>5} {t_kv:>11.4f} {'--':>8}"
+        )
+        print(
+            f"{'DECODE':>8} {B:>4} {1:>6} {B:>8} {H:>3} {D:>4} {'vk':>5} {t_vk:>11.4f} {ratio:>7.2f}x"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sglang/srt/layers/attention/linear/lightning_backend.py
@@ -77,6 +77,17 @@ class LightningAttentionBackend(MambaAttnBackendBase):
         self.linear_backend = getattr(
             model_runner.model_config.hf_config, "linear_backend", "seg_la"
         )
+        # seg_la_vk: same kernel family with [v,k] state layout for all kernels.
+        # The state pool is square (H,D,D) — inner k/v ordering is kernel-internal.
+        # The MTP scatter is a layout-agnostic whole-slot copy, so as long as every
+        # seg_la kernel (including mtp's intermediate_ssm write) uses [v,k], the
+        # path is end-to-end self-consistent with no memory_pool / scatter changes.
+        self.seg_la_state_layout = "kv"
+        if self.linear_backend == "seg_la_vk":
+            self.seg_la_state_layout = "vk"
+            self.linear_backend = (
+                "seg_la"  # reuse all existing seg_la branches unchanged
+            )
         logger.info(
             f"linear_backend for linear attention in hybrid_linear_backend: {self.linear_backend}"
         )
@@ -269,6 +280,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             caches=temp_cache,
             cache_indices=intermediate_state_indices,
             decouple=True,
+            state_layout=self.seg_la_state_layout,
         )
         return hidden
 

--- a/python/sglang/srt/layers/attention/linear/seg_la.py
+++ b/python/sglang/srt/layers/attention/linear/seg_la.py
@@ -226,6 +226,7 @@ def seg_la_p_kernel(
     V_SPLIT_DIM: tl.constexpr,
     BLOCK: tl.constexpr,
     EVEN: tl.constexpr,
+    VK: tl.constexpr,
 ):
     bid = tl.program_id(0)
     hid = tl.program_id(1)
@@ -279,15 +280,26 @@ def seg_la_p_kernel(
         + vid * V_SPLIT_DIM
         + (offs_b[:, None] * H * HEAD_DIM + offs_v[None, :])
     )
-    s_ptrs = (
-        S
-        + s_offset * stride_s
-        + hid * HEAD_DIM * HEAD_DIM
-        + kid * HEAD_DIM * K_SPLIT_DIM
-        + vid * V_SPLIT_DIM
-        + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
-    )
-    state = tl.load(s_ptrs, mask=s_scale > 0).to(tl.float32)
+    if VK:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + vid * HEAD_DIM * V_SPLIT_DIM
+            + kid * K_SPLIT_DIM
+            + (offs_v[:, None] * HEAD_DIM + offs_k[None, :])
+        )
+        state = tl.trans(tl.load(s_ptrs, mask=s_scale > 0)).to(tl.float32)
+    else:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
+        state = tl.load(s_ptrs, mask=s_scale > 0).to(tl.float32)
 
     for n in range(0, q_length, BLOCK):
         n = tl.multiple_of(n, BLOCK)
@@ -340,7 +352,10 @@ def seg_la_p_kernel(
                 mask=(n + offs_b)[:, None] < q_length,
             )
 
-    tl.store(s_ptrs, state.to(S.dtype.element_ty))
+    if VK:
+        tl.store(s_ptrs, tl.trans(state).to(S.dtype.element_ty))
+    else:
+        tl.store(s_ptrs, state.to(S.dtype.element_ty))
 
 
 # used for speculative
@@ -368,6 +383,7 @@ def seg_la_s_kernel(
     V_SPLIT_DIM: tl.constexpr,
     BLOCK: tl.constexpr,
     EVEN: tl.constexpr,
+    VK: tl.constexpr,
 ):
     bid = tl.program_id(0)
     hid = tl.program_id(1)
@@ -421,15 +437,26 @@ def seg_la_s_kernel(
         + vid * V_SPLIT_DIM
         + (offs_b[:, None] * H * HEAD_DIM + offs_v[None, :])
     )
-    s_ptrs = (
-        S
-        + s_offset * stride_s
-        + hid * HEAD_DIM * HEAD_DIM
-        + kid * HEAD_DIM * K_SPLIT_DIM
-        + vid * V_SPLIT_DIM
-        + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
-    )
-    state = tl.load(s_ptrs, mask=s_scale > 0).to(tl.float32)
+    if VK:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + vid * HEAD_DIM * V_SPLIT_DIM
+            + kid * K_SPLIT_DIM
+            + (offs_v[:, None] * HEAD_DIM + offs_k[None, :])
+        )
+        state = tl.trans(tl.load(s_ptrs, mask=s_scale > 0)).to(tl.float32)
+    else:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
+        state = tl.load(s_ptrs, mask=s_scale > 0).to(tl.float32)
 
     if EVEN:
         q = tl.load(q_ptrs).to(tl.float32)
@@ -497,6 +524,7 @@ def seg_la_d_kernel(
     HEAD_DIM: tl.constexpr,
     K_SPLIT_DIM: tl.constexpr,
     V_SPLIT_DIM: tl.constexpr,
+    VK: tl.constexpr,
 ):
     bid = tl.program_id(0)
     hid = tl.program_id(1)
@@ -528,22 +556,36 @@ def seg_la_d_kernel(
         + vid * V_SPLIT_DIM
         + (offs_v)
     )
-    s_ptrs = (
-        S
-        + s_offset * stride_s
-        + hid * HEAD_DIM * HEAD_DIM
-        + kid * HEAD_DIM * K_SPLIT_DIM
-        + vid * V_SPLIT_DIM
-        + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
-    )
+    if VK:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + vid * HEAD_DIM * V_SPLIT_DIM
+            + kid * K_SPLIT_DIM
+            + (offs_v[:, None] * HEAD_DIM + offs_k[None, :])
+        )
+    else:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
     state = tl.load(s_ptrs).to(tl.float32)
 
     k = tl.load(k_ptrs).to(tl.float32)
     v = tl.load(v_ptrs).to(tl.float32)
     q = tl.load(q_ptrs).to(tl.float32) * softmax_scale
 
-    state = state * tl.exp(decay_scale) + k[:, None] * v
-    o = tl.sum(q[:, None] * state, axis=0)
+    if VK:
+        state = state * tl.exp(decay_scale) + v[:, None] * k[None, :]
+        o = tl.sum(q[None, :] * state, axis=1)
+    else:
+        state = state * tl.exp(decay_scale) + k[:, None] * v
+        o = tl.sum(q[:, None] * state, axis=0)
 
     tl.store(out_ptrs, o.to(Out.dtype.element_ty))
     tl.store(s_ptrs, state.to(S.dtype.element_ty))
@@ -572,6 +614,7 @@ def seg_la_mtp_kernel(
     HEAD_DIM: tl.constexpr,
     K_SPLIT_DIM: tl.constexpr,
     V_SPLIT_DIM: tl.constexpr,
+    VK: tl.constexpr,
 ):
     bid = tl.program_id(0)
     hid = tl.program_id(1)
@@ -604,33 +647,61 @@ def seg_la_mtp_kernel(
         + (offs_v)
     )
     # (bs, qo_heads, d, d)
-    s_ptrs = (
-        S
-        + s_offset * stride_s
-        + hid * HEAD_DIM * HEAD_DIM
-        + kid * HEAD_DIM * K_SPLIT_DIM
-        + vid * V_SPLIT_DIM
-        + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
-    )
+    if VK:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + vid * HEAD_DIM * V_SPLIT_DIM
+            + kid * K_SPLIT_DIM
+            + (offs_v[:, None] * HEAD_DIM + offs_k[None, :])
+        )
+    else:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
     state = tl.load(s_ptrs).to(tl.float32)
     # (bs, step, kv_heads, d, d)
     cache_indices = tl.load(cache_indices + bid)
-    c_ptrs = (
-        CACHES
-        + cache_indices * stride_c
-        + hid * HEAD_DIM * HEAD_DIM
-        + kid * HEAD_DIM * K_SPLIT_DIM
-        + vid * V_SPLIT_DIM
-        + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
-    )
+    # Under VK, intermediate_ssm is written in [v,k] — the same layout as temporal —
+    # so fused_mamba_state_scatter_with_mask (a layout-agnostic whole-slot copy)
+    # commits [v,k] → [v,k] and stays consistent. The c_ptrs swap is mandatory:
+    # forgetting it would silently corrupt state on MTP commit.
+    if VK:
+        c_ptrs = (
+            CACHES
+            + cache_indices * stride_c
+            + hid * HEAD_DIM * HEAD_DIM
+            + vid * HEAD_DIM * V_SPLIT_DIM
+            + kid * K_SPLIT_DIM
+            + (offs_v[:, None] * HEAD_DIM + offs_k[None, :])
+        )
+    else:
+        c_ptrs = (
+            CACHES
+            + cache_indices * stride_c
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
 
     for i in range(step):
         q = tl.load(q_ptrs).to(tl.float32) * softmax_scale
         k = tl.load(k_ptrs).to(tl.float32)
         v = tl.load(v_ptrs).to(tl.float32)
 
-        state = state * decay_scale + k[:, None] * v
-        o = tl.sum(q[:, None] * state, axis=0)
+        if VK:
+            state = state * decay_scale + v[:, None] * k[None, :]
+            o = tl.sum(q[None, :] * state, axis=1)
+        else:
+            state = state * decay_scale + k[:, None] * v
+            o = tl.sum(q[:, None] * state, axis=0)
 
         tl.store(out_ptrs, o.to(Out.dtype.element_ty))
         tl.store(c_ptrs, state.to(CACHES.dtype.element_ty))
@@ -665,7 +736,14 @@ def seg_la_fwd(
     cache_indices=None,
     softmax_scale=None,
     decouple=False,
+    state_layout: str = "kv",
 ):
+    assert state_layout in (
+        "kv",
+        "vk",
+    ), f"Unsupported seg_la state_layout: {state_layout}"
+    VK = state_layout == "vk"
+
     length, qo_heads, HEAD_DIM = q.shape
     _, kv_heads, _ = k.shape
     bs = meta.batch_size
@@ -720,6 +798,7 @@ def seg_la_fwd(
                 HEAD_DIM=HEAD_DIM,
                 K_SPLIT_DIM=K_SPLIT_DIM,
                 V_SPLIT_DIM=V_SPLIT_DIM,
+                VK=VK,
                 num_warps=num_warps,
                 num_stages=num_stages,
             )
@@ -753,6 +832,7 @@ def seg_la_fwd(
                 V_SPLIT_DIM=V_SPLIT_DIM,
                 BLOCK=BLOCK,
                 EVEN=EVEN,
+                VK=VK,
                 num_warps=num_warps,
                 num_stages=num_stages,
             )
@@ -784,6 +864,7 @@ def seg_la_fwd(
                 V_SPLIT_DIM=V_SPLIT_DIM,
                 BLOCK=BLOCK,
                 EVEN=EVEN,
+                VK=VK,
                 num_warps=num_warps,
                 num_stages=num_stages,
             )
@@ -842,6 +923,7 @@ def seg_la_fwd(
             HEAD_DIM=HEAD_DIM,
             K_SPLIT_DIM=K_SPLIT_DIM,
             V_SPLIT_DIM=V_SPLIT_DIM,
+            VK=VK,
             num_warps=num_warps,
             num_stages=num_stages,
         )

--- a/test/manual/lightning/test_seg_la_vk_e2e_parity.py
+++ b/test/manual/lightning/test_seg_la_vk_e2e_parity.py
@@ -1,0 +1,252 @@
+"""E2E parity test: seg_la vs seg_la_vk on a real Ling / Bailing-MoE-Linear model.
+
+This test is **USER-RUN** — it needs a real checkpoint + GPUs + time.
+Claude authored it; the user executes it.
+
+Loads the same model twice (sequentially to save memory) — baseline with
+default ``linear_backend`` (``"seg_la"``) and override
+``json_model_override_args='{"linear_backend":"seg_la_vk"}'``.  Greedy-decodes
+a fixed prompt set (single, batched, long) and asserts **identical token ids**.
+Also runs a spec variant (NEXTN) to cover the MTP+scatter path.
+
+Usage::
+    MODEL=/root/.cache/modelscope/hub/models/inclusionAI/Ling-2___6-flash
+    python3 test/manual/lightning/test_seg_la_vk_e2e_parity.py --model-path "$MODEL" --tp-size 4
+
+Passing this test is the gate that confirms ``seg_la_vk`` is end-to-end
+correct with no ``memory_pool.py`` / scatter changes needed.
+"""
+
+import argparse
+import sys
+
+import torch
+
+from sglang import Engine
+
+PROMPTS = [
+    "The capital of France is",
+    "Explain the key differences between linear attention and standard self-attention in one paragraph.",
+    "Write a Python function to compute Fibonacci numbers recursively.",
+    "In 2019, the European Space Agency launched",
+    "A recipe for chocolate chip cookies:",
+]
+
+# Longer prompt to exercise prefill chunking
+LONG_PROMPT = (
+    "The theory of general relativity, proposed by Albert Einstein in 1915, "
+    "fundamentally changed our understanding of gravity. Instead of viewing gravity "
+    "as a force between masses, Einstein described it as the curvature of spacetime "
+    "caused by mass and energy. This revolutionary framework has been confirmed by "
+    "numerous experiments and observations over the past century, including the "
+    "precession of Mercury's orbit, the bending of starlight during solar eclipses, "
+    "and the recent detection of gravitational waves by LIGO. Describe the core "
+    "principles of general relativity and its major experimental confirmations:"
+)
+
+
+def _build_engine(
+    model_path: str,
+    tp_size: int,
+    extra_args: dict,
+    spec: bool = False,
+    model_impl: str = "auto",
+):
+    """Build an sglang.Engine with the given overrides."""
+    kwargs = dict(
+        model_path=model_path,
+        tp_size=tp_size,
+        model_impl=model_impl,
+        trust_remote_code=True,
+        mem_fraction_static=0.75,
+        max_running_requests=64,
+        log_level="error",
+    )
+    if extra_args:
+        kwargs["json_model_override_args"] = _to_json_str(extra_args)
+    if spec:
+        kwargs.update(
+            speculative_algorithm="NEXTN",
+            speculative_num_steps=3,
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=4,
+            mamba_scheduler_strategy="extra_buffer",
+        )
+    return Engine(**kwargs)
+
+
+def _to_json_str(d: dict) -> str:
+    import json
+
+    return json.dumps(d)
+
+
+def _greedy_generate(engine: Engine, prompts: list, max_tokens: int = 64):
+    """Greedy (temperature=0) generate and return list of token-id lists."""
+    try:
+        outputs = engine.generate(
+            prompts,
+            sampling_params={"temperature": 0.0, "max_new_tokens": max_tokens},
+        )
+    except Exception:
+        # Fallback: generate one-by-one if batched generate fails
+        outputs = []
+        for p in prompts:
+            outputs.append(
+                engine.generate(
+                    p,
+                    sampling_params={"temperature": 0.0, "max_new_tokens": max_tokens},
+                )
+            )
+    tokens = []
+    for out in outputs:
+        if hasattr(out, "output_ids"):
+            tokens.append(out.output_ids)
+        elif isinstance(out, dict):
+            tokens.append(out.get("output_ids", []))
+        else:
+            raise TypeError(f"Unexpected output type: {type(out)}")
+    return tokens
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-path", required=True)
+    ap.add_argument("--tp-size", type=int, default=4)
+    ap.add_argument(
+        "--model-impl",
+        type=str,
+        default="auto",
+        help="Model implementation backend, e.g. 'auto' or 'modelscope'",
+    )
+    ap.add_argument("--max-tokens", type=int, default=64)
+    ap.add_argument(
+        "--skip-spec", action="store_true", help="Skip speculative decoding test"
+    )
+    args = ap.parse_args()
+
+    torch.cuda.empty_cache()
+
+    # ---- Baseline: seg_la (kv, default) ----
+    print("=== Loading baseline (seg_la / kv) ===", flush=True)
+    engine_kv = _build_engine(
+        args.model_path,
+        args.tp_size,
+        model_impl=args.model_impl,
+        extra_args={},
+        spec=False,
+    )
+    try:
+        prompts = list(PROMPTS) + [LONG_PROMPT]
+        kv_tokens = _greedy_generate(engine_kv, prompts, args.max_tokens)
+
+        # Also test batched (first 3 prompts together)
+        kv_batch = _greedy_generate(
+            engine_kv, [PROMPTS[0], PROMPTS[1], PROMPTS[2]], args.max_tokens
+        )
+        print(
+            f"  baseline generated {sum(len(t) for t in kv_tokens)} total tokens",
+            flush=True,
+        )
+    finally:
+        engine_kv.shutdown()
+        del engine_kv
+        torch.cuda.empty_cache()
+
+    # ---- Override: seg_la_vk ----
+    print("=== Loading override (seg_la_vk / vk) ===", flush=True)
+    engine_vk = _build_engine(
+        args.model_path,
+        args.tp_size,
+        model_impl=args.model_impl,
+        extra_args={"linear_backend": "seg_la_vk"},
+        spec=False,
+    )
+    try:
+        prompts = list(PROMPTS) + [LONG_PROMPT]
+        vk_tokens = _greedy_generate(engine_vk, prompts, args.max_tokens)
+        vk_batch = _greedy_generate(
+            engine_vk, [PROMPTS[0], PROMPTS[1], PROMPTS[2]], args.max_tokens
+        )
+        print(
+            f"  override generated {sum(len(t) for t in vk_tokens)} total tokens",
+            flush=True,
+        )
+    finally:
+        engine_vk.shutdown()
+        del engine_vk
+        torch.cuda.empty_cache()
+
+    # ---- Assert identical ----
+    all_ok = True
+    for i, (kv_tok, vk_tok) in enumerate(
+        zip(kv_tokens + kv_batch, vk_tokens + vk_batch)
+    ):
+        if kv_tok != vk_tok:
+            print(f"\nFAIL: prompt group {i}: tokens differ!", flush=True)
+            print(
+                f"  kv ({len(kv_tok)}): {kv_tok[:20]}{'...' if len(kv_tok) > 20 else ''}",
+                flush=True,
+            )
+            print(
+                f"  vk ({len(vk_tok)}): {vk_tok[:20]}{'...' if len(vk_tok) > 20 else ''}",
+                flush=True,
+            )
+            all_ok = False
+    if all_ok:
+        print(
+            "\nPASS: all prompts produce identical token ids (seg_la == seg_la_vk)",
+            flush=True,
+        )
+
+    # ---- Spec variant (NEXTN → MTP + scatter) ----
+    if not args.skip_spec:
+        torch.cuda.empty_cache()
+        print("\n=== Loading baseline (seg_la + spec) ===", flush=True)
+        engine_kv_spec = _build_engine(
+            args.model_path,
+            args.tp_size,
+            model_impl=args.model_impl,
+            extra_args={},
+            spec=True,
+        )
+        try:
+            kv_spec_tokens = _greedy_generate(
+                engine_kv_spec, list(PROMPTS), args.max_tokens
+            )
+        finally:
+            engine_kv_spec.shutdown()
+            del engine_kv_spec
+            torch.cuda.empty_cache()
+
+        print("=== Loading override (seg_la_vk + spec) ===", flush=True)
+        engine_vk_spec = _build_engine(
+            args.model_path,
+            args.tp_size,
+            model_impl=args.model_impl,
+            extra_args={"linear_backend": "seg_la_vk"},
+            spec=True,
+        )
+        try:
+            vk_spec_tokens = _greedy_generate(
+                engine_vk_spec, list(PROMPTS), args.max_tokens
+            )
+        finally:
+            engine_vk_spec.shutdown()
+            del engine_vk_spec
+            torch.cuda.empty_cache()
+
+        for i, (kv_tok, vk_tok) in enumerate(zip(kv_spec_tokens, vk_spec_tokens)):
+            if kv_tok != vk_tok:
+                print(f"\nFAIL (spec): prompt {i}: tokens differ!", flush=True)
+                all_ok = False
+        if all(
+            kv_spec_tokens[i] == vk_spec_tokens[i] for i in range(len(kv_spec_tokens))
+        ):
+            print("PASS (spec): all prompts produce identical token ids", flush=True)
+
+    sys.exit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/attention/unittests/lightning/test_seg_la_state_layout.py
+++ b/test/registered/attention/unittests/lightning/test_seg_la_state_layout.py
@@ -1,0 +1,342 @@
+"""Kernel-level correctness test for seg_la state_layout (kv vs vk).
+
+Calls ``seg_la_fwd`` directly (no server, no model), comparing
+``state_layout="kv"`` and ``"vk"`` across prefill (zero / nonzero init),
+decode, spec, and MTP.  The primary assertion is vk == kv (identical by
+construction under refined-B) and, where state is written, vk final state
+== kv final state transposed.
+
+State tensors are passed to the kernel *uncloned* so the in-place state
+write-back is actually verified (not the original inputs).
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.linear.seg_la import SegLaMeta, seg_la_fwd
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase, is_in_amd_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-large")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_decays(H, D, device):
+    """slope ∈ (0.3/H, 0.3) → decay = exp(-slope)."""
+    slope = 0.3 * torch.arange(1, H + 1, device=device, dtype=torch.float32) / H
+    return slope.view(H, 1, 1)
+
+
+def _make_packed_inputs(B, S, H, D, device="cuda", dtype=torch.bfloat16):
+    total = B * S
+    q = torch.randn(total, H, D, device=device, dtype=dtype)
+    k = torch.randn(total, H, D, device=device, dtype=dtype)
+    v = torch.randn(total, H, D, device=device, dtype=dtype)
+    q_offsets = torch.arange(0, total + 1, S, device=device, dtype=torch.int32)
+    return q, k, v, q_offsets
+
+
+def _make_seg_meta(B, S, q_offsets, s_scales_val, s_offsets, mask=None):
+    return SegLaMeta(
+        batch_size=B,
+        max_q_length=S,
+        q_offsets=q_offsets,
+        s_offsets=s_offsets,
+        q_lengths=q_offsets.diff(),
+        s_scales=torch.full(
+            (B,), s_scales_val, device=q_offsets.device, dtype=torch.int32
+        ),
+        mask=mask,
+    )
+
+
+def _new_state(B, H, D, device):
+    """Return a random state pool [B, H, D, D] fp32 in kv layout."""
+    return torch.randn(B, H, D, D, device=device, dtype=torch.float32)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestSegLaStateLayout(CustomTestCase):
+    H = 2
+    D = 128  # decode needs K_SPLIT_DIM=128 → HEAD_DIM=128
+    atol = 5e-2 if is_in_amd_ci() else 3e-2
+    rtol = 5e-2 if is_in_amd_ci() else 3e-2
+
+    def setUp(self):
+        torch.manual_seed(42)
+        torch.cuda.manual_seed_all(42)
+
+    # ---- helpers ----
+    def _run_both_layouts(
+        self,
+        B,
+        S,
+        state_kv,
+        decay,
+        softmax_scale,
+        q,
+        k,
+        v,
+        q_offsets,
+        caches_kv=None,
+        caches_vk=None,
+        cache_indices=None,
+        mask=None,
+        has_init=True,
+    ):
+        """Run seg_la_fwd for kv and vk.
+
+        ``state_kv`` / ``caches_kv`` are passed *uncloned* so the kernel's
+        in-place state write is observable on return. ``has_init`` controls
+        s_scales (1 = read existing state, 0 = zero-init).
+        Returns (o_kv, o_vk, s_kv_final, s_vk_final, caches_kv, caches_vk).
+        """
+        s_offsets = torch.arange(B, device=q.device, dtype=torch.int32)
+        # state_vk is an independent [v,k]-laid-out tensor (transpose + copy).
+        state_vk = state_kv.clone().transpose(-1, -2).contiguous()
+        s_scales_val = 1 if has_init else 0
+
+        meta = _make_seg_meta(B, S, q_offsets, s_scales_val, s_offsets, mask=mask)
+        ci_kv = cache_indices.clone() if cache_indices is not None else None
+        ci_vk = cache_indices.clone() if cache_indices is not None else None
+
+        # kv — kernel writes final state back into state_kv in place
+        o_kv = seg_la_fwd(
+            q,
+            k,
+            v,
+            state_kv,
+            decay,
+            meta,
+            caches=caches_kv,
+            cache_indices=ci_kv,
+            softmax_scale=softmax_scale,
+            state_layout="kv",
+        )
+        # vk — kernel writes final state back into state_vk in place
+        o_vk = seg_la_fwd(
+            q,
+            k,
+            v,
+            state_vk,
+            decay,
+            meta,
+            caches=caches_vk,
+            cache_indices=ci_vk,
+            softmax_scale=softmax_scale,
+            state_layout="vk",
+        )
+        return o_kv, o_vk, state_kv, state_vk, caches_kv, caches_vk
+
+    def _assert_output_match(self, o_kv, o_vk):
+        self.assertTrue(
+            torch.allclose(o_vk, o_kv, atol=self.atol, rtol=self.rtol),
+            f"vk != kv output  max_diff={(o_vk - o_kv).abs().max().item():.6f}",
+        )
+
+    def _assert_state_transpose_match(self, s_kv_final, s_vk_final):
+        """vk final state must equal kv final state transposed (kernel-written)."""
+        s_kv_t = s_kv_final.transpose(-1, -2)
+        self.assertTrue(
+            torch.allclose(s_vk_final, s_kv_t, atol=self.atol, rtol=self.rtol),
+            f"state: vk != kv.transpose  max_diff={(s_vk_final - s_kv_t).abs().max().item():.6f}",
+        )
+
+    # ---- PREFILL ----
+    def test_prefill_zero_init_vsplit32(self):
+        """bs=2 → V_SPLIT_DIM=32; s_scales=0 (zero state init)."""
+        B, S, H, D = 2, 64, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = torch.zeros(B, H, D, D, device=q.device, dtype=torch.float32)
+
+        o_kv, o_vk, skv, svk, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            has_init=False,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        self._assert_state_transpose_match(skv, svk)
+
+    def test_prefill_zero_init_vsplit64(self):
+        """bs=4 → V_SPLIT_DIM=64; s_scales=0."""
+        B, S, H, D = 4, 64, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = torch.zeros(B, H, D, D, device=q.device, dtype=torch.float32)
+
+        o_kv, o_vk, skv, svk, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            has_init=False,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        self._assert_state_transpose_match(skv, svk)
+
+    def test_prefill_nonzero_init(self):
+        """s_scales=1 with random state — exercises tl.trans on prefill load."""
+        B, S, H, D = 2, 64, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = _new_state(B, H, D, q.device)
+
+        o_kv, o_vk, skv, svk, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            has_init=True,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        self._assert_state_transpose_match(skv, svk)
+
+    # ---- DECODE ----
+    def test_decode_vsplit32(self):
+        """bs ≤ 128 → V_SPLIT_DIM=32."""
+        B, S, H, D = 64, 1, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = _new_state(B, H, D, q.device)
+
+        o_kv, o_vk, skv, svk, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            has_init=True,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        self._assert_state_transpose_match(skv, svk)
+
+    def test_decode_vsplit64(self):
+        """bs > 128 → V_SPLIT_DIM=64."""
+        B, S, H, D = 256, 1, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = _new_state(B, H, D, q.device)
+
+        o_kv, o_vk, skv, svk, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            has_init=True,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        self._assert_state_transpose_match(skv, svk)
+
+    # ---- SPEC ----
+    def test_spec_chain(self):
+        """Speculative decode: chain mask, spec writes no state (read-only).
+
+        s_scales=1 so the VK tl.trans-on-load path is exercised.
+        """
+        B, S, H, D = 2, 16, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = _new_state(B, H, D, q.device)
+        mask = torch.tril(torch.ones(B, S, S, device=q.device, dtype=torch.int32))
+
+        o_kv, o_vk, _, _, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            mask=mask,
+            has_init=True,
+        )
+        # Spec does NOT write back state; compare outputs only.
+        self._assert_output_match(o_kv, o_vk)
+
+    # ---- MTP ----
+    def test_mtp_chain(self):
+        """MTP path: caches/intermediate_ssm with step=4 tokens per request.
+
+        Ensures both s_ptrs and c_ptrs are swapped consistently — the MTP
+        scatter (layout-agnostic whole-slot copy) stays correct.
+        """
+        step = 4
+        B = step
+        H, D = self.H, self.D
+        S = step
+        q, k, v, q_offsets = _make_packed_inputs(B, step, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = _new_state(B, H, D, q.device)
+
+        # Sentinel init so unwritten slots stay distinguishable; kernel writes
+        # real values. caches_vk is an independent [v,k] tensor.
+        caches_kv = torch.full(
+            (B, step, H, D, D), -1.0, device=q.device, dtype=torch.float32
+        )
+        caches_vk = caches_kv.clone().transpose(-1, -2).contiguous()
+        cache_indices = torch.arange(B, device=q.device, dtype=torch.int32)
+
+        o_kv, o_vk, _, _, caches_kv, caches_vk = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            caches_kv=caches_kv,
+            caches_vk=caches_vk,
+            cache_indices=cache_indices,
+            has_init=True,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        # MTP writes to caches, not state; caches_vk == transpose(caches_kv).
+        self._assert_state_transpose_match(caches_kv, caches_vk)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

SGLang's Lightning-Attention models (Ling / Bailing-MoE-Linear) currently run linear attention through the in-tree `seg_la` Triton kernels, which store the per-head SSM state matrix in `[k,v]` (K-major) layout. We are integrating **cuLA** (https://github.com/inclusionAI/cuLA) into SGLang as an alternative linear-attention backend (`linear_backend="cula"`) to lift decode throughput on these models. cuLA's KVBuffer path, however, operates on the opposite `[v,k]` (V-major) state layout.

This layout mismatch is the blocker for letting the seg_la and cuLA backends share the same state pool and for any downstream `[v,k]` consumer. This PR is **groundwork for that integration**: it adds an opt-in `[v,k]` state-layout variant to the entire live seg_la kernel family (`linear_backend="seg_la_vk"`), so the seg_la path can produce/consume a genuine `[v,k]` state buffer — without rewriting the proven `[k,v]` recurrence math, touching the memory pool, or changing the MTP-scatter plumbing. The default `[k,v]` path stays byte-identical.

## Modifications

Add an opt-in `[v,k]` (V-major) state layout to all **live** seg_la kernels, selected by a new `linear_backend="seg_la_vk"` config value. The default `[k,v]` path is unchanged.

- **`python/sglang/srt/layers/attention/linear/seg_la.py`**
  - Added `VK: tl.constexpr` to `seg_la_p_kernel` (prefill), `seg_la_s_kernel` (spec), `seg_la_d_kernel` (decode), `seg_la_mtp_kernel` (MTP).
  - Added `state_layout: str = "kv"` arg to `seg_la_fwd` (asserts `("kv","vk")`), threaded as `VK` into all four kernel launches.
  - **Matmul kernels** (prefill/spec): the state is loaded once before / stored once after the block loop, so under `VK` the state pointer is swapped to the `[v,k]` layout and a single `tl.trans` is applied on load/store — the in-register recurrence math is untouched. Transpose cost is outside the hot loop.
  - **Elementwise kernels** (decode/mtp): the `[v,k]` recurrence is computed natively (`state += v[:,None]*k[None,:]`, `o = sum(q[None,:]*state, axis=1)`) with **zero** added transpose.
  - **MTP**: both the `temporal` state pointer (`s_ptrs`) **and** the `intermediate_ssm` cache pointer (`c_ptrs`) are swapped to `[v,k]`, with a comment that the layout-agnostic `fused_mamba_state_scatter_with_mask` therefore commits `[v,k]→[v,k]` consistently.
  - `VK` is a `tl.constexpr`, so the default `kv` path compiles byte-identical to before (only the taken branch is JIT-compiled).
  - `seg_la_kernel` (dead, commented-out caller) is intentionally left `[k,v]`-only.

- **`python/sglang/srt/layers/attention/linear/lightning_backend.py`**
  - `linear_backend="seg_la_vk"` is normalized in `__init__` to `self.linear_backend="seg_la"` + `self.seg_la_state_layout="vk"`, reusing every existing `seg_la` dispatch branch unchanged.
  - `_linear_attention_entry` passes `state_layout=self.seg_la_state_layout` to `seg_la_fwd`.

- **No `memory_pool.py` / scatter changes.** The Lightning state pool is square `(H,D,D)`; the inner `(k,v)` ordering is kernel-internal. Every external consumer (allocation, prefix copy, host offload, MTP scatter) is a layout-agnostic whole-slot copy, so `seg_la_vk` is end-to-end self-consistent as long as the whole kernel family uses `[v,k]`.

- **Tests / bench**
  - `test/registered/attention/unittests/lightning/test_seg_la_state_layout.py` — kernel-level correctness (registered CI `base-b-test-1-gpu-large`): prefill (zero + nonzero init), decode, spec, MTP; both `V_SPLIT_DIM=32/64` paths. Asserts `o_vk == o_kv` and, where state is written, `state_vk == state_kv.transpose(-1,-2)` against **kernel-mutated** tensors.
  - `test/manual/lightning/test_seg_la_vk_e2e_parity.py` — user-run E2E parity: loads Ling-2.6-flash with `seg_la` vs `seg_la_vk`, greedy-decodes, asserts identical token ids (incl. a NEXTN spec variant for the MTP path).
  - `benchmark/lightning_cula/bench_state_layout.py` — operator-level kv-vs-vk timing (prefill + decode sweeps).

## Accuracy Tests

- **Kernel-level** (`test_seg_la_state_layout.py`, 7 cases, all pass): `o_vk == o_kv` (max diff 0.0 for prefill/spec/mtp, ≤0.03 for decode bf16) and `state_vk == state_kv.transpose(-1,-2)` (0.0), verifying the `[v,k]` layout is a faithful transpose of `[k,v]` across prefill/decode/spec/MTP and both `V_SPLIT_DIM` partition paths.

- **E2E parity** (Ling-2.6-flash, tp=4, greedy): `seg_la` and `seg_la_vk` produce **identical token ids** on short and long prompts.

- **GSM8K** (300 examples, 5-shot, Ling-2.6-flash, tp=4):

  | backend | score | latency | throughput |
  |---|---|---|---|
  | seg_la (kv)    | 0.920 | 37.65s | 1557 tok/s |
  | seg_la_vk (vk) | 0.933 | 37.43s | 1690 tok/s |

  Within statistical noise (std ≈ 0.25) → accuracy-equivalent.

## Speed Tests and Profiling

Operator-level benchmark (`bench_state_layout.py`, CUDA-event, H=8 D=128, B200 sm_100), `vk`/`kv` ms/iter ratio:

| path | B×S configs | ratio |
|---|---|---|
| PREFILL | (1,256)…(1,8192), (4,512), (8,1024), (16,512) | 0.98–1.00x |
| DECODE  | B=1,32,128,256 | 0.99–1.05x |

`vk` is performance-equivalent to `kv` (transpose is outside the hot loop for matmul kernels; native for elementwise kernels). The default `kv` path is byte-identical, so existing users see no change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28080460770](https://github.com/sgl-project/sglang/actions/runs/28080460770)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28080460637](https://github.com/sgl-project/sglang/actions/runs/28080460637)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->