### PR TITLE
fix: restore DP-attention shm barrier in SchedulerRequestReceiver los…

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -237,6 +237,18 @@ class SchedulerRequestReceiver:
                 and has_shm_features(recv_reqs)
             ):
                 barrier(group=self.tp_cpu_group)
+            elif (
+                    self.server_args.enable_dp_attention
+                    and self.model_config.is_multimodal
+                    and has_shm_features(recv_reqs)
+            ):
+                # Under disagg_prefill, there is no subsequent control_reqs broadcast
+                # on tp_cpu_group to act as an implicit barrier, so we must explicitly
+                # synchronize after each broadcast layer before calling shm_unlink.
+                if self.ps.attn_tp_size > 1:
+                    barrier(group=self.attn_tp_cpu_group)
+                if self.ps.attn_cp_size > 1:
+                    barrier(group=self.attn_cp_cpu_group)
             for req in recv_reqs:
                 unwrap_shm_features(req)
 


### PR DESCRIPTION
…t during #25610 refactor

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Problem

After PR #25610 refactored request-ingress logic from `scheduler.py` into
`SchedulerRequestReceiver`, the DP-attention barrier originally introduced
by PR #23027 was not carried over to the new location.

This causes `FileNotFoundError: /psm_xxxxxxxx` when running:
- Multimodal model (e.g. Kimi-K2.5)
- PD disaggregation (`event_loop_overlap_disagg_prefill`)
- `dp_size > 1` + `--enable-dp-attention`

**Stack trace:**
```
event_loop_overlap_disagg_prefill
  → request_receiver.recv_requests()
  → _broadcast_reqs_across_ranks → broadcast_pyobj (attn_tp_cpu_group)
      → pickle.loads → __setstate__ → shm_open
FileNotFoundError: [Errno 2] No such file or directory: '/psm_xxxxxxxx'
```

## Root Cause

`_finalize_shm_features` only adds a barrier for the non-DP-attention path.
The comment states "under DP-attention no barrier is needed because the
subsequent `control_reqs` broadcast on `tp_cpu_group` acts as an implicit barrier."

However, in the `disagg_prefill` code path there is **no** subsequent
`control_reqs` broadcast, so the assumption does not hold. The source rank
(TP0) races ahead from `broadcast_pyobj` to `unwrap_shm_features →
materialize → shm_unlink` before receiver ranks (TP1+) have completed
`pickle.loads → shm_open`.

## Fix

Add an `elif` branch in `_finalize_shm_features` that explicitly barriers
on `attn_tp_cpu_group` (and `attn_cp_cpu_group` if CP is enabled) for the
DP-attention case, symmetric with the existing `tp_cpu_group` barrier for
the non-DP-attention path.

## Verification

Verified on Kimi-K2.5, PD disaggregation, dp_size=2, tp_size=8,
`--enable-dp-attention`. Previously crashed within minutes; no crash
observed after applying this fix.

## Related

- Fixes the root cause described in #23022
- PR #23027 attempted the same fix targeting `scheduler.py`, but became
  conflicted after #25610 moved the code to `request_receiver.py`

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28083220758](https://github.com/sgl-project/sglang/actions/runs/28083220758)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28083220674](https://github.com/sgl-project/sglang/actions/runs/28083220674)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->