### PR TITLE
[NPU] fix dcp break

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -177,6 +177,7 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
         k_scale: Optional[float] = None,
         v_scale: Optional[float] = None,
         layer_id_override: Optional[int] = None,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
     ):
         loc, _ = unwrap_write_loc(loc_info)
         if layer_id_override is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
fix dcp break, add dcp_kv_mask param.
## Modifications

<!-- Detail the changes made in this pull request. -->
add dcp_kv_mask param for set_kv_buffer.

before this pr:

File "/sglang/python/sglang/srt/layers/radix_attention.py", line 145, in forward
    return get_attn_backend().forward(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py", line 887, in forward
    return self.forward_extend(
           ^^^^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py", line 835, in forward_extend
    return self.full_attn_backend.forward_extend(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py", line 1121, in forward_extend
    return self.forward_mtp(
           ^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py", line 1858, in forward_mtp
    self.token_to_kv_pool.set_kv_buffer(
  File "/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 2063, in set_kv_buffer
    self.full_kv_pool.set_kv_buffer(
TypeError: NPUMHATokenToKVPool.set_kv_buffer() got an unexpected keyword argument 'dcp_kv_mask

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
aime26 score 0.9333
## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28083492423](https://github.com/sgl-project/sglang/actions/runs/28083492423)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28083492237](https://github.com/sgl-project/sglang/actions/runs/28083492237)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->