### PR TITLE
[diffusion][perf]: Shard Qwen Text Embed in SP 

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -17,6 +17,7 @@ from diffusers.models.normalization import AdaLayerNormContinuous
 from sglang.multimodal_gen.configs.models.dits.qwenimage import QwenImageDitConfig
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+    get_ring_parallel_world_size,
     get_sp_parallel_rank,
     get_sp_world_size,
 )
@@ -99,6 +100,72 @@ def _shard_text_for_sp(
         freqs_cis = (img_cache, txt_cache)
 
     return encoder_hidden_states, freqs_cis
+
+
+def _pad_shard_text_for_sp_varlen(
+    encoder_hidden_states: torch.Tensor,
+    freqs_cis: Optional[Tuple[torch.Tensor, torch.Tensor]],
+    image_seq_len: int,
+) -> Tuple[
+    torch.Tensor,
+    Optional[Tuple[torch.Tensor, torch.Tensor]],
+    torch.Tensor,
+    Dict[str, int],
+]:
+    """Right-pad a non-divisible replicated text stream to a multiple of the SP
+    world size and shard it evenly across ranks, so the joint ``[text, image]``
+    sequence is fully sequence-parallel.
+
+    The pad tokens occupy a single contiguous block at the tail of the last
+    rank's text chunk. The returned ``attn_mask`` (joint ``[text, image]``
+    validity mask) and ``attn_mask_meta`` (``gap_start`` / ``gap_end``) describe
+    that block so ``USPAttention`` excludes it from attention via the varlen
+    kernel.
+
+    Callers must ensure the text length is NOT divisible by the SP world size;
+    the evenly-divisible case is a plain ``_shard_text_for_sp`` with no mask.
+
+    Returns ``(encoder_hidden_states, freqs_cis, attn_mask, attn_mask_meta)``.
+    """
+    sp_size = get_sp_world_size()
+    t_real = encoder_hidden_states.shape[1]
+    num_pad = sp_size - t_real % sp_size
+
+    encoder_hidden_states = F.pad(encoder_hidden_states, (0, 0, 0, num_pad))
+    if freqs_cis is not None:
+        img_cache, txt_cache = freqs_cis
+        txt_cache = F.pad(txt_cache, (0, 0, 0, num_pad))
+        freqs_cis = (img_cache, txt_cache)
+
+    local_txt = (t_real + num_pad) // sp_size
+    encoder_hidden_states, freqs_cis = _shard_text_for_sp(
+        encoder_hidden_states, freqs_cis
+    )
+
+    sp_rank = get_sp_parallel_rank()
+    txt_start = sp_rank * local_txt
+    valid_txt = min(local_txt, max(t_real - txt_start, 0))
+    text_mask = torch.zeros(
+        encoder_hidden_states.shape[0],
+        local_txt,
+        dtype=torch.bool,
+        device=encoder_hidden_states.device,
+    )
+    text_mask[:, :valid_txt] = True
+    image_mask = torch.ones(
+        encoder_hidden_states.shape[0],
+        image_seq_len,
+        dtype=torch.bool,
+        device=encoder_hidden_states.device,
+    )
+    joint_mask = torch.cat([text_mask, image_mask], dim=1)
+    # Gathered joint layout is rank-major [txt_0, img_0, ..., txt_{sp-1},
+    # img_{sp-1}]; the pad block is the tail of the last rank's text chunk.
+    gap_meta = {
+        "gap_start": (sp_size - 1) * (local_txt + image_seq_len) + local_txt - num_pad,
+        "gap_end": (sp_size - 1) * (local_txt + image_seq_len) + local_txt,
+    }
+    return encoder_hidden_states, freqs_cis, joint_mask, gap_meta
 
 
 def _get_qkv_projections(
@@ -1380,6 +1447,7 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
 
         block_attention_kwargs = attention_kwargs.copy() if attention_kwargs else {}
         sp_text_sharded = False
+        sp_size = get_sp_world_size()
         if encoder_hidden_states_mask is not None:
             encoder_hidden_states_mask = encoder_hidden_states_mask.to(
                 device=hidden_states.device, dtype=torch.bool
@@ -1397,20 +1465,29 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             block_attention_kwargs["attn_mask_meta"] = build_varlen_mask_meta(
                 joint_mask
             )
-        elif (
-            get_sp_world_size() > 1
-            and encoder_hidden_states.shape[1] % get_sp_world_size() == 0
-        ):
-            # No per-token text mask (single-request path) and the text length
-            # divides evenly across SP ranks: shard the otherwise replicated
-            # text stream instead of duplicating it. When it does NOT divide
-            # evenly we skip sharding and fall through to the replicated-text
-            # path, avoiding the masked (SDPA) attention fallback on non-FA
-            # backends.
+        elif sp_size > 1 and encoder_hidden_states.shape[1] % sp_size == 0:
+            # Text divides evenly across SP ranks: plain even shard, no mask.
             encoder_hidden_states, freqs_cis = _shard_text_for_sp(
                 encoder_hidden_states, freqs_cis
             )
             sp_text_sharded = True
+        elif sp_size > 1 and get_ring_parallel_world_size() == 1:
+            # Text does not divide evenly: pad to an SP multiple and shard, with a
+            # pad-gap mask so USPAttention excludes the padding via the varlen
+            # kernel. The varlen masked path does not support ring parallelism, so
+            # uneven text under ring>1 instead falls through to the replicated
+            # path below.
+            (
+                encoder_hidden_states,
+                freqs_cis,
+                pad_mask,
+                pad_meta,
+            ) = _pad_shard_text_for_sp_varlen(
+                encoder_hidden_states, freqs_cis, hidden_states.shape[1]
+            )
+            sp_text_sharded = True
+            block_attention_kwargs["attn_mask"] = pad_mask
+            block_attention_kwargs["attn_mask_meta"] = pad_meta
         block_attention_kwargs["sp_text_sharded"] = sp_text_sharded
 
         temb = self.time_text_embed(timestep, hidden_states, additional_t_cond)

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -17,6 +17,7 @@ from diffusers.models.normalization import AdaLayerNormContinuous
 from sglang.multimodal_gen.configs.models.dits.qwenimage import QwenImageDitConfig
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+    get_sp_parallel_rank,
     get_sp_world_size,
 )
 from sglang.multimodal_gen.runtime.layers.attention import (
@@ -71,6 +72,33 @@ def _local_seq_len(seq_len: int, sp_world_size: int) -> int:
     if padded_len % sp_world_size != 0:
         padded_len += sp_world_size - (padded_len % sp_world_size)
     return padded_len // sp_world_size
+
+
+def _shard_text_for_sp(
+    encoder_hidden_states: torch.Tensor,
+    freqs_cis: Optional[Tuple[torch.Tensor, torch.Tensor]],
+) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+    """Shard the replicated text stream evenly across SP ranks.
+
+    The image latents are already sharded by the pipeline while the text stream
+    is replicated. This splits the text embeddings (and their RoPE cache) so each
+    rank keeps ``1/sp_size`` of the text tokens, making the joint attention fully
+    sequence-sharded (``num_replicated_prefix=0``). Callers must ensure the text
+    length divides evenly across SP ranks.
+    """
+    sp_size = get_sp_world_size()
+    if sp_size == 1:
+        return encoder_hidden_states, freqs_cis
+
+    sp_rank = get_sp_parallel_rank()
+    encoder_hidden_states = torch.chunk(encoder_hidden_states, sp_size, dim=1)[sp_rank]
+
+    if freqs_cis is not None:
+        img_cache, txt_cache = freqs_cis
+        txt_cache = torch.chunk(txt_cache, sp_size, dim=0)[sp_rank]
+        freqs_cis = (img_cache, txt_cache)
+
+    return encoder_hidden_states, freqs_cis
 
 
 def _get_qkv_projections(
@@ -659,6 +687,9 @@ class QwenImageCrossAttention(nn.Module):
         # Varlen metadata precomputed in QwenImageTransformer2DModel.forward,
         # paired with the same ``attn_mask`` for the USPAttention FA fast path.
         attn_mask_meta = cross_attention_kwargs.get("attn_mask_meta")
+        # When the text stream is sharded across SP ranks the joint sequence is
+        # fully sequence-parallel, so no leading tokens are replicated.
+        sp_text_sharded = cross_attention_kwargs.get("sp_text_sharded", False)
 
         (
             img_query,
@@ -740,7 +771,7 @@ class QwenImageCrossAttention(nn.Module):
             joint_value,
             attn_mask=attn_mask,
             attn_mask_meta=attn_mask_meta,
-            num_replicated_prefix=seq_len_txt,
+            num_replicated_prefix=0 if sp_text_sharded else seq_len_txt,
         )
 
         # Reshape back
@@ -1348,6 +1379,7 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
         encoder_hidden_states, _ = self.txt_in(encoder_hidden_states)
 
         block_attention_kwargs = attention_kwargs.copy() if attention_kwargs else {}
+        sp_text_sharded = False
         if encoder_hidden_states_mask is not None:
             encoder_hidden_states_mask = encoder_hidden_states_mask.to(
                 device=hidden_states.device, dtype=torch.bool
@@ -1365,6 +1397,21 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             block_attention_kwargs["attn_mask_meta"] = build_varlen_mask_meta(
                 joint_mask
             )
+        elif (
+            get_sp_world_size() > 1
+            and encoder_hidden_states.shape[1] % get_sp_world_size() == 0
+        ):
+            # No per-token text mask (single-request path) and the text length
+            # divides evenly across SP ranks: shard the otherwise replicated
+            # text stream instead of duplicating it. When it does NOT divide
+            # evenly we skip sharding and fall through to the replicated-text
+            # path, avoiding the masked (SDPA) attention fallback on non-FA
+            # backends.
+            encoder_hidden_states, freqs_cis = _shard_text_for_sp(
+                encoder_hidden_states, freqs_cis
+            )
+            sp_text_sharded = True
+        block_attention_kwargs["sp_text_sharded"] = sp_text_sharded
 
         temb = self.time_text_embed(timestep, hidden_states, additional_t_cond)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Currently Qwen Image (and alternatives) don't shard text embedding in SP and replicate it on all GPUs (Similarly to FLUX before #27066). This saves some comms, but balloons the GEMMs. 

This PR shards the text embedding when it's divisable by the number of GPUs. This does not happen always, as the text encoder shape is prompt-dependent. If it's not divisable, it goes to varlen path.

## Modifications

<!-- Detail the changes made in this pull request. -->
- Add text sharding helper for Qwen
- Shard text embedding and text RoPE if cleanly divisable,
- Add varlen path

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

short prompt = `A cat holding a sign that says hello world, love`
long prompt = ` A photorealistic portrait of an elderly fisherman with a weathered face, deep wrinkles, and a thick grey beard, standing on a wooden dock at golden hour, holding a wicker basket full of freshly caught silver fish, with seagulls flying overhead and a calm harbor reflecting orange sunlight` 
Command:
```
sglang generate --model-path Qwen/Qwen-Image-2512 --height 2048 --width 2048 --ulysses-degree 8 --ring-degree 1 --num-gpus 8 --num-inference-steps 50 --guidance-scale 0.0 --prompt <prompt> --dit-cpu-offload False --dit-layerwise-offload False --text-encoder-cpu-offload False --image-encoder-cpu-offload False --vae-cpu-offload False --warmup True --warmup-steps 2 --vae-precision bf16 --image-encoder-precision bf16 --seed 42 --enable-torch-compile
```

#### Short prompt before vs after:
<img width="2048" height="2048" alt="A_cat_holding_a_sign_that_says_hello_world_love_20260623-132822_c2b21450" src="https://github.com/user-attachments/assets/9da2b3ac-1e33-4b0d-93c4-d2e5fbb711a4" />
<img width="2048" height="2048" alt="A_cat_holding_a_sign_that_says_hello_world_love_20260623-133232_652217ab" src="https://github.com/user-attachments/assets/f56a8cd6-0de0-4f47-8d6b-4b3eccce3121" />

#### Long prompt before vs after:
<img width="2048" height="2048" alt="A_photorealistic_portrait_of_an_elderly_fisherman_with_a_weathered_face_deep_wrinkles_and_a_thick_20260623-133643_c7ab7982" src="https://github.com/user-attachments/assets/ce9a118d-bd63-4fd7-add8-7bde420bc109" />
<img width="2048" height="2048" alt="A_photorealistic_portrait_of_an_elderly_fisherman_with_a_weathered_face_deep_wrinkles_and_a_thick_20260623-134050_c30f7b92" src="https://github.com/user-attachments/assets/5a0675a4-f306-45af-b15e-86fcce7f6dd3" />

#### Non-divisable case still works (prompt=A cat holding a sign that says hello world):
<img width="2048" height="2048" alt="A_cat_holding_a_sign_that_says_hello_world_20260623-134502_81a2d906" src="https://github.com/user-attachments/assets/80d771fd-49d1-4ee7-ba3e-4c7c9d0e3716" />

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

### Short prompt:
#### 1. High-level Summary
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 8900.76 ms | 8666.43 ms | **-234.33 ms (-2.6%)** | ✅ |
| **Throughput** | 0.11 req/s | 0.12 req/s | - | - |


#### 2. Stage Breakdown
| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 0.04 | 0.04 | +0.00 | +6.8% | ⚪️ |
| TextEncodingStage | 28.59 | 49.57 | +20.97 | +73.4% | ⚪️ |
| LatentPreparationStage | 0.15 | 0.16 | +0.01 | +4.8% | ⚪️ |
| TimestepPreparationStage | 0.50 | 0.46 | -0.04 | -8.4% | ⚪️ |
| DenoisingStage | 8315.74 | 7945.23 | -370.51 | -4.5% | ⚪️ |
| DecodingStage | 553.20 | 668.41 | +115.20 | +20.8% | ⚪️ |
| Scheduler.return_result.spill_arrays | 0.07 | 0.04 | -0.03 | -47.3% | ⚪️ |
| SchedulerClient.materialize_file_refs | 0.01 | 0.01 | +0.00 | +4.5% | ⚪️ |

### Long prompt:
#### 1. High-level Summary
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 8957.24 ms | 8648.30 ms | **-308.93 ms (-3.4%)** | ✅ |
| **Throughput** | 0.11 req/s | 0.12 req/s | - | - |


#### 2. Stage Breakdown
| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 0.04 | 0.04 | -0.00 | -4.8% | ⚪️ |
| TextEncodingStage | 35.06 | 28.69 | -6.37 | -18.2% | ⚪️ |
| LatentPreparationStage | 0.15 | 0.15 | -0.01 | -3.4% | ⚪️ |
| TimestepPreparationStage | 0.52 | 0.42 | -0.10 | -18.7% | ⚪️ |
| DenoisingStage | 8364.31 | 7945.69 | -418.62 | -5.0% | ⚪️ |
| DecodingStage | 554.65 | 663.99 | +109.34 | +19.7% | ⚪️ |
| Scheduler.return_result.spill_arrays | 0.04 | 0.03 | -0.01 | -18.9% | ⚪️ |
| SchedulerClient.materialize_file_refs | 0.01 | 0.01 | +0.00 | +15.3% | ⚪️ |


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28237525258](https://github.com/sgl-project/sglang/actions/runs/28237525258)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28237525116](https://github.com/sgl-project/sglang/actions/runs/28237525116)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->