### PR TITLE
[perf] Route slow (non-fast) tokenizers (e.g. Kimi) through `.encode()` on the `--enable-dynamic-batch-tokenizer` path (completes #25265)

### DIFF
--- a/python/sglang/srt/managers/async_dynamic_batch_tokenizer.py
+++ b/python/sglang/srt/managers/async_dynamic_batch_tokenizer.py
@@ -8,8 +8,7 @@ to reduce tokenization overhead when multiple requests arrive concurrently.
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from functools import partial
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -119,48 +118,79 @@ class AsyncDynamicbatchTokenizer:
         result_futures: List[asyncio.Future],
     ) -> None:
         """Process a dynamic batch of encode requests for single string prompts."""
-        # Check if all kwargs are identical for efficient batch processing
-        first_kw = kwargs_list[0]
-        can_batch = all(kw == first_kw for kw in kwargs_list[1:])
-        kwargs = first_kw if can_batch else None
+        can_batch = all(kw == kwargs_list[0] for kw in kwargs_list[1:])
+        if not can_batch and len(prompts) > 1:
+            logger.warning(
+                f"AsyncDynamicbatchTokenizer: Dynamic batching disabled for batch of "
+                f"{len(prompts)} requests due to differing kwargs. This reduces "
+                f"performance benefits. Consider using consistent tokenization "
+                f"parameters across requests."
+            )
 
+        encode_fn = self._build_encode_fn(prompts, kwargs_list, can_batch)
         try:
-            # If every request uses identical kwargs we can run a single
-            # batch tokenizer call for a big speed-up.
-            if can_batch and len(prompts) > 1:
-                encode_fn = partial(self.tokenizer, prompts, **kwargs)
-                results = await asyncio.get_running_loop().run_in_executor(
-                    self._executor, encode_fn
-                )
-
-                for i, fut in enumerate(result_futures):
-                    if not fut.done():
-                        data = {k: v[i] for k, v in results.items()}
-                        fut.set_result(data)
-            else:
-                # Process each request individually due to different kwargs
-                if len(prompts) > 1 and not can_batch:
-                    logger.warning(
-                        f"AsyncDynamicbatchTokenizer: Dynamic batching disabled for batch of {len(prompts)} "
-                        f"requests due to differing kwargs. This reduces performance benefits. "
-                        f"Consider using consistent tokenization parameters across requests."
-                    )
-
-                encode_fn = lambda prompts=prompts, kwargs=kwargs_list: [
-                    self.tokenizer(p, **kw) for p, kw in zip(prompts, kwargs_list)
-                ]
-                results = await asyncio.get_running_loop().run_in_executor(
-                    self._executor, encode_fn
-                )
-
-                for fut, res in zip(result_futures, results):
-                    if not fut.done():
-                        fut.set_result(res)
+            results = await asyncio.get_running_loop().run_in_executor(
+                self._executor, encode_fn
+            )
+            self._set_results(result_futures, results)
         except Exception as e:
             logger.error(f"Error in dynamic batch processing: {e}")
-            for fut in result_futures:
-                if not fut.done():
-                    fut.set_exception(e)
+            self._set_exception(result_futures, e)
+
+    def _build_encode_fn(
+        self,
+        prompts: List[str],
+        kwargs_list: List[Dict],
+        can_batch: bool,
+    ) -> Callable[[], List[Dict]]:
+        """Pick the encode strategy once and return a zero-arg callable that
+        produces one result dict per prompt. The callable runs in the executor,
+        keeping the strategy decision off the (blocking) tokenizer thread.
+
+        - Slow (non-fast) tokenizer with no kwargs: call ``encode()`` per prompt
+          instead of ``__call__``. ``__call__`` runs the slow Python ``_encode_plus``
+          -> ``convert_tokens_to_ids(tokenize(text))`` chain, whereas a slow
+          tokenizer's ``encode()`` typically returns ids straight from its fast
+          backend (e.g. Kimi's ``TikTokenTokenizer`` -> tiktoken/Rust). Mirrors the
+          regular-path fix in #25265, extended to the dynamic-batch path. The path
+          passes no kwargs (cross-encoder never reaches here), so nothing is dropped;
+          if any kwarg is present we fall through to ``__call__`` for exact semantics.
+        - Uniform kwargs across >1 prompt: one batched ``__call__`` (Rust
+          ``encode_batch``), then split per prompt (all keys preserved).
+        - Otherwise: per-item ``__call__`` honoring each request's kwargs.
+        """
+        is_slow = not getattr(self.tokenizer, "is_fast", False)
+        no_kwargs = all(not kw for kw in kwargs_list)
+        if is_slow and no_kwargs:
+            return lambda: [{"input_ids": self.tokenizer.encode(p)} for p in prompts]
+
+        if can_batch and len(prompts) > 1:
+            kwargs = kwargs_list[0]
+
+            def encode_batched():
+                encoded = self.tokenizer(prompts, **kwargs)
+                return [
+                    {k: v[i] for k, v in encoded.items()} for i in range(len(prompts))
+                ]
+
+            return encode_batched
+
+        return lambda: [self.tokenizer(p, **kw) for p, kw in zip(prompts, kwargs_list)]
+
+    @staticmethod
+    def _set_results(result_futures: List[asyncio.Future], results: List[Dict]) -> None:
+        """Resolve each pending future with its result (skip already-done ones,
+        e.g. futures cancelled by a disconnected client)."""
+        for fut, result in zip(result_futures, results):
+            if not fut.done():
+                fut.set_result(result)
+
+    @staticmethod
+    def _set_exception(result_futures: List[asyncio.Future], exc: Exception) -> None:
+        """Fan a batch-level failure out to every pending future."""
+        for fut in result_futures:
+            if not fut.done():
+                fut.set_exception(exc)
 
     def __del__(self):
         """Clean up background tasks."""

--- a/test/manual/test_async_dynamic_batch_tokenizer.py
+++ b/test/manual/test_async_dynamic_batch_tokenizer.py
@@ -60,6 +60,11 @@ class TestAsyncDynamicbatchTokenizer:
 
             return MockBatchEncoding(result)
 
+        # Stand in for a fast HF tokenizer (batched __call__ returning a
+        # BatchEncoding). is_fast=True keeps it on the __call__ path; the slow
+        # encode() routing is covered by the registered unit test instead.
+        mock_encode.is_fast = True
+
         # Return the function directly - the AsyncDynamicbatchTokenizer will call it
         return mock_encode
 
@@ -193,6 +198,8 @@ class TestAsyncDynamicbatchTokenizer:
         # Create a new async tokenizer with a failing tokenizer
         def failing_tokenizer(*args, **kwargs):
             raise ValueError("Tokenizer error")
+
+        failing_tokenizer.is_fast = True  # exercise the __call__ path, not encode()
 
         async_tokenizer = AsyncDynamicbatchTokenizer(
             tokenizer=failing_tokenizer, max_batch_size=4, batch_wait_timeout_s=0.01

--- a/test/registered/unit/managers/test_async_dynamic_batch_tokenizer_slow.py
+++ b/test/registered/unit/managers/test_async_dynamic_batch_tokenizer_slow.py
@@ -1,0 +1,307 @@
+"""Unit tests for AsyncDynamicbatchTokenizer dispatch & future resolution — no server.
+
+`_process_dynamic_batch` picks one of three encode strategies and resolves each
+request's future. These tests pin every branch and the resolution semantics that a
+refactor must not regress:
+
+Dispatch (`_build_encode_fn`):
+  - slow (`is_fast=False`) tokenizer, no kwargs -> ``encode()`` per prompt (skips the
+    slow ``__call__`` -> ``tokenize()`` chain), single & concurrently-batched, ids
+    byte-for-byte equal to the stock ``__call__``;
+  - missing ``is_fast`` attribute is treated as slow;
+  - fast (`is_fast=True`) tokenizer stays on the batched ``__call__`` path, and the
+    per-prompt split preserves every key (``attention_mask``, ``token_type_ids``);
+  - non-empty kwargs fall back to ``__call__`` (semantics preserved);
+  - heterogeneous kwargs run per item and emit the batching-disabled warning;
+  - a single fast request with kwargs runs per item without warning.
+
+Resolution (`_set_results` / `_set_exception`):
+  - a future cancelled by a disconnected client is skipped while its siblings still
+    resolve;
+  - a tokenizer error is fanned out to every pending future;
+  - a pre-cancelled future is left cancelled when the batch errors.
+
+Minimal char-level tokenizers stand in for tiktoken/HF (Fakes; the fast one also
+spies on which path ran), so no model download / GPU. Two driving seams are used on
+purpose: ``_encode_*`` exercise the real public ``encode()`` (coalescing + executor),
+while ``_process_batch`` drives ``_process_dynamic_batch`` directly with crafted
+futures for deterministic control over batching and cancellation. These are
+behavior-based example tests.
+"""
+
+import asyncio
+import logging
+import unittest
+
+from transformers import PreTrainedTokenizer
+
+from sglang.srt.managers.async_dynamic_batch_tokenizer import AsyncDynamicbatchTokenizer
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+_LOGGER = "sglang.srt.managers.async_dynamic_batch_tokenizer"
+
+
+class _MiniSlowTokenizer(PreTrainedTokenizer):
+    """Minimal slow tokenizer (is_fast == False).
+
+    ``encode(text)`` returns ids straight from a "fast backend" (no tokenize()),
+    mirroring Kimi's tiktoken-backed ``encode()``. The stock ``__call__`` path goes
+    through ``_tokenize`` (counted); for char-level input both produce the same ids
+    (no structural special tokens), so the routed ``encode()`` output is byte-for-byte
+    equal to the stock ``__call__`` output.
+    """
+
+    def __init__(self, **kw):
+        self.slow_tokenize_calls = 0
+        super().__init__(**kw)
+
+    @property
+    def vocab_size(self):
+        return 256
+
+    def get_vocab(self):
+        return {chr(c): c for c in range(256)}
+
+    def _tokenize(self, text, **kw):
+        self.slow_tokenize_calls += 1  # slow HF path marker
+        return list(text)
+
+    def _convert_token_to_id(self, tok):
+        return ord(tok) if len(tok) == 1 else 0
+
+    def _convert_id_to_token(self, idx):
+        return chr(idx)
+
+    def encode(self, text, **kwargs):
+        if kwargs:  # defer to the (slow) base impl, matching real slow tokenizers
+            return super().encode(text, **kwargs)
+        return [ord(c) for c in text]
+
+
+class _MiniFastTokenizer:
+    """Minimal duck-typed fast tokenizer (is_fast == True), records which path ran.
+
+    ``__call__`` returns ``attention_mask`` alongside ``input_ids`` (and
+    ``token_type_ids`` when asked) so tests can assert the batched-split path keeps
+    every key.
+    """
+
+    is_fast = True
+
+    def __init__(self):
+        self.call_calls = 0
+        self.encode_calls = 0
+
+    def __call__(self, prompts, **kw):
+        self.call_calls += 1
+        single = isinstance(prompts, str)
+        items = [prompts] if single else list(prompts)
+        ids = [[ord(c) for c in p] for p in items]
+        out = {"input_ids": ids, "attention_mask": [[1] * len(x) for x in ids]}
+        if kw.get("return_token_type_ids"):
+            out["token_type_ids"] = [[0] * len(x) for x in ids]
+        if single:
+            out = {k: v[0] for k, v in out.items()}
+        return out
+
+    def encode(self, text, **kw):
+        self.encode_calls += 1
+        return [ord(c) for c in text]
+
+
+class _NoIsFastTokenizer:
+    """Duck-typed tokenizer with NO ``is_fast`` attribute (getattr default -> slow)."""
+
+    def __call__(self, prompts, **kw):  # pragma: no cover - must not be reached
+        raise AssertionError("missing-is_fast tokenizer should route to encode()")
+
+    def encode(self, text, **kw):
+        return [ord(c) for c in text]
+
+
+class _FailingTokenizer:
+    """Fast tokenizer whose ``__call__`` always raises (tests exception fan-out)."""
+
+    is_fast = True
+    error = ValueError("tokenizer boom")
+
+    def __call__(self, prompts, **kw):
+        raise self.error
+
+
+_PROMPT = "hello, 世界 def f(x): return x*2"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _stop(adbt):
+    """The one structure-sensitive touch in this file: cancel the private background
+    batcher task so the coalescing loop doesn't outlive the test. Isolated here (not
+    inlined at each call site) so a rename lands in one place and the test bodies stay
+    structure-insensitive."""
+    task = getattr(adbt, "_batcher_task", None)
+    if task is not None:
+        task.cancel()
+
+
+async def _encode_one(adbt, prompt, **kwargs):
+    try:
+        return await adbt.encode(prompt, **kwargs)
+    finally:
+        _stop(adbt)
+
+
+async def _encode_concurrent(adbt, prompts):
+    try:
+        return await asyncio.gather(*(adbt.encode(p) for p in prompts))
+    finally:
+        _stop(adbt)
+
+
+async def _process_batch(tok, prompts, kwargs_list, cancel=()):
+    """Drive ``_process_dynamic_batch`` directly with crafted futures for
+    deterministic control over batching and cancellation. Returns the futures."""
+    adbt = AsyncDynamicbatchTokenizer(tok)
+    loop = asyncio.get_running_loop()
+    futures = [loop.create_future() for _ in prompts]
+    for i in cancel:
+        futures[i].cancel()
+    await adbt._process_dynamic_batch(prompts, kwargs_list, futures)
+    await asyncio.sleep(0)  # let cancellations settle
+    return futures
+
+
+class TestAsyncDynamicBatchTokenizerDispatch(CustomTestCase):
+    # ---- slow / encode routing -------------------------------------------------
+    def test_single_non_fast_uses_encode(self):
+        tok = _MiniSlowTokenizer()
+        self.assertFalse(tok.is_fast)
+        stock_ids = tok(_PROMPT)["input_ids"]
+
+        tok.slow_tokenize_calls = 0
+        out = _run(_encode_one(AsyncDynamicbatchTokenizer(tok), _PROMPT))
+
+        self.assertEqual(out["input_ids"], stock_ids)  # byte-for-byte equal
+        self.assertEqual(tok.slow_tokenize_calls, 0)  # slow path skipped
+
+    def test_concurrent_batch_non_fast_uses_encode(self):
+        tok = _MiniSlowTokenizer()
+        prompts = [_PROMPT, _PROMPT + "!", "abc", "中文字符"]
+        stock = [tok(p)["input_ids"] for p in prompts]
+
+        tok.slow_tokenize_calls = 0
+        outs = _run(_encode_concurrent(AsyncDynamicbatchTokenizer(tok), prompts))
+
+        self.assertEqual([o["input_ids"] for o in outs], stock)
+        self.assertEqual(tok.slow_tokenize_calls, 0)
+
+    def test_missing_is_fast_attr_treated_as_slow(self):
+        # getattr(tokenizer, "is_fast", False) -> False, so it must route to encode()
+        # (the _NoIsFastTokenizer.__call__ asserts if reached).
+        outs = _run(
+            _encode_concurrent(
+                AsyncDynamicbatchTokenizer(_NoIsFastTokenizer()), ["ab", "cde"]
+            )
+        )
+        self.assertEqual([o["input_ids"] for o in outs], [[97, 98], [99, 100, 101]])
+
+    # ---- fast / __call__ routing ----------------------------------------------
+    def test_fast_tokenizer_stays_on_call_path(self):
+        tok = _MiniFastTokenizer()
+        outs = _run(
+            _encode_concurrent(AsyncDynamicbatchTokenizer(tok), ["abc", "de", "fghi"])
+        )
+        self.assertTrue(all("input_ids" in o for o in outs))
+        self.assertEqual(tok.encode_calls, 0)  # encode() not used for fast tokenizers
+        self.assertGreater(tok.call_calls, 0)  # original __call__ path used
+
+    def test_batched_call_preserves_all_keys(self):
+        # Coalesced fast-tokenizer requests run one batched __call__; the per-prompt
+        # split must keep every key (not just input_ids), e.g. attention_mask.
+        tok = _MiniFastTokenizer()
+        prompts = ["abc", "de", "fghi"]
+        outs = _run(_encode_concurrent(AsyncDynamicbatchTokenizer(tok), prompts))
+        for prompt, out in zip(prompts, outs):
+            self.assertEqual(out["input_ids"], [ord(c) for c in prompt])
+            self.assertEqual(out["attention_mask"], [1] * len(prompt))
+
+    def test_token_type_ids_preserved_in_batched_call(self):
+        # Uniform return_token_type_ids -> one batched __call__; the split keeps
+        # token_type_ids per prompt.
+        tok = _MiniFastTokenizer()
+        prompts = ["abc", "defg"]
+        futs = _run(_process_batch(tok, prompts, [{"return_token_type_ids": True}] * 2))
+        for prompt, fut in zip(prompts, futs):
+            res = fut.result()
+            self.assertEqual(res["input_ids"], [ord(c) for c in prompt])
+            self.assertEqual(res["token_type_ids"], [0] * len(prompt))
+
+    # ---- kwargs handling -------------------------------------------------------
+    def test_kwargs_present_falls_back_to_call(self):
+        tok = _MiniSlowTokenizer()
+        tok.slow_tokenize_calls = 0
+        out = _run(
+            _encode_one(
+                AsyncDynamicbatchTokenizer(tok), _PROMPT, add_special_tokens=False
+            )
+        )
+        self.assertIn("input_ids", out)
+        self.assertGreater(tok.slow_tokenize_calls, 0)  # fell back to slow __call__
+
+    def test_heterogeneous_kwargs_run_per_item_and_warn(self):
+        # Differing kwargs across a coalesced batch disable batching: each request is
+        # tokenized with its own kwargs, and a warning is emitted.
+        tok = _MiniFastTokenizer()
+        prompts = ["abc", "de"]
+        kwargs_list = [{"return_token_type_ids": True}, {}]
+        with self.assertLogs(_LOGGER, level="WARNING") as cm:
+            futs = _run(_process_batch(tok, prompts, kwargs_list))
+        self.assertTrue(any("batching disabled" in m.lower() for m in cm.output))
+        self.assertIn("token_type_ids", futs[0].result())  # honored its kwarg
+        self.assertNotIn("token_type_ids", futs[1].result())  # honored empty kwargs
+
+    def test_single_fast_with_kwargs_runs_per_item_without_warning(self):
+        tok = _MiniFastTokenizer()
+        logger = logging.getLogger(_LOGGER)
+        with self.assertNoLogs(logger, level="WARNING"):
+            futs = _run(_process_batch(tok, ["abc"], [{"return_token_type_ids": True}]))
+        self.assertIn("token_type_ids", futs[0].result())
+
+
+class TestAsyncDynamicBatchTokenizerResolution(CustomTestCase):
+    def test_cancelled_future_skipped_others_resolved(self):
+        # A client disconnect cancels its future; _set_results must skip it (no
+        # "invalid state") while siblings still resolve.
+        tok = _MiniFastTokenizer()
+        futs = _run(
+            _process_batch(tok, ["abc", "de", "fghi"], [{}, {}, {}], cancel=[1])
+        )
+        self.assertTrue(futs[1].cancelled())
+        self.assertEqual(futs[0].result()["input_ids"], [97, 98, 99])
+        self.assertEqual(futs[2].result()["input_ids"], [102, 103, 104, 105])
+
+    def test_tokenizer_error_fans_out_to_all_pending(self):
+        # A tokenizer error is delivered to every pending future (not just the first).
+        tok = _FailingTokenizer()
+        futs = _run(_process_batch(tok, ["a", "b", "c"], [{}, {}, {}]))
+        for fut in futs:
+            self.assertIsInstance(fut.exception(), ValueError)
+            self.assertEqual(str(fut.exception()), "tokenizer boom")
+
+    def test_error_leaves_precancelled_future_cancelled(self):
+        # On batch error, a future already cancelled by the client stays cancelled;
+        # only the still-pending ones receive the exception.
+        tok = _FailingTokenizer()
+        futs = _run(_process_batch(tok, ["a", "b", "c"], [{}, {}, {}], cancel=[0]))
+        self.assertTrue(futs[0].cancelled())
+        self.assertIsInstance(futs[1].exception(), ValueError)
+        self.assertIsInstance(futs[2].exception(), ValueError)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Motivation

[#25265](https://github.com/sgl-project/sglang/pull/25265) made slow tokenizers fast in `TokenizerManager._tokenize_texts` by routing non-`is_fast` tokenizers through `tokenizer.encode()` instead of the slow `__call__` — but **only on the branch taken when `--enable-dynamic-batch-tokenizer` is off**. With dynamic batching on, single-string requests go through `AsyncDynamicbatchTokenizer`, which invokes the tokenizer via `__call__`, so #25265's fast path is bypassed.

For any non-fast (`is_fast=False`) tokenizer that ships a fast `encode()` — e.g. Kimi's `TikTokenTokenizer`, or a `trust_remote_code` slow `PreTrainedTokenizer` backed by tiktoken (Rust):

- `__call__` runs the stock `_encode_plus` → `convert_tokens_to_ids(tokenize(text))` chain — a Python trie split plus an `int → str → int` round-trip over a ~160k vocab;
- `encode()` already returns the final `list[int]` straight from Rust.

That redundant work sits on the per-request TTFT critical path. See #29163.

This is **not Kimi-specific** — it completes #25265's pattern (*slow tokenizer → use `.encode()`*) on the one path it didn't reach:

- #25265 fixed the regular path;
- #25953 fixed the chat-template encode site;
- the dynamic-batch path is the remaining one.

## What this PR does

Two changes — a behavior fix, and a no-behavior-change refactor that the fix motivated.

### 1. Fix — route slow tokenizers through `.encode()` on the dynamic-batch path

- For non-`is_fast` tokenizers, build ids **per item via `self.tokenizer.encode(p)`** instead of `__call__`.
- The work still runs inside the wrapper's existing single-thread `ThreadPoolExecutor`, so tokenization stays off the event loop — **the wrapper's offload is preserved**.
- Returns the same dict shape the caller expects (`{"input_ids": ...}`).
- Fast tokenizers keep the existing batched `__call__` (the Rust `tokenizers` `encode_batch` / rayon path) **unchanged**.
- The dynamic batch tokenizer only handles `SINGLE_STRING`, non-cross-encoder inputs (`tokenizer_manager.py:747-750`), so `token_type_ids` is not involved.


### 2. Refactor — tidy `_process_dynamic_batch` (no behavior change)

Adding the slow-tokenizer branch made an existing smell acute: the method mixed *deciding how to encode* (`is_fast` / `can_batch`) with *running it and resolving futures*, and repeated the `if not fut.done(): fut.set_result(...)` guard three times. It now reads top-down:

- `_build_encode_fn(prompts, kwargs_list, can_batch)` — picks the strategy **once** (slow `.encode()` / uniform-kwargs batched `__call__` / per-item `__call__`) and returns a zero-arg callable producing one result dict per prompt.
- `_set_results` / `_set_exception` — centralize the `fut.done()` cancellation guard and the batch-level exception fan-out.
- The batched `__call__` split preserves **all** keys the tokenizer returns (`input_ids`, `attention_mask`, `token_type_ids`, …), not just `input_ids`.

## Correctness & performance

Correctness rests on the same `tokenizer.encode()` that #25265's regular-path fix uses, byte-for-byte verified against the stock slow chain (short/long inputs, `add_special_tokens` True/False, truncation, batch lists, edge cases — including empty/whitespace/CJK/emoji and special-token literals; `.encode()` and `__call__` produce identical ids on all of them).

The win is the same one #25265 reports, now extended to the dynamic-batch path: routing a slow Kimi tokenizer through tiktoken's native `.encode()` instead of the `__call__` → `_encode_plus` → `convert_tokens_to_ids(tokenize(text))` chain. `.encode()` fast path vs stock `__call__` on the real `moonshotai/Kimi-K2.5` tokenizer:

| input tokens | stock `__call__` | `.encode()` fast path | speedup |
|---:|---:|---:|---:|
| 8,000 | 21.3 ms | 2.9 ms | 7.3x |
| 60,000 | 160.5 ms | 22.0 ms | 7.3x |
| 120,000 | 316.0 ms | 43.8 ms | 7.2x |
| batch ×16 | 2.13 ms | 0.62 ms | 3.5x |

Consistent with #25265 (80k: 308→47 ms, ~6.5x) and the equivalent vLLM report (vllm-project/vllm#39590). Fast tokenizers keep the batched `__call__` unchanged.

> Validated end-to-end through the real `AsyncDynamicbatchTokenizer` with the real Kimi tokenizer (see Tests): output is byte-for-byte equal to the stock `__call__` **and** to #25265's `.encode()`, and the slow `tokenize()` is never called. The ms numbers above isolate the underlying `.encode()`-vs-`__call__` cost (the call this PR swaps) and do not include the small async-wrapper overhead. The refactor itself is cost-neutral.

## Tests

**Unit — CI** (`test/registered/unit/managers/test_async_dynamic_batch_tokenizer_slow.py`, 12 cases, CPU, no model download). A minimal char-level slow tokenizer whose `encode()` returns ids directly stands in for tiktoken.

- Dispatch:
  - non-fast tokenizer (single & concurrently-batched) → ids byte-for-byte equal to the stock `__call__`, slow `tokenize()` never called;
  - missing `is_fast` attribute → treated as slow;
  - fast tokenizer → stays on batched `__call__`, and the per-prompt split preserves every key (`attention_mask`, `token_type_ids`, not just `input_ids`);
  - non-empty kwargs → fall back to `__call__`;
  - heterogeneous kwargs → run per item and emit the batching-disabled warning;
  - single fast request with kwargs → runs per item, no warning.
- Resolution:
  - a future cancelled by a disconnected client is skipped while siblings still resolve;
  - a tokenizer error fans out to every pending future;
  - a pre-cancelled future is left cancelled when the batch errors.

Run: `python -m pytest test/registered/unit/managers/test_async_dynamic_batch_tokenizer_slow.py`

**Manual** (`test/manual/test_async_dynamic_batch_tokenizer.py`, 14 cases) also passes. Its mock tokenizer was a bare function with no `is_fast`/`encode`, which the new slow branch would route to a nonexistent `.encode()`; it is now marked `is_fast=True` (a fast-tokenizer stand-in) so it stays on the `__call__` path it was written to exercise.

Closes #29163
