### PR TITLE
Strip x-anthropic-billing-header from Anthropic API system prompt

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -84,6 +84,12 @@ ERROR_TYPE_MAP = {
 }
 
 
+# Claude Code attaches this attribution header to the system prompt as a
+# separate text block. It carries a per-request hash that would defeat
+# prefix caching, so the serving layer strips it before tokenization.
+ANTHROPIC_BILLING_HEADER = "x-anthropic-billing-header"
+
+
 def _cached_prompt_tokens(usage) -> int:
     prompt_tokens_details = getattr(usage, "prompt_tokens_details", None)
     return getattr(prompt_tokens_details, "cached_tokens", 0) or 0
@@ -158,6 +164,29 @@ def _scrub_error_message(message: str, status_code: int) -> str:
     if len(cleaned) > 500:
         cleaned = cleaned[:500] + "…"
     return cleaned or "Request failed"
+
+
+def _strip_billing_header(system_text: str) -> str:
+    """Remove ``x-anthropic-billing-header`` lines from a system prompt.
+
+    The request validator folds inline ``role: "system"`` turns into the
+    top-level ``system`` string, so the per-request hash can surface here as
+    an ordinary line. Other bytes are preserved verbatim, and when the header
+    is the final line its trailing separator is dropped to match the
+    block-list path (``"\n".join``) and avoid a dangling ``\r``.
+    """
+    lines = system_text.splitlines(keepends=True)
+    kept = [ln for ln in lines if not ln.startswith(ANTHROPIC_BILLING_HEADER)]
+    if len(kept) == len(lines):
+        return system_text
+    result = "".join(kept)
+    if lines[-1].startswith(ANTHROPIC_BILLING_HEADER):
+        # The header's separator terminator rides on the preceding line.
+        if result.endswith("\r\n"):
+            result = result[:-2]
+        elif result.endswith("\n") or result.endswith("\r"):
+            result = result[:-1]
+    return result
 
 
 class AnthropicServing:
@@ -356,18 +385,20 @@ class AnthropicServing:
                 )
                 return None
 
-        # Add system message if provided
+        # Strip the billing-header block (per-request hash that defeats prefix
+        # caching) from the system prompt in both block and string form.
         if anthropic_request.system:
             if isinstance(anthropic_request.system, str):
-                openai_messages.append(
-                    {"role": "system", "content": anthropic_request.system}
-                )
+                system_text = _strip_billing_header(anthropic_request.system)
             else:
                 system_parts = []
                 for block in anthropic_request.system:
                     if block.type == "text" and block.text:
+                        if block.text.startswith(ANTHROPIC_BILLING_HEADER):
+                            continue
                         system_parts.append(block.text)
                 system_text = "\n".join(system_parts)
+            if system_text:
                 openai_messages.append({"role": "system", "content": system_text})
 
         def _emit_user_message(parts: list[dict]) -> None:

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -22,6 +22,11 @@ from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
+# Claude Code's per-request attribution header, sent as a system text block.
+_BILLING_HEADER = (
+    "x-anthropic-billing-header: cc_version=2.1.37.abc; cc_entrypoint=cli;"
+)
+
 
 class _FakeOpenAIServingChat:
     def __init__(self, stream_lines=None):
@@ -1351,6 +1356,190 @@ class TestAnthropicServing(unittest.TestCase):
         )
         self.assertEqual(request.system, "be terse")
         self.assertEqual([m.role for m in request.messages], ["user", "user"])
+
+    def test_billing_header_stripped_from_system_blocks(self):
+        serving = self._serving()
+        request = self._anthropic_request(
+            stream=False,
+            system=[
+                {"type": "text", "text": "You are a helpful assistant."},
+                {"type": "text", "text": _BILLING_HEADER},
+            ],
+        )
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, "You are a helpful assistant.")
+
+    def test_system_blocks_without_billing_header_joined_unchanged(self):
+        serving = self._serving()
+        request = self._anthropic_request(
+            stream=False,
+            system=[
+                {"type": "text", "text": "You are a helpful assistant."},
+                {"type": "text", "text": "Be concise."},
+            ],
+        )
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(
+            system_msgs[0].content, "You are a helpful assistant.\nBe concise."
+        )
+
+    def test_system_string_without_billing_header_unchanged(self):
+        serving = self._serving()
+        request = self._anthropic_request(
+            stream=False, system="You are a helpful assistant."
+        )
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, "You are a helpful assistant.")
+
+    def test_system_string_that_is_only_billing_header_is_dropped(self):
+        serving = self._serving()
+        request = self._anthropic_request(stream=False, system=_BILLING_HEADER)
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(system_msgs, [])
+
+    def test_system_block_list_with_only_billing_header_yields_no_system(self):
+        serving = self._serving()
+        request = self._anthropic_request(
+            stream=False,
+            system=[{"type": "text", "text": _BILLING_HEADER}],
+        )
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(system_msgs, [])
+
+    def test_billing_header_in_inline_system_block_is_stripped(self):
+        serving = self._serving()
+        request = self._anthropic_request(
+            stream=False,
+            messages=[
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "Reply with exactly: OK"},
+                        {"type": "text", "text": _BILLING_HEADER},
+                    ],
+                },
+                {"role": "user", "content": "go"},
+            ],
+        )
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, "Reply with exactly: OK")
+        self.assertEqual(
+            [m.role for m in chat_request.messages], ["system", "user", "user"]
+        )
+
+    def test_inline_system_string_that_is_only_billing_header_is_dropped(self):
+        serving = self._serving()
+        request = self._anthropic_request(
+            stream=False,
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": _BILLING_HEADER},
+                {"role": "user", "content": "go"},
+            ],
+        )
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(system_msgs, [])
+        self.assertEqual([m.role for m in chat_request.messages], ["user", "user"])
+
+    def test_billing_header_merged_with_top_level_system_is_stripped(self):
+        serving = self._serving()
+        request = self._anthropic_request(
+            stream=False,
+            system=[{"type": "text", "text": "You are terse."}],
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": _BILLING_HEADER},
+                {"role": "user", "content": "go"},
+            ],
+        )
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, "You are terse.")
+
+    def test_billing_header_stripped_when_request_built_programmatically(self):
+        """Also covers count_tokens, which builds the request programmatically."""
+        serving = self._serving()
+        request = AnthropicMessagesRequest(
+            model="test-model",
+            max_tokens=1,
+            messages=[AnthropicMessage(role="user", content="hi")],
+            system=[
+                {"type": "text", "text": "You are a helpful assistant."},
+                {"type": "text", "text": _BILLING_HEADER},
+            ],
+        )
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, "You are a helpful assistant.")
+
+    def test_billing_header_string_preserves_surrounding_whitespace(self):
+        serving = self._serving()
+        kept_prefix = "  Keep this leading indent.\ntrailing space here   \n"
+        system = kept_prefix + _BILLING_HEADER + "\nfinal line\n"
+        request = self._anthropic_request(stream=False, system=system)
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, kept_prefix + "final line\n")
+
+    def test_billing_header_string_preserves_crlf_terminators(self):
+        serving = self._serving()
+        system = f"You are terse.\r\n{_BILLING_HEADER}\r\nBe concise."
+        request = self._anthropic_request(stream=False, system=system)
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, "You are terse.\r\nBe concise.")
+
+    def test_billing_header_string_final_header_after_crlf(self):
+        serving = self._serving()
+        system = f"You are terse.\r\n{_BILLING_HEADER}"
+        request = self._anthropic_request(stream=False, system=system)
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, "You are terse.")
+
+    def test_billing_header_string_final_header_after_lf(self):
+        serving = self._serving()
+        system = f"You are terse.\n{_BILLING_HEADER}"
+        request = self._anthropic_request(stream=False, system=system)
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, "You are terse.")
+
+    def test_billing_header_string_final_header_after_cr(self):
+        serving = self._serving()
+        system = f"You are terse.\r{_BILLING_HEADER}"
+        request = self._anthropic_request(stream=False, system=system)
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, "You are terse.")
+
+    def test_billing_header_string_final_header_with_trailing_newline(self):
+        serving = self._serving()
+        system = f"You are terse.\n{_BILLING_HEADER}\n"
+        request = self._anthropic_request(stream=False, system=system)
+        chat_request = serving._convert_to_chat_completion_request(request)
+        system_msgs = [m for m in chat_request.messages if m.role == "system"]
+        self.assertEqual(len(system_msgs), 1)
+        self.assertEqual(system_msgs[0].content, "You are terse.")
 
     def test_thinking_history_drop_on_missing_detector(self):
         """Replaying a thinking block on a non-reasoning model should not 400."""


### PR DESCRIPTION
## Summary

Claude Code attaches an `x-anthropic-billing-header` block to the system prompt on every request, carrying a per-request hash that defeats prefix caching. This strips it out in the Anthropic→OpenAI conversion so it never reaches tokenization.

Both `/v1/messages` and `/v1/messages/count_tokens` share the same conversion path, so they're both covered. The header is dropped whether it shows up as a block list or a string, including inline `role: "system"` turns the request validator folds into the top-level `system` string. Only the header lines themselves are removed, so the rest of the prompt (indentation, trailing whitespace, line endings) is left alone, and if there's no header it passes through unchanged.

Setting `CLAUDE_CODE_ATTRIBUTION_HEADER=0` on the client would also stop Claude Code from sending the header at all, but with this change the server handles it so that shouldn't really be necessary anymore.

cc @JustinTong0323 











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28096625037](https://github.com/sgl-project/sglang/actions/runs/28096625037)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28096624922](https://github.com/sgl-project/sglang/actions/runs/28096624922)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->