### PR TITLE
fix(gemma4): pass sampled frame indices in video metadata

### DIFF
--- a/python/sglang/srt/multimodal/processors/gemma4.py
+++ b/python/sglang/srt/multimodal/processors/gemma4.py
@@ -25,7 +25,7 @@ from sglang.srt.managers.schedule_batch import Modality, MultimodalProcessorOutp
 from sglang.srt.models.gemma4_audio import _SSCP_CONV_STRIDE_SIZES
 from sglang.srt.models.gemma4_mm import Gemma4ForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import MultimodalSpecialTokens
-from sglang.srt.utils.video_decoder import VideoDecoderWrapper
+from sglang.srt.utils.video_decoder import _BACKEND, VideoDecoderWrapper
 
 
 class Gemma4SGLangProcessor(SGLangBaseProcessor):
@@ -129,7 +129,7 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
                         "fps": fps,
                         "duration": total_frames / fps if fps and fps > 0 else None,
                         "frames_indices": frame_indices,
-                        "video_backend": "torchcodec",
+                        "video_backend": _BACKEND,
                     }
                     video_metadata_list.append(metadata)
                     converted_videos.append(video)

--- a/python/sglang/srt/multimodal/processors/gemma4.py
+++ b/python/sglang/srt/multimodal/processors/gemma4.py
@@ -13,7 +13,7 @@
 # ==============================================================================
 
 import re
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -78,7 +78,9 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
         first_stride = _SSCP_CONV_STRIDE_SIZES[0][0]
         return hop * first_stride
 
-    def _video_decoder_to_tensor(self, vdw: VideoDecoderWrapper) -> torch.Tensor:
+    def _video_decoder_to_tensor(
+        self, vdw: VideoDecoderWrapper
+    ) -> Tuple[torch.Tensor, List[int]]:
         """Convert a VideoDecoderWrapper to a (sampled_frames, C, H, W) uint8 tensor.
 
         SGLang's load_video returns VideoDecoderWrapper which the HF
@@ -98,7 +100,8 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
         else:
             indices = torch.arange(0, total, total / num_frames).int().tolist()
         frames_np = vdw.get_frames_at(indices)  # (N, H, W, C)
-        return torch.from_numpy(frames_np).permute(0, 3, 1, 2).contiguous()
+        video = torch.from_numpy(frames_np).permute(0, 3, 1, 2).contiguous()
+        return video, indices
 
     def process_mm_data(
         self, input_text, images=None, videos=None, audios=None, **kwargs
@@ -114,14 +117,31 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
                 padded.append(a)
             audios = padded
         if videos:
-            videos = [
-                (
-                    self._video_decoder_to_tensor(v)
-                    if isinstance(v, VideoDecoderWrapper)
-                    else v
-                )
-                for v in videos
-            ]
+            video_metadata_list = []
+            converted_videos = []
+            for v in videos:
+                if isinstance(v, VideoDecoderWrapper):
+                    total_frames = len(v)
+                    fps = v.avg_fps
+                    video, frame_indices = self._video_decoder_to_tensor(v)
+                    metadata = {
+                        "total_num_frames": total_frames,
+                        "fps": fps,
+                        "duration": total_frames / fps if fps and fps > 0 else None,
+                        "frames_indices": frame_indices,
+                        "video_backend": "torchcodec",
+                    }
+                    video_metadata_list.append(metadata)
+                    converted_videos.append(video)
+                else:
+                    converted_videos.append(v)
+            videos = converted_videos
+            # Only pass metadata when every video came from a
+            # VideoDecoderWrapper (the typical case).  Mixed lists are
+            # unlikely and would need per-item None handling that the HF
+            # metadata batching does not support.
+            if len(video_metadata_list) == len(videos):
+                kwargs["video_metadata"] = video_metadata_list
             kwargs.setdefault("do_sample_frames", False)
         return super().process_mm_data(
             input_text, images=images, videos=videos, audios=audios, **kwargs


### PR DESCRIPTION
Fixes #29171

Gemma4 builds video prompts with per-frame timestamps, which require both `fps` and `frames_indices`. Return the sampled frame indices alongside the converted video tensor and pass them through `video_metadata` when SGLang pre-samples `VideoDecoderWrapper` inputs with `do_sample_frames=False`.

## Motivation

Gemma4 builds video prompts with per-frame timestamps. These timestamps require both `fps` and `frames_indices` from `video_metadata`.

When SGLang pre-samples `VideoDecoderWrapper` inputs and passes the sampled tensor to HuggingFace with `do_sample_frames=False`, the sampled frame indices were not propagated. This can cause Gemma4 video requests to fail with:

```text
Cannot infer video `timestamps` when `fps` or `frames_indices` is None.
```

It can also lead to inaccurate answers for time-sensitive questions such as video duration.

## Modifications

- Return sampled frame indices together with the converted video tensor in the Gemma4 multimodal processor.
- Add `frames_indices` to `video_metadata` when processing `VideoDecoderWrapper` inputs.
- Keep `do_sample_frames=False` so HuggingFace does not sample frames again after SGLang has already done it.
- Preserve the original video metadata fields: `total_num_frames`, `fps`, and `duration`.

## Accuracy Tests

Verified with a Gemma4 `AutoProcessor` smoke test that a pre-sampled video tensor with `video_metadata["frames_indices"]` can be processed without the timestamp inference error.

Also verified that the generated video processor outputs include:

```text
pixel_values_videos
video_position_ids
```

## Speed Tests and Profiling

No speed benchmark was run. This change only propagates sampled frame indices through metadata and does not add additional decoding, model forward work, or extra frame processing.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28098524738](https://github.com/sgl-project/sglang/actions/runs/28098524738)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28098524580](https://github.com/sgl-project/sglang/actions/runs/28098524580)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->