### PR TITLE
Add experimental agent-aware KV cache hints

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -201,11 +201,28 @@ class UsageInfo(BaseModel):
     prompt_tokens_details: Optional[PromptTokensDetails] = None
     reasoning_tokens: Optional[int] = 0
 
-
 class StreamOptions(BaseModel):
     include_usage: Optional[bool] = False
     continuous_usage_stats: Optional[bool] = False
 
+class AgentHints(BaseModel):
+    workflow_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    step_id: Optional[str] = None
+    parent_step_id: Optional[str] = None
+    expected_tool_duration_ms: Optional[int] = None
+    cache_ttl_ms: Optional[int] = None
+    reuse_hint: Optional[Literal["low", "normal", "high", "keep", "reuse"]] = None
+
+    # Accept for forward compatibility, but do not use it for matching/reuse in this PR.
+    shared_prefix_hash: Optional[str] = None
+
+    @field_validator("expected_tool_duration_ms", "cache_ttl_ms")
+    @classmethod
+    def validate_non_negative(cls, value):
+        if value is not None and value < 0:
+            raise ValueError("must be non-negative")
+        return value
 
 class JsonSchemaResponseFormat(BaseModel):
     name: str
@@ -381,6 +398,8 @@ class CompletionRequest(BaseModel):
     cache_salt: Optional[Union[List[str], str]] = None
     # Priority for the request
     priority: Optional[int] = None
+    # Agent-aware KV cache hints. Optional experimental metadata.
+    agent_hints: Optional[AgentHints] = None
 
     # For custom metric labels
     custom_labels: Optional[Dict[str, str]] = None
@@ -753,6 +772,8 @@ class ChatCompletionRequest(BaseModel):
     cache_salt: Optional[Union[List[str], str]] = None
     # Priority for the request
     priority: Optional[int] = None
+    # Agent-aware KV cache hints. Optional experimental metadata.
+    agent_hints: Optional[AgentHints] = None
 
     # For PD disaggregation
     bootstrap_host: Optional[Union[List[str], str]] = None

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -583,6 +583,12 @@ class OpenAIServingChat(OpenAIServingBase):
             request
         )
         require_reasoning = self._get_reasoning_from_request(request)
+        
+        agent_hints = (
+            request.agent_hints.model_dump(exclude_none=True)
+            if request.agent_hints is not None
+            else None
+        )
 
         adapted_request = GenerateReqInput(
             **prompt_kwargs,
@@ -609,6 +615,11 @@ class OpenAIServingChat(OpenAIServingBase):
             extra_key=self._compute_extra_key(request),
             require_reasoning=require_reasoning,
             priority=request.priority,
+            agent_hints=(
+                request.agent_hints.model_dump(exclude_none=True)
+                if request.agent_hints is not None
+                else None
+            ),
             routing_key=self.extract_routing_key(raw_request),
             custom_labels=custom_labels,
             custom_logit_processor=request.custom_logit_processor,

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -127,6 +127,11 @@ class OpenAIServingCompletion(OpenAIServingBase):
             rid=request.rid,
             extra_key=self._compute_extra_key(request),
             priority=request.priority,
+            agent_hints=(
+                request.agent_hints.model_dump(exclude_none=True)
+                if request.agent_hints is not None
+                else None
+            ),
             routing_key=self.extract_routing_key(raw_request),
             custom_labels=custom_labels,
             custom_logit_processor=request.custom_logit_processor,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1,3 +1,4 @@
+# python\sglang\srt\managers\io_struct.py
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -253,6 +254,9 @@ class GenerateReqInput(BaseReq):
 
     # Priority for the request
     priority: Optional[int] = None
+    
+    # Agent-aware KV cache hints for workflow/cache metadata.
+    agent_hints: Optional[Union[Dict[str, Any], List[Optional[Dict[str, Any]]]]] = None
 
     # Extra key for classifying the request (e.g. cache_salt)
     extra_key: Optional[Union[List[str], str]] = None
@@ -442,6 +446,7 @@ class GenerateReqInput(BaseReq):
         self._normalize_logprob_params(num)
         self._normalize_custom_logit_processor(num)
         self._normalize_extra_key(num)
+        self._normalize_agent_hints(num)
         self._normalize_bootstrap_params(num)
 
     def _expand_inputs(self, num):
@@ -610,6 +615,23 @@ class GenerateReqInput(BaseReq):
             raise ValueError(
                 "Cannot use list custom_logit_processor with parallel_sample_num > 1"
             )
+    
+    def _normalize_agent_hints(self, num):
+        """Normalize agent_hints for batch and parallel sampling."""
+        if self.agent_hints is None:
+            return
+
+        if isinstance(self.agent_hints, dict):
+            self.agent_hints = [copy.deepcopy(self.agent_hints) for _ in range(num)]
+        elif isinstance(self.agent_hints, list):
+            if len(self.agent_hints) != self.batch_size:
+                raise ValueError("The length of agent_hints should be equal to the batch size.")
+            self.agent_hints = [
+                copy.deepcopy(item) if item is not None else None
+                for item in self.agent_hints
+            ] * self.parallel_sample_num
+        else:
+            raise ValueError("agent_hints should be a dict, a list of dicts, or None.")
 
     def _normalize_extra_key(self, num):
         """Normalize extra_key for batch processing."""
@@ -625,6 +647,25 @@ class GenerateReqInput(BaseReq):
             self.extra_key = self.extra_key * self.parallel_sample_num
         else:
             raise ValueError("extra_key should be a list or a string.")
+    
+    def _normalize_agent_hints(self, num):
+        """Normalize agent_hints for batch processing."""
+        if self.agent_hints is None:
+            return
+
+        if isinstance(self.agent_hints, dict):
+            self.agent_hints = [copy.deepcopy(self.agent_hints) for _ in range(num)]
+        elif isinstance(self.agent_hints, list):
+            if len(self.agent_hints) != self.batch_size:
+                raise ValueError(
+                    "The length of agent_hints should be equal to the batch size."
+                )
+            self.agent_hints = [
+                copy.deepcopy(item) if item is not None else None
+                for item in self.agent_hints
+            ] * self.parallel_sample_num
+        else:
+            raise ValueError("agent_hints should be a dict, a list of dicts, or None.")
 
     def _normalize_bootstrap_params(self, num):
         """Normalize bootstrap parameters for batch processing."""
@@ -741,6 +782,11 @@ class GenerateReqInput(BaseReq):
             routed_dp_rank=self.routed_dp_rank,
             disagg_prefill_dp_rank=self.disagg_prefill_dp_rank,
             conversation_id=self.conversation_id,
+            agent_hints=(
+                copy.deepcopy(self.agent_hints[i])
+                if self.agent_hints is not None
+                else None
+            ),
             priority=self.priority,
             extra_key=self.extra_key[i] if self.extra_key is not None else None,
             no_logs=self.no_logs,
@@ -823,9 +869,13 @@ class TokenizedGenerateReqInput(BaseReq):
     routed_dp_rank: Optional[int] = None
     # For PD disagg — hint telling decode which prefill DP worker has the KV cache
     disagg_prefill_dp_rank: Optional[int] = None
+    
+    agent_hints: Optional[Dict[str, Any]] = None
 
     # Priority for the request
     priority: Optional[int] = None
+    
+    agent_hints: Optional[Dict[str, Any]] = None
 
     # Extra key for classifying the request (e.g. cache_salt)
     extra_key: Optional[str] = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -698,6 +698,7 @@ class Req(ReqDllmMixin):
         disagg_prefill_dp_rank: Optional[int] = None,
         vocab_size: Optional[int] = None,
         priority: Optional[int] = None,
+        agent_hints: Optional[Dict[str, Any]] = None,
         metrics_collector: Optional[SchedulerMetricsCollector] = None,
         extra_key: Optional[str] = None,
         routing_key: Optional[str] = None,
@@ -817,6 +818,7 @@ class Req(ReqDllmMixin):
         self.eos_token_ids = eos_token_ids
         self.vocab_size = vocab_size
         self.priority = priority
+        self.agent_hints = agent_hints
 
         # For incremental decoding
         # ----- | --------- read_ids -------|

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2082,6 +2082,7 @@ class Scheduler(
                 disagg_prefill_dp_rank=recv_req.disagg_prefill_dp_rank,
                 vocab_size=self.model_config.vocab_size,
                 priority=recv_req.priority,
+                agent_hints=recv_req.agent_hints,
                 metrics_collector=(
                     self.metrics_collector
                     if self.metrics_reporter.enable_metrics

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1168,6 +1168,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 routed_dp_rank=obj.routed_dp_rank,
                 disagg_prefill_dp_rank=obj.disagg_prefill_dp_rank,
                 priority=obj.priority,
+                agent_hints=obj.agent_hints,
                 extra_key=obj.extra_key,
                 routing_key=obj.routing_key,
                 token_type_ids=token_type_ids,

--- a/python/sglang/srt/mem_cache/evict_policy.py
+++ b/python/sglang/srt/mem_cache/evict_policy.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Tuple, Union
 
@@ -45,6 +45,47 @@ class PriorityStrategy(EvictionStrategy):
         # Return (priority, last_access_time) so lower priority nodes are evicted first
         return (node.priority, node.last_access_time)
 
+class AgentAwareStrategy(EvictionStrategy):
+    """Agent-aware eviction.
+
+    Lower tuple values are evicted first.
+
+    This policy is intentionally conservative:
+    - no hard pinning
+    - no prefix matching changes
+    - no cross-request orchestration
+    - falls back to LRU when agent metadata is absent
+    """
+
+    HIGH_REUSE_HINTS = {"high", "keep", "reuse"}
+    LOW_REUSE_HINTS = {"low"}
+
+    def get_priority(self, node: TreeNode) -> Tuple[int, float]:
+        meta = getattr(node, "agent_meta", None)
+        bucket = 1
+
+        if meta:
+            now = time.monotonic()
+            ttl_deadline = meta.get("cache_ttl_deadline")
+            reuse_hint = meta.get("reuse_hint")
+
+            active_ttl = ttl_deadline is not None and ttl_deadline > now
+            expired_ttl = ttl_deadline is not None and ttl_deadline <= now
+
+            if expired_ttl:
+                bucket = 0
+            elif reuse_hint in self.LOW_REUSE_HINTS:
+                bucket = 0
+
+            if reuse_hint in self.HIGH_REUSE_HINTS:
+                bucket = 2
+
+            # Active TTL is the strongest soft-retention signal.
+            # It must override low reuse_hint.
+            if active_ttl:
+                bucket = 2
+
+        return (bucket, node.last_access_time)
 
 class SLRUStrategy(EvictionStrategy):
     def __init__(self, protected_threshold: int = 2):

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -1,3 +1,4 @@
+# python\sglang\srt\mem_cache\radix_cache.py
 from __future__ import annotations
 
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
@@ -244,6 +245,8 @@ class TreeNode:
         self.hash_value: Optional[List[str]] = None
         # priority for priority-aware eviction
         self.priority = priority
+        # Agent-aware KV cache metadata. Only set when a request carries agent_hints.
+        self.agent_meta: Optional[dict] = None
 
         self.id = TreeNode.counter if id is None else id
         TreeNode.counter += 1
@@ -485,6 +488,7 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         self.token_to_kv_pool_allocator.free(kv_indices[key_len:])
 
         self._tag_session_leaf(req, radix_key, node=session_leaf)
+        self._annotate_agent_cache_node(req, session_leaf)
 
         # Remove req slot release the cache lock
         if req.last_node is not None:
@@ -557,6 +561,7 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         req.last_node = new_last_node
 
         self._tag_session_leaf(req, radix_key, node=new_last_node)
+        self._annotate_agent_cache_node(req, new_last_node)
 
     def pretty_print(self):
         self._print_helper(self.root_node, 0)
@@ -680,6 +685,8 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         # new_node -> child
         # New node inherits child's priority (represents shared prefix)
         new_node = TreeNode(priority=child.priority)
+        if child.agent_meta is not None:
+            new_node.agent_meta = dict(child.agent_meta)
         new_node.hit_count = child.hit_count
         new_node.children = {key[split_len:].child_key(self.page_size): child}
         new_node.parent = child.parent
@@ -816,6 +823,46 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
                     continue
                 stack.append(child)
         return total_size
+    
+    def _annotate_agent_cache_node(self, req: Req, node: Optional[TreeNode]) -> None:
+        """Attach agent-aware cache metadata to the terminal radix node.
+
+        This is intentionally best-effort metadata for eviction scoring only.
+        It does not change prefix matching and does not pin cache entries.
+        """
+        if node is None or node is self.root_node:
+            return
+
+        hints = getattr(req, "agent_hints", None)
+        if not hints:
+            return
+        if not isinstance(hints, dict):
+            return
+
+        meta = {}
+
+        for key in (
+            "workflow_id",
+            "agent_id",
+            "step_id",
+            "parent_step_id",
+            "reuse_hint",
+        ):
+            value = hints.get(key)
+            if value is not None:
+                meta[key] = value
+
+        expected_tool_duration_ms = hints.get("expected_tool_duration_ms")
+        if expected_tool_duration_ms is not None:
+            meta["expected_tool_duration_ms"] = expected_tool_duration_ms
+
+        cache_ttl_ms = hints.get("cache_ttl_ms")
+        if cache_ttl_ms is not None:
+            meta["cache_ttl_ms"] = cache_ttl_ms
+            meta["cache_ttl_deadline"] = time.monotonic() + cache_ttl_ms / 1000.0
+
+        if meta:
+            node.agent_meta = meta
 
 
 if __name__ == "__main__":

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -17,6 +17,7 @@ import hashlib
 from typing import Any, Callable, List, Optional, Tuple
 
 from sglang.srt.environ import envs
+
 from sglang.srt.mem_cache.evict_policy import (
     EvictionStrategy,
     FIFOStrategy,
@@ -25,8 +26,10 @@ from sglang.srt.mem_cache.evict_policy import (
     LRUStrategy,
     MRUStrategy,
     PriorityStrategy,
+    AgentAwareStrategy,
     SLRUStrategy,
 )
+
 from sglang.srt.mem_cache.triton_ops.mla_buffer import (
     get_mla_kv_buffer_kernel as get_mla_kv_buffer_kernel,
 )
@@ -59,6 +62,7 @@ _EVICTION_POLICY_FACTORIES: dict[str, Callable[[], EvictionStrategy]] = {
     "mru": MRUStrategy,
     "filo": FILOStrategy,
     "priority": PriorityStrategy,
+    "agent_aware": AgentAwareStrategy,
     "slru": SLRUStrategy,
 }
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -277,7 +277,7 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
     "marlin",
 ]
 
-RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
+RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority", "agent_aware"]
 
 RL_ON_POLICY_TARGET_CHOICES = ["fsdp"]
 

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -309,6 +309,7 @@ class Session:
             return_routed_experts=req.return_routed_experts,
             routed_experts_start_len=req.routed_experts_start_len,
             priority=req.priority,
+            agent_hints=req.agent_hints,
             routing_key=req.routing_key,
             extra_key=req.extra_key,
             http_worker_ipc=req.http_worker_ipc,

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -1,3 +1,4 @@
+# test\registered\unit\entrypoints\openai\test_protocol.py
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +16,7 @@
 
 import unittest
 from typing import List, Optional
-
+import pytest
 from pydantic import BaseModel, Field, ValidationError
 
 from sglang.srt.entrypoints.openai.protocol import (
@@ -101,6 +102,26 @@ class TestCompletionRequest(unittest.TestCase):
         self.assertEqual(request.json_schema, '{"type": "object"}')
         self.assertEqual(request.lora_path, "/path/to/lora")
 
+    def test_completion_request_accepts_agent_hints(self):
+        """Test completion request accepts agent-aware KV cache hints."""
+        request = CompletionRequest(
+            model="test-model",
+            prompt="Hello",
+            agent_hints={
+                "workflow_id": "wf-1",
+                "agent_id": "agent-1",
+                "step_id": "step-1",
+                "parent_step_id": "root",
+                "expected_tool_duration_ms": 1000,
+                "cache_ttl_ms": 60000,
+                "reuse_hint": "keep",
+            },
+        )
+
+        self.assertEqual(request.agent_hints.workflow_id, "wf-1")
+        self.assertEqual(request.agent_hints.agent_id, "agent-1")
+        self.assertEqual(request.agent_hints.reuse_hint, "keep")
+
     def test_completion_request_validation_errors(self):
         """Test completion request validation errors"""
         with self.assertRaises(ValidationError):
@@ -178,6 +199,27 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertFalse(request.separate_reasoning)
         self.assertFalse(request.stream_reasoning)
         self.assertEqual(request.chat_template_kwargs, {"custom_param": "value"})
+    
+    def test_chat_completion_accepts_agent_hints(self):
+        """Test chat completion request accepts agent-aware KV cache hints."""
+        messages = [{"role": "user", "content": "Hello"}]
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            agent_hints={
+                "workflow_id": "wf-1",
+                "agent_id": "planner",
+                "step_id": "step-1",
+                "parent_step_id": "root",
+                "expected_tool_duration_ms": 1000,
+                "cache_ttl_ms": 60000,
+                "reuse_hint": "reuse",
+            },
+        )
+
+        self.assertEqual(request.agent_hints.workflow_id, "wf-1")
+        self.assertEqual(request.agent_hints.agent_id, "planner")
+        self.assertEqual(request.agent_hints.reuse_hint, "reuse")
 
     def test_chat_completion_tito_extensions(self):
         """Test chat completion with pre-tokenized prompt extensions."""
@@ -489,6 +531,17 @@ class TestValidationEdgeCases(unittest.TestCase):
         """Test negative token limits"""
         with self.assertRaises(ValidationError):
             CompletionRequest(model="test-model", prompt="Hello", max_tokens=-1)
+    
+    def test_agent_hints_reject_negative_numeric_fields(self):
+        """Test agent_hints rejects negative duration fields."""
+        for field in ("expected_tool_duration_ms", "cache_ttl_ms"):
+            with self.subTest(field=field):
+                with self.assertRaises(ValidationError):
+                    ChatCompletionRequest(
+                        model="test-model",
+                        messages=[{"role": "user", "content": "Hello"}],
+                        agent_hints={field: -1},
+                    )
 
     def test_model_serialization_roundtrip(self):
         """Test that models can be serialized and deserialized"""

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1,6 +1,7 @@
+# test\registered\unit\managers\test_io_struct.py
 import copy
 import unittest
-
+import pytest
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.test.ci.ci_register import (
     register_amd_ci,
@@ -469,6 +470,59 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         req = GenerateReqInput(text="Hello", extra_key="solo")
         req.normalize_batch_and_arguments()
         self.assertEqual(req.extra_key, "solo")
+
+    def test_generate_req_input_batch_preserves_agent_hints(self):
+        req = GenerateReqInput(
+            text=["a", "b"],
+            sampling_params={},
+            agent_hints=[
+                {"workflow_id": "wf-1", "step_id": "a", "reuse_hint": "keep"},
+                {"workflow_id": "wf-1", "step_id": "b", "reuse_hint": "low"},
+            ],
+        )
+
+        req.normalize_batch_and_arguments()
+
+        assert req[0].agent_hints["step_id"] == "a"
+        assert req[0].agent_hints["reuse_hint"] == "keep"
+        assert req[1].agent_hints["step_id"] == "b"
+        assert req[1].agent_hints["reuse_hint"] == "low"
+
+
+    def test_generate_req_input_single_agent_hints_dict_broadcasts_to_batch(self):
+        req = GenerateReqInput(
+            text=["a", "b"],
+            sampling_params={},
+            agent_hints={"workflow_id": "wf-1", "reuse_hint": "keep"},
+        )
+
+        req.normalize_batch_and_arguments()
+
+        assert req[0].agent_hints == {"workflow_id": "wf-1", "reuse_hint": "keep"}
+        assert req[1].agent_hints == {"workflow_id": "wf-1", "reuse_hint": "keep"}
+        assert req[0].agent_hints is not req[1].agent_hints
+
+
+    def test_generate_req_input_agent_hints_default_none(self):
+        req = GenerateReqInput(
+            text="hello",
+            sampling_params={},
+        )
+
+        req.normalize_batch_and_arguments()
+
+        assert req.agent_hints is None
+
+
+    def test_generate_req_input_agent_hints_rejects_bad_batch_length(self):
+        req = GenerateReqInput(
+            text=["a", "b"],
+            sampling_params={},
+            agent_hints=[{"workflow_id": "wf-1"}],
+        )
+
+        with pytest.raises(ValueError, match="agent_hints"):
+            req.normalize_batch_and_arguments()
 
     def test_logprob_parameters_normalization(self):
         """Test normalization of logprob-related parameters."""

--- a/test/registered/unit/mem_cache/test_evict_policy.py
+++ b/test/registered/unit/mem_cache/test_evict_policy.py
@@ -1,7 +1,7 @@
 """Unit tests for evict_policy.py"""
-
+# test\registered\unit\mem_cache\test_evict_policy.py
 from sglang.test.ci.ci_register import register_cpu_ci
-
+import time
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=7, suite="base-c-test-cpu")
 
@@ -15,9 +15,9 @@ from sglang.srt.mem_cache.evict_policy import (
     LRUStrategy,
     MRUStrategy,
     PriorityStrategy,
+    AgentAwareStrategy,
     SLRUStrategy,
 )
-
 
 def _make_node(**kwargs):
     node = MagicMock()
@@ -25,6 +25,7 @@ def _make_node(**kwargs):
     node.hit_count = kwargs.get("hit_count", 0)
     node.creation_time = kwargs.get("creation_time", 0.0)
     node.priority = kwargs.get("priority", 0)
+    node.agent_meta = kwargs.get("agent_meta", None)
     return node
 
 
@@ -139,6 +140,84 @@ class TestPriorityStrategy(unittest.TestCase):
             self.strategy.get_priority(old), self.strategy.get_priority(new)
         )
 
+class TestAgentAwareStrategy(unittest.TestCase):
+    def setUp(self):
+        self.strategy = AgentAwareStrategy()
+
+    def test_falls_back_to_lru_without_metadata(self):
+        old = _make_node(last_access_time=1.0)
+        new = _make_node(last_access_time=10.0)
+
+        self.assertLess(
+            self.strategy.get_priority(old),
+            self.strategy.get_priority(new),
+        )
+
+    def test_protects_active_ttl(self):
+        now = time.monotonic()
+        normal = _make_node(last_access_time=10.0)
+        protected = _make_node(
+            last_access_time=1.0,
+            agent_meta={"cache_ttl_deadline": now + 60.0},
+        )
+
+        self.assertLess(
+            self.strategy.get_priority(normal),
+            self.strategy.get_priority(protected),
+        )
+
+    def test_expired_ttl_evicted_before_normal_node(self):
+        now = time.monotonic()
+        normal = _make_node(last_access_time=1.0)
+        expired = _make_node(
+            last_access_time=10.0,
+            agent_meta={"cache_ttl_deadline": now - 1.0},
+        )
+
+        self.assertLess(
+            self.strategy.get_priority(expired),
+            self.strategy.get_priority(normal),
+        )
+
+    def test_high_reuse_hint_is_protected(self):
+        normal = _make_node(last_access_time=10.0)
+        high_reuse = _make_node(
+            last_access_time=1.0,
+            agent_meta={"reuse_hint": "keep"},
+        )
+
+        self.assertLess(
+            self.strategy.get_priority(normal),
+            self.strategy.get_priority(high_reuse),
+        )
+
+    def test_low_reuse_hint_evicted_before_normal_node(self):
+        normal = _make_node(last_access_time=1.0)
+        low_reuse = _make_node(
+            last_access_time=10.0,
+            agent_meta={"reuse_hint": "low"},
+        )
+
+        self.assertLess(
+            self.strategy.get_priority(low_reuse),
+            self.strategy.get_priority(normal),
+        )
+
+    def test_active_ttl_overrides_low_reuse_hint(self):
+        now = time.monotonic()
+        normal = _make_node(last_access_time=10.0)
+        active_ttl_low_reuse = _make_node(
+            last_access_time=1.0,
+            agent_meta={
+                "cache_ttl_deadline": now + 60.0,
+                "reuse_hint": "low",
+            },
+        )
+
+        self.assertLess(
+            self.strategy.get_priority(normal),
+            self.strategy.get_priority(active_ttl_low_reuse),
+        )
 
 class TestSLRUStrategy(unittest.TestCase):
     def setUp(self):

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -16,7 +16,7 @@ Usage:
     python -m pytest test_radix_cache_unit.py -v
     python -m pytest test_radix_cache_unit.py::TestRadixCache::test_insert_basic
 """
-
+# test\registered\unit\mem_cache\test_radix_cache_unit.py
 from sglang.srt.mem_cache.common import available_and_evictable_str
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
@@ -218,6 +218,11 @@ class TestTreeNode(unittest.TestCase):
         self.assertIsNone(node.host_value)
         self.assertIsNone(node.hash_value)
 
+    def test_init_agent_meta_default_none(self):
+        """Test TreeNode agent metadata defaults to None."""
+        node = TreeNode()
+        self.assertIsNone(node.agent_meta)
+
     def test_init_with_id(self):
         """Test initialization with custom ID."""
         node = TreeNode(id=42)
@@ -354,6 +359,54 @@ class TestRadixCache(unittest.TestCase):
                 self.assertEqual(cache.device, torch.device("cpu"))
                 self.assertIsNotNone(cache.root_node)
                 self.assertEqual(len(cache.root_node.key), 0)
+
+    def test_annotate_agent_cache_node_sets_metadata(self):
+        """Test agent_hints annotate radix cache node metadata."""
+        cache = RadixCache.create_simulated()
+        node = TreeNode()
+        req = unittest.mock.Mock()
+        req.agent_hints = {
+            "workflow_id": "wf-1",
+            "agent_id": "agent-1",
+            "step_id": "step-1",
+            "parent_step_id": "root",
+            "expected_tool_duration_ms": 1000,
+            "cache_ttl_ms": 60000,
+            "reuse_hint": "keep",
+        }
+
+        before = time.monotonic()
+        cache._annotate_agent_cache_node(req, node)
+
+        self.assertEqual(node.agent_meta["workflow_id"], "wf-1")
+        self.assertEqual(node.agent_meta["agent_id"], "agent-1")
+        self.assertEqual(node.agent_meta["step_id"], "step-1")
+        self.assertEqual(node.agent_meta["parent_step_id"], "root")
+        self.assertEqual(node.agent_meta["expected_tool_duration_ms"], 1000)
+        self.assertEqual(node.agent_meta["cache_ttl_ms"], 60000)
+        self.assertEqual(node.agent_meta["reuse_hint"], "keep")
+        self.assertGreaterEqual(node.agent_meta["cache_ttl_deadline"], before)
+
+    def test_annotate_agent_cache_node_ignores_missing_hints(self):
+        """Test missing agent_hints leaves node metadata unchanged."""
+        cache = RadixCache.create_simulated()
+        node = TreeNode()
+        req = unittest.mock.Mock()
+        req.agent_hints = None
+
+        cache._annotate_agent_cache_node(req, node)
+
+        self.assertIsNone(node.agent_meta)
+
+    def test_annotate_agent_cache_node_ignores_root_node(self):
+        """Test root node is not annotated."""
+        cache = RadixCache.create_simulated()
+        req = unittest.mock.Mock()
+        req.agent_hints = {"workflow_id": "wf-1", "reuse_hint": "keep"}
+
+        cache._annotate_agent_cache_node(req, cache.root_node)
+
+        self.assertIsNone(cache.root_node.agent_meta)
 
     def test_reset(self):
         """Test reset method."""


### PR DESCRIPTION
## Motivation

This PR adds a narrow Phase 1 implementation for experimental agent-aware KV cache metadata.

Agentic workloads often issue multi-step requests where future reuse is not purely reflected by recent access time. This change allows clients to attach lightweight request metadata such as workflow/agent/step identifiers, TTL hints, and reuse hints, then uses those hints only for local radix-cache metadata annotation and optional experimental eviction ordering.

## Modifications

- Added optional OpenAI-compatible request metadata field: `agent_hints`.
- Added supported hint fields:
  - `workflow_id`
  - `agent_id`
  - `step_id`
  - `parent_step_id`
  - `expected_tool_duration_ms`
  - `cache_ttl_ms`
  - `reuse_hint`
- Propagated `agent_hints` through:
  - OpenAI protocol request models
  - chat/completions serving request construction
  - `GenerateReqInput` normalization and slicing
  - tokenizer-manager request conversion
  - scheduler request construction
  - session-controller request construction
- Added `TreeNode.agent_meta` for radix-cache node metadata.
- Annotated radix-cache nodes with agent metadata when requests are cached.
- Added experimental `agent_aware` radix-cache eviction policy.
- Registered `agent_aware` in radix-cache eviction policy choices.
- Added targeted unit tests for:
  - OpenAI protocol validation
  - `GenerateReqInput` normalization/batching behavior
  - agent-aware eviction ranking
  - radix-cache node metadata annotation

## Accuracy Tests

Ran targeted unit tests from Windows PowerShell with local package path configured:

```powershell
$env:PYTHONPATH = (Resolve-Path .\python).Path

python3 -m pytest -q test/registered/unit/entrypoints/openai/test_protocol.py -k agent
python3 -m pytest -q test/registered/unit/managers/test_io_struct.py -k agent
python3 -m pytest -q test/registered/unit/mem_cache/test_evict_policy.py -k agent
python3 -m pytest -q test/registered/unit/mem_cache/test_radix_cache_unit.py -k agent







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28103308013](https://github.com/sgl-project/sglang/actions/runs/28103308013)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28103307981](https://github.com/sgl-project/sglang/actions/runs/28103307981)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->