### PR TITLE
fix(deepep): fix DeepEP low-latency buffer capacity

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -9,7 +9,7 @@ from sglang.srt.distributed.parallel_state import get_tp_group
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.layers import deep_gemm_wrapper
-from sglang.srt.layers.dp_attention import get_is_extend_in_batch
+from sglang.srt.layers.dp_attention import get_attention_tp_size, get_is_extend_in_batch
 from sglang.srt.layers.moe.token_dispatcher.base import (
     BaseDispatcher,
     BaseDispatcherConfig,
@@ -353,10 +353,16 @@ class _DeepEPDispatcherImplBase:
         self.deepep_mode = deepep_mode
 
         self.params_bytes = 2
-        # A large value will lead to large memory occupation, thus users should change it accordingly
-        self.num_max_dispatch_tokens_per_rank = (
+        configured_num_max_dispatch_tokens_per_rank = (
             envs.SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
         )
+        attn_tp_size = get_attention_tp_size()
+        # DeepEP low-latency receives the attention-TP scattered MoE input.
+        # The env value is the pre-scatter per-rank token capacity, so the
+        # DeepEP buffer capacity should cover only this rank's attn-TP shard.
+        self.num_max_dispatch_tokens_per_rank = (
+            configured_num_max_dispatch_tokens_per_rank + attn_tp_size - 1
+        ) // attn_tp_size
         # DeepEP internode_ll dispatch uses FINISHED_SUM_TAG=1024
         # and the logic requires num-tokens-sent-from-one-rank-to-another-rank less than it
         assert self.num_max_dispatch_tokens_per_rank <= 1024

--- a/test/registered/unit/layers/moe/test_deepep_dispatcher.py
+++ b/test/registered/unit/layers/moe/test_deepep_dispatcher.py
@@ -1,0 +1,72 @@
+import pytest
+import torch
+
+import sglang.srt.layers.moe.token_dispatcher.deepep as deepep
+from sglang.srt.environ import envs
+from sglang.srt.layers.moe.utils import DeepEPMode
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _make_dispatcher(monkeypatch, configured_capacity, attn_tp_size):
+    monkeypatch.setattr(deepep, "use_deepep", True)
+    monkeypatch.setattr(deepep, "get_attention_tp_size", lambda: attn_tp_size)
+    monkeypatch.setattr(
+        deepep._DeepEPDispatcherImplBase,
+        "set_deepep_dispatcher_dtype",
+        lambda self: None,
+    )
+
+    with envs.SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.override(
+        configured_capacity
+    ):
+        return deepep._DeepEPDispatcherImplBase(
+            group=None,
+            router_topk=8,
+            permute_fusion=False,
+            num_experts=16,
+            num_local_experts=2,
+            hidden_size=1024,
+            params_dtype=torch.bfloat16,
+            deepep_mode=DeepEPMode.AUTO,
+        )
+
+
+@pytest.mark.parametrize(
+    ("configured_capacity", "attn_tp_size", "expected_capacity"),
+    [
+        (128, 1, 128),
+        (128, 4, 32),
+        (129, 4, 33),
+    ],
+)
+def test_ll_capacity_uses_attention_tp_shard(
+    monkeypatch,
+    configured_capacity,
+    attn_tp_size,
+    expected_capacity,
+):
+    dispatcher = _make_dispatcher(
+        monkeypatch,
+        configured_capacity=configured_capacity,
+        attn_tp_size=attn_tp_size,
+    )
+
+    assert dispatcher.num_max_dispatch_tokens_per_rank == expected_capacity
+
+
+def test_ll_capacity_limit_applies_after_scatter(monkeypatch):
+    dispatcher = _make_dispatcher(
+        monkeypatch,
+        configured_capacity=4096,
+        attn_tp_size=4,
+    )
+    assert dispatcher.num_max_dispatch_tokens_per_rank == 1024
+
+    with pytest.raises(AssertionError):
+        _make_dispatcher(
+            monkeypatch,
+            configured_capacity=4097,
+            attn_tp_size=4,
+        )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

DeepEP low-latency dispatch receives the MoE input after attention-TP scatter. The configured per-rank token capacity should therefore be sized before scatter and converted to the actual DeepEP buffer capacity per attention-TP shard. Without this adjustment, runs with `attention_tp_size > 1` can allocate unnecessarily large DeepEP low-latency buffers. This is especially expensive for MTP workloads, where the low-latency buffer capacity is multiplied by the expanded decode-side token budget and can exceed **10GB** on some models.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Import `get_attention_tp_size()` in the DeepEP token dispatcher.
- Treat `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK` as the pre-scatter per-rank token capacity, then ceil-divide by attention TP size before passing the capacity to DeepEP.
- Keep behavior unchanged when `attention_tp_size == 1`.
- Add CPU unit coverage for attention-TP capacity scaling and the post-scatter DeepEP low-latency capacity limit.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Not run locally per request. Model accuracy tests are not applicable because this change only adjusts DeepEP low-latency buffer capacity sizing; it does not change routing, kernels, or model numerics.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Not run locally per request. Speed benchmarking is not applicable as a runtime throughput comparison; the expected impact is lower DeepEP low-latency RDMA buffer allocation when `attention_tp_size > 1`, especially for MTP workloads. Runtime behavior is unchanged for `attention_tp_size == 1`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28102255577](https://github.com/sgl-project/sglang/actions/runs/28102255577)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28102255420](https://github.com/sgl-project/sglang/actions/runs/28102255420)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
