### PR TITLE
[POC] Extract DSA index-K storage into an IndexKeyCache facade

### DIFF
--- a/python/sglang/srt/mem_cache/index_key_cache.py
+++ b/python/sglang/srt/mem_cache/index_key_cache.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.layers.attention.dsa import index_buf_accessor
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+
+
+class IndexKeyCache:
+    """Owns the DSA indexer's per-layer fp8+scale index-K buffer and the read /
+    store / move / transfer / offload of it.
+
+    The buffer is page-co-located with the latent KV (same loc / page indices),
+    so page allocation stays with the owning ``DSATokenToKVPool``. This object
+    holds only the index-K tensors and reads layout/context attributes back from
+    the pool (``page_size``, ``index_head_dim``, ``quant_block_size``, the layer
+    transfer counter, ...), so the existing ``index_buf_accessor`` codec keeps
+    seeing the pool object unchanged.
+    """
+
+    def __init__(self, pool: DSATokenToKVPool, index_buf_size: int):
+        self.pool = pool
+        page_size = pool.page_size
+        index_head_dim = pool.index_head_dim
+        with (
+            torch.cuda.use_mem_pool(pool.custom_mem_pool)
+            if pool.custom_mem_pool
+            else nullcontext()
+        ):
+            self.buffer = [
+                torch.zeros(
+                    # Layout:
+                    #     ref: test_attention.py :: kv_cache_cast_to_fp8
+                    #     shape: (num_pages, page_size 64 * head_dim 128 + page_size 64 * fp32_nbytes 4)
+                    #     data: for page i,
+                    #         * buf[i, :page_size * head_dim] for fp8 data
+                    #         * buf[i, page_size * head_dim:].view(float32) for scale
+                    (
+                        (index_buf_size + page_size + 1) // page_size,
+                        page_size
+                        * (
+                            index_head_dim + index_head_dim // pool.quant_block_size * 4
+                        ),
+                    ),
+                    dtype=pool.index_k_with_scale_buffer_dtype,
+                    device=pool.device,
+                )
+                for _ in range(pool.layer_num)
+            ]
+
+    def clear(self) -> None:
+        del self.buffer
+
+    def move(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
+        if tgt_loc.numel() == 0:
+            return
+        tgt_loc_flat = tgt_loc.view(-1).long()
+        src_loc_flat = src_loc.view(-1).long()
+        for index_k in self.buffer:
+            index_k[tgt_loc_flat] = index_k[src_loc_flat]
+
+    def get_buffer(self, layer_id: int) -> torch.Tensor:
+        if self.pool.layer_transfer_counter is not None:
+            self.pool.layer_transfer_counter.wait_until(
+                layer_id - self.pool.start_layer
+            )
+        return self.buffer[layer_id - self.pool.start_layer]
+
+    def get_k_continuous(self, layer_id: int, seq_len: int, page_indices: torch.Tensor):
+        if self.pool.layer_transfer_counter is not None:
+            self.pool.layer_transfer_counter.wait_until(
+                layer_id - self.pool.start_layer
+            )
+        buf = self.buffer[layer_id - self.pool.start_layer]
+        return index_buf_accessor.GetK.execute(
+            self.pool, buf, seq_len=seq_len, page_indices=page_indices
+        )
+
+    def get_k_scale_continuous(
+        self, layer_id: int, seq_len: int, page_indices: torch.Tensor
+    ):
+        if self.pool.layer_transfer_counter is not None:
+            self.pool.layer_transfer_counter.wait_until(
+                layer_id - self.pool.start_layer
+            )
+        buf = self.buffer[layer_id - self.pool.start_layer]
+        return index_buf_accessor.GetS.execute(
+            self.pool, buf, seq_len=seq_len, page_indices=page_indices
+        )
+
+    def get_k_and_scale(
+        self,
+        layer_id: int,
+        seq_len_tensor: torch.Tensor,
+        page_indices: torch.Tensor,
+        seq_len_sum: int,
+        max_seq_len: int,
+    ):
+        """Fused read of both index K and scale in one Triton call. Returns
+        (k_fp8: (seq_len, index_head_dim) uint8, k_scale: (seq_len, 4) uint8)."""
+        if self.pool.layer_transfer_counter is not None:
+            self.pool.layer_transfer_counter.wait_until(
+                layer_id - self.pool.start_layer
+            )
+        buf = self.buffer[layer_id - self.pool.start_layer]
+        return index_buf_accessor.GetKAndS.execute(
+            self.pool,
+            buf,
+            page_indices=page_indices,
+            seq_len_tensor=seq_len_tensor,
+            seq_len_sum=seq_len_sum,
+            max_seq_len=max_seq_len,
+        )
+
+    def store_quantized(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        index_k: torch.Tensor,
+        index_k_scale: torch.Tensor,
+    ) -> None:
+        buf = self.buffer[layer_id - self.pool.start_layer]
+        index_buf_accessor.SetKAndS.execute(
+            pool=self.pool,
+            buf=buf,
+            loc=loc,
+            index_k=index_k,
+            index_k_scale=index_k_scale,
+        )
+
+    def cpu_copy(self, indices):
+        # Retract frees the slots/pages and they get reused by other reqs'
+        # store_quantized, so we must offload index-K too -- otherwise resume
+        # restores kv_buffer but leaves foreign index/scale in place and DSA
+        # attention reads garbage at those token positions.
+        page_indices = indices[:: self.pool.page_size] // self.pool.page_size
+        torch.cuda.synchronize()
+        index_k_cpu = []
+        chunk_size = self.pool.cpu_offloading_chunk_size
+        page_chunk_size = max(1, chunk_size // self.pool.page_size)
+        for layer_id in range(self.pool.layer_num):
+            index_k_cpu.append([])
+            for i in range(0, len(page_indices), page_chunk_size):
+                chunk_page_indices = page_indices[i : i + page_chunk_size]
+                idx_cpu = self.buffer[layer_id][chunk_page_indices].to(
+                    "cpu", non_blocking=True
+                )
+                index_k_cpu[-1].append(idx_cpu)
+        torch.cuda.synchronize()
+        return index_k_cpu
+
+    def load_cpu_copy(self, index_k_cpu, indices) -> None:
+        page_indices = indices[:: self.pool.page_size] // self.pool.page_size
+        torch.cuda.synchronize()
+        chunk_size = self.pool.cpu_offloading_chunk_size
+        page_chunk_size = max(1, chunk_size // self.pool.page_size)
+        for layer_id in range(self.pool.layer_num):
+            for i in range(0, len(page_indices), page_chunk_size):
+                chunk_page_indices = page_indices[i : i + page_chunk_size]
+                idx_cpu = index_k_cpu[layer_id][i // page_chunk_size]
+                assert idx_cpu.shape[0] == len(chunk_page_indices)
+                idx_chunk = idx_cpu.to(self.buffer[0].device, non_blocking=True)
+                self.buffer[layer_id][chunk_page_indices] = idx_chunk
+        torch.cuda.synchronize()
+
+    def state_buf_infos(self):
+        layer_num = self.pool.layer_num
+        data_ptrs = [self.buffer[i].data_ptr() for i in range(layer_num)]
+        data_lens = [self.buffer[i].nbytes for i in range(layer_num)]
+        item_lens = [self.buffer[i][0].nbytes for i in range(layer_num)]
+        return data_ptrs, data_lens, item_lens

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -38,7 +38,6 @@ from sglang.jit_kernel.kvcache import can_use_store_cache, store_cache
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
-from sglang.srt.layers.attention.dsa import index_buf_accessor
 from sglang.srt.layers.attention.dsa.quant_k_cache import (
     quantize_k_cache,
     quantize_k_cache_separate,
@@ -47,6 +46,7 @@ from sglang.srt.layers.attention.dsa.utils import aiter_can_use_preshuffle_paged
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.allocator.mamba import MambaSlotAllocator
+from sglang.srt.mem_cache.index_key_cache import IndexKeyCache
 from sglang.srt.mem_cache.triton_ops.cache_move import (
     copy_all_layer_kv_cache_tiled,
     set_kv_buffer_prefix_valid_tiled,
@@ -2571,53 +2571,26 @@ class DSATokenToKVPool(MLATokenToKVPool):
                 ), f"HIP legacy DSA path requires page_size == 1, got {self.page_size}"
         else:
             assert self.page_size == 64
-        with (
-            torch.cuda.use_mem_pool(self.custom_mem_pool)
-            if self.custom_mem_pool
-            else nullcontext()
-        ):
-            self.index_k_with_scale_buffer = [
-                torch.zeros(
-                    # Layout:
-                    #     ref: test_attention.py :: kv_cache_cast_to_fp8
-                    #     shape: (num_pages, page_size 64 * head_dim 128 + page_size 64 * fp32_nbytes 4)
-                    #     data: for page i,
-                    #         * buf[i, :page_size * head_dim] for fp8 data
-                    #         * buf[i, page_size * head_dim:].view(float32) for scale
-                    (
-                        (index_buf_size + page_size + 1) // self.page_size,
-                        self.page_size
-                        * (
-                            index_head_dim + index_head_dim // self.quant_block_size * 4
-                        ),
-                    ),
-                    dtype=self.index_k_with_scale_buffer_dtype,
-                    device=device,
-                )
-                for _ in range(layer_num)
-            ]
+        self.index_key_cache = IndexKeyCache(self, index_buf_size)
         self._finalize_allocation_log(size)
+
+    @property
+    def index_k_with_scale_buffer(self):
+        # Back-compat alias: external readers (e.g. the HiCache host pool) index
+        # this attribute directly. The buffer now lives on self.index_key_cache.
+        return self.index_key_cache.buffer
 
     def _clear_buffers(self):
         del self.kv_buffer
-        del self.index_k_with_scale_buffer
+        self.index_key_cache.clear()
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
         """Move latent KV and the DSA indexer cache (key + scale) in lockstep."""
         super().move_kv_cache(tgt_loc, src_loc)
-
-        if tgt_loc.numel() == 0:
-            return
-
-        tgt_loc_flat = tgt_loc.view(-1).long()
-        src_loc_flat = src_loc.view(-1).long()
-        for index_k in self.index_k_with_scale_buffer:
-            index_k[tgt_loc_flat] = index_k[src_loc_flat]
+        self.index_key_cache.move(tgt_loc, src_loc)
 
     def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
-        if self.layer_transfer_counter is not None:
-            self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
-        return self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        return self.index_key_cache.get_buffer(layer_id)
 
     def get_index_k_continuous(
         self,
@@ -2625,12 +2598,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         seq_len: int,
         page_indices: torch.Tensor,
     ):
-        if self.layer_transfer_counter is not None:
-            self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
-        buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
-        return index_buf_accessor.GetK.execute(
-            self, buf, seq_len=seq_len, page_indices=page_indices
-        )
+        return self.index_key_cache.get_k_continuous(layer_id, seq_len, page_indices)
 
     def get_index_k_scale_continuous(
         self,
@@ -2638,11 +2606,8 @@ class DSATokenToKVPool(MLATokenToKVPool):
         seq_len: int,
         page_indices: torch.Tensor,
     ):
-        if self.layer_transfer_counter is not None:
-            self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
-        buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
-        return index_buf_accessor.GetS.execute(
-            self, buf, seq_len=seq_len, page_indices=page_indices
+        return self.index_key_cache.get_k_scale_continuous(
+            layer_id, seq_len, page_indices
         )
 
     def get_index_k_scale_buffer(
@@ -2653,27 +2618,8 @@ class DSATokenToKVPool(MLATokenToKVPool):
         seq_len_sum: int,
         max_seq_len: int,
     ):
-        """
-        Fused method to get both index K and scale data in a single call using Triton.
-        More efficient than calling get_index_k_continuous and get_index_k_scale_continuous separately.
-
-        :param layer_id: Layer index
-        :param seq_len: Sequence length
-        :param page_indices: Page indices tensor
-        :return: tuple of (k_fp8, k_scale) where
-                 k_fp8: (seq_len, index_head_dim), uint8
-                 k_scale: (seq_len, 4), uint8
-        """
-        if self.layer_transfer_counter is not None:
-            self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
-        buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
-        return index_buf_accessor.GetKAndS.execute(
-            self,
-            buf,
-            page_indices=page_indices,
-            seq_len_tensor=seq_len_tensor,
-            seq_len_sum=seq_len_sum,
-            max_seq_len=max_seq_len,
+        return self.index_key_cache.get_k_and_scale(
+            layer_id, seq_len_tensor, page_indices, seq_len_sum, max_seq_len
         )
 
     def set_index_k_scale_buffer(
@@ -2683,68 +2629,20 @@ class DSATokenToKVPool(MLATokenToKVPool):
         index_k: torch.Tensor,
         index_k_scale: torch.Tensor,
     ) -> None:
-        buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
-        index_buf_accessor.SetKAndS.execute(
-            pool=self, buf=buf, loc=loc, index_k=index_k, index_k_scale=index_k_scale
-        )
+        self.index_key_cache.store_quantized(layer_id, loc, index_k, index_k_scale)
 
     def get_cpu_copy(self, indices, mamba_indices=None):
-        # DSA keeps a page-indexed index_k_with_scale_buffer alongside kv_buffer.
-        # Retract frees the slots/pages and they get reused by other reqs'
-        # set_index_k_scale_buffer, so we must offload it here too -- otherwise
-        # resume restores kv_buffer but leaves foreign index/scale in place and
-        # DSA attention reads garbage at those token positions.
         kv_cache_cpu = super().get_cpu_copy(indices, mamba_indices=mamba_indices)
-
-        page_indices = indices[:: self.page_size] // self.page_size
-        torch.cuda.synchronize()
-        index_k_cpu = []
-        chunk_size = self.cpu_offloading_chunk_size
-        page_chunk_size = max(1, chunk_size // self.page_size)
-        for layer_id in range(self.layer_num):
-            index_k_cpu.append([])
-            for i in range(0, len(page_indices), page_chunk_size):
-                chunk_page_indices = page_indices[i : i + page_chunk_size]
-                idx_cpu = self.index_k_with_scale_buffer[layer_id][
-                    chunk_page_indices
-                ].to("cpu", non_blocking=True)
-                index_k_cpu[-1].append(idx_cpu)
-        torch.cuda.synchronize()
-
-        return {"kv": kv_cache_cpu, "index_k": index_k_cpu}
+        return {"kv": kv_cache_cpu, "index_k": self.index_key_cache.cpu_copy(indices)}
 
     def load_cpu_copy(self, kv_cache_cpu_dict, indices, mamba_indices=None):
         super().load_cpu_copy(
             kv_cache_cpu_dict["kv"], indices, mamba_indices=mamba_indices
         )
-
-        page_indices = indices[:: self.page_size] // self.page_size
-        index_k_cpu = kv_cache_cpu_dict["index_k"]
-        torch.cuda.synchronize()
-        chunk_size = self.cpu_offloading_chunk_size
-        page_chunk_size = max(1, chunk_size // self.page_size)
-        for layer_id in range(self.layer_num):
-            for i in range(0, len(page_indices), page_chunk_size):
-                chunk_page_indices = page_indices[i : i + page_chunk_size]
-                idx_cpu = index_k_cpu[layer_id][i // page_chunk_size]
-                assert idx_cpu.shape[0] == len(chunk_page_indices)
-                idx_chunk = idx_cpu.to(
-                    self.index_k_with_scale_buffer[0].device, non_blocking=True
-                )
-                self.index_k_with_scale_buffer[layer_id][chunk_page_indices] = idx_chunk
-        torch.cuda.synchronize()
+        self.index_key_cache.load_cpu_copy(kv_cache_cpu_dict["index_k"], indices)
 
     def get_state_buf_infos(self):
-        data_ptrs = [
-            self.index_k_with_scale_buffer[i].data_ptr() for i in range(self.layer_num)
-        ]
-        data_lens = [
-            self.index_k_with_scale_buffer[i].nbytes for i in range(self.layer_num)
-        ]
-        item_lens = [
-            self.index_k_with_scale_buffer[i][0].nbytes for i in range(self.layer_num)
-        ]
-        return data_ptrs, data_lens, item_lens
+        return self.index_key_cache.state_buf_infos()
 
     def get_kv_size_bytes(self):
         kv_size_bytes = super().get_kv_size_bytes()


### PR DESCRIPTION
## Motivation

The DSA indexer's per-layer fp8+scale index-K storage currently lives directly on `DSATokenToKVPool` — the `index_k_with_scale_buffer` tensor list plus ~10 methods for read / store / move / transfer / host-offload, all interleaved with the latent-KV pool logic. This is the storage-side counterpart to the policy/state extraction in #28609; together they give DSA index-cache a single owner per concern instead of logic scattered across the pool.

The layout codec (`index_buf_accessor`) and the fused store kernel are already factored, so this PR is the natural next seam: lift the buffer + its operations into a dedicated `IndexKeyCache`.

## What this does

- New `IndexKeyCache` (`mem_cache/index_key_cache.py`) owns the index-K buffer and the `get_buffer` / `get_k_continuous` / `get_k_scale_continuous` / `get_k_and_scale` / `store_quantized` / `move` / `cpu_copy` / `load_cpu_copy` / `state_buf_infos` operations.
- `DSATokenToKVPool` holds one (`self.index_key_cache`) and its existing methods become thin delegators.
- `index_k_with_scale_buffer` is preserved as a `@property` returning the facade's buffer, so external raw-attribute readers (the HiCache host pool) are unaffected.

## Why it's behavior-preserving (bit-identical)

Pure relocation:
- The buffer allocation, layout, and every method body are moved verbatim.
- The `index_buf_accessor` codec and the `fused_store_index_k_cache` kernel are **unchanged** and still receive the **pool** object (the facade passes `self.pool` back to the accessor), so the fp8+scale page layout, the `layer_transfer_counter.wait_until` sync, and the page co-allocation with latent KV all behave identically.
- All indexer / transfer / host call sites are **untouched** — they keep calling `pool.get_index_k_*` / `pool.set_index_k_scale_buffer` / `pool.index_k_with_scale_buffer`, which now route through the facade. Zero caller churn.

## Scope (Step 1)

- `DSATokenToKVPool` (the DSA path used by DeepSeek-V3.2 / GLM-5.2-FP8) only. The DSV4 nested pool (`c4_indexer_kv_pool`) and the NPU pool keep their current inline implementation — they can adopt `IndexKeyCache` later.
- The fused store kernel stays called from the indexer (it reads the buffer via the delegated getter). Repointing the indexer to hold the facade directly is a follow-up (Step 2).

## Validation

- `python3 -m py_compile` — OK
- `pre-commit` (isort / ruff / black) — clean on both files
- Adversarial grep: no code assigns or `del`s `index_k_with_scale_buffer` on a `DSATokenToKVPool` instance (only the unrelated DSV4 / HiCache-host classes do on their own attributes), so the read-only property is safe.

**Not yet run — required before un-drafting** (this touches the per-token-per-layer hot storage path; static checks do not cover it):

- bit-exact check on a real DSA model (dump `index_k_with_scale_buffer` / indexer topk before vs after — must be byte-identical)
- perf check (`bench_one_batch_server` + profiler — confirm zero per-forward overhead from the delegation)
- PD-disaggregation (`state_buf_infos`) and HiCache offload (`cpu_copy` / `load_cpu_copy`) transfer paths exercised
- real DSA model e2e (DeepSeek-V3.2-Exp or GLM-5.2-FP8) — an EAGLE3 proxy cannot cover indexer storage

Opening as **draft** for design review; the validation above is the un-draft gate.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28106990155](https://github.com/sgl-project/sglang/actions/runs/28106990155)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28106989935](https://github.com/sgl-project/sglang/actions/runs/28106989935)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->