### PR TITLE
[AMD] ci: register w8a8 quantization on extra-a 1-gpu-large-amd

### DIFF
--- a/test/registered/quant/test_w8a8_quantization.py
+++ b/test/registered/quant/test_w8a8_quantization.py
@@ -15,7 +15,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=232, stage="extra-a", runner_config="1-gpu-large")
-register_amd_ci(est_time=232, suite="extra-a-test-1-gpu-large-amd")
+register_amd_ci(est_time=232, stage="extra-a", runner_config="1-gpu-large-amd")
 
 
 class BaseW8A8Test(CustomTestCase):

--- a/test/registered/quant/test_w8a8_quantization.py
+++ b/test/registered/quant/test_w8a8_quantization.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -15,6 +15,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=232, stage="extra-a", runner_config="1-gpu-large")
+register_amd_ci(est_time=232, suite="extra-a-test-1-gpu-large-amd")
 
 
 class BaseW8A8Test(CustomTestCase):


### PR DESCRIPTION
## Summary

Adds `register_amd_ci(est_time=232, suite="extra-a-test-1-gpu-large-amd")` to `test/registered/quant/test_w8a8_quantization.py`, continuing to fill the thin AMD `1-gpu-large` extra coverage (3/26 vs CUDA).

w8a8 `int8` / `fp8` (including fp8 MoE) quantization kernels are supported on ROCm MI300/MI325, so this exercises a genuinely AMD-relevant path. Three variants run:

| Variant | Model | gsm8k ≥ | throughput ≥ |
|---|---|---|---|
| `TestW8A8Int8` | Llama-3-8B w8a8_int8 | 0.69 | 200 tok/s |
| `TestW8A8Fp8` | Llama-3.1-8B w8a8_fp8 | 0.69 | 200 tok/s |
| `TestW8A8Fp8MoE` | Qwen3-30B-A3B FP8 | 0.88 | 180 tok/s |

**Risk:** the absolute decode-throughput thresholds (200/200/180 tok/s) are H100-tuned and may not be portable to MI325. Verifying on both AMD lanes (mi325 + rocm720) before keeping. If either the accuracy or throughput gate trips, the `register_amd_ci` line is dropped (no register-and-skip).

No production code changes; registration only.

## Test plan

- [ ] `extra-a-test-1-gpu-large-amd` (mi325) green
- [ ] `extra-a-test-1-gpu-large-amd-rocm720` green
- [ ] gsm8k accuracy + throughput gates hold on both lanes























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28120126951](https://github.com/sgl-project/sglang/actions/runs/28120126951)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28120126348](https://github.com/sgl-project/sglang/actions/runs/28120126348)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->