### PR TITLE
[AMD] ci: register scripted-core chunked-prefill on extra-a 1-gpu-small-amd

### DIFF
--- a/test/registered/chunked_prefill/test_scripted_core_1gpu.py
+++ b/test/registered/chunked_prefill/test_scripted_core_1gpu.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.scripted_runtime.context import ScriptedContext
 from sglang.test.scripted_runtime.test_case import ScriptedTestCase
 from sglang.test.scripted_runtime_chunked_helpers import (
@@ -11,6 +11,7 @@ from sglang.test.scripted_runtime_chunked_helpers import (
 )
 
 register_cuda_ci(est_time=300, stage="extra-a", runner_config="1-gpu-small")
+register_amd_ci(est_time=300, stage="extra-a", runner_config="1-gpu-small-amd")
 
 
 _CHUNK_SIZE = 64


### PR DESCRIPTION
## Summary

Adds `register_amd_ci(est_time=300, stage="extra-a", runner_config="1-gpu-small-amd")` to `test/registered/chunked_prefill/test_scripted_core_1gpu.py`.

This is a backend-agnostic scripted-runtime test of **chunked-prefill scheduler logic** — chunk-boundary smoke tests and pause/retract/resume lifecycle — on `Qwen/Qwen3-0.6B` with the **default** backend. No flashinfer/fa, no quant kernels, no accuracy or throughput gate; assertions are purely lifecycle correctness (`assert finished`, retract/resume state). It exercises core engine behavior that should hold identically on ROCm.

Picked from a fresh extra-tier gap audit (21 CUDA `extra-a` files with no AMD registration): this is the only one with zero ROCm-blocking markers. Both `1-gpu-large` gap files are blocked (`test_session_latency` runs gpt-oss-20b mxfp4; `test_spec_ngram_extra` hardcodes flashinfer), so this lands in `1-gpu-small-amd`.

No production code changes; registration only.

## Test plan

Verified green on both AMD extra lanes (dispatched via `pr-test-amd-extra.yml`):

- [x] `extra-a-test-1-gpu-small-amd` (mi325) — ✅ [passing run](https://github.com/sgl-project/sglang/actions/runs/28120721998/job/83271713358)
- [x] `extra-a-test-1-gpu-small-amd-rocm720` — ✅ [passing run](https://github.com/sgl-project/sglang/actions/runs/28120731516/job/83271736812)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28120717556](https://github.com/sgl-project/sglang/actions/runs/28120717556)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28120717361](https://github.com/sgl-project/sglang/actions/runs/28120717361)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->