### PR TITLE
[AMD] Register 5 JIT kernel unit tests for AMD nightly CI

### DIFF
--- a/test/registered/jit/deepseek_v4/test_c128_v2.py
+++ b/test/registered/jit/deepseek_v4/test_c128_v2.py
@@ -16,10 +16,11 @@ from sglang.jit_kernel.tests.deepseek_v4.common import (
     make_state_pool,
     to_seq_extend,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=30, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 Context = Union[LegacyContext, PagedContext]
 

--- a/test/registered/jit/deepseek_v4/test_c4_v2.py
+++ b/test/registered/jit/deepseek_v4/test_c4_v2.py
@@ -16,10 +16,11 @@ from sglang.jit_kernel.tests.deepseek_v4.common import (
     make_state_pool,
     to_seq_extend,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=30, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 Context = Union[LegacyContext, PagedContext]
 

--- a/test/registered/jit/diffusion/test_group_norm_silu.py
+++ b/test/registered/jit/diffusion/test_group_norm_silu.py
@@ -7,10 +7,11 @@ import torch.nn.functional as F
 
 from sglang.jit_kernel.diffusion.group_norm_silu import apply_group_norm_silu
 from sglang.jit_kernel.diffusion.triton.group_norm_silu import triton_group_norm_silu
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=8, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=15, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"
 DTYPES = [torch.float16, torch.bfloat16, torch.float32]

--- a/test/registered/jit/diffusion/test_qwen_image_modulation.py
+++ b/test/registered/jit/diffusion/test_qwen_image_modulation.py
@@ -10,10 +10,11 @@ from sglang.jit_kernel.diffusion.triton.scale_shift import (
     fuse_residual_layernorm_scale_shift_gate_select01_kernel,
 )
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=15, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=30, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"
 DTYPES = get_ci_test_range(

--- a/test/registered/jit/diffusion/test_varlen_pack_pad.py
+++ b/test/registered/jit/diffusion/test_varlen_pack_pad.py
@@ -13,10 +13,11 @@ from sglang.jit_kernel.diffusion.triton.varlen_pack_pad import (
     fused_scatter_to_padded,
 )
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, suite="base-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=15, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"
 DTYPES = get_ci_test_range([torch.bfloat16, torch.float16], [torch.bfloat16])


### PR DESCRIPTION
## Summary

Add `register_amd_ci(suite="nightly-amd-kernel-1-gpu", nightly=True)` to **5** JIT-kernel correctness tests (previously CUDA-only) that are **validated to pass on both ROCm 7.0 and ROCm 7.2** (MI35x / gfx950). This is the next batch following #28967.

**Batch 3 (5 tests):**
- `deepseek_v4/test_c128_v2`
- `deepseek_v4/test_c4_v2`
- `diffusion/test_group_norm_silu`
- `diffusion/test_varlen_pack_pad`
- `diffusion/test_qwen_image_modulation`

## Verified on real MI35x (gfx950, per-file `pytest`)

Run with the checkout's `sglang` on `PYTHONPATH` (shadowing the image's), `SGLANG_USE_AITER=1`, on both stacks — all green on both:

| Test | ROCm 7.0 | ROCm 7.2 |
| --- | --- | --- |
| `deepseek_v4/test_c128_v2` (18 cases) | ✅ 18 passed | ✅ 18 passed |
| `deepseek_v4/test_c4_v2` (23 cases) | ✅ 23 passed | ✅ 23 passed |
| `diffusion/test_group_norm_silu` (14 cases) | ✅ 14 passed | ✅ 14 passed |
| `diffusion/test_varlen_pack_pad` (9 cases) | ✅ 9 passed | ✅ 9 passed |
| `diffusion/test_qwen_image_modulation` (32 cases) | ✅ 32 passed | ✅ 32 passed |

Harness sanity: `test_activation.py` passes 73/73 on both stacks with `PYTHONPATH` set.

## ✅ Dispatched CI verification (`run_suite` nightly kernel job — both green, 9/9 files)

`run_suite.py --hw amd --suite nightly-amd-kernel-1-gpu --nightly` on both stacks, **both jobs passed (9/9 files)**:
- ROCm 7.0 — `nightly-test-1-gpu-kernel`: ✅ [Run #28121769736](https://github.com/sgl-project/sglang/actions/runs/28121769736/job/83275282451)
- ROCm 7.2 — `nightly-test-1-gpu-kernel-rocm720`: ✅ [Run #28121771147](https://github.com/sgl-project/sglang/actions/runs/28121771147/job/83275288460)

## Placement

Mirrors NV's nightly tier (each JIT kernel test dual-registers to `base-b-kernel-unit-1-gpu-large` + `nightly-kernel-1-gpu`). AMD's `nightly-amd-kernel-1-gpu` suite is already wired in `nightly-test-amd.yml` / `nightly-test-amd-rocm720.yml`, so **no workflow changes** are needed.

## Approach — purely additive, AMD-only

- Each file keeps its existing `register_cuda_ci(...)`; we only add one `register_amd_ci(..., nightly=True)` line and `register_amd_ci` to the import.
- No new files, no moves, no workflow changes. NV / MUSA jobs untouched.

## Scope note (why these and not the rest)

Candidates were trial-registered and run on both ROCm stacks; only the ones green on **both** are kept. The remainder were dropped — their failures are **environment / portability gaps, not registration issues** (confirmed from run logs):
- `diffusion/test_fused_norm_scale_shift`: CuTeDSL collection error on ROCm.
- `test_moe_lora_align_block_size`: all cases fail on ROCm.
- Marlin / quant / norm / rope family: un-hipified CUDA headers (`ninja` compile fail), missing `flashinfer`, AOT `sgl_kernel` ops not built on ROCm images, or all-skipped (no real coverage).

These can be revisited once the ROCm jit-build / deps gaps are addressed (separate effort).

## Verification

- `collect_tests(sanity_check=False)` collects all 5 into `nightly-amd-kernel-1-gpu` (each has a `__main__` entry).

## Test plan

- [x] AMD nightly `nightly-amd-kernel-1-gpu` runs all 5 on ROCm 7.0 and 7.2 (validated green on both — see runtime table and dispatched CI runs above).
- [x] No change to NV / MUSA / per-commit AMD behavior (CUDA registrations untouched).





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28121763501](https://github.com/sgl-project/sglang/actions/runs/28121763501)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28145100280](https://github.com/sgl-project/sglang/actions/runs/28145100280)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->