### PR TITLE
[Fix] Fix embedding crash/hang with --tokenizer-worker-num > 1

### DIFF
--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -238,6 +238,14 @@ def _handle_output_by_index(output, i):
             cached_tokens=_extract_field_by_index(output, "cached_tokens", i),
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
+            retraction_counts=_extract_field_by_index(output, "retraction_counts", i),
+            cached_tokens_details=_extract_field_by_index(
+                output, "cached_tokens_details", i
+            ),
+            time_stats=_extract_field_by_index(output, "time_stats", i),
+            pooled_hidden_states=_extract_field_by_index(
+                output, "pooled_hidden_states", i, check_length=False
+            ),
         )
     elif isinstance(output, BatchStrOutput):
         new_output = BatchStrOutput(

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -5,7 +5,7 @@ from sglang.test.test_utils import maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.io_struct import BatchStrOutput
+from sglang.srt.managers.io_struct import BatchEmbeddingOutput, BatchStrOutput
 from sglang.srt.managers.multi_tokenizer_mixin import _handle_output_by_index
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
@@ -62,6 +62,46 @@ class TestMultiTokenizerMixin(unittest.TestCase):
             single_output.cached_tokens_details,
             [{"device": 1, "host": 3}],
         )
+
+    def test_batch_embedding_output_preserves_fields(self):
+        # Regression: the embedding branch of _handle_output_by_index used to
+        # omit retraction_counts (a required field), so splitting any embedding
+        # batch raised TypeError and crashed the multi-tokenizer routing loop.
+        hidden0, hidden1 = object(), object()
+        time0, time1 = object(), object()
+        output = BatchEmbeddingOutput(
+            rids=["rid-0", "rid-1"],
+            finished_reasons=[None, {"type": "length"}],
+            embeddings=[[0.1, 0.2], [0.3, 0.4]],
+            prompt_tokens=[10, 20],
+            cached_tokens=[3, 4],
+            placeholder_tokens_idx=[None, None],
+            placeholder_tokens_val=[None, None],
+            retraction_counts=[0, 2],
+            cached_tokens_details=[
+                {"device": 3, "host": 0},
+                {"device": 1, "host": 3},
+            ],
+            time_stats=[time0, time1],
+            pooled_hidden_states=[hidden0, hidden1],
+        )
+
+        single_output = _handle_output_by_index(output, 1)
+
+        self.assertIsInstance(single_output, BatchEmbeddingOutput)
+        self.assertIsNot(single_output, output)
+        self.assertEqual(single_output.rids, ["rid-1"])
+        self.assertEqual(single_output.embeddings, [[0.3, 0.4]])
+        self.assertEqual(single_output.prompt_tokens, [20])
+        self.assertEqual(single_output.cached_tokens, [4])
+        self.assertEqual(single_output.retraction_counts, [2])
+        self.assertEqual(
+            single_output.cached_tokens_details,
+            [{"device": 1, "host": 3}],
+        )
+        self.assertEqual(single_output.time_stats, [time1])
+        self.assertEqual(len(single_output.pooled_hidden_states), 1)
+        self.assertIs(single_output.pooled_hidden_states[0], hidden1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Serving any **embedding model with `--tokenizer-worker-num > 1`** is currently broken. The embedding branch of `_handle_output_by_index` (in the multi-tokenizer-worker / multi-http-worker output routing path) omits the required `retraction_counts` field when reconstructing a per-request `BatchEmbeddingOutput`. Since `retraction_counts` has no default, splitting any embedding batch raises:

```
TypeError: BatchEmbeddingOutput.__init__() missing 1 required positional argument: 'retraction_counts'
```

This crashes the router/detokenizer event loop, so embedding requests either log the crash (with `--enable-tokenizer-batch-encode`) or **silently hang** (HTTP 000) without it. The `BatchTokenIDOutput` and `BatchStrOutput` branches already pass `retraction_counts`; the embedding branch was missed when the field was introduced in #24944.

This is exactly the configuration high-throughput embedding serving wants: embedding/score requests are prefill-only and very short-lived, so the single tokenizer process saturates a CPU core at high QPS and multiple tokenizer workers are needed to keep the GPU fed.

## Modifications

- `python/sglang/srt/managers/multi_tokenizer_mixin.py`: in the `BatchEmbeddingOutput` branch of `_handle_output_by_index`, pass `retraction_counts` (fixes the crash), and also forward `cached_tokens_details`, `time_stats`, and `pooled_hidden_states` so these request-level fields are partitioned per request instead of dropped — matching the other two branches.
- `test/registered/unit/managers/test_multi_tokenizer_mixin.py`: add a two-request `BatchEmbeddingOutput` regression case (the suite previously only covered `BatchStrOutput`). It asserts the split output preserves `retraction_counts`, `cached_tokens_details`, `time_stats`, and `pooled_hidden_states`. Verified to **fail** against the pre-fix source and **pass** after the fix.

## Accuracy Tests

N/A — no change to kernels or model forward. Output values are unchanged; the patch only fixes per-request fan-out of an already-computed batch output.

## Speed Tests and Profiling

End-to-end on a single B300, `Qwen3-VL-Embedding-2B`, `--is-embedding`, distinct ~512-token inputs (prefix cache disabled so every request does a real prefill), 144–192 in-flight:

| Config | Aggregate QPS | GPU util |
|---|---|---|
| `--tokenizer-worker-num 1` (frontend-bound) | ~300 | ~58% |
| `--tokenizer-worker-num 8` (this PR; previously hung) | **~640** | ~91% |

With the fix, the 8-worker embedding server starts and serves correctly (previously hung at startup/first request), the tokenizer frontend stops being the bottleneck, and throughput scales ~2.1× until the GPU saturates.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28126467020](https://github.com/sgl-project/sglang/actions/runs/28126467020)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28126466747](https://github.com/sgl-project/sglang/actions/runs/28126466747)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->