### PR TITLE
[Unified HiCache] Fix SWA loss in write_back eviction

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -410,11 +410,39 @@ class SWAComponent(TreeComponent):
             else:
                 # Internal: tombstone SWA + cascade
                 x_next = lru.get_prev_no_lock(x)
+
+                self._maybe_backup_swa_before_tombstone(x)
                 self.cache._evict_component_and_detach_lru(
                     x, self, target=EvictLayer.DEVICE, tracker=tracker
                 )
                 self.cache._cascade_evict(x, self, tracker)
                 x = x_next
+
+    def _maybe_backup_swa_before_tombstone(self, node: UnifiedTreeNode) -> None:
+        """Back up an internal node's SWA+FULL to host before the sliding window
+        tombstones its SWA on device (HiCache write_back only).
+
+        Without this the SWA chunk is dropped, so a later host hit at a boundary
+        inside the node can't rebuild the window. write_backup leaves a host-only
+        SWA copy that LOAD_BACK restores. The D->H copy is drained synchronously
+        (writing_check) before we tombstone the device chunk, so the host copy is
+        fully materialized and a later evict_host in this sweep can't race it.
+        """
+        cache = self.cache
+        controller = cache.cache_controller
+        if controller is None or controller.write_policy != "write_back":
+            return
+        ct = self.component_type
+        cd = node.component_data[ct]
+        # Nothing to preserve if SWA already gone, already on host, or the node's
+        # FULL slice is not on device (write_backup needs live FULL indices and
+        # would otherwise orphan/duplicate the existing host backup).
+        if cd.value is None or cd.host_value is not None:
+            return
+        if node.backuped or node.component_data[BASE_COMPONENT_TYPE].value is None:
+            return
+        if cache.write_backup(node, write_back=True) > 0:
+            cache.writing_check(write_back=True)
 
     def acquire_component_lock(
         self,

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -3220,6 +3220,69 @@ class UnifiedRadixCacheSuite:
 
         tree.sanity_check()
 
+    def test_swa_write_back_internal_node_backed_up_before_tombstone(self):
+        """write_back + SWA: the sliding window force-evicts SWA from device
+        before the FULL leaf is ever evicted/backed-up. An *internal* node's
+        in-window SWA chunk must be backed up to host (not silently dropped),
+        otherwise a later host hit cannot reconstruct a valid SWA window at a
+        boundary inside that node -- a decode-time host cache-hit correctness
+        failure.
+
+        Regression guard: without the backup-before-tombstone, the internal
+        node's SWA goes to None on both device and host (GONE) while its FULL
+        stays live, so this asserts host_value is populated instead.
+        """
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA")
+        if self._skip_unsupported_hicache_test():
+            return
+        if self.cfg.has_mamba:
+            self.skipTest("SWA-only keeps the split topology precise")
+
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        self._init_hicache(tree, write_policy="write_back")
+        ps = self.cfg.page_size
+        tail_size = ((self.cfg.sliding_window_size + ps - 1) // ps) * ps
+        wp = max(1, tail_size // ps)
+
+        # Long enough that _maybe_split_leaf_for_swa_lock splits the insert into
+        # an out-of-window internal node + a window-capped leaf.
+        seq = self._make_seq(1, wp + 3)
+        if (
+            allocator.full_available_size() < len(seq)
+            or allocator.swa_available_size() < len(seq)
+        ):
+            self.skipTest("kv pool too small for split topology")
+        self._insert(tree, allocator, req_to_token_pool, seq)
+        tree.writing_check(write_back=True)
+
+        m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
+        leaf = m.last_device_node
+        parent = leaf.parent
+        self.assertIsNot(parent, tree.root_node, "expected a split internal node")
+
+        ct = ComponentType.SWA
+        # Internal node currently holds SWA on device only, FULL on device.
+        self.assertIsNotNone(parent.component_data[ct].value)
+        self.assertIsNone(parent.component_data[ct].host_value)
+        self.assertFalse(parent.backuped)
+        self.assertIsNotNone(parent.component_data[ComponentType.FULL].value)
+
+        # Force SWA-only device eviction (window pressure) without evicting FULL.
+        tree.evict(EvictParams(num_tokens=0, swa_num_tokens=len(seq)))
+        tree.writing_check(write_back=True)
+
+        pcd = parent.component_data[ct]
+        self.assertIsNone(
+            pcd.value, "SWA device chunk should be tombstoned by window pressure"
+        )
+        self.assertIsNotNone(
+            pcd.host_value,
+            "write_back must back up an internal node's SWA to host before "
+            "tombstoning it, so a later host hit can restore the SWA window",
+        )
+        tree.sanity_check()
+
     def test_hicache_evict_to_host_updates_aux_lru(self):
         """Aux components (MAMBA / SWA) move from device LRU to host LRU on D->H eviction."""
         aux_types = [

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -3248,10 +3248,9 @@ class UnifiedRadixCacheSuite:
         # Long enough that _maybe_split_leaf_for_swa_lock splits the insert into
         # an out-of-window internal node + a window-capped leaf.
         seq = self._make_seq(1, wp + 3)
-        if (
-            allocator.full_available_size() < len(seq)
-            or allocator.swa_available_size() < len(seq)
-        ):
+        if allocator.full_available_size() < len(
+            seq
+        ) or allocator.swa_available_size() < len(seq):
             self.skipTest("kv pool too small for split topology")
         self._insert(tree, allocator, req_to_token_pool, seq)
         tree.writing_check(write_back=True)


### PR DESCRIPTION
## Summary
- When swa + hicache + write_back, tombstone internal node won't backup the internal node. So when evict leaf happens later, the internal node's swa value is already gone, causing cache hit rate drop. The PR fixes that by backing up the node before tombstoning an internal node.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28131824346](https://github.com/sgl-project/sglang/actions/runs/28131824346)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28131824253](https://github.com/sgl-project/sglang/actions/runs/28131824253)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->