### PR TITLE
[Parser] Preserve flat max_dynamic_patch for image content

### DIFF
--- a/python/sglang/srt/parser/jinja_template_utils.py
+++ b/python/sglang/srt/parser/jinja_template_utils.py
@@ -161,8 +161,10 @@ def process_content_for_template_format(
                     image_obj = chunk.get("image_url") or {}
                     if isinstance(image_obj, str):
                         image_obj = {"url": image_obj, "detail": chunk.get("detail")}
-                    mdp = image_obj.get("max_dynamic_patch", None)
                     # Also allow flat style: chunk["max_dynamic_patch"]
+                    mdp = image_obj.get(
+                        "max_dynamic_patch", chunk.get("max_dynamic_patch", None)
+                    )
                     image_data.append(
                         ImageData(
                             url=image_obj["url"],

--- a/test/registered/unit/parser/test_jinja_template_utils.py
+++ b/test/registered/unit/parser/test_jinja_template_utils.py
@@ -285,6 +285,35 @@ class TestTemplateContentFormatDetection(CustomTestCase):
         self.assertEqual(len(modalities), 1)
         self.assertEqual(modalities[0], ["vision"])
 
+    def test_process_content_image_with_flat_max_dynamic_patch(self):
+        """Test flat image max_dynamic_patch is preserved in ImageData."""
+        msg_dict = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": "http://example.com/image.jpg",
+                    "detail": "high",
+                    "max_dynamic_patch": 8,
+                }
+            ],
+        }
+
+        image_data = []
+        video_data = []
+        audio_data = []
+        modalities = []
+
+        result = process_content_for_template_format(
+            msg_dict, "openai", image_data, video_data, audio_data, modalities
+        )
+
+        self.assertEqual(result["content"], [{"type": "image"}])
+        self.assertEqual(len(image_data), 1)
+        self.assertEqual(image_data[0].url, "http://example.com/image.jpg")
+        self.assertEqual(image_data[0].detail, "high")
+        self.assertEqual(image_data[0].max_dynamic_patch, 8)
+
     def test_process_content_filter_none_values(self):
         """Test that None values are filtered out of processed messages."""
         msg_dict = {


### PR DESCRIPTION
## Motivation

`process_content_for_template_format()` documents support for flat image chunk metadata via `chunk["max_dynamic_patch"]`, but the image path only read `max_dynamic_patch` from the nested `image_url` object. This meant Responses-style `input_image` payloads with flat `max_dynamic_patch` lost that value when converted into `ImageData`.

This is a small follow-up under #20865 to add unit coverage for parser behavior without launching a server or loading model weights.

## Modifications

- Preserve flat `max_dynamic_patch` for image chunks by using it as a fallback when the nested image object does not define one.
- Add a unit test covering `input_image` content with flat `max_dynamic_patch`, including URL, detail, normalized content, and `ImageData.max_dynamic_patch`.

## Accuracy Tests

N/A. This does not affect model outputs.

## Speed Tests and Profiling

N/A. This only changes request content preprocessing for image metadata.

## Checklist

- [ ] Format your code according to the contribution guide. (`pre-commit` was not available locally; `git diff --check` passed.)
- [x] Add unit tests according to the contribution guide.
- [ ] Update documentation according to the contribution guide. (No docs update needed for this small behavior fix.)
- [ ] Provide accuracy and speed benchmark results. (N/A.)
- [x] Follow the SGLang code style guidance.

Local test:

```bash
PYTHONPATH=python pytest test/registered/unit/parser/test_jinja_template_utils.py -q
```

```text
........................                                                 [100%]
24 passed, 4 warnings in 6.01s
```







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28128953719](https://github.com/sgl-project/sglang/actions/runs/28128953719)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28128953666](https://github.com/sgl-project/sglang/actions/runs/28128953666)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->