### PR TITLE
[disagg] Fix KV-event publisher port collision under pure data parallelism

### DIFF
--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -36,6 +36,28 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 
+def select_kv_publisher_dp_rank(
+    attn_dp_size: int, attn_dp_rank: int, dp_rank: Optional[int]
+) -> int:
+    """Index used to offset this scheduler's KV-event publisher port.
+
+    Each independent KV cache must publish on its own port so a consumer can
+    subscribe per replica. There are always ``dp_size`` such publishers; which
+    rank distinguishes them depends on the parallelism mode:
+
+    - DP-attention (``attn_dp_size > 1``): each attention-DP rank owns a KV
+      cache shard, so distinguish by ``attn_dp_rank``.
+    - Pure DP (``attn_dp_size == 1``): every worker has ``attn_dp_rank == 0``,
+      so distinguish by ``dp_rank`` (the data-parallel replica index).
+
+    Both span ``0..dp_size-1``, matching the ``dp_size`` advertised in
+    ``/server_info`` and the per-rank ports the router subscribes to.
+    """
+    if attn_dp_size > 1:
+        return attn_dp_rank
+    return dp_rank or 0
+
+
 class EventBatch(
     msgspec.Struct,
     array_like=True,  # type: ignore[call-arg]

--- a/python/sglang/srt/managers/scheduler_components/kv_events_publisher.py
+++ b/python/sglang/srt/managers/scheduler_components/kv_events_publisher.py
@@ -15,6 +15,7 @@ import zmq
 from sglang.srt.disaggregation.kv_events import (
     EventPublisherFactory,
     KVEventBatch,
+    select_kv_publisher_dp_rank,
 )
 from sglang.srt.managers.io_struct import sock_send
 
@@ -64,7 +65,10 @@ class SchedulerKvEventsPublisher:
 
         if self.enable_kv_cache_events:
             self.kv_event_publisher = EventPublisherFactory.create(
-                kv_events_config, self.ps.attn_dp_rank
+                kv_events_config,
+                select_kv_publisher_dp_rank(
+                    self.ps.attn_dp_size, self.ps.attn_dp_rank, self.ps.dp_rank
+                ),
             )
 
     def emit_kv_metrics(self):

--- a/test/registered/unit/disaggregation/test_kv_events.py
+++ b/test/registered/unit/disaggregation/test_kv_events.py
@@ -1,0 +1,98 @@
+"""Unit tests for srt/disaggregation/kv_events KV-event publisher rank selection.
+
+Covers the data-parallel rank used to offset each scheduler's KV-event
+publisher port, across pure DP, DP-attention, and single-replica modes. The
+port offset must make every independent KV cache publish on a distinct port so
+the router can subscribe per replica (the `dp_size` it reads from
+`/server_info`).
+"""
+
+import unittest
+
+from sglang.srt.disaggregation.kv_events import (
+    ZmqEventPublisher,
+    select_kv_publisher_dp_rank,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestSelectKvPublisherDpRank(CustomTestCase):
+    def test_select_rank_across_modes(self):
+        # (label, attn_dp_size, attn_dp_rank, dp_rank, expected)
+        cases = [
+            # Pure DP (no dp-attention): attn_dp_rank is 0 for every worker,
+            # so the replica is distinguished by dp_rank.
+            ("pure_dp_worker0", 1, 0, 0, 0),
+            ("pure_dp_worker1", 1, 0, 1, 1),
+            ("pure_dp_worker3", 1, 0, 3, 3),
+            # DP-attention: each attn-dp rank owns a KV shard; distinguish by
+            # attn_dp_rank. dp_rank is ignored entirely in this mode.
+            ("dp_attention_rank0", 2, 0, None, 0),
+            ("dp_attention_rank1", 2, 1, None, 1),
+            ("dp_attention_ignores_dp_rank", 2, 1, 99, 1),
+            # Single replica / no DP.
+            ("single_dp_rank_none", 1, 0, None, 0),
+            ("single_dp_rank_zero", 1, 0, 0, 0),
+        ]
+        for label, attn_dp_size, attn_dp_rank, dp_rank, expected in cases:
+            with self.subTest(label):
+                self.assertEqual(
+                    select_kv_publisher_dp_rank(attn_dp_size, attn_dp_rank, dp_rank),
+                    expected,
+                )
+
+    def test_workers_bind_sequential_ports_per_replica(self):
+        # Each replica r must publish on port_base + r, since the router opens
+        # one SUB socket per rank at port_base + r. Regression: pre-fix every
+        # pure-DP worker offset by attn_dp_rank == 0, so all collapsed onto the
+        # single port tcp://*:5557 -> the 2nd worker crashed binding an
+        # already-bound port.
+        endpoint = "tcp://*:5557"
+        expected = [f"tcp://*:{5557 + r}" for r in range(4)]
+
+        # Pure DP: replica index is dp_rank (attn_dp_rank is 0 for all).
+        pure_dp = [
+            ZmqEventPublisher.offset_endpoint_port(
+                endpoint, select_kv_publisher_dp_rank(1, 0, r)
+            )
+            for r in range(4)
+        ]
+        self.assertEqual(pure_dp, expected)
+
+        # DP-attention: replica index is attn_dp_rank.
+        dp_attention = [
+            ZmqEventPublisher.offset_endpoint_port(
+                endpoint, select_kv_publisher_dp_rank(4, a, None)
+            )
+            for a in range(4)
+        ]
+        self.assertEqual(dp_attention, expected)
+
+    def test_publisher_rank_count_matches_advertised_dp_size(self):
+        # The router subscribes to `dp_size` per-rank ports (from /server_info).
+        # The engine must produce exactly `dp_size` distinct publisher ranks in
+        # both modes, otherwise some subscribed ports get no data.
+        for dp_size in (1, 2, 4):
+            with self.subTest(f"pure_dp_{dp_size}"):
+                ranks = {
+                    select_kv_publisher_dp_rank(
+                        attn_dp_size=1, attn_dp_rank=0, dp_rank=r
+                    )
+                    for r in range(dp_size)
+                }
+                self.assertEqual(len(ranks), dp_size)
+            with self.subTest(f"dp_attention_{dp_size}"):
+                ranks = {
+                    select_kv_publisher_dp_rank(
+                        attn_dp_size=dp_size, attn_dp_rank=a, dp_rank=None
+                    )
+                    for a in range(dp_size)
+                }
+                self.assertEqual(len(ranks), dp_size)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When an engine runs **pure data parallelism** (`--dp-size N` *without* `--enable-dp-attention`) and KV-event publishing is enabled (`--kv-events-config`), all `N` data-parallel workers publish KV events on the **same** ZMQ port.

The publisher offsets its endpoint port by `attn_dp_rank`. But `compute_dp_attention_world_info` sets `attn_dp_rank = 0` for **every** worker when DP-attention is off (the real replica index lives in `dp_rank`, which `DataParallelController` assigns `0..N-1`). So every publisher offsets by `0`:

- **Binding endpoint** (`tcp://*:PORT`): the second worker dies at startup with
  `zmq.error.ZMQError: Address already in use` — the engine never starts.
- **Connecting endpoint** (`tcp://host:PORT`): no crash, but only `PORT+0` ever
  carries data; the other `N-1` per-rank streams a consumer subscribes to stay empty.

Meanwhile `/server_info` already advertises `dp_size = N`, and a KV-aware router opens one SUB socket per rank `0..N-1` — so it expects `N` distinct publisher ports the engine never provides.

## Modifications

- Add `select_kv_publisher_dp_rank(attn_dp_size, attn_dp_rank, dp_rank)` in `python/sglang/srt/disaggregation/kv_events.py`. It returns the rank that spans `0..dp_size-1` in the active mode: `attn_dp_rank` under DP-attention (`attn_dp_size > 1`), `dp_rank` under pure DP.
- Use it in `SchedulerKvEventsPublisher.init_kv_events` in place of the bare `self.ps.attn_dp_rank`.

The publisher count is exactly `dp_size` in both modes (pure DP distinguished by `dp_rank`, DP-attention by `attn_dp_rank`), which matches the `dp_size` advertised in `/server_info` and the per-rank ports a KV-aware router subscribes to. **DP-attention behavior is unchanged.** No router-side change is needed.

## Verification

- New CPU unit test `test/registered/unit/disaggregation/test_kv_events.py` (`base-a-test-cpu`): rank selection across pure DP / DP-attention / single / `dp_rank=None`; the sequential per-replica port mapping (`port_base + rank`) in both modes; and that the publisher count matches the advertised `dp_size`.
- Verified on 2×H200: before, a pure-DP-2 engine with `--kv-events-config '{"endpoint":"tcp://*:5557"}'` crashed the second worker on bind; with real ZMQ `bind()` calls, the old offset collides on `tcp://*:5557` while the new one binds `tcp://*:5557` and `tcp://*:5558` cleanly.

## Checklist

- [x] Format the code and run unit tests
- [x] Add unit tests covering the new behavior
- [x] Pure-Python change; no GPU-specific code paths affected

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28133448715](https://github.com/sgl-project/sglang/actions/runs/28133448715)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28133448616](https://github.com/sgl-project/sglang/actions/runs/28133448616)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->