### PR TITLE
[Diffusion] Add checkpoint namespace resolver for fused weights and quant metadata  

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/qwenimage.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/qwenimage.py
@@ -31,6 +31,23 @@ class QwenImageArchConfig(DiTArchConfig):
         default_factory=lambda: {
             # LoRA mappings
             r"^(transformer_blocks\.\d+\.attn\..*\.lora_[AB])\.default$": r"\1",
+            # Diffusers stores to_out as a flat Linear; runtime wraps it in ModuleList.
+            r"^(transformer_blocks\.\d+\.attn\.to_out)\.(weight|bias)$": r"\1.0.\2",
+            r"^(transformer_blocks\.\d+\.attn)\.add_q_proj\.(weight|bias)$": (
+                r"\1.to_added_qkv.\2",
+                0,
+                3,
+            ),
+            r"^(transformer_blocks\.\d+\.attn)\.add_k_proj\.(weight|bias)$": (
+                r"\1.to_added_qkv.\2",
+                1,
+                3,
+            ),
+            r"^(transformer_blocks\.\d+\.attn)\.add_v_proj\.(weight|bias)$": (
+                r"\1.to_added_qkv.\2",
+                2,
+                3,
+            ),
             # SVDquant mappings
             r"(.*)\.add_qkv_proj\.(.+)$": r"\1.to_added_qkv.\2",
             r"(transformer_blocks\.\d+\.(img_mlp|txt_mlp)\..*\.(smooth_factor_orig|wcscales))$": r"\1",

--- a/python/sglang/multimodal_gen/runtime/layers/quantization/configs/nunchaku_config.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/configs/nunchaku_config.py
@@ -10,11 +10,22 @@ from safetensors.torch import load_file as safetensors_load_file
 from torch import nn
 
 from sglang.multimodal_gen.runtime.layers.linear import LinearBase
+from sglang.multimodal_gen.runtime.loader.checkpoint_name_resolver import (
+    CheckpointNameResolver,
+)
+from sglang.multimodal_gen.runtime.loader.utils import get_param_names_mapping
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 from .base_config import QuantizationConfig, QuantizeMethodBase
 
 logger = init_logger(__name__)
+
+
+def _get_model_param_names_mapping(model: nn.Module) -> dict:
+    mapping = getattr(model, "param_names_mapping", None)
+    if mapping is not None:
+        return mapping
+    return getattr(getattr(model, "module", None), "param_names_mapping", {})
 
 
 @lru_cache(maxsize=1)
@@ -252,18 +263,24 @@ def _patch_nunchaku_scales(
 
     num_wtscale = 0
     num_wcscales = 0
+    resolver = CheckpointNameResolver(
+        get_param_names_mapping(_get_model_param_names_mapping(model))
+    )
+    metadata_maps = resolver.metadata_key_map(
+        state_dict.keys(), ("wtscale", "wcscales")
+    )
 
     from ..nunchaku_linear import NunchakuSVDQLinearMethod
 
     for name, module in model.named_modules():
-        wt = state_dict.get(f"{name}.wtscale")
+        wt = state_dict.get(metadata_maps["wtscale"].get(name, f"{name}.wtscale"))
         if wt is not None:
             if _patch_native_svdq_linear(module, wt, SVDQW4A4Linear):
                 num_wtscale += 1
             elif _patch_sglang_svdq_linear(module, wt, NunchakuSVDQLinearMethod):
                 num_wtscale += 1
 
-        wc = state_dict.get(f"{name}.wcscales")
+        wc = state_dict.get(metadata_maps["wcscales"].get(name, f"{name}.wcscales"))
         if wc is not None:
             # Some modules may have wcscales as a direct attribute/Parameter.
             existing = getattr(module, "wcscales", None)

--- a/python/sglang/multimodal_gen/runtime/layers/quantization/configs/nunchaku_config.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/configs/nunchaku_config.py
@@ -10,11 +10,21 @@ from safetensors.torch import load_file as safetensors_load_file
 from torch import nn
 
 from sglang.multimodal_gen.runtime.layers.linear import LinearBase
+from sglang.multimodal_gen.runtime.loader.checkpoint_name_resolver import (
+    CheckpointNameResolver,
+)
+from sglang.multimodal_gen.runtime.loader.utils import get_param_names_mapping
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 from .base_config import QuantizationConfig, QuantizeMethodBase
 
 logger = init_logger(__name__)
+
+
+def _get_model_param_names_mapping(model: nn.Module) -> dict:
+    return getattr(model, "param_names_mapping", None) or getattr(
+        getattr(model, "module", None), "param_names_mapping", {}
+    )
 
 
 @lru_cache(maxsize=1)
@@ -252,18 +262,24 @@ def _patch_nunchaku_scales(
 
     num_wtscale = 0
     num_wcscales = 0
+    resolver = CheckpointNameResolver(
+        get_param_names_mapping(_get_model_param_names_mapping(model))
+    )
+    metadata_maps = resolver.metadata_key_map(
+        state_dict.keys(), ("wtscale", "wcscales")
+    )
 
     from ..nunchaku_linear import NunchakuSVDQLinearMethod
 
     for name, module in model.named_modules():
-        wt = state_dict.get(f"{name}.wtscale")
+        wt = state_dict.get(metadata_maps["wtscale"].get(name, f"{name}.wtscale"))
         if wt is not None:
             if _patch_native_svdq_linear(module, wt, SVDQW4A4Linear):
                 num_wtscale += 1
             elif _patch_sglang_svdq_linear(module, wt, NunchakuSVDQLinearMethod):
                 num_wtscale += 1
 
-        wc = state_dict.get(f"{name}.wcscales")
+        wc = state_dict.get(metadata_maps["wcscales"].get(name, f"{name}.wcscales"))
         if wc is not None:
             # Some modules may have wcscales as a direct attribute/Parameter.
             existing = getattr(module, "wcscales", None)

--- a/python/sglang/multimodal_gen/runtime/loader/checkpoint_name_resolver.py
+++ b/python/sglang/multimodal_gen/runtime/loader/checkpoint_name_resolver.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SourceParamShard:
+    source_name: str
+    merge_index: int | None
+    num_params_to_merge: int | None
+
+
+class CheckpointNameResolver:
+    """Small wrapper around checkpoint-to-runtime parameter name mapping."""
+
+    def __init__(self, mapping_fn: Callable[[str], tuple[str, Any, Any]]):
+        self.mapping_fn = mapping_fn
+        self.reverse_param_names_mapping: dict[str, tuple[str, Any, Any]] = {}
+        self.source_param_shards_by_target: dict[str, list[SourceParamShard]] = (
+            defaultdict(list)
+        )
+        self._fused_sources_by_target: dict[str, dict[int, str]] = defaultdict(dict)
+        self._fused_expected_by_target: dict[str, int] = {}
+
+    def map_source_param(self, source_name: str) -> tuple[str, Any, Any]:
+        return self.mapping_fn(source_name)
+
+    def record_source_param(
+        self,
+        source_name: str,
+        target_name: str,
+        merge_index: int | None,
+        num_params_to_merge: int | None,
+    ) -> None:
+        # Legacy single-entry mapping kept for backward compatibility.
+        # Use source_param_shards_by_target when all source shards are needed.
+        self.reverse_param_names_mapping[target_name] = (
+            source_name,
+            merge_index,
+            num_params_to_merge,
+        )
+        self.source_param_shards_by_target[target_name].append(
+            SourceParamShard(source_name, merge_index, num_params_to_merge)
+        )
+        if merge_index is None:
+            return
+        self._fused_sources_by_target[target_name][merge_index] = source_name
+        self._fused_expected_by_target[target_name] = int(num_params_to_merge)
+
+    def validate_complete_fused_params(self) -> None:
+        incomplete: list[str] = []
+        for target_name, expected in sorted(self._fused_expected_by_target.items()):
+            seen = self._fused_sources_by_target.get(target_name, {})
+            if len(seen) == expected:
+                continue
+            missing = [idx for idx in range(expected) if idx not in seen]
+            present = ", ".join(f"{idx}:{seen[idx]}" for idx in sorted(seen))
+            incomplete.append(
+                f"{target_name} missing shard(s) {missing}; present [{present}]"
+            )
+        if incomplete:
+            raise ValueError(
+                "Incomplete fused checkpoint parameter merge: " + "; ".join(incomplete)
+            )
+
+    def metadata_key_map(
+        self,
+        source_keys: Iterable[str],
+        suffixes: Iterable[str],
+    ) -> dict[str, dict[str, str]]:
+        suffix_set = set(suffixes)
+        maps: dict[str, dict[str, str]] = {suffix: {} for suffix in suffix_set}
+        for key in source_keys:
+            for suffix in suffix_set:
+                marker = f".{suffix}"
+                if not key.endswith(marker):
+                    continue
+                source_module = key[: -len(marker)]
+                # Keep checkpoint-side lookup available for callers that already
+                # have source names; the first key wins if duplicates appear.
+                maps[suffix].setdefault(source_module, key)
+                for param_suffix in ("weight", "bias"):
+                    target_name, _, _ = self.map_source_param(
+                        f"{source_module}.{param_suffix}"
+                    )
+                    if not target_name:
+                        continue
+                    runtime_module = target_name.rsplit(".", 1)[0]
+                    maps[suffix].setdefault(runtime_module, key)
+        return maps

--- a/python/sglang/multimodal_gen/runtime/loader/checkpoint_name_resolver.py
+++ b/python/sglang/multimodal_gen/runtime/loader/checkpoint_name_resolver.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SourceParamShard:
+    source_name: str
+    merge_index: int | None
+    num_params_to_merge: int | None
+
+
+class CheckpointNameResolver:
+    """Small wrapper around checkpoint-to-runtime parameter name mapping."""
+
+    def __init__(self, mapping_fn: Callable[[str], tuple[str, Any, Any]]):
+        self.mapping_fn = mapping_fn
+        self.reverse_param_names_mapping: dict[str, tuple[str, Any, Any]] = {}
+        self.source_param_shards_by_target: dict[str, list[SourceParamShard]] = (
+            defaultdict(list)
+        )
+        self._fused_sources_by_target: dict[str, dict[int, str]] = defaultdict(dict)
+        self._fused_expected_by_target: dict[str, int] = {}
+
+    def map_source_param(self, source_name: str) -> tuple[str, Any, Any]:
+        return self.mapping_fn(source_name)
+
+    def record_source_param(
+        self,
+        source_name: str,
+        target_name: str,
+        merge_index: int | None,
+        num_params_to_merge: int | None,
+    ) -> None:
+        self.reverse_param_names_mapping[target_name] = (
+            source_name,
+            merge_index,
+            num_params_to_merge,
+        )
+        self.source_param_shards_by_target[target_name].append(
+            SourceParamShard(source_name, merge_index, num_params_to_merge)
+        )
+        if merge_index is None:
+            return
+        self._fused_sources_by_target[target_name][merge_index] = source_name
+        self._fused_expected_by_target[target_name] = int(num_params_to_merge)
+
+    def validate_complete_fused_params(self) -> None:
+        incomplete: list[str] = []
+        for target_name, expected in sorted(self._fused_expected_by_target.items()):
+            seen = self._fused_sources_by_target.get(target_name, {})
+            if len(seen) == expected:
+                continue
+            missing = [idx for idx in range(expected) if idx not in seen]
+            present = ", ".join(f"{idx}:{seen[idx]}" for idx in sorted(seen))
+            incomplete.append(
+                f"{target_name} missing shard(s) {missing}; present [{present}]"
+            )
+        if incomplete:
+            raise ValueError(
+                "Incomplete fused checkpoint parameter merge: " + "; ".join(incomplete)
+            )
+
+    def metadata_key_map(
+        self,
+        source_keys: Iterable[str],
+        suffixes: Iterable[str],
+    ) -> dict[str, dict[str, str]]:
+        suffix_set = set(suffixes)
+        maps: dict[str, dict[str, str]] = {suffix: {} for suffix in suffix_set}
+        for key in source_keys:
+            for suffix in suffix_set:
+                marker = f".{suffix}"
+                if not key.endswith(marker):
+                    continue
+                source_module = key[: -len(marker)]
+                maps[suffix].setdefault(source_module, key)
+                for param_suffix in ("weight", "bias"):
+                    target_name, _, _ = self.map_source_param(
+                        f"{source_module}.{param_suffix}"
+                    )
+                    if not target_name:
+                        continue
+                    runtime_module = target_name.rsplit(".", 1)[0]
+                    maps[suffix].setdefault(runtime_module, key)
+        return maps

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -416,10 +416,13 @@ def load_model_from_full_model_state_dict(
     param_dict = dict(model.named_parameters())
 
     # map names from checkpoint to customized names
-    custom_param_sd, reverse_param_names_mapping = hf_to_custom_state_dict(
-        full_sd_iterator,
-        param_names_mapping,
-        valid_target_names=set(meta_sd.keys()),
+    custom_param_sd, reverse_param_names_mapping, checkpoint_name_resolver = (
+        hf_to_custom_state_dict(
+            full_sd_iterator,
+            param_names_mapping,
+            valid_target_names=set(meta_sd.keys()),
+            return_resolver=True,
+        )
     )  # type: ignore
 
     is_fsdp_model = isinstance(model, FSDPModule) or any(
@@ -597,6 +600,9 @@ def load_model_from_full_model_state_dict(
             )
 
     model.reverse_param_names_mapping = reverse_param_names_mapping
+    model.checkpoint_source_param_shards_by_target = dict(
+        checkpoint_name_resolver.source_param_shards_by_target
+    )
 
     if non_quantized_dtype_mismatch_counts:
         logger.debug(

--- a/python/sglang/multimodal_gen/runtime/loader/utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/utils.py
@@ -14,6 +14,9 @@ from typing import Any, Dict, Type
 import torch
 from torch import nn
 
+from sglang.multimodal_gen.runtime.loader.checkpoint_name_resolver import (
+    CheckpointNameResolver,
+)
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
@@ -103,7 +106,13 @@ def hf_to_custom_state_dict(
     hf_param_sd: dict[str, torch.Tensor] | Iterator[tuple[str, torch.Tensor]],
     param_names_mapping: Callable[[str], tuple[str, Any, Any]],
     valid_target_names: set[str] | None = None,
-) -> tuple[dict[str, torch.Tensor], dict[str, tuple[str, Any, Any]]]:
+    return_resolver: bool = False,
+) -> (
+    tuple[dict[str, torch.Tensor], dict[str, tuple[str, Any, Any]]]
+    | tuple[
+        dict[str, torch.Tensor], dict[str, tuple[str, Any, Any]], CheckpointNameResolver
+    ]
+):
     """
     Converts a Hugging Face parameter state dictionary to a custom parameter state dictionary.
 
@@ -117,11 +126,11 @@ def hf_to_custom_state_dict(
     """
     custom_param_sd = {}
     to_merge_params = defaultdict(dict)  # type: ignore
-    reverse_param_names_mapping = {}
+    resolver = CheckpointNameResolver(param_names_mapping)
     if isinstance(hf_param_sd, dict):
         hf_param_sd = hf_param_sd.items()  # type: ignore
     for source_param_name, full_tensor in hf_param_sd:  # type: ignore
-        target_param_name, merge_index, num_params_to_merge = param_names_mapping(
+        target_param_name, merge_index, num_params_to_merge = resolver.map_source_param(
             source_param_name
         )
         if (
@@ -135,8 +144,9 @@ def hf_to_custom_state_dict(
             num_params_to_merge = None
         if target_param_name == "" or target_param_name is None:  # type: ignore[comparison-overlap]
             continue
-        reverse_param_names_mapping[target_param_name] = (
+        resolver.record_source_param(
             source_param_name,
+            target_param_name,
             merge_index,
             num_params_to_merge,
         )
@@ -172,7 +182,10 @@ def hf_to_custom_state_dict(
                     full_tensor.dtype,
                 )
         custom_param_sd[target_param_name] = full_tensor
-    return custom_param_sd, reverse_param_names_mapping
+    resolver.validate_complete_fused_params()
+    if return_resolver:
+        return custom_param_sd, resolver.reverse_param_names_mapping, resolver
+    return custom_param_sd, resolver.reverse_param_names_mapping
 
 
 class skip_init_modules:

--- a/python/sglang/multimodal_gen/test/unit/test_checkpoint_name_resolver.py
+++ b/python/sglang/multimodal_gen/test/unit/test_checkpoint_name_resolver.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+
+import torch
+
+from sglang.multimodal_gen.configs.models.dits.qwenimage import QwenImageArchConfig
+from sglang.multimodal_gen.runtime.loader.checkpoint_name_resolver import (
+    CheckpointNameResolver,
+)
+from sglang.multimodal_gen.runtime.loader.utils import (
+    get_param_names_mapping,
+    hf_to_custom_state_dict,
+)
+
+
+class TestCheckpointNameResolver(unittest.TestCase):
+    def _qwen_mapping(self):
+        return get_param_names_mapping(QwenImageArchConfig().param_names_mapping)
+
+    def test_qwenimage_to_out_direct_rename(self):
+        mapped, _, _ = self._qwen_mapping()("transformer_blocks.0.attn.to_out.weight")
+
+        self.assertEqual(mapped, "transformer_blocks.0.attn.to_out.0.weight")
+
+    def test_qwenimage_added_qkv_fused_mapping(self):
+        state_dict = {
+            "transformer_blocks.0.attn.add_q_proj.weight": torch.ones(1, 2),
+            "transformer_blocks.0.attn.add_k_proj.weight": torch.ones(1, 2) * 2,
+            "transformer_blocks.0.attn.add_v_proj.weight": torch.ones(1, 2) * 3,
+        }
+
+        custom_sd, _, resolver = hf_to_custom_state_dict(
+            state_dict, self._qwen_mapping(), return_resolver=True
+        )
+
+        fused = custom_sd["transformer_blocks.0.attn.to_added_qkv.weight"]
+        self.assertTrue(
+            torch.equal(fused, torch.tensor([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]]))
+        )
+        shards = resolver.source_param_shards_by_target[
+            "transformer_blocks.0.attn.to_added_qkv.weight"
+        ]
+        self.assertEqual([shard.source_name for shard in shards], list(state_dict))
+
+    def test_incomplete_fused_mapping_raises(self):
+        state_dict = {
+            "transformer_blocks.0.attn.add_q_proj.weight": torch.ones(1, 2),
+            "transformer_blocks.0.attn.add_k_proj.weight": torch.ones(1, 2),
+        }
+
+        with self.assertRaisesRegex(ValueError, "missing shard"):
+            hf_to_custom_state_dict(state_dict, self._qwen_mapping())
+
+    def test_metadata_key_map_uses_checkpoint_side_candidates(self):
+        resolver = CheckpointNameResolver(self._qwen_mapping())
+
+        metadata_map = resolver.metadata_key_map(
+            ["transformer_blocks.0.attn.add_q_proj.wtscale"], ("wtscale",)
+        )
+
+        self.assertEqual(
+            metadata_map["wtscale"]["transformer_blocks.0.attn.to_added_qkv"],
+            "transformer_blocks.0.attn.add_q_proj.wtscale",
+        )
+
+    def test_ignored_tensor_stays_ignored(self):
+        custom_sd, _ = hf_to_custom_state_dict(
+            {"transformer_blocks.0.attn.to_qkv.wtscale": torch.ones(())},
+            self._qwen_mapping(),
+        )
+
+        self.assertEqual(custom_sd, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR adds a reusable checkpoint namespace resolver for diffusion model loading.

Diffusion checkpoints can use parameter names that differ from the SGLang runtime namespace. Existing `param_names_mapping` handles one-way renaming during state-dict conversion, but it does not fully cover split-to-fused parameters, checkpoint-side quantization metadata, or incomplete fused mappings.

The resolver keeps existing model-config mappings as the source of truth while recording checkpoint-source shards, validating fused parameter completeness, preserving backward-compatible reverse mappings, and resolving quantization metadata through the same namespace mapping.

As an initial use case, this PR fixes Qwen-Image checkpoint loading by:

- mapping `attn.to_out.{weight,bias}` to `attn.to_out.0.{weight,bias}`;
- merging Diffusers `add_q_proj`, `add_k_proj`, and `add_v_proj` into runtime `to_added_qkv`;

The same resolver also fixes two broader diffusion checkpoint-loading issues:   

- incomplete split-to-fused parameter groups are now reported with explicit missing-shard diagnostics; and 
- Nunchaku/SVDQuant `wtscale` and `wcscales` metadata can now be resolved when stored under checkpoint-side names.

This pr intentionally focuses on the shared resolver, fused-parameter validation, Qwen-Image mappings, and Nunchaku/SVDQuant metadata lookup. Larger namespace-remapping follow-ups—such as ModelOpt `ignore` / `exclude_modules` remapping, LoRA namespace normalization, and component-specific quantization mapping—are intentionally deferred to future PRs built on top of this resolver to keep the initial scope manageable.
## Modifications

- Added `CheckpointNameResolver` for diffusion checkpoint loading.
  - Wraps the existing `param_names_mapping` function.
  - Records checkpoint-source parameter shards for each runtime target parameter.
  - Preserves the legacy `reverse_param_names_mapping` for backward compatibility.
  - Validates incomplete fused parameter merges and raises a clear error when any expected shard is missing.
  - Provides checkpoint-side metadata key lookup for quantization metadata such as `wtscale` and `wcscales`.

- Integrated the resolver into `hf_to_custom_state_dict`.
  - Existing callers receive the same return values by default.
  - New callers can request the resolver with `return_resolver=True`.
  - Fused parameter loading now verifies that all expected shards are present.

- Integrated resolver metadata into FSDP loading.
  - The model now retains `checkpoint_source_param_shards_by_target` for callers that need the complete checkpoint-source shard list.

- Fixed Qwen-Image checkpoint namespace mappings.
  - Maps `attn.to_out.{weight,bias}` to `attn.to_out.0.{weight,bias}`.
  - Maps Diffusers `add_q_proj`, `add_k_proj`, and `add_v_proj` into the runtime fused `to_added_qkv` parameter.

- Updated Nunchaku/SVDQuant scale patching.
  - Uses the resolver to locate `wtscale` and `wcscales` metadata even when keys use checkpoint-side names rather than runtime module names.

- Added unit tests covering:
  - Qwen-Image `to_out` rename.
  - Qwen-Image added-QKV fused mapping.
  - Incomplete fused parameter detection.
  - Quantization metadata key lookup.
  - Ignored metadata tensors.

## Accuracy Tests

This PR does not change model forward computation. It only changes checkpoint name resolution and loading behavior.  And it is tested through unit tests. 

## Speed Tests and Profiling

No speed impact is expected. The resolver only runs during checkpoint loading / quant metadata patching and does not affect inference-time forward execution. No inference benchmarking was performed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).














<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28134454346](https://github.com/sgl-project/sglang/actions/runs/28134454346)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28134454272](https://github.com/sgl-project/sglang/actions/runs/28134454272)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->