### PR TITLE
[Spec] DFlash: support pure-MLA targets with an fp8 KV cache (Kimi-K2.x-NVFP4)

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2483,6 +2483,16 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 f"Unsupported kv_cache_dtype: {self.server_args.kv_cache_dtype}."
             )
 
+        # DFLASH draft-KV decouple: the fp8 target records its kv_cache_dtype into the shared
+        # server_args, but the bf16 draft's fa4 attention needs K.dtype == Q.dtype. Give the
+        # draft its own KV in the draft compute dtype (set directly, not the shared args).
+        if (
+            self.is_draft_worker
+            and self.spec_algorithm.is_dflash()
+            and self.kv_cache_dtype != self.dtype
+        ):
+            self.kv_cache_dtype = self.dtype
+
     def init_cublas(self):
         """We need to run a small matmul to init cublas. Otherwise, it will raise some errors later."""
         dtype = torch.float16

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2491,6 +2491,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             and self.server_args.speculative_draft_attention_backend == "fa4"
             and self.kv_cache_dtype != self.dtype
         ):
+            logger.info(
+                "DFLASH fa4 draft: overriding KV cache dtype %s -> %s "
+                "(fa4 needs K.dtype == Q.dtype; cannot read the target's quantized KV).",
+                self.kv_cache_dtype,
+                self.dtype,
+            )
             self.kv_cache_dtype = self.dtype
 
     def init_cublas(self):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2483,12 +2483,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 f"Unsupported kv_cache_dtype: {self.server_args.kv_cache_dtype}."
             )
 
-        # DFLASH draft-KV decouple: the fp8 target records its kv_cache_dtype into the shared
-        # server_args, but the bf16 draft's fa4 attention needs K.dtype == Q.dtype. Give the
-        # draft its own KV in the draft compute dtype (set directly, not the shared args).
+        # DFLASH: fa4 draft attention can't read the target's fp8 KV (needs K.dtype == Q.dtype),
+        # so give the fa4 draft its own compute-dtype KV. fp8-capable backends keep the target dtype.
         if (
             self.is_draft_worker
             and self.spec_algorithm.is_dflash()
+            and self.server_args.speculative_draft_attention_backend == "fa4"
             and self.kv_cache_dtype != self.dtype
         ):
             self.kv_cache_dtype = self.dtype

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1107,7 +1107,6 @@ class DFlashWorkerV2(BaseSpecWorker):
         cache per-step intermediate states. After acceptance, we need to commit the
         state corresponding to each request's last accepted step.
         """
-        # Eligibility resolved once at init (pure-MLA targets have no state to commit).
         if not self._need_mamba_verify_commit:
             return
         attn_backend = self.target_worker.model_runner.attn_backend
@@ -1539,9 +1538,8 @@ class DFlashWorkerV2(BaseSpecWorker):
         batch.out_cache_loc = verify_out_cache_loc
         sampling_info = batch.sampling_info
 
-        need_mamba_verify_commit = self._need_mamba_verify_commit
         seq_lens_pre_verify = (
-            batch.seq_lens.clone() if need_mamba_verify_commit else None
+            batch.seq_lens.clone() if self._need_mamba_verify_commit else None
         )
         seq_lens_cpu_backup = batch.seq_lens_cpu
         seq_lens_sum_backup = batch.seq_lens_sum
@@ -1661,7 +1659,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                     1, accept_len.to(torch.int64)[:, None], bonus[:, None]
                 )
 
-        if need_mamba_verify_commit:
+        if self._need_mamba_verify_commit:
             assert seq_lens_pre_verify is not None
             self._update_target_mamba_state_after_verify(
                 batch=batch,

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -117,6 +117,14 @@ class DFlashWorkerV2(BaseSpecWorker):
         self.nccl_port = nccl_port
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
+        # Mamba verify-commit eligibility (model-static; resolve once). Gate on mambaish_config
+        # too, not bare hasattr: HybridAttnBackend delegates into an inner MLA backend lacking it.
+        self._need_mamba_verify_commit = (
+            self.model_runner.mambaish_config is not None
+            and hasattr(
+                self.model_runner.attn_backend, "update_mamba_state_after_mtp_verify"
+            )
+        )
         self.page_size = server_args.page_size
         # Normalized in arg_groups.speculative_hook.handle_speculative_decoding.
         self.draft_window_size: Optional[int] = (
@@ -1099,9 +1107,10 @@ class DFlashWorkerV2(BaseSpecWorker):
         cache per-step intermediate states. After acceptance, we need to commit the
         state corresponding to each request's last accepted step.
         """
-        attn_backend = self.target_worker.model_runner.attn_backend
-        if not hasattr(attn_backend, "update_mamba_state_after_mtp_verify"):
+        # Eligibility resolved once at init (pure-MLA targets have no state to commit).
+        if not self._need_mamba_verify_commit:
             return
+        attn_backend = self.target_worker.model_runner.attn_backend
 
         last_correct_step_indices = commit_lens.to(torch.int64) - 1
         mamba_steps_to_track = None
@@ -1530,10 +1539,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         batch.out_cache_loc = verify_out_cache_loc
         sampling_info = batch.sampling_info
 
-        need_mamba_verify_commit = hasattr(
-            self.target_worker.model_runner.attn_backend,
-            "update_mamba_state_after_mtp_verify",
-        )
+        need_mamba_verify_commit = self._need_mamba_verify_commit
         seq_lens_pre_verify = (
             batch.seq_lens.clone() if need_mamba_verify_commit else None
         )

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -117,8 +117,6 @@ class DFlashWorkerV2(BaseSpecWorker):
         self.nccl_port = nccl_port
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
-        # Mamba verify-commit eligibility (model-static; resolve once). Gate on mambaish_config
-        # too, not bare hasattr: HybridAttnBackend delegates into an inner MLA backend lacking it.
         self._need_mamba_verify_commit = (
             self.model_runner.mambaish_config is not None
             and hasattr(

--- a/test/registered/quant/test_kimi_k26_nvfp4_dflash.py
+++ b/test/registered/quant/test_kimi_k26_nvfp4_dflash.py
@@ -12,9 +12,7 @@ register_cuda_ci(est_time=3600, suite="nightly-8-gpu-b200", nightly=True)
 MODEL_PATH = "nvidia/Kimi-K2.6-NVFP4"
 DRAFT_MODEL_PATH = "nvidia/Kimi-K2.6-DFlash"
 
-# trtllm_mla verify exercises the pure-MLA fp8-KV DFlash path (bf16 draft-KV decouple +
-# Mamba verify-commit guard) without depending on the cuteDSL fold kernel, which only
-# needs a newer flashinfer. The target keeps fp8 KV; the fa4 draft gets its own bf16 KV.
+# trtllm_mla verify only; cuteDSL fold verify depends on the flashinfer version.
 EXTRA_ARGS = [
     "--trust-remote-code",
     "--quantization=modelopt_fp4",

--- a/test/registered/quant/test_kimi_k26_nvfp4_dflash.py
+++ b/test/registered/quant/test_kimi_k26_nvfp4_dflash.py
@@ -1,0 +1,72 @@
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+# Kimi-K2.6 NVFP4 (pure-MLA target, fp8 KV) + DFlash speculative decoding on 8x B200, tp=8.
+register_cuda_ci(est_time=3600, suite="nightly-8-gpu-b200", nightly=True)
+
+MODEL_PATH = "nvidia/Kimi-K2.6-NVFP4"
+DRAFT_MODEL_PATH = "nvidia/Kimi-K2.6-DFlash"
+
+# trtllm_mla verify exercises the pure-MLA fp8-KV DFlash path (bf16 draft-KV decouple +
+# Mamba verify-commit guard) without depending on the cuteDSL fold kernel, which only
+# needs a newer flashinfer. The target keeps fp8 KV; the fa4 draft gets its own bf16 KV.
+EXTRA_ARGS = [
+    "--trust-remote-code",
+    "--quantization=modelopt_fp4",
+    "--moe-runner-backend=flashinfer_trtllm",
+    "--fp4-gemm-backend=flashinfer_cutlass",
+    "--attention-backend=trtllm_mla",
+    "--kv-cache-dtype=fp8_e4m3",
+    "--mem-fraction-static=0.85",
+    "--max-running-requests=16",
+    "--speculative-algorithm=DFLASH",
+    f"--speculative-draft-model-path={DRAFT_MODEL_PATH}",
+    "--speculative-num-draft-tokens=8",
+    "--speculative-draft-attention-backend=fa4",
+    "--speculative-draft-model-quantization=unquant",
+    "--speculative-draft-window-size=4096",
+]
+
+
+class TestKimiK26Nvfp4Dflash(unittest.TestCase):
+    """Kimi-K2.6 NVFP4 (pure-MLA, fp8 KV) with DFlash speculative decoding on 8x B200 (tp=8).
+
+    Runs both an accuracy test (gsm8k) and a performance test (bs=1/8/16), and gates the
+    speculative-decoding accept length. Guards the pure-MLA fp8-KV DFlash path.
+    """
+
+    def test_kimi_k26_nvfp4_dflash(self):
+        variants = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                tp_size=8,
+                extra_args=EXTRA_ARGS,
+                variant="TP8+DFLASH",
+            ),
+        ]
+
+        run_combined_tests(
+            models=variants,
+            test_name="Kimi-K2.6-NVFP4 DFlash",
+            # Thresholds from a measured tp=8 run: gsm8k 0.936 (full set), accept length ~2.66.
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.92,
+                num_examples=200,
+                api="completion",
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[1, 8, 16],
+                spec_accept_length_threshold=2.0,
+                profile_dir="performance_profiles_kimi_k26_nvfp4_dflash",
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two fixes that let **DFlash** run on a **pure-MLA target with an fp8 KV cache** (`nvidia/Kimi-K2.5-NVFP4` / `Kimi-K2.6-NVFP4`, B200). Without them DFlash verify crashes at target-verify and the server never reaches ready.

The MLA spec-verify routing already exists (`HybridAttnBackend._select_backend`) — this PR only fixes the two crashes. `trtllm_mla` verify works today. **The cuteDSL fold verify kernel additionally requires `flashinfer >= 0.6.13`** (which ships the fold kernel); that is a separate flashinfer bump, not part of this PR.

### Changes
1. **Mamba verify-commit guard** — skip for pure-MLA (`mambaish_config is None`). `HybridAttnBackend` delegates the commit into an inner MLA backend that lacks it, so a bare `hasattr()` passes → `AttributeError` at verify. (`dflash_worker_v2.py`)
2. **bf16 draft-KV decouple** — on an fp8 target, give the `fa4` draft its own bf16 KV in `configure_kv_cache_dtype` (`fa4` needs `K.dtype == Q.dtype`). Scoped to `fa4` + the draft runner, so the target keeps fp8. (`model_runner.py`)

## Validation

`Kimi-K2.6-NVFP4` + draft `Kimi-K2.6-DFlash`, 8×B200 tp=8 — boots clean (target KV fp8, `fa4` draft KV bf16; separate pools). **GSM8K 5-shot, full 1319-set: 0.936** (Invalid 0.001).

Verify-kernel comparison (same config, only the verify backend differs; cuteDSL needs **flashinfer >= 0.6.13**) — 50K-prefix aiperf, `tok/s/user`:

| cc | `trtllm_mla` | cuteDSL | edge |
|---:|---:|---:|---:|
| 1  | 238.3 | 266.8 | +12% |
| 4  | 150.9 | 196.0 | +30% |
| 8  |  95.5 | 145.5 | +52% |
| 16 |  60.0 | 101.0 | **+68%** |

Accept-length is identical (cuteDSL 2.66 vs `trtllm_mla` 2.65, n≈870), so the delta is the verify kernel, not acceptance.

**Nightly:** `test/registered/quant/test_kimi_k26_nvfp4_dflash.py` (`nightly-8-gpu-b200`, tp=8, `trtllm_mla` arm) — gsm8k + perf/accept gate.

## Reproduce (8×B200, tp=8)

```bash
python3 -m sglang.launch_server \
  --model-path nvidia/Kimi-K2.6-NVFP4 --served-model-name nvidia/Kimi-K2.6-NVFP4 \
  --trust-remote-code --tp 8 --quantization modelopt_fp4 \
  --moe-runner-backend flashinfer_trtllm --fp4-gemm-backend flashinfer_cutlass \
  --attention-backend trtllm_mla --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 \
  --speculative-algorithm DFLASH --speculative-draft-model-path nvidia/Kimi-K2.6-DFlash \
  --speculative-draft-model-quantization unquant --speculative-num-draft-tokens 8 \
  --speculative-draft-attention-backend fa4 --speculative-draft-window-size 4096
```

cuteDSL fold verify (**flashinfer >= 0.6.13**): replace `--attention-backend trtllm_mla` with `--prefill-attention-backend trtllm_mla --decode-attention-backend cutedsl_mla --speculative-attention-mode decode`.

- Accuracy: `python3 -m sglang.test.few_shot_gsm8k --num-shots 5 --num-questions 1319 --port 30000`
- Throughput (50K-prefix, cc-sweep): `aiperf profile --model nvidia/Kimi-K2.6-NVFP4 --endpoint-type chat --endpoint /v1/chat/completions --url localhost:30000 --seq-dist "3000,1000:100" --prompt-prefix-length 50000 --prompt-prefix-pool-size $CC --concurrency $CC --request-count $((CC*5)) --num-dataset-entries $((CC*5)) --warmup-request-count $((CC*5)) --extra-inputs ignore_eos:true --streaming --use-legacy-max-tokens --tokenizer nvidia/Kimi-K2.6-NVFP4 --tokenizer-trust-remote-code`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28836679509](https://github.com/sgl-project/sglang/actions/runs/28836679509)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28836679395](https://github.com/sgl-project/sglang/actions/runs/28836679395)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->