### PR TITLE
Fix dummy weight init for tensor subclasses

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -1469,7 +1469,10 @@ def initialize_dummy_weights(
         if torch.is_floating_point(param):
             generator = torch.Generator(device=param.data.device)
             generator.manual_seed(seed)
-            if torch.finfo(param.data.dtype).bits < 16:
+            # Tensor subclasses such as MXFP8 wrappers expose a low-bit raw
+            # storage dtype through `.data`, but their wrapper `uniform_` also
+            # updates side tensors such as block scales.
+            if torch.finfo(param.dtype).bits < 16:
                 # uniform_ doesn't support < 16-bit datatypes (FP8)
                 dtype = param.data.dtype
                 tmp_param = param.data.to(torch.float16)


### PR DESCRIPTION
## Summary

Fix `initialize_dummy_weights()` so tensor subclasses are classified by their logical dtype instead of their raw storage dtype.

## Motivation

Some tensor subclasses expose low-bit storage through `.data`, while the wrapper tensor itself reports the logical dtype that its tensor operations support. For example, MXFP wrappers can have a logical `bfloat16` dtype while `.data` is FP8 storage.

The previous dummy init check used `param.data.dtype`, which sent these wrappers through the low-bit fallback path. That fallback only rewrites the raw storage tensor and bypasses wrapper `uniform_()` logic that also updates side tensors such as block scales.

Using `param.dtype` keeps plain low-bit tensors on the fallback path, while allowing tensor subclasses with supported logical dtypes to use their own `uniform_()` implementation.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28141477996](https://github.com/sgl-project/sglang/actions/runs/28141477996)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28141479837](https://github.com/sgl-project/sglang/actions/runs/28141479837)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->