### PR TITLE
WIP - test 29178

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -396,6 +396,7 @@ class FusedMoE(torch.nn.Module):
         loaded_weight: torch.Tensor,
         tp_rank: int,
         is_bias: bool = False,
+        load_full_w2: bool = False,
     ):
         # Load grouped weight scales for group quantization
         # or model weights
@@ -407,6 +408,7 @@ class FusedMoE(torch.nn.Module):
                 expert_data=expert_data,
                 tp_rank=tp_rank,
                 is_bias=is_bias,
+                load_full=load_full_w2,
             )
         elif shard_id in ("w1", "w3", "w13"):
             self._load_w13(
@@ -510,6 +512,7 @@ class FusedMoE(torch.nn.Module):
         loaded_weight: torch.Tensor,
         tp_rank: int,
         is_bias: bool = False,
+        load_full: bool = False,
     ):
         """Load w2 weights for down projection.
 
@@ -536,6 +539,14 @@ class FusedMoE(torch.nn.Module):
 
         if shard_id != "w2":
             raise ValueError(f"shard_id must be 'w2', got {shard_id}")
+
+        # Some grouped/actorder schemes (e.g. compressed-tensors wNa16 on ROCm)
+        # keep the full, unsharded w2 scale on every TP rank (load_full_w2=True).
+        # In that case the loaded scale already matches expert_data, so copy it
+        # whole instead of narrowing, which would index out of range.
+        if load_full:
+            expert_data.copy_(loaded_weight)
+            return
 
         # Index the loaded weight for tp sharding.
         # down_proj: "RowParallel" so tp sharding on input_dim
@@ -945,6 +956,7 @@ class FusedMoE(torch.nn.Module):
                     loaded_weight=loaded_weight,
                     expert_data=expert_data,
                     tp_rank=tp_rank,
+                    load_full_w2=getattr(param, "load_full_w2", False),
                 )
             elif quant_method == FusedMoeWeightScaleSupported.TENSOR.value:
                 # INT4-FP8 (INT4 MoE Weight, FP8 Compute): Adjust FP8 per-tensor scaling number for e4m3fnuz (AMD)


### PR DESCRIPTION


compressed-tensors wNa16 group-quant MoE on ROCm (CompressedTensorsWNA16TritonMoE) keeps the full, unsharded w2 weight_scale on every TP rank and flags it with load_full_w2=True (group axis = intermediate*moe_tp_size / group_size). The generic
FusedMoE weight loader ignored that flag: _weight_loader_impl ->
_load_model_weight_or_group_weight_scale -> _load_w2 always narrowed the scale by shard_size * tp_rank. For the full (unsharded) scale this offset overshoots the group axis, e.g. for moonshotai/Kimi-K2.6 at TP=8 (intermediate=2048, group_size=32 -> 64 groups) it raises:

  IndexError: start out of range (expected to be in range of [-64, 64], but got 320)

crashing model load and failing the nightly-8-gpu-kimi-k26 / -mi35x-kimi-k26 jobs.

Fix: thread load_full_w2 (read from the param) through to _load_w2; when set, copy the full scale instead of narrowing. Only affects the load_full_w2 path; all other MoE quant schemes are unchanged.

Offline-verified on MI300X (gfx942): the stock loader reproduces the exact IndexError (got 320, range [-64,64]); with the fix the full scale is copied whole and matches the source.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28143151918](https://github.com/sgl-project/sglang/actions/runs/28143151918)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28143151822](https://github.com/sgl-project/sglang/actions/runs/28143151822)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->