### PR TITLE
Fix breakable EAGLE prefill graph for FP4 MoE

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2635,18 +2635,30 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Skip prefill CG for EAGLE target on tc_piecewise: that backend
         # captures CaptureHiddenMode.NULL while runtime requests FULL, so
         # the captured graph is dead, and capturing it perturbs FP4 /
-        # TRTLLM-MoE state and corrupts decode replay (see #28386). BCG
-        # captures FULL for EAGLE target in PrefillCudaGraphRunner.__init__
-        # (restored from #25795), so it does NOT need this skip.
+        # TRTLLM-MoE state and corrupts decode replay (see #28386).
+        #
+        # Breakable captures FULL for EAGLE target, so it can still be used
+        # for most target prefill graphs. However, ModelOpt FP4 with the
+        # FlashInfer TRTLLM MoE runner has the same state-safety issue: after
+        # target prefill BCG capture, speculative target/draft decode graph
+        # capture can fail in cuBLAS or DSA KV-buffer kernels. Route only this
+        # FP4/MoE combination through eager target prefill and leave other BCG
+        # EAGLE target cases enabled.
+        is_prefill_bcg = check_cuda_graph_backend(Phase.PREFILL, Backend.BREAKABLE)
+        is_prefill_bcg_fp4_moe = (
+            is_prefill_bcg
+            and self.server_args.quantization == "modelopt_fp4"
+            and self.server_args.moe_runner_backend == "flashinfer_trtllm"
+        )
         if (
             self.spec_algorithm.is_eagle()
             and not self.is_draft_worker
             and not self.server_args.enable_return_hidden_states
-            and not check_cuda_graph_backend(Phase.PREFILL, Backend.BREAKABLE)
+            and (not is_prefill_bcg or is_prefill_bcg_fp4_moe)
         ):
             logger.info(
-                "Disable prefill CUDA graph for EAGLE target on tc_piecewise "
-                "to avoid FP4/MoE decode-replay corruption (#28386)."
+                "Disable prefill CUDA graph for EAGLE target to avoid FP4/MoE "
+                "decode graph capture/replay corruption."
             )
             self.prefill_cuda_graph_runner = self.eager_runner
             return


### PR DESCRIPTION
## Summary
- Skip EAGLE target prefill CUDA graph for the Breakable prefill backend only when running ModelOpt FP4 with the FlashInfer TRTLLM MoE runner.
- Keep Breakable target prefill CUDA graphs enabled for other EAGLE target cases.
- Preserve the existing tc_piecewise EAGLE target prefill graph skip.

## Root Cause
For GLM-5.2 NVFP4 with EAGLE MTP and `--cuda-graph-backend-prefill=breakable`, capturing the target prefill graph can perturb the FP4/TRTLLM-MoE state before speculative target/draft decode graph capture. On 4x GB300 this reproduced as decode graph capture failures in cuBLAS or the DSA KV-buffer Triton path.

This mirrors the existing tc_piecewise skip, but Breakable was previously exempt because it captures `CaptureHiddenMode.FULL` for EAGLE target prefill. That is still fine for most cases, so this PR narrows the Breakable skip to the observed FP4 + FlashInfer TRTLLM MoE combination.

## Validation
- `python3 -m py_compile python/sglang/srt/model_executor/model_runner.py`
- Repo pre-commit hooks on commit passed, including AST, isort, ruff legacy alias, and related checks.
- Live launch on `baizhou-dev`, latest `origin/main` (`8b7a1e908a`), 4x GB300, GLM-5.2 NVFP4, MTP 5-1-6, `SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM=1`, `--cuda-graph-backend-prefill=breakable`, no HiCache:
  - EAGLE target prefill skip logged on all TP ranks.
  - Target verify CUDA graph capture completed on all TP ranks.
  - Draft decode CUDA graph capture completed.
  - Server reached `/health` 200.

## Notes
- With the original HiCache flags restored, graph capture also passed after this patch, but startup later hit the separate HiCache/DSA host-memory setup path (`Allocating 34.38 GB host memory for DSA indexer`). This PR is scoped to the CUDA graph capture crash.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28144300568](https://github.com/sgl-project/sglang/actions/runs/28144300568)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28144300462](https://github.com/sgl-project/sglang/actions/runs/28144300462)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->