### PR TITLE
Fix: prevent scheduler hang caused by admission validation mismatch

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2118,19 +2118,27 @@ class Scheduler(
                 self._add_request_to_queue(req)
                 return
 
-        # initialize before returning
-        self.init_req_max_new_tokens(req)
-
-        # Validate prompt length
+        # Validate prompt length first.
+        # Pass pool capacity so the effective limit reserves decode space when
+        # the KV pool is smaller than the model's context length. We do this
+        # BEFORE init_req_max_new_tokens so that max_new_tokens is computed
+        # against the (possibly truncated) input length and we don't end up
+        # with max_new_tokens=0 for a request whose input was just truncated.
         error_msg = validate_input_length(
             req,
             self.max_req_input_len,
             self.server_args.allow_auto_truncate,
+            max_total_num_tokens=self.max_total_num_tokens,
+            page_size=self.page_size,
         )
         if error_msg:
+            self.init_req_max_new_tokens(req)
             req.set_finish_with_abort(error_msg)
             self._add_request_to_queue(req)
             return
+
+        # initialize after truncation so max_new_tokens uses the final input_len
+        self.init_req_max_new_tokens(req)
 
         if not recv_req.return_logprob and recv_req.logprob_start_len != -1:
             # When return_logprob is False, logprob_start_len should be ignored
@@ -2403,6 +2411,8 @@ class Scheduler(
             req,
             self.max_req_input_len,
             self.server_args.allow_auto_truncate,
+            max_total_num_tokens=self.max_total_num_tokens,
+            page_size=self.page_size,
         )
         if error_msg:
             self._add_request_to_queue(req)

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -140,36 +140,60 @@ class GenerationBatchResult:
 
 
 def validate_input_length(
-    req: Req, max_req_input_len: int, allow_auto_truncate: bool
+    req: Req,
+    max_req_input_len: int,
+    allow_auto_truncate: bool,
+    max_total_num_tokens: Optional[int] = None,
+    page_size: int = 1,
 ) -> Optional[str]:
-    """Validate and potentially truncate input length.
+    """Validate and potentially truncate input length."""
 
-    Args:
-        req: The request containing input_ids to validate
-        max_req_input_len: Maximum allowed input length
-        allow_auto_truncate: Whether to truncate long inputs
+    input_len = len(req.origin_input_ids)
+    requested_new_tokens = req.sampling_params.max_new_tokens
 
-    Returns:
-        Error message if validation fails, None if successful
-    """
-    if len(req.origin_input_ids) >= max_req_input_len:
-        if allow_auto_truncate:
-            logger.warning(
-                "Request length is longer than the KV cache pool size or "
-                "the max context length. Truncated. "
-                f"{len(req.origin_input_ids)=}, {max_req_input_len=}."
-            )
-            req.origin_input_ids = req.origin_input_ids[:max_req_input_len]
-            return None
-        else:
-            error_msg = (
-                f"Input length ({len(req.origin_input_ids)} tokens) exceeds "
-                f"the maximum allowed length ({max_req_input_len} tokens). "
-                f"Use a shorter input or enable --allow-auto-truncate."
-            )
-            return error_msg
+    # Align the validation limit with PrefillAdder's admission check:
+    # add_one_req() requires:
+    #
+    #   input_len + page_size < max_total_num_tokens
+    #
+    # Otherwise a request may pass validation/truncation but be
+    # permanently rejected with NO_TOKEN during scheduling.
+    if max_total_num_tokens is not None:
+        max_req_input_len = min(
+            max_req_input_len,
+            max(0, max_total_num_tokens - page_size - 1),
+        )
+    if input_len < max_req_input_len:
+        return None
 
-    return None
+    if allow_auto_truncate and max_req_input_len > 0:
+        logger.warning(
+            "Request length is longer than the KV cache pool size or "
+            "the max context length. Truncated. "
+            f"{input_len=}, {max_req_input_len=}, "
+            f"{max_total_num_tokens=}, {requested_new_tokens=}."
+        )
+        req.origin_input_ids = req.origin_input_ids[:max_req_input_len]
+        return None
+
+    if max_req_input_len <= 0:
+        return (
+            f"KV cache pool is too small to serve this request: "
+            f"max_total_num_tokens={max_total_num_tokens}, "
+            f"requested max_new_tokens={requested_new_tokens}, "
+            f"page_size={page_size}. Reduce max_new_tokens, or increase "
+            f"--mem-fraction-static / decrease --max-running-requests / "
+            f"--context-length on the server."
+        )
+
+    return (
+        f"Input length ({input_len} tokens) exceeds the effective limit "
+        f"({max_req_input_len} tokens; "
+        f"max_total_num_tokens={max_total_num_tokens}, "
+        f"max_new_tokens={requested_new_tokens}). "
+        f"Use a shorter input, reduce max_new_tokens, or enable "
+        f"--allow-auto-truncate."
+    )
 
 
 def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:


### PR DESCRIPTION

## Motivation

Followup of #25126 / related to #28530 (which was closed as fixed by #25126, but only the scheduler-side clamp was updated there).

#25126 fixed `init_req_max_new_tokens` in `scheduler.py` so the per-request `max_new_tokens` is clamped against `max_total_num_tokens - ceil_page(input_len) - page_size - 1`. However the **admission-side** check in `validate_input_length` (`python/sglang/srt/managers/utils.py`) still uses `max_req_input_len = min(context_len, max_token_pool_size) - 5`, which in TP setups can be larger than `max_total_num_tokens`.

Result: a request can pass admission, then never satisfy PrefillAdder's budget (`extend_input_len + max_new_tokens + page_size < rem_total_tokens`), sit in the waiting queue forever, and hang the scheduler — exactly the symptom described in #28530.


### Repro

TP=8, observed at runtime on current main:
- `input_len = 837717`
- `max_total_num_tokens = 756736`
- `max_req_input_len ≈ context_length` (much larger than `max_total_num_tokens`)
- request accepted by `validate_input_length`, then stuck in the waiting queue indefinitely (no schedulable batch).


## Modifications

- `python/sglang/srt/managers/utils.py`: `validate_input_length` now takes optional `max_total_num_tokens` / `page_size` and tightens `max_req_input_len` to `min(max_req_input_len, max_total_num_tokens - page_size - 1)` so it matches PrefillAdder's budget. Error/warning messages are also extended to surface `max_total_num_tokens` and `requested_new_tokens`.
- `python/sglang/srt/managers/scheduler.py`: pass `max_total_num_tokens=self.max_total_num_tokens, page_size=self.page_size` at the two call sites (generation and embedding handlers), and run `validate_input_length` before `init_req_max_new_tokens` so an oversized prompt is rejected with a clear error instead of entering the scheduler with an unsatisfiable token budget.

### Open question

This PR keeps the existing behavior where `init_req_max_new_tokens` may clamp `max_new_tokens` to 0 for boundary cases. Such requests can still complete prefill without generating additional tokens.

Whether such requests should be rejected at admission time instead is a separate API behavior discussion and can be addressed in a follow-up PR if needed (cc @hnyls2002 since you reviewed #25126).


## Accuracy Tests

N/A — this PR only changes admission-time input-length validation; it does not modify any kernel, model forward, or sampling code paths.

## Speed Tests and Profiling

N/A — no inference hot-path changes. The added clamp is a single `min()` per request at admission time.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28144368507](https://github.com/sgl-project/sglang/actions/runs/28144368507)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28144368429](https://github.com/sgl-project/sglang/actions/runs/28144368429)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->