### PR TITLE
Add MiMo V2.5 Blackwell vision FA4 recipe

### DIFF
--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -88,6 +88,7 @@ import { MiMoV25Deployment } from '/src/snippets/autoregressive/mimo-v25-deploym
 **MiMo-V2.5 (310B):**
 - The checkpoint has a TP=4-interleaved fused `qkv_proj`; attention-TP per DP group **must** be 4. Use `--dp = TP / 4`; for TP > 4 this also requires DP-attention. Total GPUs must be a multiple of 4. A bare `--tp 8` without `--dp 2` will fail to load with `MiMoV2 fused qkv_proj checkpoint is TP=4-interleaved; got attention tp_size=8`.
 - Single-node deployments: H100/H200 8× GPUs (`--tp 8 --dp 2`), B200 4× GPUs (`--tp 4`, dp=1, no DP-attn flag needed), GB300 4× GPUs (`--tp 4`, single NVL4 node). FP8 quantization.
+- On Blackwell, pass `--mm-attention-backend fa4` for the V2.5 vision encoder. The checkpoint config requests FlashAttention-3 internally, but SGLang rejects FA3 on Blackwell and expects FA4 for multimodal attention.
 - `--enable-dp-lm-head` and `--mm-enable-dp-encoder` are required whenever `--enable-dp-attention` is on, to keep LM head and encoder sharding consistent.
 - EAGLE MTP uses the checkpoint's MTP weights. Enable with `--speculative-algorithm EAGLE` and `--enable-multi-layer-eagle` (both Hopper and Blackwell).
 - **Multimodal**: Supports image, video, and audio understanding; see Section 4.3 for invocation examples.

--- a/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -11,8 +11,8 @@ export const MiMoV25Deployment = () => {
   //   so attention-TP per DP group must be 4; effective parallelism = TP/DP = 4.
   //     H200  → tp=8, dp=2, single-node, FP8 (verified)
   //     H100  → tp=8, dp=2, single-node, FP8
-  //     B200  → tp=4, dp=1, single-node, FP8
-  //     GB300 → tp=4, dp=1, single-node, FP8
+  //     B200  → tp=4, dp=1, single-node, FP8 (Blackwell: vision fa4)
+  //     GB300 → tp=4, dp=1, single-node, FP8 (Blackwell: vision fa4)
   //
   //   Optional toggles:
   //     EAGLE MTP — adds --speculative-* flags + SGLANG_ENABLE_SPEC_V2=1.
@@ -350,6 +350,7 @@ export const MiMoV25Deployment = () => {
         flags.push(`  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 64}'`);
       }
     } else {
+      if (blackwell) flags.push("  --mm-attention-backend fa4");
       flags.push("  --mem-fraction-static 0.65");
       flags.push("  --chunked-prefill-size 16384");
     }


### PR DESCRIPTION
## Motivation

MiMo-V2.5 base is the multimodal checkpoint. Its vision blocks request FlashAttention-3 internally, which maps to the `fa3` multimodal attention backend. SGLang rejects `fa3` on Blackwell with `ValueError: The 'fa3' backend is not supported on Blackwell GPUs`.

The Pro Blackwell recipe already uses FA4 for text attention, but the base B200/GB300 recipe did not override the multimodal attention backend. The generated command should pass `--mm-attention-backend fa4` on Blackwell so the vision encoder uses the supported backend.

## Changes

- Add `--mm-attention-backend fa4` to the MiMo-V2.5 base command on B200/GB300.
- Document why the flag is required for the V2.5 vision encoder on Blackwell.

## Validation

- Static selector check: confirmed the generated base/Blackwell command path now includes `--mm-attention-backend fa4`.
- B200 model validation evidence from the cookbook/KDA run:
  - Model: `XiaomiMiMo/MiMo-V2.5`, TP=4 on 4x B200.
  - Launch included `--mm-attention-backend fa4` with the Blackwell multimodal recipe.
  - Server reached `server_ready` and completed six workload captures: random/sharegpt × low/mid/high concurrency.
  - Captured server info reported `mm_attention_backend: "fa4"`, confirming the multimodal attention override took effect.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28144466744](https://github.com/sgl-project/sglang/actions/runs/28144466744)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28148279748](https://github.com/sgl-project/sglang/actions/runs/28148279748)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->