### PR TITLE
[AMD] Raise VLM MMMU nondeterministic suite timeout for Qwen2.5-VL-3B (fixes pr-test-amd timeout)

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -488,7 +488,7 @@ jobs:
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 45
+        timeout-minutes: 60
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-nondeterministic --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -490,7 +490,7 @@ jobs:
       - name: Run test
         timeout-minutes: 45
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-nondeterministic --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-nondeterministic --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   stage-b-test-1-gpu-small-amd-mi35x:
     needs: [check-changes, wait-for-stage-a-amd]

--- a/test/registered/models/test_vlm_models.py
+++ b/test/registered/models/test_vlm_models.py
@@ -14,7 +14,7 @@ from sglang.test.test_utils import is_in_amd_ci, is_in_ci
 
 
 register_cuda_ci(est_time=317, stage="extra-a", runner_config="1-gpu-large")
-register_amd_ci(est_time=850, suite="stage-b-test-1-gpu-small-amd-nondeterministic")
+register_amd_ci(est_time=2000, suite="stage-b-test-1-gpu-small-amd-nondeterministic")
 
 _is_hip = is_hip()
 # VLM models for testing


### PR DESCRIPTION
## Motivation

The `stage-b-test-1-gpu-small-amd-nondeterministic` job on `pr-test-amd` fails on `test/registered/models/test_vlm_models.py`:

```
✗ TIMEOUT: .../test/registered/models/test_vlm_models.py after 1800 seconds
{"file": ".../test_vlm_models.py", "passed": false, "elapsed": 1800}
```

(CI monitor cluster **R209**.)

This started after #29095 swapped the AMD VLM test model from `openbmb/MiniCPM-V-2_6` (disabled for NaN-in-logits) to `Qwen/Qwen2.5-VL-3B-Instruct`. The MMMU `mmmu_val` eval (≈900 questions, via lmms-eval) for the new model does not finish inside the suite's `--timeout-per-file 1800`, and `est_time` was left at the old `850`.

## This is a timeout-budget issue, not a hang or a perf regression

Verified on MI355X (gfx950), ROCm 7.2, same image as CI:

- The server starts cleanly (graphs captured ~19s) and serves the entire eval; the CI log shows continuous prefill/decode progress for the full ~30 min until the 1800s cut-off — no hang, no crash.
- **Server-side generation is not the bottleneck.** A worst-case throughput probe (batch 64, 1024×1024 image, forced full 256 output tokens) measured ~9.6 req/s → all ~900 MMMU questions generate in **~1.6 min** of pure inference. The wall-clock cost is dominated by the lmms-eval harness: runtime install/build of `lmms-eval` + its dependency tree, MMMU dataset download, and per-sample CPU preprocessing/dispatch — all of which progress, just slowly, and overrun the 1800s budget.

## Fix

Raise the budget to match the heavier model, matching peer large-VLM suites:

- `pr-test-amd.yml`: `--timeout-per-file` `1800` → `2700` for the nondeterministic suite, and bump that step's `timeout-minutes` `45` → `60` so the per-file budget has headroom for the harness install/dataset steps that run before the per-file timer.
- `test_vlm_models.py`: `est_time` `850` → `2000` to reflect the new model's real wall time.

No SGLang runtime/kernel code is touched. The eval itself and the `mmmu_accuracy=0.4` threshold are unchanged.

## Suggested reviewers

- @yhyang201 — author of #29095 (the model swap that surfaced this)
- @michaelzhang-ai — maintainer of the AMD PR-test workflow







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28144551549](https://github.com/sgl-project/sglang/actions/runs/28144551549)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28144551479](https://github.com/sgl-project/sglang/actions/runs/28144551479)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->