### PR TITLE
[Test] Add unit tests for disaggregation/kv_events and disaggregation/utils (#20865)

### DIFF
--- a/test/registered/unit/disaggregation/test_kv_events.py
+++ b/test/registered/unit/disaggregation/test_kv_events.py
@@ -1,0 +1,200 @@
+"""Unit tests for srt/disaggregation/kv_events."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import msgspec
+
+from sglang.srt.disaggregation.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+    EventPublisherFactory,
+    KVEventBatch,
+    KVEventsConfig,
+    NullEventPublisher,
+    ZmqEventPublisher,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestOffsetEndpointPort(CustomTestCase):
+    """Tests for ZmqEventPublisher.offset_endpoint_port (pure static method)."""
+
+    def test_none_endpoint_returns_none_for_any_rank(self):
+        self.assertIsNone(ZmqEventPublisher.offset_endpoint_port(None, 0))
+        self.assertIsNone(ZmqEventPublisher.offset_endpoint_port(None, 5))
+
+    def test_rank_zero_returns_endpoint_unchanged(self):
+        self.assertEqual(
+            ZmqEventPublisher.offset_endpoint_port("tcp://*:5557", 0),
+            "tcp://*:5557",
+        )
+        self.assertEqual(
+            ZmqEventPublisher.offset_endpoint_port("inproc://cache", 0),
+            "inproc://cache",
+        )
+
+    def test_inproc_endpoint_gets_dp_suffix(self):
+        self.assertEqual(
+            ZmqEventPublisher.offset_endpoint_port("inproc://cache", 2),
+            "inproc://cache_dp2",
+        )
+
+    def test_tcp_wildcard_port_offset_by_rank(self):
+        self.assertEqual(
+            ZmqEventPublisher.offset_endpoint_port("tcp://*:5557", 1),
+            "tcp://*:5558",
+        )
+
+    def test_tcp_host_port_offset_by_rank(self):
+        self.assertEqual(
+            ZmqEventPublisher.offset_endpoint_port("tcp://host:5557", 3),
+            "tcp://host:5560",
+        )
+
+    def test_tcp_without_colon_returns_unchanged(self):
+        # Contains "tcp" but has no ":" to locate a port, so it is returned as-is.
+        self.assertEqual(
+            ZmqEventPublisher.offset_endpoint_port("tcpsocket", 1),
+            "tcpsocket",
+        )
+
+    def test_unknown_scheme_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            ZmqEventPublisher.offset_endpoint_port("udp://host:5557", 1)
+
+
+class TestKVEventsConfig(CustomTestCase):
+    """Tests for KVEventsConfig.from_cli."""
+
+    def test_from_cli_defaults(self):
+        config = KVEventsConfig.from_cli("{}")
+        self.assertEqual(config.publisher, "null")
+        self.assertEqual(config.endpoint, "tcp://*:5557")
+        self.assertIsNone(config.replay_endpoint)
+        self.assertEqual(config.buffer_steps, 10_000)
+        self.assertEqual(config.hwm, 100_000)
+        self.assertEqual(config.max_queue_size, 100_000)
+        self.assertEqual(config.topic, "")
+
+    def test_from_cli_overrides(self):
+        config = KVEventsConfig.from_cli(
+            '{"publisher": "zmq", "endpoint": "tcp://localhost:6000"}'
+        )
+        self.assertEqual(config.publisher, "zmq")
+        self.assertEqual(config.endpoint, "tcp://localhost:6000")
+        # Untouched fields keep their defaults.
+        self.assertIsNone(config.replay_endpoint)
+
+    def test_from_cli_invalid_json_raises(self):
+        with self.assertRaises(Exception):
+            KVEventsConfig.from_cli("{not valid json")
+
+
+class TestMsgspecRoundTrips(CustomTestCase):
+    """msgspec.msgpack encode/decode round-trips for KV cache event structs."""
+
+    def setUp(self):
+        self.encoder = msgspec.msgpack.Encoder()
+
+    def _round_trip(self, value, typ):
+        decoder = msgspec.msgpack.Decoder(typ)
+        return decoder.decode(self.encoder.encode(value))
+
+    def test_block_stored_round_trip(self):
+        event = BlockStored(
+            block_hashes=[1, 2, 3],
+            parent_block_hash=10,
+            token_ids=[4, 5, 6],
+            block_size=16,
+            lora_id=7,
+            medium="GPU",
+        )
+        self.assertEqual(self._round_trip(event, BlockStored), event)
+
+    def test_block_removed_round_trip(self):
+        event = BlockRemoved(block_hashes=[9, 8], medium="CPU_PINNED")
+        self.assertEqual(self._round_trip(event, BlockRemoved), event)
+
+    def test_all_blocks_cleared_round_trip(self):
+        event = AllBlocksCleared()
+        self.assertEqual(self._round_trip(event, AllBlocksCleared), event)
+
+    def test_kv_event_batch_mixed_events_round_trip(self):
+        batch = KVEventBatch(
+            ts=123.5,
+            events=[
+                BlockStored(
+                    block_hashes=[1, 2],
+                    parent_block_hash=None,
+                    token_ids=[3, 4],
+                    block_size=8,
+                    lora_id=None,
+                    medium="GPU",
+                ),
+                BlockRemoved(block_hashes=[5], medium="DISK"),
+                AllBlocksCleared(),
+            ],
+        )
+        decoded = self._round_trip(batch, KVEventBatch)
+        self.assertEqual(decoded, batch)
+        self.assertEqual(
+            [type(e).__name__ for e in decoded.events],
+            ["BlockStored", "BlockRemoved", "AllBlocksCleared"],
+        )
+
+
+class TestNullEventPublisher(CustomTestCase):
+    """Tests for the no-op NullEventPublisher."""
+
+    def test_publish_accepts_event_batch(self):
+        publisher = NullEventPublisher()
+        batch = KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+        self.assertIsNone(publisher.publish(batch))
+
+    def test_shutdown_is_noop(self):
+        publisher = NullEventPublisher()
+        self.assertIsNone(publisher.shutdown())
+
+
+class TestEventPublisherFactory(CustomTestCase):
+    """Tests for EventPublisherFactory create/register behavior."""
+
+    def setUp(self):
+        # Snapshot the registry so register_publisher tests cannot leak state.
+        self._saved_registry = dict(EventPublisherFactory._registry)
+
+    def tearDown(self):
+        EventPublisherFactory._registry = dict(self._saved_registry)
+
+    def test_create_with_none_config_returns_null_publisher(self):
+        self.assertIsInstance(EventPublisherFactory.create(None), NullEventPublisher)
+        # Any falsy config short-circuits to the null publisher.
+        self.assertIsInstance(EventPublisherFactory.create(""), NullEventPublisher)
+
+    def test_null_kind_resolves_to_null_publisher(self):
+        # The "null" kind maps to NullEventPublisher in the registry.
+        self.assertIs(EventPublisherFactory._registry["null"], NullEventPublisher)
+
+    def test_create_unknown_publisher_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            EventPublisherFactory.create('{"publisher": "does-not-exist"}')
+
+    def test_register_publisher_adds_to_registry(self):
+        EventPublisherFactory.register_publisher("custom-null", NullEventPublisher)
+        self.assertIn("custom-null", EventPublisherFactory._registry)
+        self.assertIs(
+            EventPublisherFactory._registry["custom-null"], NullEventPublisher
+        )
+
+    def test_register_duplicate_publisher_raises_key_error(self):
+        with self.assertRaises(KeyError):
+            EventPublisherFactory.register_publisher("null", NullEventPublisher)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_utils.py
+++ b/test/registered/unit/disaggregation/test_utils.py
@@ -1,0 +1,249 @@
+"""Unit tests for srt/disaggregation/utils."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+
+from sglang.srt.disaggregation.base.conn import StateType
+from sglang.srt.disaggregation.utils import (
+    DisaggregationMode,
+    ReqToMetadataIdxAllocator,
+    append_state_component,
+    filter_kv_indices_for_cp_rank,
+    page_indices_to_cp_rank_page_indices,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestPageIndicesToCpRankPageIndices(CustomTestCase):
+    """Tests for page_indices_to_cp_rank_page_indices."""
+
+    def test_cp_size_one_is_passthrough(self):
+        page_indices = np.array([3, 4, 5])
+        result = page_indices_to_cp_rank_page_indices(
+            page_indices=page_indices, total_pages=3, cp_rank=0, cp_size=1
+        )
+        # cp_size <= 1 returns the exact input array.
+        self.assertIs(result, page_indices)
+
+    def test_empty_array_returns_empty(self):
+        page_indices = np.array([], dtype=np.int64)
+        result = page_indices_to_cp_rank_page_indices(
+            page_indices=page_indices, total_pages=0, cp_rank=1, cp_size=4
+        )
+        self.assertEqual(result.size, 0)
+
+    def test_even_split_exact_local_indices(self):
+        # total_pages=8, cp_size=2 -> each rank owns 4 contiguous pages.
+        page_indices = np.arange(8)
+        np.testing.assert_array_equal(
+            page_indices_to_cp_rank_page_indices(
+                page_indices=page_indices, total_pages=8, cp_rank=0, cp_size=2
+            ),
+            np.array([0, 1, 2, 3]),
+        )
+        np.testing.assert_array_equal(
+            page_indices_to_cp_rank_page_indices(
+                page_indices=page_indices, total_pages=8, cp_rank=1, cp_size=2
+            ),
+            np.array([4, 5, 6, 7]),
+        )
+
+    def test_uneven_split_remainder_distribution(self):
+        # total_pages=7, cp_size=3 -> remainder 1 goes to rank 0 (min(cp_rank, rem)).
+        page_indices = np.arange(7)
+        np.testing.assert_array_equal(
+            page_indices_to_cp_rank_page_indices(
+                page_indices=page_indices, total_pages=7, cp_rank=0, cp_size=3
+            ),
+            np.array([0, 1, 2]),
+        )
+        np.testing.assert_array_equal(
+            page_indices_to_cp_rank_page_indices(
+                page_indices=page_indices, total_pages=7, cp_rank=1, cp_size=3
+            ),
+            np.array([3, 4]),
+        )
+        np.testing.assert_array_equal(
+            page_indices_to_cp_rank_page_indices(
+                page_indices=page_indices, total_pages=7, cp_rank=2, cp_size=3
+            ),
+            np.array([5, 6]),
+        )
+
+    def test_global_to_local_mapping_with_offset(self):
+        # Pages live at a non-zero first_page; local slices map back to globals.
+        page_indices = np.arange(100, 106)
+        np.testing.assert_array_equal(
+            page_indices_to_cp_rank_page_indices(
+                page_indices=page_indices, total_pages=6, cp_rank=0, cp_size=3
+            ),
+            np.array([100, 101]),
+        )
+        np.testing.assert_array_equal(
+            page_indices_to_cp_rank_page_indices(
+                page_indices=page_indices, total_pages=6, cp_rank=1, cp_size=3
+            ),
+            np.array([102, 103]),
+        )
+        np.testing.assert_array_equal(
+            page_indices_to_cp_rank_page_indices(
+                page_indices=page_indices, total_pages=6, cp_rank=2, cp_size=3
+            ),
+            np.array([104, 105]),
+        )
+
+    def test_rank_beyond_total_pages_returns_empty(self):
+        # total_pages=2, cp_size=4 -> ranks 2 and 3 own no pages.
+        page_indices = np.array([10, 11])
+        result = page_indices_to_cp_rank_page_indices(
+            page_indices=page_indices, total_pages=2, cp_rank=3, cp_size=4
+        )
+        self.assertEqual(result.size, 0)
+
+
+class TestReqToMetadataIdxAllocator(CustomTestCase):
+    """Tests for ReqToMetadataIdxAllocator."""
+
+    def test_initial_pool_size(self):
+        allocator = ReqToMetadataIdxAllocator(4)
+        self.assertEqual(allocator.size, 4)
+        self.assertEqual(allocator.available_size(), 4)
+
+    def test_alloc_returns_fifo_order(self):
+        allocator = ReqToMetadataIdxAllocator(3)
+        self.assertEqual(allocator.alloc(), 0)
+        self.assertEqual(allocator.alloc(), 1)
+        self.assertEqual(allocator.alloc(), 2)
+
+    def test_alloc_returns_none_when_exhausted(self):
+        allocator = ReqToMetadataIdxAllocator(2)
+        allocator.alloc()
+        allocator.alloc()
+        self.assertIsNone(allocator.alloc())
+        self.assertEqual(allocator.available_size(), 0)
+
+    def test_free_then_alloc_returns_freed_index(self):
+        allocator = ReqToMetadataIdxAllocator(2)
+        allocator.alloc()
+        idx = allocator.alloc()
+        allocator.free(idx)
+        self.assertEqual(allocator.alloc(), idx)
+
+    def test_multiple_free_alloc_cycles_maintain_state(self):
+        allocator = ReqToMetadataIdxAllocator(3)
+        a = allocator.alloc()  # 0
+        b = allocator.alloc()  # 1
+        allocator.free(a)
+        allocator.free(b)
+        # Remaining free slot (2) is dequeued before the freed ones (FIFO).
+        self.assertEqual(allocator.alloc(), 2)
+        self.assertEqual(allocator.alloc(), a)
+        self.assertEqual(allocator.alloc(), b)
+        self.assertIsNone(allocator.alloc())
+
+
+class TestDisaggregationMode(CustomTestCase):
+    """Tests for the DisaggregationMode enum."""
+
+    def test_to_engine_type(self):
+        self.assertEqual(
+            DisaggregationMode.to_engine_type(DisaggregationMode.PREFILL.value),
+            "prefill",
+        )
+        self.assertEqual(
+            DisaggregationMode.to_engine_type(DisaggregationMode.DECODE.value),
+            "decode",
+        )
+        # Anything that is not prefill/decode (e.g. NULL) maps to "unified".
+        self.assertEqual(
+            DisaggregationMode.to_engine_type(DisaggregationMode.NULL.value),
+            "unified",
+        )
+
+    def test_all_members_accessible(self):
+        self.assertEqual(DisaggregationMode.NULL.value, "null")
+        self.assertEqual(DisaggregationMode.PREFILL.value, "prefill")
+        self.assertEqual(DisaggregationMode.DECODE.value, "decode")
+        self.assertEqual(
+            {member.name for member in DisaggregationMode},
+            {"NULL", "PREFILL", "DECODE"},
+        )
+
+
+class TestFilterKvIndicesForCpRank(CustomTestCase):
+    """Tests for filter_kv_indices_for_cp_rank."""
+
+    @staticmethod
+    def _stub_kv_mgr(cp_rank, cp_size):
+        # Minimal stub: only the CP rank/size attributes are read.
+        return SimpleNamespace(attn_cp_rank=cp_rank, attn_cp_size=cp_size)
+
+    def test_cp_size_one_returns_all_indices(self):
+        kv_indices = np.array([5, 6, 7, 8])
+        index_slice = slice(0, 4)
+        new_indices, new_slice = filter_kv_indices_for_cp_rank(
+            self._stub_kv_mgr(0, 1), kv_indices, index_slice
+        )
+        np.testing.assert_array_equal(new_indices, kv_indices)
+        self.assertEqual(new_slice, slice(0, 4))
+
+    def test_subset_per_rank_with_cp_size_two(self):
+        kv_indices = np.array([0, 1, 2, 3])
+        index_slice = slice(10, 14)
+
+        new_indices, new_slice = filter_kv_indices_for_cp_rank(
+            self._stub_kv_mgr(0, 2), kv_indices, index_slice
+        )
+        np.testing.assert_array_equal(new_indices, np.array([0, 1]))
+        self.assertEqual(new_slice, slice(10, 12))
+
+        new_indices, new_slice = filter_kv_indices_for_cp_rank(
+            self._stub_kv_mgr(1, 2), kv_indices, index_slice
+        )
+        np.testing.assert_array_equal(new_indices, np.array([2, 3]))
+        self.assertEqual(new_slice, slice(12, 14))
+
+
+class TestAppendStateComponent(CustomTestCase):
+    """Tests for append_state_component."""
+
+    @staticmethod
+    def _stub_kv_args():
+        # Minimal stub exposing the five state-component lists the helper appends to.
+        return SimpleNamespace(
+            state_types=[],
+            state_data_ptrs=[],
+            state_data_lens=[],
+            state_item_lens=[],
+            state_dim_per_tensor=[],
+        )
+
+    def test_append_to_empty_lists(self):
+        kv_args = self._stub_kv_args()
+        append_state_component(kv_args, StateType.MAMBA, [1, 2], [3, 4], [5, 6], [7])
+        self.assertEqual(kv_args.state_types, [StateType.MAMBA])
+        self.assertEqual(kv_args.state_data_ptrs, [[1, 2]])
+        self.assertEqual(kv_args.state_data_lens, [[3, 4]])
+        self.assertEqual(kv_args.state_item_lens, [[5, 6]])
+        self.assertEqual(kv_args.state_dim_per_tensor, [[7]])
+
+    def test_append_multiple_components_and_default_dim(self):
+        kv_args = self._stub_kv_args()
+        append_state_component(kv_args, StateType.MAMBA, [1], [2], [3], [4])
+        # dim_per_tensor defaults to an empty list when omitted.
+        append_state_component(kv_args, StateType.SWA, [8], [9], [10])
+        self.assertEqual(kv_args.state_types, [StateType.MAMBA, StateType.SWA])
+        self.assertEqual(kv_args.state_data_ptrs, [[1], [8]])
+        self.assertEqual(kv_args.state_data_lens, [[2], [9]])
+        self.assertEqual(kv_args.state_item_lens, [[3], [10]])
+        self.assertEqual(kv_args.state_dim_per_tensor, [[4], []])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
38 tests covering disaggregation KV event publishing and utility functions.

No server, no GPU, no model loading.
Ref: #20865

## Motivation

Added two new test files: `test/registered/unit/disaggregation/test_kv_events.py` and `test/registered/unit/disaggregation/test_utils.py`

`disaggregation/kv_events.py` and `disaggregation/utils.py` currently have no dedicated unit tests.

`kv_events.py` implements the KV cache event publishing pipeline used in prefill/decode disaggregation. It covers endpoint port arithmetic for DP attention ranks, msgspec-encoded event structs (BlockStored, BlockRemoved, AllBlocksCleared), a pydantic-based config parser, and a registry-backed publisher factory. Regressions here silently break KV event delivery across disaggregated ranks.

`utils.py` implements the CP-rank page index partitioning logic and the request-to-metadata index allocator used in disaggregated KV transfer. `page_indices_to_cp_rank_page_indices` distributes page indices across CP ranks with remainder-aware allocation. `ReqToMetadataIdxAllocator` is a deque-backed FIFO allocator for metadata slots. Both can regress silently and are critical to correctness of KV transfer in disaggregated serving.

## Coverage

`kv_events.py` (21 tests):
- `ZmqEventPublisher.offset_endpoint_port` — None/rank-0 passthrough, inproc suffix appended, tcp wildcard port offset, tcp host port offset, no-colon passthrough, unknown scheme raises ValueError.
- `KVEventsConfig.from_cli` — valid JSON defaults, field overrides, invalid JSON raises.
- msgspec struct round-trips — BlockStored, BlockRemoved, AllBlocksCleared, KVEventBatch with mixed events.
- `NullEventPublisher` — publish no-op, shutdown no-op.
- `EventPublisherFactory` — None config returns NullEventPublisher, null kind resolves to NullEventPublisher, unknown publisher raises ValueError, register adds to registry, duplicate registration raises KeyError. Registry restored in tearDown.

`utils.py` (17 tests):
- `page_indices_to_cp_rank_page_indices` — cp_size=1 passthrough, empty array, even split exact local indices, uneven split remainder distribution, global-to-local offset mapping, rank beyond total pages returns empty.
- `ReqToMetadataIdxAllocator` — initial pool size, FIFO alloc order, exhaustion returns None, free-then-alloc returns freed index, multiple free/alloc cycles.
- `DisaggregationMode` — to_engine_type for prefill/decode/unified, all members accessible.
- `filter_kv_indices_for_cp_rank` — cp_size=1 all indices, per-rank subset with minimal stub.
- `append_state_component` — empty list append, multiple appends with default dim.

Both files are registered via:
```python
register_cpu_ci(est_time=5, suite="base-a-test-cpu")
```

## Test plan

```
python3 test/registered/unit/disaggregation/test_kv_events.py -v
```

```
test_create_unknown_publisher_raises_value_error (__main__.TestEventPublisherFactory) ... ok
test_create_with_none_config_returns_null_publisher (__main__.TestEventPublisherFactory) ... ok
test_null_kind_resolves_to_null_publisher (__main__.TestEventPublisherFactory) ... ok
test_register_duplicate_publisher_raises_key_error (__main__.TestEventPublisherFactory) ... ok
test_register_publisher_adds_to_registry (__main__.TestEventPublisherFactory) ... ok
test_from_cli_defaults (__main__.TestKVEventsConfig) ... ok
test_from_cli_invalid_json_raises (__main__.TestKVEventsConfig) ... ok
test_from_cli_overrides (__main__.TestKVEventsConfig) ... ok
test_all_blocks_cleared_round_trip (__main__.TestMsgspecRoundTrips) ... ok
test_block_removed_round_trip (__main__.TestMsgspecRoundTrips) ... ok
test_block_stored_round_trip (__main__.TestMsgspecRoundTrips) ... ok
test_kv_event_batch_mixed_events_round_trip (__main__.TestMsgspecRoundTrips) ... ok
test_publish_accepts_event_batch (__main__.TestNullEventPublisher) ... ok
test_shutdown_is_noop (__main__.TestNullEventPublisher) ... ok
test_inproc_endpoint_gets_dp_suffix (__main__.TestOffsetEndpointPort) ... ok
test_none_endpoint_returns_none_for_any_rank (__main__.TestOffsetEndpointPort) ... ok
test_rank_zero_returns_endpoint_unchanged (__main__.TestOffsetEndpointPort) ... ok
test_tcp_host_port_offset_by_rank (__main__.TestOffsetEndpointPort) ... ok
test_tcp_wildcard_port_offset_by_rank (__main__.TestOffsetEndpointPort) ... ok
test_tcp_without_colon_returns_unchanged (__main__.TestOffsetEndpointPort) ... ok
test_unknown_scheme_raises_value_error (__main__.TestOffsetEndpointPort) ... ok

----------------------------------------------------------------------
Ran 21 tests in 0.002s
```

```
python3 test/registered/unit/disaggregation/test_utils.py -v
```

```
test_append_multiple_components_and_default_dim (__main__.TestAppendStateComponent) ... ok
test_append_to_empty_lists (__main__.TestAppendStateComponent) ... ok
test_all_members_accessible (__main__.TestDisaggregationMode) ... ok
test_to_engine_type (__main__.TestDisaggregationMode) ... ok
test_cp_size_one_returns_all_indices (__main__.TestFilterKvIndicesForCpRank) ... ok
test_subset_per_rank_with_cp_size_two (__main__.TestFilterKvIndicesForCpRank) ... ok
test_cp_size_one_is_passthrough (__main__.TestPageIndicesToCpRankPageIndices) ... ok
test_empty_array_returns_empty (__main__.TestPageIndicesToCpRankPageIndices) ... ok
test_even_split_exact_local_indices (__main__.TestPageIndicesToCpRankPageIndices) ... ok
test_global_to_local_mapping_with_offset (__main__.TestPageIndicesToCpRankPageIndices) ... ok
test_rank_beyond_total_pages_returns_empty (__main__.TestPageIndicesToCpRankPageIndices) ... ok
test_uneven_split_remainder_distribution (__main__.TestPageIndicesToCpRankPageIndices) ... ok
test_alloc_returns_fifo_order (__main__.TestReqToMetadataIdxAllocator) ... ok
test_alloc_returns_none_when_exhausted (__main__.TestReqToMetadataIdxAllocator) ... ok
test_free_then_alloc_returns_freed_index (__main__.TestReqToMetadataIdxAllocator) ... ok
test_initial_pool_size (__main__.TestReqToMetadataIdxAllocator) ... ok
test_multiple_free_alloc_cycles_maintain_state (__main__.TestReqToMetadataIdxAllocator) ... ok

----------------------------------------------------------------------
Ran 17 tests in 0.003s
```

## Accuracy Tests
N/A — test-only change. No kernel or model-forward code is touched.

## Speed Tests and Profiling
N/A — this PR only adds unit tests and does not affect the inference path.

## Checklist
- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process
Ping Merge Oncalls to start the process. See the PR Merge Process.
Get approvals from CODEOWNERS and other reviewers.
Trigger CI tests with comments or contact authorized users to do so.
Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28144836621](https://github.com/sgl-project/sglang/actions/runs/28144836621)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28144836516](https://github.com/sgl-project/sglang/actions/runs/28144836516)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->