### PR TITLE
Fix fixed-size HiCache capacity under PP

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -73,6 +73,7 @@ logger = logging.getLogger(__name__)
 from sglang.srt.mem_cache.pool_host import HostKVCache
 from sglang.srt.mem_cache.pool_host.base import (
     HICACHE_HOST_MEMORY_RESERVE_BYTES,
+    sync_fixed_hicache_size,
     synchronized,
 )
 from sglang.srt.mem_cache.pool_host.common import (
@@ -1435,7 +1436,9 @@ class MambaPoolHost(HostKVCache):
         self.size_per_token = self.get_size_per_token()
 
         if host_size > 0:
-            self.size = int(host_size * 1e9 // self.size_per_token)
+            self.size = sync_fixed_hicache_size(
+                int(host_size * 1e9 // self.size_per_token), host_size
+            )
         else:
             self.size = int(device_pool.size * host_to_device_ratio)
 

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -25,6 +25,47 @@ _is_hip = is_hip()
 HICACHE_HOST_MEMORY_RESERVE_BYTES: int = 10 * (1024**3)
 
 
+def sync_fixed_hicache_size(size: int, host_size: int) -> int:
+    """Sync fixed-size HiCache token capacity across distributed ranks.
+
+    A fixed --hicache-size is specified in GB, but each PP stage may have a
+    different bytes/token because it owns different layers. Use the global
+    minimum token capacity so all stages expose the same host-cache capacity.
+    Ratio-based sizing already derives from the synced device pool size.
+    """
+    if host_size <= 0 or not torch.distributed.is_available():
+        return size
+
+    if not torch.distributed.is_initialized():
+        return size
+
+    try:
+        from sglang.srt.distributed.parallel_state import get_world_group
+
+        world_group = get_world_group()
+    except AssertionError:
+        return size
+
+    if world_group.world_size <= 1:
+        return size
+
+    tensor = torch.tensor(size, dtype=torch.int64)
+    torch.distributed.all_reduce(
+        tensor,
+        op=torch.distributed.ReduceOp.MIN,
+        group=world_group.cpu_group,
+    )
+    synced_size = int(tensor.item())
+
+    if synced_size != size:
+        logger.info(
+            "Sync fixed-size HiCache host token capacity from %d to %d.",
+            size,
+            synced_size,
+        )
+    return synced_size
+
+
 def synchronized(func):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
@@ -58,7 +99,9 @@ class HostKVCache(abc.ABC):
         self.dtype = device_pool.store_dtype
         self.size_per_token = self.get_size_per_token()
         if host_size > 0:
-            self.size = int(host_size * 1e9 // self.size_per_token)
+            self.size = sync_fixed_hicache_size(
+                int(host_size * 1e9 // self.size_per_token), host_size
+            )
         else:
             self.size = int(device_pool.size * host_to_device_ratio)
         # Align up the host memory pool size to the page size

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -26,11 +26,12 @@ HICACHE_HOST_MEMORY_RESERVE_BYTES: int = 10 * (1024**3)
 
 
 def sync_fixed_hicache_size(size: int, host_size: int) -> int:
-    """Sync fixed-size HiCache token capacity across distributed ranks.
+    """Sync fixed-size HiCache token capacity across PP ranks.
 
     A fixed --hicache-size is specified in GB, but each PP stage may have a
     different bytes/token because it owns different layers. Use the global
-    minimum token capacity so all stages expose the same host-cache capacity.
+    minimum token capacity within the PP group so all stages expose the same
+    host-cache capacity.
     Ratio-based sizing already derives from the synced device pool size.
     """
     if host_size <= 0 or not torch.distributed.is_available():
@@ -40,20 +41,20 @@ def sync_fixed_hicache_size(size: int, host_size: int) -> int:
         return size
 
     try:
-        from sglang.srt.distributed.parallel_state import get_world_group
+        from sglang.srt.distributed.parallel_state import get_pp_group
 
-        world_group = get_world_group()
+        pp_group = get_pp_group()
     except AssertionError:
         return size
 
-    if world_group.world_size <= 1:
+    if pp_group.world_size <= 1:
         return size
 
     tensor = torch.tensor(size, dtype=torch.int64)
     torch.distributed.all_reduce(
         tensor,
         op=torch.distributed.ReduceOp.MIN,
-        group=world_group.cpu_group,
+        group=pp_group.cpu_group,
     )
     synced_size = int(tensor.item())
 


### PR DESCRIPTION
  ## Motivation

  Fix a PP scheduling divergence issue when HiCache L2 is enabled with a fixed `--hicache-size`.

  In PP mode, different pipeline stages may own different numbers of layers, so their HiCache bytes per token can differ. With a fixed `--hicache-size`, each stage
  previously converted GB to host-token capacity independently:

  ```python
  host_tokens = hicache_size_gb * 1e9 // size_per_token

  This can make host-cache token capacity differ across PP stages even though the device KV token capacity has already been synchronized. Under pressure, those
  different host capacities can lead to different radix/HiCache residency states and eventually different scheduling decisions for the same PP microbatch.

  Observed before this fix with GLM-5.2 FP8, tp=4, pp=4, nnodes=2, --hicache-size 100:

  PP0/PP1:
  size_per_token=12464
  host_tokens=8023168
  requested_gb=100.000766

  PP2/PP3:
  size_per_token=13120
  host_tokens=7621952
  requested_gb=100.000010

  This is about a 5.26% host-token capacity difference across PP stages.

  ## Modifications

  Add sync_fixed_hicache_size() for fixed-size HiCache host pools.

  When --hicache-size > 0, the locally computed host-token capacity is synchronized across distributed ranks with ReduceOp.MIN, matching the existing device KV capacity
  behavior. Ratio-based sizing is unchanged because it already derives from the synchronized device pool size.

  This is applied to:

  - HostKVCache
  - MambaPoolHost

  After this fix, the same GLM-5.2 FP8 setup shows aligned host-token capacity:

  PP0/PP1:
  unaligned_host_tokens=8023106
  Sync fixed-size HiCache host token capacity from 8023106 to 7621951
  host_tokens=7621952
  requested_gb=95.000010

  PP2/PP3:
  unaligned_host_tokens=7621951
  host_tokens=7621952
  requested_gb=100.000010

  The expected behavior is that stages with smaller bytes/token may allocate less than the configured GB limit, so that all PP stages expose the same host-token
  capacity.

  ## Accuracy Tests

  Not applicable. This PR does not change model forward computation or kernels.

  ## Speed Tests and Profiling

  No speed benchmark was run. The added synchronization happens only during host pool initialization for fixed-size HiCache, not on the inference hot path.

  ## Checklist

  - [ ] Format your code according to the Format code with pre-commit (https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [x] Add unit tests according to the Run and add unit tests (https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to Write documentations (https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [x] Provide accuracy and speed benchmark results according to Test the accuracy (https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy)
    and Benchmark the speed (https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).

  - [x] Follow the SGLang code style guidance (https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28147469393](https://github.com/sgl-project/sglang/actions/runs/28147469393)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28147469316](https://github.com/sgl-project/sglang/actions/runs/28147469316)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->