### PR TITLE
[AMD] ci: register PCG + speculative-decoding extra on extra-a 2-gpu-large-amd

### DIFF
--- a/test/registered/cuda_graph/piecewise/test_pcg_with_speculative_decoding_extra.py
+++ b/test/registered/cuda_graph/piecewise/test_pcg_with_speculative_decoding_extra.py
@@ -6,10 +6,11 @@ test_pcg_with_speculative_decoding.py.
 
 import unittest
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.server_fixtures.pcg_spec_fixture import PCGSpecBase
 
 register_cuda_ci(est_time=531, stage="extra-a", runner_config="2-gpu-large")
+register_amd_ci(est_time=531, stage="extra-a", runner_config="2-gpu-large-amd")
 
 
 class TestPCGWithMTP(PCGSpecBase, unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds `register_amd_ci(est_time=531, stage="extra-a", runner_config="2-gpu-large-amd")` to `test/registered/cuda_graph/piecewise/test_pcg_with_speculative_decoding_extra.py` — the last unblocked CUDA `extra-a` file with no AMD registration.

This is the PCG (piecewise CUDA graph) coexistence test with non-EAGLE3 speculative decoding:
- `TestPCGWithMTP` — Qwen3.5-35B-A3B FP8 + NEXTN/MTP + mamba scheduler
- `TestPCGWithSTANDALONE` — Llama-3.1-8B + STANDALONE draft + `tc_piecewise` prefill
- `TestPCGWithNGRAM` — Qwen2.5-Coder-7B + NGRAM + `tc_piecewise` prefill

**Why plausibly AMD-safe:** basic piecewise CUDA graph is already AMD-proven (`test_piecewise_cuda_graph_support_1_gpu` runs on `stage-b-test-1-gpu-large-amd`), and MTP/NGRAM spec paths run on ROCm via triton. No FlashInfer/FA3/fa4, no mxfp4, no DeepGEMM/Marlin.

**Risk (being verified):** the per-commit EAGLE3 piecewise+spec sibling is CUDA-only, so the combined piecewise+spec path isn't AMD-proven, and the 35B-A3B FP8 + mamba MTP class is the main portability risk. Verifying on both AMD lanes; if any class trips on ROCm the `register_amd_ci` line is dropped (no register-and-skip).

No production code changes; registration only.

## Test plan

- [ ] `extra-a-test-2-gpu-large-amd` (mi325) green
- [ ] `extra-a-test-2-gpu-large-amd-rocm720` green











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28145386120](https://github.com/sgl-project/sglang/actions/runs/28145386120)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28145386029](https://github.com/sgl-project/sglang/actions/runs/28145386029)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->