### PR TITLE
[AMD] ci: enable triton NGRAM speculative-decoding on extra-a 1-gpu-large-amd

### DIFF
--- a/test/registered/spec/test_spec_ngram_extra.py
+++ b/test/registered/spec/test_spec_ngram_extra.py
@@ -2,19 +2,28 @@ import unittest
 
 import requests
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.srt.utils import is_hip
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.server_fixtures.ngram_fixture import NgramServerBase
 
 # Extra: Triton + Flashinfer NGRAM backends + non-overlap (sync V2) variant.
 # Sibling per-commit file (test_spec_ngram.py) keeps the Paged variant.
 register_cuda_ci(est_time=400, stage="extra-a", runner_config="1-gpu-large")
+# AMD: the flashinfer attention backend is not built in the ROCm sgl_kernel,
+# so only the triton-backend NGRAM class runs on ROCm (the flashinfer classes
+# are skipped on ROCm below). This still adds new AMD coverage: the per-commit
+# sibling (test_spec_ngram.py) is flashinfer-only and CUDA-only.
+register_amd_ci(est_time=200, stage="extra-a", runner_config="1-gpu-large-amd")
+
+_AMD_SKIP_BACKEND = "flashinfer attention backend is CUDA-only (not in the ROCm sgl_kernel build)"
 
 
 class TestNgramSpeculativeDecodingTriton(NgramServerBase, GSM8KMixin):
     attention_backend = "triton"
 
 
+@unittest.skipIf(is_hip(), _AMD_SKIP_BACKEND)
 class TestNgramSpeculativeDecodingNoOverlap(NgramServerBase, GSM8KMixin):
     """Non-overlap path: the scheduler drives the V2 worker synchronously
     (seq_lens advance via GenerationBatchResult.new_seq_lens, accepted tokens
@@ -24,6 +33,7 @@ class TestNgramSpeculativeDecodingNoOverlap(NgramServerBase, GSM8KMixin):
     extra_args = ["--disable-overlap-schedule"]
 
 
+@unittest.skipIf(is_hip(), _AMD_SKIP_BACKEND)
 class TestNgramSpeculativeDecodingFlashinfer(NgramServerBase, GSM8KMixin):
     attention_backend = "flashinfer"
     extra_args = ["--speculative-ngram-external-sam-budget", "8"]


### PR DESCRIPTION
## Summary

Enables the **triton** NGRAM speculative-decoding class on AMD by unbundling it from the flashinfer-only classes — a fix-to-enable, not a pure registration.

`test_spec_ngram_extra.py` had one portable class (`TestNgramSpeculativeDecodingTriton`, `attention_backend="triton"`) bundled with two flashinfer classes, which kept the whole file CUDA-only. flashinfer isn't built in the ROCm `sgl_kernel`, so:

- Guard the two flashinfer classes (`...NoOverlap`, `...Flashinfer`) with `@unittest.skipIf(is_hip(), ...)` — the same precedent already used in `test_spec_standalone_extra.py`.
- Add `register_amd_ci(est_time=200, stage="extra-a", runner_config="1-gpu-large-amd")`.

On ROCm only `TestNgramSpeculativeDecodingTriton` runs (triton attention + NGRAM spec + GSM8K accuracy/accept-length gates on `Qwen2.5-Coder-7B-Instruct`). This is **genuinely new AMD coverage** — the per-commit sibling `test_spec_ngram.py` is flashinfer-only and CUDA-only, so the triton NGRAM path has no AMD coverage today. It also fills the thin `extra-a-test-1-gpu-large-amd` suite (3 → 4).

`register_cuda_ci` unchanged; all three classes still run on NVIDIA.

## Test plan

- [ ] `extra-a-test-1-gpu-large-amd` (mi325) green — triton class runs (`passed: true`), flashinfer classes skipped
- [ ] `extra-a-test-1-gpu-large-amd-rocm720` green











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28145675741](https://github.com/sgl-project/sglang/actions/runs/28145675741)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28145675635](https://github.com/sgl-project/sglang/actions/runs/28145675635)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->