### PR TITLE
[BUG] Fix stale attention metadata after Eagle pre-planner pads the batch

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2832,6 +2832,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         else:
             forward_batch.prepare_attn_tp_scatter_input(self)
 
+        # The Eagle pre-planner may have called init_forward_metadata with the
+        # unpadded batch and then marked metadata as ready.  If batch_size
+        # changed (DP-attention padding etc.), force a re-init so the attention
+        # backend creates metadata for the final padded batch size.
+        if (
+            forward_batch.forward_metadata_ready
+            and not forward_batch.forward_metadata_replan_equivalent
+            and forward_batch.batch_size != forward_batch.forward_metadata_planned_bs
+        ):
+            forward_batch.forward_metadata_ready = False
+
         # Normalize num_token_non_padded to be local to this attention TP rank if needed.
         # The skip is scoped to DSACPLayerCommunicator-style CP (DSA, MLA): those
         # flavors already feed a zigzag-split rank-local layout whose token count


### PR DESCRIPTION
## Problem

When Eagle speculative decoding + DP-attention (`global_num_tokens_cpu` is set) are both enabled, `flash_mla_with_kvcache` raises `"num_splits must have shape(b+1)"` with the following sequence:

1. Eagle pre-planner calls `init_forward_metadata` with the **unpadded** batch
2. `mark_forward_metadata_ready(False)` prevents re-init
3. `prepare_mlp_sync_batch` pads `batch_size` in-place — but the stored `forward_metadata` still has `num_splits` shaped for the old unpadded batch
4. The attention kernel receives `q` with the padded batch but `num_splits` with the unpadded shape → crash

## Fix

In `_forward_raw` (`model_runner.py`), after `prepare_mlp_sync_batch` changes the batch, detect the staleness and clear `forward_metadata_ready` to let `init_forward_metadata` re-run with the final padded batch:

```python
if (
    forward_batch.forward_metadata_ready
    and not forward_batch.forward_metadata_replan_equivalent
    and forward_batch.batch_size != forward_batch.forward_metadata_planned_bs
):
    forward_batch.forward_metadata_ready = False











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28145748899](https://github.com/sgl-project/sglang/actions/runs/28145748899)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28145748780](https://github.com/sgl-project/sglang/actions/runs/28145748780)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->