### PR TITLE
Guard HiCache host memory across local workers

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -53,6 +53,7 @@ from sglang.srt.entrypoints.engine_info_bootstrap_server import (
 )
 from sglang.srt.entrypoints.engine_score_mixin import EngineScoreMixin
 from sglang.srt.entrypoints.EngineBase import EngineBase
+from sglang.srt.environ import envs
 from sglang.srt.managers.data_parallel_controller import (
     SCHEDULER_PIDS_ARG,
     run_data_parallel_controller_process,
@@ -1261,6 +1262,9 @@ def _set_envs_and_config(server_args: ServerArgs):
         )
     os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "8"
     os.environ["CUDA_MODULE_LOADING"] = "AUTO"
+    envs.SGLANG_HICACHE_LOCAL_PROCESS_COUNT.set(
+        _calculate_local_scheduler_process_count(server_args)
+    )
 
     if os.environ.get("TRTLLM_ENABLE_PDL", "1") != "0":
         # flashinfer uses this environment variable for various kernels from MoE to quant kernels
@@ -1418,6 +1422,19 @@ def _calculate_rank_ranges(
     )
 
     return pp_rank_range, tp_rank_range, pp_size_per_node, tp_size_per_node
+
+
+def _calculate_local_scheduler_process_count(server_args: ServerArgs) -> int:
+    pp_rank_range, tp_rank_range, _, _ = _calculate_rank_ranges(
+        server_args.nnodes,
+        server_args.pp_size,
+        server_args.tp_size,
+        server_args.node_rank,
+    )
+    local_size = len(pp_rank_range) * len(tp_rank_range)
+    if server_args.dp_size > 1 and not server_args.enable_dp_attention:
+        local_size *= server_args.dp_size
+    return max(local_size, 1)
 
 
 def _compute_parallelism_ranks(

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -371,6 +371,8 @@ class Envs:
     # Hi-Cache
     SGLANG_HICACHE_HF3FS_CONFIG_PATH = EnvStr(None)
     SGLANG_HICACHE_DECODE_OFFLOAD_STRIDE = EnvInt(None)
+    # Number of local model worker processes sharing the host-memory budget.
+    SGLANG_HICACHE_LOCAL_PROCESS_COUNT = EnvInt(0)
     SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR = EnvStr(None)
     # File-backend LRU eviction (opt-in; sizes accept SI/IEC suffixes, "0" disables).
     SGLANG_HICACHE_FILE_BACKEND_MAX_SIZE = EnvStr(None)

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.hicache_storage import PoolName
 
 import numpy as np
-import psutil
 import torch
 
 from sglang.jit_kernel.hicache import (
@@ -41,6 +40,16 @@ from sglang.srt.mem_cache.memory_pool import (
     MHATokenToKVPool,
     MLATokenToKVPool,
 )
+from sglang.srt.mem_cache.pool_host import HostKVCache
+from sglang.srt.mem_cache.pool_host.base import (
+    synchronized,
+    validate_hicache_host_memory,
+)
+from sglang.srt.mem_cache.pool_host.common import (
+    ALLOC_MEMORY_FUNCS,
+    get_allocator_from_storage,
+)
+from sglang.srt.mem_cache.pool_host.hisparse import HiSparseHostPoolMixin
 from sglang.srt.utils import is_cuda, is_hip, is_mps, is_npu, is_xpu
 
 _is_cuda = is_cuda()
@@ -64,22 +73,11 @@ if _is_cuda or _is_hip:
         transfer_kv_per_layer_pf_lf,
         transfer_kv_per_layer_ph_lf,
     )
+
 if _is_npu:
     from sgl_kernel_npu.kvcacheio import TransferDirection, transfer_kv_dim_exchange
 
 logger = logging.getLogger(__name__)
-
-
-from sglang.srt.mem_cache.pool_host import HostKVCache
-from sglang.srt.mem_cache.pool_host.base import (
-    HICACHE_HOST_MEMORY_RESERVE_BYTES,
-    synchronized,
-)
-from sglang.srt.mem_cache.pool_host.common import (
-    ALLOC_MEMORY_FUNCS,
-    get_allocator_from_storage,
-)
-from sglang.srt.mem_cache.pool_host.hisparse import HiSparseHostPoolMixin
 
 _WRITE_BACK_STAGING_PAGE_CHUNK = 64
 
@@ -1446,19 +1444,21 @@ class MambaPoolHost(HostKVCache):
             self.size > device_pool.size
         ), "The host memory should be larger than the device memory with the current protocol"
 
-        host_mem = psutil.virtual_memory()
         requested_bytes = self.size * self.size_per_token
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
-        if requested_bytes > available_bytes:
-            raise ValueError(
-                f"Not enough host memory available. Requesting "
-                f"{requested_bytes / 1e9:.2f} GB but only have "
-                f"{available_bytes / 1e9:.2f} GB free. Please reduce the "
-                f"size of the hierarchical cache."
-            )
+        (
+            _,
+            aggregate_requested_bytes,
+            local_process_count,
+        ) = validate_hicache_host_memory(
+            requested_bytes,
+            description="hierarchical Mamba cache",
+        )
         logger.info(
-            "Allocating %.2f GB host memory for hierarchical Mamba cache (layout=%s).",
+            "Allocating %.2f GB host memory for hierarchical Mamba cache "
+            "(%.2f GB aggregate across %d local processes, layout=%s).",
             requested_bytes / 1e9,
+            aggregate_requested_bytes / 1e9,
+            local_process_count,
             self.layout,
         )
 
@@ -2079,14 +2079,14 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         self.gpu_device = device_buffers[0].device if device_buffers else device
 
         requested_bytes = self.layer_num * num_host_pages * self.item_bytes
-        host_mem = psutil.virtual_memory()
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
-        if requested_bytes > available_bytes:
-            raise ValueError(
-                f"Not enough host memory for V4 paged pool {pool_name}. "
-                f"Requesting {requested_bytes / 1e9:.2f} GB but only have "
-                f"{available_bytes / 1e9:.2f} GB free."
-            )
+        (
+            _,
+            aggregate_requested_bytes,
+            local_process_count,
+        ) = validate_hicache_host_memory(
+            requested_bytes,
+            description=f"V4 paged pool {pool_name}",
+        )
 
         alloc_func = ALLOC_MEMORY_FUNCS[self.gpu_device]
         self.data_refs = []
@@ -2123,9 +2123,12 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
 
         logger.info(
             "Allocating %.2f GB host memory for V4 paged pool '%s' "
-            "(layers=%d, pages=%d, item_bytes=%d, layout=%s).",
+            "(%.2f GB aggregate across %d local processes, "
+            "layers=%d, pages=%d, item_bytes=%d, layout=%s).",
             requested_bytes / 1e9,
             self.pool_name,
+            aggregate_requested_bytes / 1e9,
+            local_process_count,
             self.layer_num,
             num_host_pages,
             self.item_bytes,
@@ -2458,14 +2461,14 @@ class DeepSeekV4StateHostPool(HostKVCache):
         self.size_per_token = self.state_page_bytes
 
         requested_bytes = self.layer_num * num_host_pages * self.state_page_bytes
-        host_mem = psutil.virtual_memory()
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
-        if requested_bytes > available_bytes:
-            raise ValueError(
-                f"Not enough host memory for V4 state pool {pool_name}. "
-                f"Requesting {requested_bytes / 1e9:.2f} GB but only have "
-                f"{available_bytes / 1e9:.2f} GB free."
-            )
+        (
+            _,
+            aggregate_requested_bytes,
+            local_process_count,
+        ) = validate_hicache_host_memory(
+            requested_bytes,
+            description=f"V4 state pool {pool_name}",
+        )
 
         alloc_func = ALLOC_MEMORY_FUNCS[self.gpu_device]
         self.data_refs = []
@@ -2501,9 +2504,12 @@ class DeepSeekV4StateHostPool(HostKVCache):
             raise ValueError(f"Unsupported layout: {self.layout}")
         logger.info(
             "Allocating %.2f GB host memory for V4 state pool '%s' "
-            "(layers=%d, pages=%d, state_page_bytes=%d, layout=%s).",
+            "(%.2f GB aggregate across %d local processes, "
+            "layers=%d, pages=%d, state_page_bytes=%d, layout=%s).",
             requested_bytes / 1e9,
             self.pool_name,
+            aggregate_requested_bytes / 1e9,
+            local_process_count,
             self.layer_num,
             num_host_pages,
             self.state_page_bytes,
@@ -2993,17 +2999,20 @@ class DSAIndexerPoolHost(HostKVCache):
 
         buf_elem_size = self.page_num * self.layer_num * self.indexer_page_stride_size
         requested_bytes = buf_elem_size * self.indexer_dtype.itemsize
-        host_mem = psutil.virtual_memory()
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
-        if requested_bytes > available_bytes:
-            raise ValueError(
-                f"Not enough host memory for DSA indexer hierarchical cache. "
-                f"Requesting {requested_bytes / 1e9:.2f} GB but only have "
-                f"{available_bytes / 1e9:.2f} GB free."
-            )
+        (
+            _,
+            aggregate_requested_bytes,
+            local_process_count,
+        ) = validate_hicache_host_memory(
+            requested_bytes,
+            description="DSA indexer hierarchical cache",
+        )
         logger.info(
-            "Allocating %.2f GB host memory for DSA indexer (layout=%s).",
+            "Allocating %.2f GB host memory for DSA indexer "
+            "(%.2f GB aggregate across %d local processes, layout=%s).",
             requested_bytes / 1e9,
+            aggregate_requested_bytes / 1e9,
+            local_process_count,
             layout,
         )
         self.init_kv_buffer()

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import logging
+import os
 import threading
 from functools import wraps
 from typing import Optional
@@ -9,6 +10,7 @@ from typing import Optional
 import psutil
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.mem_cache.pool_host.common import (
     _cuda_host_unregister,
@@ -32,6 +34,55 @@ def synchronized(func):
             return func(self, *args, **kwargs)
 
     return wrapper
+
+
+def get_local_hicache_process_count() -> int:
+    """Best-effort count of ranks sharing the same host memory budget."""
+    local_process_count = envs.SGLANG_HICACHE_LOCAL_PROCESS_COUNT.get()
+    if local_process_count > 0:
+        return local_process_count
+
+    try:
+        from sglang.srt.distributed.parallel_state import get_world_group
+
+        local_size = getattr(get_world_group(), "local_size", 0)
+        if local_size > 0:
+            return local_size
+    except Exception:
+        pass
+
+    for env_name in ("LOCAL_SIZE", "LOCAL_WORLD_SIZE"):
+        try:
+            local_size = int(os.environ.get(env_name, "0"))
+            if local_size > 0:
+                return local_size
+        except ValueError:
+            pass
+
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        return max(1, torch.distributed.get_world_size())
+    return 1
+
+
+def validate_hicache_host_memory(
+    requested_bytes: int,
+    *,
+    description: str,
+) -> tuple[int, int, int]:
+    host_mem = psutil.virtual_memory()
+    available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
+    local_process_count = get_local_hicache_process_count()
+    aggregate_requested_bytes = requested_bytes * local_process_count
+    if aggregate_requested_bytes > available_bytes:
+        raise ValueError(
+            f"Not enough host memory available for {description}. "
+            f"Requesting {requested_bytes / 1e9:.2f} GB per local process "
+            f"across {local_process_count} local processes "
+            f"({aggregate_requested_bytes / 1e9:.2f} GB total), but only have "
+            f"{available_bytes / 1e9:.2f} GB free. Please reduce the size of "
+            f"the hierarchical cache."
+        )
+    return available_bytes, aggregate_requested_bytes, local_process_count
 
 
 class HostKVCache(abc.ABC):
@@ -71,21 +122,22 @@ class HostKVCache(abc.ABC):
             self.size > device_pool.size
         ), "The host memory should be larger than the device memory with the current protocol"
 
-        # Verify there is enough available host memory.
-        host_mem = psutil.virtual_memory()
         requested_bytes = self.size * self.size_per_token
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
-        if requested_bytes > available_bytes:
-            raise ValueError(
-                f"Not enough host memory available. Requesting "
-                f"{requested_bytes / 1e9:.2f} GB but only have "
-                f"{available_bytes / 1e9:.2f} GB free. Please reduce the "
-                f"size of the hierarchical cache."
-            )
-        else:
-            logger.info(
-                f"Allocating {requested_bytes / 1e9:.2f} GB host memory for hierarchical KV cache."
-            )
+        (
+            _,
+            aggregate_requested_bytes,
+            local_process_count,
+        ) = validate_hicache_host_memory(
+            requested_bytes,
+            description="hierarchical KV cache",
+        )
+        logger.info(
+            "Allocating %.2f GB host memory for hierarchical KV cache "
+            "(%.2f GB aggregate across %d local processes).",
+            requested_bytes / 1e9,
+            aggregate_requested_bytes / 1e9,
+            local_process_count,
+        )
 
         self.kv_buffer = self.init_kv_buffer()
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1840,7 +1840,8 @@ class ServerArgs:
     ] = 2.0
     hicache_size: A[
         int,
-        "The size of host KV cache memory pool in gigabytes, which will override the hicache_ratio if set.",
+        "The size of host KV cache memory pool in gigabytes per local worker process. "
+        "This overrides hicache_ratio if set.",
     ] = 0
     hicache_write_policy: A[
         str,

--- a/test/registered/unit/mem_cache/test_hicache_host_memory_guard.py
+++ b/test/registered/unit/mem_cache/test_hicache_host_memory_guard.py
@@ -1,0 +1,146 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_register_cpu_ci():
+    repo_root = Path(__file__).resolve().parents[4]
+    module_path = repo_root / "python/sglang/test/ci/ci_register.py"
+    spec = importlib.util.spec_from_file_location("_ci_register", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.register_cpu_ci
+
+
+register_cpu_ci = _load_register_cpu_ci()
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _load_base_module():
+    repo_root = Path(__file__).resolve().parents[4]
+    module_path = repo_root / "python/sglang/srt/mem_cache/pool_host/base.py"
+
+    stub_modules = {
+        "psutil": types.ModuleType("psutil"),
+        "torch": types.ModuleType("torch"),
+        "sglang": types.ModuleType("sglang"),
+        "sglang.srt": types.ModuleType("sglang.srt"),
+        "sglang.srt.environ": types.ModuleType("sglang.srt.environ"),
+        "sglang.srt.mem_cache": types.ModuleType("sglang.srt.mem_cache"),
+        "sglang.srt.mem_cache.memory_pool": types.ModuleType(
+            "sglang.srt.mem_cache.memory_pool"
+        ),
+        "sglang.srt.mem_cache.pool_host": types.ModuleType(
+            "sglang.srt.mem_cache.pool_host"
+        ),
+        "sglang.srt.mem_cache.pool_host.common": types.ModuleType(
+            "sglang.srt.mem_cache.pool_host.common"
+        ),
+        "sglang.srt.utils": types.ModuleType("sglang.srt.utils"),
+    }
+    stub_modules["torch"].distributed = types.SimpleNamespace(
+        is_available=lambda: False,
+        is_initialized=lambda: False,
+    )
+    stub_modules["psutil"].virtual_memory = lambda: types.SimpleNamespace(available=0)
+    stub_modules["sglang.srt.environ"].envs = types.SimpleNamespace(
+        SGLANG_HICACHE_LOCAL_PROCESS_COUNT=types.SimpleNamespace(get=lambda: 0)
+    )
+    stub_modules["sglang.srt.mem_cache.memory_pool"].KVCache = object
+    stub_modules["sglang.srt.mem_cache.pool_host.common"]._cuda_host_unregister = (
+        lambda _: None
+    )
+    stub_modules["sglang.srt.mem_cache.pool_host.common"].get_allocator_from_storage = (
+        lambda _: None
+    )
+    stub_modules["sglang.srt.utils"].is_cuda = lambda: False
+    stub_modules["sglang.srt.utils"].is_hip = lambda: False
+
+    previous_modules = {name: sys.modules.get(name) for name in stub_modules}
+    try:
+        sys.modules.update(stub_modules)
+        spec = importlib.util.spec_from_file_location(
+            "_hicache_host_base_under_test",
+            module_path,
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, previous_module in previous_modules.items():
+            if previous_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous_module
+
+
+base = _load_base_module()
+
+
+class TestHiCacheHostMemoryGuard(unittest.TestCase):
+    def test_get_local_hicache_process_count_uses_hicache_env(self):
+        with patch.object(
+            base.envs.SGLANG_HICACHE_LOCAL_PROCESS_COUNT,
+            "get",
+            return_value=4,
+        ):
+            self.assertEqual(base.get_local_hicache_process_count(), 4)
+
+    def test_validate_hicache_host_memory_accounts_for_local_processes(self):
+        requested_bytes = 20 * 10**9
+        available_bytes = 100 * 10**9
+
+        with (
+            patch.object(base, "get_local_hicache_process_count", return_value=4),
+            patch.object(
+                base.psutil,
+                "virtual_memory",
+                return_value=types.SimpleNamespace(
+                    available=available_bytes + base.HICACHE_HOST_MEMORY_RESERVE_BYTES
+                ),
+            ),
+        ):
+            actual_available, aggregate_requested, local_process_count = (
+                base.validate_hicache_host_memory(
+                    requested_bytes,
+                    description="test pool",
+                )
+            )
+
+        self.assertEqual(actual_available, available_bytes)
+        self.assertEqual(aggregate_requested, 80 * 10**9)
+        self.assertEqual(local_process_count, 4)
+
+    def test_get_local_hicache_process_count_uses_local_size_env(self):
+        with patch.dict(base.os.environ, {"LOCAL_SIZE": "4"}):
+            self.assertEqual(base.get_local_hicache_process_count(), 4)
+
+    def test_validate_hicache_host_memory_rejects_aggregate_overcommit(self):
+        requested_bytes = 30 * 10**9
+        available_bytes = 100 * 10**9
+
+        with (
+            patch.object(base, "get_local_hicache_process_count", return_value=4),
+            patch.object(
+                base.psutil,
+                "virtual_memory",
+                return_value=types.SimpleNamespace(
+                    available=available_bytes + base.HICACHE_HOST_MEMORY_RESERVE_BYTES
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "120.00 GB total.*100.00 GB free",
+            ):
+                base.validate_hicache_host_memory(
+                    requested_bytes,
+                    description="test pool",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Propagate a HiCache-specific local worker count from the SGLang launcher.
- Validate HiCache host-memory allocations against aggregate local worker demand, not only per-process demand.
- Reuse the guard for KV cache, Mamba cache, V4 HiSparse pools, and DSA indexer host pools.
- Clarify that `--hicache-size` is per local worker process.

## Root cause
The GLM-5.2 NVFP4 launch with TP=4 and `--hicache-size 150` was not failing at the breakable CUDA graph capture point. Saved logs showed target/draft graph capture completed, then all four local ranks each allocated `150.00 GB` HiCache host KV, followed by DSA indexer allocations around `34.38 GB` per rank.

The old guard compared one process's allocation against host free memory. On a colocated TP launch, all local workers share the same host-memory budget, so each rank could pass the check individually while the aggregate allocation overcommitted the node/pod.

## Tests
- `PYTHONPATH=python python3 -m unittest test.registered.unit.mem_cache.test_hicache_host_memory_guard`
- `uvx ruff check python/sglang/srt/environ.py python/sglang/srt/entrypoints/engine.py python/sglang/srt/mem_cache/pool_host/base.py python/sglang/srt/mem_cache/memory_pool_host.py test/registered/unit/mem_cache/test_hicache_host_memory_guard.py`
- `python3 scripts/ci/check_registered_tests.py`
- `python3 -m py_compile python/sglang/srt/environ.py python/sglang/srt/entrypoints/engine.py python/sglang/srt/mem_cache/pool_host/base.py python/sglang/srt/mem_cache/memory_pool_host.py python/sglang/srt/server_args.py test/registered/unit/mem_cache/test_hicache_host_memory_guard.py`
- pre-commit hooks during commit











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28146224393](https://github.com/sgl-project/sglang/actions/runs/28146224393)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28146224285](https://github.com/sgl-project/sglang/actions/runs/28146224285)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->