### PR TITLE
fix: batch BlockRemoved events per radix node

### DIFF
--- a/python/sglang/srt/mem_cache/events.py
+++ b/python/sglang/srt/mem_cache/events.py
@@ -84,7 +84,7 @@ class KVCacheEventMixin:
                 page_index += 1
 
     def _record_remove_event(self, node: Any, medium=None):
-        # One BlockRemoved per chunk.
+        # One BlockRemoved per radix node.
         # ``medium`` defaults to StorageMedium.GPU but callers may override for
         # lower-tier removals (e.g. StorageMedium.CPU when evicting from host).
         if self.enable_kv_cache_events:
@@ -95,20 +95,21 @@ class KVCacheEventMixin:
             if node.hash_value is None:
                 node.hash_value = compute_node_hash_values(node, self.page_size)
 
-            page_index = 0
+            block_hashes = []
             logical_len = len(node.key)
+            page_index = 0
             for start in range(0, logical_len, self.page_size):
                 end = min(start + self.page_size, logical_len)
                 if end <= start:
                     continue
 
-                block_hash = hash_str_to_int64(node.hash_value[page_index])
-
-                self.kv_event_queue.append(
-                    BlockRemoved(block_hashes=[block_hash], medium=medium)
-                )
-
+                block_hashes.append(hash_str_to_int64(node.hash_value[page_index]))
                 page_index += 1
+
+            if block_hashes:
+                self.kv_event_queue.append(
+                    BlockRemoved(block_hashes=block_hashes, medium=medium)
+                )
 
     def _record_all_cleared_event(self):
         if self.enable_kv_cache_events:

--- a/test/manual/test_kv_events.py
+++ b/test/manual/test_kv_events.py
@@ -140,10 +140,12 @@ class TestKvEvents(CustomTestCase):
                 elif isinstance(event, BlockRemoved):
                     # Validate BlockRemoved structure
                     self.assertIsInstance(event.block_hashes, list)
-                    self.assertEqual(
-                        len(event.block_hashes), 1, "Should have one hash per block"
+                    self.assertGreater(
+                        len(event.block_hashes),
+                        0,
+                        "Should have at least one removed block hash",
                     )
-                    removed_hashes.add(event.block_hashes[0])
+                    removed_hashes.update(event.block_hashes)
 
             # Verify we got both BlockStored and BlockRemoved events
             self.assertGreater(

--- a/test/registered/unit/mem_cache/test_mamba_unittest.py
+++ b/test/registered/unit/mem_cache/test_mamba_unittest.py
@@ -29,6 +29,10 @@ register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=9, suite="stage-b-test-1-gpu-small-amd")
 
 
+def _event_hashes(events):
+    return [block_hash for event in events for block_hash in event.block_hashes]
+
+
 class TestMamba(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -374,9 +378,9 @@ class TestMamba(unittest.TestCase):
         result = tree.evict(EvictParams(num_tokens=1))
         self.assertGreaterEqual(result.num_tokens_evicted, 1)
         events = tree.take_events()
-        removed_hashes = [
-            e.block_hashes[0] for e in events if isinstance(e, BlockRemoved)
-        ]
+        removed_hashes = _event_hashes(
+            [e for e in events if isinstance(e, BlockRemoved)]
+        )
         self.assertCountEqual(removed_hashes, stored_hashes)
 
     def test_mamba_radix_cache_kv_events_split_hash(self):

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -484,22 +484,25 @@ class TestRadixCache(unittest.TestCase):
         mock_allocator.device = torch.device("cpu")
 
         cache = RadixCache.create_simulated(
-            mock_allocator=mock_allocator, enable_kv_cache_events=True
+            mock_allocator=mock_allocator,
+            page_size=2,
+            enable_kv_cache_events=True,
         )
 
         # Insert and then evict data
+        seq = [1, 2, 3, 4]
         cache.insert(
             InsertParams(
-                key=RadixKey(array("q", [1, 2, 3])),
-                value=torch.tensor([10, 20, 30], dtype=torch.int64),
+                key=RadixKey(array("q", seq)),
+                value=torch.tensor([10, 20, 30, 40], dtype=torch.int64),
             )
         )
-        result = cache.evict(EvictParams(num_tokens=3))
+        result = cache.evict(EvictParams(num_tokens=len(seq)))
         self.assertIsInstance(result, EvictResult)
         self.assertGreaterEqual(
             result.num_tokens_evicted,
-            3,
-            f"evicted {result.num_tokens_evicted} tokens, expected at least 3",
+            len(seq),
+            f"evicted {result.num_tokens_evicted} tokens, expected at least {len(seq)}",
         )
 
         # Take events - should include both store and remove events
@@ -510,10 +513,17 @@ class TestRadixCache(unittest.TestCase):
         event_types = [type(event).__name__ for event in events]
         self.assertIn("BlockStored", event_types)
 
+        stored_hashes = [
+            event.block_hashes[0]
+            for event in events
+            if isinstance(event, BlockStored)
+        ]
+        self.assertEqual(len(stored_hashes), 2)
+
         # Verify BlockRemoved event content
         remove_events = [e for e in events if isinstance(e, BlockRemoved)]
-        for event in remove_events:
-            self.assertGreater(len(event.block_hashes), 0)
+        self.assertEqual(len(remove_events), 1)
+        self.assertEqual(remove_events[0].block_hashes, stored_hashes)
 
     def test_extra_key_isolation(self):
         """Test that keys with different extra_key values are isolated."""

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -514,9 +514,7 @@ class TestRadixCache(unittest.TestCase):
         self.assertIn("BlockStored", event_types)
 
         stored_hashes = [
-            event.block_hashes[0]
-            for event in events
-            if isinstance(event, BlockStored)
+            event.block_hashes[0] for event in events if isinstance(event, BlockStored)
         ]
         self.assertEqual(len(stored_hashes), 2)
 

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -27,6 +27,10 @@ register_cuda_ci(est_time=9, stage="base-b", runner_config="1-gpu-large")
 register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
 
 
+def _event_hashes(events):
+    return [block_hash for event in events for block_hash in event.block_hashes]
+
+
 class _DummyReq:
     def __init__(self):
         self._kv_committed_len = 0
@@ -172,9 +176,9 @@ class TestSWA(unittest.TestCase):
 
         result = tree.evict(EvictParams(num_tokens=1, swa_num_tokens=0))
         self.assertGreaterEqual(result.num_tokens_evicted, 1)
-        removed_hashes = [
-            e.block_hashes[0] for e in tree.take_events() if isinstance(e, BlockRemoved)
-        ]
+        removed_hashes = _event_hashes(
+            [e for e in tree.take_events() if isinstance(e, BlockRemoved)]
+        )
         self.assertCountEqual(removed_hashes, stored_hashes)
 
     def test_swa_radix_cache_kv_events_split_hash(self):

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -443,6 +443,9 @@ class TestUnifiedRadixCacheKVEvents(CustomTestCase):
             events = [e for e in events if e.medium == medium]
         return events
 
+    def _event_hashes(self, events):
+        return [block_hash for event in events for block_hash in event.block_hashes]
+
     def _leaf_for(self, tree, tokens):
         match = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", tokens))))
         self.assertIsNot(match.last_device_node, tree.root_node)
@@ -512,7 +515,8 @@ class TestUnifiedRadixCacheKVEvents(CustomTestCase):
         result = tree.evict(EvictParams(num_tokens=len(seq)))
         self.assertGreaterEqual(result.num_tokens_evicted, len(seq))
         removed = self._removed_events(tree, StorageMedium.GPU)
-        self.assertCountEqual([e.block_hashes[0] for e in removed], stored_hashes)
+        self.assertEqual(len(removed), 1)
+        self.assertEqual(removed[0].block_hashes, stored_hashes)
 
     def test_kv_events_split_preserves_block_hash_parentage(self):
         tree, allocator, _ = build_fixture(self.cfg, enable_kv_cache_events=True)
@@ -554,7 +558,7 @@ class TestUnifiedRadixCacheKVEvents(CustomTestCase):
 
         tree.evict(EvictParams(num_tokens=len(seq)))
         removed_gpu = self._removed_events(tree, StorageMedium.GPU)
-        self.assertCountEqual([e.block_hashes[0] for e in removed_gpu], stored_hashes)
+        self.assertCountEqual(self._event_hashes(removed_gpu), stored_hashes)
 
         self._load_back_node(tree, node)
         restored_gpu = self._stored_events(tree, StorageMedium.GPU)
@@ -564,7 +568,7 @@ class TestUnifiedRadixCacheKVEvents(CustomTestCase):
         self._removed_events(tree, StorageMedium.GPU)
         tree.evict_host(len(seq))
         removed_cpu = self._removed_events(tree, StorageMedium.CPU)
-        self.assertCountEqual([e.block_hashes[0] for e in removed_cpu], stored_hashes)
+        self.assertCountEqual(self._event_hashes(removed_cpu), stored_hashes)
 
     def test_hicache_split_pending_write_through_publishes_fragments(self):
         tree, allocator, _ = build_fixture(self.cfg, enable_kv_cache_events=True)


### PR DESCRIPTION
## Summary

- Batch removed page hashes into one `BlockRemoved` event per removed radix node.
- Keep `BlockStored` emission unchanged.
- Update radix, unified radix, SWA, Mamba, and manual KV event tests for multi-hash removal events.

## Motivation / Context

A removed radix node can contain multiple full pages. Emitting one removal event per page adds avoidable event volume and networking overhead for KV-event subscribers. Sending the removed hashes together keeps the event stream more compact while preserving ordering within the removed node.

This is useful for any remote KV-event subscriber that tracks cache state from the event stream; Dynamo-style KV-aware routing is one example, but the core benefit is reduced event chatter.

## Compatibility / Consumer Impact

I checked the in-tree consumer paths this can affect.

`experimental/sgl-router` already treats `BlockRemoved.block_hashes` as a multi-hash payload, not a singleton. Its wire type stores `BlockRemoved.block_hashes` as `Vec<i64>`, the decoder reads the full vector, and the event pump passes the full slice into `HashTree::remove`. The tree remover then iterates every hash in the slice. There is also existing decode coverage for `BlockRemoved([100, 200], ...)`, so a batched removal event is already consumable by the SGL router path.

`sgl-model-gateway` / SMG does not appear to consume SGLang KV cache events in this checkout. Its cache-aware path maintains text/tenant tree state and mesh `TreeOperation::{Insert, Remove}` operations, not `BlockRemoved` / `block_hashes` events. I did not find `BlockRemoved`, `kv_events`, `kv-events`, or `block_hashes` usage under `sgl-model-gateway`. So this change should not affect SMG's cache-aware or mesh state path.

The patch does not change the event type, publisher, topic, `medium`, or field shape. It only sends the same removed hashes in fewer `BlockRemoved` messages when they come from the same removed radix node.

## Validation

Local checks:

- `python -m py_compile python/sglang/srt/mem_cache/events.py test/manual/test_kv_events.py test/registered/unit/mem_cache/test_mamba_unittest.py test/registered/unit/mem_cache/test_radix_cache_unit.py test/registered/unit/mem_cache/test_swa_unittest.py test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py`
- `git diff --check`

Focused tests with patched SGLang source:

- Focused SGLang cache tests: `5 passed, 17 warnings in 32.60s`
  - The warnings are existing pytest/SWIG/PyTorch deprecation/config warnings, not KV-event failures.
- FlashInfer JIT smoke passed after configuring the CUDA 13 nvcc/nvvm runtime.

Exact eviction before/after:

- Same Dynamo checkout, model, and SGLang arguments in both runs: one worker, `page_size=16`, `context_length=256`, `max_total_tokens=256`, and 12 deterministic unique 96-token prompts (6 pages each).
- An identical, temporary publisher-boundary probe counted every raw `BlockRemoved` event and its `block_hashes` width in both source trees. The probe and temporary test harness were removed after validation.
- Unpatched `origin/main` (`9fd6d0ec`): `1 passed in 62.27s`; 60 removal events, 60 removed hashes, max `block_hashes` length 1, and 50 exact `Failed to find block` warnings.
- Patched (`201dec9e5`): `1 passed in 65.40s`; 10 removal events, 60 removed hashes, max `block_hashes` length 6, and 0 exact `Failed to find block` warnings.
- Exact greps for `Could not find nvcc` and `Ninja build failed` were zero in both runs.

This fixed workload preserves all 60 removed hashes while reducing removal events from 60 to 10 and eliminating the 50 Dynamo indexer warnings reproduced on unpatched main.

Additional general integration coverage:

- Patched Dynamo/SGLang KV router basic integration: `1 passed in 150.04s`.
- Patched Dynamo/SGLang multi-worker router-decision integration: `1 passed in 79.81s`.
- Unpatched `origin/main` router-decision baseline: `1 passed in 110.10s`.

The router-decision baseline emitted no removals (`BlockRemoved=0`) and no `Failed to find block` warnings, so these router integrations are general coverage only; the eviction workload above is the removal-warning evidence.

The multi-worker integration used a temporary test harness bump from `mem_fraction_static=0.4` to `0.405`, because the second worker reported a minimum viable value of `0.4005`. That temporary edit was restored after validation.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28154455036](https://github.com/sgl-project/sglang/actions/runs/28154455036)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28154454817](https://github.com/sgl-project/sglang/actions/runs/28154454817)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
