### PR TITLE
Fix FP4 KV cache for Qwen3.6 hybrid linear pools

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -114,6 +114,7 @@ class TritonAttnBackend(AttentionBackend):
         # Lazy import to avoid the initialization of cuda context
         from sglang.srt.layers.attention.triton_ops.decode_attention import (
             decode_attention_fwd,
+            decode_attention_fwd_fp4,
         )
         from sglang.srt.layers.attention.triton_ops.extend_attention import (
             build_unified_kv_indices,
@@ -127,6 +128,7 @@ class TritonAttnBackend(AttentionBackend):
         super().__init__()
 
         self.decode_attention_fwd = torch.compiler.disable(decode_attention_fwd)
+        self.decode_attention_fwd_fp4 = torch.compiler.disable(decode_attention_fwd_fp4)
         self.extend_attention_fwd = torch.compiler.disable(extend_attention_fwd)
         self.extend_attention_fwd_unified = torch.compiler.disable(
             extend_attention_fwd_unified
@@ -1664,11 +1666,73 @@ class TritonAttnBackend(AttentionBackend):
                 device=q.device,
             )
             self.forward_metadata.attn_lse.fill_(-float("inf"))
-            self.decode_attention_fwd(
-                q_for_decode,
-                self.token_to_kv_pool.get_key_buffer(layer.layer_id),
-                self.token_to_kv_pool.get_value_buffer(layer.layer_id),
-                o_for_decode,
+            if (
+                getattr(self.token_to_kv_pool, "supports_fp4_decode_attention", False)
+                and not self.use_mla
+            ):
+                self.decode_attention_fwd_fp4(
+                    q_for_decode,
+                    self.token_to_kv_pool.get_key_fp4_buffer(layer.layer_id),
+                    self.token_to_kv_pool.get_key_scale_buffer(layer.layer_id),
+                    self.token_to_kv_pool.get_value_fp4_buffer(layer.layer_id),
+                    self.token_to_kv_pool.get_value_scale_buffer(layer.layer_id),
+                    o_for_decode,
+                    kv_indptr,
+                    kv_indices,
+                    attn_logits,
+                    self.forward_metadata.attn_lse,
+                    self.forward_metadata.num_kv_splits,
+                    self.max_kv_splits,
+                    layer.scaling,
+                    k_descale,
+                    v_descale,
+                    logit_cap=logits_soft_cap,
+                    sinks=sinks,
+                    xai_temperature_len=layer.xai_temperature_len,
+                    has_mla=self.use_mla,
+                    use_pdl=self.use_pdl,
+                )
+            else:
+                self.decode_attention_fwd(
+                    q_for_decode,
+                    self.token_to_kv_pool.get_key_buffer(layer.layer_id),
+                    self.token_to_kv_pool.get_value_buffer(layer.layer_id),
+                    o_for_decode,
+                    kv_indptr,
+                    kv_indices,
+                    attn_logits,
+                    self.forward_metadata.attn_lse,
+                    self.forward_metadata.num_kv_splits,
+                    self.max_kv_splits,
+                    layer.scaling,
+                    k_descale,
+                    v_descale,
+                    logit_cap=logits_soft_cap,
+                    sinks=sinks,
+                    xai_temperature_len=layer.xai_temperature_len,
+                )
+            local_lse = torch.logsumexp(
+                self.forward_metadata.attn_lse[
+                    : q_for_decode.shape[0], : q_for_decode.shape[1], :
+                ],
+                dim=-1,
+            )
+            o = cp_lse_ag_out_rs(o_for_decode, local_lse, group)
+            return o.reshape(-1, layer.tp_q_head_num * layer.v_head_dim).to(q.dtype)
+
+        q_view = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        o_view = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+        if (
+            getattr(self.token_to_kv_pool, "supports_fp4_decode_attention", False)
+            and not self.use_mla
+        ):
+            self.decode_attention_fwd_fp4(
+                q_view,
+                self.token_to_kv_pool.get_key_fp4_buffer(layer.layer_id),
+                self.token_to_kv_pool.get_key_scale_buffer(layer.layer_id),
+                self.token_to_kv_pool.get_value_fp4_buffer(layer.layer_id),
+                self.token_to_kv_pool.get_value_scale_buffer(layer.layer_id),
+                o_view,
                 kv_indptr,
                 kv_indices,
                 attn_logits,
@@ -1681,36 +1745,30 @@ class TritonAttnBackend(AttentionBackend):
                 logit_cap=logits_soft_cap,
                 sinks=sinks,
                 xai_temperature_len=layer.xai_temperature_len,
+                has_mla=self.use_mla,
+                use_pdl=self.use_pdl,
             )
-            local_lse = torch.logsumexp(
-                self.forward_metadata.attn_lse[
-                    : q_for_decode.shape[0], : q_for_decode.shape[1], :
-                ],
-                dim=-1,
+        else:
+            self.decode_attention_fwd(
+                q_view,
+                self.token_to_kv_pool.get_key_buffer(layer.layer_id),
+                self.token_to_kv_pool.get_value_buffer(layer.layer_id),
+                o_view,
+                kv_indptr,
+                kv_indices,
+                attn_logits,
+                self.forward_metadata.attn_lse,
+                self.forward_metadata.num_kv_splits,
+                self.max_kv_splits,
+                layer.scaling,
+                k_descale,
+                v_descale,
+                logit_cap=logits_soft_cap,
+                sinks=sinks,
+                xai_temperature_len=layer.xai_temperature_len,
+                has_mla=self.use_mla,
+                use_pdl=self.use_pdl,
             )
-            o = cp_lse_ag_out_rs(o_for_decode, local_lse, group)
-            return o.reshape(-1, layer.tp_q_head_num * layer.v_head_dim).to(q.dtype)
-
-        self.decode_attention_fwd(
-            q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
-            self.token_to_kv_pool.get_key_buffer(layer.layer_id),
-            self.token_to_kv_pool.get_value_buffer(layer.layer_id),
-            o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
-            kv_indptr,
-            kv_indices,
-            attn_logits,
-            self.forward_metadata.attn_lse,
-            self.forward_metadata.num_kv_splits,
-            self.max_kv_splits,
-            layer.scaling,
-            k_descale,
-            v_descale,
-            logit_cap=logits_soft_cap,
-            sinks=sinks,
-            xai_temperature_len=layer.xai_temperature_len,
-            has_mla=self.use_mla,
-            use_pdl=self.use_pdl,
-        )
         return o
 
 

--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -520,6 +520,323 @@ def _decode_grouped_att_m_fwd(
 
 
 @triton.jit
+def _fp4_e2m1_to_float(fp4_vals):
+    mag = fp4_vals & 0x07
+    sign = (fp4_vals & 0x08) != 0
+    vals = tl.where(
+        mag == 0,
+        0.0,
+        tl.where(
+            mag == 1,
+            0.5,
+            tl.where(
+                mag == 2,
+                1.0,
+                tl.where(
+                    mag == 3,
+                    1.5,
+                    tl.where(
+                        mag == 4,
+                        2.0,
+                        tl.where(mag == 5, 3.0, tl.where(mag == 6, 4.0, 6.0)),
+                    ),
+                ),
+            ),
+        ),
+    )
+    return tl.where(sign, -vals, vals)
+
+
+@triton.jit
+def _load_block_fp4(
+    Buffer,
+    Scale_Buffer,
+    kv_loc,
+    cur_kv_head,
+    offs_d,
+    stride_buf_bs,
+    stride_buf_h,
+    stride_scale_bs,
+    stride_scale_b,
+    HEAD_DIM: tl.constexpr,
+    mask,
+):
+    byte_offs = offs_d // 2
+    scale_block = offs_d // 16
+    packed = tl.load(
+        Buffer + kv_loc * stride_buf_bs + cur_kv_head * stride_buf_h + byte_offs,
+        mask=mask,
+        other=0,
+    )
+    low = packed & 0x0F
+    high = (packed >> 4) & 0x0F
+    fp4_vals = tl.where((offs_d & 1) == 0, low, high)
+    scale_u8 = tl.load(
+        Scale_Buffer
+        + kv_loc * stride_scale_bs
+        + (cur_kv_head * (HEAD_DIM // 16) + scale_block) * stride_scale_b,
+        mask=mask,
+        other=127,
+    )
+    scale_bits = scale_u8.to(tl.uint32) << 23
+    scale = scale_bits.to(tl.float32, bitcast=True)
+    return _fp4_e2m1_to_float(fp4_vals) * scale
+
+
+@triton.jit
+def _fwd_fp4_grouped_kernel_stage1(
+    Q,
+    K_Buffer,
+    K_Scale_Buffer,
+    V_Buffer,
+    V_Scale_Buffer,
+    sm_scale_withk,
+    kv_indptr,
+    kv_indices,
+    Att_Out,
+    Att_Lse,
+    num_kv_splits,
+    stride_qbs,
+    stride_qh,
+    stride_buf_kbs,
+    stride_buf_kh,
+    stride_k_scale_bs,
+    stride_k_scale_b,
+    stride_buf_vbs,
+    stride_buf_vh,
+    stride_v_scale_bs,
+    stride_v_scale_b,
+    stride_mid_ob,
+    stride_mid_oh,
+    stride_mid_os,
+    kv_group_num: tl.constexpr,
+    q_head_num: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    MIN_BLOCK_KV: tl.constexpr,
+    logit_cap: tl.constexpr,
+    xai_temperature_len: tl.constexpr,
+    Lk: tl.constexpr,
+    Lv: tl.constexpr,
+    USE_PDL: tl.constexpr = False,
+):
+    cur_batch = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    cur_kv_head = cur_head_id // tl.cdiv(kv_group_num, BLOCK_H)
+    split_kv_id = tl.program_id(2)
+
+    if BLOCK_H < kv_group_num:
+        VALID_BLOCK_H: tl.constexpr = BLOCK_H
+    else:
+        VALID_BLOCK_H: tl.constexpr = kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = cur_head < (cur_head_id + 1) * VALID_BLOCK_H
+    mask_h = mask_h & (cur_head < q_head_num)
+
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    mask_d = offs_d < Lk
+    mask_dv = offs_dv < Lv
+
+    cur_batch_kv_start_idx = tl.load(kv_indptr + cur_batch)
+    cur_batch_seq_len = tl.load(kv_indptr + cur_batch + 1) - cur_batch_kv_start_idx
+    kv_splits = tl.load(num_kv_splits + cur_batch)
+
+    if xai_temperature_len > 0:
+        offs_qidx = cur_batch_seq_len - 1
+        xai_temperature_scale = 1.0 / tl.log2(float(xai_temperature_len))
+        _qtemp = tl.log2(offs_qidx.to(tl.float32)) * xai_temperature_scale
+        xai_temperature_reg = tl.where(offs_qidx > xai_temperature_len, _qtemp, 1.0)
+
+    offs_q = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_d[None, :]
+
+    kv_len_per_split = (
+        tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    )
+    split_kv_start = kv_len_per_split * split_kv_id
+    split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
+
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
+
+    if split_kv_end > split_kv_start:
+        q = tl.load(Q + offs_q, mask=(mask_h[:, None]) & (mask_d[None, :]), other=0.0)
+        q_k = q.to(tl.float32)
+        for start_n in tl.range(split_kv_start, split_kv_end, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            kv_loc = tl.load(
+                kv_indices + cur_batch_kv_start_idx + offs_n,
+                mask=offs_n < split_kv_end,
+                other=0,
+            )
+            k = _load_block_fp4(
+                K_Buffer,
+                K_Scale_Buffer,
+                kv_loc[None, :],
+                cur_kv_head,
+                offs_d[:, None],
+                stride_buf_kbs,
+                stride_buf_kh,
+                stride_k_scale_bs,
+                stride_k_scale_b,
+                Lk,
+                (offs_n[None, :] < split_kv_end) & (mask_d[:, None]),
+            )
+            qk = tl.dot(q_k, k)
+            qk *= sm_scale_withk
+
+            if logit_cap > 0:
+                qk = logit_cap * tanh(qk / logit_cap)
+
+            if xai_temperature_len > 0:
+                qk *= xai_temperature_reg[:, None]
+
+            qk = tl.where(
+                mask_h[:, None] & (offs_n[None, :] < split_kv_end), qk, float("-inf")
+            )
+            v = _load_block_fp4(
+                V_Buffer,
+                V_Scale_Buffer,
+                kv_loc[:, None],
+                cur_kv_head,
+                offs_dv[None, :],
+                stride_buf_vbs,
+                stride_buf_vh,
+                stride_v_scale_bs,
+                stride_v_scale_b,
+                Lv,
+                (offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
+            )
+
+            n_e_max = tl.maximum(tl.max(qk, 1), e_max)
+            re_scale = tl.exp(e_max - n_e_max)
+            p = tl.exp(qk - n_e_max[:, None])
+            acc *= re_scale[:, None]
+            acc += tl.dot(p.to(tl.float32), v)
+
+            e_sum = e_sum * re_scale + tl.sum(p, 1)
+            e_max = n_e_max
+
+        offs_mid_o = (
+            cur_batch * stride_mid_ob
+            + cur_head[:, None] * stride_mid_oh
+            + split_kv_id * stride_mid_os
+            + offs_dv[None, :]
+        )
+
+        tl.store(
+            Att_Out + offs_mid_o,
+            acc / e_sum[:, None],
+            mask=(mask_h[:, None]) & (mask_dv[None, :]),
+        )
+
+        offs_mid_o_1 = (
+            cur_batch * stride_mid_ob
+            + cur_head * stride_mid_oh
+            + split_kv_id * stride_mid_os
+        ) // Lv
+
+        tl.store(
+            Att_Lse + offs_mid_o_1,
+            e_max + tl.log(e_sum),
+            mask=mask_h,
+        )
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
+
+def _decode_fp4_grouped_att_m_fwd(
+    q,
+    k_buffer,
+    k_scale_buffer,
+    v_buffer,
+    v_scale_buffer,
+    att_out,
+    att_lse,
+    kv_indptr,
+    kv_indices,
+    num_kv_splits,
+    max_kv_splits,
+    sm_scale_withk,
+    logit_cap,
+    xai_temperature_len=-1,
+    use_pdl=False,
+):
+    BLOCK = 32
+    Lk = k_buffer.shape[-1] * 2
+    Lv = v_buffer.shape[-1] * 2
+
+    if _is_hip and Lk >= 576:
+        BLOCK = 16
+
+    BLOCK_DMODEL = triton.next_power_of_2(Lk)
+    BLOCK_DV = triton.next_power_of_2(Lv)
+
+    batch, head_num = q.shape[0], q.shape[1]
+    kv_group_num = q.shape[1] // k_buffer.shape[1]
+
+    BLOCK_H = 16
+    MAX_KV_SPLITS = max_kv_splits
+    grid = (
+        batch,
+        triton.cdiv(head_num, min(BLOCK_H, kv_group_num)),
+        MAX_KV_SPLITS,
+    )
+
+    extra_kargs = {}
+    num_stages = 2
+    if _is_hip:
+        extra_kargs = {"waves_per_eu": 1, "matrix_instr_nonkdim": 16, "kpack": 2}
+        num_stages = 1
+
+    _fwd_fp4_grouped_kernel_stage1[grid](
+        q,
+        k_buffer,
+        k_scale_buffer,
+        v_buffer,
+        v_scale_buffer,
+        sm_scale_withk,
+        kv_indptr,
+        kv_indices,
+        att_out,
+        att_lse,
+        num_kv_splits,
+        q.stride(0),
+        q.stride(1),
+        k_buffer.stride(0),
+        k_buffer.stride(1),
+        k_scale_buffer.stride(0),
+        k_scale_buffer.stride(1),
+        v_buffer.stride(0),
+        v_buffer.stride(1),
+        v_scale_buffer.stride(0),
+        v_scale_buffer.stride(1),
+        att_out.stride(0),
+        att_out.stride(1),
+        att_out.stride(2),
+        kv_group_num=kv_group_num,
+        q_head_num=head_num,
+        BLOCK_DMODEL=BLOCK_DMODEL,
+        BLOCK_DV=BLOCK_DV,
+        BLOCK_N=BLOCK,
+        BLOCK_H=BLOCK_H,
+        MIN_BLOCK_KV=_MIN_BLOCK_KV,
+        logit_cap=logit_cap,
+        xai_temperature_len=xai_temperature_len,
+        num_warps=4,
+        num_stages=num_stages,
+        Lk=Lk,
+        Lv=Lv,
+        USE_PDL=use_pdl,
+        **extra_kargs,
+    )
+
+
+@triton.jit
 def _fwd_kernel_stage2(
     Mid_O,
     Mid_O_1,
@@ -734,6 +1051,66 @@ def decode_attention_fwd_grouped(
         o,
         v_scale,
         v_buffer,
+        kv_indptr,
+        num_kv_splits,
+        max_kv_splits,
+        sinks,
+        use_pdl=use_pdl,
+    )
+
+
+def decode_attention_fwd_fp4(
+    q,
+    k_buffer,
+    k_scale_buffer,
+    v_buffer,
+    v_scale_buffer,
+    o,
+    kv_indptr,
+    kv_indices,
+    attn_logits,
+    attn_lse,
+    num_kv_splits,
+    max_kv_splits,
+    sm_scale,
+    k_scale,
+    v_scale,
+    logit_cap=0.0,
+    sinks=None,
+    xai_temperature_len=-1,
+    has_mla=False,
+    use_pdl=False,
+):
+    assert max_kv_splits == attn_logits.shape[2]
+    assert q.shape[0] <= kv_indptr.shape[0] - 1
+    assert q.shape[0] <= attn_logits.shape[0]
+    if has_mla:
+        raise NotImplementedError("FP4 fused decode does not support MLA pools yet")
+
+    _decode_fp4_grouped_att_m_fwd(
+        q,
+        k_buffer,
+        k_scale_buffer,
+        v_buffer,
+        v_scale_buffer,
+        attn_logits,
+        attn_lse,
+        kv_indptr,
+        kv_indices,
+        num_kv_splits,
+        max_kv_splits,
+        sm_scale * k_scale,
+        logit_cap,
+        xai_temperature_len=xai_temperature_len,
+        use_pdl=use_pdl,
+    )
+    _decode_softmax_reducev_fwd(
+        attn_logits,
+        attn_lse,
+        q,
+        o,
+        v_scale,
+        o,
         kv_indptr,
         num_kv_splits,
         max_kv_splits,

--- a/python/sglang/srt/layers/quantization/kvfp4_tensor.py
+++ b/python/sglang/srt/layers/quantization/kvfp4_tensor.py
@@ -149,6 +149,10 @@ class BlockFP4KVQuantizeUtil:
         return scaled.view(b, m, n).to(dtype)
 
 
+# Backward-compatible name used by FP4 KV memory pools.
+KVFP4QuantizeUtil = BlockFP4KVQuantizeUtil
+
+
 class NVFP4KVQuantizeUtil:
     """Utility class for NVFP4 quantization and dequantization with two-level scaling
     (global FP32 + block FP8 E4M3).

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -63,6 +63,7 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
     is_cuda,
+    is_float4_e2m1fn_x2,
     is_hip,
     is_npu,
     next_power_of_2,
@@ -1800,6 +1801,20 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
         del self.k_scale_buffer
         del self.v_scale_buffer
 
+    supports_fp4_decode_attention = True
+
+    def get_key_fp4_buffer(self, layer_id: int):
+        return self.k_buffer[layer_id - self.start_layer]
+
+    def get_value_fp4_buffer(self, layer_id: int):
+        return self.v_buffer[layer_id - self.start_layer]
+
+    def get_key_scale_buffer(self, layer_id: int):
+        return self.k_scale_buffer[layer_id - self.start_layer]
+
+    def get_value_scale_buffer(self, layer_id: int):
+        return self.v_scale_buffer[layer_id - self.start_layer]
+
     def _get_key_buffer(self, layer_id: int):
         # for internal use of referencing
         if self.store_dtype != self.dtype:
@@ -1930,7 +1945,9 @@ class HybridLinearKVPool(KVCache):
         assert not enable_kvcache_transpose
         self.use_mla = use_mla
         if not use_mla:
-            TokenToKVPoolClass = MHATokenToKVPool
+            TokenToKVPoolClass = (
+                MHATokenToKVPoolFP4 if is_float4_e2m1fn_x2(dtype) else MHATokenToKVPool
+            )
 
             if current_platform.is_out_of_tree():
                 TokenToKVPoolClass = current_platform.get_mha_kv_pool_cls()
@@ -2019,6 +2036,33 @@ class HybridLinearKVPool(KVCache):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
 
+    def _full_pool_supports_fp4_decode_attention(self):
+        return getattr(self.full_kv_pool, "supports_fp4_decode_attention", False)
+
+    @property
+    def supports_fp4_decode_attention(self):
+        return self._full_pool_supports_fp4_decode_attention()
+
+    def get_key_fp4_buffer(self, layer_id: int):
+        self._wait_for_layer(layer_id)
+        layer_id = self._transfer_full_attention_id(layer_id)
+        return self.full_kv_pool.get_key_fp4_buffer(layer_id)
+
+    def get_value_fp4_buffer(self, layer_id: int):
+        self._wait_for_layer(layer_id)
+        layer_id = self._transfer_full_attention_id(layer_id)
+        return self.full_kv_pool.get_value_fp4_buffer(layer_id)
+
+    def get_key_scale_buffer(self, layer_id: int):
+        self._wait_for_layer(layer_id)
+        layer_id = self._transfer_full_attention_id(layer_id)
+        return self.full_kv_pool.get_key_scale_buffer(layer_id)
+
+    def get_value_scale_buffer(self, layer_id: int):
+        self._wait_for_layer(layer_id)
+        layer_id = self._transfer_full_attention_id(layer_id)
+        return self.full_kv_pool.get_value_scale_buffer(layer_id)
+
     def get_key_buffer(self, layer_id: int):
         self._wait_for_layer(layer_id)
         layer_id = self._transfer_full_attention_id(layer_id)
@@ -2098,6 +2142,10 @@ class HybridLinearKVPool(KVCache):
             self.mamba_pool.load_cpu_copy(mamba_cpu, mamba_indices)
 
     def get_v_head_dim(self):
+        if hasattr(self.full_kv_pool, "v_head_dim"):
+            return self.full_kv_pool.v_head_dim
+        if hasattr(self.full_kv_pool, "kv_lora_rank"):
+            return self.full_kv_pool.kv_lora_rank
         return self.full_kv_pool.get_value_buffer(0).shape[-1]
 
     def set_mla_kv_buffer(


### PR DESCRIPTION
## Summary

This updates FP4 KV cache support for Qwen3.6 hybrid linear-attention models so decode can consume packed FP4 KV buffers directly instead of falling back to full-pool dequantization.

## Changes

- Select `MHATokenToKVPoolFP4` for non-MLA hybrid full-attention layers when the requested KV dtype is `torch.float4_e2m1fn_x2`.
- Expose raw packed FP4 K/V buffers and scale buffers from `MHATokenToKVPoolFP4`, and forward those accessors through `HybridLinearKVPool` with the full-attention layer-id mapping.
- Add a Triton FP4 decode attention path that unpacks E2M1 FP4 KV values and applies the block scale inside the decode kernel.
- Route Triton decode through the FP4 path when the token-to-KV pool supports it, while keeping the existing decode path for FP8/BF16/MLA.
- Keep the `KVFP4QuantizeUtil` compatibility name for FP4 KV memory-pool users.
- Avoid deriving `v_head_dim` through `get_value_buffer(0)` when the backing pool exposes `v_head_dim` or `kv_lora_rank`, which avoids accidental FP4 pool dequantization.

## Validation

- `python3 -m py_compile python/sglang/srt/layers/attention/triton_ops/decode_attention.py python/sglang/srt/layers/attention/triton_backend.py python/sglang/srt/mem_cache/memory_pool.py python/sglang/srt/layers/quantization/kvfp4_tensor.py`
- `git diff --check`
- FP4 decode attention numerical checks against dequantized FP4 reference:
  - batch=2, q_heads=8, kv_heads=2, head_dim=64, seq_lens=(19, 37), max_abs=0.0009765625
  - batch=1, q_heads=8, kv_heads=1, head_dim=256, seq_lens=(1000,), max_abs=0.0001220703125
- Served `/mnt/waiwai/models/Qwen3.6-35B-A3B-FP8` with `--kv-cache-dtype fp4_e2m1`, `--context-length 256000`, `--tp-size 2`, and `--max-running-requests 4`; `/health` returned 200.
- 1000 prompt / 1000 output benchmark after warmup:
  - concurrency=1: 126.90 output tok/s, avg latency 7.878s
  - concurrency=4: 481.76 output tok/s, avg latency 8.302s
- Multimodal smoke test through `/v1/chat/completions` with an image URL returned 200 and identified a red image.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28151800255](https://github.com/sgl-project/sglang/actions/runs/28151800255)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28151800093](https://github.com/sgl-project/sglang/actions/runs/28151800093)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->