### PR TITLE
Fix FlashInfer allreduce fusion PDL completion

### DIFF
--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -708,7 +708,10 @@ def fake_flashinfer_allreduce_residual_rmsnorm(
     eps: float = 1e-6,
     max_token_num: int = 16384,
     use_oneshot: Optional[bool] = None,
-    trigger_completion_at_end: bool = False,
+    # End the PDL dependency chain before later FlashInfer TRTLLM MoE kernels.
+    # Otherwise decode CUDA graph capture can start TMA-heavy work before the
+    # fused allreduce has published its completion signal.
+    trigger_completion_at_end: bool = True,
     fp32_acc: bool = False,
     use_attn_tp_group: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -728,7 +731,10 @@ def flashinfer_allreduce_residual_rmsnorm(
     eps: float = 1e-6,
     max_token_num: int = 2048,
     use_oneshot: Optional[bool] = None,
-    trigger_completion_at_end: bool = False,
+    # End the PDL dependency chain before later FlashInfer TRTLLM MoE kernels.
+    # Otherwise decode CUDA graph capture can start TMA-heavy work before the
+    # fused allreduce has published its completion signal.
+    trigger_completion_at_end: bool = True,
     fp32_acc: bool = False,
     use_attn_tp_group: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/test/registered/unit/layers/test_flashinfer_comm_fusion.py
+++ b/test/registered/unit/layers/test_flashinfer_comm_fusion.py
@@ -43,8 +43,9 @@ class _FakeFlashInferComm:
         residual_in,
         rms_gamma,
         rms_eps,
-        **_kwargs,
+        **kwargs,
     ):
+        self.calls.append(kwargs)
         allreduced = input * workspace.world_size
         expected_residual = allreduced + residual_in
         variance = expected_residual.to(torch.float32).pow(2).mean(dim=-1, keepdim=True)
@@ -176,12 +177,16 @@ class TestFlashInferCommFusion(unittest.TestCase):
         original_create = fusion._create_allreduce_fusion_workspace
         original_manager = fusion._attn_tp_workspace_manager
         original_unavailable = fusion._flashinfer_allreduce_unavailable
+        original_supports_trigger_completion = (
+            fusion._flashinfer_allreduce_supports_trigger_completion
+        )
         try:
             fusion._flashinfer_comm = fake_comm
             fusion._create_allreduce_fusion_workspace = (
                 fake_comm.create_allreduce_fusion_workspace
             )
             fusion._flashinfer_allreduce_unavailable = False
+            fusion._flashinfer_allreduce_supports_trigger_completion = True
 
             for backend in ("trtllm", "mnnvl"):
                 with self.subTest(backend=backend):
@@ -226,11 +231,15 @@ class TestFlashInferCommFusion(unittest.TestCase):
 
                     torch.testing.assert_close(norm_out, expected_norm)
                     torch.testing.assert_close(residual_out, expected_residual)
+                    self.assertTrue(fake_comm.calls[-1]["trigger_completion_at_end"])
         finally:
             fusion._flashinfer_comm = original_comm
             fusion._create_allreduce_fusion_workspace = original_create
             fusion._attn_tp_workspace_manager = original_manager
             fusion._flashinfer_allreduce_unavailable = original_unavailable
+            fusion._flashinfer_allreduce_supports_trigger_completion = (
+                original_supports_trigger_completion
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix the FlashInfer AllReduce Fusion CUDA graph crash by ending the PDL dependency chain at the fused allreduce + residual + RMSNorm call.

The PR now keeps the normal auto-enable path intact for `GlmMoeDsaForCausalLM`; it does not rely on disabling FlashInfer AllReduce Fusion for GLM FP4.




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28154616456](https://github.com/sgl-project/sglang/actions/runs/28154616456)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28154616379](https://github.com/sgl-project/sglang/actions/runs/28154616379)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->