### PR TITLE
[v0.5.9] Fix TRTLLM MHA FP8 V scale

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -730,7 +730,13 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else 1.0
         )
         bmm1_scale = q_scale * k_scale * layer.scaling
-        bmm2_scale = 1.0
+        v_scale = (
+            layer.v_scale_float
+            if getattr(layer, "v_scale_float", None) is not None
+            else 1.0
+        )
+        # bmm2_scale is applied to the PV matmul, so FP8 V cache reads need the V descale.
+        bmm2_scale = v_scale
         # sink: additional value per head in the denominator of the softmax.
         attention_sink = kwargs.get("sinks", None)
 
@@ -815,7 +821,13 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else 1.0
         )
         bmm1_scale = q_scale * k_scale * layer.scaling
-        bmm2_scale = 1.0
+        v_scale = (
+            layer.v_scale_float
+            if getattr(layer, "v_scale_float", None) is not None
+            else 1.0
+        )
+        # bmm2_scale is applied to the PV matmul, so FP8 V cache reads need the V descale.
+        bmm2_scale = v_scale
 
         page_table = self._get_layer_page_table(layer, forward_batch)
 


### PR DESCRIPTION
## Summary

Backport the TRTLLM MHA FP8 V-cache scale fix to `release/v0.5.9`.

`trtllm_mha_backend.py` already descales QK with `bmm1_scale`, but the FP8 path hardcoded `bmm2_scale = 1.0`. FlashInfer/TRTLLM MHA applies `bmm2_scale` to the PV matmul, so FP8 V-cache reads also need the layer's `v_scale_float`. Without that descale, the attention output is badly scaled and `nvidia/Llama-3.1-70B-Instruct-FP8` produces low-quality/repetitive text.

This keeps the release branch's existing Q path unchanged and only passes `layer.v_scale_float` to `bmm2_scale` in both decode and extend paths.

Mainline note: this is the release-branch backport of the scale issue fixed more broadly on `main` by #28144.

## Repro

On a B200 with the `lmsysorg/sglang:v0.5.9` release container:

```bash
python3 -m sglang.launch_server \
  --model nvidia/Llama-3.1-70B-Instruct-FP8 \
  --tp 1 \
  --attention-backend trtllm_mha \
  --trust-remote-code \
  --host 127.0.0.1 \
  --port 30000 \
  --random-seed 1234 \
  --disable-cuda-graph \
  --disable-flashinfer-autotune \
  --skip-server-warmup
```

Prompt check:

```bash
curl -s http://127.0.0.1:30000/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"nvidia/Llama-3.1-70B-Instruct-FP8","prompt":"The capital of France is","temperature":0,"max_tokens":1}'
```

## Accuracy

GSM8K setup: B200, `nvidia/Llama-3.1-70B-Instruct-FP8`, `lmsysorg/sglang:v0.5.9`, `--attention-backend trtllm_mha`, `--disable-cuda-graph`, `/v1/completions`, 5-shot, `temperature=0`, `max_tokens=512`, `num_examples=200`.

| case | prompt output for `The capital of France is` | GSM8K score | latency | output throughput | completion tokens |
|---|---:|---:|---:|---:|---:|
| before, default `v0.5.9` | ` not` | `0.015` | `54.431 s` | `1550.841 tok/s` | `84414` |
| after, `v0.5.9` + this patch | ` a` | `0.940` | `20.267 s` | `886.474 tok/s` | `17966` |

Additional prompt check:

| case | output |
|---|---|
| before | ` not the only thing that is changing. The Eiffel Tower is a popular tourist destination, and the Eiffel Tower is a popular tourist destination. The` |
| after | ` a city of love, art, fashion, and cuisine. Paris is a must-visit destination for anyone who loves history, culture, and beauty. Here are` |

## Tests

```bash
git diff --check
python3 -c "import pathlib; path=pathlib.Path('python/sglang/srt/layers/attention/trtllm_mha_backend.py'); compile(path.read_text(), str(path), 'exec')"
```

Also ran the B200 prompt and GSM8K accuracy checks above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->