### PR TITLE
[hicache] Fix hf3fs extra (non-KV) pool page size

### DIFF
--- a/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py
+++ b/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py
@@ -579,8 +579,8 @@ class HiCacheHF3FS(HiCacheStorage):
             return
         super().register_mem_host_pool_v2(host_pool, host_pool_name)
 
-        pool_page_size = getattr(host_pool, "page_size", 1) or 1
-        pool_bytes_per_page = host_pool.get_ksize_per_token() * pool_page_size
+        dummy_page = host_pool.get_dummy_flat_data_page()
+        pool_bytes_per_page = dummy_page.numel() * dummy_page.element_size()
         pool_num_pages = self.file_size // pool_bytes_per_page
         pool_file_path = f"{self.file_path}.{host_pool_name}"
         namespace = host_pool_name  # e.g. PoolName.MAMBA, PoolName.INDEXER


### PR DESCRIPTION
## Problem
`HiCacheHF3FS.register_mem_host_pool_v2` sizes each extra (non-KV) pool with
`get_ksize_per_token() * page_size` (K only). But `_pool_batch_set` writes one
combined K+V page per key (`get_data_page(flat=True)`) and `_pool_batch_get`
reads into `get_dummy_flat_data_page()` of that same combined size. So the K-only
`bytes_per_page` under-counts the real page: per-page offsets and `num_pages` are
wrong and the write trips `Hf3fsClient.check` (`size > bytes_per_page`), crashing
the backup thread so nothing is persisted to L3.

The KV pool is unaffected because it is zero-copy split into separate `-k`/`-v`
keys, so its per-entry write equals the K-only size. The bug surfaces on hybrid
models that register an extra pool (e.g. SWA) with `--hicache-storage-backend hf3fs`.

## Fix
Size each extra pool from `get_dummy_flat_data_page()` — the exact buffer the
read/write path uses — so `bytes_per_page`, offsets, `num_pages` and the size
check all match the real I/O.

## Verification
Verified end-to-end on an internal hybrid-SWA setup (TP=4) with hicache L3=hf3fs:
after the fix the extra pool registers the correct `bytes_per_page`, and a
write_through + flush + replay cycle shows `backuped_tokens_total` and
`prefetched_tokens_total` both increasing with `cache_source=storage_HiCacheHF3FS`.

## Original commits
- `a18ae1173`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28154866777](https://github.com/sgl-project/sglang/actions/runs/28154866777)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28154866577](https://github.com/sgl-project/sglang/actions/runs/28154866577)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->