### PR TITLE
[KDA-Pilot] Add diffusion causal Conv3D cat-pad CUDA fast path for Cosmos3

### DIFF
--- a/python/sglang/jit_kernel/csrc/diffusion/causal_conv3d_cat_pad.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/causal_conv3d_cat_pad.cuh
@@ -1,0 +1,261 @@
+// Native CUDA fast path for Cosmos3 VAE causal-Conv3D cat/pad copy.
+//
+// The op writes the output of:
+//   pad(cat(cache_x, x, dim=T), (Wl, Wr, Ht, Hb, Dl - cache_t, Dr))
+// for 5D NCTHW tensors. It is a memory-bound copy/zero-fill kernel and is only
+// entered for contiguous CUDA tensors; unsupported cases fall back to Triton in
+// the Python caller.
+
+#pragma once
+
+#include <sgl_kernel/tensor.h>   // For TensorMatcher, SymbolicSize, SymbolicDevice
+#include <sgl_kernel/utils.h>    // For RuntimeCheck, div_ceil
+#include <sgl_kernel/utils.cuh>  // For LaunchKernel
+
+#include <cstdint>
+
+namespace sglang_causal_conv3d_cat_pad {
+
+namespace {
+
+constexpr int kBlockSize = 256;
+
+template <typename ET, int kVec>
+__global__ void __launch_bounds__(kBlockSize) cat_pad_flat_kernel(
+    const ET* __restrict__ x,
+    const ET* __restrict__ cache,
+    ET* __restrict__ out,
+    int64_t total_vecs,
+    int64_t channels,
+    int64_t t_size,
+    int64_t h_size,
+    int64_t w_size,
+    int64_t cache_t,
+    int64_t out_t,
+    int64_t out_h,
+    int64_t out_w,
+    int64_t pad_d_left,
+    int64_t pad_h_top,
+    int64_t pad_w_left) {
+  union Pack {
+    ET elem[kVec];
+    uint4 raw;
+  };
+
+  const int64_t nthreads = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t vid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       vid < total_vecs;
+       vid += nthreads) {
+    int64_t base = vid * kVec;
+    int64_t ow = base % out_w;
+    int64_t tmp = base / out_w;
+    int64_t oh = tmp % out_h;
+    tmp /= out_h;
+    int64_t od = tmp % out_t;
+    tmp /= out_t;
+    int64_t oc = tmp % channels;
+    int64_t ob = tmp / channels;
+
+    int64_t ih = oh - pad_h_top;
+    int64_t src_t = od - pad_d_left;
+    bool interior = ih >= 0 && ih < h_size && src_t >= 0 && src_t < cache_t + t_size;
+
+    const ET* src = nullptr;
+    if (interior) {
+      if (src_t < cache_t) {
+        src =
+            cache + (((ob * channels + oc) * cache_t + src_t) * h_size + ih) * w_size;
+      } else {
+        src = x
+            + (((ob * channels + oc) * t_size + (src_t - cache_t)) * h_size + ih) * w_size;
+      }
+    }
+
+    Pack pack;
+#pragma unroll
+    for (int i = 0; i < kVec; ++i) {
+      ET value = ET(0);
+      if (interior) {
+        const int64_t iw = ow - pad_w_left;
+        if (iw >= 0 && iw < w_size) {
+          value = SGLANG_LDG(src + iw);
+        }
+      }
+      pack.elem[i] = value;
+
+      if (++ow == out_w) {
+        ow = 0;
+        if (++oh == out_h) {
+          oh = 0;
+          if (++od == out_t) {
+            od = 0;
+            if (++oc == channels) {
+              oc = 0;
+              ++ob;
+            }
+          }
+        }
+        ih = oh - pad_h_top;
+        src_t = od - pad_d_left;
+        interior = ih >= 0 && ih < h_size && src_t >= 0 && src_t < cache_t + t_size;
+        if (interior) {
+          if (src_t < cache_t) {
+            src =
+                cache + (((ob * channels + oc) * cache_t + src_t) * h_size + ih) * w_size;
+          } else {
+            src = x
+                + (((ob * channels + oc) * t_size + (src_t - cache_t)) * h_size + ih) * w_size;
+          }
+        } else {
+          src = nullptr;
+        }
+      }
+    }
+
+    reinterpret_cast<uint4*>(out)[vid] = pack.raw;
+  }
+}
+
+template <typename ET, int kVec>
+void launch_cat_pad_flat(
+    const void* x,
+    const void* cache,
+    void* out,
+    int64_t total,
+    int64_t channels,
+    int64_t t_size,
+    int64_t h_size,
+    int64_t w_size,
+    int64_t cache_t,
+    int64_t out_t,
+    int64_t out_h,
+    int64_t out_w,
+    int64_t depth_left,
+    int64_t pad_h_top,
+    int64_t pad_w_left,
+    DLDevice device) {
+  const int64_t total_vecs = total / kVec;
+  const uint32_t grid =
+      static_cast<uint32_t>(host::div_ceil(total_vecs, static_cast<int64_t>(kBlockSize)));
+  host::LaunchKernel(grid, kBlockSize, device)(
+      cat_pad_flat_kernel<ET, kVec>,
+      static_cast<const ET*>(x),
+      static_cast<const ET*>(cache),
+      static_cast<ET*>(out),
+      total_vecs,
+      channels,
+      t_size,
+      h_size,
+      w_size,
+      cache_t,
+      out_t,
+      out_h,
+      out_w,
+      depth_left,
+      pad_h_top,
+      pad_w_left);
+}
+
+}  // namespace
+
+template <typename T>
+struct CausalConv3dCatPadKernel {
+  static void run(
+      tvm::ffi::TensorView out,
+      tvm::ffi::TensorView x,
+      tvm::ffi::TensorView cache,
+      int64_t pad_w_left,
+      int64_t pad_w_right,
+      int64_t pad_h_top,
+      int64_t pad_h_bottom,
+      int64_t pad_d_left,
+      int64_t pad_d_right) {
+    using namespace host;
+
+    auto bsz = SymbolicSize{"batch"};
+    auto channels = SymbolicSize{"channels"};
+    auto t_size = SymbolicSize{"t_size"};
+    auto h_size = SymbolicSize{"h_size"};
+    auto w_size = SymbolicSize{"w_size"};
+    auto cache_t = SymbolicSize{"cache_t"};
+    auto out_t = SymbolicSize{"out_t"};
+    auto out_h = SymbolicSize{"out_h"};
+    auto out_w = SymbolicSize{"out_w"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+
+    TensorMatcher({bsz, channels, t_size, h_size, w_size})
+        .with_dtype<T>()
+        .template with_device<kDLCUDA>(device)
+        .verify(x);
+    TensorMatcher({bsz, channels, cache_t, h_size, w_size})
+        .with_dtype<T>()
+        .template with_device<kDLCUDA>(device)
+        .verify(cache);
+    TensorMatcher({bsz, channels, out_t, out_h, out_w})
+        .with_dtype<T>()
+        .template with_device<kDLCUDA>(device)
+        .verify(out);
+
+    const int64_t depth_left = pad_d_left - cache_t.unwrap();
+    RuntimeCheck(depth_left >= 0, "pad_d_left must be >= cache_t");
+    RuntimeCheck(pad_d_right == 0, "pad_d_right must be 0");
+    RuntimeCheck(pad_w_left == pad_w_right, "width padding must be symmetric");
+    RuntimeCheck(pad_h_top == pad_h_bottom, "height padding must be symmetric");
+    RuntimeCheck(
+        out_t.unwrap() == t_size.unwrap() + cache_t.unwrap() + depth_left + pad_d_right, "out_t mismatch");
+    RuntimeCheck(out_h.unwrap() == h_size.unwrap() + pad_h_top + pad_h_bottom, "out_h mismatch");
+    RuntimeCheck(out_w.unwrap() == w_size.unwrap() + pad_w_left + pad_w_right, "out_w mismatch");
+
+    const int64_t total =
+        bsz.unwrap() * channels.unwrap() * out_t.unwrap() * out_h.unwrap() * out_w.unwrap();
+    if (total == 0) {
+      return;
+    }
+
+    constexpr int kVec = 16 / sizeof(T);
+    RuntimeCheck(total % kVec == 0, "output element count must be divisible by vector width");
+    RuntimeCheck(
+        reinterpret_cast<uintptr_t>(out.data_ptr()) % 16 == 0, "output pointer must be 16-byte aligned");
+
+    if constexpr (sizeof(T) == 2) {
+      launch_cat_pad_flat<uint16_t, kVec>(
+          x.data_ptr(),
+          cache.data_ptr(),
+          out.data_ptr(),
+          total,
+          channels.unwrap(),
+          t_size.unwrap(),
+          h_size.unwrap(),
+          w_size.unwrap(),
+          cache_t.unwrap(),
+          out_t.unwrap(),
+          out_h.unwrap(),
+          out_w.unwrap(),
+          depth_left,
+          pad_h_top,
+          pad_w_left,
+          device.unwrap());
+    } else {
+      launch_cat_pad_flat<uint32_t, kVec>(
+          x.data_ptr(),
+          cache.data_ptr(),
+          out.data_ptr(),
+          total,
+          channels.unwrap(),
+          t_size.unwrap(),
+          h_size.unwrap(),
+          w_size.unwrap(),
+          cache_t.unwrap(),
+          out_t.unwrap(),
+          out_h.unwrap(),
+          out_w.unwrap(),
+          depth_left,
+          pad_h_top,
+          pad_w_left,
+          device.unwrap());
+    }
+  }
+};
+
+}  // namespace sglang_causal_conv3d_cat_pad

--- a/python/sglang/jit_kernel/csrc/diffusion/causal_conv3d_cat_pad.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/causal_conv3d_cat_pad.cuh
@@ -5,6 +5,9 @@
 // for 5D NCTHW tensors. It is a memory-bound copy/zero-fill kernel and is only
 // entered for contiguous CUDA tensors; unsupported cases fall back to Triton in
 // the Python caller.
+//
+// Developed with MIT HAN Lab Kernel Design Agents:
+// https://github.com/mit-han-lab/kernel-design-agents
 
 #pragma once
 

--- a/python/sglang/jit_kernel/csrc/diffusion/causal_conv3d_cat_pad.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/causal_conv3d_cat_pad.cuh
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include <sgl_kernel/tensor.h>   // For TensorMatcher, SymbolicSize, SymbolicDevice
-#include <sgl_kernel/utils.h>    // For RuntimeCheck, div_ceil
+#include <sgl_kernel/tensor.h>  // For TensorMatcher, SymbolicSize, SymbolicDevice
+#include <sgl_kernel/utils.h>   // For RuntimeCheck, div_ceil
+
 #include <sgl_kernel/utils.cuh>  // For LaunchKernel
 
 #include <cstdint>
@@ -43,9 +44,7 @@ __global__ void __launch_bounds__(kBlockSize) cat_pad_flat_kernel(
   };
 
   const int64_t nthreads = static_cast<int64_t>(gridDim.x) * blockDim.x;
-  for (int64_t vid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-       vid < total_vecs;
-       vid += nthreads) {
+  for (int64_t vid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; vid < total_vecs; vid += nthreads) {
     int64_t base = vid * kVec;
     int64_t ow = base % out_w;
     int64_t tmp = base / out_w;
@@ -63,11 +62,9 @@ __global__ void __launch_bounds__(kBlockSize) cat_pad_flat_kernel(
     const ET* src = nullptr;
     if (interior) {
       if (src_t < cache_t) {
-        src =
-            cache + (((ob * channels + oc) * cache_t + src_t) * h_size + ih) * w_size;
+        src = cache + (((ob * channels + oc) * cache_t + src_t) * h_size + ih) * w_size;
       } else {
-        src = x
-            + (((ob * channels + oc) * t_size + (src_t - cache_t)) * h_size + ih) * w_size;
+        src = x + (((ob * channels + oc) * t_size + (src_t - cache_t)) * h_size + ih) * w_size;
       }
     }
 
@@ -100,11 +97,9 @@ __global__ void __launch_bounds__(kBlockSize) cat_pad_flat_kernel(
         interior = ih >= 0 && ih < h_size && src_t >= 0 && src_t < cache_t + t_size;
         if (interior) {
           if (src_t < cache_t) {
-            src =
-                cache + (((ob * channels + oc) * cache_t + src_t) * h_size + ih) * w_size;
+            src = cache + (((ob * channels + oc) * cache_t + src_t) * h_size + ih) * w_size;
           } else {
-            src = x
-                + (((ob * channels + oc) * t_size + (src_t - cache_t)) * h_size + ih) * w_size;
+            src = x + (((ob * channels + oc) * t_size + (src_t - cache_t)) * h_size + ih) * w_size;
           }
         } else {
           src = nullptr;
@@ -135,8 +130,7 @@ void launch_cat_pad_flat(
     int64_t pad_w_left,
     DLDevice device) {
   const int64_t total_vecs = total / kVec;
-  const uint32_t grid =
-      static_cast<uint32_t>(host::div_ceil(total_vecs, static_cast<int64_t>(kBlockSize)));
+  const uint32_t grid = static_cast<uint32_t>(host::div_ceil(total_vecs, static_cast<int64_t>(kBlockSize)));
   host::LaunchKernel(grid, kBlockSize, device)(
       cat_pad_flat_kernel<ET, kVec>,
       static_cast<const ET*>(x),
@@ -160,8 +154,8 @@ void launch_cat_pad_flat(
 
 template <typename T>
 struct CausalConv3dCatPadKernel {
-  static void run(
-      tvm::ffi::TensorView out,
+  static void
+  run(tvm::ffi::TensorView out,
       tvm::ffi::TensorView x,
       tvm::ffi::TensorView cache,
       int64_t pad_w_left,
@@ -202,21 +196,18 @@ struct CausalConv3dCatPadKernel {
     RuntimeCheck(pad_d_right == 0, "pad_d_right must be 0");
     RuntimeCheck(pad_w_left == pad_w_right, "width padding must be symmetric");
     RuntimeCheck(pad_h_top == pad_h_bottom, "height padding must be symmetric");
-    RuntimeCheck(
-        out_t.unwrap() == t_size.unwrap() + cache_t.unwrap() + depth_left + pad_d_right, "out_t mismatch");
+    RuntimeCheck(out_t.unwrap() == t_size.unwrap() + cache_t.unwrap() + depth_left + pad_d_right, "out_t mismatch");
     RuntimeCheck(out_h.unwrap() == h_size.unwrap() + pad_h_top + pad_h_bottom, "out_h mismatch");
     RuntimeCheck(out_w.unwrap() == w_size.unwrap() + pad_w_left + pad_w_right, "out_w mismatch");
 
-    const int64_t total =
-        bsz.unwrap() * channels.unwrap() * out_t.unwrap() * out_h.unwrap() * out_w.unwrap();
+    const int64_t total = bsz.unwrap() * channels.unwrap() * out_t.unwrap() * out_h.unwrap() * out_w.unwrap();
     if (total == 0) {
       return;
     }
 
     constexpr int kVec = 16 / sizeof(T);
     RuntimeCheck(total % kVec == 0, "output element count must be divisible by vector width");
-    RuntimeCheck(
-        reinterpret_cast<uintptr_t>(out.data_ptr()) % 16 == 0, "output pointer must be 16-byte aligned");
+    RuntimeCheck(reinterpret_cast<uintptr_t>(out.data_ptr()) % 16 == 0, "output pointer must be 16-byte aligned");
 
     if constexpr (sizeof(T) == 2) {
       launch_cat_pad_flat<uint16_t, kVec>(

--- a/python/sglang/jit_kernel/diffusion/causal_conv3d_cat_pad.py
+++ b/python/sglang/jit_kernel/diffusion/causal_conv3d_cat_pad.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
+@cache_once
+def _jit_causal_conv3d_cat_pad_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "diffusion_causal_conv3d_cat_pad",
+        *args,
+        cuda_files=["diffusion/causal_conv3d_cat_pad.cuh"],
+        cuda_wrappers=[
+            (
+                "causal_conv3d_cat_pad",
+                "sglang_causal_conv3d_cat_pad::"
+                f"CausalConv3dCatPadKernel<{args}>::run",
+            )
+        ],
+    )
+
+
+def _causal_conv3d_cat_pad_fake_impl(
+    x: torch.Tensor,
+    cache_x: torch.Tensor,
+    pad_w_left: int,
+    pad_w_right: int,
+    pad_h_top: int,
+    pad_h_bottom: int,
+    pad_d_left: int,
+    pad_d_right: int,
+) -> torch.Tensor:
+    cache_t = cache_x.shape[2]
+    depth_left = pad_d_left - cache_t
+    return torch.empty(
+        (
+            x.shape[0],
+            x.shape[1],
+            x.shape[2] + cache_t + depth_left + pad_d_right,
+            x.shape[3] + pad_h_top + pad_h_bottom,
+            x.shape[4] + pad_w_left + pad_w_right,
+        ),
+        device=x.device,
+        dtype=x.dtype,
+    )
+
+
+@register_custom_op(
+    op_name="diffusion_causal_conv3d_cat_pad",
+    mutates_args=[],
+    fake_impl=_causal_conv3d_cat_pad_fake_impl,
+)
+def _causal_conv3d_cat_pad_custom_op(
+    x: torch.Tensor,
+    cache_x: torch.Tensor,
+    pad_w_left: int,
+    pad_w_right: int,
+    pad_h_top: int,
+    pad_h_bottom: int,
+    pad_d_left: int,
+    pad_d_right: int,
+) -> torch.Tensor:
+    out = _causal_conv3d_cat_pad_fake_impl(
+        x,
+        cache_x,
+        pad_w_left,
+        pad_w_right,
+        pad_h_top,
+        pad_h_bottom,
+        pad_d_left,
+        pad_d_right,
+    )
+    module = _jit_causal_conv3d_cat_pad_module(x.dtype)
+    module.causal_conv3d_cat_pad(
+        out,
+        x,
+        cache_x,
+        pad_w_left,
+        pad_w_right,
+        pad_h_top,
+        pad_h_bottom,
+        pad_d_left,
+        pad_d_right,
+    )
+    return out
+
+
+def fused_causal_conv3d_cat_pad_cuda(
+    x: torch.Tensor,
+    cache_x: torch.Tensor,
+    padding: list[int] | tuple[int, ...],
+) -> torch.Tensor:
+    if x.dtype not in _SUPPORTED_DTYPES:
+        raise RuntimeError(f"unsupported dtype for causal Conv3D cat/pad: {x.dtype}")
+    if not torch.compiler.is_compiling():
+        if (
+            not x.is_cuda
+            or not cache_x.is_cuda
+            or x.dim() != 5
+            or cache_x.dim() != 5
+            or not x.is_contiguous()
+            or not cache_x.is_contiguous()
+            or not can_use_fused_causal_conv3d_cat_pad_cuda(x, cache_x, padding)
+        ):
+            raise RuntimeError("unsupported input for causal Conv3D cat/pad CUDA")
+    return _causal_conv3d_cat_pad_custom_op(x, cache_x, *padding)
+
+
+def can_use_fused_causal_conv3d_cat_pad_cuda(
+    x: torch.Tensor,
+    cache_x: torch.Tensor,
+    padding: list[int] | tuple[int, ...],
+) -> bool:
+    if x.dtype not in _SUPPORTED_DTYPES:
+        return False
+    pad_w_left, pad_w_right, pad_h_top, pad_h_bottom, pad_d_left, pad_d_right = padding
+    cache_t = cache_x.shape[2]
+    depth_left = pad_d_left - cache_t
+    if depth_left < 0 or pad_d_right != 0:
+        return False
+    out_numel = (
+        x.shape[0]
+        * x.shape[1]
+        * (x.shape[2] + cache_t + depth_left + pad_d_right)
+        * (x.shape[3] + pad_h_top + pad_h_bottom)
+        * (x.shape[4] + pad_w_left + pad_w_right)
+    )
+    elem_size = 4 if x.dtype == torch.float32 else 2
+    vec_elems = 16 // elem_size
+    return out_numel % vec_elems == 0

--- a/python/sglang/multimodal_gen/runtime/layers/parallel_conv.py
+++ b/python/sglang/multimodal_gen/runtime/layers/parallel_conv.py
@@ -15,11 +15,41 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
 from sglang.multimodal_gen.runtime.platforms import current_platform
 
 if current_platform.is_cuda():
+    from sglang.jit_kernel.diffusion.causal_conv3d_cat_pad import (
+        can_use_fused_causal_conv3d_cat_pad_cuda,
+        fused_causal_conv3d_cat_pad_cuda,
+    )
     from sglang.jit_kernel.diffusion.triton.causal_conv3d_pad import (
-        fused_causal_conv3d_cat_pad,
+        fused_causal_conv3d_cat_pad as fused_causal_conv3d_cat_pad_triton,
     )
 else:
-    fused_causal_conv3d_cat_pad = None
+    can_use_fused_causal_conv3d_cat_pad_cuda = None
+    fused_causal_conv3d_cat_pad_cuda = None
+    fused_causal_conv3d_cat_pad_triton = None
+
+
+_causal_conv3d_cat_pad_cuda_failed = False
+
+
+def fused_causal_conv3d_cat_pad(
+    x: torch.Tensor,
+    cache_x: torch.Tensor,
+    padding: list[int],
+) -> torch.Tensor:
+    global _causal_conv3d_cat_pad_cuda_failed
+    if (
+        fused_causal_conv3d_cat_pad_cuda is not None
+        and can_use_fused_causal_conv3d_cat_pad_cuda(x, cache_x, padding)
+        and not _causal_conv3d_cat_pad_cuda_failed
+    ):
+        try:
+            return fused_causal_conv3d_cat_pad_cuda(x, cache_x, padding)
+        except Exception:
+            _causal_conv3d_cat_pad_cuda_failed = True
+    if fused_causal_conv3d_cat_pad_triton is None:
+        raise RuntimeError("causal Conv3D cat/pad fusion is only available on CUDA")
+    return fused_causal_conv3d_cat_pad_triton(x, cache_x, padding)
+
 
 _SPATIAL_PARALLEL_DECODE_DISABLED = contextvars.ContextVar(
     "spatial_parallel_decode_disabled", default=False

--- a/python/sglang/multimodal_gen/runtime/layers/parallel_conv.py
+++ b/python/sglang/multimodal_gen/runtime/layers/parallel_conv.py
@@ -13,6 +13,9 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_decode_parallel_world_size,
 )
 from sglang.multimodal_gen.runtime.platforms import current_platform
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
 
 if current_platform.is_cuda():
     from sglang.jit_kernel.diffusion.causal_conv3d_cat_pad import (
@@ -45,6 +48,10 @@ def fused_causal_conv3d_cat_pad(
         try:
             return fused_causal_conv3d_cat_pad_cuda(x, cache_x, padding)
         except Exception:
+            logger.warning(
+                "fused_causal_conv3d_cat_pad_cuda failed, falling back to Triton",
+                exc_info=True,
+            )
             _causal_conv3d_cat_pad_cuda_failed = True
     if fused_causal_conv3d_cat_pad_triton is None:
         raise RuntimeError("causal Conv3D cat/pad fusion is only available on CUDA")

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
@@ -464,7 +464,7 @@ class Cosmos3DenoisingStage(PipelineStage):
             compile_kwargs = {
                 "mode": "default",
                 "fullgraph": False,
-                "dynamic": True,
+                "dynamic": False,
             }
 
         gen_layers = getattr(transformer, "gen_layers", None)

--- a/test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py
+++ b/test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+
+import torch
+
+from sglang.jit_kernel.benchmark import marker
+from sglang.jit_kernel.diffusion.causal_conv3d_cat_pad import (
+    fused_causal_conv3d_cat_pad_cuda,
+)
+from sglang.jit_kernel.diffusion.triton.causal_conv3d_pad import (
+    fused_causal_conv3d_cat_pad as fused_causal_conv3d_cat_pad_triton,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=20,
+    suite="base-b-kernel-benchmark-1-gpu-large",
+    disabled="standalone benchmark",
+)
+
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    channels: int
+    t_size: int
+    h_size: int
+    w_size: int
+    cache_t: int
+    trace_count: int
+
+
+CASES = [
+    Case("c1024_t1_h30_w52_cache1", 1024, 1, 30, 52, 1, 8),
+    Case("c1024_t1_h30_w52_cache2", 1024, 1, 30, 52, 2, 8),
+    Case("c1024_t2_h60_w104_cache1", 1024, 2, 60, 104, 1, 5),
+    Case("c1024_t2_h60_w104_cache2", 1024, 2, 60, 104, 2, 5),
+    Case("c512_t4_h120_w208_cache1", 512, 4, 120, 208, 1, 5),
+    Case("c512_t4_h120_w208_cache2", 512, 4, 120, 208, 2, 5),
+    Case("c256_t4_h240_w416_cache1", 256, 4, 240, 416, 1, 6),
+    Case("c256_t4_h240_w416_cache2", 256, 4, 240, 416, 2, 6),
+]
+CASE_BY_NAME = {case.name: case for case in CASES}
+CASE_NAMES = [case.name for case in CASES]
+
+
+def make_inputs(case: Case) -> tuple[torch.Tensor, torch.Tensor, tuple[int, ...]]:
+    generator = torch.Generator(device=DEVICE)
+    generator.manual_seed(case.channels * 1009 + case.t_size * 251 + case.cache_t)
+    x = torch.randn(
+        (1, case.channels, case.t_size, case.h_size, case.w_size),
+        device=DEVICE,
+        dtype=DTYPE,
+        generator=generator,
+    )
+    cache_x = torch.randn(
+        (1, case.channels, case.cache_t, case.h_size, case.w_size),
+        device=DEVICE,
+        dtype=DTYPE,
+        generator=generator,
+    )
+    padding = (1, 1, 1, 1, case.cache_t, 0)
+    return x, cache_x, padding
+
+
+@marker.parametrize("case_name", CASE_NAMES, ci_vals=CASE_NAMES[:2])
+@marker.benchmark("provider", ["triton", "cuda"])
+def benchmark(case_name: str, provider: str) -> marker.BenchResult:
+    case = CASE_BY_NAME[case_name]
+    x, cache_x, padding = make_inputs(case)
+    fn = (
+        fused_causal_conv3d_cat_pad_triton
+        if provider == "triton"
+        else fused_causal_conv3d_cat_pad_cuda
+    )
+    actual = fused_causal_conv3d_cat_pad_cuda(x, cache_x, padding)
+    expected = fused_causal_conv3d_cat_pad_triton(x, cache_x, padding)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    return marker.do_bench(
+        fn,
+        input_args=(x, cache_x, padding),
+        use_cuda_graph=False,
+        replay_iters=200,
+        graph_clone_args=(0, 1),
+        memory_args=(x, cache_x),
+        memory_output="out",
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py
+++ b/test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py
@@ -1,0 +1,88 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.jit_kernel.diffusion.causal_conv3d_cat_pad import (
+    fused_causal_conv3d_cat_pad_cuda,
+)
+from sglang.jit_kernel.diffusion.triton.causal_conv3d_pad import (
+    fused_causal_conv3d_cat_pad as fused_causal_conv3d_cat_pad_triton,
+)
+from sglang.jit_kernel.utils import get_ci_test_range
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=45, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=45, suite="base-b-kernel-unit-1-gpu-b200")
+
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+
+COSMOS3_CASES = get_ci_test_range(
+    [
+        (1024, 1, 30, 52, 1),
+        (1024, 1, 30, 52, 2),
+        (1024, 2, 60, 104, 1),
+        (1024, 2, 60, 104, 2),
+        (512, 4, 120, 208, 1),
+        (512, 4, 120, 208, 2),
+        (256, 4, 240, 416, 1),
+        (256, 4, 240, 416, 2),
+    ],
+    [(1024, 1, 30, 52, 1), (512, 4, 120, 208, 2)],
+)
+
+
+def _make_inputs(
+    channels: int,
+    t_size: int,
+    h_size: int,
+    w_size: int,
+    cache_t: int,
+) -> tuple[torch.Tensor, torch.Tensor, tuple[int, ...]]:
+    generator = torch.Generator(device=DEVICE)
+    generator.manual_seed(channels * 1009 + t_size * 251 + h_size + cache_t)
+    x = torch.randn(
+        (1, channels, t_size, h_size, w_size),
+        device=DEVICE,
+        dtype=DTYPE,
+        generator=generator,
+    )
+    cache_x = torch.randn(
+        (1, channels, cache_t, h_size, w_size),
+        device=DEVICE,
+        dtype=DTYPE,
+        generator=generator,
+    )
+    padding = (1, 1, 1, 1, cache_t, 0)
+    return x, cache_x, padding
+
+
+@pytest.mark.parametrize("channels,t_size,h_size,w_size,cache_t", COSMOS3_CASES)
+def test_causal_conv3d_cat_pad(
+    channels: int,
+    t_size: int,
+    h_size: int,
+    w_size: int,
+    cache_t: int,
+) -> None:
+    x, cache_x, padding = _make_inputs(channels, t_size, h_size, w_size, cache_t)
+    actual = fused_causal_conv3d_cat_pad_cuda(x, cache_x, padding)
+    expected = fused_causal_conv3d_cat_pad_triton(x, cache_x, padding)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_causal_conv3d_cat_pad_torch_compile() -> None:
+    x, cache_x, padding = _make_inputs(1024, 1, 30, 52, 1)
+
+    @torch.compile(fullgraph=True)
+    def fn(x: torch.Tensor, cache_x: torch.Tensor) -> torch.Tensor:
+        return fused_causal_conv3d_cat_pad_cuda(x, cache_x, padding)
+
+    actual = fn(x, cache_x)
+    expected = fused_causal_conv3d_cat_pad_triton(x, cache_x, padding)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
Powered by [KDA-Pilot](https://github.com/mit-han-lab/kernel-design-agents), we propose a native CUDA JIT fast path for the Cosmos3 VAE causal Conv3D cat/pad copy pattern.

## Motivation

Add a native CUDA JIT fast path for the Cosmos3 VAE causal Conv3D cat/pad copy pattern from KDA-Pilot task `b200_diffusion_causal_conv3d_cat_pad__multi_shape` / [BBuf/KDA-Pilot#132](https://github.com/BBuf/KDA-Pilot/pull/132).

The hot pattern is equivalent to:

```python
F.pad(torch.cat([cache_x, x], dim=2), (Wl, Wr, Ht, Hb, Dl - cache_t, Dr))
```

for contiguous 5D `NCTHW` tensors. A Cosmos3-Nano T2V trace at `832x480x9f, 4 steps` hits 48 fuseable calls across 8 production shapes in VAE decode. This is not a denoise kernel, so expected model-level impact is modest and should show up around decode/total rather than denoise.

## Modifications

- Add `diffusion_causal_conv3d_cat_pad` lightweight JIT CUDA kernel.
- Mark the CUDA csrc file with the MIT HAN Lab Kernel Design Agents provenance comment.
- Register it as an eager SGLang custom op with a fake impl so direct `torch.compile` tracing sees an opaque op instead of tracing JIT/module loading.
- Wire `parallel_conv.causal_conv3d_cat_pad` to try CUDA by default, then fall back to the existing Triton implementation if the JIT load/launch fails.
- Use static Cosmos3 compile shapes (`dynamic=False`) for the compiled gen-layer path; this keeps the Cosmos3 `--enable-torch-compile` model path runnable with the compile-safe custom op.
- Add a concise correctness test over the Cosmos3 shape set plus a direct `torch.compile(fullgraph=True)` custom-op test.
- Add a standalone benchmark for the 8 traced Cosmos3 shapes.

## Accuracy Tests

```bash
python3 -m py_compile \
  python/sglang/jit_kernel/diffusion/causal_conv3d_cat_pad.py \
  python/sglang/multimodal_gen/runtime/layers/parallel_conv.py \
  python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py \
  test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py \
  test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py
python3 -m ruff format --check ...
python3 -m ruff check ...
git diff --check
```

B200:

```bash
CUDA_VISIBLE_DEVICES=0 \
PYTHONPATH=/tmp/sglang_catpad_pr/python:/tmp/sglang_catpad_pr \
TVM_FFI_CACHE_DIR=/tmp/tvm-ffi-catpad-b200-final \
python3 -m pytest -q test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py -s
```

Result: `9 passed`.

H100:

```bash
CUDA_VISIBLE_DEVICES=0 \
PYTHONPATH=/tmp/sglang_catpad_pr/python:/tmp/sglang_catpad_pr \
TVM_FFI_CACHE_DIR=/tmp/tvm-ffi-catpad-h100-final \
python3 -m pytest -q test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py -s
```

Result: `9 passed`.

## Speed Tests and Profiling

Kernel benchmark command:

```bash
CUDA_VISIBLE_DEVICES=0 \
PYTHONPATH=/tmp/sglang_catpad_pr/python:/tmp/sglang_catpad_pr \
TVM_FFI_CACHE_DIR=/tmp/tvm-ffi-catpad-<gpu> \
python3 test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py
```

B200 kernel benchmark:

| Case | Trace calls | Triton us | CUDA us | Speedup |
| --- | ---: | ---: | ---: | ---: |
| c1024_t1_h30_w52_cache1 | 8 | 19.072 | 14.336 | 1.33x |
| c1024_t1_h30_w52_cache2 | 8 | 26.624 | 19.456 | 1.37x |
| c1024_t2_h60_w104_cache1 | 5 | 81.920 | 48.032 | 1.71x |
| c1024_t2_h60_w104_cache2 | 5 | 109.568 | 61.440 | 1.78x |
| c512_t4_h120_w208_cache1 | 5 | 250.688 | 126.976 | 1.97x |
| c512_t4_h120_w208_cache2 | 5 | 306.176 | 150.528 | 2.03x |
| c256_t4_h240_w416_cache1 | 6 | 487.392 | 231.392 | 2.11x |
| c256_t4_h240_w416_cache2 | 6 | 598.272 | 274.400 | 2.18x |

Weighted by traced call count: **10.621 ms -> 5.240 ms**, **2.03x**, saves **5.381 ms** in the kernel group.

H100 kernel benchmark:

| Case | Trace calls | Triton us | CUDA us | Speedup |
| --- | ---: | ---: | ---: | ---: |
| c1024_t1_h30_w52_cache1 | 8 | 18.752 | 15.296 | 1.23x |
| c1024_t1_h30_w52_cache2 | 8 | 28.192 | 19.456 | 1.45x |
| c1024_t2_h60_w104_cache1 | 5 | 90.336 | 50.976 | 1.77x |
| c1024_t2_h60_w104_cache2 | 5 | 118.560 | 65.888 | 1.80x |
| c512_t4_h120_w208_cache1 | 5 | 279.744 | 137.856 | 2.03x |
| c512_t4_h120_w208_cache2 | 5 | 334.816 | 164.160 | 2.04x |
| c256_t4_h240_w416_cache1 | 6 | 546.336 | 251.520 | 2.17x |
| c256_t4_h240_w416_cache2 | 6 | 659.616 | 300.352 | 2.20x |

Weighted by traced call count: **11.729 ms -> 5.684 ms**, **2.06x**, saves **6.045 ms** in the kernel group.

B200 model E2E benchmark with `torch.compile` enabled:

- Host: `ion-b200`, NVIDIA B200, `CUDA_VISIBLE_DEVICES=7`.
- Model path: `nvidia/Cosmos3-Nano`, native `Cosmos3Pipeline`; no diffusers fallback observed.
- Shape: T2V `832x480x9f`, `num_inference_steps=4`, `seed=42`, `save_output=False`.
- Compile path: `enable_torch_compile=True`, Cosmos3 gen layers compiled with `{'mode': 'default', 'fullgraph': False, 'dynamic': False}`.
- Measurement: one loaded local `DiffGenerator` process per implementation, 4 warmup requests, median of 15 measured requests. The baseline forces the existing Triton fallback; the PR row uses the default CUDA fast path. Metric is `GenerationResult.metrics.total_duration_ms`.

| Implementation | Median E2E ms | Mean E2E ms | Min / Max E2E ms | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Triton fallback | 181.521 | 181.388 | 176.617 / 187.432 | 1.00x |
| CUDA JIT fast path | 177.687 | 177.554 | 173.898 / 180.383 | **1.021x (+2.11%)** |

## B200 Visual Output Check

Visual equivalence check uses eager generation (`--enable-torch-compile false`) to compare the current `main` Triton path with this PR's default CUDA fast path. Performance evidence above uses the `torch.compile` path.

- Host/GPU: `ion-b200`, NVIDIA B200, `CUDA_VISIBLE_DEVICES=7`.
- Main commit: `e4976683f4`; PR commit: `869bad2b1053`.
- Prompt/shape: `A blue box slides across a clean warehouse floor.`, `832x480x9f`, `num_inference_steps=4`, `seed=42`.
- Native `Cosmos3Pipeline` was used for both runs; no diffusers fallback was observed.
- Decoded-video comparison: SSIM All `1.000000`, PSNR `inf`.

Left is `main`; right is this PR:

![Cosmos3 main vs PR visual comparison](https://raw.githubusercontent.com/BBuf/sglang/pr29281-assets/cosmos3/main_vs_pr.gif)

MP4 artifacts: [main.mp4](https://raw.githubusercontent.com/BBuf/sglang/pr29281-assets/cosmos3/main.mp4), [pr.mp4](https://raw.githubusercontent.com/BBuf/sglang/pr29281-assets/cosmos3/pr.mp4).

## Checklist

- [x] Default path tries CUDA first and falls back to Triton on failure.
- [x] No environment variable is required to enable the CUDA kernel.
- [x] Direct custom op registration is eager and has a fake impl for `torch.compile` compatibility.
- [x] Cosmos3 `--enable-torch-compile` model path tested on B200 with `dynamic=False` compile shapes.
- [x] B200 kernel benchmark and unit test included.
- [x] H100 kernel benchmark and unit test included.
- [x] Cosmos3 native model smoke tested on B200 and H100.

## Review and Merge Process

This is a focused KDA-Pilot kernel integration PR. The expected useful effect is the 2x faster VAE cat/pad kernel group; whole-model speedup is intentionally modest because the group is only a small slice of Cosmos3 T2V runtime.





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28213972400](https://github.com/sgl-project/sglang/actions/runs/28213972400)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28213972315](https://github.com/sgl-project/sglang/actions/runs/28213972315)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->