### PR TITLE
Fix unfinished free-oow KV ownership

### DIFF
--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -67,6 +67,14 @@ class InsertParams:
     # General
     chunked: bool = False
     priority: int = 0
+    # Skipped leaf values are usually owned by the cache insert. Unfinished
+    # requests still own their full KV through ReqToTokenPool, so they opt out.
+    free_skipped_leaf_value: bool = True
+    # Existing-node overlaps are normally duplicate request KV and can be freed
+    # during insert. Unfinished SWA requests defer that decision until after
+    # match_prefix, because out-of-window full nodes can overlap without being a
+    # valid device prefix to lock.
+    free_insert_overlap_value: bool = True
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -67,13 +67,11 @@ class InsertParams:
     # General
     chunked: bool = False
     priority: int = 0
-    # Skipped leaf values are usually owned by the cache insert. Unfinished
-    # requests still own their full KV through ReqToTokenPool, so they opt out.
+    # If insert skips creating a leaf, the remaining FULL KV is not owned by the tree.
+    # Finished requests should free it; unfinished requests keep it in ReqToTokenPool.
     free_skipped_leaf_value: bool = True
-    # Existing-node overlaps are normally duplicate request KV and can be freed
-    # during insert. Unfinished SWA requests defer that decision until after
-    # match_prefix, because out-of-window full nodes can overlap without being a
-    # valid device prefix to lock.
+    # FULL overlap is not enough for SWA prefix reuse: the SWA side may be tombstoned.
+    # For unfinished requests, defer freeing until match_prefix confirms replacement.
     free_insert_overlap_value: bool = True
 
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -728,6 +728,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             insert_params = InsertParams(
                 prev_prefix_len=req.cache_protected_len,
                 priority=getattr(req, "priority", 0) or 0,
+                free_skipped_leaf_value=True,
             )
 
             # components prepare insert data + return effective cache_len
@@ -798,6 +799,8 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             prev_prefix_len=req.cache_protected_len,
             chunked=chunked,
             priority=getattr(req, "priority", 0) or 0,
+            free_skipped_leaf_value=False,
+            free_insert_overlap_value=False,
         )
         effective_cache_len = len(token_ids)
         for comp in self._components_tuple:
@@ -842,13 +845,17 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
         new_indices = match_result.device_indices
         new_last_node = match_result.last_device_node
-        new_prefix_len = result.prefix_len
         assert (
             req.cache_protected_len <= len(new_indices) + self.page_size - 1
         ), f"{req.cache_protected_len=}, {len(new_indices)=}, {page_aligned_len=}"
-        assert new_prefix_len <= len(
-            new_indices
-        ), f"{new_prefix_len=}, {len(new_indices)=}"
+        if req.cache_protected_len < len(new_indices):
+            old_indices = kv_indices_orig[
+                req.cache_protected_len : len(new_indices)
+            ].to(device=new_indices.device)
+            replacement_indices = new_indices[req.cache_protected_len :]
+            duplicate_indices = old_indices[old_indices != replacement_indices]
+            if duplicate_indices.numel() > 0:
+                self.token_to_kv_pool_allocator.free(duplicate_indices)
         self.req_to_token_pool.write(
             (req.req_pool_idx, slice(req.cache_protected_len, len(new_indices))),
             new_indices[req.cache_protected_len :],
@@ -1146,7 +1153,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                     consumed_from = min(consumed_from, comp_consumed_from)
 
                 dup_start = max(0, params.prev_prefix_len - total_prefix_length)
-                if dup_start < consumed_from:
+                if params.free_insert_overlap_value and dup_start < consumed_from:
                     self.token_to_kv_pool_allocator.free(
                         value_slice[dup_start:consumed_from]
                     )
@@ -1169,10 +1176,8 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 )
                 for comp in self._components_tuple
             ):
-                # TODO: When leaf creation is skipped, We should release all component
-                # resources here or propagate a flag so that
-                # cleanup_after_caching_req can free them properly.
-                self.token_to_kv_pool_allocator.free(value)
+                if params.free_skipped_leaf_value:
+                    self.token_to_kv_pool_allocator.free(value)
                 return InsertResult(prefix_len=total_prefix_length)
             target_node = self._add_new_node(node, key, value, priority=priority)
             is_new_leaf = True

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1176,6 +1176,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 )
                 for comp in self._components_tuple
             ):
+                # TODO: When leaf creation is skipped, We should release all component
+                # resources here or propagate a flag so that
+                # cleanup_after_caching_req can free them properly.
                 if params.free_skipped_leaf_value:
                     self.token_to_kv_pool_allocator.free(value)
                 return InsertResult(prefix_len=total_prefix_length)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1892,6 +1892,192 @@ class UnifiedRadixCacheSuite:
         )
         tree.sanity_check()
 
+    def test_unfinished_req_frees_matched_overlap_after_deferred_insert(self):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        if self.cfg.page_size != 1 or self.cfg.sliding_window_size != 4:
+            self.skipTest("requires page_size=1, sliding_window_size=4")
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+
+        tokens = self._make_seq(1, 8)
+        self._insert(tree, allocator, req_to_token_pool, tokens)
+        cached = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", tokens))))
+        self.assertEqual(len(cached.device_indices), len(tokens))
+
+        req = self._make_req(req_to_token_pool)
+        req.origin_input_ids = tokens
+        req.output_ids = []
+        req.full_untruncated_fill_ids = array("q", tokens)
+        req.fill_len = len(req.full_untruncated_fill_ids)
+        fresh_indices = self._alloc(allocator, len(tokens))
+        req_to_token_pool.write(
+            (req.req_pool_idx, slice(0, len(tokens))), fresh_indices
+        )
+        req.kv_committed_len = len(tokens)
+        req.last_node = tree.root_node
+        req.cache_protected_len = 0
+        req.swa_uuid_for_lock = None
+        req.extra_key = None
+        req.swa_evicted_seqlen = 0
+
+        full_available_before = allocator.full_attn_allocator.available_size()
+        with envs.SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS.override(True):
+            tree.cache_unfinished_req(req)
+
+        self.assertTrue(torch.equal(req.prefix_indices, cached.device_indices))
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(),
+            full_available_before + len(tokens),
+            "fresh duplicate full KV should be freed after match_prefix replaces it",
+        )
+
+        tree.dec_lock_ref(
+            req.last_node,
+            DecLockRefParams(swa_uuid_for_lock=getattr(req, "swa_uuid_for_lock", None)),
+        )
+        tree.sanity_check()
+
+    def test_swa_unfinished_req_keeps_unmatched_tombstone_overlap_tail(self):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        if self.cfg.page_size != 1 or self.cfg.sliding_window_size != 4:
+            self.skipTest("requires page_size=1, sliding_window_size=4")
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+
+        tokens = self._make_seq(1, 30)
+        self._insert(tree, allocator, req_to_token_pool, tokens)
+
+        def node_at_prefix(prefix_len: int):
+            node = tree.root_node
+            pos = 0
+            while pos < prefix_len:
+                suffix = RadixKey(array("q", tokens[pos:]))
+                child = node.children[suffix.child_key(tree.page_size)]
+                child_end = pos + len(child.key)
+                if child_end > prefix_len:
+                    child = tree._split_node(child.key, child, prefix_len - pos)
+                    child_end = prefix_len
+                node = child
+                pos = child_end
+            return node
+
+        node_at_prefix(20)
+        tombstone_node = node_at_prefix(23)
+        self.assertGreater(len(tombstone_node.children), 0)
+        tracker = {ct: 0 for ct in tree.tree_components}
+        tree._evict_component_and_detach_lru(
+            tombstone_node,
+            tree.components[ComponentType.SWA],
+            target=EvictLayer.DEVICE,
+            tracker=tracker,
+        )
+        tree._update_evictable_leaf_sets(tombstone_node)
+
+        prefix_tokens = tokens[:23]
+        matched = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", prefix_tokens)))
+        )
+        self.assertEqual(len(matched.device_indices), 20)
+        lock_result = tree.inc_lock_ref(matched.last_device_node)
+
+        req = self._make_req(req_to_token_pool)
+        req.origin_input_ids = prefix_tokens
+        req.output_ids = []
+        req.full_untruncated_fill_ids = array("q", prefix_tokens)
+        req.fill_len = len(req.full_untruncated_fill_ids)
+        tail_indices = self._alloc(allocator, 3)
+        req_indices = torch.cat([matched.device_indices, tail_indices])
+        req_to_token_pool.write(
+            (req.req_pool_idx, slice(0, len(prefix_tokens))), req_indices
+        )
+        req.kv_committed_len = len(prefix_tokens)
+        req.last_node = matched.last_device_node
+        req.cache_protected_len = len(matched.device_indices)
+        req.prefix_indices = matched.device_indices
+        req.swa_uuid_for_lock = lock_result.swa_uuid_for_lock
+        req.extra_key = None
+        req.swa_evicted_seqlen = len(prefix_tokens)
+
+        full_available_before = allocator.full_attn_allocator.available_size()
+        with envs.SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS.override(True):
+            tree.cache_unfinished_req(req)
+
+        self.assertEqual(len(req.prefix_indices), len(prefix_tokens))
+        self.assertTrue(torch.equal(req.prefix_indices[:20], matched.device_indices))
+        self.assertTrue(torch.equal(req.prefix_indices[20:], tail_indices))
+        self.assertEqual(req.cache_protected_len, len(matched.device_indices))
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(),
+            full_available_before,
+            "unmatched out-of-window overlap must remain request-owned",
+        )
+
+        tree.dec_lock_ref(
+            req.last_node,
+            DecLockRefParams(swa_uuid_for_lock=getattr(req, "swa_uuid_for_lock", None)),
+        )
+        tree.sanity_check()
+
+    def test_swa_skipped_leaf_preserves_unfinished_full_value(self):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        tree, allocator, _ = build_fixture(self.cfg)
+
+        tokens = self._make_seq(1, 3)
+        value = self._alloc(allocator, len(tokens))
+        self.assertIsNotNone(value)
+
+        allocator.free_swa(value)
+        full_available_after_alloc = allocator.full_attn_allocator.available_size()
+
+        result = tree.insert(
+            InsertParams(
+                key=RadixKey(array("q", tokens)),
+                value=value,
+                swa_evicted_seqlen=len(tokens),
+                free_skipped_leaf_value=False,
+            )
+        )
+
+        self.assertEqual(result.prefix_len, 0)
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(),
+            full_available_after_alloc,
+            "unfinished insert must keep skipped full KV owned by the request",
+        )
+
+        allocator.full_attn_allocator.free(value)
+        tree.sanity_check()
+
+    def test_swa_skipped_leaf_frees_finished_value(self):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        tree, allocator, _ = build_fixture(self.cfg)
+
+        tokens = self._make_seq(1, 3)
+        value = self._alloc(allocator, len(tokens))
+        self.assertIsNotNone(value)
+        full_available_after_alloc = allocator.full_attn_allocator.available_size()
+
+        allocator.free_swa(value)
+
+        result = tree.insert(
+            InsertParams(
+                key=RadixKey(array("q", tokens)),
+                value=value,
+                swa_evicted_seqlen=len(tokens),
+                free_skipped_leaf_value=True,
+            )
+        )
+
+        self.assertEqual(result.prefix_len, 0)
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(),
+            full_available_after_alloc + len(tokens),
+            "finished insert should still release skipped full KV",
+        )
+        tree.sanity_check()
+
     def test_swa_sanity_check_passes_after_deep_match(self):
         if not self._swa_pinning_cfg_supported():
             self.skipTest("requires SWA-only config with node size >= cushion")


### PR DESCRIPTION
## Summary
- Add insert ownership flags so skipped leaves can distinguish finished inserts from unfinished request inserts.
- Preserve request-owned full KV in cache_unfinished_req until match_prefix determines which fresh KV was actually replaced by cached KV.
- Add regression tests for skipped SWA leaves and tombstone overlap ownership.

## Root cause
SWA free-out-of-window can make unified radix insertion skip leaf creation or overlap an out-of-window full KV tombstone. For unfinished requests, those full KV slots are still owned by the active request through ReqToTokenPool, so freeing them during insert can corrupt allocator ownership. The fix defers overlap freeing for unfinished requests until after match_prefix and keeps skipped-leaf values request-owned on unfinished inserts.

## Tests
- git diff --check origin/main...HEAD
- python -m py_compile python/sglang/srt/mem_cache/base_prefix_cache.py python/sglang/srt/mem_cache/unified_radix_cache.py test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28223336657](https://github.com/sgl-project/sglang/actions/runs/28223336657)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28223336561](https://github.com/sgl-project/sglang/actions/runs/28223336561)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->