### PR TITLE
Fix nonzero exit on child process crash

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -3112,7 +3112,7 @@ class SignalHandler:
         if self.tokenizer_manager._subprocess_watchdog is not None:
             self.tokenizer_manager._subprocess_watchdog.stop()
         self.tokenizer_manager.dump_requests_before_crash()
-        kill_process_tree(os.getpid())
+        kill_process_tree(os.getpid(), exit_code=1)
 
 
 # Note: request abort handling logic

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1271,13 +1271,15 @@ def kill_process_tree(
     include_parent: bool = True,
     skip_pid: int = None,
     wait_timeout: Optional[float] = None,
+    exit_code: int = 0,
 ):
     """Kill the process and all its child processes.
 
     `wait_timeout` (seconds) blocks until every killed process is reaped and
     raises `RuntimeError` on timeout; `None` is fire-and-forget. The
-    `parent_pid == os.getpid()` branch calls `sys.exit(0)` and cannot wait
-    for itself -- use `include_parent=False` if child reap must finish first.
+    `parent_pid == os.getpid()` branch calls `sys.exit(exit_code)` and cannot
+    wait for itself -- use `include_parent=False` if child reap must finish
+    first.
     """
     logger.info(
         f"kill_process_tree called: parent_pid={parent_pid}, "
@@ -1308,7 +1310,7 @@ def kill_process_tree(
         try:
             if parent_pid == os.getpid():
                 itself.kill()
-                sys.exit(0)
+                sys.exit(exit_code)
 
             itself.kill()
 

--- a/test/registered/unit/utils/test_kill_process_tree.py
+++ b/test/registered/unit/utils/test_kill_process_tree.py
@@ -1,0 +1,52 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for process tree cleanup helpers."""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.utils.common import kill_process_tree
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+class TestKillProcessTree(CustomTestCase):
+    def test_current_process_exit_code_defaults_to_zero(self):
+        proc = MagicMock()
+        proc.children.return_value = []
+
+        with patch("sglang.srt.utils.common.psutil.Process", return_value=proc):
+            with self.assertRaises(SystemExit) as ctx:
+                kill_process_tree(os.getpid())
+
+        proc.kill.assert_called_once()
+        self.assertEqual(ctx.exception.code, 0)
+
+    def test_current_process_exit_code_can_be_overridden(self):
+        proc = MagicMock()
+        proc.children.return_value = []
+
+        with patch("sglang.srt.utils.common.psutil.Process", return_value=proc):
+            with self.assertRaises(SystemExit) as ctx:
+                kill_process_tree(os.getpid(), exit_code=1)
+
+        proc.kill.assert_called_once()
+        self.assertEqual(ctx.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When a scheduler or other child process crashes, the tokenizer manager receives `SIGQUIT` and tears down the process tree. Previously, `kill_process_tree()` always exited the current process with status code `0`, so Kubernetes could treat child process failures, including CUDA illegal memory access crashes, as successful exits.

This makes failures harder to detect in production because the container may terminate with a misleading success status.

## Modifications

- Add an `exit_code` argument to `kill_process_tree()`, defaulting to `0` to preserve existing behavior.
- Pass `exit_code=1` from `TokenizerManager`'s running-phase `SIGQUIT` handler, since this path usually means a child process failed.
- Add unit tests covering the default exit code and the overridden non-zero exit code behavior.

## Accuracy Tests

Not applicable. This PR does not affect model outputs, kernels, sampling, or forward computation.

## Speed Tests and Profiling

Not applicable. This PR only changes process teardown behavior on failure paths and has no expected impact on inference performance.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not needed for this internal failure-path fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28156624593](https://github.com/sgl-project/sglang/actions/runs/28156624593)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28156624433](https://github.com/sgl-project/sglang/actions/runs/28156624433)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->