### PR TITLE
[sgl-kernel/cpu]: exclude amx gemm source from arm build

### DIFF
--- a/sgl-kernel/csrc/cpu/CMakeLists.txt
+++ b/sgl-kernel/csrc/cpu/CMakeLists.txt
@@ -93,6 +93,7 @@ endif()
 # Keep them out of Arm64 bootstrap builds until native Arm paths land.
 set(SGLANG_CPU_X86_ONLY_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/gemm_int4.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gemm_int8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moe.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moe_fp8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moe_int4.cpp

--- a/sgl-kernel/csrc/cpu/aarch64/gemm_int8.cpp
+++ b/sgl-kernel/csrc/cpu/aarch64/gemm_int8.cpp
@@ -56,6 +56,23 @@ void int8_scaled_mm_impl<at::BFloat16>(
 
 }  // anonymous namespace
 
+std::tuple<at::Tensor, at::Tensor> per_token_quant_int8_cpu(at::Tensor& /*A*/) {
+  TORCH_CHECK(false, "not implemented yet");
+  return {at::Tensor(), at::Tensor()};
+}
+
+at::Tensor int8_scaled_mm_cpu(
+    at::Tensor& /*mat1*/,
+    at::Tensor& /*mat2*/,
+    at::Tensor& /*scales1*/,
+    at::Tensor& /*scales2*/,
+    const std::optional<at::Tensor>& /*bias*/,
+    at::ScalarType /*out_dtype*/,
+    bool /*is_vnni*/) {
+  TORCH_CHECK(false, "not implemented yet");
+  return at::Tensor();
+}
+
 // weight     :  static, per-channel, symmetric
 // activation : dynamic,   per-token, symmetric
 //

--- a/sgl-kernel/csrc/cpu/gemm_int8.cpp
+++ b/sgl-kernel/csrc/cpu/gemm_int8.cpp
@@ -473,7 +473,6 @@ at::Tensor int8_scaled_mm_cpu(
   return out;
 }
 
-#ifndef __aarch64__
 // fused `per_token_quant_int8_cpu` and `int8_scaled_mm_cpu`
 at::Tensor int8_scaled_mm_with_quant(
     at::Tensor& mat1,
@@ -540,4 +539,3 @@ at::Tensor int8_scaled_mm_with_quant(
   });
   return out;
 }
-#endif  // #ifndef __aarch64__


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

A minor refine to exclude Intel AMX gemm source from Arm build.

## Modifications

Remove unnecessary ifdef guards. Exclude amx gemm source from arm build.

## Accuracy Tests

N/A

## Speed Tests and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28158137961](https://github.com/sgl-project/sglang/actions/runs/28158137961)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #28209048990](https://github.com/sgl-project/sglang/actions/runs/28209048990)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->