### PR TITLE
[Attention] Add FlashInfer's Cascade Attention Backend for cross-request shared-prefix decode

### DIFF
--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -56,6 +56,31 @@ def create_flashinfer_backend(runner):
         return FlashInferMLAAttnBackend(runner)
 
 
+@register_attention_backend("flashinfer-cascade")
+def create_flashinfer_cascade_backend(runner):
+    """FlashInfer backend with a cross-request shared-prefix decode path.
+
+    Uses ``MultiLevelCascadeAttentionWrapper`` to batch the leading shared-
+    prefix portion of the running batch into a single matmul. Stock
+    ``flashinfer`` runs ``BatchDecodeWithPagedKVCacheWrapper`` per-request
+    even when prefixes are deduped at the storage layer; this backend wires
+    the cascade wrapper into SGLang's decode path. Decode-only and eager-
+    plus-CG; extend (prefill) defers to the parent ``flashinfer`` path.
+    """
+    assert (
+        not runner.model_config.is_encoder_decoder
+    ), "Cross attention is not supported in the flashinfer-cascade backend."
+    assert not runner.use_mla_backend, (
+        "flashinfer-cascade backend currently supports MHA/GQA only; MLA is "
+        "out of scope."
+    )
+    from sglang.srt.layers.attention.flashinfer_cascade_backend import (
+        FlashInferCascadeAttnBackend,
+    )
+
+    return FlashInferCascadeAttnBackend(runner)
+
+
 @register_attention_backend("trtllm_mla")
 def create_trtllm_mla_backend(runner):
     if not runner.use_mla_backend:

--- a/python/sglang/srt/layers/attention/flashinfer_cascade_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_cascade_backend.py
@@ -51,9 +51,9 @@ if is_flashinfer_available():
 
 class _CascadePlanState(msgspec.Struct):
     """Per-step cascade plan state. Set by ``init_forward_metadata`` (eager)
-    or ``init_forward_metadata_replay_cuda_graph`` (CG) when the cascade
-    arms; consumed by ``forward_decode``. ``None`` means cascade did not
-    fire for this step (parent's per-request path runs instead).
+    or ``init_forward_metadata_out_graph`` (CG) when the cascade arms;
+    consumed by ``forward_decode``. ``None`` means cascade did not fire for
+    this step (parent's per-request path runs instead).
     """
 
     common_prefix_tokens: int
@@ -142,7 +142,7 @@ class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
 
         # ---- CG-mode state ----
         # Per-bs wrappers + pre-allocated buffers. Filled lazily during
-        # init_forward_metadata_capture_cuda_graph (called once per
+        # init_forward_metadata_out_graph(in_capture=True) (called once per
         # cuda_graph_bs by the runner). Each entry holds a wrapper sized
         # to one specific captured batch size; FlashInfer's CG-mode
         # contract enforces fixed batch_size across plan() calls.
@@ -237,15 +237,16 @@ class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
         if min_seq <= 1:
             return 0
         scan_n = min(min_seq, self._cascade_scan_cap)
-        # Single sync to materialize the [bs, scan_n] slice on host.
-        leading = self.req_to_token[req_pool_indices[:bs].long(), :scan_n].cpu().numpy()
-        first_row = leading[0]
-        match_mask = (leading == first_row[None, :]).all(axis=0)
-        false_positions = (~match_mask).nonzero()[0]
-        if false_positions.size == 0:
-            common = scan_n
-        else:
-            common = int(false_positions[0])
+        # Compare/reduce entirely on-device and sync only a single scalar
+        # back to host (instead of copying the whole [bs, scan_n] slice).
+        leading = self.req_to_token[req_pool_indices[:bs].long(), :scan_n]
+        # mismatch[j] is True if any request's slot j differs from request 0's.
+        mismatch = (leading != leading[0:1]).any(dim=0)
+        # Append a True sentinel at index scan_n so argmax always resolves to
+        # the first divergence -- or to scan_n itself when fully shared. This
+        # keeps the whole reduction on-device with one scalar sync.
+        sentinel = torch.ones(1, dtype=torch.bool, device=mismatch.device)
+        common = int(torch.cat([mismatch, sentinel]).to(torch.uint8).argmax().item())
         common = min(common, min_seq - 1)
         return max(0, common)
 
@@ -286,7 +287,11 @@ class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
             [0, common_prefix_tokens], dtype=torch.int32, device=device
         )
         rpi = forward_batch.req_pool_indices
-        first_rpi = int(rpi[0].item())
+        # Materialize the pool indices to host once; the per-request loop below
+        # then indexes a Python list instead of issuing bs separate .item()
+        # device syncs per decode step.
+        rpi_list = rpi[:bs].cpu().tolist()
+        first_rpi = int(rpi_list[0])
         kv_indices_l0 = self.req_to_token[first_rpi, :common_prefix_tokens].to(
             torch.int32
         )
@@ -312,7 +317,7 @@ class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
             kv_indices_l1 = torch.empty(total_unique, dtype=torch.int32, device=device)
             offset = 0
             for i in range(bs):
-                rpi_i = int(rpi[i].item())
+                rpi_i = int(rpi_list[i])
                 ul = unique_lens[i]
                 if ul > 0:
                     kv_indices_l1[offset : offset + ul] = self.req_to_token[
@@ -369,8 +374,13 @@ class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
             return
         d = self._device
 
-        qo_indptr_l0 = torch.zeros(2, dtype=torch.int32, device=d)
-        qo_indptr_l1 = torch.zeros(bs + 1, dtype=torch.int32, device=d)
+        # qo_indptr_l0 = [0, bs] and qo_indptr_l1 = [0, 1, ..., bs] are static
+        # for a given captured bs (one query per request, every replay). Set
+        # them once here -- the buffer addresses stay stable for the captured
+        # graph and the values never change, so the per-replay copies in
+        # _fill_cg_cascade_plan are unnecessary.
+        qo_indptr_l0 = torch.tensor([0, bs], dtype=torch.int32, device=d)
+        qo_indptr_l1 = torch.arange(bs + 1, dtype=torch.int32, device=d)
         kv_indptr_l0 = torch.zeros(2, dtype=torch.int32, device=d)
         kv_indptr_l1 = torch.zeros(bs + 1, dtype=torch.int32, device=d)
         kv_indices_l0 = torch.zeros(
@@ -430,7 +440,9 @@ class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
 
         # Read seq_lens host-side once (small sync, bs values).
         if seq_lens_cpu is None:
-            seq_lens_cpu = self.kv_indptr[0].new_zeros(bs)  # safe placeholder
+            # Build the placeholder on CPU directly -- a device tensor here
+            # would force an extra GPU->CPU sync via the .tolist() below.
+            seq_lens_cpu = torch.zeros(bs, dtype=torch.int32, device="cpu")
         seq_lens_list = seq_lens_cpu[:bs].tolist()
         rpi_list = req_pool_indices[:bs].cpu().tolist()
 
@@ -438,10 +450,7 @@ class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
         # shared slots. With page_size=1 the "last page" is always full
         # (single token per slot), and last_page_len = 1 if there is at
         # least one shared slot, else 0 to indicate level 0 is empty.
-        bufs["qo_indptr_l0"].copy_(
-            torch.tensor([0, bs], dtype=torch.int32),
-            non_blocking=True,
-        )
+        # qo_indptr_l0 ([0, bs]) is static and pre-initialized at allocation.
         bufs["kv_indptr_l0"].copy_(
             torch.tensor([0, common_prefix_tokens], dtype=torch.int32),
             non_blocking=True,
@@ -463,12 +472,8 @@ class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
             bufs["last_page_l0"].fill_(0)
 
         # Level 1: bs unique tails of length (seq_len - common_prefix).
-        # qo_indptr_l1 = [0, 1, 2, ..., bs] (one query per request).
-        qo_l1_cpu = list(range(bs + 1))
-        bufs["qo_indptr_l1"].copy_(
-            torch.tensor(qo_l1_cpu, dtype=torch.int32),
-            non_blocking=True,
-        )
+        # qo_indptr_l1 = [0, 1, 2, ..., bs] (one query per request) is static and
+        # pre-initialized at allocation.
         unique_lens = [max(0, int(s) - common_prefix_tokens) for s in seq_lens_list]
         kv_indptr_l1_cpu = [0]
         cum = 0
@@ -570,9 +575,14 @@ class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
         if self._dbg_enabled:
             logger.info("Cascade fires: bs=%d, common_prefix_tokens=%d", bs, common)
 
-    def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
+    def init_cuda_graph_state(
+        self,
+        max_bs: int,
+        max_num_tokens: int,
+        kv_indices_buf: Optional[torch.Tensor] = None,
+    ):
         # Parent allocates cuda_graph_kv_indices etc. for its decode wrappers.
-        super().init_cuda_graph_state(max_bs, max_num_tokens)
+        super().init_cuda_graph_state(max_bs, max_num_tokens, kv_indices_buf)
 
         # Size cascade buffers for the worst case in the captured set. We
         # don't know the full cuda_graph_bs list here -- only max_bs. Each
@@ -584,162 +594,111 @@ class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
         # Worst-case per-request tail length: same context window.
         self._cg_max_pages_per_req = int(self.max_context_len)
 
-    def init_forward_metadata_capture_cuda_graph(
+    def init_forward_metadata_out_graph(
         self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode,
-        spec_info,
+        forward_batch: ForwardBatch,
+        in_capture: bool = False,
     ):
-        # Parent captures its per-request decode wrappers for this bs.
-        super().init_forward_metadata_capture_cuda_graph(
-            bs,
-            num_tokens,
-            req_pool_indices,
-            seq_lens,
-            encoder_lens,
-            forward_mode,
-            spec_info,
-        )
+        """CUDA-graph metadata hook (current out-of-graph API).
+
+        Replaces the deprecated ``init_forward_metadata_{capture,replay}_cuda_graph``
+        pair. The decode CUDA-graph runner calls this once per captured batch
+        size with ``in_capture=True`` (before recording the graph), and again
+        before every ``graph.replay()`` with ``in_capture=False``. Eager decode
+        does not reach here -- it uses ``init_forward_metadata`` above.
+
+          * Capture (``in_capture=True``): allocate the per-bs cascade wrapper,
+            prime it with a synthetic plan, and arm ``_cg_cascade_plan`` so the
+            ``forward_decode`` recorded into the graph invokes the cascade
+            wrapper's ``run()`` for this bs.
+          * Replay (``in_capture=False``): detect the actual shared prefix and
+            refill the pre-allocated buffers in place so the recorded ``run()``
+            reads the current step's metadata.
+        """
+        # Parent sets up its per-request decode wrappers for this bs -- our
+        # fallback path, and required for non-decode capture modes.
+        super().init_forward_metadata_out_graph(forward_batch, in_capture)
 
         self._in_cuda_graph = True
         self._cascade_plan = None
         self._cg_cascade_plan = None
 
-        # Cascade-CG path is decode-only. Other modes (target_verify, etc.)
-        # use the parent's per-request prefill wrapper and bypass us.
-        if not forward_mode.is_decode_or_idle():
-            return
-        if self._cg_disabled:
-            return
-        if not is_flashinfer_available():
-            return
-        if bs < self.cascade_min_batch_size:
-            # bs too small to ever fire cascade; don't waste a wrapper here.
-            return
-
-        # Allocate per-bs cascade wrapper + buffers lazily.
-        self._allocate_cg_cascade_for_bs(bs)
-
-        # Prime the wrapper with a synthetic plan so the captured run() has
-        # valid scheduler state. We use common_prefix=1 + bs unique tails
-        # of length (seq_lens[i]-1) -- this exercises both levels at the
-        # max shape that will be seen at replay. The actual slot ids written
-        # here are placeholders; replay overwrites them in-place.
-        seq_lens_cpu = seq_lens.cpu()
-        synthetic_common = 1
-        # Capture-time req_pool_indices may point at slots whose req_to_token
-        # rows are zero-filled. That's fine: cascade reads slot ids and
-        # treats them as kv-cache offsets; the captured kernel just records
-        # the launch, it does not validate slot contents.
-        ok = self._fill_cg_cascade_plan(
-            bs,
-            req_pool_indices,
-            seq_lens_cpu,
-            synthetic_common,
-        )
-        if ok:
-            self._cg_cascade_plan_state_capture = _CascadePlanState(
-                common_prefix_tokens=synthetic_common, bs=bs
-            )
-            # Stash a "fired at capture" plan so forward_decode takes the
-            # cascade path during the capture run. The captured graph will
-            # then permanently invoke wrapper.run(...) for this bs.
-            self._cg_cascade_plan = self._cg_cascade_plan_state_capture
-        else:
-            # Capture-time plan failure: leave cascade off for this bs;
-            # forward_decode will fall through to parent for this bs's
-            # captured graph. Safe -- we just lose CG cascade for this bs.
-            self._cg_cascade_wrappers.pop(bs, None)
-            self._cg_cascade_buffers.pop(bs, None)
-            if self._dbg_enabled:
-                logger.warning(
-                    "CG cascade capture-plan failed at bs=%d; falling back "
-                    "to parent's per-request decode for this bs.",
-                    bs,
-                )
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode,
-        spec_info,
-        seq_lens_cpu: Optional[torch.Tensor] = None,
-    ):
-        # Parent fills its per-request decode wrappers' indptr/indices for
-        # this bs. We always run super so the parent's path works even if
-        # cascade capture failed for this bs.
-        super().init_forward_metadata_replay_cuda_graph(
-            bs,
-            req_pool_indices,
-            seq_lens,
-            seq_lens_sum,
-            encoder_lens,
-            forward_mode,
-            spec_info,
-            seq_lens_cpu=seq_lens_cpu,
-        )
-
-        self._in_cuda_graph = True
-        self._cascade_plan = None
-        self._cg_cascade_plan = None
-
+        forward_mode = forward_batch.forward_mode
         if forward_mode is not None and not forward_mode.is_decode_or_idle():
             return
         if self._cg_disabled:
             self._dbg_skip_in_cg += 1
             return
-        if bs not in self._cg_cascade_wrappers:
-            # Cascade not allocated for this bs (e.g., bs < min_batch_size at
-            # capture time). Captured graph for this bs has parent's path,
-            # not ours, so just return.
+        if not is_flashinfer_available():
+            return
+
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens_cpu = forward_batch.seq_lens_cpu
+
+        if bs < self.cascade_min_batch_size:
+            # bs too small to ever fire cascade; the parent's per-request
+            # decode handles this captured graph.
             self._dbg_skip_in_cg += 1
             return
 
-        # Detect actual common prefix using only the replay-hook inputs
-        # (forward_batch is not threaded through this hook by SGLang's runner).
-        common = self._detect_common_prefix_from_rpi(
-            bs,
-            req_pool_indices,
-            seq_lens_cpu,
-        )
-        # Plan cascade with the actual detected common prefix. We always
-        # plan (even if common < threshold) because the captured graph for
-        # this bs has cascade run() recorded at capture time -- there is no
-        # mid-graph fallback to parent's per-request path. Cascade with
-        # common=0 is mathematically equivalent to per-request decode plus
-        # a no-op level-0 launch, so always arm under CG.
-        ok = self._fill_cg_cascade_plan(
-            bs,
-            req_pool_indices,
-            seq_lens_cpu,
-            common,
-        )
+        if in_capture:
+            # Allocate the per-bs cascade wrapper + buffers lazily, then prime
+            # it with a synthetic plan (common_prefix=1 + bs unique tails) so
+            # the captured run() has valid scheduler state. Capture-time slot
+            # ids may point at zero-filled req_to_token rows; that is fine --
+            # the captured kernel only records the launch, and replay overwrites
+            # the buffers in place.
+            self._allocate_cg_cascade_for_bs(bs)
+            synth_seq_lens_cpu = (
+                seq_lens_cpu
+                if seq_lens_cpu is not None
+                else forward_batch.seq_lens.cpu()
+            )
+            ok = self._fill_cg_cascade_plan(bs, req_pool_indices, synth_seq_lens_cpu, 1)
+            if ok:
+                # Arm so forward_decode takes the cascade path during the
+                # capture run; the captured graph then permanently invokes
+                # wrapper.run(...) for this bs.
+                self._cg_cascade_plan = _CascadePlanState(common_prefix_tokens=1, bs=bs)
+            else:
+                # Capture-time plan failure: drop cascade for this bs and let
+                # the captured graph use the parent's per-request decode.
+                self._cg_cascade_wrappers.pop(bs, None)
+                self._cg_cascade_buffers.pop(bs, None)
+                if self._dbg_enabled:
+                    logger.warning(
+                        "CG cascade capture-plan failed at bs=%d; falling back "
+                        "to parent's per-request decode for this bs.",
+                        bs,
+                    )
+            return
+
+        # ---- Replay: detect actual common prefix + refill buffers in place ----
+        if bs not in self._cg_cascade_wrappers:
+            # Cascade not captured for this bs (capture-plan failed, or
+            # bs < min_batch_size at capture); the parent's path runs.
+            self._dbg_skip_in_cg += 1
+            return
+
+        common = self._detect_common_prefix_from_rpi(bs, req_pool_indices, seq_lens_cpu)
+        # Always plan (even below threshold): the captured graph for this bs has
+        # cascade run() recorded, with no mid-graph fallback. Cascade with
+        # common=0 is mathematically equivalent to per-request decode plus a
+        # no-op level-0 launch, so always arm under CG.
+        ok = self._fill_cg_cascade_plan(bs, req_pool_indices, seq_lens_cpu, common)
         if not ok:
-            # Replay-time plan failure is fatal for this step's correctness
-            # -- the captured graph will read stale buffers. Best we can do
-            # is log and let it run; the test harness will catch it.
             if self._dbg_enabled:
                 logger.warning(
                     "CG cascade replay-plan failed at bs=%d, common=%d "
-                    "(captured graph may produce incorrect output for "
-                    "this step).",
+                    "(captured graph may produce incorrect output for this "
+                    "step).",
                     bs,
                     common,
                 )
             return
 
-        self._cg_cascade_plan = _CascadePlanState(
-            common_prefix_tokens=common,
-            bs=bs,
-        )
+        self._cg_cascade_plan = _CascadePlanState(common_prefix_tokens=common, bs=bs)
         self._dbg_cascade_run_cg += 1
         if common >= self.cascade_min_prefix_tokens:
             self._dbg_cascade_fired_cg += 1

--- a/python/sglang/srt/layers/attention/flashinfer_cascade_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_cascade_backend.py
@@ -1,0 +1,820 @@
+"""FlashInfer Cascade attention backend.
+
+Subclasses ``FlashInferAttnBackend`` and adds a
+``MultiLevelCascadeAttentionWrapper`` decode path that batches the leading
+shared-prefix portion of the running batch into a single matmul. The stock
+``flashinfer`` backend runs ``BatchDecodeWithPagedKVCacheWrapper`` per-request
+even when prefixes are deduped at the storage layer (RadixAttention shares
+pages, but Q.K is still computed per-request). FlashInfer ships
+``MultiLevelCascadeAttentionWrapper`` which can batch the shared portion
+across requests; this backend wires it into SGLang's decode path.
+
+Scope:
+    * Decode-only. Extend (prefill) falls through to the parent class.
+    * Eager mode: cascade fires when (1) the detected shared-prefix length
+      passes ``--cascade-min-prefix-tokens`` and (2) batch size passes
+      ``--cascade-min-batch-size``. Otherwise the parent per-request path
+      runs.
+    * CUDA-graph mode: every captured ``cuda_graph_bs`` gets its own
+      wrapper plus pre-allocated indptr/indices buffers; ``plan()`` writes
+      into those buffers per replay step (host-side, before the graph
+      fires); the captured ``run()`` reads from the same addresses.
+      Cascade is always armed in CG-mode regardless of threshold:
+      ``common_prefix=0`` is mathematically equivalent to per-request
+      decode plus a no-op level-0 launch, so correctness holds at every
+      bs in the captured list while keeping the capture graph singular.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Optional
+
+import msgspec
+import torch
+
+from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
+from sglang.srt.layers.dp_attention import get_attention_tp_size
+from sglang.srt.utils import is_flashinfer_available
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+logger = logging.getLogger(__name__)
+
+if is_flashinfer_available():
+    from flashinfer import MultiLevelCascadeAttentionWrapper
+
+
+class _CascadePlanState(msgspec.Struct):
+    """Per-step cascade plan state. Set by ``init_forward_metadata`` (eager)
+    or ``init_forward_metadata_replay_cuda_graph`` (CG) when the cascade
+    arms; consumed by ``forward_decode``. ``None`` means cascade did not
+    fire for this step (parent's per-request path runs instead).
+    """
+
+    common_prefix_tokens: int
+    bs: int
+
+
+class FlashInferCascadeAttnBackend(FlashInferAttnBackend):
+    """FlashInfer backend with a cross-request shared-prefix decode path.
+
+    Detection (eager): walks each request's leading slot indices in
+    ``req_to_token``, finds the longest run where every request's slot
+    matches request 0's. Cascade fires when that run is at least
+    ``cascade_min_prefix_tokens`` long AND batch size is at least
+    ``cascade_min_batch_size``.
+
+    Detection (CG-mode): same algorithm, but driven from ``req_pool_indices``
+    + ``seq_lens`` (forward_batch is not available at replay-time).
+
+    Under CUDA graphs every captured ``cuda_graph_bs`` gets its own wrapper
+    plus pre-allocated indptr/indices buffers; ``plan()`` writes into those
+    buffers per replay step (host-side, before the graph fires); the captured
+    ``run()`` reads from the same addresses. Cascade is always armed in
+    CG-mode regardless of threshold: cascade with ``common_prefix=0`` is
+    mathematically equivalent to per-request decode plus a no-op level-0
+    launch, so correctness holds at every bs in the captured list while
+    keeping the capture graph singular (instead of capturing two arms per
+    bs).
+    """
+
+    def __init__(self, model_runner: ModelRunner, **kwargs):
+        super().__init__(model_runner, **kwargs)
+
+        self.cascade_min_prefix_tokens: int = int(
+            getattr(model_runner.server_args, "cascade_min_prefix_tokens", 128)
+        )
+        self.cascade_min_batch_size: int = int(
+            getattr(model_runner.server_args, "cascade_min_batch_size", 4)
+        )
+        if self.cascade_min_prefix_tokens < 1:
+            self.cascade_min_prefix_tokens = 1
+        if self.cascade_min_batch_size < 2:
+            self.cascade_min_batch_size = 2
+
+        # Tracks whether the current step is inside CG capture/replay (set by
+        # the CG hooks below; reset by eager init).
+        self._in_cuda_graph: bool = False
+
+        # Parent's KV pool: SGLang treats each slot as a 1-page row in the
+        # flashinfer wrapper (page_size=1). We mirror that here for the
+        # cascade wrapper so kv_indices are slot ids the same way.
+        self.cascade_page_size: int = 1
+        self.num_qo_heads: int = (
+            model_runner.model_config.num_attention_heads // get_attention_tp_size()
+        )
+        self.num_kv_heads_local: int = model_runner.model_config.get_num_kv_heads(
+            get_attention_tp_size()
+        )
+        self.head_dim_local: int = model_runner.model_config.head_dim
+        self.q_dtype = model_runner.dtype
+        self.kv_dtype = model_runner.kv_cache_dtype
+
+        self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self.req_to_token_stride = self.req_to_token.shape[1]
+        self._device = model_runner.device
+
+        # Cap detection cost: scan at most this many leading slot positions.
+        # Most realistic prefixes are <= 16K tokens; a hard cap keeps the
+        # CPU-side scan O(min(seq_len, cap)).
+        self._cascade_scan_cap: int = 32768
+
+        # Eager-mode cascade wrapper. Use_cuda_graph=False; plan allocates
+        # scheduler state per call (acceptable for eager since plan runs
+        # per step anyway).
+        self._cascade_decode_wrapper: Optional[MultiLevelCascadeAttentionWrapper] = None
+        if is_flashinfer_available():
+            self._cascade_decode_wrapper = MultiLevelCascadeAttentionWrapper(
+                num_levels=2,
+                float_workspace_buffer=self.workspace_buffer,
+                kv_layout="NHD",
+                use_cuda_graph=False,
+            )
+
+        # Eager plan stash. Set by init_forward_metadata; read by
+        # forward_decode. ``None`` means eager cascade did not arm.
+        self._cascade_plan: Optional[_CascadePlanState] = None
+
+        # ---- CG-mode state ----
+        # Per-bs wrappers + pre-allocated buffers. Filled lazily during
+        # init_forward_metadata_capture_cuda_graph (called once per
+        # cuda_graph_bs by the runner). Each entry holds a wrapper sized
+        # to one specific captured batch size; FlashInfer's CG-mode
+        # contract enforces fixed batch_size across plan() calls.
+        self._cg_cascade_wrappers: dict = {}  # bs -> MultiLevelCascadeAttentionWrapper
+        self._cg_cascade_buffers: dict = {}  # bs -> dict of pre-alloc tensors
+        # Per-replay plan stash for CG path (separate from eager path so
+        # the two arms cannot interfere). Set by replay hook; read by
+        # forward_decode when ``_in_cuda_graph`` is true.
+        self._cg_cascade_plan: Optional[_CascadePlanState] = None
+        # CG buffer sizing (set in init_cuda_graph_state).
+        self._cg_max_bs: int = 0
+        # Worst-case shared prefix length: cap by (max_context_len, scan_cap).
+        # Using max_context_len ensures level-0 indices buffer can hold any
+        # plausible prefix within the model's context window.
+        self._cg_max_shared_pages: int = 0
+        # Worst-case unique slots per request: max_context_len.
+        self._cg_max_pages_per_req: int = 0
+
+        # Toggle: SGLANG_CASCADE_DISABLE_CUDA_GRAPH=1 forces eager-only cascade
+        # even when CG is enabled (useful for debugging and bisection).
+        self._cg_disabled: bool = (
+            os.environ.get("SGLANG_CASCADE_DISABLE_CUDA_GRAPH", "0") == "1"
+        )
+
+        # Debug counters. Set ``SGLANG_CASCADE_DEBUG=1`` to log per-step
+        # decisions. Used by tests to confirm fire/skip behavior.
+        self._dbg_enabled: bool = os.environ.get("SGLANG_CASCADE_DEBUG", "0") == "1"
+        self._dbg_total_decode_steps: int = 0
+        self._dbg_cascade_fired: int = 0  # eager fires (>= threshold)
+        self._dbg_cascade_fired_cg: int = 0  # CG-mode fires (>= threshold)
+        self._dbg_cascade_run_cg: int = (
+            0  # CG-mode actually ran (incl. below-threshold)
+        )
+        self._dbg_skip_below_bs: int = 0
+        self._dbg_skip_below_prefix: int = 0
+        self._dbg_skip_below_prefix_cg: int = 0  # CG ran but threshold not met
+        self._dbg_skip_in_cg: int = 0
+        self._dbg_skip_not_decode: int = 0
+
+        logger.info(
+            "FlashInferCascadeAttnBackend initialized "
+            "(min_prefix_tokens=%d, min_batch_size=%d, num_qo_heads=%d, "
+            "num_kv_heads=%d, head_dim=%d, cg_disabled=%s)",
+            self.cascade_min_prefix_tokens,
+            self.cascade_min_batch_size,
+            self.num_qo_heads,
+            self.num_kv_heads_local,
+            self.head_dim_local,
+            self._cg_disabled,
+        )
+
+    def cascade_debug_counters(self) -> dict:
+        """Snapshot of debug counters; used by tests to assert fire/skip
+        behavior. Always available regardless of ``SGLANG_CASCADE_DEBUG``.
+        """
+        return {
+            "total_decode_steps": self._dbg_total_decode_steps,
+            "cascade_fired": self._dbg_cascade_fired,
+            "cascade_fired_cg": self._dbg_cascade_fired_cg,
+            "cascade_run_cg": self._dbg_cascade_run_cg,
+            "skip_below_bs": self._dbg_skip_below_bs,
+            "skip_below_prefix": self._dbg_skip_below_prefix,
+            "skip_below_prefix_cg": self._dbg_skip_below_prefix_cg,
+            "skip_in_cg": self._dbg_skip_in_cg,
+            "skip_not_decode": self._dbg_skip_not_decode,
+        }
+
+    # ------------------------------------------------------------------
+    # Detection helpers (host-side; used in both eager and CG paths)
+    # ------------------------------------------------------------------
+
+    def _detect_common_prefix_from_rpi(
+        self,
+        bs: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens_cpu: Optional[torch.Tensor],
+    ) -> int:
+        """CG-friendly detection: walks the leading slot indices using only
+        ``req_pool_indices`` and ``seq_lens_cpu`` (no forward_batch).
+
+        Returns the count of leading positions where all requests share the
+        same slot index, capped at ``min_seq - 1`` so each request keeps at
+        least 1 unique slot for its current decode token.
+        """
+        if bs < 2:
+            return 0
+        if seq_lens_cpu is None:
+            seq_lens_cpu = req_pool_indices.new_empty(0)  # placeholder
+        if seq_lens_cpu.numel() == 0:
+            return 0
+        min_seq = int(seq_lens_cpu[:bs].min().item())
+        if min_seq <= 1:
+            return 0
+        scan_n = min(min_seq, self._cascade_scan_cap)
+        # Single sync to materialize the [bs, scan_n] slice on host.
+        leading = self.req_to_token[req_pool_indices[:bs].long(), :scan_n].cpu().numpy()
+        first_row = leading[0]
+        match_mask = (leading == first_row[None, :]).all(axis=0)
+        false_positions = (~match_mask).nonzero()[0]
+        if false_positions.size == 0:
+            common = scan_n
+        else:
+            common = int(false_positions[0])
+        common = min(common, min_seq - 1)
+        return max(0, common)
+
+    def _detect_common_prefix_tokens(self, forward_batch: ForwardBatch, bs: int) -> int:
+        """Eager-mode detection wrapper -- forwards to the CG-friendly impl
+        using the forward_batch's seq_lens_cpu / req_pool_indices.
+        """
+        seq_lens_cpu = forward_batch.seq_lens_cpu
+        if seq_lens_cpu is None:
+            seq_lens_cpu = forward_batch.seq_lens.cpu()
+        return self._detect_common_prefix_from_rpi(
+            bs, forward_batch.req_pool_indices, seq_lens_cpu
+        )
+
+    # ------------------------------------------------------------------
+    # Eager-mode cascade plan
+    # ------------------------------------------------------------------
+
+    def _build_cascade_plan_args(
+        self,
+        forward_batch: ForwardBatch,
+        bs: int,
+        common_prefix_tokens: int,
+    ):
+        """Eager-mode plan builder. Allocates fresh tensors and calls
+        ``self._cascade_decode_wrapper.plan(...)``. Returns a stash state
+        on success, ``None`` on failure (caller falls through to parent).
+        """
+        device = forward_batch.input_ids.device
+
+        seq_lens_cpu = forward_batch.seq_lens_cpu
+        if seq_lens_cpu is None:
+            seq_lens_cpu = forward_batch.seq_lens.cpu()
+        seq_lens_list = seq_lens_cpu[:bs].tolist()
+
+        qo_indptr_l0 = torch.tensor([0, bs], dtype=torch.int32, device=device)
+        kv_indptr_l0 = torch.tensor(
+            [0, common_prefix_tokens], dtype=torch.int32, device=device
+        )
+        rpi = forward_batch.req_pool_indices
+        first_rpi = int(rpi[0].item())
+        kv_indices_l0 = self.req_to_token[first_rpi, :common_prefix_tokens].to(
+            torch.int32
+        )
+        last_page_len_l0 = torch.tensor([1], dtype=torch.int32, device=device)
+
+        qo_indptr_l1 = torch.zeros(bs + 1, dtype=torch.int32, device=device)
+        qo_indptr_l1[1:] = torch.arange(1, bs + 1, dtype=torch.int32, device=device)
+
+        unique_lens = [s - common_prefix_tokens for s in seq_lens_list]
+        total_unique = sum(unique_lens)
+        kv_indptr_l1 = torch.zeros(bs + 1, dtype=torch.int32, device=device)
+        kv_indptr_l1_cpu = [0]
+        cum = 0
+        for ul in unique_lens:
+            cum += ul
+            kv_indptr_l1_cpu.append(cum)
+        kv_indptr_l1.copy_(
+            torch.tensor(kv_indptr_l1_cpu, dtype=torch.int32),
+            non_blocking=True,
+        )
+
+        if total_unique > 0:
+            kv_indices_l1 = torch.empty(total_unique, dtype=torch.int32, device=device)
+            offset = 0
+            for i in range(bs):
+                rpi_i = int(rpi[i].item())
+                ul = unique_lens[i]
+                if ul > 0:
+                    kv_indices_l1[offset : offset + ul] = self.req_to_token[
+                        rpi_i,
+                        common_prefix_tokens : common_prefix_tokens + ul,
+                    ].to(torch.int32)
+                    offset += ul
+        else:
+            return None
+
+        last_page_len_l1 = torch.ones(bs, dtype=torch.int32, device=device)
+
+        try:
+            self._cascade_decode_wrapper.plan(
+                qo_indptr_arr=[qo_indptr_l0, qo_indptr_l1],
+                paged_kv_indptr_arr=[kv_indptr_l0, kv_indptr_l1],
+                paged_kv_indices_arr=[kv_indices_l0, kv_indices_l1],
+                paged_kv_last_page_len=[last_page_len_l0, last_page_len_l1],
+                num_qo_heads=self.num_qo_heads,
+                num_kv_heads=self.num_kv_heads_local,
+                head_dim=self.head_dim_local,
+                page_size=self.cascade_page_size,
+                causal=False,
+                pos_encoding_mode="NONE",
+                q_data_type=self.q_dtype,
+                kv_data_type=self.kv_dtype,
+            )
+        except Exception as e:
+            if self._dbg_enabled:
+                logger.warning("Cascade plan failed, falling through: %s", e)
+            return None
+
+        return _CascadePlanState(common_prefix_tokens=common_prefix_tokens, bs=bs)
+
+    # ------------------------------------------------------------------
+    # CG-mode cascade plan
+    # ------------------------------------------------------------------
+
+    def _allocate_cg_cascade_for_bs(self, bs: int) -> None:
+        """Allocate per-bs cascade wrapper + indptr/indices buffers. Called
+        lazily on first capture for each cuda_graph_bs entry.
+
+        Buffer sizing per level (FlashInfer 0.6.8.post1 contract):
+            Level 0 (shared, 1 merged group):
+                qo_indptr [2], paged_kv_indptr [2],
+                paged_kv_indices [_cg_max_shared_pages],
+                paged_kv_last_page_len [1]
+            Level 1 (bs unique tails):
+                qo_indptr [bs + 1], paged_kv_indptr [bs + 1],
+                paged_kv_indices [bs * _cg_max_pages_per_req],
+                paged_kv_last_page_len [bs]
+        """
+        if bs in self._cg_cascade_wrappers:
+            return
+        d = self._device
+
+        qo_indptr_l0 = torch.zeros(2, dtype=torch.int32, device=d)
+        qo_indptr_l1 = torch.zeros(bs + 1, dtype=torch.int32, device=d)
+        kv_indptr_l0 = torch.zeros(2, dtype=torch.int32, device=d)
+        kv_indptr_l1 = torch.zeros(bs + 1, dtype=torch.int32, device=d)
+        kv_indices_l0 = torch.zeros(
+            self._cg_max_shared_pages, dtype=torch.int32, device=d
+        )
+        # Level-1 indices: bs requests, each up to max_pages_per_req slots.
+        kv_indices_l1 = torch.zeros(
+            bs * self._cg_max_pages_per_req, dtype=torch.int32, device=d
+        )
+        last_page_l0 = torch.ones(1, dtype=torch.int32, device=d)
+        last_page_l1 = torch.ones(bs, dtype=torch.int32, device=d)
+
+        wrapper = MultiLevelCascadeAttentionWrapper(
+            num_levels=2,
+            float_workspace_buffer=self.workspace_buffer,
+            kv_layout="NHD",
+            use_cuda_graph=True,
+            qo_indptr_buf_arr=[qo_indptr_l0, qo_indptr_l1],
+            paged_kv_indptr_buf_arr=[kv_indptr_l0, kv_indptr_l1],
+            paged_kv_indices_buf_arr=[kv_indices_l0, kv_indices_l1],
+            paged_kv_last_page_len_buf_arr=[last_page_l0, last_page_l1],
+        )
+
+        self._cg_cascade_wrappers[bs] = wrapper
+        self._cg_cascade_buffers[bs] = {
+            "qo_indptr_l0": qo_indptr_l0,
+            "qo_indptr_l1": qo_indptr_l1,
+            "kv_indptr_l0": kv_indptr_l0,
+            "kv_indptr_l1": kv_indptr_l1,
+            "kv_indices_l0": kv_indices_l0,
+            "kv_indices_l1": kv_indices_l1,
+            "last_page_l0": last_page_l0,
+            "last_page_l1": last_page_l1,
+        }
+
+    def _fill_cg_cascade_plan(
+        self,
+        bs: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens_cpu: Optional[torch.Tensor],
+        common_prefix_tokens: int,
+    ) -> bool:
+        """Fill the per-bs cascade buffers in-place with the current step's
+        metadata and call plan(). Returns False on failure (caller logs and
+        falls through to parent's CG decode path).
+
+        Buffers are written via ``.copy_()`` / index assignment so device
+        addresses remain stable across replays (the captured graph reads
+        from these same addresses).
+        """
+        wrapper = self._cg_cascade_wrappers.get(bs)
+        bufs = self._cg_cascade_buffers.get(bs)
+        if wrapper is None or bufs is None:
+            return False
+
+        d = self._device
+
+        # Read seq_lens host-side once (small sync, bs values).
+        if seq_lens_cpu is None:
+            seq_lens_cpu = self.kv_indptr[0].new_zeros(bs)  # safe placeholder
+        seq_lens_list = seq_lens_cpu[:bs].tolist()
+        rpi_list = req_pool_indices[:bs].cpu().tolist()
+
+        # Level 0: 1 merged group of bs queries reading common_prefix_tokens
+        # shared slots. With page_size=1 the "last page" is always full
+        # (single token per slot), and last_page_len = 1 if there is at
+        # least one shared slot, else 0 to indicate level 0 is empty.
+        bufs["qo_indptr_l0"].copy_(
+            torch.tensor([0, bs], dtype=torch.int32),
+            non_blocking=True,
+        )
+        bufs["kv_indptr_l0"].copy_(
+            torch.tensor([0, common_prefix_tokens], dtype=torch.int32),
+            non_blocking=True,
+        )
+        if common_prefix_tokens > 0:
+            # Slot ids: leading common_prefix_tokens from request 0. All
+            # requests share these slots (RadixAttention dedupes matched
+            # prefixes -> equal leading slot ids imply same physical KV).
+            shared_slots = self.req_to_token[
+                int(rpi_list[0]), :common_prefix_tokens
+            ].to(torch.int32)
+            bufs["kv_indices_l0"][:common_prefix_tokens].copy_(
+                shared_slots, non_blocking=True
+            )
+            bufs["last_page_l0"].fill_(1)
+        else:
+            # No shared slots -> level 0 is a no-op. last_page_len=0 and
+            # kv_indices is unread (kv_indptr_l0[1] = 0).
+            bufs["last_page_l0"].fill_(0)
+
+        # Level 1: bs unique tails of length (seq_len - common_prefix).
+        # qo_indptr_l1 = [0, 1, 2, ..., bs] (one query per request).
+        qo_l1_cpu = list(range(bs + 1))
+        bufs["qo_indptr_l1"].copy_(
+            torch.tensor(qo_l1_cpu, dtype=torch.int32),
+            non_blocking=True,
+        )
+        unique_lens = [max(0, int(s) - common_prefix_tokens) for s in seq_lens_list]
+        kv_indptr_l1_cpu = [0]
+        cum = 0
+        for ul in unique_lens:
+            cum += ul
+            kv_indptr_l1_cpu.append(cum)
+        total_unique = cum
+        bufs["kv_indptr_l1"].copy_(
+            torch.tensor(kv_indptr_l1_cpu, dtype=torch.int32),
+            non_blocking=True,
+        )
+        # Sanity: total_unique must fit in pre-alloc buffer.
+        if total_unique > bufs["kv_indices_l1"].numel():
+            return False
+
+        if total_unique > 0:
+            # Build the level-1 indices CPU-side then bulk-copy to the
+            # pre-allocated buffer. A Python loop is fine here (bs <= 80).
+            offset = 0
+            for i in range(bs):
+                ul = unique_lens[i]
+                if ul == 0:
+                    continue
+                slots = self.req_to_token[
+                    int(rpi_list[i]),
+                    common_prefix_tokens : common_prefix_tokens + ul,
+                ].to(torch.int32)
+                bufs["kv_indices_l1"][offset : offset + ul].copy_(
+                    slots, non_blocking=True
+                )
+                offset += ul
+
+        bufs["last_page_l1"].fill_(1)
+
+        try:
+            # plan() runs host-side (it does .cpu() syncs internally to read
+            # qo_indptr's last value etc.). It writes into the wrapper's
+            # internal scheduler buffers, which are also fixed-shape since
+            # the wrapper was built with use_cuda_graph=True.
+            wrapper.plan(
+                qo_indptr_arr=[bufs["qo_indptr_l0"], bufs["qo_indptr_l1"]],
+                paged_kv_indptr_arr=[bufs["kv_indptr_l0"], bufs["kv_indptr_l1"]],
+                paged_kv_indices_arr=[
+                    bufs["kv_indices_l0"][: max(1, common_prefix_tokens)],
+                    bufs["kv_indices_l1"][: max(1, total_unique)],
+                ],
+                paged_kv_last_page_len=[bufs["last_page_l0"], bufs["last_page_l1"]],
+                num_qo_heads=self.num_qo_heads,
+                num_kv_heads=self.num_kv_heads_local,
+                head_dim=self.head_dim_local,
+                page_size=self.cascade_page_size,
+                causal=False,
+                pos_encoding_mode="NONE",
+                q_data_type=self.q_dtype,
+                kv_data_type=self.kv_dtype,
+            )
+        except Exception as e:
+            if self._dbg_enabled:
+                logger.warning("CG cascade plan failed at bs=%d: %s", bs, e)
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Forward-metadata hooks
+    # ------------------------------------------------------------------
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch) -> None:
+        # Always run the parent so non-cascade paths (extend, target verify,
+        # draft extend, fallback decode) keep working.
+        super().init_forward_metadata(forward_batch)
+
+        # Reset both arms; CG hooks set their respective state below.
+        self._in_cuda_graph = False
+        self._cascade_plan = None
+        self._cg_cascade_plan = None
+
+        if not forward_batch.forward_mode.is_decode_or_idle():
+            if self._dbg_enabled:
+                self._dbg_skip_not_decode += 1
+            return
+
+        bs = int(forward_batch.req_pool_indices.shape[0])
+        self._dbg_total_decode_steps += 1
+
+        if bs < self.cascade_min_batch_size:
+            self._dbg_skip_below_bs += 1
+            return
+
+        common = self._detect_common_prefix_tokens(forward_batch, bs)
+        if common < self.cascade_min_prefix_tokens:
+            self._dbg_skip_below_prefix += 1
+            return
+
+        plan = self._build_cascade_plan_args(forward_batch, bs, common)
+        if plan is None:
+            return
+        self._cascade_plan = plan
+        self._dbg_cascade_fired += 1
+        if self._dbg_enabled:
+            logger.info("Cascade fires: bs=%d, common_prefix_tokens=%d", bs, common)
+
+    def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
+        # Parent allocates cuda_graph_kv_indices etc. for its decode wrappers.
+        super().init_cuda_graph_state(max_bs, max_num_tokens)
+
+        # Size cascade buffers for the worst case in the captured set. We
+        # don't know the full cuda_graph_bs list here -- only max_bs. Each
+        # per-bs wrapper is allocated lazily in the capture hook.
+        self._cg_max_bs = max_bs
+        # Worst-case shared prefix length: cap at the model's context window
+        # (cascade slot ids must lie within req_to_token's row width).
+        self._cg_max_shared_pages = int(self.max_context_len)
+        # Worst-case per-request tail length: same context window.
+        self._cg_max_pages_per_req = int(self.max_context_len)
+
+    def init_forward_metadata_capture_cuda_graph(
+        self,
+        bs: int,
+        num_tokens: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode,
+        spec_info,
+    ):
+        # Parent captures its per-request decode wrappers for this bs.
+        super().init_forward_metadata_capture_cuda_graph(
+            bs,
+            num_tokens,
+            req_pool_indices,
+            seq_lens,
+            encoder_lens,
+            forward_mode,
+            spec_info,
+        )
+
+        self._in_cuda_graph = True
+        self._cascade_plan = None
+        self._cg_cascade_plan = None
+
+        # Cascade-CG path is decode-only. Other modes (target_verify, etc.)
+        # use the parent's per-request prefill wrapper and bypass us.
+        if not forward_mode.is_decode_or_idle():
+            return
+        if self._cg_disabled:
+            return
+        if not is_flashinfer_available():
+            return
+        if bs < self.cascade_min_batch_size:
+            # bs too small to ever fire cascade; don't waste a wrapper here.
+            return
+
+        # Allocate per-bs cascade wrapper + buffers lazily.
+        self._allocate_cg_cascade_for_bs(bs)
+
+        # Prime the wrapper with a synthetic plan so the captured run() has
+        # valid scheduler state. We use common_prefix=1 + bs unique tails
+        # of length (seq_lens[i]-1) -- this exercises both levels at the
+        # max shape that will be seen at replay. The actual slot ids written
+        # here are placeholders; replay overwrites them in-place.
+        seq_lens_cpu = seq_lens.cpu()
+        synthetic_common = 1
+        # Capture-time req_pool_indices may point at slots whose req_to_token
+        # rows are zero-filled. That's fine: cascade reads slot ids and
+        # treats them as kv-cache offsets; the captured kernel just records
+        # the launch, it does not validate slot contents.
+        ok = self._fill_cg_cascade_plan(
+            bs,
+            req_pool_indices,
+            seq_lens_cpu,
+            synthetic_common,
+        )
+        if ok:
+            self._cg_cascade_plan_state_capture = _CascadePlanState(
+                common_prefix_tokens=synthetic_common, bs=bs
+            )
+            # Stash a "fired at capture" plan so forward_decode takes the
+            # cascade path during the capture run. The captured graph will
+            # then permanently invoke wrapper.run(...) for this bs.
+            self._cg_cascade_plan = self._cg_cascade_plan_state_capture
+        else:
+            # Capture-time plan failure: leave cascade off for this bs;
+            # forward_decode will fall through to parent for this bs's
+            # captured graph. Safe -- we just lose CG cascade for this bs.
+            self._cg_cascade_wrappers.pop(bs, None)
+            self._cg_cascade_buffers.pop(bs, None)
+            if self._dbg_enabled:
+                logger.warning(
+                    "CG cascade capture-plan failed at bs=%d; falling back "
+                    "to parent's per-request decode for this bs.",
+                    bs,
+                )
+
+    def init_forward_metadata_replay_cuda_graph(
+        self,
+        bs: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_sum: int,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode,
+        spec_info,
+        seq_lens_cpu: Optional[torch.Tensor] = None,
+    ):
+        # Parent fills its per-request decode wrappers' indptr/indices for
+        # this bs. We always run super so the parent's path works even if
+        # cascade capture failed for this bs.
+        super().init_forward_metadata_replay_cuda_graph(
+            bs,
+            req_pool_indices,
+            seq_lens,
+            seq_lens_sum,
+            encoder_lens,
+            forward_mode,
+            spec_info,
+            seq_lens_cpu=seq_lens_cpu,
+        )
+
+        self._in_cuda_graph = True
+        self._cascade_plan = None
+        self._cg_cascade_plan = None
+
+        if forward_mode is not None and not forward_mode.is_decode_or_idle():
+            return
+        if self._cg_disabled:
+            self._dbg_skip_in_cg += 1
+            return
+        if bs not in self._cg_cascade_wrappers:
+            # Cascade not allocated for this bs (e.g., bs < min_batch_size at
+            # capture time). Captured graph for this bs has parent's path,
+            # not ours, so just return.
+            self._dbg_skip_in_cg += 1
+            return
+
+        # Detect actual common prefix using only the replay-hook inputs
+        # (forward_batch is not threaded through this hook by SGLang's runner).
+        common = self._detect_common_prefix_from_rpi(
+            bs,
+            req_pool_indices,
+            seq_lens_cpu,
+        )
+        # Plan cascade with the actual detected common prefix. We always
+        # plan (even if common < threshold) because the captured graph for
+        # this bs has cascade run() recorded at capture time -- there is no
+        # mid-graph fallback to parent's per-request path. Cascade with
+        # common=0 is mathematically equivalent to per-request decode plus
+        # a no-op level-0 launch, so always arm under CG.
+        ok = self._fill_cg_cascade_plan(
+            bs,
+            req_pool_indices,
+            seq_lens_cpu,
+            common,
+        )
+        if not ok:
+            # Replay-time plan failure is fatal for this step's correctness
+            # -- the captured graph will read stale buffers. Best we can do
+            # is log and let it run; the test harness will catch it.
+            if self._dbg_enabled:
+                logger.warning(
+                    "CG cascade replay-plan failed at bs=%d, common=%d "
+                    "(captured graph may produce incorrect output for "
+                    "this step).",
+                    bs,
+                    common,
+                )
+            return
+
+        self._cg_cascade_plan = _CascadePlanState(
+            common_prefix_tokens=common,
+            bs=bs,
+        )
+        self._dbg_cascade_run_cg += 1
+        if common >= self.cascade_min_prefix_tokens:
+            self._dbg_cascade_fired_cg += 1
+            if self._dbg_enabled:
+                logger.info(
+                    "Cascade fires (CG): bs=%d, common_prefix_tokens=%d",
+                    bs,
+                    common,
+                )
+        else:
+            self._dbg_skip_below_prefix_cg += 1
+            if self._dbg_enabled:
+                logger.info(
+                    "Cascade ran (CG, below threshold): bs=%d, "
+                    "common_prefix_tokens=%d",
+                    bs,
+                    common,
+                )
+
+    # ------------------------------------------------------------------
+    # forward_decode (eager + CG dispatch)
+    # ------------------------------------------------------------------
+
+    def forward_decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+    ):
+        # Resolve which cascade wrapper (if any) to invoke. Eager path uses
+        # ``_cascade_decode_wrapper``; CG path uses the per-bs entry from
+        # ``_cg_cascade_wrappers``. The selection is purely based on Python
+        # state at call time; under CG capture/replay this resolves once at
+        # capture (when ``_in_cuda_graph=True`` and ``_cg_cascade_plan`` is
+        # set) and the captured graph then invokes wrapper.run() for that
+        # specific wrapper instance every replay.
+        if self._in_cuda_graph and self._cg_cascade_plan is not None:
+            wrapper = self._cg_cascade_wrappers.get(self._cg_cascade_plan.bs)
+        elif (not self._in_cuda_graph) and self._cascade_plan is not None:
+            wrapper = self._cascade_decode_wrapper
+        else:
+            wrapper = None
+
+        if wrapper is None:
+            return super().forward_decode(
+                q, k, v, layer, forward_batch, save_kv_cache=save_kv_cache
+            )
+
+        # Cascade arm: write KV-cache for current decode tokens, then run
+        # the cascade wrapper.
+        cache_loc = (
+            forward_batch.out_cache_loc
+            if not layer.is_cross_attention
+            else forward_batch.encoder_out_cache_loc
+        )
+        if k is not None:
+            assert v is not None
+            if save_kv_cache:
+                self.token_to_kv_pool.set_kv_buffer(
+                    layer, cache_loc, k, v, layer.k_scale, layer.v_scale
+                )
+
+        # KV pool returns (K, V), each [size+page_size, num_kv_heads, head_dim].
+        # Cascade wrapper with page_size=1 expects [num_pages, 1,
+        # num_kv_heads, head_dim] per K/V -- add a singleton page dim.
+        k_buf, v_buf = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+        kv_for_run = (k_buf.unsqueeze(1), v_buf.unsqueeze(1))
+
+        q_3d = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+
+        out = wrapper.run(q_3d, kv_for_run)
+        return out.view(-1, layer.tp_q_head_num * layer.head_dim)
+
+    # forward_extend is unchanged from the parent: cascade is decode-only
+    # in this initial scope.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -192,6 +192,7 @@ ATTENTION_BACKEND_CHOICES = [
     "fa3",
     "fa4",
     "flashinfer",
+    "flashinfer-cascade",
     "flashmla",
     "trtllm_mla",
     "cutedsl_mla",
@@ -1391,6 +1392,19 @@ class ServerArgs:
             choices=ATTENTION_BACKEND_CHOICES,
         ),
     ] = None
+    cascade_min_prefix_tokens: A[
+        int,
+        "Minimum shared-prefix length (in tokens) required for the flashinfer-cascade "
+        "backend to fire its MultiLevelCascadeAttentionWrapper decode path. Below this, "
+        "the per-request flashinfer path runs instead. Only used when "
+        "--attention-backend flashinfer-cascade is set.",
+    ] = 128
+    cascade_min_batch_size: A[
+        int,
+        "Minimum running batch size required for the flashinfer-cascade backend to "
+        "fire. Below this, the per-request flashinfer path runs instead. Only used "
+        "when --attention-backend flashinfer-cascade is set.",
+    ] = 4
     sampling_backend: A[
         Optional[str],
         Arg(

--- a/test/manual/attention/test_flashinfer_cascade_backend.py
+++ b/test/manual/attention/test_flashinfer_cascade_backend.py
@@ -1,0 +1,472 @@
+"""FlashInfer cascade attention backend integration test.
+
+Boots Qwen2.5-0.5B/TP=1 with ``--attention-backend flashinfer-cascade`` and
+verifies:
+
+    1. **Boot test** — the server comes up healthy with the new backend.
+    2. **Below-threshold equivalence** — at bs=2 (below the bs threshold of 4),
+       cascade does NOT fire. Output must be bit-identical to the stock
+       ``flashinfer`` backend (greedy, temperature=0). First 32 tokens.
+    3. **Cascade fires at threshold** — at bs=8 with a shared 256-token
+       prefix (above thresholds), cascade fires. Output must be epsilon-
+       equivalent to the ``flashinfer`` baseline (small drift acceptable due
+       to LSE merge precision; we require >= 7/8 prompts match the baseline).
+    4. **CG smoke test** — bs=8 captured CUDA graph executes >= 10 decode
+       steps without crash and without garbage output (token IDs in vocab).
+    5. **Threshold fallback** — at bs=4 with a 64-token prefix (below the
+       prefix threshold), cascade does NOT fire even though bs is at the
+       threshold. Verified via the backend's debug-counter endpoint
+       (env ``SGLANG_CASCADE_DEBUG=1``) -- we just inspect the server log
+       which prints the per-step decision when debug is on.
+
+Manual integration test: launches a subprocess server, hits ``/generate``,
+greps logs for cascade dispatch markers. Not registered for CI.
+
+Usage:
+    pytest test/manual/attention/test_flashinfer_cascade_backend.py -v -s
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODEL = os.environ.get("SGLANG_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+PORT = int(os.environ.get("CASCADE_TEST_PORT", "30078"))
+BASE_URL = f"http://127.0.0.1:{PORT}"
+HEALTH_TIMEOUT = 240
+
+LONG_SYSTEM_PROMPT = (
+    "You are a meticulous assistant. "
+    "Answer the user's question with a single short word. "
+    "Do not add explanation, punctuation, or any extra text. "
+    "Examples: Q: capital of France? A: Paris. Q: capital of Japan? A: Tokyo. "
+    "Q: capital of Germany? A: Berlin. "
+    "If the question has no clear single-word answer, reply 'Unknown'. "
+    "Always reply with exactly one word and nothing else. "
+) * 8  # roughly ~256 tokens after tokenization for shared-prefix tests
+
+SHORT_SHARED_PREFIX = "Answer with one word. Examples: Q: capital of France? A: Paris."
+
+CAPITAL_PROMPTS = [
+    "What is the capital of Italy?",
+    "What is the capital of Spain?",
+    "What is the capital of Portugal?",
+    "What is the capital of Greece?",
+    "What is the capital of Norway?",
+    "What is the capital of Sweden?",
+    "What is the capital of Finland?",
+    "What is the capital of Ireland?",
+]
+
+MAX_TOKENS = 8
+
+
+def _wait_for_health(base_url: str, max_wait: int = HEALTH_TIMEOUT) -> bool:
+    deadline = time.time() + max_wait
+    while time.time() < deadline:
+        try:
+            r = requests.get(f"{base_url}/health", timeout=2)
+            if r.status_code == 200:
+                return True
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(2)
+    return False
+
+
+def _kill(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        proc.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait(timeout=10)
+
+
+def _launch(
+    extra_args: list[str], log_path: Path, debug_cascade: bool = False
+) -> subprocess.Popen:
+    cmd = [
+        sys.executable,
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        MODEL,
+        "--port",
+        str(PORT),
+        "--host",
+        "127.0.0.1",
+        "--mem-fraction-static",
+        "0.5",
+        "--context-length",
+        "4096",
+    ] + extra_args
+    print(f"\n[cascade-test] launching: {' '.join(cmd)}", flush=True)
+    log_fh = open(log_path, "w")
+    env = {**os.environ, "PYTHONUNBUFFERED": "1"}
+    repo_python = str(REPO_ROOT / "python")
+    env["PYTHONPATH"] = repo_python + ":" + env.get("PYTHONPATH", "")
+    if debug_cascade:
+        env["SGLANG_CASCADE_DEBUG"] = "1"
+    return subprocess.Popen(
+        cmd,
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        env=env,
+    )
+
+
+def _completion(
+    system: str, user: str, max_tokens: int = MAX_TOKENS
+) -> tuple[str, list[int]]:
+    """Returns (text, token_ids) so we can assert tokens are in vocab range."""
+    payload = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+    }
+    r = requests.post(f"{BASE_URL}/v1/chat/completions", json=payload, timeout=60)
+    r.raise_for_status()
+    j = r.json()
+    text = j["choices"][0]["message"]["content"]
+    return text, []
+
+
+def _generate_concurrent(prompts_with_system: list[tuple[str, str]]) -> list[str]:
+    """Issue all prompts simultaneously via threads so they batch in one
+    decode step group on the server side. Greedy decoding makes outputs
+    deterministic regardless of arrival order.
+    """
+    import concurrent.futures as cf
+
+    def _one(payload):
+        sysp, user = payload
+        text, _ = _completion(sysp, user)
+        return text
+
+    out = [None] * len(prompts_with_system)
+    with cf.ThreadPoolExecutor(max_workers=len(prompts_with_system)) as ex:
+        futs = {ex.submit(_one, p): i for i, p in enumerate(prompts_with_system)}
+        for f in cf.as_completed(futs):
+            i = futs[f]
+            out[i] = f.result()
+    return out
+
+
+def _run_server_and_collect(
+    extra_args: list[str],
+    label: str,
+    log_path: Path,
+    payloads: list[tuple[str, str]],
+    debug_cascade: bool = False,
+) -> tuple[list[str], str]:
+    proc = _launch(extra_args, log_path, debug_cascade=debug_cascade)
+    try:
+        if not _wait_for_health(BASE_URL):
+            tail = log_path.read_text(errors="replace").splitlines()[-40:]
+            pytest.fail(
+                f"{label} server did not become ready within {HEALTH_TIMEOUT}s.\n"
+                + "\n".join(tail)
+            )
+        print(
+            f"\n[cascade-test] {label} -- collecting {len(payloads)} outputs",
+            flush=True,
+        )
+        outs = _generate_concurrent(payloads)
+        return outs, log_path.read_text(errors="replace")
+    finally:
+        _kill(proc)
+        time.sleep(5)
+
+
+# ---------------- Tests ----------------
+
+
+def test_cascade_backend_boots():
+    """Boot test: server comes up healthy with the new backend."""
+    log_path = Path("/tmp/sglang_cascade_boot.log")
+    extra = [
+        "--page-size",
+        "1",
+        "--attention-backend",
+        "flashinfer-cascade",
+        "--disable-cuda-graph",
+    ]
+    proc = _launch(extra, log_path)
+    try:
+        ok = _wait_for_health(BASE_URL)
+        text = log_path.read_text(errors="replace")
+        if not ok:
+            tail = text.splitlines()[-40:]
+            pytest.fail(
+                f"cascade-backend server did not become ready within "
+                f"{HEALTH_TIMEOUT}s.\n" + "\n".join(tail)
+            )
+        # Confirm our backend log line was emitted.
+        assert (
+            "FlashInferCascadeAttnBackend initialized" in text
+        ), "Expected init log not found. Tail:\n" + "\n".join(text.splitlines()[-30:])
+        # Smoke: one completion succeeds.
+        text_out, _ = _completion(SHORT_SHARED_PREFIX, "What is the capital of Italy?")
+        assert isinstance(text_out, str) and len(text_out) > 0
+    finally:
+        _kill(proc)
+        time.sleep(5)
+
+
+def test_cascade_below_threshold_matches_flashinfer():
+    """At bs=2 (below bs threshold of 4), cascade must NOT fire — output must
+    be bit-identical to stock ``flashinfer`` greedy.
+
+    Note: with bs=2 we issue 2 concurrent requests so they batch together.
+    SGLang's scheduler may execute them in separate decode steps under
+    load; we use --disable-cuda-graph and rely on greedy determinism so
+    the comparison is stable regardless.
+    """
+    payloads = [(SHORT_SHARED_PREFIX, q) for q in CAPITAL_PROMPTS[:2]]
+
+    base_log = Path("/tmp/sglang_cascade_below_baseline.log")
+    cascade_log = Path("/tmp/sglang_cascade_below_test.log")
+
+    base_outs, _ = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer",
+            "--disable-cuda-graph",
+        ],
+        label="flashinfer baseline (bs=2)",
+        log_path=base_log,
+        payloads=payloads,
+    )
+
+    cascade_outs, log_text = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer-cascade",
+            "--disable-cuda-graph",
+            "--cascade-min-prefix-tokens",
+            "128",
+            "--cascade-min-batch-size",
+            "4",
+        ],
+        label="flashinfer-cascade (bs=2, below threshold)",
+        log_path=cascade_log,
+        payloads=payloads,
+        debug_cascade=True,
+    )
+
+    print("\n[cascade-test] below-threshold compare:", flush=True)
+    mismatches = []
+    for prompt, b, c in zip(payloads, base_outs, cascade_outs):
+        if b != c:
+            mismatches.append((prompt, b, c))
+        print(
+            f"  {'OK' if b == c else 'MISMATCH'} q={prompt[1][:40]!r}\n"
+            f"    base   = {b!r}\n"
+            f"    cascade= {c!r}",
+            flush=True,
+        )
+
+    # Expect no mismatches (greedy bit-equal). Allow at most 1 if a small
+    # FP rounding sneaks in (bs=2 cascade should NOT have fired at all,
+    # which is the key invariant — and we additionally confirm via debug
+    # that no cascade-fire was logged).
+    assert "Cascade fires" not in log_text, (
+        "Cascade fired at bs=2 below threshold — detection broken. "
+        "Tail:\n" + "\n".join(log_text.splitlines()[-40:])
+    )
+    assert not mismatches, (
+        f"{len(mismatches)}/{len(payloads)} below-threshold outputs differ:\n"
+        + "\n".join(
+            f"  q={p[1][:40]!r}: base={b!r} cascade={c!r}" for p, b, c in mismatches
+        )
+    )
+
+
+def test_cascade_fires_at_threshold():
+    """At bs=8 + ~256 token shared prefix (above thresholds), cascade fires.
+
+    Output must be ε-equivalent (>= 7/8 prompts string-equal vs flashinfer
+    baseline). LSE merge introduces small FP drift; one prompt may diverge
+    on the last token. We disable CG so cascade always fires in eager.
+    """
+    payloads = [(LONG_SYSTEM_PROMPT, q) for q in CAPITAL_PROMPTS]
+
+    base_log = Path("/tmp/sglang_cascade_fire_baseline.log")
+    cascade_log = Path("/tmp/sglang_cascade_fire_test.log")
+
+    base_outs, _ = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer",
+            "--disable-cuda-graph",
+        ],
+        label="flashinfer baseline (bs=8)",
+        log_path=base_log,
+        payloads=payloads,
+    )
+
+    cascade_outs, log_text = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer-cascade",
+            "--disable-cuda-graph",
+            "--cascade-min-prefix-tokens",
+            "128",
+            "--cascade-min-batch-size",
+            "4",
+        ],
+        label="flashinfer-cascade (bs=8, above threshold)",
+        log_path=cascade_log,
+        payloads=payloads,
+        debug_cascade=True,
+    )
+
+    print("\n[cascade-test] cascade-fires compare:", flush=True)
+    matches = 0
+    for prompt, b, c in zip(payloads, base_outs, cascade_outs):
+        ok = b == c
+        if ok:
+            matches += 1
+        print(
+            f"  {'OK' if ok else 'DRIFT'} q={prompt[1][:40]!r}\n"
+            f"    base   = {b!r}\n"
+            f"    cascade= {c!r}",
+            flush=True,
+        )
+
+    # Confirm cascade actually fired at least once (no point in checking
+    # equivalence if it didn't).
+    cascade_fire_count = log_text.count("Cascade fires")
+    assert cascade_fire_count > 0, (
+        "Cascade did not fire even with bs=8 + 256-token prefix. "
+        "Log tail:\n" + "\n".join(log_text.splitlines()[-50:])
+    )
+
+    # >= 7/8 prompts must match the baseline byte-for-byte.
+    assert matches >= len(payloads) - 1, (
+        f"Only {matches}/{len(payloads)} cascade outputs matched baseline; "
+        "expected >= 7/8 (LSE merge tolerance)."
+    )
+
+
+def test_cascade_cuda_graph_smoke():
+    """CG smoke: with default CG enabled, the server runs ≥10 decode steps
+    at bs=8 without crashing and produces non-garbage output.
+
+    Cascade is intentionally disabled inside captured graphs (it's
+    eager-only); this test verifies that CG capture/replay still works
+    cleanly when the cascade backend is loaded — i.e., that we did not
+    break the parent's CG path.
+    """
+    # 10 sequential single-prompt completions exercise repeated decode
+    # steps; the underlying CG path captures and replays many times.
+    log_path = Path("/tmp/sglang_cascade_cg_smoke.log")
+    extra = [
+        "--page-size",
+        "1",
+        "--attention-backend",
+        "flashinfer-cascade",
+        # Default --cuda-graph-max-bs (80); CG enabled.
+    ]
+    proc = _launch(extra, log_path, debug_cascade=True)
+    try:
+        if not _wait_for_health(BASE_URL):
+            tail = log_path.read_text(errors="replace").splitlines()[-40:]
+            pytest.fail("CG-mode server did not become ready.\n" + "\n".join(tail))
+
+        # Issue 10 single prompts back-to-back (CG fires at bs=1 captures).
+        outs = []
+        for q in (
+            CAPITAL_PROMPTS[:10] if len(CAPITAL_PROMPTS) >= 10 else CAPITAL_PROMPTS * 2
+        ):
+            text, _ = _completion(SHORT_SHARED_PREFIX, q, max_tokens=12)
+            outs.append(text)
+
+        assert all(
+            isinstance(t, str) and len(t) > 0 for t in outs
+        ), f"Some CG outputs are empty: {outs}"
+        # Sanity: outputs should not be all-equal garbage like "!!!" repeats.
+        for t in outs:
+            # No null bytes, no obviously-broken token patterns.
+            assert "\x00" not in t
+            # Allow short answers; just disallow long stretches of "!"
+            assert not re.match(r"^!{5,}", t), f"Garbage output: {t!r}"
+
+        # CG replay path is taken — debug counter should show CG-skips.
+        log_text = log_path.read_text(errors="replace")
+        # Boot succeeded, decode happened, no crash. That's the smoke bar.
+        assert "FlashInferCascadeAttnBackend initialized" in log_text
+    finally:
+        _kill(proc)
+        time.sleep(5)
+
+
+def test_cascade_below_prefix_threshold_does_not_fire():
+    """At bs=4 (at the bs threshold) with prefix=64 tokens (below the prefix
+    threshold of 128), cascade must NOT fire. We assert this via the
+    server log: the debug-mode init never logs "Cascade fires" for this
+    workload.
+
+    Detection runs at slot-aligned granularity (page_size=1); the system
+    prompt SHORT_SHARED_PREFIX tokenizes to roughly 16-25 tokens for
+    Qwen2.5 — comfortably below the 128 token threshold.
+    """
+    payloads = [(SHORT_SHARED_PREFIX, q) for q in CAPITAL_PROMPTS[:4]]
+
+    log_path = Path("/tmp/sglang_cascade_below_prefix.log")
+    _outs, log_text = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer-cascade",
+            "--disable-cuda-graph",
+            "--cascade-min-prefix-tokens",
+            "128",
+            "--cascade-min-batch-size",
+            "4",
+        ],
+        label="flashinfer-cascade (bs=4, prefix below threshold)",
+        log_path=log_path,
+        payloads=payloads,
+        debug_cascade=True,
+    )
+
+    # The short shared prefix is ~25 tokens after the chat template; well
+    # below 128. Cascade must not have logged a fire.
+    assert "Cascade fires" not in log_text, (
+        "Cascade fired at prefix < 128 tokens — threshold gate broken. "
+        "Tail:\n" + "\n".join(log_text.splitlines()[-50:])
+    )

--- a/test/manual/attention/test_flashinfer_cascade_cg.py
+++ b/test/manual/attention/test_flashinfer_cascade_cg.py
@@ -1,0 +1,491 @@
+"""FlashInfer cascade CG-mode integration test.
+
+Boots Qwen2.5-0.5B/TP=1 with ``--attention-backend flashinfer-cascade`` and
+verifies CG-mode cascade firing:
+
+    1. **CG-fires test (KEY)** -- bs=8 (in default cuda_graph_bs), shared
+       ~256-token prefix, CG enabled (default). Run >= 10 decode steps.
+       Output epsilon-equivalent to flashinfer baseline (>= 7/8 prompts
+       byte-equal). Verify via debug log/counter that cascade actually
+       fired under CG (not the eager fallback / not the parent path).
+
+    2. **CG fallback test** -- bs=8 (in cuda_graph_bs), shared prefix below
+       threshold (~25 tokens), CG enabled. Cascade does NOT cross the
+       "fired" counter (>= threshold) but the captured cascade graph still
+       RUNS with common=0 / common < threshold (the always-cascade-in-CG
+       design choice). Output epsilon-equivalent to flashinfer baseline.
+
+    3. **Eager regression test** -- bs > cuda_graph_max_bs forces eager
+       path. With shared 256-token prefix, eager cascade fires. Output
+       epsilon-equivalent to flashinfer baseline.
+
+    4. **Eager-mode cross-check** -- re-runs the cascade-fires-at-threshold
+       behavior in eager mode to confirm CG-mode additions did not regress
+       the eager path.
+
+Manual integration test: launches a subprocess server, hits ``/generate``,
+greps logs for cascade dispatch markers. Not registered for CI.
+
+Usage:
+    pytest test/manual/attention/test_flashinfer_cascade_cg.py -v -s
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODEL = os.environ.get("SGLANG_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+PORT = int(os.environ.get("CASCADE_CG_TEST_PORT", "30079"))
+BASE_URL = f"http://127.0.0.1:{PORT}"
+HEALTH_TIMEOUT = 240
+
+LONG_SYSTEM_PROMPT = (
+    "You are a meticulous assistant. "
+    "Answer the user's question with a single short word. "
+    "Do not add explanation, punctuation, or any extra text. "
+    "Examples: Q: capital of France? A: Paris. Q: capital of Japan? A: Tokyo. "
+    "Q: capital of Germany? A: Berlin. "
+    "If the question has no clear single-word answer, reply 'Unknown'. "
+    "Always reply with exactly one word and nothing else. "
+) * 8  # roughly ~256 tokens after tokenization for shared-prefix tests
+
+SHORT_SHARED_PREFIX = "Answer with one word. Examples: Q: capital of France? A: Paris."
+
+CAPITAL_PROMPTS = [
+    "What is the capital of Italy?",
+    "What is the capital of Spain?",
+    "What is the capital of Portugal?",
+    "What is the capital of Greece?",
+    "What is the capital of Norway?",
+    "What is the capital of Sweden?",
+    "What is the capital of Finland?",
+    "What is the capital of Ireland?",
+]
+
+MAX_TOKENS = 8
+
+
+def _wait_for_health(base_url: str, max_wait: int = HEALTH_TIMEOUT) -> bool:
+    deadline = time.time() + max_wait
+    while time.time() < deadline:
+        try:
+            r = requests.get(f"{base_url}/health", timeout=2)
+            if r.status_code == 200:
+                return True
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(2)
+    return False
+
+
+def _kill(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        proc.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait(timeout=10)
+
+
+def _launch(
+    extra_args: list[str], log_path: Path, debug_cascade: bool = False
+) -> subprocess.Popen:
+    cmd = [
+        sys.executable,
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        MODEL,
+        "--port",
+        str(PORT),
+        "--host",
+        "127.0.0.1",
+        "--mem-fraction-static",
+        "0.5",
+        "--context-length",
+        "4096",
+    ] + extra_args
+    print(f"\n[cascade-cg-test] launching: {' '.join(cmd)}", flush=True)
+    log_fh = open(log_path, "w")
+    env = {**os.environ, "PYTHONUNBUFFERED": "1"}
+    repo_python = str(REPO_ROOT / "python")
+    env["PYTHONPATH"] = repo_python + ":" + env.get("PYTHONPATH", "")
+    if debug_cascade:
+        env["SGLANG_CASCADE_DEBUG"] = "1"
+    return subprocess.Popen(
+        cmd,
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        env=env,
+    )
+
+
+def _completion(
+    system: str, user: str, max_tokens: int = MAX_TOKENS
+) -> tuple[str, list[int]]:
+    payload = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+    }
+    r = requests.post(f"{BASE_URL}/v1/chat/completions", json=payload, timeout=60)
+    r.raise_for_status()
+    j = r.json()
+    text = j["choices"][0]["message"]["content"]
+    return text, []
+
+
+def _generate_concurrent(prompts_with_system: list[tuple[str, str]]) -> list[str]:
+    import concurrent.futures as cf
+
+    def _one(payload):
+        sysp, user = payload
+        text, _ = _completion(sysp, user)
+        return text
+
+    out = [None] * len(prompts_with_system)
+    with cf.ThreadPoolExecutor(max_workers=len(prompts_with_system)) as ex:
+        futs = {ex.submit(_one, p): i for i, p in enumerate(prompts_with_system)}
+        for f in cf.as_completed(futs):
+            i = futs[f]
+            out[i] = f.result()
+    return out
+
+
+def _run_server_and_collect(
+    extra_args: list[str],
+    label: str,
+    log_path: Path,
+    payloads: list[tuple[str, str]],
+    debug_cascade: bool = False,
+) -> tuple[list[str], str]:
+    proc = _launch(extra_args, log_path, debug_cascade=debug_cascade)
+    try:
+        if not _wait_for_health(BASE_URL):
+            tail = log_path.read_text(errors="replace").splitlines()[-40:]
+            pytest.fail(
+                f"{label} server did not become ready within {HEALTH_TIMEOUT}s.\n"
+                + "\n".join(tail)
+            )
+        print(
+            f"\n[cascade-cg-test] {label} -- collecting {len(payloads)} outputs",
+            flush=True,
+        )
+        outs = _generate_concurrent(payloads)
+        return outs, log_path.read_text(errors="replace")
+    finally:
+        _kill(proc)
+        time.sleep(5)
+
+
+# ---------------- Tests ----------------
+
+
+def test_cascade_cg_fires_at_threshold():
+    """KEY test: at bs=8 + ~256 token shared prefix, CG enabled (default),
+    cascade fires inside the captured graph for bs=8.
+
+    Output must be epsilon-equivalent (>= 7/8 string-equal vs flashinfer
+    baseline). And the log must contain "Cascade fires (CG)" so we know
+    cascade ran inside the captured graph (not the eager path, not the
+    parent's per-request decode).
+    """
+    payloads = [(LONG_SYSTEM_PROMPT, q) for q in CAPITAL_PROMPTS]
+
+    base_log = Path("/tmp/sglang_cascade_cg_fire_baseline.log")
+    cascade_log = Path("/tmp/sglang_cascade_cg_fire_test.log")
+
+    # Baseline: stock flashinfer with default CG.
+    base_outs, _ = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer",
+        ],
+        label="flashinfer baseline (CG, bs=8)",
+        log_path=base_log,
+        payloads=payloads,
+    )
+
+    # Cascade: flashinfer-cascade with default CG. bs=8 must hit the CG
+    # cascade path because 8 is in the default cuda_graph_bs list.
+    cascade_outs, log_text = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer-cascade",
+            "--cascade-min-prefix-tokens",
+            "128",
+            "--cascade-min-batch-size",
+            "4",
+        ],
+        label="flashinfer-cascade CG (bs=8, above threshold)",
+        log_path=cascade_log,
+        payloads=payloads,
+        debug_cascade=True,
+    )
+
+    print("\n[cascade-cg-test] cascade-fires compare:", flush=True)
+    matches = 0
+    for prompt, b, c in zip(payloads, base_outs, cascade_outs):
+        ok = b == c
+        if ok:
+            matches += 1
+        print(
+            f"  {'OK' if ok else 'DRIFT'} q={prompt[1][:40]!r}\n"
+            f"    base   = {b!r}\n"
+            f"    cascade= {c!r}",
+            flush=True,
+        )
+
+    # KEY assertion: cascade fired inside the captured graph.
+    cg_fire_count = log_text.count("Cascade fires (CG)")
+    assert cg_fire_count > 0, (
+        "Cascade did not fire under CG. "
+        "Expected 'Cascade fires (CG)' log entry. Tail:\n"
+        + "\n".join(log_text.splitlines()[-60:])
+    )
+
+    # >= 7/8 prompts must match the baseline byte-for-byte.
+    assert matches >= len(payloads) - 1, (
+        f"Only {matches}/{len(payloads)} cascade outputs matched baseline; "
+        "expected >= 7/8 (LSE merge tolerance)."
+    )
+
+
+def test_cascade_cg_fallback_below_prefix_threshold():
+    """At bs=8 (in cuda_graph_bs) with a shared prefix below threshold
+    (~25 tokens of SHORT_SHARED_PREFIX << 128), cascade must not log a
+    fired event (>= threshold) but the captured cascade graph still runs
+    correctly with common < threshold.
+
+    Output must remain epsilon-equivalent to the flashinfer baseline.
+    """
+    payloads = [(SHORT_SHARED_PREFIX, q) for q in CAPITAL_PROMPTS]
+
+    base_log = Path("/tmp/sglang_cascade_cg_fallback_baseline.log")
+    cascade_log = Path("/tmp/sglang_cascade_cg_fallback_test.log")
+
+    base_outs, _ = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer",
+        ],
+        label="flashinfer baseline (CG, bs=8, short prefix)",
+        log_path=base_log,
+        payloads=payloads,
+    )
+
+    cascade_outs, log_text = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer-cascade",
+            "--cascade-min-prefix-tokens",
+            "128",
+            "--cascade-min-batch-size",
+            "4",
+        ],
+        label="flashinfer-cascade CG (bs=8, prefix below threshold)",
+        log_path=cascade_log,
+        payloads=payloads,
+        debug_cascade=True,
+    )
+
+    print("\n[cascade-cg-test] cg-fallback compare:", flush=True)
+    matches = 0
+    for prompt, b, c in zip(payloads, base_outs, cascade_outs):
+        ok = b == c
+        if ok:
+            matches += 1
+        print(
+            f"  {'OK' if ok else 'DRIFT'} q={prompt[1][:40]!r}\n"
+            f"    base   = {b!r}\n"
+            f"    cascade= {c!r}",
+            flush=True,
+        )
+
+    # Cascade must not have fired at threshold (the short prefix is
+    # ~25 tokens << 128).
+    cg_fire_count = log_text.count("Cascade fires (CG)")
+    assert cg_fire_count == 0, (
+        f"Cascade fired (CG) at common < threshold. count={cg_fire_count}. "
+        "Tail:\n" + "\n".join(log_text.splitlines()[-60:])
+    )
+
+    # Output epsilon-equivalent to baseline (the always-cascade-in-CG path
+    # produces output identical to per-request decode when common < threshold).
+    assert matches >= len(payloads) - 1, (
+        f"Only {matches}/{len(payloads)} fallback outputs matched baseline; "
+        "expected >= 7/8 -- the always-cascade-in-CG path should be "
+        "mathematically equivalent to per-request decode."
+    )
+
+
+def test_cascade_eager_fires_at_high_batch():
+    """Regression for the eager path: at bs > cuda_graph_max_bs, eager mode
+    fires. We exercise this by running 16 concurrent prompts on a server
+    with --cuda-graph-max-bs=8 (so bs=16 falls to eager). Cascade must fire
+    via the eager path -- "Cascade fires:" log (no "(CG)" suffix).
+    """
+    payloads = [(LONG_SYSTEM_PROMPT, q) for q in CAPITAL_PROMPTS] * 2  # 16 reqs
+
+    base_log = Path("/tmp/sglang_cascade_eager_high_baseline.log")
+    cascade_log = Path("/tmp/sglang_cascade_eager_high_test.log")
+
+    base_outs, _ = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer",
+            "--cuda-graph-max-bs",
+            "8",
+        ],
+        label="flashinfer baseline (eager fallback, bs=16)",
+        log_path=base_log,
+        payloads=payloads,
+    )
+
+    cascade_outs, log_text = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer-cascade",
+            "--cuda-graph-max-bs",
+            "8",
+            "--cascade-min-prefix-tokens",
+            "128",
+            "--cascade-min-batch-size",
+            "4",
+        ],
+        label="flashinfer-cascade eager (bs=16, above cg max)",
+        log_path=cascade_log,
+        payloads=payloads,
+        debug_cascade=True,
+    )
+
+    print("\n[cascade-cg-test] eager-fires compare:", flush=True)
+    matches = 0
+    for prompt, b, c in zip(payloads, base_outs, cascade_outs):
+        ok = b == c
+        if ok:
+            matches += 1
+        print(
+            f"  {'OK' if ok else 'DRIFT'} q={prompt[1][:40]!r}\n"
+            f"    base   = {b!r}\n"
+            f"    cascade= {c!r}",
+            flush=True,
+        )
+
+    # KEY: eager path used (not CG path).
+    eager_fire = re.findall(r"Cascade fires: bs=", log_text)
+    cg_fire = re.findall(r"Cascade fires \(CG\): bs=", log_text)
+    print(
+        f"  eager_fire_count={len(eager_fire)}, cg_fire_count={len(cg_fire)}",
+        flush=True,
+    )
+    # bs=16 may also batch as smaller groups; the assertion is that EAGER
+    # cascade fired at least once on this workload.
+    assert len(eager_fire) > 0, (
+        "Eager cascade did not fire at bs > cuda_graph_max_bs. "
+        "Expected 'Cascade fires:' (without (CG) suffix). Tail:\n"
+        + "\n".join(log_text.splitlines()[-60:])
+    )
+
+    assert matches >= len(payloads) - 2, (
+        f"Only {matches}/{len(payloads)} eager outputs matched baseline; "
+        "expected >= N-2 (LSE merge tolerance + slight scheduling jitter)."
+    )
+
+
+def test_cascade_eager_regression_still_passes():
+    """Regression cross-check: re-run the cascade-fires-at-threshold scenario
+    in eager mode to confirm CG-mode additions did not break the eager path.
+
+    bs=8 with --disable-cuda-graph + ~256 token shared prefix. Cascade
+    must fire via the eager path. >= 7/8 byte-equal vs flashinfer
+    baseline.
+    """
+    payloads = [(LONG_SYSTEM_PROMPT, q) for q in CAPITAL_PROMPTS]
+
+    base_log = Path("/tmp/sglang_cascade_p14_eager_baseline.log")
+    cascade_log = Path("/tmp/sglang_cascade_p14_eager_test.log")
+
+    base_outs, _ = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer",
+            "--disable-cuda-graph",
+        ],
+        label="flashinfer baseline (eager, bs=8)",
+        log_path=base_log,
+        payloads=payloads,
+    )
+
+    cascade_outs, log_text = _run_server_and_collect(
+        extra_args=[
+            "--page-size",
+            "1",
+            "--attention-backend",
+            "flashinfer-cascade",
+            "--disable-cuda-graph",
+            "--cascade-min-prefix-tokens",
+            "128",
+            "--cascade-min-batch-size",
+            "4",
+        ],
+        label="flashinfer-cascade eager (bs=8)",
+        log_path=cascade_log,
+        payloads=payloads,
+        debug_cascade=True,
+    )
+
+    matches = sum(1 for b, c in zip(base_outs, cascade_outs) if b == c)
+    eager_fire_count = log_text.count("Cascade fires:")  # eager log marker
+    cg_fire_count = log_text.count("Cascade fires (CG)")
+    print(
+        f"\n[cascade-cg-test] p14-eager regression: "
+        f"matches={matches}/{len(payloads)}, eager_fires={eager_fire_count}, "
+        f"cg_fires={cg_fire_count}",
+        flush=True,
+    )
+    # CG must NOT have fired -- we passed --disable-cuda-graph.
+    assert (
+        cg_fire_count == 0
+    ), f"CG cascade fired with --disable-cuda-graph. count={cg_fire_count}"
+    assert eager_fire_count > 0, "Eager cascade path stopped firing."
+    assert (
+        matches >= len(payloads) - 1
+    ), f"Eager-path regression: only {matches}/{len(payloads)} match baseline."

--- a/test/registered/unit/layers/attention/test_flashinfer_cascade_backend.py
+++ b/test/registered/unit/layers/attention/test_flashinfer_cascade_backend.py
@@ -1,0 +1,107 @@
+"""Unit tests for srt/layers/attention/flashinfer_cascade_backend.py
+
+Covers the shared-prefix detection logic (``_detect_common_prefix_from_rpi``)
+that gates cascade dispatch in both the eager and CUDA-graph paths. This is the
+branch-heavy, correctness-critical core of the backend, so we exercise it in
+isolation -- constructing the backend via ``__new__`` and populating only the
+two attributes the method reads (``req_to_token`` and ``_cascade_scan_cap``)
+rather than launching a server or allocating flashinfer wrappers.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.flashinfer_cascade_backend import (
+    FlashInferCascadeAttnBackend,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+# Needs a GPU only so the module's flashinfer imports resolve; the detection
+# logic under test runs on plain CPU tensors and launches no server.
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+def _make_backend(req_to_token: torch.Tensor, scan_cap: int = 32768):
+    """Build a FlashInferCascadeAttnBackend with only the fields that
+    ``_detect_common_prefix_from_rpi`` reads, skipping the heavy ``__init__``."""
+    backend = FlashInferCascadeAttnBackend.__new__(FlashInferCascadeAttnBackend)
+    backend.req_to_token = req_to_token
+    backend._cascade_scan_cap = scan_cap
+    return backend
+
+
+def _req_to_token(rows):
+    return torch.tensor(rows, dtype=torch.int32)
+
+
+class TestCascadePrefixDetection(CustomTestCase):
+    def _detect(self, backend, bs, rpi, seq_lens):
+        return backend._detect_common_prefix_from_rpi(
+            bs,
+            torch.tensor(rpi, dtype=torch.int64),
+            None if seq_lens is None else torch.tensor(seq_lens, dtype=torch.int32),
+        )
+
+    def test_below_min_batch_returns_zero(self):
+        # bs < 2 can never share a cross-request prefix.
+        backend = _make_backend(_req_to_token([[100, 101, 102, 103]]))
+        self.assertEqual(self._detect(backend, 1, [0], [4]), 0)
+
+    def test_missing_seq_lens_returns_zero(self):
+        backend = _make_backend(_req_to_token([[1, 2], [1, 2]]))
+        self.assertEqual(self._detect(backend, 2, [0, 1], None), 0)
+
+    def test_min_seq_le_one_returns_zero(self):
+        # A request with seq_len 1 has no slot to spare for a shared prefix.
+        backend = _make_backend(_req_to_token([[5, 6, 7], [5, 6, 7]]))
+        self.assertEqual(self._detect(backend, 2, [0, 1], [1, 3]), 0)
+
+    def test_full_share_capped_at_min_seq_minus_one(self):
+        # All four requests share every scanned slot; the result is capped so
+        # each request keeps >= 1 unique slot for its own decode token.
+        rows = [[9, 9, 9, 9, 9, 9, 9, 9] for _ in range(4)]
+        backend = _make_backend(_req_to_token(rows))
+        # min_seq = 3 -> cap at 2.
+        self.assertEqual(self._detect(backend, 4, [0, 1, 2, 3], [3, 3, 3, 3]), 2)
+
+    def test_partial_share_returns_divergence_index(self):
+        # First 5 slots identical, slot 5 differs across requests.
+        rows = [
+            [100, 101, 102, 103, 104, 200, 0, 0],
+            [100, 101, 102, 103, 104, 210, 0, 0],
+            [100, 101, 102, 103, 104, 220, 0, 0],
+            [100, 101, 102, 103, 104, 230, 0, 0],
+        ]
+        backend = _make_backend(_req_to_token(rows))
+        self.assertEqual(self._detect(backend, 4, [0, 1, 2, 3], [20, 20, 20, 20]), 5)
+
+    def test_no_share_returns_zero(self):
+        # Requests diverge at the very first slot.
+        rows = [[1, 9, 9], [2, 9, 9], [3, 9, 9], [4, 9, 9]]
+        backend = _make_backend(_req_to_token(rows))
+        self.assertEqual(self._detect(backend, 4, [0, 1, 2, 3], [20, 20, 20, 20]), 0)
+
+    def test_scan_cap_limits_detection(self):
+        # Rows share the first 5 slots, but the scan cap stops at 3, so at most
+        # 3 shared slots are reported (still bounded by min_seq - 1).
+        rows = [[7, 7, 7, 7, 7, 9, 0, 0] for _ in range(4)]
+        backend = _make_backend(_req_to_token(rows), scan_cap=3)
+        self.assertEqual(self._detect(backend, 4, [0, 1, 2, 3], [20, 20, 20, 20]), 3)
+
+    def test_respects_req_pool_indices_ordering(self):
+        # Detection must read the rows named by req_pool_indices (not rows 0..bs).
+        rows = [
+            [50, 51, 52, 99, 0],  # row 0 (unused in batch)
+            [10, 11, 12, 13, 14],  # row 1
+            [10, 11, 12, 99, 14],  # row 2 diverges at slot 3
+            [10, 11, 12, 77, 14],  # row 3 diverges at slot 3
+        ]
+        backend = _make_backend(_req_to_token(rows))
+        # Batch = rows [1, 2, 3]; shared prefix is slots 0..2 -> 3.
+        self.assertEqual(self._detect(backend, 3, [1, 2, 3], [10, 10, 10]), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Cross-request shared-prefix decode — "cascade inference", via FlashInfer's
`MultiLevelCascadeAttentionWrapper` — has been tracked since #1715 and attempted
several times, but **no implementation has landed on `main` to date**:

- **#2101** — `feat: use cascade attention kernel (single level)`. Single-level
  cascade wired into the existing flashinfer backend. Closed unmerged (2025-05).
- **#5206** — `feat: import flashinfer cascade attention kernel`. Cascade decode
  kernels added to the flashinfer backend, gated by batch size / common-prefix
  length. Closed unmerged (2025-11).
- **#23184** — `Cascade attention kernels`. Adds an `enable_cascade` flag to
  `flashinfer_backend.py` (including CUDA-graph metadata). Open since 2026-04
  but still `REVIEW_REQUIRED` / unmerged.

I'm opening this PR because cascade inference is still **not available on `main`**:
the two earlier attempts were closed without merging, and the remaining open one
has been awaiting review for months. This PR takes a different, lower-risk
integration approach and is rebased on current `main`. Thanks to the earlier
authors (@james-p-xu, @ZelinMa557, @scanhex12) — this builds on the same idea.

## What's different here

- **A dedicated backend, not a flag on the shared one.** `flashinfer-cascade` is
  registered as its own `--attention-backend` choice and *subclasses*
  `FlashInferAttnBackend`, so the default `flashinfer` path is left unchanged and
  cascade is fully opt-in. The prior PRs all add an `enable_cascade` flag that
  mutates the shared flashinfer backend in place, which widens the regression
  surface for every existing flashinfer user.
- **Multi-level wrapper** (`MultiLevelCascadeAttentionWrapper`), vs the
  single-level kernel in #2101.
- **Explicit, documented thresholds** — `--cascade-min-prefix-tokens` (default
  128) and `--cascade-min-batch-size` (default 4) — with a safe fall-through to
  the parent per-request path below either threshold.
- **CUDA-graph mode works** through the current attention-backend graph API
  (`init_forward_metadata_out_graph(fb, in_capture)`), not the deprecated
  `init_forward_metadata_{capture,replay}_cuda_graph` hooks. Each captured
  `cuda_graph_bs` gets its own wrapper + pre-allocated indptr/indices buffers;
  cascade is always armed under CG because `common_prefix=0` is mathematically
  equivalent to per-request decode plus a no-op level-0 launch.

## Summary

Adds a new attention backend `flashinfer-cascade` that uses FlashInfer's
`MultiLevelCascadeAttentionWrapper` to batch the leading shared-prefix portion
of the running batch into a single matmul during decode. Stock `flashinfer`
runs `BatchDecodeWithPagedKVCacheWrapper` per-request even when prefixes are
deduped at the storage layer (RadixAttention shares pages, but Q·K is still
computed per-request). This backend wires the cascade wrapper into SGLang's
decode path.

- New backend: `python/sglang/srt/layers/attention/flashinfer_cascade_backend.py`
- Registered as `--attention-backend flashinfer-cascade`
- Two thresholds gate dispatch (`--cascade-min-prefix-tokens`,
  `--cascade-min-batch-size`); below either, the parent per-request path runs.
- Decode-only. Extend (prefill) falls through to the parent class.
- Eager and CUDA-graph decode both supported.

## Test plan

- [x] Pre-commit lint passes (isort, ruff F401/F821/UP037, black, codespell)
- [x] `flashinfer-cascade` registered in `ATTENTION_BACKENDS`; backend imports
- [x] `--attention-backend flashinfer-cascade`, `--cascade-min-prefix-tokens`,
      `--cascade-min-batch-size` exposed via argparse
- [x] Server boots with `--attention-backend flashinfer-cascade` and serves
      `/generate` (Qwen2.5-0.5B / TP=1)
- [x] **Eager** cascade fires under a shared-prefix batch (bs=8,
      `common_prefix_tokens=167`) with correct outputs and no regression vs the
      per-request path
- [x] **CUDA-graph** cascade fires (bs=8, `common_prefix_tokens=167`) with
      correct outputs and no plan failures
- [x] Registered unit test for the shared-prefix detection logic:
      `test/registered/unit/layers/attention/test_flashinfer_cascade_backend.py`
      (`register_cuda_ci`, base-b / 1-gpu-small; no server launch)
- [x] Manual integration tests under `test/manual/attention/test_flashinfer_cascade_*.py`

## Review updates

Addresses the automated review pass:

- Removed per-decode-step host↔device syncs in the cascade dispatch path
  (on-device prefix detection with a single scalar sync; one host copy of
  `req_pool_indices` per step instead of `bs` `.item()` calls; pre-initialized
  static CG query indptrs; CPU-built `seq_lens_cpu` fallback).
- Migrated the CUDA-graph cascade path off the deprecated legacy CG hooks (which
  the current full-decode CUDA-graph runner no longer invokes — cascade had been
  silently falling back to per-request decode under CUDA graphs) onto the
  supported `init_forward_metadata_out_graph` API. CG cascade now fires.
- Added the registered unit test above.
