### PR TITLE
[Feature] DiffusionGemma: retire Triton onto FA2 NVFP4 KV cache (stacked on #29304 + #28054)

### DIFF
--- a/docs/supported_models/text_generation/diffusion_language_models.md
+++ b/docs/supported_models/text_generation/diffusion_language_models.md
@@ -51,6 +51,56 @@ max_post_edit_steps: 16
 penalty_lambda: 0
 ```
 
+## DiffusionGemma (uniform-state diffusion, `Gemma4Renoise`)
+
+DiffusionGemma is a uniform-state (renoising) block-diffusion model with no mask
+token. Each block is a fixed-length canvas of `canvas_length` tokens that the
+`Gemma4Renoise` sampler denoises over
+`max_denoising_steps` reverse steps, feeding the previous step's logits back as
+self-conditioning.
+
+The required runtime settings are applied automatically for `Gemma4Renoise` (the triton
+attention backend, eager mode, and unchunked prefill, needed because the full-attention
+head_dim is 512 and the canvas uses bidirectional attention), so a default launch works:
+
+```shell
+sglang serve \
+  --model-path google/diffusiongemma-26B-A4B-it \
+  --dllm-algorithm Gemma4Renoise \
+  --trust-remote-code \
+  --host 0.0.0.0 \
+  --port 30000
+```
+
+Gemma4Renoise Config (defaults follow the checkpoint's `generation_config.json`):
+
+```yaml
+# Number of reverse denoising steps per canvas.
+max_denoising_steps: 48
+# Optional. Makes the renoise sampling reproducible (also shared across TP ranks).
+seed: 1234
+sampler_config:
+  # Entropy budget. Accept the lowest-entropy canvas positions within this bound each step (the rest are re-noised).
+  entropy_bound: 0.1
+# Linear temperature schedule applied over the denoising steps.
+temperature_schedule:
+  t_min: 0.4
+  t_max: 0.8
+# Stop early once the canvas is stable and confident.
+stopping_config:
+  confidence_threshold: 0.005
+  stability_threshold: 1
+```
+
+Notes and current limitations:
+
+- Sampling is governed by the renoise schedule, so request-level `logprobs`, penalties,
+  `logit_bias`, and grammar / structured output (`json_schema` / `regex` / `ebnf` / `structural_tag`) are not
+  applied and are rejected with a 400. Core sampling controls (`temperature`, `top_k`,
+  `top_p`) are accepted but have no effect.
+- Streaming is block-level: one fully-denoised canvas (`canvas_length` tokens) per chunk.
+- `max_tokens` truncates the returned text, but the canvas is always fully denoised.
+
 ## Example Client Code Snippet
 
 Just like other supported models, diffusion language models can be used via the REST API or Python client.
@@ -109,3 +159,4 @@ Below the supported models are summarized in a table.
 | **LLaDA2.0 (mini, flash)** | `inclusionAI/LLaDA2.0-flash` | LLaDA2.0-flash is a diffusion language model featuring a 100B Mixture-of-Experts (MoE) architecture. |
 | **SDAR (JetLM)**           | `JetLM/SDAR-8B-Chat`         | SDAR series diffusion language model (Chat), dense architecture.                                 |
 | **SDAR (JetLM)**           | `JetLM/SDAR-30B-A3B-Chat`    | SDAR series diffusion language model (Chat), MoE architecture.                                   |
+| **DiffusionGemma**         | `google/diffusiongemma-26B-A4B-it` | Uniform-state (renoising) block-diffusion model, 26B-A4B MoE with a Gemma4 vision tower (text and image input). |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -80,7 +80,8 @@ dependencies = [
   "torchcodec==0.11.1 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec 0.11.1 for torch 2.11.x (0.10 is ABI-incompatible: references the pre-2.11 c10::MessageLogger ctor signature). Not available on Linux ARM.
   "torchvision",
   "tqdm",
-  "transformers==5.8.1",
+  "mistral_common>=1.11.0",
+  "transformers==5.11.0",
   "uvicorn",
   "uvloop",
   "watchfiles",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -643,6 +643,7 @@ class ModelConfig:
             "Gemma4ForCausalLM",
             "Gemma4ForConditionalGeneration",
             "Gemma4UnifiedForConditionalGeneration",
+            "DiffusionGemmaForBlockDiffusion",
         ]
 
     def _detect_attention_sinks(self) -> bool:
@@ -1652,6 +1653,7 @@ multimodal_model_archs = [
     "Gemma3nForConditionalGeneration",
     "Gemma4ForConditionalGeneration",
     "Gemma4UnifiedForConditionalGeneration",
+    "DiffusionGemmaForBlockDiffusion",
     "Glm4vForConditionalGeneration",
     "Glm4vMoeForConditionalGeneration",
     "GlmOcrForConditionalGeneration",
@@ -1858,6 +1860,7 @@ def is_hybrid_swa_model(
         "Gemma4ForConditionalGeneration",
         "Gemma4UnifiedForConditionalGeneration",
         "LagunaForCausalLM",
+        "DiffusionGemmaForBlockDiffusion",
     }
     if any(arch in hybrid_swa_archs for arch in model_architectures):
         # Only treat Laguna as hybrid SWA when it actually has a sliding window.
@@ -1928,6 +1931,7 @@ def get_hybrid_layer_ids(
         "Gemma4ForCausalLM" in model_architectures
         or "Gemma4ForConditionalGeneration" in model_architectures
         or "Gemma4UnifiedForConditionalGeneration" in model_architectures
+        or "DiffusionGemmaForBlockDiffusion" in model_architectures
     ):
         layer_types = getattr(hf_text_config, "layer_types", [])
         swa_attention_layer_ids = [

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1859,6 +1859,7 @@ def is_hybrid_swa_model(
         "Gemma4ForCausalLM",
         "Gemma4ForConditionalGeneration",
         "Gemma4UnifiedForConditionalGeneration",
+        "Gemma3ForConditionalGeneration",
         "LagunaForCausalLM",
         "DiffusionGemmaForBlockDiffusion",
     }
@@ -1932,6 +1933,7 @@ def get_hybrid_layer_ids(
         or "Gemma4ForConditionalGeneration" in model_architectures
         or "Gemma4UnifiedForConditionalGeneration" in model_architectures
         or "DiffusionGemmaForBlockDiffusion" in model_architectures
+        or "Gemma3ForConditionalGeneration" in model_architectures
     ):
         layer_types = getattr(hf_text_config, "layer_types", [])
         swa_attention_layer_ids = [

--- a/python/sglang/srt/dllm/algorithm/gemma4_renoise.py
+++ b/python/sglang/srt/dllm/algorithm/gemma4_renoise.py
@@ -1,0 +1,162 @@
+"""Uniform-state (renoising) block-diffusion algorithm for DiffusionGemma.
+
+Two phases, distinguished by `forward_batch.dllm_is_encoder`:
+  * encoder/prefill: one forward to write the context KV cache (no denoising).
+  * decoder/denoise: for one canvas, run `max_denoising_steps` reverse steps,
+    feeding the previous step's logits back as self-conditioning.
+
+Ported from the HF `diffusion_gemma` EntropyBoundSampler + linear temperature
+schedule + StableAndConfident stopping. Defaults follow the checkpoint's
+generation_config.json and may be overridden via --dllm-algorithm-config.
+"""
+
+from typing import List, Tuple, Union
+
+import torch
+
+from sglang.srt.distributed import get_tp_group
+from sglang.srt.dllm.algorithm.base import DllmAlgorithm
+from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+class Gemma4Renoise(DllmAlgorithm):
+    def __init__(self, config: DllmConfig):
+        super().__init__(config)
+
+        ac = config.algorithm_config or {}
+        self.max_denoising_steps = ac.get("max_denoising_steps", 48)
+        if self.max_denoising_steps < 1:
+            raise ValueError("max_denoising_steps must be >= 1")
+        s = ac.get("sampler_config", {})
+        self.entropy_bound = s.get("entropy_bound", 0.1)
+        t = ac.get("temperature_schedule", {})
+        self.t_min = t.get("t_min", 0.4)
+        self.t_max = t.get("t_max", 0.8)
+        st = ac.get("stopping_config", {})
+        self.confidence_threshold = st.get("confidence_threshold", 0.005)
+        self.stability_threshold = st.get("stability_threshold", 1)
+
+        self.vocab_size = None
+        self._base_seed = ac.get("seed", None)
+        self._generator = None
+
+    def _temperature(self, step: int) -> float:
+        return self.t_min + (self.t_max - self.t_min) * (
+            step / self.max_denoising_steps
+        )
+
+    def _seed_generator(self, device) -> torch.Generator:
+        # Re-seed per decode. Under TP, broadcast rank 0's seed so all ranks draw
+        # identical canvases from the all-gathered logits.
+        if self._generator is None or self._generator.device != device:
+            self._generator = torch.Generator(device=device)
+        if self._base_seed is not None:
+            seed = int(self._base_seed)
+        else:
+            seed = int(torch.randint(0, torch.iinfo(torch.int32).max, ()).item())
+        tp_group = get_tp_group()
+        if tp_group.world_size > 1:
+            t = torch.tensor([seed], dtype=torch.int64, device=device)
+            tp_group.broadcast(t, src=0)
+            seed = int(t.item())
+        self._generator.manual_seed(seed)
+        return self._generator
+
+    def _init_canvas(self, shape, device, gen) -> torch.Tensor:
+        return torch.randint(
+            low=0, high=self.vocab_size, size=shape, device=device, generator=gen
+        )
+
+    def _renoise(self, denoiser, token_entropy, gen) -> torch.Tensor:
+        # EntropyBound: keep the lowest-entropy positions within entropy_bound,
+        # re-noise the complement with fresh uniform tokens.
+        sorted_e, idx = torch.sort(token_entropy, dim=-1, descending=False)
+        cum = torch.cumsum(sorted_e, dim=-1)
+        sel = (cum - sorted_e) <= self.entropy_bound
+        mask = torch.zeros_like(sel).scatter(-1, idx, sel)
+        rand = self._init_canvas(denoiser.shape, denoiser.device, gen)
+        return torch.where(mask, denoiser, rand)
+
+    def _stop(self, history, argmax, token_entropy) -> torch.Tensor:
+        # Per-request [bs] bool: each request stops on its own stability/confidence.
+        bs = argmax.shape[0]
+        if len(history) == self.stability_threshold:
+            stable = torch.ones(bs, dtype=torch.bool, device=argmax.device)
+            for c in history:
+                stable &= (argmax == c).all(dim=1)
+        else:
+            stable = torch.zeros(bs, dtype=torch.bool, device=argmax.device)
+        history.append(argmax)
+        if len(history) > self.stability_threshold:
+            history.pop(0)
+        confident = token_entropy.mean(dim=1) < self.confidence_threshold
+        return stable & confident
+
+    def run(
+        self,
+        model_runner: ModelRunner,
+        forward_batch: ForwardBatch,
+    ) -> Tuple[Union[LogitsProcessorOutput, torch.Tensor], List[torch.Tensor], bool]:
+        if self.vocab_size is None:
+            self.vocab_size = model_runner.model_config.hf_config.text_config.vocab_size
+
+        if forward_batch.dllm_is_encoder:
+            # Skip an empty (fully-cached) encode round, rope can't reshape 0 tokens.
+            if forward_batch.input_ids.numel() == 0:
+                return None, [], False
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            return out.logits_output, [], out.can_run_graph
+
+        bs = forward_batch.batch_size
+        L = self.block_size
+        device = forward_batch.input_ids.device
+        gen = self._seed_generator(device)
+
+        current = self._init_canvas((bs, L), device, gen)
+        forward_batch.input_ids[:] = current.reshape(-1)
+        self_cond = None
+        history: List[torch.Tensor] = []
+        out = None
+        # Each request freezes its canvas once it stops while the rest keep denoising.
+        done = torch.zeros(bs, dtype=torch.bool, device=device)
+        # Emit the greedy argmax (not the multinomial canvas), frozen per-item on stop.
+        argmax = current.clone()
+
+        for step in reversed(range(1, self.max_denoising_steps + 1)):
+            forward_batch.dllm_self_conditioning_logits = self_cond
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+
+            logits = (out.logits_output.full_logits / self._temperature(step)).view(
+                bs, L, -1
+            )
+            token_entropy = torch.distributions.Categorical(logits=logits).entropy()
+            probs = torch.softmax(logits, dim=-1)
+            denoiser = torch.multinomial(
+                probs.reshape(bs * L, -1), num_samples=1, generator=gen
+            ).view(bs, L)
+
+            keep = done.view(bs, 1)
+            argmax = torch.where(keep, argmax, torch.argmax(logits, dim=-1))
+            current = torch.where(
+                keep, current, self._renoise(denoiser, token_entropy, gen)
+            )
+            forward_batch.input_ids[:] = current.reshape(-1)
+            if self_cond is None:
+                self_cond = logits.reshape(bs * L, -1)
+            else:
+                self_cond = torch.where(
+                    done.view(bs, 1, 1), self_cond.view(bs, L, -1), logits
+                ).reshape(bs * L, -1)
+
+            done |= self._stop(history, argmax, token_entropy) & (~done)
+            if bool(done.all()):
+                break
+
+        next_token_ids = [argmax[i] for i in range(bs)]
+        return out.logits_output, next_token_ids, out.can_run_graph
+
+
+Algorithm = Gemma4Renoise

--- a/python/sglang/srt/dllm/algorithm/gemma4_renoise.py
+++ b/python/sglang/srt/dllm/algorithm/gemma4_renoise.py
@@ -132,8 +132,11 @@ class Gemma4Renoise(DllmAlgorithm):
             logits = (out.logits_output.full_logits / self._temperature(step)).view(
                 bs, L, -1
             )
-            token_entropy = torch.distributions.Categorical(logits=logits).entropy()
-            probs = torch.softmax(logits, dim=-1)
+            # One log_softmax pass yields both probs and entropy (the
+            # Categorical equivalent allocates extra full-vocab buffers).
+            log_probs = torch.log_softmax(logits, dim=-1)
+            probs = torch.exp(log_probs)
+            token_entropy = -torch.sum(probs * log_probs, dim=-1)
             denoiser = torch.multinomial(
                 probs.reshape(bs * L, -1), num_samples=1, generator=gen
             ).view(bs, L)
@@ -155,6 +158,9 @@ class Gemma4Renoise(DllmAlgorithm):
             if bool(done.all()):
                 break
 
+        # One D2H copy for the whole batch, so the scheduler's per-request
+        # tolist() reads host memory.
+        argmax = argmax.cpu()
         next_token_ids = [argmax[i] for i in range(bs)]
         return out.logits_output, next_token_ids, out.can_run_graph
 

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -12,12 +12,16 @@ class DllmConfig:
         block_size: int,
         mask_id: int,
         max_running_requests: int,
+        is_uniform: bool,
     ):
         self.algorithm = algorithm
         self.algorithm_config = algorithm_config
         self.block_size = block_size
         self.mask_id = mask_id
         self.max_running_requests = max_running_requests
+        # Uniform-state (renoising) diffusion (DiffusionGemma) vs masked diffusion
+        # (LLaDA2 / SDAR). Selects the per-round scheduling in ReqDllmMixin.
+        self.is_uniform = is_uniform
 
     @staticmethod
     def from_server_args(
@@ -35,6 +39,11 @@ class DllmConfig:
             "LLaDA2MoeModelLM": {"block_size": 32, "mask_id": 156895},
             "SDARForCausalLM": {"block_size": 4, "mask_id": 151669},
             "SDARMoeForCausalLM": {"block_size": 4, "mask_id": 151669},
+            "DiffusionGemmaForBlockDiffusion": {
+                "block_size": None,
+                "mask_id": -1,
+                "is_uniform": True,
+            },
         }
 
         arch = model_config.hf_config.architectures[0]
@@ -42,6 +51,11 @@ class DllmConfig:
             params = DLLM_PARAMS[arch]
             block_size = params["block_size"]
             mask_id = params["mask_id"]
+            is_uniform = params.get("is_uniform", False)
+            if is_uniform:
+                # canvas_length lives only on the Gemma4 config, so read it here, not
+                # in the eager dict above (built for every dLLM, masked ones lack it).
+                block_size = model_config.hf_config.canvas_length
         else:
             raise RuntimeError(f"Unknown diffusion LLM: {arch}")
 
@@ -72,4 +86,5 @@ class DllmConfig:
             block_size=block_size,
             mask_id=mask_id,
             max_running_requests=max_running_requests,
+            is_uniform=is_uniform,
         )

--- a/python/sglang/srt/dllm/mixin/req.py
+++ b/python/sglang/srt/dllm/mixin/req.py
@@ -23,11 +23,14 @@ class ReqDllmMixin:
         self.dllm_block_offset = 0
         self.dllm_config = dllm_config
 
-        if self.dllm_config is not None:
-            if len(self.origin_input_ids) < self.dllm_config.block_size:
-                self.dllm_phase = DllmReqPhase.INCOMING_DECODE
-            else:
-                self.dllm_phase = DllmReqPhase.INCOMING_PREFILL
+        if self.dllm_config is None:
+            return
+        if self.dllm_config.is_uniform:
+            self.dllm_phase = DllmReqPhase.INCOMING_PREFILL
+        elif len(self.origin_input_ids) < self.dllm_config.block_size:
+            self.dllm_phase = DllmReqPhase.INCOMING_DECODE
+        else:
+            self.dllm_phase = DllmReqPhase.INCOMING_PREFILL
 
     def is_dllm(self: Req) -> bool:
         return self.dllm_config is not None
@@ -46,31 +49,58 @@ class ReqDllmMixin:
             # still incoming stage
             return
 
-        input_block = self.full_untruncated_fill_ids[prefix_length:min_required_length]
-        is_prefill_phase = self.dllm_config.mask_id not in input_block
-
-        if is_prefill_phase:
-            self.dllm_phase = DllmReqPhase.STAGING_PREFILL
+        if self.dllm_config.is_uniform:
+            # Uniform: the canvas begins once the cached prefix covers the real context.
+            in_prefill = prefix_length < self.seqlen
         else:
-            self.dllm_phase = DllmReqPhase.STAGING_DECODE
+            # Masked: the staging block still contains mask tokens to fill.
+            input_block = self.full_untruncated_fill_ids[
+                prefix_length:min_required_length
+            ]
+            in_prefill = self.dllm_config.mask_id not in input_block
+
+        self.dllm_phase = (
+            DllmReqPhase.STAGING_PREFILL if in_prefill else DllmReqPhase.STAGING_DECODE
+        )
 
     def _init_fill_ids_for_dllm(self: Req):
-        self.dllm_block_offset = (
-            0
-            if not self.dllm_initialized
-            else self.dllm_block_offset + self.dllm_config.block_size
-        )
-        self.full_untruncated_fill_ids = (
-            self.origin_input_ids
-            + self.output_ids
-            + array("q", [self.dllm_config.mask_id] * self.dllm_config.block_size)
-        )
+        if self.dllm_config.is_uniform:
+            # Uniform (DiffusionGemma renoise): append a placeholder canvas (zeros)
+            # only once the real context is fully cached, else encode context with no
+            # canvas. Re-expressed in main's dllm_initialized idiom (#28054 used fill_len).
+            context_len = self.seqlen
+            self.dllm_block_offset = context_len
+            if self.dllm_initialized and len(self.prefix_indices) >= context_len:
+                self.full_untruncated_fill_ids = (
+                    self.origin_input_ids
+                    + self.output_ids
+                    + array("q", [0] * self.dllm_config.block_size)
+                )
+            else:
+                self.full_untruncated_fill_ids = self.origin_input_ids + self.output_ids
+        else:
+            self.dllm_block_offset = (
+                0
+                if not self.dllm_initialized
+                else self.dllm_block_offset + self.dllm_config.block_size
+            )
+            self.full_untruncated_fill_ids = (
+                self.origin_input_ids
+                + self.output_ids
+                + array("q", [self.dllm_config.mask_id] * self.dllm_config.block_size)
+            )
         self.dllm_initialized = True
 
-    def _update_block_offset_for_dllm(self):
+    def _update_block_offset_for_dllm(self: Req):
         prefix_len = len(self.prefix_indices)
-        assert (
-            prefix_len % self.dllm_config.block_size == 0
-        ), f"Unexpected prefix len: {prefix_len}"
-        if prefix_len > self.dllm_block_offset:
-            self.dllm_block_offset = prefix_len
+        if self.dllm_config.is_uniform:
+            context_len = self.seqlen
+            assert (
+                prefix_len <= context_len
+            ), f"Unexpected uniform prefix len {prefix_len} > context {context_len}"
+        else:
+            assert (
+                prefix_len % self.dllm_config.block_size == 0
+            ), f"Unexpected prefix len: {prefix_len}"
+            if prefix_len > self.dllm_block_offset:
+                self.dllm_block_offset = prefix_len

--- a/python/sglang/srt/dllm/mixin/req.py
+++ b/python/sglang/srt/dllm/mixin/req.py
@@ -89,6 +89,9 @@ class ReqDllmMixin:
                 + self.output_ids
                 + array("q", [self.dllm_config.mask_id] * self.dllm_config.block_size)
             )
+        # #28054's uniform canvas scheduler reads/writes req.fill_len; keep it maintained
+        # alongside main's dllm_initialized so both the masked and uniform paths work.
+        self.fill_len = len(self.full_untruncated_fill_ids)
         self.dllm_initialized = True
 
     def _update_block_offset_for_dllm(self: Req):

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -4,9 +4,16 @@ import logging
 from array import array
 from typing import TYPE_CHECKING, List, Optional, Set, Union
 
+from http import HTTPStatus
+
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.dllm.mixin.req import DllmReqPhase
-from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.managers.schedule_batch import (
+    FINISH_ABORT,
+    FINISH_LENGTH,
+    Req,
+    ScheduleBatch,
+)
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
 from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
@@ -51,6 +58,7 @@ class SchedulerDllmMixin:
 
         can_run_list = adder.can_run_list
         if not can_run_list:
+            self._break_dllm_pool_deadlock()
             return None
 
         # Record metrics and update state
@@ -87,9 +95,22 @@ class SchedulerDllmMixin:
 
                 req.output_ids.extend(next_token_ids)
                 req.update_finish_state(new_accepted_len=new_tokens)
+                if (
+                    not req.finished()
+                    and req.seqlen + self.dllm_config.block_size
+                    > self.model_config.context_len
+                ):
+                    # The next canvas would overrun the req_to_token row.
+                    req.finished_reason = FINISH_LENGTH(length=len(req.output_ids))
 
                 if req.finished():
-                    release_kv_cache(req, self.tree_cache)
+                    # Uniform: the last canvas KV is the decoder's transient
+                    # denoising KV, keep it out of the radix tree.
+                    release_kv_cache(
+                        req,
+                        self.tree_cache,
+                        is_insert=not self.dllm_config.is_uniform,
+                    )
                     req.time_stats.set_completion_time()
 
             self.output_streamer.stream_output(batch.reqs, batch.return_logprob)
@@ -103,7 +124,26 @@ class SchedulerDllmMixin:
             dp_cooperation_info=batch.dp_cooperation_info,
         )
 
+    def _dllm_pool_headroom(self: Scheduler) -> int:
+        allocator = self.token_to_kv_pool_allocator
+        if hasattr(allocator, "full_available_size"):
+            return min(
+                int(allocator.full_available_size())
+                + self.tree_cache.full_evictable_size(),
+                int(allocator.swa_available_size())
+                + self.tree_cache.swa_evictable_size(),
+            )
+        return int(allocator.available_size()) + self.tree_cache.evictable_size()
+
     def _fetch_waiting_reqs(self: Scheduler):
+        # Back-pressure: while the pool cannot fit one canvas round, admitting
+        # another request only burns the survivors' headroom on its prefill.
+        if (
+            self.dllm_manager.waiting_queue
+            and self._dllm_pool_headroom()
+            <= self.dllm_config.block_size + self.token_to_kv_pool_allocator.page_size
+        ):
+            return
         # Calculate how many requests can be added to DLLM manager
         max_dllm_capacity = self.dllm_config.max_running_requests - len(
             self.dllm_manager.waiting_queue
@@ -237,6 +277,43 @@ class SchedulerDllmMixin:
         )
 
         return new_batch
+
+    def _break_dllm_pool_deadlock(self: Scheduler):
+        """Break the deadlock where staged requests hold the whole pool.
+
+        Nothing runs and nothing can extend, so nothing would ever finish.
+        Abort the least-progressed holder so the others run to completion.
+        """
+        if len(self.running_batch.reqs) > 0:
+            return
+        holders = [
+            r
+            for r in self.dllm_manager.waiting_queue
+            if r.dllm_phase
+            in (DllmReqPhase.STAGING_PREFILL, DllmReqPhase.STAGING_DECODE)
+        ]
+        if not holders:
+            return
+        if (
+            self._dllm_pool_headroom()
+            > self.dllm_config.block_size + self.token_to_kv_pool_allocator.page_size
+        ):
+            return
+
+        req = min(holders, key=lambda r: len(r.output_ids))
+        self.dllm_manager.waiting_queue = [
+            r for r in self.dllm_manager.waiting_queue if r is not req
+        ]
+        self.dllm_manager.staging_queue = [
+            r for r in self.dllm_manager.staging_queue if r is not req
+        ]
+        req.finished_reason = FINISH_ABORT(
+            "KV pool exhausted. Retry the request.",
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+        release_kv_cache(req, self.tree_cache, is_insert=False)
+        self.output_streamer.stream_output([req], req.return_logprob)
+        logger.warning("dLLM pool deadlock: aborted %s", req.rid)
 
     def process_dllm_incoming_reqs(
         self: Scheduler, adder: PrefillAdder, reqs: List[Req]

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import logging
 from array import array
-from typing import TYPE_CHECKING, List, Optional, Set, Union
-
 from http import HTTPStatus
+from typing import TYPE_CHECKING, List, Optional, Set, Union
 
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.dllm.mixin.req import DllmReqPhase

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -313,6 +313,13 @@ def _nvfp4_inner_pool_and_layer_id(token_to_kv_pool, layer_id: int):
     )
     return inner_pool, local_layer_id
 
+def _shape_nvfp4_kv_scale_for_flashinfer(scale: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+    if scale is None:
+        return None
+    if scale.dim() == 3:
+        return scale.unsqueeze(1)
+    return scale
+
 
 class FlashInferAttnBackend(AttentionBackend):
     """Flashinfer attention kernels."""
@@ -541,12 +548,38 @@ class FlashInferAttnBackend(AttentionBackend):
             self.token_to_kv_pool, layer.layer_id
         )
         k_sf, v_sf = kv_pool.get_kv_scale_buffer(local_layer_id)
+        k_sf = _shape_nvfp4_kv_scale_for_flashinfer(k_sf)
+        v_sf = _shape_nvfp4_kv_scale_for_flashinfer(v_sf)
         k_global, v_global = kv_pool.get_kv_global_scale(local_layer_id)
         return kv_cache, {
             "kv_cache_sf": (k_sf, v_sf),
             "k_scale": k_global,
             "v_scale": v_global,
         }
+
+    def _should_vo_split(self, layer: RadixAttention) -> bool:
+        return self.enable_vo_split and layer.head_dim == 512
+
+    @staticmethod
+    def _slice_last_dim_for_vo_split(x: Optional[torch.Tensor], pass_id: int):
+        if x is None:
+            return None
+        half = x.shape[-1] // 2
+        return x[..., pass_id * half : (pass_id + 1) * half]
+
+    def _vo_split_paged_inputs(self, paged_kv_cache, paged_kv_kwargs, pass_id: int):
+        k_cache, v_cache = paged_kv_cache
+        split_kwargs = dict(paged_kv_kwargs)
+        if split_kwargs.get("kv_cache_sf") is not None:
+            k_sf, v_sf = split_kwargs["kv_cache_sf"]
+            split_kwargs["kv_cache_sf"] = (
+                k_sf,
+                self._slice_last_dim_for_vo_split(v_sf, pass_id),
+            )
+        return (
+            k_cache,
+            self._slice_last_dim_for_vo_split(v_cache, pass_id),
+        ), split_kwargs
 
     def _run_paged_native(
         self,
@@ -560,7 +593,45 @@ class FlashInferAttnBackend(AttentionBackend):
         logits_soft_cap,
         return_lse,
         paged_kv_kwargs,
+        trace_label=None,
+        trace_layer=None,
+        vo_split: bool = False,
     ):
+        if vo_split:
+            outs = []
+            lse = None
+            for pass_id in range(2):
+                split_cache, split_kwargs = self._vo_split_paged_inputs(
+                    paged_kv_cache, paged_kv_kwargs, pass_id
+                )
+                result = self._run_paged_native(
+                    wrapper,
+                    q,
+                    split_cache,
+                    causal=causal,
+                    sm_scale=sm_scale,
+                    window_left=window_left,
+                    logits_soft_cap=logits_soft_cap,
+                    return_lse=return_lse,
+                    paged_kv_kwargs=split_kwargs,
+                    trace_label=(
+                        f"{trace_label}_vosplit{pass_id}"
+                        if trace_label is not None
+                        else None
+                    ),
+                    trace_layer=trace_layer,
+                    vo_split=False,
+                )
+                if return_lse:
+                    out_i, lse_i = result
+                    if lse is None:
+                        lse = lse_i
+                    outs.append(out_i)
+                else:
+                    outs.append(result)
+            out = torch.cat(outs, dim=-1)
+            return (out, lse) if return_lse else out
+
         wrapper._causal = causal
         wrapper._pos_encoding_mode = "NONE"
         wrapper._use_fp16_qk_reduction = False
@@ -569,9 +640,100 @@ class FlashInferAttnBackend(AttentionBackend):
         wrapper._sm_scale = sm_scale
         wrapper._rope_scale = None
         wrapper._rope_theta = None
-        return wrapper.run(
+        self._trace_gemma4_geometry_dispatch(
+            label=trace_label,
+            layer=trace_layer,
+            paged_kv_cache=paged_kv_cache,
+            paged_kv_kwargs=paged_kv_kwargs,
+            wrapper=wrapper,
+            vo_split=vo_split,
+        )
+        out = wrapper.run(
             q, paged_kv_cache, return_lse=return_lse, **paged_kv_kwargs
         )
+        if self.is_nvfp4_native and _fp4_kv_module_trace_enabled():
+            layer_id = getattr(trace_layer, "layer_id", None)
+            key = (trace_label, int(layer_id) if layer_id is not None else None)
+            if key not in self._nvfp4_module_trace_seen:
+                self._nvfp4_module_trace_seen.add(key)
+                extra_flags = os.environ.get("FLASHINFER_EXTRA_CUDAFLAGS", "")
+                k_sf, v_sf = paged_kv_kwargs.get("kv_cache_sf", (None, None))
+                logger.warning(
+                    "FP4 KV FlashInfer module trace label=%s layer=%s "
+                    "extra_cuda_flags=%r deswizzle_macro_active=%s "
+                    "wrapper=%s kv_cache=%s k_sf=%s v_sf=%s k_scale=%s v_scale=%s",
+                    trace_label,
+                    layer_id,
+                    extra_flags,
+                    "FLASHINFER_PAGED_V_SF_DESWIZZLE" in extra_flags,
+                    _flashinfer_wrapper_trace_summary(wrapper),
+                    _tensor_trace_summary(paged_kv_cache),
+                    _tensor_trace_summary(k_sf),
+                    _tensor_trace_summary(v_sf),
+                    _scale_trace_value(paged_kv_kwargs.get("k_scale")),
+                    _scale_trace_value(paged_kv_kwargs.get("v_scale")),
+                )
+        return out
+
+    def _plan_decode_as_prefill_vo_split(
+        self,
+        *,
+        decode_wrapper,
+        prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper,
+        q: torch.Tensor,
+        layer: RadixAttention,
+    ) -> None:
+        if self.skip_prefill:
+            raise RuntimeError("VO-split decode-as-prefill requires prefill wrappers")
+
+        wrapper_id = self._get_wrapper_idx(layer)
+        geom = self.wrapper_geometries[wrapper_id]
+        bs = q.shape[0]
+        qo_indptr = self.qo_indptr[wrapper_id]
+        qo_indptr[: bs + 1].copy_(
+            torch.arange(bs + 1, dtype=torch.int32, device=qo_indptr.device)
+        )
+        qo_indptr = qo_indptr[: bs + 1]
+
+        if not all(
+            hasattr(decode_wrapper, name)
+            for name in (
+                "_paged_kv_indptr_buf",
+                "_paged_kv_indices_buf",
+                "_paged_kv_last_page_len_buf",
+            )
+        ):
+            raise RuntimeError(
+                "VO-split decode-as-prefill requires a planned decode wrapper"
+            )
+
+        updater = self.indices_updater_prefill
+        plan_kwargs = {
+            "head_dim_vo": geom.head_dim_vo,
+            "q_data_type": updater.q_data_type,
+            "kv_data_type": updater.kv_data_type,
+            "custom_mask": None,
+            "non_blocking": True,
+            "fixed_split_size": self.prefill_split_tile_size,
+        }
+        if updater.k_data_type != updater.v_data_type:
+            plan_kwargs.update(
+                k_data_type=updater.k_data_type,
+                v_data_type=updater.v_data_type,
+            )
+
+        prefill_wrapper.begin_forward(
+            qo_indptr,
+            decode_wrapper._paged_kv_indptr_buf[: bs + 1],
+            decode_wrapper._paged_kv_indices_buf,
+            decode_wrapper._paged_kv_last_page_len_buf[:bs],
+            geom.num_qo_heads,
+            geom.num_kv_heads,
+            geom.head_dim,
+            1,
+            **plan_kwargs,
+        )
+
 
     def _process_multi_item_scoring(
         self, forward_batch: ForwardBatch
@@ -1083,6 +1245,7 @@ class FlashInferAttnBackend(AttentionBackend):
                     logits_soft_cap=logits_soft_cap,
                     return_lse=False,
                     paged_kv_kwargs=paged_kv_kwargs,
+                    vo_split=self._should_vo_split(layer),
                 )
             else:
                 o = prefill_wrapper_paged.forward(
@@ -1161,6 +1324,7 @@ class FlashInferAttnBackend(AttentionBackend):
                         logits_soft_cap=logits_soft_cap,
                         return_lse=True,
                         paged_kv_kwargs=paged_kv_kwargs,
+                        vo_split=self._should_vo_split(layer),
                     )
                 else:
                     o2, s2 = prefill_wrapper_paged.forward_return_lse(
@@ -1230,6 +1394,7 @@ class FlashInferAttnBackend(AttentionBackend):
                 logits_soft_cap=layer.logit_cap,
                 return_lse=False,
                 paged_kv_kwargs=paged_kv_kwargs,
+                vo_split=self._should_vo_split(layer),
             )
         else:
             o = decode_wrapper.forward(

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -34,6 +34,9 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
+from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPoolFP4
+from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
@@ -48,6 +51,7 @@ from sglang.srt.utils import (
     get_int_env_var,
     is_flashinfer_available,
     is_sm100_supported,
+    is_sm120_supported,
     next_power_of_2,
     require_gathered_buffer,
 )
@@ -286,6 +290,28 @@ def fast_prefill_plan(
         0,  # num_colocated_ctas
     ]
     self._plan_info = self._cached_module.plan(*args)
+def _is_nvfp4_native_kv_pool(token_to_kv_pool) -> bool:
+    if isinstance(token_to_kv_pool, MHATokenToKVPoolFP4):
+        return True
+    return (
+        isinstance(token_to_kv_pool, SWAKVPool)
+        and isinstance(token_to_kv_pool.full_kv_pool, MHATokenToKVPoolFP4)
+        and isinstance(token_to_kv_pool.swa_kv_pool, MHATokenToKVPoolFP4)
+    )
+
+
+def _nvfp4_inner_pool_and_layer_id(token_to_kv_pool, layer_id: int):
+    if not isinstance(token_to_kv_pool, SWAKVPool):
+        return token_to_kv_pool, layer_id
+
+    token_to_kv_pool._wait_for_layer(layer_id)
+    local_layer_id, is_swa_layer = token_to_kv_pool.layers_mapping[layer_id]
+    inner_pool = (
+        token_to_kv_pool.swa_kv_pool
+        if is_swa_layer
+        else token_to_kv_pool.full_kv_pool
+    )
+    return inner_pool, local_layer_id
 
 
 class FlashInferAttnBackend(AttentionBackend):
@@ -310,6 +336,9 @@ class FlashInferAttnBackend(AttentionBackend):
         )
         self.use_sliding_window_kv_pool = self._swa_kv_pool is not None
         self.enable_mis = model_runner.server_args.enable_mis
+        self.is_nvfp4_native = _is_nvfp4_native_kv_pool(
+            self.token_to_kv_pool
+        ) and is_sm120_supported()
 
         # FIXME: remove dllm workarounds from flashinfer
         self.dllm_config = DllmConfig.from_server_args(model_runner.server_args)
@@ -324,6 +353,8 @@ class FlashInferAttnBackend(AttentionBackend):
                 get_parallel().attn_tp_size
             ),
         )
+        if self.is_nvfp4_native:
+            self.decode_use_tensor_cores = True
         self.max_context_len = model_runner.model_config.context_len
         self.skip_prefill = skip_prefill
         self.is_multimodal = model_runner.model_config.is_multimodal
@@ -498,6 +529,49 @@ class FlashInferAttnBackend(AttentionBackend):
 
         kvcache = model_runner.token_to_kv_pool_allocator.get_kvcache()
         return kvcache if isinstance(kvcache, BaseSWAKVPool) else None
+    def _get_paged_kv_cache_and_kwargs(self, layer: RadixAttention):
+        kv_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+        if not self.is_nvfp4_native:
+            return kv_cache, {
+                "k_scale": layer.k_scale_float,
+                "v_scale": layer.v_scale_float,
+            }
+
+        kv_pool, local_layer_id = _nvfp4_inner_pool_and_layer_id(
+            self.token_to_kv_pool, layer.layer_id
+        )
+        k_sf, v_sf = kv_pool.get_kv_scale_buffer(local_layer_id)
+        k_global, v_global = kv_pool.get_kv_global_scale(local_layer_id)
+        return kv_cache, {
+            "kv_cache_sf": (k_sf, v_sf),
+            "k_scale": k_global,
+            "v_scale": v_global,
+        }
+
+    def _run_paged_native(
+        self,
+        wrapper,
+        q,
+        paged_kv_cache,
+        *,
+        causal,
+        sm_scale,
+        window_left,
+        logits_soft_cap,
+        return_lse,
+        paged_kv_kwargs,
+    ):
+        wrapper._causal = causal
+        wrapper._pos_encoding_mode = "NONE"
+        wrapper._use_fp16_qk_reduction = False
+        wrapper._window_left = -1 if window_left is None else window_left
+        wrapper._logits_soft_cap = 0.0 if logits_soft_cap is None else logits_soft_cap
+        wrapper._sm_scale = sm_scale
+        wrapper._rope_scale = None
+        wrapper._rope_theta = None
+        return wrapper.run(
+            q, paged_kv_cache, return_lse=return_lse, **paged_kv_kwargs
+        )
 
     def _process_multi_item_scoring(
         self, forward_batch: ForwardBatch
@@ -987,36 +1061,50 @@ class FlashInferAttnBackend(AttentionBackend):
                 not layer.is_cross_attention
                 and layer.attn_type != AttentionType.ENCODER_ONLY
             )
-            o = prefill_wrapper_paged.forward(
-                q.view(-1, layer.tp_q_head_num, layer.head_dim),
-                self.token_to_kv_pool.get_kv_buffer(layer.layer_id),
-                causal=causal,
-                sm_scale=layer.scaling,
-                # Disable sliding window attention for multi-item scoring:
-                # - Sliding window could cut across item boundaries, breaking semantic coherence
-                # - Multi-item sequences need full attention to properly handle delimiter tokens
-                # - Specialized multi-item parameters (prefix_len_ptr, token_pos_in_items_ptr)
-                #   provide more precise attention control than simple sliding windows
-                # - Item-aware masking takes precedence over window-based masking
-                window_left=(
-                    layer.sliding_window_size
-                    if not (
-                        self.forward_metadata.multi_item_params
-                        and self.forward_metadata.multi_item_params.is_enabled()
-                    )
-                    else -1
-                ),
-                logits_soft_cap=logits_soft_cap,
-                # Must use _float to avoid device-to-host copy that breaks cuda graph capture.
-                k_scale=layer.k_scale_float,
-                v_scale=layer.v_scale_float,
+            paged_kv_cache, paged_kv_kwargs = self._get_paged_kv_cache_and_kwargs(
+                layer
             )
+            paged_window_left = (
+                layer.sliding_window_size
+                if not (
+                    self.forward_metadata.multi_item_params
+                    and self.forward_metadata.multi_item_params.is_enabled()
+                )
+                else -1
+            )
+            if self.is_nvfp4_native:
+                o = self._run_paged_native(
+                    prefill_wrapper_paged,
+                    q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                    paged_kv_cache,
+                    causal=causal,
+                    sm_scale=layer.scaling,
+                    window_left=paged_window_left,
+                    logits_soft_cap=logits_soft_cap,
+                    return_lse=False,
+                    paged_kv_kwargs=paged_kv_kwargs,
+                )
+            else:
+                o = prefill_wrapper_paged.forward(
+                    q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                    paged_kv_cache,
+                    causal=causal,
+                    sm_scale=layer.scaling,
+                    window_left=paged_window_left,
+                    logits_soft_cap=logits_soft_cap,
+                    **paged_kv_kwargs,
+                )
         else:
             # If `k`/`v` are not explicitly provided, fall back to the KV cache stored in
             # `self.token_to_kv_pool` for this layer. This enables attention over
             # previously cached context without re-materializing KV tensors (e.g., the
             # IQuestLoopCoder path uses token_to_kv_pool as the KV source).
             if k is None and v is None:
+                if self.is_nvfp4_native:
+                    raise RuntimeError(
+                        "FlashInfer ragged fallback cannot read packed NVFP4 KV "
+                        "as dense K/V. Use paged attention for native FP4 KV."
+                    )
                 k = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)[0]
                 v = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)[1]
             causal = True
@@ -1059,14 +1147,31 @@ class FlashInferAttnBackend(AttentionBackend):
                     window_left=swa_window_left,
                     logits_soft_cap=logits_soft_cap,
                 )
-                o2, s2 = prefill_wrapper_paged.forward_return_lse(
-                    q.view(-1, layer.tp_q_head_num, layer.head_dim),
-                    self.token_to_kv_pool.get_kv_buffer(layer.layer_id),
-                    causal=False,
-                    sm_scale=layer.scaling,
-                    window_left=swa_window_left,
-                    logits_soft_cap=logits_soft_cap,
+                paged_kv_cache, paged_kv_kwargs = self._get_paged_kv_cache_and_kwargs(
+                    layer
                 )
+                if self.is_nvfp4_native:
+                    o2, s2 = self._run_paged_native(
+                        prefill_wrapper_paged,
+                        q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                        paged_kv_cache,
+                        causal=False,
+                        sm_scale=layer.scaling,
+                        window_left=swa_window_left,
+                        logits_soft_cap=logits_soft_cap,
+                        return_lse=True,
+                        paged_kv_kwargs=paged_kv_kwargs,
+                    )
+                else:
+                    o2, s2 = prefill_wrapper_paged.forward_return_lse(
+                        q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                        paged_kv_cache,
+                        causal=False,
+                        sm_scale=layer.scaling,
+                        window_left=swa_window_left,
+                        logits_soft_cap=logits_soft_cap,
+                        **paged_kv_kwargs,
+                    )
 
                 o, _ = _safe_merge_state(o1, s1, o2, s2)
 
@@ -1113,16 +1218,27 @@ class FlashInferAttnBackend(AttentionBackend):
                     layer.v_scale,
                 )
 
-        # Call the wrapped function
-        o = decode_wrapper.forward(
-            q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
-            self.token_to_kv_pool.get_kv_buffer(layer.layer_id),
-            sm_scale=layer.scaling,
-            logits_soft_cap=layer.logit_cap,
-            # Must use _float to avoid device-to-host copy that breaks cuda graph capture.
-            k_scale=layer.k_scale_float,
-            v_scale=layer.v_scale_float,
-        )
+        paged_kv_cache, paged_kv_kwargs = self._get_paged_kv_cache_and_kwargs(layer)
+        if self.is_nvfp4_native:
+            o = self._run_paged_native(
+                decode_wrapper,
+                q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                paged_kv_cache,
+                causal=False,
+                sm_scale=layer.scaling,
+                window_left=-1,
+                logits_soft_cap=layer.logit_cap,
+                return_lse=False,
+                paged_kv_kwargs=paged_kv_kwargs,
+            )
+        else:
+            o = decode_wrapper.forward(
+                q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                paged_kv_cache,
+                sm_scale=layer.scaling,
+                logits_soft_cap=layer.logit_cap,
+                **paged_kv_kwargs,
+            )
 
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 
@@ -1149,6 +1265,9 @@ class FlashInferIndicesUpdaterDecode:
         )
         self.head_dim = model_runner.model_config.head_dim
         self.data_type = model_runner.kv_cache_dtype
+        self.kv_data_type = (
+            torch.uint8 if attn_backend.is_nvfp4_native else self.data_type
+        )
         self.q_data_type = model_runner.dtype
         self.sliding_window_size = model_runner.sliding_window_size
         self.attn_backend = attn_backend
@@ -1375,6 +1494,7 @@ class FlashInferIndicesUpdaterDecode:
                 self.head_dim,
                 1,
                 data_type=self.data_type,
+                kv_data_type=self.kv_data_type,
                 q_data_type=self.q_data_type,
                 non_blocking=True,
                 fixed_split_size=fixed_split_size,
@@ -1394,6 +1514,7 @@ class FlashInferIndicesUpdaterDecode:
                 self.head_dim,
                 1,
                 data_type=self.data_type,
+                kv_data_type=self.kv_data_type,
                 q_data_type=self.q_data_type,
                 non_blocking=True,
                 fixed_split_size=fixed_split_size,
@@ -1417,6 +1538,9 @@ class FlashInferIndicesUpdaterPrefill:
         )
         self.head_dim = model_runner.model_config.head_dim
         self.data_type = model_runner.kv_cache_dtype
+        self.kv_data_type = (
+            torch.uint8 if attn_backend.is_nvfp4_native else self.data_type
+        )
         self.q_data_type = model_runner.dtype
         self.sliding_window_size = model_runner.sliding_window_size
         self.attn_backend = attn_backend
@@ -1819,7 +1943,7 @@ class FlashInferIndicesUpdaterPrefill:
             self.head_dim,
             1,
             q_data_type=self.q_data_type,
-            kv_data_type=self.data_type,
+            kv_data_type=self.kv_data_type,
             custom_mask=use_custom_mask,
             non_blocking=True,
             fixed_split_size=fixed_split_size,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -3687,6 +3687,23 @@ class FlashInferIndicesUpdaterDecode:
                 )
             )
 
+        # Gemma-4 full-attention (head_dim==512) NVFP4: BatchDecodeWithPagedKVCache
+        # has no head_dim_vo and would JIT-compile an unsupported symmetric vo=512
+        # FP4 module (FlashInfer #3684 only provides asymmetric qk=512/vo=256).
+        # forward_decode routes this layer through the prefill wrapper (vo=256
+        # decode-as-prefill); the decode wrapper here is planned only for its index
+        # buffers, which are dtype-independent, so plan it as bf16 to avoid
+        # requesting the FP4 vo=512 module. Mirrors vLLM #46329, which routes all
+        # VO-split decode through the prefill wrapper.
+        _geom = self.wrapper_geometries[wrapper_id]
+        _decode_data_type = self.kv_data_type
+        if (
+            self.attn_backend.is_nvfp4_native
+            and _flashinfer_vo_split_enabled()
+            and _geom.head_dim == 512
+        ):
+            _decode_data_type = self.q_data_type
+
         global global_override_indptr_cpu
         locally_override = False
         if seq_lens_cpu is not None and global_override_indptr_cpu is None:
@@ -3705,7 +3722,7 @@ class FlashInferIndicesUpdaterDecode:
         if wrapper_uses_fast_decode_plan:
             # When begin_forward is replaced with fast_decode_plan, pass global_override_indptr_cpu
             plan_kwargs = {
-                "data_type": self.kv_data_type,
+                "data_type": _decode_data_type,
                 "q_data_type": self.q_data_type,
                 "non_blocking": True,
                 "fixed_split_size": fixed_split_size,
@@ -3733,7 +3750,7 @@ class FlashInferIndicesUpdaterDecode:
         else:
             # When using original begin_forward, don't pass global_override_indptr_cpu
             plan_kwargs = {
-                "data_type": self.kv_data_type,
+                "data_type": _decode_data_type,
                 "q_data_type": self.q_data_type,
                 "non_blocking": True,
                 "fixed_split_size": fixed_split_size,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -73,6 +73,210 @@ def _cuda_graph_capture_max_bs(server_args, max_bs: int) -> int:
     if mul_base % get_parallel().attn_cp_size != 0:
         mul_base *= get_parallel().attn_cp_size
     return (max_bs + mul_base - 1) // mul_base * mul_base
+def _fp4_kv_radix_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_FP4_KV_TRACE_RADIX") == "1"
+
+
+def _fp4_kv_page_pair_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_FP4_KV_TRACE_PAGE_PAIR") == "1"
+
+
+def _fp4_kv_merge_state_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_FP4_KV_TRACE_MERGE_STATE") == "1"
+
+
+def _fp4_kv_prefix_ref_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_FP4_KV_TRACE_PREFIX_REF") == "1"
+
+
+def _fp4_kv_dense_cache_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_FP4_KV_TRACE_DENSE_CACHE") == "1"
+
+
+def _fp4_kv_dense_quant_attention_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_FP4_KV_TRACE_DENSE_QUANT_ATTENTION") == "1"
+
+
+def _fp4_kv_module_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_FP4_KV_TRACE_MODULE") == "1"
+
+
+def _gemma4_geometry_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_GEMMA4_TRACE_GEOMETRY") == "1"
+
+
+def _flashinfer_vo_split_enabled() -> bool:
+    return os.environ.get("SGLANG_FLASHINFER_VOSPLIT") == "1"
+
+
+def _flashinfer_vo_split_head_dim_vo(head_dim_qk: int) -> int:
+    # Gemma 4 global layers are the current target: Q/K stay 512-wide while
+    # V/O are handled as two exact 256-wide passes.
+    if _flashinfer_vo_split_enabled() and head_dim_qk == 512:
+        return 256
+    return head_dim_qk
+
+
+def _trace_k_scale_multipliers() -> List[float]:
+    raw = os.environ.get("SGLANG_FP4_KV_TRACE_K_SCALE_MULTIPLIERS")
+    if raw in (None, ""):
+        return []
+    values = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            value = float(item)
+        except ValueError:
+            continue
+        if value > 0:
+            values.append(value)
+    return values[:16]
+
+
+def _trace_k_head_scale_policy_enabled() -> bool:
+    return os.environ.get("SGLANG_FP4_KV_TRACE_K_HEAD_SCALE_POLICY") == "1"
+
+
+def _trace_layer_enabled(layer_id: int) -> bool:
+    raw = os.environ.get("SGLANG_FP4_KV_TRACE_LAYERS")
+    if raw in (None, ""):
+        return True
+    enabled = {item.strip() for item in raw.split(",") if item.strip()}
+    return str(layer_id) in enabled
+
+
+def _trace_value_limit(default: int = 8) -> int:
+    raw = os.environ.get("SGLANG_FP4_KV_TRACE_VALUES")
+    if raw in (None, ""):
+        return default
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return default
+
+
+def _trace_token_limit(default: int = 128) -> int:
+    raw = os.environ.get("SGLANG_FP4_KV_PREFIX_REF_MAX_TOKENS")
+    if raw in (None, ""):
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
+
+
+def _trace_q_row_limit(default: Optional[int] = None) -> Optional[int]:
+    raw = os.environ.get("SGLANG_FP4_KV_PREFIX_REF_MAX_Q_ROWS")
+    if raw in (None, ""):
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
+
+
+def _trace_cpu_values(value):
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        return value.detach().to("cpu").tolist()
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    try:
+        return list(value)
+    except TypeError:
+        return value
+
+
+def _trace_tensor_values(value, limit: int = 8):
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        flat = value.detach().flatten()
+        length = flat.numel()
+        return {
+            "len": length,
+            "dtype": str(value.dtype),
+            "shape": list(value.shape),
+            "head": flat[:limit].to("cpu").tolist(),
+            "tail": flat[max(0, length - limit) :].to("cpu").tolist(),
+        }
+    values = _trace_cpu_values(value)
+    if isinstance(values, list):
+        return {
+            "len": len(values),
+            "head": values[:limit],
+            "tail": values[-limit:] if values else [],
+        }
+    return values
+
+
+def _trace_simple_value(value):
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (torch.dtype, torch.device)):
+        return str(value)
+    if isinstance(value, torch.Tensor):
+        return _tensor_trace_summary(value)
+    if isinstance(value, (list, tuple)):
+        if len(value) > 8:
+            return f"{type(value).__name__}(len={len(value)})"
+        return [_trace_simple_value(item) for item in value]
+    if isinstance(value, dict):
+        if len(value) > 16:
+            return f"dict(len={len(value)})"
+        return {str(k): _trace_simple_value(v) for k, v in value.items()}
+    if callable(value):
+        return f"callable:{getattr(value, '__name__', type(value).__name__)}"
+    text = repr(value)
+    if len(text) > 240:
+        text = text[:240] + "..."
+    return text
+
+
+def _flashinfer_wrapper_trace_summary(wrapper) -> dict:
+    interesting = {}
+    for name in sorted(dir(wrapper)):
+        if name.startswith("__"):
+            continue
+        lower = name.lower()
+        if not any(
+            marker in lower
+            for marker in (
+                "backend",
+                "cache",
+                "dtype",
+                "jit",
+                "kv",
+                "module",
+                "paged",
+                "plan",
+                "uri",
+            )
+        ):
+            continue
+        try:
+            value = getattr(wrapper, name)
+        except Exception as exc:
+            interesting[name] = f"error:{exc!r}"
+            continue
+        if callable(value) and not (
+            "cache" in lower or "module" in lower or "plan" in lower
+        ):
+            continue
+        interesting[name] = _trace_simple_value(value)
+    return {"class": type(wrapper).__name__, "state": interesting}
+
+
+def _trace_rids(forward_batch: ForwardBatch):
+    rids = getattr(forward_batch, "rids", None)
+    if rids is None:
+        return None
+    return [str(rid) for rid in rids]
 
 
 if envs.SGLANG_ENABLE_TORCH_COMPILE.get():
@@ -123,6 +327,72 @@ if is_flashinfer_available():
 class WrapperDispatch(Enum):
     SLIDING_WINDOW = auto()
     CROSS_ATTENTION = auto()
+
+
+@dataclass(frozen=True)
+class FlashInferWrapperGeometry:
+    num_qo_heads: int
+    num_kv_heads: int
+    head_dim: int
+    head_dim_vo: int
+
+
+def _tp_sharded_kv_heads(total_num_kv_heads: int, tp_size: int) -> int:
+    if total_num_kv_heads >= tp_size:
+        assert total_num_kv_heads % tp_size == 0
+        return total_num_kv_heads // tp_size
+    assert tp_size % total_num_kv_heads == 0
+    return 1
+
+
+def _flashinfer_wrapper_geometries(
+    model_config, dispatch_reason: Optional[WrapperDispatch], num_wrappers: int
+) -> List[FlashInferWrapperGeometry]:
+    tp_size = get_attention_tp_size()
+    hf_config = model_config.hf_config
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    if hf_text_config is None:
+        if hasattr(hf_config, "get_text_config"):
+            hf_text_config = hf_config.get_text_config()
+        else:
+            hf_text_config = getattr(hf_config, "text_config", hf_config)
+
+    num_attention_heads = getattr(
+        hf_text_config, "num_attention_heads", model_config.num_attention_heads
+    )
+    total_num_kv_heads = getattr(hf_text_config, "num_key_value_heads", None)
+    num_kv_heads = (
+        _tp_sharded_kv_heads(total_num_kv_heads, tp_size)
+        if total_num_kv_heads is not None
+        else model_config.get_num_kv_heads(tp_size)
+    )
+    head_dim = getattr(hf_text_config, "head_dim", model_config.head_dim)
+    base = FlashInferWrapperGeometry(
+        num_qo_heads=num_attention_heads // tp_size,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        head_dim_vo=_flashinfer_vo_split_head_dim_vo(head_dim),
+    )
+    if dispatch_reason == WrapperDispatch.SLIDING_WINDOW and num_wrappers == 2:
+        swa_head_dim = getattr(hf_text_config, "swa_head_dim", base.head_dim)
+        swa_total_num_kv_heads = getattr(
+            hf_text_config, "swa_num_key_value_heads", None
+        )
+        swa_num_kv_heads = (
+            _tp_sharded_kv_heads(swa_total_num_kv_heads, tp_size)
+            if swa_total_num_kv_heads is not None
+            else base.num_kv_heads
+        )
+        return [
+            FlashInferWrapperGeometry(
+                num_qo_heads=base.num_qo_heads,
+                num_kv_heads=swa_num_kv_heads,
+                head_dim=swa_head_dim,
+                head_dim_vo=_flashinfer_vo_split_head_dim_vo(swa_head_dim),
+            ),
+            base,
+        ]
+    return [base for _ in range(num_wrappers)]
 
 
 @dataclass
@@ -300,6 +570,18 @@ def _is_nvfp4_native_kv_pool(token_to_kv_pool) -> bool:
     )
 
 
+def _is_fp8_k_nvfp4_v_pool(token_to_kv_pool) -> bool:
+    if isinstance(token_to_kv_pool, MHATokenToKVPoolFP4):
+        return bool(getattr(token_to_kv_pool, "mixed_fp8_k_nvfp4_v", False))
+    return (
+        isinstance(token_to_kv_pool, SWAKVPool)
+        and bool(
+            getattr(token_to_kv_pool.full_kv_pool, "mixed_fp8_k_nvfp4_v", False)
+        )
+        and bool(getattr(token_to_kv_pool.swa_kv_pool, "mixed_fp8_k_nvfp4_v", False))
+    )
+
+
 def _nvfp4_inner_pool_and_layer_id(token_to_kv_pool, layer_id: int):
     if not isinstance(token_to_kv_pool, SWAKVPool):
         return token_to_kv_pool, layer_id
@@ -313,12 +595,296 @@ def _nvfp4_inner_pool_and_layer_id(token_to_kv_pool, layer_id: int):
     )
     return inner_pool, local_layer_id
 
+
 def _shape_nvfp4_kv_scale_for_flashinfer(scale: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
     if scale is None:
         return None
     if scale.dim() == 3:
         return scale.unsqueeze(1)
     return scale
+
+
+def _tensor_trace_summary(x):
+    if isinstance(x, torch.Tensor):
+        return {
+            "shape": tuple(x.shape),
+            "dtype": str(x.dtype),
+            "stride": tuple(x.stride()),
+            "device": str(x.device),
+        }
+    if isinstance(x, (tuple, list)):
+        return tuple(_tensor_trace_summary(item) for item in x)
+    return repr(x)
+
+
+def _scale_trace_value(x):
+    try:
+        if isinstance(x, torch.Tensor):
+            if x.numel() == 1:
+                return float(x.detach().float().cpu().item())
+            return _tensor_trace_summary(x)
+        return float(x)
+    except Exception:
+        return repr(x)
+
+
+def _float_tensor_trace_values(x: torch.Tensor, limit: int = 32):
+    try:
+        flat = x.detach().float().reshape(-1).cpu()
+        values = [float(v) for v in flat[:limit]]
+        return {
+            "count": int(flat.numel()),
+            "values": values,
+            "truncated": int(flat.numel()) > limit,
+            "min": float(flat.min().item()) if flat.numel() else None,
+            "max": float(flat.max().item()) if flat.numel() else None,
+        }
+    except Exception:
+        return repr(x)
+
+
+def _page_view_trace_summary(x):
+    if not isinstance(x, torch.Tensor):
+        return _tensor_trace_summary(x)
+    return {
+        "shape": tuple(x.shape),
+        "dtype": str(x.dtype),
+        "stride": tuple(x.stride()),
+        "device": str(x.device),
+        "storage_offset": x.storage_offset(),
+        "data_ptr": x.data_ptr(),
+    }
+
+
+def _trace_numeric_tensor_stats(x, limit: Optional[int] = None):
+    if not isinstance(x, torch.Tensor):
+        return _tensor_trace_summary(x)
+    if limit is None:
+        limit = _trace_value_limit()
+
+    summary = _tensor_trace_summary(x)
+    try:
+        flat = x.detach().flatten()
+        sample = flat[:limit].to("cpu")
+        summary["sample"] = sample.tolist()
+    except Exception as exc:
+        summary["sample_error"] = repr(exc)
+        flat = None
+
+    try:
+        work = x.detach().float()
+        finite = torch.isfinite(work)
+        summary["finite"] = bool(finite.all().detach().cpu().item())
+        if work.numel() > 0 and bool(finite.any().detach().cpu().item()):
+            finite_values = work[finite]
+            summary["min"] = float(finite_values.min().detach().cpu().item())
+            summary["max"] = float(finite_values.max().detach().cpu().item())
+            summary["mean"] = float(finite_values.mean().detach().cpu().item())
+    except Exception as exc:
+        summary["stats_error"] = repr(exc)
+
+    return summary
+
+
+def _trace_tensor_raw_bytes(x, limit: Optional[int] = None):
+    if not isinstance(x, torch.Tensor):
+        return _tensor_trace_summary(x)
+    if limit is None:
+        limit = _trace_value_limit(16)
+
+    try:
+        byte_view = x.detach().contiguous().view(torch.uint8).flatten()
+        return {
+            "shape": tuple(x.shape),
+            "dtype": str(x.dtype),
+            "stride": tuple(x.stride()),
+            "bytes": byte_view[:limit].to("cpu").tolist(),
+        }
+    except Exception as exc:
+        summary = _tensor_trace_summary(x)
+        summary["bytes_error"] = repr(exc)
+        return summary
+
+
+def _trace_sample_page_bytes(x, page_ids, limit: Optional[int] = None):
+    if not isinstance(x, torch.Tensor):
+        return _tensor_trace_summary(x)
+    if limit is None:
+        limit = _trace_value_limit(16)
+
+    samples = []
+    for page_id in page_ids:
+        try:
+            page = int(page_id)
+        except (TypeError, ValueError):
+            samples.append({"page": repr(page_id), "error": "invalid page id"})
+            continue
+
+        if page < 0 or page >= x.shape[0]:
+            samples.append(
+                {
+                    "page": page,
+                    "error": "page out of range",
+                    "first_dim": int(x.shape[0]),
+                }
+            )
+            continue
+
+        samples.append(
+            {
+                "page": page,
+                "value": _trace_tensor_raw_bytes(x[page], limit=limit),
+            }
+        )
+    return samples
+
+
+def _trace_plan_sample_pages(plan, limit: int = 4):
+    if not isinstance(plan, dict):
+        return []
+    kv_indices = plan.get("kv_indices_used")
+    if not isinstance(kv_indices, dict):
+        return []
+    values = list(kv_indices.get("head") or []) + list(kv_indices.get("tail") or [])
+    pages = []
+    for value in values:
+        try:
+            page = int(value)
+        except (TypeError, ValueError):
+            continue
+        if page not in pages:
+            pages.append(page)
+        if len(pages) >= limit:
+            break
+    return pages
+
+
+def _trace_tensor_key(x):
+    if not isinstance(x, torch.Tensor):
+        return repr(x)
+    return (
+        tuple(x.shape),
+        str(x.dtype),
+        str(x.device),
+        tuple(x.stride()),
+        x.storage_offset(),
+    )
+
+
+def _trace_sample_rows(forward_batch: ForwardBatch, fallback_tokens: int):
+    try:
+        extend_seq_lens_cpu = getattr(forward_batch, "extend_seq_lens_cpu", None)
+        if extend_seq_lens_cpu:
+            rows = []
+            cursor = 0
+            for seq_len in extend_seq_lens_cpu:
+                cursor += int(seq_len)
+                rows.append(cursor - 1)
+            return rows
+    except Exception:
+        pass
+    if fallback_tokens <= 0:
+        return []
+    return [fallback_tokens - 1]
+
+
+def _trace_tensor_rows(x, rows, limit: Optional[int] = None):
+    if not isinstance(x, torch.Tensor):
+        return _tensor_trace_summary(x)
+    if limit is None:
+        limit = _trace_value_limit()
+    samples = []
+    for row in rows:
+        try:
+            row_id = int(row)
+        except (TypeError, ValueError):
+            samples.append({"row": repr(row), "error": "invalid row"})
+            continue
+        if row_id < 0 or row_id >= x.shape[0]:
+            samples.append(
+                {
+                    "row": row_id,
+                    "error": "row out of range",
+                    "first_dim": int(x.shape[0]),
+                }
+            )
+            continue
+        samples.append({"row": row_id, "value": _trace_numeric_tensor_stats(x[row_id], limit)})
+    return {
+        "tensor": _tensor_trace_summary(x),
+        "rows": samples,
+    }
+
+
+def _trace_nvfp4_write_samples(token_to_kv_pool, layer_id: int, page_ids):
+    try:
+        kv_pool, local_layer_id = _nvfp4_inner_pool_and_layer_id(
+            token_to_kv_pool, layer_id
+        )
+        getter = getattr(kv_pool, "get_fp4_kv_write_trace_samples", None)
+        if getter is None:
+            return None
+        return getter(local_layer_id, page_ids)
+    except Exception as exc:
+        return {"error": repr(exc)}
+
+
+def _trace_compare_tensors(a: torch.Tensor, b: torch.Tensor):
+    if not isinstance(a, torch.Tensor) or not isinstance(b, torch.Tensor):
+        return {
+            "a": _tensor_trace_summary(a),
+            "b": _tensor_trace_summary(b),
+            "error": "non-tensor input",
+        }
+    summary = {
+        "a": _tensor_trace_summary(a),
+        "b": _tensor_trace_summary(b),
+        "shape_match": tuple(a.shape) == tuple(b.shape),
+    }
+    if tuple(a.shape) != tuple(b.shape):
+        return summary
+    try:
+        af = a.detach().float()
+        bf = b.detach().float()
+        diff = af - bf
+        finite = torch.isfinite(af) & torch.isfinite(bf)
+        summary["finite_pair"] = bool(finite.all().detach().cpu().item())
+        if diff.numel() > 0:
+            summary["max_abs"] = float(diff.abs().max().detach().cpu().item())
+            summary["rms"] = float(
+                torch.sqrt(torch.mean(diff * diff)).detach().cpu().item()
+            )
+            summary["cosine"] = float(
+                torch.nn.functional.cosine_similarity(
+                    af.flatten(), bf.flatten(), dim=0, eps=1e-12
+                )
+                .detach()
+                .cpu()
+                .item()
+            )
+    except Exception as exc:
+        summary["compare_error"] = repr(exc)
+    return summary
+
+
+def _trace_select_lse_slice(s: torch.Tensor, qo_start: int, qo_end: int, q_len: int):
+    if not isinstance(s, torch.Tensor):
+        return None
+    if s.dim() < 2:
+        return None
+    try:
+        if s.shape[0] >= qo_end:
+            return s[qo_start:qo_end]
+        if s.shape[-1] >= qo_end:
+            moved = s.transpose(0, -1)
+            return moved[qo_start:qo_end]
+        if s.shape[0] == q_len:
+            return s
+        if s.shape[-1] == q_len:
+            return s.transpose(0, -1)
+    except Exception:
+        return None
+    return None
 
 
 class FlashInferAttnBackend(AttentionBackend):
@@ -346,6 +912,10 @@ class FlashInferAttnBackend(AttentionBackend):
         self.is_nvfp4_native = _is_nvfp4_native_kv_pool(
             self.token_to_kv_pool
         ) and is_sm120_supported()
+        self.is_fp8_k_nvfp4_v = self.is_nvfp4_native and _is_fp8_k_nvfp4_v_pool(
+            self.token_to_kv_pool
+        )
+        self.enable_vo_split = _flashinfer_vo_split_enabled()
 
         # FIXME: remove dllm workarounds from flashinfer
         self.dllm_config = DllmConfig.from_server_args(model_runner.server_args)
@@ -362,6 +932,17 @@ class FlashInferAttnBackend(AttentionBackend):
         )
         if self.is_nvfp4_native:
             self.decode_use_tensor_cores = True
+        if self.is_fp8_k_nvfp4_v:
+            logger.warning(
+                "SGLang FP4 KV mixed mode enabled: K cache uses FP8 e4m3, "
+                "V cache uses packed NVFP4. Capacity claims must use the "
+                "mixed-KV denominator, not full NVFP4 K+V."
+            )
+        if self.enable_vo_split:
+            logger.warning(
+                "SGLang FlashInfer VO split enabled: D=512 paged prefill "
+                "and decode-as-prefill use two D_VO=256 passes."
+            )
         self.max_context_len = model_runner.model_config.context_len
         self.skip_prefill = skip_prefill
         self.is_multimodal = model_runner.model_config.is_multimodal
@@ -502,6 +1083,17 @@ class FlashInferAttnBackend(AttentionBackend):
                 )
             )
 
+        self._geometry_trace_seen = set()
+        self.wrapper_geometries = _flashinfer_wrapper_geometries(
+            model_runner.model_config, self.dispatch_reason, self.num_wrappers
+        )
+        if _gemma4_geometry_trace_enabled():
+            logger.warning(
+                "SGLang FlashInfer wrapper geometries dispatch=%s geometries=%s",
+                self.dispatch_reason,
+                self.wrapper_geometries,
+            )
+
         # Create indices updater
         if not skip_prefill:
             self.indices_updater_prefill = FlashInferIndicesUpdaterPrefill(
@@ -515,27 +1107,1213 @@ class FlashInferAttnBackend(AttentionBackend):
         self.decode_cuda_graph_metadata = {}
         self.prefill_cuda_graph_metadata = {}  # For verify
         self.draft_extend_cuda_graph_metadata = {}  # For draft extend
+        self._nvfp4_trace_seen = set()
+        self._nvfp4_batch_trace_seen = set()
+        self._nvfp4_page_pair_trace_seen = set()
+        self._nvfp4_merge_state_trace_seen = set()
+        self._nvfp4_prefix_ref_trace_seen = set()
+        self._nvfp4_dense_cache_trace_seen = set()
+        self._nvfp4_module_trace_seen = set()
+        self._nvfp4_last_paged_plan = {}
+        self._nvfp4_last_paged_plan_tensors = {}
+        self._nvfp4_dense_reference_by_layer = {}
 
-    @staticmethod
-    def _resolve_swa_kv_pool(model_runner: ModelRunner) -> Optional[BaseSWAKVPool]:
-        """Return the SWA KV pool to translate against, or None for non-SWA models.
+    def _trace_gemma4_geometry_dispatch(
+        self,
+        *,
+        label: Optional[str],
+        layer: Optional[RadixAttention],
+        paged_kv_cache=None,
+        paged_kv_kwargs=None,
+        wrapper=None,
+        vo_split: bool = False,
+    ) -> None:
+        if (
+            not _gemma4_geometry_trace_enabled()
+            or layer is None
+            or label is None
+        ):
+            return
+        layer_id = getattr(layer, "layer_id", None)
+        key = (label, int(layer_id) if layer_id is not None else None)
+        if key in self._geometry_trace_seen:
+            return
+        self._geometry_trace_seen.add(key)
+        k_sf = v_sf = None
+        if isinstance(paged_kv_kwargs, dict):
+            k_sf, v_sf = paged_kv_kwargs.get("kv_cache_sf", (None, None))
+        wrapper_id = self._get_wrapper_idx(layer)
+        planned = (
+            self.wrapper_geometries[wrapper_id]
+            if 0 <= wrapper_id < len(self.wrapper_geometries)
+            else None
+        )
+        logger.warning(
+            "SGLang Gemma4 FlashInfer geometry label=%s layer=%s "
+            "wrapper_id=%s planned=%s layer_q_heads=%s layer_k_heads=%s "
+            "layer_v_heads=%s layer_head_dim=%s sliding_window=%s "
+            "vo_split=%s wrapper=%s kv_cache=%s k_sf=%s v_sf=%s",
+            label,
+            layer_id,
+            wrapper_id,
+            planned,
+            getattr(layer, "tp_q_head_num", None),
+            getattr(layer, "tp_k_head_num", None),
+            getattr(layer, "tp_v_head_num", None),
+            getattr(layer, "head_dim", None),
+            getattr(layer, "sliding_window_size", None),
+            vo_split,
+            _flashinfer_wrapper_trace_summary(wrapper),
+            _tensor_trace_summary(paged_kv_cache),
+            _tensor_trace_summary(k_sf),
+            _tensor_trace_summary(v_sf),
+        )
 
-        EAGLE-like draft workers share the target allocator for token bookkeeping,
-        but own a separate draft KV pool. Do not use the target allocator's SWA
-        mapping for that draft pool. FROZEN_KV MTP is the exception: its draft
-        path reads target KV directly, so it still needs the allocator pool when
-        the active pool is not SWA.
-        """
-        active_pool = model_runner.token_to_kv_pool
-        if isinstance(active_pool, BaseSWAKVPool):
-            return active_pool
+    def _trace_nvfp4_native_call(
+        self,
+        *,
+        label: str,
+        layer: RadixAttention,
+        q: torch.Tensor,
+        paged_kv_cache,
+        paged_kv_kwargs,
+    ):
+        if not self.is_nvfp4_native or os.environ.get("SGLANG_FP4_KV_TRACE_BACKEND") != "1":
+            return
+        key = (label, int(layer.layer_id))
+        if key in self._nvfp4_trace_seen:
+            return
+        self._nvfp4_trace_seen.add(key)
 
-        if model_runner.is_draft_worker:
-            if not model_runner.spec_algorithm.is_frozen_kv_mtp():
-                return None
+        metadata = self.forward_metadata
+        metadata_summary = {
+            "type": type(metadata).__name__ if metadata is not None else None,
+            "use_ragged": getattr(metadata, "use_ragged", None),
+            "extend_no_prefix": getattr(metadata, "extend_no_prefix", None),
+        }
+        k_sf, v_sf = paged_kv_kwargs.get("kv_cache_sf", (None, None))
+        logger.warning(
+            "NVFP4 KV backend trace label=%s layer=%s wrapper_idx=%s "
+            "metadata=%s q=%s kv_cache=%s k_sf=%s v_sf=%s "
+            "k_scale=%s v_scale=%s",
+            label,
+            layer.layer_id,
+            self._get_wrapper_idx(layer),
+            metadata_summary,
+            _tensor_trace_summary(q),
+            _tensor_trace_summary(paged_kv_cache),
+            _tensor_trace_summary(k_sf),
+            _tensor_trace_summary(v_sf),
+            _scale_trace_value(paged_kv_kwargs.get("k_scale")),
+            _scale_trace_value(paged_kv_kwargs.get("v_scale")),
+        )
 
-        kvcache = model_runner.token_to_kv_pool_allocator.get_kvcache()
-        return kvcache if isinstance(kvcache, BaseSWAKVPool) else None
+    def _trace_nvfp4_forward_batch(
+        self,
+        *,
+        label: str,
+        forward_batch: ForwardBatch,
+        use_ragged: Optional[bool],
+        extend_no_prefix: Optional[bool],
+    ):
+        if not self.is_nvfp4_native or not _fp4_kv_radix_trace_enabled():
+            return
+
+        rids = _trace_rids(forward_batch)
+        rid_filter = os.environ.get("SGLANG_FP4_KV_TRACE_RID")
+        if rid_filter not in (None, "") and (rids is None or rid_filter not in rids):
+            return
+
+        extend_prefix_lens_cpu = _trace_cpu_values(
+            getattr(forward_batch, "extend_prefix_lens_cpu", None)
+        )
+        seq_lens_cpu = _trace_cpu_values(getattr(forward_batch, "seq_lens_cpu", None))
+        key = (
+            label,
+            tuple(rids or ()),
+            tuple(extend_prefix_lens_cpu or ()),
+            tuple(seq_lens_cpu or ()),
+            bool(use_ragged),
+            bool(extend_no_prefix),
+        )
+        if key in self._nvfp4_batch_trace_seen:
+            return
+        self._nvfp4_batch_trace_seen.add(key)
+
+        logger.warning(
+            "FP4 KV FlashInfer batch trace label=%s rids=%s mode=%s "
+            "seq_lens_cpu=%s extend_prefix_lens_cpu=%s use_ragged=%s "
+            "extend_no_prefix=%s req_pool_indices=%s out_cache_loc=%s",
+            label,
+            rids,
+            getattr(forward_batch, "forward_mode", None),
+            seq_lens_cpu,
+            extend_prefix_lens_cpu,
+            use_ragged,
+            extend_no_prefix,
+            _tensor_trace_summary(getattr(forward_batch, "req_pool_indices", None)),
+            _tensor_trace_summary(getattr(forward_batch, "out_cache_loc", None)),
+        )
+
+    def _capture_nvfp4_paged_plan(
+        self,
+        *,
+        label: str,
+        wrapper_id: int,
+        req_pool_indices: torch.Tensor,
+        paged_kernel_lens: torch.Tensor,
+        prefix_lens: torch.Tensor,
+        seq_lens: torch.Tensor,
+        kv_start_idx: Optional[torch.Tensor],
+        qo_indptr: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        kv_indices: torch.Tensor,
+        use_ragged: bool,
+    ):
+        if not self.is_nvfp4_native:
+            return
+        if (
+            not _fp4_kv_page_pair_trace_enabled()
+            and not _fp4_kv_prefix_ref_trace_enabled()
+        ):
+            return
+
+        try:
+            used = int(kv_indptr[-1].detach().to("cpu").item())
+        except Exception:
+            used = 0
+        kv_indices_used = kv_indices[:used]
+        tensor_plan = None
+        if _fp4_kv_prefix_ref_trace_enabled():
+            try:
+                tensor_plan = {
+                    "label": label,
+                    "wrapper_id": int(wrapper_id),
+                    "qo_indptr": qo_indptr.detach().clone(),
+                    "kv_indptr": kv_indptr.detach().clone(),
+                    "kv_indices": kv_indices_used.detach().clone(),
+                    "prefix_lens": prefix_lens.detach().clone(),
+                    "seq_lens": seq_lens.detach().clone(),
+                }
+            except Exception as exc:
+                tensor_plan = {"error": repr(exc)}
+            self._nvfp4_last_paged_plan_tensors[int(wrapper_id)] = tensor_plan
+
+        plan = {
+            "label": label,
+            "wrapper_id": int(wrapper_id),
+            "use_ragged": bool(use_ragged),
+            "req_pool_indices": _trace_tensor_values(req_pool_indices),
+            "paged_kernel_lens": _trace_tensor_values(paged_kernel_lens),
+            "prefix_lens": _trace_tensor_values(prefix_lens),
+            "seq_lens": _trace_tensor_values(seq_lens),
+            "kv_start_idx": _trace_tensor_values(kv_start_idx),
+            "kv_indptr": _trace_tensor_values(kv_indptr),
+            "kv_indices_used": _trace_tensor_values(kv_indices_used),
+        }
+        self._nvfp4_last_paged_plan[int(wrapper_id)] = plan
+
+        if not _fp4_kv_page_pair_trace_enabled():
+            return
+
+        key = (
+            label,
+            int(wrapper_id),
+            tuple(plan["kv_indptr"]["head"] if plan["kv_indptr"] else ()),
+            tuple(plan["kv_indices_used"]["head"] if plan["kv_indices_used"] else ()),
+            tuple(plan["kv_indices_used"]["tail"] if plan["kv_indices_used"] else ()),
+        )
+        if key in self._nvfp4_page_pair_trace_seen:
+            return
+        self._nvfp4_page_pair_trace_seen.add(key)
+        logger.warning("FP4 KV paged plan trace %s", plan)
+
+    def _trace_nvfp4_page_pair(
+        self,
+        *,
+        label: str,
+        layer: RadixAttention,
+        paged_kv_cache,
+        paged_kv_kwargs,
+    ):
+        if not self.is_nvfp4_native or not _fp4_kv_page_pair_trace_enabled():
+            return
+
+        wrapper_id = int(self._get_wrapper_idx(layer))
+        plan = self._nvfp4_last_paged_plan.get(wrapper_id)
+        k_cache, v_cache = paged_kv_cache
+        k_sf, v_sf = paged_kv_kwargs.get("kv_cache_sf", (None, None))
+        first_dims = [
+            tensor.shape[0] if isinstance(tensor, torch.Tensor) else None
+            for tensor in (k_cache, v_cache, k_sf, v_sf)
+        ]
+        summary = {
+            "label": label,
+            "layer": int(layer.layer_id),
+            "wrapper_id": wrapper_id,
+            "plan": plan,
+            "k_cache": _page_view_trace_summary(k_cache),
+            "v_cache": _page_view_trace_summary(v_cache),
+            "k_sf": _page_view_trace_summary(k_sf),
+            "v_sf": _page_view_trace_summary(v_sf),
+            "first_dims": first_dims,
+            "first_dim_match": len(set(first_dims)) == 1,
+            "k_scale": _scale_trace_value(paged_kv_kwargs.get("k_scale")),
+            "v_scale": _scale_trace_value(paged_kv_kwargs.get("v_scale")),
+        }
+        key = (label, int(layer.layer_id), wrapper_id, repr(plan))
+        if key in self._nvfp4_page_pair_trace_seen:
+            return
+        self._nvfp4_page_pair_trace_seen.add(key)
+        logger.warning("FP4 KV page-pair trace %s", summary)
+
+    def _trace_nvfp4_merge_state(
+        self,
+        *,
+        label: str,
+        layer: RadixAttention,
+        paged_kv_cache,
+        paged_kv_kwargs,
+        o1: torch.Tensor,
+        s1: torch.Tensor,
+        o2: torch.Tensor,
+        s2: torch.Tensor,
+        merged: Optional[torch.Tensor],
+        swa_window_left: Optional[int],
+    ):
+        if (
+            not self.is_nvfp4_native
+            or not _fp4_kv_merge_state_trace_enabled()
+            or not _trace_layer_enabled(int(layer.layer_id))
+        ):
+            return
+
+        wrapper_id = int(self._get_wrapper_idx(layer))
+        plan = self._nvfp4_last_paged_plan.get(wrapper_id)
+        page_ids = _trace_plan_sample_pages(plan)
+        key = (
+            label,
+            int(layer.layer_id),
+            wrapper_id,
+            tuple(page_ids),
+            _trace_tensor_key(o1),
+            _trace_tensor_key(o2),
+        )
+        if key in self._nvfp4_merge_state_trace_seen:
+            return
+        self._nvfp4_merge_state_trace_seen.add(key)
+
+        k_cache, v_cache = paged_kv_cache
+        k_sf, v_sf = paged_kv_kwargs.get("kv_cache_sf", (None, None))
+        summary = {
+            "label": label,
+            "layer": int(layer.layer_id),
+            "wrapper_id": wrapper_id,
+            "swa_window_left": swa_window_left,
+            "plan": plan,
+            "sample_page_ids": page_ids,
+            "page_bytes": {
+                "k_cache": _trace_sample_page_bytes(k_cache, page_ids),
+                "v_cache": _trace_sample_page_bytes(v_cache, page_ids),
+                "k_sf": _trace_sample_page_bytes(k_sf, page_ids),
+                "v_sf": _trace_sample_page_bytes(v_sf, page_ids),
+            },
+            "write_trace": _trace_nvfp4_write_samples(
+                self.token_to_kv_pool, int(layer.layer_id), page_ids
+            ),
+            "k_scale": _scale_trace_value(paged_kv_kwargs.get("k_scale")),
+            "v_scale": _scale_trace_value(paged_kv_kwargs.get("v_scale")),
+            "merge_inputs": {
+                "o1_ragged": _trace_numeric_tensor_stats(o1),
+                "s1_ragged": _trace_numeric_tensor_stats(s1),
+                "o2_paged": _trace_numeric_tensor_stats(o2),
+                "s2_paged": _trace_numeric_tensor_stats(s2),
+            },
+            "merged": _trace_numeric_tensor_stats(merged),
+        }
+        logger.warning("FP4 KV merge-state trace %s", summary)
+
+    def _trace_nvfp4_dense_cache_state(
+        self,
+        *,
+        label: str,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        q: Optional[torch.Tensor] = None,
+        o: Optional[torch.Tensor] = None,
+        o1: Optional[torch.Tensor] = None,
+        s1: Optional[torch.Tensor] = None,
+        o2: Optional[torch.Tensor] = None,
+        s2: Optional[torch.Tensor] = None,
+        merged: Optional[torch.Tensor] = None,
+        paged_kv_kwargs: Optional[dict] = None,
+    ):
+        if (
+            not self.is_nvfp4_native
+            or not _fp4_kv_dense_cache_trace_enabled()
+            or not _trace_layer_enabled(int(layer.layer_id))
+        ):
+            return
+
+        rids = _trace_rids(forward_batch)
+        rid_filter = os.environ.get("SGLANG_FP4_KV_TRACE_RID")
+        if rid_filter not in (None, "") and (rids is None or rid_filter not in rids):
+            return
+
+        extend_prefix_lens_cpu = _trace_cpu_values(
+            getattr(forward_batch, "extend_prefix_lens_cpu", None)
+        )
+        extend_seq_lens_cpu = _trace_cpu_values(
+            getattr(forward_batch, "extend_seq_lens_cpu", None)
+        )
+        seq_lens_cpu = _trace_cpu_values(getattr(forward_batch, "seq_lens_cpu", None))
+        row_source = o if isinstance(o, torch.Tensor) else merged
+        if not isinstance(row_source, torch.Tensor):
+            row_source = o1 if isinstance(o1, torch.Tensor) else q
+        sample_rows = _trace_sample_rows(
+            forward_batch,
+            int(row_source.shape[0]) if isinstance(row_source, torch.Tensor) else 0,
+        )
+        key = (
+            label,
+            int(layer.layer_id),
+            tuple(rids or ()),
+            tuple(extend_prefix_lens_cpu or ()),
+            tuple(extend_seq_lens_cpu or ()),
+            tuple(sample_rows),
+            _trace_tensor_key(row_source),
+        )
+        if key in self._nvfp4_dense_cache_trace_seen:
+            return
+        self._nvfp4_dense_cache_trace_seen.add(key)
+
+        wrapper_id = int(self._get_wrapper_idx(layer))
+        summary = {
+            "kind": "attention",
+            "label": label,
+            "layer": int(layer.layer_id),
+            "forward_pass_id": getattr(forward_batch, "forward_pass_id", None),
+            "wrapper_id": wrapper_id,
+            "rids": rids,
+            "mode": repr(getattr(forward_batch, "forward_mode", None)),
+            "seq_lens_cpu": seq_lens_cpu,
+            "extend_prefix_lens_cpu": extend_prefix_lens_cpu,
+            "extend_seq_lens_cpu": extend_seq_lens_cpu,
+            "sample_rows": sample_rows,
+            "req_pool_indices": _trace_tensor_values(
+                getattr(forward_batch, "req_pool_indices", None)
+            ),
+            "out_cache_loc": _trace_tensor_values(
+                getattr(forward_batch, "out_cache_loc", None)
+            ),
+            "q_rows": _trace_tensor_rows(q, sample_rows) if q is not None else None,
+            "o_rows": _trace_tensor_rows(o, sample_rows) if o is not None else None,
+            "o1_rows": _trace_tensor_rows(o1, sample_rows) if o1 is not None else None,
+            "s1_rows": _trace_tensor_rows(s1, sample_rows) if s1 is not None else None,
+            "o2_rows": _trace_tensor_rows(o2, sample_rows) if o2 is not None else None,
+            "s2_rows": _trace_tensor_rows(s2, sample_rows) if s2 is not None else None,
+            "merged_rows": (
+                _trace_tensor_rows(merged, sample_rows) if merged is not None else None
+            ),
+        }
+        if paged_kv_kwargs is not None:
+            summary["k_scale"] = _scale_trace_value(paged_kv_kwargs.get("k_scale"))
+            summary["v_scale"] = _scale_trace_value(paged_kv_kwargs.get("v_scale"))
+        logger.warning("FP4 KV dense-cache attention trace %s", summary)
+
+    def _trace_nvfp4_dense_quant_attention_loss(
+        self,
+        *,
+        label: str,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        o: torch.Tensor,
+        sm_scale: float,
+        logits_soft_cap: Optional[float],
+    ):
+        if (
+            not self.is_nvfp4_native
+            or not _fp4_kv_dense_quant_attention_trace_enabled()
+            or not _trace_layer_enabled(int(layer.layer_id))
+        ):
+            return
+        try:
+            from sglang.srt.layers.quantization.kvfp4_tensor import (
+                E2M1_MAX,
+                MAX_BLOCK_SCALE_FP8,
+                NVFP4KVQuantizeUtil,
+            )
+
+            k_global, v_global = self.token_to_kv_pool._get_kv_global_scale_tensor(
+                layer.layer_id
+            )
+            q3 = q.view(-1, layer.tp_q_head_num, layer.head_dim).contiguous()
+            k3 = k.view(-1, layer.tp_k_head_num, layer.head_dim).contiguous()
+            v3 = v.view(-1, layer.tp_v_head_num, layer.head_dim).contiguous()
+            o3 = o.view(-1, layer.tp_q_head_num, layer.head_dim).contiguous()
+            if label == "forward_extend_ragged_no_prefix":
+                self._nvfp4_dense_reference_by_layer[int(layer.layer_id)] = {
+                    "q": q3.detach(),
+                    "k": k3.detach(),
+                    "v": v3.detach(),
+                    "o": o3.detach(),
+                    "rids": _trace_rids(forward_batch),
+                    "seq_lens_cpu": _trace_cpu_values(
+                        getattr(forward_batch, "seq_lens_cpu", None)
+                    ),
+                    "extend_seq_lens_cpu": _trace_cpu_values(
+                        getattr(forward_batch, "extend_seq_lens_cpu", None)
+                    ),
+                    "forward_pass_id": getattr(forward_batch, "forward_pass_id", None),
+                }
+
+            k_fp4, k_sf, _ = NVFP4KVQuantizeUtil.quantize(k3, k_global)
+            v_fp4, v_sf, _ = NVFP4KVQuantizeUtil.quantize(v3, v_global)
+            k_deq = NVFP4KVQuantizeUtil.dequantize(
+                k_fp4.view(torch.uint8),
+                k_sf.reshape(k3.shape[0], -1),
+                k_global,
+                dtype=k3.dtype,
+            ).view_as(k3)
+            v_deq = NVFP4KVQuantizeUtil.dequantize(
+                v_fp4.view(torch.uint8),
+                v_sf.reshape(v3.shape[0], -1),
+                v_global,
+                dtype=v3.dtype,
+            ).view_as(v3)
+            k_scale_multiplier_refs = []
+            for multiplier in _trace_k_scale_multipliers():
+                alt_k_global = (k_global.float() * multiplier).contiguous()
+                alt_k_fp4, alt_k_sf, _ = NVFP4KVQuantizeUtil.quantize(
+                    k3, alt_k_global
+                )
+                alt_k_deq = NVFP4KVQuantizeUtil.dequantize(
+                    alt_k_fp4.view(torch.uint8),
+                    alt_k_sf.reshape(k3.shape[0], -1),
+                    alt_k_global,
+                    dtype=k3.dtype,
+                ).view_as(k3)
+                k_scale_multiplier_refs.append(
+                    {
+                        "multiplier": multiplier,
+                        "k_global": _scale_trace_value(alt_k_global),
+                        "k_deq": alt_k_deq,
+                    }
+                )
+            k_head_scale_policy_refs = []
+            if _trace_k_head_scale_policy_enabled():
+                denom = E2M1_MAX * MAX_BLOCK_SCALE_FP8
+                head_amax = k3.detach().abs().amax(dim=(0, 2)).float()
+                base_k_global = k_global.float().reshape(1).contiguous()
+                head_multipliers = _trace_k_scale_multipliers() or [1.0]
+                for multiplier in head_multipliers[:16]:
+                    head_globals = (head_amax / denom * multiplier).clamp(min=1e-8)
+                    head_chunks = []
+                    ratio_values = []
+                    sf_before_values = []
+                    sf_after_values = []
+                    for head_id in range(k3.shape[1]):
+                        head_global = head_globals[head_id : head_id + 1].contiguous()
+                        head_fp4, head_sf, _ = NVFP4KVQuantizeUtil.quantize(
+                            k3[:, head_id : head_id + 1, :].contiguous(),
+                            head_global,
+                        )
+                        # FlashInfer's paged attention receives a single global scale.
+                        # This simulates carrying per-head effective globals by folding
+                        # the ratio into the stored FP8 block-scale buffer.
+                        ratio = (head_global / base_k_global).contiguous()
+                        head_sf_for_base = (head_sf.float() * ratio).to(
+                            torch.float8_e4m3fn
+                        )
+                        head_deq = NVFP4KVQuantizeUtil.dequantize(
+                            head_fp4.view(torch.uint8),
+                            head_sf_for_base.reshape(k3.shape[0], -1),
+                            base_k_global,
+                            dtype=k3.dtype,
+                        ).view(k3.shape[0], 1, k3.shape[2])
+                        head_chunks.append(head_deq)
+                        ratio_values.append(ratio.reshape(()))
+                        sf_before_values.append(head_sf.float().reshape(-1))
+                        sf_after_values.append(head_sf_for_base.float().reshape(-1))
+                    k_head_scale_policy_refs.append(
+                        {
+                            "policy": "per_kv_head_amax_folded_sf",
+                            "multiplier": multiplier,
+                            "k_globals": _float_tensor_trace_values(head_globals),
+                            "global_to_base_ratios": _float_tensor_trace_values(
+                                torch.stack(ratio_values)
+                            ),
+                            "sf_before": _float_tensor_trace_values(
+                                torch.cat(sf_before_values)
+                            ),
+                            "sf_after": _float_tensor_trace_values(
+                                torch.cat(sf_after_values)
+                            ),
+                            "k_deq": torch.cat(head_chunks, dim=1),
+                        }
+                    )
+
+            sample_rows = _trace_sample_rows(forward_batch, int(o3.shape[0]))
+            head_repeat = layer.tp_q_head_num // layer.tp_k_head_num
+            if head_repeat <= 0 or layer.tp_q_head_num % layer.tp_k_head_num != 0:
+                raise RuntimeError(
+                    f"unsupported GQA mapping: q_heads={layer.tp_q_head_num}, "
+                    f"kv_heads={layer.tp_k_head_num}"
+                )
+
+            def attention_ref(kv_k: torch.Tensor, kv_v: torch.Tensor, row_id: int):
+                q_row = q3[row_id].float()
+                k_prefix = kv_k[: row_id + 1].float()
+                v_prefix = kv_v[: row_id + 1].float()
+                k_rep = k_prefix.repeat_interleave(head_repeat, dim=1)
+                v_rep = v_prefix.repeat_interleave(head_repeat, dim=1)
+                scores = torch.einsum("hd,thd->ht", q_row, k_rep) * sm_scale
+                if logits_soft_cap is not None and float(logits_soft_cap) > 0:
+                    scores = float(logits_soft_cap) * torch.tanh(
+                        scores / float(logits_soft_cap)
+                    )
+                probs = torch.softmax(scores, dim=-1)
+                return torch.einsum("ht,thd->hd", probs, v_rep).to(o3.dtype)
+
+            rows = []
+            for row in sample_rows:
+                row_id = int(row)
+                if row_id < 0 or row_id >= o3.shape[0]:
+                    continue
+                bf16_ref = attention_ref(k3, v3, row_id)
+                fp4_ref = attention_ref(k_deq, v_deq, row_id)
+                fp4_k_ref = attention_ref(k_deq, v3, row_id)
+                fp4_v_ref = attention_ref(k3, v_deq, row_id)
+                multiplier_rows = []
+                for alt in k_scale_multiplier_refs:
+                    alt_k_deq = alt["k_deq"]
+                    alt_fp4_ref = attention_ref(alt_k_deq, v_deq, row_id)
+                    alt_fp4_k_ref = attention_ref(alt_k_deq, v3, row_id)
+                    multiplier_rows.append(
+                        {
+                            "multiplier": alt["multiplier"],
+                            "k_global": alt["k_global"],
+                            "k_dequant_prefix_vs_bf16_prefix": (
+                                _trace_compare_tensors(
+                                    alt_k_deq[: row_id + 1],
+                                    k3[: row_id + 1],
+                                )
+                            ),
+                            "fp4_ref_vs_bf16_ref": _trace_compare_tensors(
+                                alt_fp4_ref, bf16_ref
+                            ),
+                            "fp4_k_only_ref_vs_bf16_ref": (
+                                _trace_compare_tensors(alt_fp4_k_ref, bf16_ref)
+                            ),
+                        }
+                    )
+                head_policy_rows = []
+                for policy in k_head_scale_policy_refs:
+                    policy_k_deq = policy["k_deq"]
+                    policy_fp4_ref = attention_ref(policy_k_deq, v_deq, row_id)
+                    policy_fp4_k_ref = attention_ref(policy_k_deq, v3, row_id)
+                    head_policy_rows.append(
+                        {
+                            "policy": policy["policy"],
+                            "multiplier": policy["multiplier"],
+                            "k_globals": policy["k_globals"],
+                            "global_to_base_ratios": policy["global_to_base_ratios"],
+                            "sf_before": policy["sf_before"],
+                            "sf_after": policy["sf_after"],
+                            "k_dequant_prefix_vs_bf16_prefix": (
+                                _trace_compare_tensors(
+                                    policy_k_deq[: row_id + 1],
+                                    k3[: row_id + 1],
+                                )
+                            ),
+                            "fp4_ref_vs_bf16_ref": _trace_compare_tensors(
+                                policy_fp4_ref, bf16_ref
+                            ),
+                            "fp4_k_only_ref_vs_bf16_ref": (
+                                _trace_compare_tensors(policy_fp4_k_ref, bf16_ref)
+                            ),
+                        }
+                    )
+                actual = o3[row_id]
+                row_record = {
+                    "row": row_id,
+                    "actual_vs_bf16_ref": _trace_compare_tensors(
+                        actual, bf16_ref
+                    ),
+                    "actual_vs_fp4_ref": _trace_compare_tensors(actual, fp4_ref),
+                    "fp4_ref_vs_bf16_ref": _trace_compare_tensors(
+                        fp4_ref, bf16_ref
+                    ),
+                    "fp4_k_only_ref_vs_bf16_ref": _trace_compare_tensors(
+                        fp4_k_ref, bf16_ref
+                    ),
+                    "fp4_v_only_ref_vs_bf16_ref": _trace_compare_tensors(
+                        fp4_v_ref, bf16_ref
+                    ),
+                    "actual": _trace_numeric_tensor_stats(actual),
+                    "bf16_ref": _trace_numeric_tensor_stats(bf16_ref),
+                    "fp4_ref": _trace_numeric_tensor_stats(fp4_ref),
+                    "fp4_k_only_ref": _trace_numeric_tensor_stats(fp4_k_ref),
+                    "fp4_v_only_ref": _trace_numeric_tensor_stats(fp4_v_ref),
+                }
+                if multiplier_rows:
+                    row_record["k_scale_multiplier_refs"] = multiplier_rows
+                if head_policy_rows:
+                    row_record["k_head_scale_policy_refs"] = head_policy_rows
+                rows.append(row_record)
+
+            if rows:
+                logger.warning(
+                    "FP4 KV dense-quant attention trace %s",
+                    {
+                        "kind": "dense_quant_attention",
+                        "label": label,
+                        "layer": int(layer.layer_id),
+                        "forward_pass_id": getattr(
+                            forward_batch, "forward_pass_id", None
+                        ),
+                        "rids": _trace_rids(forward_batch),
+                        "mode": repr(getattr(forward_batch, "forward_mode", None)),
+                        "sample_rows": sample_rows,
+                        "k_global": _scale_trace_value(k_global),
+                        "v_global": _scale_trace_value(v_global),
+                        "logits_soft_cap": (
+                            None if logits_soft_cap is None else float(logits_soft_cap)
+                        ),
+                        "rows": rows,
+                    },
+                )
+        except Exception as exc:
+            logger.warning(
+                "FP4 KV dense-quant attention trace failed layer=%s error=%r",
+                int(layer.layer_id),
+                exc,
+            )
+
+    def _trace_nvfp4_prefix_reference(
+        self,
+        *,
+        label: str,
+        layer: RadixAttention,
+        q: torch.Tensor,
+        suffix_k: torch.Tensor,
+        suffix_v: torch.Tensor,
+        paged_kv_cache,
+        paged_kv_kwargs,
+        o1: torch.Tensor,
+        s1: torch.Tensor,
+        o2: torch.Tensor,
+        s2: torch.Tensor,
+        merged: torch.Tensor,
+        swa_window_left: Optional[int],
+        sm_scale: float,
+        logits_soft_cap: Optional[float],
+    ):
+        if (
+            not self.is_nvfp4_native
+            or not _fp4_kv_prefix_ref_trace_enabled()
+            or not _trace_layer_enabled(int(layer.layer_id))
+        ):
+            return
+
+        wrapper_id = int(self._get_wrapper_idx(layer))
+        plan = self._nvfp4_last_paged_plan_tensors.get(wrapper_id)
+        key = (label, int(layer.layer_id), wrapper_id, _trace_tensor_key(q))
+        if key in self._nvfp4_prefix_ref_trace_seen:
+            return
+        self._nvfp4_prefix_ref_trace_seen.add(key)
+
+        summary = {
+            "label": label,
+            "layer": int(layer.layer_id),
+            "wrapper_id": wrapper_id,
+            "swa_window_left": swa_window_left,
+            "plan_error": None,
+        }
+        try:
+            if not isinstance(plan, dict) or "error" in plan:
+                summary["plan_error"] = plan
+                logger.warning("FP4 KV prefix-reference trace %s", summary)
+                return
+
+            qo_indptr = plan["qo_indptr"].to(device=q.device, dtype=torch.long)
+            kv_indptr = plan["kv_indptr"].to(device=q.device, dtype=torch.long)
+            kv_indices = plan["kv_indices"].to(device=q.device, dtype=torch.long)
+            prefix_lens = plan["prefix_lens"].to(device=q.device, dtype=torch.long)
+
+            req_idx = None
+            for idx, prefix_len in enumerate(prefix_lens.detach().cpu().tolist()):
+                if int(prefix_len) > 0:
+                    req_idx = idx
+                    break
+            if req_idx is None:
+                summary["skip"] = "no cached prefix"
+                logger.warning("FP4 KV prefix-reference trace %s", summary)
+                return
+
+            qo_start = int(qo_indptr[req_idx].detach().cpu().item())
+            qo_end = int(qo_indptr[req_idx + 1].detach().cpu().item())
+            kv_start = int(kv_indptr[req_idx].detach().cpu().item())
+            kv_end = int(kv_indptr[req_idx + 1].detach().cpu().item())
+            token_limit = _trace_token_limit()
+            kv_end = min(kv_end, kv_start + token_limit)
+            q_row_limit = _trace_q_row_limit()
+            if q_row_limit is not None:
+                qo_end = min(qo_end, qo_start + q_row_limit)
+            q_req = q[qo_start:qo_end].float()
+            prefix_slots = kv_indices[kv_start:kv_end]
+            summary.update(
+                {
+                    "request_index": req_idx,
+                    "qo_range": [qo_start, qo_end],
+                    "kv_range": [kv_start, kv_end],
+                    "prefix_slots": _trace_tensor_values(prefix_slots),
+                    "token_limit": token_limit,
+                    "q_row_limit": q_row_limit,
+                }
+            )
+            if q_req.numel() == 0 or prefix_slots.numel() == 0:
+                summary["skip"] = "empty q or prefix"
+                logger.warning("FP4 KV prefix-reference trace %s", summary)
+                return
+
+            k_cache, v_cache = paged_kv_cache
+            k_sf, v_sf = paged_kv_kwargs.get("kv_cache_sf", (None, None))
+            if not all(isinstance(x, torch.Tensor) for x in (k_cache, v_cache, v_sf)):
+                summary["error"] = "missing tensor cache or scale views"
+                summary["cache"] = _tensor_trace_summary(paged_kv_cache)
+                summary["scale"] = _tensor_trace_summary((k_sf, v_sf))
+                logger.warning("FP4 KV prefix-reference trace %s", summary)
+                return
+
+            k_packed = k_cache[prefix_slots]
+            v_packed = v_cache[prefix_slots]
+            k_scale = k_sf[prefix_slots] if isinstance(k_sf, torch.Tensor) else None
+            v_scale = v_sf[prefix_slots]
+            if k_scale is not None and k_scale.dim() == 4 and k_scale.shape[1] == 1:
+                k_scale = k_scale[:, 0]
+            if v_scale.dim() == 4 and v_scale.shape[1] == 1:
+                v_scale = v_scale[:, 0]
+            if k_scale is not None:
+                k_scale = k_scale.view(torch.float8_e4m3fn)
+            v_scale = v_scale.view(torch.float8_e4m3fn)
+            k_scale_for_dequant = (
+                k_scale.reshape(k_scale.shape[0], -1)
+                if k_scale is not None
+                else None
+            )
+            v_scale_for_dequant = v_scale.reshape(v_scale.shape[0], -1)
+
+            from sglang.srt.layers.quantization.kvfp4_tensor import (
+                NVFP4KVQuantizeUtil,
+            )
+
+            if k_scale_for_dequant is None:
+                k_ref = k_packed.float()
+            else:
+                k_ref = NVFP4KVQuantizeUtil.dequantize(
+                    k_packed.view(torch.uint8),
+                    k_scale_for_dequant,
+                    paged_kv_kwargs["k_scale"],
+                    dtype=torch.float32,
+                ).float()
+            v_ref = NVFP4KVQuantizeUtil.dequantize(
+                v_packed.view(torch.uint8),
+                v_scale_for_dequant,
+                paged_kv_kwargs["v_scale"],
+                dtype=torch.float32,
+            ).float()
+
+            q_heads = q_req.shape[1]
+            kv_heads = k_ref.shape[1]
+            if q_heads % kv_heads != 0:
+                summary["error"] = "q heads are not divisible by kv heads"
+                summary["q_heads"] = int(q_heads)
+                summary["kv_heads"] = int(kv_heads)
+                logger.warning("FP4 KV prefix-reference trace %s", summary)
+                return
+
+            kv_head_for_q = torch.arange(q_heads, device=q.device) // (
+                q_heads // kv_heads
+            )
+            k_for_q = k_ref[:, kv_head_for_q, :]
+            v_for_q = v_ref[:, kv_head_for_q, :]
+            logits = torch.einsum("qhd,thd->qht", q_req, k_for_q) * float(sm_scale)
+            if logits_soft_cap is not None and float(logits_soft_cap) > 0:
+                logits = float(logits_soft_cap) * torch.tanh(
+                    logits / float(logits_soft_cap)
+                )
+            lse_ref = torch.logsumexp(logits, dim=-1)
+            lse_ref_base2 = lse_ref * 1.4426950408889634
+            probs = torch.softmax(logits, dim=-1)
+            o2_ref = torch.einsum("qht,thd->qhd", probs, v_for_q).to(o2.dtype)
+
+            o2_slice = o2[qo_start:qo_end]
+            s2_slice = _trace_select_lse_slice(s2, qo_start, qo_end, qo_end - qo_start)
+            summary["reference"] = {
+                "q": _trace_numeric_tensor_stats(q_req),
+                "k_dequant": _trace_numeric_tensor_stats(k_ref),
+                "v_dequant": _trace_numeric_tensor_stats(v_ref),
+                "lse_ref": _trace_numeric_tensor_stats(lse_ref),
+                "lse_ref_base2": _trace_numeric_tensor_stats(lse_ref_base2),
+                "o2_ref": _trace_numeric_tensor_stats(o2_ref),
+                "o2_flashinfer": _trace_numeric_tensor_stats(o2_slice),
+                "o2_compare": _trace_compare_tensors(o2_ref, o2_slice),
+            }
+            if isinstance(s2_slice, torch.Tensor):
+                summary["reference"]["s2_flashinfer"] = _trace_numeric_tensor_stats(
+                    s2_slice
+                )
+                summary["reference"]["s2_compare"] = _trace_compare_tensors(
+                    lse_ref_base2, s2_slice
+                )
+                summary["reference"]["s2_compare_natural_log"] = (
+                    _trace_compare_tensors(lse_ref, s2_slice)
+                )
+            else:
+                summary["reference"]["s2_compare"] = {
+                    "error": "could not select comparable s2 slice",
+                    "s2": _tensor_trace_summary(s2),
+                }
+
+            s1_slice = _trace_select_lse_slice(s1, qo_start, qo_end, qo_end - qo_start)
+            merged_slice = merged[qo_start:qo_end]
+            o1_slice = o1[qo_start:qo_end].float()
+            if isinstance(s1_slice, torch.Tensor) and isinstance(s2_slice, torch.Tensor):
+                o2_slice_f = o2_slice.float()
+                s1_work = s1_slice.float().unsqueeze(-1)
+                s2_work = s2_slice.float().unsqueeze(-1)
+                m = torch.maximum(s1_work, s2_work)
+                w1 = torch.exp2(s1_work - m)
+                w2 = torch.exp2(s2_work - m)
+                manual_merged = ((o1_slice * w1) + (o2_slice_f * w2)) / (w1 + w2)
+                summary["merge_compare"] = _trace_compare_tensors(
+                    manual_merged.to(merged.dtype), merged_slice
+                )
+            else:
+                summary["merge_compare"] = {
+                    "error": "could not select comparable s1/s2 slices",
+                    "s1": _tensor_trace_summary(s1),
+                    "s2": _tensor_trace_summary(s2),
+                }
+
+            suffix_k_req_raw = suffix_k.view(
+                -1, layer.tp_k_head_num, layer.head_dim
+            )[qo_start:qo_end].contiguous()
+            suffix_v_req_raw = suffix_v.view(
+                -1, layer.tp_v_head_num, layer.head_dim
+            )[qo_start:qo_end].contiguous()
+            suffix_k_req = suffix_k_req_raw.float()
+            suffix_v_req = suffix_v_req_raw.float()
+
+            def attention_ref_for_q(
+                kv_k: torch.Tensor,
+                kv_v: torch.Tensor,
+                q_rows: torch.Tensor,
+            ):
+                if kv_k.shape[0] == 0:
+                    out = torch.zeros_like(q_rows)
+                    lse = torch.full(
+                        q_rows.shape[:2],
+                        float("-inf"),
+                        dtype=torch.float32,
+                        device=q_rows.device,
+                    )
+                    return out, lse
+                q_heads_ref = q_rows.shape[1]
+                kv_heads_ref = kv_k.shape[1]
+                kv_head_for_q_ref = torch.arange(
+                    q_heads_ref, device=q_rows.device
+                ) // (q_heads_ref // kv_heads_ref)
+                k_for_q_ref = kv_k[:, kv_head_for_q_ref, :]
+                v_for_q_ref = kv_v[:, kv_head_for_q_ref, :]
+                logits_ref = (
+                    torch.einsum("qhd,thd->qht", q_rows, k_for_q_ref)
+                    * float(sm_scale)
+                )
+                if logits_soft_cap is not None and float(logits_soft_cap) > 0:
+                    logits_ref = float(logits_soft_cap) * torch.tanh(
+                        logits_ref / float(logits_soft_cap)
+                    )
+                lse_ref_local = torch.logsumexp(logits_ref, dim=-1)
+                probs_ref = torch.softmax(logits_ref, dim=-1)
+                out_ref = torch.einsum("qht,thd->qhd", probs_ref, v_for_q_ref)
+                return out_ref, lse_ref_local
+
+            def causal_suffix_ref(
+                kv_k: torch.Tensor,
+                kv_v: torch.Tensor,
+                q_rows: torch.Tensor,
+            ):
+                outs = []
+                lses = []
+                for row_idx in range(q_rows.shape[0]):
+                    out_i, lse_i = attention_ref_for_q(
+                        kv_k[: row_idx + 1],
+                        kv_v[: row_idx + 1],
+                        q_rows[row_idx : row_idx + 1],
+                    )
+                    outs.append(out_i)
+                    lses.append(lse_i)
+                return torch.cat(outs, dim=0), torch.cat(lses, dim=0)
+
+            def full_with_prefix_ref(
+                prefix_k: torch.Tensor,
+                prefix_v: torch.Tensor,
+                suffix_k_local: torch.Tensor,
+                suffix_v_local: torch.Tensor,
+                q_rows: torch.Tensor,
+            ):
+                outs = []
+                lses = []
+                for row_idx in range(q_rows.shape[0]):
+                    full_k = torch.cat(
+                        [prefix_k, suffix_k_local[: row_idx + 1]], dim=0
+                    )
+                    full_v = torch.cat(
+                        [prefix_v, suffix_v_local[: row_idx + 1]], dim=0
+                    )
+                    out_i, lse_i = attention_ref_for_q(
+                        full_k, full_v, q_rows[row_idx : row_idx + 1]
+                    )
+                    outs.append(out_i)
+                    lses.append(lse_i)
+                return torch.cat(outs, dim=0), torch.cat(lses, dim=0)
+
+            runtime_suffix_o, runtime_suffix_lse = causal_suffix_ref(
+                suffix_k_req, suffix_v_req, q_req
+            )
+            runtime_full_o, runtime_full_lse = full_with_prefix_ref(
+                k_ref.float(), v_ref.float(), suffix_k_req, suffix_v_req, q_req
+            )
+
+            from sglang.srt.layers.quantization.kvfp4_tensor import (
+                NVFP4KVQuantizeUtil as _NVFP4KVQuantizeUtilForSuffix,
+            )
+
+            suffix_k_fp4, suffix_k_sf, _ = _NVFP4KVQuantizeUtilForSuffix.quantize(
+                suffix_k_req_raw, paged_kv_kwargs["k_scale"]
+            )
+            suffix_v_fp4, suffix_v_sf, _ = _NVFP4KVQuantizeUtilForSuffix.quantize(
+                suffix_v_req_raw, paged_kv_kwargs["v_scale"]
+            )
+            suffix_k_fp4_ref = _NVFP4KVQuantizeUtilForSuffix.dequantize(
+                suffix_k_fp4.view(torch.uint8),
+                suffix_k_sf.reshape(suffix_k_req.shape[0], -1),
+                paged_kv_kwargs["k_scale"],
+                dtype=torch.float32,
+            ).view_as(suffix_k_req)
+            suffix_v_fp4_ref = _NVFP4KVQuantizeUtilForSuffix.dequantize(
+                suffix_v_fp4.view(torch.uint8),
+                suffix_v_sf.reshape(suffix_v_req.shape[0], -1),
+                paged_kv_kwargs["v_scale"],
+                dtype=torch.float32,
+            ).view_as(suffix_v_req)
+            all_fp4_suffix_o, all_fp4_suffix_lse = causal_suffix_ref(
+                suffix_k_fp4_ref, suffix_v_fp4_ref, q_req
+            )
+            all_fp4_full_o, all_fp4_full_lse = full_with_prefix_ref(
+                k_ref.float(),
+                v_ref.float(),
+                suffix_k_fp4_ref,
+                suffix_v_fp4_ref,
+                q_req,
+            )
+            runtime_suffix_lse_base2 = runtime_suffix_lse * 1.4426950408889634
+            runtime_full_lse_base2 = runtime_full_lse * 1.4426950408889634
+            all_fp4_suffix_lse_base2 = all_fp4_suffix_lse * 1.4426950408889634
+            all_fp4_full_lse_base2 = all_fp4_full_lse * 1.4426950408889634
+            summary["runtime_full_reference"] = {
+                "suffix_o_bf16_vs_o1": (
+                    _trace_compare_tensors(
+                        runtime_suffix_o.to(o1_slice.dtype), o1_slice
+                    )
+                    if isinstance(s1_slice, torch.Tensor)
+                    else {"error": "missing s1 slice"}
+                ),
+                "suffix_lse_bf16_base2_vs_s1": (
+                    _trace_compare_tensors(runtime_suffix_lse_base2, s1_slice)
+                    if isinstance(s1_slice, torch.Tensor)
+                    else {"error": "missing s1 slice"}
+                ),
+                "suffix_lse_bf16_natural_vs_s1": (
+                    _trace_compare_tensors(runtime_suffix_lse, s1_slice)
+                    if isinstance(s1_slice, torch.Tensor)
+                    else {"error": "missing s1 slice"}
+                ),
+                "full_prefix_fp4_suffix_bf16_vs_merged": _trace_compare_tensors(
+                    runtime_full_o.to(merged_slice.dtype), merged_slice
+                ),
+                "full_prefix_fp4_suffix_bf16_lse_base2": _trace_numeric_tensor_stats(
+                    runtime_full_lse_base2
+                ),
+                "suffix_o_fp4_vs_o1": (
+                    _trace_compare_tensors(
+                        all_fp4_suffix_o.to(o1_slice.dtype), o1_slice
+                    )
+                    if isinstance(s1_slice, torch.Tensor)
+                    else {"error": "missing s1 slice"}
+                ),
+                "suffix_lse_fp4_base2_vs_s1": (
+                    _trace_compare_tensors(all_fp4_suffix_lse_base2, s1_slice)
+                    if isinstance(s1_slice, torch.Tensor)
+                    else {"error": "missing s1 slice"}
+                ),
+                "full_prefix_fp4_suffix_fp4_vs_merged": _trace_compare_tensors(
+                    all_fp4_full_o.to(merged_slice.dtype), merged_slice
+                ),
+                "full_prefix_fp4_suffix_fp4_lse_base2": _trace_numeric_tensor_stats(
+                    all_fp4_full_lse_base2
+                ),
+            }
+
+            dense_ref = self._nvfp4_dense_reference_by_layer.get(int(layer.layer_id))
+            if isinstance(dense_ref, dict):
+                q_len = qo_end - qo_start
+                dense_row_start = int(prefix_lens[req_idx].detach().cpu().item())
+                dense_row_end = dense_row_start + q_len
+                dense_q = dense_ref["q"]
+                dense_k = dense_ref["k"]
+                dense_v = dense_ref["v"]
+                dense_o = dense_ref["o"]
+                summary["dense_reference"] = {
+                    "dense_rids": dense_ref.get("rids"),
+                    "dense_forward_pass_id": dense_ref.get("forward_pass_id"),
+                    "dense_seq_lens_cpu": dense_ref.get("seq_lens_cpu"),
+                    "dense_extend_seq_lens_cpu": dense_ref.get("extend_seq_lens_cpu"),
+                    "dense_row_range": [dense_row_start, dense_row_end],
+                }
+                if dense_row_end <= dense_q.shape[0]:
+                    dense_q_req = dense_q[dense_row_start:dense_row_end].float()
+                    dense_prefix_k = dense_k[:dense_row_start].float()
+                    dense_prefix_v = dense_v[:dense_row_start].float()
+                    dense_suffix_k = dense_k[dense_row_start:dense_row_end].float()
+                    dense_suffix_v = dense_v[dense_row_start:dense_row_end].float()
+                    dense_full_k = dense_k[:dense_row_end].float()
+                    dense_full_v = dense_v[:dense_row_end].float()
+                    dense_o_slice = dense_o[dense_row_start:dense_row_end]
+                    q_req_f = q_req.float()
+
+                    def dense_attention_ref(kv_k: torch.Tensor, kv_v: torch.Tensor):
+                        if kv_k.shape[0] == 0:
+                            out = torch.zeros_like(q_req_f)
+                            lse = torch.full(
+                                q_req_f.shape[:2],
+                                float("-inf"),
+                                dtype=torch.float32,
+                                device=q_req_f.device,
+                            )
+                            return out, lse
+                        q_heads = q_req_f.shape[1]
+                        kv_heads = kv_k.shape[1]
+                        kv_head_for_q = torch.arange(q_heads, device=q_req_f.device) // (
+                            q_heads // kv_heads
+                        )
+                        k_for_q = kv_k[:, kv_head_for_q, :]
+                        v_for_q = kv_v[:, kv_head_for_q, :]
+                        logits = (
+                            torch.einsum("qhd,thd->qht", q_req_f, k_for_q)
+                            * float(sm_scale)
+                        )
+                        if logits_soft_cap is not None and float(logits_soft_cap) > 0:
+                            logits = float(logits_soft_cap) * torch.tanh(
+                                logits / float(logits_soft_cap)
+                            )
+                        lse = torch.logsumexp(logits, dim=-1)
+                        probs = torch.softmax(logits, dim=-1)
+                        out = torch.einsum("qht,thd->qhd", probs, v_for_q)
+                        return out, lse
+
+                    def dense_causal_suffix_ref(kv_k: torch.Tensor, kv_v: torch.Tensor):
+                        outs = []
+                        lses = []
+                        for row_idx in range(q_req_f.shape[0]):
+                            out_i, lse_i = dense_attention_ref(
+                                kv_k[: row_idx + 1],
+                                kv_v[: row_idx + 1],
+                            )
+                            outs.append(out_i[row_idx : row_idx + 1])
+                            lses.append(lse_i[row_idx : row_idx + 1])
+                        return torch.cat(outs, dim=0), torch.cat(lses, dim=0)
+
+                    def dense_causal_full_ref(kv_k: torch.Tensor, kv_v: torch.Tensor):
+                        outs = []
+                        lses = []
+                        for row_idx in range(q_req_f.shape[0]):
+                            end = dense_row_start + row_idx + 1
+                            out_i, lse_i = dense_attention_ref(kv_k[:end], kv_v[:end])
+                            outs.append(out_i[row_idx : row_idx + 1])
+                            lses.append(lse_i[row_idx : row_idx + 1])
+                        return torch.cat(outs, dim=0), torch.cat(lses, dim=0)
+
+                    dense_prefix_o, dense_prefix_lse = dense_attention_ref(
+                        dense_prefix_k, dense_prefix_v
+                    )
+                    dense_suffix_o, dense_suffix_lse = dense_causal_suffix_ref(
+                        dense_suffix_k, dense_suffix_v
+                    )
+                    dense_full_o, dense_full_lse = dense_causal_full_ref(
+                        dense_full_k, dense_full_v
+                    )
+                    dense_prefix_lse_base2 = dense_prefix_lse * 1.4426950408889634
+                    dense_suffix_lse_base2 = dense_suffix_lse * 1.4426950408889634
+                    dense_full_lse_base2 = dense_full_lse * 1.4426950408889634
+                    dense_section = summary["dense_reference"]
+                    dense_section.update(
+                        {
+                            "q_compare": _trace_compare_tensors(dense_q_req, q_req_f),
+                            "dense_o_flashinfer": _trace_numeric_tensor_stats(
+                                dense_o_slice
+                            ),
+                            "dense_full_ref": _trace_numeric_tensor_stats(dense_full_o),
+                            "dense_o_compare": _trace_compare_tensors(
+                                dense_full_o.to(dense_o_slice.dtype), dense_o_slice
+                            ),
+                            "prefix_o_vs_o2": _trace_compare_tensors(
+                                dense_prefix_o.to(o2_slice.dtype), o2_slice
+                            ),
+                            "prefix_lse_base2_vs_s2": (
+                                _trace_compare_tensors(dense_prefix_lse_base2, s2_slice)
+                                if isinstance(s2_slice, torch.Tensor)
+                                else {"error": "missing s2 slice"}
+                            ),
+                            "suffix_o_vs_o1": (
+                                _trace_compare_tensors(
+                                    dense_suffix_o.to(o1_slice.dtype), o1_slice
+                                )
+                                if isinstance(s1_slice, torch.Tensor)
+                                else {"error": "missing s1 slice"}
+                            ),
+                            "suffix_lse_base2_vs_s1": (
+                                _trace_compare_tensors(dense_suffix_lse_base2, s1_slice)
+                                if isinstance(s1_slice, torch.Tensor)
+                                else {"error": "missing s1 slice"}
+                            ),
+                            "full_o_vs_merged": _trace_compare_tensors(
+                                dense_full_o.to(merged_slice.dtype), merged_slice
+                            ),
+                            "full_lse_base2": _trace_numeric_tensor_stats(
+                                dense_full_lse_base2
+                            ),
+                        }
+                    )
+                else:
+                    summary["dense_reference"]["error"] = "dense reference too short"
+                    summary["dense_reference"]["dense_shape"] = _tensor_trace_summary(
+                        dense_q
+                    )
+            else:
+                summary["dense_reference"] = {
+                    "error": "missing dense no-prefix reference"
+                }
+        except Exception as exc:
+            summary["error"] = repr(exc)
+
+        logger.warning("FP4 KV prefix-reference trace %s", summary)
+
     def _get_paged_kv_cache_and_kwargs(self, layer: RadixAttention):
         kv_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
         if not self.is_nvfp4_native:
@@ -556,6 +2334,43 @@ class FlashInferAttnBackend(AttentionBackend):
             "k_scale": k_global,
             "v_scale": v_global,
         }
+
+    def _suffix_attention_inputs(
+        self,
+        layer: RadixAttention,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        paged_kv_kwargs,
+    ):
+        if (
+            not self.is_nvfp4_native
+            or self.is_fp8_k_nvfp4_v
+            or k is None
+            or v is None
+        ):
+            if k is None or v is None:
+                return k, v, {}
+            return (
+                k.view(-1, layer.tp_k_head_num, layer.head_dim),
+                v.view(-1, layer.tp_v_head_num, layer.head_dim),
+                {},
+            )
+
+        from sglang.srt.layers.quantization.kvfp4_tensor import NVFP4KVQuantizeUtil
+
+        k3 = k.view(-1, layer.tp_k_head_num, layer.head_dim).contiguous()
+        v3 = v.view(-1, layer.tp_v_head_num, layer.head_dim).contiguous()
+        k_fp4, k_sf, _ = NVFP4KVQuantizeUtil.quantize(k3, paged_kv_kwargs["k_scale"])
+        v_fp4, v_sf, _ = NVFP4KVQuantizeUtil.quantize(v3, paged_kv_kwargs["v_scale"])
+        return (
+            k_fp4.view(torch.uint8),
+            v_fp4.view(torch.uint8),
+            {
+                "kv_cache_sf": (k_sf, v_sf),
+                "k_scale": paged_kv_kwargs["k_scale"],
+                "v_scale": paged_kv_kwargs["v_scale"],
+            },
+        )
 
     def _should_vo_split(self, layer: RadixAttention) -> bool:
         return self.enable_vo_split and layer.head_dim == 512
@@ -734,6 +2549,26 @@ class FlashInferAttnBackend(AttentionBackend):
             **plan_kwargs,
         )
 
+    @staticmethod
+    def _resolve_swa_kv_pool(model_runner: ModelRunner) -> Optional[BaseSWAKVPool]:
+        """Return the SWA KV pool to translate against, or None for non-SWA models.
+
+        EAGLE-like draft workers share the target allocator for token bookkeeping,
+        but own a separate draft KV pool. Do not use the target allocator's SWA
+        mapping for that draft pool. FROZEN_KV MTP is the exception: its draft
+        path reads target KV directly, so it still needs the allocator pool when
+        the active pool is not SWA.
+        """
+        active_pool = model_runner.token_to_kv_pool
+        if isinstance(active_pool, BaseSWAKVPool):
+            return active_pool
+
+        if model_runner.is_draft_worker:
+            if not model_runner.spec_algorithm.is_frozen_kv_mtp():
+                return None
+
+        kvcache = model_runner.token_to_kv_pool_allocator.get_kvcache()
+        return kvcache if isinstance(kvcache, BaseSWAKVPool) else None
 
     def _process_multi_item_scoring(
         self, forward_batch: ForwardBatch
@@ -1062,6 +2897,12 @@ class FlashInferAttnBackend(AttentionBackend):
                 multi_item_params,
                 swa_out_cache_loc=swa_out_cache_loc,
             )
+            self._trace_nvfp4_forward_batch(
+                label="init_forward_metadata_extend",
+                forward_batch=forward_batch,
+                use_ragged=use_ragged,
+                extend_no_prefix=extend_no_prefix,
+            )
 
     def init_cuda_graph_state(
         self,
@@ -1235,6 +3076,49 @@ class FlashInferAttnBackend(AttentionBackend):
                 else -1
             )
             if self.is_nvfp4_native:
+                self._trace_nvfp4_forward_batch(
+                    label="forward_extend_paged",
+                    forward_batch=forward_batch,
+                    use_ragged=self.forward_metadata.use_ragged,
+                    extend_no_prefix=self.forward_metadata.extend_no_prefix,
+                )
+                q_native = q.view(-1, layer.tp_q_head_num, layer.head_dim)
+                self._trace_nvfp4_native_call(
+                    label="extend_paged",
+                    layer=layer,
+                    q=q_native,
+                    paged_kv_cache=paged_kv_cache,
+                    paged_kv_kwargs=paged_kv_kwargs,
+                )
+                self._trace_nvfp4_page_pair(
+                    label="extend_paged",
+                    layer=layer,
+                    paged_kv_cache=paged_kv_cache,
+                    paged_kv_kwargs=paged_kv_kwargs,
+                )
+                o = self._run_paged_native(
+                    prefill_wrapper_paged,
+                    q_native,
+                    paged_kv_cache,
+                    causal=causal,
+                    sm_scale=layer.scaling,
+                    window_left=paged_window_left,
+                    logits_soft_cap=logits_soft_cap,
+                    return_lse=False,
+                    paged_kv_kwargs=paged_kv_kwargs,
+                    trace_label="extend_paged",
+                    trace_layer=layer,
+                    vo_split=self._should_vo_split(layer),
+                )
+                self._trace_nvfp4_dense_cache_state(
+                    label="forward_extend_paged",
+                    layer=layer,
+                    forward_batch=forward_batch,
+                    q=q_native,
+                    o=o,
+                    paged_kv_kwargs=paged_kv_kwargs,
+                )
+            else:
                 o = self._run_paged_native(
                     prefill_wrapper_paged,
                     q.view(-1, layer.tp_q_head_num, layer.head_dim),
@@ -1245,17 +3129,9 @@ class FlashInferAttnBackend(AttentionBackend):
                     logits_soft_cap=logits_soft_cap,
                     return_lse=False,
                     paged_kv_kwargs=paged_kv_kwargs,
+                    trace_label="extend_paged",
+                    trace_layer=layer,
                     vo_split=self._should_vo_split(layer),
-                )
-            else:
-                o = prefill_wrapper_paged.forward(
-                    q.view(-1, layer.tp_q_head_num, layer.head_dim),
-                    paged_kv_cache,
-                    causal=causal,
-                    sm_scale=layer.scaling,
-                    window_left=paged_window_left,
-                    logits_soft_cap=logits_soft_cap,
-                    **paged_kv_kwargs,
                 )
         else:
             # If `k`/`v` are not explicitly provided, fall back to the KV cache stored in
@@ -1280,6 +3156,12 @@ class FlashInferAttnBackend(AttentionBackend):
                 save_kv_cache = False
 
             if self.forward_metadata.extend_no_prefix:
+                self._trace_nvfp4_forward_batch(
+                    label="forward_extend_ragged_no_prefix",
+                    forward_batch=forward_batch,
+                    use_ragged=self.forward_metadata.use_ragged,
+                    extend_no_prefix=self.forward_metadata.extend_no_prefix,
+                )
                 # NOTE: FlashInfer currently has limitations with head_dim = 32 or other dimensions
                 # The FlashInfer head_dim limitation itself is tracked here:
                 # https://github.com/flashinfer-ai/flashinfer/issues/1048
@@ -1291,6 +3173,14 @@ class FlashInferAttnBackend(AttentionBackend):
                     sm_scale=layer.scaling,
                     logits_soft_cap=logits_soft_cap,
                 )
+                if self.is_nvfp4_native:
+                    self._trace_nvfp4_dense_cache_state(
+                        label="forward_extend_ragged_no_prefix",
+                        layer=layer,
+                        forward_batch=forward_batch,
+                        q=q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                        o=o,
+                    )
 
             else:
                 swa_window_left = (
@@ -1301,22 +3191,65 @@ class FlashInferAttnBackend(AttentionBackend):
                     )
                     else -1
                 )
-                o1, s1 = self.prefill_wrapper_ragged.forward_return_lse(
-                    q.view(-1, layer.tp_q_head_num, layer.head_dim),
-                    k.view(-1, layer.tp_k_head_num, layer.head_dim),
-                    v.view(-1, layer.tp_v_head_num, layer.head_dim),
-                    causal=causal,
-                    sm_scale=layer.scaling,
-                    window_left=swa_window_left,
-                    logits_soft_cap=logits_soft_cap,
-                )
                 paged_kv_cache, paged_kv_kwargs = self._get_paged_kv_cache_and_kwargs(
                     layer
                 )
+                (
+                    suffix_k_for_attention,
+                    suffix_v_for_attention,
+                    suffix_attention_kwargs,
+                ) = self._suffix_attention_inputs(
+                    layer, k, v, paged_kv_kwargs
+                )
+                q_native = q.view(-1, layer.tp_q_head_num, layer.head_dim)
+                if suffix_attention_kwargs:
+                    self.prefill_wrapper_ragged._causal = causal
+                    self.prefill_wrapper_ragged._pos_encoding_mode = "NONE"
+                    self.prefill_wrapper_ragged._use_fp16_qk_reduction = False
+                    self.prefill_wrapper_ragged._window_left = swa_window_left
+                    self.prefill_wrapper_ragged._logits_soft_cap = logits_soft_cap
+                    self.prefill_wrapper_ragged._sm_scale = layer.scaling
+                    self.prefill_wrapper_ragged._rope_scale = None
+                    self.prefill_wrapper_ragged._rope_theta = None
+                    o1, s1 = self.prefill_wrapper_ragged.run_return_lse(
+                        q_native,
+                        suffix_k_for_attention,
+                        suffix_v_for_attention,
+                        **suffix_attention_kwargs,
+                    )
+                else:
+                    o1, s1 = self.prefill_wrapper_ragged.forward_return_lse(
+                        q_native,
+                        suffix_k_for_attention,
+                        suffix_v_for_attention,
+                        causal=causal,
+                        sm_scale=layer.scaling,
+                        window_left=swa_window_left,
+                        logits_soft_cap=logits_soft_cap,
+                    )
                 if self.is_nvfp4_native:
+                    self._trace_nvfp4_forward_batch(
+                        label="forward_extend_merge_paged",
+                        forward_batch=forward_batch,
+                        use_ragged=self.forward_metadata.use_ragged,
+                        extend_no_prefix=self.forward_metadata.extend_no_prefix,
+                    )
+                    self._trace_nvfp4_native_call(
+                        label="extend_merge_paged",
+                        layer=layer,
+                        q=q_native,
+                        paged_kv_cache=paged_kv_cache,
+                        paged_kv_kwargs=paged_kv_kwargs,
+                    )
+                    self._trace_nvfp4_page_pair(
+                        label="extend_merge_paged",
+                        layer=layer,
+                        paged_kv_cache=paged_kv_cache,
+                        paged_kv_kwargs=paged_kv_kwargs,
+                    )
                     o2, s2 = self._run_paged_native(
                         prefill_wrapper_paged,
-                        q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                        q_native,
                         paged_kv_cache,
                         causal=False,
                         sm_scale=layer.scaling,
@@ -1324,20 +3257,69 @@ class FlashInferAttnBackend(AttentionBackend):
                         logits_soft_cap=logits_soft_cap,
                         return_lse=True,
                         paged_kv_kwargs=paged_kv_kwargs,
+                        trace_label="extend_merge_paged",
+                        trace_layer=layer,
                         vo_split=self._should_vo_split(layer),
                     )
                 else:
-                    o2, s2 = prefill_wrapper_paged.forward_return_lse(
-                        q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                    o2, s2 = self._run_paged_native(
+                        prefill_wrapper_paged,
+                        q_native,
                         paged_kv_cache,
                         causal=False,
                         sm_scale=layer.scaling,
                         window_left=swa_window_left,
                         logits_soft_cap=logits_soft_cap,
-                        **paged_kv_kwargs,
+                        return_lse=True,
+                        paged_kv_kwargs=paged_kv_kwargs,
+                        trace_label="extend_merge_paged",
+                        trace_layer=layer,
+                        vo_split=self._should_vo_split(layer),
                     )
 
                 o, _ = _safe_merge_state(o1, s1, o2, s2)
+                if self.is_nvfp4_native:
+                    self._trace_nvfp4_dense_cache_state(
+                        label="forward_extend_merge_paged",
+                        layer=layer,
+                        forward_batch=forward_batch,
+                        q=q_native,
+                        o1=o1,
+                        s1=s1,
+                        o2=o2,
+                        s2=s2,
+                        merged=o,
+                        paged_kv_kwargs=paged_kv_kwargs,
+                    )
+                    self._trace_nvfp4_merge_state(
+                        label="extend_merge_paged",
+                        layer=layer,
+                        paged_kv_cache=paged_kv_cache,
+                        paged_kv_kwargs=paged_kv_kwargs,
+                        o1=o1,
+                        s1=s1,
+                        o2=o2,
+                        s2=s2,
+                        merged=o,
+                        swa_window_left=swa_window_left,
+                    )
+                    self._trace_nvfp4_prefix_reference(
+                        label="extend_merge_paged",
+                        layer=layer,
+                        q=q_native,
+                        suffix_k=k,
+                        suffix_v=v,
+                        paged_kv_cache=paged_kv_cache,
+                        paged_kv_kwargs=paged_kv_kwargs,
+                        o1=o1,
+                        s1=s1,
+                        o2=o2,
+                        s2=s2,
+                        merged=o,
+                        swa_window_left=swa_window_left,
+                        sm_scale=layer.scaling,
+                        logits_soft_cap=logits_soft_cap,
+                    )
 
             if save_kv_cache:
                 self.token_to_kv_pool.set_kv_buffer(
@@ -1347,6 +3329,24 @@ class FlashInferAttnBackend(AttentionBackend):
                     v,
                     layer.k_scale,
                     layer.v_scale,
+                )
+            if (
+                self.is_nvfp4_native
+                and self.forward_metadata.use_ragged
+                and self.forward_metadata.extend_no_prefix
+                and k is not None
+                and v is not None
+            ):
+                self._trace_nvfp4_dense_quant_attention_loss(
+                    label="forward_extend_ragged_no_prefix",
+                    layer=layer,
+                    forward_batch=forward_batch,
+                    q=q,
+                    k=k,
+                    v=v,
+                    o=o,
+                    sm_scale=layer.scaling,
+                    logits_soft_cap=logits_soft_cap,
                 )
 
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
@@ -1383,10 +3383,18 @@ class FlashInferAttnBackend(AttentionBackend):
                 )
 
         paged_kv_cache, paged_kv_kwargs = self._get_paged_kv_cache_and_kwargs(layer)
-        if self.is_nvfp4_native:
+        if self._should_vo_split(layer):
+            q_native = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+            prefill_wrapper = self.prefill_wrappers_paged[self._get_wrapper_idx(layer)]
+            self._plan_decode_as_prefill_vo_split(
+                decode_wrapper=decode_wrapper,
+                prefill_wrapper=prefill_wrapper,
+                q=q_native,
+                layer=layer,
+            )
             o = self._run_paged_native(
-                decode_wrapper,
-                q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                prefill_wrapper,
+                q_native,
                 paged_kv_cache,
                 causal=False,
                 sm_scale=layer.scaling,
@@ -1394,9 +3402,43 @@ class FlashInferAttnBackend(AttentionBackend):
                 logits_soft_cap=layer.logit_cap,
                 return_lse=False,
                 paged_kv_kwargs=paged_kv_kwargs,
-                vo_split=self._should_vo_split(layer),
+                trace_label="decode_as_prefill",
+                trace_layer=layer,
+                vo_split=True,
+            )
+            return o.view(-1, layer.tp_q_head_num * layer.head_dim)
+
+        if self.is_nvfp4_native:
+            q_native = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+            self._trace_nvfp4_native_call(
+                label="decode",
+                layer=layer,
+                q=q_native,
+                paged_kv_cache=paged_kv_cache,
+                paged_kv_kwargs=paged_kv_kwargs,
+            )
+            o = self._run_paged_native(
+                decode_wrapper,
+                q_native,
+                paged_kv_cache,
+                causal=False,
+                sm_scale=layer.scaling,
+                window_left=-1,
+                logits_soft_cap=layer.logit_cap,
+                return_lse=False,
+                paged_kv_kwargs=paged_kv_kwargs,
+                trace_label="decode",
+                trace_layer=layer,
             )
         else:
+            self._trace_gemma4_geometry_dispatch(
+                label="decode",
+                layer=layer,
+                paged_kv_cache=paged_kv_cache,
+                paged_kv_kwargs=paged_kv_kwargs,
+                wrapper=decode_wrapper,
+                vo_split=False,
+            )
             o = decode_wrapper.forward(
                 q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
                 paged_kv_cache,
@@ -1429,13 +3471,21 @@ class FlashInferIndicesUpdaterDecode:
             get_parallel().attn_tp_size
         )
         self.head_dim = model_runner.model_config.head_dim
+        self.head_dim_vo = _flashinfer_vo_split_head_dim_vo(self.head_dim)
         self.data_type = model_runner.kv_cache_dtype
         self.kv_data_type = (
             torch.uint8 if attn_backend.is_nvfp4_native else self.data_type
         )
+        self.k_data_type = (
+            torch.float8_e4m3fn
+            if attn_backend.is_fp8_k_nvfp4_v
+            else self.kv_data_type
+        )
+        self.v_data_type = self.kv_data_type
         self.q_data_type = model_runner.dtype
         self.sliding_window_size = model_runner.sliding_window_size
         self.attn_backend = attn_backend
+        self.wrapper_geometries = attn_backend.wrapper_geometries
 
         # Buffers and wrappers
         self.kv_indptr = attn_backend.kv_indptr
@@ -1543,6 +3593,7 @@ class FlashInferIndicesUpdaterDecode:
                 use_sliding_window_kv_pool=use_sliding_window_kv_pool,
                 fixed_split_size=fixed_split_size,
                 disable_split_kv=disable_split_kv,
+                wrapper_id=wrapper_id,
             )
 
     def update_cross_attention(
@@ -1582,6 +3633,7 @@ class FlashInferIndicesUpdaterDecode:
                 seq_lens_cpu=kv_lens_cpu,
                 fixed_split_size=fixed_split_size,
                 disable_split_kv=disable_split_kv,
+                wrapper_id=wrapper_id,
             )
 
     def call_begin_forward(
@@ -1597,6 +3649,7 @@ class FlashInferIndicesUpdaterDecode:
         use_sliding_window_kv_pool: bool = False,
         fixed_split_size: Optional[int] = None,
         disable_split_kv: Optional[bool] = None,
+        wrapper_id: int = 0,
     ):
         if spec_info is None or getattr(spec_info, "kv_indptr", None) is None:
             bs = len(req_pool_indices)
@@ -1650,42 +3703,58 @@ class FlashInferIndicesUpdaterDecode:
 
         if wrapper_uses_fast_decode_plan:
             # When begin_forward is replaced with fast_decode_plan, pass global_override_indptr_cpu
+            plan_kwargs = {
+                "data_type": self.kv_data_type,
+                "q_data_type": self.q_data_type,
+                "non_blocking": True,
+                "fixed_split_size": fixed_split_size,
+                "disable_split_kv": (
+                    disable_split_kv if disable_split_kv is not None else False
+                ),
+                "global_override_indptr_cpu": global_override_indptr_cpu,
+            }
+            if self.k_data_type != self.v_data_type:
+                plan_kwargs.update(
+                    k_data_type=self.k_data_type,
+                    v_data_type=self.v_data_type,
+                )
+            geom = self.wrapper_geometries[wrapper_id]
             wrapper.begin_forward(
                 kv_indptr,
                 kv_indices,
                 self.kv_last_page_len[:bs],
-                self.num_qo_heads,
-                self.num_kv_heads,
-                self.head_dim,
+                geom.num_qo_heads,
+                geom.num_kv_heads,
+                geom.head_dim,
                 1,
-                data_type=self.data_type,
-                kv_data_type=self.kv_data_type,
-                q_data_type=self.q_data_type,
-                non_blocking=True,
-                fixed_split_size=fixed_split_size,
-                disable_split_kv=(
-                    disable_split_kv if disable_split_kv is not None else False
-                ),
-                global_override_indptr_cpu=global_override_indptr_cpu,
+                **plan_kwargs,
             )
         else:
             # When using original begin_forward, don't pass global_override_indptr_cpu
+            plan_kwargs = {
+                "data_type": self.kv_data_type,
+                "q_data_type": self.q_data_type,
+                "non_blocking": True,
+                "fixed_split_size": fixed_split_size,
+                "disable_split_kv": (
+                    disable_split_kv if disable_split_kv is not None else False
+                ),
+            }
+            if self.k_data_type != self.v_data_type:
+                plan_kwargs.update(
+                    k_data_type=self.k_data_type,
+                    v_data_type=self.v_data_type,
+                )
+            geom = self.wrapper_geometries[wrapper_id]
             wrapper.begin_forward(
                 kv_indptr,
                 kv_indices,
                 self.kv_last_page_len[:bs],
-                self.num_qo_heads,
-                self.num_kv_heads,
-                self.head_dim,
+                geom.num_qo_heads,
+                geom.num_kv_heads,
+                geom.head_dim,
                 1,
-                data_type=self.data_type,
-                kv_data_type=self.kv_data_type,
-                q_data_type=self.q_data_type,
-                non_blocking=True,
-                fixed_split_size=fixed_split_size,
-                disable_split_kv=(
-                    disable_split_kv if disable_split_kv is not None else False
-                ),
+                **plan_kwargs,
             )
 
         if locally_override:
@@ -1702,13 +3771,21 @@ class FlashInferIndicesUpdaterPrefill:
             get_parallel().attn_tp_size
         )
         self.head_dim = model_runner.model_config.head_dim
+        self.head_dim_vo = _flashinfer_vo_split_head_dim_vo(self.head_dim)
         self.data_type = model_runner.kv_cache_dtype
         self.kv_data_type = (
             torch.uint8 if attn_backend.is_nvfp4_native else self.data_type
         )
+        self.k_data_type = (
+            torch.float8_e4m3fn
+            if attn_backend.is_fp8_k_nvfp4_v
+            else self.kv_data_type
+        )
+        self.v_data_type = self.kv_data_type
         self.q_data_type = model_runner.dtype
         self.sliding_window_size = model_runner.sliding_window_size
         self.attn_backend = attn_backend
+        self.wrapper_geometries = attn_backend.wrapper_geometries
         # Buffers and wrappers
         self.kv_indptr = attn_backend.kv_indptr
         self.kv_last_page_len = attn_backend.kv_last_page_len
@@ -1789,6 +3866,7 @@ class FlashInferIndicesUpdaterPrefill:
             fixed_split_size=fixed_split_size,
             multi_item_params=multi_item_params,
             seq_lens_cpu=seq_lens_cpu,
+            wrapper_id=0,
         )
 
     def update_sliding_window(
@@ -1869,6 +3947,7 @@ class FlashInferIndicesUpdaterPrefill:
                 fixed_split_size=fixed_split_size,
                 multi_item_params=multi_item_params,
                 cross_attention_custom_mask=swa_paged_custom_mask,
+                wrapper_id=wrapper_id,
             )
 
     def _build_swa_prefix_custom_mask(
@@ -1958,6 +4037,7 @@ class FlashInferIndicesUpdaterPrefill:
                 cross_attention_custom_mask=(
                     cross_attention_custom_mask if wrapper_id == 1 else None
                 ),
+                wrapper_id=wrapper_id,
             )
 
     def call_begin_forward(
@@ -1979,8 +4059,10 @@ class FlashInferIndicesUpdaterPrefill:
         multi_item_params: Optional[MultiItemScoringParams] = None,
         cross_attention_custom_mask: Optional[torch.Tensor] = None,
         seq_lens_cpu: Optional[torch.Tensor] = None,
+        wrapper_id: int = 0,
     ):
         bs = len(seq_lens)
+        geom = self.wrapper_geometries[wrapper_id]
         if spec_info is None:
             assert prefix_lens is not None
             assert len(seq_lens) == len(req_pool_indices)
@@ -2029,13 +4111,25 @@ class FlashInferIndicesUpdaterPrefill:
 
         # extend part
         if use_ragged:
+            has_cached_prefix = bool(torch.any(prefix_lens[:bs] > 0).item())
+            ragged_kv_data_type = (
+                self.kv_data_type
+                if (
+                    has_cached_prefix
+                    and
+                    self.attn_backend.is_nvfp4_native
+                    and not self.attn_backend.is_fp8_k_nvfp4_v
+                )
+                else self.q_data_type
+            )
             wrapper_ragged.begin_forward(
                 qo_indptr,
                 qo_indptr,
-                self.num_qo_heads,
-                self.num_kv_heads,
-                self.head_dim,
+                geom.num_qo_heads,
+                geom.num_kv_heads,
+                geom.head_dim,
                 q_data_type=self.q_data_type,
+                kv_data_type=ragged_kv_data_type,
             )
 
         if use_sliding_window_kv_pool:
@@ -2046,6 +4140,20 @@ class FlashInferIndicesUpdaterPrefill:
                     kv_indices[:kv_last_index]
                 )
             )
+
+        self.attn_backend._capture_nvfp4_paged_plan(
+            label="prefill",
+            wrapper_id=wrapper_id,
+            req_pool_indices=req_pool_indices,
+            paged_kernel_lens=paged_kernel_lens,
+            prefix_lens=prefix_lens,
+            seq_lens=seq_lens,
+            kv_start_idx=kv_start_idx,
+            qo_indptr=qo_indptr,
+            kv_indptr=kv_indptr,
+            kv_indices=kv_indices,
+            use_ragged=use_ragged,
+        )
 
         # cached part
         # Conditionally set multi-item parameters
@@ -2064,10 +4172,26 @@ class FlashInferIndicesUpdaterPrefill:
             token_pos_in_items_len = 0
             max_item_len_ptr = None
 
+        paged_plan_kwargs = {
+            "head_dim_vo": geom.head_dim_vo,
+            "q_data_type": self.q_data_type,
+            "kv_data_type": self.kv_data_type,
+            "custom_mask": use_custom_mask,
+            "non_blocking": True,
+            "fixed_split_size": fixed_split_size,
+            "prefix_len_ptr": prefix_len_ptr,
+            "token_pos_in_items_ptr": token_pos_in_items_ptr,
+            "token_pos_in_items_len": token_pos_in_items_len,
+            "max_item_len_ptr": max_item_len_ptr,
+        }
+        if self.k_data_type != self.v_data_type:
+            paged_plan_kwargs.update(
+                k_data_type=self.k_data_type,
+                v_data_type=self.v_data_type,
+            )
         # fast_prefill_plan (installed at capture) is sync-free: it needs the
         # host-known qo/kv layout from the caller. Assert rather than silently
         # fall back to plan()'s blocking D2H on the replay hot-path.
-        paged_plan_kwargs = {}
         num_tokens_per_req = getattr(spec_info, "num_tokens_per_req", None)
         uses_fast_prefill = (
             hasattr(wrapper_paged.begin_forward, "func")
@@ -2090,7 +4214,7 @@ class FlashInferIndicesUpdaterPrefill:
             )
             kv_indptr_host = torch.zeros(bs + 1, dtype=torch.int32, device="cpu")
             kv_indptr_host[1:] = torch.cumsum(seq_lens_cpu_i32, dim=0)
-            paged_plan_kwargs = dict(
+            paged_plan_kwargs.update(
                 qo_indptr_host=qo_indptr_host,
                 kv_indptr_host=kv_indptr_host,
                 kv_lens_host=seq_lens_cpu_i32,
@@ -2103,19 +4227,10 @@ class FlashInferIndicesUpdaterPrefill:
             kv_indptr,
             kv_indices,
             self.kv_last_page_len[:bs],
-            self.num_qo_heads,
-            self.num_kv_heads,
-            self.head_dim,
+            geom.num_qo_heads,
+            geom.num_kv_heads,
+            geom.head_dim,
             1,
-            q_data_type=self.q_data_type,
-            kv_data_type=self.kv_data_type,
-            custom_mask=use_custom_mask,
-            non_blocking=True,
-            fixed_split_size=fixed_split_size,
-            prefix_len_ptr=prefix_len_ptr,
-            token_pos_in_items_ptr=token_pos_in_items_ptr,
-            token_pos_in_items_len=token_pos_in_items_len,
-            max_item_len_ptr=max_item_len_ptr,
             **paged_plan_kwargs,
         )
 

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -29,15 +29,13 @@ from sglang.srt.layers.attention.utils import (
 )
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
-from sglang.srt.mem_cache.memory_pool import KVWriteLoc
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc, MHATokenToKVPoolFP4
+from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
-from sglang.srt.mem_cache.memory_pool import MHATokenToKVPoolFP4
-from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
@@ -74,6 +72,8 @@ def _cuda_graph_capture_max_bs(server_args, max_bs: int) -> int:
     if mul_base % get_parallel().attn_cp_size != 0:
         mul_base *= get_parallel().attn_cp_size
     return (max_bs + mul_base - 1) // mul_base * mul_base
+
+
 def _fp4_kv_radix_trace_enabled() -> bool:
     return os.environ.get("SGLANG_FP4_KV_TRACE_RADIX") == "1"
 
@@ -561,6 +561,8 @@ def fast_prefill_plan(
         0,  # num_colocated_ctas
     ]
     self._plan_info = self._cached_module.plan(*args)
+
+
 def _is_nvfp4_native_kv_pool(token_to_kv_pool) -> bool:
     if isinstance(token_to_kv_pool, MHATokenToKVPoolFP4):
         return True
@@ -576,9 +578,7 @@ def _is_fp8_k_nvfp4_v_pool(token_to_kv_pool) -> bool:
         return bool(getattr(token_to_kv_pool, "mixed_fp8_k_nvfp4_v", False))
     return (
         isinstance(token_to_kv_pool, SWAKVPool)
-        and bool(
-            getattr(token_to_kv_pool.full_kv_pool, "mixed_fp8_k_nvfp4_v", False)
-        )
+        and bool(getattr(token_to_kv_pool.full_kv_pool, "mixed_fp8_k_nvfp4_v", False))
         and bool(getattr(token_to_kv_pool.swa_kv_pool, "mixed_fp8_k_nvfp4_v", False))
     )
 
@@ -590,14 +590,14 @@ def _nvfp4_inner_pool_and_layer_id(token_to_kv_pool, layer_id: int):
     token_to_kv_pool._wait_for_layer(layer_id)
     local_layer_id, is_swa_layer = token_to_kv_pool.layers_mapping[layer_id]
     inner_pool = (
-        token_to_kv_pool.swa_kv_pool
-        if is_swa_layer
-        else token_to_kv_pool.full_kv_pool
+        token_to_kv_pool.swa_kv_pool if is_swa_layer else token_to_kv_pool.full_kv_pool
     )
     return inner_pool, local_layer_id
 
 
-def _shape_nvfp4_kv_scale_for_flashinfer(scale: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+def _shape_nvfp4_kv_scale_for_flashinfer(
+    scale: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
     if scale is None:
         return None
     if scale.dim() == 3:
@@ -810,7 +810,9 @@ def _trace_tensor_rows(x, rows, limit: Optional[int] = None):
                 }
             )
             continue
-        samples.append({"row": row_id, "value": _trace_numeric_tensor_stats(x[row_id], limit)})
+        samples.append(
+            {"row": row_id, "value": _trace_numeric_tensor_stats(x[row_id], limit)}
+        )
     return {
         "tensor": _tensor_trace_summary(x),
         "rows": samples,
@@ -910,9 +912,9 @@ class FlashInferAttnBackend(AttentionBackend):
         )
         self.use_sliding_window_kv_pool = self._swa_kv_pool is not None
         self.enable_mis = model_runner.server_args.enable_mis
-        self.is_nvfp4_native = _is_nvfp4_native_kv_pool(
-            self.token_to_kv_pool
-        ) and is_sm120_supported()
+        self.is_nvfp4_native = (
+            _is_nvfp4_native_kv_pool(self.token_to_kv_pool) and is_sm120_supported()
+        )
         self.is_fp8_k_nvfp4_v = self.is_nvfp4_native and _is_fp8_k_nvfp4_v_pool(
             self.token_to_kv_pool
         )
@@ -1129,11 +1131,7 @@ class FlashInferAttnBackend(AttentionBackend):
         wrapper=None,
         vo_split: bool = False,
     ) -> None:
-        if (
-            not _gemma4_geometry_trace_enabled()
-            or layer is None
-            or label is None
-        ):
+        if not _gemma4_geometry_trace_enabled() or layer is None or label is None:
             return
         layer_id = getattr(layer, "layer_id", None)
         key = (label, int(layer_id) if layer_id is not None else None)
@@ -1179,7 +1177,10 @@ class FlashInferAttnBackend(AttentionBackend):
         paged_kv_cache,
         paged_kv_kwargs,
     ):
-        if not self.is_nvfp4_native or os.environ.get("SGLANG_FP4_KV_TRACE_BACKEND") != "1":
+        if (
+            not self.is_nvfp4_native
+            or os.environ.get("SGLANG_FP4_KV_TRACE_BACKEND") != "1"
+        ):
             return
         key = (label, int(layer.layer_id))
         if key in self._nvfp4_trace_seen:
@@ -1588,9 +1589,7 @@ class FlashInferAttnBackend(AttentionBackend):
             k_scale_multiplier_refs = []
             for multiplier in _trace_k_scale_multipliers():
                 alt_k_global = (k_global.float() * multiplier).contiguous()
-                alt_k_fp4, alt_k_sf, _ = NVFP4KVQuantizeUtil.quantize(
-                    k3, alt_k_global
-                )
+                alt_k_fp4, alt_k_sf, _ = NVFP4KVQuantizeUtil.quantize(k3, alt_k_global)
                 alt_k_deq = NVFP4KVQuantizeUtil.dequantize(
                     alt_k_fp4.view(torch.uint8),
                     alt_k_sf.reshape(k3.shape[0], -1),
@@ -1741,13 +1740,9 @@ class FlashInferAttnBackend(AttentionBackend):
                 actual = o3[row_id]
                 row_record = {
                     "row": row_id,
-                    "actual_vs_bf16_ref": _trace_compare_tensors(
-                        actual, bf16_ref
-                    ),
+                    "actual_vs_bf16_ref": _trace_compare_tensors(actual, bf16_ref),
                     "actual_vs_fp4_ref": _trace_compare_tensors(actual, fp4_ref),
-                    "fp4_ref_vs_bf16_ref": _trace_compare_tensors(
-                        fp4_ref, bf16_ref
-                    ),
+                    "fp4_ref_vs_bf16_ref": _trace_compare_tensors(fp4_ref, bf16_ref),
                     "fp4_k_only_ref_vs_bf16_ref": _trace_compare_tensors(
                         fp4_k_ref, bf16_ref
                     ),
@@ -1902,9 +1897,7 @@ class FlashInferAttnBackend(AttentionBackend):
                 k_scale = k_scale.view(torch.float8_e4m3fn)
             v_scale = v_scale.view(torch.float8_e4m3fn)
             k_scale_for_dequant = (
-                k_scale.reshape(k_scale.shape[0], -1)
-                if k_scale is not None
-                else None
+                k_scale.reshape(k_scale.shape[0], -1) if k_scale is not None else None
             )
             v_scale_for_dequant = v_scale.reshape(v_scale.shape[0], -1)
 
@@ -1971,8 +1964,8 @@ class FlashInferAttnBackend(AttentionBackend):
                 summary["reference"]["s2_compare"] = _trace_compare_tensors(
                     lse_ref_base2, s2_slice
                 )
-                summary["reference"]["s2_compare_natural_log"] = (
-                    _trace_compare_tensors(lse_ref, s2_slice)
+                summary["reference"]["s2_compare_natural_log"] = _trace_compare_tensors(
+                    lse_ref, s2_slice
                 )
             else:
                 summary["reference"]["s2_compare"] = {
@@ -1983,7 +1976,9 @@ class FlashInferAttnBackend(AttentionBackend):
             s1_slice = _trace_select_lse_slice(s1, qo_start, qo_end, qo_end - qo_start)
             merged_slice = merged[qo_start:qo_end]
             o1_slice = o1[qo_start:qo_end].float()
-            if isinstance(s1_slice, torch.Tensor) and isinstance(s2_slice, torch.Tensor):
+            if isinstance(s1_slice, torch.Tensor) and isinstance(
+                s2_slice, torch.Tensor
+            ):
                 o2_slice_f = o2_slice.float()
                 s1_work = s1_slice.float().unsqueeze(-1)
                 s2_work = s2_slice.float().unsqueeze(-1)
@@ -2001,12 +1996,12 @@ class FlashInferAttnBackend(AttentionBackend):
                     "s2": _tensor_trace_summary(s2),
                 }
 
-            suffix_k_req_raw = suffix_k.view(
-                -1, layer.tp_k_head_num, layer.head_dim
-            )[qo_start:qo_end].contiguous()
-            suffix_v_req_raw = suffix_v.view(
-                -1, layer.tp_v_head_num, layer.head_dim
-            )[qo_start:qo_end].contiguous()
+            suffix_k_req_raw = suffix_k.view(-1, layer.tp_k_head_num, layer.head_dim)[
+                qo_start:qo_end
+            ].contiguous()
+            suffix_v_req_raw = suffix_v.view(-1, layer.tp_v_head_num, layer.head_dim)[
+                qo_start:qo_end
+            ].contiguous()
             suffix_k_req = suffix_k_req_raw.float()
             suffix_v_req = suffix_v_req_raw.float()
 
@@ -2026,14 +2021,13 @@ class FlashInferAttnBackend(AttentionBackend):
                     return out, lse
                 q_heads_ref = q_rows.shape[1]
                 kv_heads_ref = kv_k.shape[1]
-                kv_head_for_q_ref = torch.arange(
-                    q_heads_ref, device=q_rows.device
-                ) // (q_heads_ref // kv_heads_ref)
+                kv_head_for_q_ref = torch.arange(q_heads_ref, device=q_rows.device) // (
+                    q_heads_ref // kv_heads_ref
+                )
                 k_for_q_ref = kv_k[:, kv_head_for_q_ref, :]
                 v_for_q_ref = kv_v[:, kv_head_for_q_ref, :]
-                logits_ref = (
-                    torch.einsum("qhd,thd->qht", q_rows, k_for_q_ref)
-                    * float(sm_scale)
+                logits_ref = torch.einsum("qhd,thd->qht", q_rows, k_for_q_ref) * float(
+                    sm_scale
                 )
                 if logits_soft_cap is not None and float(logits_soft_cap) > 0:
                     logits_ref = float(logits_soft_cap) * torch.tanh(
@@ -2071,12 +2065,8 @@ class FlashInferAttnBackend(AttentionBackend):
                 outs = []
                 lses = []
                 for row_idx in range(q_rows.shape[0]):
-                    full_k = torch.cat(
-                        [prefix_k, suffix_k_local[: row_idx + 1]], dim=0
-                    )
-                    full_v = torch.cat(
-                        [prefix_v, suffix_v_local[: row_idx + 1]], dim=0
-                    )
+                    full_k = torch.cat([prefix_k, suffix_k_local[: row_idx + 1]], dim=0)
+                    full_v = torch.cat([prefix_v, suffix_v_local[: row_idx + 1]], dim=0)
                     out_i, lse_i = attention_ref_for_q(
                         full_k, full_v, q_rows[row_idx : row_idx + 1]
                     )
@@ -2210,14 +2200,13 @@ class FlashInferAttnBackend(AttentionBackend):
                             return out, lse
                         q_heads = q_req_f.shape[1]
                         kv_heads = kv_k.shape[1]
-                        kv_head_for_q = torch.arange(q_heads, device=q_req_f.device) // (
-                            q_heads // kv_heads
-                        )
+                        kv_head_for_q = torch.arange(
+                            q_heads, device=q_req_f.device
+                        ) // (q_heads // kv_heads)
                         k_for_q = kv_k[:, kv_head_for_q, :]
                         v_for_q = kv_v[:, kv_head_for_q, :]
-                        logits = (
-                            torch.einsum("qhd,thd->qht", q_req_f, k_for_q)
-                            * float(sm_scale)
+                        logits = torch.einsum("qhd,thd->qht", q_req_f, k_for_q) * float(
+                            sm_scale
                         )
                         if logits_soft_cap is not None and float(logits_soft_cap) > 0:
                             logits = float(logits_soft_cap) * torch.tanh(
@@ -2343,12 +2332,7 @@ class FlashInferAttnBackend(AttentionBackend):
         v: torch.Tensor,
         paged_kv_kwargs,
     ):
-        if (
-            not self.is_nvfp4_native
-            or self.is_fp8_k_nvfp4_v
-            or k is None
-            or v is None
-        ):
+        if not self.is_nvfp4_native or self.is_fp8_k_nvfp4_v or k is None or v is None:
             if k is None or v is None:
                 return k, v, {}
             return (
@@ -2464,9 +2448,7 @@ class FlashInferAttnBackend(AttentionBackend):
             wrapper=wrapper,
             vo_split=vo_split,
         )
-        out = wrapper.run(
-            q, paged_kv_cache, return_lse=return_lse, **paged_kv_kwargs
-        )
+        out = wrapper.run(q, paged_kv_cache, return_lse=return_lse, **paged_kv_kwargs)
         if self.is_nvfp4_native and _fp4_kv_module_trace_enabled():
             layer_id = getattr(trace_layer, "layer_id", None)
             key = (trace_label, int(layer_id) if layer_id is not None else None)
@@ -3065,9 +3047,7 @@ class FlashInferAttnBackend(AttentionBackend):
                 not layer.is_cross_attention
                 and layer.attn_type != AttentionType.ENCODER_ONLY
             )
-            paged_kv_cache, paged_kv_kwargs = self._get_paged_kv_cache_and_kwargs(
-                layer
-            )
+            paged_kv_cache, paged_kv_kwargs = self._get_paged_kv_cache_and_kwargs(layer)
             paged_window_left = (
                 layer.sliding_window_size
                 if not (
@@ -3199,9 +3179,7 @@ class FlashInferAttnBackend(AttentionBackend):
                     suffix_k_for_attention,
                     suffix_v_for_attention,
                     suffix_attention_kwargs,
-                ) = self._suffix_attention_inputs(
-                    layer, k, v, paged_kv_kwargs
-                )
+                ) = self._suffix_attention_inputs(layer, k, v, paged_kv_kwargs)
                 q_native = q.view(-1, layer.tp_q_head_num, layer.head_dim)
                 if suffix_attention_kwargs:
                     self.prefill_wrapper_ragged._causal = causal
@@ -3478,9 +3456,7 @@ class FlashInferIndicesUpdaterDecode:
             torch.uint8 if attn_backend.is_nvfp4_native else self.data_type
         )
         self.k_data_type = (
-            torch.float8_e4m3fn
-            if attn_backend.is_fp8_k_nvfp4_v
-            else self.kv_data_type
+            torch.float8_e4m3fn if attn_backend.is_fp8_k_nvfp4_v else self.kv_data_type
         )
         self.v_data_type = self.kv_data_type
         self.q_data_type = model_runner.dtype
@@ -3795,9 +3771,7 @@ class FlashInferIndicesUpdaterPrefill:
             torch.uint8 if attn_backend.is_nvfp4_native else self.data_type
         )
         self.k_data_type = (
-            torch.float8_e4m3fn
-            if attn_backend.is_fp8_k_nvfp4_v
-            else self.kv_data_type
+            torch.float8_e4m3fn if attn_backend.is_fp8_k_nvfp4_v else self.kv_data_type
         )
         self.v_data_type = self.kv_data_type
         self.q_data_type = model_runner.dtype
@@ -4134,8 +4108,7 @@ class FlashInferIndicesUpdaterPrefill:
                 self.kv_data_type
                 if (
                     has_cached_prefix
-                    and
-                    self.attn_backend.is_nvfp4_native
+                    and self.attn_backend.is_nvfp4_native
                     and not self.attn_backend.is_fp8_k_nvfp4_v
                 )
                 else self.q_data_type

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -4202,6 +4202,19 @@ class FlashInferIndicesUpdaterPrefill:
             "token_pos_in_items_len": token_pos_in_items_len,
             "max_item_len_ptr": max_item_len_ptr,
         }
+        # NVFP4 split-KV is lossy on the extend geometry (qo_len << kv_len from a
+        # reused radix prefix): with little query parallelism the FA2 scheduler
+        # splits the KV dimension flash-decoding style, but a split boundary can
+        # land mid scale-factor block (NVFP4 packs a per-16 FP8 scale) and the
+        # small per-split chunk trips the 1-byte-KV tile-count floor, corrupting
+        # prefix-cached reads. Verified on E2B/E4B: forcing split-KV off restores
+        # radix-on retrieval out to 1448 tokens (== bf16); leaving it on cliffs at
+        # ~600 tok of reused-prefix context. Disable split-KV for native FP4 until
+        # the split path respects the per-16 scale blocks + tile floor. The kernel
+        # is shared with vLLM via FlashInfer #3684, so the gate belongs upstream
+        # too (keyed on FP4 kv_data_type); pinned here where FP4 is unambiguous.
+        if getattr(self.attn_backend, "is_nvfp4_native", False):
+            paged_plan_kwargs["disable_split_kv"] = True
         if self.k_data_type != self.v_data_type:
             paged_plan_kwargs.update(
                 k_data_type=self.k_data_type,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.runtime_context import get_parallel
 
 """

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -2332,29 +2332,24 @@ class FlashInferAttnBackend(AttentionBackend):
         v: torch.Tensor,
         paged_kv_kwargs,
     ):
-        if not self.is_nvfp4_native or self.is_fp8_k_nvfp4_v or k is None or v is None:
-            if k is None or v is None:
-                return k, v, {}
-            return (
-                k.view(-1, layer.tp_k_head_num, layer.head_dim),
-                v.view(-1, layer.tp_v_head_num, layer.head_dim),
-                {},
-            )
-
-        from sglang.srt.layers.quantization.kvfp4_tensor import NVFP4KVQuantizeUtil
-
-        k3 = k.view(-1, layer.tp_k_head_num, layer.head_dim).contiguous()
-        v3 = v.view(-1, layer.tp_v_head_num, layer.head_dim).contiguous()
-        k_fp4, k_sf, _ = NVFP4KVQuantizeUtil.quantize(k3, paged_kv_kwargs["k_scale"])
-        v_fp4, v_sf, _ = NVFP4KVQuantizeUtil.quantize(v3, paged_kv_kwargs["v_scale"])
+        # On the cached-prefix merge path the SUFFIX (the new, uncached tokens)
+        # attends to itself in a ragged pass whose output is merge_state-combined
+        # with the fp4 cached prefix. Run that suffix pass in native bf16 k/v --
+        # exactly like the no-prefix ragged path above (and like vLLM's unified FA2
+        # path) -- instead of re-quantizing the suffix to NVFP4 first. The suffix is
+        # still written to the fp4 KV cache (set_kv_buffer) and read as fp4 during
+        # decode; only this prefill self-attention stays bf16. Re-quantizing the
+        # freshest, most attention-relevant tokens here (then merging them with the
+        # dequantized prefix) measurably degraded GSM8K -- radix-on 0.357 vs
+        # radix-off 0.480 (n=300, matched client), where radix-off == vLLM 0.457 ==
+        # bf16. Attending the suffix in bf16 closes that gap while keeping the
+        # prefix cached in fp4.
+        if k is None or v is None:
+            return k, v, {}
         return (
-            k_fp4.view(torch.uint8),
-            v_fp4.view(torch.uint8),
-            {
-                "kv_cache_sf": (k_sf, v_sf),
-                "k_scale": paged_kv_kwargs["k_scale"],
-                "v_scale": paged_kv_kwargs["v_scale"],
-            },
+            k.view(-1, layer.tp_k_head_num, layer.head_dim),
+            v.view(-1, layer.tp_v_head_num, layer.head_dim),
+            {},
         )
 
     def _should_vo_split(self, layer: RadixAttention) -> bool:

--- a/python/sglang/srt/layers/quantization/kvfp4_tensor.py
+++ b/python/sglang/srt/layers/quantization/kvfp4_tensor.py
@@ -154,8 +154,8 @@ class NVFP4KVQuantizeUtil:
     (global FP32 + block FP8 E4M3).
 
     Quantize formula:  x_fp4 * block_scale * global_scale = x_bf16
-    - Quantize: ``nvfp4_kv_quantize`` (SM100/SM120),
-      fallback ``fp4_quantize`` (SM90)
+    - Quantize: ``nvfp4_kv_quantize`` (SM100),
+      fallback ``fp4_quantize`` (SM90/SM120)
     - Dequantize: ``nvfp4_kv_dequantize`` (SM100+)
     """
 
@@ -165,8 +165,8 @@ class NVFP4KVQuantizeUtil:
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Quantize BF16/FP16 tensor to NVFP4 format.
 
-        Requires SM90/SM100/SM120.  Uses ``nvfp4_kv_quantize`` on SM100/SM120,
-        falls back to ``fp4_quantize`` on SM90.
+        Requires SM90/SM100/SM120.  Uses ``nvfp4_kv_quantize`` on SM100,
+        falls back to ``fp4_quantize`` on SM90/SM120.
 
         Args:
             tensor: Input tensor of shape [B, M, N]
@@ -198,7 +198,7 @@ class NVFP4KVQuantizeUtil:
         elif global_scale.dim() == 0:
             global_scale = global_scale.unsqueeze(0)
 
-        if is_sm100_supported() or is_sm120_supported():
+        if is_sm100_supported():
             from flashinfer import nvfp4_kv_quantize
 
             # nvfp4_kv_quantize takes global_scale directly (not inverted)

--- a/python/sglang/srt/layers/quantization/kvfp4_tensor.py
+++ b/python/sglang/srt/layers/quantization/kvfp4_tensor.py
@@ -154,7 +154,8 @@ class NVFP4KVQuantizeUtil:
     (global FP32 + block FP8 E4M3).
 
     Quantize formula:  x_fp4 * block_scale * global_scale = x_bf16
-    - Quantize: ``nvfp4_kv_quantize`` (SM100+), fallback ``fp4_quantize`` (SM90)
+    - Quantize: ``nvfp4_kv_quantize`` (SM100/SM120),
+      fallback ``fp4_quantize`` (SM90)
     - Dequantize: ``nvfp4_kv_dequantize`` (SM100+)
     """
 
@@ -164,7 +165,7 @@ class NVFP4KVQuantizeUtil:
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Quantize BF16/FP16 tensor to NVFP4 format.
 
-        Requires SM90+.  Uses ``nvfp4_kv_quantize`` on SM100+ (native PTX),
+        Requires SM90/SM100/SM120.  Uses ``nvfp4_kv_quantize`` on SM100/SM120,
         falls back to ``fp4_quantize`` on SM90.
 
         Args:
@@ -177,9 +178,15 @@ class NVFP4KVQuantizeUtil:
                 block_scales: shape [B, M, N/16], dtype float8_e4m3fn
                 global_scale: passthrough
         """
-        from sglang.srt.utils import is_sm90_supported, is_sm100_supported
+        from sglang.srt.utils import (
+            is_sm90_supported,
+            is_sm100_supported,
+            is_sm120_supported,
+        )
 
-        assert is_sm90_supported(), "NVFP4 KV cache quantize requires SM90+ GPU"
+        assert (
+            is_sm90_supported() or is_sm100_supported() or is_sm120_supported()
+        ), "NVFP4 KV cache quantize requires SM90/SM100/SM120 GPU"
 
         b, m, n = tensor.shape
         tensor_2d = tensor.reshape(b * m, n)
@@ -191,7 +198,7 @@ class NVFP4KVQuantizeUtil:
         elif global_scale.dim() == 0:
             global_scale = global_scale.unsqueeze(0)
 
-        if is_sm100_supported():
+        if is_sm100_supported() or is_sm120_supported():
             from flashinfer import nvfp4_kv_quantize
 
             # nvfp4_kv_quantize takes global_scale directly (not inverted)

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -15,6 +15,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
@@ -38,6 +40,8 @@ _is_hip = is_hip()
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization.base_config import QuantizationConfig
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+logger = logging.getLogger(__name__)
 
 
 class AttentionType(Enum):
@@ -105,6 +109,19 @@ class RadixAttention(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.logit_capping_method = logit_capping_method
         self.xai_temperature_len = -1
+
+        if os.environ.get("SGLANG_GEMMA_KV_GEOMETRY") == "1":
+            logger.info(
+                "SGLANG_GEMMA_KV_GEOMETRY layer=%s heads=%s kv_heads=%s "
+                "head_dim=%s v_head_dim=%s sliding_window=%s attn_type=%s",
+                self.layer_id,
+                self.tp_q_head_num,
+                self.tp_k_head_num,
+                self.qk_head_dim,
+                self.v_head_dim,
+                self.sliding_window_size,
+                self.attn_type.value,
+            )
 
     def forward(
         self,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -762,6 +762,9 @@ class Req(ReqDllmMixin):
         self.full_untruncated_fill_ids = array("q")
         self.extend_range: Optional[Range] = None
         self.dllm_initialized: bool = False
+        # Uniform-diffusion (DiffusionGemma #28054) fill length; the canvas scheduler
+        # mutates this. Main tracks masked dLLM via dllm_initialized; uniform needs this.
+        self.fill_len: int = 0
 
         self.session = session
         self.input_embeds = input_embeds
@@ -1519,6 +1522,7 @@ class Req(ReqDllmMixin):
         self.swa_prefix_lock_released = False
         self.extend_range = None
         self.dllm_initialized = False
+        self.fill_len = 0
         self.is_retracted = True
         self.retracted_stain = True
         self.input_token_logprobs = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -38,7 +38,9 @@ ScheduleBatch -> ForwardBatch
 
 import copy
 import dataclasses
+import hashlib
 import logging
+import os
 import re
 from array import array
 from concurrent.futures import Future
@@ -129,6 +131,38 @@ INIT_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 MM_PAD_SHIFT_VALUE = 1_000_000
 
 logger = logging.getLogger(__name__)
+
+
+def _fp4_kv_radix_trace_enabled(rid: Optional[str] = None) -> bool:
+    if os.environ.get("SGLANG_FP4_KV_TRACE_RADIX") != "1":
+        return False
+    rid_filter = os.environ.get("SGLANG_FP4_KV_TRACE_RID")
+    return rid_filter in (None, "", str(rid))
+
+
+def _trace_len(value) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return len(value)
+    except TypeError:
+        return None
+
+
+def _trace_sequence_summary(value, *, limit: int = 8):
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        data = value.detach().to("cpu").flatten().tolist()
+    else:
+        data = list(value)
+    encoded = ",".join(str(x) for x in data).encode("utf-8")
+    return {
+        "len": len(data),
+        "head": data[:limit],
+        "tail": data[-limit:] if len(data) > limit else data,
+        "hash": hashlib.blake2b(encoded, digest_size=8).hexdigest(),
+    }
 
 
 @lru_cache(maxsize=1)
@@ -1199,6 +1233,42 @@ class Req(ReqDllmMixin):
                 self.cache_protected_len = match_result.cache_protected_len
             else:
                 self.cache_protected_len = len(self.prefix_indices)
+
+            if _fp4_kv_radix_trace_enabled(self.rid):
+                logger.warning(
+                    "FP4 KV radix trace rid=%s input_len=%s match_tokens=%s "
+                    "origin=%s fill=%s match=%s extra_key=%s "
+                    "prefix_indices_len=%s prefix_indices=%s "
+                    "host_hit_length=%s swa_host_hit_length=%s "
+                    "mamba_host_hit_length=%s cache_protected_len=%s "
+                    "tree_page_size=%s tree_disable=%s last_node=%s "
+                    "last_host_node=%s best_match_node=%s force_miss=%s",
+                    self.rid,
+                    input_len,
+                    len(token_ids_to_match),
+                    _trace_sequence_summary(self.origin_input_ids),
+                    _trace_sequence_summary(self.fill_ids),
+                    _trace_sequence_summary(token_ids_to_match),
+                    self.extra_key,
+                    _trace_len(self.prefix_indices),
+                    _trace_sequence_summary(self.prefix_indices),
+                    self.host_hit_length,
+                    self.swa_host_hit_length,
+                    self.mamba_host_hit_length,
+                    self.cache_protected_len,
+                    getattr(tree_cache, "page_size", None),
+                    getattr(tree_cache, "disable", None),
+                    type(self.last_node).__name__
+                    if self.last_node is not None
+                    else None,
+                    type(self.last_host_node).__name__
+                    if self.last_host_node is not None
+                    else None,
+                    type(self.best_match_node).__name__
+                    if self.best_match_node is not None
+                    else None,
+                    envs.SGLANG_RADIX_FORCE_MISS.get(),
+                )
 
             if self.is_dllm():
                 self._update_block_offset_for_dllm()

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1261,15 +1261,21 @@ class Req(ReqDllmMixin):
                     self.cache_protected_len,
                     getattr(tree_cache, "page_size", None),
                     getattr(tree_cache, "disable", None),
-                    type(self.last_node).__name__
-                    if self.last_node is not None
-                    else None,
-                    type(self.last_host_node).__name__
-                    if self.last_host_node is not None
-                    else None,
-                    type(self.best_match_node).__name__
-                    if self.best_match_node is not None
-                    else None,
+                    (
+                        type(self.last_node).__name__
+                        if self.last_node is not None
+                        else None
+                    ),
+                    (
+                        type(self.last_host_node).__name__
+                        if self.last_host_node is not None
+                        else None
+                    ),
+                    (
+                        type(self.best_match_node).__name__
+                        if self.best_match_node is not None
+                        else None
+                    ),
                     envs.SGLANG_RADIX_FORCE_MISS.get(),
                 )
 

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -645,19 +645,33 @@ class PrefillAdder:
             int(self.rem_total_tokens),
         )
         if _rem_tokens <= 0:
+            # rem_total_tokens over-reserves (max_new_tokens per running req),
+            # so let a staged canvas round proceed past it.
             _rem_tokens = self.rem_dllm_tokens
 
+        # But never past the immediate headroom (cur_rem_tokens carries no
+        # such reservations): over-admitting crashes the alloc in
+        # prepare_for_extend.
+        _rem_tokens = min(_rem_tokens, int(self.cur_rem_tokens) - self.page_size)
+        if self.is_hybrid_swa:
+            _rem_tokens = min(_rem_tokens, int(self.rem_swa_tokens) - self.page_size)
         return _rem_tokens
 
     def _add_dllm_req(self, req: Req, prefix_len: int):
         # FIXME: consider the case when rem_dllm_tokens < dllm_block_size,
         # the diffusion unmask process may have some problems
         # Make sure at least one page is available
-        trunc_len = (
-            min(self.rem_dllm_tokens, self.dllm_block_size)
-            // self.page_size
-            * self.page_size
-        )
+        if self.dllm_config.is_uniform:
+            # Uniform extends the actual remaining tokens (variable-length encode or
+            # the full canvas), not a forced page-aligned block.
+            available = req.fill_len - prefix_len
+            trunc_len = min(self.rem_dllm_tokens, self.dllm_block_size, available)
+        else:
+            trunc_len = (
+                min(self.rem_dllm_tokens, self.dllm_block_size)
+                // self.page_size
+                * self.page_size
+            )
 
         req.set_extend_range(prefix_len, prefix_len + trunc_len)
 
@@ -682,6 +696,11 @@ class PrefillAdder:
             req.prefix_indices
         )
         truncated = cand_extend_input_len > _rem_tokens
+        if truncated and self.dllm_config.is_uniform and not req.is_dllm_prefill():
+            # A canvas decode round extends the whole block or not at all
+            # (the denoiser writes bs * block_size tokens). #28054 guard, kept in
+            # main's set_extend_range API.
+            return AddReqResult.NO_TOKEN
         new_len = min(cand_extend_input_len, _rem_tokens)
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2220,7 +2220,9 @@ class Scheduler(
             if req.return_logprob:
                 unsupported.append("logprobs")
             if sp.regex or sp.json_schema or sp.ebnf or sp.structural_tag:
-                unsupported.append("structured output (regex/json_schema/ebnf/structural_tag)")
+                unsupported.append(
+                    "structured output (regex/json_schema/ebnf/structural_tag)"
+                )
             if sp.logit_bias:
                 unsupported.append("logit_bias")
             if (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2211,6 +2211,33 @@ class Scheduler(
             self._add_request_to_queue(req)
             return
 
+        # Uniform-state diffusion samples the canvas from the renoise schedule and
+        # bypasses logit post-processing, so request-level sampling controls have no
+        # effect. Reject them explicitly rather than ignore them silently.
+        if self.dllm_config is not None and self.dllm_config.is_uniform:
+            sp = req.sampling_params
+            unsupported = []
+            if req.return_logprob:
+                unsupported.append("logprobs")
+            if sp.regex or sp.json_schema or sp.ebnf or sp.structural_tag:
+                unsupported.append("structured output (regex/json_schema/ebnf/structural_tag)")
+            if sp.logit_bias:
+                unsupported.append("logit_bias")
+            if (
+                sp.frequency_penalty
+                or sp.presence_penalty
+                or sp.repetition_penalty != 1.0
+            ):
+                unsupported.append("presence/frequency/repetition penalties")
+            if unsupported:
+                req.set_finish_with_abort(
+                    "DiffusionGemma does not support "
+                    + ", ".join(unsupported)
+                    + " (sampling is governed by the renoise schedule)."
+                )
+                self._add_request_to_queue(req)
+                return
+
         if not recv_req.return_logprob and recv_req.logprob_start_len != -1:
             # When return_logprob is False, logprob_start_len should be ignored
             recv_req.logprob_start_len = -1
@@ -2613,7 +2640,40 @@ class Scheduler(
         if self.dllm_config is not None and self.dllm_manager.any_staging_reqs():
             chunked_req_to_exclude.update(self.dllm_manager.staging_queue)
             for req in self.dllm_manager.staging_queue:
-                self.stash_chunked_request(req)
+                if (
+                    self.dllm_config.is_uniform
+                    and not req.is_dllm_prefill()
+                    and req.fill_len > self.dllm_config.block_size
+                ):
+                    # Uniform dLLM: drop the canvas from the cached prefix so the
+                    # next round re-encodes it causally (its KV is the decoder's
+                    # transient denoising KV). Free its slots except the page
+                    # shared with the context.
+                    block = self.dllm_config.block_size
+                    ctx = req.fill_len - block
+                    req_to_token = self.req_to_token_pool.req_to_token
+                    slots = req_to_token[req.req_pool_idx, ctx : ctx + block].to(
+                        torch.int64
+                    )
+                    page = self.token_to_kv_pool_allocator.page_size
+                    retained = 0
+                    if ctx > 0:
+                        shared_page = (
+                            int(req_to_token[req.req_pool_idx, ctx - 1].item()) // page
+                        )
+                        keep = (slots // page) == shared_page
+                        retained = int(keep.sum().item())
+                        slots = slots[~keep]
+                    self.token_to_kv_pool_allocator.free(slots)
+                    # Shrink the KV bookkeeping past the retained shared-page
+                    # slots so a later release cannot re-free the freed ones.
+                    req.kv_committed_len = ctx + retained
+                    req.kv_allocated_len = ctx + retained
+                    req.fill_len = ctx
+                    self.stash_chunked_request(req)
+                    req.fill_len = ctx + block
+                else:
+                    self.stash_chunked_request(req)
 
         if self.chunked_req is not None:
             # Move the chunked request out of the batch so that we can merge
@@ -3549,7 +3609,9 @@ class Scheduler(
         idle = (
             self.running_batch.is_empty()
             and self.chunked_req is None
-            and not self.dllm_manager.any_staging_reqs()
+            # dLLM requests hold KV in dllm_manager.waiting_queue between
+            # rounds, so a starved round must not count as idle.
+            and self.dllm_manager.is_empty()
             and (self.last_batch is None or self.last_batch.is_empty())
             and (self.cur_batch is None or self.cur_batch.is_empty())
             and (not self.enable_overlap or len(self.result_queue) == 0)

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -449,13 +449,17 @@ class TpModelWorker(BaseTpWorker):
             self.model_config.context_len - 1,
             self.model_runner.max_token_pool_size - 1,
         )
+        max_req_input_len = max_req_len - 5
+        if self.dllm_algorithm is not None:
+            # The canvas extends past the prompt within the same row.
+            max_req_input_len -= self.dllm_algorithm.block_size
         return (
             self.model_runner.max_total_num_tokens,
             self.server_args.max_prefill_tokens,
             self.model_runner.max_running_requests,
             self.server_args.max_queued_requests,
             max_req_len,
-            max_req_len - 5,
+            max_req_input_len,
             self.random_seed,
             self.device,
             self.model_runner.forward_stream,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1976,10 +1976,27 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
         )
 
         denom = E2M1_MAX * MAX_BLOCK_SCALE_FP8
+        # Calibration headroom. A global scale of amax/denom maps this warmup's amax
+        # to the very TOP of the NVFP4 representable range, i.e. ZERO headroom: any
+        # serving-time |k|/|v| larger than the single eager warmup prefill's amax
+        # saturates the fp4 + fp8-block range and is clipped. The warmup is short and
+        # not guaranteed representative of real traffic, so a tight (headroom=1) fit
+        # clips the heavier tails of real data, and the clipped KV reads compound into
+        # runaway repetition the deeper a sequence is decoded. Quantization-calibration
+        # practice is to leave headroom above the observed max; here the risk is
+        # strongly asymmetric (under-scaling -> catastrophic degeneration, over-scaling
+        # -> only minor precision loss), so we map amax into a FRACTION of the range.
+        # Default 2.0 = amax sits at half the representable range. Measured on
+        # Gemma-4-12B (GB10 / GSM8K 5-shot): headroom 1.0 -> 6-10% garbled, acc 0.33;
+        # 2.0 -> ~2% garbled, acc matches the bf16-KV baseline; >=4.0 starts to lose
+        # precision again. A checkpoint that ships k_scale/v_scale overrides this path.
+        headroom = float(os.environ.get("SGLANG_FP4_KV_AUTOCALIB_HEADROOM", "2.0"))
+        if headroom <= 0:
+            headroom = 1.0
         k_amax = cache_k.detach().abs().amax().float()
         v_amax = cache_v.detach().abs().amax().float()
-        k_gs = (k_amax / denom).clamp_(min=1e-8)
-        v_gs = (v_amax / denom).clamp_(min=1e-8)
+        k_gs = (k_amax * headroom / denom).clamp_(min=1e-8)
+        v_gs = (v_amax * headroom / denom).clamp_(min=1e-8)
         self.k_global[local_layer_id].copy_(k_gs)
         self.v_global[local_layer_id].copy_(v_gs)
         self.k_global_float[local_layer_id] = float(k_gs)
@@ -1988,12 +2005,13 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
         if not explicit_autocalib:
             logger.info(
                 "NVFP4 KV auto-calibrated layer %d: k_amax=%.4g v_amax=%.4g "
-                "k_gs=%.4g v_gs=%.4g (n_tokens=%d)",
+                "k_gs=%.4g v_gs=%.4g headroom=%.3g (n_tokens=%d)",
                 layer_id,
                 float(k_amax),
                 float(v_amax),
                 self.k_global_float[local_layer_id],
                 self.v_global_float[local_layer_id],
+                headroom,
                 cache_k.shape[0],
             )
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 import logging
+import os
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
@@ -1745,6 +1746,8 @@ class NoOpMHATokenToKVPool(MHATokenToKVPool):
 
 
 class MHATokenToKVPoolFP4(MHATokenToKVPool):
+    SF_VEC_SIZE = 16
+
     def _create_buffers(self):
         with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
             with (
@@ -1757,8 +1760,8 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
                 m = self.size + self.page_size
                 n = self.head_num
                 k = self.head_dim
+                v = self.v_head_dim
 
-                scale_block_size = 16
                 self.store_dtype = torch.uint8
                 self.k_buffer = [
                     torch.zeros(
@@ -1770,7 +1773,7 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
                 ]
                 self.v_buffer = [
                     torch.zeros(
-                        (m, n, k // 2),
+                        (m, n, v // 2),
                         dtype=self.store_dtype,
                         device=self.device,
                     )
@@ -1779,7 +1782,7 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
 
                 self.k_scale_buffer = [
                     torch.zeros(
-                        (m, (n * k) // scale_block_size),
+                        (m, n, k // self.SF_VEC_SIZE),
                         dtype=self.store_dtype,
                         device=self.device,
                     )
@@ -1787,54 +1790,220 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
                 ]
                 self.v_scale_buffer = [
                     torch.zeros(
-                        (m, (n * k) // scale_block_size),
+                        (m, n, v // self.SF_VEC_SIZE),
                         dtype=self.store_dtype,
                         device=self.device,
                     )
                     for _ in range(self.layer_num)
                 ]
 
+                self.k_global = torch.ones(
+                    (self.layer_num, 1), dtype=torch.float32, device=self.device
+                )
+                self.v_global = torch.ones(
+                    (self.layer_num, 1), dtype=torch.float32, device=self.device
+                )
+                self.k_global_float = [1.0 for _ in range(self.layer_num)]
+                self.v_global_float = [1.0 for _ in range(self.layer_num)]
+                self._gs_calibrated = [False for _ in range(self.layer_num)]
+                self._autocalib_warned = False
+
+        self.k_data_ptrs = torch.tensor(
+            [x.data_ptr() for x in self.k_buffer],
+            dtype=torch.uint64,
+            device=self.device,
+        )
+        self.v_data_ptrs = torch.tensor(
+            [x.data_ptr() for x in self.v_buffer],
+            dtype=torch.uint64,
+            device=self.device,
+        )
+        self.k_scale_data_ptrs = torch.tensor(
+            [x.data_ptr() for x in self.k_scale_buffer],
+            dtype=torch.uint64,
+            device=self.device,
+        )
+        self.v_scale_data_ptrs = torch.tensor(
+            [x.data_ptr() for x in self.v_scale_buffer],
+            dtype=torch.uint64,
+            device=self.device,
+        )
+        self.data_ptrs = torch.cat(
+            [
+                self.k_data_ptrs,
+                self.v_data_ptrs,
+                self.k_scale_data_ptrs,
+                self.v_scale_data_ptrs,
+            ],
+            dim=0,
+        )
+        self.data_strides = torch.tensor(
+            [
+                np.prod(x.shape[1:]) * x.dtype.itemsize
+                for x in (
+                    self.k_buffer
+                    + self.v_buffer
+                    + self.k_scale_buffer
+                    + self.v_scale_buffer
+                )
+            ],
+            device=self.device,
+        )
+
     def _clear_buffers(self):
         del self.k_buffer
         del self.v_buffer
         del self.k_scale_buffer
         del self.v_scale_buffer
+        del self.k_global
+        del self.v_global
+        del self.k_global_float
+        del self.v_global_float
+        del self._gs_calibrated
 
     def _get_key_buffer(self, layer_id: int):
-        # for internal use of referencing
-        if self.store_dtype != self.dtype:
-            cache_k_nope_fp4 = self.k_buffer[layer_id - self.start_layer].view(
-                torch.uint8
-            )
-            cache_k_nope_fp4_sf = self.k_scale_buffer[layer_id - self.start_layer]
-
-            from sglang.srt.layers.quantization.kvfp4_tensor import (
-                BlockFP4KVQuantizeUtil,
-            )
-
-            cache_k_nope_fp4_dequant = BlockFP4KVQuantizeUtil.batched_dequantize(
-                cache_k_nope_fp4, cache_k_nope_fp4_sf
-            )
-            return cache_k_nope_fp4_dequant
         return self.k_buffer[layer_id - self.start_layer]
 
     def _get_value_buffer(self, layer_id: int):
-        # for internal use of referencing
-        if self.store_dtype != self.dtype:
-            cache_v_nope_fp4 = self.v_buffer[layer_id - self.start_layer].view(
-                torch.uint8
-            )
-            cache_v_nope_fp4_sf = self.v_scale_buffer[layer_id - self.start_layer]
-
-            from sglang.srt.layers.quantization.kvfp4_tensor import (
-                BlockFP4KVQuantizeUtil,
-            )
-
-            cache_v_nope_fp4_dequant = BlockFP4KVQuantizeUtil.batched_dequantize(
-                cache_v_nope_fp4, cache_v_nope_fp4_sf
-            )
-            return cache_v_nope_fp4_dequant
         return self.v_buffer[layer_id - self.start_layer]
+
+    def get_kv_scale_buffer(self, layer_id: int):
+        local_layer_id = layer_id - self.start_layer
+        return (
+            self.k_scale_buffer[local_layer_id].view(torch.float8_e4m3fn),
+            self.v_scale_buffer[local_layer_id].view(torch.float8_e4m3fn),
+        )
+
+    def get_kv_global_scale(self, layer_id: int):
+        local_layer_id = layer_id - self.start_layer
+        return self.k_global_float[local_layer_id], self.v_global_float[local_layer_id]
+
+    def _get_kv_global_scale_tensor(self, layer_id: int):
+        local_layer_id = layer_id - self.start_layer
+        return (
+            self.k_global[local_layer_id : local_layer_id + 1],
+            self.v_global[local_layer_id : local_layer_id + 1],
+        )
+
+    @staticmethod
+    def _scale_to_positive_float(scale) -> Optional[float]:
+        if scale is None:
+            return None
+        try:
+            value = float(scale.detach().to("cpu").item())
+        except AttributeError:
+            value = float(scale)
+        return value if value > 0.0 else None
+
+    def _maybe_load_layer_global_scales(self, layer: RadixAttention, layer_id: int):
+        local_layer_id = layer_id - self.start_layer
+        k_scale = self._scale_to_positive_float(
+            getattr(layer, "k_scale_float", None)
+        ) or self._scale_to_positive_float(getattr(layer, "k_scale", None))
+        v_scale = self._scale_to_positive_float(
+            getattr(layer, "v_scale_float", None)
+        ) or self._scale_to_positive_float(getattr(layer, "v_scale", None))
+
+        if k_scale is not None:
+            self.k_global[local_layer_id].fill_(k_scale)
+            self.k_global_float[local_layer_id] = k_scale
+        if v_scale is not None:
+            self.v_global[local_layer_id].fill_(v_scale)
+            self.v_global_float[local_layer_id] = v_scale
+
+    def _maybe_calibrate_global_scales(
+        self,
+        layer: RadixAttention,
+        layer_id: int,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+    ):
+        from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+
+        local_layer_id = layer_id - self.start_layer
+        if self._gs_calibrated[local_layer_id]:
+            return
+        if os.environ.get("SGLANG_FP4_KV_AUTOCALIB", "1") == "0":
+            self._gs_calibrated[local_layer_id] = True
+            return
+        has_calibrated_scale = (
+            self._scale_to_positive_float(getattr(layer, "k_scale_float", None))
+            is not None
+            or self._scale_to_positive_float(getattr(layer, "v_scale_float", None))
+            is not None
+            or self._scale_to_positive_float(getattr(layer, "k_scale", None))
+            is not None
+            or self._scale_to_positive_float(getattr(layer, "v_scale", None))
+            is not None
+        )
+        if has_calibrated_scale:
+            self._gs_calibrated[local_layer_id] = True
+            return
+        explicit_autocalib = getattr(self, "_explicit_autocalib_in_progress", False)
+        if not self._autocalib_warned and not explicit_autocalib:
+            self._autocalib_warned = True
+            logger.warning(
+                "NVFP4 KV cache: this model ships no calibrated KV scales; "
+                "auto-calibrating per-layer global scales from the first eager prefill. "
+                "Disable with SGLANG_FP4_KV_AUTOCALIB=0."
+            )
+        if get_is_capture_mode():
+            raise RuntimeError(
+                "NVFP4 KV cache global scales must be calibrated before CUDA "
+                "graph capture. Run an eager prefill first or provide checkpoint "
+                "k_scale/v_scale values."
+            )
+        try:
+            from sglang.srt.compilation.piecewise_context_manager import (
+                get_pcg_capture_stream,
+                is_in_piecewise_cuda_graph,
+            )
+        except Exception:
+            pass
+        else:
+            if is_in_piecewise_cuda_graph() or get_pcg_capture_stream() is not None:
+                raise RuntimeError(
+                    "NVFP4 KV cache global scales must be calibrated before "
+                    "piecewise CUDA graph capture. Run an eager prefill first or "
+                    "provide checkpoint k_scale/v_scale values."
+                )
+
+        from sglang.srt.layers.quantization.kvfp4_tensor import (
+            E2M1_MAX,
+            MAX_BLOCK_SCALE_FP8,
+        )
+
+        denom = E2M1_MAX * MAX_BLOCK_SCALE_FP8
+        k_amax = cache_k.detach().abs().amax().float()
+        v_amax = cache_v.detach().abs().amax().float()
+        k_gs = (k_amax / denom).clamp_(min=1e-8)
+        v_gs = (v_amax / denom).clamp_(min=1e-8)
+        self.k_global[local_layer_id].copy_(k_gs)
+        self.v_global[local_layer_id].copy_(v_gs)
+        self.k_global_float[local_layer_id] = float(k_gs)
+        self.v_global_float[local_layer_id] = float(v_gs)
+        self._gs_calibrated[local_layer_id] = True
+        if not explicit_autocalib:
+            logger.info(
+                "NVFP4 KV auto-calibrated layer %d: k_amax=%.4g v_amax=%.4g "
+                "k_gs=%.4g v_gs=%.4g (n_tokens=%d)",
+                layer_id,
+                float(k_amax),
+                float(v_amax),
+                self.k_global_float[local_layer_id],
+                self.v_global_float[local_layer_id],
+                cache_k.shape[0],
+            )
+
+    def get_kv_size_bytes(self):
+        k_size_bytes, v_size_bytes = super().get_kv_size_bytes()
+        for k_scale_cache in self.k_scale_buffer:
+            k_size_bytes += get_tensor_size_bytes(k_scale_cache)
+        for v_scale_cache in self.v_scale_buffer:
+            v_size_bytes += get_tensor_size_bytes(v_scale_cache)
+        k_size_bytes += get_tensor_size_bytes(self.k_global)
+        v_size_bytes += get_tensor_size_bytes(self.v_global)
+        return k_size_bytes, v_size_bytes
 
     def set_kv_buffer(
         self,
@@ -1854,25 +2023,23 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
             layer_id = layer_id_override
         else:
             layer_id = layer.layer_id
-        if cache_k.dtype != self.dtype:
-            if k_scale is not None:
-                cache_k.div_(k_scale)
-            if v_scale is not None:
-                cache_v.div_(v_scale)
+        self._maybe_load_layer_global_scales(layer, layer_id)
+        self._maybe_calibrate_global_scales(layer, layer_id, cache_k, cache_v)
+        k_global, v_global = self._get_kv_global_scale_tensor(layer_id)
 
-            from sglang.srt.layers.quantization.kvfp4_tensor import (
-                BlockFP4KVQuantizeUtil,
-            )
+        from sglang.srt.layers.quantization.kvfp4_tensor import NVFP4KVQuantizeUtil
 
-            cache_k, cache_k_fp4_sf = BlockFP4KVQuantizeUtil.batched_quantize(cache_k)
-            cache_v, cache_v_fp4_sf = BlockFP4KVQuantizeUtil.batched_quantize(cache_v)
+        cache_k, cache_k_fp4_sf, _ = NVFP4KVQuantizeUtil.quantize(
+            cache_k.contiguous(), k_global
+        )
+        cache_v, cache_v_fp4_sf, _ = NVFP4KVQuantizeUtil.quantize(
+            cache_v.contiguous(), v_global
+        )
 
-        if self.store_dtype != self.dtype:
-            cache_k = cache_k.view(self.store_dtype)
-            cache_v = cache_v.view(self.store_dtype)
-
-            cache_k_fp4_sf = cache_k_fp4_sf.view(self.store_dtype)
-            cache_v_fp4_sf = cache_v_fp4_sf.view(self.store_dtype)
+        cache_k = cache_k.view(self.store_dtype)
+        cache_v = cache_v.view(self.store_dtype)
+        cache_k_fp4_sf = cache_k_fp4_sf.view(self.store_dtype)
+        cache_v_fp4_sf = cache_v_fp4_sf.view(self.store_dtype)
 
         if get_is_capture_mode() and self.alt_stream is not None:
             # Overlap the copy of K and V cache for small batch size
@@ -1892,6 +2059,49 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
 
             self.k_scale_buffer[layer_id - self.start_layer][loc] = cache_k_fp4_sf
             self.v_scale_buffer[layer_id - self.start_layer][loc] = cache_v_fp4_sf
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        if self.layer_num == 0:
+            return
+
+        size_limit = self.size + self.page_size
+        maybe_detect_oob(tgt_loc, 0, size_limit, "move_kv_cache tgt_loc")
+        maybe_detect_oob(src_loc, 0, size_limit, "move_kv_cache src_loc")
+
+        N = tgt_loc.numel()
+        if N == 0:
+            return
+
+        if self._kv_copy_config is None:
+            for buffers in (
+                self.k_buffer,
+                self.v_buffer,
+                self.k_scale_buffer,
+                self.v_scale_buffer,
+            ):
+                for buffer in buffers:
+                    buffer[tgt_loc] = buffer[src_loc]
+            return
+
+        cfg = self._kv_copy_config
+        cap = int(cfg.get("num_locs_upper", 256))
+        grid = (self.data_ptrs.numel(), cfg["byte_tiles"])
+
+        for start in range(0, N, cap):
+            end = min(start + cap, N)
+            chunk_len = end - start
+            upper = next_power_of_2(chunk_len)
+            copy_all_layer_kv_cache_tiled[grid](
+                self.data_ptrs,
+                self.data_strides,
+                tgt_loc[start:end],
+                src_loc[start:end],
+                chunk_len,
+                upper,
+                BYTES_PER_TILE=cfg["bytes_per_tile"],
+                num_warps=cfg["num_warps"],
+                num_stages=2,
+            )
 
 
 class HybridLinearKVPool(KVCache):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1918,7 +1918,9 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
         cache_k: torch.Tensor,
         cache_v: torch.Tensor,
     ):
-        from sglang.srt.model_executor.runner_utils.capture_mode import get_is_capture_mode
+        from sglang.srt.model_executor.runner_utils.capture_mode import (
+            get_is_capture_mode,
+        )
 
         local_layer_id = layer_id - self.start_layer
         if self._gs_calibrated[local_layer_id]:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1918,7 +1918,7 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
         cache_k: torch.Tensor,
         cache_v: torch.Tensor,
     ):
-        from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+        from sglang.srt.model_executor.runner_utils.capture_mode import get_is_capture_mode
 
         local_layer_id = layer_id - self.start_layer
         if self._gs_calibrated[local_layer_id]:

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Dict, List, Optional, Tuple
 
 import torch
@@ -88,6 +89,25 @@ class SWAKVPool(BaseSWAKVPool):
         logger.info(
             f"SWAKVPool mem usage: {self.mem_usage:.2f} GB, swa size: {self.size_swa}, full size: {self.size}"
         )
+        if os.environ.get("SGLANG_GEMMA_KV_GEOMETRY") == "1":
+            logger.info(
+                "SGLANG_GEMMA_KV_SWAKVPOOL dtype=%s page_size=%s "
+                "head_num=%s head_dim=%s full_layers=%s swa_layers=%s "
+                "full_pool=%s swa_pool=%s full_tokens=%s swa_tokens=%s "
+                "k_size_bytes=%s v_size_bytes=%s",
+                self.dtype,
+                self.page_size,
+                self.head_num,
+                self.head_dim,
+                full_attention_layer_ids,
+                swa_attention_layer_ids,
+                type(self.full_kv_pool).__name__,
+                type(self.swa_kv_pool).__name__,
+                self.size,
+                self.size_swa,
+                k_size,
+                v_size,
+            )
 
     def register_mapping(self, full_to_swa_index_mapping: torch.Tensor):
         self.full_to_swa_index_mapping = full_to_swa_index_mapping

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -540,6 +540,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # forward-path re-plan would clobber their metadata.
     forward_metadata_replan_equivalent: bool = False
 
+    # DiffusionGemma (uniform-state block diffusion) extras.
+    # None (not dLLM) keeps the field invisible to TBO's field filter.
+    dllm_is_encoder: Optional[bool] = None
+    dllm_self_conditioning_logits: Optional[torch.Tensor] = None
+
     def mark_forward_metadata_ready(self, replan_equivalent: bool = False):
         """Record that attention metadata was pre-planned for this batch.
 
@@ -783,17 +788,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         # Override the positions with diffusion LLM or spec_info
         if batch.dllm_config is not None:
-            block_size = batch.dllm_config.block_size
-            # Use int64 for AMD rotary embedding kernel compatibility
-            positions_dtype = torch.int64 if is_hip() or _is_npu else torch.int32
-            ret.positions = torch.tensor(
-                [
-                    i
-                    for block_offset in (req.dllm_block_offset for req in batch.reqs)
-                    for i in range(block_offset, block_offset + block_size)
-                ],
-                dtype=positions_dtype,
-            ).to(device, non_blocking=True)
+            ret._init_dllm_positions(batch, device)
         elif (
             ret.spec_info is not None
             and getattr(ret.spec_info, "positions", None) is not None
@@ -980,6 +975,24 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             or self.contains_video_inputs()
             or self.contains_image_inputs()
         )
+
+    def _init_dllm_positions(self, batch: ScheduleBatch, device: torch.device):
+        if batch.dllm_config.is_uniform:
+            self.dllm_is_encoder = all(req.is_dllm_prefill() for req in batch.reqs)
+        # Masked always uses fixed block-offset positions. Uniform uses them only
+        # for the canvas decode, since its encode is a variable-length prompt.
+        if not (batch.dllm_config.is_uniform and self.dllm_is_encoder):
+            block_size = batch.dllm_config.block_size
+            # Use int64 for AMD rotary embedding kernel compatibility
+            positions_dtype = torch.int64 if is_hip() or _is_npu else torch.int32
+            self.positions = torch.tensor(
+                [
+                    i
+                    for block_offset in (req.dllm_block_offset for req in batch.reqs)
+                    for i in range(block_offset, block_offset + block_size)
+                ],
+                dtype=positions_dtype,
+            ).to(device, non_blocking=True)
 
     def _init_ngram_embedding_info(self, batch: ScheduleBatch, device: torch.device):
         if self.forward_mode.is_decode():

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -28,6 +28,8 @@ ScheduleBatch -> ForwardBatch
 from __future__ import annotations
 
 import hashlib
+import logging
+import os
 import warnings
 from dataclasses import dataclass
 from enum import IntEnum, auto
@@ -72,6 +74,33 @@ if TYPE_CHECKING:
 _skip_attn_backend_init_warned = False
 
 _is_npu = is_npu()
+logger = logging.getLogger(__name__)
+
+
+def _fp4_kv_radix_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_FP4_KV_TRACE_RADIX") == "1"
+
+
+def _trace_sequence_summary(value, *, limit: int = 8):
+    if value is None:
+        return None
+    dtype = None
+    shape = None
+    if isinstance(value, torch.Tensor):
+        dtype = str(value.dtype)
+        shape = list(value.shape)
+        data = value.detach().to("cpu").flatten().tolist()
+    else:
+        data = list(value)
+    encoded = ",".join(str(x) for x in data).encode("utf-8")
+    return {
+        "len": len(data),
+        "dtype": dtype,
+        "shape": shape,
+        "head": data[:limit],
+        "tail": data[-limit:] if len(data) > limit else data,
+        "hash": hashlib.blake2b(encoded, digest_size=8).hexdigest(),
+    }
 
 
 class ForwardMode(IntEnum):
@@ -512,6 +541,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For dumper: int-hashed request / bootstrap-room IDs (derived from rids)
     rids_int: Optional[torch.Tensor] = None
     bootstrap_room_ids_int: Optional[torch.Tensor] = None
+    forward_pass_id: Optional[int] = None
 
     # kv-canary token-id validator snapshot
     req_all_ids_flat: Optional[torch.Tensor] = None
@@ -826,6 +856,23 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             if ret.positions is None:
                 ret.positions = positions
             ret.extend_logprob_start_lens_cpu = extend_logprob_start_lens
+
+            if _fp4_kv_radix_trace_enabled():
+                logger.warning(
+                    "FP4 KV ForwardBatch trace rids=%s mode=%s "
+                    "seq_lens_cpu=%s extend_prefix_lens_cpu=%s "
+                    "extend_seq_lens_cpu=%s input_ids=%s positions=%s "
+                    "out_cache_loc=%s req_pool_indices=%s",
+                    [str(rid) for rid in ret.rids],
+                    ret.forward_mode,
+                    _trace_sequence_summary(ret.seq_lens_cpu),
+                    _trace_sequence_summary(ret.extend_prefix_lens_cpu),
+                    _trace_sequence_summary(ret.extend_seq_lens_cpu),
+                    _trace_sequence_summary(ret.input_ids),
+                    _trace_sequence_summary(ret.positions),
+                    _trace_sequence_summary(ret.out_cache_loc),
+                    _trace_sequence_summary(ret.req_pool_indices),
+                )
 
         if model_runner.use_ngram_embedding:
             ret._init_ngram_embedding_info(batch, device)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -196,6 +196,10 @@ from sglang.srt.state_capturer.routed_experts import (
     get_global_experts_capturer,
     set_global_experts_capturer,
 )
+from sglang.srt.utils.common import (
+    require_attn_tp_gather,
+    require_mlp_tp_gather,
+)
 from sglang.srt.utils import (
     MultiprocessingSerializer,
     broadcast_pyobj,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -126,8 +126,11 @@ from sglang.srt.layers.cp.utils import (
     get_cp_strategy,
 )
 from sglang.srt.layers.dp_attention import (
+    DpPaddingMode,
     get_attention_tp_group,
     initialize_dp_attention,
+    set_dp_buffer_len,
+    set_is_extend_in_batch,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.moe.hash_topk import HashTopK
@@ -197,10 +200,6 @@ from sglang.srt.state_capturer.routed_experts import (
     get_global_experts_capturer,
     set_global_experts_capturer,
 )
-from sglang.srt.utils.common import (
-    require_attn_tp_gather,
-    require_mlp_tp_gather,
-)
 from sglang.srt.utils import (
     MultiprocessingSerializer,
     broadcast_pyobj,
@@ -220,6 +219,10 @@ from sglang.srt.utils import (
     reserve_rope_cache_for_long_sequences,
     set_cuda_arch,
     slow_rank_detector,
+)
+from sglang.srt.utils.common import (
+    require_attn_tp_gather,
+    require_mlp_tp_gather,
 )
 from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
@@ -961,7 +964,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 "only for graph-safety experiments."
             )
 
-
     def _calibrate_nvfp4_kv_cache(self) -> None:
         """Run one eager prefill to freeze NVFP4 KV global scales before capture."""
         fp4_pools = self._get_nvfp4_native_kv_pools()
@@ -1003,15 +1005,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 raise RuntimeError("no request-pool slot available")
 
             vocab_size = max(1, int(self.model_config.vocab_size))
-            input_ids = torch.arange(
-                num_tokens, dtype=torch.int64, device=self.device
-            ) % vocab_size
-            positions = torch.arange(
-                num_tokens, dtype=torch.int64, device=self.device
+            input_ids = (
+                torch.arange(num_tokens, dtype=torch.int64, device=self.device)
+                % vocab_size
             )
-            seq_lens = torch.tensor(
-                [num_tokens], dtype=torch.int64, device=self.device
-            )
+            positions = torch.arange(num_tokens, dtype=torch.int64, device=self.device)
+            seq_lens = torch.tensor([num_tokens], dtype=torch.int64, device=self.device)
             seq_lens_cpu = torch.tensor([num_tokens], dtype=torch.int64)
             extend_prefix_lens = torch.zeros(
                 (1,), dtype=torch.int32, device=self.device
@@ -1152,9 +1151,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 sum(1 for flag in getattr(pool, "_gs_calibrated", []) if flag)
                 for pool in fp4_pools
             )
-            total = sum(
-                len(getattr(pool, "_gs_calibrated", [])) for pool in fp4_pools
-            )
+            total = sum(len(getattr(pool, "_gs_calibrated", [])) for pool in fp4_pools)
             if calibrated != total:
                 raise RuntimeError(
                     f"only calibrated {calibrated}/{total} NVFP4 KV layers"

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1162,9 +1162,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 num_tokens,
             )
         except Exception as e:
-            logger.warning(
-                "NVFP4 KV cache calibration warmup failed; first real prefill "
-                "will remain the fallback for auto-calibration. Error: %s",
+            # A failed warmup silently drops us onto the first-real-prefill fallback,
+            # which under-samples the per-channel KV max (esp. K) and materially
+            # DEGRADES NVFP4 KV quality (measured ~-9pt GSM8K on Gemma-4-12B, with an
+            # elevated invalid/garble rate). The usual culprit is a build missing the
+            # dp_attention imports used by this warmup (NameError on DpPaddingMode /
+            # set_dp_buffer_len). Log loudly so a broken/stale build is caught instead
+            # of silently serving degraded KV.
+            logger.error(
+                "NVFP4 KV cache calibration warmup FAILED (%s). Falling back to "
+                "first-real-prefill auto-calibration, which under-samples the KV max "
+                "and DEGRADES NVFP4 KV accuracy (measured ~-9pt GSM8K on Gemma-4-12B, "
+                "with elevated invalid/garble). Fix the warmup (e.g. ensure the "
+                "dp_attention imports are present / rebuild a current image) or ship "
+                "calibrated k_scale/v_scale in the checkpoint.",
                 e,
             )
         finally:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -934,6 +934,29 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         else:
             zero_pool(pool, loc)
 
+    def _disable_cuda_graph_for_nvfp4_kv_if_needed(self) -> None:
+        """Avoid graph-captured native FP4 KV until the FlashInfer path is graph-safe."""
+        if not self._get_nvfp4_native_kv_pools():
+            return
+        if os.environ.get("SGLANG_FP4_KV_ENABLE_CUDA_GRAPH", "0") == "1":
+            return
+
+        disabled = False
+        if not self.server_args.disable_cuda_graph:
+            self.server_args.disable_cuda_graph = True
+            disabled = True
+        if not self.server_args.disable_piecewise_cuda_graph:
+            self.server_args.disable_piecewise_cuda_graph = True
+            disabled = True
+        if disabled:
+            logger.warning(
+                "Disabling CUDA graph capture for native FP4 KV cache. "
+                "Current FlashInfer FA2 NVFP4 KV graph capture can produce "
+                "corrupt decode output; set SGLANG_FP4_KV_ENABLE_CUDA_GRAPH=1 "
+                "only for graph-safety experiments."
+            )
+
+
     def _calibrate_nvfp4_kv_cache(self) -> None:
         """Run one eager prefill to freeze NVFP4 KV global scales before capture."""
         fp4_pools = self._get_nvfp4_native_kv_pools()
@@ -1178,6 +1201,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Freeze NVFP4 KV global scales via one eager prefill before
         # the eager runner warms kernels and cuda graphs capture.
         self._calibrate_nvfp4_kv_cache()
+        self._disable_cuda_graph_for_nvfp4_kv_if_needed()
         self.eager_runner = EagerRunner(self)
 
         # cuda-graph capture: prefill before decode, so both coalesce onto the

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -149,6 +149,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     cuda_graph_fully_disabled,
 )
 from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
     ForwardBatch,
     ForwardMode,
     PPProxyTensors,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -896,6 +896,271 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         else:
             self.init_attention_backend()
 
+    def _get_nvfp4_native_kv_pools(self) -> list:
+        from sglang.srt.mem_cache.memory_pool import MHATokenToKVPoolFP4
+        from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+
+        pool = self.token_to_kv_pool
+        if isinstance(pool, MHATokenToKVPoolFP4):
+            return [pool]
+        if (
+            isinstance(pool, SWAKVPool)
+            and isinstance(pool.full_kv_pool, MHATokenToKVPoolFP4)
+            and isinstance(pool.swa_kv_pool, MHATokenToKVPoolFP4)
+        ):
+            return [pool.full_kv_pool, pool.swa_kv_pool]
+        return []
+
+    def _zero_nvfp4_kv_cache_slots(self, loc: torch.Tensor) -> None:
+        from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+
+        def zero_pool(pool, pool_loc):
+            if pool_loc.numel() == 0:
+                return
+            for buffers_name in (
+                "k_buffer",
+                "v_buffer",
+                "k_scale_buffer",
+                "v_scale_buffer",
+            ):
+                for buf in getattr(pool, buffers_name, []):
+                    buf[pool_loc].zero_()
+
+        pool = self.token_to_kv_pool
+        if isinstance(pool, SWAKVPool):
+            zero_pool(pool.full_kv_pool, loc)
+            swa_loc = pool.translate_loc_from_full_to_swa(loc)
+            zero_pool(pool.swa_kv_pool, swa_loc[swa_loc > 0])
+        else:
+            zero_pool(pool, loc)
+
+    def _calibrate_nvfp4_kv_cache(self) -> None:
+        """Run one eager prefill to freeze NVFP4 KV global scales before capture."""
+        fp4_pools = self._get_nvfp4_native_kv_pools()
+        if not fp4_pools:
+            return
+        if os.environ.get("SGLANG_FP4_KV_AUTOCALIB", "1") == "0":
+            return
+
+        allocator = self.token_to_kv_pool_allocator
+        out_cache_loc = None
+        allocated_out_cache_loc = None
+        req_pool_idx = None
+        explicit_calib_marked = False
+        try:
+            page_size = max(1, int(getattr(allocator, "page_size", 1)))
+            token_limits = [
+                4096,
+                int(self.model_config.context_len),
+                int(getattr(self.req_to_token_pool, "max_context_len", 4096)),
+            ]
+            max_prefill_tokens = getattr(self.server_args, "max_prefill_tokens", None)
+            if max_prefill_tokens is not None and max_prefill_tokens > 0:
+                token_limits.append(int(max_prefill_tokens))
+            max_total_num_tokens = int(getattr(self, "max_total_num_tokens", 0))
+            if max_total_num_tokens > page_size:
+                token_limits.append(max_total_num_tokens - page_size)
+            available_size = int(allocator.available_size())
+            if available_size > page_size:
+                token_limits.append(available_size - page_size)
+
+            num_tokens = max(1, min(token_limits))
+            if num_tokens <= 0:
+                return
+            if num_tokens > available_size:
+                raise RuntimeError(
+                    f"need {num_tokens} KV slots, only {available_size} available"
+                )
+            if not getattr(self.req_to_token_pool, "free_slots", None):
+                raise RuntimeError("no request-pool slot available")
+
+            vocab_size = max(1, int(self.model_config.vocab_size))
+            input_ids = torch.arange(
+                num_tokens, dtype=torch.int64, device=self.device
+            ) % vocab_size
+            positions = torch.arange(
+                num_tokens, dtype=torch.int64, device=self.device
+            )
+            seq_lens = torch.tensor(
+                [num_tokens], dtype=torch.int64, device=self.device
+            )
+            seq_lens_cpu = torch.tensor([num_tokens], dtype=torch.int64)
+            extend_prefix_lens = torch.zeros(
+                (1,), dtype=torch.int32, device=self.device
+            )
+            extend_seq_lens = torch.tensor(
+                [num_tokens], dtype=torch.int32, device=self.device
+            )
+
+            if page_size == 1:
+                out_cache_loc = allocator.alloc(num_tokens)
+            else:
+                out_cache_loc = allocator.alloc_extend(
+                    extend_prefix_lens.to(torch.int64),
+                    torch.zeros((1,), dtype=torch.int64),
+                    seq_lens,
+                    seq_lens_cpu,
+                    torch.tensor([-1], dtype=torch.int64, device=self.device),
+                    num_tokens,
+                )
+            if out_cache_loc is None:
+                raise RuntimeError(f"failed to allocate {num_tokens} KV slots")
+            allocated_out_cache_loc = out_cache_loc
+
+            req_pool_idx = self.req_to_token_pool.free_slots.pop(0)
+            req_pool_indices = torch.tensor(
+                [req_pool_idx], dtype=torch.int64, device=self.device
+            )
+            self.req_to_token_pool.write(
+                (req_pool_idx, slice(0, num_tokens)), out_cache_loc
+            )
+
+            global_num_tokens_cpu = None
+            global_num_tokens_for_logprob_cpu = None
+            global_num_tokens_gpu = None
+            global_num_tokens_for_logprob_gpu = None
+            global_dp_buffer_len = None
+            require_mlp_tp_gather_ = require_mlp_tp_gather(self.server_args)
+            if require_mlp_tp_gather_:
+                global_num_tokens_cpu = [num_tokens] * self.server_args.dp_size
+            elif require_attn_tp_gather(self.server_args):
+                global_num_tokens_cpu = [num_tokens]
+            if global_num_tokens_cpu is not None:
+                global_dp_buffer_len = sum(global_num_tokens_cpu)
+                global_num_tokens_for_logprob_cpu = list(global_num_tokens_cpu)
+                global_num_tokens_gpu = torch.tensor(
+                    global_num_tokens_cpu, dtype=torch.int32, device=self.device
+                )
+                global_num_tokens_for_logprob_gpu = global_num_tokens_gpu.clone()
+
+            forward_batch = ForwardBatch(
+                forward_mode=ForwardMode.EXTEND,
+                batch_size=1,
+                input_ids=input_ids,
+                req_pool_indices=req_pool_indices,
+                seq_lens=seq_lens,
+                seq_lens_cpu=seq_lens_cpu,
+                orig_seq_lens=seq_lens,
+                out_cache_loc=out_cache_loc,
+                seq_lens_sum=num_tokens,
+                positions=positions,
+                extend_num_tokens=num_tokens,
+                extend_seq_lens=extend_seq_lens,
+                extend_prefix_lens=extend_prefix_lens,
+                extend_start_loc=torch.zeros(
+                    (1,), dtype=torch.int32, device=self.device
+                ),
+                extend_prefix_lens_cpu=[0],
+                extend_seq_lens_cpu=[num_tokens],
+                return_logprob=False,
+                spec_algorithm=self.spec_algorithm,
+                capture_hidden_mode=CaptureHiddenMode.NULL,
+                global_forward_mode=ForwardMode.EXTEND,
+                global_num_tokens_cpu=global_num_tokens_cpu,
+                global_num_tokens_for_logprob_cpu=global_num_tokens_for_logprob_cpu,
+                global_num_tokens_gpu=global_num_tokens_gpu,
+                global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
+                global_dp_buffer_len=global_dp_buffer_len,
+                dp_padding_mode=DpPaddingMode.get_default_mode_in_cuda_graph(),
+                num_token_non_padded=torch.tensor(
+                    [num_tokens], dtype=torch.int32, device=self.device
+                ),
+            )
+
+            if forward_batch.global_num_tokens_cpu is not None:
+                forward_batch.prepare_mlp_sync_batch(self)
+            else:
+                forward_batch.prepare_attn_tp_scatter_input(self)
+                set_dp_buffer_len(
+                    None,
+                    num_tokens,
+                    forward_batch.dp_padding_mode.is_max_len(),
+                    None,
+                )
+                set_is_extend_in_batch(False)
+
+            kwargs = {}
+            signature = inspect.signature(self.model.forward).parameters
+            if "get_embedding" in signature:
+                kwargs["get_embedding"] = True
+            if self.pp_size > 1 and "pp_proxy_tensors" in signature:
+                hc_hidden_size = getattr(self.model_config, "hc_hidden_size", None)
+                pp_tensors = {
+                    "hidden_states": torch.zeros(
+                        (
+                            num_tokens,
+                            hc_hidden_size or self.model_config.hidden_size,
+                        ),
+                        dtype=self.model_config.dtype,
+                        device=self.device,
+                    )
+                }
+                if hc_hidden_size is None:
+                    pp_tensors["residual"] = torch.zeros(
+                        (num_tokens, self.model_config.hidden_size),
+                        dtype=self.model_config.dtype,
+                        device=self.device,
+                    )
+                kwargs["pp_proxy_tensors"] = PPProxyTensors(pp_tensors)
+
+            if hasattr(self.model, "prepare_forward_batch"):
+                self.model.prepare_forward_batch(forward_batch)
+            self.attn_backend.init_forward_metadata(forward_batch)
+
+            for pool in fp4_pools:
+                setattr(pool, "_explicit_autocalib_in_progress", True)
+            explicit_calib_marked = True
+            with forward_context(ForwardContext(attn_backend=self.attn_backend)):
+                with torch.inference_mode():
+                    self.model.forward(
+                        input_ids,
+                        positions,
+                        forward_batch,
+                        **kwargs,
+                    )
+            torch.get_device_module(self.device).synchronize()
+
+            calibrated = sum(
+                sum(1 for flag in getattr(pool, "_gs_calibrated", []) if flag)
+                for pool in fp4_pools
+            )
+            total = sum(
+                len(getattr(pool, "_gs_calibrated", [])) for pool in fp4_pools
+            )
+            if calibrated != total:
+                raise RuntimeError(
+                    f"only calibrated {calibrated}/{total} NVFP4 KV layers"
+                )
+            logger.info(
+                "NVFP4 KV cache calibrated %d layers from %d eager prefill tokens",
+                calibrated,
+                num_tokens,
+            )
+        except Exception as e:
+            logger.warning(
+                "NVFP4 KV cache calibration warmup failed; first real prefill "
+                "will remain the fallback for auto-calibration. Error: %s",
+                e,
+            )
+        finally:
+            if explicit_calib_marked:
+                for pool in fp4_pools:
+                    setattr(pool, "_explicit_autocalib_in_progress", False)
+            if allocated_out_cache_loc is not None:
+                try:
+                    self._zero_nvfp4_kv_cache_slots(allocated_out_cache_loc)
+                except Exception:
+                    pass
+                allocator.free(allocated_out_cache_loc)
+            if req_pool_idx is not None:
+                try:
+                    self.req_to_token_pool.req_to_token[
+                        req_pool_idx, : allocated_out_cache_loc.numel()
+                    ].zero_()
+                except Exception:
+                    pass
+                self.req_to_token_pool.free_slots.append(req_pool_idx)
+
     def init_cuda_graphs(self, capture_decode_cuda_graph: bool = True):
         """Capture cuda graphs. Requires init_attention_backends() to have run.
 
@@ -910,6 +1175,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # it. Always built: it serves both the fully-disabled case (decode/prefill
         # runners point at it) and the eager fallback when a cg runner can't run a
         # batch.
+        # Freeze NVFP4 KV global scales via one eager prefill before
+        # the eager runner warms kernels and cuda graphs capture.
+        self._calibrate_nvfp4_kv_cache()
         self.eager_runner = EagerRunner(self)
 
         # cuda-graph capture: prefill before decode, so both coalesce onto the

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -945,8 +945,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if not self.server_args.disable_cuda_graph:
             self.server_args.disable_cuda_graph = True
             disabled = True
-        if not self.server_args.disable_piecewise_cuda_graph:
-            self.server_args.disable_piecewise_cuda_graph = True
+        if not self.server_args.disable_prefill_cuda_graph:
+            self.server_args.disable_prefill_cuda_graph = True
             disabled = True
         if disabled:
             logger.warning(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -935,7 +935,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if isinstance(pool, SWAKVPool):
             zero_pool(pool.full_kv_pool, loc)
             swa_loc = pool.translate_loc_from_full_to_swa(loc)
-            zero_pool(pool.swa_kv_pool, swa_loc[swa_loc > 0])
+            zero_pool(pool.swa_kv_pool, swa_loc[swa_loc >= 0])
         else:
             zero_pool(pool, loc)
 

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -704,6 +704,11 @@ class ModelRunnerKVCacheMixin:
                         "swa_v_head_dim": self.model_config.swa_v_head_dim,
                         "v_head_dim": self.model_config.v_head_dim,
                     }
+                token_to_kv_pool_class = (
+                    MHATokenToKVPoolFP4
+                    if is_float4_e2m1fn_x2(self.kv_cache_dtype)
+                    else MHATokenToKVPool
+                )
                 self.token_to_kv_pool = SWAKVPool(
                     size=self.full_max_total_num_tokens,
                     size_swa=self.swa_max_total_num_tokens,
@@ -720,6 +725,7 @@ class ModelRunnerKVCacheMixin:
                     enable_kv_cache_copy=(
                         self.server_args.speculative_algorithm is not None
                     ),
+                    token_to_kv_pool_class=token_to_kv_pool_class,
                     **kwargs,
                 )
             elif config := self.mambaish_config:

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -83,6 +83,8 @@ def _get_dsv4_compress_state_dtype_sizes() -> tuple[int, int]:
         "Unsupported SGLANG_DSV4_COMPRESS_STATE_DTYPE="
         f"{dtype_name!r}. Expected one of: float32, fp32, bfloat16, bf16."
     )
+
+
 def _fp4_kv_mixed_kv_enabled() -> bool:
     return os.environ.get("SGLANG_FP4_KV_MIXED_KV") == "1"
 

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -14,6 +14,7 @@ Two entry points, same core computation:
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
@@ -82,6 +83,29 @@ def _get_dsv4_compress_state_dtype_sizes() -> tuple[int, int]:
         "Unsupported SGLANG_DSV4_COMPRESS_STATE_DTYPE="
         f"{dtype_name!r}. Expected one of: float32, fp32, bfloat16, bf16."
     )
+def _fp4_kv_mixed_kv_enabled() -> bool:
+    return os.environ.get("SGLANG_FP4_KV_MIXED_KV") == "1"
+
+
+def _mixed_fp8_k_nvfp4_v_cell_size(
+    head_num: int,
+    head_dim: int,
+    v_head_dim: int,
+    num_layers: int,
+    kv_size: int,
+) -> int:
+    """Per-token bytes for the experimental FP8-K + NVFP4-V cache.
+
+    MHATokenToKVPoolFP4 stores K densely as FP8 e4m3 and V as packed NVFP4
+    plus one FP8 scale per 16 V elements. This must be larger than the
+    full-FP4 logical dtype estimate, otherwise mem_fraction_static can
+    understate the realized physical K/V allocation.
+    """
+    scale_block_size = 16
+    k_data_size = head_num * head_dim * num_layers * kv_size
+    v_data_size = head_num * (v_head_dim // 2) * num_layers * kv_size
+    v_scale_size = head_num * (v_head_dim // scale_block_size) * num_layers * kv_size
+    return k_data_size + v_data_size + v_scale_size
 
 
 class MemoryPoolConfigurator:
@@ -213,9 +237,18 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 scale_block_size = 16
                 n = model_config.get_num_kv_heads(tp_size)
                 k = model_config.head_dim
-                cell_size = (cell_size // 2) + (
-                    (n * k * num_layers * 2 * kv_size) // scale_block_size
-                )
+                if _fp4_kv_mixed_kv_enabled():
+                    cell_size = _mixed_fp8_k_nvfp4_v_cell_size(
+                        n,
+                        k,
+                        model_config.v_head_dim,
+                        num_layers,
+                        kv_size,
+                    )
+                else:
+                    cell_size = (cell_size // 2) + (
+                        (n * k * num_layers * 2 * kv_size) // scale_block_size
+                    )
 
         return cell_size
 
@@ -255,18 +288,36 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
         self._swa_full_tokens_ratio = mr.server_args.swa_full_tokens_ratio
 
         # Full layer per-token memory (bytes)
-        self._full_per_token = (
-            model_config.get_num_kv_heads(tp_size)
-            * (model_config.head_dim + model_config.v_head_dim)
-            * kv_size
-        )
+        if is_float4_e2m1fn_x2(kv_cache_dtype) and _fp4_kv_mixed_kv_enabled():
+            self._full_per_token = _mixed_fp8_k_nvfp4_v_cell_size(
+                model_config.get_num_kv_heads(tp_size),
+                model_config.head_dim,
+                model_config.v_head_dim,
+                1,
+                kv_size,
+            )
+        else:
+            self._full_per_token = (
+                model_config.get_num_kv_heads(tp_size)
+                * (model_config.head_dim + model_config.v_head_dim)
+                * kv_size
+            )
 
         # SWA layer per-token memory (bytes)
-        self._swa_per_token = (
-            model_config.get_swa_num_kv_heads(tp_size)
-            * (model_config.swa_head_dim + model_config.swa_v_head_dim)
-            * kv_size
-        )
+        if is_float4_e2m1fn_x2(kv_cache_dtype) and _fp4_kv_mixed_kv_enabled():
+            self._swa_per_token = _mixed_fp8_k_nvfp4_v_cell_size(
+                model_config.get_swa_num_kv_heads(tp_size),
+                model_config.swa_head_dim,
+                model_config.swa_v_head_dim,
+                1,
+                kv_size,
+            )
+        else:
+            self._swa_per_token = (
+                model_config.get_swa_num_kv_heads(tp_size)
+                * (model_config.swa_head_dim + model_config.swa_v_head_dim)
+                * kv_size
+            )
 
         # Bytes per token of max_total_num_tokens.
         #
@@ -285,6 +336,19 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
                 + self._swa_full_tokens_ratio
                 * self._swa_per_token
                 * self._swa_layers_num
+            )
+        if os.environ.get("SGLANG_GEMMA_KV_GEOMETRY") == "1":
+            logger.info(
+                "SGLANG_GEMMA_KV_POOL_CONFIG full_layers=%s swa_layers=%s "
+                "full_per_token_bytes=%s swa_per_token_bytes=%s "
+                "swa_full_tokens_ratio=%s cell_size_bytes=%s mixed_kv=%s",
+                self._full_layers_num,
+                self._swa_layers_num,
+                self._full_per_token,
+                self._swa_per_token,
+                self._swa_full_tokens_ratio,
+                self._cell_size,
+                _fp4_kv_mixed_kv_enabled(),
             )
 
     def _solve_pool_sizes(

--- a/python/sglang/srt/models/gemma4_diffusion.py
+++ b/python/sglang/srt/models/gemma4_diffusion.py
@@ -83,6 +83,7 @@ from sglang.srt.utils import add_prefix, make_layers
 
 logger = logging.getLogger(__name__)
 
+
 class DiffusionGemmaAttention(nn.Module):
     """Gemma4 attention with a per-phase causal/bidirectional switch.
 

--- a/python/sglang/srt/models/gemma4_diffusion.py
+++ b/python/sglang/srt/models/gemma4_diffusion.py
@@ -1,0 +1,694 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""SGLang DiffusionGemma (block-diffusion, multimodal) model.
+
+`DiffusionGemmaForBlockDiffusion` is an encoder-decoder uniform-state
+block-diffusion model with a vision tower. The encoder encodes context causally
+into a KV cache. The decoder denoises a fixed-length canvas, attending
+bidirectionally over the canvas and to that cached context. Image soft tokens are
+injected into the encoder input embeddings only. The decoder canvas never sees
+image tokens. Encoder and decoder share all transformer
+weights and differ only by a per-layer `layer_scalar` (the decoder additionally
+owns a `self_conditioning` block). The checkpoint stores the transformer weights
+once under `model.decoder.*`, plus `model.encoder.language_model.layers.*.layer_scalar`.
+
+Within sglang's dllm framework the two phases map to:
+  * encoder (context)  -> a causal prefill that writes the KV cache
+  * decoder (canvas)   -> a bidirectional DLLM_EXTEND step driven by the
+    Gemma4Renoise algorithm, which feeds the previous step's logits back as
+    self-conditioning.
+
+`forward_batch.dllm_is_encoder` selects the phase (set in forward_batch_info.py).
+The causal encode and bidirectional canvas passes use two RadixAttention instances.
+"""
+
+import logging
+import re
+from typing import Iterable, List, Optional, Set, Tuple
+
+import torch
+from torch import nn
+from transformers import PreTrainedModel
+
+from sglang.srt.distributed import (
+    get_pp_group,
+    get_tensor_model_parallel_world_size,
+)
+from sglang.srt.layers.activation import GeluAndMul
+from sglang.srt.layers.layernorm import Gemma4RMSNorm, RMSNorm
+from sglang.srt.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.radix_attention import AttentionType, RadixAttention
+from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+    flatten_nested_list,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
+from sglang.srt.models.gemma3_causal import Gemma3MLP, Gemma3TextScaledWordEmbedding
+from sglang.srt.models.gemma4_causal import Gemma4MoE, Gemma4Router
+from sglang.srt.models.gemma4_mm import (
+    Gemma4ForConditionalGeneration,
+    Gemma4MultimodalEmbedder,
+)
+from sglang.srt.models.gemma4_vision import Gemma4VisionEncoder
+from sglang.srt.utils import add_prefix, make_layers
+
+logger = logging.getLogger(__name__)
+
+class DiffusionGemmaAttention(nn.Module):
+    """Gemma4 attention with a per-phase causal/bidirectional switch.
+
+    Sliding layers: head_dim=`swa_head_dim`, kv_heads=`swa_num_key_value_heads`, real v_proj.
+    Full layers:    head_dim=`head_dim`, kv_heads=`num_key_value_heads`, no v_proj in the
+                    checkpoint (value == normed key, handled in load_weights by
+                    duplicating k_proj into the fused v shard).
+    """
+
+    def __init__(
+        self,
+        layer_id: int,
+        config,  # text_config
+        head_dim: int,
+        num_kv_heads: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        tp_size = get_tensor_model_parallel_world_size()
+
+        layer_type = config.layer_types[layer_id]
+        # Inclusive (HF) -> exclusive (sglang), matching gemma4_causal.
+        self.sliding_window = (
+            config.sliding_window - 1 if layer_type == "sliding_attention" else None
+        )
+
+        self.total_num_heads = config.num_attention_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+
+        self.total_num_kv_heads = num_kv_heads
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        if self.total_num_kv_heads >= tp_size:
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            assert tp_size % self.total_num_kv_heads == 0
+
+        self.head_dim = head_dim
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+
+        self.qkv_proj = QKVParallelLinear(
+            config.hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=config.attention_bias,
+            quant_config=quant_config,
+            prefix=add_prefix("qkv_proj", prefix),
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+            quant_config=quant_config,
+            prefix=add_prefix("o_proj", prefix),
+        )
+
+        # Gemma4 q/k/v RMSNorm: *w for q/k (scale_shift=0), no-scale for v.
+        self.q_norm = Gemma4RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Gemma4RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.v_norm = Gemma4RMSNorm(
+            self.head_dim, eps=config.rms_norm_eps, scale_shift=0.0, with_scale=False
+        )
+
+        rope_parameters = dict(config.rope_parameters[layer_type])
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=config.max_position_embeddings,
+            base=rope_parameters.get("rope_theta", 10000.0),
+            rope_scaling={"rope_type": rope_parameters.get("rope_type", "default")},
+            partial_rotary_factor=rope_parameters.get("partial_rotary_factor", 1.0),
+            is_neox_style=True,
+        )
+
+        attn_common = dict(
+            num_kv_heads=self.num_kv_heads,
+            layer_id=layer_id,
+            logit_cap=0.0,
+            sliding_window_size=self.sliding_window,
+            quant_config=quant_config,
+            prefix=add_prefix("attn", prefix),
+        )
+        # scaling = 1.0 (Gemma4 folds scale into q_norm). Two attn instances share
+        # the same q/k/v/o projections, differing only in the attention mask.
+        self.attn = RadixAttention(self.num_heads, self.head_dim, 1.0, **attn_common)
+        self.attn_bidir = RadixAttention(
+            self.num_heads,
+            self.head_dim,
+            1.0,
+            attn_type=AttentionType.ENCODER_ONLY,
+            **attn_common,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+        q = self.q_norm(q.unflatten(-1, (self.num_heads, self.head_dim))).flatten(
+            -2, -1
+        )
+        k = self.k_norm(k.unflatten(-1, (self.num_kv_heads, self.head_dim))).flatten(
+            -2, -1
+        )
+        v = self.v_norm(v.unflatten(-1, (self.num_kv_heads, self.head_dim))).flatten(
+            -2, -1
+        )
+
+        q, k = self.rotary_emb(positions, q, k)
+
+        attn = self.attn if forward_batch.dllm_is_encoder else self.attn_bidir
+        attn_output = attn(q, k, v, forward_batch)
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+class DiffusionGemmaSelfConditioning(nn.Module):
+    """Gated MLP mapping the previous step's soft embeddings into a signal added
+    to the decoder's input embeddings. Checkpoint stores gate/up/down directly
+    (not under `.mlp.`). post_norm is no-scale so it has no checkpoint weight."""
+
+    def __init__(self, config, quant_config=None, prefix: str = ""):
+        super().__init__()
+        self.pre_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_norm = Gemma4RMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+            scale_shift=0.0,
+            with_scale=False,
+        )
+        self.gate_up_proj = MergedColumnParallelLinear(
+            config.hidden_size,
+            [config.intermediate_size] * 2,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("gate_up_proj", prefix),
+        )
+        self.down_proj = RowParallelLinear(
+            config.intermediate_size,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("down_proj", prefix),
+        )
+        self.act_fn = GeluAndMul()
+
+    def forward(self, inputs_embeds, signal):
+        gate_up, _ = self.gate_up_proj(self.pre_norm(signal))
+        h, _ = self.down_proj(self.act_fn(gate_up))
+        return self.post_norm(inputs_embeds + h)
+
+
+class DiffusionGemmaDecoderLayer(nn.Module):
+    """Shared encoder/decoder layer: attention + parallel dense-MLP & MoE branches
+    summed, then `* layer_scalar` (encoder vs decoder scalar selected per phase).
+    The router gates on the raw residual; the experts consume
+    `pre_feedforward_layernorm_2(residual)`."""
+
+    def __init__(
+        self,
+        layer_id: int,
+        config,  # text_config
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.layer_id = layer_id
+        layer_type = config.layer_types[layer_id]
+        is_full = layer_type == "full_attention"
+        # SGLang naming: base head_dim/num_key_value_heads are the full-attention
+        # layers, swa_* are the sliding-window layers (set by the gemma4 config hook).
+        head_dim = (
+            config.head_dim
+            if is_full
+            else getattr(config, "swa_head_dim", config.head_dim)
+        )
+        num_kv_heads = (
+            config.num_key_value_heads
+            if is_full
+            else getattr(config, "swa_num_key_value_heads", config.num_key_value_heads)
+        )
+
+        self.self_attn = DiffusionGemmaAttention(
+            layer_id=layer_id,
+            config=config,
+            head_dim=head_dim,
+            num_kv_heads=num_kv_heads,
+            quant_config=quant_config,
+            prefix=add_prefix("self_attn", prefix),
+        )
+        self.mlp = Gemma3MLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_activation=config.hidden_activation,
+            quant_config=quant_config,
+            prefix=add_prefix("mlp", prefix),
+        )
+        self.router = Gemma4Router(
+            config, quant_config=quant_config, prefix=add_prefix("router", prefix)
+        )
+        self.moe = Gemma4MoE(
+            hidden_size=config.hidden_size,
+            layer_id=layer_id,
+            config=config,
+            quant_config=quant_config,
+            prefix=add_prefix("moe", prefix),
+        )
+
+        eps = config.rms_norm_eps
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=eps)
+        self.pre_feedforward_layernorm = RMSNorm(config.hidden_size, eps=eps)
+        self.pre_feedforward_layernorm_2 = RMSNorm(config.hidden_size, eps=eps)
+        self.post_feedforward_layernorm = RMSNorm(config.hidden_size, eps=eps)
+        self.post_feedforward_layernorm_1 = RMSNorm(config.hidden_size, eps=eps)
+        self.post_feedforward_layernorm_2 = RMSNorm(config.hidden_size, eps=eps)
+
+        # Encoder and decoder use the same weights but distinct per-layer scalars.
+        self.register_buffer("layer_scalar", torch.ones(1), persistent=True)
+        self.register_buffer("encoder_layer_scalar", torch.ones(1), persistent=True)
+
+    def forward(self, positions, hidden_states, forward_batch):
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(positions, hidden_states, forward_batch)
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        h1 = self.post_feedforward_layernorm_1(
+            self.mlp(self.pre_feedforward_layernorm(residual))
+        )
+        # MoE branch: the router gates on the RAW residual (the router's input
+        # norm is with_scale=False, so ln2's learned per-channel weights would
+        # change the routed direction). Experts still get the ln2-normed input.
+        moe_in = self.pre_feedforward_layernorm_2(residual)
+        router_logits = self.router(residual)
+        h2 = self.post_feedforward_layernorm_2(self.moe(moe_in, router_logits))
+
+        hidden_states = self.post_feedforward_layernorm(h1 + h2)
+        hidden_states = residual + hidden_states
+
+        scalar = (
+            self.encoder_layer_scalar
+            if forward_batch.dllm_is_encoder
+            else self.layer_scalar
+        )
+        return hidden_states * scalar
+
+
+class DiffusionGemmaModel(nn.Module):
+    """Shared transformer stack (stored under `model.decoder.*`) + the decoder's
+    self-conditioning block."""
+
+    def __init__(self, config, quant_config=None, prefix: str = ""):
+        super().__init__()
+        text_config = config.text_config
+        self.config = text_config
+
+        self.embed_tokens = Gemma3TextScaledWordEmbedding(
+            text_config.vocab_size,
+            text_config.hidden_size,
+            text_config.pad_token_id,
+            embed_scale=text_config.hidden_size**0.5,
+        )
+        self.self_conditioning = DiffusionGemmaSelfConditioning(
+            text_config,
+            quant_config=quant_config,
+            prefix=add_prefix("self_conditioning", prefix),
+        )
+        self.pp_group = get_pp_group()
+        self.layers, self.start_layer, self.end_layer = make_layers(
+            text_config.num_hidden_layers,
+            lambda idx, prefix: DiffusionGemmaDecoderLayer(
+                layer_id=idx,
+                config=text_config,
+                quant_config=quant_config,
+                prefix=prefix,
+            ),
+            pp_rank=self.pp_group.rank_in_group,
+            pp_size=self.pp_group.world_size,
+            prefix=add_prefix("layers", prefix),
+        )
+        self.norm = RMSNorm(text_config.hidden_size, eps=text_config.rms_norm_eps)
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.embed_tokens
+
+    def forward(self, input_ids, positions, forward_batch, input_embeds=None):
+        # embed_tokens applies the sqrt(hidden) scale internally.
+        hidden_states = (
+            self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+        )
+
+        if not forward_batch.dllm_is_encoder:
+            sc_logits = forward_batch.dllm_self_conditioning_logits
+            if sc_logits is not None:
+                # full_logits are float32, so cast probs to the bf16 embedding dtype.
+                probs = sc_logits.softmax(dim=-1).to(self.embed_tokens.weight.dtype)
+                soft = torch.matmul(probs, self.embed_tokens.weight)
+            else:
+                soft = torch.zeros_like(hidden_states)
+            hidden_states = self.self_conditioning(hidden_states, soft)
+
+        for i in range(self.start_layer, self.end_layer):
+            hidden_states = self.layers[i](positions, hidden_states, forward_batch)
+
+        hidden_states = self.norm(hidden_states)
+        return hidden_states
+
+
+class DiffusionGemmaForBlockDiffusion(PreTrainedModel):
+    base_model_prefix = "model"
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(
+        self,
+        config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(config=config)
+        self.config = config
+        self.text_config = config.text_config
+        self.quant_config = quant_config
+
+        # Shared stack lives under `model` here, but the checkpoint stores it
+        # under `model.decoder.*` (remapped in load_weights).
+        self.model = DiffusionGemmaModel(
+            config, quant_config=quant_config, prefix=add_prefix("model", prefix)
+        )
+        self.pp_group = get_pp_group()
+        # Vision tower and projection run only on the first PP rank (encoder input
+        # embedding stage).
+        self.vision_tower = None
+        self.embed_vision = None
+        if self.pp_group.is_first_rank:
+            self.vision_tower = Gemma4VisionEncoder(
+                config.vision_config,
+                quant_config=quant_config,
+                prefix=add_prefix("vision_tower", prefix),
+                mask_pad_before_pool=True,
+            )
+            self.embed_vision = Gemma4MultimodalEmbedder(
+                config.vision_config,
+                self.text_config,
+                quant_config=quant_config,
+                prefix=add_prefix("embed_vision", prefix),
+            )
+        if self.text_config.tie_word_embeddings:
+            self.lm_head = self.model.embed_tokens
+        else:
+            self.lm_head = ParallelLMHead(
+                self.text_config.vocab_size,
+                self.text_config.hidden_size,
+                quant_config=quant_config,
+                prefix=add_prefix("lm_head", prefix),
+            )
+        # Softcapping is handled by LogitsProcessor. skip_all_gather: the tied
+        # lm_head is replicated, every TP rank already has full-vocab logits.
+        self.logits_processor = LogitsProcessor(
+            self.text_config, skip_all_gather=True, return_full_logits=True
+        )
+        self.post_init()
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.model.embed_tokens
+
+    def get_attention_sliding_window_size(self):
+        # Inclusive (HF) -> exclusive (sglang).
+        return self.text_config.sliding_window - 1
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        **kwargs,
+    ):
+        # Image soft tokens are injected only on the encoder (causal-context) pass.
+        if (
+            input_embeds is None
+            and self.vision_tower is not None
+            and forward_batch.dllm_is_encoder
+            and forward_batch.contains_image_inputs()
+        ):
+            hidden_states = general_mm_embed_routine(
+                input_ids=input_ids,
+                forward_batch=forward_batch,
+                language_model=self.model,
+                data_embedding_funcs={Modality.IMAGE: self.get_image_feature},
+                positions=positions,
+            )
+        else:
+            hidden_states = self.model(
+                input_ids, positions, forward_batch, input_embeds
+            )
+        if forward_batch.dllm_is_encoder:
+            # Encoder passes only write the context KV and their logits are unused.
+            return None
+        return self.logits_processor(
+            input_ids, hidden_states, self.lm_head, forward_batch
+        )
+
+    def pad_input_ids(
+        self, input_ids: List[int], mm_inputs: MultimodalInputs
+    ) -> List[int]:
+        pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+        return pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        vt = self.vision_tower
+        embed = self.model.embed_tokens.weight
+        all_embeds = []
+        for item in items:
+            all_pixel_values = flatten_nested_list([item.feature])
+            all_position_ids = flatten_nested_list(
+                [getattr(item, "image_position_ids", None)]
+            )
+            for pv_idx, pv in enumerate(all_pixel_values):
+                if pv.dim() in (2, 3) and pv.shape[-1] == self.text_config.hidden_size:
+                    all_embeds.append(pv.to(embed.device))
+                    continue
+                if pv_idx >= len(all_position_ids) or all_position_ids[pv_idx] is None:
+                    raise ValueError(
+                        f"pixel_values[{pv_idx}] has no matching image_position_ids."
+                    )
+                pp = all_position_ids[pv_idx]
+                if pv.dim() == 2:
+                    pv = pv.unsqueeze(0)
+                if pp.dim() == 2:
+                    pp = pp.unsqueeze(0)
+                pv = pv.to(device=vt.device, dtype=embed.dtype)
+                pp = pp.to(device=vt.device)
+                pooled, pooler_mask = vt(pv, pp)
+                for hs, mask in zip(pooled, pooler_mask):
+                    real_tokens = hs[mask]
+                    all_embeds.append(
+                        self.embed_vision(
+                            inputs_embeds=real_tokens.unsqueeze(0)
+                        ).squeeze(0)
+                    )
+        if all_embeds:
+            return torch.cat(all_embeds, dim=0)
+        return torch.empty(
+            0, self.text_config.hidden_size, device=embed.device, dtype=embed.dtype
+        )
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        fused_expert_params_mapping = [
+            # (param_name, ckpt_weight_name, shard_ids). gate_up_proj is [E, 2*I, H]
+            ("moe.experts.w13_weight", "moe.experts.gate_up_proj", ("w1", "w3")),
+            ("moe.experts.w2_weight", "moe.experts.down_proj", ("w2",)),
+        ]
+        num_experts = self.text_config.num_experts
+        # Full-attention layers have no v_proj in the checkpoint (value == key).
+        k_eq_v_layers = {
+            i
+            for i, lt in enumerate(self.text_config.layer_types)
+            if lt == "full_attention"
+        }
+
+        params_dict = dict(self.named_parameters())
+        params_dict.update(dict(self.named_buffers()))
+        loaded_params: Set[str] = set()
+
+        for name, loaded_weight in weights:
+            # Vision weights (model.encoder.vision_tower.* / .embed_vision.*) load
+            # into the reused first-rank Gemma4 vision modules.
+            if name.startswith("model.encoder.vision_tower.") or name.startswith(
+                "model.encoder.embed_vision."
+            ):
+                if self.vision_tower is None:
+                    continue
+                name = Gemma4ForConditionalGeneration._remap_tower_name(
+                    name[len("model.encoder.") :], params_dict
+                )
+                for (
+                    param_name,
+                    weight_name,
+                    shard_id,
+                ) in Gemma4ForConditionalGeneration.stacked_params_mapping:
+                    if weight_name not in name:
+                        continue
+                    fused = name.replace(weight_name, param_name)
+                    if fused not in params_dict:
+                        continue
+                    param = params_dict[fused]
+                    param.weight_loader(param, loaded_weight, shard_id)
+                    loaded_params.add(fused)
+                    break
+                else:
+                    if name in params_dict:
+                        param = params_dict[name]
+                        wl = getattr(param, "weight_loader", default_weight_loader)
+                        wl(param, loaded_weight)
+                        loaded_params.add(name)
+                continue
+
+            # Encoder text weights are tied to the decoder, so keep only the encoder's
+            # per-layer scalar, skip everything else under model.encoder.*.
+            if name.startswith("model.encoder."):
+                m = re.search(r"layers\.(\d+)\.layer_scalar", name)
+                if m is None:
+                    continue
+                tgt = f"model.layers.{m.group(1)}.encoder_layer_scalar"
+                if tgt in params_dict:
+                    default_weight_loader(params_dict[tgt], loaded_weight)
+                    loaded_params.add(tgt)
+                continue
+
+            # The real stack is stored under model.decoder.* -> our model.*
+            name = name.replace("model.decoder.", "model.")
+            # Route router/expert weights into the Gemma4MoE subtree.
+            name = name.replace(".router.per_expert_scale", ".moe.per_expert_scale")
+            if ".experts." in name and ".moe.experts." not in name:
+                name = name.replace(".experts.", ".moe.experts.")
+
+            if self.text_config.tie_word_embeddings and "lm_head" in name:
+                continue
+
+            should_dup_k_to_v = (
+                ".k_proj." in name
+                and k_eq_v_layers
+                and (m := re.search(r"layers\.(\d+)\.", name)) is not None
+                and int(m.group(1)) in k_eq_v_layers
+            )
+
+            orig_name = name
+            # 1) Fused MoE experts (checked first: gate_up_proj contains "up_proj").
+            for param_name, weight_name, shard_ids in fused_expert_params_mapping:
+                name = orig_name
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                for i in range(num_experts):
+                    chunks = loaded_weight[i].chunk(len(shard_ids), dim=0)
+                    for chunk, sid in zip(chunks, shard_ids):
+                        weight_loader(param, chunk, name, sid, i)
+                loaded_params.add(name)
+                break
+            else:
+                # 2) Fused QKV / gate_up (+ k->v dup for full-attention layers).
+                for param_name, weight_name, shard_id in stacked_params_mapping:
+                    name = orig_name
+                    if weight_name not in name:
+                        continue
+                    name = name.replace(weight_name, param_name)
+                    if name not in params_dict:
+                        continue
+                    param = params_dict[name]
+                    weight_loader = param.weight_loader
+                    weight_loader(param, loaded_weight, shard_id)
+                    if should_dup_k_to_v and weight_name == "k_proj":
+                        weight_loader(param, loaded_weight, "v")
+                    loaded_params.add(name)
+                    break
+                else:
+                    # 3) Everything else (norms, scalars, router.proj/scale, embed).
+                    name = orig_name
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None or name not in params_dict:
+                        continue
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                    loaded_params.add(name)
+
+        unloaded = params_dict.keys() - loaded_params
+        if unloaded:
+            logger.warning(
+                "Some weights were not initialized from checkpoint: %s",
+                sorted(unloaded),
+            )
+        return loaded_params
+
+
+EntryClass = DiffusionGemmaForBlockDiffusion

--- a/python/sglang/srt/models/gemma4_vision.py
+++ b/python/sglang/srt/models/gemma4_vision.py
@@ -461,9 +461,7 @@ class Gemma4VisionPatchEmbedder(nn.Module):
 
 
 class Gemma4VisionPooler(nn.Module):
-    def __init__(
-        self, config: Gemma4VisionConfig, mask_pad_before_pool: bool = False
-    ):
+    def __init__(self, config: Gemma4VisionConfig, mask_pad_before_pool: bool = False):
         super().__init__()
         self.hidden_size = config.hidden_size
         self.root_hidden_size = self.hidden_size**0.5

--- a/python/sglang/srt/models/gemma4_vision.py
+++ b/python/sglang/srt/models/gemma4_vision.py
@@ -461,10 +461,14 @@ class Gemma4VisionPatchEmbedder(nn.Module):
 
 
 class Gemma4VisionPooler(nn.Module):
-    def __init__(self, config: Gemma4VisionConfig):
+    def __init__(
+        self, config: Gemma4VisionConfig, mask_pad_before_pool: bool = False
+    ):
         super().__init__()
         self.hidden_size = config.hidden_size
         self.root_hidden_size = self.hidden_size**0.5
+        # When True, zero padding patches before pooling (HF-reference parity).
+        self.mask_pad_before_pool = mask_pad_before_pool
 
     def _avg_pool_by_positions(
         self, x: torch.Tensor, patch_positions: torch.Tensor, length: int
@@ -510,6 +514,10 @@ class Gemma4VisionPooler(nn.Module):
         if hidden_states.shape[1] == length:
             mask = padding_positions
         else:
+            if self.mask_pad_before_pool:
+                hidden_states = hidden_states.masked_fill(
+                    padding_positions.unsqueeze(-1), 0.0
+                )
             hidden_states, mask = self._avg_pool_by_positions(
                 hidden_states, patch_positions, length
             )
@@ -530,6 +538,7 @@ class Gemma4VisionEncoder(nn.Module):
         config: Gemma4VisionConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        mask_pad_before_pool: bool = False,
     ):
         super().__init__()
         self.config = config
@@ -542,7 +551,9 @@ class Gemma4VisionEncoder(nn.Module):
             quant_config=quant_config,
             prefix=add_prefix("encoder", prefix),
         )
-        self.pooler = Gemma4VisionPooler(config)
+        self.pooler = Gemma4VisionPooler(
+            config, mask_pad_before_pool=mask_pad_before_pool
+        )
 
         # Post-pooling standardization (normalizes vision tokens before projection)
         self.standardize = getattr(config, "standardize", False)

--- a/python/sglang/srt/multimodal/processors/diffusion_gemma.py
+++ b/python/sglang/srt/multimodal/processors/diffusion_gemma.py
@@ -1,0 +1,69 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import re
+from typing import Dict, List, Optional, Union
+
+from sglang.srt.managers.multimodal_processor import (
+    BaseMultimodalProcessor as SGLangBaseProcessor,
+)
+from sglang.srt.managers.schedule_batch import Modality, MultimodalProcessorOutput
+from sglang.srt.models.gemma4_diffusion import DiffusionGemmaForBlockDiffusion
+from sglang.srt.multimodal.processors.base_processor import MultimodalSpecialTokens
+
+
+class DiffusionGemmaSGLangProcessor(SGLangBaseProcessor):
+    """Image multimodal processor for DiffusionGemma (image-only, reuses the stock
+    Gemma4 image processor resolved from the checkpoint)."""
+
+    models = [DiffusionGemmaForBlockDiffusion]
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        self.mm_tokens = MultimodalSpecialTokens(
+            image_token="<|image|>",
+            image_token_id=hf_config.image_token_id,
+            # Also match the HF-expanded placeholder (boi + soft tokens + eoi).
+            image_token_regex=re.compile(
+                r"<\|image>(?:<\|image\|>)+<image\|>|<\|image\|>"
+            ),
+        ).build(_processor)
+        self.ATTR_NAME_TO_MODALITY["image_position_ids"] = Modality.IMAGE
+
+    async def process_mm_data_async(
+        self,
+        image_data: Optional[List[Union[str, bytes, Dict]]] = None,
+        input_text: str = "",
+        request_obj=None,
+        *args,
+        **kwargs,
+    ):
+        if kwargs.get("audio_data") or getattr(request_obj, "video_data", None):
+            raise ValueError(
+                "DiffusionGemma serving supports image input only "
+                "(audio/video are not implemented)."
+            )
+        base_output = await self.load_mm_data(
+            prompt=input_text,
+            image_data=image_data,
+            multimodal_tokens=self.mm_tokens,
+        )
+        mm_items, input_ids, _ = self.process_and_combine_mm_data(
+            base_output, self.mm_tokens
+        )
+        return MultimodalProcessorOutput(
+            input_ids=input_ids.tolist(),
+            mm_items=mm_items,
+            im_token_id=self.mm_tokens.image_token_id,
+        )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4132,12 +4132,20 @@ class ServerArgs:
             "Gemma3nForCausalLM",
             "Gemma3nForConditionalGeneration",
         ]:
-            # FIXME: https://github.com/sgl-project/sglang/pull/7367 is not compatible with gemma2 model.
-            # It failed at this test: https://github.com/sgl-project/sglang/actions/runs/16255155597/job/45890331952#step:4:736
-            logger.warning(
-                f"Disable hybrid SWA memory for {model_arch} as it is not yet supported."
-            )
-            self.disable_hybrid_swa_memory = True
+            if (
+                model_arch == "Gemma3ForConditionalGeneration"
+                and os.environ.get("SGLANG_GEMMA3_ENABLE_HYBRID_SWA") == "1"
+            ):
+                logger.warning(
+                    "Enable experimental hybrid SWA memory for Gemma3ForConditionalGeneration."
+                )
+            else:
+                # FIXME: https://github.com/sgl-project/sglang/pull/7367 is not compatible with gemma2 model.
+                # It failed at this test: https://github.com/sgl-project/sglang/actions/runs/16255155597/job/45890331952#step:4:736
+                logger.warning(
+                    f"Disable hybrid SWA memory for {model_arch} as it is not yet supported."
+                )
+                self.disable_hybrid_swa_memory = True
         elif model_arch in (
             "Gemma4ForConditionalGeneration",
             "Gemma4ForCausalLM",
@@ -4160,11 +4168,17 @@ class ServerArgs:
 
             prefill_backend, decode_backend = self.get_attention_backends()
             accepted_backends = ("trtllm_mha", "triton", "ascend", "intel_xpu")
+            if os.environ.get("SGLANG_FLASHINFER_VOSPLIT") == "1":
+                accepted_backends = accepted_backends + ("flashinfer",)
+                logger.warning(
+                    "Enable experimental FlashInfer attention backend for Gemma4 "
+                    "under SGLANG_FLASHINFER_VOSPLIT=1."
+                )
             assert (
                 prefill_backend in accepted_backends
                 and decode_backend in accepted_backends
             ), (
-                "Gemma4 only supports trtllm_mha, triton, or intel_xpu attention backend, "
+                f"Gemma4 only supports {accepted_backends} attention backend, "
                 f"got prefill={prefill_backend}, decode={decode_backend}"
             )
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6162,6 +6162,24 @@ class ServerArgs:
     def _handle_dllm_inference(self):
         if self.dllm_algorithm is None:
             return
+        # DiffusionGemma: head_dim 512 exceeds the flashinfer/fa3 cap, and the
+        # bidirectional canvas needs eager triton with unchunked prefill.
+        if self.dllm_algorithm == "Gemma4Renoise":
+            if (
+                self.attention_backend != "triton"
+                or self.prefill_attention_backend not in (None, "triton")
+                or self.decode_attention_backend not in (None, "triton")
+            ):
+                logger.warning(
+                    "Attention backend forced to triton for DiffusionGemma "
+                    "(head_dim 512 exceeds the flashinfer/fa3 cap)."
+                )
+                self.attention_backend = "triton"
+                self.prefill_attention_backend = None
+                self.decode_attention_backend = None
+            self.cuda_graph_config.decode.backend = Backend.DISABLED
+            self.cuda_graph_config.prefill.backend = Backend.DISABLED
+            self.chunked_prefill_size = -1
         # On AMD/HIP, disable cuda graph for DLLM and use triton backend
         if is_hip():
             if (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4906,10 +4906,15 @@ class ServerArgs:
                             f"{KV4_ATTENTION_MLA_BACKEND_CHOICES}, but got {self.attention_backend}"
                         )
                     else:  # !FA4 + MHA
+                        # NVFP4 KV is uint8-packed; only a backend with an fp4
+                        # unpack/dequant path can read it. triton / torch_native /
+                        # flex_attention route the extend op to Triton's
+                        # extend_attention_fwd, whose `tl.dot` rejects the uint8
+                        # KV ("only int8 supported") and SIGQUITs the scheduler on
+                        # the first prefill (notably Gemma-4, whose default backend
+                        # is triton). Restrict KV4 MHA to the fp4-capable kernels so
+                        # an incompatible choice fails clearly at startup instead.
                         KV4_ATTENTION_MHA_BACKEND_CHOICES = [
-                            "triton",
-                            "torch_native",
-                            "flex_attention",
                             "trtllm_mha",
                         ]
                         if is_sm120_supported():

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4868,6 +4868,8 @@ class ServerArgs:
                             "torch_native",
                             "flex_attention",
                         ]
+                        if is_sm120_supported():
+                            KV4_FA4_MHA_BACKEND_CHOICES.append("flashinfer")
                         assert (
                             self.decode_attention_backend_str
                             in KV4_FA4_MHA_BACKEND_CHOICES
@@ -4896,6 +4898,8 @@ class ServerArgs:
                             "flex_attention",
                             "trtllm_mha",
                         ]
+                        if is_sm120_supported():
+                            KV4_ATTENTION_MHA_BACKEND_CHOICES.append("flashinfer")
                         assert (
                             self.attention_backend in KV4_ATTENTION_MHA_BACKEND_CHOICES
                         ), (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6181,16 +6181,33 @@ class ServerArgs:
         if self.dllm_algorithm is None:
             return
         # DiffusionGemma: head_dim 512 exceeds the flashinfer/fa3 cap, and the
-        # bidirectional canvas needs eager triton with unchunked prefill.
+        # bidirectional canvas needs eager mode with unchunked prefill.
         if self.dllm_algorithm == "Gemma4Renoise":
-            if (
+            # Triton-retirement allowance: our asymmetric VO-split (FlashInfer #3684,
+            # qk=512/vo=256) handles the 512-wide full-attention head, so when the
+            # VO-split knob is on we route DiffusionGemma through FlashInfer instead
+            # of forcing Triton — unlocking native NVFP4 KV for the canvas. The
+            # bidirectional canvas still requires eager mode + unchunked prefill, so
+            # cuda graph stays DISABLED and chunked_prefill_size stays -1 regardless.
+            vosplit_on = os.environ.get("SGLANG_FLASHINFER_VOSPLIT", "0") == "1"
+            if vosplit_on:
+                if self.attention_backend not in (None, "flashinfer"):
+                    logger.warning(
+                        "DiffusionGemma: VO-split knob on — routing through FlashInfer "
+                        "(NVFP4 KV path) instead of forced Triton."
+                    )
+                self.attention_backend = "flashinfer"
+                self.prefill_attention_backend = None
+                self.decode_attention_backend = None
+            elif (
                 self.attention_backend != "triton"
                 or self.prefill_attention_backend not in (None, "triton")
                 or self.decode_attention_backend not in (None, "triton")
             ):
                 logger.warning(
                     "Attention backend forced to triton for DiffusionGemma "
-                    "(head_dim 512 exceeds the flashinfer/fa3 cap)."
+                    "(head_dim 512 exceeds the flashinfer/fa3 cap; set "
+                    "SGLANG_FLASHINFER_VOSPLIT=1 to use the FlashInfer VO-split path)."
                 )
                 self.attention_backend = "triton"
                 self.prefill_attention_backend = None

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -158,6 +158,7 @@ class HfModelConfigParser(ModelConfigParserBase):
             "gemma4_assistant",
             "gemma4_unified",
             "gemma4_unified_assistant",
+            "diffusion_gemma",
         ):
             # Gemma4 configs use base attributes for SWA layers and `global_*`
             # variants for full-attention layers.  SGLang expects the opposite:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -912,6 +912,65 @@ class TestHiCacheArgs(unittest.TestCase):
         self.assertIsNone(args.decode_attention_backend)
 
 
+class TestKV4Compatibility(unittest.TestCase):
+    def _make_args(
+        self,
+        *,
+        attention_backend: str,
+        prefill_attention_backend: str,
+        decode_attention_backend: str,
+    ) -> ServerArgs:
+        args = ServerArgs(model_path="dummy")
+        args.kv_cache_dtype = "fp4_e2m1"
+        args.attention_backend = attention_backend
+        args.prefill_attention_backend_str = prefill_attention_backend
+        args.decode_attention_backend_str = decode_attention_backend
+        return args
+
+    @patch.object(ServerArgs, "use_mla_backend", return_value=False)
+    @patch("sglang.srt.server_args.is_cuda", return_value=True)
+    @patch("sglang.srt.server_args.is_sm120_supported", return_value=True)
+    def test_sm120_allows_flashinfer_mha_kv4(
+        self, _mock_sm120, _mock_cuda, _mock_use_mla_backend
+    ):
+        args = self._make_args(
+            attention_backend="flashinfer",
+            prefill_attention_backend="flashinfer",
+            decode_attention_backend="flashinfer",
+        )
+
+        args._handle_kv4_compatibility()
+
+    @patch.object(ServerArgs, "use_mla_backend", return_value=False)
+    @patch("sglang.srt.server_args.is_cuda", return_value=True)
+    @patch("sglang.srt.server_args.is_sm120_supported", return_value=False)
+    def test_non_sm120_rejects_flashinfer_mha_kv4(
+        self, _mock_sm120, _mock_cuda, _mock_use_mla_backend
+    ):
+        args = self._make_args(
+            attention_backend="flashinfer",
+            prefill_attention_backend="flashinfer",
+            decode_attention_backend="flashinfer",
+        )
+
+        with self.assertRaisesRegex(AssertionError, "KV4 MHA expects"):
+            args._handle_kv4_compatibility()
+
+    @patch.object(ServerArgs, "use_mla_backend", return_value=False)
+    @patch("sglang.srt.server_args.is_cuda", return_value=True)
+    @patch("sglang.srt.server_args.is_sm120_supported", return_value=True)
+    def test_sm120_allows_flashinfer_mha_kv4_with_fa4_prefill(
+        self, _mock_sm120, _mock_cuda, _mock_use_mla_backend
+    ):
+        args = self._make_args(
+            attention_backend="fa4",
+            prefill_attention_backend="fa4",
+            decode_attention_backend="flashinfer",
+        )
+
+        args._handle_kv4_compatibility()
+
+
 class TestNgramExternalSamArgs(CustomTestCase):
     def test_prepare_server_args_parses_external_sam_args(self):
         server_args = prepare_server_args(


### PR DESCRIPTION
## What this is

Retires **DiffusionGemma** (the block-diffusion `google/diffusiongemma-26B-A4B-it`) off the Triton attention backend onto the FA2 path with **native NVFP4 KV cache**, on both SM120 and SM121.

Upstream forces DiffusionGemma onto Triton for two reasons — its full-attention head is **512-wide** and its denoising **canvas is bidirectional**. Those are exactly the two things the NVFP4-KV foundation already solves: the asymmetric **VO-split** (qk=512 / vo=256) handles the 512 head, and the bidirectional canvas (`AttentionType.ENCODER_ONLY`) flows through the existing FA2 non-causal path with **no special kernel work**. So flipping `SGLANG_FLASHINFER_VOSPLIT=1` routes `Gemma4Renoise` onto FlashInfer with a 4-bit KV cache.

## Net-new in this PR (small)

1. **Triton-retirement allowance** (`server_args.py`) — gate the forced-Triton for `Gemma4Renoise` on the VO-split knob; when on, route to FlashInfer (keeping eager + unchunked for the dynamic canvas).
2. **Re-derivation fix** (`schedule_batch.py`, `dllm/mixin/req.py`) — restore the `req.fill_len` field the uniform-diffusion scheduler needs, which current main's Req dropped after #28054's base (main tracks masked dLLM via `dllm_initialized`).

## Stacked on (all unmerged — this is a draft for coordination)

- **#29304** — my NVFP4 KV foundation (SM120/121 + VO-split + FP4 prefix-cache gate).
- **#28054** — @rwang5203's DiffusionGemma support (the `Gemma4Renoise` sampler + `gemma4_diffusion` model). Their commits are included here only because the chain is unmerged; I'll rebase this down to just the delta once they land.
- **flashinfer-ai/flashinfer#3684** — the VO-split kernel.

## Validation

Comparative faithfulness (DiffusionGemma decoding is intrinsically a little noisy, so the gate is nvfp4-output ≈ bf16-on-Triton control, not literal retrieval): **FAITHFUL on both SM120 and SM121 (GB10 / DGX Spark)** — several prompts character-identical to the bf16 control. The 26B-A4B model runs bf16 weights + 4-bit KV and fits the Spark's unified memory.



















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->