### PR TITLE
Fix CI broken by #28450

### DIFF
--- a/test/registered/moe/test_topk_padded_region.py
+++ b/test/registered/moe/test_topk_padded_region.py
@@ -109,15 +109,15 @@ class TestTopkPaddedRegion(CustomTestCase):
 
     def test_invalid_pad_count_tensor_raises(self):
         x = torch.rand((8, 8), device=self.DEVICE, dtype=torch.float32)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             _fill_padded_rows(x, 4, 0.0)  # python int, not a tensor
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             _fill_padded_rows(
                 x,
                 torch.tensor([1, 2], device=self.DEVICE, dtype=torch.int32),
                 0.0,
             )
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             _fill_padded_rows(
                 x,
                 torch.tensor(4.0, device=self.DEVICE, dtype=torch.float32),


### PR DESCRIPTION
https://github.com/sgl-project/sglang/pull/28450

@rbrugaro-amd, please pay attention to these CI failures in the future. For example, it's caught in https://github.com/sgl-project/sglang/actions/runs/28067472170/job/83096113232 in the original PR itself, and not a flake (it fails 100% of the time). We should make sure at least stage-b CUDA can pass succesfully.

Thanks.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28174867227](https://github.com/sgl-project/sglang/actions/runs/28174867227)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28174866841](https://github.com/sgl-project/sglang/actions/runs/28174866841)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->