### PR TITLE
[MLX] Fix FutureMap relay unit test to use RelayPayload

### DIFF
--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -384,6 +384,7 @@ class TestMlxAuxiliaryStateRunnerCache(unittest.TestCase):
 
     def test_mlx_scheduler_init_overlap_keeps_future_map_relay(self):
         from sglang.srt.managers import scheduler as scheduler_module
+        from sglang.srt.managers.overlap_utils import RelayPayload
         from sglang.srt.managers.scheduler import Scheduler
         from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
         from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -417,7 +418,9 @@ class TestMlxAuxiliaryStateRunnerCache(unittest.TestCase):
 
         self.assertIsNotNone(scheduler.future_map)
         indices = torch.tensor([1], dtype=torch.int64)
-        scheduler.future_map.stash(indices, torch.tensor([7], dtype=torch.int64))
+        scheduler.future_map.stash(
+            indices, RelayPayload(bonus_tokens=torch.tensor([7], dtype=torch.int64))
+        )
         self.assertEqual(int(scheduler.future_map.output_tokens_buf[1].item()), 7)
 
     def test_decode_finalize_does_not_snapshot_auxiliary_state(self):


### PR DESCRIPTION
## Motivation

`test_mlx_scheduler_init_overlap_keeps_future_map_relay` (in `test/registered/unit/hardware_backend/mlx/test_attention_patching.py`) fails on current `main`:

```
AttributeError: 'Tensor' object has no attribute 'draft_probs'
  overlap_utils.py:211  if payload.draft_probs is not None:
  overlap_utils.py:341  self._lazy_init_forward_buf(payload)
  test_attention_patching.py:420  scheduler.future_map.stash(indices, torch.tensor([7], ...))
```

`FutureMap.stash()` was refactored to take a `RelayPayload` dataclass (unifying the previous Tensor / `EagleDraftInput` type switch), but this MLX unit test still passed a raw token `torch.Tensor`, so `_lazy_init_forward_buf` dereferenced `payload.draft_probs` on a Tensor.

Reported by @changminbark; addressing in a separate PR per @yeahdongcn's request.

## Modifications

- Wrap the relayed token tensor in `RelayPayload(bonus_tokens=...)` (the non-spec relay path), matching the current `stash()` API. The assertion (`output_tokens_buf[1] == 7`) is unchanged.

## Accuracy Tests

N/A — test-only change.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28181570689](https://github.com/sgl-project/sglang/actions/runs/28181570689)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28181570577](https://github.com/sgl-project/sglang/actions/runs/28181570577)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->