### PR TITLE
[diffusion] Fix FLUX.2 NVFP4 scale layout on flashinfer cutlass/cudnn

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
@@ -593,30 +593,18 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
         padded_scales = torch.zeros((B, M_padded, K_padded), dtype=scales.dtype)
         padded_scales[:B, :M, :K] = scales
 
-        _, flashinfer_backend = _get_fp4_gemm_op()
-        uses_flux1_scale_layout = not getattr(
-            self.quant_config, "checkpoint_uses_packed_qkv", False
-        ) and getattr(layer, "prefix", "").startswith(
-            ("transformer_blocks.", "single_transformer_blocks.")
+        # The trtllm backend returned above with its own scale shuffle, so every
+        # GEMM consumer that reaches this point expects the TMA blockscale
+        # layout: the sgl_kernel CUTLASS fallback (backend is None) and flashinfer
+        # cutlass/cudnn/auto. The latter covers FLUX.1 transformer blocks as well
+        # as packed-qkv checkpoints such as FLUX.2 (which CI only ever exercised
+        # via trtllm on B200, so this case was previously missed and produced a
+        # corrupted latent on sm_120). Every reachable backend needs it, so always
+        # permute.
+        padded_scales = padded_scales.reshape(
+            B, M_padded // 128, 4, 32, K_padded // 4, 4
         )
-        # The trtllm backend already returned above with its own scale shuffle,
-        # so every GEMM consumer that reaches this point expects the TMA
-        # blockscale layout: the sgl_kernel CUTLASS fallback (flashinfer_backend
-        # is None), the FLUX.1 cutlass/cudnn path (uses_flux1_scale_layout), and
-        # also flashinfer cutlass/cudnn/auto for packed-qkv checkpoints such as
-        # FLUX.2 (which CI only ever exercised via trtllm on B200, so this case
-        # was previously missed and produced a corrupted latent on sm_120).
-        needs_tma_scale_layout = (
-            flashinfer_backend is None
-            or uses_flux1_scale_layout
-            or flashinfer_backend in ("cutlass", "cudnn", "auto")
-        )
-        if needs_tma_scale_layout:
-            # CUTLASS / CUDNN / auto paths need the TMA scale layout.
-            padded_scales = padded_scales.reshape(
-                B, M_padded // 128, 4, 32, K_padded // 4, 4
-            )
-            padded_scales = padded_scales.permute(0, 1, 4, 3, 2, 5)
+        padded_scales = padded_scales.permute(0, 1, 4, 3, 2, 5)
 
         padded_scales = padded_scales.contiguous().cuda()
         padded_scales = (

--- a/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
@@ -599,8 +599,20 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
         ) and getattr(layer, "prefix", "").startswith(
             ("transformer_blocks.", "single_transformer_blocks.")
         )
-        if flashinfer_backend is None or uses_flux1_scale_layout:
-            # CUTLASS and FLUX.1 CUDNN paths need the TMA scale layout.
+        # The trtllm backend already returned above with its own scale shuffle,
+        # so every GEMM consumer that reaches this point expects the TMA
+        # blockscale layout: the sgl_kernel CUTLASS fallback (flashinfer_backend
+        # is None), the FLUX.1 cutlass/cudnn path (uses_flux1_scale_layout), and
+        # also flashinfer cutlass/cudnn/auto for packed-qkv checkpoints such as
+        # FLUX.2 (which CI only ever exercised via trtllm on B200, so this case
+        # was previously missed and produced a corrupted latent on sm_120).
+        needs_tma_scale_layout = (
+            flashinfer_backend is None
+            or uses_flux1_scale_layout
+            or flashinfer_backend in ("cutlass", "cudnn", "auto")
+        )
+        if needs_tma_scale_layout:
+            # CUTLASS / CUDNN / auto paths need the TMA scale layout.
             padded_scales = padded_scales.reshape(
                 B, M_padded // 128, 4, 32, K_padded // 4, 4
             )


### PR DESCRIPTION
ModelOptFp4LinearMethod.process_weights_after_loading only converted the NVFP4 block-scales to the TMA layout when `flashinfer_backend is None` (sgl_kernel CUTLASS fallback) or `uses_flux1_scale_layout` was set. The latter requires `not checkpoint_uses_packed_qkv`, which is False for packed-qkv checkpoints such as FLUX.2-dev-NVFP4. As a result, when the flashinfer cutlass/cudnn/auto backend was selected, FLUX.2 weight scales were left in linear layout while the kernel expects the TMA layout, producing a corrupted (constant) latent and a flat output image with no error raised.

This path is only reachable on GPUs where the default trtllm FP4 backend is unavailable (e.g. sm_120 / RTX PRO 6000), since trtllm returns earlier with its own scale shuffle. CI exercises FLUX.2 NVFP4 exclusively via trtllm on B200 (sm_100), so the cutlass/cudnn path was never covered.

Apply the TMA scale permute for any flashinfer cutlass/cudnn/auto backend in addition to the existing cases. The checkpoint stores swizzled scales; they are de-swizzled to linear earlier and the permute re-swizzles them back to TMA (the two ops are exact inverses), so FLUX.1 behavior is unchanged. Verified end-to-end: FLUX.2-dev-NVFP4 (mixed), cutlass backend, on an RTX PRO 6000 (sm_120) now produces correct images.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28245918252](https://github.com/sgl-project/sglang/actions/runs/28245918252)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28245918059](https://github.com/sgl-project/sglang/actions/runs/28245918059)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->