### PR TITLE
qwen3_next: support quantized .weight_packed/.qweight in _make_packed_weight_loader

### DIFF
--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -270,7 +270,28 @@ class Qwen3GatedDeltaNet(nn.Module):
         (packed-format) checkpoint weights (shard_id=None), and delegates
         to the standard MergedColumnParallelLinear loader for split checkpoint
         weights (shard_id=int/tuple)."""
-        original_loader = module.weight.weight_loader
+        # Quantized checkpoints (NVFP4 / compressed-tensors, AWQ, GPTQ, ...)
+        # either omit ``.weight`` entirely or expose it as a plain Tensor
+        # without ``weight_loader``; the canonical Parameter that carries
+        # ``weight_loader`` lives on ``.weight_packed`` (compressed-tensors)
+        # or ``.qweight`` (AWQ / GPTQ). Find it via an explicit loop -- we
+        # cannot use ``a or b`` here because ``a`` may already be a
+        # multi-element Tensor, which would itself raise ``RuntimeError:
+        # Boolean value of Tensor with more than one value is ambiguous``.
+        # See https://github.com/sgl-project/sglang/issues/13639.
+        weight_param = None
+        for _attr in ("weight", "weight_packed", "qweight"):
+            candidate = getattr(module, _attr, None)
+            if candidate is not None and hasattr(candidate, "weight_loader"):
+                weight_param = candidate
+                break
+        if weight_param is None:
+            raise AttributeError(
+                f"_make_packed_weight_loader: {type(module).__name__} "
+                "exposes neither .weight nor .weight_packed nor .qweight "
+                "carrying a weight_loader"
+            )
+        original_loader = weight_param.weight_loader
 
         def weight_loader(param, loaded_weight, loaded_shard_id=None):
             if loaded_shard_id is None:


### PR DESCRIPTION
Fixes #13639.

`Qwen3HybridLinearAttention._make_packed_weight_loader` reads `module.weight.weight_loader` directly. On NVFP4 (compressed-tensors) and similar quantized checkpoints, `MergedColumnParallelLinear` does not register a `.weight` attribute at all (or, on older builds, exposes it as a plain Tensor without `weight_loader`); the canonical Parameter with the loader lives on `.weight_packed` (compressed-tensors) or `.qweight` (AWQ / GPTQ). Either way the unconditional access crashes the constructor of `Qwen3HybridLinearAttention` before the first forward pass with:

```
AttributeError: 'MergedColumnParallelLinear' object has no attribute 'weight'
```

`_override_weight_loader` already handles a similar missing-attribute case for the override side (iterating over optional attrs with `getattr(module, attr, None)`); this PR mirrors that pattern on the read side. The lookup uses an explicit loop with `is None` / `hasattr` rather than a chained `or` expression so we never coerce a multi-element Tensor to `bool` (which would itself raise `RuntimeError: Boolean value of Tensor with more than one value is ambiguous`).

### Repro

Any NVFP4 Qwen3-Coder-Next checkpoint reproduces it. Tested with both:

- `RedHatAI/Qwen3-Coder-Next-NVFP4`
- `saricles/Qwen3-Coder-Next-NVFP4-GB10`

```bash
docker run --rm --runtime=nvidia --gpus all --shm-size=32g -p 30000:30000 \
  -v <hf-cache>:/root/.cache/huggingface \
  lmsysorg/sglang:v0.5.14-cu130 \
  python3 -m sglang.launch_server \
    --model-path saricles/Qwen3-Coder-Next-NVFP4-GB10 \
    --quantization compressed-tensors --port 30000
```

### Status on v0.5.14 (2026-06-27)

Re-verified against the freshly released `lmsysorg/sglang:v0.5.14-cu130` image. Without this patch the engine still aborts at the exact same call site (`qwen3_next.py:273` in v0.5.14 — `original_loader = module.weight.weight_loader`), confirmed at line 16-44 of the stock log:

```
File "/sgl-workspace/sglang/python/sglang/srt/models/qwen3_next.py", line 273, in _make_packed_weight_loader
    original_loader = module.weight.weight_loader
                      ^^^^^^^^^^^^^
AttributeError: 'MergedColumnParallelLinear' object has no attribute 'weight'
[2026-06-27 13:06:35] Received sigquit from a child process. It usually means the child failed.
[2026-06-27 13:06:35] kill_process_tree called: parent_pid=63, include_parent=True, pid=63
```

The branch is rebased on current `main` (HEAD `3306233`) and the patch applies cleanly. With the patch applied to the v0.5.14 image the same workload reaches `CompressedTensorsW4A4Nvfp4MoE` and proceeds through shard loading (4/10, ~29 s per shard) as expected.

### Live verification

Verified end-to-end on an NVIDIA DGX Spark (GB10, sm_121) against `saricles/Qwen3-Coder-Next-NVFP4-GB10` (W4A4 NVFP4 / compressed-tensors, ~46 GiB checkpoint).

After the patch:

- `Application startup complete` — engine reaches steady state (model load 252 s, 43.52 GB memory usage, KV cache 163 K tokens allocated, CUDA graphs captured for bs=[1, 2, 4, 8, 12, 15]).
- Non-streaming completion answers `print 1+1 in python` with the correct Python snippet.
- Streaming endpoint returns 603 SSE chunks for a 600-token completion (~50 tok/s), `[DONE]` marker present.
- Long-context: a 3026-token prompt asking the model to count occurrences of "fox" in 300 repetitions of "The quick brown fox..." returns the correct integer `100` in 830 ms (prefill ~3 650 tok/s).

### Note for users on `v0.5.10.post1`

The stable docker image has an older `_override_weight_loader` that still uses the unconditional `param = module.weight` form and hits the same `AttributeError` one frame higher. `main` (and v0.5.14) already refactored that helper to iterate over `("weight", "weight_scale_inv", "weight_scale", "input_scale", "weight_offset")` with `getattr(..., None)` — but note that the refactored list still does **not** include `weight_packed` or `qweight`, so a checkpoint that registers only `.weight_packed` (the compressed-tensors NVFP4 convention; see `compressed_tensors_w4a4_nvfp4.py::create_weights` → `layer.register_parameter("weight_packed", weight)`) would also miss the override path. Happy to send a second PR aligning `_override_weight_loader` with the same `("weight", "weight_packed", "qweight")` lookup if useful.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28290311611](https://github.com/sgl-project/sglang/actions/runs/28290311611)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28290311563](https://github.com/sgl-project/sglang/actions/runs/28290311563)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->