### PR TITLE
[Test] Add unit tests for srt/compilation (#20865)

### DIFF
--- a/test/registered/unit/compilation/test_compilation_config.py
+++ b/test/registered/unit/compilation/test_compilation_config.py
@@ -1,0 +1,157 @@
+"""Unit tests for CompilationConfig and register_split_op in srt/compilation/compilation_config.py."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import sglang.srt.compilation.compilation_config as _config_mod
+from sglang.srt.compilation.compilation_config import (
+    CompilationConfig,
+    register_split_op,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestRegisterSplitOp(CustomTestCase):
+    def setUp(self):
+        # Save SPLIT_OPS contents; restore after each test to avoid pollution.
+        self._orig_ops = list(_config_mod.SPLIT_OPS)
+
+    def tearDown(self):
+        _config_mod.SPLIT_OPS[:] = self._orig_ops
+
+    def test_explicit_op_name_appends_prefixed_string(self):
+        @register_split_op(op_name="my_custom_op")
+        def some_func():
+            pass
+
+        self.assertIn("sglang.my_custom_op", _config_mod.SPLIT_OPS)
+
+    def test_no_op_name_uses_function_dunder_name(self):
+        @register_split_op()
+        def unique_fn_for_test():
+            pass
+
+        self.assertIn("sglang.unique_fn_for_test", _config_mod.SPLIT_OPS)
+
+    def test_decorated_function_is_still_callable(self):
+        sentinel = []
+
+        @register_split_op(op_name="sentinel_op")
+        def push_sentinel():
+            sentinel.append(1)
+
+        push_sentinel()
+        self.assertEqual(sentinel, [1])
+
+    def test_decorated_function_returns_original(self):
+        def original():
+            return 42
+
+        decorated = register_split_op(op_name="ret_op")(original)
+        self.assertIs(decorated, original)
+
+    def test_multiple_registrations_accumulate(self):
+        before = len(_config_mod.SPLIT_OPS)
+
+        @register_split_op(op_name="op_alpha")
+        def fa():
+            pass
+
+        @register_split_op(op_name="op_beta")
+        def fb():
+            pass
+
+        self.assertEqual(len(_config_mod.SPLIT_OPS), before + 2)
+        self.assertIn("sglang.op_alpha", _config_mod.SPLIT_OPS)
+        self.assertIn("sglang.op_beta", _config_mod.SPLIT_OPS)
+
+
+class TestCompilationConfigConstruction(CustomTestCase):
+    def setUp(self):
+        self._orig_ops = list(_config_mod.SPLIT_OPS)
+
+    def tearDown(self):
+        _config_mod.SPLIT_OPS[:] = self._orig_ops
+
+    def test_capture_sizes_stored(self):
+        cfg = CompilationConfig(capture_sizes=[1, 4, 8])
+        self.assertEqual(cfg.get_capture_sizes(), [1, 4, 8])
+
+    def test_default_compiler_is_eager(self):
+        cfg = CompilationConfig(capture_sizes=[1])
+        self.assertEqual(cfg.compiler, "eager")
+
+    def test_custom_compiler_stored(self):
+        cfg = CompilationConfig(capture_sizes=[1], compiler="eager")
+        self.assertEqual(cfg.compiler, "eager")
+
+    def test_enable_debug_mode_default_is_false(self):
+        cfg = CompilationConfig(capture_sizes=[1])
+        self.assertFalse(cfg.get_enable_debug_mode())
+
+    def test_enable_debug_mode_can_be_set(self):
+        cfg = CompilationConfig(capture_sizes=[1], enable_debug_mode=True)
+        self.assertTrue(cfg.get_enable_debug_mode())
+
+    def test_split_ops_populated_from_global_split_ops(self):
+        @register_split_op(op_name="injected_op")
+        def _dummy():
+            pass
+
+        cfg = CompilationConfig(capture_sizes=[1])
+        self.assertIn("sglang.injected_op", cfg.split_ops)
+
+    def test_split_ops_is_independent_copy_from_global(self):
+        cfg = CompilationConfig(capture_sizes=[1])
+        original_len = len(cfg.split_ops)
+        # Mutating the global after construction must not affect the config.
+        _config_mod.SPLIT_OPS.append("sglang.post_construction_op")
+        self.assertEqual(len(cfg.split_ops), original_len)
+
+    def test_configure_inductor_noop_for_eager_compiler(self):
+        # Should not raise or import inductor config.
+        cfg = CompilationConfig(capture_sizes=[1], compiler="eager")
+        self.assertEqual(cfg.compiler, "eager")
+
+
+class TestCompilationConfigMutators(CustomTestCase):
+    def test_add_split_op_appends_to_instance_split_ops(self):
+        cfg = CompilationConfig(capture_sizes=[1])
+        cfg.add_split_op("my.op")
+        self.assertIn("my.op", cfg.split_ops)
+
+    def test_add_split_op_does_not_affect_global_split_ops(self):
+        cfg = CompilationConfig(capture_sizes=[1])
+        before = list(_config_mod.SPLIT_OPS)
+        cfg.add_split_op("instance.only.op")
+        self.assertEqual(_config_mod.SPLIT_OPS, before)
+
+    def test_add_traced_file_stored_in_set(self):
+        cfg = CompilationConfig(capture_sizes=[1])
+        cfg.add_traced_file("/some/file.py")
+        self.assertIn("/some/file.py", cfg.get_traced_files())
+
+    def test_add_traced_file_deduplicates(self):
+        cfg = CompilationConfig(capture_sizes=[1])
+        cfg.add_traced_file("/path/a.py")
+        cfg.add_traced_file("/path/a.py")
+        self.assertEqual(len(cfg.get_traced_files()), 1)
+
+    def test_get_traced_files_empty_initially(self):
+        cfg = CompilationConfig(capture_sizes=[1])
+        self.assertEqual(len(cfg.get_traced_files()), 0)
+
+    def test_multiple_traced_files_all_stored(self):
+        cfg = CompilationConfig(capture_sizes=[1])
+        cfg.add_traced_file("/a.py")
+        cfg.add_traced_file("/b.py")
+        self.assertIn("/a.py", cfg.get_traced_files())
+        self.assertIn("/b.py", cfg.get_traced_files())
+        self.assertEqual(len(cfg.get_traced_files()), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/compilation/test_compilation_counter.py
+++ b/test/registered/unit/compilation/test_compilation_counter.py
@@ -1,0 +1,128 @@
+"""Unit tests for CompilationCounter in srt/compilation/compilation_counter.py."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+from sglang.srt.compilation.compilation_counter import (
+    CompilationCounter,
+    compilation_counter,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestCompilationCounterDefaults(CustomTestCase):
+    def test_all_fields_start_at_zero(self):
+        c = CompilationCounter()
+        for field in c.__dataclass_fields__:
+            self.assertEqual(getattr(c, field), 0, msg=f"{field} should default to 0")
+
+    def test_all_expected_fields_exist(self):
+        c = CompilationCounter()
+        expected = [
+            "num_models_seen",
+            "num_graphs_seen",
+            "num_piecewise_graphs_seen",
+            "num_piecewise_capturable_graphs_seen",
+            "num_backend_compilations",
+            "num_gpu_runner_capture_triggers",
+            "num_cudagraph_captured",
+            "num_inductor_compiles",
+            "num_eager_compiles",
+            "num_cache_entries_updated",
+            "num_compiled_artifacts_saved",
+            "dynamo_as_is_count",
+        ]
+        for name in expected:
+            self.assertTrue(hasattr(c, name), msg=f"missing field {name}")
+
+
+class TestCompilationCounterClone(CustomTestCase):
+    def test_clone_produces_independent_copy(self):
+        c = CompilationCounter()
+        c.num_graphs_seen = 5
+        cloned = c.clone()
+        cloned.num_graphs_seen = 99
+        self.assertEqual(c.num_graphs_seen, 5)
+
+    def test_clone_copies_all_values(self):
+        c = CompilationCounter()
+        c.num_models_seen = 3
+        c.num_backend_compilations = 7
+        cloned = c.clone()
+        self.assertEqual(cloned.num_models_seen, 3)
+        self.assertEqual(cloned.num_backend_compilations, 7)
+
+    def test_clone_of_fresh_counter_is_all_zeros(self):
+        c = CompilationCounter()
+        cloned = c.clone()
+        for field in cloned.__dataclass_fields__:
+            self.assertEqual(getattr(cloned, field), 0)
+
+    def test_original_unaffected_after_clone_mutated(self):
+        c = CompilationCounter()
+        c.num_inductor_compiles = 10
+        cloned = c.clone()
+        cloned.num_inductor_compiles = 0
+        self.assertEqual(c.num_inductor_compiles, 10)
+
+
+class TestCompilationCounterExpect(CustomTestCase):
+    def test_expect_passes_when_diff_matches_exactly(self):
+        c = CompilationCounter()
+        with c.expect(num_graphs_seen=1):
+            c.num_graphs_seen += 1
+
+    def test_expect_passes_for_zero_diff(self):
+        c = CompilationCounter()
+        with c.expect(num_models_seen=0):
+            pass  # no mutation
+
+    def test_expect_passes_for_multiple_fields(self):
+        c = CompilationCounter()
+        with c.expect(num_graphs_seen=1, num_models_seen=2):
+            c.num_graphs_seen += 1
+            c.num_models_seen += 2
+
+    def test_expect_raises_assertion_error_on_wrong_diff(self):
+        c = CompilationCounter()
+        with self.assertRaises(AssertionError) as ctx:
+            with c.expect(num_graphs_seen=2):
+                c.num_graphs_seen += 1  # diff is 1, not 2
+        msg = str(ctx.exception)
+        self.assertIn("num_graphs_seen", msg)
+        self.assertIn("expected diff is 2", msg)
+
+    def test_expect_error_message_contains_before_after_values(self):
+        c = CompilationCounter()
+        c.num_backend_compilations = 4
+        with self.assertRaises(AssertionError) as ctx:
+            with c.expect(num_backend_compilations=3):
+                c.num_backend_compilations += 10
+        msg = str(ctx.exception)
+        self.assertIn("before it is 4", msg)
+        self.assertIn("after it is 14", msg)
+
+    def test_expect_raises_when_one_field_has_wrong_diff(self):
+        c = CompilationCounter()
+        with self.assertRaises(AssertionError):
+            with c.expect(num_graphs_seen=1, num_models_seen=0):
+                c.num_graphs_seen += 5  # diff is 5, not 1
+
+
+class TestCompilationCounterSingleton(CustomTestCase):
+    def test_module_level_singleton_is_consistent_across_imports(self):
+        from sglang.srt.compilation.compilation_counter import (
+            compilation_counter as cc2,
+        )
+
+        self.assertIs(compilation_counter, cc2)
+
+    def test_singleton_is_a_compilation_counter(self):
+        self.assertIsInstance(compilation_counter, CompilationCounter)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/compilation/test_compile.py
+++ b/test/registered/unit/compilation/test_compile.py
@@ -1,0 +1,200 @@
+"""Unit tests for IntermediateTensors and helpers in srt/compilation/compile.py."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from typing import Optional
+
+import torch
+
+from sglang.srt.compilation.compile import (
+    IntermediateTensors,
+    _infer_dynamic_arg_dims_from_annotations,
+    _normalize_dims,
+)
+from sglang.test.test_utils import CustomTestCase
+
+# ---------------------------------------------------------------------------
+# IntermediateTensors
+# ---------------------------------------------------------------------------
+
+
+class TestIntermediateTensorsGetitem(CustomTestCase):
+    def test_string_key_returns_tensor(self):
+        t = torch.zeros(4)
+        it = IntermediateTensors({"hidden": t})
+        self.assertIs(it["hidden"], t)
+
+    def test_string_key_missing_raises_key_error(self):
+        it = IntermediateTensors({"hidden": torch.zeros(4)})
+        with self.assertRaises(KeyError):
+            _ = it["nonexistent"]
+
+    def test_slice_returns_new_intermediate_tensors(self):
+        h = torch.arange(8, dtype=torch.float32)
+        it = IntermediateTensors({"h": h})
+        sliced = it[1:4]
+        self.assertIsInstance(sliced, IntermediateTensors)
+
+    def test_slice_applies_to_each_tensor(self):
+        h = torch.arange(8, dtype=torch.float32)
+        r = torch.arange(8, dtype=torch.float32) * 2
+        it = IntermediateTensors({"h": h, "r": r})
+        sliced = it[2:5]
+        self.assertEqual(sliced["h"].tolist(), h[2:5].tolist())
+        self.assertEqual(sliced["r"].tolist(), r[2:5].tolist())
+
+    def test_slice_shares_storage_with_original(self):
+        # IntermediateTensors.__getitem__ uses v[key] which returns a tensor
+        # view, not a copy. Mutating the slice mutates the underlying storage.
+        h = torch.zeros(6)
+        it = IntermediateTensors({"h": h})
+        sliced = it[0:3]
+        sliced["h"][0] = 99.0
+        self.assertEqual(it["h"][0].item(), 99.0)
+
+
+class TestIntermediateTensorsSetitem(CustomTestCase):
+    def test_setitem_stores_new_tensor(self):
+        it = IntermediateTensors({"a": torch.zeros(3)})
+        new_t = torch.ones(3)
+        it["a"] = new_t
+        self.assertIs(it.tensors["a"], new_t)
+
+    def test_setitem_adds_new_key(self):
+        it = IntermediateTensors({})
+        t = torch.zeros(2)
+        it["z"] = t
+        self.assertIs(it["z"], t)
+
+
+class TestIntermediateTensorsLenAndItems(CustomTestCase):
+    def test_len_returns_number_of_tensors(self):
+        it = IntermediateTensors({"a": torch.zeros(1), "b": torch.zeros(1)})
+        self.assertEqual(len(it), 2)
+
+    def test_len_of_empty_is_zero(self):
+        it = IntermediateTensors({})
+        self.assertEqual(len(it), 0)
+
+    def test_items_returns_key_tensor_pairs(self):
+        ta = torch.zeros(2)
+        it = IntermediateTensors({"a": ta})
+        pairs = list(it.items())
+        self.assertEqual(len(pairs), 1)
+        self.assertEqual(pairs[0][0], "a")
+        self.assertIs(pairs[0][1], ta)
+
+    def test_items_multiple_tensors(self):
+        ta = torch.zeros(2)
+        tb = torch.ones(3)
+        it = IntermediateTensors({"a": ta, "b": tb})
+        result = dict(it.items())
+        self.assertIs(result["a"], ta)
+        self.assertIs(result["b"], tb)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_dims
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeDims(CustomTestCase):
+    def test_scalar_non_negative_wraps_in_list(self):
+        self.assertEqual(_normalize_dims(0, 4), [0])
+
+    def test_scalar_positive_preserved(self):
+        self.assertEqual(_normalize_dims(2, 4), [2])
+
+    def test_scalar_negative_resolved_relative_to_ndim(self):
+        self.assertEqual(_normalize_dims(-1, 4), [3])
+
+    def test_scalar_negative_one_with_ndim_3(self):
+        self.assertEqual(_normalize_dims(-1, 3), [2])
+
+    def test_list_positive_dims_unchanged(self):
+        self.assertEqual(_normalize_dims([0, 1, 2], 4), [0, 1, 2])
+
+    def test_list_with_negative_dim_resolved(self):
+        self.assertEqual(_normalize_dims([0, -1], 3), [0, 2])
+
+    def test_list_all_negative_resolved(self):
+        self.assertEqual(_normalize_dims([-2, -1], 4), [2, 3])
+
+    def test_empty_list_returns_empty(self):
+        self.assertEqual(_normalize_dims([], 3), [])
+
+
+# ---------------------------------------------------------------------------
+# _infer_dynamic_arg_dims_from_annotations
+# ---------------------------------------------------------------------------
+
+
+class TestInferDynamicArgDims(CustomTestCase):
+    def test_torch_tensor_annotation_detected(self):
+        def fn(x: torch.Tensor, y: int):
+            pass
+
+        result = _infer_dynamic_arg_dims_from_annotations(fn)
+        self.assertIn("x", result)
+        self.assertEqual(result["x"], 0)
+        self.assertNotIn("y", result)
+
+    def test_optional_torch_tensor_annotation_detected(self):
+        def fn(x: Optional[torch.Tensor]):
+            pass
+
+        result = _infer_dynamic_arg_dims_from_annotations(fn)
+        self.assertIn("x", result)
+        self.assertEqual(result["x"], 0)
+
+    def test_string_annotation_torch_tensor_detected(self):
+        # Simulate annotations stored as strings (from __future__ import annotations).
+        def fn(x):
+            pass
+
+        # Manually assign a string annotation as if from __future__ imports.
+        fn.__annotations__ = {"x": "torch.Tensor"}
+        result = _infer_dynamic_arg_dims_from_annotations(fn)
+        self.assertIn("x", result)
+
+    def test_no_tensor_params_raises_value_error(self):
+        def fn(x: int, y: str):
+            pass
+
+        with self.assertRaises(ValueError) as ctx:
+            _infer_dynamic_arg_dims_from_annotations(fn)
+        self.assertIn("dynamic_arg_dims", str(ctx.exception))
+
+    def test_no_annotated_params_raises_value_error(self):
+        def fn(x, y):
+            pass
+
+        with self.assertRaises(ValueError):
+            _infer_dynamic_arg_dims_from_annotations(fn)
+
+    def test_multiple_tensor_params_all_detected(self):
+        def fn(a: torch.Tensor, b: torch.Tensor, n: int):
+            pass
+
+        result = _infer_dynamic_arg_dims_from_annotations(fn)
+        self.assertIn("a", result)
+        self.assertIn("b", result)
+        self.assertNotIn("n", result)
+        self.assertEqual(result["a"], 0)
+        self.assertEqual(result["b"], 0)
+
+    def test_returns_dict_with_zero_values(self):
+        def fn(x: torch.Tensor):
+            pass
+
+        result = _infer_dynamic_arg_dims_from_annotations(fn)
+        self.assertIsInstance(result, dict)
+        for v in result.values():
+            self.assertEqual(v, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/compilation/test_compile_phase.py
+++ b/test/registered/unit/compilation/test_compile_phase.py
@@ -1,0 +1,95 @@
+"""Unit tests for phase-flag context managers in srt/compilation/compile_phase.py."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.compilation.compile_phase import (
+    enable_torch_compile_warmup,
+    get_pcg_capture_stream,
+    is_in_torch_compile_warmup,
+    set_pcg_capture_stream,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestEnableTorchCompileWarmup(CustomTestCase):
+    def test_flag_is_false_before_context(self):
+        self.assertFalse(is_in_torch_compile_warmup())
+
+    def test_flag_is_true_inside_context(self):
+        with enable_torch_compile_warmup():
+            self.assertTrue(is_in_torch_compile_warmup())
+
+    def test_flag_is_false_after_context_exits(self):
+        with enable_torch_compile_warmup():
+            pass
+        self.assertFalse(is_in_torch_compile_warmup())
+
+    def test_flag_restored_to_false_after_exception_inside_context(self):
+        try:
+            with enable_torch_compile_warmup():
+                raise RuntimeError("intentional")
+        except RuntimeError:
+            pass
+        self.assertFalse(is_in_torch_compile_warmup())
+
+    def test_nested_inner_context_sees_true(self):
+        with enable_torch_compile_warmup():
+            self.assertTrue(is_in_torch_compile_warmup())
+            with enable_torch_compile_warmup():
+                self.assertTrue(is_in_torch_compile_warmup())
+
+    def test_after_all_nested_contexts_exit_flag_is_false(self):
+        with enable_torch_compile_warmup():
+            with enable_torch_compile_warmup():
+                pass
+        self.assertFalse(is_in_torch_compile_warmup())
+
+
+class TestSetPcgCaptureStream(CustomTestCase):
+    def test_get_returns_none_before_context(self):
+        self.assertIsNone(get_pcg_capture_stream())
+
+    def test_get_returns_stream_inside_context(self):
+        mock_stream = MagicMock()
+        with set_pcg_capture_stream(mock_stream):
+            self.assertIs(get_pcg_capture_stream(), mock_stream)
+
+    def test_get_returns_none_after_context_exits(self):
+        mock_stream = MagicMock()
+        with set_pcg_capture_stream(mock_stream):
+            pass
+        self.assertIsNone(get_pcg_capture_stream())
+
+    def test_get_returns_none_after_exception_inside_context(self):
+        mock_stream = MagicMock()
+        try:
+            with set_pcg_capture_stream(mock_stream):
+                raise ValueError("intentional")
+        except ValueError:
+            pass
+        self.assertIsNone(get_pcg_capture_stream())
+
+    def test_nested_inner_stream_overrides_outer_inside_inner(self):
+        outer = MagicMock()
+        inner = MagicMock()
+        with set_pcg_capture_stream(outer):
+            self.assertIs(get_pcg_capture_stream(), outer)
+            with set_pcg_capture_stream(inner):
+                self.assertIs(get_pcg_capture_stream(), inner)
+
+    def test_after_all_nested_contexts_exit_stream_is_none(self):
+        outer = MagicMock()
+        inner = MagicMock()
+        with set_pcg_capture_stream(outer):
+            with set_pcg_capture_stream(inner):
+                pass
+        self.assertIsNone(get_pcg_capture_stream())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/compilation/test_fix_functionalization.py
+++ b/test/registered/unit/compilation/test_fix_functionalization.py
@@ -1,0 +1,193 @@
+"""Unit tests for FixFunctionalizationPass helpers in srt/compilation/fix_functionalization.py."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import operator
+import unittest
+
+import torch.fx as fx
+from torch._higher_order_ops.auto_functionalize import auto_functionalized
+
+from sglang.srt.compilation.fix_functionalization import FixFunctionalizationPass
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_pass() -> FixFunctionalizationPass:
+    """Return a FixFunctionalizationPass with nodes_to_remove initialised."""
+    p = FixFunctionalizationPass()
+    p.nodes_to_remove = []
+    return p
+
+
+# ---------------------------------------------------------------------------
+# getitem_users
+# ---------------------------------------------------------------------------
+
+
+class TestGetitemUsers(CustomTestCase):
+    def test_returns_empty_dict_when_no_getitem_users(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        parent = g.call_function(operator.add, (a, a))
+        # output uses parent directly, no getitem
+        g.output(parent)
+        fxp = _make_pass()
+        result = fxp.getitem_users(parent)
+        self.assertEqual(result, {})
+
+    def test_returns_correct_mapping_for_single_getitem_user(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        parent = g.call_function(operator.add, (a, a))
+        item0 = g.call_function(operator.getitem, (parent, 0))
+        g.output(item0)
+        fxp = _make_pass()
+        result = fxp.getitem_users(parent)
+        self.assertEqual(len(result), 1)
+        self.assertIs(result[0], item0)
+
+    def test_returns_correct_mapping_for_multiple_getitem_users(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        parent = g.call_function(operator.add, (a, a))
+        item0 = g.call_function(operator.getitem, (parent, 0))
+        item2 = g.call_function(operator.getitem, (parent, 2))
+        g.output((item0, item2))
+        fxp = _make_pass()
+        result = fxp.getitem_users(parent)
+        self.assertEqual(len(result), 2)
+        self.assertIs(result[0], item0)
+        self.assertIs(result[2], item2)
+
+    def test_non_getitem_user_excluded(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        parent = g.call_function(operator.add, (a, a))
+        # A user that is NOT operator.getitem
+        other_user = g.call_function(operator.neg, (parent,))
+        g.output(other_user)
+        fxp = _make_pass()
+        result = fxp.getitem_users(parent)
+        self.assertEqual(result, {})
+
+
+# ---------------------------------------------------------------------------
+# insert_defunctionalized
+# ---------------------------------------------------------------------------
+
+
+class TestInsertDefunctionalized(CustomTestCase):
+    def _make_auto_fn_graph(self):
+        """Graph: placeholder x, auto_functionalized(operator.add, self=x, other=x), output."""
+        g = fx.Graph()
+        x = g.placeholder("x")
+        # args[0] is the function insert_defunctionalized will call
+        node = g.call_function(
+            auto_functionalized,
+            args=(operator.add,),
+            kwargs={"self": x, "other": x},
+        )
+        g.output(node)
+        return g, x, node
+
+    def test_inserts_one_extra_node(self):
+        g, x, af_node = self._make_auto_fn_graph()
+        count_before = sum(1 for _ in g.nodes)
+        fxp = _make_pass()
+        fxp.insert_defunctionalized(g, af_node)
+        count_after = sum(1 for _ in g.nodes)
+        self.assertEqual(count_after, count_before + 1)
+
+    def test_new_node_inserted_immediately_before_auto_fn_node(self):
+        g, x, af_node = self._make_auto_fn_graph()
+        fxp = _make_pass()
+        fxp.insert_defunctionalized(g, af_node)
+        nodes = list(g.nodes)
+        idx = nodes.index(af_node)
+        self.assertGreater(idx, 0)
+        new_node = nodes[idx - 1]
+        # The new node's target is args[0] of the auto_functionalized node
+        self.assertIs(new_node.target, operator.add)
+
+    def test_new_node_uses_kwargs_from_original(self):
+        g, x, af_node = self._make_auto_fn_graph()
+        fxp = _make_pass()
+        fxp.insert_defunctionalized(g, af_node)
+        nodes = list(g.nodes)
+        idx = nodes.index(af_node)
+        new_node = nodes[idx - 1]
+        # kwargs should be propagated from af_node.kwargs
+        self.assertIn("self", new_node.kwargs)
+        self.assertIn("other", new_node.kwargs)
+        self.assertIs(new_node.kwargs["self"], x)
+
+    def test_raises_if_node_is_not_auto_functionalized(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        plain_node = g.call_function(operator.add, (a, a))
+        g.output(plain_node)
+        fxp = _make_pass()
+        with self.assertRaises(AssertionError):
+            fxp.insert_defunctionalized(g, plain_node)
+
+
+# ---------------------------------------------------------------------------
+# replace_users_with_mutated_args
+# ---------------------------------------------------------------------------
+
+
+class TestReplaceUsersWithMutatedArgs(CustomTestCase):
+    def _make_graph_with_getitem(self):
+        """placeholder a, placeholder b, add(a,b), getitem(add, 0), output(getitem)."""
+        g = fx.Graph()
+        a = g.placeholder("a")
+        b = g.placeholder("b")
+        parent = g.call_function(operator.add, (a, b))
+        item0 = g.call_function(operator.getitem, (parent, 0))
+        g.output(item0)
+        out_node = next(n for n in g.nodes if n.op == "output")
+        return g, a, b, parent, item0, out_node
+
+    def test_getitem_user_staged_for_removal(self):
+        _, a, b, parent, item0, _ = self._make_graph_with_getitem()
+        fxp = _make_pass()
+        fxp.replace_users_with_mutated_args(parent, {0: b})
+        self.assertIn(item0, fxp.nodes_to_remove)
+
+    def test_uses_of_getitem_replaced_with_arg(self):
+        _, a, b, parent, item0, out_node = self._make_graph_with_getitem()
+        # Before replacement: output uses item0
+        self.assertIs(out_node.args[0], item0)
+        fxp = _make_pass()
+        fxp.replace_users_with_mutated_args(parent, {0: b})
+        # After replacement: output uses b
+        self.assertIs(out_node.args[0], b)
+
+    def test_no_getitem_users_means_nothing_staged(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        parent = g.call_function(operator.add, (a, a))
+        g.output(parent)
+        fxp = _make_pass()
+        fxp.replace_users_with_mutated_args(parent, {0: a})
+        self.assertEqual(fxp.nodes_to_remove, [])
+
+    def test_multiple_getitem_users_replaced_independently(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        b = g.placeholder("b")
+        c = g.placeholder("c")
+        parent = g.call_function(operator.add, (a, b))
+        item0 = g.call_function(operator.getitem, (parent, 0))
+        item1 = g.call_function(operator.getitem, (parent, 1))
+        g.output((item0, item1))
+        fxp = _make_pass()
+        fxp.replace_users_with_mutated_args(parent, {0: b, 1: c})
+        self.assertIn(item0, fxp.nodes_to_remove)
+        self.assertIn(item1, fxp.nodes_to_remove)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/compilation/test_fx_utils.py
+++ b/test/registered/unit/compilation/test_fx_utils.py
@@ -1,0 +1,198 @@
+"""Unit tests for FX-graph utility functions in srt/compilation/fx_utils.py."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import operator
+import unittest
+
+import torch.fx as fx
+
+from sglang.srt.compilation.fx_utils import (
+    find_getitem,
+    find_getitem_maybe,
+    find_specified_fn,
+    find_specified_fn_maybe,
+    get_only_user,
+    is_func,
+)
+from sglang.test.test_utils import CustomTestCase
+
+# ---------------------------------------------------------------------------
+# Small helpers to build minimal FX graphs
+# ---------------------------------------------------------------------------
+
+
+def _graph_with_call(target, *extra_targets):
+    """Return (graph, placeholder, call_node) for a call_function node."""
+    g = fx.Graph()
+    a = g.placeholder("a")
+    node = g.call_function(target, (a, a))
+    g.output(node)
+    return g, a, node
+
+
+def _graph_with_getitem_user(parent_target, idx):
+    """Return (graph, placeholder, parent, getitem_node)."""
+    g = fx.Graph()
+    a = g.placeholder("a")
+    parent = g.call_function(parent_target, (a, a))
+    item = g.call_function(operator.getitem, (parent, idx))
+    g.output(item)
+    return g, a, parent, item
+
+
+# ---------------------------------------------------------------------------
+# is_func
+# ---------------------------------------------------------------------------
+
+
+class TestIsFunc(CustomTestCase):
+    def test_returns_true_for_matching_call_function_node(self):
+        _, _, node = _graph_with_call(operator.add)
+        self.assertTrue(is_func(node, operator.add))
+
+    def test_returns_false_for_wrong_target(self):
+        _, _, node = _graph_with_call(operator.add)
+        self.assertFalse(is_func(node, operator.mul))
+
+    def test_returns_false_for_placeholder_op(self):
+        _, placeholder, _ = _graph_with_call(operator.add)
+        self.assertFalse(is_func(placeholder, operator.add))
+
+    def test_returns_false_for_output_node(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        out = g.output(a)
+        self.assertFalse(is_func(out, operator.add))
+
+    def test_getitem_node_matches_operator_getitem(self):
+        _, _, _, item = _graph_with_getitem_user(operator.add, 0)
+        self.assertTrue(is_func(item, operator.getitem))
+
+
+# ---------------------------------------------------------------------------
+# find_specified_fn_maybe / find_specified_fn
+# ---------------------------------------------------------------------------
+
+
+class TestFindSpecifiedFn(CustomTestCase):
+    def _make_nodes(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        add_node = g.call_function(operator.add, (a, a))
+        g.output(add_node)
+        return list(g.nodes), add_node
+
+    def test_find_maybe_returns_node_when_present(self):
+        nodes, add_node = self._make_nodes()
+        result = find_specified_fn_maybe(nodes, operator.add)
+        self.assertIs(result, add_node)
+
+    def test_find_maybe_returns_none_when_absent(self):
+        nodes, _ = self._make_nodes()
+        result = find_specified_fn_maybe(nodes, operator.mul)
+        self.assertIsNone(result)
+
+    def test_find_maybe_returns_first_match(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        n1 = g.call_function(operator.add, (a, a))
+        n2 = g.call_function(operator.add, (a, a))
+        g.output((n1, n2))
+        nodes = list(g.nodes)
+        result = find_specified_fn_maybe(nodes, operator.add)
+        self.assertIs(result, n1)
+
+    def test_find_raises_when_absent(self):
+        nodes, _ = self._make_nodes()
+        with self.assertRaises(AssertionError):
+            find_specified_fn(nodes, operator.mul)
+
+    def test_find_returns_node_when_present(self):
+        nodes, add_node = self._make_nodes()
+        result = find_specified_fn(nodes, operator.add)
+        self.assertIs(result, add_node)
+
+
+# ---------------------------------------------------------------------------
+# find_getitem_maybe / find_getitem
+# ---------------------------------------------------------------------------
+
+
+class TestFindGetitem(CustomTestCase):
+    def test_find_getitem_maybe_returns_node_for_matching_index(self):
+        _, _, parent, item0 = _graph_with_getitem_user(operator.add, 0)
+        result = find_getitem_maybe(parent, 0)
+        self.assertIs(result, item0)
+
+    def test_find_getitem_maybe_returns_none_when_no_user(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        parent = g.call_function(operator.add, (a, a))
+        g.output(parent)
+        result = find_getitem_maybe(parent, 0)
+        self.assertIsNone(result)
+
+    def test_find_getitem_maybe_returns_none_for_wrong_index(self):
+        _, _, parent, _ = _graph_with_getitem_user(operator.add, 0)
+        result = find_getitem_maybe(parent, 5)
+        self.assertIsNone(result)
+
+    def test_find_getitem_returns_node_for_matching_index(self):
+        _, _, parent, item0 = _graph_with_getitem_user(operator.add, 0)
+        result = find_getitem(parent, 0)
+        self.assertIs(result, item0)
+
+    def test_find_getitem_raises_when_index_absent(self):
+        _, _, parent, _ = _graph_with_getitem_user(operator.add, 0)
+        with self.assertRaises(AssertionError):
+            find_getitem(parent, 99)
+
+    def test_find_getitem_with_multiple_users_returns_correct_one(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        parent = g.call_function(operator.add, (a, a))
+        item0 = g.call_function(operator.getitem, (parent, 0))
+        item2 = g.call_function(operator.getitem, (parent, 2))
+        g.output((item0, item2))
+
+        self.assertIs(find_getitem(parent, 0), item0)
+        self.assertIs(find_getitem(parent, 2), item2)
+
+
+# ---------------------------------------------------------------------------
+# get_only_user
+# ---------------------------------------------------------------------------
+
+
+class TestGetOnlyUser(CustomTestCase):
+    def test_returns_the_single_user(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        user = g.call_function(operator.neg, (a,))
+        g.output(user)
+        self.assertIs(get_only_user(a), user)
+
+    def test_raises_with_zero_users(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        g.output(None)
+        with self.assertRaises(AssertionError):
+            get_only_user(a)
+
+    def test_raises_with_two_users(self):
+        g = fx.Graph()
+        a = g.placeholder("a")
+        u1 = g.call_function(operator.neg, (a,))
+        u2 = g.call_function(operator.neg, (a,))
+        g.output((u1, u2))
+        # a has two distinct user nodes
+        self.assertEqual(len(a.users), 2)
+        with self.assertRaises(AssertionError):
+            get_only_user(a)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/compilation/test_inductor_pass.py
+++ b/test/registered/unit/compilation/test_inductor_pass.py
@@ -1,0 +1,181 @@
+"""Unit tests for pass_context, InductorPass, and CallableInductorPass in srt/compilation/inductor_pass.py."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+from sglang.srt.compilation.inductor_pass import (
+    CallableInductorPass,
+    InductorPass,
+    PassContext,
+    get_pass_context,
+    pass_context,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestPassContextManager(CustomTestCase):
+    def test_get_pass_context_raises_outside_context(self):
+        with self.assertRaises(AssertionError):
+            get_pass_context()
+
+    def test_get_pass_context_returns_correct_shape_inside(self):
+        with pass_context(42):
+            ctx = get_pass_context()
+            self.assertEqual(ctx.runtime_shape, 42)
+
+    def test_get_pass_context_returns_none_shape_when_none_passed(self):
+        with pass_context(None):
+            ctx = get_pass_context()
+            self.assertIsNone(ctx.runtime_shape)
+
+    def test_context_restored_to_none_on_normal_exit(self):
+        with pass_context(10):
+            pass
+        with self.assertRaises(AssertionError):
+            get_pass_context()
+
+    def test_context_restored_after_exception_inside(self):
+        try:
+            with pass_context(99):
+                raise RuntimeError("intentional")
+        except RuntimeError:
+            pass
+        with self.assertRaises(AssertionError):
+            get_pass_context()
+
+    def test_nested_inner_context_overrides_shape(self):
+        with pass_context(10):
+            self.assertEqual(get_pass_context().runtime_shape, 10)
+            with pass_context(20):
+                self.assertEqual(get_pass_context().runtime_shape, 20)
+            # outer restored correctly
+            self.assertEqual(get_pass_context().runtime_shape, 10)
+
+    def test_pass_context_is_a_pass_context_instance(self):
+        with pass_context(7):
+            ctx = get_pass_context()
+            self.assertIsInstance(ctx, PassContext)
+
+
+class TestInductorPassHashSource(CustomTestCase):
+    def test_hash_source_string_is_deterministic(self):
+        h1 = InductorPass.hash_source("hello world")
+        h2 = InductorPass.hash_source("hello world")
+        self.assertEqual(h1, h2)
+
+    def test_hash_source_different_strings_differ(self):
+        h1 = InductorPass.hash_source("alpha")
+        h2 = InductorPass.hash_source("beta")
+        self.assertNotEqual(h1, h2)
+
+    def test_hash_source_function_is_deterministic(self):
+        def my_func():
+            return 1
+
+        h1 = InductorPass.hash_source(my_func)
+        h2 = InductorPass.hash_source(my_func)
+        self.assertEqual(h1, h2)
+
+    def test_hash_source_different_functions_differ(self):
+        def func_a():
+            return 1
+
+        def func_b():
+            return 2
+
+        h1 = InductorPass.hash_source(func_a)
+        h2 = InductorPass.hash_source(func_b)
+        self.assertNotEqual(h1, h2)
+
+    def test_hash_source_class_is_deterministic(self):
+        class MyPass(InductorPass):
+            def __call__(self, graph):
+                pass
+
+        p = MyPass()
+        h1 = InductorPass.hash_source(p)
+        h2 = InductorPass.hash_source(p)
+        self.assertEqual(h1, h2)
+
+    def test_hash_source_returns_hex_string(self):
+        h = InductorPass.hash_source("test")
+        self.assertIsInstance(h, str)
+        # sha256 hexdigest is 64 hex chars
+        self.assertEqual(len(h), 64)
+        int(h, 16)  # must be valid hex
+
+
+class TestInductorPassHashDict(CustomTestCase):
+    def test_hash_dict_is_deterministic(self):
+        d = {"a": 1, "b": 2}
+        h1 = InductorPass.hash_dict(d)
+        h2 = InductorPass.hash_dict(d)
+        self.assertEqual(h1, h2)
+
+    def test_hash_dict_key_order_independent(self):
+        h1 = InductorPass.hash_dict({"a": 1, "b": 2})
+        h2 = InductorPass.hash_dict({"b": 2, "a": 1})
+        self.assertEqual(h1, h2)
+
+    def test_hash_dict_different_contents_differ(self):
+        h1 = InductorPass.hash_dict({"x": 1})
+        h2 = InductorPass.hash_dict({"x": 2})
+        self.assertNotEqual(h1, h2)
+
+    def test_hash_dict_returns_hex_string(self):
+        h = InductorPass.hash_dict({"k": "v"})
+        self.assertIsInstance(h, str)
+        self.assertEqual(len(h), 64)
+
+
+class TestCallableInductorPass(CustomTestCase):
+    def test_call_invokes_the_wrapped_callable(self):
+        calls = []
+
+        def tracker(graph):
+            calls.append(graph)
+
+        p = CallableInductorPass(tracker)
+        sentinel = object()
+        p(sentinel)
+        self.assertEqual(calls, [sentinel])
+
+    def test_uuid_matches_hash_source_of_callable(self):
+        def my_fn(graph):
+            pass
+
+        p = CallableInductorPass(my_fn)
+        expected = InductorPass.hash_source(my_fn)
+        self.assertEqual(p.uuid(), expected)
+
+    def test_explicit_uuid_overrides_auto_hash(self):
+        def my_fn(graph):
+            pass
+
+        p = CallableInductorPass(my_fn, uuid="custom-uuid")
+        self.assertEqual(p.uuid(), "custom-uuid")
+
+    def test_uuid_is_stable_across_calls(self):
+        def fn(g):
+            pass
+
+        p = CallableInductorPass(fn)
+        self.assertEqual(p.uuid(), p.uuid())
+
+    def test_two_callable_passes_with_different_fns_have_different_uuids(self):
+        def fn_a(g):
+            return 1
+
+        def fn_b(g):
+            return 2
+
+        pa = CallableInductorPass(fn_a)
+        pb = CallableInductorPass(fn_b)
+        self.assertNotEqual(pa.uuid(), pb.uuid())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/compilation/test_pass_manager.py
+++ b/test/registered/unit/compilation/test_pass_manager.py
@@ -1,0 +1,219 @@
+"""Unit tests for PostGradPassManager in srt/compilation/pass_manager.py."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import torch.fx as fx
+
+from sglang.srt.compilation.fix_functionalization import FixFunctionalizationPass
+from sglang.srt.compilation.inductor_pass import (
+    SGLangInductorPass,
+    pass_context,
+)
+from sglang.srt.compilation.pass_manager import PostGradPassManager
+from sglang.test.test_utils import CustomTestCase
+
+# ---------------------------------------------------------------------------
+# Stub passes used across tests
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysApplicablePass(SGLangInductorPass):
+    """A pass that always runs and records calls."""
+
+    def __init__(self):
+        super().__init__()
+        self.call_count = 0
+
+    def __call__(self, graph: fx.Graph):
+        self.call_count += 1
+
+    def is_applicable_for_shape(self, shape):
+        return True
+
+
+class _ShapeFilteredPass(SGLangInductorPass):
+    """A pass that is only applicable for a specific shape."""
+
+    def __init__(self, accept_shape):
+        super().__init__()
+        self.accept_shape = accept_shape
+        self.call_count = 0
+
+    def __call__(self, graph: fx.Graph):
+        self.call_count += 1
+
+    def is_applicable_for_shape(self, shape):
+        return shape == self.accept_shape
+
+
+def _empty_graph() -> fx.Graph:
+    """Return a minimal valid FX graph (placeholder + output) for pass calls."""
+    g = fx.Graph()
+    g.output(None)
+    return g
+
+
+# ---------------------------------------------------------------------------
+# add()
+# ---------------------------------------------------------------------------
+
+
+class TestPostGradPassManagerAdd(CustomTestCase):
+    def test_add_with_valid_inductor_pass_succeeds(self):
+        pm = PostGradPassManager()
+        pm.add(_AlwaysApplicablePass())
+        self.assertEqual(len(pm.passes), 1)
+
+    def test_add_with_non_inductor_pass_raises_assertion_error(self):
+        pm = PostGradPassManager()
+        with self.assertRaises(AssertionError):
+            pm.add(object())  # not an InductorPass
+
+    def test_add_multiple_passes_all_stored(self):
+        pm = PostGradPassManager()
+        pm.add(_AlwaysApplicablePass())
+        pm.add(_AlwaysApplicablePass())
+        self.assertEqual(len(pm.passes), 2)
+
+    def test_add_with_plain_function_raises(self):
+        pm = PostGradPassManager()
+        with self.assertRaises(AssertionError):
+            pm.add(lambda g: None)
+
+
+# ---------------------------------------------------------------------------
+# configure()
+# ---------------------------------------------------------------------------
+
+
+class TestPostGradPassManagerConfigure(CustomTestCase):
+    def test_configure_creates_fix_functionalization_attribute(self):
+        pm = PostGradPassManager()
+        pm.configure()
+        self.assertTrue(hasattr(pm, "fix_functionalization"))
+
+    def test_configure_creates_fix_functionalization_pass_instance(self):
+        pm = PostGradPassManager()
+        pm.configure()
+        self.assertIsInstance(pm.fix_functionalization, FixFunctionalizationPass)
+
+    def test_configure_creates_pass_config_dict(self):
+        pm = PostGradPassManager()
+        pm.configure()
+        self.assertIsInstance(pm.pass_config, dict)
+
+
+# ---------------------------------------------------------------------------
+# __call__() -- shape-based dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestPostGradPassManagerCall(CustomTestCase):
+    def _make_configured_pm(self):
+        pm = PostGradPassManager()
+        pm.configure()
+        return pm
+
+    def test_applicable_pass_is_invoked(self):
+        pm = self._make_configured_pm()
+        p = _AlwaysApplicablePass()
+        pm.add(p)
+        g = _empty_graph()
+        with pass_context(8):
+            pm(g)
+        self.assertEqual(p.call_count, 1)
+
+    def test_inapplicable_pass_is_skipped(self):
+        pm = self._make_configured_pm()
+        # Only applicable for shape 99, but we run with shape 8.
+        p = _ShapeFilteredPass(accept_shape=99)
+        pm.add(p)
+        g = _empty_graph()
+        with pass_context(8):
+            pm(g)
+        self.assertEqual(p.call_count, 0)
+
+    def test_shape_filtered_pass_runs_on_matching_shape(self):
+        pm = self._make_configured_pm()
+        p = _ShapeFilteredPass(accept_shape=42)
+        pm.add(p)
+        g = _empty_graph()
+        with pass_context(42):
+            pm(g)
+        self.assertEqual(p.call_count, 1)
+
+    def test_fix_functionalization_always_runs(self):
+        pm = self._make_configured_pm()
+        # Add a pass that is never applicable; fix_functionalization should still run.
+        p = _ShapeFilteredPass(accept_shape=-1)
+        pm.add(p)
+        g = _empty_graph()
+        # Should not raise; fix_functionalization runs even when user passes are skipped.
+        with pass_context(7):
+            pm(g)
+        self.assertEqual(p.call_count, 0)
+
+    def test_passes_invoked_in_registration_order(self):
+        pm = self._make_configured_pm()
+        order = []
+
+        class _OrderRecorder(SGLangInductorPass):
+            def __init__(self, tag):
+                super().__init__()
+                self.tag = tag
+
+            def __call__(self, graph):
+                order.append(self.tag)
+
+        pm.add(_OrderRecorder("first"))
+        pm.add(_OrderRecorder("second"))
+        g = _empty_graph()
+        with pass_context(1):
+            pm(g)
+        self.assertEqual(order, ["first", "second"])
+
+    def test_call_without_pass_context_raises(self):
+        pm = self._make_configured_pm()
+        g = _empty_graph()
+        with self.assertRaises(AssertionError):
+            pm(g)  # no pass_context active
+
+
+# ---------------------------------------------------------------------------
+# uuid()
+# ---------------------------------------------------------------------------
+
+
+class TestPostGradPassManagerUuid(CustomTestCase):
+    def test_uuid_returns_a_string(self):
+        pm = PostGradPassManager()
+        pm.configure()
+        self.assertIsInstance(pm.uuid(), str)
+
+    def test_uuid_is_stable(self):
+        pm = PostGradPassManager()
+        pm.configure()
+        self.assertEqual(pm.uuid(), pm.uuid())
+
+    def test_uuid_changes_when_pass_added(self):
+        pm = PostGradPassManager()
+        pm.configure()
+        uuid_before = pm.uuid()
+        pm.add(_AlwaysApplicablePass())
+        uuid_after = pm.uuid()
+        self.assertNotEqual(uuid_before, uuid_after)
+
+    def test_uuid_returns_hex_string(self):
+        pm = PostGradPassManager()
+        pm.configure()
+        h = pm.uuid()
+        self.assertEqual(len(h), 64)
+        int(h, 16)  # valid hex
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
141 tests covering the srt/compilation torch-compile pipeline utilities.

No server, no GPU, no model loading.
Ref: #20865

## Motivation

Added eight new test files under `test/registered/unit/compilation/` covering the pure-logic layer of SGLang's torch.compile integration.

`srt/compilation/` currently has no dedicated unit tests. The compilation subsystem is SGLang's port of the vLLM piecewise torch.compile machinery. Eight of its fourteen files are importable and testable on CPU: the counter, phase flags, config registry, inductor pass infrastructure, FX graph utilities, functionalization helpers, pass manager, and compile-time tensor/dim utilities. Regressions in these files silently break the compilation pipeline without obvious error messages.

Notable behavioral invariants verified: `CompilationCounter.expect()` delta-assertion correctness and informative error messages; exception-safety of both context managers in `compile_phase.py`; `hash_source`/`hash_dict` determinism and key-order independence; `IntermediateTensors.__getitem__` with a slice returns a view (shared storage), not a copy — a latent behavioral subtlety caught empirically during test development; `PostGradPassManager.__call__` applies passes in registration order, skips inapplicable passes, and always runs fix_functionalization last.

## Coverage

`compilation_counter.py` (14 tests):
- `CompilationCounter` defaults all zero, all expected fields exist.
- `clone()` produces an independent deep copy; mutating original does not affect clone.
- `expect()` passes on exact diff match, passes on zero diff, passes on multiple fields, raises AssertionError with informative message on wrong diff, raises when one field has wrong diff.
- Module-level singleton is consistent across imports.

`compile_phase.py` (12 tests):
- `enable_torch_compile_warmup` — flag False before/after context, True inside, restored after exception, nested inner context sees True, all nested contexts exit to False.
- `set_pcg_capture_stream` / `get_pcg_capture_stream` — None before/after context, stream returned inside, restored after exception, nested inner stream overrides outer inside inner, all nested contexts exit to None.

`compilation_config.py` (19 tests):
- `register_split_op` with explicit name appends correct string, without name uses `__name__`, decorated function still callable, duplicate registration appends again.
- `CompilationConfig` construction populates split_ops from global SPLIT_OPS.
- `configure_inductor` early-returns for non-inductor compiler.
- `add_split_op` appends to instance split_ops without affecting global, `add_traced_file` deduplicates, `get_traced_files` empty initially.

`inductor_pass.py` (22 tests):
- `pass_context` — correct shape inside, restores None on exit, restores on exception, nested inner overrides outer.
- `get_pass_context()` raises AssertionError outside context.
- `hash_source` — deterministic for string/function/class, different inputs differ, returns hex string.
- `hash_dict` — deterministic, key-order independent, different contents differ, returns hex string.
- `CallableInductorPass` — callable invoked, uuid matches hash_source, stable across calls, explicit uuid overrides auto, different functions produce different uuids.

`fx_utils.py` (19 tests):
- `is_func` — True for matching call_function node, False for wrong target, False for placeholder/output ops, True for operator.getitem.
- `find_specified_fn_maybe` — None when absent, node when present, returns first match.
- `find_specified_fn` — raises when absent, returns node when present.
- `find_getitem_maybe` — None when no user, None for wrong index, node for matching index, correct node with multiple users.
- `find_getitem` — raises when index absent, returns correct node.
- `get_only_user` — returns single user, raises with zero users, raises with two users.

`compile.py` (26 tests):
- `IntermediateTensors.__getitem__` — string key returns tensor, missing key raises KeyError, slice returns new IntermediateTensors, slice shares storage with original (view semantics, not copy).
- `__setitem__` — stores new tensor, adds new key.
- `len` and `items` — zero for empty, correct count, key-tensor pairs.
- `_normalize_dims` — scalar positive, scalar negative, scalar -1 with ndim=3, list positive unchanged, list with negative resolved, list all negative, empty list.
- `_infer_dynamic_arg_dims_from_annotations` — torch.Tensor detected, Optional[torch.Tensor] detected, string annotation detected, multiple tensor params all detected, no annotated params raises ValueError, no tensor params raises ValueError, returns dict with zero values.

`fix_functionalization.py` (12 tests):
- `getitem_users` — empty dict when no getitem users, non-getitem user excluded, correct mapping for single/multiple getitem users.
- `insert_defunctionalized` — inserts one extra node, inserted immediately before auto_fn node, uses kwargs from original, raises if node is not auto_functionalized.
- `replace_users_with_mutated_args` — no getitem users means nothing staged, uses of getitem replaced with arg, getitem user staged for removal, multiple getitem users replaced independently.

`pass_manager.py` (17 tests):
- `add()` — valid InductorPass succeeds, multiple passes all stored, plain function raises, non-InductorPass raises AssertionError.
- `__call__()` — raises without pass_context, applicable pass invoked, inapplicable pass skipped, passes invoked in registration order, shape-filtered pass runs on matching shape, fix_functionalization always runs.
- `configure()` — creates fix_functionalization attribute and pass instance, creates pass config dict.
- `uuid()` — returns string, returns hex string, stable across calls, changes when pass added.

All files registered via:
```python
register_cpu_ci(est_time=5, suite="base-a-test-cpu")
```

## Test plan

```
python3 test/registered/unit/compilation/test_compilation_counter.py -v
```

```
test_clone_copies_all_values (__main__.TestCompilationCounterClone) ... ok
test_clone_of_fresh_counter_is_all_zeros (__main__.TestCompilationCounterClone) ... ok
test_clone_produces_independent_copy (__main__.TestCompilationCounterClone) ... ok
test_original_unaffected_after_clone_mutated (__main__.TestCompilationCounterClone) ... ok
test_all_expected_fields_exist (__main__.TestCompilationCounterDefaults) ... ok
test_all_fields_start_at_zero (__main__.TestCompilationCounterDefaults) ... ok
test_expect_error_message_contains_before_after_values (__main__.TestCompilationCounterExpect) ... ok
test_expect_passes_for_multiple_fields (__main__.TestCompilationCounterExpect) ... ok
test_expect_passes_for_zero_diff (__main__.TestCompilationCounterExpect) ... ok
test_expect_passes_when_diff_matches_exactly (__main__.TestCompilationCounterExpect) ... ok
test_expect_raises_assertion_error_on_wrong_diff (__main__.TestCompilationCounterExpect) ... ok
test_expect_raises_when_one_field_has_wrong_diff (__main__.TestCompilationCounterExpect) ... ok
test_module_level_singleton_is_consistent_across_imports (__main__.TestCompilationCounterSingleton) ... ok
test_singleton_is_a_compilation_counter (__main__.TestCompilationCounterSingleton) ... ok

----------------------------------------------------------------------
Ran 14 tests in 0.000s
```

```
python3 test/registered/unit/compilation/test_compile_phase.py -v
```

```
test_after_all_nested_contexts_exit_flag_is_false (__main__.TestEnableTorchCompileWarmup) ... ok
test_flag_is_false_after_context_exits (__main__.TestEnableTorchCompileWarmup) ... ok
test_flag_is_false_before_context (__main__.TestEnableTorchCompileWarmup) ... ok
test_flag_is_true_inside_context (__main__.TestEnableTorchCompileWarmup) ... ok
test_flag_restored_to_false_after_exception_inside_context (__main__.TestEnableTorchCompileWarmup) ... ok
test_nested_inner_context_sees_true (__main__.TestEnableTorchCompileWarmup) ... ok
test_after_all_nested_contexts_exit_stream_is_none (__main__.TestSetPcgCaptureStream) ... ok
test_get_returns_none_after_context_exits (__main__.TestSetPcgCaptureStream) ... ok
test_get_returns_none_after_exception_inside_context (__main__.TestSetPcgCaptureStream) ... ok
test_get_returns_none_before_context (__main__.TestSetPcgCaptureStream) ... ok
test_get_returns_stream_inside_context (__main__.TestSetPcgCaptureStream) ... ok
test_nested_inner_stream_overrides_outer_inside_inner (__main__.TestSetPcgCaptureStream) ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.001s
```

```
python3 test/registered/unit/compilation/test_compilation_config.py -v
```

```
test_add_split_op_appends_to_instance_split_ops (__main__.TestCompilationConfigMutators) ... ok
test_add_split_op_does_not_affect_global_split_ops (__main__.TestCompilationConfigMutators) ... ok
test_add_traced_file_deduplicates (__main__.TestCompilationConfigMutators) ... ok
test_add_traced_file_stored_in_set (__main__.TestCompilationConfigMutators) ... ok
test_get_traced_files_empty_initially (__main__.TestCompilationConfigMutators) ... ok
test_multiple_traced_files_all_stored (__main__.TestCompilationConfigMutators) ... ok

----------------------------------------------------------------------
Ran 19 tests in 0.000s
```

```
python3 test/registered/unit/compilation/test_inductor_pass.py -v
```

```
test_call_invokes_the_wrapped_callable (__main__.TestCallableInductorPass) ... ok
test_explicit_uuid_overrides_auto_hash (__main__.TestCallableInductorPass) ... ok
test_two_callable_passes_with_different_fns_have_different_uuids (__main__.TestCallableInductorPass) ... ok
test_uuid_is_stable_across_calls (__main__.TestCallableInductorPass) ... ok
test_uuid_matches_hash_source_of_callable (__main__.TestCallableInductorPass) ... ok
test_hash_dict_different_contents_differ (__main__.TestInductorPassHashDict) ... ok
test_hash_dict_is_deterministic (__main__.TestInductorPassHashDict) ... ok
test_hash_dict_key_order_independent (__main__.TestInductorPassHashDict) ... ok
test_hash_dict_returns_hex_string (__main__.TestInductorPassHashDict) ... ok
test_hash_source_class_is_deterministic (__main__.TestInductorPassHashSource) ... ok
test_hash_source_different_functions_differ (__main__.TestInductorPassHashSource) ... ok
test_hash_source_different_strings_differ (__main__.TestInductorPassHashSource) ... ok
test_hash_source_function_is_deterministic (__main__.TestInductorPassHashSource) ... ok
test_hash_source_returns_hex_string (__main__.TestInductorPassHashSource) ... ok
test_hash_source_string_is_deterministic (__main__.TestInductorPassHashSource) ... ok
test_context_restored_after_exception_inside (__main__.TestPassContextManager) ... ok
test_context_restored_to_none_on_normal_exit (__main__.TestPassContextManager) ... ok
test_get_pass_context_raises_outside_context (__main__.TestPassContextManager) ... ok
test_get_pass_context_returns_correct_shape_inside (__main__.TestPassContextManager) ... ok
test_get_pass_context_returns_none_shape_when_none_passed (__main__.TestPassContextManager) ... ok
test_nested_inner_context_overrides_shape (__main__.TestPassContextManager) ... ok
test_pass_context_is_a_pass_context_instance (__main__.TestPassContextManager) ... ok

----------------------------------------------------------------------
Ran 22 tests in 0.002s
```

```
python3 test/registered/unit/compilation/test_fx_utils.py -v
```

```
test_find_getitem_maybe_returns_node_for_matching_index (__main__.TestFindGetitem) ... ok
test_find_getitem_maybe_returns_none_for_wrong_index (__main__.TestFindGetitem) ... ok
test_find_getitem_maybe_returns_none_when_no_user (__main__.TestFindGetitem) ... ok
test_find_getitem_raises_when_index_absent (__main__.TestFindGetitem) ... ok
test_find_getitem_returns_node_for_matching_index (__main__.TestFindGetitem) ... ok
test_find_getitem_with_multiple_users_returns_correct_one (__main__.TestFindGetitem) ... ok
test_find_maybe_returns_first_match (__main__.TestFindSpecifiedFn) ... ok
test_find_maybe_returns_node_when_present (__main__.TestFindSpecifiedFn) ... ok
test_find_maybe_returns_none_when_absent (__main__.TestFindSpecifiedFn) ... ok
test_find_raises_when_absent (__main__.TestFindSpecifiedFn) ... ok
test_find_returns_node_when_present (__main__.TestFindSpecifiedFn) ... ok
test_raises_with_two_users (__main__.TestGetOnlyUser) ... ok
test_raises_with_zero_users (__main__.TestGetOnlyUser) ... ok
test_returns_the_single_user (__main__.TestGetOnlyUser) ... ok
test_getitem_node_matches_operator_getitem (__main__.TestIsFunc) ... ok
test_returns_false_for_output_node (__main__.TestIsFunc) ... ok
test_returns_false_for_placeholder_op (__main__.TestIsFunc) ... ok
test_returns_false_for_wrong_target (__main__.TestIsFunc) ... ok
test_returns_true_for_matching_call_function_node (__main__.TestIsFunc) ... ok

----------------------------------------------------------------------
Ran 19 tests in 0.001s
```

```
python3 test/registered/unit/compilation/test_compile.py -v
```

```
test_multiple_tensor_params_all_detected (__main__.TestInferDynamicArgDims) ... ok
test_no_annotated_params_raises_value_error (__main__.TestInferDynamicArgDims) ... ok
test_no_tensor_params_raises_value_error (__main__.TestInferDynamicArgDims) ... ok
test_optional_torch_tensor_annotation_detected (__main__.TestInferDynamicArgDims) ... ok
test_returns_dict_with_zero_values (__main__.TestInferDynamicArgDims) ... ok
test_string_annotation_torch_tensor_detected (__main__.TestInferDynamicArgDims) ... ok
test_torch_tensor_annotation_detected (__main__.TestInferDynamicArgDims) ... ok
test_slice_applies_to_each_tensor (__main__.TestIntermediateTensorsGetitem) ... ok
test_slice_returns_new_intermediate_tensors (__main__.TestIntermediateTensorsGetitem) ... ok
test_slice_shares_storage_with_original (__main__.TestIntermediateTensorsGetitem) ... ok
test_string_key_missing_raises_key_error (__main__.TestIntermediateTensorsGetitem) ... ok
test_string_key_returns_tensor (__main__.TestIntermediateTensorsGetitem) ... ok
test_items_multiple_tensors (__main__.TestIntermediateTensorsLenAndItems) ... ok
test_items_returns_key_tensor_pairs (__main__.TestIntermediateTensorsLenAndItems) ... ok
test_len_of_empty_is_zero (__main__.TestIntermediateTensorsLenAndItems) ... ok
test_len_returns_number_of_tensors (__main__.TestIntermediateTensorsLenAndItems) ... ok
test_setitem_adds_new_key (__main__.TestIntermediateTensorsSetitem) ... ok
test_setitem_stores_new_tensor (__main__.TestIntermediateTensorsSetitem) ... ok
test_empty_list_returns_empty (__main__.TestNormalizeDims) ... ok
test_list_all_negative_resolved (__main__.TestNormalizeDims) ... ok
test_list_positive_dims_unchanged (__main__.TestNormalizeDims) ... ok
test_list_with_negative_dim_resolved (__main__.TestNormalizeDims) ... ok
test_scalar_negative_one_with_ndim_3 (__main__.TestNormalizeDims) ... ok
test_scalar_negative_resolved_relative_to_ndim (__main__.TestNormalizeDims) ... ok
test_scalar_non_negative_wraps_in_list (__main__.TestNormalizeDims) ... ok
test_scalar_positive_preserved (__main__.TestNormalizeDims) ... ok

----------------------------------------------------------------------
Ran 26 tests in 0.018s
```

```
python3 test/registered/unit/compilation/test_fix_functionalization.py -v
```

```
test_non_getitem_user_excluded (__main__.TestGetitemUsers) ... ok
test_returns_correct_mapping_for_multiple_getitem_users (__main__.TestGetitemUsers) ... ok
test_returns_correct_mapping_for_single_getitem_user (__main__.TestGetitemUsers) ... ok
test_returns_empty_dict_when_no_getitem_users (__main__.TestGetitemUsers) ... ok
test_inserts_one_extra_node (__main__.TestInsertDefunctionalized) ... ok
test_new_node_inserted_immediately_before_auto_fn_node (__main__.TestInsertDefunctionalized) ... ok
test_new_node_uses_kwargs_from_original (__main__.TestInsertDefunctionalized) ... ok
test_raises_if_node_is_not_auto_functionalized (__main__.TestInsertDefunctionalized) ... ok
test_getitem_user_staged_for_removal (__main__.TestReplaceUsersWithMutatedArgs) ... ok
test_multiple_getitem_users_replaced_independently (__main__.TestReplaceUsersWithMutatedArgs) ... ok
test_no_getitem_users_means_nothing_staged (__main__.TestReplaceUsersWithMutatedArgs) ... ok
test_uses_of_getitem_replaced_with_arg (__main__.TestReplaceUsersWithMutatedArgs) ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.001s
```

```
python3 test/registered/unit/compilation/test_pass_manager.py -v
```

```
test_add_multiple_passes_all_stored (__main__.TestPostGradPassManagerAdd) ... ok
test_add_with_non_inductor_pass_raises_assertion_error (__main__.TestPostGradPassManagerAdd) ... ok
test_add_with_plain_function_raises (__main__.TestPostGradPassManagerAdd) ... ok
test_add_with_valid_inductor_pass_succeeds (__main__.TestPostGradPassManagerAdd) ... ok
test_applicable_pass_is_invoked (__main__.TestPostGradPassManagerCall) ... ok
test_call_without_pass_context_raises (__main__.TestPostGradPassManagerCall) ... ok
test_fix_functionalization_always_runs (__main__.TestPostGradPassManagerCall) ... ok
test_inapplicable_pass_is_skipped (__main__.TestPostGradPassManagerCall) ... ok
test_passes_invoked_in_registration_order (__main__.TestPostGradPassManagerCall) ... ok
test_shape_filtered_pass_runs_on_matching_shape (__main__.TestPostGradPassManagerCall) ... ok
test_configure_creates_fix_functionalization_attribute (__main__.TestPostGradPassManagerConfigure) ... ok
test_configure_creates_fix_functionalization_pass_instance (__main__.TestPostGradPassManagerConfigure) ... ok
test_configure_creates_pass_config_dict (__main__.TestPostGradPassManagerConfigure) ... ok
test_uuid_changes_when_pass_added (__main__.TestPostGradPassManagerUuid) ... ok
test_uuid_is_stable (__main__.TestPostGradPassManagerUuid) ... ok
test_uuid_returns_a_string (__main__.TestPostGradPassManagerUuid) ... ok
test_uuid_returns_hex_string (__main__.TestPostGradPassManagerUuid) ... ok

----------------------------------------------------------------------
Ran 17 tests in 0.008s
```

## Accuracy Tests
N/A — test-only change. No kernel or model-forward code is touched.

## Speed Tests and Profiling
N/A — this PR only adds unit tests and does not affect the inference path.

## Checklist
- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process
Ping Merge Oncalls to start the process. See the PR Merge Process.
Get approvals from CODEOWNERS and other reviewers.
Trigger CI tests with comments or contact authorized users to do so.
Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28191852933](https://github.com/sgl-project/sglang/actions/runs/28191852933)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28191853488](https://github.com/sgl-project/sglang/actions/runs/28191853488)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->