### PR TITLE
Fix async generator reader lock leak causing pause_generation to hang

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -290,6 +290,7 @@ class RuntimeHandle:
 
     async def _run_generate(self, obj, chunk_callback, stream: bool, request):
         ready_event = None
+        gen = None
         try:
             ready_event = self._install_on_ready(chunk_callback) if stream else None
             gen = self.tokenizer_manager.generate_request(obj, request=request)
@@ -318,10 +319,13 @@ class RuntimeHandle:
             logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
             self._send_native_error(chunk_callback, str(e))
         finally:
+            if gen is not None:
+                await gen.aclose()
             if stream:
                 self._uninstall_on_ready(chunk_callback)
 
     async def _run_embed(self, obj, chunk_callback, request):
+        gen = None
         try:
             gen = self.tokenizer_manager.generate_request(obj, request=request)
             result = await gen.__anext__()
@@ -331,6 +335,9 @@ class RuntimeHandle:
         except Exception as e:
             logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
             self._send_native_error(chunk_callback, str(e))
+        finally:
+            if gen is not None:
+                await gen.aclose()
 
     # Bounded so a stuck TM loop can't deadlock the gRPC handler thread that
     # called abort. abort_request only enqueues a message on the ZMQ socket,

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -607,8 +607,11 @@ async def health_generate(request: Request) -> Response:
         )
 
     async def gen():
-        async for _ in _global_state.tokenizer_manager.generate_request(gri, request):
-            break
+        gen_iter = _global_state.tokenizer_manager.generate_request(gri, request)
+        try:
+            await gen_iter.__anext__()
+        finally:
+            await gen_iter.aclose()
 
     task = asyncio.create_task(gen())
 
@@ -617,12 +620,18 @@ async def health_generate(request: Request) -> Response:
     while time.time() < tic + HEALTH_CHECK_TIMEOUT:
         await asyncio.sleep(1)
         if _global_state.tokenizer_manager.last_receive_tstamp > tic:
-            task.cancel()
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
+            except (asyncio.TimeoutError, Exception):
+                pass
             _global_state.tokenizer_manager.rid_to_state.pop(rid, None)
             _global_state.tokenizer_manager.server_status = ServerStatus.Up
             return Response(status_code=200)
-
     task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
     tic_time = time.strftime("%H:%M:%S", time.localtime(tic))
     last_receive_time = time.strftime(
         "%H:%M:%S", time.localtime(_global_state.tokenizer_manager.last_receive_tstamp)
@@ -806,38 +815,41 @@ async def generate_request(obj: GenerateReqInput, request: Request):
             background=_global_state.tokenizer_manager.create_abort_task(obj),
         )
     else:
+        gen = _global_state.tokenizer_manager.generate_request(obj, request)
         try:
-            ret = await _global_state.tokenizer_manager.generate_request(
-                obj, request
-            ).__anext__()
+            ret = await gen.__anext__()
             return orjson_response(ret)
         except ValueError as e:
             logger.error(f"[http_server] Error: {e}")
             return _create_error_response(e)
+        finally:
+            await gen.aclose()
 
 
 @app.api_route("/encode", methods=["POST", "PUT"])
 async def encode_request(obj: EmbeddingReqInput, request: Request):
     """Handle an embedding request."""
+    gen = _global_state.tokenizer_manager.generate_request(obj, request)
     try:
-        ret = await _global_state.tokenizer_manager.generate_request(
-            obj, request
-        ).__anext__()
+        ret = await gen.__anext__()
         return ret
     except ValueError as e:
         return _create_error_response(e)
+    finally:
+        await gen.aclose()
 
 
 @app.api_route("/classify", methods=["POST", "PUT"])
 async def classify_request(obj: EmbeddingReqInput, request: Request):
     """Handle a reward model request. Now the arguments and return values are the same as embedding models."""
+    gen = _global_state.tokenizer_manager.generate_request(obj, request)
     try:
-        ret = await _global_state.tokenizer_manager.generate_request(
-            obj, request
-        ).__anext__()
+        ret = await gen.__anext__()
         return ret
     except ValueError as e:
         return _create_error_response(e)
+    finally:
+        await gen.aclose()
 
 
 @app.api_route("/flush_cache", methods=["GET", "POST"])

--- a/python/sglang/srt/entrypoints/ollama/serving.py
+++ b/python/sglang/srt/entrypoints/ollama/serving.py
@@ -109,9 +109,13 @@ class OllamaServing:
         start_time = time.time_ns()
 
         # Get response from tokenizer manager
-        response = await self.tokenizer_manager.generate_request(
+        gen = self.tokenizer_manager.generate_request(
             gen_request, raw_request
-        ).__anext__()
+        )
+        try:
+            response = await gen.__anext__()
+        finally:
+            await gen.aclose()
 
         end_time = time.time_ns()
         total_duration = end_time - start_time
@@ -226,9 +230,13 @@ class OllamaServing:
         """Generate non-streaming generate response."""
         start_time = time.time_ns()
 
-        response = await self.tokenizer_manager.generate_request(
+        gen = self.tokenizer_manager.generate_request(
             gen_request, raw_request
-        ).__anext__()
+        )
+        try:
+            response = await gen.__anext__()
+        finally:
+            await gen.aclose()
 
         end_time = time.time_ns()
         total_duration = end_time - start_time

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1245,9 +1245,13 @@ class OpenAIServingChat(OpenAIServingBase):
     ) -> Union[ChatCompletionResponse, ErrorResponse, ORJSONResponse]:
         """Handle non-streaming chat completion request"""
         try:
-            ret = await self.tokenizer_manager.generate_request(
+            gen = self.tokenizer_manager.generate_request(
                 adapted_request, raw_request
-            ).__anext__()
+            )
+            try:
+                ret = await gen.__anext__()
+            finally:
+                await gen.aclose()
         except ValueError as e:
             return self.create_error_response(str(e))
 

--- a/python/sglang/srt/entrypoints/openai/serving_classify.py
+++ b/python/sglang/srt/entrypoints/openai/serving_classify.py
@@ -135,12 +135,13 @@ class OpenAIServingClassify(OpenAIServingBase):
         """Handle non-streaming classification request."""
         # Generate request ID
 
+        gen = self.tokenizer_manager.generate_request(adapted_request, raw_request)
         try:
-            ret = await self.tokenizer_manager.generate_request(
-                adapted_request, raw_request
-            ).__anext__()
+            ret = await gen.__anext__()
         except ValueError as e:
             return self.create_error_response(str(e))
+        finally:
+            await gen.aclose()
 
         if not isinstance(ret, list):
             ret = [ret]

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -453,10 +453,13 @@ class OpenAIServingCompletion(OpenAIServingBase):
     ) -> Union[CompletionResponse, ErrorResponse, ORJSONResponse]:
         """Handle non-streaming completion request"""
         try:
-            generator = self.tokenizer_manager.generate_request(
+            gen = self.tokenizer_manager.generate_request(
                 adapted_request, raw_request
             )
-            ret = await generator.__anext__()
+            try:
+                ret = await gen.__anext__()
+            finally:
+                await gen.aclose()
         except ValueError as e:
             return self.create_error_response(str(e))
 

--- a/python/sglang/srt/entrypoints/openai/serving_embedding.py
+++ b/python/sglang/srt/entrypoints/openai/serving_embedding.py
@@ -245,9 +245,13 @@ class OpenAIServingEmbedding(OpenAIServingBase):
     ) -> Union[EmbeddingResponse, ErrorResponse, ORJSONResponse]:
         """Handle the embedding request"""
         try:
-            ret = await self.tokenizer_manager.generate_request(
+            gen = self.tokenizer_manager.generate_request(
                 adapted_request, raw_request
-            ).__anext__()
+            )
+            try:
+                ret = await gen.__anext__()
+            finally:
+                await gen.aclose()
         except ValueError as e:
             return self.create_error_response(str(e))
 

--- a/python/sglang/srt/entrypoints/openai/serving_rerank.py
+++ b/python/sglang/srt/entrypoints/openai/serving_rerank.py
@@ -304,9 +304,13 @@ class OpenAIServingRerank(OpenAIServingBase):
                     "If you are serving a decoder-only reranker (e.g., Qwen3-Reranker), "
                     "please provide the corresponding --chat-template and launch without --is-embedding."
                 )
-            ret = await self.tokenizer_manager.generate_request(
+            gen = self.tokenizer_manager.generate_request(
                 adapted_request, raw_request
-            ).__anext__()
+            )
+            try:
+                ret = await gen.__anext__()
+            finally:
+                await gen.aclose()
         except ValueError as e:
             return self.create_error_response(str(e))
 
@@ -444,9 +448,13 @@ class OpenAIServingRerank(OpenAIServingBase):
                 )
 
                 # Execute generation request
-                ret = await self.tokenizer_manager.generate_request(
+                gen = self.tokenizer_manager.generate_request(
                     gen_request, raw_request
-                ).__anext__()
+                )
+                try:
+                    ret = await gen.__anext__()
+                finally:
+                    await gen.aclose()
 
                 # Extract yes/no probabilities from logprobs
                 score = self._extract_score_from_logprobs(ret)

--- a/python/sglang/srt/entrypoints/openai/serving_transcription.py
+++ b/python/sglang/srt/entrypoints/openai/serving_transcription.py
@@ -190,9 +190,13 @@ class OpenAIServingTranscription(OpenAIServingBase):
     ]:
         """Handle non-streaming transcription request."""
         try:
-            ret = await self.tokenizer_manager.generate_request(
+            gen = self.tokenizer_manager.generate_request(
                 adapted_request, raw_request
-            ).__anext__()
+            )
+            try:
+                ret = await gen.__anext__()
+            finally:
+                await gen.aclose()
         except ValueError as e:
             return self.create_error_response(str(e))
 

--- a/python/sglang/srt/entrypoints/warmup.py
+++ b/python/sglang/srt/entrypoints/warmup.py
@@ -124,4 +124,8 @@ async def voice_chat(disaggregation_mode: str, tokenizer_manager: TokenizerManag
             generate_req_input.bootstrap_room = 0
             generate_req_input.bootstrap_host = FAKE_BOOTSTRAP_HOST
 
-        await tokenizer_manager.generate_request(generate_req_input, None).__anext__()
+        gen = tokenizer_manager.generate_request(generate_req_input, None)
+        try:
+            await gen.__anext__()
+        finally:
+            await gen.aclose()

--- a/report.md
+++ b/report.md
@@ -1,0 +1,73 @@
+# Fix: Async Generator Reader Lock Leak Causing `pause_generation("abort")` to Hang
+
+## Problem
+
+Running `test/registered/rl/test_update_weights_from_tensor.py` hangs indefinitely.
+The hang occurs in `TestServerUpdateWeightsFromTensorNonBlocking.test_update_weights`,
+which calls the HTTP `pause_generation` endpoint with `mode="abort"`.
+
+## Root Cause
+
+`pause_generation("abort")` polls `model_update_lock.is_locked()` in a loop, waiting
+for the RWLock reader count to reach 0. However, the reader count was permanently > 0
+because multiple HTTP endpoint handlers leaked reader locks.
+
+The leak pattern: `generate_request()` returns an async generator that acquires the
+`model_update_lock` reader lock. Many endpoints consumed only the first result via
+`.__anext__()` but never called `.aclose()` on the generator. In Python, unclosed async
+generators are not cleaned up until the event loop shuts down, so the reader lock
+remained held indefinitely.
+
+### Affected call sites (10 files, ~14 call sites)
+
+| File | Endpoint / Function |
+|------|-------------------|
+| `http_server.py` | `/generate` (non-streaming), `/encode`, `/classify` |
+| `http_server.py` | `/health` / `/health_generate` (task cancellation interrupted cleanup) |
+| `warmup.py` | Server warmup request |
+| `grpc_bridge.py` | gRPC generate (non-streaming) and embed |
+| `openai/serving_chat.py` | Non-streaming chat completions |
+| `openai/serving_completions.py` | Non-streaming completions |
+| `openai/serving_embedding.py` | Embedding requests |
+| `openai/serving_classify.py` | Classification requests |
+| `openai/serving_rerank.py` | Reranking requests (2 sites) |
+| `openai/serving_transcription.py` | Transcription requests |
+| `ollama/serving.py` | Ollama chat and generate |
+
+## Fix
+
+For every `generate_request().__anext__()` call, wrap it with proper cleanup:
+
+```python
+# Before (leaks reader lock):
+ret = await tokenizer_manager.generate_request(obj, request).__anext__()
+
+# After (properly releases reader lock):
+gen = tokenizer_manager.generate_request(obj, request)
+try:
+    ret = await gen.__anext__()
+finally:
+    await gen.aclose()
+```
+
+For the health check, additionally replaced `task.cancel()` (which could interrupt
+the generator's lock-release cleanup mid-flight) with `asyncio.shield(task)` to
+ensure the reader lock is always released.
+
+## Verification
+
+All 5 tests in `test_update_weights_from_tensor.py` pass (ran in ~250s):
+
+- `TestUpdateWeightsFromTensor.test_update_weights_from_tensor`
+- `TestUpdateWeightsFromTensor.test_update_weights_from_tensor_load_format_direct`
+- `TestUpdateWeightsFromTensor.test_update_weights_from_tensor_load_format_custom`
+- `TestUpdateWeightsFromTensor.test_update_weights_from_tensor_load_format_flattened_bucket`
+- `TestServerUpdateWeightsFromTensorNonBlocking.test_update_weights`
+
+## Debugging Notes
+
+The root cause was identified by adding temporary tracing to `RWLock.acquire_reader()`
+and `RWLock.release_reader()` which showed:
+- `readers=2` with health generation enabled (one from `/health_generate`, one from warmup)
+- `readers=1` with health generation disabled (from warmup only)
+- No matching `release_reader` calls — confirming the async generators were never closed


### PR DESCRIPTION
## Summary
- Multiple HTTP endpoint handlers called `generate_request().__anext__()` without closing the async generator, permanently leaking the `model_update_lock` reader lock
- This caused `pause_generation("abort")` to spin forever waiting for the reader count to reach 0, hanging `test_update_weights_from_tensor.py`
- Fix: wrap every `__anext__()` call with `try/finally: await gen.aclose()` across 10 files, and fix the health check to not interrupt generator cleanup via task cancellation

## Test plan
- [x] All 5 tests in `test/registered/rl/test_update_weights_from_tensor.py` pass (~250s)
- See `report.md` for full debugging notes





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28195347355](https://github.com/sgl-project/sglang/actions/runs/28195347355)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28195347208](https://github.com/sgl-project/sglang/actions/runs/28195347208)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->