### PR TITLE
[Fix] Stop leaking Pydantic tool defaults into the chat prompt

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -644,14 +644,18 @@ class OpenAIServingChat(OpenAIServingBase):
         tools = None
         if request.tools and request.tool_choice != "none":
             request.skip_special_tokens = False
+            # Use exclude_unset so Pydantic defaults the client did not provide
+            # (e.g. strict=False, defer_loading=None) are not injected into the
+            # tool schema rendered into the prompt by apply_chat_template, which
+            # would otherwise cause a train-serving prompt mismatch. See #29061.
             if not isinstance(request.tool_choice, str):
                 tools = [
-                    item.model_dump()
+                    item.model_dump(exclude_unset=True)
                     for item in request.tools
                     if item.function.name == request.tool_choice.function.name
                 ]
             else:
-                tools = [item.model_dump() for item in request.tools]
+                tools = [item.model_dump(exclude_unset=True) for item in request.tools]
             if self.tool_call_parser:
                 parser = FunctionCallParser(request.tools, self.tool_call_parser)
                 tool_call_constraint = parser.get_structure_constraint(
@@ -762,7 +766,11 @@ class OpenAIServingChat(OpenAIServingBase):
                 # insert an empty system prompt to help render tool system prompt
                 messages.insert(0, {"role": "system", "content": ""})
             if request.tools:
-                messages[0]["tools"] = [tool.model_dump() for tool in request.tools]
+                # exclude_unset: keep client-provided tool schema intact in the
+                # prompt, without leaking Pydantic defaults. See #29061.
+                messages[0]["tools"] = [
+                    tool.model_dump(exclude_unset=True) for tool in request.tools
+                ]
 
             # Default encoding (dsv4/dsv32)
             if self.chat_encoding_spec == "dsv4":

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -16,7 +16,7 @@
 import unittest
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
@@ -472,6 +472,70 @@ class TestFunctionDeferLoading(unittest.TestCase):
         self.assertEqual(parts[0].type, "tool_reference")
         self.assertEqual(parts[0].name, "search_db")
         self.assertEqual(parts[1].type, "text")
+
+
+class TestToolPromptSerialization(unittest.TestCase):
+    """Tools rendered into the prompt via apply_chat_template must preserve the
+    client-provided schema and not leak Pydantic defaults (strict=False,
+    defer_loading=None), which would change the prompt. See #29061.
+
+    The serving path dumps tools with model_dump(exclude_unset=True); these
+    tests pin that contract on the validated Tool model.
+    """
+
+    def _dump(self, raw):
+        tools = TypeAdapter(List[Tool]).validate_python(raw)
+        return [t.model_dump(exclude_unset=True) for t in tools]
+
+    def test_unset_defaults_not_leaked_into_prompt(self):
+        """A minimal tool must round-trip without injected strict/defer_loading."""
+        raw = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "add",
+                    "description": "Add two numbers.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        dumped = self._dump(raw)
+        self.assertEqual(dumped, raw)
+        self.assertNotIn("strict", dumped[0]["function"])
+        self.assertNotIn("defer_loading", dumped[0]["function"])
+        self.assertNotIn("defer_loading", dumped[0])
+
+    def test_tool_level_defer_loading_propagation_preserved(self):
+        """exclude_unset must keep the value propagated to Function by the
+        validator, so defer_loading support (#22702) does not regress."""
+        raw = [
+            {
+                "type": "function",
+                "defer_loading": True,
+                "function": {"name": "add", "parameters": {"type": "object"}},
+            }
+        ]
+        dumped = self._dump(raw)
+        self.assertTrue(dumped[0]["function"]["defer_loading"])
+
+    def test_explicit_values_preserved(self):
+        """Values the client explicitly sets must survive, even when equal to
+        the field default (strict=False, defer_loading=False)."""
+        raw = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "add",
+                    "parameters": {"type": "object"},
+                    "strict": True,
+                    "defer_loading": False,
+                },
+            }
+        ]
+        dumped = self._dump(raw)
+        self.assertTrue(dumped[0]["function"]["strict"])
+        self.assertIn("defer_loading", dumped[0]["function"])
+        self.assertFalse(dumped[0]["function"]["defer_loading"])
 
 
 class TestValidationEdgeCases(unittest.TestCase):

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -460,7 +460,7 @@ class ServingChatTestCase(unittest.TestCase):
 
         self.chat._process_messages(req, is_multimodal=False)
 
-        expected_tools = [tool.model_dump() for tool in req.tools]
+        expected_tools = [tool.model_dump(exclude_unset=True) for tool in req.tools]
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertEqual(kwargs["tools"], expected_tools)
 
@@ -504,9 +504,12 @@ class ServingChatTestCase(unittest.TestCase):
         second_tools = self.tm.tokenizer.apply_chat_template.call_args_list[1].kwargs[
             "tools"
         ]
-        self.assertEqual(first_tools, [tool.model_dump() for tool in req.tools])
         self.assertEqual(
-            second_tools, [tool.function.model_dump() for tool in req.tools]
+            first_tools, [tool.model_dump(exclude_unset=True) for tool in req.tools]
+        )
+        self.assertEqual(
+            second_tools,
+            [tool.function.model_dump(exclude_unset=True) for tool in req.tools],
         )
 
     def test_xgrammar_tag_omits_reasoning_when_parser_owns_it(self):


### PR DESCRIPTION
## Motivation

Fixes #29061.

The OpenAI chat endpoint dumps tools for the prompt with bare `item.model_dump()`, which injects Pydantic defaults the client never sent (`strict: false`, top-level `defer_loading: null`) into the dict passed to `apply_chat_template`. Templates that render the tool schema into the prompt then feed the model a different schema than the client sent, a train serving mismatch. The prompt facing schema should match `apply_chat_template(..., tools=raw_tools)`.

## Modifications

- `serving_chat.py`: dump tools with `model_dump(exclude_unset=True)` at the three prompt facing sites, so only client provided fields reach the prompt.
- `test_protocol.py`: add `TestToolPromptSerialization` (defaults not leaked, propagated `defer_loading` preserved, explicit values preserved).
- `test_serving_chat.py`: update two existing tests to the new output.

Notes: `exclude_unset` over `exclude_none` so intentional client nulls survive. `defer_loading` propagation (#22702) still works (validator assignment marks the field set). Constrained decoding is unaffected (it reads the `Tool` objects, not the dump).

## Accuracy Tests

Not applicable, no kernel or model forward changes. Unit tests cover the contract.

## Speed Tests and Profiling

Not applicable, negligible overhead off the forward path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28196703989](https://github.com/sgl-project/sglang/actions/runs/28196703989)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28196703742](https://github.com/sgl-project/sglang/actions/runs/28196703742)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->