### PR TITLE
[CI] Fix false spec accept length failure after profiling phase

### DIFF
--- a/python/sglang/test/performance_test_runner.py
+++ b/python/sglang/test/performance_test_runner.py
@@ -86,6 +86,20 @@ def run_performance_test(
             perf_runner.add_report(results, variant=model.variant)
             print(f"✓ Performance test succeeded for {model.model_path}")
 
+            # The cumulative /server_info accept length is reset by the cache
+            # flush before the profiling phase, so it can be missing here. Fall
+            # back to the per-run accept lengths captured during benchmarking.
+            if avg_spec_accept_length is None:
+                run_accept_lengths = [
+                    r.acc_length
+                    for r in results
+                    if r.acc_length is not None and r.acc_length > 0
+                ]
+                if run_accept_lengths:
+                    avg_spec_accept_length = sum(run_accept_lengths) / len(
+                        run_accept_lengths
+                    )
+
             # Validate speculative decoding accept length if threshold is set
             error_msg = None
             passed = True


### PR DESCRIPTION
## Motivation

The nightly speculative-decoding perf tests (e.g. `registered/quant/test_kimi_k25_nvfp4_eagle.py`) can fail with:

```
performance - Spec accept length threshold set but no accept length reported
```

even when accept length is healthy and well above the threshold (the report table shows e.g. `4.0 / 3.88 / 3.95`, and accuracy passes). See the failing job: https://github.com/sgl-project/sglang/actions/runs/28144385103/job/83348284318

### Root cause

`NightlyBenchmarkRunner._get_spec_accept_length()` reads the cumulative `avg_spec_accept_length` from `/server_info` *after* the benchmark subprocess finishes. That field is only present when the scheduler's cumulative spec counter (`spec_total_num_forward_ct`) is `> 0`.

`bench_one_batch_server` runs a "Profile all cases" phase *after* the main benchmark. Each profiling `run_one_case` starts with a `/flush_cache`, and when the server is idle `flush_cache()` calls `metrics_reporter.reset_metrics()`, zeroing the spec counters. The profiling run then only executes `profile_steps=5` decode steps, while the cumulative counters are only incremented at `decode_log_interval=40` boundaries. Since `5 < 40`, the counters are never repopulated, so `/server_info` omits `avg_spec_accept_length`, the query returns `None`, and the perf gate fails.

## Modifications

When the post-benchmark server snapshot does not report an accept length, fall back to the per-run accept lengths already captured in `benchmark_results` (each `BenchmarkResult.acc_length` is read during the main benchmark phase, before the profiling flush). Behavior is unchanged when the server snapshot is available (e.g. non-profiled runs).

## Verification

Reproduced the exact failure scenario by driving `run_performance_test` with the failing job's per-run accept lengths (`4.0 / 3.88 / 3.95`) and a `None` server-reported `avg_spec_accept_length` (i.e. counters wiped by the profiling flush), `threshold=2.8`:

**Before (current `origin/main`):**
```
✓ Performance test succeeded for nvidia/Kimi-K2.5-NVFP4
✗ Spec accept length threshold set but no accept length reported
passed                 = False
error                  = Spec accept length threshold set but no accept length reported
avg_spec_accept_length = None
```

**After (this PR):**
```
✓ Performance test succeeded for nvidia/Kimi-K2.5-NVFP4
✓ Spec accept length 3.94 >= threshold 2.8
passed                 = True
error                  = None
avg_spec_accept_length = 3.9433333333333334
```

## Checklist

- [x] Format / lint via pre-commit
- [x] Reproduced the failure and verified the fix resolves it (before/after above)



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28200600289](https://github.com/sgl-project/sglang/actions/runs/28200600289)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28200600221](https://github.com/sgl-project/sglang/actions/runs/28200600221)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->