### PR TITLE
[test] Report token tps in fwd occupancy kit and force ignore_eos

### DIFF
--- a/python/sglang/test/kits/fwd_occupancy_kit.py
+++ b/python/sglang/test/kits/fwd_occupancy_kit.py
@@ -82,20 +82,23 @@ class FwdOccupancyMixin:
         resp = requests.get(
             self.base_url + "/metrics", timeout=_METRICS_REQUEST_TIMEOUT
         )
-        assert resp.status_code == 200, (
-            f"/metrics returned {resp.status_code}; the test class's server "
-            "must be launched with --enable-metrics"
-        )
-        assert "sglang:fwd_occupancy" in resp.text, (
-            "sglang:fwd_occupancy gauge not exposed; set "
-            "SGLANG_ENABLE_METRICS_DEVICE_TIMER=1 in the server's env and "
-            "pass --enable-metrics"
-        )
+        if resp.status_code != 200:
+            raise AssertionError(
+                f"/metrics returned {resp.status_code}; the test class's "
+                "server must be launched with --enable-metrics"
+            )
+        if "sglang:fwd_occupancy" not in resp.text:
+            raise AssertionError(
+                "sglang:fwd_occupancy gauge not exposed; set "
+                "SGLANG_ENABLE_METRICS_DEVICE_TIMER=1 in the server's env "
+                "and pass --enable-metrics"
+            )
 
     def _fwd_occupancy_fire(self, prompt: str, max_new_tokens: int):
-        """Fire one /generate, return completion_tokens (0 on failure).
+        """Fire one /generate, return (completion_tokens, wall_time).
         Must not be called concurrently -- that would break the
         single-batch invariant."""
+        t0 = time.perf_counter()
         try:
             resp = requests.post(
                 self.base_url + "/generate",
@@ -112,11 +115,13 @@ class FwdOccupancyMixin:
         except requests.RequestException:
             # Final stats-vs-threshold is the signal; individual fire
             # failure isn't.
-            return 0
+            return 0, 0.0
+        elapsed = time.perf_counter() - t0
         try:
-            return resp.json().get("meta_info", {}).get("completion_tokens", 0)
+            tokens = resp.json().get("meta_info", {}).get("completion_tokens", 0)
         except ValueError:  # non-JSON body
-            return 0
+            tokens = 0
+        return tokens, elapsed
 
     def _fwd_occupancy_warmup(self):
         """Fill cuda graphs + step the device-timer past its first NaN
@@ -130,17 +135,18 @@ class FwdOccupancyMixin:
     def _fwd_occupancy_measure(self):
         """Background-fire one long single-batch request, scrape
         /metrics on the foreground; return (non-NaN samples,
-        token_tps) -- token_tps is completion_tokens / wall time of
-        the long request (0.0 on failure)."""
+        token_tps)."""
         samples = []
         request_done = threading.Event()
-        result = {"completion_tokens": 0}
+        result = {"completion_tokens": 0, "elapsed": 0.0}
 
         def fire_one():
             try:
-                result["completion_tokens"] = self._fwd_occupancy_fire(
-                    self.fwd_occupancy_prompt,
-                    self.fwd_occupancy_max_new_tokens,
+                result["completion_tokens"], result["elapsed"] = (
+                    self._fwd_occupancy_fire(
+                        self.fwd_occupancy_prompt,
+                        self.fwd_occupancy_max_new_tokens,
+                    )
                 )
             finally:
                 request_done.set()
@@ -148,7 +154,6 @@ class FwdOccupancyMixin:
         firer = threading.Thread(target=fire_one, daemon=True)
         firer.start()
 
-        wall_start = time.perf_counter()
         while not request_done.is_set():
             v = self._scrape_fwd_occupancy()
             if v is not None:
@@ -156,8 +161,11 @@ class FwdOccupancyMixin:
             time.sleep(self.fwd_occupancy_scrape_interval)
 
         firer.join(timeout=_GENERATE_REQUEST_TIMEOUT)
-        wall_time = max(time.perf_counter() - wall_start, 1e-6)
-        token_tps = result["completion_tokens"] / wall_time
+        token_tps = (
+            result["completion_tokens"] / result["elapsed"]
+            if result["elapsed"] > 0
+            else 0.0
+        )
         return samples, token_tps
 
     def test_fwd_occupancy(self):
@@ -178,7 +186,8 @@ class FwdOccupancyMixin:
         samples_sorted = sorted(samples)
         median = statistics.median(samples_sorted)
         peak = samples_sorted[-1]
-        p10 = samples_sorted[max(0, len(samples_sorted) // 10 - 1)]
+        p10_idx = min(len(samples_sorted) - 1, max(0, len(samples_sorted) // 10))
+        p10 = samples_sorted[p10_idx]
         print(
             "\n"
             + tabulate.tabulate(

--- a/python/sglang/test/kits/fwd_occupancy_kit.py
+++ b/python/sglang/test/kits/fwd_occupancy_kit.py
@@ -93,16 +93,18 @@ class FwdOccupancyMixin:
         )
 
     def _fwd_occupancy_fire(self, prompt: str, max_new_tokens: int):
-        """Fire one /generate. Must not be called concurrently -- that
-        would break the single-batch invariant."""
+        """Fire one /generate, return completion_tokens (0 on failure).
+        Must not be called concurrently -- that would break the
+        single-batch invariant."""
         try:
-            requests.post(
+            resp = requests.post(
                 self.base_url + "/generate",
                 json={
                     "text": prompt,
                     "sampling_params": {
                         "temperature": 0.0,
                         "max_new_tokens": max_new_tokens,
+                        "ignore_eos": True,
                     },
                 },
                 timeout=_GENERATE_REQUEST_TIMEOUT,
@@ -110,7 +112,11 @@ class FwdOccupancyMixin:
         except requests.RequestException:
             # Final stats-vs-threshold is the signal; individual fire
             # failure isn't.
-            pass
+            return 0
+        try:
+            return resp.json().get("meta_info", {}).get("completion_tokens", 0)
+        except ValueError:  # non-JSON body
+            return 0
 
     def _fwd_occupancy_warmup(self):
         """Fill cuda graphs + step the device-timer past its first NaN
@@ -123,13 +129,16 @@ class FwdOccupancyMixin:
 
     def _fwd_occupancy_measure(self):
         """Background-fire one long single-batch request, scrape
-        /metrics on the foreground; return non-NaN samples."""
+        /metrics on the foreground; return (non-NaN samples,
+        token_tps) -- token_tps is completion_tokens / wall time of
+        the long request (0.0 on failure)."""
         samples = []
         request_done = threading.Event()
+        result = {"completion_tokens": 0}
 
         def fire_one():
             try:
-                self._fwd_occupancy_fire(
+                result["completion_tokens"] = self._fwd_occupancy_fire(
                     self.fwd_occupancy_prompt,
                     self.fwd_occupancy_max_new_tokens,
                 )
@@ -139,6 +148,7 @@ class FwdOccupancyMixin:
         firer = threading.Thread(target=fire_one, daemon=True)
         firer.start()
 
+        wall_start = time.perf_counter()
         while not request_done.is_set():
             v = self._scrape_fwd_occupancy()
             if v is not None:
@@ -146,12 +156,14 @@ class FwdOccupancyMixin:
             time.sleep(self.fwd_occupancy_scrape_interval)
 
         firer.join(timeout=_GENERATE_REQUEST_TIMEOUT)
-        return samples
+        wall_time = max(time.perf_counter() - wall_start, 1e-6)
+        token_tps = result["completion_tokens"] / wall_time
+        return samples, token_tps
 
     def test_fwd_occupancy(self):
         self._assert_metrics_device_timer_enabled()
         self._fwd_occupancy_warmup()
-        samples = self._fwd_occupancy_measure()
+        samples, token_tps = self._fwd_occupancy_measure()
 
         self.assertGreaterEqual(
             len(samples),
@@ -176,6 +188,7 @@ class FwdOccupancyMixin:
                     ["peak", f"{peak:.2f}"],
                     ["p10", f"{p10:.2f}"],
                     ["threshold", f"{self.fwd_occupancy_threshold:.2f}"],
+                    ["token tps", f"{token_tps:.2f}"],
                 ],
                 headers=["fwd_occupancy", "value"],
                 tablefmt="github",


### PR DESCRIPTION
## Motivation

The `fwd_occupancy` kit reports GPU occupancy but not the actual single-stream decode throughput. This adds a `token tps` line so the printed report pairs occupancy with tokens/s, making regressions easier to triage.

It also sets `ignore_eos=True` on the measurement request so the decode window always runs to `max_new_tokens`. Under greedy decoding the current code-gen prompt can emit EOS well before 2048 tokens, which both shortens the occupancy sampling window (risk of falling below `min_samples`) and dilutes the measured TPS.

## Changes

- `_fwd_occupancy_fire`: parse `completion_tokens` from the `/generate` response `meta_info` (returns 0 on failure); add `ignore_eos: True`.
- `_fwd_occupancy_measure`: time the long request with `time.perf_counter` and return `(samples, token_tps)` where `token_tps = completion_tokens / wall_time`.
- `test_fwd_occupancy`: unpack the tuple and print a `token tps` row in the report table.

No behavioral assertion is added for TPS (informational only), so existing thresholds are unaffected.

## Checklist

- [x] Code changes are sufficiently tested.
- [x] Format the code with `pre-commit`.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28201909580](https://github.com/sgl-project/sglang/actions/runs/28201909580)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28201909500](https://github.com/sgl-project/sglang/actions/runs/28201909500)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->