### PR TITLE
[AMD] Register 1 kernel unit test for AMD nightly CI

### DIFF
--- a/test/registered/kernels/test_gather_spec_extras.py
+++ b/test/registered/kernels/test_gather_spec_extras.py
@@ -1,6 +1,7 @@
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=10, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 import unittest
 


### PR DESCRIPTION
## Summary

Add `register_amd_ci(suite="nightly-amd-kernel-1-gpu", nightly=True)` to **1** kernel correctness test (previously CUDA-only) that is **validated to pass on both ROCm 7.0 and ROCm 7.2** (MI35x / gfx950). This is the next batch following #28967 and #29197.

This batch extends the effort from `test/registered/jit/**` into the sibling `test/registered/kernels/**` directory (same target `nightly-amd-kernel-1-gpu` suite, same additive mechanism), since the `jit/` 1-GPU well is exhausted.

**Batch 4 (1 test):**
- `kernels/test_gather_spec_extras` — fused Triton spec-decode gather (`gather_spec_extras`) vs torch advanced-index oracle (bit-exact)

## Verified on real MI35x (gfx950, per-file `pytest`)

Run with the checkout's `sglang` on `PYTHONPATH` (shadowing the image's), `SGLANG_USE_AITER=1`, on both stacks — green on both:

| Test | ROCm 7.0 | ROCm 7.2 |
| --- | --- | --- |
| `kernels/test_gather_spec_extras` (7 tests / 19 subtests) | ✅ 7 passed | ✅ 7 passed + 19 subtests |

Harness sanity: `test_activation.py` passes 73/73 on both stacks with `PYTHONPATH` set.

## ✅ Dispatched CI verification (`run_suite` nightly kernel job — both green)

`run_suite.py --hw amd --suite nightly-amd-kernel-1-gpu --nightly` on both stacks, **both `nightly-test-1-gpu-kernel` jobs passed** (`test_gather_spec_extras` ran green, not skipped):
- ROCm 7.0 — `nightly-test-1-gpu-kernel`: ✅ [Run #28201739022](https://github.com/sgl-project/sglang/actions/runs/28201739022/job/83542749807)
- ROCm 7.2 — `nightly-test-1-gpu-kernel-rocm720`: ✅ [Run #28201740590](https://github.com/sgl-project/sglang/actions/runs/28201740590/job/83542755672)

## Placement

The kernel test dual-registers to its existing per-commit CUDA stage (`base-b` / `1-gpu-small`) and now additionally to AMD's `nightly-amd-kernel-1-gpu`, which is already wired in `nightly-test-amd.yml` / `nightly-test-amd-rocm720.yml`, so **no workflow changes** are needed.

## Approach — purely additive, AMD-only

- The file keeps its existing `register_cuda_ci(...)`; we only add one `register_amd_ci(..., nightly=True)` line and `register_amd_ci` to the import.
- No new files, no moves, no workflow changes. NV / MUSA jobs untouched.

## Scope note (why this one and not the other `kernels/` candidates)

All `kernels/` tests with a CUDA registration and no AMD registration were trial-registered and run on both ROCm stacks; only the ones green on **both** are kept. The other candidates were dropped — failures are **environment / portability gaps, not registration issues** (confirmed from run logs on ROCm 7.2):
- `kernels/test_fused_topk_deepseek`: 85 failed / 47 passed — real numerical divergence of the MoE biased-grouped-topk kernel vs the torch reference on AMD.
- `kernels/test_gemma4_fused_routing`: 1 failed / 46 passed — `test_scale_applied` shows ~0.156 absolute weight divergence (not just top-K tie-break).
- `kernels/test_mhc_kernels`: 20 failed / 4 passed — TileLang mHC kernels not portable on the ROCm image.
- NV-only `kernels/` tests skipped by construction: `test_dsa_indexer` (Hopper FP8 guard), `test_cp_prefix_len_fa3_parity` + `test_mla_cp_fa3_parity` (FA3/Hopper), `test_sm120_*` (Blackwell), `test_fp4_moe` (nvfp4/B200).

These can be revisited once the ROCm kernel portability gaps are addressed (separate effort).

## Verification

- `collect_tests(sanity_check=True)` + `validate_all_suites` pass, and the test is collected into `nightly-amd-kernel-1-gpu` (count 16 → 17). The file has a `__main__` entry.

## Test plan

- [x] AMD nightly `nightly-amd-kernel-1-gpu` runs the test on ROCm 7.0 and 7.2 (validated green on both — see runtime table and dispatched CI runs above).
- [x] No change to NV / MUSA / per-commit AMD behavior (CUDA registration untouched).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28201734362](https://github.com/sgl-project/sglang/actions/runs/28201734362)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28258120165](https://github.com/sgl-project/sglang/actions/runs/28258120165)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


