### PR TITLE
Fix GLM and Mistral nightly regressions

### DIFF
--- a/python/sglang/srt/models/mistral_large_3_eagle.py
+++ b/python/sglang/srt/models/mistral_large_3_eagle.py
@@ -18,6 +18,7 @@ from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.models.deepseek_v2 import DeepseekV2DecoderLayer, DeepseekV2Model
 from sglang.srt.models.mistral_large_3 import MistralLarge3ForCausalLM
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import add_prefix
 
 
@@ -34,13 +35,20 @@ class MistralLarge3EagleModel(DeepseekV2Model):
         nn.Module.__init__(self)
 
         self.config = config
+        self.use_dsa = is_deepseek_dsa(config)
+        self.padding_id = config.pad_token_id
         self.vocab_size = config.vocab_size
+        self.first_k_dense_replace = config.first_k_dense_replace
         assert get_pp_group().world_size == 1
         self.pp_group = get_pp_group()
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         self.mla_enable_prefill_cp = (
-            is_prefill_context_parallel_enabled() and not is_deepseek_dsa(config)
+            is_prefill_context_parallel_enabled() and not self.use_dsa
         )
+        if self.dsa_enable_prefill_cp or self.mla_enable_prefill_cp:
+            self.cp_size = get_parallel().attn_cp_size
+        else:
+            self.cp_size = None
 
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
@@ -75,6 +83,7 @@ class MistralLarge3EagleModel(DeepseekV2Model):
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.layers_to_capture = []
         self.llama_4_scaling_config = getattr(config, "llama_4_scaling", None)
+        self.gemm_output_zero_allocator_size = 0
 
     def forward(
         self,

--- a/test/registered/8-gpu-models/test_glm_46.py
+++ b/test/registered/8-gpu-models/test_glm_46.py
@@ -27,6 +27,7 @@ class TestGLM46(unittest.TestCase):
         base_args = [
             "--tp=8",
             "--trust-remote-code",
+            "--flashinfer-allreduce-fusion-backend=trtllm",
         ]
 
         variants = [


### PR DESCRIPTION
## Summary

Fix two nightly B200 failures found in the release branch cut run:

- Pin GLM-4.6 nightly back to the FlashInfer TRTLLM allreduce fusion backend.
- Mirror the DeepSeek parent runtime attributes in the Mistral-Large-3 EAGLE draft model.

## Root Cause

### GLM-4.6

Nightly log bisection showed:

- Last passing scheduled NVIDIA nightly: `2026-06-15`, SHA `1a66059`, GLM score `0.930`.
- First failing scheduled NVIDIA nightly: `2026-06-17`, SHA `d86a7e7`, GLM score `0.048`.

The likely culprit is `32685874f3` (`Reenable MNNVL backend for FlashInfer allreduce fusion`). After that change, B200 auto-resolves FlashInfer allreduce fusion to `auto`/MNNVL. GLM-4.6 then hits scheduler/tokenizer watchdog timeouts during the accuracy run, and the eval client converts the resulting connection failures into empty GSM8K answers.

This PR pins the GLM-4.6 test back to `--flashinfer-allreduce-fusion-backend=trtllm`, matching the backend behavior from the last passing nightly.

### Mistral-Large-3 EAGLE

The current failing run crashes in draft CUDA graph capture with:

```text
AttributeError: 'MistralLarge3EagleModel' object has no attribute 'use_dsa'
```

`MistralLarge3EagleModel` bypasses `DeepseekV2Model.__init__` and reconstructs the module manually. Newer inherited DeepSeek forward logic reads parent attributes such as `use_dsa` and `first_k_dense_replace`, so the draft model needs to mirror those runtime fields.

## Validation

Local checks:

```bash
python3 -m py_compile python/sglang/srt/models/mistral_large_3_eagle.py test/registered/8-gpu-models/test_glm_46.py
git diff --check -- python/sglang/srt/models/mistral_large_3_eagle.py test/registered/8-gpu-models/test_glm_46.py
```

Commit hooks also passed during commit, including `ruff`, `isort`, and `validate registered test CI registries`.

I will trigger the targeted B200 rerun via `/rerun-test` after opening this PR.









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28207293446](https://github.com/sgl-project/sglang/actions/runs/28207293446)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28207293381](https://github.com/sgl-project/sglang/actions/runs/28207293381)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->