### PR TITLE
[sglang-miles] exclude shared skip-topk layer indexer weights from RL weight check

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1596,6 +1596,10 @@ class DeepseekV2AttentionMLA(
                     else:
                         self.next_skip_topk = False
 
+            if self.skip_topk:
+                for p in self.indexer.parameters():
+                    p._skip_weight_check = True
+
         self.kv_b_proj = ColumnParallelLinear(
             self.kv_lora_rank,
             self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),


### PR DESCRIPTION
## Problem

On DSA models with **cross-layer index sharing** (`index_topk_freq > 1`, e.g. GLM-5.2), "skip-topk" layers reuse the source computing layer's top-k indices and **never run their own indexer** — `forward_mla` gates `self.indexer(...)` behind `not self.skip_topk`. Those layers' indexer weights (`wq_b`/`wk`/`k_norm`/`weights_proj`) are therefore **absent from the checkpoint and never loaded**, so they keep uninitialized values.

`DeepseekV2AttentionMLA` still builds the `Indexer` module on every DSA layer (uniform layout, correct for V3.2 where every layer computes). So on a sharing model the RL weight-update equality checker (`WeightChecker`) compares those never-loaded skip-layer indexer params and fails with `max_abs_err=nan` on `*.self_attn.indexer.wq_b/wk` (and `k_norm`).

This only surfaces on sharing models (GLM-5.2); plain DSA (DeepSeek-V3.2, `index_topk_freq=1`) has an indexer on every layer and is unaffected.

## Fix

Tag the skip-layer indexer params with `_skip_weight_check` (already honored by `WeightChecker` → routed to non-fatal `info`). The weights are provably never read at forward, so excluding them from the equality check is safe and the per-layer module layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28205643775](https://github.com/sgl-project/sglang/actions/runs/28205643775)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28205643694](https://github.com/sgl-project/sglang/actions/runs/28205643694)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->