### PR TITLE
[RL] GLM 5.2: skip shared indexer weights from RL weight check

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1678,6 +1678,10 @@ class DeepseekV2AttentionMLA(
                 self.skip_topk = dsa_layer_skips_topk(config, layer_id)
                 self.next_skip_topk = dsa_layer_skips_topk(config, layer_id + 1)
 
+            if self.skip_topk:
+                for p in self.indexer.parameters():
+                    p._skip_weight_check = True
+
         self.kv_b_proj = ColumnParallelLinear(
             self.kv_lora_rank,
             self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),


### PR DESCRIPTION
## Problem

On DSA models with **cross-layer index sharing** (`index_topk_freq > 1`), "skip-topk" layers reuse the source computing layer's top-k indices and **never run their own indexer** — `forward_mla` gates `self.indexer(...)` behind `not self.skip_topk`. Those layers' indexer weights (`wq_b`/`wk`/`k_norm`/`weights_proj`) are absent from the checkpoint and never loaded, so they keep uninitialized values.

`DeepseekV2AttentionMLA` still builds the `Indexer` on every DSA layer (uniform layout, correct for plain DSA where every layer computes its own top-k). On a sharing model the RL weight-update equality checker (`WeightChecker`) then compares those never-loaded skip-layer indexer params and fails with `max_abs_err=nan` on `*.self_attn.indexer.wq_b/wk`.

Plain DSA (`index_topk_freq=1`) has an indexer on every layer and is unaffected.

## Fix

Tag the skip-layer indexer params with `_skip_weight_check` (already honored by `WeightChecker`, routed to non-fatal `info`). The params are provably never read at forward, so excluding them from the equality check is safe and the per-layer module layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28206685286](https://github.com/sgl-project/sglang/actions/runs/28206685286)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28206685178](https://github.com/sgl-project/sglang/actions/runs/28206685178)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:white_check_mark: [Run #28206685287](https://github.com/sgl-project/sglang/actions/runs/28206685287)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->