### PR TITLE
Add yueming-yuan to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1361,7 +1361,7 @@
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
         "can_rerun_stage": true,
-        "cooldown_interval_minutes": 60,
+        "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yundai424": {

--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1357,6 +1357,13 @@
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
+    "yueming-yuan": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 60,
+        "reason": "custom override"
+    },
     "yundai424": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
Add my GitHub username (`yueming-yuan`) to `.github/CI_PERMISSIONS.json` so that the `/tag-and-rerun-ci` and related slash commands work.

- `can_tag_run_ci_label`: true
- `can_rerun_failed_ci`: true
- `can_rerun_stage`: true
- `cooldown_interval_minutes`: 60
- `reason`: custom override















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28206364974](https://github.com/sgl-project/sglang/actions/runs/28206364974)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28206364881](https://github.com/sgl-project/sglang/actions/runs/28206364881)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->