### PR TITLE
[dflash] fa3/fa4: device-side page table; drop seq_lens_cpu D2H sync

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -29,7 +29,7 @@ from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.speculative.spec_info import SpecInput
+from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 from sglang.srt.utils import get_compiler_backend
 
 if TYPE_CHECKING:
@@ -212,10 +212,6 @@ class FlashAttentionBackend(AttentionBackend):
     - For each forward batch, init_replay_cuda_graph will be called first and then replay the graph.
     """
 
-    # Page table is built on-device (the shared kernel self-guards per request),
-    # so the seq_lens_cpu D2H is never needed -- like trtllm_mha / trtllm_mla.
-    needs_cpu_seq_lens: bool = False
-
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -253,6 +249,11 @@ class FlashAttentionBackend(AttentionBackend):
         self.max_num_pages = (
             self.max_context_len + self.page_size - 1
         ) // self.page_size
+        # Opt out of the seq_lens_cpu D2H only for dflash (the worker adapted to
+        # the GPU-only relay); EAGLE/MTP/standalone/non-spec keep the CPU mirror.
+        self.needs_cpu_seq_lens = not SpeculativeAlgorithm.from_string(
+            model_runner.server_args.speculative_algorithm
+        ).is_dflash()
         self.use_mla = model_runner.model_config.attention_arch == AttentionArch.MLA
         self.skip_prefill = skip_prefill
         self.attn_cp_size = model_runner.attn_cp_size

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -14,6 +14,9 @@ from sglang.srt.layers.attention.triton_ops.metadata import (
     normal_decode_set_metadata,
     prepare_swa_spec_page_table_triton,
 )
+from sglang.srt.layers.attention.triton_ops.trtllm_mha_page_table import (
+    build_trtllm_mha_page_table,
+)
 from sglang.srt.layers.attention.utils import assert_buffer_fits
 from sglang.srt.layers.cp.base import CPAttentionBackendKind, get_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_v2_active
@@ -209,6 +212,11 @@ class FlashAttentionBackend(AttentionBackend):
     - For each forward batch, init_replay_cuda_graph will be called first and then replay the graph.
     """
 
+    # Build the page table on-device from seq_lens via the shared
+    # build_trtllm_mha_page_table kernel (self-guards per request), so the
+    # seq_lens_cpu D2H sync is never needed. matches trtllm_mha / trtllm_mla.
+    needs_cpu_seq_lens: bool = False
+
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -230,6 +238,11 @@ class FlashAttentionBackend(AttentionBackend):
         # extra metadata for handling speculative decoding topk > 1, extended draft decode and verify
         self.forward_metadata_spec_decode_expand: FlashAttentionMetadata = None
         self.max_context_len = model_runner.model_config.context_len
+        # Static page-table width (upper bound). The device-side page-table build
+        # sizes to this constant, so no runtime host max is needed.
+        self.max_num_pages = (
+            self.max_context_len + self.page_size - 1
+        ) // self.page_size
         self.device = model_runner.device
         self.decode_cuda_graph_metadata = {}
         self.target_verify_metadata = {}
@@ -489,6 +502,14 @@ class FlashAttentionBackend(AttentionBackend):
         seqlens_in_batch = forward_batch.seq_lens
         batch_size = forward_batch.batch_size
         device = seqlens_in_batch.device
+        # Eager (non-cuda-graph) path may need a host-side max for dynamic
+        # page-table sizing. Use the published mirror when available, else
+        # sync from the GPU tensor (this path is not the overlap hot path).
+        seq_lens_cpu = (
+            forward_batch.seq_lens_cpu
+            if forward_batch.seq_lens_cpu is not None
+            else seqlens_in_batch.cpu()
+        )
 
         if forward_batch.forward_mode.is_decode_or_idle():
             # Draft Decode
@@ -497,7 +518,7 @@ class FlashAttentionBackend(AttentionBackend):
                     metadata.cache_seqlens_int32 = (
                         seqlens_in_batch + (self.speculative_step_id + 1)
                     ).to(torch.int32)
-                    metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item() + (
+                    metadata.max_seq_len_k = seq_lens_cpu.max().item() + (
                         self.speculative_step_id + 1
                     )
                     metadata.cu_seqlens_q = torch.arange(
@@ -516,7 +537,7 @@ class FlashAttentionBackend(AttentionBackend):
                     # Draft-extend's idle batch (padded for DP MLP-sync) has no
                     # tree; build plain metadata (padded output is discarded).
                     metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-                    metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                    metadata.max_seq_len_k = seq_lens_cpu.max().item()
                     metadata.cu_seqlens_q = torch.arange(
                         0, batch_size + 1, dtype=torch.int32, device=device
                     )
@@ -529,7 +550,7 @@ class FlashAttentionBackend(AttentionBackend):
                 else:
                     metadata.cache_seqlens_int32 = (seqlens_in_batch).to(torch.int32)
                     metadata.max_seq_len_q = self.topk
-                    metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                    metadata.max_seq_len_k = seq_lens_cpu.max().item()
                     metadata.cu_seqlens_q = torch.arange(
                         0,
                         batch_size * self.topk + 1,
@@ -579,7 +600,7 @@ class FlashAttentionBackend(AttentionBackend):
             else:
                 # Normal Decode
                 metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                metadata.max_seq_len_k = seq_lens_cpu.max().item()
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
@@ -625,8 +646,7 @@ class FlashAttentionBackend(AttentionBackend):
                 ).to(torch.int32)
                 metadata.max_seq_len_q = self.speculative_num_draft_tokens
                 metadata.max_seq_len_k = (
-                    forward_batch.seq_lens_cpu.max().item()
-                    + self.speculative_num_draft_tokens
+                    seq_lens_cpu.max().item() + self.speculative_num_draft_tokens
                 )
                 metadata.cu_seqlens_q = torch.arange(
                     0,
@@ -649,7 +669,7 @@ class FlashAttentionBackend(AttentionBackend):
             else:
                 metadata.cache_seqlens_int32 = forward_batch.seq_lens.to(torch.int32)
                 metadata.max_seq_len_q = self.speculative_num_draft_tokens
-                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                metadata.max_seq_len_k = seq_lens_cpu.max().item()
                 metadata.cu_seqlens_q = torch.arange(
                     0,
                     batch_size * self.speculative_num_draft_tokens + 1,
@@ -749,7 +769,7 @@ class FlashAttentionBackend(AttentionBackend):
             include_draft_extend_v2=True
         ):
             metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-            metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = seq_lens_cpu.max().item()
             metadata.cu_seqlens_k = torch.nn.functional.pad(
                 torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
             )
@@ -2257,6 +2277,35 @@ class FlashAttentionBackend(AttentionBackend):
 
         return metadata, metadata_expand
 
+    def _fill_page_table_device(
+        self,
+        metadata: FlashAttentionMetadata,
+        req_pool_indices: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+    ):
+        """Build the page table on-device from per-request KV lengths (no sync).
+
+        Fills ``metadata.page_table`` (a [bs, max_num_pages] buffer) in place
+        with block ids derived from ``cache_seqlens`` (a GPU tensor); for SWA
+        models it also fills ``metadata.swa_page_table`` via the full->SWA
+        lookup. The Triton kernel self-guards per request on the device-side
+        length, so the grid and buffer width use the static ``max_num_pages``
+        upper bound while the actual writes stay bounded by ``cache_seqlens``
+        — no host-side max / D2H sync.
+        """
+        has_swa = self.use_sliding_window_kv_pool
+        build_trtllm_mha_page_table(
+            req_to_token=self.req_to_token,
+            req_pool_indices=req_pool_indices,
+            cache_seqlens=cache_seqlens,
+            page_table=metadata.page_table,
+            page_size=self.page_size,
+            swa_page_table=metadata.swa_page_table if has_swa else None,
+            full_to_swa=(
+                self.token_to_kv_pool.full_to_swa_index_mapping if has_swa else None
+            ),
+        )
+
     def _apply_cuda_graph_metadata(
         self,
         bs: int,
@@ -2277,7 +2326,10 @@ class FlashAttentionBackend(AttentionBackend):
         are gone.
         """
         seq_lens = seq_lens[:bs]
-        seq_lens_cpu = seq_lens_cpu[:bs]
+        # The GPU-only path passes seq_lens_cpu=None; the topk>1 branches below
+        # still need a host max, so sync locally in that case (not the dflash
+        # overlap hot path, which uses topk=1 and the device-side build).
+        seq_lens_cpu = seq_lens_cpu[:bs] if seq_lens_cpu is not None else None
         req_pool_indices = req_pool_indices[:bs]
         device = seq_lens.device
         metadata = None
@@ -2298,17 +2350,10 @@ class FlashAttentionBackend(AttentionBackend):
                 if self.topk <= 1:
                     # When topk = 1, we use the normal decode metadata
                     metadata = self.decode_cuda_graph_metadata[bs]
-                    max_len = seq_lens_cpu.max().item()
-                    metadata.max_seq_len_k = max_len + self.speculative_step_id + 1
-                    max_seq_pages = (
-                        metadata.max_seq_len_k + self.page_size - 1
-                    ) // self.page_size
+                    # Static upper bound; the device-side page-table build below
+                    # self-guards on cache_seqlens, so no host max is needed.
+                    metadata.max_seq_len_k = self.max_context_len
 
-                    assert_buffer_fits(
-                        max_seq_pages,
-                        metadata.page_table.shape[1],
-                        "FA3 draft-decode page_table",
-                    )
                     normal_decode_set_metadata(
                         metadata.cache_seqlens_int32,
                         metadata.cu_seqlens_k,
@@ -2316,7 +2361,7 @@ class FlashAttentionBackend(AttentionBackend):
                         self.req_to_token,
                         req_pool_indices,
                         self.decode_cuda_graph_metadata["strided_indices"],
-                        max_seq_pages,
+                        self.max_num_pages,
                         seq_lens,
                         self.speculative_step_id + 1,
                         self.page_size,
@@ -2341,7 +2386,11 @@ class FlashAttentionBackend(AttentionBackend):
                     # metadata.cu_seqlens_q already set in capture
                     # metadata.cu_seqlens_k is not needed
 
-                    metadata.max_seq_len_k = seq_lens_cpu.max().item()
+                    metadata.max_seq_len_k = (
+                        (seq_lens_cpu if seq_lens_cpu is not None else seq_lens.cpu())
+                        .max()
+                        .item()
+                    )
                     max_seq_pages = (
                         metadata.max_seq_len_k + self.page_size - 1
                     ) // self.page_size
@@ -2389,16 +2438,11 @@ class FlashAttentionBackend(AttentionBackend):
             else:
                 # Normal Decode
                 metadata = self.decode_cuda_graph_metadata[bs]
-                max_len = seq_lens_cpu.max().item()
-                max_seq_pages = (max_len + self.page_size - 1) // self.page_size
-                metadata.max_seq_len_k = max_len
-
-                assert_buffer_fits(
-                    max_seq_pages,
-                    metadata.page_table.shape[1],
-                    "FA3 decode page_table",
-                )
                 if self.is_prefill_aware_swa:
+                    # Prefill-aware SWA still needs a host max to bound the
+                    # per-batch page table built below.
+                    max_len = seq_lens_cpu.max().item()
+                    metadata.max_seq_len_k = max_len
                     pa_max_len = min(
                         self._pa_swa_max_prefill_len + self.sliding_window_size,
                         max_len,
@@ -2417,6 +2461,9 @@ class FlashAttentionBackend(AttentionBackend):
                             dst_kv_lens=metadata.cache_seqlens_int32,
                         )
                 else:
+                    # Static upper bound; the fused kernel self-guards on
+                    # seq_lens, so no host max / D2H sync is needed.
+                    metadata.max_seq_len_k = self.max_context_len
                     normal_decode_set_metadata(
                         metadata.cache_seqlens_int32,
                         metadata.cu_seqlens_k,
@@ -2424,7 +2471,7 @@ class FlashAttentionBackend(AttentionBackend):
                         self.req_to_token,
                         req_pool_indices,
                         self.decode_cuda_graph_metadata["strided_indices"],
-                        max_seq_pages,
+                        self.max_num_pages,
                         seq_lens,
                         0,
                         self.page_size,
@@ -2464,40 +2511,25 @@ class FlashAttentionBackend(AttentionBackend):
                     (seq_lens + self.speculative_num_draft_tokens)
                 )
 
-                metadata.max_seq_len_k = (
-                    seq_lens_cpu.max().item() + self.speculative_num_draft_tokens
-                )
+                # Static upper bound; page table built on-device below.
+                metadata.max_seq_len_k = self.max_context_len
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
                 )
-                max_seq_pages = (
-                    metadata.max_seq_len_k + self.page_size - 1
-                ) // self.page_size
-                page_indices = self.req_to_token[
-                    req_pool_indices[:, None],
-                    self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
-                ]
-                if (
-                    self.use_sliding_window_kv_pool
-                    and metadata.swa_page_table is not None
-                ):
-                    swa_page_indices = (
-                        self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                            page_indices
-                        )
-                    )
-                    metadata.swa_page_table[:, :max_seq_pages].copy_(
-                        swa_page_indices // self.page_size
-                    )
-                page_indices //= self.page_size
-                metadata.page_table[:, :max_seq_pages].copy_(page_indices)
+                self._fill_page_table_device(
+                    metadata, req_pool_indices, metadata.cache_seqlens_int32
+                )
             else:
                 # When topk > 1, we need two specific target verify metadata, and then merge states
                 # 1. The first half of metadata for prefix tokens
                 metadata = self.target_verify_metadata_topk_normal[bs]
                 metadata.cache_seqlens_int32.copy_(seq_lens)
                 # metadata.max_seq_len_q = self.speculative_num_draft_tokens, already set in capture
-                metadata.max_seq_len_k = seq_lens_cpu.max().item()
+                metadata.max_seq_len_k = (
+                    (seq_lens_cpu if seq_lens_cpu is not None else seq_lens.cpu())
+                    .max()
+                    .item()
+                )
                 # metadata.cu_seqlens_q already set in capture
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
@@ -2583,7 +2615,11 @@ class FlashAttentionBackend(AttentionBackend):
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)
 
-            metadata.max_seq_len_k = seq_lens_cpu.max().item()
+            metadata.max_seq_len_k = (
+                (seq_lens_cpu if seq_lens_cpu is not None else seq_lens.cpu())
+                .max()
+                .item()
+            )
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2277,6 +2277,17 @@ class FlashAttentionBackend(AttentionBackend):
 
         return metadata, metadata_expand
 
+    @staticmethod
+    def _host_max_seq_len(
+        seq_lens_cpu: Optional[torch.Tensor], seq_lens: torch.Tensor
+    ) -> int:
+        """Host-side max KV length. Prefers the published CPU mirror; falls back
+        to a local D2H when it is absent (the GPU-only path). Used by the topk>1
+        / draft-extend branches that still need a host max for buffer sizing --
+        not the dflash overlap hot path (topk=1, device-side build)."""
+        src = seq_lens_cpu if seq_lens_cpu is not None else seq_lens.cpu()
+        return src.max().item()
+
     def _fill_page_table_device(
         self,
         metadata: FlashAttentionMetadata,
@@ -2386,10 +2397,8 @@ class FlashAttentionBackend(AttentionBackend):
                     # metadata.cu_seqlens_q already set in capture
                     # metadata.cu_seqlens_k is not needed
 
-                    metadata.max_seq_len_k = (
-                        (seq_lens_cpu if seq_lens_cpu is not None else seq_lens.cpu())
-                        .max()
-                        .item()
+                    metadata.max_seq_len_k = self._host_max_seq_len(
+                        seq_lens_cpu, seq_lens
                     )
                     max_seq_pages = (
                         metadata.max_seq_len_k + self.page_size - 1
@@ -2525,11 +2534,7 @@ class FlashAttentionBackend(AttentionBackend):
                 metadata = self.target_verify_metadata_topk_normal[bs]
                 metadata.cache_seqlens_int32.copy_(seq_lens)
                 # metadata.max_seq_len_q = self.speculative_num_draft_tokens, already set in capture
-                metadata.max_seq_len_k = (
-                    (seq_lens_cpu if seq_lens_cpu is not None else seq_lens.cpu())
-                    .max()
-                    .item()
-                )
+                metadata.max_seq_len_k = self._host_max_seq_len(seq_lens_cpu, seq_lens)
                 # metadata.cu_seqlens_q already set in capture
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
@@ -2615,11 +2620,7 @@ class FlashAttentionBackend(AttentionBackend):
             metadata = self.draft_extend_metadata[bs]
             metadata.cache_seqlens_int32.copy_(seq_lens)
 
-            metadata.max_seq_len_k = (
-                (seq_lens_cpu if seq_lens_cpu is not None else seq_lens.cpu())
-                .max()
-                .item()
-            )
+            metadata.max_seq_len_k = self._host_max_seq_len(seq_lens_cpu, seq_lens)
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -212,9 +212,8 @@ class FlashAttentionBackend(AttentionBackend):
     - For each forward batch, init_replay_cuda_graph will be called first and then replay the graph.
     """
 
-    # Build the page table on-device from seq_lens via the shared
-    # build_trtllm_mha_page_table kernel (self-guards per request), so the
-    # seq_lens_cpu D2H sync is never needed. matches trtllm_mha / trtllm_mla.
+    # Page table is built on-device (the shared kernel self-guards per request),
+    # so the seq_lens_cpu D2H is never needed -- like trtllm_mha / trtllm_mla.
     needs_cpu_seq_lens: bool = False
 
     def __init__(
@@ -502,9 +501,8 @@ class FlashAttentionBackend(AttentionBackend):
         seqlens_in_batch = forward_batch.seq_lens
         batch_size = forward_batch.batch_size
         device = seqlens_in_batch.device
-        # Eager (non-cuda-graph) path may need a host-side max for dynamic
-        # page-table sizing. Use the published mirror when available, else
-        # sync from the GPU tensor (this path is not the overlap hot path).
+        # Eager path needs a host int for dynamic page-table sizing: the CPU
+        # mirror when published, else a local D2H (not the overlap hot path).
         seq_lens_cpu = (
             forward_batch.seq_lens_cpu
             if forward_batch.seq_lens_cpu is not None
@@ -2281,10 +2279,9 @@ class FlashAttentionBackend(AttentionBackend):
     def _host_max_seq_len(
         seq_lens_cpu: Optional[torch.Tensor], seq_lens: torch.Tensor
     ) -> int:
-        """Host-side max KV length. Prefers the published CPU mirror; falls back
-        to a local D2H when it is absent (the GPU-only path). Used by the topk>1
-        / draft-extend branches that still need a host max for buffer sizing --
-        not the dflash overlap hot path (topk=1, device-side build)."""
+        """Host-side max KV length: the CPU mirror when published, else a local
+        D2H. For cold paths (topk>1, draft-extend, eager) that need a host max --
+        not the dflash hot path (topk=1, device-side build)."""
         src = seq_lens_cpu if seq_lens_cpu is not None else seq_lens.cpu()
         return src.max().item()
 
@@ -2294,15 +2291,10 @@ class FlashAttentionBackend(AttentionBackend):
         req_pool_indices: torch.Tensor,
         cache_seqlens: torch.Tensor,
     ):
-        """Build the page table on-device from per-request KV lengths (no sync).
-
-        Fills ``metadata.page_table`` (a [bs, max_num_pages] buffer) in place
-        with block ids derived from ``cache_seqlens`` (a GPU tensor); for SWA
-        models it also fills ``metadata.swa_page_table`` via the full->SWA
-        lookup. The Triton kernel self-guards per request on the device-side
-        length, so the grid and buffer width use the static ``max_num_pages``
-        upper bound while the actual writes stay bounded by ``cache_seqlens``
-        — no host-side max / D2H sync.
+        """Fill metadata.page_table (and swa_page_table for SWA models) in place
+        on-device from cache_seqlens, no D2H. The Triton kernel self-guards per
+        request, so the grid/buffer width use the static max_num_pages bound
+        while writes stay bounded by cache_seqlens.
         """
         has_swa = self.use_sliding_window_kv_pool
         build_trtllm_mha_page_table(
@@ -2361,11 +2353,9 @@ class FlashAttentionBackend(AttentionBackend):
                 if self.topk <= 1:
                     # When topk = 1, we use the normal decode metadata
                     metadata = self.decode_cuda_graph_metadata[bs]
-                    # Page table built on-device below (self-guards on
-                    # cache_seqlens). max_seq_len_k is intentionally left unset:
-                    # the FA3 kernel reads cache_seqlens + page_table only, and
-                    # scheduler_metadata is normal-decode-only, so nothing
-                    # consumes it on this path.
+                    # Page table built on-device (self-guards on cache_seqlens);
+                    # max_seq_len_k left unset -- unread here (scheduler_metadata
+                    # is normal-decode-only).
                     normal_decode_set_metadata(
                         metadata.cache_seqlens_int32,
                         metadata.cu_seqlens_k,
@@ -2471,11 +2461,9 @@ class FlashAttentionBackend(AttentionBackend):
                             dst_kv_lens=metadata.cache_seqlens_int32,
                         )
                 else:
-                    # Page table uses the static max_num_pages bound (the fused
-                    # kernel self-guards on seq_lens, no D2H). max_seq_len_k only
-                    # drives the FA3 scheduler_metadata precompute below, so use
-                    # the free CPU mirror for a tight split heuristic when it is
-                    # published, else fall back to the static upper bound.
+                    # Page table uses the static max_num_pages bound (no D2H).
+                    # max_seq_len_k only feeds scheduler_metadata below, so use
+                    # the free CPU mirror for a tight split heuristic when present.
                     metadata.max_seq_len_k = (
                         seq_lens_cpu.max().item()
                         if seq_lens_cpu is not None
@@ -2528,10 +2516,9 @@ class FlashAttentionBackend(AttentionBackend):
                     (seq_lens + self.speculative_num_draft_tokens)
                 )
 
-                # Page table built on-device below (self-guards on cache_seqlens).
-                # max_seq_len_k is intentionally left unset: the FA3 kernel reads
-                # cache_seqlens + page_table only, and scheduler_metadata is
-                # normal-decode-only, so nothing consumes it on this path.
+                # Page table built on-device (self-guards on cache_seqlens);
+                # max_seq_len_k left unset -- unread here (scheduler_metadata is
+                # normal-decode-only).
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
                 )

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2470,9 +2470,16 @@ class FlashAttentionBackend(AttentionBackend):
                             dst_kv_lens=metadata.cache_seqlens_int32,
                         )
                 else:
-                    # Static upper bound; the fused kernel self-guards on
-                    # seq_lens, so no host max / D2H sync is needed.
-                    metadata.max_seq_len_k = self.max_context_len
+                    # Page table uses the static max_num_pages bound (the fused
+                    # kernel self-guards on seq_lens, no D2H). max_seq_len_k only
+                    # drives the FA3 scheduler_metadata precompute below, so use
+                    # the free CPU mirror for a tight split heuristic when it is
+                    # published, else fall back to the static upper bound.
+                    metadata.max_seq_len_k = (
+                        seq_lens_cpu.max().item()
+                        if seq_lens_cpu is not None
+                        else self.max_context_len
+                    )
                     normal_decode_set_metadata(
                         metadata.cache_seqlens_int32,
                         metadata.cu_seqlens_k,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2450,7 +2450,7 @@ class FlashAttentionBackend(AttentionBackend):
                 if self.is_prefill_aware_swa:
                     # Prefill-aware SWA still needs a host max to bound the
                     # per-batch page table built below.
-                    max_len = seq_lens_cpu.max().item()
+                    max_len = self._host_max_seq_len(seq_lens_cpu, seq_lens)
                     metadata.max_seq_len_k = max_len
                     pa_max_len = min(
                         self._pa_swa_max_prefill_len + self.sliding_window_size,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2361,10 +2361,11 @@ class FlashAttentionBackend(AttentionBackend):
                 if self.topk <= 1:
                     # When topk = 1, we use the normal decode metadata
                     metadata = self.decode_cuda_graph_metadata[bs]
-                    # Static upper bound; the device-side page-table build below
-                    # self-guards on cache_seqlens, so no host max is needed.
-                    metadata.max_seq_len_k = self.max_context_len
-
+                    # Page table built on-device below (self-guards on
+                    # cache_seqlens). max_seq_len_k is intentionally left unset:
+                    # the FA3 kernel reads cache_seqlens + page_table only, and
+                    # scheduler_metadata is normal-decode-only, so nothing
+                    # consumes it on this path.
                     normal_decode_set_metadata(
                         metadata.cache_seqlens_int32,
                         metadata.cu_seqlens_k,
@@ -2527,8 +2528,10 @@ class FlashAttentionBackend(AttentionBackend):
                     (seq_lens + self.speculative_num_draft_tokens)
                 )
 
-                # Static upper bound; page table built on-device below.
-                metadata.max_seq_len_k = self.max_context_len
+                # Page table built on-device below (self-guards on cache_seqlens).
+                # max_seq_len_k is intentionally left unset: the FA3 kernel reads
+                # cache_seqlens + page_table only, and scheduler_metadata is
+                # normal-decode-only, so nothing consumes it on this path.
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
                 )

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -238,11 +238,6 @@ class FlashAttentionBackend(AttentionBackend):
         # extra metadata for handling speculative decoding topk > 1, extended draft decode and verify
         self.forward_metadata_spec_decode_expand: FlashAttentionMetadata = None
         self.max_context_len = model_runner.model_config.context_len
-        # Static page-table width (upper bound). The device-side page-table build
-        # sizes to this constant, so no runtime host max is needed.
-        self.max_num_pages = (
-            self.max_context_len + self.page_size - 1
-        ) // self.page_size
         self.device = model_runner.device
         self.decode_cuda_graph_metadata = {}
         self.target_verify_metadata = {}
@@ -254,6 +249,11 @@ class FlashAttentionBackend(AttentionBackend):
         self.kv_cache_dtype = model_runner.kv_cache_dtype
         self.kv_cache_dtype_str = model_runner.server_args.kv_cache_dtype
         self.page_size = model_runner.page_size
+        # Static page-table width (upper bound). The device-side page-table build
+        # sizes to this constant, so no runtime host max is needed.
+        self.max_num_pages = (
+            self.max_context_len + self.page_size - 1
+        ) // self.page_size
         self.use_mla = model_runner.model_config.attention_arch == AttentionArch.MLA
         self.skip_prefill = skip_prefill
         self.attn_cp_size = model_runner.attn_cp_size

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -817,7 +817,7 @@ class FlashAttentionBackend(AttentionBackend):
                 self._pa_swa_prefill_lens[
                     forward_batch.req_pool_indices[:batch_size]
                 ] = forward_batch.seq_lens[:batch_size].to(torch.int32)
-                max_pf = int(forward_batch.seq_lens_cpu[:batch_size].max().item())
+                max_pf = int(seq_lens_cpu[:batch_size].max().item())
                 if max_pf > self._pa_swa_max_prefill_len:
                     self._pa_swa_max_prefill_len = max_pf
 

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2285,30 +2285,6 @@ class FlashAttentionBackend(AttentionBackend):
         src = seq_lens_cpu if seq_lens_cpu is not None else seq_lens.cpu()
         return src.max().item()
 
-    def _fill_page_table_device(
-        self,
-        metadata: FlashAttentionMetadata,
-        req_pool_indices: torch.Tensor,
-        cache_seqlens: torch.Tensor,
-    ):
-        """Fill metadata.page_table (and swa_page_table for SWA models) in place
-        on-device from cache_seqlens, no D2H. The Triton kernel self-guards per
-        request, so the grid/buffer width use the static max_num_pages bound
-        while writes stay bounded by cache_seqlens.
-        """
-        has_swa = self.use_sliding_window_kv_pool
-        build_trtllm_mha_page_table(
-            req_to_token=self.req_to_token,
-            req_pool_indices=req_pool_indices,
-            cache_seqlens=cache_seqlens,
-            page_table=metadata.page_table,
-            page_size=self.page_size,
-            swa_page_table=metadata.swa_page_table if has_swa else None,
-            full_to_swa=(
-                self.token_to_kv_pool.full_to_swa_index_mapping if has_swa else None
-            ),
-        )
-
     def _apply_cuda_graph_metadata(
         self,
         bs: int,
@@ -2522,8 +2498,19 @@ class FlashAttentionBackend(AttentionBackend):
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
                 )
-                self._fill_page_table_device(
-                    metadata, req_pool_indices, metadata.cache_seqlens_int32
+                has_swa = self.use_sliding_window_kv_pool
+                build_trtllm_mha_page_table(
+                    req_to_token=self.req_to_token,
+                    req_pool_indices=req_pool_indices,
+                    cache_seqlens=metadata.cache_seqlens_int32,
+                    page_table=metadata.page_table,
+                    page_size=self.page_size,
+                    swa_page_table=metadata.swa_page_table if has_swa else None,
+                    full_to_swa=(
+                        self.token_to_kv_pool.full_to_swa_index_mapping
+                        if has_swa
+                        else None
+                    ),
                 )
             else:
                 # When topk > 1, we need two specific target verify metadata, and then merge states

--- a/test/registered/attention/test_trtllm_mha_page_table.py
+++ b/test/registered/attention/test_trtllm_mha_page_table.py
@@ -6,6 +6,11 @@ it never reads a runtime max (no D2H sync). This test checks the device build is
 bit-identical to the legacy gather for the columns each request uses, for both
 the full page table and the SWA-translated page table, across context lengths,
 page sizes, and batch sizes.
+
+It also pins the invariant that lets the no-host-max (GPU-only) path hand the
+kernel a static ``max_num_pages``-wide buffer: every column past a request's
+page count must be left untouched, i.e. the kernel bounds its writes by the
+device-side ``cache_seqlens`` alone.
 """
 
 import unittest
@@ -20,7 +25,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 # Triton kernel unit test for the trtllm_mha device-side page-table build.
-register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=14, stage="base-b", runner_config="1-gpu-small")
 
 
 def _build_page_table_reference(
@@ -142,6 +147,82 @@ class TestTrtllmMhaPageTable(CustomTestCase):
                     self._run_case(
                         max_ctx, page_size, num_reqs=max(64, bs), bs=bs, swa=True
                     )
+
+    def _run_self_guard_case(self, max_context_len, page_size, bs, swa=False):
+        """Short sequences against a full static buffer -- the GPU-only shape.
+
+        Pre-fill the page table with a sentinel and run the kernel with the
+        static ``max_num_pages`` width (no host max to tighten it). Used columns
+        must hold the right block ids; every tail column must keep the sentinel,
+        proving the kernel never writes past the device-side ``cache_seqlens``.
+        """
+        torch.manual_seed(0)
+        dev = "cuda"
+        num_reqs = max(64, bs)
+        max_num_pages = (max_context_len + page_size - 1) // page_size
+        n_slots = num_reqs * max_context_len
+        req_to_token = torch.randint(
+            0, n_slots, (num_reqs, max_context_len), dtype=torch.int32, device=dev
+        )
+        req_pool_indices = torch.randperm(num_reqs, device=dev)[:bs].to(torch.int32)
+        # Cap lengths well below max_context_len so most tail columns stay unused.
+        hi = max(2, max_context_len // 8)
+        cache_seqlens = torch.randint(1, hi + 1, (bs,), dtype=torch.int32, device=dev)
+        full_to_swa = (
+            torch.randint(0, n_slots, (n_slots,), dtype=torch.int32, device=dev)
+            if swa
+            else None
+        )
+
+        SENTINEL = -1
+        page_table = torch.full(
+            (bs, max_num_pages), SENTINEL, dtype=torch.int32, device=dev
+        )
+        swa_page_table = (
+            torch.full((bs, max_num_pages), SENTINEL, dtype=torch.int32, device=dev)
+            if swa
+            else None
+        )
+        build_trtllm_mha_page_table(
+            req_to_token=req_to_token,
+            req_pool_indices=req_pool_indices,
+            cache_seqlens=cache_seqlens,
+            page_table=page_table,
+            page_size=page_size,
+            swa_page_table=swa_page_table,
+            full_to_swa=full_to_swa,
+        )
+        pt_ref, swa_ref = _build_page_table_reference(
+            req_to_token, req_pool_indices, cache_seqlens, page_size, full_to_swa
+        )
+
+        tag = f"max_ctx={max_context_len} page_size={page_size} bs={bs} swa={swa}"
+        for i in range(bs):
+            npages = (int(cache_seqlens[i].item()) + page_size - 1) // page_size
+            self.assertTrue(
+                torch.equal(page_table[i, :npages], pt_ref[i, :npages]),
+                f"used-column mismatch req={i} {tag}",
+            )
+            self.assertTrue(
+                torch.all(page_table[i, npages:] == SENTINEL),
+                f"kernel wrote past cache_seqlens req={i} npages={npages} {tag}",
+            )
+            if swa:
+                self.assertTrue(
+                    torch.equal(swa_page_table[i, :npages], swa_ref[i, :npages]),
+                    f"swa used-column mismatch req={i} {tag}",
+                )
+                self.assertTrue(
+                    torch.all(swa_page_table[i, npages:] == SENTINEL),
+                    f"swa wrote past cache_seqlens req={i} npages={npages} {tag}",
+                )
+
+    def test_writes_bounded_by_cache_seqlens(self):
+        for max_ctx in (4096, 131072):
+            for page_size in (1, 64, 256):
+                for bs in (1, 8):
+                    self._run_self_guard_case(max_ctx, page_size, bs=bs)
+                    self._run_self_guard_case(max_ctx, page_size, bs=bs, swa=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Build the page table on-device via `build_trtllm_mha_page_table` (Triton kernel from #28106, self-guards per request on `cache_seqlens`) in the cuda-graph decode / draft-decode / target-verify paths — no host-side `seq_lens_cpu.max().item()` for page-table sizing
- Set `needs_cpu_seq_lens = not is_dflash()` so **only dflash** opts out of the CPU mirror; EAGLE/MTP/standalone keep `True` until #29589 adds preallocated tree-mask scratch
- `max_seq_len_k` uses the static `max_context_len` bound on device-build paths (fa3 kernel never reads it — only `cache_seqlens` + `page_table`)
- `_host_max_seq_len` helper for cold paths (topk>1, draft-extend, prefill-aware SWA) that still need a host max — falls back to `max_context_len` when `seq_lens_cpu` is `None`
- Test: page-table write-boundedness for the no-host-max path

## Background

PR #29232 unified dflash's seq_lens CPU-value relay through the FutureMap. But dflash+fa3 still paid a `resolve_seq_lens_cpu` D2H + `synchronize()` (~370us/iter of forward occupancy) because fa3 declared `needs_cpu_seq_lens = True` and read `seq_lens_cpu.max().item()` for dynamic page-table sizing.

trtllm_mha solved this in #28106 with a device-side page-table builder. This PR reuses that pattern for fa3, scoped to dflash only.

## Follow-ups

- **#29589**: extends sync-free to all spec algos (EAGLE/MTP) via preallocated `cuda_graph_custom_mask` + unconditional `needs_cpu_seq_lens = False`