### PR TITLE
[AMD] Fuse bf16 kv_b_proj prefill epilogue via fused_gemm_a16w16_split_cat

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -499,6 +499,9 @@ class Envs:
     # decode without runtime permutes.
     SGLANG_AITER_KV_CACHE_LAYOUT = EnvStr("nhd")
     SGLANG_ROCM_FUSED_DECODE_MLA = EnvBool(False)
+    # Fuse the bf16 kv_b_proj GEMM + nope/v split + k_pe cat + fp8 cast into a
+    # single aiter Triton kernel (fused_gemm_a16w16_split_cat) on ROCm.
+    SGLANG_AITER_FUSED_KVB_SPLIT_CAT = EnvBool(False)
     SGLANG_ROCM_DISABLE_LINEARQUANT = EnvBool(False)
     SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(4096)
     # Enable dual-stream MoE (shared experts vs routed experts) on the

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -61,6 +61,7 @@ except ImportError:
     )
 
 from sglang.srt.configs.model_config import AttentionArch
+from sglang.srt.environ import envs
 from sglang.srt.layers.attention.aiter_utils import (
     forward_decode_vectorized_5d,
     forward_extend_vectorized_5d,
@@ -82,6 +83,27 @@ _use_mla_ps_kernel = get_bool_env_var("SGLANG_AITER_MLA_PERSIST", "True")
 # Use fp8 prefill only on gfx95
 _use_fp8_prefill_attn = (
     get_bool_env_var("SGLANG_AITER_FP8_PREFILL_ATTN", "True") and is_gfx95_supported()
+)
+
+# Opt-in (default off): fuse the bf16 kv_b_proj GEMM with its nope/v split,
+# k_pe cat, and fp8 cast into a single Triton kernel (bf16 analog of the MXFP4
+# fused_gemm_afp4wfp4_split_cat path). Only valid on gfx95 with bf16/fp16
+# kv_b_proj weights and fp8 prefill attention. Requires a recent aiter exposing
+# fused_gemm_a16w16_split_cat; falls back to the unfused path if not present.
+_has_fused_gemm_a16w16_split_cat = False
+try:
+    from aiter.ops.triton.gemm.fused.fused_gemm_a16w16_split_cat import (
+        fused_gemm_a16w16_split_cat,
+    )
+
+    _has_fused_gemm_a16w16_split_cat = True
+except ImportError:
+    pass
+
+_use_fused_kvb_split_cat = (
+    envs.SGLANG_AITER_FUSED_KVB_SPLIT_CAT.get()
+    and is_gfx95_supported()
+    and _has_fused_gemm_a16w16_split_cat
 )
 
 # Persist
@@ -2028,6 +2050,25 @@ class AiterAttnBackend(AttentionBackend):
                                 fp8_dtype,
                             )
                         )[0]
+                    elif (
+                        _use_fp8_prefill_attn
+                        and _use_fused_kvb_split_cat
+                        and layer.kv_b_proj.weight.dtype
+                        in (torch.bfloat16, torch.float16)
+                    ):
+                        # BF16 weights + FP8 prefill: fuse the kv_b_proj GEMM,
+                        # nope/v split, and k_pe cat into a single kernel
+                        # (fused_gemm_a16w16_split_cat) that writes k and v
+                        # directly in FP8, avoiding separate split / cat /
+                        # float8_copy passes.
+                        k, v = fused_gemm_a16w16_split_cat(
+                            x=kvc.squeeze(1).contiguous(),
+                            w=layer.kv_b_proj.weight,
+                            y=k_pe.expand(-1, layer.tp_k_head_num, -1),
+                            S1=qk_nope_head_dim,
+                            S2=layer.v_head_dim,
+                            dtype=fp8_dtype,
+                        )
                     else:
                         kv = layer.kv_b_proj(kvc.contiguous())[0]
 

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -2028,7 +2028,19 @@ class AiterAttnBackend(AttentionBackend):
                         K_Buffer, [kv_lora_rank, qk_rope_head_dim], dim=-1
                     )
 
-                    if self.kv_cache_dtype == fp8_dtype:
+                    use_fused_a16w16 = (
+                        _use_fp8_prefill_attn
+                        and _use_fused_kvb_split_cat
+                        and layer.kv_b_proj.weight.dtype
+                        in (torch.bfloat16, torch.float16)
+                    )
+
+                    if self.kv_cache_dtype == fp8_dtype and not use_fused_a16w16:
+                        # The fused a16w16 split-cat GEMM consumes the fp8 latent
+                        # directly (fp8 A upconverted on load, fp8 k_pe stored
+                        # straight to the fp8 output), so skip this dequant for
+                        # that path -- it is the per-layer fp8->bf16 cast of the
+                        # kvc[N,512] + k_pe[N,64] KV latent.
                         dtype = q.dtype
 
                         kvc = kvc.to(dtype)
@@ -2050,19 +2062,22 @@ class AiterAttnBackend(AttentionBackend):
                                 fp8_dtype,
                             )
                         )[0]
-                    elif (
-                        _use_fp8_prefill_attn
-                        and _use_fused_kvb_split_cat
-                        and layer.kv_b_proj.weight.dtype
-                        in (torch.bfloat16, torch.float16)
-                    ):
+                    elif use_fused_a16w16:
                         # BF16 weights + FP8 prefill: fuse the kv_b_proj GEMM,
                         # nope/v split, and k_pe cat into a single kernel
                         # (fused_gemm_a16w16_split_cat) that writes k and v
                         # directly in FP8, avoiding separate split / cat /
                         # float8_copy passes.
+                        #
+                        # When the KV cache is fp8, kvc/k_pe are still fp8 here
+                        # (dequant skipped above): the kernel upconverts the fp8
+                        # A tile to the weight dtype before the dot and stores
+                        # the fp8 k_pe straight into the fp8 output, eliminating
+                        # the fp8->bf16 dequant. It also builds A block pointers
+                        # from x.stride(0/1), so the row-strided index_select +
+                        # split view feeds in without a .contiguous() copy.
                         k, v = fused_gemm_a16w16_split_cat(
-                            x=kvc.squeeze(1).contiguous(),
+                            x=kvc.squeeze(1),
                             w=layer.kv_b_proj.weight,
                             y=k_pe.expand(-1, layer.tp_k_head_num, -1),
                             S1=qk_nope_head_dim,

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -39,11 +39,31 @@ if _is_cuda:
 elif _is_musa:
     from sgl_kernel import concat_mla_k
 
+# Opt-in (default off): fuse the bf16 kv_b_proj GEMM with its nope/v split,
+# k_pe cat, and fp8 cast into a single Triton kernel (the bf16 analog of the
+# MXFP4 fused_gemm_afp4wfp4_split_cat path). Requires a recent aiter exposing
+# fused_gemm_a16w16_split_cat; falls back to the unfused path if not present.
+_has_fused_gemm_a16w16_split_cat = False
 if _use_aiter_gfx95:
     from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
 
     from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
     from sglang.srt.layers.quantization.rocm_mxfp4_utils import fused_rms_mxfp4_quant
+
+    try:
+        from aiter.ops.triton.gemm.fused.fused_gemm_a16w16_split_cat import (
+            fused_gemm_a16w16_split_cat,
+        )
+
+        _has_fused_gemm_a16w16_split_cat = True
+    except ImportError:
+        pass
+
+_use_fused_kvb_split_cat = (
+    envs.SGLANG_AITER_FUSED_KVB_SPLIT_CAT.get()
+    and _use_aiter_gfx95
+    and _has_fused_gemm_a16w16_split_cat
+)
 
 
 def _resolve_attn_backend(forward_batch: ForwardBatch):
@@ -289,6 +309,23 @@ class DeepseekMHAForwardMixin:
                     fp8_dtype,
                 )
             )[0]
+        elif (
+            _use_fp8_prefill_attn
+            and _use_fused_kvb_split_cat
+            and self.kv_b_proj.weight.dtype in (torch.bfloat16, torch.float16)
+        ):
+            # BF16 weights + FP8 prefill: fuse the kv_b_proj GEMM, nope/v split,
+            # and k_pe cat into a single kernel (fused_gemm_a16w16_split_cat)
+            # that writes k and v directly in FP8, avoiding separate split / cat
+            # / float8_copy passes.
+            k, v = fused_gemm_a16w16_split_cat(
+                x=kv_a,
+                w=self.kv_b_proj.weight,
+                y=k_pe.expand(-1, self.num_local_heads, -1),
+                S1=self.qk_nope_head_dim,
+                S2=self.v_head_dim,
+                dtype=fp8_dtype,
+            )
         else:
             if _use_aiter_gfx95 and self.kv_b_proj.weight.dtype == torch.float8_e4m3fn:
                 kv = self.kv_b_proj(kv_a_quanted)[0]


### PR DESCRIPTION
# [AMD] Fuse bf16 `kv_b_proj` prefill epilogue via aiter `fused_gemm_a16w16_split_cat`

## Motivation

DeepSeek MLA prefill materializes K/V by running the `kv_b_proj` GEMM, then splitting
nope/v, concatenating `k_pe`, and casting to fp8 — several separate elementwise passes on
the attention critical path (× 61 layers). The MXFP4-weight path already had a fused
kernel; the bf16-weight path did not. Additionally, with an fp8 KV cache the gathered KV
latent was dequantized fp8→bf16 *before* the GEMM (a per-layer copy) — pure overhead once
a fused kernel that accepts fp8 input exists.

## Modifications

Route the bf16-weight kv_b materialization through aiter
`fused_gemm_a16w16_split_cat`, which fuses the GEMM + nope/v split + `k_pe` cat + fp8
store into one kernel. When the KV cache is fp8 (`use_fused_a16w16`):
- skip the fp8→bf16 dequant of `kvc`/`k_pe`;
- pass the row-strided `kvc.squeeze(1)` without `.contiguous()` (the kernel builds A block
  pointers from `x.stride(0/1)`);
- the aiter kernel upconverts the fp8 A tile to the weight dtype before `tl.dot`
  (ROCm/aiter#3940) and stores the fp8 `k_pe` straight to the fp8 output.

Gated by `SGLANG_AITER_FUSED_KVB_SPLIT_CAT` (+ `SGLANG_AITER_FP8_PREFILL_ATTN`) and a
bf16/fp16 `kv_b_proj` weight; off by default. Falls back to the unfused path if the aiter
kernel is unavailable. **The fp8-input path requires ROCm/aiter#3940 in the pinned aiter.**

## Before and After this PR
Before:
<img width="1545" height="761" alt="image" src="https://github.com/user-attachments/assets/86445693-b373-41e4-93d7-b1465f790237" />
After"
<img width="2838" height="539" alt="image" src="https://github.com/user-attachments/assets/691ddac5-e584-47d8-a18f-394463e77ee6" />

The fp8-direct (commit: c6d41efeeabfdd5e17af12af478c045c1f02ce7d)
path removes the per-layer fp8→bf16 dequant that ran before the GEMM. Anchoring on
`vectorized_gather_kernel` (the gathered-prefix KV latent gather — only these layers show
the pattern; direct/current-token layers go straight to the GEMM in both builds):

```
unfused:  vectorized_gather -> manual_unroll<128,4> BFloat16 (×2, DEQUANT) -> fused_gemm_a16w16_split_cat
fused fp8: vectorized_gather -> fused_gemm_a16w16_split_cat            (dequant gone)
```
## Accuracy Tests

GSM8K, 500 questions, 5-shot, greedy (temp 0), DeepSeek-R1 **fp8 KV cache**, MI355X
TP8 + DP-attention + MoRI EP. Invalid = 0.000.

| build | GSM8K acc |
|---|---|
| baseline (unfused, dequant path) | 0.968 |
| fused + fp8-direct (this PR) | 0.962 |

Within the ~±1% run-to-run nondeterminism of the fp8/DP/MoRI stack (a numerically-identical
control change measured 0.958 vs 0.968 in the same harness). The fused path introduces a
single-fp8-ULP K/V difference (~2e-3 rel err from fp32-accum ordering) with no measurable
accuracy impact.

## Speed Tests and Profiling

**bench_serving** (`--dataset-name random --random-input-len 4096 --random-output-len 128`,
DeepSeek-R1 fp8, MI355X TP8+DP+MoRI; server warmed, 3 reps, steady-state). Baseline =
unfused (`SGLANG_AITER_FUSED_KVB_SPLIT_CAT=0`) vs this PR = fused + fp8-direct:

| metric | unfused | fused + fp8 | delta |
|---|---|---|---|
| Median TTFT | 4029 ms | 3627 ms | **−10.0%** |
| Mean TTFT | 4002 ms | 3635 ms | −9.2% |
| Output token throughput | 1765 tok/s | 1888 tok/s | **+7.0%** |
| Benchmark duration | 11.03 s | 10.31 s | −6.5% |

(Warmup matters: the first measured rep on a cold server is an autotune outlier; reported
numbers are steady-state.)

## Notes

- fp8 prefill-attn path is gfx95-gated (`is_gfx95_supported()`); validated on MI355X.
  Upstream CI likely cannot exercise it — AMD reviewer validation needed.
- Merge order: land ROCm/aiter#3940 (fp8 A) first, then this.
