### PR TITLE
[AMD] sgl-kernel: enable NGRAM speculative decoding on ROCm (build ngram_utils)

### DIFF
--- a/sgl-kernel/csrc/common_extension_rocm.cc
+++ b/sgl-kernel/csrc/common_extension_rocm.cc
@@ -164,6 +164,12 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
       "()");
   m.impl("build_tree_kernel_efficient", torch::kCUDA, &build_tree_kernel_efficient);
 
+  m.def(
+      "reconstruct_indices_from_tree_mask(Tensor tree_mask, Tensor verified_seq_len, Tensor positions, "
+      "Tensor retrive_index, Tensor retrive_next_token, Tensor retrive_next_sibling, "
+      "int batch_size, int draft_token_num) -> ()");
+  m.impl("reconstruct_indices_from_tree_mask", torch::kCUDA, &reconstruct_indices_from_tree_mask);
+
   /*
    * From csrc/kvcacheio
    */

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -54,6 +54,7 @@ sources = [
     "csrc/moe/moe_topk_softmax_kernels.cu",
     "csrc/moe/moe_topk_sigmoid_kernels.cu",
     "csrc/speculative/eagle_utils.cu",
+    "csrc/speculative/ngram_utils.cu",
     "csrc/kvcacheio/transfer.cu",
     "csrc/memory/weak_ref_tensor.cpp",
     "csrc/elementwise/pos_enc.cu",


### PR DESCRIPTION
## Summary

Enables **NGRAM speculative decoding on ROCm** by building the missing kernel op into the ROCm `sgl_kernel`.

### Root cause
`srt/speculative/ngram_worker.py:_prepare_for_speculative_decoding` calls `sgl_kernel`'s `reconstruct_indices_from_tree_mask`, but that op was **CUDA-only**:
- `sgl-kernel/setup_rocm.py` compiled only `csrc/speculative/eagle_utils.cu` — **not** `csrc/speculative/ngram_utils.cu`, where the op is defined.
- The op was registered only in `csrc/common_extension.cc` (CUDA); the ROCm registration file `csrc/common_extension_rocm.cc` never declared it.

On ROCm this raised, at the first speculative-decode step:
```
AttributeError: '_OpNamespace' 'sgl_kernel' object has no attribute 'reconstruct_indices_from_tree_mask'
```
which crashed the scheduler — so **any** NGRAM-spec run on ROCm dies immediately (independent of attention backend / model).

### Fix
- Add `csrc/speculative/ngram_utils.cu` to the ROCm build sources in `setup_rocm.py`.
- Register `reconstruct_indices_from_tree_mask` in `common_extension_rocm.cc` (the decl already exists in `sgl_kernel_ops.h`).

The kernel is plain CUDA C++ (no warp intrinsics / tensor cores) and already carries a `#ifdef USE_ROCM` include branch, so it hipifies cleanly.

## Test plan

Verified locally on **MI355X (gfx950)**, ROCm 7.2:
- Rebuilt the ROCm `sgl_kernel` with this change; `torch.ops.sgl_kernel.reconstruct_indices_from_tree_mask` now dispatches.
- Before: `python -m sglang.launch_server ... --speculative-algorithm NGRAM --attention-backend triton` crashed with the AttributeError above.
- After: the same server launches (`ready to roll`) and serves correct output (`Qwen2.5-Coder-7B-Instruct`, e.g. "The capital of France is" → "Paris. Paris is located in the northern part of France...").

Note: validated on gfx950; the AMD CI NGRAM-spec lanes (e.g. `test_spec_ngram*`) run on gfx942/MI325 — this unblocks them there as well. A follow-up will enable the triton NGRAM-spec test for AMD CI on top of this.















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28258198996](https://github.com/sgl-project/sglang/actions/runs/28258198996)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28258198792](https://github.com/sgl-project/sglang/actions/runs/28258198792)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->