### PR TITLE
Fix unified radix cache SWA and Mamba consistency bugs

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/auxiliary_state.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/auxiliary_state.py
@@ -346,10 +346,11 @@ class MlxAuxiliaryStateComponent(MambaComponent):
         insert_params=None,
     ) -> None:
         if not is_finished:
+            insert_skipped = insert_result is None or insert_result.insert_skipped
             if (
                 insert_params is not None
                 and insert_params.mamba_value is not None
-                and (insert_result is None or insert_result.mamba_exist)
+                and (insert_skipped or insert_result.mamba_exist)
             ):
                 self.cache.req_to_token_pool.auxiliary_state_pool.free(
                     insert_params.mamba_value

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -67,6 +67,10 @@ class InsertParams:
     # General
     chunked: bool = False
     priority: int = 0
+    defer_overlap_free: bool = False
+    deferred_overlap_values: list[tuple[int, torch.Tensor]] = dataclasses.field(
+        default_factory=list
+    )
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -86,6 +86,7 @@ class InsertResult:
     mamba_exist: bool = False
     inserted_host_node: Any = None
     insert_skipped: bool = False
+    mamba_inserted_node: Any = None
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -71,6 +71,9 @@ class InsertParams:
     deferred_overlap_values: list[tuple[int, torch.Tensor]] = dataclasses.field(
         default_factory=list
     )
+    created_node_records: list[tuple[int, Any, Any]] = dataclasses.field(
+        default_factory=list
+    )
 
 
 @dataclasses.dataclass
@@ -82,6 +85,7 @@ class InsertResult:
     last_device_node: Any = None
     mamba_exist: bool = False
     inserted_host_node: Any = None
+    insert_skipped: bool = False
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/mem_cache/unified_cache_components/README.md
+++ b/python/sglang/srt/mem_cache/unified_cache_components/README.md
@@ -125,9 +125,9 @@ Insert a key-value pair into the tree.
      - If partially within window: **splits node** at boundary, recovers SWA on the window portion (returns `start_idx`)
      - If entirely outside window: returns `prefix_len` (no consumption)
    - Mamba: returns `prefix_len` (no consumption, default behavior)
-4. Before creating a new leaf, checks `should_skip_leaf_creation()` per component — any veto aborts leaf creation and frees remaining value
-5. Creates leaf via `_add_new_node` (clones value tensor, updates Full leaf-set tracking)
-6. Calls `commit_insert_component_data()` per component on the final target node (SWA may trigger a secondary split for window boundary; Mamba sets mamba pool indices and inserts into Mamba LRU)
+4. Creates leaf via `_add_new_node` (clones value tensor, inserts into Full LRU), even if auxiliary components such as SWA will store a tombstone for that span
+5. Calls `commit_insert_component_data()` per component on the final target node (SWA may trigger a secondary split for window boundary; Mamba sets mamba pool indices and inserts into Mamba LRU)
+6. When called by `cache_unfinished_req`, the caller re-matches the inserted key and rolls back any newly-created suffix or Mamba value that is not on the accepted matched path, without freeing request-owned KV slots
 
 ---
 
@@ -262,9 +262,9 @@ Each component implements these hooks. See `tree_component.py` for the ABC and d
 | Hook | Purpose | Called By | Default |
 |------|---------|-----------|----------|
 | `update_component_on_insert_overlap()` | Handle key overlap with an existing node during insert. Returns the index within `value_slice` from which this component consumed (took ownership of) pool slots. Full/Mamba: no consumption (`prefix_len`). SWA: may recover tombstoned nodes within the sliding window boundary. | `_insert_helper` | returns `prefix_len` |
-| `should_skip_leaf_creation()` | Veto leaf creation when the entire new leaf would be a tombstone for this component. SWA: vetoes if `swa_evicted_seqlen ≥ total_prefix_len + key_len`. | `_insert_helper` | `False` |
 | `recover_after_unevict()` | Rebuild auxiliary component data after `_unevict_node_on_insert()` restores a Full device value from fresh KV indices. SWA uses this to rebuild in-window SWA data. | `_insert_helper` | no-op |
 | `commit_insert_component_data()` | Finalize component data on the target node after the insert walk completes. Full: no-op (handled by `_add_new_node`). SWA: checks window boundary, may split node — parent becomes tombstone, child gets SWA data. Mamba: sets mamba pool indices and inserts into Mamba LRU. | `_insert_helper` | no-op |
+| `should_skip_leaf_creation()` | Legacy no-op hook retained on `TreeComponent`; `_insert_helper` no longer calls it because Full leaves are materialized even when auxiliary components tombstone the span. | not called | `False` |
 
 ### Node Split
 

--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -136,6 +136,7 @@ class MambaComponent(TreeComponent):
             self.cache.component_evictable_size_[self.component_type] += len(
                 params.mamba_value
             )
+            result.mamba_inserted_node = node
             return
         if node.component_data[self.component_type].value is None:
             node.component_data[self.component_type].value = params.mamba_value
@@ -148,6 +149,7 @@ class MambaComponent(TreeComponent):
                 params.mamba_value
             )
             node.last_access_time = get_and_increase_time_counter()
+            result.mamba_inserted_node = node
             return
         self.cache.lru_lists[self.component_type].reset_node_mru(node)
         node.last_access_time = get_and_increase_time_counter()
@@ -294,6 +296,19 @@ class MambaComponent(TreeComponent):
             assert slot is not None, "Can not alloc mamba cache"
         return slot
 
+    def _request_mamba_slot(self, req: Req) -> torch.Tensor:
+        if self.enable_mamba_extra_buffer:
+            keep_idx = self.cache.req_to_token_pool.get_mamba_ping_pong_keep_idx(req)
+            return req.mamba_ping_pong_track_buffer[keep_idx].unsqueeze(-1)
+        return req.mamba_pool_idx.unsqueeze(-1)
+
+    def _copy_mamba_state_to_request(self, req: Req, src: torch.Tensor) -> None:
+        self.cache.req_to_token_pool.mamba_pool.copy_from(
+            src, self._request_mamba_slot(req)
+        )
+        req.mamba_cow_src_index = None
+        req.mamba_needs_clear = False
+
     def prepare_for_caching_req(
         self,
         req: Req,
@@ -364,8 +379,16 @@ class MambaComponent(TreeComponent):
                     req, mamba_ping_pong_track_buffer_to_keep=keep_idx
                 )
         else:
+            insert_skipped = insert_result is None or insert_result.insert_skipped
+            if insert_skipped and insert_params.mamba_value is not None:
+                self._copy_mamba_state_to_request(req, insert_params.mamba_value)
+            elif insert_result is not None and not self.enable_mamba_extra_buffer:
+                mamba_value = req.last_node.component_data[self.component_type].value
+                if mamba_value is not None:
+                    req.mamba_cow_src_index = mamba_value
+                    req.mamba_needs_clear = False
             if insert_params.mamba_value is not None and (
-                insert_result is None or insert_result.mamba_exist
+                insert_skipped or insert_result.mamba_exist
             ):
                 self.cache.req_to_token_pool.mamba_allocator.free(
                     insert_params.mamba_value

--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -111,6 +111,13 @@ class MambaComponent(TreeComponent):
                 req.mamba_pool_idx = dst_index[0]
             req.mamba_cow_src_index = mamba_value
             req.mamba_needs_clear = False
+        elif cow_mamba and req is not None and req.mamba_cow_src_index is not None:
+            # A queued request can keep a COW source from an earlier match. If
+            # this re-match has no donor, that source may point at an evicted
+            # slot; clear it so admission zero-clears instead of copying freed state.
+            req.mamba_cow_src_index = None
+            if req.mamba_pool_idx is not None:
+                req.mamba_needs_clear = True
 
         # HiCache: if mamba was evicted from device but has host backup,
         # ensure mamba_host_hit_length >= 1 so load_back is triggered.

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -207,11 +207,6 @@ class SWAComponent(TreeComponent):
             # Branch 3: entire value_slice is outside SWA window — not consumed
             return prefix_len
 
-    def should_skip_leaf_creation(
-        self, total_prefix_len: int, key_len: int, params: InsertParams
-    ) -> bool:
-        return params.swa_evicted_seqlen >= total_prefix_len + key_len
-
     def recover_after_unevict(
         self,
         node: UnifiedTreeNode,

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -564,8 +564,9 @@ class SWAComponent(TreeComponent):
         token_ids_len: int,
         is_finished: bool,
     ) -> Optional[int]:
-        if is_finished:
-            insert_params.swa_evicted_seqlen = req.swa_evicted_seqlen
+        # Unfinished requests can already have an SWA-evicted prefix; preserve
+        # that boundary so insertion creates a tombstone instead of live SWA KV.
+        insert_params.swa_evicted_seqlen = req.swa_evicted_seqlen
         return None
 
     def free_out_of_window_slots(

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -169,6 +169,7 @@ class SWAComponent(TreeComponent):
         if not is_tombstone:
             return prefix_len
 
+        full_cd = node.component_data[BASE_COMPONENT_TYPE]
         swa_evicted_seqlen = params.swa_evicted_seqlen
         assert (
             node.component_data[self.component_type].lock_ref == 0
@@ -179,21 +180,19 @@ class SWAComponent(TreeComponent):
 
         if swa_evicted_seqlen <= total_prefix_len:
             # Branch 1: entire value_slice is within SWA window — recover
-            self.cache.token_to_kv_pool_allocator.free(
-                node.component_data[BASE_COMPONENT_TYPE].value
-            )
-            node.component_data[BASE_COMPONENT_TYPE].value = value_slice.clone()
-            swa_value = self._translate_full_to_swa(
-                node.component_data[BASE_COMPONENT_TYPE].value
-            )
+            if full_cd.lock_ref > 0:
+                return prefix_len
+            self.cache.token_to_kv_pool_allocator.free(full_cd.value)
+            full_cd.value = value_slice.clone()
+            swa_value = self._translate_full_to_swa(full_cd.value)
             self._restore_device_value(node, swa_value)
             return 0
         elif swa_evicted_seqlen < total_prefix_len + prefix_len:
             # Branch 2: value_slice[start_idx:] is within SWA window — partial recover
             start_idx = swa_evicted_seqlen - total_prefix_len
-            self.cache.token_to_kv_pool_allocator.free(
-                node.component_data[BASE_COMPONENT_TYPE].value[start_idx:]
-            )
+            if full_cd.lock_ref > 0:
+                return prefix_len
+            self.cache.token_to_kv_pool_allocator.free(full_cd.value[start_idx:])
             self.cache._split_node(node.key, node, start_idx)
             node.component_data[BASE_COMPONENT_TYPE].value = value_slice[
                 start_idx:

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -169,6 +169,9 @@ class SWAComponent(TreeComponent):
         if not is_tombstone:
             return prefix_len
 
+        if params.defer_overlap_free:
+            return prefix_len
+
         full_cd = node.component_data[BASE_COMPONENT_TYPE]
         swa_evicted_seqlen = params.swa_evicted_seqlen
         assert (

--- a/python/sglang/srt/mem_cache/unified_cache_components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/tree_component.py
@@ -193,8 +193,11 @@ class TreeComponent(ABC):
     def should_skip_leaf_creation(
         self, total_prefix_len: int, key_len: int, params: InsertParams
     ) -> bool:
-        """Return True to veto leaf creation when the entire new leaf would
-        be a tombstone for this component."""
+        """Legacy hook kept for downstream component compatibility.
+
+        UnifiedRadixCache no longer calls this hook; Full leaves are materialized
+        even when auxiliary components store a tombstone for the same span.
+        """
         return False
 
     def recover_after_unevict(

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1161,19 +1161,6 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         is_new_leaf = False
         # Create new leaf for remaining suffix
         if len(key):
-            if any(
-                comp.should_skip_leaf_creation(
-                    total_prefix_len=total_prefix_length,
-                    key_len=len(key),
-                    params=params,
-                )
-                for comp in self._components_tuple
-            ):
-                # TODO: When leaf creation is skipped, We should release all component
-                # resources here or propagate a flag so that
-                # cleanup_after_caching_req can free them properly.
-                self.token_to_kv_pool_allocator.free(value)
-                return InsertResult(prefix_len=total_prefix_length)
             target_node = self._add_new_node(node, key, value, priority=priority)
             is_new_leaf = True
         else:

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1271,6 +1271,16 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         result.inserted_host_node = new_node
         return result
 
+    def _node_is_on_matched_path(
+        self, node: UnifiedTreeNode, accepted_node: UnifiedTreeNode
+    ) -> bool:
+        cur = accepted_node
+        while cur is not None:
+            if cur is node:
+                return True
+            cur = cur.parent
+        return False
+
     def _forget_unfinished_component_value(
         self, node: UnifiedTreeNode, component_type: ComponentType
     ) -> None:
@@ -1283,6 +1293,14 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             lru.remove_node(node)
         self.component_evictable_size_[component_type] -= len(cd.value)
         cd.value = None
+        if (
+            component_type != BASE_COMPONENT_TYPE
+            and cd.host_value is not None
+            and cd.host_lock_ref == 0
+        ):
+            host_lru = self.host_lru_lists[component_type]
+            if not host_lru.in_list(node):
+                host_lru.insert_mru(node)
 
     def _forget_unfinished_subtree_values(self, node: UnifiedTreeNode) -> None:
         for child in list(node.children.values()):
@@ -1360,6 +1378,13 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             if accepted_len >= created_end:
                 continue
             self._detach_unaccepted_created_suffix(root, start_len, accepted_len)
+            result.insert_skipped = True
+
+        mamba_node = result.mamba_inserted_node
+        if mamba_node is not None and not self._node_is_on_matched_path(
+            mamba_node, accepted_node
+        ):
+            self._forget_unfinished_component_value(mamba_node, ComponentType.MAMBA)
             result.insert_skipped = True
 
     # ---- Evict Helpers ----

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -843,13 +843,26 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
         new_indices = match_result.device_indices
         new_last_node = match_result.last_device_node
-        new_prefix_len = result.prefix_len
+        self._rollback_unaccepted_unfinished_insert(
+            insert_params=insert_params,
+            result=result,
+            accepted_len=len(new_indices),
+            accepted_node=new_last_node,
+        )
+        if len(new_indices) < req.cache_protected_len:
+            result.insert_skipped = True
+            req.prefix_indices = kv_indices_orig.to(dtype=torch.int64, copy=True)
+            for comp in self._components_tuple:
+                comp.cleanup_after_caching_req(
+                    req,
+                    is_finished=False,
+                    insert_result=result,
+                    insert_params=insert_params,
+                )
+            return
         assert (
             req.cache_protected_len <= len(new_indices) + self.page_size - 1
         ), f"{req.cache_protected_len=}, {len(new_indices)=}, {page_aligned_len=}"
-        assert new_prefix_len <= len(
-            new_indices
-        ), f"{new_prefix_len=}, {len(new_indices)=}"
         for start, overlap_value in insert_params.deferred_overlap_values:
             matched_len = min(len(overlap_value), max(0, len(new_indices) - start))
             if matched_len > 0:
@@ -875,6 +888,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         req.cache_protected_len = len(new_indices)
         req.last_node = new_last_node
         req.swa_uuid_for_lock = lock_result.swa_uuid_for_lock
+        req.swa_prefix_lock_released = False
 
         # cleanup
         for comp in self._components_tuple:
@@ -1123,6 +1137,12 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             node.priority = max(node.priority, priority)
 
             if node.evicted:
+                if params.defer_overlap_free:
+                    return InsertResult(
+                        prefix_len=total_prefix_length,
+                        mamba_exist=True,
+                        insert_skipped=True,
+                    )
                 self._unevict_node_on_insert(node, value[:prefix_len])
                 # FULL was restored from the request's fresh KV. Aux
                 # components (e.g. SWA) may still hold tombstones and need
@@ -1170,6 +1190,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         is_new_leaf = False
         # Create new leaf for remaining suffix
         if len(key):
+            params.created_node_records.append(
+                (total_prefix_length, node, key.child_key(self.page_size))
+            )
             target_node = self._add_new_node(node, key, value, priority=priority)
             is_new_leaf = True
         else:
@@ -1247,6 +1270,97 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         self._update_evictable_leaf_sets(node)
         result.inserted_host_node = new_node
         return result
+
+    def _forget_unfinished_component_value(
+        self, node: UnifiedTreeNode, component_type: ComponentType
+    ) -> None:
+        cd = node.component_data[component_type]
+        if cd.value is None:
+            return
+        assert cd.lock_ref == 0
+        lru = self.lru_lists[component_type]
+        if lru.in_list(node):
+            lru.remove_node(node)
+        self.component_evictable_size_[component_type] -= len(cd.value)
+        cd.value = None
+
+    def _forget_unfinished_subtree_values(self, node: UnifiedTreeNode) -> None:
+        for child in list(node.children.values()):
+            self._forget_unfinished_subtree_values(child)
+
+        for component_type in self.tree_components:
+            self._forget_unfinished_component_value(node, component_type)
+            host_cd = node.component_data[component_type]
+            if host_cd.host_value is not None:
+                host_lru = self.host_lru_lists[component_type]
+                if host_lru.in_list(node):
+                    host_lru.remove_node(node)
+                host_cd.host_value = None
+        self.evictable_device_leaves.discard(node)
+        self.evictable_host_leaves.discard(node)
+        node.children.clear()
+        node.parent = None
+
+    def _single_path_subtree_len(self, node: UnifiedTreeNode) -> int:
+        total_len = len(node.key)
+        while len(node.children) == 1:
+            node = next(iter(node.children.values()))
+            total_len += len(node.key)
+        return total_len
+
+    def _detach_unfinished_subtree(self, node: UnifiedTreeNode) -> None:
+        parent = node.parent
+        assert parent is not None
+        key = node.key.child_key(self.page_size)
+        assert parent.children.get(key) is node
+        parent.children.pop(key)
+        self._forget_unfinished_subtree_values(node)
+        self._update_evictable_leaf_sets(parent)
+
+    def _detach_unaccepted_created_suffix(
+        self,
+        root: UnifiedTreeNode,
+        start_len: int,
+        accepted_len: int,
+    ) -> None:
+        if accepted_len <= start_len:
+            self._detach_unfinished_subtree(root)
+            return
+
+        node = root
+        node_start = start_len
+        while node_start + len(node.key) < accepted_len:
+            assert len(node.children) == 1
+            node_start += len(node.key)
+            node = next(iter(node.children.values()))
+
+        node_end = node_start + len(node.key)
+        if node_end == accepted_len:
+            for child in list(node.children.values()):
+                self._detach_unfinished_subtree(child)
+            self._update_evictable_leaf_sets(node)
+            return
+
+        keep_node = self._split_node(node.key, node, accepted_len - node_start)
+        self._detach_unfinished_subtree(node)
+        self._update_evictable_leaf_sets(keep_node)
+
+    def _rollback_unaccepted_unfinished_insert(
+        self,
+        insert_params: InsertParams,
+        result: InsertResult,
+        accepted_len: int,
+        accepted_node: UnifiedTreeNode,
+    ) -> None:
+        for start_len, parent, child_key in reversed(insert_params.created_node_records):
+            root = parent.children.get(child_key)
+            if root is None:
+                continue
+            created_end = start_len + self._single_path_subtree_len(root)
+            if accepted_len >= created_end:
+                continue
+            self._detach_unaccepted_created_suffix(root, start_len, accepted_len)
+            result.insert_skipped = True
 
     # ---- Evict Helpers ----
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -798,6 +798,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             prev_prefix_len=req.cache_protected_len,
             chunked=chunked,
             priority=getattr(req, "priority", 0) or 0,
+            defer_overlap_free=True,
         )
         effective_cache_len = len(token_ids)
         for comp in self._components_tuple:
@@ -849,6 +850,10 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         assert new_prefix_len <= len(
             new_indices
         ), f"{new_prefix_len=}, {len(new_indices)=}"
+        for start, overlap_value in insert_params.deferred_overlap_values:
+            matched_len = min(len(overlap_value), max(0, len(new_indices) - start))
+            if matched_len > 0:
+                self.token_to_kv_pool_allocator.free(overlap_value[:matched_len])
         self.req_to_token_pool.write(
             (req.req_pool_idx, slice(req.cache_protected_len, len(new_indices))),
             new_indices[req.cache_protected_len :],
@@ -1147,9 +1152,13 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
                 dup_start = max(0, params.prev_prefix_len - total_prefix_length)
                 if dup_start < consumed_from:
-                    self.token_to_kv_pool_allocator.free(
-                        value_slice[dup_start:consumed_from]
-                    )
+                    duplicate_value = value_slice[dup_start:consumed_from]
+                    if params.defer_overlap_free:
+                        params.deferred_overlap_values.append(
+                            (total_prefix_length + dup_start, duplicate_value.clone())
+                        )
+                    else:
+                        self.token_to_kv_pool_allocator.free(duplicate_value)
 
             self._inc_hit_count(node, params.chunked)
             total_prefix_length += prefix_len

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1201,6 +1201,65 @@ class UnifiedRadixCacheSuite:
         tree.dec_lock_ref(node, lock_result.to_dec_params())
         tree.sanity_check()
 
+    def test_swa_unfinished_insert_rolls_back_unaccepted_suffix_after_tombstone(
+        self,
+    ):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        if self.cfg.page_size != 1 or self.cfg.sliding_window_size != 4:
+            self.skipTest("requires page_size=1, sliding_window_size=4")
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+
+        prefix = self._make_seq(1, 4)
+        old_suffix = self._make_seq(100, 1)
+        fresh_suffix = self._make_seq(200, 1)
+        self._insert(tree, allocator, req_to_token_pool, prefix)
+        self._insert(tree, allocator, req_to_token_pool, prefix + old_suffix)
+
+        prefix_node = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", prefix)))
+        ).last_device_node
+        old_child_key = RadixKey(array("q", old_suffix)).child_key(tree.page_size)
+        self.assertIn(old_child_key, prefix_node.children)
+
+        swa_component = tree.components[ComponentType.SWA]
+        tracker = {ct: 0 for ct in tree.tree_components}
+        tree._evict_component_and_detach_lru(prefix_node, swa_component, tracker=tracker)
+        self.assertIsNone(prefix_node.component_data[ComponentType.SWA].value)
+
+        req = self._make_req(req_to_token_pool)
+        tokens = prefix + fresh_suffix
+        req.origin_input_ids = array("q", tokens)
+        req.output_ids = []
+        req.full_untruncated_fill_ids = array("q", tokens)
+        req.set_extend_range(0, len(req.full_untruncated_fill_ids))
+        fresh_value = self._alloc(allocator, len(tokens))
+        req_to_token_pool.write((req.req_pool_idx, slice(0, len(tokens))), fresh_value)
+        req.kv_committed_len = len(tokens)
+        req.last_node = tree.root_node
+        req.cache_protected_len = 0
+        req.swa_uuid_for_lock = None
+        req.extra_key = None
+        req.swa_evicted_seqlen = 0
+
+        full_available_before = allocator.full_attn_allocator.available_size()
+
+        tree.cache_unfinished_req(req)
+
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(), full_available_before
+        )
+        self.assertEqual(req.cache_protected_len, 0)
+        self.assertEqual(req.prefix_indices.tolist(), fresh_value.tolist())
+        self.assertIn(old_child_key, prefix_node.children)
+        self.assertNotIn(
+            RadixKey(array("q", fresh_suffix)).child_key(tree.page_size),
+            prefix_node.children,
+        )
+        self.assertIsNone(prefix_node.component_data[ComponentType.SWA].value)
+
+        tree.sanity_check()
+
     def test_diagnostics(self):
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
         self._insert(tree, allocator, req_to_token_pool, self._make_seq(1, 2))

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1098,6 +1098,54 @@ class UnifiedRadixCacheSuite:
         self.assertIsNone(node.component_data[ComponentType.SWA].value)
         tree.sanity_check()
 
+    def test_swa_overlap_recovery_preserves_locked_full_value(self):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        if self.cfg.page_size != 1 or self.cfg.sliding_window_size != 4:
+            self.skipTest("requires page_size=1, sliding_window_size=4")
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+
+        tokens = self._make_seq(1, 4)
+        self._insert(tree, allocator, req_to_token_pool, tokens)
+        self._insert(tree, allocator, req_to_token_pool, tokens + self._make_seq(100, 1))
+
+        node = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", tokens)))
+        ).last_device_node
+        old_full_value = node.component_data[ComponentType.FULL].value.clone()
+        swa_component = tree.components[ComponentType.SWA]
+        tracker = {ct: 0 for ct in tree.tree_components}
+        tree._evict_component_and_detach_lru(node, swa_component, tracker=tracker)
+        self.assertIsNone(node.component_data[ComponentType.SWA].value)
+
+        lock_result = tree.inc_lock_ref(node)
+        fresh_value = self._alloc(allocator, len(tokens))
+        full_available_before_insert = allocator.full_attn_allocator.available_size()
+
+        tree.insert(
+            InsertParams(
+                key=RadixKey(array("q", tokens)),
+                value=fresh_value,
+                prev_prefix_len=0,
+                swa_evicted_seqlen=0,
+            )
+        )
+
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(),
+            full_available_before_insert + len(tokens),
+        )
+        self.assertTrue(
+            torch.equal(
+                node.component_data[ComponentType.FULL].value,
+                old_full_value,
+            )
+        )
+        self.assertIsNone(node.component_data[ComponentType.SWA].value)
+
+        tree.dec_lock_ref(node, lock_result.to_dec_params())
+        tree.sanity_check()
+
     def test_diagnostics(self):
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
         self._insert(tree, allocator, req_to_token_pool, self._make_seq(1, 2))

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1027,6 +1027,47 @@ class UnifiedRadixCacheSuite:
         )
         tree.sanity_check()
 
+    def test_swa_unfinished_req_preserves_existing_eviction_boundary(self):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        if self.cfg.page_size != 1 or self.cfg.sliding_window_size != 4:
+            self.skipTest("requires page_size=1, sliding_window_size=4")
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+
+        req = self._make_req(req_to_token_pool)
+        tokens = self._make_seq(1, 8)
+        evicted_len = 4
+        req.origin_input_ids = array("q", tokens)
+        req.output_ids = []
+        req.full_untruncated_fill_ids = array("q", tokens)
+        req.set_extend_range(0, len(req.full_untruncated_fill_ids))
+        kv_indices = self._alloc(allocator, len(tokens))
+        req_to_token_pool.write((req.req_pool_idx, slice(0, len(tokens))), kv_indices)
+        req.kv_committed_len = len(tokens)
+        req.last_node = tree.root_node
+        req.cache_protected_len = 0
+        req.swa_uuid_for_lock = None
+        req.extra_key = None
+        req.swa_evicted_seqlen = evicted_len
+
+        tree.cache_unfinished_req(req)
+
+        first = next(iter(tree.root_node.children.values()))
+        self.assertEqual(len(first.key), evicted_len)
+        self.assertIsNone(first.component_data[ComponentType.SWA].value)
+        live = next(iter(first.children.values()))
+        self.assertEqual(len(live.key), len(tokens) - evicted_len)
+        self.assertIsNotNone(live.component_data[ComponentType.SWA].value)
+
+        m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", tokens))))
+        self.assertEqual(len(m.device_indices), len(tokens))
+
+        tree.dec_lock_ref(
+            req.last_node,
+            DecLockRefParams(swa_uuid_for_lock=getattr(req, "swa_uuid_for_lock", None)),
+        )
+        tree.sanity_check()
+
     def test_diagnostics(self):
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
         self._insert(tree, allocator, req_to_token_pool, self._make_seq(1, 2))

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -85,6 +85,7 @@ class CacheConfig:
 
     # Mamba
     enable_mamba_extra_buffer: bool = False
+    enable_mamba_extra_buffer_lazy: bool = False
     mamba_cache_size: int = 20
     mamba_intermediate_size: int = 256
     mamba_n_groups: int = 1
@@ -130,6 +131,8 @@ class CacheConfig:
             parts.append(f"h{self.head_num}l{self.num_layers}")
         if self.is_eagle:
             parts.append("eagle")
+        if self.enable_mamba_extra_buffer_lazy:
+            parts.append("mamba_lazy")
         return "_".join(parts)
 
 
@@ -248,6 +251,7 @@ def build_fixture(cfg: CacheConfig, *, enable_kv_cache_events: bool = False):
             cache_params=mamba2_cache_params,
             mamba_layer_ids=cfg.non_full_layer_ids,
             enable_mamba_extra_buffer=cfg.enable_mamba_extra_buffer,
+            enable_mamba_extra_buffer_lazy=cfg.enable_mamba_extra_buffer_lazy,
             speculative_num_draft_tokens=3,
         )
     else:
@@ -327,6 +331,7 @@ def build_fixture(cfg: CacheConfig, *, enable_kv_cache_events: bool = False):
         sliding_window_size=cfg.sliding_window_size,
         tree_components=cfg.components,
         enable_mamba_extra_buffer=cfg.enable_mamba_extra_buffer,
+        enable_mamba_extra_buffer_lazy=cfg.enable_mamba_extra_buffer_lazy,
         enable_kv_cache_events=enable_kv_cache_events,
         eviction_policy=cfg.eviction_policy,
         is_eagle=cfg.is_eagle,
@@ -335,6 +340,85 @@ def build_fixture(cfg: CacheConfig, *, enable_kv_cache_events: bool = False):
     tree.cache_init_params = cache_init_params
 
     return tree, allocator, req_to_token_pool
+
+
+class TestUnifiedRadixCacheLazyMambaRollback(CustomTestCase):
+    cfg = CacheConfig(
+        page_size=1,
+        components=(ComponentType.FULL, ComponentType.SWA, ComponentType.MAMBA),
+        sliding_window_size=128,
+        enable_mamba_extra_buffer=True,
+        enable_mamba_extra_buffer_lazy=True,
+        mamba_cache_size=60,
+        head_num=8,
+        num_layers=32,
+        full_attention_layer_ids=(7, 15, 23, 31),
+        kv_size=1024,
+        max_context_len=1024,
+    )
+    _rid = 0
+
+    def _make_req(self, req_to_token_pool):
+        sp = SamplingParams(temperature=0, max_new_tokens=1)
+        req = Req(
+            rid=self._rid,
+            origin_input_text="",
+            origin_input_ids=array("q"),
+            sampling_params=sp,
+        )
+        self._rid += 1
+        req_to_token_pool.alloc([req])
+        return req
+
+    def _fill_mamba_state(self, req_to_token_pool, indices, marker):
+        mamba_indices = indices.reshape(-1)
+        mamba_cache = req_to_token_pool.mamba_pool.mamba_cache
+        mamba_cache.temporal[:, mamba_indices] = marker
+        for offset, conv_buf in enumerate(mamba_cache.conv, start=1):
+            conv_buf[:, mamba_indices] = marker + offset
+
+    def _snapshot_mamba_state(self, req_to_token_pool, indices):
+        mamba_indices = indices.reshape(-1)
+        mamba_cache = req_to_token_pool.mamba_pool.mamba_cache
+        return (
+            mamba_cache.temporal[:, mamba_indices].float().cpu().clone(),
+            [conv[:, mamba_indices].float().cpu().clone() for conv in mamba_cache.conv],
+        )
+
+    def test_lazy_copy_back_uses_keep_slot(self):
+        tree, _, req_to_token_pool = build_fixture(self.cfg)
+        req = self._make_req(req_to_token_pool)
+
+        keep_idx = req_to_token_pool.get_mamba_ping_pong_keep_idx(req)
+        other_idx = req_to_token_pool.get_mamba_ping_pong_other_idx(
+            req.mamba_next_track_idx
+        )
+        keep_slot = req.mamba_ping_pong_track_buffer[keep_idx].unsqueeze(0)
+        self.assertNotEqual(keep_idx, other_idx)
+        self.assertEqual(int(req.mamba_ping_pong_track_buffer[other_idx].item()), -1)
+
+        source_slot = req_to_token_pool.mamba_allocator.alloc(1)
+        self.assertIsNotNone(source_slot)
+        self._fill_mamba_state(req_to_token_pool, keep_slot, marker=7)
+        self._fill_mamba_state(req_to_token_pool, source_slot, marker=41)
+        expected_temporal, expected_conv = self._snapshot_mamba_state(
+            req_to_token_pool, source_slot
+        )
+
+        mamba_component = tree.components[ComponentType.MAMBA]
+        self.assertEqual(
+            int(mamba_component._request_mamba_slot(req).item()),
+            int(keep_slot.item()),
+        )
+        mamba_component._copy_mamba_state_to_request(req, source_slot)
+
+        actual_temporal, actual_conv = self._snapshot_mamba_state(
+            req_to_token_pool, keep_slot
+        )
+        self.assertTrue(torch.equal(actual_temporal, expected_temporal))
+        for actual, expected in zip(actual_conv, expected_conv):
+            self.assertTrue(torch.equal(actual, expected))
+        self.assertEqual(int(req.mamba_ping_pong_track_buffer[other_idx].item()), -1)
 
 
 class TestUnifiedRadixCacheEagleHiCacheStorageKey(CustomTestCase):
@@ -1204,10 +1288,10 @@ class UnifiedRadixCacheSuite:
     def test_swa_unfinished_insert_rolls_back_unaccepted_suffix_after_tombstone(
         self,
     ):
-        if not self.cfg.has_swa or self.cfg.has_mamba:
-            self.skipTest("requires SWA without Mamba")
-        if self.cfg.page_size != 1 or self.cfg.sliding_window_size != 4:
-            self.skipTest("requires page_size=1, sliding_window_size=4")
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA")
+        if self.cfg.page_size != 1:
+            self.skipTest("requires page_size=1")
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
 
         prefix = self._make_seq(1, 4)
@@ -1242,6 +1326,20 @@ class UnifiedRadixCacheSuite:
         req.extra_key = None
         req.swa_evicted_seqlen = 0
 
+        if self.cfg.has_mamba:
+            req.mamba_last_track_seqlen = len(tokens)
+            if self.cfg.enable_mamba_extra_buffer:
+                keep_idx = req_to_token_pool.get_mamba_ping_pong_keep_idx(req)
+                original_mamba_slot = req.mamba_ping_pong_track_buffer[
+                    keep_idx
+                ].unsqueeze(0)
+            else:
+                original_mamba_slot = req.mamba_pool_idx.unsqueeze(0)
+            self._fill_mamba_state(req_to_token_pool, original_mamba_slot, marker=41)
+            expected_temporal, expected_conv = self._snapshot_mamba_state(
+                req_to_token_pool, original_mamba_slot
+            )
+
         full_available_before = allocator.full_attn_allocator.available_size()
 
         tree.cache_unfinished_req(req)
@@ -1257,6 +1355,21 @@ class UnifiedRadixCacheSuite:
             prefix_node.children,
         )
         self.assertIsNone(prefix_node.component_data[ComponentType.SWA].value)
+
+        if self.cfg.has_mamba:
+            if self.cfg.enable_mamba_extra_buffer:
+                keep_idx = req_to_token_pool.get_mamba_ping_pong_keep_idx(req)
+                current_mamba_slot = req.mamba_ping_pong_track_buffer[
+                    keep_idx
+                ].unsqueeze(0)
+            else:
+                current_mamba_slot = req.mamba_pool_idx.unsqueeze(0)
+            actual_temporal, actual_conv = self._snapshot_mamba_state(
+                req_to_token_pool, current_mamba_slot
+            )
+            self.assertTrue(torch.equal(actual_temporal, expected_temporal))
+            for actual, expected in zip(actual_conv, expected_conv):
+                self.assertTrue(torch.equal(actual, expected))
 
         tree.sanity_check()
 
@@ -1445,10 +1558,20 @@ class UnifiedRadixCacheSuite:
         if not self.cfg.has_mamba:
             self.skipTest("requires Mamba component")
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
-        mamba_pool = req_to_token_pool.mamba_pool
 
         seq = self._make_seq(1, 2)
         self._insert(tree, allocator, req_to_token_pool, seq)
+        source = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", seq)))
+        ).last_device_node
+        src_value = source.component_data[ComponentType.MAMBA].value
+        self._fill_mamba_state(req_to_token_pool, src_value, marker=11)
+        expected_temporal, expected_conv = self._snapshot_mamba_state(
+            req_to_token_pool, src_value
+        )
+        full_protected_before = tree.full_protected_size()
+        swa_protected_before = tree.swa_protected_size()
+        mamba_protected_before = tree.mamba_protected_size()
 
         req2 = self._make_req(req_to_token_pool)
         m = tree.match_prefix(
@@ -1456,14 +1579,17 @@ class UnifiedRadixCacheSuite:
         )
         self.assertEqual(len(m.device_indices), len(seq))
         self.assertIsNotNone(req2.mamba_pool_idx)
-
-        src_value = m.last_device_node.component_data[ComponentType.MAMBA].value
-        self.assertTrue(
-            torch.all(
-                mamba_pool.mamba_cache.conv[0][:, req2.mamba_pool_idx]
-                == mamba_pool.mamba_cache.conv[0][:, src_value]
-            )
+        self.assertTrue(torch.equal(req2.mamba_cow_src_index, src_value))
+        self.assertFalse(req2.mamba_needs_clear)
+        self.assertEqual(tree.full_protected_size(), full_protected_before)
+        self.assertEqual(tree.swa_protected_size(), swa_protected_before)
+        self.assertEqual(tree.mamba_protected_size(), mamba_protected_before)
+        actual_temporal, actual_conv = self._snapshot_mamba_state(
+            req_to_token_pool, src_value
         )
+        self.assertTrue(torch.equal(actual_temporal, expected_temporal))
+        for actual, expected in zip(actual_conv, expected_conv):
+            self.assertTrue(torch.equal(actual, expected))
         tree.sanity_check()
 
     def test_swa_insert_and_match(self):
@@ -3051,9 +3177,9 @@ class UnifiedRadixCacheSuite:
             return
         mamba_indices = indices.reshape(-1)
         mamba_cache = req_to_token_pool.mamba_pool.mamba_cache
-        mamba_cache.temporal[:, mamba_indices].fill_(marker)
+        mamba_cache.temporal[:, mamba_indices] = marker
         for offset, conv_buf in enumerate(mamba_cache.conv, start=1):
-            conv_buf[:, mamba_indices].fill_(marker + offset)
+            conv_buf[:, mamba_indices] = marker + offset
 
     def _snapshot_mamba_state(self, req_to_token_pool, indices):
         mamba_indices = indices.reshape(-1)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1068,6 +1068,36 @@ class UnifiedRadixCacheSuite:
         )
         tree.sanity_check()
 
+    def test_swa_insert_keeps_full_leaf_when_entire_span_is_outside_window(self):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        if self.cfg.page_size != 1 or self.cfg.sliding_window_size != 4:
+            self.skipTest("requires page_size=1, sliding_window_size=4")
+        tree, allocator, _ = build_fixture(self.cfg)
+
+        tokens = self._make_seq(1, 4)
+        value = self._alloc(allocator, len(tokens))
+        full_available_before = allocator.full_attn_allocator.available_size()
+
+        tree.insert(
+            InsertParams(
+                key=RadixKey(array("q", tokens)),
+                value=value,
+                prev_prefix_len=0,
+                swa_evicted_seqlen=len(tokens),
+            )
+        )
+
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(), full_available_before
+        )
+        node = next(iter(tree.root_node.children.values()))
+        self.assertTrue(
+            torch.equal(node.component_data[ComponentType.FULL].value, value)
+        )
+        self.assertIsNone(node.component_data[ComponentType.SWA].value)
+        tree.sanity_check()
+
     def test_diagnostics(self):
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
         self._insert(tree, allocator, req_to_token_pool, self._make_seq(1, 2))

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1146,6 +1146,61 @@ class UnifiedRadixCacheSuite:
         tree.dec_lock_ref(node, lock_result.to_dec_params())
         tree.sanity_check()
 
+    def test_swa_unfinished_req_preserves_fresh_overlap_when_locked_tombstone_rejects_match(
+        self,
+    ):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        if self.cfg.page_size != 1 or self.cfg.sliding_window_size != 4:
+            self.skipTest("requires page_size=1, sliding_window_size=4")
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+
+        tokens = self._make_seq(1, 4)
+        self._insert(tree, allocator, req_to_token_pool, tokens)
+        self._insert(tree, allocator, req_to_token_pool, tokens + self._make_seq(100, 1))
+
+        node = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", tokens)))
+        ).last_device_node
+        old_full_value = node.component_data[ComponentType.FULL].value.clone()
+        swa_component = tree.components[ComponentType.SWA]
+        tracker = {ct: 0 for ct in tree.tree_components}
+        tree._evict_component_and_detach_lru(node, swa_component, tracker=tracker)
+        lock_result = tree.inc_lock_ref(node)
+
+        req = self._make_req(req_to_token_pool)
+        req.origin_input_ids = array("q", tokens)
+        req.output_ids = []
+        req.full_untruncated_fill_ids = array("q", tokens)
+        req.set_extend_range(0, len(req.full_untruncated_fill_ids))
+        fresh_value = self._alloc(allocator, len(tokens))
+        req_to_token_pool.write((req.req_pool_idx, slice(0, len(tokens))), fresh_value)
+        req.kv_committed_len = len(tokens)
+        req.last_node = tree.root_node
+        req.cache_protected_len = 0
+        req.swa_uuid_for_lock = None
+        req.extra_key = None
+        req.swa_evicted_seqlen = 0
+        full_available_before = allocator.full_attn_allocator.available_size()
+
+        tree.cache_unfinished_req(req)
+
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(), full_available_before
+        )
+        self.assertEqual(req.cache_protected_len, 0)
+        self.assertEqual(req.prefix_indices.tolist(), fresh_value.tolist())
+        self.assertTrue(
+            torch.equal(
+                node.component_data[ComponentType.FULL].value,
+                old_full_value,
+            )
+        )
+        self.assertIsNone(node.component_data[ComponentType.SWA].value)
+
+        tree.dec_lock_ref(node, lock_result.to_dec_params())
+        tree.sanity_check()
+
     def test_diagnostics(self):
         tree, allocator, req_to_token_pool = build_fixture(self.cfg)
         self._insert(tree, allocator, req_to_token_pool, self._make_seq(1, 2))


### PR DESCRIPTION
## Motivation
This PR fixes several unified-cache consistency bugs around unfinished request insertion, SWA eviction boundaries, and Mamba state ownership.

`cache_unfinished_req` inserts partial KV during chunked prefill, then immediately calls `match_prefix` to decide what prefix is actually reusable. In unified cache, these two paths use different criteria:
  - `insert` follows token-ID overlap and may create nodes, update component values, and transfer KV ownership.
  - `match_prefix` also requires valid `Full` / `SWA` / `Mamba` component state.

That means an unfinished insert can modify cache state that the follow-up match later rejects. The fixes here make that path transactional: provisional changes are only kept for the accepted prefix, and rejected state is rolled back.


## Modifications
Unfinished inserts now preserve SWA eviction metadata, defer unsafe overlap frees, record newly-created nodes/component state, run the follow-up prefix match, and then roll back the part that was not accepted.

This PR also fixes adjacent SWA/Mamba consistency issues exposed by the same path:
- SWA tombstones should not prevent Full KV leaf creation.
- SWA recovery must not overwrite locked Full KV.
- donated Mamba state must be restored if a provisional insert is rejected.
- stale Mamba COW metadata must be cleared when a rematch has no donor.

The commits are intentionally kept fine-grained: each commit corresponds to one cache consistency bug and its targeted regression coverage.

### Bugs & Fixes

#### Bug 0: unfinished inserts dropped the existing SWA eviction boundary
- **Root cause:** `SWA.prepare_for_caching_req(...)` only copied `req.swa_evicted_seqlen` for finished inserts. 
    - Unfinished requests can also have an SWA-evicted prefix, so using the default boundary `0` loses the distinction between live SWA KV and SWA tombstones
- **Fix:** Always copy `req.swa_evicted_seqlen` into `InsertParams`, including on unfinished inserts.
- **Commit:** 9329829d1d

#### Bug 1: SWA could prevent creation of a valid Full KV leaf
- **Root cause:** `SWA.should_skip_leaf_creation(...)` could veto leaf creation when the new leaf was fully outside the SWA window. That decision is valid only for SWA data; the Full KV leaf is still valid and should remain cacheable.
- **Fix:** Remove the SWA leaf-creation veto path. Full KV creates the leaf, while SWA leaves the component value as a tombstone when the leaf is outside the SWA window.
- **Commit:** 00bab67a45

#### Bug 2: `SWA` recovery could overwrite locked Full KV
- **Root cause:** SWA tombstone recovery could free/replace the node's Full KV without checking whether the Full component was still locked by an active request.
- **Fix:** If `Full.lock_ref > 0`, skip SWA recovery instead of replacing locked Full KV.
- **Commit:** 5671075dcd

#### Bug 3: overlap KV could be freed before rematch accepted it
- **Root cause:** `_insert_helper` freed duplicate overlap KV immediately. On the unfinished insert path, this happens before `cache_unfinished_req` knows how much of the inserted prefix the follow-up `match_prefix` will accept.
- **Fix:** Add `defer_overlap_free` / `deferred_overlap_values`; on unfinished inserts, free only the overlap that is inside the rematch-accepted prefix.
- **Commit:** 79fa16561a

#### Bug 4: rejected suffix nodes could remain in the tree
- **Root cause:** `_insert_helper` could create suffix nodes that the follow-up `match_prefix` rejected because required component state was missing or tombstoned. Those nodes were left in the radix tree even though the request did not accept them.
- **Fix:** Add `created_node_records` and rollback helpers to detach created suffix nodes beyond the accepted prefix.
- **Commit:** 75753e4386

#### Bug 5: Mamba state could be donated to a rejected node
- **Root cause:** Unfinished insert can donate request-owned Mamba state to the tree. If the follow-up match rejects that inserted node, the tree must not keep the state and the request still needs it. Lazy Mamba extra-buffer mode also requires restoring into the keep slot, not the unallocated other slot.
- **Fix:** Track `mamba_inserted_node`; if it is not on the accepted path, remove its tree value, copy the donated state back to the request slot, and clean up the donated cache state.
- **Commit:** 044ce65dca

#### Bug 6: stale Mamba COW source could survive a rematch with no donor
- **Root cause:** A queued request can keep `mamba_cow_src_index` from an earlier match. If a later rematch with `cow_mamba=True` finds no Mamba donor, the stale source can point at evicted or freed Mamba state.
- **Fix:** When rematch has no valid donor, clear the stale COW source and mark the request for zero-clear if it already owns a Mamba slot.
- **Commit:** f47963f9f4







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28208642920](https://github.com/sgl-project/sglang/actions/runs/28208642920)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28208642804](https://github.com/sgl-project/sglang/actions/runs/28208642804)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->