### PR TITLE
[spec] Stop draft workers from clobbering the global server_args

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -526,7 +526,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.model_specific_adjustment()
 
         # Set the global server_args in the scheduler process
-        self.maybe_init_global_server_args(server_args)
+        self.init_global_server_args(server_args)
 
         # Init OpenMP threads binding for CPU
         if self.device == "cpu":
@@ -603,6 +603,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # For weight updates
         self._model_update_group = {}
         self._weights_send_group = {}
+
+        # Restore the target's global server_args (no-op for a target runner).
+        self.maybe_restore_global_server_args()
 
     def _build_model_config(
         self, server_args, model_path=None, model_revision=None, is_draft_model=False
@@ -1156,14 +1159,23 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     f"You can fix this by setting arguments `--tp` and `--ep` correctly."
                 )
 
-    def maybe_init_global_server_args(self, server_args: ServerArgs):
-        # Draft workers share the process with their target and must not clobber
-        # the global server_args with their own (possibly mutated) copy.
+    def init_global_server_args(self, server_args: ServerArgs):
+        # The global server_args is a process-wide singleton read during
+        # construction (initialize/capturers) and at runtime. A draft worker
+        # shares the process with its target and may be built from a mutated
+        # copy (DFLASH deep-copies and overrides the draft attention backend and
+        # context length), so it must read its own args while constructing but
+        # leave the target's args installed afterwards. Save the target's args
+        # here and restore them in maybe_restore_global_server_args().
         if self.is_draft_worker:
-            return
+            self._prev_global_server_args = get_global_server_args()
         set_global_server_args_for_scheduler(server_args)
         # FIXME: hacky set `use_mla_backend`
         get_global_server_args().use_mla_backend = self.use_mla_backend
+
+    def maybe_restore_global_server_args(self):
+        if self.is_draft_worker:
+            set_global_server_args_for_scheduler(self._prev_global_server_args)
 
     def init_torch_distributed(self):
         tic = time.perf_counter()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -526,11 +526,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.model_specific_adjustment()
 
         # Set the global server_args in the scheduler process
-        set_global_server_args_for_scheduler(server_args)
-        global_server_args = get_global_server_args()
-
-        # FIXME: hacky set `use_mla_backend`
-        global_server_args.use_mla_backend = self.use_mla_backend
+        self.maybe_init_global_server_args(server_args)
 
         # Init OpenMP threads binding for CPU
         if self.device == "cpu":
@@ -1159,6 +1155,15 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     f"where moe_tp_size is equal to tp_size ({self.tp_size}) divided by ep_size ({self.moe_ep_size}). "
                     f"You can fix this by setting arguments `--tp` and `--ep` correctly."
                 )
+
+    def maybe_init_global_server_args(self, server_args: ServerArgs):
+        # Draft workers share the process with their target and must not clobber
+        # the global server_args with their own (possibly mutated) copy.
+        if self.is_draft_worker:
+            return
+        set_global_server_args_for_scheduler(server_args)
+        # FIXME: hacky set `use_mla_backend`
+        get_global_server_args().use_mla_backend = self.use_mla_backend
 
     def init_torch_distributed(self):
         tic = time.perf_counter()

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -15,11 +15,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     compute_position,
 )
-from sglang.srt.server_args import (
-    ServerArgs,
-    get_global_server_args,
-    set_global_server_args_for_scheduler,
-)
+from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
@@ -143,7 +139,6 @@ class DFlashWorkerV2(BaseSpecWorker):
         draft_server_args.context_length = (
             target_worker.model_runner.model_config.context_len
         )
-        saved_server_args = get_global_server_args()
         self._draft_worker = TpModelWorker(
             server_args=draft_server_args,
             gpu_id=gpu_id,
@@ -156,7 +151,6 @@ class DFlashWorkerV2(BaseSpecWorker):
             nccl_port=nccl_port,
             is_draft_worker=True,
         )
-        set_global_server_args_for_scheduler(saved_server_args)
         self.draft_model_runner = self._draft_worker.model_runner
         # Keep the same alias that other spec-v2 workers expose.
         self._draft_worker.draft_runner = self.draft_model_runner

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -1,6 +1,6 @@
 import logging
 
-from sglang.srt.server_args import ServerArgs, get_global_server_args
+from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import is_blackwell, is_hip, is_musa, is_npu
 
 logger = logging.getLogger(__name__)
@@ -118,7 +118,7 @@ class DraftBackendFactory:
         return DeepseekSparseAttnBackend(self.draft_model_runner, skip_prefill=False)
 
     def _create_flashinfer_decode_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             from sglang.srt.layers.attention.flashinfer_backend import (
                 FlashInferMultiStepDraftBackend,
             )
@@ -193,7 +193,7 @@ class DraftBackendFactory:
         )
 
     def _create_trtllm_mla_decode_backend(self, backend: str = "trtllm-gen"):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             raise ValueError(
                 "trtllm_mla backend requires MLA model (use_mla_backend=True)."
             )
@@ -213,7 +213,7 @@ class DraftBackendFactory:
         return self._create_trtllm_mla_decode_backend(backend="cute-dsl")
 
     def _create_tokenspeed_mla_decode_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             raise ValueError(
                 "tokenspeed_mla backend requires MLA model (use_mla_backend=True)."
             )
@@ -254,7 +254,7 @@ class DraftBackendFactory:
         )
 
     def _create_flashinfer_prefill_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             from sglang.srt.layers.attention.flashinfer_backend import (
                 FlashInferAttnBackend,
             )
@@ -302,7 +302,7 @@ class DraftBackendFactory:
         return TRTLLMHAAttnBackend(self.draft_model_runner, skip_prefill=False)
 
     def _create_trtllm_mla_prefill_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             raise ValueError(
                 "trtllm_mla backend requires MLA model (use_mla_backend=True)."
             )
@@ -312,7 +312,7 @@ class DraftBackendFactory:
         return TRTLLMMLABackend(self.draft_model_runner, skip_prefill=False)
 
     def _create_tokenspeed_mla_prefill_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             raise ValueError(
                 "tokenspeed_mla backend requires MLA model (use_mla_backend=True)."
             )


### PR DESCRIPTION
## Motivation

`ModelRunner.__init__` writes a process-global `server_args`
(`set_global_server_args_for_scheduler`), read both during construction
(`initialize()` → `torchao_config`, `init_*_capturer()` → `enable_return_*`) and
at runtime (`use_mla_backend` via `cp_utils`, `draft_utils`, …). A **draft worker**
for speculative decoding runs in the same process as its target and clobbers that
global with its own `ServerArgs`.

EAGLE gets away with this because it passes the *same* `ServerArgs` object to its
draft worker. DFLASH passes a deepcopied/mutated copy (different attention backend,
context length), so it wrapped draft-worker construction in a save/restore dance:

```python
saved_server_args = get_global_server_args()
self._draft_worker = TpModelWorker(server_args=draft_server_args, ...)
set_global_server_args_for_scheduler(saved_server_args)
```

## Changes

- **`model_runner.py`**: centralize the dance into `ModelRunner`. A draft runner
  installs its own args for the duration of construction (so every in-construction
  read still sees its own config) via `init_global_server_args`, then restores the
  target's args at the end of `__init__` via `maybe_restore_global_server_args`.
  No-op for a target runner.
- **`dflash_worker_v2.py`**: drop the now-redundant external save/restore.
- **`draft_utils.py`**: `DraftBackendFactory` selected the draft's attention backend
  via `get_global_server_args().use_mla_backend`; read
  `self.draft_model_runner.use_mla_backend` directly instead — a per-runner property
  belongs to the runner, not a process global.

## Net effect

Behavior-preserving relative to `main` for both EAGLE and DFLASH — the global
state seen during construction and at runtime is unchanged; DFLASH's save/restore
is simply moved out of the spec worker and into `ModelRunner`, so any future draft
worker built from a mutated `ServerArgs` is handled automatically. No change for
non-speculative runs.

## Checklist

- [x] Pre-commit hooks pass (isort/ruff/black/codespell).
- [ ] Spec-v2 e2e (EAGLE + DFLASH) on GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28210743272](https://github.com/sgl-project/sglang/actions/runs/28210743272)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28210743217](https://github.com/sgl-project/sglang/actions/runs/28210743217)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->