### PR TITLE
fix(bench): pass DCP_RANK/DCP_WORLD_SIZE to set_mla_kv_buffer_kernel

### DIFF
--- a/test/registered/jit/benchmark/bench_set_mla_kv_buffer.py
+++ b/test/registered/jit/benchmark/bench_set_mla_kv_buffer.py
@@ -48,6 +48,8 @@ def _triton_baseline(kv_buffer, loc, cache_k_nope, cache_k_rope):
         nope_dim,
         rope_dim,
         BLOCK=BLOCK,
+        DCP_RANK=0,
+        DCP_WORLD_SIZE=1,
         **pdl_kwargs,
     )
 


### PR DESCRIPTION
## Summary
- `set_mla_kv_buffer_kernel` gained two `tl.constexpr` parameters (`DCP_RANK`, `DCP_WORLD_SIZE`) in #14194, but `bench_set_mla_kv_buffer.py::_triton_baseline` calls the kernel directly and was not updated.
- jit-kernel-benchmark CI fails with `TypeError: dynamic_func() missing 2 required positional arguments: 'DCP_RANK' and 'DCP_WORLD_SIZE'` (e.g. https://github.com/sgl-project/sglang/actions/runs/28205020964/job/83554428992).
- Pass `DCP_RANK=0, DCP_WORLD_SIZE=1` — the benchmark runs single-process where DCP is always disabled, matching what `get_attention_dcp_rank()` / `get_attention_dcp_world_size()` return in that case.

## Test plan
- [x] `python3 test/registered/jit/benchmark/bench_set_mla_kv_buffer.py` runs to completion locally and prints the perf table.
- [ ] jit-kernel-benchmark CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28210174240](https://github.com/sgl-project/sglang/actions/runs/28210174240)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28210174174](https://github.com/sgl-project/sglang/actions/runs/28210174174)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->