### PR TITLE
[diffusion] Document VAE decode parallel group axes

### DIFF
--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -69,6 +69,7 @@ _DP: GroupCoordinator | None = None
 _VAE_DECODE: GroupCoordinator | None = None
 _DIT: ProcessGroup | None = None
 _VAE: ProcessGroup | None = None
+_VAE_DECODE_PARALLEL_AXES = "tp-sp-pp-cfg"
 
 TensorMetadata = namedtuple("TensorMetadata", ["device", "dtype", "size"])
 
@@ -199,6 +200,14 @@ def init_parallel_group_coordinator(
                 )
             ),
         )
+
+
+def _get_vae_decode_group_ranks(
+    rank_generator: RankGenerator,
+) -> list[list[int]]:
+    # VAE decode happens after each DP replica owns a different request result.
+    # Decode can shard one request across TP/SP/PP/CFG ranks, but must not cross DP.
+    return rank_generator.get_ranks(_VAE_DECODE_PARALLEL_AXES)
 
 
 def get_tp_group() -> GroupCoordinator:
@@ -461,7 +470,7 @@ def initialize_model_parallel(
     global _VAE_DECODE
     assert _VAE_DECODE is None, "VAE decode parallel group is already initialized"
     _VAE_DECODE = init_parallel_group_coordinator(
-        group_ranks=rank_generator.get_ranks("tp-sp-pp-cfg"),
+        group_ranks=_get_vae_decode_group_ranks(rank_generator),
         local_rank=get_world_group().local_rank,
         backend=backend,
         parallel_mode="vae_decode",

--- a/python/sglang/multimodal_gen/test/unit/test_vae_spatial_parallel_decode.py
+++ b/python/sglang/multimodal_gen/test/unit/test_vae_spatial_parallel_decode.py
@@ -255,7 +255,7 @@ class TestVAESpatialParallelDecode(unittest.TestCase):
         )
 
         self.assertEqual(
-            rank_generator.get_ranks("tp-sp-pp-cfg"),
+            parallel_state._get_vae_decode_group_ranks(rank_generator),
             [list(range(0, 8)), list(range(8, 16))],
         )
 


### PR DESCRIPTION
## Summary

- name the VAE decode parallel axes used by the dedicated decode group
- document why VAE decode can span TP/SP/PP/CFG ranks but must not cross DP ranks
- make the existing unit test use the same helper instead of duplicating the raw axes string


## Testing

- pre-commit run --files python/sglang/multimodal_gen/runtime/distributed/parallel_state.py python/sglang/multimodal_gen/test/unit/test_vae_spatial_parallel_decode.py











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28213327089](https://github.com/sgl-project/sglang/actions/runs/28213327089)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28213327001](https://github.com/sgl-project/sglang/actions/runs/28213327001)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->