### PR TITLE
Clean up full KV for SWA tombstone leaves

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache_components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/full_component.py
@@ -143,11 +143,11 @@ class FullComponent(TreeComponent):
             _, x = heapq.heappop(heap)
             if x not in self.cache.evictable_device_leaves:
                 continue
-            self.cache._evict_device_leaf(x, tracker)
-            if x.parent is not None and x.parent in self.cache.evictable_device_leaves:
+            parent = self.cache._evict_device_leaf(x, tracker)
+            if parent is not None and parent in self.cache.evictable_device_leaves:
                 heapq.heappush(
                     heap,
-                    (self.cache.eviction_strategy.get_priority(x.parent), x.parent),
+                    (self.cache.eviction_strategy.get_priority(parent), parent),
                 )
 
     def drive_host_eviction(
@@ -164,11 +164,11 @@ class FullComponent(TreeComponent):
             _, x = heapq.heappop(heap)
             if x not in self.cache.evictable_host_leaves:
                 continue
-            self.cache._evict_host_leaf(x, tracker)
-            if x.parent is not None and x.parent in self.cache.evictable_host_leaves:
+            parent = self.cache._evict_host_leaf(x, tracker)
+            if parent in self.cache.evictable_host_leaves:
                 heapq.heappush(
                     heap,
-                    (self.cache.eviction_strategy.get_priority(x.parent), x.parent),
+                    (self.cache.eviction_strategy.get_priority(parent), parent),
                 )
 
     def acquire_component_lock(

--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -545,6 +545,8 @@ class MambaComponent(TreeComponent):
             if x in self.cache.evictable_host_leaves:
                 # Host leaf: atomic eviction (all components host + delete)
                 self.cache._evict_host_leaf(x, tracker)
+                if not host_lru.in_list(x_next):
+                    x_next = host_lru.get_lru_no_host_lock()
             else:
                 # Internal: tombstone Mamba + cascade
                 assert cd.host_value is not None

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -834,6 +834,8 @@ class SWAComponent(TreeComponent):
             cd = x.component_data[ct]
             if x in self.cache.evictable_host_leaves:
                 self.cache._evict_host_leaf(x, tracker)
+                if not host_lru.in_list(x_next):
+                    x_next = host_lru.get_lru_no_host_lock()
             else:
                 assert cd.host_value is not None
                 self.cache._evict_component_and_detach_lru(

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1337,13 +1337,57 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                     lru.remove_node(node)
         return device_freed, host_freed
 
+    def _delete_swa_tombstone_leaf_all_layers(
+        self,
+        node: UnifiedTreeNode,
+        tracker: dict[ComponentType, int],
+        tracker_target: EvictLayer,
+        *,
+        has_device: bool,
+        has_host: bool,
+    ) -> UnifiedTreeNode:
+        if has_device:
+            self._record_remove_event(node, medium=StorageMedium.GPU)
+            for comp in self.components.values():
+                if comp.node_has_component_data(node):
+                    self._evict_component_and_detach_lru(
+                        node,
+                        comp,
+                        target=EvictLayer.DEVICE,
+                        tracker=(
+                            tracker if EvictLayer.DEVICE in tracker_target else None
+                        ),
+                    )
+            node.component_data[BASE_COMPONENT_TYPE].value = None
+
+        if has_host:
+            self._record_remove_event(node, medium=StorageMedium.CPU)
+            for comp in self.components.values():
+                if comp.node_has_component_data(node, target=EvictLayer.HOST):
+                    self._evict_component_and_detach_lru(
+                        node,
+                        comp,
+                        target=EvictLayer.HOST,
+                        tracker=tracker if EvictLayer.HOST in tracker_target else None,
+                    )
+
+        self.evictable_device_leaves.discard(node)
+        self.evictable_host_leaves.discard(node)
+        self._remove_leaf_from_parent(node)
+        parent = node.parent
+        self._update_evictable_leaf_sets(parent)
+        return parent
+
     def _iteratively_delete_tombstone_leaf(
-        self, deleted_node: UnifiedTreeNode, tracker: dict[ComponentType, int]
+        self,
+        deleted_node: UnifiedTreeNode,
+        tracker: dict[ComponentType, int],
+        tracker_target: EvictLayer = EvictLayer.DEVICE,
     ):
         """Walk up from *deleted_node* and cascade-delete childless ancestors.
 
-        Only the Full (base) component decides whether a node survives:
-          - Full device present  → keep as D-leaf
+        Full (base) usually decides whether a node survives:
+          - Full device present  → keep as D-leaf, unless SWA is absent on all layers
           - Full host present    → keep as H-leaf
           - neither              → evict all remaining data, delete, continue up
         """
@@ -1357,6 +1401,21 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
             has_device = cur.component_data[ct].value is not None
             has_host = cur.component_data[ct].host_value is not None
+            swa_missing_all_layers = (
+                not self.enable_storage
+                and ComponentType.SWA in self.components
+                and cur.component_data[ComponentType.SWA].value is None
+                and cur.component_data[ComponentType.SWA].host_value is None
+            )
+            if swa_missing_all_layers and (has_device or has_host):
+                cur = self._delete_swa_tombstone_leaf_all_layers(
+                    cur,
+                    tracker,
+                    tracker_target,
+                    has_device=has_device,
+                    has_host=has_host,
+                )
+                continue
 
             if has_device:
                 self._update_evictable_leaf_sets(cur)
@@ -1366,7 +1425,12 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             for comp in self.components.values():
                 if comp.node_has_component_data(cur):
                     self._evict_component_and_detach_lru(
-                        cur, comp, target=EvictLayer.DEVICE, tracker=tracker
+                        cur,
+                        comp,
+                        target=EvictLayer.DEVICE,
+                        tracker=(
+                            tracker if EvictLayer.DEVICE in tracker_target else None
+                        ),
                     )
 
             if has_host:
@@ -1377,7 +1441,10 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             for comp in self.components.values():
                 if comp.node_has_component_data(cur, target=EvictLayer.HOST):
                     self._evict_component_and_detach_lru(
-                        cur, comp, target=EvictLayer.HOST, tracker=tracker
+                        cur,
+                        comp,
+                        target=EvictLayer.HOST,
+                        tracker=tracker if EvictLayer.HOST in tracker_target else None,
                     )
 
             self.evictable_host_leaves.discard(cur)
@@ -1533,7 +1600,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             tracker[comp.component_type] += hf
         self.evictable_host_leaves.discard(node)
         self._remove_leaf_from_parent(node)
-        self._iteratively_delete_tombstone_leaf(node, tracker)
+        self._iteratively_delete_tombstone_leaf(
+            node, tracker, tracker_target=EvictLayer.HOST
+        )
 
     # ---- HiCache: Backup / LoadBack ----
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1337,7 +1337,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                     lru.remove_node(node)
         return device_freed, host_freed
 
-    def _delete_swa_tombstone_leaf_all_layers(
+    def _delete_tombstone_leaf_all_layers(
         self,
         node: UnifiedTreeNode,
         tracker: dict[ComponentType, int],
@@ -1387,7 +1387,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         """Walk up from *deleted_node* and cascade-delete childless ancestors.
 
         Full (base) usually decides whether a node survives:
-          - Full device present  → keep as D-leaf, unless SWA is absent on all layers
+          - Full device present  → keep as D-leaf, unless a required component is absent
           - Full host present    → keep as H-leaf
           - neither              → evict all remaining data, delete, continue up
         """
@@ -1401,14 +1401,14 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
             has_device = cur.component_data[ct].value is not None
             has_host = cur.component_data[ct].host_value is not None
-            swa_missing_all_layers = (
-                not self.enable_storage
-                and ComponentType.SWA in self.components
-                and cur.component_data[ComponentType.SWA].value is None
-                and cur.component_data[ComponentType.SWA].host_value is None
+            required_component_missing_all_layers = not self.enable_storage and any(
+                component_type in self.components
+                and cur.component_data[component_type].value is None
+                and cur.component_data[component_type].host_value is None
+                for component_type in (ComponentType.SWA, ComponentType.MAMBA)
             )
-            if swa_missing_all_layers and (has_device or has_host):
-                cur = self._delete_swa_tombstone_leaf_all_layers(
+            if required_component_missing_all_layers and (has_device or has_host):
+                cur = self._delete_tombstone_leaf_all_layers(
                     cur,
                     tracker,
                     tracker_target,
@@ -1452,6 +1452,8 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             parent = cur.parent
             self._update_evictable_leaf_sets(parent)
             cur = parent
+
+        return cur
 
     def _for_each_component_lru(
         self,
@@ -1548,7 +1550,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
     def _evict_device_leaf(
         self, node: UnifiedTreeNode, tracker: dict[ComponentType, int]
-    ) -> None:
+    ) -> Optional[UnifiedTreeNode]:
         """Evict a device leaf node, choosing the right strategy:
 
         - backuped: demote to host via _evict_to_host (node stays in tree)
@@ -1565,10 +1567,10 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             ):
                 written = self.write_backup(node, write_back=True)
                 if written == 0:
-                    return
+                    return None
                 self.writing_check(write_back=True)
                 self._evict_to_host(node, tracker)
-                return
+                return node.parent
             else:
                 # Write-through: node has no backup, delete entirely.
                 self._record_remove_event(node, medium=StorageMedium.GPU)
@@ -1580,13 +1582,13 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 parent = node.parent
                 self._remove_leaf_from_parent(node)
                 self._update_evictable_leaf_sets(parent)
-                self._iteratively_delete_tombstone_leaf(node, tracker)
-                return
+                return self._iteratively_delete_tombstone_leaf(node, tracker)
         self._evict_to_host(node, tracker)
+        return node.parent
 
     def _evict_host_leaf(
         self, node: UnifiedTreeNode, tracker: dict[ComponentType, int]
-    ) -> None:
+    ) -> UnifiedTreeNode:
         """Atomically evict all components on a host leaf.
 
         All freed tokens are accumulated into *tracker*."""
@@ -1600,7 +1602,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             tracker[comp.component_type] += hf
         self.evictable_host_leaves.discard(node)
         self._remove_leaf_from_parent(node)
-        self._iteratively_delete_tombstone_leaf(
+        return self._iteratively_delete_tombstone_leaf(
             node, tracker, tracker_target=EvictLayer.HOST
         )
 

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -2136,42 +2136,6 @@ class UnifiedRadixCacheSuite:
         )
         tree.sanity_check()
 
-    def test_tombstone_cleanup_counts_host_parent_for_host_eviction(self):
-        if not self.cfg.has_swa and not self.cfg.has_mamba:
-            self.skipTest("requires SWA or Mamba component")
-
-        tree, _, _ = build_fixture(self.cfg)
-        parent = UnifiedTreeNode(self.cfg.components)
-        deleted = UnifiedTreeNode(self.cfg.components)
-
-        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
-        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
-        parent.parent = tree.root_node
-        deleted.parent = parent
-        parent.component_data[ComponentType.FULL].value = None
-        parent.component_data[ComponentType.FULL].host_value = torch.arange(
-            len(parent.key), dtype=torch.int64, device=tree.device
-        )
-        for component_type in (ComponentType.SWA, ComponentType.MAMBA):
-            if component_type in tree.components:
-                parent.component_data[component_type].value = None
-                parent.component_data[component_type].host_value = None
-        parent_key = parent.key.child_key(tree.page_size)
-        tree.root_node.children[parent_key] = parent
-        tree._update_evictable_leaf_sets(parent)
-        self.assertIn(parent, tree.evictable_host_leaves)
-
-        tracker = {ct: 0 for ct in tree.tree_components}
-
-        tree._iteratively_delete_tombstone_leaf(
-            deleted, tracker, tracker_target=EvictLayer.HOST
-        )
-
-        self.assertNotIn(parent_key, tree.root_node.children)
-        self.assertEqual(tracker[ComponentType.FULL], len(parent.key))
-        self.assertIsNone(parent.component_data[ComponentType.FULL].host_value)
-        tree.sanity_check()
-
     def test_tombstone_cleanup_host_eviction_recovers_stale_lru_cursor(self):
         if not self.cfg.has_swa or not self.cfg.has_mamba or self.cfg.page_size != 1:
             self.skipTest("requires SWA+Mamba with page_size=1")
@@ -2234,105 +2198,6 @@ class UnifiedRadixCacheSuite:
                 self.assertFalse(host_lru.in_list(remaining))
                 tree.sanity_check()
 
-    def test_tombstone_cleanup_evict_host_frees_real_host_pool(self):
-        if not self.cfg.has_swa or self.cfg.has_mamba or self.cfg.page_size != 1:
-            self.skipTest("SWA-only page_size=1 keeps HiCache fixture small")
-
-        tree, _, _ = build_fixture(self.cfg)
-        self._init_hicache(tree)
-        host_pool = tree.cache_controller.mem_pool_host
-
-        parent = UnifiedTreeNode(self.cfg.components)
-        child = UnifiedTreeNode(self.cfg.components)
-        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
-        child.key = RadixKey(array("q", self._make_seq(1000, 1)))
-        parent.parent = tree.root_node
-        child.parent = parent
-
-        host_available_before = host_pool.available_size()
-        parent_host_value = host_pool.alloc(len(parent.key))
-        child_host_value = host_pool.alloc(len(child.key))
-        self.assertIsNotNone(parent_host_value)
-        self.assertIsNotNone(child_host_value)
-        self.assertEqual(
-            host_pool.available_size(),
-            host_available_before - len(parent.key) - len(child.key),
-        )
-
-        parent.component_data[ComponentType.FULL].value = None
-        parent.component_data[ComponentType.FULL].host_value = parent_host_value.clone()
-        parent.component_data[ComponentType.SWA].value = None
-        parent.component_data[ComponentType.SWA].host_value = None
-        child.component_data[ComponentType.FULL].value = None
-        child.component_data[ComponentType.FULL].host_value = child_host_value.clone()
-        child.component_data[ComponentType.SWA].value = None
-        child.component_data[ComponentType.SWA].host_value = None
-
-        parent_key = parent.key.child_key(tree.page_size)
-        child_key = child.key.child_key(tree.page_size)
-        tree.root_node.children[parent_key] = parent
-        parent.children[child_key] = child
-        tree._update_evictable_leaf_sets(parent)
-        tree._update_evictable_leaf_sets(child)
-        self.assertNotIn(parent, tree.evictable_host_leaves)
-        self.assertIn(child, tree.evictable_host_leaves)
-
-        evicted = tree.evict_host(len(child.key))
-
-        self.assertEqual(evicted, len(parent.key) + len(child.key))
-        self.assertNotIn(parent_key, tree.root_node.children)
-        self.assertEqual(host_pool.available_size(), host_available_before)
-        tree.sanity_check()
-
-    def test_tombstone_cleanup_keeps_parent_when_swa_device_present(self):
-        if not self.cfg.has_swa:
-            self.skipTest("requires SWA component")
-
-        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
-        parent = UnifiedTreeNode(self.cfg.components)
-        deleted = UnifiedTreeNode(self.cfg.components)
-
-        full_value = self._alloc(allocator, self.cfg.page_size)
-        self.assertIsNotNone(full_value)
-        swa_value = allocator.translate_loc_from_full_to_swa(full_value)
-
-        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
-        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
-        parent.parent = tree.root_node
-        deleted.parent = parent
-        parent.component_data[ComponentType.FULL].value = full_value.clone()
-        parent.component_data[ComponentType.SWA].value = swa_value.clone()
-        if self.cfg.has_mamba:
-            mamba_value = req_to_token_pool.mamba_allocator.alloc(1)
-            self.assertIsNotNone(mamba_value)
-            parent.component_data[ComponentType.MAMBA].value = mamba_value.clone()
-        parent_key = parent.key.child_key(tree.page_size)
-        tree.root_node.children[parent_key] = parent
-        tree.component_evictable_size_[ComponentType.FULL] += len(full_value)
-        tree.component_evictable_size_[ComponentType.SWA] += len(swa_value)
-        tree.lru_lists[ComponentType.SWA].insert_mru(parent)
-        if self.cfg.has_mamba:
-            tree.component_evictable_size_[ComponentType.MAMBA] += len(mamba_value)
-            tree.lru_lists[ComponentType.MAMBA].insert_mru(parent)
-        tree._update_evictable_leaf_sets(parent)
-        self.assertEqual(
-            len(tree.match_prefix(MatchPrefixParams(key=parent.key)).device_indices),
-            len(parent.key),
-        )
-
-        tracker = {ct: 0 for ct in tree.tree_components}
-
-        tree._iteratively_delete_tombstone_leaf(deleted, tracker)
-
-        self.assertIn(parent_key, tree.root_node.children)
-        self.assertIs(tree.root_node.children[parent_key], parent)
-        self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
-        self.assertEqual(
-            len(tree.match_prefix(MatchPrefixParams(key=parent.key)).device_indices),
-            len(parent.key),
-        )
-        tree.sanity_check()
-
     def test_tombstone_cleanup_keeps_parent_when_swa_host_present(self):
         if not self.cfg.has_swa:
             self.skipTest("requires SWA component")
@@ -2370,44 +2235,6 @@ class UnifiedRadixCacheSuite:
         self.assertIn(parent_key, tree.root_node.children)
         self.assertIs(tree.root_node.children[parent_key], parent)
         self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
-
-    def test_tombstone_cleanup_keeps_parent_when_mamba_host_present(self):
-        if not self.cfg.has_mamba or self.cfg.has_swa:
-            self.skipTest("requires Mamba without SWA")
-
-        tree, allocator, _ = build_fixture(self.cfg)
-        parent = UnifiedTreeNode(self.cfg.components)
-        deleted = UnifiedTreeNode(self.cfg.components)
-
-        full_value = self._alloc(allocator, self.cfg.page_size)
-        self.assertIsNotNone(full_value)
-
-        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
-        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
-        parent.parent = tree.root_node
-        deleted.parent = parent
-        parent.component_data[ComponentType.FULL].value = full_value.clone()
-        parent.component_data[ComponentType.FULL].host_value = torch.arange(
-            len(full_value), dtype=torch.int64, device=tree.device
-        )
-        parent.component_data[ComponentType.MAMBA].value = None
-        parent.component_data[ComponentType.MAMBA].host_value = torch.zeros(
-            1, dtype=torch.int64, device=tree.device
-        )
-        parent_key = parent.key.child_key(tree.page_size)
-        tree.root_node.children[parent_key] = parent
-        tree.component_evictable_size_[ComponentType.FULL] += len(full_value)
-        tree.host_lru_lists[ComponentType.MAMBA].insert_mru(parent)
-        tree._update_evictable_leaf_sets(parent)
-
-        tracker = {ct: 0 for ct in tree.tree_components}
-
-        tree._iteratively_delete_tombstone_leaf(deleted, tracker)
-
-        self.assertIn(parent_key, tree.root_node.children)
-        self.assertIs(tree.root_node.children[parent_key], parent)
-        self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
-        tree.sanity_check()
 
     def test_tombstone_cleanup_keeps_parent_when_storage_enabled(self):
         if not self.cfg.has_swa and not self.cfg.has_mamba:

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1934,6 +1934,339 @@ class UnifiedRadixCacheSuite:
         self.assertIs(tree.root_node.children[parent_key], parent)
         self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
 
+    def test_tombstone_cleanup_deletes_swa_tombstone_full_parent(self):
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA component")
+
+        tree, allocator, _ = build_fixture(self.cfg)
+        parent = UnifiedTreeNode(self.cfg.components)
+        deleted = UnifiedTreeNode(self.cfg.components)
+
+        full_available_before = allocator.full_attn_allocator.available_size()
+        swa_available_before = allocator.swa_attn_allocator.available_size()
+        full_value = self._alloc(allocator, self.cfg.page_size)
+        self.assertIsNotNone(full_value)
+        allocator.free_swa(full_value)
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(),
+            full_available_before - len(full_value),
+        )
+        self.assertEqual(
+            allocator.swa_attn_allocator.available_size(), swa_available_before
+        )
+
+        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
+        parent.parent = tree.root_node
+        deleted.parent = parent
+        parent.component_data[ComponentType.FULL].value = full_value.clone()
+        parent.component_data[ComponentType.SWA].value = None
+        parent_key = parent.key.child_key(tree.page_size)
+        tree.root_node.children[parent_key] = parent
+        tree.component_evictable_size_[ComponentType.FULL] += len(full_value)
+        tree._update_evictable_leaf_sets(parent)
+        self.assertIn(parent, tree.evictable_device_leaves)
+
+        tracker = {ct: 0 for ct in tree.tree_components}
+
+        tree._iteratively_delete_tombstone_leaf(deleted, tracker)
+
+        self.assertNotIn(parent_key, tree.root_node.children)
+        self.assertNotIn(parent, tree.evictable_device_leaves)
+        self.assertEqual(tracker[ComponentType.FULL], len(full_value))
+        self.assertEqual(tracker[ComponentType.SWA], 0)
+        self.assertEqual(tree.full_evictable_size(), 0)
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(), full_available_before
+        )
+        self.assertEqual(
+            allocator.swa_attn_allocator.available_size(), swa_available_before
+        )
+        tree.sanity_check()
+
+    def test_tombstone_cleanup_deletes_swa_tombstone_mamba_parent(self):
+        if not self.cfg.has_swa or not self.cfg.has_mamba:
+            self.skipTest("requires SWA and Mamba components")
+
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+        parent = UnifiedTreeNode(self.cfg.components)
+        deleted = UnifiedTreeNode(self.cfg.components)
+
+        full_available_before = allocator.full_attn_allocator.available_size()
+        swa_available_before = allocator.swa_attn_allocator.available_size()
+        mamba_available_before = req_to_token_pool.mamba_allocator.available_size()
+
+        full_value = self._alloc(allocator, self.cfg.page_size)
+        self.assertIsNotNone(full_value)
+        allocator.free_swa(full_value)
+        mamba_value = req_to_token_pool.mamba_allocator.alloc(1)
+        self.assertIsNotNone(mamba_value)
+
+        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
+        parent.parent = tree.root_node
+        deleted.parent = parent
+        parent.component_data[ComponentType.FULL].value = full_value.clone()
+        parent.component_data[ComponentType.SWA].value = None
+        parent.component_data[ComponentType.SWA].host_value = None
+        parent.component_data[ComponentType.MAMBA].value = mamba_value.clone()
+        parent_key = parent.key.child_key(tree.page_size)
+        tree.root_node.children[parent_key] = parent
+        tree.component_evictable_size_[ComponentType.FULL] += len(full_value)
+        tree.component_evictable_size_[ComponentType.MAMBA] += len(mamba_value)
+        tree.lru_lists[ComponentType.MAMBA].insert_mru(parent)
+        tree._update_evictable_leaf_sets(parent)
+        self.assertIn(parent, tree.evictable_device_leaves)
+        self.assertTrue(tree.lru_lists[ComponentType.MAMBA].in_list(parent))
+
+        tracker = {ct: 0 for ct in tree.tree_components}
+
+        tree._iteratively_delete_tombstone_leaf(deleted, tracker)
+
+        self.assertNotIn(parent_key, tree.root_node.children)
+        self.assertNotIn(parent, tree.evictable_device_leaves)
+        self.assertFalse(tree.lru_lists[ComponentType.MAMBA].in_list(parent))
+        self.assertIsNone(parent.component_data[ComponentType.FULL].value)
+        self.assertIsNone(parent.component_data[ComponentType.MAMBA].value)
+        self.assertEqual(tracker[ComponentType.FULL], len(full_value))
+        self.assertEqual(tracker[ComponentType.SWA], 0)
+        self.assertEqual(tracker[ComponentType.MAMBA], len(mamba_value))
+        self.assertEqual(tree.full_evictable_size(), 0)
+        self.assertEqual(tree.mamba_evictable_size(), 0)
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(), full_available_before
+        )
+        self.assertEqual(
+            allocator.swa_attn_allocator.available_size(), swa_available_before
+        )
+        self.assertEqual(
+            req_to_token_pool.mamba_allocator.available_size(), mamba_available_before
+        )
+        tree.sanity_check()
+
+    def test_tombstone_cleanup_deletes_swa_tombstone_full_host_parent(self):
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA component")
+
+        tree, allocator, _ = build_fixture(self.cfg)
+        parent = UnifiedTreeNode(self.cfg.components)
+        deleted = UnifiedTreeNode(self.cfg.components)
+
+        full_available_before = allocator.full_attn_allocator.available_size()
+        swa_available_before = allocator.swa_attn_allocator.available_size()
+        full_value = self._alloc(allocator, self.cfg.page_size)
+        self.assertIsNotNone(full_value)
+        allocator.free_swa(full_value)
+
+        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
+        parent.parent = tree.root_node
+        deleted.parent = parent
+        parent.component_data[ComponentType.FULL].value = full_value.clone()
+        parent.component_data[ComponentType.FULL].host_value = torch.arange(
+            len(full_value), dtype=torch.int64, device=tree.device
+        )
+        parent.component_data[ComponentType.SWA].value = None
+        parent.component_data[ComponentType.SWA].host_value = None
+        parent_key = parent.key.child_key(tree.page_size)
+        tree.root_node.children[parent_key] = parent
+        tree.component_evictable_size_[ComponentType.FULL] += len(full_value)
+        tree._update_evictable_leaf_sets(parent)
+        self.assertIn(parent, tree.evictable_device_leaves)
+
+        tracker = {ct: 0 for ct in tree.tree_components}
+
+        tree._iteratively_delete_tombstone_leaf(deleted, tracker)
+
+        self.assertNotIn(parent_key, tree.root_node.children)
+        self.assertNotIn(parent, tree.evictable_device_leaves)
+        self.assertEqual(tracker[ComponentType.FULL], len(full_value))
+        self.assertIsNone(parent.component_data[ComponentType.FULL].host_value)
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(), full_available_before
+        )
+        self.assertEqual(
+            allocator.swa_attn_allocator.available_size(), swa_available_before
+        )
+        tree.sanity_check()
+
+    def test_tombstone_cleanup_counts_host_parent_for_host_eviction(self):
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA component")
+
+        tree, _, _ = build_fixture(self.cfg)
+        parent = UnifiedTreeNode(self.cfg.components)
+        deleted = UnifiedTreeNode(self.cfg.components)
+
+        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
+        parent.parent = tree.root_node
+        deleted.parent = parent
+        parent.component_data[ComponentType.FULL].value = None
+        parent.component_data[ComponentType.FULL].host_value = torch.arange(
+            len(parent.key), dtype=torch.int64, device=tree.device
+        )
+        parent.component_data[ComponentType.SWA].value = None
+        parent.component_data[ComponentType.SWA].host_value = None
+        parent_key = parent.key.child_key(tree.page_size)
+        tree.root_node.children[parent_key] = parent
+        tree._update_evictable_leaf_sets(parent)
+        self.assertIn(parent, tree.evictable_host_leaves)
+
+        tracker = {ct: 0 for ct in tree.tree_components}
+
+        tree._iteratively_delete_tombstone_leaf(
+            deleted, tracker, tracker_target=EvictLayer.HOST
+        )
+
+        self.assertNotIn(parent_key, tree.root_node.children)
+        self.assertEqual(tracker[ComponentType.FULL], len(parent.key))
+        self.assertIsNone(parent.component_data[ComponentType.FULL].host_value)
+        tree.sanity_check()
+
+    def test_tombstone_cleanup_evict_host_frees_real_host_pool(self):
+        if not self.cfg.has_swa or self.cfg.has_mamba or self.cfg.page_size != 1:
+            self.skipTest("SWA-only page_size=1 keeps HiCache fixture small")
+
+        tree, _, _ = build_fixture(self.cfg)
+        self._init_hicache(tree)
+        host_pool = tree.cache_controller.mem_pool_host
+
+        parent = UnifiedTreeNode(self.cfg.components)
+        child = UnifiedTreeNode(self.cfg.components)
+        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+        child.key = RadixKey(array("q", self._make_seq(1000, 1)))
+        parent.parent = tree.root_node
+        child.parent = parent
+
+        host_available_before = host_pool.available_size()
+        parent_host_value = host_pool.alloc(len(parent.key))
+        child_host_value = host_pool.alloc(len(child.key))
+        self.assertIsNotNone(parent_host_value)
+        self.assertIsNotNone(child_host_value)
+        self.assertEqual(
+            host_pool.available_size(),
+            host_available_before - len(parent.key) - len(child.key),
+        )
+
+        parent.component_data[ComponentType.FULL].value = None
+        parent.component_data[ComponentType.FULL].host_value = parent_host_value.clone()
+        parent.component_data[ComponentType.SWA].value = None
+        parent.component_data[ComponentType.SWA].host_value = None
+        child.component_data[ComponentType.FULL].value = None
+        child.component_data[ComponentType.FULL].host_value = child_host_value.clone()
+        child.component_data[ComponentType.SWA].value = None
+        child.component_data[ComponentType.SWA].host_value = None
+
+        parent_key = parent.key.child_key(tree.page_size)
+        child_key = child.key.child_key(tree.page_size)
+        tree.root_node.children[parent_key] = parent
+        parent.children[child_key] = child
+        tree._update_evictable_leaf_sets(parent)
+        tree._update_evictable_leaf_sets(child)
+        self.assertNotIn(parent, tree.evictable_host_leaves)
+        self.assertIn(child, tree.evictable_host_leaves)
+
+        evicted = tree.evict_host(len(child.key))
+
+        self.assertEqual(evicted, len(parent.key) + len(child.key))
+        self.assertNotIn(parent_key, tree.root_node.children)
+        self.assertEqual(host_pool.available_size(), host_available_before)
+        tree.sanity_check()
+
+    def test_tombstone_cleanup_keeps_parent_when_swa_device_present(self):
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA component")
+
+        tree, allocator, _ = build_fixture(self.cfg)
+        parent = UnifiedTreeNode(self.cfg.components)
+        deleted = UnifiedTreeNode(self.cfg.components)
+
+        full_value = self._alloc(allocator, self.cfg.page_size)
+        self.assertIsNotNone(full_value)
+        swa_value = allocator.translate_loc_from_full_to_swa(full_value)
+
+        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
+        parent.parent = tree.root_node
+        deleted.parent = parent
+        parent.component_data[ComponentType.FULL].value = full_value.clone()
+        parent.component_data[ComponentType.SWA].value = swa_value.clone()
+        parent_key = parent.key.child_key(tree.page_size)
+        tree.root_node.children[parent_key] = parent
+
+        tracker = {ct: 0 for ct in tree.tree_components}
+
+        tree._iteratively_delete_tombstone_leaf(deleted, tracker)
+
+        self.assertIn(parent_key, tree.root_node.children)
+        self.assertIs(tree.root_node.children[parent_key], parent)
+        self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
+
+    def test_tombstone_cleanup_keeps_parent_when_swa_host_present(self):
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA component")
+
+        tree, allocator, _ = build_fixture(self.cfg)
+        parent = UnifiedTreeNode(self.cfg.components)
+        deleted = UnifiedTreeNode(self.cfg.components)
+
+        full_value = self._alloc(allocator, self.cfg.page_size)
+        self.assertIsNotNone(full_value)
+        swa_value = allocator.translate_loc_from_full_to_swa(full_value)
+        allocator.free_swa(full_value)
+
+        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
+        parent.parent = tree.root_node
+        deleted.parent = parent
+        parent.component_data[ComponentType.FULL].value = full_value.clone()
+        parent.component_data[ComponentType.FULL].host_value = torch.arange(
+            len(full_value), dtype=torch.int64, device=tree.device
+        )
+        parent.component_data[ComponentType.SWA].value = None
+        parent.component_data[ComponentType.SWA].host_value = swa_value.clone()
+        parent_key = parent.key.child_key(tree.page_size)
+        tree.root_node.children[parent_key] = parent
+
+        tracker = {ct: 0 for ct in tree.tree_components}
+
+        tree._iteratively_delete_tombstone_leaf(deleted, tracker)
+
+        self.assertIn(parent_key, tree.root_node.children)
+        self.assertIs(tree.root_node.children[parent_key], parent)
+        self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
+
+    def test_tombstone_cleanup_keeps_parent_when_storage_enabled(self):
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA component")
+
+        tree, allocator, _ = build_fixture(self.cfg)
+        tree.enable_storage = True
+        parent = UnifiedTreeNode(self.cfg.components)
+        deleted = UnifiedTreeNode(self.cfg.components)
+
+        full_value = self._alloc(allocator, self.cfg.page_size)
+        self.assertIsNotNone(full_value)
+        allocator.free_swa(full_value)
+
+        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
+        parent.parent = tree.root_node
+        deleted.parent = parent
+        parent.component_data[ComponentType.FULL].value = full_value.clone()
+        parent.component_data[ComponentType.SWA].value = None
+        parent_key = parent.key.child_key(tree.page_size)
+        tree.root_node.children[parent_key] = parent
+
+        tracker = {ct: 0 for ct in tree.tree_components}
+
+        tree._iteratively_delete_tombstone_leaf(deleted, tracker)
+
+        self.assertIn(parent_key, tree.root_node.children)
+        self.assertIs(tree.root_node.children[parent_key], parent)
+        self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
+
     def test_internal_readonly_does_not_modify_tree(self):
         """Verify readonly match does not modify tree structure (no split)."""
         if self.cfg.page_size > 1 or self.cfg.has_mamba or self.cfg.has_swa:

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1966,6 +1966,14 @@ class UnifiedRadixCacheSuite:
         tree.component_evictable_size_[ComponentType.FULL] += len(full_value)
         tree._update_evictable_leaf_sets(parent)
         self.assertIn(parent, tree.evictable_device_leaves)
+        self.assertEqual(
+            len(
+                tree.match_prefix(
+                    MatchPrefixParams(key=parent.key)
+                ).device_indices
+            ),
+            0,
+        )
 
         tracker = {ct: 0 for ct in tree.tree_components}
 
@@ -1982,9 +1990,17 @@ class UnifiedRadixCacheSuite:
         self.assertEqual(
             allocator.swa_attn_allocator.available_size(), swa_available_before
         )
+        self.assertEqual(
+            len(
+                tree.match_prefix(
+                    MatchPrefixParams(key=parent.key)
+                ).device_indices
+            ),
+            0,
+        )
         tree.sanity_check()
 
-    def test_tombstone_cleanup_deletes_swa_tombstone_mamba_parent(self):
+    def test_tombstone_cleanup_deletes_mamba_data_for_swa_tombstone(self):
         if not self.cfg.has_swa or not self.cfg.has_mamba:
             self.skipTest("requires SWA and Mamba components")
 
@@ -2044,6 +2060,44 @@ class UnifiedRadixCacheSuite:
         )
         tree.sanity_check()
 
+    def test_tombstone_cleanup_deletes_mamba_tombstone_full_parent(self):
+        if not self.cfg.has_mamba or self.cfg.has_swa:
+            self.skipTest("requires Mamba without SWA")
+
+        tree, allocator, _ = build_fixture(self.cfg)
+        parent = UnifiedTreeNode(self.cfg.components)
+        deleted = UnifiedTreeNode(self.cfg.components)
+
+        full_available_before = allocator.available_size()
+        full_value = self._alloc(allocator, self.cfg.page_size)
+        self.assertIsNotNone(full_value)
+
+        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
+        parent.parent = tree.root_node
+        deleted.parent = parent
+        parent.component_data[ComponentType.FULL].value = full_value.clone()
+        parent.component_data[ComponentType.MAMBA].value = None
+        parent.component_data[ComponentType.MAMBA].host_value = None
+        parent_key = parent.key.child_key(tree.page_size)
+        tree.root_node.children[parent_key] = parent
+        tree.component_evictable_size_[ComponentType.FULL] += len(full_value)
+        tree._update_evictable_leaf_sets(parent)
+        self.assertIn(parent, tree.evictable_device_leaves)
+
+        tracker = {ct: 0 for ct in tree.tree_components}
+
+        tree._iteratively_delete_tombstone_leaf(deleted, tracker)
+
+        self.assertNotIn(parent_key, tree.root_node.children)
+        self.assertNotIn(parent, tree.evictable_device_leaves)
+        self.assertIsNone(parent.component_data[ComponentType.FULL].value)
+        self.assertEqual(tracker[ComponentType.FULL], len(full_value))
+        self.assertEqual(tracker[ComponentType.MAMBA], 0)
+        self.assertEqual(tree.full_evictable_size(), 0)
+        self.assertEqual(allocator.available_size(), full_available_before)
+        tree.sanity_check()
+
     def test_tombstone_cleanup_deletes_swa_tombstone_full_host_parent(self):
         if not self.cfg.has_swa:
             self.skipTest("requires SWA component")
@@ -2091,8 +2145,8 @@ class UnifiedRadixCacheSuite:
         tree.sanity_check()
 
     def test_tombstone_cleanup_counts_host_parent_for_host_eviction(self):
-        if not self.cfg.has_swa:
-            self.skipTest("requires SWA component")
+        if not self.cfg.has_swa and not self.cfg.has_mamba:
+            self.skipTest("requires SWA or Mamba component")
 
         tree, _, _ = build_fixture(self.cfg)
         parent = UnifiedTreeNode(self.cfg.components)
@@ -2106,8 +2160,10 @@ class UnifiedRadixCacheSuite:
         parent.component_data[ComponentType.FULL].host_value = torch.arange(
             len(parent.key), dtype=torch.int64, device=tree.device
         )
-        parent.component_data[ComponentType.SWA].value = None
-        parent.component_data[ComponentType.SWA].host_value = None
+        for component_type in (ComponentType.SWA, ComponentType.MAMBA):
+            if component_type in tree.components:
+                parent.component_data[component_type].value = None
+                parent.component_data[component_type].host_value = None
         parent_key = parent.key.child_key(tree.page_size)
         tree.root_node.children[parent_key] = parent
         tree._update_evictable_leaf_sets(parent)
@@ -2178,7 +2234,7 @@ class UnifiedRadixCacheSuite:
         if not self.cfg.has_swa:
             self.skipTest("requires SWA component")
 
-        tree, allocator, _ = build_fixture(self.cfg)
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
         parent = UnifiedTreeNode(self.cfg.components)
         deleted = UnifiedTreeNode(self.cfg.components)
 
@@ -2192,8 +2248,27 @@ class UnifiedRadixCacheSuite:
         deleted.parent = parent
         parent.component_data[ComponentType.FULL].value = full_value.clone()
         parent.component_data[ComponentType.SWA].value = swa_value.clone()
+        if self.cfg.has_mamba:
+            mamba_value = req_to_token_pool.mamba_allocator.alloc(1)
+            self.assertIsNotNone(mamba_value)
+            parent.component_data[ComponentType.MAMBA].value = mamba_value.clone()
         parent_key = parent.key.child_key(tree.page_size)
         tree.root_node.children[parent_key] = parent
+        tree.component_evictable_size_[ComponentType.FULL] += len(full_value)
+        tree.component_evictable_size_[ComponentType.SWA] += len(swa_value)
+        tree.lru_lists[ComponentType.SWA].insert_mru(parent)
+        if self.cfg.has_mamba:
+            tree.component_evictable_size_[ComponentType.MAMBA] += len(mamba_value)
+            tree.lru_lists[ComponentType.MAMBA].insert_mru(parent)
+        tree._update_evictable_leaf_sets(parent)
+        self.assertEqual(
+            len(
+                tree.match_prefix(
+                    MatchPrefixParams(key=parent.key)
+                ).device_indices
+            ),
+            len(parent.key),
+        )
 
         tracker = {ct: 0 for ct in tree.tree_components}
 
@@ -2202,12 +2277,21 @@ class UnifiedRadixCacheSuite:
         self.assertIn(parent_key, tree.root_node.children)
         self.assertIs(tree.root_node.children[parent_key], parent)
         self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
+        self.assertEqual(
+            len(
+                tree.match_prefix(
+                    MatchPrefixParams(key=parent.key)
+                ).device_indices
+            ),
+            len(parent.key),
+        )
+        tree.sanity_check()
 
     def test_tombstone_cleanup_keeps_parent_when_swa_host_present(self):
         if not self.cfg.has_swa:
             self.skipTest("requires SWA component")
 
-        tree, allocator, _ = build_fixture(self.cfg)
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
         parent = UnifiedTreeNode(self.cfg.components)
         deleted = UnifiedTreeNode(self.cfg.components)
 
@@ -2226,6 +2310,10 @@ class UnifiedRadixCacheSuite:
         )
         parent.component_data[ComponentType.SWA].value = None
         parent.component_data[ComponentType.SWA].host_value = swa_value.clone()
+        if self.cfg.has_mamba:
+            mamba_value = req_to_token_pool.mamba_allocator.alloc(1)
+            self.assertIsNotNone(mamba_value)
+            parent.component_data[ComponentType.MAMBA].value = mamba_value.clone()
         parent_key = parent.key.child_key(tree.page_size)
         tree.root_node.children[parent_key] = parent
 
@@ -2237,9 +2325,47 @@ class UnifiedRadixCacheSuite:
         self.assertIs(tree.root_node.children[parent_key], parent)
         self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
 
+    def test_tombstone_cleanup_keeps_parent_when_mamba_host_present(self):
+        if not self.cfg.has_mamba or self.cfg.has_swa:
+            self.skipTest("requires Mamba without SWA")
+
+        tree, allocator, _ = build_fixture(self.cfg)
+        parent = UnifiedTreeNode(self.cfg.components)
+        deleted = UnifiedTreeNode(self.cfg.components)
+
+        full_value = self._alloc(allocator, self.cfg.page_size)
+        self.assertIsNotNone(full_value)
+
+        parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+        deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
+        parent.parent = tree.root_node
+        deleted.parent = parent
+        parent.component_data[ComponentType.FULL].value = full_value.clone()
+        parent.component_data[ComponentType.FULL].host_value = torch.arange(
+            len(full_value), dtype=torch.int64, device=tree.device
+        )
+        parent.component_data[ComponentType.MAMBA].value = None
+        parent.component_data[ComponentType.MAMBA].host_value = torch.zeros(
+            1, dtype=torch.int64, device=tree.device
+        )
+        parent_key = parent.key.child_key(tree.page_size)
+        tree.root_node.children[parent_key] = parent
+        tree.component_evictable_size_[ComponentType.FULL] += len(full_value)
+        tree.host_lru_lists[ComponentType.MAMBA].insert_mru(parent)
+        tree._update_evictable_leaf_sets(parent)
+
+        tracker = {ct: 0 for ct in tree.tree_components}
+
+        tree._iteratively_delete_tombstone_leaf(deleted, tracker)
+
+        self.assertIn(parent_key, tree.root_node.children)
+        self.assertIs(tree.root_node.children[parent_key], parent)
+        self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
+        tree.sanity_check()
+
     def test_tombstone_cleanup_keeps_parent_when_storage_enabled(self):
-        if not self.cfg.has_swa:
-            self.skipTest("requires SWA component")
+        if not self.cfg.has_swa and not self.cfg.has_mamba:
+            self.skipTest("requires SWA or Mamba component")
 
         tree, allocator, _ = build_fixture(self.cfg)
         tree.enable_storage = True
@@ -2248,14 +2374,18 @@ class UnifiedRadixCacheSuite:
 
         full_value = self._alloc(allocator, self.cfg.page_size)
         self.assertIsNotNone(full_value)
-        allocator.free_swa(full_value)
+        if self.cfg.has_swa:
+            allocator.free_swa(full_value)
 
         parent.key = RadixKey(array("q", self._make_seq(1, 1)))
         deleted.key = RadixKey(array("q", self._make_seq(1000, 1)))
         parent.parent = tree.root_node
         deleted.parent = parent
         parent.component_data[ComponentType.FULL].value = full_value.clone()
-        parent.component_data[ComponentType.SWA].value = None
+        for component_type in (ComponentType.SWA, ComponentType.MAMBA):
+            if component_type in tree.components:
+                parent.component_data[component_type].value = None
+                parent.component_data[component_type].host_value = None
         parent_key = parent.key.child_key(tree.page_size)
         tree.root_node.children[parent_key] = parent
 

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1967,11 +1967,7 @@ class UnifiedRadixCacheSuite:
         tree._update_evictable_leaf_sets(parent)
         self.assertIn(parent, tree.evictable_device_leaves)
         self.assertEqual(
-            len(
-                tree.match_prefix(
-                    MatchPrefixParams(key=parent.key)
-                ).device_indices
-            ),
+            len(tree.match_prefix(MatchPrefixParams(key=parent.key)).device_indices),
             0,
         )
 
@@ -1991,11 +1987,7 @@ class UnifiedRadixCacheSuite:
             allocator.swa_attn_allocator.available_size(), swa_available_before
         )
         self.assertEqual(
-            len(
-                tree.match_prefix(
-                    MatchPrefixParams(key=parent.key)
-                ).device_indices
-            ),
+            len(tree.match_prefix(MatchPrefixParams(key=parent.key)).device_indices),
             0,
         )
         tree.sanity_check()
@@ -2180,6 +2172,68 @@ class UnifiedRadixCacheSuite:
         self.assertIsNone(parent.component_data[ComponentType.FULL].host_value)
         tree.sanity_check()
 
+    def test_tombstone_cleanup_host_eviction_recovers_stale_lru_cursor(self):
+        if not self.cfg.has_swa or not self.cfg.has_mamba or self.cfg.page_size != 1:
+            self.skipTest("requires SWA+Mamba with page_size=1")
+
+        for component_type in (ComponentType.SWA, ComponentType.MAMBA):
+            with self.subTest(component_type=component_type):
+                tree, _, _ = build_fixture(self.cfg)
+                missing_component = (
+                    ComponentType.MAMBA
+                    if component_type == ComponentType.SWA
+                    else ComponentType.SWA
+                )
+
+                parent = UnifiedTreeNode(self.cfg.components)
+                child = UnifiedTreeNode(self.cfg.components)
+                remaining = UnifiedTreeNode(self.cfg.components)
+                parent.key = RadixKey(array("q", self._make_seq(1, 1)))
+                child.key = RadixKey(array("q", self._make_seq(1000, 1)))
+                remaining.key = RadixKey(array("q", self._make_seq(2000, 1)))
+                parent.parent = tree.root_node
+                child.parent = parent
+                remaining.parent = tree.root_node
+
+                for node in (child, parent, remaining):
+                    node.component_data[ComponentType.FULL].host_value = torch.arange(
+                        len(node.key), dtype=torch.int64, device=tree.device
+                    )
+                    for ct in (ComponentType.SWA, ComponentType.MAMBA):
+                        if node is parent and ct == missing_component:
+                            continue
+                        node.component_data[ct].host_value = torch.arange(
+                            1, dtype=torch.int64, device=tree.device
+                        )
+
+                parent_key = parent.key.child_key(tree.page_size)
+                child_key = child.key.child_key(tree.page_size)
+                remaining_key = remaining.key.child_key(tree.page_size)
+                tree.root_node.children[parent_key] = parent
+                parent.children[child_key] = child
+                tree.root_node.children[remaining_key] = remaining
+                tree._update_evictable_leaf_sets(parent)
+                tree._update_evictable_leaf_sets(child)
+                tree._update_evictable_leaf_sets(remaining)
+
+                for ct in (ComponentType.SWA, ComponentType.MAMBA):
+                    host_lru = tree.host_lru_lists[ct]
+                    for node in (child, parent, remaining):
+                        if node.component_data[ct].host_value is not None:
+                            host_lru.insert_mru(node)
+
+                host_lru = tree.host_lru_lists[component_type]
+                self.assertIs(host_lru.get_lru_no_host_lock(), child)
+                self.assertIs(host_lru.get_prev_no_host_lock(child), parent)
+
+                evicted = tree.evict_host(3, component_type)
+
+                self.assertEqual(evicted, 3)
+                self.assertEqual(tree.root_node.children, {})
+                self.assertFalse(host_lru.in_list(parent))
+                self.assertFalse(host_lru.in_list(remaining))
+                tree.sanity_check()
+
     def test_tombstone_cleanup_evict_host_frees_real_host_pool(self):
         if not self.cfg.has_swa or self.cfg.has_mamba or self.cfg.page_size != 1:
             self.skipTest("SWA-only page_size=1 keeps HiCache fixture small")
@@ -2262,11 +2316,7 @@ class UnifiedRadixCacheSuite:
             tree.lru_lists[ComponentType.MAMBA].insert_mru(parent)
         tree._update_evictable_leaf_sets(parent)
         self.assertEqual(
-            len(
-                tree.match_prefix(
-                    MatchPrefixParams(key=parent.key)
-                ).device_indices
-            ),
+            len(tree.match_prefix(MatchPrefixParams(key=parent.key)).device_indices),
             len(parent.key),
         )
 
@@ -2278,11 +2328,7 @@ class UnifiedRadixCacheSuite:
         self.assertIs(tree.root_node.children[parent_key], parent)
         self.assertTrue(all(evicted == 0 for evicted in tracker.values()))
         self.assertEqual(
-            len(
-                tree.match_prefix(
-                    MatchPrefixParams(key=parent.key)
-                ).device_indices
-            ),
+            len(tree.match_prefix(MatchPrefixParams(key=parent.key)).device_indices),
             len(parent.key),
         )
         tree.sanity_check()


### PR DESCRIPTION
## Summary
- Delete leaf ancestors whose Full KV remains after SWA has been tombstoned on all active tiers.
- Free device and host component state consistently while preserving storage-enabled behavior.
- Add regression coverage for device, host, HiCache host eviction, storage-enabled retention, SWA-present retention, and SWA+Mamba cleanup cases.

## Root cause
SWA tombstone leaves could leave a childless Full KV ancestor in the unified radix tree even though the SWA component for that span was absent on both device and host. That ancestor was still counted as evictable Full KV and could keep stale component state around.

## Performance validation
GB300 FP4, 1 prefill worker + 1 decode worker (12 GPUs total), concurrency 30, 1200-second profiling, and `--swa-full-tokens-ratio 0.02`.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Completed requests | 343 | 385 | +12.24% |
| Total token throughput | 37,486.84 tok/s | 40,566.76 tok/s | +8.22% |
| Mean TTFT | 117.22 s | 103.26 s | -11.91% |
| P50 TTFT | 131.54 s | 77.96 s | -40.73% |
| Prompt cache hit | 3.378% | 5.074% | +1.696 pp |
| Full pool occupancy, time mean | 74.17% | 8.39% | -65.78 pp |
| SWA pool occupancy, time mean | 88.88% | 87.16% | -1.72 pp |

All observed cleanup events satisfied the expected SWA device/host absence and lock-free conditions.

## Testing
- `git diff --check`
- Targeted GB300 tests: **118 passed, 110 skipped** with `-k tombstone_cleanup`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28507761928](https://github.com/sgl-project/sglang/actions/runs/28507761928)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28507761243](https://github.com/sgl-project/sglang/actions/runs/28507761243)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->