### PR TITLE
[Responses] Fix max_output_tokens overestimate on multimodal requests (fixes #29287)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1464,23 +1464,32 @@ class ResponsesRequest(BaseModel):
 
     def to_sampling_params(
         self,
-        default_max_tokens: int,
+        default_max_tokens: Optional[int] = None,
         default_params: Optional[Dict] = None,
         stop: Optional[Union[str, List[str]]] = None,
         tool_call_constraint: Optional[ToolCallConstraint] = None,
     ) -> Dict[str, Any]:
-        """Convert to sampling parameters for generation."""
+        """Convert to sampling parameters for generation.
+
+        ``default_max_tokens`` may be ``None``: when neither it nor
+        ``max_output_tokens`` is set, ``max_new_tokens`` is left ``None`` so the
+        scheduler clamps the budget against the real (post-expansion) input
+        length, matching the Chat Completions path. See issue #29287.
+        """
         if default_params is None:
             default_params = {}
 
         # Use max_output_tokens if available, otherwise use max_tokens for backwards compatibility
         if self.max_output_tokens is not None:
-            max_tokens = min(self.max_output_tokens, default_max_tokens)
+            max_tokens = self.max_output_tokens
+            if default_max_tokens is not None:
+                max_tokens = min(max_tokens, default_max_tokens)
         else:
             max_tokens = default_max_tokens
 
         # Headroom for BOS/EOS the engine appends on top of prompt+budget.
-        max_tokens -= 2
+        if max_tokens is not None:
+            max_tokens -= 2
 
         temperature = self.temperature
         if temperature is None:

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -270,27 +270,15 @@ class OpenAIServingResponses(OpenAIServingChat):
                     assert len(tool_list) == 0
                     tool_sessions = {}
                 for i, engine_prompt in enumerate(engine_prompts):
-                    # Calculate default max tokens from context length minus prompt length
-                    if isinstance(engine_prompt, list):
-                        prompt_length = len(engine_prompt)
-                    elif isinstance(engine_prompt, str):
-                        prompt_length = len(tokenizer.encode(engine_prompt))
-                    else:
-                        prompt_length = 0
-
-                    context_len = (
-                        self.tokenizer_manager.model_config.context_len
-                        if hasattr(self.tokenizer_manager.model_config, "context_len")
-                        else 4096
-                    )
-                    # Account for reserved tokens (e.g., EAGLE speculative decoding slots)
-                    # that the tokenizer_manager adds during validation
-                    num_reserved_tokens = self.tokenizer_manager.num_reserved_tokens
-                    default_max_tokens = max(
-                        context_len - prompt_length - num_reserved_tokens, 512
-                    )  # Ensure minimum 512 tokens
+                    # Leave the default budget unset so the scheduler clamps
+                    # max_new_tokens against the real (post-expansion) input
+                    # length, mirroring the Chat Completions path. Pre-computing
+                    # it here under-counted multimodal prompts (image tokens are
+                    # only expanded engine-side), so default_max_tokens was
+                    # overestimated and triggered spurious context-length 400s.
+                    # See issue #29287.
                     sampling_params = request.to_sampling_params(
-                        default_max_tokens,
+                        None,
                         self.default_sampling_params,
                         stop=(
                             processed_messages.stop

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -122,6 +122,28 @@ class ResponsesSamplingParamsTestCase(unittest.TestCase):
         )
         self.assertEqual(params["structural_tag"], '{"type": "structural_tag"}')
 
+    def test_none_default_and_no_max_output_leaves_max_new_tokens_none(self):
+        # With neither a default budget nor max_output_tokens, max_new_tokens
+        # stays None so the scheduler clamps against the real input length
+        # (mirrors Chat Completions). See issue #29287.
+        request = ResponsesRequest(model="x", input="hi", store=False)
+        params = request.to_sampling_params(default_max_tokens=None)
+        self.assertIsNone(params["max_new_tokens"])
+
+    def test_none_default_with_max_output_tokens_honored(self):
+        request = ResponsesRequest(
+            model="x", input="hi", store=False, max_output_tokens=100
+        )
+        params = request.to_sampling_params(default_max_tokens=None)
+        # 100 minus the 2-token BOS/EOS headroom.
+        self.assertEqual(params["max_new_tokens"], 98)
+
+    def test_default_budget_still_caps_when_provided(self):
+        # Backwards compatible: an explicit default budget still applies.
+        request = ResponsesRequest(model="x", input="hi", store=False)
+        params = request.to_sampling_params(default_max_tokens=128)
+        self.assertEqual(params["max_new_tokens"], 126)
+
 
 class ResponsesResponseFromRequestTestCase(unittest.TestCase):
     def test_parallel_tool_calls_false_preserved(self):


### PR DESCRIPTION
## Summary

Fixes #29287.

The Responses API pre-computed `default_max_tokens = context_len - prompt_length`.
For **multimodal** requests `prompt_length` came from
`len(tokenizer.encode(engine_prompt_string))`, which only counts the `<image>`
placeholder — not the engine-side **post-expansion** token count. So
`default_max_tokens` was overestimated, and `_validate_one_request` then rejected
`input + default_max_tokens > context_len` with a spurious 400 (any model on the
multimodal arch path, e.g. KimiK2.6 sharing `KimiK25ForConditionalGeneration`).

The expanded count isn't available at the `serving_responses` layer (image
tokens are only expanded engine-side), which is why a serving-side recompute
can't be made accurate.

## Fix (option 2 from the issue discussion)

Mirror the Chat Completions route: stop pre-computing `default_max_tokens` and
pass `None`, leaving `max_new_tokens` unset so the **scheduler clamps** the
budget against the real post-expansion `input_len` — one source of truth.

- `ResponsesRequest.to_sampling_params`: `default_max_tokens: Optional[int] = None`,
  with `None`-safe handling (`max_output_tokens` is still honored and capped when
  a concrete default is supplied).
- `serving_responses.py`: drop the `prompt_length` / `default_max_tokens`
  computation and pass `None`.

This reuses the exact path Chat already uses for unspecified `max_tokens`
(`tokenizer_manager` skips the total check when `max_new_tokens is None`, the
scheduler substitutes a sentinel and clamps to the real input/system limits), so
text Responses requests behave identically to before.

## Tests

`test_responses_protocol.py::ResponsesSamplingParamsTestCase`: `None` default +
no `max_output_tokens` leaves `max_new_tokens=None`; `None` default +
`max_output_tokens=100` → `98`; an explicit `default_max_tokens=128` still caps
to `126` (backwards compatible). Pass locally.

Per the issue thread @hhy-seven preferred this (option 2); opening as draft for
maintainer confirmation.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28214767690](https://github.com/sgl-project/sglang/actions/runs/28214767690)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28214767634](https://github.com/sgl-project/sglang/actions/runs/28214767634)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->