### PR TITLE
[WIP][DSA] Use static page-table width in CUDA graph replay to drop seq_lens_cpu host read

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
@@ -88,9 +88,12 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
         Returns:
             PrecomputedMetadata containing all shared intermediate results
         """
-        # Slice inputs to batch size
+        # Slice inputs to batch size. seq_lens_cpu may be None when the backend
+        # has opted out of the host seq-len mirror; the decode path below no
+        # longer reads it (static page-table width).
         seq_lens = seq_lens[:bs]
-        seq_lens_cpu = seq_lens_cpu[:bs]
+        if seq_lens_cpu is not None:
+            seq_lens_cpu = seq_lens_cpu[:bs]
         req_pool_indices = req_pool_indices[:bs]
 
         # Dispatch to mode-specific precomputation
@@ -113,7 +116,11 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
         seq_lens_cpu: torch.Tensor,
     ) -> PrecomputedMetadata:
         """Precompute metadata for normal decode mode."""
-        max_len = int(seq_lens_cpu.max().item())
+        # Static page-table width (= captured buffer width) instead of a
+        # seq_lens_cpu.max() host read. The kernel bounds each row's reads by the
+        # GPU cache_seqlens, so copying the full width is correct and keeps the
+        # multi-step draft replay independent of the host seq-len mirror.
+        max_len = self.decode_cuda_graph_metadata[bs].page_table_1.shape[1]
 
         # Convert to int32 and compute cumsum
         cache_seqlens = seq_lens.to(torch.int32)

--- a/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
@@ -88,9 +88,7 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
         Returns:
             PrecomputedMetadata containing all shared intermediate results
         """
-        # Slice inputs to batch size. seq_lens_cpu may be None when the backend
-        # has opted out of the host seq-len mirror; the decode path below no
-        # longer reads it (static page-table width).
+        # Slice inputs to batch size
         seq_lens = seq_lens[:bs]
         if seq_lens_cpu is not None:
             seq_lens_cpu = seq_lens_cpu[:bs]
@@ -116,10 +114,6 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
         seq_lens_cpu: torch.Tensor,
     ) -> PrecomputedMetadata:
         """Precompute metadata for normal decode mode."""
-        # Static page-table width (= captured buffer width) instead of a
-        # seq_lens_cpu.max() host read. The kernel bounds each row's reads by the
-        # GPU cache_seqlens, so copying the full width is correct and keeps the
-        # multi-step draft replay independent of the host seq-len mirror.
         max_len = self.decode_cuda_graph_metadata[bs].page_table_1.shape[1]
 
         # Convert to int32 and compute cumsum

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1187,11 +1187,6 @@ class DeepseekSparseAttnBackend(
         also call this directly via _apply_cuda_graph_metadata when they
         need to pass out_cache_loc / actual_forward_mode explicitly.
         """
-        # NOTE: the decode / target_verify / draft_extend replay branches below
-        # derive the page-table width statically (metadata.page_table_1.shape[1])
-        # rather than from seq_lens_cpu.max(), so seq_lens_cpu may be None here
-        # once the backend opts out of the host seq-len mirror.
-
         if bs not in self.decode_cuda_graph_metadata:
             self._build_forward_metadata_cuda_graph(
                 bs,
@@ -1215,10 +1210,6 @@ class DeepseekSparseAttnBackend(
         metadata: DSAMetadata = self.decode_cuda_graph_metadata[bs]
         if forward_mode.is_decode_or_idle():
             # Normal Decode
-            # Static page-table width (= captured buffer width) instead of a
-            # seq_lens_cpu.max() host read. The kernel bounds each row's reads by
-            # the GPU cache_seqlens, so copying the full width is correct and keeps
-            # this path independent of the host seq-len mirror (no per-step D2H).
             max_len = metadata.page_table_1.shape[1]
 
             cache_seqlens = seq_lens.to(torch.int32)
@@ -1234,8 +1225,6 @@ class DeepseekSparseAttnBackend(
             metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
             seqlens_expanded = cache_seqlens
         elif forward_mode.is_target_verify():
-            # Static width (captured buffer already reserves +num_draft_tokens);
-            # avoids the seq_lens_cpu.max() host read. See the decode branch note.
             max_seqlen_k = metadata.page_table_1.shape[1]
 
             cache_seqlens = (seq_lens + self.speculative_num_draft_tokens).to(
@@ -1266,9 +1255,6 @@ class DeepseekSparseAttnBackend(
             )
             metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
         elif forward_mode.is_draft_extend_v2():
-            # Static width; avoids the seq_lens_cpu.max() host read. See the decode
-            # branch note. (The spec_info.num_accept_tokens .tolist() below is a
-            # separate host dependency, tracked by the draft-extend cuda-graph work.)
             max_seqlen_k = metadata.page_table_1.shape[1]
             cache_seqlens = seq_lens.to(torch.int32)
             metadata.cache_seqlens_int32.copy_(cache_seqlens)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1187,7 +1187,10 @@ class DeepseekSparseAttnBackend(
         also call this directly via _apply_cuda_graph_metadata when they
         need to pass out_cache_loc / actual_forward_mode explicitly.
         """
-        assert seq_lens_cpu is not None
+        # NOTE: the decode / target_verify / draft_extend replay branches below
+        # derive the page-table width statically (metadata.page_table_1.shape[1])
+        # rather than from seq_lens_cpu.max(), so seq_lens_cpu may be None here
+        # once the backend opts out of the host seq-len mirror.
 
         if bs not in self.decode_cuda_graph_metadata:
             self._build_forward_metadata_cuda_graph(
@@ -1206,14 +1209,17 @@ class DeepseekSparseAttnBackend(
         self.set_dsa_prefill_impl(forward_batch=None)
 
         seq_lens = seq_lens[:bs]
-        seq_lens_cpu = seq_lens_cpu[:bs]
         req_pool_indices = req_pool_indices[:bs]
 
         # Normal Decode
         metadata: DSAMetadata = self.decode_cuda_graph_metadata[bs]
         if forward_mode.is_decode_or_idle():
             # Normal Decode
-            max_len = int(seq_lens_cpu.max().item())
+            # Static page-table width (= captured buffer width) instead of a
+            # seq_lens_cpu.max() host read. The kernel bounds each row's reads by
+            # the GPU cache_seqlens, so copying the full width is correct and keeps
+            # this path independent of the host seq-len mirror (no per-step D2H).
+            max_len = metadata.page_table_1.shape[1]
 
             cache_seqlens = seq_lens.to(torch.int32)
             metadata.cache_seqlens_int32.copy_(cache_seqlens)
@@ -1228,9 +1234,9 @@ class DeepseekSparseAttnBackend(
             metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
             seqlens_expanded = cache_seqlens
         elif forward_mode.is_target_verify():
-            max_seqlen_k = int(
-                seq_lens_cpu.max().item() + self.speculative_num_draft_tokens
-            )
+            # Static width (captured buffer already reserves +num_draft_tokens);
+            # avoids the seq_lens_cpu.max() host read. See the decode branch note.
+            max_seqlen_k = metadata.page_table_1.shape[1]
 
             cache_seqlens = (seq_lens + self.speculative_num_draft_tokens).to(
                 torch.int32
@@ -1260,7 +1266,10 @@ class DeepseekSparseAttnBackend(
             )
             metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
         elif forward_mode.is_draft_extend_v2():
-            max_seqlen_k = int(seq_lens_cpu.max().item())
+            # Static width; avoids the seq_lens_cpu.max() host read. See the decode
+            # branch note. (The spec_info.num_accept_tokens .tolist() below is a
+            # separate host dependency, tracked by the draft-extend cuda-graph work.)
+            max_seqlen_k = metadata.page_table_1.shape[1]
             cache_seqlens = seq_lens.to(torch.int32)
             metadata.cache_seqlens_int32.copy_(cache_seqlens)
             metadata.cu_seqlens_k[1:].copy_(


### PR DESCRIPTION
## Motivation

During scheduler overlap (CPU work hidden behind GPU compute), the DeepSeek Sparse Attention (DSA) **CUDA-graph replay** paths sized their page-table copy from `seq_lens_cpu.max().item()`. That `.item()` forces a per-step **device-to-host read** of the sequence-length mirror, which serializes the critical path *between decode steps*. It's most visible on slower host CPUs (e.g. GB200 Grace) and with fast GPU steps (small batch + spec decode + FP4), where the host read no longer hides under GPU work.

## Change

Replace the dynamic `seq_lens_cpu.max()` width with the **static captured buffer width** (`metadata.page_table_1.shape[1]`) in the DSA replay paths:

- `dsa_backend.py::_apply_cuda_graph_metadata` — `decode` / `target_verify` / `draft_extend_v2` branches.
- `dsa/dsa_backend_mtp_precompute.py::_precompute_decode_mode` (multi-step-draft precompute), and tolerate `seq_lens_cpu is None` in `_precompute_replay_metadata`.

This is correct because the attention kernel already bounds each row's reads by the GPU-side `cache_seqlens`; copying the full captured width is safe, and the captured buffer already reserves `+num_draft_tokens` for target-verify. It mirrors how `trtllm_mla` sizes its page table.

The replay paths are now independent of the host seq-len mirror (`seq_lens_cpu` may be `None` there). This is a **prerequisite** for dropping `needs_cpu_seq_lens` for DSA — that flag flip is intentionally **not** in this PR, since the remaining draft-extend host sync (`num_accept_tokens.tolist()`) is being addressed by concurrent draft-extend CUDA-graph work.

## Accuracy validation

GLM-5.2-NVFP4, TP=4, EAGLE spec decode (steps=5, topk=1, draft-tokens=6), DSA backend, fp8_e4m3 KV cache. DSA decode CUDA graphs active throughout (observed `accept len ~5.7–6.0`, `accept rate ~0.94–1.0`).

| Eval | Result | Notes |
|---|---|---|
| GSM8K (`sgl-eval`, 1319 ex, chat + thinking, greedy) | **0.9515** | error_rate 0.0, truncated 3% (long-thinking outliers) |
| GSM8K (`few_shot_gsm8k`, 1319 ex, 5-shot greedy) | **0.939** | invalid 0.0 |

No accuracy regression.

## Test plan

- [x] GSM8K accuracy (above) on GLM-5.2-NVFP4 with DSA + EAGLE.
- [ ] Confirm no behavior change for MLA/other backends (paths untouched; only DSA replay branches modified).

Made with [Cursor](https://cursor.com)



















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28228194536](https://github.com/sgl-project/sglang/actions/runs/28228194536)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28228194363](https://github.com/sgl-project/sglang/actions/runs/28228194363)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->