### PR TITLE
[NPU] Fix mllama cross-attention crash in ascend extend SDPA

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_torch_native_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_torch_native_backend.py
@@ -126,11 +126,12 @@ class AscendTorchNativeAttnBackend:
                     atten_start_kv = int(encoder_lens[seq_idx].item())
                     atten_end_kv = atten_start_kv + extend_seq_len_q
 
-            if (
+            is_swa_self_attn = (
                 sliding_window_size is not None
                 and sliding_window_size > -1
                 and encoder_lens is None
-            ):
+            )
+            if is_swa_self_attn:
                 # For extend, the sliding window must be anchored at the first
                 # query token in this chunk rather than the final sequence
                 # length. Otherwise a large extend chunk can no longer fit in
@@ -140,10 +141,21 @@ class AscendTorchNativeAttnBackend:
                 )
 
             per_req_query = query[:, start_q:end_q, :]
-            query_start_idx = max(prefill_seq_len_q - atten_start_kv, 0)
-            seq_len_kv = atten_end_kv - atten_start_kv
+
+            # SWA crops the front of the KV window, so the redundant query
+            # tensor must match the cropped window to keep Q.len == K.len for
+            # the causal mask. In cross-attention (and non-SWA self-attention)
+            # the original sizing — text seq len — must be preserved, since Q
+            # (text) and KV (encoder) lengths legitimately differ there.
+            if is_swa_self_attn:
+                redundant_len = atten_end_kv - atten_start_kv
+                query_start_idx = max(prefill_seq_len_q - atten_start_kv, 0)
+            else:
+                redundant_len = int(seq_lens[seq_idx].item())
+                query_start_idx = prefill_seq_len_q
+
             per_req_query_redundant = torch.zeros(
-                (per_req_query.shape[0], seq_len_kv, per_req_query.shape[2]),
+                (per_req_query.shape[0], redundant_len, per_req_query.shape[2]),
                 dtype=per_req_query.dtype,
                 device=per_req_query.device,
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

PR #26147 (Gemma4 SWA support) introduced a regression that crashes mllama (Llama-3.2-11B-Vision-Instruct) cross-attention on the Ascend NPU backend, preventing the server  from starting.

Root cause: The SWA change reassigned the redundant query tensor size in run_sdpa_forward_extend from seq_lens[seq_idx] (text sequence length) to atten_end_kv - atten_start_kv (KV window size). This is correct for SWA self-attention but breaks cross-attention:

 - In cross-attention, Q comes from text (16 tokens) while KV comes from the encoder/image (6404 tokens).
 - The redundant Q tensor was sized to the encoder length (6404), but only 16 real queries exist, so the assignment fails with a shape mismatch.

## Modifications

python/sglang/srt/hardware_backend/npu/attention/ascend_torch_native_backend.py

  - Extracted an is_swa_self_attn flag (sliding_window_size > -1 and encoder_lens is None) to remove the duplicated condition check.
  - Branched the redundant query tensor sizing by scenario:
    - SWA self-attention: redundant_len = atten_end_kv - atten_start_kv (cropped window size, keeping Q.len == K.len for the causal mask).
    - Cross-attention / non-SWA self-attention: redundant_len = seq_lens[seq_idx] (preserving the original text sequence length semantics).

  SWA gemma4 self-attention behavior is unchanged; mllama cross-attention is restored.

## Accuracy Tests

```bash
Total latency: 165.395 s
Score: 0.330
Output throughput: 18.036 token/s
[METRIC] mmmu_score=0.3301 labels={"model": "/home/weights/Llama-3.2-11B-Vision-Instruct", "eval": "mmmu"}
[METRIC] mmmu_latency=165.39523256011307 labels={"model": "/home/weights/Llama-3.2-11B-Vision-Instruct", "eval": "mmmu"}
Writing report to /tmp/mmmu__home_weights_Llama-3.2-11B-Vision-Instruct.html
{'Overall-Art and Design': {'num': 10, 'acc': 0.4}, 'Art': {'num': 10, 'acc': 0.4}, 'Overall-Business': {'num': 30, 'acc': 0.367}, 'Accounting': {'num': 30, 'acc': 0.367}, 'Overall-Tech and Engineering': {'num': 60, 'acc': 0.3}, 'Agriculture': {'num': 30, 'acc': 0.267}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.333}, 'Overall': {'num': 100, 'acc': 0.33}, 'score': 0.3301, 'latency': 165.39523256011307, 'output_throughput': 18.035586357761705}
Writing results to /tmp/mmmu__home_weights_Llama-3.2-11B-Vision-Instruct.json

==========================================
/home/weights/Llama-3.2-11B-Vision-Instruct - metrics={'Overall-Art and Design': {'num': 10, 'acc': 0.4}, 'Art': {'num': 10, 'acc': 0.4}, 'Overall-Business': {'num': 30, 'acc': 0.367}, 'Accounting': {'num': 30, 'acc': 0.367}, 'Overall-Tech and Engineering': {'num': 60, 'acc': 0.3}, 'Agriculture': {'num': 30, 'acc': 0.267}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.333}, 'Overall': {'num': 100, 'acc': 0.33}, 'score': 0.3301, 'latency': 165.3952, 'output_throughput': 18.035586357761705} score=0.3301
==========================================

.Cleaning up server process 94350

----------------------------------------------------------------------
Ran 1 test in 283.137s

OK

```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28215759966](https://github.com/sgl-project/sglang/actions/runs/28215759966)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28215759870](https://github.com/sgl-project/sglang/actions/runs/28215759870)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->