### PR TITLE
Fix test_type_based_dispatcher after TokenizedGenerateReqInput field changes

### DIFF
--- a/test/registered/utils/test_type_based_dispatcher.py
+++ b/test/registered/utils/test_type_based_dispatcher.py
@@ -140,7 +140,7 @@ class TestTypeBasedDispatcher(unittest.TestCase):
             TokenizedEmbeddingReqInput(
                 input_text="",
                 input_ids=[1, 2],
-                image_inputs=dict(),
+                mm_inputs=dict(),
                 token_type_ids=[1, 2],
                 sampling_params=SamplingParams(),
             )
@@ -152,7 +152,9 @@ class TestTypeBasedDispatcher(unittest.TestCase):
                     TokenizedGenerateReqInput(
                         input_text="",
                         input_ids=[1, 2],
+                        input_embeds=None,
                         mm_inputs=dict(),
+                        token_type_ids=None,
                         sampling_params=SamplingParams(),
                         return_logprob=False,
                         logprob_start_len=0,
@@ -169,7 +171,7 @@ class TestTypeBasedDispatcher(unittest.TestCase):
                     TokenizedEmbeddingReqInput(
                         input_text="",
                         input_ids=[1, 2],
-                        image_inputs=dict(),
+                        mm_inputs=dict(),
                         token_type_ids=[1, 2],
                         sampling_params=SamplingParams(),
                     )

--- a/test/registered/utils/test_type_based_dispatcher.py
+++ b/test/registered/utils/test_type_based_dispatcher.py
@@ -124,7 +124,9 @@ class TestTypeBasedDispatcher(unittest.TestCase):
             TokenizedGenerateReqInput(
                 input_text="",
                 input_ids=[1, 2],
+                input_embeds=None,
                 mm_inputs=dict(),
+                token_type_ids=None,
                 sampling_params=SamplingParams(),
                 return_logprob=False,
                 logprob_start_len=0,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`test/registered/utils/test_type_based_dispatcher.py` started failing in AMD CI with:
```
TypeError: TokenizedGenerateReqInput.init() missing 2 required positional arguments: 'input_embeds' and 'token_type_ids'
```

Root cause is #29214 ("[Cleanup] IPC struct renames, better typing, and SenderWrapper removal"), which reordered the dataclass fields in `python/sglang/srt/managers/io_struct.py`:
- `TokenizedGenerateReqInput`: `input_embeds` and `token_type_ids` were moved from optional fields (`= None`) to required positional fields.
- `TokenizedEmbeddingReqInput`: the `image_inputs` field was renamed to `mm_inputs`.
The test constructors were not updated in that PR, so they now raise `TypeError` at instantiation. This is a test-only fix to match the new struct definitions.
## Modifications
In `test/registered/utils/test_type_based_dispatcher.py`:
- Add `input_embeds=None` and `token_type_ids=None` to the two `TokenizedGenerateReqInput(...)` calls.
- Rename `image_inputs=dict()` to `mm_inputs=dict()` in the two `TokenizedEmbeddingReqInput(...)` calls.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28216006718](https://github.com/sgl-project/sglang/actions/runs/28216006718)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28216008216](https://github.com/sgl-project/sglang/actions/runs/28216008216)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->