### PR TITLE
[AMD] Fix fused append+remap DeepEP equivalence test on aiter path

### DIFF
--- a/test/registered/moe/test_fused_append_remap_deepep.py
+++ b/test/registered/moe/test_fused_append_remap_deepep.py
@@ -14,7 +14,7 @@ from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_kernels impo
     fused_append_remap_shared_experts_deepep,
     fused_append_shared_experts,
 )
-from sglang.srt.layers.moe.topk import TopKConfig, _remap_topk_for_deepep
+from sglang.srt.layers.moe.topk import TopKConfig, _remap_topk_for_deepep, _use_aiter
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
@@ -109,12 +109,13 @@ class TestFusedAppendRemapDeepEP(CustomTestCase):
     def test_equivalence_with_eager_append_then_remap(self):
         """Fused kernel == fused_append_shared_experts() + _remap_topk_for_deepep().
 
-        The eager remap overwrites the shared weight with 1/routed_scaling_factor,
-        so the fused kernel is invoked with that same value to make the two paths
-        bit-identical (ids are identical regardless of the scaling factor).
+        The eager remap overwrites the shared weight: 1.0 on the aiter/HIP path
+        (routed_scaling_factor is pre-folded into the routed topk weights), else
+        1/routed_scaling_factor. The fused kernel is invoked with that same value
+        so the two paths stay bit-identical (ids match regardless of scaling).
         """
         rsf = 2.5
-        scale_factor = 1.0 / rsf
+        scale_factor = 1.0 if _use_aiter else 1.0 / rsf
         for m, k, npr, ep_size, ep_rank, s in self.CASES:
             with self.subTest(m=m, k=k, npr=npr, ep_rank=ep_rank, s=s):
                 shared_id_base, num_local_routed = self._shared_id_base(


### PR DESCRIPTION
## Motivation

`test/registered/moe/test_fused_append_remap_deepep.py::test_equivalence_with_eager_append_then_remap`
fails on AMD nightly CI:
```
AssertionError: False is not true # torch.allclose(fused_w, eager_w) (m=1, k=8, npr=256, ep_rank=0, s=1)
```
The test was added in #28450 (de2d01c8) and assumed `_remap_topk_for_deepep()`
always overwrites the fused shared-expert weight with `1/routed_scaling_factor`.
PR #28237 (3d3a7ec0) later changed `_remap_topk_for_deepep()` so that on the
**aiter/HIP path** (`_use_aiter == True`) the shared weight is forced to `1.0`
(routed_scaling_factor is pre-folded into the routed topk weights, and
`forward_deepep` skips the post-MoE multiply for `_use_aiter`). The equivalence
test was not updated, so on AMD the eager side now yields `1.0` while the fused
kernel is still invoked with `1/rsf = 0.4` → mismatch. On CUDA `_use_aiter` is
`False`, so the test still passed there — which is why only AMD CI broke.
## Modification
Pick the `scale_factor` passed to the fused kernel based on `_use_aiter` so it
matches the eager remap's branch:
- aiter/HIP: `1.0`
- otherwise: `1.0 / routed_scaling_factor`
This keeps the two paths bit-identical on both backends. No kernel/runtime
behavior change — test-only fix. Docstring updated to document the branch.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28216923730](https://github.com/sgl-project/sglang/actions/runs/28216923730)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28216923448](https://github.com/sgl-project/sglang/actions/runs/28216923448)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->