### PR TITLE
[CPU] use faster exp in silu_and_mul

### DIFF
--- a/sgl-kernel/csrc/cpu/activation.cpp
+++ b/sgl-kernel/csrc/cpu/activation.cpp
@@ -72,7 +72,7 @@ at::Tensor silu_and_mul_cpu(at::Tensor& input) {
         num_tokens,
         d,
         [](float x) { return x / (1.f + std::exp(-x)); },
-        [](Vec x) { return x / (Vec(1.f) + x.neg().exp()); });
+        [](Vec x) { return x / (Vec(1.f) + x.neg().exp_u20()); });
   });
   return out;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR speeds up the CPU `silu_and_mul_cpu` vector path by replacing `exp()` with `exp_u20()` in `sgl-kernel/csrc/cpu/activation.cpp`.

This matches the faster vector exponential approximation already used by other CPU kernels in `sgl-kernel`, while keeping the scalar fallback unchanged.

## Modifications

replace `exp()` to `exp_u20`, which is a faster vectorized approximation of `exp(x)` provided by PyTorch's `at::vec::Vectorized<float>` implementation.

`exp()` from torch uses sleef u10. And u20 means 20 ULP (units in the last place) relative to IEEE-754 float semantics — accurate enough for inference hot paths (softmax, SiLU, gated activations, Mamba/FLA recurrences), but faster than sleef u10.

## Accuracy Tests

`python test/registered/cpu/test_activation.py`

## Speed Tests and Profiling

tested on 32 core gen6 Xeon and achive **6%** to **29%** speedup. 

Shape | Dtype | Before | After | Speedup
-- | -- | -- | -- | --
(1, 18432) | bf16 | 10.311 us | 9.103 us | 1.133x
(17, 18432) | bf16 | 29.097 us | 22.425 us | 1.298x
(1000, 18432) | bf16 | 462.275 us | 392.141 us | 1.179x
(1, 18432) | fp16 | 12.866 us | 11.206 us | 1.148x
(17, 18432) | fp16 | 27.284 us | 25.828 us | 1.056x
(1000, 18432) | fp16 | 518.754 us | 401.485 us | 1.292x


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28219169654](https://github.com/sgl-project/sglang/actions/runs/28219169654)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28219169566](https://github.com/sgl-project/sglang/actions/runs/28219169566)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->