### PR TITLE
[Enhancement] Explicitly destroy old CUDA graphs before re-capture in weight update

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1831,6 +1831,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 and current_platform.support_cuda_graph()
             )
         ):
+            if getattr(self, "decode_cuda_graph_runner", None) is not None:
+                del self.decode_cuda_graph_runner
+                self.decode_cuda_graph_runner = None
+            if getattr(self, "prefill_cuda_graph_runner", None) is not None:
+                del self.prefill_cuda_graph_runner
+                self.prefill_cuda_graph_runner = None
+            gc.collect()
+            torch.cuda.empty_cache()
             self.init_decode_cuda_graph()
 
         logger.info("Update weights end.")


### PR DESCRIPTION
## Motivation

When `update_weights_from_disk` is called with `recapture_cuda_graph=True`, the old decode/prefill graph runners are not explicitly destroyed before `init_decode_cuda_graph()` re-captures new ones.

`init_decode_cuda_graph()` does set `self.decode_cuda_graph_runner = None` at its start, but this only drops the Python reference — the underlying CUDA graph objects remain in GPU memory until Python's GC collects them, which is non-deterministic and may not happen before the new graphs are allocated. This means both old and new CUDA graphs coexist in GPU memory during re-capture, causing unnecessarily high **peak GPU memory usage**.

For models with large CUDA graph footprints (e.g., 32B models with `--cuda-graph-max-bs 64`), this can waste several GB of GPU memory and potentially trigger OOM during re-capture.

## Modifications

In `ModelRunner.update_weights_from_disk()`, added explicit cleanup before calling `init_decode_cuda_graph()`:

1. `del` the old `decode_cuda_graph_runner` and `prefill_cuda_graph_runner` (guarded by `getattr` for compatibility)
2. `gc.collect()` to ensure Python releases the CUDA graph objects immediately
3. `torch.cuda.empty_cache()` to return the freed GPU memory to the CUDA allocator

This ensures old CUDA graph memory is fully released **before** new graphs are captured.

## Accuracy Tests

No model output changes — this PR only affects the order of resource cleanup, not the graph capture logic itself.

Verified that inference output is identical before and after weight update with `recapture_cuda_graph=True`:

```
# Before update
Generate: "Answer! I'm a bit confused about"

# After same-arch update + re-capture
Generate: "Answer! I'm a bit confused about"
```

## Speed Tests and Profiling

Not applicable — this change does not affect inference speed. It reduces **peak memory** during the re-capture transient, not steady-state memory or latency.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28219738878](https://github.com/sgl-project/sglang/actions/runs/28219738878)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28219738771](https://github.com/sgl-project/sglang/actions/runs/28219738771)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->