### PR TITLE
[Bugfix] fix non-first PP-rank token count for multimodal models

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2808,10 +2808,22 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         input_embeds: torch.Tensor = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
-        # Minor fix for multi-modal model: input_ids is None
-        len_input_ids = (
-            input_ids.shape[0] if input_ids is not None else input_embeds.shape[0]
-        )
+        # Minor fix for multi-modal model: input_ids is None. On non-first PP
+        # ranks both input_ids and input_embeds are None (the stage input
+        # arrives via pp_proxy_tensors), so fall back to the relayed hidden
+        # states for the token count.
+        #
+        # NOTE: this count is correct only when context parallelism is off.
+        # Under attn_cp_size > 1 PP0 CP-splits the hidden states before send
+        # (base_runner sizes the prefill relay to num_tokens // attn_cp_size),
+        # so shape[0] would undercount. multimodal + CP + PP is unsupported and
+        # not validated -- do not enable that combination.
+        if input_ids is not None:
+            len_input_ids = input_ids.shape[0]
+        elif input_embeds is not None:
+            len_input_ids = input_embeds.shape[0]
+        else:
+            len_input_ids = pp_proxy_tensors["hidden_states"].shape[0]
         if self.dsa_enable_prefill_cp:
             if can_dsa_cp_split(
                 len_input_ids, self.cp_size, self.use_dsa, forward_batch


### PR DESCRIPTION
## Motivation

A multimodal model whose language model is `deepseek_v2.py` (e.g.
`KimiK25ForConditionalGeneration`) **crashes under pipeline parallelism** at cuda-graph
capture on any non-first PP rank, independent of speculative decoding:

```
models/<mm_model>.py: forward -> general_mm_embed_routine -> language_model(...)
models/deepseek_v2.py: forward
    len_input_ids = input_ids.shape[0] if input_ids is not None else input_embeds.shape[0]
AttributeError: 'NoneType' object has no attribute 'shape'
```

On a non-first PP rank the stage input arrives via `pp_proxy_tensors` (relayed hidden
states), so `input_ids` is `None`. For a multimodal target, the wrapper
`general_mm_embed_routine` additionally calls the language model with `input_embeds=None`
(it only embeds tokens on the first rank). Both being `None`, the `len_input_ids`
computation dereferences `None.shape`. Pure-text targets avoid this because they never go
through `general_mm_embed_routine` and `input_ids` is non-`None` on every rank.

This is a **pre-existing base-model bug** (reproduces with **no speculative decoding**); it
is orthogonal to, but blocks, running such models under PP.

## Modifications

- **`models/deepseek_v2.py`** — when both `input_ids` and `input_embeds` are `None`, derive
  the token count from the relayed hidden states:

  ```python
  if input_ids is not None:
      len_input_ids = input_ids.shape[0]
  elif input_embeds is not None:
      len_input_ids = input_embeds.shape[0]
  else:
      len_input_ids = pp_proxy_tensors["hidden_states"].shape[0]
  ```

No behavior change for the existing paths (first PP rank / non-PP / pure-text); it only adds
the previously-missing non-first-PP-rank branch for multimodal targets.

**On context parallelism.** This count is correct only when CP is off. Under `attn_cp_size > 1`
the runtime CP-shards the PP proxy on non-first PP stages (`base_runner` sizes the prefill relay
to `num_tokens // attn_cp_size`), so `shape[0]` would undercount. **multimodal + CP + PP is
unsupported and not validated** — a `NOTE` comment in the code says so, and the combination
should not be enabled. (An earlier revision added a global `attn_cp_size>1 + pp_size>1` reject in
`ServerArgs`; that was dropped to avoid removing a config the runtime otherwise permits, leaving
the single-file model fix with no server-arg surface.)

## Accuracy Tests

Enables the model to run under PP where it previously aborted at capture. Validated on
**Kimi-K2.7-Code** (`KimiK25ForConditionalGeneration`, DeepSeek-V3-style MLA/MoE, 555 GB),
2-node **TP8×PP2** (cross-node): server boots (previously crashed at capture), single +
concurrent requests succeed, `cuda graph: True` on every decode batch. No change to outputs on non-multimodal / non-PP paths.

## Speed Tests and Profiling

Not a perf change. 
## Checklist

- [X] Minimal, behavior-preserving fix for the existing paths.
- [X] Provide validation (Kimi-K2 boots + runs under PP).
- [X] The non-first-PP-rank multimodal forward is exercised by the Kimi-K2 e2e PP run (a
  dedicated CPU forward harness is impractical for the full model). No new unit test: the change
  is a one-file `None`-guard with no server-arg surface (the earlier CP+PP arg guard was dropped).
- [X] pre-commit passes (isort / ruff / black / clang-format / codespell / end-of-file — no changes needed).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28220110923](https://github.com/sgl-project/sglang/actions/runs/28220110923)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28220110903](https://github.com/sgl-project/sglang/actions/runs/28220110903)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->