### PR TITLE
[Diffusion] Fuse LTX2 Ada values

### DIFF
--- a/python/sglang/jit_kernel/diffusion/triton/ltx2_ada_values.py
+++ b/python/sglang/jit_kernel/diffusion/triton/ltx2_ada_values.py
@@ -1,0 +1,184 @@
+# Adapted from NVlabs/Sana sol-engine LTX2 Ada-value fusion.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _ltx2_ada_values9_kernel(
+    temb_ptr,
+    table_ptr,
+    out0_ptr,
+    out1_ptr,
+    out2_ptr,
+    out3_ptr,
+    out4_ptr,
+    out5_ptr,
+    out6_ptr,
+    out7_ptr,
+    out8_ptr,
+    rows: tl.constexpr,
+    hidden: tl.constexpr,
+    total_params: tl.constexpr,
+    table_stride_p: tl.constexpr,
+    table_stride_d: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    cols = tl.arange(0, BLOCK_N)
+    mask = cols < hidden
+    temb_row = temb_ptr + row * total_params * hidden
+    base = row * hidden + cols
+
+    table0 = tl.load(
+        table_ptr + 0 * table_stride_p + cols * table_stride_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    temb0 = tl.load(
+        temb_row + (0 * hidden + cols),
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    table1 = tl.load(
+        table_ptr + 1 * table_stride_p + cols * table_stride_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    temb1 = tl.load(
+        temb_row + (1 * hidden + cols),
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    table2 = tl.load(
+        table_ptr + 2 * table_stride_p + cols * table_stride_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    temb2 = tl.load(
+        temb_row + (2 * hidden + cols),
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    table3 = tl.load(
+        table_ptr + 3 * table_stride_p + cols * table_stride_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    temb3 = tl.load(
+        temb_row + (3 * hidden + cols),
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    table4 = tl.load(
+        table_ptr + 4 * table_stride_p + cols * table_stride_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    temb4 = tl.load(
+        temb_row + (4 * hidden + cols),
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    table5 = tl.load(
+        table_ptr + 5 * table_stride_p + cols * table_stride_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    temb5 = tl.load(
+        temb_row + (5 * hidden + cols),
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    table6 = tl.load(
+        table_ptr + 6 * table_stride_p + cols * table_stride_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    temb6 = tl.load(
+        temb_row + (6 * hidden + cols),
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    table7 = tl.load(
+        table_ptr + 7 * table_stride_p + cols * table_stride_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    temb7 = tl.load(
+        temb_row + (7 * hidden + cols),
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    table8 = tl.load(
+        table_ptr + 8 * table_stride_p + cols * table_stride_d,
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+    temb8 = tl.load(
+        temb_row + (8 * hidden + cols),
+        mask=mask,
+        other=0.0,
+    ).to(tl.bfloat16)
+
+    tl.store(out0_ptr + base, (table0 + temb0).to(tl.bfloat16), mask=mask)
+    tl.store(out1_ptr + base, (table1 + temb1).to(tl.bfloat16), mask=mask)
+    tl.store(out2_ptr + base, (table2 + temb2).to(tl.bfloat16), mask=mask)
+    tl.store(out3_ptr + base, (table3 + temb3).to(tl.bfloat16), mask=mask)
+    tl.store(out4_ptr + base, (table4 + temb4).to(tl.bfloat16), mask=mask)
+    tl.store(out5_ptr + base, (table5 + temb5).to(tl.bfloat16), mask=mask)
+    tl.store(out6_ptr + base, (table6 + temb6).to(tl.bfloat16), mask=mask)
+    tl.store(out7_ptr + base, (table7 + temb7).to(tl.bfloat16), mask=mask)
+    tl.store(out8_ptr + base, (table8 + temb8).to(tl.bfloat16), mask=mask)
+
+
+def ltx2_ada_values9(
+    scale_shift_table: torch.Tensor,
+    timestep: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    if timestep.ndim != 3:
+        raise ValueError("timestep must have shape [B, S, 9 * D]")
+    if not timestep.is_cuda or timestep.dtype != torch.bfloat16:
+        raise ValueError("timestep must be a CUDA bfloat16 tensor")
+    if not timestep.is_contiguous():
+        raise ValueError("timestep must be contiguous")
+    if scale_shift_table.ndim != 2 or scale_shift_table.shape[0] != 9:
+        raise ValueError("scale_shift_table must have shape [9, D]")
+    if (
+        not scale_shift_table.is_cuda
+        or scale_shift_table.dtype not in (torch.bfloat16, torch.float32)
+        or scale_shift_table.stride(-1) != 1
+    ):
+        raise ValueError(
+            "scale_shift_table must be CUDA, bf16/fp32, last-dim contiguous"
+        )
+
+    total_params = int(scale_shift_table.shape[0])
+    hidden = int(scale_shift_table.shape[1])
+    if hidden <= 0 or timestep.shape[-1] != total_params * hidden:
+        raise ValueError("timestep last dim must equal 9 * hidden")
+    if hidden % 256 != 0 or hidden > 8192:
+        raise ValueError("hidden size is outside the supported LTX2 fast-path range")
+
+    batch, seq, _ = timestep.shape
+    rows = int(batch * seq)
+    outs = tuple(
+        torch.empty((batch, seq, hidden), device=timestep.device, dtype=timestep.dtype)
+        for _ in range(9)
+    )
+    _ltx2_ada_values9_kernel[(rows,)](
+        timestep,
+        scale_shift_table,
+        *outs,
+        rows,
+        hidden,
+        total_params,
+        scale_shift_table.stride(0),
+        scale_shift_table.stride(1),
+        BLOCK_N=triton.next_power_of_2(hidden),
+        num_warps=4 if hidden >= 4096 else 8,
+    )
+    return outs

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -49,8 +49,7 @@ logger = init_logger(__name__)
 ADALN_NUM_BASE_PARAMS = 6
 ADALN_NUM_CROSS_ATTN_PARAMS = 3
 
-_LTX2_FUSED_ADA_VALUES_ALL_RUNTIME_DISABLED = False
-_LTX2_FUSED_ADA_VALUES_ALL_WARNING_EMITTED = False
+_LTX2_FUSED_ADA_VALUES_RUNTIME_DISABLED = False
 
 
 def adaln_embedding_coefficient(cross_attention_adaln: bool) -> int:
@@ -59,13 +58,10 @@ def adaln_embedding_coefficient(cross_attention_adaln: bool) -> int:
     )
 
 
-def _ltx2_disable_fused_ada_values_all(exc: Exception) -> None:
-    global _LTX2_FUSED_ADA_VALUES_ALL_RUNTIME_DISABLED
-    global _LTX2_FUSED_ADA_VALUES_ALL_WARNING_EMITTED
-    _LTX2_FUSED_ADA_VALUES_ALL_RUNTIME_DISABLED = True
-    if not _LTX2_FUSED_ADA_VALUES_ALL_WARNING_EMITTED:
-        logger.warning("Disabling LTX2 fused Ada values fast path: %s", exc)
-        _LTX2_FUSED_ADA_VALUES_ALL_WARNING_EMITTED = True
+def _ltx2_disable_fused_ada_values(exc: Exception) -> None:
+    global _LTX2_FUSED_ADA_VALUES_RUNTIME_DISABLED
+    _LTX2_FUSED_ADA_VALUES_RUNTIME_DISABLED = True
+    logger.warning_once(f"Disabling LTX2 fused Ada values fast path: {exc}")
 
 
 def _ltx2_try_fused_ada_values9(
@@ -74,7 +70,7 @@ def _ltx2_try_fused_ada_values9(
     timestep: torch.Tensor,
 ) -> tuple[torch.Tensor, ...] | None:
     if (
-        _LTX2_FUSED_ADA_VALUES_ALL_RUNTIME_DISABLED
+        _LTX2_FUSED_ADA_VALUES_RUNTIME_DISABLED
         or get_tp_world_size() != 1
         or not timestep.is_cuda
         or timestep.dtype != torch.bfloat16
@@ -100,7 +96,7 @@ def _ltx2_try_fused_ada_values9(
 
         return ltx2_ada_values9(scale_shift_table, timestep)
     except Exception as exc:
-        _ltx2_disable_fused_ada_values_all(exc)
+        _ltx2_disable_fused_ada_values(exc)
         return None
 
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -49,11 +49,59 @@ logger = init_logger(__name__)
 ADALN_NUM_BASE_PARAMS = 6
 ADALN_NUM_CROSS_ATTN_PARAMS = 3
 
+_LTX2_FUSED_ADA_VALUES_ALL_RUNTIME_DISABLED = False
+_LTX2_FUSED_ADA_VALUES_ALL_WARNING_EMITTED = False
+
 
 def adaln_embedding_coefficient(cross_attention_adaln: bool) -> int:
     return ADALN_NUM_BASE_PARAMS + (
         ADALN_NUM_CROSS_ATTN_PARAMS if cross_attention_adaln else 0
     )
+
+
+def _ltx2_disable_fused_ada_values_all(exc: Exception) -> None:
+    global _LTX2_FUSED_ADA_VALUES_ALL_RUNTIME_DISABLED
+    global _LTX2_FUSED_ADA_VALUES_ALL_WARNING_EMITTED
+    _LTX2_FUSED_ADA_VALUES_ALL_RUNTIME_DISABLED = True
+    if not _LTX2_FUSED_ADA_VALUES_ALL_WARNING_EMITTED:
+        logger.warning("Disabling LTX2 fused Ada values fast path: %s", exc)
+        _LTX2_FUSED_ADA_VALUES_ALL_WARNING_EMITTED = True
+
+
+def _ltx2_try_fused_ada_values9(
+    scale_shift_table: torch.Tensor,
+    batch_size: int,
+    timestep: torch.Tensor,
+) -> tuple[torch.Tensor, ...] | None:
+    if (
+        _LTX2_FUSED_ADA_VALUES_ALL_RUNTIME_DISABLED
+        or get_tp_world_size() != 1
+        or not timestep.is_cuda
+        or timestep.dtype != torch.bfloat16
+        or timestep.ndim != 3
+        or int(timestep.shape[0]) != int(batch_size)
+        or not timestep.is_contiguous()
+        or not scale_shift_table.is_cuda
+        or scale_shift_table.dtype not in (torch.bfloat16, torch.float32)
+        or scale_shift_table.ndim != 2
+        or int(scale_shift_table.shape[0]) != 9
+        or scale_shift_table.stride(-1) != 1
+    ):
+        return None
+
+    hidden = int(scale_shift_table.shape[1])
+    if hidden % 256 != 0 or hidden > 8192 or timestep.shape[-1] != 9 * hidden:
+        return None
+
+    try:
+        from sglang.jit_kernel.diffusion.triton.ltx2_ada_values import (
+            ltx2_ada_values9,
+        )
+
+        return ltx2_ada_values9(scale_shift_table, timestep)
+    except Exception as exc:
+        _ltx2_disable_fused_ada_values_all(exc)
+        return None
 
 
 def _ltx2_is_perturbed(
@@ -1010,13 +1058,21 @@ class LTX2TransformerBlock(nn.Module):
         v2a_cross_attn_perturbation_mask: Optional[torch.Tensor] = None,
         audio_replicated_for_sp: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-
         batch_size = hidden_states.size(0)
+        video_ada_values = _ltx2_try_fused_ada_values9(
+            self.scale_shift_table, batch_size, temb
+        )
+        audio_ada_values = _ltx2_try_fused_ada_values9(
+            self.audio_scale_shift_table, batch_size, temb_audio
+        )
 
         # 1. Video and Audio Self-Attention
-        vshift_msa, vscale_msa, vgate_msa = self.get_ada_values(
-            self.scale_shift_table, batch_size, temb, slice(0, 3)
-        )
+        if video_ada_values is None:
+            vshift_msa, vscale_msa, vgate_msa = self.get_ada_values(
+                self.scale_shift_table, batch_size, temb, slice(0, 3)
+            )
+        else:
+            vshift_msa, vscale_msa, vgate_msa = video_ada_values[0:3]
         norm_hidden_states = (
             self.rms_norm(hidden_states, self.norm_eps) * (1 + vscale_msa) + vshift_msa
         )
@@ -1030,9 +1086,12 @@ class LTX2TransformerBlock(nn.Module):
         )
         hidden_states = hidden_states + attn_hidden_states * vgate_msa
 
-        ashift_msa, ascale_msa, agate_msa = self.get_ada_values(
-            self.audio_scale_shift_table, batch_size, temb_audio, slice(0, 3)
-        )
+        if audio_ada_values is None:
+            ashift_msa, ascale_msa, agate_msa = self.get_ada_values(
+                self.audio_scale_shift_table, batch_size, temb_audio, slice(0, 3)
+            )
+        else:
+            ashift_msa, ascale_msa, agate_msa = audio_ada_values[0:3]
         norm_audio_hidden_states = (
             self.rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_msa)
             + ashift_msa
@@ -1053,9 +1112,12 @@ class LTX2TransformerBlock(nn.Module):
                 raise ValueError(
                     "cross_attention_adaln requires prompt modulation tensors."
                 )
-            vshift_q, vscale_q, vgate_q = self.get_ada_values(
-                self.scale_shift_table, batch_size, temb, slice(6, 9)
-            )
+            if video_ada_values is None:
+                vshift_q, vscale_q, vgate_q = self.get_ada_values(
+                    self.scale_shift_table, batch_size, temb, slice(6, 9)
+                )
+            else:
+                vshift_q, vscale_q, vgate_q = video_ada_values[6:9]
             v_prompt_shift, v_prompt_scale = self.get_ada_values(
                 self.prompt_scale_shift_table, batch_size, temb_prompt, slice(None)
             )
@@ -1072,9 +1134,12 @@ class LTX2TransformerBlock(nn.Module):
             )
             hidden_states = hidden_states + attn_hidden_states * vgate_q
 
-            ashift_q, ascale_q, agate_q = self.get_ada_values(
-                self.audio_scale_shift_table, batch_size, temb_audio, slice(6, 9)
-            )
+            if audio_ada_values is None:
+                ashift_q, ascale_q, agate_q = self.get_ada_values(
+                    self.audio_scale_shift_table, batch_size, temb_audio, slice(6, 9)
+                )
+            else:
+                ashift_q, ascale_q, agate_q = audio_ada_values[6:9]
             a_prompt_shift, a_prompt_scale = self.get_ada_values(
                 self.audio_prompt_scale_shift_table,
                 batch_size,
@@ -1222,18 +1287,24 @@ class LTX2TransformerBlock(nn.Module):
                 audio_hidden_states + v2a_gate * v2a_attn_hidden_states
             )
         # 4. Feedforward
-        vshift_mlp, vscale_mlp, vgate_mlp = self.get_ada_values(
-            self.scale_shift_table, batch_size, temb, slice(3, 6)
-        )
+        if video_ada_values is None:
+            vshift_mlp, vscale_mlp, vgate_mlp = self.get_ada_values(
+                self.scale_shift_table, batch_size, temb, slice(3, 6)
+            )
+        else:
+            vshift_mlp, vscale_mlp, vgate_mlp = video_ada_values[3:6]
         norm_hidden_states = (
             self.rms_norm(hidden_states, self.norm_eps) * (1 + vscale_mlp) + vshift_mlp
         )
         ff_output = self.ff(norm_hidden_states)
         hidden_states = hidden_states + ff_output * vgate_mlp
 
-        ashift_mlp, ascale_mlp, agate_mlp = self.get_ada_values(
-            self.audio_scale_shift_table, batch_size, temb_audio, slice(3, 6)
-        )
+        if audio_ada_values is None:
+            ashift_mlp, ascale_mlp, agate_mlp = self.get_ada_values(
+                self.audio_scale_shift_table, batch_size, temb_audio, slice(3, 6)
+            )
+        else:
+            ashift_mlp, ascale_mlp, agate_mlp = audio_ada_values[3:6]
         norm_audio_hidden_states = (
             self.rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_mlp)
             + ashift_mlp
@@ -1641,7 +1712,6 @@ class LTX2VideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
         audio_replicated_for_sp: bool = False,
         **kwargs,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-
         batch_size = hidden_states.size(0)
         audio_timestep = audio_timestep if audio_timestep is not None else timestep
 

--- a/test/registered/jit/diffusion/test_ltx2_ada_values.py
+++ b/test/registered/jit/diffusion/test_ltx2_ada_values.py
@@ -1,0 +1,69 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.jit_kernel.diffusion.triton.ltx2_ada_values import ltx2_ada_values9
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=8, suite="base-b-kernel-unit-1-gpu-large")
+
+DEVICE = "cuda"
+
+
+@pytest.fixture(autouse=True)
+def cuda_setup():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    torch.cuda.manual_seed(0)
+
+
+def _reference(
+    scale_shift_table: torch.Tensor,
+    timestep: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    batch, seq, _ = timestep.shape
+    hidden = scale_shift_table.shape[1]
+    return (
+        scale_shift_table.to(device=timestep.device, dtype=timestep.dtype)
+        .view(1, 1, 9, hidden)
+        .add(timestep.reshape(batch, seq, 9, hidden))
+        .unbind(dim=2)
+    )
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("batch,seq,hidden", [(1, 1, 4096), (2, 3, 2048)])
+@pytest.mark.parametrize("table_dtype", [torch.bfloat16, torch.float32])
+def test_ltx2_ada_values9(
+    batch: int,
+    seq: int,
+    hidden: int,
+    table_dtype: torch.dtype,
+) -> None:
+    scale_shift_table = torch.randn(
+        9, hidden, device=DEVICE, dtype=table_dtype
+    ).contiguous()
+    timestep = torch.randn(
+        batch, seq, 9 * hidden, device=DEVICE, dtype=torch.bfloat16
+    ).contiguous()
+
+    actual = ltx2_ada_values9(scale_shift_table, timestep)
+    expected = _reference(scale_shift_table, timestep)
+
+    assert len(actual) == 9
+    for actual_value, expected_value in zip(actual, expected):
+        torch.testing.assert_close(actual_value, expected_value, atol=0, rtol=0)
+
+
+@torch.no_grad()
+def test_ltx2_ada_values9_rejects_unsupported_shape() -> None:
+    scale_shift_table = torch.randn(8, 4096, device=DEVICE, dtype=torch.bfloat16)
+    timestep = torch.randn(1, 1, 9 * 4096, device=DEVICE, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="scale_shift_table"):
+        ltx2_ada_values9(scale_shift_table, timestep)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

Fuse the LTX-2.3 Ada value materialization path used by `LTX2TransformerBlock`.

The block repeatedly computes:

```python
scale_shift_table[None, None] + timestep.reshape(batch, -1, total_params, hidden)
```

and then slices out the self-attention, MLP, and prompt-cross-attention Ada values. For the `cross_attention_adaln` LTX-2.3 transformer blocks this can be computed once as 9 Ada tensors per stream, then reused across the block.

This PR is adapted from the LTX2 Ada-value fusion idea in [NVlabs/Sana `sol-engine`](https://github.com/NVlabs/Sana/tree/sol-engine), specifically the `ltx2_ada_values9` Triton path from [`NVlabs/Sana@00cb598`](https://github.com/NVlabs/Sana/blob/00cb59836c297bd5fad401000ee65f9042f29d02/python/sglang/jit_kernel/diffusion/triton/ltx2_ada_values.py). This PR intentionally keeps only the "Ada values all" slice of that work and does not bring over the additional Sana packed/gate/RMSNorm variants.

## Modifications

- Add `sglang.jit_kernel.diffusion.triton.ltx2_ada_values.ltx2_ada_values9`.
- Wire `LTX2TransformerBlock.forward` to compute video and audio Ada values once per block when the fast-path guards pass.
- Keep the path enabled by default with no user-facing environment variable.
- Fall back to the existing `get_ada_values(...)` path when tensor dtype, shape, contiguity, TP size, or kernel execution is unsupported.
- Add CUDA correctness coverage for bf16/fp32 Ada tables and multiple batch/sequence shapes.

## Accuracy Tests

Local static checks:

```bash
python3 -m ruff format --check \
  python/sglang/jit_kernel/diffusion/triton/ltx2_ada_values.py \
  python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py \
  test/registered/jit/diffusion/test_ltx2_ada_values.py
python3 -m ruff check \
  python/sglang/jit_kernel/diffusion/triton/ltx2_ada_values.py \
  python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py \
  test/registered/jit/diffusion/test_ltx2_ada_values.py
python3 -m py_compile \
  python/sglang/jit_kernel/diffusion/triton/ltx2_ada_values.py \
  python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py \
  test/registered/jit/diffusion/test_ltx2_ada_values.py
git diff --check
```

B200 CUDA unit test:

```bash
CUDA_VISIBLE_DEVICES=7 \
PYTHONPATH=python \
FLASHINFER_DISABLE_VERSION_CHECK=1 \
pytest -q test/registered/jit/diffusion/test_ltx2_ada_values.py -s
```

Result: `5 passed`.

## Speed Tests

B200 model E2E benchmark:

```bash
CUDA_VISIBLE_DEVICES=7 \
PYTHONPATH=/tmp/sglang_ada_<impl>/python:/tmp/sglang_ada_<impl> \
FLASHINFER_DISABLE_VERSION_CHECK=1 \
HF_HUB_OFFLINE=1 \
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
sglang generate \
  --backend=sglang \
  --model-path=Lightricks/LTX-2.3 \
  --pipeline-class-name=LTX2TwoStageHQPipeline \
  --ltx2-two-stage-device-mode original \
  --prompt="A beautiful sunset over the ocean" \
  --seed=42 \
  --width=1920 --height=1088 --num-frames=121 \
  --num-inference-steps=15 \
  --save-output --warmup \
  --perf-dump-path /tmp/ltx23_ada_values_e2e/<impl>/perf.json \
  --output-file-path /tmp/ltx23_ada_values_e2e/<impl>/<impl>.mp4
```

- Host: `ion-b200`, NVIDIA B200, `CUDA_VISIBLE_DEVICES=7`.
- Baseline commit: `a10a24e9a7`.
- PR commit: `b340931ba1`.
- Model path: `Lightricks/LTX-2.3`, native `LTX2TwoStageHQPipeline`; no diffusers fallback observed.
- Shape: T2V `1920x1088x121f`, HQ `num_inference_steps=15`, `seed=42`.
- Measurement: `sglang generate --warmup`; metric is `perf.json` `total_duration_ms`, with warmup excluded.

| Implementation | E2E ms | LTX2AVDenoisingStage ms | LTX2RefinementStage ms | Peak reserved MB | Speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| Main | 46856.69 | 29914.72 | 12773.60 | 67902 | 1.00x |
| Fused Ada values | 42177.99 | 26291.73 | 11758.51 | 67902 | **1.111x (+10.0%)** |

`compare_perf.py` reported:

```text
E2E Latency: 46856.69 ms -> 42177.99 ms, -4678.70 ms (-10.0%)
LTX2AVDenoisingStage: 29914.72 ms -> 26291.73 ms, -3622.99 ms (-12.1%)
LTX2RefinementStage: 12773.60 ms -> 11758.51 ms, -1015.09 ms (-7.9%)
```

## B200 Visual Output Check

Visual equivalence uses the same full LTX-2.3 HQ command as the model benchmark above.

- Decoded-video comparison: SSIM All `1.000000`, PSNR average `inf`.
- The generated videos are byte-level decoded-frame equivalent under ffmpeg SSIM/PSNR.

Left is `main`; right is this PR:

![LTX-2.3 HQ main vs fused Ada values](https://raw.githubusercontent.com/BBuf/sglang/pr-ltx2-ada-assets/ltx2-ada-values/main_vs_ada.gif)

MP4 artifacts: [main.mp4](https://raw.githubusercontent.com/BBuf/sglang/pr-ltx2-ada-assets/ltx2-ada-values/main.mp4), [ada.mp4](https://raw.githubusercontent.com/BBuf/sglang/pr-ltx2-ada-assets/ltx2-ada-values/ada.mp4), [side-by-side.mp4](https://raw.githubusercontent.com/BBuf/sglang/pr-ltx2-ada-assets/ltx2-ada-values/main_vs_ada.mp4).

Perf and metric artifacts: [main_perf.json](https://raw.githubusercontent.com/BBuf/sglang/pr-ltx2-ada-assets/ltx2-ada-values/main_perf.json), [ada_perf.json](https://raw.githubusercontent.com/BBuf/sglang/pr-ltx2-ada-assets/ltx2-ada-values/ada_perf.json), [ssim.log](https://raw.githubusercontent.com/BBuf/sglang/pr-ltx2-ada-assets/ltx2-ada-values/ssim.log), [psnr.log](https://raw.githubusercontent.com/BBuf/sglang/pr-ltx2-ada-assets/ltx2-ada-values/psnr.log).

## Checklist

- [x] Default path tries fused Ada values and falls back to the existing PyTorch/Triton path on unsupported inputs.
- [x] No environment variable is required to enable this optimization.
- [x] B200 CUDA correctness test passed.
- [x] LTX-2.3 HQ native model benchmark completed on B200.
- [x] Video output checked against `main`.

## Review and Merge Process

This is a focused follow-up to the Sana-inspired LTX2 fuse work. The useful effect is reducing repeated Ada value materialization inside LTX-2.3 DiT blocks; the whole-model speedup is visible in both stage-1 denoising and stage-2 refinement while decoded output remains identical.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28225971649](https://github.com/sgl-project/sglang/actions/runs/28225971649)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28230173744](https://github.com/sgl-project/sglang/actions/runs/28230173744)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->