### PR TITLE
Fix mamba radix cache `auto` strategy crashing on non-FLA platforms (MPS/MLX)

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4517,11 +4517,23 @@ class ServerArgs:
         if self.mamba_radix_cache_strategy == "auto":
             wants_overlap = not self.disable_overlap_schedule
             wants_paging = self.page_size is not None and self.page_size > 1
-            if (
+            # extra_buffer relies on the FLA kernels, which only exist on
+            # CUDA/MUSA/NPU. On other platforms (e.g. MPS/MLX) it cannot be
+            # used, so fall back to no_buffer instead of crashing later in
+            # _validate_mamba_extra_buffer.
+            fla_available = is_cuda() or is_musa() or is_npu()
+            wants_extra_buffer = (
                 wants_overlap or wants_paging
-            ) and self._support_mamba_cache_extra_buffer(model_arch):
+            ) and self._support_mamba_cache_extra_buffer(model_arch)
+            if wants_extra_buffer and fla_available:
                 self.mamba_radix_cache_strategy = "extra_buffer"
             else:
+                if wants_extra_buffer and not fla_available:
+                    logger.info(
+                        "extra_buffer mamba radix cache requires CUDA/MUSA/NPU "
+                        "(FLA); falling back to no_buffer and disabling the "
+                        "overlap schedule."
+                    )
                 self.mamba_radix_cache_strategy = "no_buffer"
                 self.disable_overlap_schedule = True
 


### PR DESCRIPTION
## Motivation

Hybrid-GDN models (Qwen3.5 / Qwen3-Next, MiniCPMV4.6, etc.) cannot be launched on Apple Silicon / MPS / MLX. Argument validation crashes with:

```
File ".../sglang/srt/server_args.py", line 4501, in _validate_mamba_extra_buffer
    is_cuda() or is_musa() or is_npu()
AssertionError: extra_buffer needs CUDA/MUSA/NPU (FLA).
```

Repro (macOS, Apple Silicon):

```
SGLANG_USE_MLX=1 python -m sglang.launch_server \
    --model-path mlx-community/Qwen3.5-MoE-... \
    --quantization mlx_q4 --disable-cuda-graph ...
```

Root cause: the `auto` selector in `_handle_mamba_radix_cache` chose the `extra_buffer` strategy based only on the model architecture and `linear_attn_backend`, without checking the hardware. `extra_buffer` relies on the FLA kernels, which only exist on CUDA/MUSA/NPU. On MPS/MLX the overlap schedule stays enabled and `linear_attn_backend` defaults to `triton`, so `_support_mamba_cache_extra_buffer()` returns `True` and `auto` always picks `extra_buffer`, which then trips the hardware assert in `_validate_mamba_extra_buffer`.

## Modifications

- In `ServerArgs._handle_mamba_radix_cache`, only select `extra_buffer` when FLA is actually available (`is_cuda() or is_musa() or is_npu()`). Otherwise fall back to `no_buffer` (disabling the overlap schedule, which that path requires) and log an info line explaining the fallback.

This is a server-args-only change; it does not touch model forward / kernel code, so model outputs are unaffected. On supported (CUDA/MUSA/NPU) platforms the auto-selection is unchanged.

After the fix, the `no_buffer` fallback validates cleanly on MPS/MLX: `page_size` defaults to `None`, `disable_overlap_schedule` is set to `True`, and the attention backend is not `trtllm_mha`.

## Accuracy Tests

N/A — no change to kernels or model forward code (server-args strategy selection only).

## Speed Tests and Profiling

N/A — does not change inference paths on supported platforms.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28221921128](https://github.com/sgl-project/sglang/actions/runs/28221921128)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28221920558](https://github.com/sgl-project/sglang/actions/runs/28221920558)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->