### PR TITLE
[AMD] [Docker] Update MoRI to v1.2.1

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -110,7 +110,7 @@ ARG ENABLE_MORI=0
 ARG NIC_BACKEND=none
 
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
-ARG MORI_COMMIT="bf99bdf18fc69887a346913ca01c315c2aa9bd4c"
+ARG MORI_COMMIT="e31d426a13e96e1cbff96a1c904d291aefe8c46a"
 
 # NIXL (upstream ai-dynamo/nixl) — KV transfer backend for prefill/decode disaggregation.
 # Built from source for ROCm; needs UCX built --with-rocm (built here from openucx).


### PR DESCRIPTION
## Summary

This PR upgrades the MoRI version used by the ROCm Docker image from `v1.2.0` to `v1.2.1`.

Related to #27669, which updated MoRI to `v1.2.0`. The new `v1.2.1` tag includes the corresponding upstream fix for MoRI support on ROCm 7.1.4, so this bump brings that support fix into the SGLang ROCm Docker build.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28763724351](https://github.com/sgl-project/sglang/actions/runs/28763724351)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28763724295](https://github.com/sgl-project/sglang/actions/runs/28763724295)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->