### PR TITLE
[Docs] Cookbook: match playground docker image resolution to deployment (hw|quant)

### DIFF
--- a/docs_new/src/snippets/_playground.jsx
+++ b/docs_new/src/snippets/_playground.jsx
@@ -1074,7 +1074,9 @@ export const Playground = ({ config }) => {
     }
     let cmd;
     if (mode === "docker") {
-      const image = (config.dockerImages && config.dockerImages[sel.hw]) || "lmsysorg/sglang:dev";
+      // Image keyed by `hw|quant` (most specific) then `hw`; `:dev` if unmapped (matches _deployment.jsx).
+      const di = config.dockerImages || {};
+      const image = di[`${sel.hw}|${sel.quant}`] || di[sel.hw] || "lmsysorg/sglang:dev";
       const portFlag = f.find((x) => x.split(/[\s=]/)[0] === "--port");
       const servePort = portFlag ? portFlag.slice("--port".length).trim() : "{{PORT}}";
       const dockerLines = [


### PR DESCRIPTION
## What

Follow-up to [#29380](https://github.com/sgl-project/sglang/pull/29380). That PR taught the **Deployment** engine (`_deployment.jsx`) to resolve `dockerImages` by `hw|quant` → `hw`, but the **Playground** engine (`_playground.jsx`) has its own copy of the docker-image resolver that was left keying by `hw` only.

Result: for a per-quant image override, the Playground's Docker output showed the wrong image. Concretely, GLM-5.2 **NVFP4** rendered `lmsysorg/sglang:latest` in the Playground while the Deployment widget correctly showed `lmsysorg/sglang:dev-glm52-nvfp4`.

This applies the identical resolver to `_playground.jsx` so the two engines stay in sync.

## Safety

Backward-compatible: the resolver differs from the old behavior **only** when a config's `dockerImages` has a `hw|quant` key. The only config with such keys today is GLM-5.2, so every other cookbook's rendered image is byte-for-byte unchanged. `mint validate` passes.

## Files

- `docs_new/src/snippets/_playground.jsx` — resolve `dockerImages` by `hw|quant` then `hw` (matches `_deployment.jsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28224813320](https://github.com/sgl-project/sglang/actions/runs/28224813320)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28224813203](https://github.com/sgl-project/sglang/actions/runs/28224813203)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->