### PR TITLE
[Feature] Add DeepEP v2 MoE dispatcher

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -27,6 +27,7 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.moe.token_dispatcher import (
     DeepEPDispatcher,
+    DeepEPV2Dispatcher,
     MooncakeEPDispatcher,
     MoriEPDispatcher,
     NixlEPDispatcher,
@@ -1058,6 +1059,10 @@ class MaybeTboDeepEPDispatcher(BaseDispatcher):
         if get_moe_a2a_backend().is_deepep():
             self._inners = [
                 DeepEPDispatcher(**kwargs) for _ in range(num_inner_dispatchers)
+            ]
+        elif get_moe_a2a_backend().is_deepep_v2():
+            self._inners = [
+                DeepEPV2Dispatcher(**kwargs) for _ in range(num_inner_dispatchers)
             ]
         elif get_moe_a2a_backend().is_mooncake():
             self._inners = [

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -273,6 +273,7 @@ def get_moe_impl_class(quant_config: Optional[QuantizationConfig]):
     if (
         get_moe_a2a_backend().is_mori()
         or get_moe_a2a_backend().is_deepep()
+        or get_moe_a2a_backend().is_deepep_v2()
         or get_moe_a2a_backend().is_mooncake()
         or get_moe_a2a_backend().is_nixl()
     ):

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -87,6 +87,8 @@ class DeepEPMoE(FusedMoE):
             self.deprecate_flag = True
         elif _is_npu:
             self.deprecate_flag = True
+        elif get_moe_a2a_backend().is_deepep_v2():
+            self.deprecate_flag = True
         elif deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and isinstance(
             quant_config, Fp8Config
         ):

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -94,6 +94,7 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
         return StandardDispatcher(moe_runner_config)
     elif (
         a2a_backend.is_deepep()
+        or a2a_backend.is_deepep_v2()
         or a2a_backend.is_mooncake()
         or a2a_backend.is_mori()
         or a2a_backend.is_nixl()

--- a/python/sglang/srt/layers/moe/token_dispatcher/__init__.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/__init__.py
@@ -16,6 +16,7 @@ from sglang.srt.layers.moe.token_dispatcher.deepep import (
     DeepEPNormalCombineInput,
     DeepEPNormalDispatchOutput,
 )
+from sglang.srt.layers.moe.token_dispatcher.deepep_v2 import DeepEPV2Dispatcher
 from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
     FlashinferDispatcher,
     FlashinferDispatchOutput,
@@ -70,6 +71,7 @@ __all__ = [
     "StandardCombineInput",
     "DeepEPConfig",
     "DeepEPDispatcher",
+    "DeepEPV2Dispatcher",
     "DeepEPNormalDispatchOutput",
     "DeepEPLLDispatchOutput",
     "DeepEPLLCombineInput",

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py
@@ -130,10 +130,10 @@ class DeepEPV2Dispatcher(BaseDispatcher):
         group: torch.distributed.ProcessGroup,
         router_topk: int,
         permute_fusion: bool = False,
-        num_experts: int = None,
-        num_local_experts: int = None,
-        hidden_size: int = None,
-        params_dtype: torch.dtype = None,
+        num_experts: int | None = None,
+        num_local_experts: int | None = None,
+        hidden_size: int | None = None,
+        params_dtype: torch.dtype | None = None,
         async_finish: bool = False,
         **kwargs,
     ):
@@ -235,7 +235,8 @@ class DeepEPV2Dispatcher(BaseDispatcher):
                 and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
             ),
         )
-        event.current_stream_wait() if self.async_finish else ()
+        if self.async_finish:
+            event.current_stream_wait()
 
         if isinstance(recv_x, tuple):
             recv_x, recv_x_scale = recv_x
@@ -277,7 +278,8 @@ class DeepEPV2Dispatcher(BaseDispatcher):
             async_with_compute_stream=self.async_finish,
             allocate_on_comm_stream=previous_event is not None,
         )
-        event.current_stream_wait() if self.async_finish else ()
+        if self.async_finish:
+            event.current_stream_wait()
         self.handle = None
         self._current_use_fp8_dispatch = False
         return combined_hidden_states

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py
@@ -35,6 +35,7 @@ try:
         raise ImportError("DeepEP v2 ElasticBuffer is GPU-only")
 
     from deep_ep import ElasticBuffer
+
     from sglang.srt.layers.quantization.fp8_kernel import (
         sglang_per_token_group_quant_fp8,
     )

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import logging
+from enum import Enum, auto
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.layers.moe.token_dispatcher.base import (
+    BaseDispatcher,
+    CombineInput,
+    DispatchOutput,
+)
+from sglang.srt.layers.moe.token_dispatcher.deepep import (
+    DeepEPNormalDispatchOutput,
+    DeepEPPDispatchHooks,
+)
+from sglang.srt.layers.moe.topk import TopKOutput
+from sglang.srt.layers.moe.utils import (
+    DeepEPOutputDtype,
+    get_deepep_output_dtype,
+)
+from sglang.srt.utils import get_bool_env_var, is_hip, is_npu
+
+_is_npu = is_npu()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
+
+if TYPE_CHECKING:
+    from sglang.srt.batch_overlap.single_batch_overlap import CombineOverlapArgs
+
+try:
+    if _is_npu:
+        raise ImportError("DeepEP v2 ElasticBuffer is GPU-only")
+
+    from deep_ep import ElasticBuffer
+    from sglang.srt.layers.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+
+    use_deepep_v2 = True
+except ImportError:
+    use_deepep_v2 = False
+
+logger = logging.getLogger(__name__)
+
+
+class DeepEPV2Buffer:
+    _buffer = None
+    _buffer_key = None
+    _num_comm_sms = 0
+
+    @classmethod
+    def allow_hybrid_mode(cls) -> bool:
+        return not get_bool_env_var("EP_DISABLE_GIN")
+
+    @classmethod
+    def get_buffer(
+        cls,
+        group: torch.distributed.ProcessGroup,
+        hidden_size: int,
+        router_topk: int,
+        num_max_dispatch_tokens_per_rank: int,
+        num_experts: int,
+        use_fp8_dispatch: bool,
+    ):
+        if not use_deepep_v2:
+            raise ImportError(
+                "DeepEP v2 requires a DeepEP package that exports ElasticBuffer. "
+                "Please install a recent DeepEP package from "
+                "https://github.com/deepseek-ai/DeepEP."
+            )
+
+        allow_hybrid_mode = cls.allow_hybrid_mode()
+        required_bytes = ElasticBuffer.get_buffer_size_hint(
+            group,
+            num_max_dispatch_tokens_per_rank,
+            hidden_size,
+            num_topk=router_topk,
+            use_fp8_dispatch=use_fp8_dispatch,
+            allow_hybrid_mode=allow_hybrid_mode,
+        )
+        buffer_key = (
+            group,
+            hidden_size,
+            router_topk,
+            num_max_dispatch_tokens_per_rank,
+            use_fp8_dispatch,
+            allow_hybrid_mode,
+        )
+
+        if (
+            cls._buffer is not None
+            and cls._buffer_key == buffer_key
+            and cls._buffer.num_bytes >= required_bytes
+        ):
+            return cls._buffer, cls._num_comm_sms
+
+        cls._buffer = ElasticBuffer(
+            group,
+            num_max_tokens_per_rank=num_max_dispatch_tokens_per_rank,
+            hidden=hidden_size,
+            num_topk=router_topk,
+            use_fp8_dispatch=use_fp8_dispatch,
+            allow_hybrid_mode=allow_hybrid_mode,
+        )
+        cls._buffer_key = buffer_key
+        cls._num_comm_sms = cls._buffer.get_theoretical_num_sms(
+            num_experts, router_topk
+        )
+        logger.info(
+            "Initialized DeepEP v2 ElasticBuffer with %s bytes and %s comm SMs.",
+            cls._buffer.num_bytes,
+            cls._num_comm_sms,
+        )
+        return cls._buffer, cls._num_comm_sms
+
+
+class _Stage(Enum):
+    INITIAL = auto()
+    AFTER_DISPATCH_A = auto()
+    AFTER_DISPATCH_B = auto()
+    AFTER_COMBINE_A = auto()
+
+
+class DeepEPV2Dispatcher(BaseDispatcher):
+    def __init__(
+        self,
+        group: torch.distributed.ProcessGroup,
+        router_topk: int,
+        permute_fusion: bool = False,
+        num_experts: int = None,
+        num_local_experts: int = None,
+        hidden_size: int = None,
+        params_dtype: torch.dtype = None,
+        async_finish: bool = False,
+        **kwargs,
+    ):
+        super().__init__()
+        if not use_deepep_v2:
+            raise ImportError(
+                "DeepEP v2 requires a DeepEP package that exports ElasticBuffer. "
+                "Please install a recent DeepEP package from "
+                "https://github.com/deepseek-ai/DeepEP."
+            )
+
+        self.group = group
+        self.router_topk = router_topk
+        self.permute_fusion = permute_fusion
+        self.num_experts = num_experts
+        self.num_local_experts = num_local_experts
+        self.hidden_size = hidden_size
+        self.params_dtype = params_dtype
+        self.async_finish = async_finish
+        self.handle = None
+        self._current_use_fp8_dispatch = False
+        self.num_max_dispatch_tokens_per_rank = (
+            envs.SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
+        )
+
+        self._stage = _Stage.INITIAL
+        self._deepep_dispatch_hooks = DeepEPPDispatchHooks()
+
+        self.expert_mask_gpu = None
+        if _use_aiter and num_local_experts is not None:
+            expert_mask = torch.zeros(
+                num_local_experts + 1,
+                device=torch.cuda.current_device(),
+                dtype=torch.int,
+            )
+            expert_mask[:-1] = 1
+            self.expert_mask_gpu = expert_mask
+
+        self.set_deepep_dispatcher_dtype()
+
+    def dispatch(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+    ) -> DispatchOutput:
+        self.dispatch_a(hidden_states, topk_output)
+        if self._deepep_dispatch_hooks is not None:
+            self._deepep_dispatch_hooks(self)
+        return self.dispatch_b()
+
+    def dispatch_a(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+    ):
+        self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
+        topk_ids = topk_output.topk_ids.to(torch.int64)
+        topk_weights = topk_output.topk_weights
+
+        if self.use_fp8:
+            hidden_states = sglang_per_token_group_quant_fp8(
+                hidden_states,
+                128,
+                column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+                scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+            )
+
+        previous_event = ElasticBuffer.capture() if self.async_finish else None
+        self._dispatch_intermediate_state = (
+            hidden_states,
+            topk_ids,
+            topk_weights,
+            previous_event,
+        )
+
+    def dispatch_b(self):
+        self._update_stage(_Stage.AFTER_DISPATCH_A, _Stage.AFTER_DISPATCH_B)
+        hidden_states, topk_ids, topk_weights, previous_event = (
+            self._dispatch_intermediate_state
+        )
+        del self._dispatch_intermediate_state
+
+        buffer, num_sms = self._get_buffer(isinstance(hidden_states, tuple))
+        self._current_use_fp8_dispatch = isinstance(hidden_states, tuple)
+        recv_x, recv_topk_ids, recv_topk_weights, self.handle, event = buffer.dispatch(
+            hidden_states,
+            topk_idx=topk_ids,
+            topk_weights=topk_weights,
+            num_experts=self.num_experts,
+            num_max_tokens_per_rank=self.num_max_dispatch_tokens_per_rank,
+            expert_alignment=128 if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM else 1,
+            num_sms=num_sms,
+            previous_event=previous_event,
+            async_with_compute_stream=self.async_finish,
+            allocate_on_comm_stream=previous_event is not None,
+            use_tma_aligned_col_major_sf=(
+                isinstance(hidden_states, tuple)
+                and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
+            ),
+        )
+        event.current_stream_wait() if self.async_finish else ()
+
+        if isinstance(recv_x, tuple):
+            recv_x, recv_x_scale = recv_x
+        else:
+            recv_x_scale = None
+
+        return DeepEPNormalDispatchOutput(
+            recv_x,
+            recv_x_scale,
+            recv_topk_ids,
+            recv_topk_weights,
+            self.handle.num_recv_tokens_per_expert_list,
+        )
+
+    def combine(self, combine_input: CombineInput) -> torch.Tensor:
+        self.combine_a(combine_input)
+        return self.combine_b()
+
+    def combine_a(self, combine_input: CombineInput):
+        hidden_states, _topk_ids, _topk_weights = combine_input
+        self._update_stage(_Stage.AFTER_DISPATCH_B, _Stage.AFTER_COMBINE_A)
+        previous_event = ElasticBuffer.capture() if self.async_finish else None
+        self._combine_intermediate_state = (
+            hidden_states,
+            previous_event,
+        )
+
+    def combine_b(self):
+        self._update_stage(_Stage.AFTER_COMBINE_A, _Stage.INITIAL)
+        hidden_states, previous_event = self._combine_intermediate_state
+        del self._combine_intermediate_state
+
+        buffer, num_sms = self._get_buffer(self._current_use_fp8_dispatch)
+        combined_hidden_states, _, event = buffer.combine(
+            hidden_states,
+            handle=self.handle,
+            num_sms=num_sms,
+            previous_event=previous_event,
+            async_with_compute_stream=self.async_finish,
+            allocate_on_comm_stream=previous_event is not None,
+        )
+        event.current_stream_wait() if self.async_finish else ()
+        self.handle = None
+        self._current_use_fp8_dispatch = False
+        return combined_hidden_states
+
+    def _get_buffer(self, use_fp8_dispatch: bool):
+        return DeepEPV2Buffer.get_buffer(
+            self.group,
+            self.hidden_size,
+            self.router_topk,
+            self.num_max_dispatch_tokens_per_rank,
+            self.num_experts,
+            use_fp8_dispatch,
+        )
+
+    def set_quant_config(self, quant_config: dict):
+        super().set_quant_config(quant_config)
+        self.set_deepep_dispatcher_dtype()
+
+    def set_deepep_dispatcher_dtype(self) -> None:
+        self.deepep_output_dtype = get_deepep_output_dtype(self)
+        if self.deepep_output_dtype == DeepEPOutputDtype.NVFP4:
+            raise RuntimeError(
+                "deepep_v2 currently supports bf16/fp8 dispatch only; "
+                "nvfp4 dispatch needs a dedicated ElasticBuffer path."
+            )
+        if self.deepep_output_dtype == DeepEPOutputDtype.INT8:
+            raise RuntimeError(
+                "deepep_v2 currently supports bf16/fp8 dispatch only; "
+                "int8 dispatch is NPU-specific and unsupported by ElasticBuffer."
+            )
+        self.use_fp8 = self.deepep_output_dtype == DeepEPOutputDtype.FP8
+
+    def set_overlap_args(
+        self, combine_overlap_args: CombineOverlapArgs, meta_overlap_args: dict
+    ):
+        raise ValueError("deepep_v2 does not support single-batch overlap yet.")
+
+    def clear_overlap_args(self):
+        super().clear_overlap_args()
+
+    def register_deepep_dispatch_hook(self, hook):
+        return self._deepep_dispatch_hooks.register_hook(hook)
+
+    def _update_stage(self, old_stage, new_stage):
+        assert self._stage == old_stage
+        self._stage = new_stage

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.eplb.expert_distribution import (
+    get_global_expert_distribution_recorder,
+)
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.moe.token_dispatcher.base import (
     BaseDispatcher,
@@ -22,6 +25,7 @@ from sglang.srt.layers.moe.utils import (
     DeepEPOutputDtype,
     get_deepep_output_dtype,
 )
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import get_bool_env_var, is_hip, is_npu
 
 _is_npu = is_npu()
@@ -45,6 +49,15 @@ except ImportError:
     use_deepep_v2 = False
 
 logger = logging.getLogger(__name__)
+
+
+def _should_record_stat_approx() -> bool:
+    try:
+        return (
+            get_global_server_args().expert_distribution_recorder_mode == "stat_approx"
+        )
+    except ValueError:
+        return False
 
 
 class DeepEPV2Buffer:
@@ -243,6 +256,14 @@ class DeepEPV2Dispatcher(BaseDispatcher):
             recv_x, recv_x_scale = recv_x
         else:
             recv_x_scale = None
+
+        if _should_record_stat_approx():
+            get_global_expert_distribution_recorder().on_deepep_dispatch_normal(
+                self.handle.num_recv_tokens_per_expert_list,
+                num_tokens_per_rank=None,
+                num_tokens_per_rdma_rank=None,
+                num_tokens_per_expert=None,
+            )
 
         return DeepEPNormalDispatchOutput(
             recv_x,

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -29,6 +29,7 @@ class MoeA2ABackend(Enum):
 
     NONE = "none"
     DEEPEP = "deepep"
+    DEEPEP_V2 = "deepep_v2"
     MOONCAKE = "mooncake"
     NIXL = "nixl"
     MORI = "mori"
@@ -51,6 +52,9 @@ class MoeA2ABackend(Enum):
 
     def is_deepep(self):
         return self == MoeA2ABackend.DEEPEP
+
+    def is_deepep_v2(self):
+        return self == MoeA2ABackend.DEEPEP_V2
 
     def is_mooncake(self):
         return self == MoeA2ABackend.MOONCAKE
@@ -77,6 +81,7 @@ class MoeA2ABackend(Enum):
         return self in (
             MoeA2ABackend.NONE,
             MoeA2ABackend.DEEPEP,
+            MoeA2ABackend.DEEPEP_V2,
             MoeA2ABackend.MOONCAKE,
             MoeA2ABackend.NIXL,
             MoeA2ABackend.MORI,
@@ -366,7 +371,7 @@ def is_sbo_enabled() -> bool:
 def is_deepep_class_backend() -> bool:
     """Check if the MoE backend is DeepEP-family (DeepEP, Mooncake, or Mori)."""
     b = get_moe_a2a_backend()
-    return b.is_deepep() or b.is_mooncake() or b.is_mori()
+    return b.is_deepep() or b.is_deepep_v2() or b.is_mooncake() or b.is_mori()
 
 
 def is_flashinfer_cutedsl_v1_path() -> bool:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -710,6 +710,7 @@ class DeepseekV2MoE(nn.Module):
             # not divisible by the global TP size.
             _shared_expert_use_tp1 = (
                 get_moe_a2a_backend().is_deepep()
+                or get_moe_a2a_backend().is_deepep_v2()
                 or get_moe_a2a_backend().is_mooncake()
                 or get_moe_a2a_backend().is_nixl()
                 or get_moe_a2a_backend().is_mori()
@@ -792,6 +793,7 @@ class DeepseekV2MoE(nn.Module):
 
         if (
             get_moe_a2a_backend().is_deepep()
+            or get_moe_a2a_backend().is_deepep_v2()
             or get_moe_a2a_backend().is_mooncake()
             or get_moe_a2a_backend().is_nixl()
             or get_moe_a2a_backend().is_mori()
@@ -814,6 +816,7 @@ class DeepseekV2MoE(nn.Module):
 
         self._enable_a2a_moe = (
             get_moe_a2a_backend().is_deepep()
+            or get_moe_a2a_backend().is_deepep_v2()
             or get_moe_a2a_backend().is_mooncake()
             or get_moe_a2a_backend().is_nixl()
             or get_moe_a2a_backend().is_mori()
@@ -2460,7 +2463,11 @@ class DeepseekV2Model(nn.Module):
                 )
             )
         self.layers_to_capture = []
-        if get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mooncake():
+        if (
+            get_moe_a2a_backend().is_deepep()
+            or get_moe_a2a_backend().is_deepep_v2()
+            or get_moe_a2a_backend().is_mooncake()
+        ):
             self.enable_a2a_moe = True
         else:
             self.enable_a2a_moe = False

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -152,6 +152,7 @@ def can_fuse_shared_expert(
         or getattr(config, "shared_expert_intermediate_size", 0) <= 0
         or config.shared_expert_intermediate_size != config.moe_intermediate_size
         or get_moe_a2a_backend().is_deepep()
+        or get_moe_a2a_backend().is_deepep_v2()
     ):
         return False
 
@@ -317,6 +318,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                     dict(tp_rank=0, tp_size=1)
                     if (
                         get_moe_a2a_backend().is_deepep()
+                        or get_moe_a2a_backend().is_deepep_v2()
                         or get_moe_a2a_backend().is_flashinfer()
                     )
                     else {}
@@ -335,7 +337,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         else:
             self.shared_expert_gate = torch.nn.Linear(config.hidden_size, 1, bias=False)
 
-        if get_moe_a2a_backend().is_deepep():
+        if get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_deepep_v2():
             # TODO: we will support tp < ep in the future
             self.ep_size = get_parallel().moe_ep_size
             self.num_experts = (
@@ -539,7 +541,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
 
-        if get_moe_a2a_backend().is_deepep():
+        if get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_deepep_v2():
             return self._forward_deepep(hidden_states, forward_batch)
 
         use_fused_gate = (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -249,6 +249,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
 MOE_A2A_BACKEND_CHOICES = [
     "none",
     "deepep",
+    "deepep_v2",
     "mooncake",
     "nixl",
     "mori",
@@ -1671,6 +1672,7 @@ class ServerArgs:
         Literal[
             "none",
             "deepep",
+            "deepep_v2",
             "mooncake",
             "nixl",
             "mori",
@@ -5482,6 +5484,26 @@ class ServerArgs:
                 self.enforce_shared_experts_fusion = True
                 logger.info(
                     "DeepEP Waterfill is enabled. Shared expert will be dispatched through DeepEP for load balancing."
+                )
+
+        if self.moe_a2a_backend == "deepep_v2":
+            if self.deepep_mode != "normal":
+                logger.warning(
+                    "deepep_v2 currently uses ElasticBuffer normal dispatch; "
+                    "deepep_mode is set to `normal`."
+                )
+                self.deepep_mode = "normal"
+            logger.warning("Cuda graph is disabled because deepep_mode=`normal`")
+            self.cuda_graph_config.decode.backend = Backend.DISABLED
+            self.cuda_graph_config.prefill.backend = Backend.DISABLED
+            self.ep_size = self.tp_size
+            logger.warning(
+                f"DeepEP v2 MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
+            )
+            if self.enable_single_batch_overlap:
+                raise ValueError(
+                    "deepep_v2 currently returns the normal DeepEP layout and does "
+                    "not support --enable-single-batch-overlap."
                 )
 
         if self.moe_a2a_backend == "mooncake":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1085,6 +1085,36 @@ class TestDeepEPWaterfillArgs(CustomTestCase):
         self.assertFalse(server_args.disable_cuda_graph)
         self.assertTrue(server_args.enforce_shared_experts_fusion)
 
+    def test_deepep_v2_uses_normal_mode(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="deepep_v2",
+            tp_size=4,
+            deepep_mode="auto",
+            cuda_graph_config=CudaGraphConfig(),
+        )
+        # dummy-model path short-circuits __post_init__; invoke the handler directly.
+        server_args._handle_a2a_moe()
+
+        self.assertEqual(server_args.moe_a2a_backend, "deepep_v2")
+        self.assertEqual(server_args.deepep_mode, "normal")
+        self.assertEqual(server_args.ep_size, 4)
+        self.assertEqual(server_args.cuda_graph_config.decode.backend, Backend.DISABLED)
+        self.assertEqual(
+            server_args.cuda_graph_config.prefill.backend, Backend.DISABLED
+        )
+
+    def test_deepep_v2_rejects_single_batch_overlap(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="deepep_v2",
+            enable_single_batch_overlap=True,
+            cuda_graph_config=CudaGraphConfig(),
+        )
+
+        with self.assertRaisesRegex(ValueError, "deepep_v2.*single-batch"):
+            server_args._handle_a2a_moe()
+
 
 class TestPrefillOnlyDisableKvCache(unittest.TestCase):
     """Validation for --prefill-only-disable-kv-cache.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Add an experimental `deepep_v2` MoE A2A backend that uses the official DeepEP v2 `ElasticBuffer` path.

This keeps DeepEP v2 behind an explicit backend selector (`--moe-a2a-backend deepep_v2`) without changing the existing `deepep` implementation. The integration delegates the core dispatch/combine communication to the official DeepEP package and keeps unsupported SGLang paths explicit instead of silently falling back.

## Modifications

- Add `MoeA2ABackend.DEEPEP_V2` and wire `--moe-a2a-backend deepep_v2` through server args and MoE dispatcher creation.
- Add `DeepEPV2Dispatcher` backed by DeepEP v2 `ElasticBuffer`.
- Support BF16 dispatch and FP8 dispatch through SGLang's per-token-group FP8 quantization path.
- Reuse SGLang's normal DeepEP dispatch/combine output layout so existing EP MoE compute paths can consume the result.
- Disable CUDA graph and force `deepep_mode=normal` for `deepep_v2` because this backend currently uses ElasticBuffer normal dispatch.
- Reject single-batch overlap for `deepep_v2` until that layout is supported.
- Add server-args coverage for `deepep_v2` mode normalization and SBO rejection.

## Accuracy Tests

Validated on a 2-node H100 x8 cluster with NCCL Gin / RDMA enabled through ClockworkIB. The same environment confirmed with `NET/ClockworkIB/.../GDRDMA/Shared`.

Official DeepEP v2 `ElasticBuffer` correctness passed on the DeepEP v2 benchmark shape:

```text
Topology: EP 8 x 2 / Ranks 2 x 8
Shape: 8192 tokens, hidden 7168, topk 8, experts 256
DTypes: BF16 dispatch + BF16 combine, FP8 dispatch + BF16 combine
Result: Passed
```

SGLang `DeepEPV2Dispatcher` core A2A checks passed against the official DeepEP reference dispatch/combine path, covering:

```text
BF16 dispatch + BF16 combine
FP8 dispatch + BF16 combine
masked topk
async_finish
```

Server args unit tests:

```bash
python3 -m pytest -q test/registered/unit/server_args/test_server_args.py -k deepep_v2
```

```text
2 passed, 86 deselected
```

Formatting and lint:

```bash
SKIP=no-commit-to-branch pre-commit run ruff --files \
  python/sglang/srt/batch_overlap/two_batch_overlap.py \
  python/sglang/srt/layers/moe/ep_moe/layer.py \
  python/sglang/srt/layers/moe/fused_moe_triton/layer.py \
  python/sglang/srt/layers/moe/token_dispatcher/__init__.py \
  python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py \
  python/sglang/srt/layers/moe/utils.py \
  python/sglang/srt/server_args.py \
  test/registered/unit/server_args/test_server_args.py

SKIP=no-commit-to-branch pre-commit run black-jupyter --files \
  python/sglang/srt/batch_overlap/two_batch_overlap.py \
  python/sglang/srt/layers/moe/ep_moe/layer.py \
  python/sglang/srt/layers/moe/fused_moe_triton/layer.py \
  python/sglang/srt/layers/moe/token_dispatcher/__init__.py \
  python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py \
  python/sglang/srt/layers/moe/utils.py \
  python/sglang/srt/server_args.py \
  test/registered/unit/server_args/test_server_args.py

git diff --check HEAD~2..HEAD
```

```text
ruff Passed
black-jupyter Passed
git diff --check passed
```

## Speed Tests and Profiling

The table below compares SGLang `DeepEPV2Dispatcher` with the official DeepEP v2 `ElasticBuffer` baseline on the same 2-node H100 x8 cluster and benchmark shape.

| Impl | DType | Correctness | #SM / #QPs | Dispatch BW p50 | Combine BW p50 |
|---|---|---:|---|---|---|
| Official DeepEP v2 elastic | FP8 dispatch + BF16 combine | Passed | 64 / 129 | SO 28 GB/s, SU 92 GB/s | SO 31 GB/s, SU 101 GB/s |
| Official DeepEP v2 elastic | BF16 dispatch + BF16 combine | Passed | 64 / 129 | SO 29 GB/s, SU 96 GB/s | SO 31 GB/s, SU 101 GB/s |
| SGLang `DeepEPV2Dispatcher` core A2A | BF16 dispatch + BF16 combine | Passed | auto (ElasticBuffer) | SO 29.9 GB/s, SU 97.9 GB/s | SO 31.4 GB/s, SU 102.7 GB/s |
| SGLang `DeepEPV2Dispatcher` core A2A | FP8 dispatch + BF16 combine | Passed | auto (ElasticBuffer) | SO 29.3 GB/s, SU 95.8 GB/s | SO 31.3 GB/s, SU 102.8 GB/s |

Notes:

- The DeepEP README reports logical bottleneck bandwidth. This table reports the raw SO/SU fields printed by DeepEP `tests/elastic/test_ep.py` and by the SGLang wrapper microbench.
- `--ignore-local-traffic` was not used, matching DeepEP's default logical-traffic accounting.
- The SGLang wrapper matches the same-cluster official DeepEP v2 baseline for both BF16 and FP8 dispatch, indicating no measurable integration overhead in the core A2A path on this setup.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28332795137](https://github.com/sgl-project/sglang/actions/runs/28332795137)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28333077778](https://github.com/sgl-project/sglang/actions/runs/28333077778)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
