### PR TITLE
fix(deepseekv32_detector): drop whitespace-only normal_text in tool_c…

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -256,6 +256,8 @@ class DeepSeekV32Detector(BaseFormatDetector):
             for e_token in [self.eot_token, self.invoke_end_token]:
                 if e_token in current_text:
                     current_text = current_text.replace(e_token, "")
+            if self.current_tool_id >= 0 and not current_text.strip():
+                return StreamingParseResult(normal_text="")
             return StreamingParseResult(normal_text=current_text)
 
         all_calls: list[ToolCallItem] = []

--- a/test/registered/unit/function_call/test_deepseekv32_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv32_detector.py
@@ -1,0 +1,93 @@
+"""Unit tests for DeepSeekV32Detector streaming behavior.
+
+These tests directly construct the mid-stream snapshot
+"current_tool_id >= 0 + empty buffer" -- the moment just after the model
+emits the closing </｜DSML｜function_calls> tag and is about to emit
+boundary whitespace. Feeding the full tool_call section to
+parse_streaming_increment in a single call leaves the closing tag in
+_buffer, so subsequent input gets caught by the potentially_dsml branch
+and bypasses the early-return path we want to exercise -- the bug would
+not trigger.
+"""
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestDeepSeekV32DetectorStreaming(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = DeepSeekV32Detector()
+
+    def _enter_tool_call_mode(self):
+        """Force detector state to simulate the moment when the previous
+        chunk has fully processed a tool_call section: buffer is cleared
+        and current_tool_id has advanced.
+        """
+        self.detector.current_tool_id = 0
+        self.detector._buffer = ""
+
+    # ============ Regression: #24293 ============
+
+    def test_whitespace_after_tool_call_is_suppressed(self):
+        """Once in tool_call mode, whitespace-only normal_text must be
+        suppressed; otherwise it leaks out as delta.content and breaks
+        strict Anthropic-spec clients.
+        """
+        for ws in ["\n", "\n\n", "   ", "\t\n "]:
+            with self.subTest(whitespace=repr(ws)):
+                self._enter_tool_call_mode()
+                result = self.detector.parse_streaming_increment(ws, self.tools)
+                self.assertEqual(
+                    result.normal_text,
+                    "",
+                    f"expected empty normal_text for {ws!r}, "
+                    f"got {result.normal_text!r}",
+                )
+
+    # ============ Behaviors the guard must not break ============
+
+    def test_plain_dialog_whitespace_is_preserved(self):
+        """Outside tool_call mode the guard never fires; legitimate
+        whitespace is forwarded unchanged."""
+        self.assertEqual(self.detector.current_tool_id, -1)
+        result = self.detector.parse_streaming_increment("\n", self.tools)
+        self.assertEqual(result.normal_text, "\n")
+        result = self.detector.parse_streaming_increment("hello\n\nworld", self.tools)
+        self.assertEqual(result.normal_text, "hello\n\nworld")
+
+    def test_non_empty_text_after_tool_call_still_emitted(self):
+        """In tool_call mode, real text content must still pass through."""
+        self._enter_tool_call_mode()
+        result = self.detector.parse_streaming_increment("All set!", self.tools)
+        self.assertEqual(result.normal_text, "All set!")
+
+    def test_whitespace_before_tool_call_is_unchanged(self):
+        """Whitespace before any tool_call keeps existing behavior; the
+        guard intentionally does not touch this case."""
+        result = self.detector.parse_streaming_increment("\n\n", self.tools)
+        self.assertEqual(self.detector.current_tool_id, -1)
+        self.assertEqual(result.normal_text, "\n\n")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

`DeepSeekV32Detector` (and `DeepSeekV4Detector` via inheritance) emits stray whitespace-only `delta.content` chunks immediately after a `tool_call` section. During tool_call generation, the model emits a `\n` boundary token right after `</｜DSML｜function_calls>`. The streaming parser forwards that `\n` as `normal_text`, producing an SSE chunk shape like:

```
delta = {role: "assistant", content: ""}        // standard opening
delta = {content: "\n\n"}                       // stray (pre-tool)
delta = {tool_calls: [...]}                     // tool_calls stream
delta = {content: "\n"}                         // stray (post-tool)
delta = {content: "", finish_reason: "tool_calls"}  // standard closing
```

The post-tool `"\n"` arrives between the last `tool_calls` delta and `finish_reason`. Strict Anthropic-spec consumers (e.g. Claude Code via [claude-code-router](https://github.com/musistudio/claude-code-router)) route the `text_delta` derived from this content onto the still-open `tool_use` block and reject the response:

```
API Error: Content block is not a text block
```

The same request against `https://api.deepseek.com/chat/completions` returns a clean stream with no such chunks, confirming this is a sglang detector behavior — not a model or spec issue.

Fixes #24293.

## Modifications

Two-line guard inside `parse_streaming_increment`, in the early-return path that handles "no tool marker in buffer":

```python
if self.current_tool_id >= 0 and not current_text.strip():
    return StreamingParseResult(normal_text="")
```

Once we have entered tool_call mode (`current_tool_id >= 0`), suppress chunks whose `normal_text` is whitespace-only. Outside tool_call mode (`current_tool_id == -1`) the guard never fires, so legitimate conversational whitespace is preserved.

### Why fix at the detector layer

Issue #24293 reports the same user-visible error and proposes a fix at `entrypoints/anthropic/serving.py` (the Anthropic adapter layer). Fixing at the detector layer instead has three benefits:

1. **Single change covers multiple endpoints.** Both `/v1/chat/completions` (OpenAI) and `/v1/messages` (Anthropic) share this detector. Verified empirically: with this patch applied, both endpoints emit clean streams for the same DeepSeek model and prompt.
2. **External OpenAI→Anthropic converters benefit.** The actual repro came from claude-code-router routing the OpenAI endpoint to a strict Anthropic client — they sit outside sglang's adapter, so an adapter-layer fix wouldn't help them. The detector-layer fix does.
3. **No source of stray content is better than a defensive filter.** The two approaches are complementary, but stopping the leak at the parser is the cleaner architectural choice.

### Scope and broader audit

A quick audit of other detectors was done by direct probing of the streaming method. Behavior on whitespace immediately after a completed tool_call:

| Detector | Post-tool whitespace leak | Why |
|---|---|---|
| `Qwen25Detector` (`qwen`, `qwen25`) | No | Closing tag retained in buffer; subsequent `\n` hits JSON parse path that silently returns empty |
| `MinimaxM2Detector` (`minimax-m2`) | No | `_in_tool_call` stays `True` after `</invoke>`; trailing whitespace accumulates in `_buf` |
| `Qwen3CoderDetector` (`qwen3_coder`) | **Yes** | `is_inside_tool_call=False` after `</tool_call>`; subsequent whitespace flows to `normal_text` |
| `Glm4MoeDetector` (`glm`, `glm45`) | **Yes** | After tool_call complete, next chunk hits the `not has_tool_call` early-return that emits `normal_text` |
| `Glm47MoeDetector` (`glm47`) | **Yes** | Same as above |
| `DeepSeekV32Detector` / `DeepSeekV4Detector` | **Yes (client-breaking)** | Same early-return path; the position right before `finish_reason` leaves no recovery window for downstream OpenAI→Anthropic converters |

**This PR is scoped to DeepSeek V3.2/V4** — the case with confirmed end-to-end client-breaking behavior. Each other detector with a "Yes" above has its own state machine; mixing fixes would balloon the review surface. Follow-up PRs per detector are easy to add once this lands.

## Accuracy Tests

### Function-call accuracy preserved

Confirmed that the patch does not affect tool-call selection or arguments: across 8 distinct prompts (single-arg / multi-arg / Chinese input / numeric / SQL / nested), `stream=true` and `stream=false` produced identical `tool_calls` (name, arguments, finish_reason — 8/8).

### End-to-end SSE on `/v1/chat/completions`

**Environment**: `lmsysorg/sglang:latest` (v0.5.13.post1), 8× H20 96GB TP=8, model `sgl-project/DeepSeek-V4-Flash-FP8`, `--tool-call-parser deepseekv4 --reasoning-parser deepseek-v4`.

```bash
curl -sS -N http://<server>:8999/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model":"dsv4","stream":true,
    "messages":[{"role":"user","content":"What is the weather in Beijing?"}],
    "tools":[{"type":"function","function":{
      "name":"get_weather",
      "description":"Get current weather",
      "parameters":{"type":"object",
                    "properties":{"city":{"type":"string"}},
                    "required":["city"]}
    }}],
    "tool_choice":"auto"
  }' | grep '^data:' | grep -oE '"content":[^,}]*' | sort -u
```

Before this PR (stock `main`):
```
"content":""
"content":"\n"      ← stray (post-tool, fatal for Anthropic-spec clients)
"content":"\n\n"    ← stray (pre-tool, harmless, intentionally not filtered)
"content":null
```

After this PR:
```
"content":""
"content":"\n\n"    ← pre-tool, unchanged
"content":null
```

### End-to-end SSE on `/v1/messages` (Anthropic endpoint)

Same server, same patch. Every `content_block_delta` carries a delta type matching the block type — no `text_delta` lands on a `tool_use` block:

```
event: message_start
event: content_block_start  index=0  type=text
event: content_block_delta  index=0  text_delta="\n\n"          // legal: text_delta on text block
event: content_block_stop   index=0
event: content_block_start  index=1  type=tool_use  name=get_weather
event: content_block_delta  index=1  input_json_delta="{"        // legal: input_json_delta on tool_use
event: content_block_delta  index=1  input_json_delta="\"city\":\"Beijing\"}"
event: content_block_stop   index=1
event: message_delta        stop_reason="tool_use"
event: message_stop
```

### Real Anthropic-spec client (Claude Code + claude-code-router)

- Before: first tool invocation crashes with `API Error: Content block is not a text block`.
- After: tool calls (Bash / WebFetch / custom Skills) complete cleanly.

### Unit tests

New file `test/registered/unit/function_call/test_deepseekv32_detector.py`, four cases — one regression, three "behavior preserved" guards.

Run: `python -m pytest test/registered/unit/function_call/test_deepseekv32_detector.py -v`

Before this PR (stock `main`):
```
test_whitespace_after_tool_call_is_suppressed [whitespace='\n']     FAILED  ('\n' != '')
test_whitespace_after_tool_call_is_suppressed [whitespace='\n\n']   FAILED  ('\n\n' != '')
test_whitespace_after_tool_call_is_suppressed [whitespace='   ']    FAILED  ('   ' != '')
test_whitespace_after_tool_call_is_suppressed [whitespace='\t\n ']  FAILED  ('\t\n ' != '')
test_plain_dialog_whitespace_is_preserved                           PASSED
test_non_empty_text_after_tool_call_still_emitted                   PASSED
test_whitespace_before_tool_call_is_unchanged                       PASSED

================ 4 failed, 4 passed in 8.54s ================
```

After this PR:
```
================ 4 passed, 7 warnings, 4 subtests passed in 8.21s ================
```

## Speed Tests and Profiling

Not applicable — this PR adds a `str.strip()` check in a path that runs once per streaming chunk in the detector. No measurable performance impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28227062102](https://github.com/sgl-project/sglang/actions/runs/28227062102)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28227062060](https://github.com/sgl-project/sglang/actions/runs/28227062060)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->