### PR TITLE
[DSA] Make seq_lens_cpu optional for DeepSeek Sparse Attention

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -303,6 +303,11 @@ _DSA_IMPL_T: TypeAlias = Literal[
 class DeepseekSparseAttnBackend(
     DeepseekSparseAttnBackendMTPPrecomputeMixin, AttentionBackend
 ):
+    # Decode/verify/draft graph replay rebuilds metadata from static buffers
+    # (page-table width) and never reads seq_lens_cpu / seq_lens_sum; opt out of
+    # the D2H sync. The eager fallback derives lengths from GPU seq_lens.
+    needs_cpu_seq_lens: bool = False
+
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -642,8 +647,13 @@ class DeepseekSparseAttnBackend(
 
         cache_seqlens_int32 = (forward_batch.seq_lens + draft_token_num).to(torch.int32)
         cu_seqlens_k = compute_cu_seqlens(cache_seqlens_int32)
-        assert forward_batch.seq_lens_cpu is not None
-        max_seqlen_k = int(forward_batch.seq_lens_cpu.max().item() + draft_token_num)
+        if forward_batch.seq_lens_cpu is not None:
+            max_seqlen_k = int(forward_batch.seq_lens_cpu.max().item() + draft_token_num)
+        else:
+            # needs_cpu_seq_lens=False nulls the host mirror for spec-v2 relay
+            # batches; graph replay uses the static page-table width, so only this
+            # eager (e.g. over-capture-bs) fallback needs a length here.
+            max_seqlen_k = int(forward_batch.seq_lens.max().item()) + draft_token_num
         # [b, max_seqlen_k]
         page_table = self.req_to_token_pool.req_to_token[
             forward_batch.req_pool_indices, :max_seqlen_k
@@ -2582,6 +2592,10 @@ class DeepseekSparseAttnBackend(
 
 
 class DeepseekSparseAttnMultiStepBackend:
+
+    # Per-step draft decode replays from precomputed GPU metadata; opt out so
+    # decide_needs_cpu_seq_lens' OR over the backends stays False.
+    needs_cpu_seq_lens: bool = False
 
     def __init__(
         self, model_runner: ModelRunner, topk: int, speculative_num_steps: int


### PR DESCRIPTION
Opts DSA out of the host D2H sync now that all spec-v2 paths replay under CUDA graphs.

- `needs_cpu_seq_lens = False` on both DSA backends → `resolve_seq_lens_cpu` skips the `fwd_prepare_d2h_stream.synchronize()` on the decode critical path.
- Eager `init_forward_metadata` tolerates `seq_lens_cpu=None` (derives page-table width from GPU `seq_lens`).

Stack: #29413 → **#29414** → #29415

Tested: GSM8K (no regression); `resolve_seq_lens_cpu` no longer on the decode critical path.

# Profile
Before
<img width="826" height="363" alt="Screenshot 2026-06-26 at 2 04 25 AM" src="https://github.com/user-attachments/assets/b7f9281d-6dcf-46dc-8778-15ee20049875" />

After (no streamSynchronize)
<img width="627" height="413" alt="Screenshot 2026-06-26 at 2 22 19 AM" src="https://github.com/user-attachments/assets/23eab359-ab60-40d7-b88d-21a6404ce982" />

