### PR TITLE
[DSA] Remove host H2D sync in _apply_cuda_graph_metadata

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -303,6 +303,11 @@ _DSA_IMPL_T: TypeAlias = Literal[
 class DeepseekSparseAttnBackend(
     DeepseekSparseAttnBackendMTPPrecomputeMixin, AttentionBackend
 ):
+    # Decode/verify/draft graph replay rebuilds metadata from static buffers
+    # (page-table width) and never reads seq_lens_cpu / seq_lens_sum; opt out of
+    # the D2H sync. The eager fallback derives lengths from GPU seq_lens.
+    needs_cpu_seq_lens: bool = False
+
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -642,8 +647,13 @@ class DeepseekSparseAttnBackend(
 
         cache_seqlens_int32 = (forward_batch.seq_lens + draft_token_num).to(torch.int32)
         cu_seqlens_k = compute_cu_seqlens(cache_seqlens_int32)
-        assert forward_batch.seq_lens_cpu is not None
-        max_seqlen_k = int(forward_batch.seq_lens_cpu.max().item() + draft_token_num)
+        if forward_batch.seq_lens_cpu is not None:
+            max_seqlen_k = int(forward_batch.seq_lens_cpu.max().item() + draft_token_num)
+        else:
+            # needs_cpu_seq_lens=False nulls the host mirror for spec-v2 relay
+            # batches; graph replay uses the static page-table width, so only this
+            # eager (e.g. over-capture-bs) fallback needs a length here.
+            max_seqlen_k = int(forward_batch.seq_lens.max().item()) + draft_token_num
         # [b, max_seqlen_k]
         page_table = self.req_to_token_pool.req_to_token[
             forward_batch.req_pool_indices, :max_seqlen_k
@@ -2582,6 +2592,10 @@ class DeepseekSparseAttnBackend(
 
 
 class DeepseekSparseAttnMultiStepBackend:
+
+    # Per-step draft decode replays from precomputed GPU metadata; opt out so
+    # decide_needs_cpu_seq_lens' OR over the backends stays False.
+    needs_cpu_seq_lens: bool = False
 
     def __init__(
         self, model_runner: ModelRunner, topk: int, speculative_num_steps: int

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1249,12 +1249,18 @@ class DeepseekSparseAttnBackend(
                 page_indices, repeats=self.speculative_num_draft_tokens, dim=0
             )
             metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
 
+            # Fill the constant per-req qo lengths (num_draft_tokens) on-device;
+            # torch.tensor(list, device=cuda) does a pageable H2D copy that
+            # blocks the host on the whole queued stream.
+            extend_seq_lens = torch.full(
+                (bs,),
+                self.speculative_num_draft_tokens,
+                dtype=torch.int32,
+                device=self.device,
+            )
             seqlens_expanded = seqlens_expand_triton(
-                torch.tensor(
-                    extend_seq_lens_cpu, dtype=torch.int32, device=self.device
-                ),
+                extend_seq_lens,
                 cache_seqlens,
                 self.speculative_num_draft_tokens * bs,
                 self.speculative_num_draft_tokens,
@@ -1284,11 +1290,16 @@ class DeepseekSparseAttnBackend(
             )
             metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
 
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
+            # See target-verify note: fill on-device to avoid the blocking
+            # pageable H2D from torch.tensor(list, device=cuda).
+            extend_seq_lens = torch.full(
+                (bs,),
+                self.speculative_num_draft_tokens,
+                dtype=torch.int32,
+                device=self.device,
+            )
             seqlens_expanded = seqlens_expand_triton(
-                torch.tensor(
-                    extend_seq_lens_cpu, dtype=torch.int32, device=self.device
-                ),
+                extend_seq_lens,
                 cache_seqlens,
                 self.speculative_num_draft_tokens * bs,
                 self.speculative_num_draft_tokens,


### PR DESCRIPTION
`_apply_cuda_graph_metadata` built the per-req QO-length tensor with `torch.tensor([num_draft_tokens] * bs, device=cuda)` — a pageable H2D copy that triggers a `cudaStreamSynchronize` (~8.5 ms/step on GB200) during graph replay.

Use `torch.full((bs,), num_draft_tokens, ...)` instead (async, on-device, identical values).

Stack: #29413 → #29414 → **#29415**

Tested: GSM8K 0.985; the per-step sync is gone from the NVTX trace.

# Profile
Before
<img width="627" height="244" alt="Screenshot 2026-06-26 at 2 11 48 AM" src="https://github.com/user-attachments/assets/bb3595b3-2096-48d2-90f6-69edad7a16a7" />

After
<img width="627" height="413" alt="Screenshot 2026-06-26 at 2 12 36 AM" src="https://github.com/user-attachments/assets/3d0b3cbd-0385-49d4-9157-2bd29717878f" />

