### PR TITLE
ci(amd): make sgl-data mount opt-in

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1323,6 +1323,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
+          SGLANG_AMD_MOUNT_SGL_DATA: "1"
 
       - name: Install dependencies
         run: |
@@ -1371,6 +1372,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
+          SGLANG_AMD_MOUNT_SGL_DATA: "1"
 
       - name: Install dependencies
         run: |
@@ -1455,6 +1457,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
+          SGLANG_AMD_MOUNT_SGL_DATA: "1"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -1312,6 +1312,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_start_container.sh
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
+          SGLANG_AMD_MOUNT_SGL_DATA: "1"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -1210,6 +1210,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
+          SGLANG_AMD_MOUNT_SGL_DATA: "1"
 
       - name: Install dependencies
         run: |

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -54,6 +54,10 @@ while [[ $# -gt 0 ]]; do
       echo "  --build-from-dockerfile    Build image from docker/rocm.Dockerfile"
       echo "  --gpu-arch ARCH            GPU architecture for Dockerfile build (e.g., gfx950-rocm720)"
       echo "  --rocm-version VERSION     Override ROCm version for image lookup (e.g., rocm720)"
+      echo ""
+      echo "Environment:"
+      echo "  SGLANG_AMD_MOUNT_SGL_DATA=1|0"
+      echo "      Mount /home/runner/sglang-data to /sgl-data. Defaults to 0."
       exit 0
       ;;
     *) echo "Unknown option $1"; exit 1;;
@@ -283,13 +287,27 @@ else
   fi
 fi
 
-# CACHE_HOST=/home/runner/sgl-data
-CACHE_HOST=/home/runner/temp-sglang-data
-if [[ -d "$CACHE_HOST" ]]; then
+CACHE_HOST=/home/runner/sgl-data
+MOUNT_SGL_DATA="${SGLANG_AMD_MOUNT_SGL_DATA:-0}"
+case "${MOUNT_SGL_DATA,,}" in
+  1|true|yes|on|pvc|persistent)
+    if [[ ! -d "$CACHE_HOST" ]]; then
+      echo "Error: SGLANG_AMD_MOUNT_SGL_DATA=1 but ${CACHE_HOST} does not exist." >&2
+      exit 1
+    fi
     CACHE_VOLUME="-v $CACHE_HOST:/sgl-data"
-else
+    echo "Mounting persistent CI data: ${CACHE_HOST} -> /sgl-data"
+    ;;
+  0|false|no|off|"")
     CACHE_VOLUME=""
-fi
+    echo "Not mounting ${CACHE_HOST}; /sgl-data will be container-local."
+    ;;
+  *)
+    echo "Error: unsupported SGLANG_AMD_MOUNT_SGL_DATA='${MOUNT_SGL_DATA}'" >&2
+    echo "Use 1/true/pvc/persistent or 0/false/off." >&2
+    exit 1
+    ;;
+esac
 
 echo "Launching container: ci_sglang"
 docker run -dt --user root --device=/dev/kfd ${DEVICE_FLAG} \
@@ -301,6 +319,7 @@ docker run -dt --user root --device=/dev/kfd ${DEVICE_FLAG} \
   --cap-add=SYS_PTRACE \
   -e HF_TOKEN="${HF_TOKEN:-}" \
   -e HF_HOME=/sgl-data/hf-cache \
+  -e HF_HUB_CACHE=/sgl-data/hf-cache/hub \
   -e HF_HUB_ETAG_TIMEOUT=300 \
   -e HF_HUB_DOWNLOAD_TIMEOUT=300 \
   -e MIOPEN_USER_DB_PATH=/sgl-data/miopen-cache \
@@ -310,6 +329,12 @@ docker run -dt --user root --device=/dev/kfd ${DEVICE_FLAG} \
   -w /sglang-checkout \
   --name ci_sglang \
   "${IMAGE}"
+
+docker exec ci_sglang mkdir -p \
+  /sgl-data/hf-cache/hub \
+  /sgl-data/pip-cache \
+  /sgl-data/miopen-cache \
+  /sgl-data/aiter-kernels
 
 # The checkout is owned by the runner (non-root) but the container runs as
 # root.  Git >= 2.35.2 rejects cross-user repos; mark the mount as safe so


### PR DESCRIPTION
## Summary
- make AMD CI /sgl-data PVC mounting opt-in via SGLANG_AMD_MOUNT_SGL_DATA
- keep /sgl-data as the container cache path, but use container-local storage by default
- enable the PVC mount only for MI35x Kimi-K2.6 and DeepSeek-V4-Pro jobs

## Testing
- bash -n scripts/ci/amd/amd_ci_start_container.sh
- python3 YAML parse for changed workflow files
- git diff --check
- pre-commit hooks from git commit











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28229272571](https://github.com/sgl-project/sglang/actions/runs/28229272571)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #28229272486](https://github.com/sgl-project/sglang/actions/runs/28229272486)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->