### PR TITLE
Avoid dynamic Q quantization in trtllm_mha

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -23,7 +23,6 @@ from sglang.srt.layers.attention.triton_ops.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
 from sglang.srt.layers.attention.utils import canonicalize_stride
-from sglang.srt.layers.quantization.fp8_kernel import scaled_fp8_quant
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
@@ -287,17 +286,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         k_scale = self._get_scalar_scale(layer, "k_scale_float", "k_scale")
         v_scale = self._get_scalar_scale(layer, "v_scale_float", "v_scale")
         return q_scale * k_scale * layer.scaling, v_scale
-
-    def _maybe_quantize_q(
-        self, q: torch.Tensor, *, force_fp8: bool = False
-    ) -> tuple[torch.Tensor, float | torch.Tensor]:
-        if self.data_type != torch.float8_e4m3fn:
-            return q, 1.0
-        if self.is_xqa_impl and not force_fp8:
-            return q, 1.0
-
-        q_2d, q_scale = scaled_fp8_quant(q.reshape(-1, q.shape[-1]).contiguous(), None)
-        return q_2d.reshape(q.shape), q_scale
 
     def init_cuda_graph_state(
         self,
@@ -787,9 +775,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     layer.v_scale,
                 )
 
-        # For XQA, q_dtype should be bf16. TRT-LLM-GEN uses FP8 Q; dynamically
-        # quantize it and pass the descale into BMM1 instead of unscaled casting.
-        q, q_scale = self._maybe_quantize_q(q)
+        # For XQA, q_dtype should be bf16. For trtllm-gen,
+        # q_dtype should be FP8 when KV is in FP8.
+        q_scale = 1.0
+        if self.data_type == torch.float8_e4m3fn and not self.is_xqa_impl:
+            q = q.to(torch.float8_e4m3fn)
         q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
         k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
         # shape conversion:
@@ -870,9 +860,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     layer.v_scale,
                 )
 
-        q, q_scale = self._maybe_quantize_q(
-            q, force_fp8=not forward_batch.forward_mode.is_target_verify()
-        )
+        q_scale = 1.0
+        if self.data_type == torch.float8_e4m3fn and (
+            not self.is_xqa_impl or not forward_batch.forward_mode.is_target_verify()
+        ):
+            q = q.to(torch.float8_e4m3fn)
         q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
         # [num_pages, page_size, num_kv_heads, head_dim] -> [num_pages, num_kv_heads, page_size, head_dim]
         k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)


### PR DESCRIPTION
[by Codex]

## Summary

This is a narrow follow-up to #28144 for #26518.

- Revert the dynamic FP8 quantization of Q in `trtllm_mha` back to `q.to(torch.float8_e4m3fn)` with `q_scale = 1.0`.
- Keep the #28144 K/V scale handling fix:
  `q_scale * k_scale * layer.scaling, v_scale`.
- Remove the now-unused `scaled_fp8_quant` import.

The dynamic Q quantization path is no longer needed for the Gemma4 MMLU accuracy issue because the underlying root cause was addressed by #27091 and #23280. Keeping the dynamic quantization can add overhead in the TRT-LLM-GEN path.

## MMLU Validation

Model: `nvidia/Gemma-4-26B-A4B-NVFP4`  
GPU: B200 (`umbriel-b200-037`)  
Benchmark: `benchmark/mmlu/bench_sglang.py --nsub 60 --ntrain 5 --parallel 32`

| Code / backend | Runtime | Accuracy | Latency |
| --- | --- | ---: | ---: |
| Old SGLang `24bcb37efb`, `trtllm_mha` | `lmsysorg/sglang:v0.5.12.post1-cu130`, FlashInfer `0.6.11.post1`, `--mem-fraction-static 0.65` | 0.611 | 58.143s |
| Old SGLang `24bcb37efb`, forced Triton | same as above | 0.623 | 60.091s |
| Latest main `f5708c3f91`, default `trtllm_mha` | `lmsysorg/sglang:nightly-dev-cu12-20260623-ba9d5aed`, FlashInfer `0.6.12` | 0.623 | 65.554s |
| This PR, default `trtllm_mha` | same as latest main | 0.628 | 63.209s |

Notes:

- The latest main and this PR both logged `Use trtllm_mha as default attention backend for Gemma4`.
- The old forced-Triton baseline logged `--attention-backend triton`.
- The old default run without the memory cap died around 84% in this environment; the old repro numbers above use `--mem-fraction-static 0.65` so the run completes cleanly.

## Checks

- `git diff --check`
- `python3 -m py_compile python/sglang/srt/layers/attention/trtllm_mha_backend.py`































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28247404585](https://github.com/sgl-project/sglang/actions/runs/28247404585)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28247404406](https://github.com/sgl-project/sglang/actions/runs/28247404406)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->