### PR TITLE
[NPU] Enable pinned memory and fuse shared output to optimize LLaDA2

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/allocator_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/allocator_npu.py
@@ -34,6 +34,7 @@ class NPUPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
         last_loc: torch.Tensor,
         extend_num_tokens: int,
         num_new_pages: int = None,
+        use_cpu_lens: bool = False,
     ):
         if self.debug_mode:
             assert torch.all(
@@ -41,10 +42,16 @@ class NPUPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
             )
 
         if num_new_pages is None:
-            num_new_pages_tensor = (
-                (seq_lens + self.roundup) // self.page_size
-                - (prefix_lens + self.roundup) // self.page_size
-            ).sum()
+            if use_cpu_lens:
+                num_new_pages_tensor = (
+                    (seq_lens_cpu + self.roundup) // self.page_size
+                    - (prefix_lens_cpu + self.roundup) // self.page_size
+                ).sum()
+            else:
+                num_new_pages_tensor = (
+                    (seq_lens + self.roundup) // self.page_size
+                    - (prefix_lens + self.roundup) // self.page_size
+                ).sum()
             num_new_pages_item = num_new_pages_tensor.item()
         else:
             num_new_pages_item = num_new_pages

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -1079,7 +1079,12 @@ class FusedMoE(torch.nn.Module):
                 f"Unsupported weight_name {weight_name} for FusedMoE weight_loader_fused. Nothing is loaded."
             )
 
-    def forward(self, hidden_states: torch.Tensor, topk_output: TopKOutput):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+        shared_state: Optional[torch.Tensor] = None,
+    ):
         if self._use_ascend_fuseep:
             from sglang.srt.hardware_backend.npu.moe.fuseep import forward_fuseep
 
@@ -1108,9 +1113,14 @@ class FusedMoE(torch.nn.Module):
                 # Make sure there is torch lib op registration for the whole moe layer
                 return self.forward_impl(hidden_states, topk_output)
         else:
-            return self.forward_impl(hidden_states, topk_output)
+            return self.forward_impl(hidden_states, topk_output, shared_state)
 
-    def forward_impl(self, hidden_states: torch.Tensor, topk_output: TopKOutput):
+    def forward_impl(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+        shared_state: Optional[torch.Tensor] = None,
+    ):
         origin_hidden_states_dim = hidden_states.shape[-1]
         assert self.quant_method is not None
 
@@ -1120,6 +1130,7 @@ class FusedMoE(torch.nn.Module):
 
         combine_input = self.run_moe_core(
             dispatch_output=dispatch_output,
+            shared_state=shared_state,
         )
 
         with use_symmetric_memory(
@@ -1154,11 +1165,16 @@ class FusedMoE(torch.nn.Module):
 
         return self.dispatcher.combine(combine_input=combine_input)
 
-    def run_moe_core(self, dispatch_output: DispatchOutput) -> CombineInput:
+    def run_moe_core(
+        self,
+        dispatch_output: DispatchOutput,
+        shared_state: Optional[torch.Tensor] = None,
+    ) -> CombineInput:
         # TODO: consider using symmetric memory
         return self.quant_method.apply(
             layer=self,
             dispatch_output=dispatch_output,
+            shared_state=shared_state,
         )
 
     @classmethod

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -456,11 +456,19 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         self,
         layer: torch.nn.Module,
         dispatch_output: StandardDispatchOutput,
+        shared_state: Optional[torch.Tensor] = None,
     ) -> CombineInput:
-        return self.forward(
-            layer=layer,
-            dispatch_output=dispatch_output,
-        )
+        if _is_npu:
+            return self.forward(
+                layer=layer,
+                dispatch_output=dispatch_output,
+                shared_state=shared_state,
+            )
+        else:
+            return self.forward(
+                layer=layer,
+                dispatch_output=dispatch_output,
+            )
 
     def forward_cuda(
         self,
@@ -677,6 +685,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         self,
         layer: torch.nn.Module,
         dispatch_output: DispatchOutput,
+        shared_state: Optional[torch.Tensor] = None,
     ) -> CombineInput:
 
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
@@ -763,7 +772,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
         final_hidden_states = torch.ops.npu.npu_moe_finalize_routing(
             hidden_states,
-            skip1=None,
+            skip1=shared_state,
             skip2=None,
             bias=None,
             scales=topk_weights,

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -472,8 +472,12 @@ def alloc_for_extend(
 
     # Create tensors for allocation
     _pin = _is_npu and batch.is_dllm()
-    prefix_lens_cpu = torch.tensor(batch.prefix_lens, dtype=torch.int64, pin_memory=_pin)
-    extend_lens_cpu = torch.tensor(batch.extend_lens, dtype=torch.int64, pin_memory=_pin)
+    prefix_lens_cpu = torch.tensor(
+        batch.prefix_lens, dtype=torch.int64, pin_memory=_pin
+    )
+    extend_lens_cpu = torch.tensor(
+        batch.extend_lens, dtype=torch.int64, pin_memory=_pin
+    )
     prefix_lens_device = prefix_lens_cpu.to(batch.device, non_blocking=True)
     extend_lens_device = extend_lens_cpu.to(batch.device, non_blocking=True)
 
@@ -481,7 +485,9 @@ def alloc_for_extend(
     req_pool_indices = alloc_req_slots(
         batch.req_to_token_pool, batch.reqs, batch.tree_cache
     )
-    req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64, pin_memory=_pin)
+    req_pool_indices_cpu = torch.tensor(
+        req_pool_indices, dtype=torch.int64, pin_memory=_pin
+    )
     req_pool_indices_device = req_pool_indices_cpu.to(batch.device, non_blocking=True)
 
     # Allocate KV cache (throws exception on failure)

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -373,6 +373,9 @@ def alloc_paged_token_slots_extend(
         if dsv4_state_lens is not None:
             extra_alloc_kwargs["dsv4_state_lens"] = dsv4_state_lens
 
+    if _is_npu and batch.is_dllm():
+        extra_alloc_kwargs["use_cpu_lens"] = True
+
     out = allocator.alloc_extend(
         prefix_lens,
         prefix_lens_cpu,
@@ -468,8 +471,9 @@ def alloc_for_extend(
     prefix_tensors = [r.prefix_indices for r in batch.reqs]
 
     # Create tensors for allocation
-    prefix_lens_cpu = torch.tensor(batch.prefix_lens, dtype=torch.int64)
-    extend_lens_cpu = torch.tensor(batch.extend_lens, dtype=torch.int64)
+    _pin = _is_npu and batch.is_dllm()
+    prefix_lens_cpu = torch.tensor(batch.prefix_lens, dtype=torch.int64, pin_memory=_pin)
+    extend_lens_cpu = torch.tensor(batch.extend_lens, dtype=torch.int64, pin_memory=_pin)
     prefix_lens_device = prefix_lens_cpu.to(batch.device, non_blocking=True)
     extend_lens_device = extend_lens_cpu.to(batch.device, non_blocking=True)
 
@@ -477,7 +481,7 @@ def alloc_for_extend(
     req_pool_indices = alloc_req_slots(
         batch.req_to_token_pool, batch.reqs, batch.tree_cache
     )
-    req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
+    req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64, pin_memory=_pin)
     req_pool_indices_device = req_pool_indices_cpu.to(batch.device, non_blocking=True)
 
     # Allocate KV cache (throws exception on failure)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -793,6 +793,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     for i in range(block_offset, block_offset + block_size)
                 ],
                 dtype=positions_dtype,
+                pin_memory=_is_npu,
             ).to(device, non_blocking=True)
         elif (
             ret.spec_info is not None
@@ -807,12 +808,13 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         else:
             if isinstance(extend_seq_lens, list):
                 # Main path: H2D from host lists; populate *_cpu mirrors.
+                _pin = _is_npu and batch.is_dllm()
                 assert isinstance(extend_prefix_lens, list)
                 ret.extend_seq_lens = torch.tensor(
-                    extend_seq_lens, dtype=torch.int32
+                    extend_seq_lens, dtype=torch.int32, pin_memory=_pin
                 ).to(device, non_blocking=True)
                 ret.extend_prefix_lens = torch.tensor(
-                    extend_prefix_lens, dtype=torch.int32
+                    extend_prefix_lens, dtype=torch.int32, pin_memory=_pin
                 ).to(device, non_blocking=True)
                 ret.extend_prefix_lens_cpu = extend_prefix_lens
                 ret.extend_seq_lens_cpu = extend_seq_lens

--- a/python/sglang/srt/models/llada2.py
+++ b/python/sglang/srt/models/llada2.py
@@ -337,11 +337,16 @@ class LLaDA2MoeSparseMoeBlock(nn.Module):
             shared_output = self.shared_experts(hidden_states)
         return shared_output
 
-    def _forward_router_experts(self, hidden_states: torch.Tensor):
+    def _forward_router_experts(
+        self, hidden_states: torch.Tensor, shared_output: Optional[torch.Tensor] = None
+    ):
         # router_logits: (num_tokens, n_experts)
         router_logits = self.gate(hidden_states)
         topk_output = self.topk(hidden_states, router_logits)
-        return self.experts(hidden_states, topk_output)
+        if _is_npu:
+            return self.experts(hidden_states, topk_output, shared_output)
+        else:
+            return self.experts(hidden_states, topk_output)
 
     def forward_normal_dual_stream(
         self,
@@ -375,9 +380,14 @@ class LLaDA2MoeSparseMoeBlock(nn.Module):
             )
         else:
             shared_output = self._forward_shared_experts(hidden_states)
-            final_hidden_states = self._forward_router_experts(hidden_states)
+            if _is_npu:
+                final_hidden_states = self._forward_router_experts(
+                    hidden_states, shared_output
+                )
+            else:
+                final_hidden_states = self._forward_router_experts(hidden_states)
 
-        if self.num_shared_experts > 0:
+        if not _is_npu and self.num_shared_experts > 0:
             final_hidden_states = final_hidden_states + shared_output
 
         if self.tp_size > 1 and not should_skip_post_experts_all_reduce(

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -690,7 +690,7 @@ def get_available_gpu_memory(
 
 
 def is_pin_memory_available(device=None) -> bool:
-    if not torch.cuda.is_available():
+    if not (torch.cuda.is_available() or (hasattr(torch, "npu") and torch.npu.is_available())):
         return False
     if device is not None and str(device) == "cpu":
         return False

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -690,7 +690,10 @@ def get_available_gpu_memory(
 
 
 def is_pin_memory_available(device=None) -> bool:
-    if not (torch.cuda.is_available() or (hasattr(torch, "npu") and torch.npu.is_available())):
+    if not (
+        torch.cuda.is_available()
+        or (hasattr(torch, "npu") and torch.npu.is_available())
+    ):
         return False
     if device is not None and str(device) == "cpu":
         return False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

- NPU supports pinned memory, which can be utilized to optimize memory allocation. While var-length prefill for DLLM is not supported, synchronization overhead leads to performance degradation.
- Fusing ```shared_output``` with ```npu_moe_finalize_routing``` for LLaDA2 improves performance

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Enable pinned memory for NPU
- Allocate tensors in prepare_for_extend in pinned memory for DLLM inference on NPU
- Fusing ```shared_output``` with ```npu_moe_finalize_routing``` for LLaDA2 

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
### LLaDA2.1-flash accuracy test, GSM8K 1000 prompts:

```
python ./bench_sglang.py --num-questions 1000 --port 8188 --data-path ~/test.jsonl --parallel 4
```
- Baseline
Accuracy: 0.894
Invalid: 0.000
Latency: 884.772 s
Output throughput: 148.636 token/s

- New version
Accuracy: 0.898
Invalid: 0.000
Latency: 797.202 s
Output throughput: 164.137 token/s

This pull request does not affect the accuracy for other models.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->


## Speed Tests and Profiling
### Environment:
- sgl-kernel-npu 2026.6.1
- torch 2.8.0
- torch_npu 2.8.0.post4
- CANN 9.0

### Server launch (LLaDA2.1-flash model)
```python3 -m sglang.launch_server --model-path=/tmp/do_not_delete_this_folder_with_LLaDA2.1-flash_weights/LLaDA2.1-flash --host 127.0.0.1 --port 8188 --attention-backend ascend --dtype float16 --kv-cache-dtype auto --dllm-algorithm JointThreshold --tp-size 8 --max-running-requests 16 --enable-tokenizer-batch-encode --trust-remote-code  --disable-radix-cache --disable-overlap-schedule --mem-fraction-static 0.8  --cuda-graph-bs 1 2 3 4 8 16```

### Benchmark:
```
python3 -m sglang.bench_serving --port 8188 --host 127.0.0.1 --dataset-name generated-shared-prefix --num-prompts 32 --gsp-num-groups 1 --gsp-prompts-per-group 32 --gsp-system-prompt-len 0 --gsp-question-len 8192--gsp-output-len 1536 --request-rate 100 --max-concurrency X --flush-cache --output-details
```
### Results:
| Concurrency | Baseline Duration (s) | PR Duration (s) | Speedup |
| :--- | :--- | :--- | :--- | 
| 1 | 307.03 | 271.55 | 1.13 |
| 2 | 187.4  | 167.35 | 1.12 |
| 4 | 113.86 | 101.59 | 1.12 |
| 8 | 71.22  | 63.88  | 1.11 |

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28242561924](https://github.com/sgl-project/sglang/actions/runs/28242561924)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28242561891](https://github.com/sgl-project/sglang/actions/runs/28242561891)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->