### PR TITLE
[AMD] [GLM5] Fuse DSA indexer query Hadamard + FP8 quant (gfx950)

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -58,6 +58,9 @@ _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
+# Opt-in: fuse the indexer query's hadamard (rotate_activation) + fp8 act_quant
+# into one Triton kernel (gfx950). Enable with SGLANG_DSA_FUSE_HADAMARD_QUANT=1.
+_DSA_FUSE_HADAMARD_QUANT = get_bool_env_var("SGLANG_DSA_FUSE_HADAMARD_QUANT")
 # Whether the aiter preshuffle paged-MQA path (page_size=64 + Preshuffle=True +
 # KVBlockSize=64) can be used. Falls back to the legacy page_size=1 / KVBlockSize=1
 # path when the gluon kernel is unavailable (Triton<3.5 and no AOT bundle).
@@ -385,6 +388,15 @@ class Indexer(MultiPlatformOp):
             device=get_global_server_args().device,
         )
         self.block_size = block_size
+        # Fuse the query hadamard + fp8 quant when opted in, on gfx950, and the
+        # shape is a single quant group (head_dim == block_size, power of 2).
+        self.fuse_hadamard_quant = (
+            _DSA_FUSE_HADAMARD_QUANT
+            and _is_hip
+            and _is_gfx95_supported
+            and self.head_dim == self.block_size
+            and (self.head_dim & (self.head_dim - 1)) == 0
+        )
         self.scale_fmt = scale_fmt
         self.softmax_scale = self.head_dim**-0.5
 
@@ -436,6 +448,31 @@ class Indexer(MultiPlatformOp):
         weights = weights * self.n_heads**-0.5
         weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
         return weights
+
+    def _quant_query(self, query, act_quant, weights=None):
+        """Quantize the indexer query to fp8. When fusion is enabled the query
+        is passed in WITHOUT the hadamard (skipped in _get_q_k_bf16) and the
+        fused kernel does hadamard + quant in one pass; otherwise it has already
+        been hadamard'd and we just act_quant it.
+
+        If `weights` (the head-gate, ready before quant on the decode path) is
+        passed AND fusion is on, the kernel also folds
+        `_apply_q_scale_and_softmax_scale` and returns
+        `(q_fp8, q_scale, weights_scaled)`; the caller then skips that elementwise.
+        Otherwise returns `(q_fp8, q_scale)`."""
+        if self.fuse_hadamard_quant:
+            from sglang.srt.layers.attention.dsa.triton_hadamard_quant import (
+                fused_hadamard_act_quant,
+            )
+
+            return fused_hadamard_act_quant(
+                query,
+                self.block_size,
+                self.scale_fmt,
+                weights=weights,
+                softmax_scale=self.softmax_scale,
+            )
+        return act_quant(query, self.block_size, self.scale_fmt)
 
     @torch.compile(dynamic=True)
     def _apply_q_scale_and_softmax_scale(
@@ -506,7 +543,8 @@ class Indexer(MultiPlatformOp):
         if enable_dual_stream:
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
-            query = rotate_activation(query)
+            if not self.fuse_hadamard_quant:
+                query = rotate_activation(query)
 
             with torch.cuda.stream(self.alt_stream):
                 key = rotate_activation(key)
@@ -519,7 +557,8 @@ class Indexer(MultiPlatformOp):
             key = rotate_activation(key)
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
-            query = rotate_activation(query)
+            if not self.fuse_hadamard_quant:
+                query = rotate_activation(query)
 
             with torch.cuda.stream(self.alt_stream):
                 key = cp_all_gather_rerange_output(
@@ -531,7 +570,8 @@ class Indexer(MultiPlatformOp):
             current_stream.wait_stream(self.alt_stream)
             return query, key
         else:
-            query = rotate_activation(query)
+            if not self.fuse_hadamard_quant:
+                query = rotate_activation(query)
             key = rotate_activation(key)
 
         # allgather+rerrange
@@ -1486,7 +1526,15 @@ class Indexer(MultiPlatformOp):
             query, key = self._get_q_k_bf16(
                 q_lora, x, positions, enable_dual_stream, forward_batch=forward_batch
             )
-            q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+            if self.fuse_hadamard_quant:
+                # fold _apply_q_scale_and_softmax_scale (weights * q_scale *
+                # softmax_scale) into the fused quant kernel: weights is ready here
+                # and the kernel already emits q_scale, so no separate launch.
+                q_fp8, q_scale, weights = self._quant_query(
+                    query, act_quant, weights=weights
+                )
+            else:
+                q_fp8, q_scale = self._quant_query(query, act_quant)
             with torch.cuda.stream(self.alt_stream):
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
@@ -1495,7 +1543,8 @@ class Indexer(MultiPlatformOp):
                     act_quant=act_quant,
                 )
             current_stream.wait_stream(self.alt_stream)
-            weights = self._apply_q_scale_and_softmax_scale(weights, q_scale)
+            if not self.fuse_hadamard_quant:
+                weights = self._apply_q_scale_and_softmax_scale(weights, q_scale)
         else:
             query, key = self._get_q_k_bf16(
                 q_lora, x, positions, enable_dual_stream, forward_batch=forward_batch
@@ -1505,7 +1554,7 @@ class Indexer(MultiPlatformOp):
                 current_stream = torch.cuda.current_stream()
                 self.alt_stream.wait_stream(current_stream)
 
-                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+                q_fp8, q_scale = self._quant_query(query, act_quant)
                 with torch.cuda.stream(self.alt_stream):
                     self._store_index_k_cache(
                         forward_batch=forward_batch,
@@ -1515,7 +1564,7 @@ class Indexer(MultiPlatformOp):
                     )
                 current_stream.wait_stream(self.alt_stream)
             elif not in_piecewise_or_breakable_cuda_graph:
-                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+                q_fp8, q_scale = self._quant_query(query, act_quant)
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
                     layer_id=layer_id,
@@ -1527,7 +1576,7 @@ class Indexer(MultiPlatformOp):
                 # still need q_fp8 for paged topk and q_scale for
                 # logits_head_gate_graph. K-cache storage is handled by the
                 # full graph split path when prefill requires it.
-                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+                q_fp8, q_scale = self._quant_query(query, act_quant)
 
             # aiter (ROCm gfx95): the 3-tuple (fp8, scale, bf16) from
             # fused_rms_fp8_group_quant is passed directly to _get_logits_head_gate,

--- a/python/sglang/srt/layers/attention/dsa/triton_hadamard_quant.py
+++ b/python/sglang/srt/layers/attention/dsa/triton_hadamard_quant.py
@@ -1,0 +1,193 @@
+"""Fused Walsh-Hadamard transform + block fp8 quant for the DSA indexer query.
+
+Replaces the two-pass `act_quant(rotate_activation(q))` (hadamard writes a bf16
+tensor, then act_quant reads it back and quantizes) with a single kernel: the
+post-hadamard row stays in registers and is quantized in place, removing one
+bf16 round-trip of the query per layer. Decode is bandwidth-bound, so dropping a
+memory pass is the relevant win.
+
+The hadamard is done as a matmul against the +/-1 Sylvester matrix (accumulated
+in fp32) then scaled by 1/sqrt(N) -- numerically equivalent to
+`fast_hadamard_transform(x, scale=N**-0.5)`. The quant matches tilelang
+`act_quant`: block-wise (group=128) absmax, s = max(absmax, 1e-4)/fp8_max
+(round_scale when scale_fmt is set), e4m3fn output + fp32 scale.
+"""
+
+from functools import lru_cache
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+
+_IS_FNUZ = is_fp8_fnuz()
+_FP8_DTYPE = torch.float8_e4m3fnuz if _IS_FNUZ else torch.float8_e4m3fn
+_FP8_MAX = 224.0 if _IS_FNUZ else 448.0
+
+
+@lru_cache(maxsize=4)
+def _hadamard_pm1(n: int, device: str, dtype: torch.dtype) -> torch.Tensor:
+    """+/-1 Sylvester (natural-order) Hadamard matrix [n, n]."""
+    h = torch.ones(1, 1, dtype=torch.float32)
+    while h.shape[0] < n:
+        h = torch.cat([torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0)
+    assert h.shape[0] == n, "n must be a power of 2"
+    return h.to(device=device, dtype=dtype)
+
+
+@triton.jit
+def _hadamard_quant_kernel(
+    x_ptr,
+    h_ptr,
+    y_ptr,
+    s_ptr,
+    w_ptr,
+    wo_ptr,
+    M,
+    inv_sqrt_n,
+    fp8_max,
+    fp8_min,
+    softmax_scale,
+    ROUND_SCALE: tl.constexpr,
+    FUSE_WEIGHTS: tl.constexpr,
+    N: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    rows = pid * BLOCK_M + tl.arange(0, BLOCK_M)
+    rmask = rows < M
+    n = tl.arange(0, N)
+
+    x = tl.load(
+        x_ptr + rows[:, None] * N + n[None, :], mask=rmask[:, None], other=0.0
+    ).to(
+        h_ptr.dtype.element_ty
+    )  # [BLOCK_M, N]
+    h = tl.load(h_ptr + n[:, None] * N + n[None, :])  # [N, N] +/-1
+
+    # hadamard: (x @ H_pm1) accumulated in fp32, then * 1/sqrt(N)
+    had = tl.dot(x, h).to(tl.float32) * inv_sqrt_n  # [BLOCK_M, N]
+
+    amax = tl.maximum(tl.max(tl.abs(had), axis=1), 1e-4)  # [BLOCK_M]
+    if ROUND_SCALE:
+        # match fast_round_scale: 2 ** ceil(log2(amax / fp8_max))
+        s = tl.exp2(tl.ceil(tl.log2(amax / fp8_max)))
+    else:
+        s = amax / fp8_max
+    y = tl.clamp(had / s[:, None], fp8_min, fp8_max).to(y_ptr.dtype.element_ty)
+
+    tl.store(y_ptr + rows[:, None] * N + n[None, :], y, mask=rmask[:, None])
+    tl.store(s_ptr + rows, s, mask=rmask)
+
+    # Optional fold of `_apply_q_scale_and_softmax_scale`: the indexer rescales the
+    # per-(token,head) head-gate `weights` by this row's quant scale `s` (==q_scale)
+    # and the softmax scale. `w`/`s` are row-aligned, so emit it here instead of a
+    # separate elementwise launch.
+    if FUSE_WEIGHTS:
+        w = tl.load(w_ptr + rows, mask=rmask, other=0.0).to(tl.float32)
+        tl.store(wo_ptr + rows, w * s * softmax_scale, mask=rmask)
+
+
+def fused_hadamard_act_quant(
+    x: torch.Tensor,
+    block_size: int = 128,
+    scale_fmt: Optional[str] = None,
+    weights: Optional[torch.Tensor] = None,
+    softmax_scale: float = 1.0,
+):
+    """Fused hadamard(scale=N**-0.5) + block fp8 quant.
+
+    Drop-in for `act_quant(rotate_activation(x), block_size, scale_fmt)` when the
+    last dim N is a power of 2 and == block_size (one quant group). Returns
+    (fp8 tensor same shape as x, fp32 scale of shape x.shape[:-1] + (1,)).
+
+    If `weights` (the indexer head-gate, shape x.shape[:-1]) is given, also folds
+    `_apply_q_scale_and_softmax_scale` (weights * q_scale * softmax_scale) into the
+    same kernel and returns it as a third value `(y, s, weights_scaled)` of shape
+    x.shape[:-1] + (1,) -- eliminating the separate elementwise launch.
+    """
+    assert x.is_contiguous(), "input must be contiguous"
+    N = x.size(-1)
+    assert N == block_size, "fused path requires head_dim == block_size (one group)"
+    assert (N & (N - 1)) == 0, "N must be a power of 2 for the hadamard"
+
+    y = torch.empty_like(x, dtype=_FP8_DTYPE)
+    s = x.new_empty(*x.size()[:-1], 1, dtype=torch.float32)
+    x2 = x.view(-1, N)
+    M = x2.shape[0]
+    h = _hadamard_pm1(N, x.device, torch.bfloat16)
+
+    fuse_weights = weights is not None
+    if fuse_weights:
+        assert (
+            weights.shape == x.shape[:-1]
+        ), f"weights {tuple(weights.shape)} must match x.shape[:-1] {tuple(x.shape[:-1])}"
+        w_in = weights.contiguous().view(-1)
+        w_out = torch.empty(M, dtype=torch.float32, device=x.device)
+    else:
+        w_in = x2  # unused dummy ptr
+        w_out = s.view(-1)  # unused dummy ptr
+
+    BLOCK_M = 32
+    grid = (triton.cdiv(M, BLOCK_M),)
+    _hadamard_quant_kernel[grid](
+        x2,
+        h,
+        y.view(-1, N),
+        s.view(-1),
+        w_in,
+        w_out,
+        M,
+        float(N) ** -0.5,
+        _FP8_MAX,
+        -_FP8_MAX,
+        float(softmax_scale),
+        ROUND_SCALE=scale_fmt is not None,
+        FUSE_WEIGHTS=fuse_weights,
+        N=N,
+        BLOCK_M=BLOCK_M,
+    )
+    if fuse_weights:
+        return y, s, w_out.view(*weights.shape, 1)
+    return y, s
+
+
+# Standalone correctness check vs act_quant(rotate_activation(x)).
+# Run on the box: PYTHONPATH=python python3 -m sglang.srt.layers.attention.dsa.triton_hadamard_quant
+if __name__ == "__main__":
+    from sglang.srt.layers.attention.dsa.dsa_indexer import rotate_activation
+    from sglang.srt.layers.attention.dsa.tilelang_kernel import act_quant
+
+    torch.manual_seed(0)
+    softmax_scale = 0.1337
+    for shape in [(8, 32, 128), (4096, 32, 128), (1, 8, 128)]:
+        x = (
+            torch.randn(*shape, device="cuda", dtype=torch.bfloat16) * 0.3
+        ).contiguous()
+        y_ref, s_ref = act_quant(rotate_activation(x.clone()), 128, None)
+        y_f, s_f = fused_hadamard_act_quant(x.clone(), 128, None)
+        # compare fp8 bytes and scales
+        same_fp8 = (
+            (y_ref.view(torch.uint8) == y_f.view(torch.uint8)).float().mean().item()
+        )
+        s_maxrel = ((s_ref - s_f).abs() / (s_ref.abs() + 1e-9)).max().item()
+        # dequantized cosine
+        dq_ref = y_ref.float() * s_ref.float()
+        dq_f = y_f.float() * s_f.float()
+        cos = torch.nn.functional.cosine_similarity(
+            dq_ref.flatten(), dq_f.flatten(), dim=0
+        ).item()
+        # weights fold vs _apply_q_scale_and_softmax_scale
+        w = (torch.randn(*shape[:-1], device="cuda", dtype=torch.bfloat16)).contiguous()
+        w_ref = w.unsqueeze(-1) * s_f * softmax_scale
+        _, _, w_fused = fused_hadamard_act_quant(
+            x.clone(), 128, None, weights=w, softmax_scale=softmax_scale
+        )
+        w_maxabs = (w_ref.float() - w_fused.float()).abs().max().item()
+        print(
+            f"shape={shape}: fp8_exact_frac={same_fp8:.5f} "
+            f"scale_maxrel={s_maxrel:.3e} dequant_cos={cos:.6f} "
+            f"weights_fold_maxabs={w_maxabs:.3e}"
+        )


### PR DESCRIPTION
## Motivation

The DSA indexer issues many tiny per-layer kernels (~4µs each: qk-rmsnorm, rope+cache, fp8 quant, Hadamard, top-k). On gfx950 these run serially (no multi-stream overlap), so per-kernel launch overhead and under-occupied launches dominate the indexer's wall-time. This fuses adjacent query-side ops to cut the launch count.

## Modifications

Fuse the indexer query's **Hadamard transform + block FP8 quant** into a single Triton kernel (`fused_hadamard_act_quant`), replacing the two-pass `act_quant(rotate_activation(q))` which writes a bf16 tensor to HBM then reads it back. The fused kernel keeps the post-Hadamard row in registers and quantizes in place, removing one bf16 HBM round-trip of the query per layer.

On the decode path, the same kernel also folds **`_apply_q_scale_and_softmax_scale`** (`weights * q_scale * softmax_scale`): the kernel already emits `q_scale`, and the head-gate `weights` are row-aligned and ready before the quant, so the per-(token,head) rescale is emitted as an extra output instead of a separate elementwise launch (`triton_poi_fused_mul_unsqueeze`).

- Opt-in, shape-guarded: `SGLANG_DSA_FUSE_HADAMARD_QUANT=1`, gfx950, `head_dim == block_size == 128`; default off, two-pass path unchanged. Query-only.
- Hadamard = matmul vs the ±1 Sylvester matrix (fp32 accum) ×`1/sqrt(N)`, equivalent to `fast_hadamard_transform(x, scale=N**-0.5)`. Quant matches `act_quant` (group=128 absmax, e4m3fn + fp32 scale).

## Accuracy Tests

GLM-5.1-MXFP4, MI355X TP4, GSM8K (1319 questions):

| config | GSM8K |
|---|---|
| fusion on | 0.938 |

Numerically equivalent to the two-pass path: the fp8 output agrees to within 1 ULP, and the folded `weights * q_scale * softmax_scale` is bit-exact vs `_apply_q_scale_and_softmax_scale`. Matches the GLM-5.1-MXFP4 baseline.

## Speed Benchmarks

GLM-5.1-MXFP4, MI355X TP4, graphs-on, random 8192/512, `sglang.bench_serving`, median.

Baseline (fusion off):

| concurrency | TTFT (ms) | TPOT (ms) | E2EL (ms) |
|---|---|---|---|
| 4  | 1616.69  | 22.53 | 13029.63 |
| 8  | 2667.60  | 26.50 | 16241.42 |
| 16 | 4737.31  | 34.08 | 22163.20 |
| 32 | 8899.95  | 46.72 | 32786.16 |
| 64 | 17356.27 | 69.54 | 52926.13 |

Fusion on (Δ vs baseline):

| concurrency | TTFT (ms) | TPOT (ms) | E2EL (ms) |
|---|---|---|---|
| 4  | 1596.57 (−1.24%)  | 22.31 (−0.98%) | 12996.50 (−0.25%) |
| 8  | 2628.63 (−1.46%)  | 26.27 (−0.87%) | 16052.06 (−1.17%) |
| 16 | 4652.54 (−1.79%)  | 33.88 (−0.59%) | 21980.28 (−0.83%) |
| 32 | 8771.57 (−1.44%)  | 46.11 (−1.31%) | 32383.37 (−1.23%) |
| 64 | 16943.11 (−2.38%) | 69.12 (−0.60%) | 52261.78 (−1.26%) |

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process.
2. Get approvals from CODEOWNERS and other reviewers.
3. Trigger CI tests with comments.
