### PR TITLE
fix(schedule_policy): enforce single chunked-prefill invariant via has_chunked_req

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -993,6 +993,11 @@ class PrefillAdder:
                     req.retracted_stain,
                 )
             else:
+                # Only one chunked prefill may be in flight at a time (asserted
+                # downstream). Reject a second one explicitly instead of relying
+                # on the chunk budget to make this branch unreachable.
+                if has_chunked_req:
+                    return AddReqResult.OTHER
                 # Make sure at least one page is available
                 trunc_len = self.rem_chunk_tokens // self.page_size * self.page_size
 

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -447,6 +447,48 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(adder2.rem_chunk_tokens, 0)  # 3 - 3 = 0
         self.assertEqual(result3, AddReqResult.OTHER)
 
+    def test_add_one_req_rejects_second_chunked_prefill_when_one_in_flight(self):
+        # A request whose input exceeds rem_chunk_tokens is admitted as a chunked
+        # prefill. At most one chunked prefill may be in flight at a time (asserted
+        # downstream as `assert self.chunked_req is None`). When has_chunked_req is
+        # True, add_one_req must reject a second one instead of creating it.
+        self.mock_token_allocator.available_size.return_value = 1000
+
+        def make_req(rid):
+            req = self.create_mock_req(rid, priority=0, max_new_tokens=16)
+            req.host_hit_length = 0
+            req.prefix_indices = []
+            # input (100) > rem_chunk_tokens (32) -> takes the chunked-prefill path
+            req.full_untruncated_fill_ids = list(range(100))
+            req.last_node = MagicMock()
+            req.sampling_params.ignore_eos = False
+            return req
+
+        # Baseline: with no chunked req in flight the request IS admitted as a
+        # chunked prefill (confirms rem_chunk_tokens is large enough to chunk).
+        adder_ok = self.create_adder(
+            self.create_running_batch([]),
+            rem_input_tokens=10000,
+            rem_chunk_tokens=32,
+        )
+        adder_ok.add_one_req(
+            make_req("ok"), has_chunked_req=False, truncation_align_size=None
+        )
+        self.assertIsNotNone(adder_ok.new_chunked_req)
+
+        # Guard: a chunked prefill is already in flight -> the same request is
+        # rejected (OTHER) and no second chunked prefill is created.
+        adder_guard = self.create_adder(
+            self.create_running_batch([]),
+            rem_input_tokens=10000,
+            rem_chunk_tokens=32,
+        )
+        result = adder_guard.add_one_req(
+            make_req("guard"), has_chunked_req=True, truncation_align_size=None
+        )
+        self.assertEqual(result, AddReqResult.OTHER)
+        self.assertIsNone(adder_guard.new_chunked_req)
+
     def _build_hybrid_swa_chunked_req(
         self,
         *,


### PR DESCRIPTION
## Motivation

`PrefillAdder.add_one_req` receives `has_chunked_req` (the scheduler passes
`self.chunked_req is not None`) but never uses it. The "only one chunked prefill in flight
at a time" invariant — asserted in the scheduler as `assert self.chunked_req is None` —
currently holds only as a side effect of budget accounting: an in-flight chunked request
has consumed `rem_chunk_tokens`, so a second one is rejected by the budget check before it
reaches the chunked-prefill branch. Any change that frees chunk budget while a chunked
request is in flight breaks that and admits a second chunked prefill, tripping the assertion.

## Modifications

Use the already-plumbed `has_chunked_req` to reject a second chunked prefill explicitly.
No effect on the normal path (`has_chunked_req` is `False` there); on current `main` the
branch is unreachable when it's `True` (budget rejects first), so this only hardens the
invariant.

## Test

Added `test_add_one_req_rejects_second_chunked_prefill_when_one_in_flight` in
`test/registered/unit/managers/test_prefill_adder.py`: a request that needs chunking is
admitted when `has_chunked_req=False` and rejected (`AddReqResult.OTHER`, no `new_chunked_req`)
when `True`.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28248597578](https://github.com/sgl-project/sglang/actions/runs/28248597578)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28248597510](https://github.com/sgl-project/sglang/actions/runs/28248597510)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->