### PR TITLE
[SMG] Support messages (chat) input in /v1/tokenize

### DIFF
--- a/docs_new/docs/advanced_features/sgl_model_gateway.mdx
+++ b/docs_new/docs/advanced_features/sgl_model_gateway.mdx
@@ -339,7 +339,7 @@ curl -X POST http://localhost:30000/workers \
 
 ### Tokenization Endpoints
 
-The gateway provides HTTP endpoints for text tokenization with batch support, designed to mirror the SGLang Python tokenization API.
+The gateway provides HTTP endpoints for text and chat tokenization with batch support, designed to mirror the SGLang Python tokenization API.
 
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
   <colgroup>
@@ -358,7 +358,7 @@ The gateway provides HTTP endpoints for text tokenization with batch support, de
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`POST`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`/v1/tokenize`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Tokenize text to token IDs (single or batch)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Tokenize text or chat messages to token IDs (single or batch)</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`POST`</td>
@@ -410,6 +410,22 @@ The gateway provides HTTP endpoints for text tokenization with batch support, de
   "prompt": ["Hello", "World", "How are you?"]
 }
 ```
+
+#### Chat Tokenize Request
+
+Provide `messages` instead of `prompt` to tokenize a chat conversation. The gateway applies the model's chat template (the same rendering used by chat completions) and returns a single (non-batch) token list. Exactly one of `prompt` or `messages` must be provided.
+
+```json Config
+{
+  "model": "meta-llama/Llama-3.1-8B-Instruct",
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello, world!"}
+  ]
+}
+```
+
+The optional chat fields `tools`, `tool_choice`, `reasoning_effort`, `continue_final_message`, and `chat_template_kwargs` are also accepted and forwarded to the template. Chat tokenization requires a HuggingFace tokenizer that has a chat template; other tokenizers return `400`.
 
 #### Tokenize Response
 

--- a/sgl-model-gateway/src/routers/tokenize/handlers.rs
+++ b/sgl-model-gateway/src/routers/tokenize/handlers.rs
@@ -10,16 +10,21 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use serde_json::Value;
 use tracing::{debug, error, warn};
 
 use crate::{
     app_context::AppContext,
     core::{steps::TokenizerConfigRequest, Job, UNKNOWN_MODEL_ID},
-    protocols::tokenize::{
-        AddTokenizerRequest, AddTokenizerResponse, CountResult, DetokenizeRequest,
-        DetokenizeResponse, ListTokenizersResponse, RemoveTokenizerResponse, TextResult,
-        TokenizeRequest, TokenizeResponse, TokenizerInfo, TokensResult,
+    protocols::{
+        chat::ChatCompletionRequest,
+        tokenize::{
+            AddTokenizerRequest, AddTokenizerResponse, CountResult, DetokenizeRequest,
+            DetokenizeResponse, ListTokenizersResponse, RemoveTokenizerResponse, TextResult,
+            TokenizeRequest, TokenizeResponse, TokenizerInfo, TokensResult,
+        },
     },
+    routers::grpc::utils::process_chat_messages,
     tokenizer::{registry::TokenizerEntry, traits::Tokenizer, TokenizerRegistry},
 };
 
@@ -76,29 +81,79 @@ fn get_tokenizer(registry: &TokenizerRegistry, model: &str) -> Result<Arc<dyn To
 // Tokenize / Detokenize Handlers
 // ============================================================================
 
-/// Handle POST /v1/tokenize
-pub async fn tokenize(registry: &Arc<TokenizerRegistry>, request: TokenizeRequest) -> Response {
-    debug!("Tokenize request for model: {}", request.model);
+/// Handle POST /v1/tokenize.
+///
+/// Accepts exactly one of `prompt` (text/batch) or `messages` (chat-style). The
+/// raw body is deserialized into the upstream `openai-protocol` `TokenizeRequest`
+/// / `ChatCompletionRequest` (discriminated on which key is present, since
+/// `TokenizeRequest.prompt` is required and it has no `messages` field), so the
+/// gateway tracks the upstream schemas without a hand-maintained mirror.
+/// `messages` is rendered locally via the gRPC router's `process_chat_messages`.
+pub async fn tokenize(registry: &Arc<TokenizerRegistry>, body: Value) -> Response {
+    // Match the Python validator: exactly one of `prompt` / `messages`.
+    let has_prompt = body.get("prompt").is_some_and(|v| !v.is_null());
+    let has_messages = body.get("messages").is_some_and(|v| !v.is_null());
+    if has_prompt == has_messages {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "Exactly one of 'prompt' or 'messages' must be provided.",
+            "invalid_request",
+        );
+    }
 
-    let tokenizer = match get_tokenizer(registry, &request.model) {
-        Ok(t) => t,
-        Err(e) => {
-            return error_response(StatusCode::BAD_REQUEST, &e, "tokenizer_not_found");
+    // Deserialize into the matching upstream type, look up the tokenizer, and
+    // resolve the text(s) to encode. `messages` renders the chat template once
+    // (a conversation is a single, non-batch result); `prompt` may be a batch.
+    // Both feed the shared encode loop below.
+    let (tokenizer, texts, is_batch): (Arc<dyn Tokenizer>, Vec<String>, bool) = if has_messages {
+        let chat: ChatCompletionRequest = match serde_json::from_value(body) {
+            Ok(c) => c,
+            Err(e) => {
+                return error_response(StatusCode::BAD_REQUEST, &e.to_string(), "invalid_request")
+            }
+        };
+        let tokenizer = match get_tokenizer(registry, &chat.model) {
+            Ok(t) => t,
+            Err(e) => return error_response(StatusCode::BAD_REQUEST, &e, "tokenizer_not_found"),
+        };
+        match process_chat_messages(&chat, tokenizer.as_ref()) {
+            Ok(p) => (tokenizer, vec![p.text], false),
+            Err(e) => return error_response(StatusCode::BAD_REQUEST, &e, "chat_template_error"),
         }
+    } else {
+        let req: TokenizeRequest = match serde_json::from_value(body) {
+            Ok(r) => r,
+            Err(e) => {
+                return error_response(StatusCode::BAD_REQUEST, &e.to_string(), "invalid_request")
+            }
+        };
+        let tokenizer = match get_tokenizer(registry, &req.model) {
+            Ok(t) => t,
+            Err(e) => return error_response(StatusCode::BAD_REQUEST, &e, "tokenizer_not_found"),
+        };
+        let is_batch = req.prompt.is_batch();
+        (
+            tokenizer,
+            req.prompt
+                .as_strings()
+                .into_iter()
+                .map(str::to_owned)
+                .collect(),
+            is_batch,
+        )
     };
 
-    let texts = request.prompt.as_strings();
-    let is_batch = request.prompt.is_batch();
-
-    // Tokenize each text
+    // Encode each text without special tokens: the chat template emits BOS/EOS
+    // as text, and the gateway's generate/chat paths also encode with `false`,
+    // so `/tokenize` output matches what the engine actually consumes (the
+    // tokenize API has used `false` since #16087). This differs from the Python
+    // server's prompt-path default of `True`, but is intentional and pre-existing.
     let mut all_tokens: Vec<Vec<u32>> = Vec::with_capacity(texts.len());
     let mut all_counts: Vec<i32> = Vec::with_capacity(texts.len());
     let mut all_char_counts: Vec<i32> = Vec::with_capacity(texts.len());
-
-    for text in texts {
-        // Don't add special tokens for tokenize API (matches Python behavior)
-        let encoding = match tokenizer.encode(text, false) {
-            Ok(enc) => enc,
+    for text in &texts {
+        let token_ids = match tokenizer.encode(text, false) {
+            Ok(enc) => enc.token_ids().to_vec(),
             Err(e) => {
                 error!("Tokenization failed: {}", e);
                 return error_response(
@@ -108,16 +163,13 @@ pub async fn tokenize(registry: &Arc<TokenizerRegistry>, request: TokenizeReques
                 );
             }
         };
-
-        let token_ids: Vec<u32> = encoding.token_ids().to_vec();
-        let count = token_ids.len() as i32;
-
-        all_tokens.push(token_ids);
-        all_counts.push(count);
+        all_counts.push(token_ids.len() as i32);
         all_char_counts.push(text.chars().count() as i32);
+        all_tokens.push(token_ids);
     }
 
-    // Format response based on single vs batch
+    // Single (non-batch) result collapses the one-element vectors. `char_count`
+    // reflects the encoded text(s); the Python server returns `max_model_len`.
     let (tokens, count, char_count) = if is_batch {
         (
             TokensResult::Batch(all_tokens),
@@ -391,4 +443,128 @@ pub async fn get_tokenizer_status(context: &Arc<AppContext>, tokenizer_id: &str)
         &format!("Tokenizer '{}' not found and no pending job", tokenizer_id),
         "not_found",
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn empty_registry() -> Arc<TokenizerRegistry> {
+        Arc::new(TokenizerRegistry::new())
+    }
+
+    /// Registry holding a single (non-HF) MockTokenizer registered under `name`.
+    async fn registry_with_mock(name: &str) -> Arc<TokenizerRegistry> {
+        let registry = Arc::new(TokenizerRegistry::new());
+        registry
+            .load("mock-id", name, "mock", || async {
+                Ok(Arc::new(crate::tokenizer::MockTokenizer::new()) as Arc<dyn Tokenizer>)
+            })
+            .await
+            .expect("register mock tokenizer");
+        registry
+    }
+
+    async fn read(resp: Response) -> (StatusCode, Value) {
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        (status, json)
+    }
+
+    #[tokio::test]
+    async fn rejects_both_prompt_and_messages() {
+        let r = tokenize(
+            &empty_registry(),
+            json!({
+                "model": "m",
+                "prompt": "hi",
+                "messages": [{"role": "user", "content": "hi"}]
+            }),
+        )
+        .await;
+        let (status, body) = read(r).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["type"], "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn rejects_neither_prompt_nor_messages() {
+        let r = tokenize(&empty_registry(), json!({ "model": "m" })).await;
+        let (status, body) = read(r).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["type"], "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn messages_with_non_hf_tokenizer_returns_400() {
+        // MockTokenizer has no chat template / is not an HF tokenizer, so
+        // process_chat_messages must reject it cleanly (not 500).
+        let r = tokenize(
+            &registry_with_mock("test-model").await,
+            json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }),
+        )
+        .await;
+        let (status, body) = read(r).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["type"], "chat_template_error");
+    }
+
+    #[tokio::test]
+    async fn prompt_path_unchanged() {
+        // Regression: a single text input returns a single (non-batch) result.
+        let r = tokenize(
+            &registry_with_mock("test-model").await,
+            json!({ "model": "test-model", "prompt": "hello world" }),
+        )
+        .await;
+        let (status, body) = read(r).await;
+        assert_eq!(status, StatusCode::OK);
+        // Single result: `tokens` is a flat list of ints, not a list of lists.
+        assert!(
+            body["tokens"][0].is_number(),
+            "single (non-batch) token list"
+        );
+        assert!(body["count"].is_number());
+    }
+
+    #[tokio::test]
+    async fn prompt_batch_returns_batch() {
+        // A list `prompt` returns a batch: `tokens` is a list of token lists and
+        // `count` is a list. This is the branch most sensitive to the refactor.
+        let r = tokenize(
+            &registry_with_mock("test-model").await,
+            json!({ "model": "test-model", "prompt": ["a b", "c d e"] }),
+        )
+        .await;
+        let (status, body) = read(r).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["tokens"].as_array().map(Vec::len), Some(2));
+        assert!(body["tokens"][0].is_array(), "batch => list of token lists");
+        assert!(body["count"].is_array());
+    }
+
+    #[tokio::test]
+    async fn unknown_model_returns_tokenizer_not_found() {
+        // Validation (exactly-one) passes, then tokenizer lookup fails -> 400.
+        let r = tokenize(
+            &empty_registry(),
+            json!({ "model": "missing", "prompt": "hi" }),
+        )
+        .await;
+        let (status, body) = read(r).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["type"], "tokenizer_not_found");
+    }
+
+    // The successful `messages` path requires a real HuggingFace tokenizer with a
+    // chat template, so it is covered by the e2e / transformers-parity checks
+    // rather than these unit tests (which use a non-HF MockTokenizer).
 }

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -48,7 +48,7 @@ use crate::{
         parser::{ParseFunctionCallRequest, SeparateReasoningRequest},
         rerank::V1RerankReqInput,
         responses::{ResponsesGetParams, ResponsesRequest},
-        tokenize::{AddTokenizerRequest, DetokenizeRequest, TokenizeRequest},
+        tokenize::{AddTokenizerRequest, DetokenizeRequest},
         validated::ValidatedJson,
         worker_spec::{WorkerConfigRequest, WorkerUpdateRequest},
     },
@@ -469,11 +469,8 @@ async fn update_worker(
 // Tokenize / Detokenize Handlers
 // ============================================================================
 
-async fn v1_tokenize(
-    State(state): State<Arc<AppState>>,
-    Json(request): Json<TokenizeRequest>,
-) -> Response {
-    tokenize::tokenize(&state.context.tokenizer_registry, request).await
+async fn v1_tokenize(State(state): State<Arc<AppState>>, Json(body): Json<Value>) -> Response {
+    tokenize::tokenize(&state.context.tokenizer_registry, body).await
 }
 
 async fn v1_detokenize(


### PR DESCRIPTION
The gateway's /v1/tokenize only accepted `prompt` (text), while the Python server's /tokenize also accepts `messages` and applies the chat template before encoding. This makes callers (e.g. the slime rollout engine) carry their own tokenizer + chat-template config instead of delegating to SGLang.

Add `messages` support by rendering the chat template locally and encoding the result, reusing the gRPC router's `process_chat_messages`.

The handler deserializes the raw body directly into the upstream `openai-protocol` types — `TokenizeRequest` for `prompt`, `ChatCompletionRequest` for `messages` — discriminating on which key is present (the upstream `TokenizeRequest` has a required `prompt` and no `messages`, so a messages-only body can't deserialize into it). This avoids a hand-maintained mirror struct: the gateway tracks the upstream schemas, and an incompatible bump trips the compiler instead of silently lagging.

- Exactly one of `prompt` / `messages` must be provided (matches Python).
- messages -> render via HuggingFace chat template -> encode (single result); both prompt and messages feed one shared encode/response path.
- Non-HF tokenizer / missing template -> clean 400, not 500.
- prompt path unchanged.

Verified token-for-token parity against HuggingFace transformers for both the messages and prompt paths.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The model gateway's `/v1/tokenize` endpoint only accepts `prompt` (text), while the Python inference server's `/tokenize` also accepts `messages` (chat-style) and applies the model's chat template before encoding (see `python/sglang/srt/entrypoints/openai/serving_tokenize.py::_tokenize_chat_request` and PR #23981).

This asymmetry forces callers who work with chat conversations to carry their own tokenizer + chat-template configuration and tokenize client-side, instead of delegating to SGLang. For example, the [slime](https://github.com/THUDM/slime) RL rollout engine currently loads its own HF tokenizer, applies the chat template, and sends `input_ids`; with this change it can send `messages` and let the router own tokenization/templating end-to-end.

Concretely, today, a `messages`-only request is rejected with HTTP 422 before reaching the handler, because the request type comes from the external `openai-protocol` crate whose `TokenizeRequest` has a **required** `prompt` and **no** `messages` field.

## Modifications

<!-- Detail the changes made in this pull request. -->

Add `messages` support to `/v1/tokenize`, mirroring the Python server:

- The handler now takes the raw JSON body and discriminates on which key is present (`prompt` vs `messages`), then deserializes directly into the upstream `openai-protocol` types — `TokenizeRequest` for `prompt`, `ChatCompletionRequest` for `messages`. This is required because the upstream `TokenizeRequest` has a required `prompt` and no `messages` field, so a messages-only body can't deserialize into it (and 422s at the extractor today). Reusing the upstream types directly avoids a hand-maintained mirror struct: the gateway tracks the upstream schemas automatically, and an incompatible crate bump trips the compiler instead of silently lagging.
- When `messages` is provided, the chat template is rendered locally by reusing the gRPC router's existing `process_chat_messages` (`routers/grpc/utils.rs`); the rendered text is then encoded. A conversation produces a single (non-batch) result.
- `prompt` and `messages` feed one shared encode + response-building path (no duplicated logic between the two).
- Validation: exactly one of `prompt` / `messages` must be provided (matches the Python validator) → `400 invalid_request`.
- Error handling: a non-HuggingFace tokenizer or a tokenizer without a chat template yields a clean `400 chat_template_error` (not a 500); a malformed body yields `400 invalid_request`. The existing `prompt` path (single and batch) is unchanged.

Encoding uses `add_special_tokens=false` for both paths. This matches the gateway's own generate/chat tokenization (`routers/grpc/regular/stages/{generate,chat}/preparation.rs`), so `/tokenize` output equals what the engine actually consumes. The tokenize API has used `false` since #16087. Note this differs from the Python server's *prompt-path* default of `add_special_tokens=true`; that divergence is intentional and pre-existing (the gateway doesn't expose the flag, and matching the engine's own tokenization matters more for round-tripping `input_ids`). The `messages` path matches Python's chat path exactly (Python also forces `false` there).

Added Rust unit tests (`routers::tokenize::handlers::tests`): both/neither → 400, `messages` + non-HF tokenizer → 400, `prompt` single and batch shapes, and unknown-model → `tokenizer_not_found`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A for model outputs. Tokenization correctness was verified token-for-token against HuggingFace `transformers` as an oracle, using the same tokenizer for both sides (TinyLlama-1.1B-Chat). The router (MiniJinja-rendered chat template + encode) produced identical token ids to `transformers` (Jinja2 `apply_chat_template(..., tokenize=False, add_generation_prompt=True)` + `encode(add_special_tokens=False)`) for both the `messages` and `prompt` paths. Validation cases (`both` / `neither`) returned 400 as expected.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A — no inference or hot-path changes. Tokenization remains a local operation over the tokenizer registry; the `messages` path adds only a chat-template render (already used by the gRPC chat router) plus an encode.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28254909594](https://github.com/sgl-project/sglang/actions/runs/28254909594)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28254909830](https://github.com/sgl-project/sglang/actions/runs/28254909830)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->