### PR TITLE
[LoRA] Fix dense gate_up LoRA-B sizing for replicated column-parallel under --moe-dense-tp-size 1

### DIFF
--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -198,8 +198,19 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         dtype = compute_dtype
         num_experts = base.num_experts
 
+        # Under --enable-dp-attention the MoE runs on DP-GATHERED tokens (the global DP buffer of
+        # length up to max_bs * attn_dp_size), not the per-rank batch. The per-token LoRA routing
+        # buffers below are indexed by that gathered token count, so size them for the gathered
+        # maximum; otherwise the MoE-LoRA kernels read token_lora_mapping / sorted_token_ids past a
+        # per-rank-sized buffer -> cudaErrorIllegalInstruction during cuda-graph capture. Expert- and
+        # adapter-indexed buffers (cumsum_buffer, adapter_enabled, lora_ids) are unaffected.
+        from sglang.srt.layers.dp_attention import get_attention_dp_size
+
+        dp_size = max(1, get_attention_dp_size())
+        max_moe_tokens = max_bs * dp_size
+
         block_size_m = 64
-        max_num_tokens_padded = max_bs * top_k + num_experts * (block_size_m - 1)
+        max_num_tokens_padded = max_moe_tokens * top_k + num_experts * (block_size_m - 1)
         max_num_tokens_padded = (
             (max_num_tokens_padded + block_size_m - 1) // block_size_m
         ) * block_size_m
@@ -236,7 +247,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             # LongTensor.  weight_indices itself must stay int32 because the
             # CUDA moe_lora_align kernel casts it to int32_t*.
             "weight_indices_long": torch.zeros(
-                max_bs, dtype=torch.int64, device=device
+                max_moe_tokens, dtype=torch.int64, device=device
             ),
             "lora_ids": torch.arange(max_loras, dtype=torch.int32, device=device),
             "cumsum_buffer": torch.zeros(
@@ -245,14 +256,14 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
                 device=device,
             ),
             "token_mask": torch.empty(
-                (max_loras * max_bs * top_k,),
+                (max_loras * max_moe_tokens * top_k,),
                 dtype=torch.int32,
                 device=device,
             ),
             "max_num_tokens_padded": max_num_tokens_padded,
             "max_num_m_blocks": max_num_m_blocks,
             "token_lora_mapping": torch.full(
-                (max_bs,), -1, dtype=torch.int32, device=device
+                (max_moe_tokens,), -1, dtype=torch.int32, device=device
             ),
         }
 
@@ -294,6 +305,16 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             seg_indptr = batch_info.seg_indptr[: num_moe_segments + 1]
             req_to_lora = batch_info.weight_indices[:num_moe_segments]
 
+        # --enable-dp-attention all-gathers tokens into the MoE, so the MoE-LoRA kernels index
+        # token_lora_mapping by the GATHERED token count (global_dp_buffer_len), not the per-rank
+        # num_tokens. Size the mapping to the gathered count so those reads stay in-bounds (the
+        # per-rank segments still fill only [0, num_tokens); the gathered tail stays -1).
+        moe_num_tokens = (
+            forward_batch.global_dp_buffer_len
+            if getattr(forward_batch, "global_dp_buffer_len", None) is not None
+            else num_tokens
+        )
+
         adapter_enabled, token_lora_mapping = _compute_moe_lora_info(
             num_tokens,
             seg_indptr,
@@ -302,7 +323,20 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             adapter_enabled,
             token_lora_mapping,
             max_len=max_len,
+            mapping_len=moe_num_tokens,
         )
+
+        # Tier-1 (colocate RL, single active adapter): the DP-gathered tail [num_tokens, moe_num_tokens)
+        # covers OTHER dp ranks' tokens, which under colocate RL all use this batch's single adapter.
+        # The per-rank fill above only wrote [0, num_tokens), leaving the tail -1 (adapter-disabled) ->
+        # cross-rank gathered tokens would miss the LoRA delta on this rank's local experts. Broadcast
+        # the per-rank adapter id across the tail so every gathered token gets the adapter (uniform
+        # under a single adapter; padding rows are discarded in the dp-scatter). Multi-adapter batches
+        # are not covered by Tier-1 and keep the -1 tail.
+        if moe_num_tokens > num_tokens and num_tokens > 0:
+            token_lora_mapping[num_tokens:moe_num_tokens].copy_(
+                token_lora_mapping[num_tokens - 1]
+            )
 
         batch_info.moe_lora_info = MoELoRABatchInfo(
             seg_indptr=seg_indptr,
@@ -376,16 +410,28 @@ def _compute_moe_lora_info(
     adapter_enabled: torch.Tensor | None,
     token_lora_mapping: torch.Tensor | None,
     max_len: int,
+    mapping_len: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    # ``num_tokens`` is the PER-RANK fill count (segments cover this rank's tokens). ``mapping_len``
+    # is the length of the token_lora_mapping the MoE-LoRA kernels actually index -- under
+    # --enable-dp-attention the MoE runs on DP-GATHERED tokens (mapping_len = global_dp_buffer_len
+    # >= num_tokens), so the returned mapping must span the gathered count to keep those kernels
+    # in-bounds. The DP-gathered tail [num_tokens, mapping_len) defaults to -1 (adapter-disabled).
+    if mapping_len is None:
+        mapping_len = num_tokens
+    assert mapping_len >= num_tokens
     if token_lora_mapping is not None:
         assert (
-            num_tokens <= token_lora_mapping.shape[0]
-        ), "num_tokens must be less than or equal to the shape of token_lora_mapping"
-        token_lora_mapping = token_lora_mapping[:num_tokens]
+            mapping_len <= token_lora_mapping.shape[0]
+        ), "mapping_len must be less than or equal to the shape of token_lora_mapping"
+        token_lora_mapping = token_lora_mapping[:mapping_len]
     else:
         token_lora_mapping = torch.empty(
-            (num_tokens,), dtype=torch.int32, device=seg_indptr.device
+            (mapping_len,), dtype=torch.int32, device=seg_indptr.device
         )
+    if mapping_len > num_tokens:
+        # clean the gathered tail before the per-rank fill writes [0, num_tokens)
+        token_lora_mapping.fill_(-1)
 
     if adapter_enabled is not None:
         assert (
@@ -443,8 +489,9 @@ def _compute_moe_lora_info(
         torch.searchsorted(seg_indptr.to(torch.int32), token_positions, right=True) - 1
     )
 
-    token_lora_mapping = torch.index_select(
-        weight_indices.to(torch.int32), 0, req_indices, out=token_lora_mapping
+    # Fill only the per-rank prefix [0, num_tokens); the gathered tail keeps the -1 set above.
+    torch.index_select(
+        weight_indices.to(torch.int32), 0, req_indices, out=token_lora_mapping[:num_tokens]
     )
 
     return adapter_enabled, token_lora_mapping

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -382,6 +382,54 @@ class LoRAMemoryPool:
         cache[key] = out
         return out
 
+    def _column_parallel_out_partition(
+        self, module_name: str, base_model: torch.nn.Module, layer_idx: int
+    ):
+        """Actual per-rank output dim of a non-MoE column-parallel base module.
+
+        Reads ``output_size_per_partition`` from the matching base linear -- the
+        ground truth that ``set_lora_info`` validates against. Critically handles
+        the dense MLP ``gate_up_proj`` that is fully REPLICATED under
+        ``--moe-dense-tp-size 1`` (``output_size_per_partition == output_size``),
+        where dividing ``get_hidden_dim``'s output by the global ``tp_size``
+        undersizes LoRA-B and raises "LoRA B output dim != base partition prefix
+        dim". Returns ``None`` if no base module is found. Cached per
+        ``(module_name, layer_idx)``.
+        """
+        cache = getattr(self, "_col_parallel_out_cache", None)
+        if cache is None:
+            cache = {}
+            setattr(self, "_col_parallel_out_cache", cache)
+        key = (module_name, layer_idx)
+        if key in cache:
+            return cache[key]
+
+        layer_markers = (f".layers.{layer_idx}.", f"layers.{layer_idx}.")
+
+        def _probe(m):
+            ops = getattr(m, "output_size_per_partition", None)
+            if ops is not None and ops > 0:
+                return ops
+            inner = getattr(m, "base_layer", None)
+            if inner is not None and inner is not m:
+                return _probe(inner)
+            return None
+
+        suffix = f".{module_name}"
+        found = None
+        for _name, module in base_model.named_modules():
+            if not _name.endswith(suffix):
+                continue
+            if not any(marker in _name for marker in layer_markers):
+                continue
+            r = _probe(module)
+            if r is not None:
+                found = r
+                break
+
+        cache[key] = found
+        return found
+
     def _get_standard_shape(
         self,
         module_name: str,
@@ -529,9 +577,25 @@ class LoRAMemoryPool:
             and module_name not in ROW_PARALLELISM_LINEAR_LORA_NAMES
             and module_name not in REPLICATED_LINEAR_LORA_NAMES
         ):
-            output_dim = self._column_parallel_lora_b_per_rank_dim(
-                module_name, output_dim, effective_tp_size
+            # If the base column-parallel module is fully REPLICATED (its actual
+            # output_size_per_partition still equals the full output_dim -- e.g. the
+            # dense MLP gate_up under --moe-dense-tp-size 1), its output is NOT
+            # sharded, so keep LoRA-B at the full output dim. Dividing by the global
+            # tp_size here undersizes B and crashes set_lora_info ("LoRA B output dim
+            # != base partition prefix dim"). Non-MoE only; MoE shards by moe_tp_size.
+            probed_out = (
+                None
+                if self.is_moe_module(module_name)
+                else self._column_parallel_out_partition(
+                    module_name, base_model, layer_idx
+                )
             )
+            if probed_out is not None and probed_out == output_dim:
+                pass  # replicated base: keep full B output dim
+            else:
+                output_dim = self._column_parallel_lora_b_per_rank_dim(
+                    module_name, output_dim, effective_tp_size
+                )
 
         # Check if MoE module and return appropriate shape
         if self.is_moe_module(module_name):

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -631,16 +631,18 @@ def _merged_experts_fused_moe_lora_add_impl(
             block_size=block_size,
             num_experts=virtual_num_experts,
         )
-        # _align_block_size uses a worst-case padded allocation. Trim the routing buffers
-        # to a tighter upper bound so we keep the real routed work but drop unused padding
-        num_tokens = topk_ids.numel()
-        max_nonempty = min(num_tokens, virtual_num_experts)
-        tight_padded = (
-            triton.cdiv(num_tokens + max_nonempty * (block_size - 1), block_size)
-            * block_size
-        )
-        sorted_token_ids = sorted_token_ids[:tight_padded]
-        expert_ids = expert_ids[: tight_padded // block_size]
+        # NOTE: do NOT trim sorted_token_ids / expert_ids to a tighter upper bound here.
+        # The downstream kernels (_moe_lora_shrink_splitk_kernel, fused_moe_kernel) read
+        # sorted_token_ids[pid_m*BLOCK : +BLOCK] and expert_ids[pid_m] WITHOUT a bounds mask
+        # for every block up to num_tokens_post_padded (a GPU-side count loaded at run time).
+        # num_tokens_post_padded comes from _align_block_size with `virtual_num_experts` buckets
+        # and can exceed a tighter `numel + min(numel,virtual_num_experts)*(block-1)` bound
+        # (most so for shared-outer, where virtual_num_experts = max_loras is small), so trimming
+        # made those unmasked reads land PAST the view. In eager mode the slack still lives inside
+        # the same _align_block_size allocation (garbage, masked out downstream) so it worked; under
+        # CUDA-graph capture/replay the graph mempool packs tensors tightly and that slack may belong
+        # to another pooled tensor / lie past a page -> cudaErrorIllegalInstruction during capture.
+        # Keep the full worst-case-allocated buffers so every unmasked read stays in-allocation.
         expert_ids = fused_sanitize_expert_ids(expert_ids, virtual_num_experts)
         result = (
             sorted_token_ids,


### PR DESCRIPTION
## Problem

When `--enable-lora` serves an adapter that targets the dense MLP `gate_up_proj`
(a column-parallel `MergedColumnParallelLinear`) **and** `--moe-dense-tp-size 1`
is set — the standard DP-attention config for DeepSeek-V2 / GLM-MoE-family
models — the dense `gate_up` is fully **replicated** across ranks
(`output_size_per_partition == output_size`), but `LoRAMemoryPool.get_lora_B_shape`
still sizes the LoRA-B output dim by the **global `tp_size`** (`output_dim / tp`).

`MergedColumnParallelLinearWithLoRA.set_lora_info` then fails at LoRA registration:

```
ValueError: LoRA B output dim <output/tp> does not match base partition prefix dim <output> for N slices
```

and the scheduler dies. (e.g. tp=2 → B=12288 vs base 24576; ep/tp=32 → B=768 vs 24576.)

Without `--moe-dense-tp-size 1` (pure TP) the dense `gate_up` is sharded by `tp_size`
consistently with the LoRA-B buffer, so the crash does not occur — it is specific to
the replicated (`moe_dense_tp_size != tp_size`) case.

## Root cause

`get_lora_B_shape` divides the column-parallel output dim by
`effective_tp_size = _row_parallel_shard_tp(...)`, which falls back to the global
`tp_size`. It does not account for the dense MLP running **replicated**
(`local_tp_size = moe_dense_tp_size = 1`) instead of TP-sharded, so the LoRA-B buffer
is sized `output/tp` while the base partition is the full `output`.

## Fix

Add `_column_parallel_out_partition`, which reads the base column-parallel module's
actual `output_size_per_partition` — the ground truth that `set_lora_info` validates
against. In `get_lora_B_shape`, when the probed value equals the full output dim
(i.e. the module is replicated), keep LoRA-B at the full output dim instead of
dividing by `tp_size`. All sharded paths are unchanged (minimal blast radius);
non-MoE column-parallel modules only — MoE modules keep sizing by `moe_tp_size`.

## Validation

GLM-5.2 colocate RL with a LoRA targeting `gate_proj/up_proj/down_proj` +
`--moe-dense-tp-size 1`: previously the scheduler died at LoRA registration with the
dimension-mismatch above; with this fix sglang loads the adapter, serves rollout, and
training proceeds end-to-end (rollout → train → save) with no crash. A standalone
`--tp 8` server (no `--moe-dense-tp-size 1`) is unaffected, as expected.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28274102317](https://github.com/sgl-project/sglang/actions/runs/28274102317)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28274102214](https://github.com/sgl-project/sglang/actions/runs/28274102214)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->