### PR TITLE
Fix spec-decode crash and mamba-state corruption from freed reqs in TARGET_VERIFY

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1161,6 +1161,22 @@ class HybridLinearAttnBackend(AttentionBackend):
         """
         request_number = last_correct_step_indices.shape[0]
 
+        # Freed/lingering rows (flagged with mamba_track_indices < 0 by
+        # set_mamba_track_indices_from_reqs) must also be excluded from the first
+        # (non-track) commit scatter below, which keys off state_indices_tensor +
+        # last_correct_step_indices and never reads mamba_track_indices. For a freed
+        # row last_correct_step_indices is >= 0 and state_indices_tensor is a
+        # stale-but-in-range slot, so without this the scatter would write a freed
+        # request's stale verify state into a slot that may have been re-allocated to
+        # a live request. Clamp the commit step to -1 so the kernel's step<0 guard
+        # drops these rows from both commit scatters.
+        if mamba_track_indices is not None:
+            last_correct_step_indices = torch.where(
+                mamba_track_indices[:request_number] < 0,
+                torch.full_like(last_correct_step_indices, -1),
+                last_correct_step_indices,
+            )
+
         state_indices_tensor = (
             self.linear_attn_backend.forward_metadata.mamba_cache_indices[
                 :request_number

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1568,9 +1568,20 @@ def set_mamba_track_indices_from_reqs(batch):
     all_buffers = req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
         batch.req_pool_indices
     ]  # (bs, ping_pong_size), int64, on device
+    # A finished/retracted request whose mamba state was already freed
+    # (free_mamba_cache / reset_for_retract null mamba_next_track_idx) can still be
+    # present in a TARGET_VERIFY batch for one iteration under the overlap
+    # scheduler's result lag. Building the int64 gather index from a None raises.
+    # Use a safe in-range gather index (0) for those rows, then mark their OUTPUT
+    # track index -1 so the track scatter skips them via its dst<0 guard, instead
+    # of committing a stale row into a live cache slot.
+    next_track_idx = [req.mamba_next_track_idx for req in batch.reqs]
+    none_rows = [i for i, v in enumerate(next_track_idx) if v is None]
+    for i in none_rows:
+        next_track_idx[i] = 0
     idx = (
         torch.tensor(
-            [req.mamba_next_track_idx for req in batch.reqs],
+            next_track_idx,
             dtype=torch.int64,
             pin_memory=True,
         )
@@ -1580,6 +1591,10 @@ def set_mamba_track_indices_from_reqs(batch):
     batch.mamba_track_indices = (
         torch.gather(all_buffers, 1, idx).squeeze(1).to(torch.int64)
     )
+    if none_rows:
+        batch.mamba_track_indices[
+            torch.tensor(none_rows, dtype=torch.int64, device=all_buffers.device)
+        ] = -1
 
 
 def release_req(


### PR DESCRIPTION
## Motivation

Under the overlap scheduler, a request that finished or was retracted has its mamba state freed (`free_mamba_cache` / `reset_for_retract` null `mamba_next_track_idx`) yet can still appear in the next `TARGET_VERIFY` batch for one iteration (result lag). With the mamba radix cache (`extra_buffer`) + EAGLE/NEXTN speculative decode on hybrid models (e.g. Qwen3.5) this causes two problems:

1. **Crash** — `set_mamba_track_indices_from_reqs` builds an int64 tensor from `[req.mamba_next_track_idx ...]`; the `None` raises `TypeError: 'NoneType' object cannot be interpreted as an integer`. Reported in #27325, #28312, #28407, #28484.

2. **Silent corruption** — simply defaulting the index to `0` (as proposed in #27324 and #27998) makes the post-verify commit scatter write that freed request's stale verify state into a stale-but-in-range pool slot, which under concurrent churn may already have been re-allocated to a live request → corrupted recurrent state, no crash, no log.

## Modifications

Exclude freed rows from the commit instead of defaulting them:

- `set_mamba_track_indices_from_reqs` gathers with a safe in-range index (`0`) for `None` rows, then marks their **output** track index `-1`, so the track scatter skips them via its `dst < 0` guard.
- `update_mamba_state_after_mtp_verify` clamps `last_correct_step_indices` to `-1` for those rows, so the **first (non-track)** commit scatter — which keys off `state_indices_tensor` and never reads `mamba_track_indices` — also skips them via its `step < 0` guard.

Both scatter kernels (`_fused_mamba_state_scatter_with_mask_kernel`, `_fused_conv_window_scatter_with_mask_kernel`) already early-return on `step < 0` / `dst < 0`, so live rows (`mamba_track_indices >= 0`) are byte-identical. `mamba_track_indices < 0` uniquely identifies freed rows because the gather source (`req_index_to_mamba_ping_pong_track_buffer_mapping`) is always `>= 0`.

## Testing

Validated on Qwen3.5-27B hybrid + NEXTN (`extra_buffer`, overlap on) under sustained 16-way churn with mixed short/long requests (heavy finish/retract). Before: crashed within ~30 s. After: 12 min with zero scheduler exceptions, deterministic output, and factual prompts answered correctly throughout (no corruption).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28261991980](https://github.com/sgl-project/sglang/actions/runs/28261991980)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28261991850](https://github.com/sgl-project/sglang/actions/runs/28261991850)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->