### PR TITLE
Fix cuda_graph_custom_mask undersize overflowing on long-context spec verify

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -928,7 +928,13 @@ class TritonAttnBackend(AttentionBackend):
 
         if not self.skip_prefill:
             self.cuda_graph_custom_mask = torch.zeros(
-                (max_num_tokens * self.max_context_len),
+                # The TARGET_VERIFY mask length is
+                # num_draft_tokens * (seq_len + num_draft_tokens) (see
+                # _update_target_verify_buffers seq_mask_len), so the capture-time
+                # buffer must include the +num_draft_tokens term or it overflows by
+                # max_num_tokens * num_draft_tokens at seq_len == max_context_len.
+                # (... or 0) leaves the size unchanged when spec decoding is off.
+                (max_num_tokens * (self.max_context_len + (self.num_draft_tokens or 0))),
                 dtype=torch.uint8,
                 device=self.device,
             )

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -934,7 +934,10 @@ class TritonAttnBackend(AttentionBackend):
                 # buffer must include the +num_draft_tokens term or it overflows by
                 # max_num_tokens * num_draft_tokens at seq_len == max_context_len.
                 # (... or 0) leaves the size unchanged when spec decoding is off.
-                (max_num_tokens * (self.max_context_len + (self.num_draft_tokens or 0))),
+                (
+                    max_num_tokens
+                    * (self.max_context_len + (self.num_draft_tokens or 0))
+                ),
                 dtype=torch.uint8,
                 device=self.device,
             )


### PR DESCRIPTION
## Motivation

`init_cuda_graph_state` sizes `cuda_graph_custom_mask` as `max_num_tokens * max_context_len`, but `_update_target_verify_buffers` builds the `TARGET_VERIFY` mask with length `num_draft_tokens * (seq_len + num_draft_tokens)` (`seq_mask_len`). The `+ num_draft_tokens` term is unaccounted for, so at `seq_len == max_context_len` the per-batch mask exceeds the buffer by `max_num_tokens * num_draft_tokens`, raising a tensor-size `RuntimeError` in the EAGLE verify cuda-graph path on long context.

## Modifications

Size the buffer as `max_num_tokens * (max_context_len + (num_draft_tokens or 0))`, matching `seq_mask_len`. `(... or 0)` leaves the size unchanged when speculative decoding is off. The buffer is a small `uint8` allocation, so the extra columns are negligible. The sibling `cuda_graph_kv_indices` (same `max_num_tokens * max_context_len`) is intentionally left as-is — its per-request KV length cannot exceed that bound.

## Testing

The overflow was observed in production logs (the `custom_mask[...] = spec_info.custom_mask` assignment raising a size-mismatch `RuntimeError` at `seq_len` near `max_context_len` with a full verify batch). The new size is an exact upper bound on `sum_i num_draft_tokens * (seq_len_i + num_draft_tokens)` for `bs <= max_bs`, `seq_len_i <= max_context_len`, so the assignment can no longer exceed the buffer. With spec decoding off, `(num_draft_tokens or 0) == 0` leaves the allocation byte-identical; the same engine ran 12 min of mixed-length load post-fix with no `custom_mask` errors.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28331557898](https://github.com/sgl-project/sglang/actions/runs/28331557898)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28331557819](https://github.com/sgl-project/sglang/actions/runs/28331557819)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->