### PR TITLE
[GDN] Integrate FlashInfer for MTP cache mode at final recovery stage

### DIFF
--- a/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py
@@ -364,3 +364,181 @@ def fused_sigmoid_gating_delta_rule_update(
     )
     o = o.squeeze(0)
     return o
+
+
+@triton.jit
+def fused_sigmoid_gating_delta_rule_recover_final_state_kernel(
+    A_log,
+    a,
+    dt_bias,
+    softplus_beta,
+    softplus_threshold,
+    k,
+    v,
+    b,
+    h0_source,
+    h0_indices,
+    accepted_steps,
+    T,
+    stride_a,
+    stride_k,
+    stride_v,
+    stride_b,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_KDA: tl.constexpr,
+):
+    """Recover h_K directly without writing intermediate states or outputs."""
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    bos = i_n * T
+    accepted_step = tl.load(accepted_steps + i_n)
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+
+    p_k = k + bos * stride_k + i_h * K + o_k
+    p_v = v + bos * stride_v + i_hv * V + o_v
+    p_b = b + bos * stride_b + i_hv
+
+    p_A_log = A_log + i_hv
+    if IS_KDA:
+        p_a = a + bos * stride_a + i_hv * K + o_k
+        p_dt_bias = dt_bias + i_hv * K + o_k
+    else:
+        p_a = a + bos * stride_a + i_hv
+        p_dt_bias = dt_bias + i_hv
+
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_k[:, None] & mask_v[None, :]
+
+    idx = tl.load(h0_indices + i_n)
+    p_h0 = h0_source + idx * HV * K * V + i_hv * K * V + o_v[None, :] * K + o_k[:, None]
+    b_h = tl.load(p_h0, mask=(idx >= 0) & mask_h, other=0).to(tl.float32)
+
+    b_A_log = tl.load(p_A_log).to(tl.float32)
+    b_A_coeff = -tl.exp(b_A_log)
+    if IS_KDA:
+        b_dt_bias = tl.load(p_dt_bias, mask=mask_k, other=0).to(tl.float32)
+    else:
+        b_dt_bias = tl.load(p_dt_bias).to(tl.float32)
+
+    for step_idx in range(0, T):
+        active = step_idx <= accepted_step
+
+        b_k = tl.load(p_k, mask=active & mask_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=active & mask_v, other=0).to(tl.float32)
+        b_b = tl.load(p_b, mask=active, other=0).to(tl.float32)
+
+        if IS_KDA:
+            b_a = tl.load(p_a, mask=active & mask_k, other=0).to(tl.float32)
+        else:
+            b_a = tl.load(p_a, mask=active, other=0).to(tl.float32)
+
+        x = b_a + b_dt_bias
+        beta_x = softplus_beta * x
+        softplus_x = tl.where(
+            beta_x <= softplus_threshold,
+            (1.0 / softplus_beta) * tl.log(1.0 + tl.exp(beta_x)),
+            x,
+        )
+        b_g = b_A_coeff * softplus_x
+        b_beta = 1.0 / (1.0 + tl.exp(-b_b))
+
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_k = b_k / (tl.sqrt(tl.sum(b_k * b_k) + 1e-6))
+
+        if IS_KDA:
+            b_h_gated = b_h * tl.exp(b_g[:, None])
+        else:
+            b_h_gated = b_h * tl.exp(b_g)
+
+        b_v_delta = b_v - tl.sum(b_h_gated * b_k[:, None], 0)
+        b_v_delta *= b_beta
+        b_h_next = b_h_gated + b_k[:, None] * b_v_delta[None, :]
+        b_h = tl.where(active, b_h_next, b_h)
+
+        p_k += stride_k
+        p_v += stride_v
+        p_b += stride_b
+        p_a += stride_a
+
+    tl.store(p_h0, b_h.to(p_h0.dtype.element_ty), mask=(idx >= 0) & mask_h)
+
+
+def fused_sigmoid_gating_delta_rule_recover_final_state(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    dt_bias: torch.Tensor,
+    softplus_beta: float,
+    softplus_threshold: float,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    b: torch.Tensor,
+    initial_state_source: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    accepted_steps: torch.Tensor,
+    cache_steps: int,
+    use_qk_l2norm_in_kernel: bool = False,
+    is_kda: bool = False,
+):
+    """Recovery-only GDN recurrence for gdn_mtp_cache_mode=none.
+
+    This writes h_{accepted_step} directly back to the SSM state slot and
+    skips output materialization, intermediate state writes, and the follow-up
+    scatter used by the generic target-verify path.
+    """
+    _, total_tokens, H, K = k.shape
+    HV = v.shape[2]
+    V = v.shape[3]
+    T = cache_steps
+    N = accepted_steps.shape[0]
+    assert total_tokens == N * T
+
+    stride_k = k.stride()[1]
+    stride_v = v.stride()[1]
+    stride_b = b.stride()[-2]
+    stride_a = a.stride()[-2]
+
+    BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 32)
+    NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
+    assert NK == 1, "NK > 1 is not supported yet"
+    num_stages = 3
+    num_warps = 1
+
+    fused_sigmoid_gating_delta_rule_recover_final_state_kernel[(NK, NV, N * HV)](
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        softplus_beta=softplus_beta,
+        softplus_threshold=softplus_threshold,
+        k=k,
+        v=v,
+        b=b,
+        h0_source=initial_state_source,
+        h0_indices=initial_state_indices,
+        accepted_steps=accepted_steps,
+        T=T,
+        stride_a=stride_a,
+        stride_k=stride_k,
+        stride_v=stride_v,
+        stride_b=stride_b,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        IS_KDA=is_kda,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1067,9 +1067,89 @@ class HybridLinearAttnBackend(AttentionBackend):
         state_idx_i32 = state_indices_tensor.to(torch.int32).contiguous()
         accepted_steps_i32 = accepted_steps.to(torch.int32).contiguous()
 
+        # On SM100+ with a bf16 state pool, recover via the FlashInfer MTP kernel
+        # (PR #3502). Otherwise fall back to the Triton recurrence kernel.
+        dispatcher = getattr(self.linear_attn_backend, "kernel_dispatcher", None)
+        decode_kernel = getattr(dispatcher, "decode_kernel", None)
+        use_fi_recovery = (
+            decode_kernel is not None
+            and decode_kernel.__class__.__name__ == "FlashInferGDNKernel"
+            and getattr(decode_kernel, "use_state_pool", False)
+        )
+
         # One launch per GDN layer. Factored into a closure so it can run either
         # inline (CUDA graph capture) or on the side stream (eager overlap).
         def _run_recovery():
+            if use_fi_recovery:
+                import bisect
+
+                from flashinfer.gdn_kernels.gdn_decode_bf16_state import (
+                    gated_delta_rule_mtp,
+                )
+
+                B, T = batch_size, cache_steps
+                # Round B up to the next power-of-2 in [1, 2, 4, ..., 512] so the
+                # CuTe DSL JIT sees at most 10 distinct B values across all batches.
+                # Without padding each unique scheduler batch size triggers a ~37s
+                # recompilation; with padding the prewarm at startup covers all cases.
+                _PAD_BS = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+                pi = bisect.bisect_left(_PAD_BS, B)
+                B_pad = _PAD_BS[pi] if pi < len(_PAD_BS) else B
+                n_extra = B_pad - B
+                if n_extra > 0:
+                    # Padding rows use accepted_steps=0 and state_idx=0 (slot 0 is the
+                    # reserved dummy slot). With accepted_steps=0 the kernel sets
+                    # loop_limit=0 for those rows — it reads no stash data and writes
+                    # h_0 (= initial dummy state) back to slot 0.  The stash tensors
+                    # are already allocated to max_tokens = pool_size × T_max, so
+                    # viewing B_pad × T elements is always in-bounds and avoids any
+                    # cat / zero-fill kernels on the side stream.
+                    _z = accepted_steps_i32.new_zeros(n_extra)
+                    acc_steps_pad = torch.cat([accepted_steps_i32, _z])
+                    state_idx_pad = torch.cat([state_idx_i32, _z])
+                    actual_seq_len_pad = B_pad * T
+                else:
+                    acc_steps_pad = accepted_steps_i32
+                    state_idx_pad = state_idx_i32
+                    actual_seq_len_pad = actual_seq_len
+                # PR-3502 API: pass accepted_steps [B] int32 directly so the
+                # kernel handles per-sequence step counts on the GPU.  One call
+                # per layer (45 total) instead of 4-groups × 45 layers = 180.
+                # disable_output=True: state-only recovery, output is discarded.
+                for layer_id, stash in stash_per_layer.items():
+                    layer_ssm_states = pool.mamba2_layer_cache(layer_id).temporal
+                    # Zero-copy views: no cat or zero-fill GPU kernels are launched.
+                    # Rows B..B_pad-1 may contain stale data but are never read by
+                    # the kernel when their accepted_steps entry is 0.
+                    k_bat = stash["k"][0, :actual_seq_len_pad].view(
+                        B_pad, T, stash["k"].shape[2], stash["k"].shape[3]
+                    )
+                    gated_delta_rule_mtp(
+                        A_log=stash["A_log"].detach().float(),
+                        a=stash["a"][:actual_seq_len_pad].view(
+                            B_pad, T, stash["a"].shape[-1]
+                        ),
+                        dt_bias=stash["dt_bias"].detach(),
+                        q=k_bat,
+                        k=k_bat,
+                        v=stash["v"][0, :actual_seq_len_pad].view(
+                            B_pad, T, stash["v"].shape[2], stash["v"].shape[3]
+                        ),
+                        b=stash["b"][:actual_seq_len_pad].view(
+                            B_pad, T, stash["b"].shape[-1]
+                        ),
+                        initial_state_source=layer_ssm_states,
+                        initial_state_indices=state_idx_pad,
+                        output_state_indices=state_idx_pad,
+                        accepted_steps=acc_steps_pad,
+                        disable_state_update=False,
+                        disable_output=True,
+                        use_qk_l2norm_in_kernel=True,
+                        scale=None,
+                        output=None,
+                    )
+                return
+
             for layer_id, stash in stash_per_layer.items():
                 layer_cache = pool.mamba2_layer_cache(layer_id)
                 layer_ssm_states = layer_cache.temporal  # [size+1, HV, V, K]

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -714,6 +714,13 @@ class HybridLinearAttnBackend(AttentionBackend):
             full_attn_backend.needs_cpu_seq_lens
             or linear_attn_backend.needs_cpu_seq_lens
         )
+        # gdn_mtp_cache_mode=none recovery overlap: run the (eager) SSM-state
+        # recovery on a dedicated side stream so its GPU work overlaps the next
+        # step's draft-phase compute, then join before the next target forward
+        # reads / overwrites the SSM pool. Lazily created on first recovery.
+        self._recovery_stream: Optional[torch.cuda.Stream] = None
+        self._recovery_event: Optional[torch.cuda.Event] = None
+        self._recovery_event_pending: bool = False
 
     def _is_full_attn(
         self, layer: Optional[RadixAttention], layer_id: Optional[int] = None
@@ -722,6 +729,15 @@ class HybridLinearAttnBackend(AttentionBackend):
             layer_id = layer.layer_id
         assert layer_id is not None, "either layer or layer_id must be provided"
         return layer_id in self.full_attn_layers
+
+    def _wait_recovery_if_pending(self):
+        """Join the side-stream gdn_mtp_cache_mode=none SSM recovery before a
+        target forward reads the SSM pool. The wait also prevents the upcoming
+        forward from overwriting the per-layer recovery stash while the
+        side-stream recovery is still reading it."""
+        if self._recovery_event_pending:
+            torch.cuda.current_stream().wait_event(self._recovery_event)
+            self._recovery_event_pending = False
 
     def init_forward_metadata_out_graph(
         self,
@@ -739,6 +755,7 @@ class HybridLinearAttnBackend(AttentionBackend):
             # so skip linear/mamba backend metadata which requires query_start_loc.
             self.full_attn_backend.init_forward_metadata(forward_batch)
             return
+        self._wait_recovery_if_pending()
         for attn_backend in self.attn_backend_list:
             attn_backend.init_forward_metadata(forward_batch)
 
@@ -780,6 +797,38 @@ class HybridLinearAttnBackend(AttentionBackend):
                 forward_mode,
                 spec_info,
             )
+
+    def init_forward_metadata_replay_cuda_graph(
+        self,
+        bs: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_sum: int,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode: ForwardMode,
+        spec_info: Optional[SpecInput],
+        seq_lens_cpu: Optional[torch.Tensor],
+    ):
+        if not forward_mode.is_draft_extend_v2():
+            # Join the prior step's side-stream SSM recovery before this target
+            # forward (replayed graph) reads / overwrites the SSM pool & stash.
+            # NOTE: under SGLANG_ENABLE_OVERLAP_PLAN_STREAM this runs on
+            # plan_stream, not the replay (fwd) stream; correctness relies on the
+            # worker doing fwd_stream.wait_stream(plan_stream) before the replay
+            # (eagle_worker_v2.verify), which transitively propagates this wait.
+            self._wait_recovery_if_pending()
+        for attn_backend in self.attn_backend_list:
+            attn_backend.init_forward_metadata_replay_cuda_graph(
+                bs,
+                req_pool_indices,
+                seq_lens,
+                seq_lens_sum,
+                encoder_lens,
+                forward_mode,
+                spec_info,
+                seq_lens_cpu,
+            )
+
 
     def get_cuda_graph_seq_len_fill_value(self):
         return self.full_attn_backend.get_cuda_graph_seq_len_fill_value()
@@ -1018,25 +1067,56 @@ class HybridLinearAttnBackend(AttentionBackend):
         state_idx_i32 = state_indices_tensor.to(torch.int32).contiguous()
         accepted_steps_i32 = accepted_steps.to(torch.int32).contiguous()
 
-        # One launch per GDN layer. Slice persistent buffers to the current
-        # batch size instead of storing per-call sizes in the shared stash.
-        for layer_id, stash in stash_per_layer.items():
-            layer_cache = pool.mamba2_layer_cache(layer_id)
-            layer_ssm_states = layer_cache.temporal  # [size+1, HV, V, K]
+        # One launch per GDN layer. Factored into a closure so it can run either
+        # inline (CUDA graph capture) or on the side stream (eager overlap).
+        def _run_recovery():
+            for layer_id, stash in stash_per_layer.items():
+                layer_cache = pool.mamba2_layer_cache(layer_id)
+                layer_ssm_states = layer_cache.temporal  # [size+1, HV, V, K]
 
-            fused_sigmoid_gating_delta_rule_recover_final_state(
-                A_log=stash["A_log"],
-                a=stash["a"][:actual_seq_len],
-                dt_bias=stash["dt_bias"],
-                softplus_beta=1.0,
-                softplus_threshold=20.0,
-                k=stash["k"][:, :actual_seq_len],
-                v=stash["v"][:, :actual_seq_len],
-                b=stash["b"][:actual_seq_len],
-                initial_state_source=layer_ssm_states,
-                initial_state_indices=state_idx_i32,
-                accepted_steps=accepted_steps_i32,
-                cache_steps=cache_steps,
-                use_qk_l2norm_in_kernel=True,
-                is_kda=False,
-            )
+                fused_sigmoid_gating_delta_rule_recover_final_state(
+                    A_log=stash["A_log"],
+                    a=stash["a"][:actual_seq_len],
+                    dt_bias=stash["dt_bias"],
+                    softplus_beta=1.0,
+                    softplus_threshold=20.0,
+                    k=stash["k"][:, :actual_seq_len],
+                    v=stash["v"][:, :actual_seq_len],
+                    b=stash["b"][:actual_seq_len],
+                    initial_state_source=layer_ssm_states,
+                    initial_state_indices=state_idx_i32,
+                    accepted_steps=accepted_steps_i32,
+                    cache_steps=cache_steps,
+                    use_qk_l2norm_in_kernel=True,
+                    is_kda=False,
+                )
+
+        # During CUDA graph capture, recovery must stay on the capture stream
+        # (it is normally eager / outside the graph; this is a safety guard).
+        if torch.cuda.is_current_stream_capturing():
+            _run_recovery()
+            return
+
+        # Eager path: overlap recovery on a dedicated side stream so its GPU
+        # work hides behind the next step's draft-phase compute (which does not
+        # touch the SSM pool). The next target forward joins on _recovery_event
+        # (see _wait_recovery_if_pending) before reading / overwriting the SSM
+        # pool & stash.
+        if self._recovery_stream is None:
+            self._recovery_stream = torch.cuda.Stream()
+            self._recovery_event = torch.cuda.Event()
+        # Recovery must observe the stash writes issued on the current stream
+        # during this step's verify forward.
+        self._recovery_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self._recovery_stream):
+            _run_recovery()
+        self._recovery_event.record(self._recovery_stream)
+        # state_idx_i32 / accepted_steps_i32 are fresh allocations issued on the
+        # current (main) stream but consumed by the side-stream recovery kernels.
+        # wait_stream orders but does not extend their lifetime: once this
+        # function returns the locals drop and the caching allocator may reuse
+        # the blocks on the main stream while the side stream is still reading
+        # them. record_stream pins the memory until the side stream is done.
+        state_idx_i32.record_stream(self._recovery_stream)
+        accepted_steps_i32.record_stream(self._recovery_stream)
+        self._recovery_event_pending = True

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -930,14 +930,31 @@ class HybridLinearAttnBackend(AttentionBackend):
         intermediate_state_cache = mamba_caches.intermediate_ssm
         intermediate_conv_window_cache = mamba_caches.intermediate_conv_window[0]
 
-        # Use fully fused kernel that handles masking internally
-        # This avoids separate nonzero() and index_select() calls
-        fused_mamba_state_scatter_with_mask(
-            ssm_states,
-            intermediate_state_cache,
-            state_indices_tensor,
-            last_correct_step_indices,
-        )
+        if mamba_track_indices is not None and intermediate_state_cache is None:
+            raise RuntimeError(
+                "--gdn-mtp-cache-mode=none is not supported with mamba radix "
+                "tracking because tracked prefix states require cached "
+                "intermediate SSM states."
+            )
+
+        # SSM state recovery depends on whether per-draft states were cached.
+        if intermediate_state_cache is not None:
+            # mode=full: h_K is already cached per draft-token position.
+            fused_mamba_state_scatter_with_mask(
+                ssm_states,
+                intermediate_state_cache,
+                state_indices_tensor,
+                last_correct_step_indices,
+            )
+        else:
+            # mode=none: rerun recurrence from h_0 over the accepted prefix
+            # and write h_K directly without materializing outputs.
+            self._no_cache_mtp_recompute(
+                accepted_steps=last_correct_step_indices,
+                state_indices_tensor=state_indices_tensor,
+            )
+
+        # Conv-state rollback uses cached conv windows in both modes.
         # conv intermediate uses the deduplicated sliding-window (overlapping)
         # layout, so it needs the strided-read scatter variant.
         fused_conv_window_scatter_with_mask(
@@ -947,7 +964,8 @@ class HybridLinearAttnBackend(AttentionBackend):
             last_correct_step_indices,
         )
 
-        # Track indices used for tracking mamba states for prefix cache
+        # Prefix-cache tracking requires intermediate SSM states, so it runs
+        # only on the full-cache path.
         if mamba_track_indices is not None:
             assert mamba_steps_to_track is not None
             # Use fully fused kernel for track scatter operations
@@ -962,4 +980,63 @@ class HybridLinearAttnBackend(AttentionBackend):
                 intermediate_conv_window_cache,
                 mamba_track_indices,
                 mamba_steps_to_track,
+            )
+
+    def _no_cache_mtp_recompute(
+        self,
+        accepted_steps: torch.Tensor,
+        state_indices_tensor: torch.Tensor,
+    ):
+        """Recover accepted GDN SSM state for gdn_mtp_cache_mode=none.
+
+        Replays the state-update recurrence over stashed post-conv k/v/a/b and
+        writes h_{accepted_step} directly to the request's SSM state slot.
+        """
+        # Local imports to avoid a circular dependency at module load time.
+        from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
+            fused_sigmoid_gating_delta_rule_recover_final_state,
+        )
+
+        stash_per_layer: dict = getattr(self.linear_attn_backend, "_no_cache_stash", {})
+        if not stash_per_layer:
+            # No GDN layer ran in cache_mode=none for this batch.
+            return
+
+        pool = self.linear_attn_backend.req_to_token_pool
+
+        # Recovery runs outside the captured graph. Derive per-call sizes from
+        # current tensors because the stash spans multiple batch-size captures.
+        batch_size = accepted_steps.shape[0]
+        draft_token_num = self.linear_attn_backend._no_cache_draft_token_num
+        assert draft_token_num is not None, (
+            "draft_token_num not cached — forward_extend was never called "
+            "in target_verify mode before _mamba_verify_update."
+        )
+        actual_seq_len = batch_size * draft_token_num
+        cache_steps = draft_token_num
+        # The kernel expects int32 state indices.
+        state_idx_i32 = state_indices_tensor.to(torch.int32).contiguous()
+        accepted_steps_i32 = accepted_steps.to(torch.int32).contiguous()
+
+        # One launch per GDN layer. Slice persistent buffers to the current
+        # batch size instead of storing per-call sizes in the shared stash.
+        for layer_id, stash in stash_per_layer.items():
+            layer_cache = pool.mamba2_layer_cache(layer_id)
+            layer_ssm_states = layer_cache.temporal  # [size+1, HV, V, K]
+
+            fused_sigmoid_gating_delta_rule_recover_final_state(
+                A_log=stash["A_log"],
+                a=stash["a"][:actual_seq_len],
+                dt_bias=stash["dt_bias"],
+                softplus_beta=1.0,
+                softplus_threshold=20.0,
+                k=stash["k"][:, :actual_seq_len],
+                v=stash["v"][:, :actual_seq_len],
+                b=stash["b"][:actual_seq_len],
+                initial_state_source=layer_ssm_states,
+                initial_state_indices=state_idx_i32,
+                accepted_steps=accepted_steps_i32,
+                cache_steps=cache_steps,
+                use_qk_l2norm_in_kernel=True,
+                is_kda=False,
             )

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 
@@ -287,6 +287,12 @@ class GDNAttnBackend(MambaAttnBackendBase):
         self.verify_intermediate_state_indices = torch.arange(
             self.req_to_token_pool.size, dtype=torch.int32, device=model_runner.device
         )
+        # Per-layer persistent buffers used by gdn_mtp_cache_mode=none recovery.
+        # Values are stable tensors or parameters; per-call sizes are derived
+        # from runtime tensors because the dict spans multiple CUDA graph captures.
+        self._no_cache_stash: Dict[int, Dict[str, torch.Tensor]] = {}
+        # Cached once on first forward; stable across calls.
+        self._no_cache_draft_token_num: Optional[int] = None
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         super().init_forward_metadata(forward_batch)
@@ -401,6 +407,8 @@ class GDNAttnBackend(MambaAttnBackendBase):
         ssm_states = mamba_cache_params.temporal
         if is_target_verify:
             assert isinstance(mamba_cache_params, MambaPool.SpeculativeState)
+            # In cache_mode=none, target verify skips intermediate SSM writes;
+            # accepted h_K is recovered after verification.
             intermediate_state_cache = mamba_cache_params.intermediate_ssm
             intermediate_conv_window_cache = (
                 mamba_cache_params.intermediate_conv_window[0]
@@ -474,6 +482,58 @@ class GDNAttnBackend(MambaAttnBackendBase):
             value = value.view(1, actual_seq_len, layer.num_v_heads, layer.head_v_dim)
 
         if is_target_verify:
+            # In cache_mode=none, keep post-conv GDN inputs for accepted-state
+            # recovery. Persistent buffers give CUDA graph replay stable addresses.
+            if intermediate_state_cache is None:
+                # Target layout: [1, max_tokens, heads, dim] where
+                # max_tokens = pool.size * draft_token_num covers any
+                # batch size SGLang may capture a CUDA graph for.
+                draft_token_num = forward_batch.spec_info.draft_token_num
+                max_tokens = self.req_to_token_pool.size * draft_token_num
+                actual_seq_len = query.shape[1]
+
+                stash_entry = self._no_cache_stash.get(layer.layer_id)
+                if stash_entry is None or stash_entry["k"].shape[1] < max_tokens:
+                    # Allocate outside inference_mode so buffers can be updated
+                    # across forward invocations.
+                    with torch.inference_mode(False):
+                        stash_entry = {
+                            "k": torch.empty(
+                                (key.shape[0], max_tokens, *key.shape[2:]),
+                                dtype=key.dtype,
+                                device=key.device,
+                            ),
+                            "v": torch.empty(
+                                (value.shape[0], max_tokens, *value.shape[2:]),
+                                dtype=value.dtype,
+                                device=value.device,
+                            ),
+                            "a": torch.empty(
+                                (max_tokens, *a.shape[1:]),
+                                dtype=a.dtype,
+                                device=a.device,
+                            ),
+                            "b": torch.empty(
+                                (max_tokens, *b.shape[1:]),
+                                dtype=b.dtype,
+                                device=b.device,
+                            ),
+                            "A_log": layer.A_log,
+                            "dt_bias": layer.dt_bias,
+                        }
+                    self._no_cache_stash[layer.layer_id] = stash_entry
+                # In-place slice copy with no new allocation; captured replays
+                # refresh the stable buffer slice for that graph's batch size.
+                stash_entry["k"][:, :actual_seq_len].copy_(key)
+                stash_entry["v"][:, :actual_seq_len].copy_(value)
+                stash_entry["a"][:actual_seq_len].copy_(a)
+                stash_entry["b"][:actual_seq_len].copy_(b)
+                # Do not store per-call sizes or tensor aliases in the stash;
+                # eager recovery derives them from current runtime tensors.
+                if self._no_cache_draft_token_num is None:
+                    self._no_cache_draft_token_num = (
+                        forward_batch.spec_info.draft_token_num
+                    )
             core_attn_out = self.kernel_dispatcher.target_verify(
                 A_log=layer.A_log,
                 dt_bias=layer.dt_bias,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -111,7 +111,9 @@ def conv_window_dedup_enabled(
     )
 
 
-def get_tensor_size_bytes(t: Union[torch.Tensor, List[torch.Tensor]]):
+def get_tensor_size_bytes(t: Optional[Union[torch.Tensor, List[torch.Tensor]]]):
+    if t is None:
+        return 0
     if isinstance(t, list):
         return sum(get_tensor_size_bytes(x) for x in t)
     return np.prod(t.shape) * t.dtype.itemsize
@@ -309,7 +311,9 @@ class MambaPool:
             for f in fields(self):
                 name = f.name
                 v = getattr(self, name)
-                if name in ("conv", "intermediate_conv_window"):
+                if v is None:
+                    kwargs[name] = None
+                elif name in ("conv", "intermediate_conv_window"):
                     kwargs[name] = [conv[layer] for conv in v]
                 else:
                     kwargs[name] = v[layer]
@@ -324,8 +328,10 @@ class MambaPool:
 
     @dataclass(frozen=True, kw_only=True)
     class SpeculativeState(State):
-        intermediate_ssm: torch.Tensor
-        intermediate_conv_window: List[torch.Tensor]
+        # None in gdn_mtp_cache_mode=none; recovery reconstructs h_K after verify.
+        intermediate_ssm: Optional[torch.Tensor] = None
+        # Kept in both modes for accepted conv-state rollback.
+        intermediate_conv_window: Optional[List[torch.Tensor]] = None
 
     def __init__(
         self,
@@ -401,20 +407,12 @@ class MambaPool:
                         temporal_state_shape[-1],
                         temporal_state_shape[-2],
                     )
-                # Cache intermediate SSM states per draft token during target verify
-                # Shape: [num_layers, size + 1, speculative_num_draft_tokens, HV, K, V]
-                intermediate_ssm_state_cache = torch.zeros(
-                    size=(
-                        num_mamba_layers,
-                        spec_state_size + 1,
-                        speculative_num_draft_tokens,
-                        temporal_state_shape[0],
-                        temporal_state_shape[1],
-                        temporal_state_shape[2],
-                    ),
-                    dtype=ssm_dtype,
-                    device="cuda",
-                )
+                # gdn_mtp_cache_mode controls only the SSM intermediate cache.
+                # Conv windows stay cached for accepted conv-state rollback.
+                from sglang.srt.server_args import get_global_server_args
+
+                cache_mode = get_global_server_args().gdn_mtp_cache_mode
+
                 # Cache intermediate conv windows (last K-1 inputs) per draft token
                 # during target verify.
                 #
@@ -495,22 +493,56 @@ class MambaPool:
                         for conv_shape in conv_state_shape
                     ]
                     self._intermediate_conv_window_phys = intermediate_conv_window_cache
-                self.mamba_cache = self.SpeculativeState(
-                    conv=conv_state,
-                    temporal=temporal_state,
-                    intermediate_ssm=intermediate_ssm_state_cache,
-                    intermediate_conv_window=intermediate_conv_window_cache,
-                )
-                logger.info(
-                    f"Mamba Cache is allocated. "
-                    f"max_mamba_cache_size: {size}, "
-                    f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
-                    f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
-                    f"intermediate_ssm_state_cache size: {get_tensor_size_bytes(intermediate_ssm_state_cache) / GB:.2f}GB "
-                    # Report the deduplicated PHYSICAL conv-window buffers (the view
-                    # over-reports its logical, un-deduplicated size).
-                    f"intermediate_conv_window_cache size: {get_tensor_size_bytes(self._intermediate_conv_window_phys) / GB:.2f}GB "
-                )
+
+                if cache_mode == "none":
+                    # Skip intermediate_ssm, the dominant speculative MTP state cache.
+                    # Recovery reconstructs h_K from committed h_0 after verify.
+                    self.mamba_cache = self.SpeculativeState(
+                        conv=conv_state,
+                        temporal=temporal_state,
+                        intermediate_ssm=None,
+                        intermediate_conv_window=intermediate_conv_window_cache,
+                    )
+                    logger.info(
+                        f"Mamba Cache is allocated (gdn_mtp_cache_mode=none). "
+                        f"max_mamba_cache_size: {size}, "
+                        f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
+                        f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
+                        f"intermediate_ssm_state_cache: SKIPPED "
+                        # Report the deduplicated PHYSICAL conv-window buffers.
+                        f"intermediate_conv_window_cache size: {get_tensor_size_bytes(self._intermediate_conv_window_phys) / GB:.2f}GB "
+                    )
+                else:
+                    # "full" (default): cache intermediate SSM states per draft token.
+                    # Shape: [num_layers, size + 1, speculative_num_draft_tokens, HV, K, V]
+                    intermediate_ssm_state_cache = torch.zeros(
+                        size=(
+                            num_mamba_layers,
+                            spec_state_size + 1,
+                            speculative_num_draft_tokens,
+                            temporal_state_shape[0],
+                            temporal_state_shape[1],
+                            temporal_state_shape[2],
+                        ),
+                        dtype=ssm_dtype,
+                        device="cuda",
+                    )
+                    self.mamba_cache = self.SpeculativeState(
+                        conv=conv_state,
+                        temporal=temporal_state,
+                        intermediate_ssm=intermediate_ssm_state_cache,
+                        intermediate_conv_window=intermediate_conv_window_cache,
+                    )
+                    logger.info(
+                        f"Mamba Cache is allocated. "
+                        f"max_mamba_cache_size: {size}, "
+                        f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
+                        f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
+                        f"intermediate_ssm_state_cache size: {get_tensor_size_bytes(intermediate_ssm_state_cache) / GB:.2f}GB "
+                        # Report the deduplicated PHYSICAL conv-window buffers (the view
+                        # over-reports its logical, un-deduplicated size).
+                        f"intermediate_conv_window_cache size: {get_tensor_size_bytes(self._intermediate_conv_window_phys) / GB:.2f}GB "
+                    )
             else:
                 self.mamba_cache = self.State(conv=conv_state, temporal=temporal_state)
                 logger.info(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -878,9 +878,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if self.device == "cuda" or self.device == "musa":
             self.init_cublas()
             self.init_attention_backend()
-            self.kernel_warmup()
-            self._pre_initialize_flashinfer_allreduce_workspace()
-            self.init_device_graphs()
             self.maybe_init_gdn_recovery_prewarm()
         elif self.device == "cpu":
             self.init_attention_backend()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -878,6 +878,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if self.device == "cuda" or self.device == "musa":
             self.init_cublas()
             self.init_attention_backend()
+            self.kernel_warmup()
+            self._pre_initialize_flashinfer_allreduce_workspace()
+            self.init_device_graphs()
+            self.maybe_init_gdn_recovery_prewarm()
         elif self.device == "cpu":
             self.init_attention_backend()
         elif self.device == "npu":
@@ -2512,6 +2516,104 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     module.init_buffers(
                         self.max_running_requests, chunked_prefill_size, self.device
                     )
+
+    def maybe_init_gdn_recovery_prewarm(self):
+        """Pre-JIT the FlashInfer GDN MTP recovery kernel for all B-padded variants.
+
+        B-padding in _no_cache_mtp_recompute() rounds batch size up to the next
+        power-of-2 (max 10 values: 1,2,4,...,512) so the CuTe DSL JIT sees at most
+        10 × T_max distinct (B, T) keys.  Without this prewarm, the first request
+        at each new padded-B triggers a ~37s compilation stall.
+        """
+        import time
+
+        if self.device != "cuda":
+            return
+        if self.is_draft_worker:
+            return
+        T_max = self.server_args.speculative_num_draft_tokens
+        if T_max is None:
+            return
+
+        try:
+            from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+                HybridLinearAttnBackend,
+            )
+
+            if not isinstance(self.attn_backend, HybridLinearAttnBackend):
+                return
+            linear_be = self.attn_backend.linear_attn_backend
+            dispatcher = getattr(linear_be, "kernel_dispatcher", None)
+            decode_kernel = getattr(dispatcher, "decode_kernel", None)
+            if (
+                decode_kernel is None
+                or decode_kernel.__class__.__name__ != "FlashInferGDNKernel"
+                or not getattr(decode_kernel, "use_state_pool", False)
+            ):
+                return
+
+            pool = linear_be.req_to_token_pool
+            mamba_pool = getattr(pool, "mamba_pool", None)
+            if mamba_pool is None or mamba_pool.mamba_cache is None:
+                return
+
+            # state_source shape: [pool_size+1, H, V, K] (CUDA, no transpose)
+            state_source = mamba_pool.mamba_cache.temporal[0]
+            if state_source.numel() == 0:
+                return
+            H = state_source.shape[1]  # num_heads_local
+            V = state_source.shape[2]  # head_v_dim
+            K = state_source.shape[3]  # head_k_dim
+            dev = state_source.device
+            ssm_dtype = state_source.dtype
+
+            from flashinfer.gdn_kernels.gdn_decode_bf16_state import (
+                gated_delta_rule_mtp,
+            )
+
+            _PAD_BS = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+            n_variants = len(_PAD_BS) * T_max
+            logger.info(
+                f"Pre-warming GDN recovery JIT: {len(_PAD_BS)} B_pad × {T_max} T "
+                f"= {n_variants} variants (~{n_variants * 37 / 60:.0f} min est.)"
+            )
+            tic = time.perf_counter()
+
+            # Dummy index 0 writes to slot 0 (reserved dummy) and is harmless.
+            for B_pad in _PAD_BS:
+                for T in range(1, T_max + 1):
+                    dummy_idx = torch.zeros(B_pad, dtype=torch.int32, device=dev)
+                    dummy_acc = torch.zeros(B_pad, dtype=torch.int32, device=dev)
+                    dummy_k = torch.zeros(B_pad, T, H, K, dtype=ssm_dtype, device=dev)
+                    dummy_v = torch.zeros(B_pad, T, H, V, dtype=ssm_dtype, device=dev)
+                    dummy_a = torch.zeros(B_pad, T, H, dtype=ssm_dtype, device=dev)
+                    dummy_b = torch.zeros(B_pad, T, H, dtype=ssm_dtype, device=dev)
+                    dummy_A_log = torch.zeros(H, dtype=torch.float32, device=dev)
+                    dummy_dt_bias = torch.zeros(H, dtype=ssm_dtype, device=dev)
+                    gated_delta_rule_mtp(
+                        A_log=dummy_A_log,
+                        a=dummy_a,
+                        dt_bias=dummy_dt_bias,
+                        q=dummy_k,
+                        k=dummy_k,
+                        v=dummy_v,
+                        b=dummy_b,
+                        initial_state_source=state_source,
+                        initial_state_indices=dummy_idx,
+                        output_state_indices=dummy_idx,
+                        accepted_steps=dummy_acc,
+                        disable_state_update=False,
+                        disable_output=True,
+                        use_qk_l2norm_in_kernel=True,
+                        scale=None,
+                        output=None,
+                    )
+
+            torch.cuda.synchronize()
+            elapsed = time.perf_counter() - tic
+            logger.info(f"GDN recovery JIT pre-warm done in {elapsed:.1f}s")
+        except Exception as e:
+            logger.warning(f"GDN recovery JIT pre-warm skipped: {e}")
 
     def maybe_update_ngram_token_table(
         self,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -316,6 +316,12 @@ MAMBA_BACKEND_CHOICES = ["triton", "flashinfer"]
 
 LINEAR_ATTN_KERNEL_BACKEND_CHOICES = ["triton", "cutedsl", "flashinfer"]
 
+# GDN MTP intermediate-state cache mode.
+# - "full": cache h-state at every draft token position (default behavior).
+# - "none": skip intermediate caching; reconstruct h_K by rerunning the
+#   recurrence from the committed h_0 over the accepted draft prefix.
+GDN_MTP_CACHE_MODE_CHOICES = ["full", "none"]
+
 
 # Allow external code to add more choices
 def add_load_format_choices(choices):
@@ -1800,6 +1806,18 @@ class ServerArgs:
         int,
         "The interval to track the mamba state during decode.",
     ] = 256
+    gdn_mtp_cache_mode: A[
+        str,
+        Arg(
+            help="Intermediate h-state cache mode for GDN MTP verify. "
+            "'full' (default) caches h at every draft-token position. "
+            "'none' skips intermediate caching and reconstructs h_K after verify by "
+            "re-running the GDN recurrence from the committed h_0 over the accepted "
+            "draft prefix. 'none' trades extra post-verify recovery compute for "
+            "freeing the intermediate_ssm buffer.",
+            choices=["full", "none"],
+        ),
+    ] = "full"
     enable_int8_mamba_checkpoint: A[
         bool,
         "Store radix-cached linear-attn (mamba) states in int8 (separate checkpoint pool) for ~2x cached-prefix capacity at fixed memory.",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR is a follow-up to #26520. Building on that foundation, it adds two things:

1. Side-stream overlap for GDN recovery: the recovery kernel now runs asynchronously on a dedicated CUDA side stream, overlapping with draft forward passes to hide recovery latency regardless of which backend is used.
2. A FlashInfer-backed recovery path for SM100+ with FlashInfer decode backend, using `gated_delta_rule_mtp` for final state reconstruction. Includes B-padding (round batch size to powers-of-two) and startup pre-warm to reduce FlashInfer JIT recompilation, and a zero-copy stash view for stable kernel dispatch.


## Modifications

- Fork per-layer recovery onto a dedicated CUDA side stream; synchronize via `_wait_recovery_if_pending` before the next target forward to overlap recovery with draft decoding. Applies to both Triton and FlashInfer recovery backends.
- On SM100+ with FlashInfer decode backend, use `gated_delta_rule_mtp` for recovery instead of the Triton recurrence kernel.
- Pad batch size to the next power-of-two before FlashInfer JIT dispatch to reduce the number of distinct compiled shapes.
- Pre-warm all B_pad×T shape combinations at server startup via `maybe_init_gdn_recovery_prewarm()` to eliminate first-request JIT stalls.
- Use a zero-copy stash view for recovery kernel dispatch to avoid extra copies.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->


GSM8K, nvidia/Qwen3.5-397B-A17B-NVFP4, 4×GB200, `num_examples=1319`, `num_shots=8`,
`num_threads=256`, `max_tokens=16384`, `temperature=0.6`, `top_p=0.95`, `top_k=20`.

SGLang's GSM8K evaluator reserves the first 8 test rows as the few-shot prompt and evaluates the remaining 1311 rows.

| Mode | Score | Output throughput | Latency |
|------|-------|-------------------|---------|
| `cache_mode=none` + Triton backend | 0.976 | 12219.832 tok/s | 256.834 s |
| `cache_mode=none` + FlashInfer backend | 0.979 | 10350.89 tok/s | 308.68 s |
| `cache_mode=full` + Triton backend (baseline) | 0.979 | 12401.953 tok/s | 259.837 s |

Accuracy is within noise across both recovery backends.

```
Repro commands:

export PYTHONUNBUFFERED=1
export NCCL_CUMEM_ENABLE=1
export NCCL_MNNVL_ENABLE=1
export NCCL_NVLS_ENABLE=1
export SGL_ENABLE_JIT_DEEPGEMM=false
export SGLANG_ENABLE_FLASHINFER_GEMM=true
export SGLANG_LOG_FORWARD_ITERS=1
export SGLANG_TORCH_PROFILER_DIR=/profiles

python3 -m sglang.launch_server \
--served-model-name nvidia/Qwen3.5-397B-A17B-NVFP4 \
--model-path nvidia/Qwen3.5-397B-A17B-NVFP4 \
--tensor-parallel-size 4 \
--expert-parallel-size 1 \
--quantization modelopt_fp4 \
--kv-cache-dtype fp8_e4m3 \
--fp4-gemm-backend flashinfer_cutlass \
--mamba-ssm-dtype bfloat16 \
--attention-backend trtllm_mha \
--moe-runner-backend flashinfer_trtllm \
--mamba-scheduler-strategy no_buffer \
--disable-radix-cache \
--mem-fraction-static 0.85 \
--chunked-prefill-size 32768 \
--max-prefill-tokens 32768 \
--cuda-graph-max-bs 512 \
--max-running-requests 512 \
--scheduler-recv-interval 30 \
--stream-interval 30 \
--watchdog-timeout 600 \
--speculative-algorithm NEXTN \
--speculative-num-steps 3 \
--speculative-eagle-topk 1 \
--speculative-num-draft-tokens 4 \
--gdn-mtp-cache-mode none \ # or none instead
--linear-attn-decode-backend flashinfer \  # or triton instead
--host 0.0.0.0 \
--port 30000

python3 -m sglang.test.run_eval \
  --base-url http://127.0.0.1:30000 \
  --eval-name gsm8k \
  --num-examples 1319 \
  --num-threads 256 \
  --max-tokens 16384 \
  --num-shots 8 \
  --temperature 0.6 \
  --top-p 0.95 \
  --top-k 20
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->


Output throughput (tok/s), nvidia/Qwen3.5-397B-A17B-NVFP4, 4×GB200, `random-input=1000`, `random-output=128`:

| batch size | mode = none, flashinfer backend | mode = none, triton backend | mode = full, triton backend (baseline)|
|-----------|-------------------|----------------|----------------|
| bs=64  | 3380.74 |  3298.34 | 3055.28   |
| bs=128 | 4111.65 |  3757.07    | 3800.66 |
| bs=256 | 4839.21 | 4299.16   | 4222.00   |
| bs=512 | 5778.83 | 5393.78   |5300.35  |


```
Repro commands:

export PYTHONUNBUFFERED=1
export NCCL_CUMEM_ENABLE=1
export NCCL_MNNVL_ENABLE=1
export NCCL_NVLS_ENABLE=1
export SGL_ENABLE_JIT_DEEPGEMM=false
export SGLANG_ENABLE_FLASHINFER_GEMM=true
export SGLANG_LOG_FORWARD_ITERS=1
export SGLANG_TORCH_PROFILER_DIR=/profiles

python3 -m sglang.launch_server \
--served-model-name nvidia/Qwen3.5-397B-A17B-NVFP4 \
--model-path nvidia/Qwen3.5-397B-A17B-NVFP4 \
--tensor-parallel-size 4 \
--expert-parallel-size 1 \
--quantization modelopt_fp4 \
--kv-cache-dtype fp8_e4m3 \
--fp4-gemm-backend flashinfer_cutlass \
--mamba-ssm-dtype bfloat16 \
--attention-backend trtllm_mha \
--moe-runner-backend flashinfer_trtllm \
--mamba-scheduler-strategy no_buffer \
--disable-radix-cache \
--mem-fraction-static 0.85 \
--chunked-prefill-size 32768 \
--max-prefill-tokens 32768 \
--cuda-graph-max-bs 512 \
--max-running-requests 512 \
--scheduler-recv-interval 30 \
--stream-interval 30 \
--watchdog-timeout 600 \
--speculative-algorithm NEXTN \
--speculative-num-steps 3 \
--speculative-eagle-topk 1 \
--speculative-num-draft-tokens 4 \
--gdn-mtp-cache-mode none \
--linear-attn-decode-backend flashinfer \  # or triton instead
--host 0.0.0.0 \
--port 30000

 # bs=64
  python3 -m sglang.bench_serving \
    --backend sglang --base-url http://localhost:30000 \
    --dataset-name random --random-input 1000 --random-output 128 \
    --max-concurrency 64 --request-rate inf --num-prompt 200

  # bs=128
  python3 -m sglang.bench_serving \
    --backend sglang --base-url http://localhost:30000 \
    --dataset-name random --random-input 1000 --random-output 128 \
    --max-concurrency 128 --request-rate inf --num-prompt 400

  # bs=256
  python3 -m sglang.bench_serving \
    --backend sglang --base-url http://localhost:30000 \
    --dataset-name random --random-input 1000 --random-output 128 \
    --max-concurrency 256 --request-rate inf --num-prompt 800

  # bs=512
  python3 -m sglang.bench_serving \
    --backend sglang --base-url http://localhost:30000 \
    --dataset-name random --random-input 1000 --random-output 128 \
    --max-concurrency 512 --request-rate inf --num-prompt 1600
```
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->