### PR TITLE
shm_broadcast: retry bind on EADDRINUSE (fix dp-attention port race)

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/shm_broadcast.py
+++ b/python/sglang/srt/distributed/device_communicators/shm_broadcast.py
@@ -18,6 +18,7 @@ from torch.distributed import ProcessGroup
 from zmq import IPV6  # type: ignore
 from zmq import SUB, SUBSCRIBE, XPUB, XPUB_VERBOSE, Context  # type: ignore
 
+from sglang.srt.environ import envs
 from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto, get_open_port
 from sglang.srt.utils.stale_shm_cleanup import make_shm_name
 
@@ -211,10 +212,18 @@ class MessageQueue:
             # message. otherwise, we will only receive the first subscription
             # see http://api.zeromq.org/3-3:zmq-setsockopt for more details
             self.local_socket.setsockopt(XPUB_VERBOSE, True)
-            local_subscribe_port = get_open_port()
-            socket_addr = f"tcp://127.0.0.1:{local_subscribe_port}"
-            logger.debug("Binding to %s", socket_addr)
-            self.local_socket.bind(socket_addr)
+            # Bind atomically to avoid get_open_port()'s check-then-bind race;
+            # search from SGLANG_PORT to keep the existing port range.
+            sglang_port = envs.SGLANG_PORT.get()
+            if sglang_port is not None:
+                local_subscribe_port = self.local_socket.bind_to_random_port(
+                    "tcp://127.0.0.1", min_port=sglang_port, max_port=sglang_port + 8
+                )
+            else:
+                local_subscribe_port = self.local_socket.bind_to_random_port(
+                    "tcp://127.0.0.1"
+                )
+            logger.debug("Bound to tcp://127.0.0.1:%d", local_subscribe_port)
             self.current_idx = 0
 
         else:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -394,6 +394,12 @@ class Envs:
     SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE = EnvStr(None)
     SGLANG_TCP_STORE_PORT = EnvInt(29600)
 
+    # Base port hint for ephemeral sockets (ZMQ, SHM broadcaster, etc.).
+    # When set, get_open_port() and shm_broadcast search upwards from this
+    # value instead of asking the OS for a random port.  Useful to keep all
+    # SGLang ports in a predictable range behind a firewall.
+    SGLANG_PORT = EnvInt(None)
+
     # Tool Calling
     SGLANG_FORWARD_UNKNOWN_TOOLS = EnvBool(False)
 

--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -15,9 +15,10 @@ logger = logging.getLogger(__name__)
 
 
 def get_open_port() -> int:
-    port = os.getenv("SGLANG_PORT")
+    from sglang.srt.environ import envs
+
+    port = envs.SGLANG_PORT.get()
     if port is not None:
-        port = int(port)
         while True:
             if is_port_available(port):
                 return port


### PR DESCRIPTION
## Summary

- Replace the check-then-bind pattern (`get_open_port` + `socket.bind`) in the SHM broadcaster with ZMQ's atomic `bind_to_random_port`, eliminating a TOCTOU race that caused `EADDRINUSE` under dp-attention with `attn_tp==2`.
- When `SGLANG_PORT` is set, the search range is `[SGLANG_PORT, SGLANG_PORT+8]`; otherwise ZMQ picks an arbitrary ephemeral port.
- Migrate `SGLANG_PORT` from raw `os.getenv` to the `environ.py` `EnvInt` registry (`envs.SGLANG_PORT`) for consistency with other env-var knobs, and update `get_open_port()` in `network.py` accordingly.

## Original commits

- `b42bce2`

## Test plan

- [ ] Verify dp-attention with attn_tp==2 no longer hits EADDRINUSE on startup
- [ ] Verify `SGLANG_PORT` env var still constrains port selection in `get_open_port()` and `shm_broadcast`
- [ ] Existing `test_socket_utils.py` tests pass (they use `patch.dict(os.environ)` which is compatible with `envs.SGLANG_PORT.get()`)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28265554934](https://github.com/sgl-project/sglang/actions/runs/28265554934)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28265554767](https://github.com/sgl-project/sglang/actions/runs/28265554767)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->