### PR TITLE
Fix wildcard bootstrap registration host

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -394,11 +394,12 @@ class CommonKVManager(BaseKVManager):
         else:
             # Single-node case: bootstrap server's host is the same as http server's host
             host = self.bootstrap_host
-            # If the server was bound to the wildcard address (0.0.0.0 / ::), use the
-            # actual local IP instead — a PUT to http://0.0.0.0:<port>/route is rejected
-            # with 403 by aiohttp ≥3.9 because 0.0.0.0 is not a valid HTTP Host value.
-            if host in ("0.0.0.0", "::"):
-                host = self.local_ip
+            # A wildcard bind address (0.0.0.0 / ::) is not a valid HTTP Host
+            # and can't be connected to; rewrite it to the same-family loopback,
+            # which the wildcard listener also binds.  (self.local_ip is wrong
+            # here — it can resolve to a different family than the listener,
+            # e.g. IPv6 while the server is bound to 0.0.0.0.)
+            host = {"0.0.0.0": "127.0.0.1", "::": "::1"}.get(host, host)
 
         bootstrap_na = NetworkAddress(host, self.bootstrap_port)
         url = f"{bootstrap_na.to_url()}/route"


### PR DESCRIPTION
## Summary
- rewrite wildcard bootstrap hosts to same-family loopback addresses before building the registration URL
- avoid using an auto-detected local IP that may use a different address family than the listener

## Test plan
- git diff --check
- python3 -m py_compile python/sglang/srt/disaggregation/common/conn.py

## Original commits

- `7b0853b3447a0e039fbc0b8e16f0483bfa3f9171`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28265899506](https://github.com/sgl-project/sglang/actions/runs/28265899506)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28265899378](https://github.com/sgl-project/sglang/actions/runs/28265899378)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->