### PR TITLE
Fix SWA KV cache write location length

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -778,9 +778,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         else:
             # Use original set_kv_buffer path
             if save_kv_cache and k is not None:
+                swa_loc = self.forward_metadata.swa_out_cache_loc
+                if swa_loc is not None:
+                    swa_loc = swa_loc[: cache_loc.shape[0]]
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                    KVWriteLoc(cache_loc, swa_loc),
                     k,
                     v,
                     layer.k_scale,
@@ -861,9 +864,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         else:
             # Use original set_kv_buffer path
             if save_kv_cache and k is not None:
+                swa_loc = self.forward_metadata.swa_out_cache_loc
+                if swa_loc is not None:
+                    swa_loc = swa_loc[: cache_loc.shape[0]]
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                    KVWriteLoc(cache_loc, swa_loc),
                     k,
                     v,
                     layer.k_scale,


### PR DESCRIPTION
## Summary
- Slice precomputed SWA KV write locations to match narrowed cache write locations before constructing KVWriteLoc.
- Apply the fix in both TRT-LLM MHA decode and extend KV cache write paths.

## Testing
- `git diff --check`

## Original commits

- `cb3e4729611cc5d1f4e5b753c3346a8deab6d35e`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28265948831](https://github.com/sgl-project/sglang/actions/runs/28265948831)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28265948730](https://github.com/sgl-project/sglang/actions/runs/28265948730)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->