### PR TITLE
Fix SWA cache loc slicing for all attention backends

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -778,9 +778,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         else:
             # Use original set_kv_buffer path
             if save_kv_cache and k is not None:
+                swa_loc = self.forward_metadata.swa_out_cache_loc
+                if swa_loc is not None:
+                    swa_loc = swa_loc[: cache_loc.shape[0]]
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                    KVWriteLoc(cache_loc, swa_loc),
                     k,
                     v,
                     layer.k_scale,
@@ -861,9 +864,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         else:
             # Use original set_kv_buffer path
             if save_kv_cache and k is not None:
+                swa_loc = self.forward_metadata.swa_out_cache_loc
+                if swa_loc is not None:
+                    swa_loc = swa_loc[: cache_loc.shape[0]]
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                    KVWriteLoc(cache_loc, swa_loc),
                     k,
                     v,
                     layer.k_scale,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -778,12 +778,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         else:
             # Use original set_kv_buffer path
             if save_kv_cache and k is not None:
-                swa_loc = self.forward_metadata.swa_out_cache_loc
-                if swa_loc is not None:
-                    swa_loc = swa_loc[: cache_loc.shape[0]]
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    KVWriteLoc(cache_loc, swa_loc),
+                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
                     k,
                     v,
                     layer.k_scale,
@@ -864,12 +861,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         else:
             # Use original set_kv_buffer path
             if save_kv_cache and k is not None:
-                swa_loc = self.forward_metadata.swa_out_cache_loc
-                if swa_loc is not None:
-                    swa_loc = swa_loc[: cache_loc.shape[0]]
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    KVWriteLoc(cache_loc, swa_loc),
+                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
                     k,
                     v,
                     layer.k_scale,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1101,6 +1101,15 @@ class KVWriteLoc:
     loc: torch.Tensor
     swa_loc: Optional[torch.Tensor] = None
 
+    def __post_init__(self):
+        # swa_out_cache_loc is computed once at metadata-init time from the
+        # full (possibly padded) out_cache_loc. Piecewise CUDA graphs later
+        # narrow out_cache_loc to real_num_tokens per layer, so swa_loc can
+        # be longer than loc. Slice to match since both are in the same
+        # per-token order.
+        if self.swa_loc is not None and self.swa_loc.shape[0] != self.loc.shape[0]:
+            self.swa_loc = self.swa_loc[: self.loc.shape[0]]
+
 
 def unwrap_write_loc(loc_info):
     """Return ``(loc, swa_loc)`` from a ``KVWriteLoc`` or a bare loc tensor."""


### PR DESCRIPTION
## Summary
- Move `swa_out_cache_loc` slicing into `KVWriteLoc.__post_init__` so it applies to all attention backends, not just TRT-LLM MHA.
- `swa_out_cache_loc` is computed once at metadata-init time from the full (possibly padded) `out_cache_loc`. Piecewise CUDA graphs later narrow `out_cache_loc` to `real_num_tokens` per layer via `radix_attention.py`, but `swa_out_cache_loc` on the metadata is never narrowed. This causes a shape mismatch when `KVWriteLoc` bundles them together for `set_kv_buffer`.
- The fix auto-slices `swa_loc` to match `loc`'s length at `KVWriteLoc` construction time, fixing the issue for all 8 backends (flashinfer, triton, flashattention, trtllm_mha, aiter, xpu, torch_native, musa).

## Original commits
- `53f21e2fe`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28273505004](https://github.com/sgl-project/sglang/actions/runs/28273505004)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28273504905](https://github.com/sgl-project/sglang/actions/runs/28273504905)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->