### PR TITLE
Skip FlashInfer FP8 autotune for MXFP8 quantized models

### DIFF
--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -302,7 +302,13 @@ class BaseRunner(ABC):
             "modelopt_fp8",
             "modelopt_mixed",
         )
-        fp8_gemm_needs_autotune = (
+        # Online MXFP8 (microscaling) linears dispatch to flashinfer's
+        # ``mm_mxfp8``, which the flashinfer fp8 autotune dummy run does not
+        # exercise correctly -- it triggers an illegal memory access inside the
+        # mxfp8 cutlass cubin. The mxfp8 gemm is fixed-config and needs no
+        # tuning, so skip autotune for these models.
+        model_uses_mxfp8 = "mxfp8" in (mr.model_config.quantization or "")
+        fp8_gemm_needs_autotune = not model_uses_mxfp8 and (
             get_fp8_gemm_runner_backend().is_flashinfer_cutlass()
             or (model_uses_modelopt_fp8 and is_sm100_supported())
         )


### PR DESCRIPTION
## Summary
- MXFP8 (microscaling) models dispatch to flashinfer's `mm_mxfp8`, which the FP8 autotune dummy run triggers an illegal memory access on.
- The mxfp8 gemm is fixed-config and needs no tuning, so skip autotune when quantization contains "mxfp8".

## Original commits
- `8ec074d92`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28267380773](https://github.com/sgl-project/sglang/actions/runs/28267380773)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28267380613](https://github.com/sgl-project/sglang/actions/runs/28267380613)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->