### PR TITLE
[LoRA] Map inactive virtual-expert tokens to no-LoRA

### DIFF
--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -356,13 +356,17 @@ def _compute_moe_lora_info_kernel(
     offs = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     valid = offs < seg_len
     lora_id = tl.load(weight_indices_ptr + pid_seg)
-    lora_rank = tl.load(lora_ranks_ptr + lora_id)
+    valid_lora = lora_id >= 0
+    safe_lora_id = tl.maximum(lora_id, 0)
+    lora_rank = tl.load(lora_ranks_ptr + safe_lora_id, mask=valid_lora, other=0)
+    active_lora = valid_lora & (lora_rank > 0)
     tl.store(
-        adapter_enabled_ptr + lora_id,
-        (lora_rank > 0).to(tl.int32),
-        mask=pid_m == 0,
+        adapter_enabled_ptr + safe_lora_id,
+        active_lora.to(tl.int32),
+        mask=(pid_m == 0) & valid_lora,
     )
-    tl.store(token_lora_mapping_ptr + seg_start + offs, lora_id, mask=valid)
+    token_lora_id = tl.where(active_lora, lora_id, -1)
+    tl.store(token_lora_mapping_ptr + seg_start + offs, token_lora_id, mask=valid)
 
 
 def _compute_moe_lora_info(
@@ -378,6 +382,11 @@ def _compute_moe_lora_info(
         assert (
             num_tokens <= token_lora_mapping.shape[0]
         ), "num_tokens must be less than or equal to the shape of token_lora_mapping"
+        # CUDA graph captures kernels against the full preallocated mapping
+        # buffer.  Runtime batches may be padded to a larger graph bucket than
+        # their real token count, so reset the whole buffer and only rewrite the
+        # active prefix below.
+        token_lora_mapping.fill_(-1)
         token_lora_mapping = token_lora_mapping[:num_tokens]
     else:
         token_lora_mapping = torch.empty(
@@ -420,10 +429,20 @@ def _compute_moe_lora_info(
         return adapter_enabled, token_lora_mapping
 
     if has_segments:
-        active_ranks = lora_ranks[weight_indices.long()]
-        adapter_enabled.scatter_(
-            0, weight_indices.long(), (active_ranks > 0).to(torch.int32)
+        valid_weight_indices = weight_indices >= 0
+        safe_weight_indices = torch.where(valid_weight_indices, weight_indices, 0)
+        active_ranks = torch.where(
+            valid_weight_indices,
+            lora_ranks[safe_weight_indices.long()],
+            0,
         )
+        valid_indices = weight_indices[valid_weight_indices]
+        if valid_indices.numel() != 0:
+            adapter_enabled.scatter_(
+                0,
+                valid_indices.long(),
+                (active_ranks[valid_weight_indices] > 0).to(torch.int32),
+            )
     if num_tokens == 0:
         return adapter_enabled, token_lora_mapping
     if not has_segments:
@@ -440,8 +459,13 @@ def _compute_moe_lora_info(
         torch.searchsorted(seg_indptr.to(torch.int32), token_positions, right=True) - 1
     )
 
+    active_weight_indices = torch.where(
+        valid_weight_indices & (active_ranks > 0),
+        weight_indices.to(torch.int32),
+        -1,
+    )
     token_lora_mapping = torch.index_select(
-        weight_indices.to(torch.int32), 0, req_indices, out=token_lora_mapping
+        active_weight_indices, 0, req_indices, out=token_lora_mapping
     )
 
     return adapter_enabled, token_lora_mapping

--- a/test/registered/lora/test_moe_lora_info.py
+++ b/test/registered/lora/test_moe_lora_info.py
@@ -14,12 +14,34 @@ def _expected_adapter_enabled(
     weight_indices: torch.Tensor,
 ) -> torch.Tensor:
     expected = torch.zeros_like(lora_ranks)
-    expected.scatter_(
-        0,
-        weight_indices.long(),
-        (lora_ranks[weight_indices.long()] > 0).to(torch.int32),
-    )
+    valid_weight_indices = weight_indices[weight_indices >= 0]
+    if valid_weight_indices.numel() != 0:
+        expected.scatter_(
+            0,
+            valid_weight_indices.long(),
+            (lora_ranks[valid_weight_indices.long()] > 0).to(torch.int32),
+        )
     return expected
+
+
+def _expected_token_lora_mapping(
+    lora_ranks: torch.Tensor,
+    weight_indices: torch.Tensor,
+    seg_lens: torch.Tensor,
+) -> torch.Tensor:
+    valid_weight_indices = weight_indices >= 0
+    safe_weight_indices = torch.where(valid_weight_indices, weight_indices, 0)
+    active_ranks = torch.where(
+        valid_weight_indices,
+        lora_ranks[safe_weight_indices.long()],
+        0,
+    )
+    active_weight_indices = torch.where(
+        valid_weight_indices & (active_ranks > 0),
+        weight_indices,
+        -1,
+    )
+    return torch.repeat_interleave(active_weight_indices, seg_lens)
 
 
 @pytest.mark.parametrize("use_preallocated_buffers", [False, True])
@@ -55,7 +77,9 @@ def test_compute_moe_lora_info_expands_segments(use_preallocated_buffers: bool):
     )
     torch.cuda.synchronize()
 
-    expected_mapping = torch.repeat_interleave(weight_indices, seg_lens)
+    expected_mapping = _expected_token_lora_mapping(
+        lora_ranks, weight_indices, seg_lens
+    )
     expected_enabled = _expected_adapter_enabled(lora_ranks, weight_indices)
 
     torch.testing.assert_close(actual_mapping, expected_mapping)
@@ -63,6 +87,104 @@ def test_compute_moe_lora_info_expands_segments(use_preallocated_buffers: bool):
 
     if use_preallocated_buffers:
         assert actual_mapping.data_ptr() == token_lora_mapping.data_ptr()
+        torch.testing.assert_close(
+            token_lora_mapping[num_tokens:],
+            torch.full_like(token_lora_mapping[num_tokens:], -1),
+        )
+
+
+@pytest.mark.parametrize("use_preallocated_buffers", [False, True])
+def test_compute_moe_lora_info_maps_rank_zero_segments_to_no_lora(
+    use_preallocated_buffers: bool,
+):
+    device = "cuda"
+    seg_lens = torch.tensor([2, 1, 3], dtype=torch.int32, device=device)
+    seg_indptr = torch.zeros((seg_lens.numel() + 1,), dtype=torch.int32, device=device)
+    seg_indptr[1:] = torch.cumsum(seg_lens, dim=0)
+
+    weight_indices = torch.tensor([0, 1, 0], dtype=torch.int32, device=device)
+    lora_ranks = torch.tensor([0, 16], dtype=torch.int32, device=device)
+    num_tokens = int(seg_indptr[-1].item())
+
+    if use_preallocated_buffers:
+        adapter_enabled = torch.full_like(lora_ranks, 123)
+        token_lora_mapping = torch.full(
+            (num_tokens + 5,), 456, dtype=torch.int32, device=device
+        )
+    else:
+        adapter_enabled = None
+        token_lora_mapping = None
+
+    actual_enabled, actual_mapping = _compute_moe_lora_info(
+        num_tokens,
+        seg_indptr,
+        lora_ranks,
+        weight_indices,
+        adapter_enabled,
+        token_lora_mapping,
+        max_len=int(seg_lens.max().item()),
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        actual_mapping,
+        torch.tensor([-1, -1, 1, -1, -1, -1], dtype=torch.int32, device=device),
+    )
+    torch.testing.assert_close(
+        actual_enabled, torch.tensor([0, 1], dtype=torch.int32, device=device)
+    )
+    if use_preallocated_buffers:
+        torch.testing.assert_close(
+            token_lora_mapping[num_tokens:],
+            torch.full_like(token_lora_mapping[num_tokens:], -1),
+        )
+
+
+@pytest.mark.parametrize("use_preallocated_buffers", [False, True])
+def test_compute_moe_lora_info_preserves_negative_no_lora_segments(
+    use_preallocated_buffers: bool,
+):
+    device = "cuda"
+    seg_lens = torch.tensor([1, 2, 1], dtype=torch.int32, device=device)
+    seg_indptr = torch.zeros((seg_lens.numel() + 1,), dtype=torch.int32, device=device)
+    seg_indptr[1:] = torch.cumsum(seg_lens, dim=0)
+
+    weight_indices = torch.tensor([-1, 1, 0], dtype=torch.int32, device=device)
+    lora_ranks = torch.tensor([16, 8], dtype=torch.int32, device=device)
+    num_tokens = int(seg_indptr[-1].item())
+
+    if use_preallocated_buffers:
+        adapter_enabled = torch.full_like(lora_ranks, 123)
+        token_lora_mapping = torch.full(
+            (num_tokens + 3,), 456, dtype=torch.int32, device=device
+        )
+    else:
+        adapter_enabled = None
+        token_lora_mapping = None
+
+    actual_enabled, actual_mapping = _compute_moe_lora_info(
+        num_tokens,
+        seg_indptr,
+        lora_ranks,
+        weight_indices,
+        adapter_enabled,
+        token_lora_mapping,
+        max_len=int(seg_lens.max().item()),
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        actual_mapping,
+        torch.tensor([-1, 1, 1, 0], dtype=torch.int32, device=device),
+    )
+    torch.testing.assert_close(
+        actual_enabled, torch.tensor([1, 1], dtype=torch.int32, device=device)
+    )
+    if use_preallocated_buffers:
+        torch.testing.assert_close(
+            token_lora_mapping[num_tokens:],
+            torch.full_like(token_lora_mapping[num_tokens:], -1),
+        )
 
 
 def test_compute_moe_lora_info_rejects_undercovered_launch():


### PR DESCRIPTION
## Motivation

Fixes #29157.

MoE virtual-expert LoRA uses `token_lora_mapping == -1` as the no-LoRA sentinel, but `_compute_moe_lora_info` could map rank-0 or inactive request segments to adapter slot `0`. In CUDA graph replay, the preallocated mapping buffer can also keep stale values outside the active token prefix. That lets inactive or padded tokens look like they should route through LoRA slot 0, which can corrupt decode output under concurrent multi-LoRA serving.

This PR makes the producer side enforce the invariant directly:

```text
token_lora_mapping[token] >= 0  <=>  valid adapter id with rank > 0
otherwise token_lora_mapping[token] == -1
```

## Modifications

- Map rank-0 LoRA segments to `-1` in both the Triton kernel path and the torch fallback path.
- Guard negative request-to-LoRA ids before reading `lora_ranks`, preserving `-1` as no-LoRA instead of indexing slot 0 or the tail.
- Reset the full preallocated CUDA graph `token_lora_mapping` buffer to `-1` before slicing the active token prefix.
- Extend `test_moe_lora_info.py` to cover rank-0 segments, negative no-LoRA segments, and stale preallocated-buffer tails.
- Fold in automated review feedback to avoid redundant PyTorch indexing and temporary `zeros_like` / `full_like` allocations in the fallback/test helper path.

## Accuracy Tests

End-to-end serving validation was run on an 8x H200-class NVIDIA setup with GLM-5.1-FP8, TP=8, `--enable-lora`, `--lora-use-virtual-experts`, 5 LoRA adapters, and concurrent `/v1/completions` requests:

| case | CUDA graph | result |
| --- | --- | --- |
| baseline | enabled | 15/16 garbled |
| control | disabled | 0/16 garbled |
| patched | enabled | 0/16 garbled |

The final PR also adds a small guard for pre-existing `-1` request mappings.

Validation for current head `d9c09011ee198ae4127679def9faff2827d33169`:

- Remote `Lint`: passed, including pre-commit checks, docs offline link checks, and `sgl-kernel` clang-format checks.
- Local checks:

```bash
python3 -m py_compile python/sglang/srt/lora/backend/base_backend.py test/registered/lora/test_moe_lora_info.py
git diff --check
```

Focused CUDA unit test not run locally:

```bash
python3 -m pytest test/registered/lora/test_moe_lora_info.py -q
```

The local machine used to prepare this PR does not have `pytest`, `torch`, `triton`, or CUDA test dependencies installed.

## Speed Tests and Profiling

No dedicated speed benchmark was run. The runtime change is limited to LoRA metadata preparation and CUDA graph buffer reset for MoE LoRA mapping.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28273836930](https://github.com/sgl-project/sglang/actions/runs/28273836930)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28273836864](https://github.com/sgl-project/sglang/actions/runs/28273836864)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
