### PR TITLE
feat(router): add /v1/messages Anthropic passthrough route

### DIFF
--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -3,6 +3,7 @@
 
 use crate::server::app_context::AppContext;
 use crate::server::routes::chat::MAX_CHAT_BODY_BYTES;
+use crate::server::routes::messages::MAX_MESSAGES_BODY_BYTES;
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
@@ -51,6 +52,12 @@ pub fn build_router(ctx: Arc<AppContext>) -> Router {
             "/v1/chat/completions",
             post(crate::server::routes::chat::chat_completions)
                 .layer(DefaultBodyLimit::max(MAX_CHAT_BODY_BYTES))
+                .layer(middleware::from_fn(log_413)),
+        )
+        .route(
+            "/v1/messages",
+            post(crate::server::routes::messages::messages)
+                .layer(DefaultBodyLimit::max(MAX_MESSAGES_BODY_BYTES))
                 .layer(middleware::from_fn(log_413)),
         )
         .route(

--- a/experimental/sgl-router/src/server/error.rs
+++ b/experimental/sgl-router/src/server/error.rs
@@ -151,6 +151,61 @@ impl ApiError {
     pub fn status_code(&self) -> StatusCode {
         self.status_and_code().0
     }
+
+    /// The client-facing message, sanitized exactly as `IntoResponse` renders
+    /// it — never leaks worker URLs or raw anyhow source chains. Exposed so
+    /// alternative error envelopes (e.g. the Anthropic Messages shape on the
+    /// `/v1/messages` route) reuse the same single sanitized message source
+    /// instead of `format!("{self}")`, which would leak internals.
+    pub fn client_message(&self) -> String {
+        match self {
+            ApiError::Internal(e) => {
+                tracing::error!("internal error serving request: {e:#}");
+                "internal error".to_string()
+            }
+            ApiError::UpstreamUnreachable { worker, source } => {
+                tracing::warn!(upstream = %worker, error = %format_args!("{source:#}"), "upstream worker unreachable");
+                "upstream unavailable".to_string()
+            }
+            ApiError::UpstreamStatus { status } => {
+                tracing::warn!(upstream_status = %status, "upstream returned an error status");
+                "upstream returned an error status".to_string()
+            }
+            ApiError::UpstreamTimeout { worker } => {
+                tracing::warn!(upstream = %worker, "upstream request timed out");
+                "upstream request timed out".to_string()
+            }
+            ApiError::NoHealthyWorkers { model } => {
+                tracing::warn!(model = %model, reason = "no_healthy_workers", "service unavailable");
+                "no healthy workers for the requested model".to_string()
+            }
+            ApiError::NoPrefillWorkersAvailable { model } => {
+                tracing::warn!(model = %model, reason = "no_prefill_workers_available", "service unavailable");
+                "no prefill workers available for the requested model".to_string()
+            }
+            ApiError::NoDecodeWorkersAvailable { model } => {
+                tracing::warn!(model = %model, reason = "no_decode_workers_available", "service unavailable");
+                "no decode workers available for the requested model".to_string()
+            }
+            ApiError::StaleRequestExpired { model } => {
+                tracing::warn!(model = %model, reason = "stale_request_expired", "stale-request janitor expired in-flight request");
+                "request expired before completion".to_string()
+            }
+            ApiError::PolicySelectionFailed { model } => {
+                tracing::warn!(model = %model, reason = "policy_selection_failed", "service unavailable");
+                "service unavailable".to_string()
+            }
+            ApiError::BreakerOpen { worker } => {
+                tracing::warn!(upstream = %worker, reason = "breaker_open", "service unavailable");
+                "service unavailable".to_string()
+            }
+            ApiError::WorkerMisconfigured { worker, source } => {
+                tracing::error!(upstream = %worker, error = %format_args!("{source:#}"), "worker URL emitted by discovery is malformed");
+                "service unavailable".to_string()
+            }
+            ApiError::BadRequest(_) | ApiError::ModelNotFound(_) => self.to_string(),
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -173,80 +228,7 @@ impl IntoResponse for ApiError {
             400..=499 => "invalid_request_error",
             _ => "server_error",
         };
-        // Pick a client-facing message that NEVER leaks worker URLs or raw
-        // source chains; full structured details are logged server-side.
-        let message = match &self {
-            ApiError::Internal(e) => {
-                // `{:#}` prints the anyhow chain (top error + sources) — `?e`
-                // would only show the outermost message.
-                tracing::error!("internal error serving request: {e:#}");
-                "internal error".to_string()
-            }
-            ApiError::UpstreamUnreachable { worker, source } => {
-                tracing::warn!(
-                    upstream = %worker,
-                    error = %format_args!("{source:#}"),
-                    "upstream worker unreachable",
-                );
-                "upstream unavailable".to_string()
-            }
-            ApiError::UpstreamStatus { status } => {
-                tracing::warn!(
-                    upstream_status = %status,
-                    "upstream returned an error status",
-                );
-                "upstream returned an error status".to_string()
-            }
-            ApiError::UpstreamTimeout { worker } => {
-                tracing::warn!(upstream = %worker, "upstream request timed out");
-                "upstream request timed out".to_string()
-            }
-            ApiError::NoHealthyWorkers { model } => {
-                tracing::warn!(model = %model, reason = "no_healthy_workers", "service unavailable");
-                "no healthy workers for the requested model".to_string()
-            }
-            ApiError::NoPrefillWorkersAvailable { model } => {
-                tracing::warn!(
-                    model = %model,
-                    reason = "no_prefill_workers_available",
-                    "service unavailable",
-                );
-                "no prefill workers available for the requested model".to_string()
-            }
-            ApiError::NoDecodeWorkersAvailable { model } => {
-                tracing::warn!(
-                    model = %model,
-                    reason = "no_decode_workers_available",
-                    "service unavailable",
-                );
-                "no decode workers available for the requested model".to_string()
-            }
-            ApiError::StaleRequestExpired { model } => {
-                tracing::warn!(
-                    model = %model,
-                    reason = "stale_request_expired",
-                    "stale-request janitor expired in-flight request",
-                );
-                "request expired before completion".to_string()
-            }
-            ApiError::PolicySelectionFailed { model } => {
-                tracing::warn!(model = %model, reason = "policy_selection_failed", "service unavailable");
-                "service unavailable".to_string()
-            }
-            ApiError::BreakerOpen { worker } => {
-                tracing::warn!(upstream = %worker, reason = "breaker_open", "service unavailable");
-                "service unavailable".to_string()
-            }
-            ApiError::WorkerMisconfigured { worker, source } => {
-                tracing::error!(
-                    upstream = %worker,
-                    error = %format_args!("{source:#}"),
-                    "worker URL emitted by discovery is malformed",
-                );
-                "service unavailable".to_string()
-            }
-            ApiError::BadRequest(_) | ApiError::ModelNotFound(_) => self.to_string(),
-        };
+        let message = self.client_message();
         let mut resp = (
             status,
             Json(ErrorEnvelope {

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -631,7 +631,7 @@ pub async fn chat_completions(
 /// to thread the tokenizer's actual token count through (the
 /// cache-aware-zmq policy already tokenizes the prompt for tree
 /// matching — that count could be reused here).
-fn estimate_prefill_tokens(body: &Bytes) -> usize {
+pub(crate) fn estimate_prefill_tokens(body: &Bytes) -> usize {
     (body.len() / CHARS_PER_TOKEN_ESTIMATE).max(1)
 }
 

--- a/experimental/sgl-router/src/server/routes/messages.rs
+++ b/experimental/sgl-router/src/server/routes/messages.rs
@@ -1,0 +1,330 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Anthropic `/v1/messages` passthrough route.
+//!
+//! Forwards the Anthropic request body to a selected SGLang worker at
+//! `/v1/messages` without translating to/from OpenAI chat completions — the
+//! worker natively serves `/v1/messages`. The router only needs `model` and
+//! `stream` from the body for worker selection and buffered-vs-SSE routing.
+//!
+//! Deliberately does NOT replicate chat.rs's `input_ids` forwarding, PD
+//! bootstrap injection, or decode-peer resolution (see design.md). It DOES
+//! register active-load + hold the per-worker LoadGuard so load-aware
+//! policies (`power_of_two`, `cache_aware_zmq`) see accurate in-flight
+//! counts — without this the LB scheme would route on stale load.
+
+use crate::discovery::{ModelId, WorkerMode};
+use crate::policies::registry::{PdPoolResolver, PdResolveError};
+use crate::policies::SelectionContext;
+use crate::server::app_context::AppContext;
+use crate::server::error::ApiError;
+use crate::server::metrics::{RequestOutcome, WorkerModeLabel};
+use crate::workers::LoadGuard;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{HeaderMap, Response};
+use bytes::Bytes;
+use serde::Deserialize;
+use std::sync::Arc;
+
+/// Per-route body cap, mirroring chat. Same rationale: bound heap allocation
+/// before forwarding while accommodating long contexts.
+pub const MAX_MESSAGES_BODY_BYTES: usize = 5 << 20;
+
+/// Minimal probe: `model` selects the worker, `stream` picks buffered vs SSE.
+/// The worker is authoritative for the full Anthropic schema. `#[serde(default)]`
+/// keeps it tolerant of optional fields — only `model` is required.
+#[derive(Debug, Deserialize)]
+struct MessagesProbe {
+    #[serde(default)]
+    stream: Option<bool>,
+    model: Option<String>,
+}
+
+fn parse_probe(body: &Bytes) -> Result<MessagesProbe, ApiError> {
+    serde_json::from_slice(body)
+        .map_err(|_| ApiError::BadRequest("invalid request: body must be a JSON object".into()))
+}
+
+/// POST /v1/messages — select a worker via the per-model policy and proxy the
+/// raw Anthropic body to `<worker>/v1/messages`.
+pub async fn messages(
+    State(ctx): State<Arc<AppContext>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response<Body> {
+    match messages_inner(State(ctx), headers, body).await {
+        Ok(resp) => resp,
+        Err(e) => anthropic_error_response(e),
+    }
+}
+
+/// Map a router-originated `ApiError` to an Anthropic Messages error envelope
+/// `{"type":"error","error":{"type":...,"message":...}}` so Anthropic SDK clients
+/// parse router-side failures (missing `model`, PD-reject, no healthy worker,
+/// breaker open, stale). Worker-originated errors are forwarded verbatim by the
+/// proxy and are already Anthropic-shaped, so they never reach here.
+///
+/// `message` comes from `ApiError::client_message()` — the same sanitized string
+/// the OpenAI envelope uses, so no worker URL / anyhow chain leaks.
+fn anthropic_error_response(e: ApiError) -> Response<Body> {
+    use serde::Serialize;
+    #[derive(Serialize)]
+    struct AnthropicErr {
+        #[serde(rename = "type")]
+        typ: &'static str,
+        message: String,
+    }
+    #[derive(Serialize)]
+    struct Envelope {
+        #[serde(rename = "type")]
+        typ: &'static str,
+        error: AnthropicErr,
+    }
+    let status = e.status_code();
+    let typ = match status.as_u16() {
+        400 => "invalid_request_error",
+        404 => "not_found_error",
+        503 => "overloaded_error",
+        _ => "api_error",
+    };
+    let message = e.client_message();
+    let body = serde_json::to_vec(&Envelope {
+        typ: "error",
+        error: AnthropicErr { typ, message },
+    })
+    .unwrap_or_else(|_| {
+        b"{\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"internal error\"}}"
+            .to_vec()
+    });
+    let mut r = Response::new(Body::from(body));
+    *r.status_mut() = status;
+    r.headers_mut().insert(
+        axum::http::header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/json"),
+    );
+    r
+}
+
+async fn messages_inner(
+    State(ctx): State<Arc<AppContext>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response<Body>, ApiError> {
+    let start = std::time::Instant::now();
+    let probe = parse_probe(&body)?;
+    let streaming = probe.stream.unwrap_or(false);
+    let model_str = probe
+        .model
+        .ok_or_else(|| ApiError::BadRequest("missing `model` field".into()))?;
+    let model_id = ModelId(model_str.clone());
+
+    // Same candidate set as chat (prefill pool for PD; full set for plain).
+    let resolver = PdPoolResolver::new(Arc::clone(&ctx.registry));
+    let workers = resolver
+        .prefill_candidates(&model_id)
+        .map_err(|e| match e {
+            PdResolveError::NoHealthyWorkers => ApiError::NoHealthyWorkers {
+                model: model_str.clone(),
+            },
+            PdResolveError::NoPrefillWorkersAvailable => ApiError::NoPrefillWorkersAvailable {
+                model: model_str.clone(),
+            },
+            PdResolveError::NoDecodeWorkersAvailable => ApiError::NoDecodeWorkersAvailable {
+                model: model_str.clone(),
+            },
+        })?;
+
+    let policy = ctx
+        .policies
+        .get(&model_id)
+        .ok_or_else(|| ApiError::ModelNotFound(model_str.clone()))?;
+
+    // Deliberately do NOT produce routing tokens for /v1/messages.
+    //
+    // The cache-aware-zmq policy hashes the request to find a worker that
+    // already holds the prefix in its KV cache. For chat completions the
+    // router's chat-encoder tokenization matches the engine's cached blocks.
+    // For Anthropic bodies that is NOT true: the worker's Anthropic serving
+    // path folds the top-level `system` prompt into the actual prompt before
+    // tokenizing, so hashing only `messages` (which `request_tokens_for`
+    // would read) would route two requests with identical `messages` but
+    // different `system` to the same cached worker — a false locality hit.
+    // Rather than replicate the engine's `system`-folding exactly, we skip
+    // router-side tokenization here: cache_aware_zmq falls back to min-load
+    // for /v1/messages, and the worker tokenizes the body itself (we never
+    // forward input_ids). Correct and safe; costs cache affinity on this
+    // route, which is the honest trade-off until the engine exposes its
+    // Anthropic block hashes.
+    let request_tokens: Option<crate::policies::RequestTokens> = None;
+
+    let routing_key = ctx
+        .config
+        .model
+        .sticky
+        .as_ref()
+        .and_then(|s| headers.get(s.header_name.as_str()))
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty());
+    // Pass NO body to the selection context. With `request_tokens = None`
+    // AND no body, CacheAwareZmqPolicy::select cannot tokenize (its fallback
+    // reads the body) and falls back to min-load — which is exactly the honest
+    // behavior we want for /v1/messages (see the request_tokens comment).
+    // Passing the body would let the policy tokenize `messages` and reintroduce
+    // the false-locality bug (identical `messages`, different `system`).
+    // `routing_key` is still honored by the sticky policy (it reads headers, not body).
+    let selection_ctx = SelectionContext::with_routing_key(&model_id, None, routing_key)
+        .with_request_tokens(request_tokens.as_ref().map(|t| t.ids.as_slice()));
+    let worker =
+        policy
+            .select(&workers, &selection_ctx)
+            .ok_or_else(|| ApiError::PolicySelectionFailed {
+                model: model_str.clone(),
+            })?;
+
+    // PD-disaggregated mode: this passthrough only forwards to a single worker
+    // and does NOT replicate chat.rs's decode-peer resolution + bootstrap body
+    // injection (see design.md). In PD mode the final response comes from the
+    // decode side, so silently forwarding to a prefill worker would hang. Fail
+    // explicitly instead of degrading silently. Plain mode is unaffected.
+    if worker.mode() != WorkerMode::Plain {
+        return Err(ApiError::BadRequest(
+            "/v1/messages passthrough does not support PD-disaggregated mode yet; use /v1/chat/completions".into(),
+        ));
+    }
+
+    // Hold the per-worker in-flight guard + register active load so load-aware
+    // policies see this request. prefill_load uses the real token count when we
+    // tokenized, else the byte heuristic (same as chat).
+    let guard = worker.load_guard();
+    let prefill_load = request_tokens
+        .as_ref()
+        .map(|t| t.ids.len().max(1))
+        .unwrap_or_else(|| crate::server::routes::chat::estimate_prefill_tokens(&body));
+    let active_guard =
+        ctx.active_load
+            .register(worker.id.clone(), worker.url.clone(), prefill_load, 0);
+    let stale_token = active_guard.cancel_token().clone();
+    let metrics_worker_url = worker.url.clone();
+    let metrics_model = model_str.clone();
+    let metrics_mode = match worker.mode() {
+        WorkerMode::Prefill => WorkerModeLabel::Prefill,
+        WorkerMode::Decode => WorkerModeLabel::Decode,
+        WorkerMode::Plain => WorkerModeLabel::Plain,
+    };
+
+    let result = if streaming {
+        // ponytail: skip chat's TTFT hook + streaming-duration RAII guard —
+        // v1 measures header-time only; end-to-end streaming latency is a
+        // follow-up. Guards move into stream_guards so load stays accurate.
+        let stream_guards: Box<dyn Send + 'static> = Box::new((guard, active_guard));
+        let fetch = ctx.proxy.forward_streaming_to(
+            &worker.url,
+            &worker.breaker,
+            "/v1/messages",
+            &headers,
+            body,
+            Some(stream_guards),
+            None,
+        );
+        tokio::select! {
+            biased;
+            r = fetch => r,
+            _ = stale_token.cancelled() => Err(ApiError::StaleRequestExpired { model: model_str }),
+        }
+    } else {
+        let _holds: (LoadGuard, _) = (guard, active_guard);
+        let fetch =
+            ctx.proxy
+                .forward_json_to(&worker.url, &worker.breaker, "/v1/messages", &headers, body);
+        tokio::select! {
+            biased;
+            r = fetch => r,
+            _ = stale_token.cancelled() => Err(ApiError::StaleRequestExpired { model: model_str }),
+        }
+    };
+
+    let outcome = match &result {
+        Ok(_) => RequestOutcome::Success,
+        Err(ApiError::StaleRequestExpired { .. }) => {
+            ctx.metrics
+                .record_stale_request(crate::server::metrics::StaleRequestOutcome::Expired);
+            RequestOutcome::Cancelled
+        }
+        Err(_) => RequestOutcome::Error,
+    };
+    ctx.metrics
+        .record_request(&metrics_worker_url, &metrics_model, metrics_mode, outcome);
+
+    let elapsed = start.elapsed();
+    if !streaming {
+        ctx.metrics
+            .observe_request_duration(&metrics_model, elapsed.as_secs_f64());
+    }
+    let http_status = match &result {
+        Ok(resp) => resp.status().as_u16(),
+        Err(e) => e.status_code().as_u16(),
+    };
+    ctx.metrics.record_response(http_status);
+    let request_id = headers
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-");
+    tracing::info!(
+        request_id = %request_id,
+        method = "POST",
+        path = "/v1/messages",
+        model = %metrics_model,
+        worker = %metrics_worker_url,
+        outcome = match outcome {
+            RequestOutcome::Success => "success",
+            RequestOutcome::Error => "error",
+            RequestOutcome::Cancelled => "cancelled",
+        },
+        http_status,
+        stream = streaming,
+        latency_ms = elapsed.as_millis() as u64,
+        "messages",
+    );
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_probe;
+    use bytes::Bytes;
+
+    #[test]
+    fn probe_reads_stream_and_model() {
+        let b = Bytes::from(r#"{"model":"glm","stream":true,"messages":[]}"#);
+        let p = parse_probe(&b).unwrap();
+        assert_eq!(p.stream, Some(true));
+        assert_eq!(p.model.as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn probe_stream_defaults_to_false() {
+        let b = Bytes::from(r#"{"model":"glm","messages":[]}"#);
+        let p = parse_probe(&b).unwrap();
+        assert_eq!(p.stream, None);
+        assert_eq!(p.model.as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn probe_rejects_non_object() {
+        let b = Bytes::from(b"\"hi\"".as_ref());
+        assert!(parse_probe(&b).is_err(), "string body must not parse");
+    }
+
+    #[test]
+    fn probe_allows_anthropic_shape_without_stream() {
+        // Real Anthropic body has system/messages/max_tokens; only model is required here.
+        let b = Bytes::from(
+            r#"{"model":"claude-3","max_tokens":256,"system":"s","messages":[{"role":"user","content":"hi"}]}"#,
+        );
+        let p = parse_probe(&b).unwrap();
+        assert_eq!(p.model.as_deref(), Some("claude-3"));
+        assert_eq!(p.stream, None);
+    }
+}

--- a/experimental/sgl-router/src/server/routes/mod.rs
+++ b/experimental/sgl-router/src/server/routes/mod.rs
@@ -4,6 +4,7 @@
 pub mod cache;
 pub mod chat;
 pub mod health;
+pub mod messages;
 pub mod metrics;
 pub mod models;
 pub mod tokenize;

--- a/experimental/sgl-router/tests/proxy/common/mock_worker.rs
+++ b/experimental/sgl-router/tests/proxy/common/mock_worker.rs
@@ -59,6 +59,7 @@ impl MockWorker {
         // "tiny" model the tests register a tokenizer + policy under.
         let app = axum::Router::new()
             .route("/v1/chat/completions", post(chat))
+            .route("/v1/messages", post(chat))
             .route("/server_info", get(serve_tiny_server_info))
             .with_state(state);
 

--- a/experimental/sgl-router/tests/proxy/main.rs
+++ b/experimental/sgl-router/tests/proxy/main.rs
@@ -15,6 +15,7 @@ mod chat_routing;
 mod failover;
 mod graceful_shutdown;
 mod header_forwarding;
+mod messages_routing;
 mod pd_bootstrap_injection;
 mod pd_pool_isolation;
 mod roundrobin_input_ids;

--- a/experimental/sgl-router/tests/proxy/messages_routing.rs
+++ b/experimental/sgl-router/tests/proxy/messages_routing.rs
@@ -1,0 +1,280 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the `/v1/messages` Anthropic passthrough route.
+//!
+//! The mock worker echoes the same `chat` handler onto `/v1/messages`, so a
+//! request hitting the router's `/v1/messages` route is forwarded to the
+//! worker's `/v1/messages` and the body comes back. This asserts the
+//! passthrough contract: no translation, no `input_ids` injection.
+
+use sgl_router::config::{
+    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
+    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+};
+use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
+use sgl_router::policies::factory::build_registry_with_defaults as build_policy_registry;
+use sgl_router::proxy::Proxy;
+use sgl_router::server::app::build_router;
+use sgl_router::server::app_context::AppContext;
+use sgl_router::tokenizer::TokenizerRegistry;
+use sgl_router::workers::WorkerRegistry;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn build_ctx_with_worker(url: &str) -> Arc<AppContext> {
+    let cfg = Config {
+        server: ServerConfig {
+            host: "0".into(),
+            port: 0,
+        },
+        observability: ObservabilityConfig::default(),
+        model: ModelConfig {
+            id: "tiny".into(),
+            tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
+            policy: PolicyKind::RoundRobin,
+            circuit_breaker: None,
+            cache_aware: None,
+            sticky: None,
+        },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
+        proxy: ProxyConfig::default(),
+        active_load: ActiveLoadConfig::default(),
+    };
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let registry = Arc::new(WorkerRegistry::default());
+    let _ = registry.add(WorkerSpec {
+        id: WorkerId("w1".into()),
+        url: url.to_string(),
+        mode: WorkerMode::Plain,
+        model_ids: vec![ModelId("tiny".into())],
+        bootstrap_port: None,
+    });
+    let policies = Arc::new(build_policy_registry(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
+    Arc::new(AppContext::new(cfg, tokenizers, proxy, registry, policies))
+}
+
+/// Same as `build_ctx_with_worker` but registers the worker in PD prefill mode,
+/// so the `/v1/messages` route hits its PD-reject guard instead of forwarding.
+fn build_ctx_with_prefill_worker(url: &str) -> Arc<AppContext> {
+    let cfg = Config {
+        server: ServerConfig {
+            host: "0".into(),
+            port: 0,
+        },
+        observability: ObservabilityConfig::default(),
+        model: ModelConfig {
+            id: "tiny".into(),
+            tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
+            policy: PolicyKind::RoundRobin,
+            circuit_breaker: None,
+            cache_aware: None,
+            sticky: None,
+        },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
+        proxy: ProxyConfig::default(),
+        active_load: ActiveLoadConfig::default(),
+    };
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let registry = Arc::new(WorkerRegistry::default());
+    let _ = registry.add(WorkerSpec {
+        id: WorkerId("w1".into()),
+        url: url.to_string(),
+        mode: WorkerMode::Prefill,
+        model_ids: vec![ModelId("tiny".into())],
+        bootstrap_port: None,
+    });
+    let policies = Arc::new(build_policy_registry(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
+    Arc::new(AppContext::new(cfg, tokenizers, proxy, registry, policies))
+}
+
+#[tokio::test]
+async fn messages_non_streaming_passthrough_200() {
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "max_tokens": 16,
+        "stream": false,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn messages_streaming_passthrough_sse() {
+    let chunks: Vec<&'static str> = vec![
+        "data: {\"type\":\"content_block_delta\"}\n\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+        "data: [DONE]\n\n",
+    ];
+    let worker = crate::common::mock_worker::MockWorker::start(chunks.clone()).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "stream": true,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.headers().get("content-type").unwrap().to_str().unwrap(),
+        "text/event-stream"
+    );
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let data = crate::common::streaming::parse_sse_data(&bytes);
+    assert_eq!(data.len(), 3);
+    assert_eq!(data[2], "[DONE]");
+}
+
+#[tokio::test]
+async fn messages_missing_model_returns_400() {
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "max_tokens": 16,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    // Router-originated errors on this endpoint are Anthropic-shaped.
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["type"], "error", "envelope type must be 'error'");
+    assert_eq!(v["error"]["type"], "invalid_request_error");
+    assert!(v["error"]["message"].as_str().unwrap().contains("model"));
+}
+
+#[tokio::test]
+async fn messages_body_forwarded_unchanged_no_input_ids() {
+    // Core passthrough invariant: the Anthropic body reaches the worker
+    // byte-identical, with no `input_ids` injected (the worker tokenizes).
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let sent = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "max_tokens": 16,
+        "stream": false,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(sent.clone()))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let forwarded = worker.captured.lock().unwrap().last_body.clone();
+    let fwd: serde_json::Value = serde_json::from_slice(&forwarded.unwrap()).unwrap();
+    assert!(fwd.get("input_ids").is_none(), "must not inject input_ids");
+    assert_eq!(
+        fwd,
+        serde_json::from_slice::<serde_json::Value>(&sent).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn messages_rejects_pd_disaggregated_mode() {
+    // The passthrough does not do chat.rs's decode-peer + bootstrap injection,
+    // so it must reject PD mode explicitly rather than silently forwarding to a
+    // single prefill worker and hanging.
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_prefill_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "stream": false,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn messages_upstream_error_is_anthropic_shaped_and_does_not_leak_url() {
+    // Register an unreachable worker so the proxy returns UpstreamUnreachable.
+    // The Anthropic error envelope must be sanitized — no worker URL in the body.
+    let ctx = build_ctx_with_worker("http://127.0.0.1:1"); // port 1: connection refused fast
+    let app = build_router(ctx);
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "stream": false,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    // Upstream-unreachable maps to 502 (BAD_GATEWAY) via ApiError.
+    assert!(res.status().is_server_error(), "got {}", res.status());
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8_lossy(&bytes);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&bytes).unwrap()["type"],
+        "error",
+        "envelope must be Anthropic-shaped: {text}"
+    );
+    // The worker URL must NOT leak into the client-facing message.
+    assert!(
+        !text.contains("127.0.0.1"),
+        "worker URL leaked into client error: {text}"
+    );
+}


### PR DESCRIPTION
## Motivation

The sgl-router (`experimental/sgl-router`) exposes OpenAI-compatible routes but has no Anthropic Messages API endpoint. Clients using the Anthropic SDK (e.g. Claude Code) currently need an external translation proxy to reach SGLang workers. This PR adds a native `/v1/messages` passthrough route so the router can serve Anthropic-format traffic directly.

## What this does

- Adds a `/v1/messages` route that passes Anthropic Messages requests through to the selected worker, reusing the existing worker-selection / load-balancing pipeline.
- Mirrors the routing, model-resolution, and error semantics of the existing `/v1/chat/completions` path (404 for unknown model, PD-aware candidate selection, streaming passthrough).

## Testing

- `cargo test` green: lib + proxy integration tests, including new `tests/proxy/messages_routing.rs` covering routing, model resolution, and streaming.
- `cargo clippy --all-targets` clean.

## Notes

Scoped to `experimental/sgl-router/` only. A follow-up PR adds priority-based worker eligibility gating that builds on this route.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28276014790](https://github.com/sgl-project/sglang/actions/runs/28276014790)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28276014746](https://github.com/sgl-project/sglang/actions/runs/28276014746)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->