### PR TITLE
feat(router): priority-based worker eligibility gating

### DIFF
--- a/experimental/sgl-router/benches/policy_select.rs
+++ b/experimental/sgl-router/benches/policy_select.rs
@@ -29,6 +29,7 @@ fn workers(n: usize, model: &str) -> Vec<Arc<Worker>> {
                 mode: WorkerMode::Plain,
                 model_ids: vec![ModelId(model.into())],
                 bootstrap_port: None,
+                min_priority: None,
             })
             .expect("test workers are unmixed");
     }

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -93,6 +93,16 @@ pub struct Cli {
     // ---- discovery: static ----
     /// Static worker URLs (space-separated or repeated). Mutually
     /// exclusive with `--service-discovery`.
+    ///
+    /// Each entry may carry an optional minimum-priority capability
+    /// suffix `@min_priority=N`, e.g.
+    /// `http://rtx-01:30000@min_priority=100`. A worker tagged this way is
+    /// eligible only for requests whose body `priority` is `>= N`; lower
+    /// (or absent, treated as `0`) priority requests never route to it.
+    /// Use this to keep heterogeneous/low-context workers (e.g. RTX-6000)
+    /// serving only short high-priority production traffic. A malformed
+    /// suffix fails startup. Omit the suffix for a worker that accepts any
+    /// request.
     #[arg(long, num_args = 1..)]
     pub worker_urls: Vec<String>,
 

--- a/experimental/sgl-router/src/config/mod.rs
+++ b/experimental/sgl-router/src/config/mod.rs
@@ -37,7 +37,20 @@ impl Config {
                             "discovery.static_urls.urls contains an empty or whitespace-only entry"
                         ));
                     }
-                    let parsed = url::Url::parse(trimmed).map_err(|e| {
+                    // Strip the optional `@min_priority=N` capability suffix
+                    // BEFORE URL-parsing: the suffix is not part of the URL,
+                    // and leaving it on would make `url::Url` misparse
+                    // `host:port@min_priority=N` as userinfo (hiding a bad
+                    // base URL) and would let `http://x` and
+                    // `http://x@min_priority=100` dedupe as distinct. This
+                    // also surfaces a malformed suffix (`@min_priority=abc`)
+                    // at validate time, matching the discovery task's own
+                    // parse. Same parser → single source of truth.
+                    let (base, _min_priority) =
+                        crate::discovery::static_urls::parse_worker_entry(trimmed).map_err(
+                            |e| anyhow!("discovery.static_urls.urls entry {raw:?} is invalid: {e}"),
+                        )?;
+                    let parsed = url::Url::parse(&base).map_err(|e| {
                         anyhow!("discovery.static_urls.urls entry {raw:?} is not a valid URL: {e}")
                     })?;
                     match parsed.scheme() {
@@ -151,5 +164,59 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("unsupported scheme"), "got: {err}");
+    }
+
+    #[test]
+    fn accepts_static_url_with_min_priority_suffix() {
+        // The `@min_priority=N` capability suffix is stripped before URL
+        // validation; a well-formed base URL + integer suffix is valid.
+        cfg("qwen3", &["http://rtx-01:30000@min_priority=100"])
+            .validate()
+            .expect("valid base URL + integer min_priority suffix should pass");
+    }
+
+    #[test]
+    fn rejects_static_url_malformed_min_priority_suffix() {
+        // A non-integer suffix is a config typo that must fail at startup,
+        // not silently drop the gate. Surfaced via the shared parser.
+        let err = cfg("qwen3", &["http://rtx-01:30000@min_priority=abc"])
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("min_priority") || err.contains("invalid"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_static_url_bad_base_hidden_by_suffix() {
+        // Regression: `http://host:notaport@min_priority=100`. With the
+        // suffix attached, `url::Url` would misparse it as userinfo
+        // (`host:notaport`) + host (`min_priority=100`) and PASS. Stripping
+        // the suffix first exposes the real base `http://host:notaport`,
+        // whose non-numeric port `url::Url` correctly rejects.
+        let err = cfg("qwen3", &["http://host:notaport@min_priority=100"])
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not a valid URL"), "got: {err}");
+    }
+
+    #[test]
+    fn dedupes_static_url_base_across_min_priority_suffix() {
+        // `http://x:30000` and `http://x:30000@min_priority=100` resolve to
+        // the same base worker URL — registering both would point two
+        // registry entries at one SGLang. Dedup must catch it after the
+        // suffix is stripped (it would NOT if validation ran on the raw
+        // suffixed string).
+        let err = cfg(
+            "qwen3",
+            &["http://x:30000", "http://x:30000@min_priority=100"],
+        )
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("duplicate"), "got: {err}");
     }
 }

--- a/experimental/sgl-router/src/discovery/k8s.rs
+++ b/experimental/sgl-router/src/discovery/k8s.rs
@@ -138,6 +138,7 @@ fn extract_workers(es: &EndpointSlice, mode: WorkerMode) -> Vec<WorkerSpec> {
                 mode,
                 model_ids: Vec::new(),
                 bootstrap_port: None,
+                min_priority: None,
             });
         }
     }

--- a/experimental/sgl-router/src/discovery/static_urls.rs
+++ b/experimental/sgl-router/src/discovery/static_urls.rs
@@ -26,23 +26,67 @@ use crate::discovery::{DiscoveryEvent, WorkerId, WorkerMode, WorkerSpec};
 use anyhow::Result;
 use tokio::sync::mpsc;
 
+/// Token separating a worker URL from an optional minimum-priority
+/// capability suffix in `--worker-urls` entries:
+/// `http://host:port@min_priority=100`. A distinctive literal (not a bare
+/// `@`) so it cannot collide with URL userinfo (`user:pass@host`).
+const MIN_PRIORITY_TOKEN: &str = "@min_priority=";
+
+/// Split a `--worker-urls` entry into its base URL and optional
+/// `min_priority` capability. `http://h:p@min_priority=100` yields
+/// `("http://h:p", Some(100))`; a plain URL yields `(url, None)`.
+///
+/// A present-but-unparseable suffix (e.g. `@min_priority=abc`) is a config
+/// error the caller surfaces, rather than silently dropping the isolation
+/// guarantee — a worker that should be priority-gated must never fall back
+/// to "accept everything" because of a typo. `rsplit_once` so a `@` inside
+/// the URL (userinfo) doesn't get mistaken for the capability token.
+///
+/// `pub(crate)` so config validation ([`crate::config::Config::validate`])
+/// can strip the suffix BEFORE URL-parsing/deduping the base URL — otherwise
+/// validation would run against the raw suffixed string and `url::Url` would
+/// misparse `host:port@min_priority=N` as userinfo, letting malformed base
+/// URLs and with/without-suffix duplicates slip past startup checks.
+pub(crate) fn parse_worker_entry(entry: &str) -> Result<(String, Option<i64>)> {
+    match entry.rsplit_once(MIN_PRIORITY_TOKEN) {
+        Some((url, prio_str)) => {
+            let prio = prio_str.trim().parse::<i64>().map_err(|_| {
+                anyhow::anyhow!(
+                    "invalid min_priority in worker URL entry {entry:?}: \
+                     {prio_str:?} is not an integer"
+                )
+            })?;
+            Ok((url.to_string(), Some(prio)))
+        }
+        None => Ok((entry.to_string(), None)),
+    }
+}
+
 /// Spawn the static-URLs producer task and return its `JoinHandle`.
 ///
 /// Returns `Result` for parity with [`crate::discovery::k8s::spawn`] (which
-/// can fail to construct a `kube::Client`); this backend itself is
-/// infallible.
+/// can fail to construct a `kube::Client`) AND because a malformed
+/// `@min_priority=` suffix is rejected here rather than ignored.
 pub async fn spawn(
     cfg: StaticUrlsDiscoveryConfig,
     tx: mpsc::Sender<DiscoveryEvent>,
 ) -> Result<tokio::task::JoinHandle<()>> {
+    // Parse + validate every entry up front so a bad suffix fails startup
+    // loudly instead of after the task is detached.
+    let parsed: Vec<(String, Option<i64>)> = cfg
+        .urls
+        .iter()
+        .map(|e| parse_worker_entry(e))
+        .collect::<Result<_>>()?;
     let handle = tokio::spawn(async move {
-        for url in cfg.urls {
+        for (url, min_priority) in parsed {
             let spec = WorkerSpec {
                 id: WorkerId(url.clone()),
                 url,
                 mode: WorkerMode::Plain,
                 model_ids: Vec::new(),
                 bootstrap_port: None,
+                min_priority,
             };
             if tx.send(DiscoveryEvent::Added(spec)).await.is_err() {
                 tracing::info!(
@@ -77,6 +121,37 @@ pub async fn spawn(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_entry_plain_url_has_no_min_priority() {
+        let (url, prio) = parse_worker_entry("http://w0:30000").unwrap();
+        assert_eq!(url, "http://w0:30000");
+        assert_eq!(prio, None);
+    }
+
+    #[test]
+    fn parse_entry_extracts_min_priority_suffix() {
+        let (url, prio) = parse_worker_entry("http://rtx-01:30000@min_priority=100").unwrap();
+        assert_eq!(url, "http://rtx-01:30000");
+        assert_eq!(prio, Some(100));
+    }
+
+    #[test]
+    fn parse_entry_rejects_non_integer_min_priority() {
+        let err = parse_worker_entry("http://w:30000@min_priority=high")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("min_priority"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_entry_userinfo_at_is_not_mistaken_for_token() {
+        // A bare `@` (here in a hypothetical userinfo position) must not be
+        // treated as the capability token — only `@min_priority=` splits.
+        let (url, prio) = parse_worker_entry("http://user@host:30000").unwrap();
+        assert_eq!(url, "http://user@host:30000");
+        assert_eq!(prio, None);
+    }
 
     /// Task exits cleanly when the consumer drops the receiver mid-fanout.
     /// Without this early exit, the producer would block forever on the

--- a/experimental/sgl-router/src/discovery/types.rs
+++ b/experimental/sgl-router/src/discovery/types.rs
@@ -58,6 +58,20 @@ pub struct WorkerSpec {
     pub model_ids: Vec<ModelId>,
     #[serde(default)]
     pub bootstrap_port: Option<u16>,
+    /// Minimum request priority this worker will accept. `Some(N)` means
+    /// the worker is eligible only for requests whose effective priority
+    /// is `>= N`; `None` (the default) means it accepts any request.
+    ///
+    /// Used to isolate heterogeneous capacity — e.g. an RTX-6000 worker
+    /// registered with `min_priority = Some(100)` only serves
+    /// high-priority production traffic and never internal/long requests,
+    /// which carry priority `0`. Seeded by the static-urls discovery
+    /// backend (`url@min_priority=N`) today; the k8s backend currently
+    /// always sets `None` (pod-label seeding is a future addition). NOT
+    /// overridden by `/server_info` introspection (which only resolves
+    /// mode/bootstrap) nor dropped on reconcile re-introspection.
+    #[serde(default)]
+    pub min_priority: Option<i64>,
 }
 
 /// Event produced by a discovery backend and consumed by `WorkerManager`.
@@ -97,6 +111,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId("qwen".into())],
             bootstrap_port: None,
+            min_priority: None,
         };
         let s = serde_json::to_string(&w).unwrap();
         let d: WorkerSpec = serde_json::from_str(&s).unwrap();
@@ -111,11 +126,37 @@ mod tests {
             mode: WorkerMode::Prefill,
             model_ids: vec![ModelId("qwen".into())],
             bootstrap_port: Some(8997),
+            min_priority: None,
         };
         let s = serde_json::to_string(&w).unwrap();
         assert!(s.contains("\"bootstrap_port\":8997"));
         let d: WorkerSpec = serde_json::from_str(&s).unwrap();
         assert_eq!(w, d);
+    }
+
+    #[test]
+    fn worker_spec_with_min_priority_round_trip() {
+        let w = WorkerSpec {
+            id: WorkerId("rtx1".into()),
+            url: "http://10.0.0.9:30000".into(),
+            mode: WorkerMode::Plain,
+            model_ids: vec![ModelId("glm".into())],
+            bootstrap_port: None,
+            min_priority: Some(100),
+        };
+        let s = serde_json::to_string(&w).unwrap();
+        assert!(s.contains("\"min_priority\":100"));
+        let d: WorkerSpec = serde_json::from_str(&s).unwrap();
+        assert_eq!(w, d);
+    }
+
+    #[test]
+    fn worker_spec_deserializes_with_missing_min_priority() {
+        // Older configs / hand-written JSON without the field should still
+        // parse — min_priority defaults to None (worker accepts any request).
+        let json = r#"{"id":"w","url":"http://x","mode":"plain","model_ids":["m"]}"#;
+        let w: WorkerSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(w.min_priority, None);
     }
 
     #[test]
@@ -152,6 +193,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId("m1".into())],
             bootstrap_port: None,
+            min_priority: None,
         });
         let s = serde_json::to_string(&e).unwrap();
         let d: DiscoveryEvent = serde_json::from_str(&s).unwrap();

--- a/experimental/sgl-router/src/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/src/policies/cache_aware_zmq.rs
@@ -283,6 +283,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId(model_id.into())],
             bootstrap_port: None,
+            min_priority: None,
         }))
     }
 

--- a/experimental/sgl-router/src/policies/load_based.rs
+++ b/experimental/sgl-router/src/policies/load_based.rs
@@ -43,6 +43,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         }))
     }
 

--- a/experimental/sgl-router/src/policies/mod.rs
+++ b/experimental/sgl-router/src/policies/mod.rs
@@ -166,6 +166,68 @@ pub(crate) fn extract_prompt_text_from_value(v: &serde_json::Value) -> Option<St
     None
 }
 
+/// Effective integer priority for a request, read from the body `priority`
+/// field. Missing, null, or non-integer values yield `0` — the lowest
+/// priority — so an unrecognized or absent signal is treated as
+/// internal/low-priority traffic and never gains access to priority-gated
+/// workers (see [`crate::policies::registry::filter_eligible`]).
+///
+/// Convenience wrapper for callers holding a whole request body. The ingress
+/// hot path (chat/messages) instead extracts `priority` via a lightweight
+/// probe and calls [`priority_from_value`] directly, to avoid re-walking the
+/// full body. This wrapper keeps a body-oriented entry point for any caller
+/// that already has the deserialized `Value`.
+///
+/// This mirrors the `priority` field the SGLang scheduler reads for
+/// preemption: the same value drives both engine-side scheduling and
+/// router-side worker eligibility, so the two never disagree on what
+/// "high priority" means. Production traffic carries `priority=100`
+/// (injected by the API gateway per key class); internal/self-use traffic
+/// carries `0` or omits the field.
+///
+/// Accepts integer and integer-valued float JSON (`100` and `100.0`) since
+/// gateways and SDKs serialize whole numbers inconsistently. A FRACTIONAL
+/// value (`100.5`), a non-finite float (NaN/inf), or a non-numeric value
+/// (string, object, bool) is treated as `0` — a malformed signal must never
+/// satisfy a gate by truncation.
+pub fn effective_priority(body: &serde_json::Value) -> i64 {
+    priority_from_value(body.get("priority"))
+}
+
+/// Core of [`effective_priority`], operating on the `priority` field value
+/// directly (or its absence). Lets callers that already extracted the
+/// field — e.g. via a lightweight request probe — avoid re-walking the
+/// whole body. `None` (absent), null, and any non-numeric value yield `0`.
+pub fn priority_from_value(priority: Option<&serde_json::Value>) -> i64 {
+    match priority {
+        Some(p) => {
+            if let Some(i) = p.as_i64() {
+                i
+            } else if let Some(f) = p.as_f64() {
+                // Accept ONLY integer-valued, finite, in-range floats (e.g.
+                // 100.0) — gateways/SDKs sometimes serialize whole numbers as
+                // floats. A FRACTIONAL value (100.5), a non-finite value
+                // (NaN/inf), or one outside i64 range (1e100, > i64::MAX) is a
+                // malformed priority signal and must degrade to 0 (lowest) —
+                // never satisfy a gate. Without the range check `f as i64`
+                // saturates to i64::MAX, which would pass EVERY `min_priority`
+                // gate. Upper bound is strict `<` because `i64::MAX as f64`
+                // rounds up to 2^63 (one past i64::MAX), so `==` to it would
+                // itself saturate.
+                if f.is_finite() && f.fract() == 0.0 && f >= i64::MIN as f64 && f < i64::MAX as f64
+                {
+                    f as i64
+                } else {
+                    0
+                }
+            } else {
+                0
+            }
+        }
+        None => 0,
+    }
+}
+
 /// Selection input — carries the request body and the routing tokens
 /// (computed once at ingress) so cache-aware policies can hash prefix
 /// tokens without reshaping the [`Policy`] trait or re-tokenizing.  Today's
@@ -278,5 +340,77 @@ impl PolicyRegistry {
         for entry in self.by_model.iter() {
             entry.value().attach_metrics(Arc::clone(&metrics));
         }
+    }
+}
+
+#[cfg(test)]
+mod priority_tests {
+    use super::effective_priority;
+    use serde_json::json;
+
+    #[test]
+    fn missing_priority_is_zero() {
+        assert_eq!(effective_priority(&json!({"model": "m"})), 0);
+    }
+
+    #[test]
+    fn explicit_integer_priority() {
+        assert_eq!(effective_priority(&json!({"priority": 100})), 100);
+        assert_eq!(effective_priority(&json!({"priority": 0})), 0);
+        assert_eq!(effective_priority(&json!({"priority": -5})), -5);
+    }
+
+    #[test]
+    fn integer_valued_float_priority() {
+        assert_eq!(effective_priority(&json!({"priority": 100.0})), 100);
+    }
+
+    #[test]
+    fn fractional_float_priority_is_zero() {
+        // A fractional priority is a malformed signal: it must NOT truncate
+        // to 100 and satisfy a `min_priority=100` gate. Degrade to 0 (lowest)
+        // exactly like a string/object — otherwise `100.5` would bypass
+        // isolation. Just-below and just-above-integer both degrade.
+        assert_eq!(effective_priority(&json!({"priority": 100.5})), 0);
+        assert_eq!(effective_priority(&json!({"priority": 99.9})), 0);
+        assert_eq!(effective_priority(&json!({"priority": 0.5})), 0);
+    }
+
+    #[test]
+    fn non_finite_float_priority_is_zero() {
+        // serde_json can't represent NaN/inf in standard JSON, but guard the
+        // f64 path anyway: a non-finite value must degrade to 0, not panic
+        // or saturate the cast.
+        let nan = serde_json::Value::from(f64::NAN);
+        assert_eq!(super::priority_from_value(Some(&nan)), 0);
+    }
+
+    #[test]
+    fn out_of_range_numeric_priority_is_zero() {
+        // A finite but out-of-i64-range number must degrade to 0, NOT
+        // saturate to i64::MAX (which would pass every `min_priority` gate).
+        // Covers a huge float and an unsigned integer past i64::MAX (which
+        // `as_i64()` rejects, falling through to the f64 path).
+        assert_eq!(effective_priority(&json!({"priority": 1e100})), 0);
+        assert_eq!(effective_priority(&json!({"priority": -1e100})), 0);
+        let big_u64 = serde_json::json!({ "priority": (i64::MAX as u64) + 1 });
+        assert_eq!(effective_priority(&big_u64), 0);
+    }
+
+    #[test]
+    fn null_priority_is_zero() {
+        assert_eq!(effective_priority(&json!({"priority": null})), 0);
+    }
+
+    #[test]
+    fn string_priority_is_zero() {
+        // A non-numeric priority must not crash or be coerced; treat as 0
+        // (lowest) so a malformed signal never unlocks a gated worker.
+        assert_eq!(effective_priority(&json!({"priority": "100"})), 0);
+    }
+
+    #[test]
+    fn object_priority_is_zero() {
+        assert_eq!(effective_priority(&json!({"priority": {"x": 1}})), 0);
     }
 }

--- a/experimental/sgl-router/src/policies/registry.rs
+++ b/experimental/sgl-router/src/policies/registry.rs
@@ -183,8 +183,17 @@ impl PdPoolResolver {
     }
 
     /// Pick a decode worker for a PD-mode handoff with **host affinity**
-    /// to the prefill worker. Resolves the decode pool for `model`, then
-    /// applies the affinity rules in [`select_decode_with_affinity`].
+    /// to the prefill worker. Resolves the decode pool for `model`, applies
+    /// priority-eligibility filtering (so a capacity-gated decode worker is
+    /// excluded for sub-threshold requests, mirroring the prefill path),
+    /// then the affinity rules in [`select_decode_with_affinity`].
+    ///
+    /// `request_priority` is the effective request priority; decode workers
+    /// whose `min_priority` exceeds it are removed, with the same empty-set
+    /// fallback as [`filter_eligible`] (a fully-gated pool still serves
+    /// rather than 503s). In today's topology decode pools are homogeneous
+    /// B200 (untagged), so the filter is a defensive no-op — but it keeps
+    /// the guarantee intact if heterogeneous decode capacity is ever added.
     ///
     /// Returns `Err(NoDecodeWorkersAvailable)` if the decode pool is
     /// empty (PD-mode partial failure) — the chat handler then maps to
@@ -195,10 +204,106 @@ impl PdPoolResolver {
         &self,
         model: &ModelId,
         prefill_url: &str,
+        request_priority: i64,
     ) -> Result<Arc<Worker>, PdResolveError> {
         let candidates = self.decode_candidates(model)?;
-        select_decode_with_affinity(prefill_url, &candidates)
+        let eligible = filter_eligible(&candidates, request_priority);
+        select_decode_with_affinity(prefill_url, &eligible.workers)
             .ok_or(PdResolveError::NoDecodeWorkersAvailable)
+    }
+}
+
+/// Outcome of [`filter_eligible`]: the candidate set the policy should
+/// select from, plus whether the eligibility filter excluded workers or
+/// emptied the set entirely.
+#[derive(Debug)]
+pub struct EligibleCandidates {
+    /// The workers the policy should choose among. Empty ONLY when
+    /// `excluded_all` is true (the input was non-empty but every worker was
+    /// gated above the request priority); the caller must reject the request
+    /// rather than select from an empty set.
+    pub workers: Vec<Arc<Worker>>,
+    /// True when eligibility filtering removed at least one worker but left a
+    /// non-empty set (so `workers` is a strict, non-empty subset of the
+    /// input). Drives the `worker_excluded` observability counter.
+    pub excluded_any: bool,
+    /// True when filtering removed EVERY candidate from a non-empty input —
+    /// i.e. the request's priority qualifies for no healthy worker. `workers`
+    /// is empty in this case and the caller MUST fail the request (503
+    /// `NoHealthyWorkers`) rather than spill it onto a gated worker. This is
+    /// the hard-isolation contract: an internal/long (priority-0) request is
+    /// rejected outright before it can ever reach a capacity-gated worker
+    /// (e.g. an RTX-6000), even when that worker is the only one healthy.
+    /// A loud condition — the caller increments `priority_filtered_total
+    /// {reason="empty_set_rejected"}` and logs a warning.
+    pub excluded_all: bool,
+}
+
+/// Restrict `workers` to those eligible for a request of the given
+/// `request_priority`, removing every worker whose
+/// [`Worker::min_priority`] exceeds it. A worker with `min_priority = None`
+/// accepts any request and is always retained.
+///
+/// **Hard exclusion**: an ineligible worker is never returned, even if the
+/// eligible subset is heavily loaded — the policy will queue on / pick
+/// among eligible workers rather than spill onto an ineligible one. This
+/// is what keeps internal/long requests (priority `0`) off a capacity-
+/// gated worker (e.g. an RTX-6000 tagged `min_priority=100`) whose smaller
+/// context window they would otherwise overflow.
+///
+/// **Hard isolation on empty set**: if filtering removes ALL candidates
+/// (e.g. an internal priority-0 request when only `min_priority=100`
+/// workers are healthy), the returned `workers` is EMPTY and `excluded_all`
+/// is set. The caller MUST reject the request (503) rather than fall back to
+/// the unfiltered set — spilling a long internal request onto the gated
+/// worker is exactly the failure mode this feature prevents, so isolation is
+/// preserved even at the cost of availability when no eligible capacity is
+/// healthy. (An empty *input* — no healthy workers at all — yields an empty
+/// set with `excluded_all = false`, since nothing was excluded; the caller's
+/// existing no-healthy-workers path handles it identically.)
+///
+/// A free function (not a `Policy` method) for the same reason as
+/// [`select_decode_with_affinity`]: candidate-set shaping is orthogonal to
+/// the in-pool scoring the `Policy` trait abstracts, and threading it
+/// through every policy impl would couple unrelated concerns.
+///
+/// # Trust boundary
+///
+/// The entire isolation guarantee rests on `request_priority` being a
+/// **trusted, gateway-controlled** signal, NOT a client-supplied one. In the
+/// production topology the API gateway (APIM) overrides the request body's
+/// `priority` per API-key class (high-priority prod key → `100`, internal →
+/// `0`) before the request reaches this router, and a client cannot raise its
+/// own priority. If this router were ever exposed so that callers could set
+/// `priority` directly, any caller could set `priority=100` and reach a gated
+/// worker — the gate would no longer isolate capacity. Deployments MUST keep
+/// the router behind a gateway that owns the `priority` field.
+pub fn filter_eligible(workers: &[Arc<Worker>], request_priority: i64) -> EligibleCandidates {
+    let eligible: Vec<Arc<Worker>> = workers
+        .iter()
+        .filter(|w| match w.min_priority() {
+            Some(min) => request_priority >= min,
+            None => true,
+        })
+        .cloned()
+        .collect();
+
+    // Distinguish "filtering emptied a non-empty pool" (hard-isolation
+    // rejection) from "the pool was already empty" (ordinary no-healthy-
+    // workers, nothing excluded). Only the former sets `excluded_all`.
+    if eligible.is_empty() && !workers.is_empty() {
+        return EligibleCandidates {
+            workers: Vec::new(),
+            excluded_any: false,
+            excluded_all: true,
+        };
+    }
+
+    let excluded_any = eligible.len() != workers.len();
+    EligibleCandidates {
+        workers: eligible,
+        excluded_any,
+        excluded_all: false,
     }
 }
 
@@ -308,6 +413,7 @@ mod tests {
             mode,
             model_ids: vec![ModelId(model.into())],
             bootstrap_port: None,
+            min_priority: None,
         }
     }
 
@@ -317,6 +423,99 @@ mod tests {
             let _ = r.add(s.clone());
         }
         r
+    }
+
+    /// Build a standalone worker with an optional `min_priority` tag for
+    /// exercising [`filter_eligible`] directly (no registry needed).
+    fn tagged_worker(id: &str, min_priority: Option<i64>) -> Arc<Worker> {
+        Arc::new(Worker::new(WorkerSpec {
+            id: WorkerId(id.into()),
+            url: format!("http://{id}:30000"),
+            mode: WorkerMode::Plain,
+            model_ids: vec![ModelId("m".into())],
+            bootstrap_port: None,
+            min_priority,
+        }))
+    }
+
+    #[test]
+    fn filter_eligible_keeps_all_when_none_tagged() {
+        let ws = vec![tagged_worker("a", None), tagged_worker("b", None)];
+        let out = filter_eligible(&ws, 0);
+        assert_eq!(out.workers.len(), 2);
+        assert!(!out.excluded_any);
+        assert!(!out.excluded_all);
+    }
+
+    #[test]
+    fn filter_eligible_excludes_low_priority_from_tagged_worker() {
+        // One untagged B200, one RTX tagged min_priority=100.
+        let b200 = tagged_worker("b200", None);
+        let rtx = tagged_worker("rtx", Some(100));
+        let ws = vec![Arc::clone(&b200), Arc::clone(&rtx)];
+
+        // priority=0 (internal) → only the B200 is eligible.
+        let out = filter_eligible(&ws, 0);
+        assert_eq!(out.workers.len(), 1);
+        assert_eq!(out.workers[0].url, b200.url);
+        assert!(out.excluded_any);
+        assert!(!out.excluded_all);
+    }
+
+    #[test]
+    fn filter_eligible_includes_tagged_worker_for_high_priority() {
+        let b200 = tagged_worker("b200", None);
+        let rtx = tagged_worker("rtx", Some(100));
+        let ws = vec![Arc::clone(&b200), Arc::clone(&rtx)];
+
+        // priority=100 (production) → both eligible.
+        let out = filter_eligible(&ws, 100);
+        assert_eq!(out.workers.len(), 2);
+        assert!(!out.excluded_any);
+        assert!(!out.excluded_all);
+    }
+
+    #[test]
+    fn filter_eligible_boundary_priority_equal_to_min_is_eligible() {
+        let rtx = tagged_worker("rtx", Some(100));
+        let ws = vec![Arc::clone(&rtx)];
+        // priority == min_priority is eligible (>=).
+        let out = filter_eligible(&ws, 100);
+        assert_eq!(out.workers.len(), 1);
+        assert!(!out.excluded_all);
+        // one below the threshold → empty eligible set → hard rejection.
+        let out = filter_eligible(&ws, 99);
+        assert!(out.workers.is_empty());
+        assert!(out.excluded_all);
+    }
+
+    #[test]
+    fn filter_eligible_empty_set_is_rejected_not_fallback() {
+        // Only a tagged worker is healthy; a low-priority request filters it
+        // out entirely → hard isolation: return an EMPTY set with
+        // `excluded_all` so the caller 503s rather than spilling the request
+        // onto the gated worker.
+        let rtx = tagged_worker("rtx", Some(100));
+        let ws = vec![Arc::clone(&rtx)];
+        let out = filter_eligible(&ws, 0);
+        assert!(
+            out.workers.is_empty(),
+            "gated-only pool must NOT serve a sub-threshold request",
+        );
+        assert!(out.excluded_all);
+        assert!(!out.excluded_any);
+    }
+
+    #[test]
+    fn filter_eligible_empty_input_stays_empty_without_rejection_flag() {
+        // No healthy workers at all: empty set, but nothing was *excluded* —
+        // `excluded_all` stays false so this maps to the ordinary
+        // no-healthy-workers path, not the priority-rejection counter.
+        let ws: Vec<Arc<Worker>> = vec![];
+        let out = filter_eligible(&ws, 0);
+        assert!(out.workers.is_empty());
+        assert!(!out.excluded_all);
+        assert!(!out.excluded_any);
     }
 
     /// Model with only Plain workers → Plain partition.
@@ -499,6 +698,7 @@ mod tests {
             mode,
             model_ids: vec![ModelId(model.into())],
             bootstrap_port: None,
+            min_priority: None,
         }
     }
 
@@ -517,7 +717,7 @@ mod tests {
         let prefill_url = "http://host_a:30000";
 
         let chosen = resolver
-            .decode_with_affinity(&ModelId("m".into()), prefill_url)
+            .decode_with_affinity(&ModelId("m".into()), prefill_url, 0)
             .unwrap();
         assert_eq!(
             chosen.url, "http://host_a:30001",
@@ -552,7 +752,7 @@ mod tests {
         assert!(!d1.breaker.allow(), "d1 breaker must be open");
 
         let chosen = resolver
-            .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000")
+            .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000", 0)
             .unwrap();
         assert_eq!(
             chosen.url, "http://host_b:30001",
@@ -604,7 +804,7 @@ mod tests {
         }
 
         let chosen = resolver
-            .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000")
+            .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000", 0)
             .unwrap();
         assert!(
             chosen.url == "http://host_b:30001" || chosen.url == "http://host_c:30001",
@@ -640,7 +840,7 @@ mod tests {
         let _g = d1.load_guard();
 
         let chosen = resolver
-            .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000")
+            .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000", 0)
             .unwrap();
         assert_eq!(
             chosen.url, "http://host_c:30001",
@@ -660,7 +860,7 @@ mod tests {
         )]);
         let resolver = PdPoolResolver::new(r);
         let err = resolver
-            .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000")
+            .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000", 0)
             .unwrap_err();
         assert_eq!(err, PdResolveError::NoDecodeWorkersAvailable);
     }
@@ -676,7 +876,7 @@ mod tests {
         ]);
         let resolver = PdPoolResolver::new(r);
         let chosen = resolver
-            .decode_with_affinity(&ModelId("m".into()), "not-a-url")
+            .decode_with_affinity(&ModelId("m".into()), "not-a-url", 0)
             .unwrap();
         // Both d1 and d2 are at load 0 → either is acceptable. The
         // assertion is only that the function returns Some, not None
@@ -724,7 +924,7 @@ mod tests {
         // preserves PD shape and decode_with_affinity surfaces the
         // per-pool code.
         let err = resolver
-            .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000")
+            .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000", 0)
             .unwrap_err();
         assert_eq!(err, PdResolveError::NoDecodeWorkersAvailable);
 

--- a/experimental/sgl-router/src/policies/sticky.rs
+++ b/experimental/sgl-router/src/policies/sticky.rs
@@ -237,6 +237,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         }))
     }
 

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -3,6 +3,7 @@
 
 use crate::server::app_context::AppContext;
 use crate::server::routes::chat::MAX_CHAT_BODY_BYTES;
+use crate::server::routes::messages::MAX_MESSAGES_BODY_BYTES;
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
@@ -51,6 +52,12 @@ pub fn build_router(ctx: Arc<AppContext>) -> Router {
             "/v1/chat/completions",
             post(crate::server::routes::chat::chat_completions)
                 .layer(DefaultBodyLimit::max(MAX_CHAT_BODY_BYTES))
+                .layer(middleware::from_fn(log_413)),
+        )
+        .route(
+            "/v1/messages",
+            post(crate::server::routes::messages::messages)
+                .layer(DefaultBodyLimit::max(MAX_MESSAGES_BODY_BYTES))
                 .layer(middleware::from_fn(log_413)),
         )
         .route(

--- a/experimental/sgl-router/src/server/error.rs
+++ b/experimental/sgl-router/src/server/error.rs
@@ -151,6 +151,61 @@ impl ApiError {
     pub fn status_code(&self) -> StatusCode {
         self.status_and_code().0
     }
+
+    /// The client-facing message, sanitized exactly as `IntoResponse` renders
+    /// it — never leaks worker URLs or raw anyhow source chains. Exposed so
+    /// alternative error envelopes (e.g. the Anthropic Messages shape on the
+    /// `/v1/messages` route) reuse the same single sanitized message source
+    /// instead of `format!("{self}")`, which would leak internals.
+    pub fn client_message(&self) -> String {
+        match self {
+            ApiError::Internal(e) => {
+                tracing::error!("internal error serving request: {e:#}");
+                "internal error".to_string()
+            }
+            ApiError::UpstreamUnreachable { worker, source } => {
+                tracing::warn!(upstream = %worker, error = %format_args!("{source:#}"), "upstream worker unreachable");
+                "upstream unavailable".to_string()
+            }
+            ApiError::UpstreamStatus { status } => {
+                tracing::warn!(upstream_status = %status, "upstream returned an error status");
+                "upstream returned an error status".to_string()
+            }
+            ApiError::UpstreamTimeout { worker } => {
+                tracing::warn!(upstream = %worker, "upstream request timed out");
+                "upstream request timed out".to_string()
+            }
+            ApiError::NoHealthyWorkers { model } => {
+                tracing::warn!(model = %model, reason = "no_healthy_workers", "service unavailable");
+                "no healthy workers for the requested model".to_string()
+            }
+            ApiError::NoPrefillWorkersAvailable { model } => {
+                tracing::warn!(model = %model, reason = "no_prefill_workers_available", "service unavailable");
+                "no prefill workers available for the requested model".to_string()
+            }
+            ApiError::NoDecodeWorkersAvailable { model } => {
+                tracing::warn!(model = %model, reason = "no_decode_workers_available", "service unavailable");
+                "no decode workers available for the requested model".to_string()
+            }
+            ApiError::StaleRequestExpired { model } => {
+                tracing::warn!(model = %model, reason = "stale_request_expired", "stale-request janitor expired in-flight request");
+                "request expired before completion".to_string()
+            }
+            ApiError::PolicySelectionFailed { model } => {
+                tracing::warn!(model = %model, reason = "policy_selection_failed", "service unavailable");
+                "service unavailable".to_string()
+            }
+            ApiError::BreakerOpen { worker } => {
+                tracing::warn!(upstream = %worker, reason = "breaker_open", "service unavailable");
+                "service unavailable".to_string()
+            }
+            ApiError::WorkerMisconfigured { worker, source } => {
+                tracing::error!(upstream = %worker, error = %format_args!("{source:#}"), "worker URL emitted by discovery is malformed");
+                "service unavailable".to_string()
+            }
+            ApiError::BadRequest(_) | ApiError::ModelNotFound(_) => self.to_string(),
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -173,80 +228,7 @@ impl IntoResponse for ApiError {
             400..=499 => "invalid_request_error",
             _ => "server_error",
         };
-        // Pick a client-facing message that NEVER leaks worker URLs or raw
-        // source chains; full structured details are logged server-side.
-        let message = match &self {
-            ApiError::Internal(e) => {
-                // `{:#}` prints the anyhow chain (top error + sources) — `?e`
-                // would only show the outermost message.
-                tracing::error!("internal error serving request: {e:#}");
-                "internal error".to_string()
-            }
-            ApiError::UpstreamUnreachable { worker, source } => {
-                tracing::warn!(
-                    upstream = %worker,
-                    error = %format_args!("{source:#}"),
-                    "upstream worker unreachable",
-                );
-                "upstream unavailable".to_string()
-            }
-            ApiError::UpstreamStatus { status } => {
-                tracing::warn!(
-                    upstream_status = %status,
-                    "upstream returned an error status",
-                );
-                "upstream returned an error status".to_string()
-            }
-            ApiError::UpstreamTimeout { worker } => {
-                tracing::warn!(upstream = %worker, "upstream request timed out");
-                "upstream request timed out".to_string()
-            }
-            ApiError::NoHealthyWorkers { model } => {
-                tracing::warn!(model = %model, reason = "no_healthy_workers", "service unavailable");
-                "no healthy workers for the requested model".to_string()
-            }
-            ApiError::NoPrefillWorkersAvailable { model } => {
-                tracing::warn!(
-                    model = %model,
-                    reason = "no_prefill_workers_available",
-                    "service unavailable",
-                );
-                "no prefill workers available for the requested model".to_string()
-            }
-            ApiError::NoDecodeWorkersAvailable { model } => {
-                tracing::warn!(
-                    model = %model,
-                    reason = "no_decode_workers_available",
-                    "service unavailable",
-                );
-                "no decode workers available for the requested model".to_string()
-            }
-            ApiError::StaleRequestExpired { model } => {
-                tracing::warn!(
-                    model = %model,
-                    reason = "stale_request_expired",
-                    "stale-request janitor expired in-flight request",
-                );
-                "request expired before completion".to_string()
-            }
-            ApiError::PolicySelectionFailed { model } => {
-                tracing::warn!(model = %model, reason = "policy_selection_failed", "service unavailable");
-                "service unavailable".to_string()
-            }
-            ApiError::BreakerOpen { worker } => {
-                tracing::warn!(upstream = %worker, reason = "breaker_open", "service unavailable");
-                "service unavailable".to_string()
-            }
-            ApiError::WorkerMisconfigured { worker, source } => {
-                tracing::error!(
-                    upstream = %worker,
-                    error = %format_args!("{source:#}"),
-                    "worker URL emitted by discovery is malformed",
-                );
-                "service unavailable".to_string()
-            }
-            ApiError::BadRequest(_) | ApiError::ModelNotFound(_) => self.to_string(),
-        };
+        let message = self.client_message();
         let mut resp = (
             status,
             Json(ErrorEnvelope {

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -32,6 +32,7 @@
 //! | `sgl_router_decode_affinity_total` | Counter | `outcome` |
 //! | `sgl_router_sticky_total` | Counter | `outcome` |
 //! | `sgl_router_ingress_tokenize_errors_total` | Counter | `model_id` |
+//! | `sgl_router_priority_filtered_total` | Counter | `reason` |
 //!
 //! The four `sgl_router_worker*` gauges and `sgl_router_workers` are sampled
 //! at scrape time from the live [`crate::workers::WorkerRegistry`] (passed to
@@ -144,6 +145,33 @@ impl DecodeAffinityOutcome {
     }
 }
 
+/// Outcome of pre-selection priority-eligibility filtering
+/// (`filter_eligible`). Distinguishes a normal exclusion (at least one
+/// worker was gated out, eligible set still non-empty) from a hard-isolation
+/// rejection (filtering emptied the set, so the request was 503'd rather than
+/// spilled onto a gated worker).
+#[derive(Debug, Clone, Copy)]
+pub enum PriorityFilterOutcome {
+    /// At least one worker was excluded; a non-empty eligible subset was
+    /// passed to the policy.
+    WorkerExcluded,
+    /// Filtering removed every candidate from a non-empty pool; the request
+    /// was REJECTED (503) rather than spilled onto a gated worker. A loud,
+    /// actionable signal: either high-priority capacity is under-provisioned,
+    /// or an internal/low-priority request arrived while only gated workers
+    /// were healthy. Hard-isolation guarantee — see `filter_eligible`.
+    EmptySetRejected,
+}
+
+impl PriorityFilterOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::WorkerExcluded => "worker_excluded",
+            Self::EmptySetRejected => "empty_set_rejected",
+        }
+    }
+}
+
 /// Sticky-policy selection outcome — see `StickyPolicy::select` for the
 /// four branches.
 #[derive(Debug, Clone, Copy)]
@@ -217,6 +245,7 @@ pub struct MetricsRegistry {
     decode_affinity_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     sticky_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     ingress_tokenize_errors_total: Mutex<HashMap<String, Arc<AtomicU64>>>,
+    priority_filtered_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
@@ -451,6 +480,26 @@ impl MetricsRegistry {
         let mut guard = self.ingress_tokenize_errors_total.lock();
         let counter = guard
             .entry(model_id.to_owned())
+            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+            .clone();
+        drop(guard);
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Bump `sgl_router_priority_filtered_total{reason}`.
+    ///
+    /// Counts requests affected by pre-selection priority-eligibility
+    /// filtering: `worker_excluded` when a gated worker (e.g. an RTX-6000
+    /// tagged `min_priority=100`) was removed from a low-priority request's
+    /// candidate set but eligible workers remained, and `empty_set_rejected`
+    /// when filtering emptied the candidate set so the request was rejected
+    /// (503) rather than spilled onto a gated worker. The latter staying near
+    /// zero is the health signal: a climbing `empty_set_rejected` means
+    /// eligible (e.g. B200) capacity is under-provisioned or unhealthy.
+    pub fn record_priority_filtered(&self, outcome: PriorityFilterOutcome) {
+        let mut guard = self.priority_filtered_total.lock();
+        let counter = guard
+            .entry(outcome.as_str())
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .clone();
         drop(guard);
@@ -730,6 +779,25 @@ impl MetricsRegistry {
         }
         drop(guard);
 
+        // priority_filtered_total
+        out.push_str(
+            "# HELP sgl_router_priority_filtered_total Requests affected by pre-selection priority-eligibility filtering (worker_excluded = a gated worker removed from a low-priority request but eligible workers remained; empty_set_rejected = filtering emptied the candidate set so the request was rejected with 503 rather than spilled onto a gated worker).\n",
+        );
+        out.push_str("# TYPE sgl_router_priority_filtered_total counter\n");
+        let guard = self.priority_filtered_total.lock();
+        let mut entries: Vec<(&&str, u64)> = guard
+            .iter()
+            .map(|(k, v)| (k, v.load(Ordering::Relaxed)))
+            .collect();
+        entries.sort_by_key(|e| *e.0);
+        for (reason, value) in entries {
+            out.push_str(&format!(
+                "sgl_router_priority_filtered_total{{reason=\"{}\"}} {}\n",
+                reason, value,
+            ));
+        }
+        drop(guard);
+
         out
     }
 }
@@ -796,6 +864,7 @@ mod tests {
         assert!(out.contains("# TYPE sgl_router_decode_affinity_total counter"));
         assert!(out.contains("# TYPE sgl_router_sticky_total counter"));
         assert!(out.contains("# TYPE sgl_router_ingress_tokenize_errors_total counter"));
+        assert!(out.contains("# TYPE sgl_router_priority_filtered_total counter"));
         // Pool-size series exist (at 0) for all three modes even with no
         // workers, so dashboards have a stable series to graph.
         assert!(out.contains(r#"sgl_router_workers{mode="plain"} 0"#));
@@ -830,6 +899,23 @@ mod tests {
         assert!(out.contains(
             r#"sgl_router_request_duration_seconds_bucket{model_id="tiny",le="+Inf"} 3"#
         ));
+    }
+
+    #[test]
+    fn priority_filtered_counts_both_outcomes_separately() {
+        let reg = MetricsRegistry::new();
+        reg.record_priority_filtered(PriorityFilterOutcome::WorkerExcluded);
+        reg.record_priority_filtered(PriorityFilterOutcome::WorkerExcluded);
+        reg.record_priority_filtered(PriorityFilterOutcome::EmptySetRejected);
+        let out = reg.render();
+        assert!(
+            out.contains(r#"sgl_router_priority_filtered_total{reason="worker_excluded"} 2"#),
+            "got:\n{out}",
+        );
+        assert!(
+            out.contains(r#"sgl_router_priority_filtered_total{reason="empty_set_rejected"} 1"#),
+            "got:\n{out}",
+        );
     }
 
     #[test]

--- a/experimental/sgl-router/src/server/routes/cache.rs
+++ b/experimental/sgl-router/src/server/routes/cache.rs
@@ -231,6 +231,7 @@ mod tests {
                     mode: WorkerMode::Plain,
                     model_ids: vec![ModelId("stub-model".into())],
                     bootstrap_port: None,
+                    min_priority: None,
                 })
                 .expect("worker accepted");
         }
@@ -350,6 +351,7 @@ mod tests {
                 mode: WorkerMode::Prefill,
                 model_ids: vec![ModelId("stub-model".into())],
                 bootstrap_port: Some(8998),
+                min_priority: None,
             })
             .expect("prefill accepted");
         ctx.registry
@@ -359,6 +361,7 @@ mod tests {
                 mode: WorkerMode::Decode,
                 model_ids: vec![ModelId("stub-model".into())],
                 bootstrap_port: None,
+                min_priority: None,
             })
             .expect("decode accepted");
 

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -631,7 +631,7 @@ pub async fn chat_completions(
 /// to thread the tokenizer's actual token count through (the
 /// cache-aware-zmq policy already tokenizes the prompt for tree
 /// matching — that count could be reused here).
-fn estimate_prefill_tokens(body: &Bytes) -> usize {
+pub(crate) fn estimate_prefill_tokens(body: &Bytes) -> usize {
     (body.len() / CHARS_PER_TOKEN_ESTIMATE).max(1)
 }
 

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::discovery::{ModelId, WorkerMode};
-use crate::policies::registry::{PdPoolResolver, PdResolveError};
+use crate::policies::registry::{filter_eligible, PdPoolResolver, PdResolveError};
 use crate::policies::{request_tokens_for, RequestTokens, SelectionContext};
 use crate::server::app_context::AppContext;
 use crate::server::error::ApiError;
 use crate::server::metrics::{
-    MetricsRegistry, RequestOutcome, StaleRequestOutcome, WorkerModeLabel,
+    MetricsRegistry, PriorityFilterOutcome, RequestOutcome, StaleRequestOutcome, WorkerModeLabel,
 };
 use crate::workers::{LoadGuard, Worker};
 use axum::body::Body;
@@ -66,6 +66,12 @@ struct RequestProbe {
     stream: Option<bool>,
     #[serde(default)]
     model: Option<String>,
+    /// Request priority, captured as a raw JSON value so a malformed value
+    /// (string, object, …) is tolerated rather than rejected — eligibility
+    /// resolution treats anything non-integer as `0` (lowest). Used to gate
+    /// capacity-restricted workers (see [`filter_eligible`]).
+    #[serde(default)]
+    priority: Option<serde_json::Value>,
 }
 
 /// RAII guard that records `sgl_router_request_duration_seconds` when
@@ -126,10 +132,46 @@ pub async fn chat_completions(
             },
         })?;
 
+    // Resolve the model's policy BEFORE priority filtering so an unknown /
+    // unsupported model still surfaces as 404 `ModelNotFound` rather than
+    // being masked by a 503 from the eligibility filter (which can empty the
+    // candidate set for a gated-but-policyless model). Order matters:
+    // "model not served here" is a different, earlier failure than "no
+    // eligible capacity for this priority".
     let policy = ctx
         .policies
         .get(&model_id)
         .ok_or_else(|| ApiError::ModelNotFound(model_str.clone()))?;
+
+    // Priority-eligibility filtering: capacity-restricted workers (e.g. an
+    // RTX-6000 tagged `min_priority=100`) are removed from the candidate
+    // set for requests below their threshold, BEFORE the policy scores the
+    // pool. Internal/long requests carry priority `0` and never reach such
+    // a worker; production traffic carries `priority=100`. Effective
+    // priority is read from the probe (absent/malformed → 0). Hard
+    // isolation: if filtering empties the candidate set (only gated workers
+    // are healthy and this request doesn't qualify) the request is REJECTED
+    // with 503 rather than spilled onto a gated worker — keeping long
+    // internal requests off the small-context worker even under degradation.
+    let request_priority = crate::policies::priority_from_value(probe.priority.as_ref());
+    let eligible = filter_eligible(&workers, request_priority);
+    if eligible.excluded_all {
+        tracing::warn!(
+            model = %model_str,
+            request_priority,
+            healthy_workers = workers.len(),
+            "priority filter removed all candidates; rejecting request (no eligible-capacity worker healthy for this priority)",
+        );
+        ctx.metrics
+            .record_priority_filtered(PriorityFilterOutcome::EmptySetRejected);
+        return Err(ApiError::NoHealthyWorkers {
+            model: model_str.clone(),
+        });
+    } else if eligible.excluded_any {
+        ctx.metrics
+            .record_priority_filtered(PriorityFilterOutcome::WorkerExcluded);
+    }
+    let workers = eligible.workers;
 
     // Tokenize once at ingress whenever it can pay off — decoupled from the
     // routing policy, because forwarding `input_ids` is a property of the
@@ -204,7 +246,7 @@ pub async fn chat_completions(
     let decode_peer: Option<Arc<Worker>> = if worker.mode() == WorkerMode::Prefill {
         Some(
             resolver
-                .decode_with_affinity(&model_id, &worker.url)
+                .decode_with_affinity(&model_id, &worker.url, request_priority)
                 .map_err(|e| match e {
                     PdResolveError::NoHealthyWorkers => ApiError::NoHealthyWorkers {
                         model: model_str.clone(),

--- a/experimental/sgl-router/src/server/routes/health.rs
+++ b/experimental/sgl-router/src/server/routes/health.rs
@@ -118,6 +118,7 @@ mod tests {
                     mode: WorkerMode::Plain,
                     model_ids: vec![ModelId("test".into())],
                     bootstrap_port: None,
+                    min_priority: None,
                 })
                 .expect("test worker accepted");
         }

--- a/experimental/sgl-router/src/server/routes/messages.rs
+++ b/experimental/sgl-router/src/server/routes/messages.rs
@@ -1,0 +1,330 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Anthropic `/v1/messages` passthrough route.
+//!
+//! Forwards the Anthropic request body to a selected SGLang worker at
+//! `/v1/messages` without translating to/from OpenAI chat completions — the
+//! worker natively serves `/v1/messages`. The router only needs `model` and
+//! `stream` from the body for worker selection and buffered-vs-SSE routing.
+//!
+//! Deliberately does NOT replicate chat.rs's `input_ids` forwarding, PD
+//! bootstrap injection, or decode-peer resolution (see design.md). It DOES
+//! register active-load + hold the per-worker LoadGuard so load-aware
+//! policies (`power_of_two`, `cache_aware_zmq`) see accurate in-flight
+//! counts — without this the LB scheme would route on stale load.
+
+use crate::discovery::{ModelId, WorkerMode};
+use crate::policies::registry::{PdPoolResolver, PdResolveError};
+use crate::policies::SelectionContext;
+use crate::server::app_context::AppContext;
+use crate::server::error::ApiError;
+use crate::server::metrics::{RequestOutcome, WorkerModeLabel};
+use crate::workers::LoadGuard;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{HeaderMap, Response};
+use bytes::Bytes;
+use serde::Deserialize;
+use std::sync::Arc;
+
+/// Per-route body cap, mirroring chat. Same rationale: bound heap allocation
+/// before forwarding while accommodating long contexts.
+pub const MAX_MESSAGES_BODY_BYTES: usize = 5 << 20;
+
+/// Minimal probe: `model` selects the worker, `stream` picks buffered vs SSE.
+/// The worker is authoritative for the full Anthropic schema. `#[serde(default)]`
+/// keeps it tolerant of optional fields — only `model` is required.
+#[derive(Debug, Deserialize)]
+struct MessagesProbe {
+    #[serde(default)]
+    stream: Option<bool>,
+    model: Option<String>,
+}
+
+fn parse_probe(body: &Bytes) -> Result<MessagesProbe, ApiError> {
+    serde_json::from_slice(body)
+        .map_err(|_| ApiError::BadRequest("invalid request: body must be a JSON object".into()))
+}
+
+/// POST /v1/messages — select a worker via the per-model policy and proxy the
+/// raw Anthropic body to `<worker>/v1/messages`.
+pub async fn messages(
+    State(ctx): State<Arc<AppContext>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response<Body> {
+    match messages_inner(State(ctx), headers, body).await {
+        Ok(resp) => resp,
+        Err(e) => anthropic_error_response(e),
+    }
+}
+
+/// Map a router-originated `ApiError` to an Anthropic Messages error envelope
+/// `{"type":"error","error":{"type":...,"message":...}}` so Anthropic SDK clients
+/// parse router-side failures (missing `model`, PD-reject, no healthy worker,
+/// breaker open, stale). Worker-originated errors are forwarded verbatim by the
+/// proxy and are already Anthropic-shaped, so they never reach here.
+///
+/// `message` comes from `ApiError::client_message()` — the same sanitized string
+/// the OpenAI envelope uses, so no worker URL / anyhow chain leaks.
+fn anthropic_error_response(e: ApiError) -> Response<Body> {
+    use serde::Serialize;
+    #[derive(Serialize)]
+    struct AnthropicErr {
+        #[serde(rename = "type")]
+        typ: &'static str,
+        message: String,
+    }
+    #[derive(Serialize)]
+    struct Envelope {
+        #[serde(rename = "type")]
+        typ: &'static str,
+        error: AnthropicErr,
+    }
+    let status = e.status_code();
+    let typ = match status.as_u16() {
+        400 => "invalid_request_error",
+        404 => "not_found_error",
+        503 => "overloaded_error",
+        _ => "api_error",
+    };
+    let message = e.client_message();
+    let body = serde_json::to_vec(&Envelope {
+        typ: "error",
+        error: AnthropicErr { typ, message },
+    })
+    .unwrap_or_else(|_| {
+        b"{\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"internal error\"}}"
+            .to_vec()
+    });
+    let mut r = Response::new(Body::from(body));
+    *r.status_mut() = status;
+    r.headers_mut().insert(
+        axum::http::header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/json"),
+    );
+    r
+}
+
+async fn messages_inner(
+    State(ctx): State<Arc<AppContext>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response<Body>, ApiError> {
+    let start = std::time::Instant::now();
+    let probe = parse_probe(&body)?;
+    let streaming = probe.stream.unwrap_or(false);
+    let model_str = probe
+        .model
+        .ok_or_else(|| ApiError::BadRequest("missing `model` field".into()))?;
+    let model_id = ModelId(model_str.clone());
+
+    // Same candidate set as chat (prefill pool for PD; full set for plain).
+    let resolver = PdPoolResolver::new(Arc::clone(&ctx.registry));
+    let workers = resolver
+        .prefill_candidates(&model_id)
+        .map_err(|e| match e {
+            PdResolveError::NoHealthyWorkers => ApiError::NoHealthyWorkers {
+                model: model_str.clone(),
+            },
+            PdResolveError::NoPrefillWorkersAvailable => ApiError::NoPrefillWorkersAvailable {
+                model: model_str.clone(),
+            },
+            PdResolveError::NoDecodeWorkersAvailable => ApiError::NoDecodeWorkersAvailable {
+                model: model_str.clone(),
+            },
+        })?;
+
+    let policy = ctx
+        .policies
+        .get(&model_id)
+        .ok_or_else(|| ApiError::ModelNotFound(model_str.clone()))?;
+
+    // Deliberately do NOT produce routing tokens for /v1/messages.
+    //
+    // The cache-aware-zmq policy hashes the request to find a worker that
+    // already holds the prefix in its KV cache. For chat completions the
+    // router's chat-encoder tokenization matches the engine's cached blocks.
+    // For Anthropic bodies that is NOT true: the worker's Anthropic serving
+    // path folds the top-level `system` prompt into the actual prompt before
+    // tokenizing, so hashing only `messages` (which `request_tokens_for`
+    // would read) would route two requests with identical `messages` but
+    // different `system` to the same cached worker — a false locality hit.
+    // Rather than replicate the engine's `system`-folding exactly, we skip
+    // router-side tokenization here: cache_aware_zmq falls back to min-load
+    // for /v1/messages, and the worker tokenizes the body itself (we never
+    // forward input_ids). Correct and safe; costs cache affinity on this
+    // route, which is the honest trade-off until the engine exposes its
+    // Anthropic block hashes.
+    let request_tokens: Option<crate::policies::RequestTokens> = None;
+
+    let routing_key = ctx
+        .config
+        .model
+        .sticky
+        .as_ref()
+        .and_then(|s| headers.get(s.header_name.as_str()))
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty());
+    // Pass NO body to the selection context. With `request_tokens = None`
+    // AND no body, CacheAwareZmqPolicy::select cannot tokenize (its fallback
+    // reads the body) and falls back to min-load — which is exactly the honest
+    // behavior we want for /v1/messages (see the request_tokens comment).
+    // Passing the body would let the policy tokenize `messages` and reintroduce
+    // the false-locality bug (identical `messages`, different `system`).
+    // `routing_key` is still honored by the sticky policy (it reads headers, not body).
+    let selection_ctx = SelectionContext::with_routing_key(&model_id, None, routing_key)
+        .with_request_tokens(request_tokens.as_ref().map(|t| t.ids.as_slice()));
+    let worker =
+        policy
+            .select(&workers, &selection_ctx)
+            .ok_or_else(|| ApiError::PolicySelectionFailed {
+                model: model_str.clone(),
+            })?;
+
+    // PD-disaggregated mode: this passthrough only forwards to a single worker
+    // and does NOT replicate chat.rs's decode-peer resolution + bootstrap body
+    // injection (see design.md). In PD mode the final response comes from the
+    // decode side, so silently forwarding to a prefill worker would hang. Fail
+    // explicitly instead of degrading silently. Plain mode is unaffected.
+    if worker.mode() != WorkerMode::Plain {
+        return Err(ApiError::BadRequest(
+            "/v1/messages passthrough does not support PD-disaggregated mode yet; use /v1/chat/completions".into(),
+        ));
+    }
+
+    // Hold the per-worker in-flight guard + register active load so load-aware
+    // policies see this request. prefill_load uses the real token count when we
+    // tokenized, else the byte heuristic (same as chat).
+    let guard = worker.load_guard();
+    let prefill_load = request_tokens
+        .as_ref()
+        .map(|t| t.ids.len().max(1))
+        .unwrap_or_else(|| crate::server::routes::chat::estimate_prefill_tokens(&body));
+    let active_guard =
+        ctx.active_load
+            .register(worker.id.clone(), worker.url.clone(), prefill_load, 0);
+    let stale_token = active_guard.cancel_token().clone();
+    let metrics_worker_url = worker.url.clone();
+    let metrics_model = model_str.clone();
+    let metrics_mode = match worker.mode() {
+        WorkerMode::Prefill => WorkerModeLabel::Prefill,
+        WorkerMode::Decode => WorkerModeLabel::Decode,
+        WorkerMode::Plain => WorkerModeLabel::Plain,
+    };
+
+    let result = if streaming {
+        // ponytail: skip chat's TTFT hook + streaming-duration RAII guard —
+        // v1 measures header-time only; end-to-end streaming latency is a
+        // follow-up. Guards move into stream_guards so load stays accurate.
+        let stream_guards: Box<dyn Send + 'static> = Box::new((guard, active_guard));
+        let fetch = ctx.proxy.forward_streaming_to(
+            &worker.url,
+            &worker.breaker,
+            "/v1/messages",
+            &headers,
+            body,
+            Some(stream_guards),
+            None,
+        );
+        tokio::select! {
+            biased;
+            r = fetch => r,
+            _ = stale_token.cancelled() => Err(ApiError::StaleRequestExpired { model: model_str }),
+        }
+    } else {
+        let _holds: (LoadGuard, _) = (guard, active_guard);
+        let fetch =
+            ctx.proxy
+                .forward_json_to(&worker.url, &worker.breaker, "/v1/messages", &headers, body);
+        tokio::select! {
+            biased;
+            r = fetch => r,
+            _ = stale_token.cancelled() => Err(ApiError::StaleRequestExpired { model: model_str }),
+        }
+    };
+
+    let outcome = match &result {
+        Ok(_) => RequestOutcome::Success,
+        Err(ApiError::StaleRequestExpired { .. }) => {
+            ctx.metrics
+                .record_stale_request(crate::server::metrics::StaleRequestOutcome::Expired);
+            RequestOutcome::Cancelled
+        }
+        Err(_) => RequestOutcome::Error,
+    };
+    ctx.metrics
+        .record_request(&metrics_worker_url, &metrics_model, metrics_mode, outcome);
+
+    let elapsed = start.elapsed();
+    if !streaming {
+        ctx.metrics
+            .observe_request_duration(&metrics_model, elapsed.as_secs_f64());
+    }
+    let http_status = match &result {
+        Ok(resp) => resp.status().as_u16(),
+        Err(e) => e.status_code().as_u16(),
+    };
+    ctx.metrics.record_response(http_status);
+    let request_id = headers
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-");
+    tracing::info!(
+        request_id = %request_id,
+        method = "POST",
+        path = "/v1/messages",
+        model = %metrics_model,
+        worker = %metrics_worker_url,
+        outcome = match outcome {
+            RequestOutcome::Success => "success",
+            RequestOutcome::Error => "error",
+            RequestOutcome::Cancelled => "cancelled",
+        },
+        http_status,
+        stream = streaming,
+        latency_ms = elapsed.as_millis() as u64,
+        "messages",
+    );
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_probe;
+    use bytes::Bytes;
+
+    #[test]
+    fn probe_reads_stream_and_model() {
+        let b = Bytes::from(r#"{"model":"glm","stream":true,"messages":[]}"#);
+        let p = parse_probe(&b).unwrap();
+        assert_eq!(p.stream, Some(true));
+        assert_eq!(p.model.as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn probe_stream_defaults_to_false() {
+        let b = Bytes::from(r#"{"model":"glm","messages":[]}"#);
+        let p = parse_probe(&b).unwrap();
+        assert_eq!(p.stream, None);
+        assert_eq!(p.model.as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn probe_rejects_non_object() {
+        let b = Bytes::from(b"\"hi\"".as_ref());
+        assert!(parse_probe(&b).is_err(), "string body must not parse");
+    }
+
+    #[test]
+    fn probe_allows_anthropic_shape_without_stream() {
+        // Real Anthropic body has system/messages/max_tokens; only model is required here.
+        let b = Bytes::from(
+            r#"{"model":"claude-3","max_tokens":256,"system":"s","messages":[{"role":"user","content":"hi"}]}"#,
+        );
+        let p = parse_probe(&b).unwrap();
+        assert_eq!(p.model.as_deref(), Some("claude-3"));
+        assert_eq!(p.stream, None);
+    }
+}

--- a/experimental/sgl-router/src/server/routes/messages.rs
+++ b/experimental/sgl-router/src/server/routes/messages.rs
@@ -15,11 +15,11 @@
 //! counts — without this the LB scheme would route on stale load.
 
 use crate::discovery::{ModelId, WorkerMode};
-use crate::policies::registry::{PdPoolResolver, PdResolveError};
+use crate::policies::registry::{filter_eligible, PdPoolResolver, PdResolveError};
 use crate::policies::SelectionContext;
 use crate::server::app_context::AppContext;
 use crate::server::error::ApiError;
-use crate::server::metrics::{RequestOutcome, WorkerModeLabel};
+use crate::server::metrics::{PriorityFilterOutcome, RequestOutcome, WorkerModeLabel};
 use crate::workers::LoadGuard;
 use axum::body::Body;
 use axum::extract::State;
@@ -40,6 +40,11 @@ struct MessagesProbe {
     #[serde(default)]
     stream: Option<bool>,
     model: Option<String>,
+    /// Request priority, captured as a raw JSON value so a malformed value
+    /// is tolerated (treated as `0`) rather than rejected. Gates
+    /// capacity-restricted workers (see [`filter_eligible`]).
+    #[serde(default)]
+    priority: Option<serde_json::Value>,
 }
 
 fn parse_probe(body: &Bytes) -> Result<MessagesProbe, ApiError> {
@@ -136,10 +141,57 @@ async fn messages_inner(
             },
         })?;
 
+    // Resolve the model's policy BEFORE priority filtering — see the
+    // `/v1/chat/completions` path: an unknown model must 404 `ModelNotFound`
+    // rather than be masked by a 503 from the eligibility filter emptying a
+    // gated-but-policyless model's candidate set.
     let policy = ctx
         .policies
         .get(&model_id)
         .ok_or_else(|| ApiError::ModelNotFound(model_str.clone()))?;
+
+    // PD-disaggregated mode is unsupported on this route, and that is a
+    // permanent property of the model/route — NOT a transient capacity
+    // condition. Reject it (400) BEFORE priority filtering so a PD model
+    // whose only prefill candidate is priority-gated surfaces the honest
+    // "PD not supported" error rather than a misleading 503 from the filter
+    // emptying the candidate set. A model's workers are homogeneous in mode
+    // (`prefill_candidates` yields prefill/non-Plain workers only for PD
+    // deployments), so any non-Plain candidate marks a PD topology. This
+    // passthrough forwards to a single worker and does NOT replicate
+    // chat.rs's decode-peer resolution + bootstrap body injection (see
+    // design.md); in PD mode the final response comes from the decode side,
+    // so silently forwarding to a prefill worker would hang.
+    if workers.iter().any(|w| w.mode() != WorkerMode::Plain) {
+        return Err(ApiError::BadRequest(
+            "/v1/messages passthrough does not support PD-disaggregated mode yet; use /v1/chat/completions".into(),
+        ));
+    }
+
+    // Priority-eligibility filtering — identical semantics to the
+    // `/v1/chat/completions` path: capacity-restricted workers are removed
+    // for sub-threshold requests before policy selection. Hard isolation:
+    // if filtering empties the candidate set, reject with 503 rather than
+    // spill the request onto a gated worker.
+    let request_priority = crate::policies::priority_from_value(probe.priority.as_ref());
+    let eligible = filter_eligible(&workers, request_priority);
+    if eligible.excluded_all {
+        tracing::warn!(
+            model = %model_str,
+            request_priority,
+            healthy_workers = workers.len(),
+            "priority filter removed all candidates; rejecting request (no eligible-capacity worker healthy for this priority)",
+        );
+        ctx.metrics
+            .record_priority_filtered(PriorityFilterOutcome::EmptySetRejected);
+        return Err(ApiError::NoHealthyWorkers {
+            model: model_str.clone(),
+        });
+    } else if eligible.excluded_any {
+        ctx.metrics
+            .record_priority_filtered(PriorityFilterOutcome::WorkerExcluded);
+    }
+    let workers = eligible.workers;
 
     // Deliberately do NOT produce routing tokens for /v1/messages.
     //
@@ -182,17 +234,6 @@ async fn messages_inner(
             .ok_or_else(|| ApiError::PolicySelectionFailed {
                 model: model_str.clone(),
             })?;
-
-    // PD-disaggregated mode: this passthrough only forwards to a single worker
-    // and does NOT replicate chat.rs's decode-peer resolution + bootstrap body
-    // injection (see design.md). In PD mode the final response comes from the
-    // decode side, so silently forwarding to a prefill worker would hang. Fail
-    // explicitly instead of degrading silently. Plain mode is unaffected.
-    if worker.mode() != WorkerMode::Plain {
-        return Err(ApiError::BadRequest(
-            "/v1/messages passthrough does not support PD-disaggregated mode yet; use /v1/chat/completions".into(),
-        ));
-    }
 
     // Hold the per-worker in-flight guard + register active load so load-aware
     // policies see this request. prefill_load uses the real token count when we

--- a/experimental/sgl-router/src/server/routes/metrics.rs
+++ b/experimental/sgl-router/src/server/routes/metrics.rs
@@ -138,6 +138,7 @@ mod tests {
                 mode: WorkerMode::Prefill,
                 model_ids: vec![ModelId("m".into())],
                 bootstrap_port: None,
+                min_priority: None,
             })
             .unwrap();
         let app = crate::server::app::build_router(ctx.clone());

--- a/experimental/sgl-router/src/server/routes/mod.rs
+++ b/experimental/sgl-router/src/server/routes/mod.rs
@@ -4,6 +4,7 @@
 pub mod cache;
 pub mod chat;
 pub mod health;
+pub mod messages;
 pub mod metrics;
 pub mod models;
 pub mod tokenize;

--- a/experimental/sgl-router/src/workers/manager.rs
+++ b/experimental/sgl-router/src/workers/manager.rs
@@ -352,13 +352,18 @@ fn reconcile_unresolved_workers(
         // Rebuild a discovery-shaped spec: empty `model_ids` so
         // `register_one` re-resolves them from `/server_info`; current
         // mode + bootstrap_port as the seed (`register_one` re-applies
-        // any `/server_info` override).
+        // any `/server_info` override). `min_priority` is a config-time
+        // capability that `/server_info` never carries, so it MUST be
+        // carried over from the live worker — dropping it here would let a
+        // priority-gated worker (e.g. `@min_priority=100`) silently start
+        // accepting priority-0 traffic once it finishes re-introspecting.
         let spec = WorkerSpec {
             id: id.clone(),
             url: worker.url.clone(),
             mode: worker.mode(),
             model_ids: Vec::new(),
             bootstrap_port: worker.bootstrap_port(),
+            min_priority: worker.min_priority(),
         };
         // `debug!` not `info!`: this fires every interval for each
         // still-unresolved worker, so info-level would spam for a worker
@@ -499,6 +504,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId("m".into())],
             bootstrap_port: None,
+            min_priority: None,
         };
         let cb = cb_config_for_spec(&spec, &cfg).expect("model has cb config");
         assert_eq!(cb.threshold.get(), 5);
@@ -566,6 +572,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: Vec::new(),
             bootstrap_port: None,
+            min_priority: None,
         };
         tx.send(DiscoveryEvent::Added(spec.clone())).await.unwrap();
 
@@ -610,6 +617,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: Vec::new(),
             bootstrap_port: None,
+            min_priority: None,
         };
         tx.send(DiscoveryEvent::Added(spec.clone())).await.unwrap();
 
@@ -659,6 +667,7 @@ mod tests {
                 mode: WorkerMode::Plain,
                 model_ids: Vec::new(),
                 bootstrap_port: None,
+                min_priority: None,
             };
             tx.send(DiscoveryEvent::Added(spec.clone())).await.unwrap();
             let registered = tokio::time::timeout(Duration::from_secs(2), async {
@@ -729,6 +738,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: Vec::new(),
             bootstrap_port: None,
+            min_priority: None,
         };
         tx.send(DiscoveryEvent::Added(spec.clone())).await.unwrap();
         // Wait until the manager has both registered the worker AND
@@ -830,6 +840,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: Vec::new(),
             bootstrap_port: None,
+            min_priority: None,
         };
         tx.send(DiscoveryEvent::Added(spec.clone())).await.unwrap();
         // Wait for the manager to land the registry write so the
@@ -910,6 +921,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: Vec::new(),
             bootstrap_port: None,
+            min_priority: None,
         };
         tx.send(DiscoveryEvent::Added(spec.clone())).await.unwrap();
 
@@ -1013,6 +1025,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: Vec::new(),
             bootstrap_port: None,
+            min_priority: None,
         };
         tx.send(DiscoveryEvent::Added(spec)).await.unwrap();
 
@@ -1062,13 +1075,88 @@ mod tests {
         let _ = manager_handle.await;
     }
 
-    /// Resurrection safety: a `Removed` that arrives while a reconcile
-    /// re-introspection for the same id is in-flight must NOT resurrect
-    /// the worker. The `Removed` handler awaits the in-flight handle (which
-    /// re-adds the worker), then clears it — so the worker ends up gone and
-    /// stays gone. Guards the per-id ordering contract that `pending`
-    /// enforces for the reconcile path specifically (distinct from the
-    /// Added path's `removed_awaits_in_flight_added`).
+    /// Regression: a priority-gated worker (`min_priority = Some(100)`) that
+    /// first registers while `/server_info` is unavailable must KEEP its gate
+    /// after the reconcile loop re-introspects it. The reconcile path rebuilds
+    /// a discovery-shaped spec; if it dropped `min_priority` (→ `None`) the
+    /// worker would silently start accepting priority-0 traffic once it
+    /// resolved its model ids — defeating the isolation guarantee.
+    #[tokio::test]
+    async fn reconcile_preserves_min_priority_across_reintrospection() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tokio::time::timeout;
+
+        let ready = Arc::new(AtomicBool::new(false));
+        let (worker_url, _shutdown) =
+            spawn_switchable_server_info_worker(json!({"served_model_name": "m"}), ready.clone())
+                .await;
+
+        let registry = Arc::new(WorkerRegistry::default());
+        let (tx, rx) = mpsc::channel::<DiscoveryEvent>(8);
+        let manager_handle = tokio::spawn(run_with_introspector_and_reconcile(
+            rx,
+            registry.clone(),
+            None,
+            None,
+            None,
+            fast_introspector(),
+            Duration::from_millis(150),
+        ));
+
+        let id = WorkerId("w-gated".into());
+        let model = ModelId("m".into());
+        let spec = WorkerSpec {
+            id: id.clone(),
+            url: worker_url,
+            mode: WorkerMode::Plain,
+            model_ids: Vec::new(),
+            bootstrap_port: None,
+            min_priority: Some(100),
+        };
+        tx.send(DiscoveryEvent::Added(spec)).await.unwrap();
+
+        // Wait until the worker is registered (still model-less, /server_info
+        // failing). The gate must already be present at this stage.
+        let stuck = timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(w) = registry.get(&id) {
+                    if w.model_ids.is_empty() {
+                        return w.min_priority();
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert_eq!(
+            stuck.ok().flatten(),
+            Some(100),
+            "gate must be present on initial (pre-resolve) registration",
+        );
+
+        // /server_info recovers; reconcile re-introspects and resolves models.
+        ready.store(true, Ordering::SeqCst);
+        let recovered = timeout(Duration::from_secs(3), async {
+            loop {
+                if !registry.workers_for(&model).is_empty() {
+                    return true;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert!(recovered.is_ok(), "reconcile must resolve the model id");
+
+        // The crux: the gate survived the reconcile spec rebuild.
+        assert_eq!(
+            registry.get(&id).unwrap().min_priority(),
+            Some(100),
+            "min_priority must survive reconcile re-introspection, not reset to None",
+        );
+
+        drop(tx);
+        let _ = manager_handle.await;
+    }
     #[tokio::test]
     async fn reconcile_does_not_resurrect_worker_removed_mid_reintrospection() {
         use std::sync::atomic::{AtomicBool, Ordering};
@@ -1138,6 +1226,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: Vec::new(),
             bootstrap_port: None,
+            min_priority: None,
         }))
         .await
         .unwrap();
@@ -1265,6 +1354,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: Vec::new(),
             bootstrap_port: None,
+            min_priority: None,
         }))
         .await
         .unwrap();
@@ -1336,6 +1426,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: Vec::new(),
             bootstrap_port: None,
+            min_priority: None,
         }))
         .await
         .unwrap();

--- a/experimental/sgl-router/src/workers/registry.rs
+++ b/experimental/sgl-router/src/workers/registry.rs
@@ -243,6 +243,7 @@ mod tests {
             mode,
             model_ids: models.iter().map(|m| ModelId((*m).into())).collect(),
             bootstrap_port: None,
+            min_priority: None,
         }
     }
 

--- a/experimental/sgl-router/src/workers/worker.rs
+++ b/experimental/sgl-router/src/workers/worker.rs
@@ -99,6 +99,11 @@ pub struct Worker {
     /// decode and plain). Set via `--disaggregation-bootstrap-port` at
     /// worker startup; carried from `WorkerSpec`.
     bootstrap_port: Option<u16>,
+    /// Minimum request priority this worker accepts (`None` = any). A
+    /// request with effective priority below this value is filtered out
+    /// of the candidate set before policy selection. Carried from
+    /// `WorkerSpec`; see [`crate::discovery::WorkerSpec::min_priority`].
+    min_priority: Option<i64>,
 }
 
 impl Worker {
@@ -126,6 +131,7 @@ impl Worker {
             active_requests: Arc::new(AtomicUsize::new(0)),
             bootstrap_host,
             bootstrap_port: spec.bootstrap_port,
+            min_priority: spec.min_priority,
         }
     }
 
@@ -137,6 +143,15 @@ impl Worker {
     /// SGLang bootstrap server port. `None` for decode / plain workers.
     pub fn bootstrap_port(&self) -> Option<u16> {
         self.bootstrap_port
+    }
+
+    /// Minimum request priority this worker accepts. `None` means the
+    /// worker accepts any request; `Some(N)` means it is eligible only for
+    /// requests whose effective priority is `>= N`. Consumed by the
+    /// pre-selection eligibility filter (see
+    /// [`crate::policies::registry::filter_eligible`]).
+    pub fn min_priority(&self) -> Option<i64> {
+        self.min_priority
     }
 
     /// Returns the current [`WorkerMode`] of this worker.
@@ -190,6 +205,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId("m".into())],
             bootstrap_port: None,
+            min_priority: None,
         });
         assert_eq!(w.active_load(), 0);
         let g = w.load_guard();
@@ -211,6 +227,7 @@ mod tests {
                 mode: m,
                 model_ids: vec![],
                 bootstrap_port: None,
+                min_priority: None,
             });
             assert_eq!(w.mode(), m);
         }
@@ -224,6 +241,7 @@ mod tests {
             mode: WorkerMode::Prefill,
             model_ids: vec![],
             bootstrap_port: None,
+            min_priority: None,
         });
         assert_eq!(w.mode(), WorkerMode::Prefill);
         w.set_mode(WorkerMode::Decode);
@@ -240,6 +258,7 @@ mod tests {
             mode: WorkerMode::Prefill,
             model_ids: vec![ModelId("m".into())],
             bootstrap_port: Some(8997),
+            min_priority: None,
         });
         assert_eq!(w.bootstrap_port(), Some(8997));
     }
@@ -252,6 +271,7 @@ mod tests {
             mode: WorkerMode::Plain,
             model_ids: vec![],
             bootstrap_port: None,
+            min_priority: None,
         });
         assert_eq!(w.bootstrap_port(), None);
     }
@@ -264,6 +284,7 @@ mod tests {
             mode: WorkerMode::Prefill,
             model_ids: vec![],
             bootstrap_port: Some(8997),
+            min_priority: None,
         });
         assert_eq!(w.bootstrap_host(), "10.0.0.1");
     }
@@ -276,6 +297,7 @@ mod tests {
             mode: WorkerMode::Prefill,
             model_ids: vec![],
             bootstrap_port: Some(8997),
+            min_priority: None,
         });
         assert_eq!(w.bootstrap_host(), "prefill-0.svc.cluster.local");
     }
@@ -292,6 +314,7 @@ mod tests {
             mode: WorkerMode::Prefill,
             model_ids: vec![],
             bootstrap_port: Some(8997),
+            min_priority: None,
         });
         assert_eq!(w.bootstrap_host(), "localhost");
     }

--- a/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
@@ -42,6 +42,7 @@ fn build_worker(url: &str, model: &str) -> Arc<Worker> {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId(model.into())],
         bootstrap_port: None,
+        min_priority: None,
     }))
 }
 

--- a/experimental/sgl-router/tests/component/policies/power_of_two.rs
+++ b/experimental/sgl-router/tests/component/policies/power_of_two.rs
@@ -15,6 +15,7 @@ fn worker(id: &str) -> Arc<Worker> {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("m".into())],
         bootstrap_port: None,
+        min_priority: None,
     }))
 }
 

--- a/experimental/sgl-router/tests/component/policies/round_robin.rs
+++ b/experimental/sgl-router/tests/component/policies/round_robin.rs
@@ -14,6 +14,7 @@ fn worker(id: &str) -> Arc<Worker> {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("m".into())],
         bootstrap_port: None,
+        min_priority: None,
     }))
 }
 

--- a/experimental/sgl-router/tests/component/workers/concurrent_state.rs
+++ b/experimental/sgl-router/tests/component/workers/concurrent_state.rs
@@ -77,6 +77,7 @@ fn registry_concurrent_add_remove_keeps_indexes_consistent() {
                     mode: WorkerMode::Plain,
                     model_ids: vec![model.clone()],
                     bootstrap_port: None,
+                    min_priority: None,
                 });
                 let snapshot = r.workers_for(&model);
                 for w in &snapshot {
@@ -130,6 +131,7 @@ fn load_guard_decrements_on_panic_unwind() {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("m".into())],
         bootstrap_port: None,
+        min_priority: None,
     }));
     assert_eq!(w.active_load(), 0);
 

--- a/experimental/sgl-router/tests/component/workers/manager.rs
+++ b/experimental/sgl-router/tests/component/workers/manager.rs
@@ -45,6 +45,7 @@ fn spec_for(id: &str, url: &str, mode: WorkerMode) -> WorkerSpec {
         mode,
         model_ids: Vec::new(),
         bootstrap_port: None,
+        min_priority: None,
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -77,6 +77,7 @@ fn build_ctx(url: String) -> Arc<AppContext> {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId(MODEL.into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     // Use the real loaded tokenizers (not the empty-registry test default) so
     // the cache-aware policy can tokenize at ingress.

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -56,6 +56,7 @@ fn build_ctx_with_worker(url: &str) -> Arc<AppContext> {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     let policies = Arc::new(build_policy_registry(&cfg).unwrap());
     // Per-request worker URLs flow from the registry through
@@ -733,6 +734,7 @@ async fn unknown_model_with_no_policy_returns_404_model_not_found() {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("ghost-7b".into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     let policies = Arc::new(build_policy_registry(&cfg).unwrap());
     let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
@@ -1063,6 +1065,7 @@ async fn streaming_load_guard_persists_for_body_lifetime() {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     let policies = Arc::new(build_policy_registry(&cfg).unwrap());
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
@@ -1197,6 +1200,7 @@ async fn streaming_active_load_persists_for_body_lifetime() {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     let policies = Arc::new(build_policy_registry(&cfg).unwrap());
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
@@ -1334,6 +1338,7 @@ async fn janitor_expiry_returns_504_stale_request_expired() {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     let policies = Arc::new(build_policy_registry(&cfg).unwrap());
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());

--- a/experimental/sgl-router/tests/proxy/common/mock_worker.rs
+++ b/experimental/sgl-router/tests/proxy/common/mock_worker.rs
@@ -59,6 +59,7 @@ impl MockWorker {
         // "tiny" model the tests register a tokenizer + policy under.
         let app = axum::Router::new()
             .route("/v1/chat/completions", post(chat))
+            .route("/v1/messages", post(chat))
             .route("/server_info", get(serve_tiny_server_info))
             .with_state(state);
 

--- a/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
+++ b/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
@@ -63,6 +63,7 @@ fn build_ctx_with_worker(worker_url: &str) -> Arc<AppContext> {
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         })
         .expect("test worker accepted");
     let policies = Arc::new(build_registry_with_defaults(&cfg).unwrap());

--- a/experimental/sgl-router/tests/proxy/header_forwarding.rs
+++ b/experimental/sgl-router/tests/proxy/header_forwarding.rs
@@ -49,6 +49,7 @@ async fn forwards_whitelisted_headers_strips_others() {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     let policies = Arc::new(build_policy_registry(&cfg).unwrap());
     let proxy = Arc::new(Proxy::new(Duration::from_secs(5)).unwrap());

--- a/experimental/sgl-router/tests/proxy/main.rs
+++ b/experimental/sgl-router/tests/proxy/main.rs
@@ -15,6 +15,7 @@ mod chat_routing;
 mod failover;
 mod graceful_shutdown;
 mod header_forwarding;
+mod messages_routing;
 mod pd_bootstrap_injection;
 mod pd_pool_isolation;
 mod roundrobin_input_ids;

--- a/experimental/sgl-router/tests/proxy/main.rs
+++ b/experimental/sgl-router/tests/proxy/main.rs
@@ -18,6 +18,7 @@ mod header_forwarding;
 mod messages_routing;
 mod pd_bootstrap_injection;
 mod pd_pool_isolation;
+mod priority_routing;
 mod roundrobin_input_ids;
 mod sticky_input_ids;
 mod sticky_routing;

--- a/experimental/sgl-router/tests/proxy/messages_routing.rs
+++ b/experimental/sgl-router/tests/proxy/messages_routing.rs
@@ -1,0 +1,280 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the `/v1/messages` Anthropic passthrough route.
+//!
+//! The mock worker echoes the same `chat` handler onto `/v1/messages`, so a
+//! request hitting the router's `/v1/messages` route is forwarded to the
+//! worker's `/v1/messages` and the body comes back. This asserts the
+//! passthrough contract: no translation, no `input_ids` injection.
+
+use sgl_router::config::{
+    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
+    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+};
+use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
+use sgl_router::policies::factory::build_registry_with_defaults as build_policy_registry;
+use sgl_router::proxy::Proxy;
+use sgl_router::server::app::build_router;
+use sgl_router::server::app_context::AppContext;
+use sgl_router::tokenizer::TokenizerRegistry;
+use sgl_router::workers::WorkerRegistry;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn build_ctx_with_worker(url: &str) -> Arc<AppContext> {
+    let cfg = Config {
+        server: ServerConfig {
+            host: "0".into(),
+            port: 0,
+        },
+        observability: ObservabilityConfig::default(),
+        model: ModelConfig {
+            id: "tiny".into(),
+            tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
+            policy: PolicyKind::RoundRobin,
+            circuit_breaker: None,
+            cache_aware: None,
+            sticky: None,
+        },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
+        proxy: ProxyConfig::default(),
+        active_load: ActiveLoadConfig::default(),
+    };
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let registry = Arc::new(WorkerRegistry::default());
+    let _ = registry.add(WorkerSpec {
+        id: WorkerId("w1".into()),
+        url: url.to_string(),
+        mode: WorkerMode::Plain,
+        model_ids: vec![ModelId("tiny".into())],
+        bootstrap_port: None,
+    });
+    let policies = Arc::new(build_policy_registry(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
+    Arc::new(AppContext::new(cfg, tokenizers, proxy, registry, policies))
+}
+
+/// Same as `build_ctx_with_worker` but registers the worker in PD prefill mode,
+/// so the `/v1/messages` route hits its PD-reject guard instead of forwarding.
+fn build_ctx_with_prefill_worker(url: &str) -> Arc<AppContext> {
+    let cfg = Config {
+        server: ServerConfig {
+            host: "0".into(),
+            port: 0,
+        },
+        observability: ObservabilityConfig::default(),
+        model: ModelConfig {
+            id: "tiny".into(),
+            tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
+            policy: PolicyKind::RoundRobin,
+            circuit_breaker: None,
+            cache_aware: None,
+            sticky: None,
+        },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
+        proxy: ProxyConfig::default(),
+        active_load: ActiveLoadConfig::default(),
+    };
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let registry = Arc::new(WorkerRegistry::default());
+    let _ = registry.add(WorkerSpec {
+        id: WorkerId("w1".into()),
+        url: url.to_string(),
+        mode: WorkerMode::Prefill,
+        model_ids: vec![ModelId("tiny".into())],
+        bootstrap_port: None,
+    });
+    let policies = Arc::new(build_policy_registry(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
+    Arc::new(AppContext::new(cfg, tokenizers, proxy, registry, policies))
+}
+
+#[tokio::test]
+async fn messages_non_streaming_passthrough_200() {
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "max_tokens": 16,
+        "stream": false,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn messages_streaming_passthrough_sse() {
+    let chunks: Vec<&'static str> = vec![
+        "data: {\"type\":\"content_block_delta\"}\n\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+        "data: [DONE]\n\n",
+    ];
+    let worker = crate::common::mock_worker::MockWorker::start(chunks.clone()).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "stream": true,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.headers().get("content-type").unwrap().to_str().unwrap(),
+        "text/event-stream"
+    );
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let data = crate::common::streaming::parse_sse_data(&bytes);
+    assert_eq!(data.len(), 3);
+    assert_eq!(data[2], "[DONE]");
+}
+
+#[tokio::test]
+async fn messages_missing_model_returns_400() {
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "max_tokens": 16,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    // Router-originated errors on this endpoint are Anthropic-shaped.
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["type"], "error", "envelope type must be 'error'");
+    assert_eq!(v["error"]["type"], "invalid_request_error");
+    assert!(v["error"]["message"].as_str().unwrap().contains("model"));
+}
+
+#[tokio::test]
+async fn messages_body_forwarded_unchanged_no_input_ids() {
+    // Core passthrough invariant: the Anthropic body reaches the worker
+    // byte-identical, with no `input_ids` injected (the worker tokenizes).
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let sent = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "max_tokens": 16,
+        "stream": false,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(sent.clone()))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let forwarded = worker.captured.lock().unwrap().last_body.clone();
+    let fwd: serde_json::Value = serde_json::from_slice(&forwarded.unwrap()).unwrap();
+    assert!(fwd.get("input_ids").is_none(), "must not inject input_ids");
+    assert_eq!(
+        fwd,
+        serde_json::from_slice::<serde_json::Value>(&sent).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn messages_rejects_pd_disaggregated_mode() {
+    // The passthrough does not do chat.rs's decode-peer + bootstrap injection,
+    // so it must reject PD mode explicitly rather than silently forwarding to a
+    // single prefill worker and hanging.
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_prefill_worker(&worker.url);
+    let app = build_router(ctx);
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "stream": false,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn messages_upstream_error_is_anthropic_shaped_and_does_not_leak_url() {
+    // Register an unreachable worker so the proxy returns UpstreamUnreachable.
+    // The Anthropic error envelope must be sanitized — no worker URL in the body.
+    let ctx = build_ctx_with_worker("http://127.0.0.1:1"); // port 1: connection refused fast
+    let app = build_router(ctx);
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "stream": false,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    // Upstream-unreachable maps to 502 (BAD_GATEWAY) via ApiError.
+    assert!(res.status().is_server_error(), "got {}", res.status());
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8_lossy(&bytes);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&bytes).unwrap()["type"],
+        "error",
+        "envelope must be Anthropic-shaped: {text}"
+    );
+    // The worker URL must NOT leak into the client-facing message.
+    assert!(
+        !text.contains("127.0.0.1"),
+        "worker URL leaked into client error: {text}"
+    );
+}

--- a/experimental/sgl-router/tests/proxy/messages_routing.rs
+++ b/experimental/sgl-router/tests/proxy/messages_routing.rs
@@ -58,6 +58,7 @@ fn build_ctx_with_worker(url: &str) -> Arc<AppContext> {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     let policies = Arc::new(build_policy_registry(&cfg).unwrap());
     let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
@@ -95,6 +96,7 @@ fn build_ctx_with_prefill_worker(url: &str) -> Arc<AppContext> {
         mode: WorkerMode::Prefill,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     let policies = Arc::new(build_policy_registry(&cfg).unwrap());
     let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
@@ -242,6 +244,72 @@ async fn messages_rejects_pd_disaggregated_mode() {
         .unwrap();
     let res = app.oneshot(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn messages_pd_rejection_wins_over_priority_filter() {
+    // Ordering regression (codex super-review round 5): when a PD-mode model's
+    // only prefill candidate is priority-gated AND the request is below the
+    // threshold, the permanent "PD not supported on this route" 400 must win
+    // over the eligibility filter's transient empty-set 503. PD-unsupported is
+    // a route/client error; reporting it as no-healthy-workers would mislead
+    // Anthropic clients and operators.
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let cfg = Config {
+        server: ServerConfig {
+            host: "0".into(),
+            port: 0,
+        },
+        observability: ObservabilityConfig::default(),
+        model: ModelConfig {
+            id: "tiny".into(),
+            tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
+            policy: PolicyKind::RoundRobin,
+            circuit_breaker: None,
+            cache_aware: None,
+            sticky: None,
+        },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
+        proxy: ProxyConfig::default(),
+        active_load: ActiveLoadConfig::default(),
+    };
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let registry = Arc::new(WorkerRegistry::default());
+    let _ = registry.add(WorkerSpec {
+        id: WorkerId("w1".into()),
+        url: worker.url.clone(),
+        mode: WorkerMode::Prefill,
+        model_ids: vec![ModelId("tiny".into())],
+        bootstrap_port: None,
+        min_priority: Some(100),
+    });
+    let policies = Arc::new(build_policy_registry(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(TEST_TIMEOUT).unwrap());
+    let ctx = Arc::new(AppContext::new(cfg, tokenizers, proxy, registry, policies));
+    let app = build_router(ctx);
+
+    // priority 0 (absent) is below the gate — without correct ordering the
+    // filter would empty the set and 503 before the PD check runs.
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "stream": false,
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::BAD_REQUEST,
+        "PD-unsupported (400) must win over the priority filter's empty-set 503",
+    );
 }
 
 #[tokio::test]

--- a/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
+++ b/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
@@ -142,6 +142,7 @@ async fn pd_mode_chat_injects_bootstrap_fields_into_both_bodies() {
             mode: WorkerMode::Prefill,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: Some(8997),
+            min_priority: None,
         },
         WorkerSpec {
             id: WorkerId("d1".into()),
@@ -149,6 +150,7 @@ async fn pd_mode_chat_injects_bootstrap_fields_into_both_bodies() {
             mode: WorkerMode::Decode,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
     ]);
     let app = build_router(ctx);
@@ -198,6 +200,7 @@ async fn plain_mode_chat_does_not_inject_bootstrap_fields() {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     }]);
     let app = build_router(ctx);
 
@@ -235,6 +238,7 @@ async fn pd_mode_bootstrap_port_matches_chosen_prefill_worker() {
             mode: WorkerMode::Prefill,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: Some(11111),
+            min_priority: None,
         },
         WorkerSpec {
             id: WorkerId("pB".into()),
@@ -242,6 +246,7 @@ async fn pd_mode_bootstrap_port_matches_chosen_prefill_worker() {
             mode: WorkerMode::Prefill,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: Some(22222),
+            min_priority: None,
         },
         WorkerSpec {
             id: WorkerId("d1".into()),
@@ -249,6 +254,7 @@ async fn pd_mode_bootstrap_port_matches_chosen_prefill_worker() {
             mode: WorkerMode::Decode,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
     ]);
     let app = build_router(ctx);
@@ -299,6 +305,7 @@ async fn pd_mode_prefill_5xx_does_not_poison_decode_response() {
             mode: WorkerMode::Prefill,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: Some(8997),
+            min_priority: None,
         },
         WorkerSpec {
             id: WorkerId("d1".into()),
@@ -306,6 +313,7 @@ async fn pd_mode_prefill_5xx_does_not_poison_decode_response() {
             mode: WorkerMode::Decode,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
     ]);
     let app = build_router(ctx);

--- a/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
+++ b/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
@@ -96,6 +96,7 @@ async fn pd_mode_decode_only_returns_no_prefill_workers_available() {
         mode: WorkerMode::Decode,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     }]);
     let app = build_router(ctx);
 
@@ -149,6 +150,7 @@ async fn pd_mode_chat_dispatch_fans_to_both_prefill_and_decode() {
             mode: WorkerMode::Prefill,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: Some(8997),
+            min_priority: None,
         },
         WorkerSpec {
             id: WorkerId("d1".into()),
@@ -156,6 +158,7 @@ async fn pd_mode_chat_dispatch_fans_to_both_prefill_and_decode() {
             mode: WorkerMode::Decode,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
     ]);
     let app = build_router(ctx);
@@ -234,6 +237,7 @@ async fn pd_mode_chat_dispatch_sets_decode_affinity_header() {
             mode: WorkerMode::Prefill,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
         WorkerSpec {
             id: WorkerId("p2".into()),
@@ -241,6 +245,7 @@ async fn pd_mode_chat_dispatch_sets_decode_affinity_header() {
             mode: WorkerMode::Prefill,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
         WorkerSpec {
             id: WorkerId("d1".into()),
@@ -248,6 +253,7 @@ async fn pd_mode_chat_dispatch_sets_decode_affinity_header() {
             mode: WorkerMode::Decode,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
         WorkerSpec {
             id: WorkerId("d2".into()),
@@ -255,6 +261,7 @@ async fn pd_mode_chat_dispatch_sets_decode_affinity_header() {
             mode: WorkerMode::Decode,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
     ]);
     let app = build_router(ctx);
@@ -305,6 +312,7 @@ async fn plain_mode_chat_dispatch_omits_decode_affinity_header() {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     }]);
     let app = build_router(ctx);
 
@@ -331,6 +339,7 @@ async fn pd_mode_prefill_only_returns_no_decode_workers_available() {
         mode: WorkerMode::Prefill,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     }]);
     let app = build_router(ctx);
 
@@ -359,6 +368,7 @@ async fn pd_mode_chat_response_carries_decode_affinity_header() {
             mode: WorkerMode::Prefill,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
         WorkerSpec {
             id: WorkerId("d1".into()),
@@ -366,6 +376,7 @@ async fn pd_mode_chat_response_carries_decode_affinity_header() {
             mode: WorkerMode::Decode,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
         WorkerSpec {
             id: WorkerId("d2".into()),
@@ -373,6 +384,7 @@ async fn pd_mode_chat_response_carries_decode_affinity_header() {
             mode: WorkerMode::Decode,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         },
     ]);
     let app = build_router(ctx);
@@ -411,6 +423,7 @@ async fn plain_mode_chat_response_omits_decode_affinity_header() {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     }]);
     let app = build_router(ctx);
 

--- a/experimental/sgl-router/tests/proxy/priority_routing.rs
+++ b/experimental/sgl-router/tests/proxy/priority_routing.rs
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Priority-based worker eligibility — end-to-end at the HTTP layer.
+//!
+//! A worker tagged with `min_priority = N` is eligible only for requests
+//! whose body `priority` is `>= N`. This exercises the full ingress path
+//! (`parse_probe` → `effective_priority` → `filter_eligible` → policy
+//! select → proxy) with `MockWorker` backends, asserting which worker
+//! actually received the request via its captured body.
+//!
+//! Topology under test mirrors the production goal: one untagged worker
+//! (a B200 that accepts anything) plus one `min_priority=100` worker (an
+//! RTX-6000 reserved for high-priority production traffic).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use sgl_router::config::{
+    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
+    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+};
+use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
+use sgl_router::policies::factory::build_registry_with_defaults;
+use sgl_router::proxy::Proxy;
+use sgl_router::server::app::build_router;
+use sgl_router::server::app_context::AppContext;
+use sgl_router::tokenizer::TokenizerRegistry;
+use sgl_router::workers::WorkerRegistry;
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+
+use crate::common::mock_worker::MockWorker;
+
+fn config() -> Config {
+    Config {
+        server: ServerConfig {
+            host: "0".into(),
+            port: 0,
+        },
+        observability: ObservabilityConfig::default(),
+        model: ModelConfig {
+            id: "tiny".into(),
+            tokenizer_path: "tests/fixtures/tiny_tokenizer.json".into(),
+            // RoundRobin: load-agnostic, so the ONLY reason a request lands
+            // on one worker vs another is eligibility filtering — exactly
+            // what we want to pin.
+            policy: PolicyKind::RoundRobin,
+            circuit_breaker: None,
+            cache_aware: None,
+            sticky: None,
+        },
+        discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
+            urls: vec!["http://placeholder:0".into()],
+        }),
+        proxy: ProxyConfig::default(),
+        active_load: ActiveLoadConfig::default(),
+    }
+}
+
+fn build_ctx(specs: Vec<WorkerSpec>) -> Arc<AppContext> {
+    let cfg = config();
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let registry = Arc::new(WorkerRegistry::default());
+    for s in specs {
+        let _ = registry.add(s);
+    }
+    let policies = Arc::new(build_registry_with_defaults(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(Duration::from_secs(5)).unwrap());
+    Arc::new(AppContext::new(cfg, tokenizers, proxy, registry, policies))
+}
+
+fn plain_spec(id: &str, url: &str, min_priority: Option<i64>) -> WorkerSpec {
+    WorkerSpec {
+        id: WorkerId(id.into()),
+        url: url.into(),
+        mode: WorkerMode::Plain,
+        model_ids: vec![ModelId("tiny".into())],
+        bootstrap_port: None,
+        min_priority,
+    }
+}
+
+fn chat_request(priority: Option<i64>) -> Request<Body> {
+    let mut body = serde_json::json!({
+        "model": "tiny",
+        "messages": [{"role": "user", "content": "hi"}],
+    });
+    if let Some(p) = priority {
+        body["priority"] = serde_json::json!(p);
+    }
+    Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+fn was_hit(w: &MockWorker) -> bool {
+    w.captured.lock().unwrap().last_body.is_some()
+}
+
+/// A low-priority (here: absent → 0) request must NEVER land on a
+/// `min_priority=100` worker when an untagged worker is available — even
+/// across many round-robin turns that would otherwise alternate.
+#[tokio::test]
+async fn low_priority_request_never_hits_gated_worker() {
+    let untagged = MockWorker::start(vec![]).await;
+    let gated = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(vec![
+        plain_spec("untagged", &untagged.url, None),
+        plain_spec("gated", &gated.url, Some(100)),
+    ]);
+
+    // Several requests: round-robin would hit `gated` on alternate turns
+    // if it were eligible. It must never be selected.
+    for _ in 0..6 {
+        let app = build_router(Arc::clone(&ctx));
+        let res = app.oneshot(chat_request(None)).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    assert!(
+        was_hit(&untagged),
+        "untagged worker should serve all traffic"
+    );
+    assert!(
+        !was_hit(&gated),
+        "gated (min_priority=100) worker must not receive priority-0 traffic",
+    );
+}
+
+/// A high-priority (`priority=100`) request is eligible for the gated
+/// worker. With round-robin over two eligible workers, the gated worker
+/// must receive at least one of several requests.
+#[tokio::test]
+async fn high_priority_request_can_hit_gated_worker() {
+    let untagged = MockWorker::start(vec![]).await;
+    let gated = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(vec![
+        plain_spec("untagged", &untagged.url, None),
+        plain_spec("gated", &gated.url, Some(100)),
+    ]);
+
+    for _ in 0..6 {
+        let app = build_router(Arc::clone(&ctx));
+        let res = app.oneshot(chat_request(Some(100))).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    assert!(
+        was_hit(&gated),
+        "gated worker must be eligible for priority-100 traffic and get a round-robin turn",
+    );
+}
+
+/// Boundary: `priority == min_priority` is eligible (the rule is `>=`).
+#[tokio::test]
+async fn priority_equal_to_threshold_is_eligible() {
+    let gated = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(vec![plain_spec("gated", &gated.url, Some(100))]);
+
+    let app = build_router(Arc::clone(&ctx));
+    let res = app.oneshot(chat_request(Some(100))).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert!(was_hit(&gated), "priority == min_priority must be eligible");
+}
+
+/// Hard isolation on empty set: when the ONLY healthy worker is gated above
+/// the request's priority, the request is REJECTED (503) rather than spilled
+/// onto the gated worker. Keeping a long internal (priority-0) request off a
+/// small-context worker matters more than serving it — the gated worker is
+/// exactly the capacity this request must never touch. The request must NOT
+/// land on the gated worker.
+#[tokio::test]
+async fn empty_eligible_set_is_rejected_not_served() {
+    let gated = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(vec![plain_spec("gated", &gated.url, Some(100))]);
+
+    // priority 0 (absent) qualifies for no worker → hard rejection.
+    let app = build_router(Arc::clone(&ctx));
+    let res = app.oneshot(chat_request(None)).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "a sub-threshold request with only gated capacity must be 503'd, not served",
+    );
+    assert!(
+        !was_hit(&gated),
+        "the gated worker must NOT receive a sub-threshold request, even as a last resort",
+    );
+}
+
+/// Ordering regression: a request for a model that has registered workers but
+/// NO policy entry must surface as 404 `ModelNotFound`, NOT 503 — even when
+/// the only registered worker is gated above the request priority. The
+/// eligibility filter's empty-set 503 must not mask the earlier "model not
+/// served here" failure. (See codex super-review round 4.)
+#[tokio::test]
+async fn unknown_model_with_gated_worker_is_404_not_503() {
+    let gated = MockWorker::start(vec![]).await;
+    // Register a gated worker under a model id the policy registry doesn't
+    // know about ("ghost"), while the config only builds a policy for "tiny".
+    let spec = WorkerSpec {
+        id: WorkerId("ghost-gated".into()),
+        url: gated.url.clone(),
+        mode: WorkerMode::Plain,
+        model_ids: vec![ModelId("ghost".into())],
+        bootstrap_port: None,
+        min_priority: Some(100),
+    };
+    let ctx = build_ctx(vec![spec]);
+
+    // Sub-threshold (absent → 0) request for the unknown model.
+    let mut body = serde_json::json!({
+        "model": "ghost",
+        "messages": [{"role": "user", "content": "hi"}],
+    });
+    body["priority"] = serde_json::json!(0);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let app = build_router(Arc::clone(&ctx));
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::NOT_FOUND,
+        "unknown model must 404 before the priority filter can 503",
+    );
+    assert!(
+        !was_hit(&gated),
+        "an unknown-model request must not reach any worker"
+    );
+}
+
+/// A malformed (non-integer) `priority` is treated as `0`, NOT rejected —
+/// so it is excluded from a gated worker exactly like an absent priority.
+#[tokio::test]
+async fn malformed_priority_treated_as_low() {
+    let untagged = MockWorker::start(vec![]).await;
+    let gated = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(vec![
+        plain_spec("untagged", &untagged.url, None),
+        plain_spec("gated", &gated.url, Some(100)),
+    ]);
+
+    let body = serde_json::json!({
+        "model": "tiny",
+        "messages": [{"role": "user", "content": "hi"}],
+        "priority": "definitely-not-an-int",
+    });
+    for _ in 0..6 {
+        let app = build_router(Arc::clone(&ctx));
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    assert!(was_hit(&untagged));
+    assert!(
+        !was_hit(&gated),
+        "string priority must coerce to 0 and stay off the gated worker",
+    );
+}

--- a/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
@@ -67,6 +67,7 @@ fn build_ctx(url: String) -> Arc<AppContext> {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId(MODEL.into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     let policies = Arc::new(build_registry_with_defaults(&cfg).unwrap());
     let proxy = Arc::new(Proxy::new(Duration::from_secs(5)).unwrap());

--- a/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
@@ -92,6 +92,7 @@ fn build_ctx(worker_urls: &[String]) -> Arc<AppContext> {
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId(MODEL.into())],
             bootstrap_port: None,
+            min_priority: None,
         });
     }
     // Sticky needs no cache-aware deps, so the defaults registry is fine — the

--- a/experimental/sgl-router/tests/proxy/sticky_routing.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_routing.rs
@@ -66,6 +66,7 @@ fn build_sticky_ctx(header_name: &str, worker_urls: &[String]) -> Arc<AppContext
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         });
     }
     let policies = Arc::new(build_policy_registry(&cfg).unwrap());
@@ -293,6 +294,7 @@ async fn adding_a_worker_does_not_redistribute_existing_key() {
             mode: WorkerMode::Plain,
             model_ids: vec![ModelId("tiny".into())],
             bootstrap_port: None,
+            min_priority: None,
         })
         .unwrap();
     // Guard the premise: w2 really is an eligible candidate now, so the

--- a/experimental/sgl-router/tests/proxy/timeout.rs
+++ b/experimental/sgl-router/tests/proxy/timeout.rs
@@ -64,6 +64,7 @@ async fn non_streaming_request_times_out_when_worker_hangs() {
         mode: WorkerMode::Plain,
         model_ids: vec![ModelId("tiny".into())],
         bootstrap_port: None,
+        min_priority: None,
     });
     let policies = Arc::new(build_policy_registry(&cfg).unwrap());
     let proxy = Arc::new(Proxy::new(Duration::from_millis(200)).unwrap());


### PR DESCRIPTION
## Motivation

In heterogeneous deployments, some workers run on capacity-restricted hardware (e.g. small-context consumer GPUs) that should only serve short, high-priority production traffic — never long internal/batch requests that would blow their KV budget. The router today balances across all healthy workers with no way to reserve a worker for a priority class.

## What this does

Adds an optional per-worker `min_priority` capability that gates worker eligibility **before** the load-balancing policy runs.

- Workers declare a floor via `--worker-urls host:port@min_priority=N`. Unset = accepts everything = current behavior (fully backward compatible).
- `filter_eligible` shapes the candidate set on both `/v1/chat/completions` and `/v1/messages`, for both plain and PD candidate pools, using the request's effective `priority`.
- **Hard isolation**: if filtering a non-empty pool yields an empty set, the request is rejected (503) rather than spilling onto a gated worker. An already-empty pool keeps the existing no-healthy-workers semantics.
- **Error precedence**: 404 (unknown model) and 400 (PD-unsupported on `/v1/messages`) are resolved before the filter, so a permanent error never surfaces as a transient 503.
- **Malformed priority degrades to 0 (lowest)**: non-numeric, fractional-float, non-finite, and out-of-i64-range values can never satisfy a gate.
- New counter `sgl_router_priority_filtered_total{reason}` distinguishes worker-excluded from empty-set-rejected.
- `min_priority` is preserved across `/server_info` re-introspection.

## Testing

- `cargo test` green (lib + proxy integration), including new `tests/proxy/priority_routing.rs` and unit tests for every edge above (fractional, non-finite, out-of-range, error precedence, empty-set rejection).
- `cargo clippy --all-targets` clean.

## Dependency

Built on top of #29474 (adds `/v1/messages`), since the gating applies to that route as well. This PR's branch includes that commit; please review/merge #29474 first. Once #29474 merges, the diff here reduces to the gating commit only.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28276023076](https://github.com/sgl-project/sglang/actions/runs/28276023076)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28276023026](https://github.com/sgl-project/sglang/actions/runs/28276023026)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->