### PR TITLE
[Doc] Fix CUDA 12 install instructions

### DIFF
--- a/docs_new/docs/get-started/install.mdx
+++ b/docs_new/docs/get-started/install.mdx
@@ -25,14 +25,48 @@ pip install uv
 uv pip install sglang
 ```
 
-The major version of Cuda is 13 by default. To install sglang under Cuda 12 with pip or uv, please try the following commands:
+The default pip/uv dependency set targets CUDA 13. In a CUDA 12 environment,
+use uv's exclude file support before installing SGLang, so the first resolver
+pass does not pull CUDA 13 packages:
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
-uv pip install --force-reinstall  torch==2.11.0 torchaudio==2.11.0 torchvision --index-url https://download.pytorch.org/whl/cu129
+
+cat > excludes-cu13.txt <<'EOF'
+flash-attn-4
+tilelang
+quack-kernels
+nvidia-cutlass-dsl
+nvidia-cutlass-dsl-libs-base
+nvidia-cutlass-dsl-libs-cu13
+cuda-toolkit
+cuda-tile
+nvidia-cublas
+nvidia-cuda-crt
+nvidia-cuda-cupti
+nvidia-cuda-nvcc
+nvidia-cuda-nvrtc
+nvidia-cuda-runtime
+nvidia-cuda-tileiras
+nvidia-cudnn-cu13
+nvidia-cufft
+nvidia-cufile
+nvidia-curand
+nvidia-cusolver
+nvidia-cusparse
+nvidia-cusparselt-cu13
+nvidia-nccl-cu13
+nvidia-nvjitlink
+nvidia-nvshmem-cu13
+nvidia-nvtx
+nvidia-nvvm
+EOF
+
+uv pip install --prerelease=allow --excludes excludes-cu13.txt sglang
+uv pip install --force-reinstall torch==2.11.0 torchaudio==2.11.0 torchvision --index-url https://download.pytorch.org/whl/cu129
 uv pip install --force-reinstall sglang-kernel --index-url https://docs.sglang.ai/whl/cu129/
 uv pip install --force-reinstall sgl-deep-gemm --index-url https://docs.sglang.ai/whl/cu129/ --no-deps
+uv pip install --force-reinstall cuda-python==12.9.0 cuda-bindings==12.9.4
 ```
 
 ### Quick fixes to common problems


### PR DESCRIPTION
## Motivation

Fixes #29425.

The CUDA 12 install section currently starts with `uv pip install sglang`. On current main, the default pip/uv dependency set is CUDA 13 oriented, so a clean CUDA 12 environment can pull CUDA 13 packages before the later cu129 reinstall steps run.

## Modifications

- Add an `excludes-cu13.txt` step before installing SGLang in the CUDA 12 flow.
- Install SGLang with `uv pip install --prerelease=allow --excludes excludes-cu13.txt sglang` for CUDA 12 environments.
- Keep the cu129 PyTorch, `sglang-kernel`, and `sgl-deep-gemm` reinstall steps.
- Pin CUDA Python bindings back to CUDA 12 with `cuda-python==12.9.0 cuda-bindings==12.9.4`.
- Mirror the guidance into the legacy docs tree.

## Accuracy Tests

Docs-only change; not applicable.

## Speed Tests and Profiling

Docs-only change; not applicable.

## Validation

- `git diff --check`

I did not run a full CUDA 12 install locally because this workspace does not have `uv` or a CUDA 12 runtime available, and the root filesystem is very limited.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`git diff --check` run for this docs-only change.)
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Not applicable; docs-only.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; docs-only.)
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28346668473](https://github.com/sgl-project/sglang/actions/runs/28346668473)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28346668383](https://github.com/sgl-project/sglang/actions/runs/28346668383)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->