### PR TITLE
fix(hicache): avoid per-rank-conditional TP collective in is_load_back_event_done (decode-side hierarchical cache)

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -963,18 +963,30 @@ class HiRadixCache(RadixCache):
             finish_count -= 1
 
     def is_load_back_event_done(self, consumer_index: int) -> bool:
-        """Return True after the local load-back event is complete."""
+        """Return True after the local load-back event is complete.
+
+        This is a pure per-rank GPU-event poll and must NOT issue any TP
+        collective. It is called per-request from the decode load-back path,
+        and both the number of calls and the result of the local
+        ``finish_event.query()`` differ across TP ranks. Previously this
+        conditionally called ``loading_check()`` (which runs an ``all_reduce``)
+        only on the subset of ranks whose local event had already fired, so the
+        TP collective sequence diverged and the ``all_reduce`` could deadlock
+        under TP > 1.
+
+        The ack-reaping collective is already issued exactly once per scheduler
+        iteration at a rank-invariant point (``check_hicache_events`` ->
+        ``loading_check``), so dropping it here is safe: load-back acks are still
+        reaped in lockstep, and this function only reports local readiness for
+        per-request scheduling.
+        """
         if consumer_index < 0:
             return True
 
         finish_event = self.cache_controller.layer_done_counter.events[
             consumer_index
         ].finish_event
-        if not finish_event.query():
-            return False
-
-        self.loading_check()
-        return True
+        return finish_event.query()
 
     def evictable_size(self):
         return self.evictable_size_


### PR DESCRIPTION
## Scope
Defensive correctness fix for a latent TP-collective desynchronization in the
**decode-side hierarchical cache** path. It only affects deployments that run
decode with `--enable-hierarchical-cache` under **TP > 1** (where
`decode_hicache_mixin` calls `is_load_back_event_done`). Configs that do not
enable decode-side hierarchical cache never reach this code path, so this is a
no-op for them.

## Problem
`HiRadixCache.is_load_back_event_done()` conditionally calls `loading_check()`
— which issues a TP `all_reduce` — only on ranks whose local load-back
`finish_event` has already fired:

```python
if not finish_event.query():
    return False
self.loading_check()   # TP all_reduce, runs on a per-rank-divergent subset
return True
```

This helper is invoked **per request** from the decode load-back path
(`disaggregation/decode_hicache_mixin.py`), so both the number of calls and the
local `finish_event.query()` result differ across TP ranks. The conditional
collective therefore desynchronizes the TP `all_reduce` sequence and can
**deadlock under TP > 1** (manifesting as a few requests stuck forever with
`errors=0` and idle GPUs during high-concurrency decode-side HiCache load-back).

## Fix
Make `is_load_back_event_done()` a pure per-rank GPU-event poll
(`return finish_event.query()`) and drop the collective. The load ack-reaping
collective is already issued exactly once per scheduler iteration at a
rank-invariant point (`check_hicache_events` -> `loading_check`), so acks are
still reaped in lockstep; this helper only needs to report local readiness for
per-request scheduling. This mirrors the existing rank-invariant handling in
`writing_check()`.

## Notes / test status
- `python -m py_compile` passes.
- This is a reasoned correctness hardening: it removes a per-rank-conditional TP
  collective, which is unsafe by construction. It has **not** been independently
  bisected against a live decode-hierarchical-cache TP>1 deadlock repro (our
  observed high-concurrency warmup hang was a separate router/PD-dispatch issue),
  so review of the lockstep-reaping argument above is appreciated.
- [ ] CI