### PR TITLE
[Benchmark] Filter fused MoE Triton tuning configs by estimated shared memory

### DIFF
--- a/benchmark/kernels/fused_moe_triton/common_utils.py
+++ b/benchmark/kernels/fused_moe_triton/common_utils.py
@@ -1,14 +1,14 @@
 import json
-from types import SimpleNamespace
-from typing import Dict, List, TypedDict
+from typing import Dict, List, Optional, Tuple, TypedDict
 
 import torch
+from search_space import filter_configs_by_smem
 
 from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import get_config_dtype_str
 from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_config import (
     get_config_file_name,
 )
-from sglang.srt.utils import is_gfx95_supported, is_hip
+from sglang.srt.utils import is_hip
 from sglang.srt.utils.hf_transformers_utils import get_config
 
 
@@ -60,13 +60,7 @@ def get_model_config(
         assert len(block_shape) == 2
     # Replace config with text_config for encoder-decoder models after getting block_shape and architecture
     if hasattr(config, "text_config"):
-        text_config = config.get_text_config()
-        # Some models (e.g. MiniMax-M3) carry text_config as a plain dict; wrap
-        # it so downstream attribute access works uniformly.
-        if isinstance(text_config, dict):
-            config = SimpleNamespace(**text_config)
-        else:
-            config = text_config
+        config = config.get_text_config()
 
     hidden_size = config.hidden_size
     if architecture == "DbrxForCausalLM":
@@ -155,17 +149,6 @@ def get_model_config(
         E = config.num_experts // ep_size
         topk = config.num_experts_per_tok
         intermediate_size = config.moe_intermediate_size
-    elif architecture == "MiniMaxM3SparseForConditionalGeneration":
-        # Serving fuses the shared expert into the routed-expert tensor by
-        # default (E = num_local_experts + 1), so tune for that shape unless
-        # fusion is explicitly disabled.
-        E = config.num_local_experts // ep_size + (
-            0 if disable_shared_experts_fusion else 1
-        )
-        topk = config.num_experts_per_tok + (
-            0 if disable_shared_experts_fusion or topk_ids_dir is None else 1
-        )
-        intermediate_size = config.intermediate_size
     else:
         # Default: Mixtral
         E = config.num_local_experts // ep_size
@@ -176,25 +159,12 @@ def get_model_config(
         intermediate_size, tp_size, ep_size
     )
 
-    # gfx942 (MI300X) remaps MXFP8 [1,32]->[128,128] at load; tune must match.
-    # sm100/gfx95 run native [1,32] and must not remap (mirrors fp8.py).
-    if (
-        architecture == "MiniMaxM3SparseForConditionalGeneration"
-        and is_hip()
-        and not is_gfx95_supported()
-        and block_shape == [1, 32]
-    ):
-        block_shape = [128, 128]
-
-    # text_config may not carry torch_dtype; fall back to bf16.
-    torch_dtype = getattr(config, "torch_dtype", None) or torch.bfloat16
-
     return {
         "num_experts": E,
         "topk": topk,
         "hidden_size": hidden_size,
         "shard_intermediate_size": shard_intermediate_size,
-        "dtype": torch_dtype,
+        "dtype": config.torch_dtype,
         "block_shape": block_shape,
         "architecture": architecture,
     }
@@ -245,6 +215,68 @@ def get_configs_compute_bound() -> List[Dict[str, int]]:
                                     }
                                 )
     return configs
+
+
+def get_device_shared_memory_per_block() -> Optional[int]:
+    try:
+        device_module = torch.get_device_module()
+        if not device_module.is_available():
+            return None
+        props = device_module.get_device_properties(device_module.current_device())
+    except (AttributeError, AssertionError, RuntimeError):
+        return None
+    return getattr(props, "shared_memory_per_block_optin", None) or getattr(
+        props, "shared_memory_per_block", None
+    )
+
+
+def get_moe_tuning_operand_bytes(
+    dtype: torch.dtype,
+    use_fp8_w8a8: bool,
+    use_int8_w8a8: bool,
+    use_int8_w8a16: bool,
+    use_int4_w4a16: bool,
+) -> Optional[Tuple[int, int]]:
+    if use_int4_w4a16:
+        return None
+    if use_int8_w8a16:
+        return 2, 1
+    if use_fp8_w8a8 or use_int8_w8a8:
+        return 1, 1
+    dtype_bytes = torch.empty((), dtype=dtype).element_size()
+    return dtype_bytes, dtype_bytes
+
+
+def filter_configs_by_shared_memory(
+    configs: List[BenchmarkConfig],
+    dtype: torch.dtype,
+    use_fp8_w8a8: bool,
+    use_int8_w8a8: bool,
+    use_int8_w8a16: bool,
+    use_int4_w4a16: bool,
+) -> List[BenchmarkConfig]:
+    if is_hip():
+        return configs
+
+    operand_bytes = get_moe_tuning_operand_bytes(
+        dtype,
+        use_fp8_w8a8,
+        use_int8_w8a8,
+        use_int8_w8a16,
+        use_int4_w4a16,
+    )
+    smem_limit = get_device_shared_memory_per_block()
+    if operand_bytes is None or smem_limit is None:
+        return configs
+
+    filtered_configs = filter_configs_by_smem(configs, smem_limit, *operand_bytes)
+    num_removed = len(configs) - len(filtered_configs)
+    if num_removed > 0:
+        print(
+            f"Filtered {num_removed}/{len(configs)} configurations whose estimated "
+            f"shared memory exceeds {smem_limit} bytes."
+        )
+    return filtered_configs
 
 
 def sort_config(config: BenchmarkConfig) -> BenchmarkConfig:

--- a/benchmark/kernels/fused_moe_triton/common_utils.py
+++ b/benchmark/kernels/fused_moe_triton/common_utils.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from typing import Dict, List, Optional, Tuple, TypedDict
 
 import torch
@@ -8,7 +9,7 @@ from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import get_config_d
 from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_config import (
     get_config_file_name,
 )
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import is_gfx95_supported, is_hip
 from sglang.srt.utils.hf_transformers_utils import get_config
 
 
@@ -60,7 +61,13 @@ def get_model_config(
         assert len(block_shape) == 2
     # Replace config with text_config for encoder-decoder models after getting block_shape and architecture
     if hasattr(config, "text_config"):
-        config = config.get_text_config()
+        text_config = config.get_text_config()
+        # Some models (e.g. MiniMax-M3) carry text_config as a plain dict; wrap
+        # it so downstream attribute access works uniformly.
+        if isinstance(text_config, dict):
+            config = SimpleNamespace(**text_config)
+        else:
+            config = text_config
 
     hidden_size = config.hidden_size
     if architecture == "DbrxForCausalLM":
@@ -149,6 +156,17 @@ def get_model_config(
         E = config.num_experts // ep_size
         topk = config.num_experts_per_tok
         intermediate_size = config.moe_intermediate_size
+    elif architecture == "MiniMaxM3SparseForConditionalGeneration":
+        # Serving fuses the shared expert into the routed-expert tensor by
+        # default (E = num_local_experts + 1), so tune for that shape unless
+        # fusion is explicitly disabled.
+        E = config.num_local_experts // ep_size + (
+            0 if disable_shared_experts_fusion else 1
+        )
+        topk = config.num_experts_per_tok + (
+            0 if disable_shared_experts_fusion or topk_ids_dir is None else 1
+        )
+        intermediate_size = config.intermediate_size
     else:
         # Default: Mixtral
         E = config.num_local_experts // ep_size
@@ -159,12 +177,25 @@ def get_model_config(
         intermediate_size, tp_size, ep_size
     )
 
+    # gfx942 (MI300X) remaps MXFP8 [1,32]->[128,128] at load; tune must match.
+    # sm100/gfx95 run native [1,32] and must not remap (mirrors fp8.py).
+    if (
+        architecture == "MiniMaxM3SparseForConditionalGeneration"
+        and is_hip()
+        and not is_gfx95_supported()
+        and block_shape == [1, 32]
+    ):
+        block_shape = [128, 128]
+
+    # text_config may not carry torch_dtype; fall back to bf16.
+    torch_dtype = getattr(config, "torch_dtype", None) or torch.bfloat16
+
     return {
         "num_experts": E,
         "topk": topk,
         "hidden_size": hidden_size,
         "shard_intermediate_size": shard_intermediate_size,
-        "dtype": config.torch_dtype,
+        "dtype": torch_dtype,
         "block_shape": block_shape,
         "architecture": architecture,
     }

--- a/benchmark/kernels/fused_moe_triton/search_space.py
+++ b/benchmark/kernels/fused_moe_triton/search_space.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+
+BenchmarkConfig = Dict[str, int]
+
+
+def estimate_matmul_smem_bytes(
+    config: BenchmarkConfig,
+    a_dtype_bytes: int,
+    b_dtype_bytes: Optional[int] = None,
+) -> int:
+    """Estimate staged shared memory for the fused MoE matmul tile."""
+    if b_dtype_bytes is None:
+        b_dtype_bytes = a_dtype_bytes
+
+    block_m = config["BLOCK_SIZE_M"]
+    block_n = config["BLOCK_SIZE_N"]
+    block_k = config["BLOCK_SIZE_K"]
+    num_stages = config["num_stages"]
+    return (
+        block_m * block_k * a_dtype_bytes + block_k * block_n * b_dtype_bytes
+    ) * num_stages
+
+
+def is_config_within_smem_limit(
+    config: BenchmarkConfig,
+    smem_limit_bytes: int,
+    a_dtype_bytes: int,
+    b_dtype_bytes: Optional[int] = None,
+) -> bool:
+    return (
+        estimate_matmul_smem_bytes(config, a_dtype_bytes, b_dtype_bytes)
+        <= smem_limit_bytes
+    )
+
+
+def filter_configs_by_smem(
+    configs: List[BenchmarkConfig],
+    smem_limit_bytes: Optional[int],
+    a_dtype_bytes: int,
+    b_dtype_bytes: Optional[int] = None,
+) -> List[BenchmarkConfig]:
+    if smem_limit_bytes is None:
+        return configs
+    return [
+        config
+        for config in configs
+        if is_config_within_smem_limit(
+            config,
+            smem_limit_bytes,
+            a_dtype_bytes,
+            b_dtype_bytes,
+        )
+    ]

--- a/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py
+++ b/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py
@@ -249,8 +249,10 @@ class BenchmarkWorker:
         torch.get_device_module().manual_seed_all(0)
         self.seed = seed
         # Get the device ID to allocate tensors and kernels
-        # on the respective GPU.
-        self.device_id = int(ray.get_gpu_ids()[0])
+        # on the respective GPU. Ray isolates each worker to a single visible
+        # GPU via CUDA_VISIBLE_DEVICES, so the local ordinal is always 0. On
+        # ROCm using the global ray gpu id here raises "invalid device ordinal".
+        self.device_id = 0 if is_hip() else int(ray.get_gpu_ids()[0])
         set_global_server_args_for_scheduler(server_args)
 
     def benchmark(
@@ -420,7 +422,7 @@ def main(args: argparse.Namespace):
     if args.tune:
         search_space = get_configs_compute_bound()
         if block_shape is not None:
-            block_k = block_shape[1]
+            block_n, block_k = block_shape[0], block_shape[1]
             search_space = [
                 config
                 for config in search_space

--- a/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py
+++ b/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py
@@ -12,6 +12,7 @@ import torch
 import triton
 from common_utils import (
     BenchmarkConfig,
+    filter_configs_by_shared_memory,
     get_config_filename,
     get_configs_compute_bound,
     get_default_batch_sizes,
@@ -248,10 +249,8 @@ class BenchmarkWorker:
         torch.get_device_module().manual_seed_all(0)
         self.seed = seed
         # Get the device ID to allocate tensors and kernels
-        # on the respective GPU. Ray isolates each worker to a single visible
-        # GPU via CUDA_VISIBLE_DEVICES, so the local ordinal is always 0. On
-        # ROCm using the global ray gpu id here raises "invalid device ordinal".
-        self.device_id = 0 if is_hip() else int(ray.get_gpu_ids()[0])
+        # on the respective GPU.
+        self.device_id = int(ray.get_gpu_ids()[0])
         set_global_server_args_for_scheduler(server_args)
 
     def benchmark(
@@ -421,12 +420,20 @@ def main(args: argparse.Namespace):
     if args.tune:
         search_space = get_configs_compute_bound()
         if block_shape is not None:
-            block_n, block_k = block_shape[0], block_shape[1]
+            block_k = block_shape[1]
             search_space = [
                 config
                 for config in search_space
                 if block_k % config["BLOCK_SIZE_K"] == 0
             ]
+        search_space = filter_configs_by_shared_memory(
+            search_space,
+            dtype,
+            use_fp8_w8a8,
+            use_int8_w8a8,
+            use_int8_w8a16,
+            use_int4_w4a16,
+        )
 
         filename = get_config_filename(
             E,

--- a/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton_sep.py
+++ b/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton_sep.py
@@ -16,6 +16,7 @@ import triton
 import triton.language as tl
 from common_utils import (
     BenchmarkConfig,
+    filter_configs_by_shared_memory,
     get_config_filename,
     get_configs_compute_bound,
     get_default_batch_sizes,
@@ -783,10 +784,18 @@ def main(args: argparse.Namespace):
 
     search_space = get_configs_compute_bound()
     if block_shape is not None:
-        block_n, block_k = block_shape[0], block_shape[1]
+        block_k = block_shape[1]
         search_space = [
             config for config in search_space if block_k % config["BLOCK_SIZE_K"] == 0
         ]
+    search_space = filter_configs_by_shared_memory(
+        search_space,
+        dtype,
+        use_fp8_w8a8,
+        use_int8_w8a8,
+        use_int8_w8a16,
+        use_int4_w4a16,
+    )
     filename = get_config_filename(
         E,
         shard_intermediate_size,

--- a/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton_sep.py
+++ b/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton_sep.py
@@ -784,7 +784,7 @@ def main(args: argparse.Namespace):
 
     search_space = get_configs_compute_bound()
     if block_shape is not None:
-        block_k = block_shape[1]
+        block_n, block_k = block_shape[0], block_shape[1]
         search_space = [
             config for config in search_space if block_k % config["BLOCK_SIZE_K"] == 0
         ]

--- a/test/registered/unit/test_fused_moe_tuning_search_space.py
+++ b/test/registered/unit/test_fused_moe_tuning_search_space.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def load_module(module_name: str, module_path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ci_register = load_module(
+    "ci_register",
+    REPO_ROOT / "python" / "sglang" / "test" / "ci" / "ci_register.py",
+)
+register_cpu_ci = ci_register.register_cpu_ci
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+search_space = load_module(
+    "fused_moe_tuning_search_space",
+    REPO_ROOT / "benchmark" / "kernels" / "fused_moe_triton" / "search_space.py",
+)
+
+
+def test_estimate_matmul_smem_bytes() -> None:
+    config = {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5,
+    }
+
+    assert search_space.estimate_matmul_smem_bytes(config, 2) == 1310720
+
+
+def test_estimate_matmul_smem_bytes_supports_asymmetric_operand_dtypes() -> None:
+    config = {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+    }
+
+    assert search_space.estimate_matmul_smem_bytes(config, 2, 1) == 196608
+
+
+def test_filter_configs_by_smem_keeps_boundary_config() -> None:
+    config = {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+    }
+    smem_bytes = search_space.estimate_matmul_smem_bytes(config, 2)
+
+    assert search_space.filter_configs_by_smem([config], smem_bytes, 2) == [config]
+    assert search_space.filter_configs_by_smem([config], smem_bytes - 1, 2) == []
+
+
+def test_filter_configs_by_smem_reduces_default_cuda_search_space() -> None:
+    configs = [
+        {
+            "BLOCK_SIZE_M": block_m,
+            "BLOCK_SIZE_N": block_n,
+            "BLOCK_SIZE_K": block_k,
+            "GROUP_SIZE_M": group_size,
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+        }
+        for num_stages in [2, 3, 4, 5]
+        for block_m in [16, 32, 64, 128, 256]
+        for block_k in [64, 128, 256]
+        for block_n in [32, 64, 128, 256]
+        for num_warps in [4, 8]
+        for group_size in [1, 16, 32, 64]
+    ]
+
+    filtered = search_space.filter_configs_by_smem(configs, 164 * 1024, 2)
+
+    assert len(configs) == 1920
+    assert len(filtered) == 1040


### PR DESCRIPTION
## Motivation

The fused MoE Triton tuner currently attempts all generated configurations and relies on `OutOfResources` or `RuntimeError` to reject configurations that exceed the device shared-memory limit. This wastes compilation and benchmarking time.

This PR adds a lightweight prefilter before tuning.

## Modifications

- Estimate staged shared memory from `BLOCK_SIZE_M/N/K`, operand sizes, and `num_stages`.
- Read the current device's opt-in shared-memory limit.
- Support FP16/BF16, FP8 W8A8, INT8 W8A8, and INT8 W8A16 operand sizes.
- Conservatively skip filtering for INT4 and ROCm.
- Apply the filter to both fused MoE tuning entry points.
- Add CPU-only unit tests for estimation and filtering.

## Accuracy Tests

Not applicable. This only changes the tuning search space and does not modify kernel execution or model outputs.

The baseline-selected H100 configuration remained in the filtered search space. Independent tuning runs selected different winners, so config identity is not claimed.

## Speed Tests and Profiling

Test setup:

- GPU: NVIDIA H100 80GB HBM3
- Model config: Mixtral-8x7B-Instruct-v0.1
- TP=2, EP=1, dtype=auto, batch size=1
- Separate Triton cache directories for both runs

Results:

| Mode | Configurations | Wall time |
| --- | ---: | ---: |
| Baseline | 1920 | 2643.90 s |
| SMEM prefilter | 1248 | 1384.28 s |

The prefilter removed 672/1920 configurations (35%), reduced wall-clock tuning time by 47.6%, and provided a 1.91x speedup.

On A100-SXM4-80GB, it removes 880/1920 configurations (45.83%) based on the device shared-memory limit.

## Tests

```bash
python -m pytest -q test/registered/unit/test_fused_moe_tuning_search_space.py































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28279250433](https://github.com/sgl-project/sglang/actions/runs/28279250433)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28279250388](https://github.com/sgl-project/sglang/actions/runs/28279250388)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->