### PR TITLE
[BUGFIX] Fix FlashInfer allreduce fusion auto backend on single-node sm_103

### DIFF
--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -44,6 +44,16 @@ def _mnnvl_supported(is_multi_node: bool) -> bool:
     return is_sm90_supported() and not is_multi_node
 
 
+def _is_blackwell_ultra() -> bool:
+    """B300 / GB300 (sm_103). FlashInfer's mnnvl fused allreduce+RMSNorm
+    kernel hits an illegal memory access on single-node sm_103, so `auto`
+    must resolve to trtllm there instead of mnnvl."""
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major == 10 and minor == 3
+
+
 def _resolve_backend(backend: str, is_multi_node: bool = False) -> str:
     """Resolve the requested FlashInfer allreduce fusion backend."""
     if not (is_sm90_supported() or is_sm100_supported()):
@@ -60,6 +70,10 @@ def _resolve_backend(backend: str, is_multi_node: bool = False) -> str:
                 "non-Blackwell systems."
             )
         if is_sm100_supported():
+            # mnnvl's fused kernel IMAs on single-node sm_103 (B300); trtllm is
+            # stable there, so prefer it for Blackwell Ultra single-node.
+            if _is_blackwell_ultra():
+                return "trtllm"
             return "mnnvl"
         return "trtllm"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

On single-node B300 / GB300 systems, GLM-5.1-NVFP4 can crash with a CUDA illegal memory access when running with tensor parallelism and EAGLE speculative decoding.

The crash happens in the FlashInfer allreduce fusion path:

```text
  File "/workspace/wyh/workspace/sglang/python/sglang/srt/layers/layernorm.py", line 559, in forward_with_allreduce_fusion
    return _forward_with_allreduce_fusion(
  File "/workspace/wyh/workspace/sglang/python/sglang/srt/layers/layernorm.py", line 184, in _forward_with_allreduce_fusion
    fused_result = flashinfer_allreduce_residual_rmsnorm(
  File "/workspace/wyh/workspace/sglang/python/sglang/srt/layers/flashinfer_comm_fusion.py", line 816, in flashinfer_allreduce_residual_rmsnorm
    _flashinfer_comm.allreduce_fusion(**kwargs)
  File "/usr/local/lib/python3.12/dist-packages/flashinfer/comm/allreduce.py", line 909, in allreduce_fusion
    norm_result, residual_result = trtllm_mnnvl_fused_allreduce_add_rmsnorm(
  File "/usr/local/lib/python3.12/dist-packages/flashinfer/comm/trtllm_mnnvl_ar.py", line 501, in trtllm_mnnvl_fused_allreduce_add_rmsnorm
    module.trtllm_mnnvl_allreduce_fusion(
  File "/usr/local/lib/python3.12/dist-packages/flashinfer/data/csrc/trtllm_mnnvl_allreduce.cu", line 111, in trtllm_mnnvl_allreduce_fusion
    TVM_FFI_ICHECK(status == cudaSuccess)

tvm.error.InternalError: Check failed: (status == cudaSuccess) is false: trtllm_mnnvl_allreduce_fusion failed with error code an illegal memory access was encountered
````

For DeepSeek/GLM MoE models on Blackwell, SGLang enables FlashInfer allreduce fusion with:

```text
--flashinfer-allreduce-fusion-backend=auto
```

Currently, `_resolve_backend("auto")` maps single-node Blackwell GPUs to the `mnnvl` backend through `is_sm100_supported()`. This also includes sm_103, which corresponds to B300 / GB300.

However, on single-node sm_103, the FlashInfer `trtllm_mnnvl_fused_allreduce_add_rmsnorm` path appears unstable and can trigger the illegal memory access above.

The workaround is to explicitly use:

```text
--flashinfer-allreduce-fusion-backend trtllm
```

This workaround has been verified on B300 with GLM-5.1-NVFP4, TP=4, and EAGLE speculative decoding.

This PR makes the `auto` backend selection choose `trtllm` for single-node sm_103, so users do not need to pass the manual workaround flag.

Behavior on single-node sm_100 and multi-node Blackwell remains unchanged.

## Modifications

* Add an `_is_blackwell_ultra()` helper to detect sm_103:

```python
major == 10 and minor == 3
```

* Update `_resolve_backend()` so that when `backend == "auto"`:

  * single-node sm_103 resolves to `trtllm`
  * single-node sm_100 continues to resolve to `mnnvl`
  * multi-node Blackwell behavior remains unchanged

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28280026381](https://github.com/sgl-project/sglang/actions/runs/28280026381)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28280026323](https://github.com/sgl-project/sglang/actions/runs/28280026323)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->