### PR TITLE
[Cookbook] GLM-5.2: tune GB300 NVFP4 recipes + fill benchmarks

### DIFF
--- a/docs_new/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
@@ -177,11 +177,11 @@ export const benchmarks = [
   // ---- GB300 + NVFP4 ----  (4-GPU single node, TP4; nvidia/GLM-5.2-NVFP4 via --quantization modelopt_fp4,
   // measured on the lmsysorg/sglang:dev-glm52-nvfp4 preview image, flush-cache every run.
   // tokens_per_sec_per_gpu = total server output tok/s / 4 GPUs (337→84, 1248→312, 1162→291, 1695→424, 1730→433).
-  // aime25 overrides the variant default (87.7 → 91.04, measured on this NVFP4 build); gsm8k inherits the default.)
+  // aime25 overrides the variant default (87.7 → 89.58, measured on this NVFP4 build); gsm8k inherits the default.)
   {
     match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
     sglang_version: "dev-glm52-nvfp4",
-    accuracy: { aime25_pct: 91.04 },
+    accuracy: { aime25_pct: 89.58 },
     speed: [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
         ttft_ms: 238, tpot_ms: 2.23, tokens_per_sec_per_gpu: 84 },
@@ -192,7 +192,7 @@ export const benchmarks = [
   {
     match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "balanced", nodes: "single" },
     sglang_version: "dev-glm52-nvfp4",
-    accuracy: { aime25_pct: 91.04 },
+    accuracy: { aime25_pct: 89.58 },
     speed: [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
         ttft_ms: 1169, tpot_ms: 58, tokens_per_sec_per_gpu: 291 },
@@ -203,7 +203,7 @@ export const benchmarks = [
   {
     match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "high-throughput", nodes: "single" },
     sglang_version: "dev-glm52-nvfp4",
-    accuracy: { aime25_pct: 91.04 },
+    accuracy: { aime25_pct: 89.58 },
     speed: [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1024 },
         ttft_ms: 156000, tpot_ms: 321, tokens_per_sec_per_gpu: 433 },

--- a/docs_new/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
@@ -171,7 +171,7 @@ export const benchmarks = [
   { match: { hw: "gb300", variant: "default", quant: "bf16", strategy: "low-latency",     nodes: "multi-2" } },
   { match: { hw: "gb300", variant: "default", quant: "bf16", strategy: "balanced",        nodes: "multi-2" } },
   { match: { hw: "gb300", variant: "default", quant: "bf16", strategy: "high-throughput", nodes: "multi-2" } },
-  // ---- NVFP4 (Blackwell Ultra) ----  B300 pending; GB300 measured below.
+  // ---- NVFP4 (Blackwell Ultra) ----
   { match: { hw: "b300",  variant: "default", quant: "nvfp4", strategy: "low-latency", nodes: "single" } },
   { match: { hw: "b300",  variant: "default", quant: "nvfp4", strategy: "balanced",    nodes: "single" } },
   // ---- GB300 + NVFP4 ----  (4-GPU single node, TP4; nvidia/GLM-5.2-NVFP4 via --quantization modelopt_fp4,

--- a/docs_new/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
@@ -171,9 +171,42 @@ export const benchmarks = [
   { match: { hw: "gb300", variant: "default", quant: "bf16", strategy: "low-latency",     nodes: "multi-2" } },
   { match: { hw: "gb300", variant: "default", quant: "bf16", strategy: "balanced",        nodes: "multi-2" } },
   { match: { hw: "gb300", variant: "default", quant: "bf16", strategy: "high-throughput", nodes: "multi-2" } },
-  // ---- NVFP4 (Blackwell Ultra) ----  benchmarks pending
+  // ---- NVFP4 (Blackwell Ultra) ----  B300 pending; GB300 measured below.
   { match: { hw: "b300",  variant: "default", quant: "nvfp4", strategy: "low-latency", nodes: "single" } },
   { match: { hw: "b300",  variant: "default", quant: "nvfp4", strategy: "balanced",    nodes: "single" } },
-  { match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "low-latency", nodes: "single" } },
-  { match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "balanced",    nodes: "single" } },
+  // ---- GB300 + NVFP4 ----  (4-GPU single node, TP4; nvidia/GLM-5.2-NVFP4 via --quantization modelopt_fp4,
+  // measured on the lmsysorg/sglang:dev-glm52-nvfp4 preview image, flush-cache every run.
+  // tokens_per_sec_per_gpu = total server output tok/s / 4 GPUs (337→84, 1248→312, 1162→291, 1695→424, 1730→433).
+  // aime25 overrides the variant default (87.7 → 91.04, measured on this NVFP4 build); gsm8k inherits the default.)
+  {
+    match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+    sglang_version: "dev-glm52-nvfp4",
+    accuracy: { aime25_pct: 91.04 },
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 238, tpot_ms: 2.23, tokens_per_sec_per_gpu: 84 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 315, tpot_ms: 11.9, tokens_per_sec_per_gpu: 312 },
+    ],
+  },
+  {
+    match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "balanced", nodes: "single" },
+    sglang_version: "dev-glm52-nvfp4",
+    accuracy: { aime25_pct: 91.04 },
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
+        ttft_ms: 1169, tpot_ms: 58, tokens_per_sec_per_gpu: 291 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256 },
+        ttft_ms: 6389, tpot_ms: 167, tokens_per_sec_per_gpu: 424 },
+    ],
+  },
+  {
+    match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "high-throughput", nodes: "single" },
+    sglang_version: "dev-glm52-nvfp4",
+    accuracy: { aime25_pct: 91.04 },
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1024 },
+        ttft_ms: 156000, tpot_ms: 321, tokens_per_sec_per_gpu: 433 },
+    ],
+  },
 ];

--- a/docs_new/src/snippets/configs/zai-org/glm-5.2.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.2.jsx
@@ -635,16 +635,16 @@ sgl-eval run aime25 \\
     },
 
     // ====================================================================
-    // NVFP4 (Blackwell Ultra) — nvidia/GLM-5.2-NVFP4 (Model Optimizer).
-    // TP4 on B300 / GB300, low-latency + balanced. GB300 mirrors the B300
-    // recipe (same TP4 / flags; the 4-GPU GB300 node fits the ~381 GB build).
+    // NVFP4 (Blackwell Ultra) — nvidia/GLM-5.2-NVFP4 (Model Optimizer). TP4.
+    // B300: low-latency + balanced (the 4-GPU GB300 node fits the ~381 GB build).
+    // GB300: low-latency / balanced / high-throughput measured on a single 4xGB300
+    // node — balanced & high-throughput add DP-Attention (dp4); low-latency uses MTP 5-1-6.
     // ====================================================================
     {
       match: { hw: "b300", variant: "default", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
       verified: true,
       env: [],
       flags: [
-        "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
         "--tp 4",
         "--quantization modelopt_fp4",
@@ -663,7 +663,6 @@ sgl-eval run aime25 \\
       verified: true,
       env: [],
       flags: [
-        "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
         "--tp 4",
         "--quantization modelopt_fp4",
@@ -678,7 +677,6 @@ sgl-eval run aime25 \\
       verified: true,
       env: [],
       flags: [
-        "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
         "--tp 4",
         "--quantization modelopt_fp4",
@@ -687,7 +685,7 @@ sgl-eval run aime25 \\
         "--speculative-eagle-topk 1",
         "--speculative-num-draft-tokens 6",
         "--chunked-prefill-size 8192",
-        "--mem-fraction-static 0.8",
+        "--mem-fraction-static 0.85",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",
       ],
@@ -697,12 +695,37 @@ sgl-eval run aime25 \\
       verified: true,
       env: [],
       flags: [
-        "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
         "--tp 4",
         "--quantization modelopt_fp4",
+        "--dp 4",
+        "--enable-dp-attention",
+        // Shorter draft (MTP 2-1-3) than low-latency's 5-1-6: at this concurrency the
+        // verify overhead of a long draft outweighs the accept-length gain.
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 2",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 3",
         "--chunked-prefill-size 8192",
-        "--mem-fraction-static 0.8",
+        "--mem-fraction-static 0.92",
+        "--max-running-requests 256",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "high-throughput", nodes: "single" },
+      verified: true,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--tp 4",
+        "--quantization modelopt_fp4",
+        "--dp 4",
+        "--enable-dp-attention",
+        "--chunked-prefill-size 8192",
+        "--mem-fraction-static 0.92",
+        "--max-running-requests 512",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",
       ],


### PR DESCRIPTION
## What

Builds on the GB300 NVFP4 scaffolding already in `main` (#29380 + #29466) with the **newly-measured single-node 4×GB300 (TP4)** recipes and benchmark numbers for [`nvidia/GLM-5.2-NVFP4`](https://huggingface.co/nvidia/GLM-5.2-NVFP4), plus a small `--trust-remote-code` cleanup across the NVFP4 cells.

### Recipes (`glm-5.2.jsx`) — GB300 NVFP4
| Strategy | Before (main) | After |
|---|---|---|
| Low-Latency | mem-frac **0.8** | mem-frac **0.85** (MTP 5-1-6 unchanged) |
| Balanced | bare TP4 | **+ DP-Attention (dp4) + MTP 2-1-3 + max-running 256 + mem-frac 0.92** |
| High-Throughput | *(absent)* | **new** — DP-Attention (dp4), greedy, max-running 512, mem-frac 0.92 |

Also **drop `--trust-remote-code` from every NVFP4 cell (B300 + GB300)** — GLM-5.2 (`glm_moe_dsa`) is built into sglang and the FP8 / BF16 cells never used it, so the NVFP4 cells now match. `--quantization modelopt_fp4` stays right after `--tp`.

### Benchmarks (`glm-5.2-benchmarks.jsx`) — GB300 NVFP4
Fills the previously-pending stubs for all three strategies (ISL/OSL 8192/1024; the card's per-GPU column = total server output tok/s ÷ 4 GPUs):

| Strategy | concurrency | output tok/s (total) | TPOT | TTFT |
|---|---|---|---|---|
| Low-Latency | 1 | 337 | 2.23 ms | 238 ms |
| Low-Latency | 16 | 1248 | 11.9 ms | 315 ms |
| Balanced | 64 | 1162 | 58 ms | 1169 ms |
| Balanced | 256 | 1695 | 167 ms | 6389 ms |
| High-Throughput | 1024 | 1730 | 321 ms | 156 s |

- **AIME25 = 89.58%** (per-cell override of the variant default; on par with FP8's 87.7% within AIME25 run-to-run variance).

## Notes
- Measured on the `lmsysorg/sglang:dev-glm52-nvfp4` preview image — already wired as the per-quant Docker image for `b300|nvfp4` / `gb300|nvfp4` in `main`.
- B300 NVFP4 is touched only by the `--trust-remote-code` removal; its recipes/benchmarks are otherwise unchanged. FP8 / BF16 and the MDX page are untouched (the NVFP4 prose landed in #29380).

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28283086079](https://github.com/sgl-project/sglang/actions/runs/28283086079)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28283086032](https://github.com/sgl-project/sglang/actions/runs/28283086032)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->