### PR TITLE
[MLX] Minimal Apple Silicon server startup for hybrid GDN models

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/auxiliary_state.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/auxiliary_state.py
@@ -108,6 +108,24 @@ class MlxAuxiliaryStatePool:
     def available_size(self) -> int:
         return int(self.free_slots.numel())
 
+    def alloc_group_begin(self, num_reqs: int):
+        """Mirror CUDA MambaSlotAllocator group pre-allocation. MLX doesn't
+        amortize match-prefix slot lookup, so just allocate a contiguous
+        block and remember it for alloc_group_end rollback."""
+        self._alloc_iter = None
+        if num_reqs > 0:
+            result = self.alloc(num_reqs)
+            if result is not None:
+                self._alloc_iter = iter(result.split(1))
+
+    def alloc_group_end(self):
+        """Release any unused pre-allocated group slots."""
+        if getattr(self, "_alloc_iter", None) is not None:
+            remaining = list(self._alloc_iter)
+            if remaining:
+                self.free(torch.cat(remaining))
+        self._alloc_iter = None
+
     def alloc(self, need_size: int) -> Optional[torch.Tensor]:
         if need_size > self.available_size():
             return None
@@ -215,6 +233,10 @@ class MlxAuxiliaryStateReqToTokenPool(ReqToTokenPool):
         # Keep the MLX-owned name beside it so local code can avoid model-
         # specific terminology.
         self.auxiliary_state_pool = self.mamba_pool
+        # Some sglang consumers (e.g. pool_stats_observer) reach for
+        # ``req_to_token_pool.mamba_allocator`` directly. Alias to the
+        # MLX pool so both names work.
+        self.mamba_allocator = self.mamba_pool
         self.enable_mamba_extra_buffer = False
         self.req_index_to_auxiliary_state_index_mapping = torch.zeros(
             self._alloc_size, dtype=torch.int32, device=device

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -225,7 +225,7 @@ class MlxTpModelWorker(TpModelWorker):
             )
 
         next_token_ids = torch.tensor(
-            next_token_ids_list, dtype=torch.long, device="cpu"
+            next_token_ids_list, dtype=torch.long, device=self.device
         )
 
         return GenerationBatchResult(
@@ -497,7 +497,7 @@ class MlxTpModelWorker(TpModelWorker):
         else:
             raise ValueError(f"Unknown MLX async mode: {mode}")
 
-        next_token_ids = torch.tensor(next_tokens_list, dtype=torch.long, device="cpu")
+        next_token_ids = torch.tensor(next_tokens_list, dtype=torch.long, device=self.device)
         return GenerationBatchResult(
             logits_output=LogitsProcessorOutput(next_token_logits=None),
             next_token_ids=next_token_ids,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -875,6 +875,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # runs with aux hidden state capture enabled.
         self.init_aux_hidden_state_capture()
 
+        # Apple Silicon MLX backend routes forward through MlxModelRunner and
+        # never touches the CUDA-side attention backends. Skip their init so
+        # the GDNAttnBackend / FlashInfer constructors don't try to dereference
+        # MLX-owned pools that are intentionally left as ``None``.
+        if self.device == "mps":
+            return
+
         if self.device == "cuda" or self.device == "musa":
             self.init_cublas()
             self.init_attention_backend()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4514,6 +4514,12 @@ class ServerArgs:
             return
 
         self.uses_mamba_radix_cache = True
+        # Apple Silicon MLX backend manages mamba state outside the CUDA
+        # extra-buffer FLA path; force the no_buffer strategy so the
+        # downstream CUDA-only assert doesn't fire.
+        if is_mps():
+            self.mamba_radix_cache_strategy = "no_buffer"
+            self.disable_overlap_schedule = True
         if self.mamba_radix_cache_strategy == "auto":
             wants_overlap = not self.disable_overlap_schedule
             wants_paging = self.page_size is not None and self.page_size > 1

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_attention_backend_skip.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_attention_backend_skip.py
@@ -1,0 +1,72 @@
+"""Guard the MPS early-return in ``ModelRunner.init_attention_backends``.
+
+``GDNAttnBackend.__init__`` dereferences
+``model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[0]``
+on hybrid GDN models, but the MLX stub leaves ``mamba_cache = None``
+(MLX stores mamba state in its own runner). The MPS branch must short-
+circuit before any CUDA-style backend constructor runs, so the
+``None.conv`` crash never fires.
+
+The check is a behaviour guard: we patch the constructors that would
+crash and assert they are never called on the MPS path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+_SKIP_REASON = "requires mlx (mlx_lm import path on this branch)"
+
+
+@unittest.skipUnless(_HAS_MLX, _SKIP_REASON)
+class TestMlxAttentionBackendSkip(unittest.TestCase):
+    """``init_attention_backends`` must skip on MPS."""
+
+    def test_mps_runner_does_not_call_init_attention_backend(self):
+        """Stand up a fake ModelRunner with device='mps' and verify the
+        early-return path skips init_attention_backend entirely."""
+        from sglang.srt.model_executor.model_runner import ModelRunner
+
+        # Build a ModelRunner-shaped object without running __init__.
+        # We only need the methods the test exercises.
+        runner = ModelRunner.__new__(ModelRunner)
+        runner.device = "mps"
+
+        init_attention_backend = MagicMock()
+        init_aux_hidden_state_capture = MagicMock()
+        runner.init_attention_backend = init_attention_backend
+        runner.init_aux_hidden_state_capture = init_aux_hidden_state_capture
+
+        # Should return early before any of the platform branches.
+        ModelRunner.init_attention_backends(runner)
+
+        init_aux_hidden_state_capture.assert_called_once_with()
+        init_attention_backend.assert_not_called()
+
+    def test_mps_runner_does_not_instantiate_gdn_backend(self):
+        """If init_attention_backends accidentally reaches the CUDA path
+        on MPS, GDNAttnBackend.__init__ raises AttributeError. We patch
+        the constructor to record the call and assert it never fires."""
+        from sglang.srt.model_executor import model_runner as mr_mod
+
+        runner = mr_mod.ModelRunner.__new__(mr_mod.ModelRunner)
+        runner.device = "mps"
+        runner.init_attention_backend = MagicMock()
+        runner.init_aux_hidden_state_capture = MagicMock()
+
+        with patch(
+            "sglang.srt.layers.attention.attention_registry.attn_backend_wrapper"
+        ) as wrapper:
+            mr_mod.ModelRunner.init_attention_backends(runner)
+            wrapper.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_auxiliary_state_pool.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_auxiliary_state_pool.py
@@ -1,0 +1,115 @@
+"""Guard the MLX auxiliary-state pool's CUDA-style interface parity.
+
+The sglang scheduler reaches into ``req_to_token_pool.mamba_allocator``
+in two places that the MLX path did not originally satisfy:
+
+* ``pool_stats_observer._get_mamba_token_info`` calls
+  ``mamba_allocator.available_size()``.
+* ``scheduler._get_new_batch_prefill_raw`` calls
+  ``mamba_allocator.alloc_group_begin(num_reqs)`` /
+  ``alloc_group_end()`` (CUDA-style match-prefix pre-allocation).
+
+The MLX pool must expose these names and behave the same as the CUDA
+``MambaSlotAllocator`` (release any unused group slots on end).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+_SKIP_REASON = "requires mlx"
+
+
+@unittest.skipUnless(_HAS_MLX, _SKIP_REASON)
+class TestMlxAuxiliaryStatePoolAllocGroup(unittest.TestCase):
+    """``MlxAuxiliaryStatePool.alloc_group_begin/end`` contract."""
+
+    def _make_pool(self, size: int = 16):
+        from sglang.srt.hardware_backend.mlx.kv_cache.auxiliary_state import (
+            MlxAuxiliaryStatePool,
+        )
+
+        return MlxAuxiliaryStatePool(size=size, device="cpu")
+
+    def test_alloc_group_begin_preallocates_and_iter_serves_singles(self):
+        pool = self._make_pool(size=8)
+        before = pool.available_size()
+
+        pool.alloc_group_begin(3)
+        # Group pre-allocation consumes a contiguous block of 3 slots.
+        self.assertEqual(pool.available_size(), before - 3)
+        # _alloc_iter yields single-slot tensors that satisfy the per-req
+        # alloc path used by the scheduler.
+        self.assertIsNotNone(pool._alloc_iter)
+        slot0 = next(pool._alloc_iter)
+        self.assertEqual(slot0.numel(), 1)
+
+    def test_alloc_group_end_releases_unused_slots(self):
+        pool = self._make_pool(size=8)
+        pool.alloc_group_begin(4)
+        # Consume 1 slot, leave 3 in the iterator.
+        next(pool._alloc_iter)
+        mid = pool.available_size()
+
+        pool.alloc_group_end()
+
+        # All four pre-allocated slots should now be free again.
+        self.assertEqual(pool.available_size(), mid + 3)
+        self.assertIsNone(pool._alloc_iter)
+
+    def test_alloc_group_end_is_safe_when_no_group_active(self):
+        pool = self._make_pool(size=4)
+        before = pool.available_size()
+
+        # Calling alloc_group_end without begin must be a no-op.
+        pool.alloc_group_end()
+
+        self.assertEqual(pool.available_size(), before)
+        self.assertIsNone(pool._alloc_iter)
+
+    def test_alloc_group_begin_with_zero_reqs_is_noop(self):
+        pool = self._make_pool(size=4)
+        before = pool.available_size()
+
+        pool.alloc_group_begin(0)
+        pool.alloc_group_end()
+
+        self.assertEqual(pool.available_size(), before)
+
+
+@unittest.skipUnless(_HAS_MLX, _SKIP_REASON)
+class TestMlxReqToTokenPoolMambaAllocatorAlias(unittest.TestCase):
+    """``req_to_token_pool.mamba_allocator`` must point to the MLX pool."""
+
+    def test_mamba_allocator_is_same_object_as_mamba_pool(self):
+        from sglang.srt.hardware_backend.mlx.kv_cache.auxiliary_state import (
+            MlxAuxiliaryStateReqToTokenPool,
+        )
+
+        pool = MlxAuxiliaryStateReqToTokenPool(
+            size=4,
+            max_context_len=16,
+            device="cpu",
+            enable_memory_saver=False,
+            auxiliary_state_size=8,
+        )
+
+        self.assertIs(
+            pool.mamba_allocator,
+            pool.mamba_pool,
+            msg=(
+                "MlxAuxiliaryStateReqToTokenPool.mamba_allocator must alias "
+                "mamba_pool so CUDA-style pool_stats_observer can call "
+                "mamba_allocator.available_size()."
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_server_args_mamba.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_server_args_mamba.py
@@ -1,0 +1,100 @@
+"""Guard the MPS branch in ``ServerArgs._handle_mamba_radix_cache``.
+
+The CUDA-only ``_validate_mamba_extra_buffer`` asserts
+``is_cuda() or is_musa() or is_npu()``. On Apple Silicon (MPS) the
+``auto`` strategy would otherwise resolve to ``extra_buffer`` whenever
+overlap schedule is on, crashing the MLX startup. The MPS branch must
+pin the strategy to ``no_buffer`` and force ``disable_overlap_schedule``
+so the CUDA-only assert never fires.
+
+The checks run on any platform (no MLX import needed): the early-return
+in the new branch inspects ``is_mps()`` at runtime, so we exercise the
+logic by patching ``is_mps`` rather than relying on the host machine.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _build_args() -> ServerArgs:
+    """Build a ServerArgs with a hybrid GDN model arch and auto strategy.
+
+    We can't call ``ServerArgs(...)`` directly because it would try to
+    download ``model_path`` via HuggingFace. Instead we build a bare
+    instance with ``__new__`` and set the fields the mamba branch reads.
+    """
+    args = ServerArgs.__new__(ServerArgs)
+    args.model_path = "/fake/qwen3-6-moe"
+    args.disable_radix_cache = False
+    args.mamba_radix_cache_strategy = "auto"
+    args.disable_overlap_schedule = False
+    args.page_size = 1
+    return args
+
+
+class TestMlxMambaRadixStrategy(unittest.TestCase):
+    """``_handle_mamba_radix_cache`` must route MPS to ``no_buffer``."""
+
+    def test_mps_pins_no_buffer_and_disables_overlap(self):
+        args = _build_args()
+        with patch("sglang.srt.server_args.is_mps", return_value=True):
+            args._handle_mamba_radix_cache(model_arch="Qwen3_5MoeForCausalLM")
+
+        self.assertEqual(
+            args.mamba_radix_cache_strategy,
+            "no_buffer",
+            msg="MPS backend must use no_buffer; extra_buffer is CUDA-only.",
+        )
+        self.assertTrue(
+            args.disable_overlap_schedule,
+            msg=(
+                "MPS backend must disable overlap schedule; otherwise "
+                "the auto path would later re-select extra_buffer."
+            ),
+        )
+
+    def test_non_mps_keeps_auto_resolution(self):
+        args = _build_args()
+        with patch("sglang.srt.server_args.is_mps", return_value=False):
+            args._handle_mamba_radix_cache(model_arch="Qwen3_5MoeForCausalLM")
+
+        # On non-MPS platforms the auto branch resolves the strategy
+        # via wants_overlap/wants_paging. For a model that supports
+        # extra_buffer with overlap enabled, it lands on extra_buffer.
+        self.assertIn(
+            args.mamba_radix_cache_strategy,
+            ("auto", "extra_buffer", "no_buffer", "extra_buffer_lazy"),
+            msg="Non-MPS path must keep the auto/extra_buffer/no_buffer contract.",
+        )
+
+    def test_mps_short_circuits_before_extra_buffer_assert(self):
+        """The CUDA-only assert in _validate_mamba_extra_buffer must not
+        run on MPS even with overlap enabled."""
+        args = _build_args()
+        # The validation helper would raise AssertionError on MPS; mocking
+        # it lets the test assert the call site is never reached.
+        with patch("sglang.srt.server_args.is_mps", return_value=True), patch.object(
+            ServerArgs, "_validate_mamba_extra_buffer"
+        ) as validate_extra:
+            args._handle_mamba_radix_cache(model_arch="Qwen3_5MoeForCausalLM")
+            validate_extra.assert_not_called()
+
+        self.assertNotEqual(
+            args.mamba_radix_cache_strategy,
+            "extra_buffer",
+            msg=(
+                "MPS must not end up on extra_buffer; "
+                "_validate_mamba_extra_buffer asserts CUDA/MUSA/NPU."
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Make SGLANG_USE_MLX=1 python -m sglang.launch_server work for hybrid GDN models (Qwen3.6 MoE, etc.). This PR is intentionally minimal — it just unblocks startup and basic inference through bypassing unused CUDA execution path for MLX backend . Performance, and sglang-native adaptation will be in follow-ups.

Minimal command that now works end-to-end which passed test in my M1Max:
```
SGLANG_USE_MLX=1 python -m sglang.launch_server \
  --model-path /Users/toufupi/models/Qwen3.6-35B-A3B-UD-MLX-4bit \
  --port 43440
```
main crashes very early when loading a hybrid GDN model on Apple Silicon. Five distinct crash points, all on the MLX path:

1. server_args._handle_mamba_radix_cache auto-resolves to extra_buffer, and _validate_mamba_extra_buffer asserts CUDA/MUSA/NPU.
2. model_runner.init_attention_backends instantiates GDNAttnBackend, whose __init__ dereferences req_to_token_pool.mamba_pool.mamba_cache.conv[0].shape — but the MLX pool intentionally leaves mamba_cache = None.
3. pool_stats_observer reads req_to_token_pool.mamba_allocator.available_size() but the MLX pool only exposes mamba_pool.
4. scheduler._get_new_batch_prefill_raw calls mamba_allocator.alloc_group_begin / alloc_group_end, which the MLX pool doesn't implement.
5. MlxTpModelWorker materializes next_token_ids on cpu, while _relay_forward_payload writes it into an mps-backed output_tokens_buf → mps/cpu cross-device assert under concurrency.

## Modifications


File | Δ | What
-- | -- | --
python/sglang/srt/server_args.py | +6 | Pin MPS to no_buffer + disable_overlap_schedule=True
-- | -- | --
python/sglang/srt/model_executor/model_runner.py | +7 | Short-circuit init_attention_backends on MPS
python/sglang/srt/hardware_backend/mlx/kv_cache/auxiliary_state.py | +22 | mamba_allocator alias + alloc_group_begin/end
python/sglang/srt/hardware_backend/mlx/tp_worker.py | +2 / -2 | next_token_ids device: cpu → self.device
test/registered/unit/hardware_backend/mlx/test_mlx_server_args_mamba.py | +100 | MPS branch in _handle_mamba_radix_cache
test/registered/unit/hardware_backend/mlx/test_mlx_attention_backend_skip.py | +72 | MPS early return in init_attention_backends
test/registered/unit/hardware_backend/mlx/test_mlx_auxiliary_state_pool.py | +115 | Pool interface contract
Total | +37 / -2 code, +287 tests |  

<br class="Apple-interchange-newline" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">

## Accuracy Tests


prompt | completion tokens | decoded output (both engines)
-- | -- | --
List the first 10 prime numbers, comma separated. | 40  | 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31
The capital of France is. | 10  | Paris, a city renowned for its iconic landmarks such.



## Speed Tests and Profiling
Performance (M1 Max, 64GB unified memory, macOS 26)
Qwen3.6-35B-A3B-UD-MLX-4bit — 4 prompts × max_new ∈ {32, 128, 256}, temperature=0.0:


max_new= 32  e2e median=0.802s  TPOT median=27.2ms  TPOT p90=38.5ms
max_new=128  e2e median=3.016s  TPOT median=23.6ms  TPOT p90=29.5ms
max_new=256  e2e median=5.996s  TPOT median=23.5ms  TPOT p90=29.3ms
Concurrency (8 requests, max_new=64):


conc= 1  ok=8/8  agg= 36.2 tok/s  per_req= 36.5 tok/s
conc= 2  ok=8/8  agg= 51.9 tok/s  per_req= 26.0 tok/s
conc= 4  ok=8/8  agg= 62.9 tok/s  per_req= 15.7 tok/s
conc= 8  ok=8/8  agg= 70.9 tok/s  per_req=  8.9 tok/s

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28280541431](https://github.com/sgl-project/sglang/actions/runs/28280541431)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28280541401](https://github.com/sgl-project/sglang/actions/runs/28280541401)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->