### PR TITLE
fix(kv-events): offset ZMQ publisher port by dp_rank, not attn_dp_rank

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/kv_events_publisher.py
+++ b/python/sglang/srt/managers/scheduler_components/kv_events_publisher.py
@@ -69,7 +69,8 @@ class SchedulerKvEventsPublisher:
 
         if self.enable_kv_cache_events:
             self.kv_event_publisher = EventPublisherFactory.create(
-                kv_events_config, self.ps.attn_dp_rank
+                kv_events_config,
+                self.ps.dp_rank if self.ps.dp_rank is not None else 0,
             )
 
     def emit_kv_metrics(self):


### PR DESCRIPTION
## Problem

The KV-events ZMQ publisher derives its bind port by offsetting `endpoint_port` by a rank (`EventPublisherFactory.create(..., rank)` → `offset_endpoint_port`). It passes `attn_dp_rank`.

When attention data parallelism is disabled (`enable_dp_attention=False`), `compute_dp_attention_world_info` forces `attn_dp_rank = 0` for **every** scheduler (see `python/sglang/srt/layers/dp_attention.py`). So with `dp_size > 1` and KV events enabled, all DP schedulers offset by 0 and race to bind the **same** port. Every rank past the first crashes during init:

```
zmq.error.ZMQError: Address already in use (addr='tcp://0.0.0.0:5557')
RuntimeError: Rank 0 scheduler died during initialization
```

This makes `--kv-events-config` unusable on any `dp_size > 1` deployment that does not also enable attention-DP — e.g. MLA/DSA models where attention is not sharded across DP.

## Fix

Offset by `dp_rank` instead. The data-parallel controller assigns `dp_rank` uniquely per scheduler via `range(server_args.dp_size)` (see `data_parallel_controller.py`), so each DP rank binds `port_base + dp_rank` (5557, 5558, …).

This aligns the publisher with the two consumers that already assume `port_base + dp_rank`:
- the **router-side KV-events subscriber**, which connects to `endpoint_port_base + dp_rank` per rank;
- this publisher's **own metrics payload**, which already labels `data_parallel_rank` with `dp_rank` in `emit_kv_metrics`.

`dp_rank` is `Optional[int]`; falls back to `0` when `None` (`dp_size == 1`), reusing the exact idiom already used for the metrics payload a few lines below.

## Test

Reproduced on an 8×GPU MLA/DSA model with `--dp-size 2 --kv-events-config '{"publisher":"zmq","endpoint":"tcp://0.0.0.0:5557"}'`:
- **Before**: DP1 dies with `Address already in use (5557)`.
- **After**: DP0 binds 5557, DP1 binds 5558; both ranks come up, `/server_info.kv_events` reports `endpoint_port_base=5557, dp_size=2`, and inference serves normally.

`dp_size == 1` is unaffected (offset 0, identical to before).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28280934457](https://github.com/sgl-project/sglang/actions/runs/28280934457)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28280934424](https://github.com/sgl-project/sglang/actions/runs/28280934424)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->