### PR TITLE
[NPU][Bugfix] Add scoring_func for mimo_v2

### DIFF
--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -270,6 +270,7 @@ class MiMoV2MoE(nn.Module):
             num_expert_group=config.n_group,
             topk_group=config.topk_group,
             correction_bias=self.gate.e_score_correction_bias,
+            scoring_func=config.scoring_func,
             quant_config=quant_config,
             routed_scaling_factor=1.0,
             apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk,


### PR DESCRIPTION
## Motivation
PR #29042 updated the NPU topk kernel to respect topk_config.scoring_func for norm_type selection. However, mimo_v2.py did not pass scoring_func to TopK , so it defaulted to "softmax" at the model level. For MiMo-V2.5 models configured with scoring_func="sigmoid" , this caused the NPU kernel to use incorrect softmax normalization.

## Modifications
- python/sglang/srt/models/mimo_v2.py : Pass scoring_func=config.scoring_func to the TopK initializer so the NPU backend receives the correct normalization type from the model config.

## Accuracy Tests

```
export SGLANG_ENABLE_SPEC_V2=1
export ASCEND_USE_FIA=1
export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1
sglang serve \
    --model-path ${MODEL_PATH} \
    --tp-size 8 \
    --trust-remote-code \
    --device npu \
    --mem-fraction-static 0.75 \
    --reasoning-parser mimo \
    --attention-backend ascend \
    --disable-piecewise-cuda-graph \
    --disable-radix-cache \
    --max-running-requests 64 \
    --cuda-graph-bs 1 2 4 8 16 24 32 \
    --dp-size 2 \
    --enable-dp-attention \
    --enable-dp-lm-head \
    --enable-multimodal \
    --mm-attention-backend ascend_attn \
    --quantization modelslim \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --enable-multi-layer-eagle \
    --speculative-draft-model-quantization unquant \
    --moe-a2a-backend deepep \
    --deepep-mode auto \
    --skip-server-warmup \
```

```
┌────────────────┬───────────┬──────────┬──────────┬───────┬─────────┬─────────┐
│ Model          │ Dataset   │ Metric   │ Subset   │   Num │   Score │ Cat.0   │
├────────────────┼───────────┼──────────┼──────────┼───────┼─────────┼─────────┤
│ MiMo-V2.5-W8A8 │ gsm8k     │ mean_acc │ main     │   200 │   0.985 │ default │
└────────────────┴───────────┴──────────┴──────────┴───────┴─────────┴─────────┘
```

## Speed Tests and Profiling
None.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28281763815](https://github.com/sgl-project/sglang/actions/runs/28281763815)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28281763760](https://github.com/sgl-project/sglang/actions/runs/28281763760)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->