### PR TITLE
 [NPU] correct SSM state transpose for spec decode extend with prefix

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
@@ -308,27 +308,59 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
             value = value.view(1, actual_seq_len, layer.num_v_heads, layer.head_v_dim)
 
             g, beta = fused_gdn_gating(layer.A_log, a, b, layer.dt_bias)
+            extend_ssm_states = ssm_states
+            extend_cache_indices = cache_indices
+            if not forward_batch.spec_algorithm.is_none() and any(
+                forward_batch.extend_prefix_lens_cpu
+            ):
+                prefix_batch_indices = has_initial_states.nonzero(as_tuple=True)[0]
+                if prefix_batch_indices.numel() > 0:
+                    extend_ssm_states = ssm_states[cache_indices].clone()
+                    extend_ssm_states[prefix_batch_indices] = extend_ssm_states[
+                        prefix_batch_indices
+                    ].transpose(-1, -2)
+                    extend_cache_indices = torch.arange(
+                        cache_indices.shape[0],
+                        dtype=cache_indices.dtype,
+                        device=cache_indices.device,
+                    )
+
             core_attn_out, last_recurrent_state, h = self.kernel_dispatcher.extend(
                 q=query,
                 k=key,
                 v=value,
                 g=g,
                 beta=beta,
-                ssm_states=ssm_states,
-                cache_indices=cache_indices,
+                ssm_states=extend_ssm_states,
+                cache_indices=extend_cache_indices,
                 query_start_loc=query_start_loc,
             )
             if last_recurrent_state is not None:
                 last_recurrent_state = last_recurrent_state.to(
                     ssm_states.dtype, copy=False
                 )
-                ssm_states[cache_indices] = last_recurrent_state
-            last_recurrent_state = last_recurrent_state.to(ssm_states.dtype, copy=False)
+            if not forward_batch.spec_algorithm.is_none():
+                last_recurrent_state = last_recurrent_state.transpose(-1, -2).to(
+                    ssm_states.dtype, copy=False
+                )
+            else:
+                last_recurrent_state = last_recurrent_state.to(
+                    ssm_states.dtype, copy=False
+                )
             ssm_states[cache_indices] = last_recurrent_state
             if h is not None:
                 self._track_mamba_state_extend(
                     forward_batch, h, ssm_states, forward_metadata
                 )
+                if (
+                    not forward_batch.spec_algorithm.is_none()
+                    and forward_metadata.has_mamba_track_mask
+                    and forward_metadata.track_ssm_h_dst.numel() > 0
+                ):
+                    h_track_indices = forward_metadata.track_ssm_h_dst
+                    ssm_states[h_track_indices] = ssm_states[h_track_indices].transpose(
+                        -1, -2
+                    )
 
         return core_attn_out
 
@@ -353,7 +385,7 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
 
         if intermediate_state is not None:
             intermediate_state = intermediate_state.view(
-                -1, num_value_heads, head_k_dim, head_v_dim
+                -1, num_value_heads, head_v_dim, head_k_dim
             )
 
         if self.graph_mode:
@@ -386,6 +418,6 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
 
         if intermediate_state is not None:
             intermediate_state = intermediate_state.view(
-                -1, seq_len, num_value_heads, head_k_dim, head_v_dim
+                -1, seq_len, num_value_heads, head_v_dim, head_k_dim
             )
         return attn_core_out

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
@@ -310,8 +310,10 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
             g, beta = fused_gdn_gating(layer.A_log, a, b, layer.dt_bias)
             extend_ssm_states = ssm_states
             extend_cache_indices = cache_indices
-            if not forward_batch.spec_algorithm.is_none() and any(
-                forward_batch.extend_prefix_lens_cpu
+            if (
+                not forward_batch.spec_algorithm.is_none()
+                and forward_batch.extend_prefix_lens_cpu is not None
+                and any(forward_batch.extend_prefix_lens_cpu)
             ):
                 prefix_batch_indices = has_initial_states.nonzero(as_tuple=True)[0]
                 if prefix_batch_indices.numel() > 0:

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
@@ -339,15 +339,9 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
                 last_recurrent_state = last_recurrent_state.to(
                     ssm_states.dtype, copy=False
                 )
-            if not forward_batch.spec_algorithm.is_none():
-                last_recurrent_state = last_recurrent_state.transpose(-1, -2).to(
-                    ssm_states.dtype, copy=False
-                )
-            else:
-                last_recurrent_state = last_recurrent_state.to(
-                    ssm_states.dtype, copy=False
-                )
-            ssm_states[cache_indices] = last_recurrent_state
+                if not forward_batch.spec_algorithm.is_none():
+                    last_recurrent_state = last_recurrent_state.transpose(-1, -2)
+                ssm_states[cache_indices] = last_recurrent_state
             if h is not None:
                 self._track_mamba_state_extend(
                     forward_batch, h, ssm_states, forward_metadata


### PR DESCRIPTION
## Motivation

Fix an occasional incorrect output bug in the speculative decoding inference loop on Ascend NPU under high concurrency. When Eagle draft-extend encounters prefix-cached sequences with GDN (Gated Delta Network) attention, the SSM recurrent state dimension ordering was inconsistent between the kernel's internal layout and the persistent pool layout, causing corrupted recurrent states for non-prefix entries in mixed prefix/non-prefix batches.

## Modifications

### SSM state layout handling in `forward_extend()` (non-target-verify path) 
- Before kernel dispatch: clone SSM states for cache entries and transpose   the last two dimensions for prefix-batch entries only, so the NPU kernel   receives states in its expected layout. Supply contiguous identity indices   to match the cloned tensor shape. - After kernel dispatch: transpose `last_recurrent_state` back to the pool's  native layout before writing to `ssm_states[cache_indices]`.- After `_track_mamba_state_extend()`: transpose tracked SSM states at  `track_ssm_h_dst` indices back to pool format, ensuring the persistent  cache copy matches the runtime pool layout.

### Fix duplicate `last_recurrent_state` write-back
- Consolidate the two separate `ssm_states[cache_indices] = last_recurrent_state` assignments (one guarded, one unguarded) into a single write path after   dtype conversion, eliminating the redundant unprotected assignment.

### Fix `intermediate_state` reshape in `fused_recurrent_gated_delta_rule_update()`
- Swap the last two dimensions from `(head_k_dim, head_v_d   `(head_v_dim, head_k_dim)` in both input and output reshapes, matching   the layout the NPU kernel `torch.ops.npu.recurrent_gated   expects for the intermediate state buffer used during target verification.

### Guard refinement in metadata init
- Switch `init_forward_metadata()` and `init_forward_metad   guards from `is_draft_extend(True)` to `is_draft_extend_v2()`, and add  `_prepare_mamba_track_metadata()` call in both paths to  `conv_states_mask_indices`.

## Accuracy Tests

**Model**: Qwen3.6-35B-A3B
**Hardware**: Ascend 910C × 2 (TP=2)
**Baseline**: sglang main branch

### Server launch command

```bash
python3 -m sglang.launch_server \
  --model-path /home/weight/Qwen3.6-35B-A3B/ \
  --attention-backend ascend \
  --device npu \
  --tp-size 2 \
  --chunked-prefill-size 20480 \
  --max-prefill-tokens 20480 \
  --trust-remote-code \
  --host 0.0.0.0 \
  --mem-fraction-static 0.75 \
  --port 9811 \
  --enable-prefill-delayer \
  --prefill-delayer-max-delay-passes 30 \
  --cuda-graph-bs 1 2 4 6 8 10 16 20 24 \
  --max-running-request 24 \
  --context-length 262144 \
  --mm-attention-backend ascend_attn \
  --max-mamba-cache-size 80 \
  --tool-call-parser qwen3_coder \
  --reasoning-parser qwen3 \
  --enable-metrics \
  --enable-multimodal \
  --limit-mm-data-per-request '{"video": 0, "audio": 0}' \
  --dtype bfloat16 \
  --mamba-ssm-dtype bfloat16 \
  --mamba-scheduler-strategy extra_buffer \
  --speculative-algorithm NEXTN \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4

ceval results

┌─────────────────┬─────────┬──────────┬──────────┬────────┐
│     Branch      │ Dataset │  Metric  │ #Samples │ Score
├─────────────────┼─────────┼──────────┼──────────┼────────┤
│ main (baseline) │ ceval   │ mean_acc │ 1346     │ 0.9034
├─────────────────┼─────────┼──────────┼──────────┼────────┤
│ this PR         │ ceval   │ mean_acc │ 1346     │ 0.9042
└─────────────────┴─────────┴──────────┴──────────┴────────┘
```

Accuracy is within noise — no regression.

Benchmarking and Profiling

TBD — benchmark tests pending.

Checklist

- [ ] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tes
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results accordienchmark the speed.
- [ ] Follow the SGLang code style guidance.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28285105741](https://github.com/sgl-project/sglang/actions/runs/28285105741)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28285105671](https://github.com/sgl-project/sglang/actions/runs/28285105671)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->