### PR TITLE
[skill] Refresh profiler evidence anchors

### DIFF
--- a/.claude/skills/llm-torch-profiler-analysis/SKILL.md
+++ b/.claude/skills/llm-torch-profiler-analysis/SKILL.md
@@ -72,6 +72,26 @@ own native `profile_by_stage` field for manual capture, but the unified helper
 uses workload-separated `prefill/` and `decode/` directories by default so the
 tables stay comparable across frameworks.
 
+## Real B200 Validation
+
+The current B200 smoke run was captured on `2026-06-27` on `GPUC5A6`
+(`cirrascale-gpuc5a6`) in container `sglang_bbuf` under:
+
+- `/data/bbuf/ai_infra_skills_pr72_20260627/profiler/qwen25_0_5b_live`
+
+Validated live profile:
+
+| Model | GPU | Workloads | Result |
+| --- | --- | --- | --- |
+| `Qwen/Qwen2.5-0.5B-Instruct` | 1x B200 | prefill `128->1`, decode `32->8` | generated separate `prefill/*.trace.json.gz` and `decode/*.trace.json.gz`; kernel, overlap, and fuse tables rendered with separate `extend/prefill` and `decode` sections |
+
+The same run verified Nsight Compute availability with a tiny CUDA matmul:
+
+- `/data/bbuf/ai_infra_skills_pr72_20260627/profiler/ncu_smoke_qwen_matmul.ncu-rep`
+- `/data/bbuf/ai_infra_skills_pr72_20260627/profiler/ncu_smoke.log`
+
+After server and ncu cleanup, all eight B200 GPUs reported `0 MiB` used.
+
 ## Real H100 Validation
 
 The current reference run is the `4x H100` matrix captured on `2026-04-23` on
@@ -157,7 +177,7 @@ H100 notes:
 - SGLang kernel-site reconstruction keeps sampling disabled in the mapping path so the optimized parser does not perturb SGLang table output; equality rechecks matched for `Mixtral-8x7B-Instruct-v0.1`, `Qwen3-32B`, and `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8`
 - vLLM live capture requires `--output-dir` to match the server `torch_profiler_dir`; the validated H100 flow uses `--profiler-config {"profiler":"torch","torch_profiler_dir":"..."}` and then drives `/start_profile` and `/stop_profile`
 - TensorRT-LLM validation stays on `--backend pytorch`; the H100 flow writes the trace with `TLLM_TORCH_PROFILE_TRACE` and then analyzes the saved trace
-- TensorRT-LLM current mainline was rechecked at `0722c5f47d2cae69ac1a237da51e550dd214532c` on 2026-06-26; the latest delta affects KV eviction / block-offset staging rather than profiler trace controls, so the `b9e1945` profiler evidence still applies: PyTorch profiling uses `record_shapes=True` and `with_modules=True`, but not `with_stack=True`; keep the override path for table-quality Python locations unless the target image proves otherwise
+- TensorRT-LLM current mainline was rechecked at `aaffa2f9fef3025e0f698d978385a73460344e0b` on 2026-06-27; the latest delta still affects runtime/model serving surfaces rather than the profiler trace controls, so the `b9e1945` profiler evidence still applies: PyTorch profiling uses `record_shapes=True` and `with_modules=True`, but not `with_stack=True`; keep the override path for table-quality Python locations unless the target image proves otherwise
 - TokenSpeed trace analysis has first-class registry rows for native TokenSpeed CuTe DSL MLA, MLA KV pack + FP8 quantize, fused top-k/top-p sampling, persistent lm_head GEMM, and NVFP4 GEMM + SwiGLU + quant; live capture still requires an existing torch-profiler trace until the target TokenSpeed image exposes a supported profiler API
 - on this host, keep all trace roots under `/data/...`, not `/home/...`
 

--- a/.claude/skills/llm-torch-profiler-analysis/references/fuse-overlap-catalog.md
+++ b/.claude/skills/llm-torch-profiler-analysis/references/fuse-overlap-catalog.md
@@ -28,17 +28,18 @@ overlap opportunity as novel.
 
 The catalog is grouped by reusable optimization family, not by one specific model.
 
-Refresh note `2026-06-26`: rechecked official main heads for SGLang
-`8524678889485801e7a4a12d62015be0c68f7a90`, vLLM
-`abc71548ef029132c3316b902207f254a246d593`, TensorRT-LLM
-`0722c5f47d2cae69ac1a237da51e550dd214532c`, and TokenSpeed
-`5aedf69d6b476baa65571011de6ea60fd5a238a8`. The vLLM torch.compile pass
+Refresh note `2026-06-27`: rechecked official main heads for SGLang
+`e0c0c0a45cb1bda90392bfa2bba4184f5b0638a0`, vLLM
+`091d13976c1c246714bb2112dd2e208561dda6a3`, TensorRT-LLM
+`aaffa2f9fef3025e0f698d978385a73460344e0b`, and TokenSpeed
+`d0a7faddb5ec0d4c6d037c4c3e6a781d2c5164a8`. The vLLM torch.compile pass
 inventory is split out in
 [`vllm-torch-compile-fusions.md`](vllm-torch-compile-fusions.md). Stable
-current-code families remain folded into the mainline rows below. This refresh
-adds first-class TokenSpeed-origin rows for CuTe DSL MLA, MLA KV pack+FP8
+current-code families remain folded into the mainline rows below. The prior refresh
+added first-class TokenSpeed-origin rows for CuTe DSL MLA, MLA KV pack+FP8
 quantize, sampling, lm_head GEMM, and NVFP4 GEMM+SwiGLU+quant, plus the latest
-SGLang LTX2 Ada-value diffusion fusion. Recheck PR state before treating an
+SGLang LTX2 Ada-value diffusion fusion; the SGLang `#29486` GLM-5.2 cookbook
+refresh does not add a new profiler-visible fusion family. Recheck PR state before treating an
 in-flight row as shipped.
 
 ## 1. LLM / SRT fused-kernel families

--- a/.claude/skills/llm-torch-profiler-analysis/references/overlap-catalog.md
+++ b/.claude/skills/llm-torch-profiler-analysis/references/overlap-catalog.md
@@ -26,11 +26,11 @@ necessarily present in the checked-out `sglang` tree, but they should still be
 treated as upstream or analogous kernel-overlap families before labeling an
 overlap opportunity as novel.
 
-Refresh note `2026-06-26`: rechecked official main heads for SGLang
-`8524678889485801e7a4a12d62015be0c68f7a90`, vLLM
-`abc71548ef029132c3316b902207f254a246d593`, TensorRT-LLM
-`0722c5f47d2cae69ac1a237da51e550dd214532c`, and TokenSpeed
-`5aedf69d6b476baa65571011de6ea60fd5a238a8`, then added the first
+Refresh note `2026-06-27`: rechecked official main heads for SGLang
+`e0c0c0a45cb1bda90392bfa2bba4184f5b0638a0`, vLLM
+`091d13976c1c246714bb2112dd2e208561dda6a3`, TensorRT-LLM
+`aaffa2f9fef3025e0f698d978385a73460344e0b`, and TokenSpeed
+`d0a7faddb5ec0d4c6d037c4c3e6a781d2c5164a8`. The previous refresh added the first
 TokenSpeed-origin communication-fusion row. Closed-unmerged SGLang
 [#22410](https://github.com/sgl-project/sglang/pull/22410) and FlashInfer
 [#2840](https://github.com/flashinfer-ai/flashinfer/pull/2840) were removed

--- a/.claude/skills/llm-torch-profiler-analysis/references/vllm-torch-compile-fusions.md
+++ b/.claude/skills/llm-torch-profiler-analysis/references/vllm-torch-compile-fusions.md
@@ -1,12 +1,13 @@
 # vLLM Torch Compile Fusion Patterns
 
-Refresh: `2026-06-26`.
+Refresh: `2026-06-27`.
 Source tree: vLLM `origin/main` at
-`abc71548ef029132c3316b902207f254a246d593`; no new LLM compile-fusion pass was
+`091d13976c1c246714bb2112dd2e208561dda6a3`; no new LLM compile-fusion pass was
 added after `2317682f9` in this refresh. The mainline `#40392` MLA RoPE +
 KV-cache cat fusion is already included below. Recent post-`#46735` vLLM
-changes include runtime / frontend work such as `#44800` and `#46799`, but they
-do not add a new LLM compile-fusion pass to this inventory.
+changes include runtime / model-runner work such as `#44800`, `#46762`, `#46862`,
+and `#45924`, but they do not add a new torch.compile pass registration to this
+inventory.
 
 Use this file when the fuse-pattern table reports split kernels in a trace and
 you need to decide whether the shape is already covered by vLLM's


### PR DESCRIPTION
## Summary

Refresh the in-repo `llm-torch-profiler-analysis` skill with the latest profiler evidence anchors from the shared AI-Infra skill refresh.

Changes:
- add the 2026-06-27 B200 SGLang live-profile / NCU smoke validation note
- update SGLang, vLLM, TensorRT-LLM, and TokenSpeed source-head anchors in the fuse and overlap catalogs
- refresh the vLLM torch.compile fusion reference to the current source head
- note that the latest GLM-5.2 cookbook refresh does not introduce a new profiler-visible fusion family

## Validation

```bash
git diff --check
SKIP=no-commit-to-branch pre-commit run --files \
  .claude/skills/llm-torch-profiler-analysis/SKILL.md \
  .claude/skills/llm-torch-profiler-analysis/references/fuse-overlap-catalog.md \
  .claude/skills/llm-torch-profiler-analysis/references/overlap-catalog.md \
  .claude/skills/llm-torch-profiler-analysis/references/vllm-torch-compile-fusions.md
rg -n '8524678889485801e7a4a12d62015be0c68f7a90|abc71548ef029132c3316b902207f254a246d593|0722c5f47d2cae69ac1a237da51e550dd214532c|5aedf69d6b476baa65571011de6ea60fd5a238a8|Refresh note `2026-06-26`|Refresh: `2026-06-26`' .claude/skills/llm-torch-profiler-analysis || true
```













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28284516863](https://github.com/sgl-project/sglang/actions/runs/28284516863)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #28284635964](https://github.com/sgl-project/sglang/actions/runs/28284635964)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->