### PR TITLE
Fix LongCat MLP tensor parallelism

### DIFF
--- a/python/sglang/srt/models/longcat_flash.py
+++ b/python/sglang/srt/models/longcat_flash.py
@@ -361,7 +361,8 @@ class LongcatFlashDecoderLayer(nn.Module):
             [RMSNorm(config.hidden_size, eps=config.rms_norm_eps) for i in range(2)]
         )
 
-        if enable_moe_dense_fully_dp():
+        self.enable_moe_dense_fully_dp = enable_moe_dense_fully_dp()
+        if self.enable_moe_dense_fully_dp:
             mlps_tp_rank, mlps_tp_size = 0, 1
         else:
             mlps_tp_rank, mlps_tp_size = None, None

--- a/python/sglang/srt/models/longcat_flash.py
+++ b/python/sglang/srt/models/longcat_flash.py
@@ -476,7 +476,7 @@ class LongcatFlashDecoderLayer(nn.Module):
         # first_mlp
         hidden_states = self.mlps[0](hidden_states)
         # TP all_reduce
-        if not enable_moe_dense_fully_dp():
+        if not self.enable_moe_dense_fully_dp:
             hidden_states = tensor_model_parallel_all_reduce(hidden_states)
 
         # second_attn

--- a/python/sglang/srt/models/longcat_flash.py
+++ b/python/sglang/srt/models/longcat_flash.py
@@ -497,7 +497,7 @@ class LongcatFlashDecoderLayer(nn.Module):
         )
         hidden_states = self.mlps[1](hidden_states)
         # TP all_reduce
-        if not enable_moe_dense_fully_dp():
+        if not self.enable_moe_dense_fully_dp:
             hidden_states = tensor_model_parallel_all_reduce(hidden_states)
 
         hidden_states, residual = self.mlp_layer_communicator[1].postprocess_layer(

--- a/python/sglang/srt/models/longcat_flash.py
+++ b/python/sglang/srt/models/longcat_flash.py
@@ -45,7 +45,11 @@ from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_r
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.activation import SiluAndMul
-from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
+from sglang.srt.layers.communicator import (
+    LayerCommunicator,
+    LayerScatterModes,
+    enable_moe_dense_fully_dp,
+)
 from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
@@ -133,6 +137,8 @@ class LongcatFlashMLP(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         reduce_results: bool = False,
         prefix: str = "",
+        tp_rank: Optional[int] = None,
+        tp_size: Optional[int] = None,
     ) -> None:
         super().__init__()
         self.gate_up_proj = MergedColumnParallelLinear(
@@ -141,6 +147,8 @@ class LongcatFlashMLP(nn.Module):
             bias=False,
             quant_config=quant_config,
             prefix=add_prefix("gate_up_proj", prefix),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
         )
         self.down_proj = RowParallelLinear(
             intermediate_size,
@@ -149,6 +157,8 @@ class LongcatFlashMLP(nn.Module):
             quant_config=quant_config,
             reduce_results=reduce_results,
             prefix=add_prefix("down_proj", prefix),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
         )
         if hidden_act != "silu":
             raise ValueError(
@@ -351,6 +361,11 @@ class LongcatFlashDecoderLayer(nn.Module):
             [RMSNorm(config.hidden_size, eps=config.rms_norm_eps) for i in range(2)]
         )
 
+        if enable_moe_dense_fully_dp():
+            mlps_tp_rank, mlps_tp_size = 0, 1
+        else:
+            mlps_tp_rank, mlps_tp_size = None, None
+
         self.mlps = nn.ModuleList(
             [
                 LongcatFlashMLP(
@@ -363,6 +378,8 @@ class LongcatFlashDecoderLayer(nn.Module):
                         else quant_config
                     ),
                     prefix=add_prefix(f"mlps.{i}", prefix),
+                    tp_rank=mlps_tp_rank,
+                    tp_size=mlps_tp_size,
                 )
                 for i in range(2)
             ]
@@ -458,7 +475,8 @@ class LongcatFlashDecoderLayer(nn.Module):
         # first_mlp
         hidden_states = self.mlps[0](hidden_states)
         # TP all_reduce
-        hidden_states = tensor_model_parallel_all_reduce(hidden_states)
+        if not enable_moe_dense_fully_dp():
+            hidden_states = tensor_model_parallel_all_reduce(hidden_states)
 
         # second_attn
         hidden_states, residual = self.mlp_layer_communicator[1].prepare_attn(
@@ -478,7 +496,8 @@ class LongcatFlashDecoderLayer(nn.Module):
         )
         hidden_states = self.mlps[1](hidden_states)
         # TP all_reduce
-        hidden_states = tensor_model_parallel_all_reduce(hidden_states)
+        if not enable_moe_dense_fully_dp():
+            hidden_states = tensor_model_parallel_all_reduce(hidden_states)
 
         hidden_states, residual = self.mlp_layer_communicator[1].postprocess_layer(
             hidden_states, residual, forward_batch


### PR DESCRIPTION
  ## Summary
  - Fix LongCat MLP tensor parallelism handling.

  ## Motivation
 - LongCat-Flash 2P4D dense did not support running with TP size = 1 because the MLP tensor-parallel path assumed TP sharding.
  This PR fixes the dense MLP path so it can run correctly without tensor parallelism.
  
  ## Tests
  - Successfully ran LongCat-Flash 2P4D with moe_dense_tp_size = 1.





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28290761308](https://github.com/sgl-project/sglang/actions/runs/28290761308)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #28290761239](https://github.com/sgl-project/sglang/actions/runs/28290761239)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->