### PR TITLE
Guard Blackwell TRT-LLM prefill chunk size

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_deepseek_mha_mixin.py
+++ b/python/sglang/srt/model_executor/forward_batch_deepseek_mha_mixin.py
@@ -14,6 +14,7 @@ from sglang.srt.model_executor.forward_context import (
     get_req_to_token_pool,
     get_token_to_kv_pool,
 )
+from sglang.srt.utils.common import CUDA_GRID_DIM_YZ_LIMIT, get_device_sm
 
 
 class ForwardBatchDeepSeekMHAMixin:
@@ -54,7 +55,12 @@ class ForwardBatchDeepSeekMHAMixin:
     mha_one_shot_kv_indices: Optional[torch.Tensor] = None
 
     def get_max_chunk_capacity(self):
-        return envs.SGLANG_MAX_KV_CHUNK_CAPACITY.get()
+        capacity = envs.SGLANG_MAX_KV_CHUNK_CAPACITY.get()
+        if get_device_sm() >= 100:
+            # FlashInfer TRT-LLM FMHA on Blackwell places token work on
+            # gridDim.z, whose CUDA limit is lower than the historical 128K.
+            capacity = min(capacity, CUDA_GRID_DIM_YZ_LIMIT)
+        return capacity
 
     def set_prefix_chunk_idx(self, idx: int):
         self.prefix_chunk_idx = idx

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -61,6 +61,7 @@ from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.platforms import current_platform
 from sglang.srt.speculative.decoupled_spec_io import DecoupledSpecIpcConfig
 from sglang.srt.utils.common import (
+    CUDA_GRID_DIM_YZ_LIMIT,
     LORA_TARGET_ALL_MODULES,
     SUPPORTED_LORA_TARGET_MODULES,
     cpu_has_amx_support,
@@ -5226,6 +5227,42 @@ class ServerArgs:
 
         init_cp_strategy(self)
 
+    def _needs_trtllm_fmha_chunk_guard(self) -> bool:
+        return (
+            self.device == "cuda"
+            and self.attention_backend == "dsa"
+            and self.dsa_prefill_backend == "trtllm"
+            and is_sm100_supported()
+        )
+
+    def _guard_dp_attention_trtllm_prefill_chunk(self):
+        if not self._needs_trtllm_fmha_chunk_guard():
+            return
+
+        if self.chunked_prefill_size is None or self.chunked_prefill_size <= 0:
+            self.chunked_prefill_size = max(
+                1, self.max_prefill_tokens
+            ) * self.dp_size
+            logger.warning(
+                "Blackwell DSA TRT-LLM prefill cannot safely run with "
+                "--chunked-prefill-size disabled under DP attention because the "
+                "FlashInfer TRT-LLM FMHA kernel maps token work to CUDA gridDim.z. "
+                "Setting chunked_prefill_size to %s before DP scaling.",
+                self.chunked_prefill_size,
+            )
+
+        max_chunked_prefill_size = CUDA_GRID_DIM_YZ_LIMIT * self.dp_size
+        if self.chunked_prefill_size > max_chunked_prefill_size:
+            logger.warning(
+                "Capping chunked_prefill_size from %s to %s for Blackwell DSA "
+                "TRT-LLM prefill so each DP rank stays within CUDA gridDim.y/z "
+                "limit %s.",
+                self.chunked_prefill_size,
+                max_chunked_prefill_size,
+                CUDA_GRID_DIM_YZ_LIMIT,
+            )
+            self.chunked_prefill_size = max_chunked_prefill_size
+
     def _handle_data_parallelism(self):
         if self.dp_size == 1:
             self.enable_dp_attention = False
@@ -5234,6 +5271,7 @@ class ServerArgs:
         if self.enable_dp_attention:
             self.schedule_conservativeness = self.schedule_conservativeness * 0.3
             assert self.tp_size % self.dp_size == 0
+            self._guard_dp_attention_trtllm_prefill_chunk()
             self.chunked_prefill_size = self.chunked_prefill_size // self.dp_size
             logger.warning(
                 f"DP attention is enabled. The chunked prefill size is adjusted to {self.chunked_prefill_size} to avoid MoE kernel issues. "

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -103,6 +103,9 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
+# CUDA gridDim.y and gridDim.z are limited to 65535 even when gridDim.x can be
+# much larger. Some FlashInfer TRT-LLM FMHA paths map token work to gridDim.z.
+CUDA_GRID_DIM_YZ_LIMIT = 65535
 torch_release = pkg_version.parse(torch.__version__).release
 
 

--- a/test/registered/unit/model_executor/test_forward_batch_deepseek_mha_mixin.py
+++ b/test/registered/unit/model_executor/test_forward_batch_deepseek_mha_mixin.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
+    ForwardBatchDeepSeekMHAMixin,
+)
+from sglang.srt.utils.common import CUDA_GRID_DIM_YZ_LIMIT
+
+
+class TestForwardBatchDeepSeekMHAMixin(unittest.TestCase):
+    @patch(
+        "sglang.srt.model_executor.forward_batch_deepseek_mha_mixin.envs"
+        ".SGLANG_MAX_KV_CHUNK_CAPACITY.get",
+        return_value=128 * 1024,
+    )
+    @patch(
+        "sglang.srt.model_executor.forward_batch_deepseek_mha_mixin.get_device_sm",
+        return_value=100,
+    )
+    def test_sm100_caps_mha_chunk_capacity(self, _mock_sm, _mock_env):
+        mixin = ForwardBatchDeepSeekMHAMixin()
+
+        self.assertEqual(mixin.get_max_chunk_capacity(), CUDA_GRID_DIM_YZ_LIMIT)
+
+    @patch(
+        "sglang.srt.model_executor.forward_batch_deepseek_mha_mixin.envs"
+        ".SGLANG_MAX_KV_CHUNK_CAPACITY.get",
+        return_value=128 * 1024,
+    )
+    @patch(
+        "sglang.srt.model_executor.forward_batch_deepseek_mha_mixin.get_device_sm",
+        return_value=90,
+    )
+    def test_non_sm100_preserves_mha_chunk_capacity(self, _mock_sm, _mock_env):
+        mixin = ForwardBatchDeepSeekMHAMixin()
+
+        self.assertEqual(mixin.get_max_chunk_capacity(), 128 * 1024)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -16,6 +16,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
 )
 from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
 from sglang.srt.server_args_config_parser import ConfigArgumentMerger
+from sglang.srt.utils.common import CUDA_GRID_DIM_YZ_LIMIT
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
@@ -254,6 +255,59 @@ class TestHiSparseDsaBackendPolicy(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, r"fp8_e4m3"):
             server_args._validate_hisparse_kv_cache_dtype()
+
+
+class TestDPAttentionChunkedPrefillGuard(unittest.TestCase):
+    def _new_args(self, **overrides):
+        server_args = object.__new__(ServerArgs)
+        defaults = dict(
+            attention_backend="dsa",
+            chunked_prefill_size=-1,
+            device="cuda",
+            dp_size=4,
+            dsa_prefill_backend="trtllm",
+            enable_dp_attention=True,
+            enable_dp_lm_head=False,
+            max_prefill_tokens=8192,
+            schedule_conservativeness=0.3,
+            tp_size=4,
+        )
+        defaults.update(overrides)
+        for key, value in defaults.items():
+            setattr(server_args, key, value)
+        return server_args
+
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    def test_disabled_chunked_prefill_is_restored_for_blackwell_dsa_trtllm(
+        self, _mock_sm100
+    ):
+        server_args = self._new_args(chunked_prefill_size=-1)
+
+        server_args._handle_data_parallelism()
+
+        self.assertEqual(server_args.chunked_prefill_size, 8192)
+
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    def test_oversized_chunked_prefill_is_capped_after_dp_scaling(
+        self, _mock_sm100
+    ):
+        server_args = self._new_args(
+            chunked_prefill_size=(CUDA_GRID_DIM_YZ_LIMIT + 1) * 4
+        )
+
+        server_args._handle_data_parallelism()
+
+        self.assertEqual(server_args.chunked_prefill_size, CUDA_GRID_DIM_YZ_LIMIT)
+
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    def test_non_trtllm_backend_preserves_disabled_chunked_prefill(self, _mock_sm100):
+        server_args = self._new_args(
+            chunked_prefill_size=-1, dsa_prefill_backend="flashmla_kv"
+        )
+
+        server_args._handle_data_parallelism()
+
+        self.assertEqual(server_args.chunked_prefill_size, -1)
 
 
 class TestFa4PageSizeAutoForce(CustomTestCase):


### PR DESCRIPTION
## Summary

- restore a safe chunked prefill size for Blackwell DSA TRT-LLM prefill under DP attention when `--chunked-prefill-size` is disabled
- cap oversized DP prefill chunks so each rank stays within CUDA gridDim.y/z limit 65535
- cap DeepSeek MHA chunked-prefix capacity on SM100 to avoid the same TRT-LLM FMHA launch-shape limit
- add focused unit coverage for the DP guard and SM100 MHA capacity behavior

Fixes #29453.

## Root Cause

The #29453 repro disables chunked prefill while using DP attention, DSA, and TRT-LLM prefill on Blackwell. That can let a single prefill path build TRT-LLM FMHA launches where token work lands on `gridDim.z`; observed debug output in the issue showed `numCtasZ=131072`, which exceeds CUDA's y/z grid limit of 65535 and produces `CUDA_ERROR_INVALID_VALUE` from `fmhaKernels.cuh`.

## Validation

- `git diff --check`
- `python3 -m py_compile python/sglang/srt/server_args.py python/sglang/srt/model_executor/forward_batch_deepseek_mha_mixin.py python/sglang/srt/utils/common.py test/registered/unit/server_args/test_server_args.py test/registered/unit/model_executor/test_forward_batch_deepseek_mha_mixin.py`
- B200 Spot host, container `lmsysorg/sglang:latest`, patched source mounted via `PYTHONPATH`:
  - `python3 -m pytest -q test/registered/unit/server_args/test_server_args.py::TestDPAttentionChunkedPrefillGuard test/registered/unit/model_executor/test_forward_batch_deepseek_mha_mixin.py` -> `5 passed`
  - real SM100 smoke confirmed `is_sm100_supported=True`, normalized issue-style DP chunk size `8192`, and MHA chunk capacity `65535`

The full GLM-5.2-NVFP4 long-context probe was not run end-to-end; the focused B200 check validates the code path that prevents the confirmed invalid TRT-LLM FMHA launch shape.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28296387836](https://github.com/sgl-project/sglang/actions/runs/28296387836)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28296387759](https://github.com/sgl-project/sglang/actions/runs/28296387759)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->