### PR TITLE
Fix stale nsa.* imports in dsv4 compressor

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/compress_hip.py
+++ b/python/sglang/srt/layers/attention/dsv4/compress_hip.py
@@ -15,7 +15,6 @@ from sglang.srt.layers.attention.dsv4.compressor import Compressor as _Compresso
 from sglang.srt.layers.attention.dsv4.fused_compress_triton import (
     fused_ape_pool_norm_rope,
 )
-from sglang.srt.layers.attention.nsa.nsa_indexer import rotate_activation
 from sglang.srt.layers.deepseek_v4_rope import (
     apply_rotary_emb_triton,
     fused_norm_rope_inplace_triton,

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -562,11 +562,11 @@ class CompressorBackendMixin:
         layer_id: int,
     ) -> None:
         """HIP-specific forward path using PyTorch/Triton fallbacks."""
+        from sglang.srt.layers.attention.dsa.dsa_indexer import rotate_activation
+        from sglang.srt.layers.attention.dsa.triton_kernel import act_quant
         from sglang.srt.layers.attention.dsv4.quant_k_cache import (
             quant_to_nope_fp8_rope_bf16_pack_triton,
         )
-        from sglang.srt.layers.attention.nsa.nsa_indexer import rotate_activation
-        from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
         from sglang.srt.layers.deepseek_v4_rope import fused_norm_rope_inplace_triton
 
         compress_ratio = compressor.ratio


### PR DESCRIPTION
Hi, I'm a new contributor looking for small things to get familiar with the codebase, and found this while going through the DeepSeek V4 roadmap (#23602) — most of it is already implemented, so I picked up a small cleanup.

## Motivation

The NSA→DSA rename (#25821) moved `layers/attention/nsa/` → `dsa/` and left `nsa/` as deprecation shims. #26208 landed afterwards (likely rebased over the rename) and brought back a few old `attention.nsa.*` imports in the dsv4 compressor. They still work via the shims but emit a `DeprecationWarning` on every import, so this points them at `dsa.*` directly.

## Modifications

- `compressor_v2.py`: `nsa.nsa_indexer` → `dsa.dsa_indexer`, `nsa.triton_kernel` → `dsa.triton_kernel`
- `compress_hip.py`: dropped the `nsa.nsa_indexer` line — it was a duplicate, `rotate_activation` is already imported from `dsa` right above it.

No behavior change — the shims re-export the same symbols. Left `hip_flash_mla.py` alone since its `nsa.triton_decode` import points at real code that hasn't been moved to `dsa/` yet (separate PR).

cc @ch-wan

## Accuracy Tests

N/A — pure import-path change, no kernel or model forward code touched.

## Speed Tests and Profiling

N/A — no impact on inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
