### PR TITLE
[metrics] Add SWA prefix-cache truncation counter

### DIFF
--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -236,6 +236,12 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
             )
             self.metrics_collector.increment_eviction_num_tokens(num_evicted)
 
+    def update_swa_prefix_truncation_metrics(self, num_truncated_tokens: int):
+        if self.metrics_collector is not None and num_truncated_tokens > 0:
+            self.metrics_collector.increment_swa_prefix_truncated_num_tokens(
+                num_truncated_tokens
+            )
+
     @abstractmethod
     def reset(self):
         pass

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -412,7 +412,24 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
             )
 
         value, last_node, best_value_len = self._match_prefix_helper(key)
+        self._record_swa_prefix_truncation(value, best_value_len)
         return self._match_post_processor(params, value, last_node, best_value_len)
+
+    def _record_swa_prefix_truncation(
+        self, value: List[torch.Tensor], best_value_len: int
+    ) -> None:
+        """Record prefix tokens matched in the tree but dropped from the hit.
+
+        ``_match_prefix_helper`` walks the full logical prefix into ``value`` but
+        only accepts the first ``best_value_len`` entries as a usable hit; the rest
+        is dropped because the sliding window was no longer covered by live
+        (non-tombstoned) SWA KV. The dropped token count is the SWA prefix-cache
+        truncation signal, exposed for cache-hit-rate debugging.
+        """
+        if self.metrics_collector is None or best_value_len >= len(value):
+            return
+        truncated_tokens = sum(len(v) for v in value[best_value_len:])
+        self.update_swa_prefix_truncation_metrics(truncated_tokens)
 
     def insert(self, params: InsertParams) -> InsertResult:
         if self.disable:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1916,6 +1916,16 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
             labelnames=labels.keys(),
         )
 
+        self.swa_prefix_truncated_num_tokens = Counter(
+            name="sglang:swa_prefix_truncated_tokens_total",
+            documentation=(
+                "The number of prefix tokens that matched in the radix tree but "
+                "were truncated from the cache hit because the sliding-window "
+                "attention KV had already been evicted (tombstoned)."
+            ),
+            labelnames=labels.keys(),
+        )
+
         self.load_back_duration_seconds = Histogram(
             name="sglang:load_back_duration_seconds",
             documentation="Time taken to load memory from CPU to GPU in seconds.",
@@ -1931,6 +1941,9 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
 
     def increment_eviction_num_tokens(self, num_tokens: int) -> None:
         self.eviction_num_tokens.labels(**self.labels).inc(num_tokens)
+
+    def increment_swa_prefix_truncated_num_tokens(self, num_tokens: int) -> None:
+        self.swa_prefix_truncated_num_tokens.labels(**self.labels).inc(num_tokens)
 
     def increment_load_back_num_tokens(self, num_tokens: int) -> None:
         self.load_back_num_tokens.labels(**self.labels).inc(num_tokens)

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -432,6 +432,54 @@ class TestSWA(unittest.TestCase):
         print(available_and_evictable_str(tree))
         tree.sanity_check()
 
+    def test_swa_prefix_truncation_metric_records_dropped_tokens(self):
+        # A prefix that still matches logically but has lost its sliding window to
+        # SWA eviction (tombstoning) must report the dropped tokens through the SWA
+        # prefix-truncation metric. This mirrors the truncated match in
+        # test_swa_radix_cache_1 (req5 -> 0-length hit).
+        class _SpyCollector:
+            def __init__(self):
+                self.truncated_tokens = 0
+
+            def increment_swa_prefix_truncated_num_tokens(self, num_tokens):
+                self.truncated_tokens += num_tokens
+
+        tree, allocator, _ = _build_swa_tree(
+            is_eagle=False,
+            req_size=10,
+            max_context_len=128,
+            kv_size=128,
+            kv_size_swa=64,
+            sliding_window_size=4,
+        )
+        spy = _SpyCollector()
+        tree.metrics_collector = spy
+
+        for token_ids in (
+            [1, 2, 3],
+            [1, 2, 3, 4, 5, 6, 7],
+            [10, 11, 12],
+            [1, 2, 3, 4, 5, 60, 70],
+        ):
+            kv_indices = allocator.alloc(len(token_ids))
+            key = RadixKey(array("q", token_ids))
+            tree.insert(InsertParams(key=key, value=kv_indices[: len(key)]))
+
+        # Evict SWA capacity (tombstoning the shared [1..5] prefix) while keeping
+        # the full-attention KV alive.
+        tree.evict(EvictParams(num_tokens=1, swa_num_tokens=0))
+        tree.evict(EvictParams(num_tokens=0, swa_num_tokens=1))
+        tree.evict(EvictParams(num_tokens=1, swa_num_tokens=2))
+
+        # [1, 2, 3, 4, 5] still matches in the tree, but the sliding window is no
+        # longer covered by live SWA KV, so the usable hit is truncated to zero.
+        result = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", [1, 2, 3, 4, 5])))
+        )
+        self.assertEqual(len(result.device_indices), 0)
+        self.assertGreater(spy.truncated_tokens, 0)
+        tree.sanity_check()
+
     def test_swa_radix_cache_eagle(self):
         # args
         req_size = 10


### PR DESCRIPTION
## Motivation

For hybrid sliding-window-attention (SWA) models, the prefix-cache hit rate can degrade silently when SWA KV gets evicted. A request may match a long logical prefix in the SWA radix tree, but the usable hit is truncated back to the last point still covered by `sliding_window_size` of live (non-tombstoned) SWA KV. Right now only the aggregate cache-hit rate is observable, so when the hit rate drops there's no way to tell whether it's SWA eviction or just genuinely non-shared prefixes.

`SWARadixCache._match_prefix_helper` already computes both quantities. It walks the full logical match into `value` but only accepts the first `best_value_len` entries as a usable hit. The truncated remainder was just never surfaced anywhere.

## Modifications

- `observability/metrics_collector.py`: add a `RadixCacheMetricsCollector` counter `sglang:swa_prefix_truncated_tokens_total` and `increment_swa_prefix_truncated_num_tokens`, following the existing `sglang:evicted_tokens_total` metric.
- `mem_cache/base_prefix_cache.py`: add `update_swa_prefix_truncation_metrics`, following `update_eviction_metrics`.
- `mem_cache/swa_radix_cache.py`: record the truncated token count at the `match_prefix` boundary. The helper early-returns when no collector is attached or when the match wasn't truncated (`best_value_len == len(value)`), so the common path is untouched.
- `test/registered/unit/mem_cache/test_swa_unittest.py`: add a unit test that evicts SWA capacity to tombstone a shared prefix and asserts the counter records the dropped tokens.

This is observability only, so there's no change to model outputs or KV correctness. A natural follow-up would be extending the same signal to the unified radix cache SWA path.

## Accuracy Tests

N/A, this is a metrics-only change with no model output or KV correctness impact.

## Speed Tests and Profiling

No measurable impact. The recording helper early-returns when no collector is attached or when the match isn't truncated (the common case), so it adds at most one integer comparison to the match path.

## Checklist

- [x] Format your code according to the pre-commit configuration (black, isort, ruff, codespell all pass).
- [x] Add unit tests.
- [ ] Update documentation (not applicable).
- [ ] Provide accuracy and speed benchmark results (not applicable, metrics-only).
- [x] Follow the SGLang code style guidance.
