### PR TITLE
fix(quant): load W8A8 int8 checkpoints with per-shard static input scales

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
@@ -20,7 +20,7 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsLinearScheme,
 )
 from sglang.srt.layers.quantization.int8_kernel import per_token_quant_int8
-from sglang.srt.layers.quantization.utils import requantize_with_max_scale
+from sglang.srt.layers.quantization.utils import convert_to_channelwise
 from sglang.srt.utils import is_cuda
 
 __all__ = ["CompressedTensorsW8A8Int8", "NPUCompressedTensorsW8A8Int8"]
@@ -81,7 +81,8 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
         # INPUT SCALE
         if self.is_static_input_scheme:
             input_scale = PerTensorScaleParameter(
-                data=torch.empty(1, dtype=torch.float32), weight_loader=weight_loader
+                data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+                weight_loader=weight_loader,
             )
             layer.register_parameter("input_scale", input_scale)
 
@@ -90,7 +91,8 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
                 # as the weights
                 # AZP loaded as int8 but used as int32
                 input_zero_point = PerTensorScaleParameter(
-                    data=torch.empty(1, dtype=torch.int8), weight_loader=weight_loader
+                    data=torch.empty(len(output_partition_sizes), dtype=torch.int8),
+                    weight_loader=weight_loader,
                 )
                 layer.register_parameter("input_zero_point", input_zero_point)
 
@@ -104,14 +106,13 @@ class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):
         # tensor scales (thus N scales being passed to the kernel),
         # requantize so we can always run per channel
         if self.strategy == QuantizationStrategy.TENSOR:
-            max_w_scale, weight = requantize_with_max_scale(
-                weight=layer.weight,
-                weight_scale=layer.weight_scale,
-                logical_widths=layer.logical_widths,
+            weight = layer.weight
+            weight_scale = convert_to_channelwise(
+                layer.weight_scale, layer.logical_widths
             )
 
             layer.weight = Parameter(weight.t(), requires_grad=False)
-            layer.weight_scale = Parameter(max_w_scale, requires_grad=False)
+            layer.weight_scale = Parameter(weight_scale, requires_grad=False)
 
         # If channelwise, scales are already lined up, so just transpose.
         elif self.strategy == QuantizationStrategy.CHANNEL:

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -1,7 +1,13 @@
 import unittest
 from unittest.mock import MagicMock
 
+import torch
+from compressed_tensors.quantization import QuantizationStrategy
+
 from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_int8 import (
+    CompressedTensorsW8A8Int8,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -71,6 +77,28 @@ class TestQuantLogString(CustomTestCase):
         result = model_config.get_quantization_config_log_str()
         print(f"\n[Test No Quant] Result: {result}")
         self.assertIsNone(result)
+
+
+class TestW8A8Int8StaticInputScale(CustomTestCase):
+    def test_static_scales_have_one_slot_per_logical_shard(self):
+        # A fused layer (e.g. gate_up_proj) has one activation scale per logical
+        # shard in the checkpoint. Before the fix the static scales were one slot,
+        # so loading the second shard raised IndexError during model load.
+        scheme = CompressedTensorsW8A8Int8(
+            strategy=QuantizationStrategy.TENSOR,
+            is_static_input_scheme=True,
+            input_symmetric=False,
+        )
+        layer = torch.nn.Module()
+        scheme.create_weights(
+            layer,
+            output_partition_sizes=[4, 4],
+            input_size_per_partition=8,
+            params_dtype=torch.bfloat16,
+            weight_loader=lambda *args, **kwargs: None,
+        )
+        self.assertEqual(layer.input_scale.shape, torch.Size([2]))
+        self.assertEqual(layer.input_zero_point.shape, torch.Size([2]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Motivation

Loading a compressed-tensors W8A8 int8 checkpoint with static activation scales (e.g. `nm-testing/tinyllama-w8a8-compressed`) crashes during model load:

```
IndexError: index 1 is out of bounds for dimension 0 with size 1
```

`CompressedTensorsW8A8Int8.create_weights` allocates the static `input_scale` / `input_zero_point` as one-slot `PerTensorScaleParameter`s. A fused layer such as Llama `gate_up_proj` has separate `gate_proj.input_scale` and `up_proj.input_scale` shards; the first loads into shard 0, the second into shard 1, but the parameter has length 1, so the load fails.

## Modifications

- Allocate the static `input_scale` and `input_zero_point` with `len(output_partition_sizes)` slots, like `weight_scale`, so every logical shard of a fused layer loads.
- For the TENSOR strategy, convert the per-tensor weight scale to channelwise (`convert_to_channelwise`) so the int8 GEMM kernel receives one `scales_b` per output channel; otherwise forward fails with `RuntimeError: size of scales_b is not matched`. The activation `input_scale` stays scalar.

## Testing

Real-engine E2E on a single GPU, loading the public `nm-testing/tinyllama-w8a8-compressed` checkpoint.

<details>
<summary>Reproduction (env, script, before/after)</summary>

```python
# quant_engine_matrix.py
import sglang as sgl

engine = sgl.Engine(
    model_path="nm-testing/tinyllama-w8a8-compressed",
    dtype="float16",
    mem_fraction_static=0.28,
    disable_cuda_graph=True,
    attention_backend="triton",
    sampling_backend="pytorch",
    skip_server_warmup=True,
)
out = engine.generate("The capital of France is",
                      {"temperature": 0, "max_new_tokens": 8})
print(out[0]["text"])
engine.shutdown()
```

```
main:  IndexError: index 1 is out of bounds for dimension 0 with size 1
       (parameter.py _load_into_shard_id, model fails to load)
fix:   status ok, generates " Paris.\n\n### 1"

negative control nm-testing/tinyllama-w4a16-compressed (unaffected path):
       loads and generates on both main and fix
```

</details>

A `TestW8A8Int8StaticInputScale` case added to `test/registered/quant/test_quant_config_parsing.py` (CPU): `create_weights` with `output_partition_sizes=[4, 4]` must allocate `input_scale` / `input_zero_point` of shape `(2,)`. The test fails on main (`torch.Size([1]) != torch.Size([2])`) and passes with the fix. `ruff`/`black`/`isort` clean.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28302208073](https://github.com/sgl-project/sglang/actions/runs/28302208073)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28302208028](https://github.com/sgl-project/sglang/actions/runs/28302208028)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->