### PR TITLE
fix: warn about non-obvious chunked prefill budget behavior

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7065,6 +7065,28 @@ class ServerArgs:
             assert (
                 self.chunked_prefill_size % self.page_size == 0
             ), "chunked_prefill_size must be divisible by page_size"
+            is_dynamic_chunking = self.enable_dynamic_chunking and self.pp_size > 1
+            # In fixed chunked prefill, chunked_prefill_size enables chunked
+            # prefill and limits the whole chunked-prefill step, not just a
+            # single request chunk. Dynamic PP chunking can grow chunks beyond
+            # the fixed chunked_prefill_size, so this warning does not apply.
+            if (
+                not is_dynamic_chunking
+                and self.max_prefill_tokens > self.chunked_prefill_size
+            ):
+                logger.warning(
+                    "--max-prefill-tokens (%s) is greater than "
+                    "--chunked-prefill-size (%s). chunked_prefill_size enables "
+                    "chunked prefill and limits the whole chunked-prefill step, "
+                    "not just a single request chunk. The actual difference "
+                    "from max_prefill_tokens is that chunked_prefill_size "
+                    "enables chunked prefill. Both parameters cap the "
+                    "chunked-prefill batch budget, so the effective prefill "
+                    "token budget is min(max_prefill_tokens, "
+                    "chunked_prefill_size).",
+                    self.max_prefill_tokens,
+                    self.chunked_prefill_size,
+                )
 
         # Check pdmux
         if self.enable_pdmux:


### PR DESCRIPTION
## Motivation

  chunked_prefill_size can be read as only a per-request chunk size, while max_prefill_tokens looks like the batch-level budget. In practice, for fixed chunked prefill, both parameters cap the prefill batch budget, and the effective limit is min(max_prefill_tokens, chunked_prefill_size).


in code:
PrefillAdder.budget_state() treats both budgets as independent admission limits. It returns AddReqResult.OTHER when [rem_input_tokens <= 0](https://github.com/sgl-project/sglang/blob/158960311468342ccc2ab4342a4f53372d042a90/python/sglang/srt/managers/schedule_policy.py#L613), or when [rem_chunk_tokens is not None and rem_chunk_tokens <= 0](https://github.com/sgl-project/sglang/blob/158960311468342ccc2ab4342a4f53372d042a90/python/sglang/srt/managers/schedule_policy.py#L620). Therefore, for fixed chunked prefill, admission into the current prefill batch stops when either max_prefill_tokens or chunked_prefill_size is exhausted, making the effective batch token budget min(max_prefill_tokens, chunked_prefill_size).

## Modifications

Added a startup warning when `max_prefill_tokens > chunked_prefill_size` to make the effective prefill budget explicit.

## Accuracy Tests

Not applicable. This change only adds a warning.

## Speed Tests and Profiling

Not applicable. This change only adds a warning.

## Checklist

Not applicable. This change only adds a warning.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29250809433](https://github.com/sgl-project/sglang/actions/runs/29250809433)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29250809121](https://github.com/sgl-project/sglang/actions/runs/29250809121)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->