### PR TITLE
Handle FP4 MegaMOE fallback for DeepSeek-V4

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1768,7 +1768,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         moe_runner_backend = get_moe_runner_backend()
 
         if moe_runner_backend.is_auto():
-            if self.is_deepgemm_moe_runner_backend_enabled():
+            if self.is_fp4_expert and get_moe_a2a_backend().is_megamoe():
+                # MegaMoE falls back to this normal MoE runner when the token
+                # cap is exceeded; FP4 experts need the DeepGEMM-compatible
+                # scale layout prepared by MegaMoE, not Triton's FP8 layout.
+                moe_runner_backend = MoeRunnerBackend.DEEP_GEMM
+            elif self.is_deepgemm_moe_runner_backend_enabled():
                 moe_runner_backend = MoeRunnerBackend.DEEP_GEMM
             elif (
                 _is_hip

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -155,6 +155,20 @@ _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
 _MHC_POST_MULT_VALUE = 2.0
 
 
+def _is_megamoe_fp4_fallback_mlp(mlp: nn.Module, hidden_states: torch.Tensor) -> bool:
+    if not get_moe_a2a_backend().is_megamoe():
+        return False
+
+    experts = getattr(mlp, "experts", None)
+    quant_method = getattr(experts, "quant_method", None)
+    if not getattr(quant_method, "is_fp4_expert", False):
+        return False
+
+    from sglang.srt.layers.moe.mega_moe import should_use_mega_moe
+
+    return not should_use_mega_moe(mlp, hidden_states)
+
+
 def _is_fused_mhc_post_pre_enabled() -> bool:
     # The fused path directly reuses TileLang mhc_post/mhc_pre kernels and their
     # tensor layout assumptions, so keep it disabled when either dependency is off.
@@ -1580,11 +1594,16 @@ class DeepseekV4DecoderLayer(nn.Module):
             and get_parallel().attn_dp_size > 1
             and get_moe_a2a_backend().is_none()
         )
+        # The hand-scattered path is valid for MegaMOE's native kernel. When
+        # FP4 MegaMOE exceeds its token cap, the fallback runner must keep the
+        # full-token MHC layout to match the surrounding hc_post state.
+        _megamoe_fp4_fallback = _is_megamoe_fp4_fallback_mlp(self.mlp, hidden_states)
         _use_tp_attn_a2a_scatter = (
             not _use_cp
             and envs.SGLANG_DSV4_FIX_TP_ATTN_A2A_SCATTER.get()
             and get_parallel().attn_tp_size > 1
             and not get_moe_a2a_backend().is_none()
+            and not _megamoe_fp4_fallback
         )
         # symmetric gather+scatter for the no-EP TP-MoE dp-attn path:
         # all_gatherv gather (in self.mlp's dp_gather) + reduce_scatterv combine.

--- a/test/registered/unit/layers/quantization/test_fp8_megamoe_fp4_fallback.py
+++ b/test/registered/unit/layers/quantization/test_fp8_megamoe_fp4_fallback.py
@@ -1,0 +1,106 @@
+"""Unit tests for the FP4 MegaMoE fallback runner selection.
+
+MegaMoE uses its specialized kernels while the token count stays under the
+configured cap. When a request exceeds that cap, the model falls back to the
+normal MoE runner created here. For DeepSeek-V4 FP4 experts, that fallback must
+use DeepGEMM because the MegaMoE weight preparation produces the scale layout
+that DeepGEMM consumes; Triton's FP8 path rejects it.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.layers.moe import MoeRunnerBackend, MoeRunnerConfig
+from sglang.srt.layers.moe.utils import MoeA2ABackend
+from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8MoEMethod
+
+
+class TestFp8MegaMoeFp4Fallback(unittest.TestCase):
+    def _create_runner_backend(
+        self,
+        *,
+        is_fp4_experts,
+        a2a_backend,
+        runner_backend=MoeRunnerBackend.AUTO,
+        deepgemm_enabled=False,
+    ):
+        quant_config = Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[1, 32],
+            is_fp4_experts=is_fp4_experts,
+        )
+
+        with patch(
+            "sglang.srt.layers.quantization.fp8.get_moe_runner_backend",
+            return_value=runner_backend,
+        ):
+            method = Fp8MoEMethod(quant_config)
+
+        with patch(
+            "sglang.srt.layers.quantization.fp8.get_moe_runner_backend",
+            return_value=runner_backend,
+        ), patch(
+            "sglang.srt.layers.quantization.fp8.get_moe_a2a_backend",
+            return_value=a2a_backend,
+        ), patch.object(
+            Fp8MoEMethod,
+            "is_deepgemm_moe_runner_backend_enabled",
+            return_value=deepgemm_enabled,
+        ), patch(
+            "sglang.srt.layers.quantization.fp8.MoeRunner"
+        ) as mock_runner:
+            method.create_moe_runner(object(), MoeRunnerConfig())
+
+        mock_runner.assert_called_once()
+        return mock_runner.call_args.args[0]
+
+    def test_auto_megamoe_fp4_experts_use_deep_gemm(self):
+        backend = self._create_runner_backend(
+            is_fp4_experts=True,
+            a2a_backend=MoeA2ABackend.MEGAMOE,
+        )
+
+        self.assertEqual(backend, MoeRunnerBackend.DEEP_GEMM)
+
+    def test_auto_megamoe_regular_fp8_keeps_triton_default(self):
+        backend = self._create_runner_backend(
+            is_fp4_experts=False,
+            a2a_backend=MoeA2ABackend.MEGAMOE,
+        )
+
+        self.assertEqual(backend, MoeRunnerBackend.TRITON)
+
+    def test_auto_non_megamoe_fp4_keeps_triton_default(self):
+        backend = self._create_runner_backend(
+            is_fp4_experts=True,
+            a2a_backend=MoeA2ABackend.NONE,
+        )
+
+        self.assertEqual(backend, MoeRunnerBackend.TRITON)
+
+    def test_auto_existing_deep_gemm_detection_is_preserved(self):
+        backend = self._create_runner_backend(
+            is_fp4_experts=False,
+            a2a_backend=MoeA2ABackend.DEEPEP,
+            deepgemm_enabled=True,
+        )
+
+        self.assertEqual(backend, MoeRunnerBackend.DEEP_GEMM)
+
+    def test_explicit_triton_is_preserved(self):
+        backend = self._create_runner_backend(
+            is_fp4_experts=True,
+            a2a_backend=MoeA2ABackend.MEGAMOE,
+            runner_backend=MoeRunnerBackend.TRITON,
+        )
+
+        self.assertEqual(backend, MoeRunnerBackend.TRITON)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/models/test_deepseek_v4_megamoe_scatter_guard.py
+++ b/test/registered/unit/models/test_deepseek_v4_megamoe_scatter_guard.py
@@ -1,0 +1,90 @@
+"""Unit tests for DeepSeek-V4 MegaMOE TP-attention scatter gating."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.moe.utils import MoeA2ABackend
+from sglang.srt.models import deepseek_v4
+
+
+class _QuantMethod:
+    def __init__(self, *, is_fp4_expert: bool):
+        self.is_fp4_expert = is_fp4_expert
+
+
+class _Experts:
+    def __init__(self, *, is_fp4_expert: bool):
+        self.quant_method = _QuantMethod(is_fp4_expert=is_fp4_expert)
+
+
+class _Mlp:
+    def __init__(self, *, is_fp4_expert: bool):
+        self.experts = _Experts(is_fp4_expert=is_fp4_expert)
+
+
+class TestDeepseekV4MegaMoeScatterGuard(unittest.TestCase):
+    def test_megamoe_fp4_fallback_disables_scatter(self):
+        mlp = _Mlp(is_fp4_expert=True)
+        hidden_states = torch.empty(8, 16)
+
+        with patch.object(
+            deepseek_v4,
+            "get_moe_a2a_backend",
+            return_value=MoeA2ABackend.MEGAMOE,
+        ), patch(
+            "sglang.srt.layers.moe.mega_moe.should_use_mega_moe",
+            return_value=False,
+        ) as mock_should_use:
+            self.assertTrue(
+                deepseek_v4._is_megamoe_fp4_fallback_mlp(mlp, hidden_states)
+            )
+
+        mock_should_use.assert_called_once_with(mlp, hidden_states)
+
+    def test_megamoe_fp4_native_path_keeps_scatter_available(self):
+        mlp = _Mlp(is_fp4_expert=True)
+
+        with patch.object(
+            deepseek_v4,
+            "get_moe_a2a_backend",
+            return_value=MoeA2ABackend.MEGAMOE,
+        ), patch(
+            "sglang.srt.layers.moe.mega_moe.should_use_mega_moe",
+            return_value=True,
+        ):
+            self.assertFalse(
+                deepseek_v4._is_megamoe_fp4_fallback_mlp(mlp, torch.empty(4, 16))
+            )
+
+    def test_non_megamoe_or_non_fp4_paths_keep_scatter_available(self):
+        with patch.object(
+            deepseek_v4,
+            "get_moe_a2a_backend",
+            return_value=MoeA2ABackend.NONE,
+        ):
+            self.assertFalse(
+                deepseek_v4._is_megamoe_fp4_fallback_mlp(
+                    _Mlp(is_fp4_expert=True), torch.empty(4, 16)
+                )
+            )
+
+        with patch.object(
+            deepseek_v4,
+            "get_moe_a2a_backend",
+            return_value=MoeA2ABackend.MEGAMOE,
+        ):
+            self.assertFalse(
+                deepseek_v4._is_megamoe_fp4_fallback_mlp(
+                    _Mlp(is_fp4_expert=False), torch.empty(4, 16)
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Motivation

Fixes #27416.

DeepSeek-V4 FP4 with `--moe-a2a-backend megamoe` can crash when `moe_runner_backend=auto` and a request exceeds the MegaMOE token cap. In that case MegaMOE falls back to the normal MoE runner, but `auto` previously selected Triton. Triton does not consume the FP4 scale layout prepared for the MegaMOE/DeepGEMM path, so the fallback hit a shape assertion instead of serving the long prompt.

After switching the FP4 MegaMOE fallback runner to DeepGEMM, the issue-specific repro exposed a second DeepSeek-V4-only fallback mismatch: the TP attention A2A scatter optimization can shrink the MHC post-attention layout while the fallback `hc_post` path still expects the full-token layout.

## Modifications

- In `Fp8MoEMethod.create_moe_runner`, keep explicit backend choices unchanged, but make `auto` select `MoeRunnerBackend.DEEP_GEMM` for FP4 experts when the configured MoE A2A backend is MegaMOE.
- Preserve the existing regular FP8 `auto -> Triton` behavior and the existing DeepGEMM detection logic.
- In DeepSeek-V4, detect the FP4 MegaMOE fallback path and skip `SGLANG_DSV4_FIX_TP_ATTN_A2A_SCATTER` only for that fallback, so the surrounding MHC state keeps the full-token layout expected by `hc_post`.
- Add focused unit tests for FP4 MegaMOE fallback backend selection and the DeepSeek-V4 scatter guard.

## Accuracy Tests

This is a crash fix for a fallback path, not an intended output change.

- B200 smoke validation with `deepseek-ai/DeepSeek-V4-Flash`, TP=2, `--moe-a2a-backend megamoe`, `SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=4096`:
  - 3318-token prompt: generation succeeded.
  - 5209-token prompt: generation succeeded.
- The original baseline failed on the 5209-token prompt with a Triton FP4 scale shape assertion. The patched run had no scheduler exception, Triton assertion, `mhc_post_tilelang` mismatch, or client disconnect in the checked logs.
- No full accuracy benchmark was run because unaffected paths should preserve their previous backend behavior and this PR targets a crash-only fallback.

## Speed Tests and Profiling

No speed benchmark was run. The hot-path change is limited to a backend selection branch during runner creation and a fallback-only guard around the DeepSeek-V4 scatter optimization.

The native MegaMOE path still uses the existing scatter optimization. The guard only disables that optimization when FP4 MegaMOE has already exceeded its token cap and is using the fallback runner, where correctness requires the full-token MHC layout.

## Validation

- `PATH="$HOME/.cargo/bin:$PATH" /tmp/sglang27416-precommit-venv/bin/pre-commit run --all-files`
- `PYTHONPATH=/home/bef0rewind/Projects/hobby/sglang-27416/python /tmp/sglang27416-venv/bin/python -m pytest /home/bef0rewind/Projects/hobby/sglang-27416/test/registered/unit/layers/quantization/test_fp8_megamoe_fp4_fallback.py /home/bef0rewind/Projects/hobby/sglang-27416/test/registered/unit/models/test_deepseek_v4_megamoe_scatter_guard.py -q`
  - `8 passed, 20 warnings`
- `/tmp/sglang27416-venv/bin/python -m py_compile python/sglang/srt/layers/quantization/fp8.py python/sglang/srt/models/deepseek_v4.py`
- `git diff --check HEAD~1..HEAD`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No docs update was needed for this runtime crash fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Issue-specific accuracy/smoke validation is above; no full speed benchmark was run because this is a fallback crash fix.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28307017959](https://github.com/sgl-project/sglang/actions/runs/28307017959)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28307017892](https://github.com/sgl-project/sglang/actions/runs/28307017892)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->