### PR TITLE
Fix SHM feature finalization under DP attention

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -235,27 +235,18 @@ class SchedulerRequestReceiver:
         # so that ShmPointerMMData metadata (not full tensor data) is what
         # gets serialized during broadcast_pyobj.
         if recv_reqs:
-            # Barrier for the non-DP-attention path only: there is a single
-            # broadcast_pyobj on tp_cpu_group where the source rank returns
-            # the original objects immediately while other ranks are still in
-            # pickle.loads (-> __setstate__ -> shm_open).  Without a barrier
-            # the source can call materialize() / shm_unlink before others
-            # open the segment.  recv_reqs is consistent across all ranks
-            # here (same broadcast), so the guard is deadlock-free.
-            #
-            # Under DP-attention no barrier is needed: the control_reqs
-            # broadcast on tp_cpu_group (step 3) is a collective that forces
-            # every rank to complete the earlier attn_tp / attn_cp work_reqs
-            # deserializations (steps 1-2, which call shm_open) before any
-            # rank returns from step 3.  POSIX guarantees shm_unlink only
-            # removes the name; already-open handles stay valid.
-            if (
-                not self.server_args.enable_dp_attention
-                and self.ps.tp_size > 1
-                and self.model_config.is_multimodal
-                and has_shm_features(recv_reqs)
-            ):
-                barrier(group=self.tp_cpu_group)
+            if self.model_config.is_multimodal and has_shm_features(recv_reqs):
+                # The broadcast source returns with its original objects while
+                # peer ranks may still be unpickling ShmPointerMMData
+                # (-> shm_open). Synchronize the same CPU groups that carried
+                # SHM-backed work requests before materialize() unlinks them.
+                if self.server_args.enable_dp_attention:
+                    if self.ps.attn_tp_size > 1:
+                        barrier(group=self.attn_tp_cpu_group)
+                    if self.ps.attn_cp_size > 1:
+                        barrier(group=self.attn_cp_cpu_group)
+                elif self.ps.tp_size > 1:
+                    barrier(group=self.tp_cpu_group)
             for req in recv_reqs:
                 unwrap_shm_features(req)
 

--- a/test/registered/unit/managers/test_request_receiver_shm_finalize.py
+++ b/test/registered/unit/managers/test_request_receiver_shm_finalize.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+
+from sglang.srt.managers.scheduler_components import request_receiver
+
+
+def _receiver(
+    *,
+    enable_dp_attention: bool,
+    tp_size: int = 4,
+    attn_tp_size: int = 4,
+    attn_cp_size: int = 1,
+    is_multimodal: bool = True,
+):
+    return SimpleNamespace(
+        server_args=SimpleNamespace(enable_dp_attention=enable_dp_attention),
+        ps=SimpleNamespace(
+            tp_size=tp_size,
+            attn_tp_size=attn_tp_size,
+            attn_cp_size=attn_cp_size,
+        ),
+        model_config=SimpleNamespace(is_multimodal=is_multimodal),
+        tp_cpu_group="tp",
+        attn_tp_cpu_group="attn_tp",
+        attn_cp_cpu_group="attn_cp",
+    )
+
+
+def _run_finalize(monkeypatch, receiver, *, has_shm=True):
+    calls = []
+
+    monkeypatch.setattr(
+        request_receiver,
+        "has_shm_features",
+        lambda recv_reqs: has_shm,
+    )
+    monkeypatch.setattr(
+        request_receiver,
+        "barrier",
+        lambda *, group: calls.append(("barrier", group)),
+    )
+    monkeypatch.setattr(
+        request_receiver,
+        "unwrap_shm_features",
+        lambda req: calls.append(("unwrap", req)),
+    )
+
+    reqs = ["req0", "req1"]
+    request_receiver.SchedulerRequestReceiver._finalize_shm_features(receiver, reqs)
+    return calls
+
+
+def test_finalize_shm_features_syncs_dp_attention_work_groups(monkeypatch):
+    receiver = _receiver(
+        enable_dp_attention=True,
+        attn_tp_size=4,
+        attn_cp_size=2,
+    )
+
+    calls = _run_finalize(monkeypatch, receiver)
+
+    assert calls == [
+        ("barrier", "attn_tp"),
+        ("barrier", "attn_cp"),
+        ("unwrap", "req0"),
+        ("unwrap", "req1"),
+    ]
+
+
+def test_finalize_shm_features_keeps_tp_barrier_for_non_dp_attention(monkeypatch):
+    receiver = _receiver(enable_dp_attention=False, tp_size=4)
+
+    calls = _run_finalize(monkeypatch, receiver)
+
+    assert calls == [
+        ("barrier", "tp"),
+        ("unwrap", "req0"),
+        ("unwrap", "req1"),
+    ]
+
+
+def test_finalize_shm_features_skips_barrier_without_shm_features(monkeypatch):
+    receiver = _receiver(enable_dp_attention=True)
+
+    calls = _run_finalize(monkeypatch, receiver, has_shm=False)
+
+    assert calls == [
+        ("unwrap", "req0"),
+        ("unwrap", "req1"),
+    ]


### PR DESCRIPTION
## Summary
- Synchronize on the CPU groups that broadcast SHM-backed multimodal work requests before materializing and unlinking those features.
- Preserve the existing TP-group barrier behavior for the non-DP-attention path.
- Add focused unit coverage for DP-attention, non-DP-attention, and no-SHM finalization behavior.

## Testing
- uv run python -m py_compile python/sglang/srt/managers/scheduler_components/request_receiver.py test/registered/unit/managers/test_request_receiver_shm_finalize.py
- uv run python -m pytest test/registered/unit/managers/test_request_receiver_shm_finalize.py (could not run locally: pytest is not installed in this environment)

## Source commits
- `5058b632`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28308122067](https://github.com/sgl-project/sglang/actions/runs/28308122067)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28308122022](https://github.com/sgl-project/sglang/actions/runs/28308122022)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->