### PR TITLE
Avoid empty content prelude in chat streams

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1104,7 +1104,6 @@ class OpenAIServingChat(OpenAIServingBase):
                         model=request.model,
                         index=index,
                         role="assistant",
-                        content="",
                     )
                     stream_started = True
 

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1645,6 +1645,85 @@ class ServingChatTestCase(unittest.TestCase):
             "empty-delta logprobs chunk emitted without a parser; would break client chunk-shape assumptions",
         )
 
+    def test_streaming_tool_calls_do_not_emit_empty_content_only_delta(self):
+        """Tool-call streams should not emit content="" chunks with no payload.
+
+        Some OpenAI-compatible clients treat a content-only empty delta as an
+        empty text turn and stop before the following tool_call deltas arrive.
+        """
+        self.chat.reasoning_parser = "qwen3"
+        self.chat.tool_call_parser = "qwen3_coder"
+
+        async def _mock_generate_tool_call():
+            for text, finish_reason in [
+                ("", None),
+                (
+                    "<tool_call><function=bash><parameter=cmd>ls /tmp"
+                    "</parameter></function></tool_call>",
+                    {"type": "stop", "matched": None},
+                ),
+            ]:
+                yield {
+                    "text": text,
+                    "meta_info": {
+                        "id": "chatcmpl-tool-empty-content",
+                        "prompt_tokens": 5,
+                        "completion_tokens": 2,
+                        "cached_tokens": 0,
+                        "finish_reason": finish_reason,
+                        "output_token_logprobs": None,
+                        "output_top_logprobs": None,
+                    },
+                    "index": 0,
+                }
+
+        self.tm.generate_request.return_value = _mock_generate_tool_call()
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "List /tmp"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"cmd": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            tool_choice="auto",
+            stream=True,
+        )
+
+        chunks = self._run_chat_stream(None, req)
+        parsed = self._parse_chunks(chunks)
+
+        self.assertEqual(parsed[0]["choices"][0]["delta"].get("role"), "assistant")
+        self.assertIsNone(parsed[0]["choices"][0]["delta"].get("content"))
+
+        tool_call_chunks = [
+            c
+            for c in parsed
+            if c["choices"] and c["choices"][0]["delta"].get("tool_calls") is not None
+        ]
+        self.assertTrue(tool_call_chunks, "tool_calls were not streamed")
+
+        empty_content_only_chunks = [
+            c
+            for c in parsed
+            if c["choices"]
+            and c["choices"][0]["delta"].get("content") == ""
+            and c["choices"][0]["delta"].get("tool_calls") is None
+            and c["choices"][0].get("finish_reason") is None
+        ]
+        self.assertFalse(
+            empty_content_only_chunks,
+            "content-only empty delta emitted before tool_calls",
+        )
+
     def test_non_streaming_cached_tokens_details_emits_sglext(self):
         """Test that non-streaming chat responses emit cached token details in sglext."""
 


### PR DESCRIPTION
## Motivation

Fixes #29441.

OpenAI-compatible clients can treat a streaming `delta.content == ""` chunk
with no `tool_calls` as an empty assistant text turn. For tool-call streams that
means the client may stop before later `tool_calls` deltas arrive.

The chat streaming path already emits a dedicated assistant role prelude before
content/tool-call chunks. That prelude does not need to carry an empty content
field.

## Modifications

- Stop setting `content=""` on the assistant role prelude in OpenAI chat
  streaming responses. The first chunk now carries `delta.role` only.
- Add a regression test that simulates a Qwen3-Coder tool-call stream and checks
  that:
  - the role prelude is still emitted;
  - the role prelude does not include `content=""`;
  - tool-call chunks are still streamed;
  - no `content=""` chunk appears without `tool_calls` or `finish_reason`.

## Accuracy Tests

Not applicable. This only changes OpenAI SSE response serialization for a no-op
role prelude and does not affect model execution or generated token content.

## Speed Tests and Profiling

Not applicable. This removes one empty field from the role prelude and does not
touch request scheduling, token generation, or hot model paths.

## Tests

```bash
git diff --check
PYTHONPATH=python .venv/bin/python -m py_compile \
  python/sglang/srt/entrypoints/openai/serving_chat.py \
  test/registered/unit/entrypoints/openai/test_serving_chat.py
PYTHONPATH=python .venv/bin/python -m pytest \
  test/registered/unit/entrypoints/openai/test_serving_chat.py::ServingChatTestCase::test_streaming_tool_calls_do_not_emit_empty_content_only_delta -q
PYTHONPATH=python .venv/bin/python -m pytest \
  test/registered/unit/entrypoints/openai/test_serving_chat.py::ServingChatTestCase::test_streaming_logprobs_not_flushed_on_empty_delta_step_without_parser \
  test/registered/unit/entrypoints/openai/test_serving_chat.py::ServingChatTestCase::test_streaming_logprobs_flushed_when_tool_parser_buffers_delta \
  test/registered/unit/entrypoints/openai/test_serving_chat.py::ServingChatTestCase::test_kimi_k2_streaming_tool_call_id_format -q
.venv/bin/python -m pre_commit run --files \
  python/sglang/srt/entrypoints/openai/serving_chat.py \
  test/registered/unit/entrypoints/openai/test_serving_chat.py
```

Results:

- New regression test: `1 passed`
- Nearby streaming/tool-call tests: `3 passed`
- `git diff --check`, `py_compile`, and file-scoped pre-commit passed

Hardware validation: not required. This is a CPU-testable OpenAI response shape
change in the streaming serialization path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28309589351](https://github.com/sgl-project/sglang/actions/runs/28309589351)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28309589285](https://github.com/sgl-project/sglang/actions/runs/28309589285)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->