### PR TITLE
[Spec] Publish DFLASH verify read-done event for fine-grained WAR barrier

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -995,14 +995,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         )
         with timer_ctx, self.backend.replay_session():
             self.load_batch(forward_batch, pp_proxy_tensors)
-            # Snapshot built -- publish a read-done event for the WAR barrier.
-            # Only plain DECODE: the captured decode graph reads only its static
-            # snapshot, so the forward is done reading the shared pool here. Spec
-            # verify (target_verify/dllm_extend) replays on this runner too, but
-            # those are NOT the step's last shared-buffer-reading phase (eagle
-            # publishes from draft_extend; ngram/dflash must not publish here),
-            # and some verify graphs may read beyond the snapshot in replay.
-            if forward_batch.forward_mode.is_decode():
+            # Publish a read-done event for the WAR barrier: a cuda-graph forward
+            # finishes its shared req_to_token / SWA reads at this pre-replay
+            # snapshot, so plain DECODE and DFLASH TARGET_VERIFY both qualify.
+            if forward_batch.forward_mode.is_decode() or (
+                forward_batch.forward_mode.is_target_verify()
+                and self.model_runner.spec_algorithm.is_dflash()
+            ):
                 read_done = self.device_module.Event()
                 read_done.record()
                 self.model_runner.war_fastpath_read_done_event = read_done


### PR DESCRIPTION
## What

Publish the WAR `read_done` event from the DFLASH target-verify forward so the scheduler's global `_apply_war_barrier` takes the fine-grained `wait_event(read_done)` fast path instead of the coarse `wait_stream(forward_stream)` fallback.

## Why it is valid

The target-verify cuda graph builds its page table in `load_batch` (pre-replay) and then replays reading only that static snapshot. So the forward finishes reading the shared `req_to_token` / SWA buffers *before* replay — `read_done` is recorded at exactly that point, so it is a sound WAR signal.

## WAR ordering

The over-alloc write to `req_to_token` (plan stream) stays ordered after the previous forward's read through this chain:

```
read_done  (recorded on the forward stream, after req_to_token is read)
   │  decode_cuda_graph_runner: war_fastpath_read_done_event = read_done
   ▼
schedule_stream.wait_event(read_done)         scheduler.py:1521  (_apply_war_barrier, called at loop top :1578)
   │
   ▼
plan_stream.wait_stream(schedule_stream)      dflash_info_v2.py:188  (prepare_for_decode)
   │
   ▼
over-alloc writes req_to_token (plan stream)  dflash_info_v2.py:218
```

`prepare_for_decode` already does `plan_stream.wait_stream(schedule_stream)` (originally to see the scheduler's filter/merge writes), so the plan-stream over-alloc write inherits the `read_done` dependency transitively — no explicit plan-stream wait is added. The barrier now waits only until `req_to_token` has been read (start of the verify forward) instead of the whole forward, recovering the overlap window the coarse fallback serialized.

## Dependencies

Builds on #29556 (merged) — removed `verify_done` and the dflash `_war_barrier_enabled` opt-out, routing dflash through `_apply_war_barrier`. Independent of #29343 (fa3).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28342455012](https://github.com/sgl-project/sglang/actions/runs/28342455012)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28342454942](https://github.com/sgl-project/sglang/actions/runs/28342454942)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
