### PR TITLE
Document model gateway tokenizer cache flags

### DIFF
--- a/docs_new/docs/advanced_features/sgl_model_gateway.mdx
+++ b/docs_new/docs/advanced_features/sgl_model_gateway.mdx
@@ -1310,10 +1310,10 @@ Two-level caching for optimal performance:
 </table>
 
 ```bash Command
---enable-l0-cache \
---l0-max-entries 10000 \
---enable-l1-cache \
---l1-max-memory 52428800  # 50MB
+--tokenizer-cache-enable-l0 \
+--tokenizer-cache-l0-max-entries 10000 \
+--tokenizer-cache-enable-l1 \
+--tokenizer-cache-l1-max-memory 52428800  # 50MB
 ```
 
 ***


### PR DESCRIPTION
## Motivation

Fixes #29093. The Model Gateway docs showed tokenizer cache flags that are not accepted by `launch_router.py`.

## Modifications

- Replace the old `--enable-l0-cache` / `--l0-max-entries` / `--enable-l1-cache` / `--l1-max-memory` example with the actual `--tokenizer-cache-*` CLI flags in the `docs_new` Model Gateway page.
- Leave the legacy `docs/` copy unchanged because the upstream lint job rejects legacy docs edits and points contributors to `docs_new`.

## Accuracy Tests

Not applicable. Documentation-only change.

## Speed Tests and Profiling

Not applicable. Documentation-only change.

## Tests

- `git diff --check origin/main...HEAD`
- Confirmed the old tokenizer cache flags are absent from `docs_new/docs/advanced_features/sgl_model_gateway.mdx`.
- Confirmed the accepted `--tokenizer-cache-*` flags are present in that page.

## Hardware Used

Not applicable. Documentation-only change.

## Validation Gaps

No runtime validation was needed because this only updates documented CLI flag names to match the router argument definitions.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28310294556](https://github.com/sgl-project/sglang/actions/runs/28310294556)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28310294502](https://github.com/sgl-project/sglang/actions/runs/28310294502)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->