### PR TITLE
Fix DP-attention SHM feature finalization race

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -235,27 +235,18 @@ class SchedulerRequestReceiver:
         # so that ShmPointerMMData metadata (not full tensor data) is what
         # gets serialized during broadcast_pyobj.
         if recv_reqs:
-            # Barrier for the non-DP-attention path only: there is a single
-            # broadcast_pyobj on tp_cpu_group where the source rank returns
-            # the original objects immediately while other ranks are still in
-            # pickle.loads (-> __setstate__ -> shm_open).  Without a barrier
-            # the source can call materialize() / shm_unlink before others
-            # open the segment.  recv_reqs is consistent across all ranks
-            # here (same broadcast), so the guard is deadlock-free.
-            #
-            # Under DP-attention no barrier is needed: the control_reqs
-            # broadcast on tp_cpu_group (step 3) is a collective that forces
-            # every rank to complete the earlier attn_tp / attn_cp work_reqs
-            # deserializations (steps 1-2, which call shm_open) before any
-            # rank returns from step 3.  POSIX guarantees shm_unlink only
-            # removes the name; already-open handles stay valid.
-            if (
-                not self.server_args.enable_dp_attention
-                and self.ps.tp_size > 1
-                and self.model_config.is_multimodal
-                and has_shm_features(recv_reqs)
-            ):
-                barrier(group=self.tp_cpu_group)
+            if self.model_config.is_multimodal and has_shm_features(recv_reqs):
+                # The broadcast source returns with its original objects while
+                # peer ranks may still be unpickling ShmPointerMMData
+                # (-> shm_open).  Synchronize the same CPU groups that carried
+                # SHM-backed work requests before materialize() unlinks them.
+                if self.server_args.enable_dp_attention:
+                    if self.ps.attn_tp_size > 1:
+                        barrier(group=self.attn_tp_cpu_group)
+                    if self.ps.attn_cp_size > 1:
+                        barrier(group=self.attn_cp_cpu_group)
+                elif self.ps.tp_size > 1:
+                    barrier(group=self.tp_cpu_group)
             for req in recv_reqs:
                 unwrap_shm_features(req)
 


### PR DESCRIPTION
## Motivation

Under DP-attention, the broadcast source rank returns with its original
objects while peer ranks may still be unpickling `ShmPointerMMData`
(`shm_open`).  Previously the SHM barrier only covered the non-DP-attention
path — under DP-attention no synchronization was performed, so
`materialize()` / `shm_unlink` could race with peers still opening the
shared memory segment.

## Changes

Fix by synchronizing on the same CPU groups (`attn_tp`, `attn_cp`) that
carried the SHM-backed work requests, rather than skipping the barrier
entirely under DP-attention.  The non-DP-attention path retains its
existing `tp_cpu_group` barrier.

Adds unit tests covering all three paths:
- DP-attention with both `attn_tp` and `attn_cp` groups
- Non-DP-attention with `tp_cpu_group`
- No-SHM-features skip (no barrier)

## Original commits

- `60bd82779d`

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28311128177](https://github.com/sgl-project/sglang/actions/runs/28311128177)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28311128133](https://github.com/sgl-project/sglang/actions/runs/28311128133)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->