### PR TITLE
shm_broadcast: bind XPUB port atomically to avoid pinned-port race

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/shm_broadcast.py
+++ b/python/sglang/srt/distributed/device_communicators/shm_broadcast.py
@@ -206,10 +206,19 @@ class MessageQueue:
             # message. otherwise, we will only receive the first subscription
             # see http://api.zeromq.org/3-3:zmq-setsockopt for more details
             self.local_socket.setsockopt(XPUB_VERBOSE, True)
-            local_subscribe_port = get_open_port()
-            socket_addr = f"tcp://127.0.0.1:{local_subscribe_port}"
-            logger.debug("Binding to %s", socket_addr)
-            self.local_socket.bind(socket_addr)
+            # Bind atomically to avoid get_open_port()'s check-then-bind race;
+            # search from SGLANG_PORT to keep the existing port range.
+            sglang_port = os.getenv("SGLANG_PORT")
+            if sglang_port is not None:
+                base = int(sglang_port)
+                local_subscribe_port = self.local_socket.bind_to_random_port(
+                    "tcp://127.0.0.1", min_port=base, max_port=base + 8
+                )
+            else:
+                local_subscribe_port = self.local_socket.bind_to_random_port(
+                    "tcp://127.0.0.1"
+                )
+            logger.debug("Bound to tcp://127.0.0.1:%d", local_subscribe_port)
             self.current_idx = 0
 
         else:


### PR DESCRIPTION
## Summary

When `SGLANG_PORT` is pinned and multiple `MessageQueue` writers start
concurrently on the same node, the XPUB local socket setup uses
`get_open_port()` followed by a later `bind()` — a non-atomic
check-then-bind. Two writers can be handed the same port and then collide
on `bind()` with `EADDRINUSE`.

One scheduler subprocess dies at init:

```
zmq.error.ZMQError: Address already in use (addr='tcp://127.0.0.1:50000')
  File ".../sglang/srt/distributed/parallel_state.py", line 464, in __init__
    self.mq_broadcaster = MessageQueue.create_from_process_group(self.cpu_group, 1 << 22, 6)
  File ".../sglang/srt/distributed/device_communicators/shm_broadcast.py", line 214, in __init__
    self.local_socket.bind(socket_addr)
```

which then cascades into a gloo failure on every rank:

```
RuntimeError: [gloo/transport/tcp/pair.cc] Connection reset by peer
  File ".../sglang/srt/model_executor/model_runner.py", line 1189, in get_available_gpu_memory
    torch.distributed.all_reduce(tensor, op=ReduceOp.MIN, group=group)
```

This replaces `get_open_port()` + `bind()` with zmq's `bind_to_random_port`,
which picks and binds a free port atomically. When `SGLANG_PORT` is set the
search starts at that base (`min=base`, `max=base + 8`) to preserve the
existing port range; otherwise it falls back to the default ephemeral range.

A similar atomic fix is proposed upstream in #15885 (PR #15903).

## Test

Concurrent `MessageQueue` writers under a pinned `SGLANG_PORT` no longer
hit the `EADDRINUSE` error; each binds a distinct port.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->