### PR TITLE
Handle Qwen2 attention partitioning with DP attention

### DIFF
--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -27,6 +27,7 @@ from sglang.srt.distributed import (
     get_pp_indices,
 )
 from sglang.srt.layers.activation import SiluAndMul
+from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
 from sglang.srt.layers.dp_attention import is_dp_attention_enabled
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
@@ -122,20 +123,21 @@ class Qwen2Attention(nn.Module):
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
-        tp_size = get_parallel().tp_size
+        attn_tp_rank = get_parallel().attn_tp_rank
+        attn_tp_size = get_parallel().attn_tp_size
         self.total_num_heads = num_heads
-        assert self.total_num_heads % tp_size == 0
-        self.num_heads = self.total_num_heads // tp_size
+        assert self.total_num_heads % attn_tp_size == 0
+        self.num_heads = self.total_num_heads // attn_tp_size
         self.total_num_kv_heads = num_kv_heads
-        if self.total_num_kv_heads >= tp_size:
+        if self.total_num_kv_heads >= attn_tp_size:
             # Number of KV heads is greater than TP size, so we partition
             # the KV heads across multiple tensor parallel GPUs.
-            assert self.total_num_kv_heads % tp_size == 0
+            assert self.total_num_kv_heads % attn_tp_size == 0
         else:
             # Number of KV heads is less than TP size, so we replicate
             # the KV heads across multiple tensor parallel GPUs.
-            assert tp_size % self.total_num_kv_heads == 0
-        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+            assert attn_tp_size % self.total_num_kv_heads == 0
+        self.num_kv_heads = max(1, self.total_num_kv_heads // attn_tp_size)
         if head_dim is not None:
             self.head_dim = head_dim
         else:
@@ -153,6 +155,8 @@ class Qwen2Attention(nn.Module):
             self.total_num_kv_heads,
             bias=True,
             quant_config=quant_config,
+            tp_rank=attn_tp_rank,
+            tp_size=attn_tp_size,
             prefix=add_prefix("qkv_proj", prefix),
         )
         self.o_proj = RowParallelLinear(
@@ -160,6 +164,9 @@ class Qwen2Attention(nn.Module):
             hidden_size,
             bias=False,
             quant_config=quant_config,
+            tp_rank=attn_tp_rank,
+            tp_size=attn_tp_size,
+            reduce_results=False,
             prefix=add_prefix("o_proj", prefix),
         )
 
@@ -238,6 +245,18 @@ class Qwen2DecoderLayer(nn.Module):
         self.post_attention_layernorm = RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
+        self.layer_scatter_modes = LayerScatterModes.init_new(
+            layer_id=layer_id,
+            num_layers=config.num_hidden_layers,
+            is_layer_sparse=False,
+            is_previous_layer_sparse=False,
+            is_next_layer_sparse=False,
+        )
+        self.layer_communicator = LayerCommunicator(
+            layer_scatter_modes=self.layer_scatter_modes,
+            input_layernorm=self.input_layernorm,
+            post_attention_layernorm=self.post_attention_layernorm,
+        )
 
     def forward(
         self,
@@ -247,20 +266,24 @@ class Qwen2DecoderLayer(nn.Module):
         residual: Optional[torch.Tensor],
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # Self Attention
-        if residual is None:
-            residual = hidden_states
-            hidden_states = self.input_layernorm(hidden_states)
-        else:
-            hidden_states, residual = self.input_layernorm(hidden_states, residual)
-        hidden_states = self.self_attn(
-            positions=positions,
-            hidden_states=hidden_states,
-            forward_batch=forward_batch,
+        hidden_states, residual = self.layer_communicator.prepare_attn(
+            hidden_states, residual, forward_batch
         )
+        if hidden_states.shape[0] != 0:
+            hidden_states = self.self_attn(
+                positions=positions,
+                hidden_states=hidden_states,
+                forward_batch=forward_batch,
+            )
 
         # Fully Connected
-        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        hidden_states = self.mlp(hidden_states)
+        hidden_states, residual = self.layer_communicator.prepare_mlp(
+            hidden_states, residual, forward_batch
+        )
+        hidden_states = self.mlp(hidden_states, forward_batch=forward_batch)
+        hidden_states, residual = self.layer_communicator.postprocess_layer(
+            hidden_states, residual, forward_batch
+        )
         return hidden_states, residual
 
 


### PR DESCRIPTION
## Motivation

Fixes #28615.

Qwen2 currently partitions attention with the regular tensor-parallel group. With
`--tp-size 2 --dp-size 2 --enable-dp-attention`, DP attention uses
`attn_tp_size=1`, so the KV cache expects the full Qwen2.5 KV-head count on each
rank while `qwen2.py` still emits KV tensors partitioned by regular TP.

I reproduced the latest `main` failure on 2 x H200 with
`Qwen/Qwen2.5-Coder-7B-Instruct`, triton attention, and DP attention enabled.
The server exits before readiness in the KV-store path:

```text
qwen2.py -> triton_backend.py -> memory_pool.py
RuntimeError: view size is not compatible with input tensor's size and stride
```

## Modifications

- Make `Qwen2Attention` use `get_parallel().attn_tp_rank` /
  `get_parallel().attn_tp_size` when deriving local Q/KV heads and constructing
  the QKV and output projections.
- Set the Qwen2 attention output projection to `reduce_results=False`, matching
  the DP-attention-aware Qwen3 and Qwen2-MoE implementations.
- Add dense `LayerScatterModes` / `LayerCommunicator` plumbing to
  `Qwen2DecoderLayer`, and skip self-attention on empty local-rank inputs before
  the communicator MLP path.

## Accuracy Tests

This is an output-neutral partitioning/communication fix for a crash path. The
patched server returns the same deterministic short generation on routed DP0 and
DP1 requests with temperature 0.

No dataset-level accuracy test was run.

## Speed Tests and Profiling

No benchmark was run. The change is scoped to Qwen2 model parallel plumbing and
mirrors existing DP-attention-aware dense/MoE model implementations.

The patched H200 smoke runs completed single post-warmup requests successfully
with CUDA graph enabled, but I am not making a speed claim from that smoke test.

## Validation

- `python3 -m py_compile python/sglang/srt/models/qwen2.py`: passed.
- `git diff --check origin/main..HEAD`: passed.
- `pre-commit run --files python/sglang/srt/models/qwen2.py`: passed.
- Latest-main baseline `593f5ba68f4c27d5ea5644cd46c938644b5ef61a`: failed
  before readiness on 2 x H200 with `Qwen/Qwen2.5-Coder-7B-Instruct`,
  `--attention-backend triton --tp-size 2 --dp-size 2 --enable-dp-attention
  --disable-cuda-graph`.
- Patched commit `1d47e69ddd1136acc838d0f071a3edc07b12405e`: passed on 2 x H200
  with the same model/backend, normal warmup, health generation enabled, CUDA
  graph enabled, and routed `/generate` requests to DP0 and DP1. `/health`
  became ready and both requests returned HTTP 200.
- Normal TP control on patched commit: passed on 2 x H200 with the same model
  and `--attention-backend triton --tp-size 2`, CUDA graph enabled. `/health`
  became ready and a default `/generate` request returned HTTP 200.

Hardware used:

- 2 x NVIDIA H200, driver 580.159.03
- Docker image `lmsysorg/sglang:latest`
- PyTorch 2.11.0+cu130 inside the container

Validation gaps:

- No full accuracy or throughput benchmark.
- No documentation update; this is a model execution bug fix.

## Checklist

- [x] Format/code style checked.
- [x] Focused tests added or explicitly not applicable.
- [x] Docs updated or explicitly not applicable.
- [x] Accuracy/speed evidence provided or gap justified.
- [x] Follow the SGLang code style guidance.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28315034282](https://github.com/sgl-project/sglang/actions/runs/28315034282)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28315034217](https://github.com/sgl-project/sglang/actions/runs/28315034217)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->