### PR TITLE
refactor: make mm_data_mooncake msgpack-native (drop PickleWrapper)

### DIFF
--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -30,7 +30,11 @@ from sglang.srt.distributed.parallel_state import (
     get_mooncake_transfer_engine,
 )
 from sglang.srt.environ import envs
-from sglang.srt.managers.io_struct import GenerateReqInput, TokenizedGenerateReqInput
+from sglang.srt.managers.io_struct import (
+    GenerateReqInput,
+    MooncakeMMUrlItem,
+    TokenizedGenerateReqInput,
+)
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
 from sglang.srt.managers.schedule_batch import Modality, Req
 from sglang.srt.server_args import ServerArgs
@@ -945,7 +949,7 @@ class WaitingImageRDMARequest(WaitingImageRequest):
         for modality in modalities:
             assigned_nums = self.num_items_assigned[modality]
             num_parts = modality_num_parts[modality]
-            mm_data_modality = [d for d in mm_data_all if d["modality"] == modality]
+            mm_data_modality = [d for d in mm_data_all if d.modality == modality]
             cum_num_items = 0
             cum_idx = 0
             for idx, assigned_num in enumerate(assigned_nums):
@@ -957,7 +961,7 @@ class WaitingImageRDMARequest(WaitingImageRequest):
                     {
                         "encoder_idx": idx,
                         "mm_items": [
-                            d["url"]
+                            d.url
                             for d in mm_data_modality[
                                 cum_num_items : cum_num_items + assigned_num
                             ]
@@ -1568,7 +1572,7 @@ class MMReceiverBase(ABC):
                 self.context, zmq.PULL, host=self.host
             )
             mm_data = self._extract_url_data(request_obj)
-            modalities = [m.get("modality") for m in mm_data]
+            modalities = [m.modality for m in mm_data]
             logger.info(
                 f"[{req_id}] Sending encode request to E, "
                 f"modalities={modalities}, num_items={len(mm_data)}"
@@ -1916,7 +1920,7 @@ class MMReceiverBase(ABC):
         Assign multimodal items across encoders by modality with cross-modality load balancing.
 
         Args:
-            mm_data: List of multimodal data items, each with a "modality" key
+            mm_data: List of multimodal data items, each with a modality
             encoder_num: Number of encoders
             random_shuffle: Whether to shuffle the encoder indices
 
@@ -1928,14 +1932,14 @@ class MMReceiverBase(ABC):
         if random_shuffle:
             random.shuffle(encode_idx)
         # Get unique modalities with order preserved
-        modalities = list(dict.fromkeys(mm_item.get("modality") for mm_item in mm_data))
+        modalities = list(dict.fromkeys(mm_item.modality for mm_item in mm_data))
         # Use OrderedDict to explicitly maintain modality order
         num_items_assigned = OrderedDict()
         current_offset = 0
 
         for modality in modalities:
             mm_data_modality = [
-                mm_item for mm_item in mm_data if mm_item.get("modality") == modality
+                mm_item for mm_item in mm_data if mm_item.modality == modality
             ]
             num_items = len(mm_data_modality)
             if num_items == 0:
@@ -1955,7 +1959,7 @@ class MMReceiverBase(ABC):
 
         return num_items_assigned
 
-    def _extract_url_data(self, request_obj) -> List[Dict]:
+    def _extract_url_data(self, request_obj) -> List[MooncakeMMUrlItem]:
         def flatten_mm_items(items):
             if not isinstance(items, list):
                 return [items]
@@ -1987,10 +1991,10 @@ class MMReceiverBase(ABC):
                 mm_items = flatten_mm_items(mm_items)
                 for mm_item in mm_items:
                     mm_data.append(
-                        {
-                            "url": to_raw_url(mm_item),
-                            "modality": modality,
-                        }
+                        MooncakeMMUrlItem(
+                            url=to_raw_url(mm_item),
+                            modality=modality,
+                        )
                     )
         return mm_data
 
@@ -2080,7 +2084,7 @@ class MMReceiverHTTP(MMReceiverBase):
         effective_urls = encode_urls if encode_urls is not None else self.encode_urls
 
         # get unique modalities with order preserved
-        modalities = [mm_item.get("modality") for mm_item in mm_data]
+        modalities = [mm_item.modality for mm_item in mm_data]
         modalities = list(dict.fromkeys(modalities))
         encode_requests = []
 
@@ -2098,7 +2102,7 @@ class MMReceiverHTTP(MMReceiverBase):
         for modality in modalities:
             num_items_assigned_modality = num_items_assigned.get(modality)
             mm_data_modality = [
-                mm_item for mm_item in mm_data if mm_item.get("modality") == modality
+                mm_item for mm_item in mm_data if mm_item.modality == modality
             ]
 
             num_parts = modality_num_parts[modality]
@@ -2114,7 +2118,7 @@ class MMReceiverHTTP(MMReceiverBase):
                         "encoder_idx": idx,
                         "encoder_url": effective_urls[idx],
                         "mm_items": [
-                            mm_item.get("url")
+                            mm_item.url
                             for mm_item in mm_data_modality[
                                 cum_num_items : cum_num_items + assigned_num
                             ]
@@ -2241,18 +2245,16 @@ class MMReceiverGrpc(MMReceiverBase):
 
         effective_urls = encode_urls if encode_urls is not None else self.encode_urls
 
-        # gRPC currently only supports image; flatten new dict formats to simple lists
-        if mm_data and isinstance(mm_data[0], dict):
+        # gRPC currently only supports image; flatten typed multimodal items to simple lists
+        if mm_data and isinstance(mm_data[0], MooncakeMMUrlItem):
             non_image = [
-                item.get("modality")
-                for item in mm_data
-                if item.get("modality") != Modality.IMAGE
+                item.modality for item in mm_data if item.modality != Modality.IMAGE
             ]
             if non_image:
                 raise NotImplementedError(
                     f"gRPC encode only supports IMAGE modality, got: {non_image}"
                 )
-            img_data = [item.get("url") for item in mm_data]
+            img_data = [item.url for item in mm_data]
         else:
             img_data = mm_data
         if isinstance(num_items_assigned, dict):

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -151,11 +151,16 @@ MultimodalDataInputFormat = Union[
 class MooncakeMMUrlItem(msgspec.Struct, array_like=True):
     """One multimodal item captured at tokenizer dispatch for mooncake encode routing.
 
-    ``url`` is the raw URL string from MMReceiverBase._extract_url_data
-    (ImageData.url when present); ``modality`` tags which encoder pool handles it.
+    ``url`` is the raw payload from MMReceiverBase._extract_url_data: the URL
+    string (ImageData.url, or dict["url"] when present) in the common case, or
+    the original raw multimodal item (e.g. a dict for processor/precomputed
+    formats, or bytes) when no URL is available. Typed as Any because msgspec
+    cannot express a union mixing str and bytes; the field still round-trips
+    over msgpack since every passthrough payload is a native msgpack type.
+    ``modality`` tags which encoder pool handles it.
     """
 
-    url: str
+    url: Any
     modality: Modality
 
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -148,6 +148,17 @@ MultimodalDataInputFormat = Union[
 ]
 
 
+class MooncakeMMUrlItem(msgspec.Struct, array_like=True):
+    """One multimodal item captured at tokenizer dispatch for mooncake encode routing.
+
+    ``url`` is the raw URL string from MMReceiverBase._extract_url_data
+    (ImageData.url when present); ``modality`` tags which encoder pool handles it.
+    """
+
+    url: str
+    modality: Modality
+
+
 @dataclass
 class GenerateReqInput:
     # Request ID(s). If omitted, generated during normalization. For batch
@@ -845,10 +856,9 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
 
     need_wait_for_mm_inputs: Optional[bool] = None
     num_items_assigned: Optional[Dict[Modality, List[int]]] = None
-    # Pickled Optional[List[{"url": MultimodalDataInputItem, "modality": Modality}]]
-    # from MMReceiverBase._extract_url_data. "url" is ImageData.url,
-    # dict["url"] when present, or the original raw multimodal item.
-    mm_data_mooncake: Optional[PickleWrapper] = None
+    # Multimodal URL snapshot from MMReceiverBase._extract_url_data for mooncake.
+    # Each item carries the raw URL/payload and modality captured at tokenizer dispatch.
+    mm_data_mooncake: Optional[List[MooncakeMMUrlItem]] = None
     # Encoder URL snapshot frozen at tokenizer-side dispatch time so that
     # encoder_idx assignments stay consistent in the scheduler subprocess.
     # Internal IPC only.
@@ -863,12 +873,10 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
 
     def wrap_pickle_fields(self):
         self.mm_inputs = wrap_as_pickle(self.mm_inputs)
-        self.mm_data_mooncake = wrap_as_pickle(self.mm_data_mooncake)
         self.time_stats = wrap_as_pickle(self.time_stats)
 
     def unwrap_pickle_fields(self):
         self.mm_inputs = unwrap_from_pickle(self.mm_inputs)
-        self.mm_data_mooncake = unwrap_from_pickle(self.mm_data_mooncake)
         self.time_stats = unwrap_from_pickle(self.time_stats)
 
 

--- a/test/registered/unit/managers/test_io_struct_msgpack.py
+++ b/test/registered/unit/managers/test_io_struct_msgpack.py
@@ -1,0 +1,86 @@
+import unittest
+
+from sglang.srt.managers.io_struct import (
+    MooncakeMMUrlItem,
+    TokenizedGenerateReqInput,
+    msgpack_decode,
+    msgpack_encode,
+)
+from sglang.srt.managers.schedule_batch import Modality
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
+
+register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=8, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=8, suite="base-c-test-cpu")
+
+
+class TestTokenizedGenerateReqInputMsgpack(unittest.TestCase):
+    def _make_request(self, mm_data_mooncake):
+        return TokenizedGenerateReqInput(
+            input_text="",
+            input_ids=None,
+            input_embeds=None,
+            mm_inputs=None,
+            token_type_ids=None,
+            sampling_params=SamplingParams(),
+            return_logprob=False,
+            logprob_start_len=0,
+            top_logprobs_num=0,
+            token_ids_logprob=None,
+            stream=False,
+            mm_data_mooncake=mm_data_mooncake,
+        )
+
+    def _round_trip(self, req):
+        req.wrap_pickle_fields()
+        decoded = msgpack_decode(msgpack_encode(req))
+        decoded.unwrap_pickle_fields()
+        return decoded
+
+    def test_mm_data_mooncake_round_trips_populated(self):
+        items = [
+            MooncakeMMUrlItem(url="http://x/a.jpg", modality=Modality.IMAGE),
+            MooncakeMMUrlItem(url="http://x/b.mp4", modality=Modality.VIDEO),
+        ]
+
+        decoded = self._round_trip(self._make_request(items))
+
+        self.assertEqual(decoded.mm_data_mooncake, items)
+        self.assertEqual(decoded.mm_data_mooncake[0].url, "http://x/a.jpg")
+        self.assertEqual(decoded.mm_data_mooncake[0].modality, Modality.IMAGE)
+        self.assertEqual(decoded.mm_data_mooncake[1].url, "http://x/b.mp4")
+        self.assertEqual(decoded.mm_data_mooncake[1].modality, Modality.VIDEO)
+
+    def test_mm_data_mooncake_round_trips_none(self):
+        decoded = self._round_trip(self._make_request(None))
+
+        self.assertIsNone(decoded.mm_data_mooncake)
+
+    def test_mm_data_mooncake_round_trips_empty_list(self):
+        decoded = self._round_trip(self._make_request([]))
+
+        self.assertEqual(decoded.mm_data_mooncake, [])
+
+    def test_mm_data_mooncake_round_trips_all_modalities(self):
+        for modality in (Modality.IMAGE, Modality.VIDEO, Modality.AUDIO):
+            with self.subTest(modality=modality):
+                items = [
+                    MooncakeMMUrlItem(
+                        url=f"http://x/{modality.name.lower()}",
+                        modality=modality,
+                    )
+                ]
+
+                decoded = self._round_trip(self._make_request(items))
+
+                self.assertEqual(decoded.mm_data_mooncake[0].url, items[0].url)
+                self.assertEqual(decoded.mm_data_mooncake[0].modality, modality)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_io_struct_msgpack.py
+++ b/test/registered/unit/managers/test_io_struct_msgpack.py
@@ -56,6 +56,24 @@ class TestTokenizedGenerateReqInputMsgpack(unittest.TestCase):
         self.assertEqual(decoded.mm_data_mooncake[1].url, "http://x/b.mp4")
         self.assertEqual(decoded.mm_data_mooncake[1].modality, Modality.VIDEO)
 
+    def test_mm_data_mooncake_round_trips_dict_payload(self):
+        # _extract_url_data passes raw dict multimodal items through unchanged
+        # when they carry no "url" key, so the field must survive non-string
+        # payloads over msgpack.
+        items = [
+            MooncakeMMUrlItem(
+                url={"image": "data:base64", "detail": "high"},
+                modality=Modality.IMAGE,
+            ),
+        ]
+
+        decoded = self._round_trip(self._make_request(items))
+
+        self.assertEqual(
+            decoded.mm_data_mooncake[0].url, {"image": "data:base64", "detail": "high"}
+        )
+        self.assertEqual(decoded.mm_data_mooncake[0].modality, Modality.IMAGE)
+
     def test_mm_data_mooncake_round_trips_none(self):
         decoded = self._round_trip(self._make_request(None))
 


### PR DESCRIPTION
## Motivation

Follow-up to #28688, which moved IPC dataclasses to `msgspec.Struct` and added the opt-in msgpack transport (`SGLANG_USE_PICKLE_IPC=0`). Several fields still fall back to `PickleWrapper`. This handles Task 6 of #29465: `mm_data_mooncake` on `TokenizedGenerateReqInput` was typed `Optional[PickleWrapper]` and carried a pickled `List[{"url": ..., "modality": Modality}]` produced by `MMReceiverBase._extract_url_data`. Giving it a concrete msgspec type removes the whole-field pickle round-trip on the mooncake encode path. It is the most self-contained of the open tasks: one field, a known shape, and a single producer.

Refs #29465

## Modifications

- Added a `MooncakeMMUrlItem` `msgspec.Struct` (`url`, `modality`) in `io_struct.py` and retyped `mm_data_mooncake` from `Optional[PickleWrapper]` to `Optional[List[MooncakeMMUrlItem]]`. `url` is typed `Any` because msgspec cannot express a union mixing `str` and `bytes`; every payload `_extract_url_data` produces (URL string, raw dict, or bytes) is a native msgpack type, so the field round-trips without a wrapper.
- Dropped `mm_data_mooncake` from `wrap_pickle_fields()` / `unwrap_pickle_fields()` on `TokenizedGenerateReqInput`. `mm_inputs` and `time_stats` are untouched.
- Updated the producer `MMReceiverBase._extract_url_data` to build `MooncakeMMUrlItem` instead of a dict, and switched every consumer in `encode_receiver.py` (mooncake RDMA dispatch, HTTP encode dispatch, gRPC encode, and `_assign_items_by_modality`) from `["url"]`/`["modality"]` dict access to attribute access.
- Added `test/registered/unit/managers/test_io_struct_msgpack.py` covering msgpack round-trip of `mm_data_mooncake`: populated string URLs, a raw dict payload, `None`, empty list, and each `Modality` variant.

`tokenizer_manager.py` (passes the field through) and `request_logger.py` (lists it as a log-skip name) need no change.

## Accuracy Tests

Not applicable: this is a transport type change for an internal IPC field and does not affect model outputs.

## Speed Tests and Profiling

Not applicable to accuracy; the change removes a pickle encode/decode for this field on the mooncake path under msgpack IPC.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28315034919](https://github.com/sgl-project/sglang/actions/runs/28315034919)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28315034857](https://github.com/sgl-project/sglang/actions/runs/28315034857)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->