### PR TITLE
[logprob] Add return_token_ids_in_logprobs to skip redundant token ids in logprob outputs

### DIFF
--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -1867,6 +1867,8 @@ class MMReceiverBase(ABC):
             return_logprob=recv_req.return_logprob,
             top_logprobs_num=recv_req.top_logprobs_num,
             token_ids_logprob=recv_req.token_ids_logprob,
+            return_token_ids_in_logprobs=recv_req.return_token_ids_in_logprobs,
+            return_text_in_logprobs=recv_req.return_text_in_logprobs,
             stream=recv_req.stream,
             lora_id=recv_req.lora_id,
             input_embeds=recv_req.input_embeds,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -200,6 +200,8 @@ class GenerateReqInput:
     token_ids_logprob: Optional[Union[List[List[int]], List[int]]] = None
     # Whether to detokenize tokens in text in the returned logprobs.
     return_text_in_logprobs: bool = False
+    # Whether to include token ids in the returned logprobs.
+    return_token_ids_in_logprobs: bool = True
     # Whether to stream output.
     stream: bool = False
     # Whether to log metrics for this request (e.g. health_generate calls do not log metrics)
@@ -707,6 +709,7 @@ class GenerateReqInput:
             top_logprobs_num=self.top_logprobs_num[i],
             token_ids_logprob=self.token_ids_logprob[i],
             return_text_in_logprobs=self.return_text_in_logprobs,
+            return_token_ids_in_logprobs=self.return_token_ids_in_logprobs,
             stream=self.stream,
             log_metrics=self.log_metrics,
             return_hidden_states=(
@@ -787,6 +790,10 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     top_logprobs_num: int
     # If return logprobs, the token id to return logprob for
     token_ids_logprob: Optional[List[int]]
+    # Whether to detokenize tokens in text in the returned logprobs.
+    return_text_in_logprobs: bool = False
+    # Whether to include token ids in the returned logprobs.
+    return_token_ids_in_logprobs: bool = True
     # Whether to stream output
     stream: bool
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -676,6 +676,8 @@ class Req(ReqDllmMixin):
         top_logprobs_num: int = 0,
         dllm_config: Optional[DllmConfig] = None,
         token_ids_logprob: List[int] = None,
+        return_token_ids_in_logprobs: bool = True,
+        return_text_in_logprobs: bool = False,
         stream: bool = False,
         origin_input_ids_unpadded: Optional[array[int]] = None,
         lora_id: Optional[str] = None,
@@ -887,6 +889,8 @@ class Req(ReqDllmMixin):
 
         # Logprobs (arguments)
         self.return_logprob = return_logprob
+        self.return_token_ids_in_logprobs = return_token_ids_in_logprobs
+        self.return_text_in_logprobs = return_text_in_logprobs
         # Start index to compute logprob from.
         self.logprob_start_len = 0
         self.logprob = ReqLogprob(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2068,6 +2068,8 @@ class Scheduler(
                 return_logprob=recv_req.return_logprob,
                 top_logprobs_num=recv_req.top_logprobs_num,
                 token_ids_logprob=recv_req.token_ids_logprob,
+                return_token_ids_in_logprobs=recv_req.return_token_ids_in_logprobs,
+                return_text_in_logprobs=recv_req.return_text_in_logprobs,
                 stream=recv_req.stream,
                 lora_id=recv_req.lora_id,
                 input_embeds=recv_req.input_embeds,

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -409,6 +409,11 @@ class _GenerationStreamAccumulator:
             self.spec_correct_drafts_histogram.append(req.spec_correct_drafts_histogram)
 
         if self.return_logprob:
+            drop_token_ids_logprob_idx = (
+                req.logprob.token_ids_logprob is not None
+                and not req.return_token_ids_in_logprobs
+                and not req.return_text_in_logprobs
+            )
             if (
                 req.return_logprob
                 and not req.input_logprob_sent
@@ -429,7 +434,9 @@ class _GenerationStreamAccumulator:
                     req.logprob.input_token_ids_logprobs_val
                 )
                 self.input_token_ids_logprobs_idx.append(
-                    req.logprob.input_token_ids_logprobs_idx
+                    []
+                    if drop_token_ids_logprob_idx
+                    else req.logprob.input_token_ids_logprobs_idx
                 )
                 req.input_logprob_sent = True
             else:
@@ -468,7 +475,9 @@ class _GenerationStreamAccumulator:
                     ]
                 )
                 self.output_token_ids_logprobs_idx.append(
-                    req.logprob.output_token_ids_logprobs_idx[
+                    []
+                    if drop_token_ids_logprob_idx
+                    else req.logprob.output_token_ids_logprobs_idx[
                         send_output_token_logprobs_offset:logprob_end
                     ]
                 )

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1156,6 +1156,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 logprob_start_len=obj.logprob_start_len,
                 top_logprobs_num=obj.top_logprobs_num,
                 token_ids_logprob=obj.token_ids_logprob,
+                return_text_in_logprobs=obj.return_text_in_logprobs,
+                return_token_ids_in_logprobs=obj.return_token_ids_in_logprobs,
                 stream=obj.stream,
                 rid=obj.rid,
                 http_worker_ipc=obj.http_worker_ipc,
@@ -1906,6 +1908,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     state.obj.token_ids_logprob,
                     state.obj.return_text_in_logprobs
                     and not self.server_args.skip_tokenizer_init,
+                    state.obj.return_token_ids_in_logprobs,
                     recv_obj,
                     i,
                 )
@@ -2142,6 +2145,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         top_logprobs_num: int,
         token_ids_logprob: List[int],
         return_text_in_logprobs: bool,
+        return_token_ids_in_logprobs: bool = True,
     ):
         # 1. Handle regular logprobs
         if len(state.input_token_logprobs_val) > len(state.input_token_logprobs):
@@ -2202,6 +2206,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                             len(state.input_token_ids_logprobs) :
                         ],
                         return_text_in_logprobs,
+                        return_token_ids_in_logprobs,
                     )
                 )
             if len(state.output_token_ids_logprobs_val) > len(
@@ -2216,6 +2221,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                             len(state.output_token_ids_logprobs) :
                         ],
                         return_text_in_logprobs,
+                        return_token_ids_in_logprobs,
                     )
                 )
 
@@ -2231,6 +2237,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         return_text_in_logprobs: bool,
         recv_obj: BatchStrOutput,
         recv_obj_index: int,
+        return_token_ids_in_logprobs: bool = True,
     ):
         if recv_obj.input_token_logprobs_val is None:
             return
@@ -2288,6 +2295,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             state.obj.top_logprobs_num,
             state.obj.token_ids_logprob,
             return_text_in_logprobs,
+            return_token_ids_in_logprobs,
         )
 
     def detokenize_logprob_tokens(
@@ -2295,8 +2303,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         token_logprobs_val: List[float],
         token_logprobs_idx: List[int],
         decode_to_text: bool,
+        return_token_ids: bool = True,
     ):
         if not decode_to_text:
+            if not return_token_ids:
+                return list(token_logprobs_val)
             return [
                 (logprob, token_id, None)
                 for logprob, token_id in zip(token_logprobs_val, token_logprobs_idx)
@@ -2308,6 +2319,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             token_texts = self.tokenizer.batch_decode(
                 [[idx] for idx in token_logprobs_idx]
             )
+            if not return_token_ids:
+                return list(zip(token_logprobs_val, token_texts))
             return list(zip(token_logprobs_val, token_logprobs_idx, token_texts))
 
     def detokenize_top_logprobs_tokens(
@@ -2315,6 +2328,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         token_logprobs_val: List[float],
         token_logprobs_idx: List[int],
         decode_to_text: bool,
+        return_token_ids: bool = True,
     ):
         # TODO: The current implementation only batches the detokenization for top-k tokens per single position.
         # We should batch all top-k tokens in all positions.
@@ -2323,7 +2337,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             if token_logprobs_val[i]:
                 ret.append(
                     self.detokenize_logprob_tokens(
-                        token_logprobs_val[i], token_logprobs_idx[i], decode_to_text
+                        token_logprobs_val[i],
+                        token_logprobs_idx[i] if token_logprobs_idx else None,
+                        decode_to_text,
+                        return_token_ids,
                     )
                 )
             else:

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -302,6 +302,8 @@ class Session:
             return_logprob=req.return_logprob,
             top_logprobs_num=req.top_logprobs_num,
             token_ids_logprob=req.token_ids_logprob,
+            return_token_ids_in_logprobs=req.return_token_ids_in_logprobs,
+            return_text_in_logprobs=req.return_text_in_logprobs,
             vocab_size=vocab_size,
             eos_token_ids=eos_token_ids,
             require_reasoning=req.require_reasoning,

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -603,6 +603,27 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertTrue(req[0].return_prompt_token_ids)
         self.assertTrue(req[1].return_prompt_token_ids)
 
+    def test_return_token_ids_in_logprobs_default_true(self):
+        """Default must stay True for backward compatibility (output unchanged)."""
+        req = GenerateReqInput(text="Hello")
+        req.normalize_batch_and_arguments()
+        self.assertTrue(req.return_token_ids_in_logprobs)
+
+    def test_getitem_preserves_return_token_ids_in_logprobs(self):
+        """Batch subrequests must keep the return_token_ids_in_logprobs flag."""
+        req = GenerateReqInput(
+            input_ids=[[1, 2, 3], [4, 5, 6]],
+            sampling_params=[{}, {}],
+            rid=["id1", "id2"],
+            return_logprob=True,
+            token_ids_logprob=[[7, 8], [4, 5]],
+            return_token_ids_in_logprobs=False,
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertFalse(req[0].return_token_ids_in_logprobs)
+        self.assertFalse(req[1].return_token_ids_in_logprobs)
+
     def test_regenerate_rid(self):
         """Test the regenerate_rid method."""
         req = GenerateReqInput(text="Hello")

--- a/test/registered/unit/managers/test_logprob_return_token_ids.py
+++ b/test/registered/unit/managers/test_logprob_return_token_ids.py
@@ -1,0 +1,122 @@
+"""Unit tests for return_token_ids_in_logprobs / empty-idx logprob detokenization."""
+
+import unittest
+
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=8, suite="base-c-test-cpu")
+
+
+class _FakeTokenizer:
+    """Decode each single-id list to a deterministic ``tok<id>`` string."""
+
+    def batch_decode(self, ids_lists):
+        return [f"tok{ids[0]}" for ids in ids_lists]
+
+
+class _TMStub:
+    """Minimal stand-in for ``self`` (only the logprob detokenize paths run)."""
+
+    detokenize_logprob_tokens = TokenizerManager.detokenize_logprob_tokens
+    detokenize_top_logprobs_tokens = TokenizerManager.detokenize_top_logprobs_tokens
+
+    def __init__(self, tokenizer=None):
+        self.tokenizer = tokenizer
+
+
+class TestReturnTokenIdsInLogprobs(CustomTestCase):
+    def setUp(self):
+        self.tm = _TMStub()
+        self.tm_text = _TMStub(tokenizer=_FakeTokenizer())
+
+    # ---- flat (regular / per-request) path ------------------------------
+
+    def test_flat_default_keeps_triplets(self):
+        """Default return_token_ids=True keeps [logprob, token_id, None].
+
+        Also guards the regression where removing the default value made callers
+        that omit the argument raise TypeError.
+        """
+        out = self.tm.detokenize_logprob_tokens([-1.0, -2.0], [10, 20], False)
+        self.assertEqual(out, [(-1.0, 10, None), (-2.0, 20, None)])
+
+    def test_flat_drop_token_ids_returns_scalars(self):
+        """return_token_ids=False, no text -> raw logprob scalars."""
+        out = self.tm.detokenize_logprob_tokens(
+            [-1.0, -2.0], [10, 20], False, return_token_ids=False
+        )
+        self.assertEqual(out, [-1.0, -2.0])
+
+    def test_flat_text_with_token_ids(self):
+        """decode_to_text=True, return_token_ids=True -> (logprob, id, text)."""
+        out = self.tm_text.detokenize_logprob_tokens([-1.0, -2.0], [10, 20], True)
+        self.assertEqual(out, [(-1.0, 10, "tok10"), (-2.0, 20, "tok20")])
+
+    def test_flat_text_drop_token_ids(self):
+        """decode_to_text=True, return_token_ids=False -> (logprob, text).
+
+        The combination fixed in this change: text is preserved even though the
+        token id is dropped.
+        """
+        out = self.tm_text.detokenize_logprob_tokens(
+            [-1.0, -2.0], [10, 20], True, return_token_ids=False
+        )
+        self.assertEqual(out, [(-1.0, "tok10"), (-2.0, "tok20")])
+
+    # ---- per-position (top / token_ids) path ----------------------------
+
+    def test_top_default_keeps_triplets_with_none(self):
+        """Per-position default keeps triplets; empty rows stay None."""
+        val = [[], [-1.0, -2.0], [-3.0, -4.0]]
+        idx = [[], [10, 20], [30, 40]]
+        out = self.tm.detokenize_top_logprobs_tokens(val, idx, False)
+        self.assertEqual(out[0], None)
+        self.assertEqual(out[1], [(-1.0, 10, None), (-2.0, 20, None)])
+        self.assertEqual(out[2], [(-3.0, 30, None), (-4.0, 40, None)])
+
+    def test_top_drop_token_ids_returns_scalar_rows(self):
+        """Per-position return_token_ids=False -> each row is a flat scalar list."""
+        val = [[], [-1.0, -2.0], [-3.0, -4.0]]
+        idx = [[], [10, 20], [30, 40]]
+        out = self.tm.detokenize_top_logprobs_tokens(
+            val, idx, False, return_token_ids=False
+        )
+        self.assertEqual(out, [None, [-1.0, -2.0], [-3.0, -4.0]])
+
+    def test_top_tolerates_empty_idx_after_source_drop(self):
+        """idx dropped at the scheduler source -> empty idx list must not crash.
+
+        With return_token_ids=False the idx is never needed, so a non-empty val
+        paired with an empty idx still collapses to scalar rows. This mirrors
+        ``output_streamer.accept`` appending ``[]`` for the dropped idx.
+        """
+        val = [[-1.0, -2.0, -3.0]]
+        idx = []  # dropped in output_streamer.accept()
+        out = self.tm.detokenize_top_logprobs_tokens(
+            val, idx, False, return_token_ids=False
+        )
+        self.assertEqual(out, [[-1.0, -2.0, -3.0]])
+
+    def test_top_text_drop_token_ids(self):
+        """Per-position decode_to_text=True, return_token_ids=False -> (logprob, text)."""
+        val = [[-1.0, -2.0]]
+        idx = [[10, 20]]
+        out = self.tm_text.detokenize_top_logprobs_tokens(
+            val, idx, True, return_token_ids=False
+        )
+        self.assertEqual(out, [[(-1.0, "tok10"), (-2.0, "tok20")]])
+
+    def test_scalar_values_preserved_exactly(self):
+        """The scalar path must preserve the exact logprob values/order."""
+        val = [[-13.047, -8.953, -9.672]]
+        idx = [[1, 2, 3]]
+        out = self.tm.detokenize_top_logprobs_tokens(
+            val, idx, False, return_token_ids=False
+        )
+        self.assertEqual(out, [[-13.047, -8.953, -9.672]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

RL frameworks such as **VeRL**, **Miles**, and **Relax** increasingly use SGLang
as the inference engine for **on-policy distillation (OPD)**. Beyond fetching the
logprob of the student's *sampled* token, these pipelines now also rely on
**per-position top-k token selection**.

Take **student top-k** as a typical flow:

1. The student SGLang node rollout a response `resp` from the `prompt`, and
   produces, **per position**, its own top-k token ids and logprobs.
2. The teacher node is then asked — a single `prefill(prompt, resp)` — to return
   the logprobs for **those same per-position student top-k token ids**, so the
   two distributions can be compared (KL) position-by-position.

[sgl-project/sglang#27421](https://github.com/sgl-project/sglang/pull/27421) adds
a per-position field **`token_ids_logprob_positions`** (which folds into the
`token_ids_logprob` path), so the server returns a sparse `[R, k]` response
instead of the dense `[R, |union|]` union matrix — reducing the **client-side
parse/map-building** cost from `O(R²)` to `O(R·k)` (validated **22.9× smaller**
response, `95,823 → 4,184` bytes for `R=16, k=5`, byte-for-byte equal logprobs).

**However, there is still overhead left on the table even after the response is
sparse.** Every returned entry is a `[logprob, token_id, token_text]` triplet,
and for this OPD use case a large part of it is pure overhead:

- The `token_id` is **chosen by the caller itself** — in the per-position case it
  is exactly the student top-k ids we sent in — so echoing it back is fully
  redundant.
- The `token_text` is optional and usually unnecessary for OPD (already gated by
  `return_text_in_logprobs`); the `token_id` deserves the same opt-out.


These redundant fields are not free: the logprob `val`/`idx` arrays are pickled
and shipped across **two IPC hops** (Scheduler → DetokenizerManager →
TokenizerManager). The detokenizer merely passes them through, yet still pays the
pickle/unpickle cost on every request, and with per-position ids the `idx` array
grows linearly with `seq_len × k`. Crucially, **there is currently no way for the
caller to opt out** of returning the ids / text — this PR adds that knob.

### What is redundant

```python
# token_ids_logprob = [1, 2, 3]   (caller-supplied ids; per-pos: the student top-k ids we sent in)
'input_token_ids_logprobs':
  [None,
   [[-13.047, 1, None], [-8.953, 2, None], [-9.672, 3, None]],   # id == what we sent; text == None
   ...
  ],
'output_token_ids_logprobs': [[[-7.231, 1, None], [-8.418, 2, None], [-6.918, 3, None]]]
```

Only the leading `logprob` carries information; `token_id` is echoed back from the
request and `token_text` is `None`.

## Modifications

- Add `return_token_ids_in_logprobs` to `GenerateReqInput` (default **True**, so
  existing output is byte-for-byte unchanged). It only affects the
  `token_ids_logprob` path; `top_logprobs` always keep their ids because those are
  chosen by the server and unknown to the caller.
- Plumb `return_token_ids_in_logprobs` / `return_text_in_logprobs` all the way to
  the Scheduler (`TokenizedGenerateReqInput` → `Req`, including the session and
  disagg-encode request paths).
- **Drop at the source**: in `output_streamer.accept()`, when `token_ids_logprob`
  is set and both flags are off, the redundant
  `input/output_token_ids_logprobs_idx` are appended as `[]`, so they never enter
  the ②/③ IPC hops at all.
- `detokenize_logprob_tokens` / `detokenize_top_logprobs_tokens` tolerate the
  empty idx and collapse to raw logprob scalars (or `(logprob, text)` when text is
  requested).

## Pipeline & where the cost is

```
[Client]
   │ GenerateReqInput
   ▼
TokenizerManager ──①pickle─▶ Scheduler ──②pickle─▶ Detokenizer ──③pickle─▶ TokenizerManager ──▶ [Client]
                              (computes              (pass-through,           (builds the
                               val + idx)             pickle in/out)           triplet here)
                                          └────────── idx is shipped & pickled on ② and ③ ──────────┘
```

The `[logprob, token_id, text]` triplet is only materialized on the **last hop**;
hops ② and ③ carry flat `val` + `idx` arrays. This PR removes the redundant `idx`
from ② and ③ entirely.

## Benchmark (real pickle sizes)

Per-position `token_ids_logprob`, `resp_len=7618, topk=64` (152k vocab → 5-byte
`BININT`), measured with `pickle.dumps(..., protocol=5)`:

| array | pickle size |
|---|---|
| `val` (logprob, float) | 4.42 MB |
| **`idx` (token_id, int)** | **2.47 MB** |

Dropping `idx` per request saves:

- **~2.47 MB (35.8%)** of payload and **495,170** Python objects **per hop**
- across both hops (each = dumps + loads): **~4.94 MB** of transfer and
  **~990,340** object reconstructions avoided — plus the corresponding GC pressure
  on the single-threaded detokenizer/tokenizer processes.

This is **orthogonal** to #27421: #27421 attacks the **client-side
`O(R²)` parse/map-building** cost (union → per-position); this PR attacks the
**cross-process IPC/pickle** cost that remains even after the response is already
sparse `O(R·k)`. They are complementary — the larger the per-position fan-out, the
bigger the win.

## Accuracy & Test

- Default (`return_token_ids_in_logprobs=True`) keeps the exact legacy output.
- New unit tests in
  `test/registered/unit/managers/test_logprob_return_token_ids.py` cover all four
  `(decode_to_text, return_token_ids)` combinations and the empty-idx tolerance
  after a source-side drop; `test_io_struct.py` covers the field default and
  per-request propagation through `__getitem__`.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28316252970](https://github.com/sgl-project/sglang/actions/runs/28316252970)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28316252905](https://github.com/sgl-project/sglang/actions/runs/28316252905)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->