### PR TITLE
dflash: drop verify_done barrier; rely on scheduler WAR fallback

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1488,12 +1488,8 @@ class Scheduler(
         if self.device == "cpu":
             self.schedule_stream.synchronize = lambda: None  # No-op for CPU
         # The global WAR barrier fences the scheduler's next shared-buffer write
-        # on the forward's read-done event. DFLASH opts out: it fences its own
-        # req_to_token writes with verify_done / plan-stream deps, so the global
-        # barrier would only serialize plan overlap without adding correctness.
-        self._war_barrier_enabled = (
-            is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()
-        ) and not self.spec_algorithm.is_dflash()
+        # on the previous forward's read of the shared pool.
+        self._war_barrier_enabled = is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()
         with self.device_module.StreamContext(self.schedule_stream):
             dispatch_event_loop(self)
 

--- a/python/sglang/srt/speculative/dflash_info_v2.py
+++ b/python/sglang/srt/speculative/dflash_info_v2.py
@@ -46,7 +46,6 @@ class DFlashDraftInputV2(SpecInput):
     bonus_tokens: torch.Tensor
     new_seq_lens: torch.Tensor
     hidden_states: torch.Tensor
-    verify_done: Optional[torch.cuda.Event] = None
     max_top_k: int = 1
     uniform_top_k_value: Optional[int] = None
     reserved_seq_lens_cpu: Optional[torch.Tensor] = None
@@ -113,7 +112,6 @@ class DFlashDraftInputV2(SpecInput):
             bonus_tokens=torch.empty((0,), device=device, dtype=torch.int64),
             new_seq_lens=torch.empty((0,), device=device, dtype=torch.int64),
             hidden_states=torch.empty((0, 0), device=device, dtype=torch.float16),
-            verify_done=None,
         )
 
     def prepare_for_decode(self, batch: ScheduleBatch):
@@ -126,9 +124,6 @@ class DFlashDraftInputV2(SpecInput):
         the overallocated mapping.
         """
         plan_stream, plan_stream_ctx = _get_overlap_plan_stream(batch.device)
-        if plan_stream is None and self.verify_done is not None:
-            # Ensure previous forward is completed before mutating shared buffers.
-            self.verify_done.synchronize()
 
         bs = batch.batch_size()
         if bs == 0:
@@ -191,9 +186,6 @@ class DFlashDraftInputV2(SpecInput):
                 # have just been rebuilt on the scheduler stream by filter/merge ops.
                 # The plan stream must wait for those writes before reading them.
                 plan_stream.wait_stream(caller_stream)
-
-            if plan_stream is not None and self.verify_done is not None:
-                plan_stream.wait_event(self.verify_done)
 
             cur_kv_lens = self._prepare_cur_kv_lens_gpu_buf[:bs]
             nxt_kv_lens = self._prepare_nxt_kv_lens_gpu_buf[:bs]

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1233,7 +1233,6 @@ class DFlashWorkerV2(BaseSpecWorker):
         *,
         bonus_tokens: torch.Tensor,
         seq_lens: torch.Tensor,
-        verify_done: Optional[torch.cuda.Event] = None,
     ) -> DFlashDraftInputV2:
         bs = int(seq_lens.numel())
         device = bonus_tokens.device
@@ -1243,7 +1242,6 @@ class DFlashWorkerV2(BaseSpecWorker):
             bonus_tokens=bonus_tokens.to(dtype=torch.int64),
             new_seq_lens=seq_lens.to(dtype=torch.int64),
             hidden_states=torch.empty((bs, 0), device=device, dtype=torch.float16),
-            verify_done=verify_done,
         )
 
     def _make_next_draft_input_decode(
@@ -1251,7 +1249,6 @@ class DFlashWorkerV2(BaseSpecWorker):
         *,
         bonus_tokens: torch.Tensor,
         new_seq_lens: torch.Tensor,
-        verify_done: Optional[torch.cuda.Event] = None,
     ) -> DFlashDraftInputV2:
         bs = int(new_seq_lens.numel())
         device = bonus_tokens.device
@@ -1261,7 +1258,6 @@ class DFlashWorkerV2(BaseSpecWorker):
             bonus_tokens=bonus_tokens.to(dtype=torch.int64),
             new_seq_lens=new_seq_lens.to(dtype=torch.int64),
             hidden_states=torch.empty((bs, 0), device=device, dtype=torch.float16),
-            verify_done=verify_done,
         )
 
     def forward_batch_generation(
@@ -1331,9 +1327,6 @@ class DFlashWorkerV2(BaseSpecWorker):
                 bonus_tokens=next_token_ids,
                 seq_lens=batch.seq_lens,
             )
-            verify_done = torch.get_device_module(device).Event()
-            verify_done.record()
-            batch_output.next_draft_input.verify_done = verify_done
             return batch_output
 
         # Decode / target-verify stage.
@@ -1355,9 +1348,6 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
             if on_publish is not None:
                 on_publish(next_draft_input.new_seq_lens)
-            verify_done = torch.get_device_module(self.device).Event()
-            verify_done.record()
-            next_draft_input.verify_done = verify_done
             return GenerationBatchResult(
                 logits_output=None,
                 next_token_ids=empty_ids,
@@ -1732,9 +1722,6 @@ class DFlashWorkerV2(BaseSpecWorker):
             bonus_tokens=bonus,
             new_seq_lens=new_seq_lens,
         )
-        verify_done = torch.get_device_module(device).Event()
-        verify_done.record()
-        next_draft_input.verify_done = verify_done
 
         return GenerationBatchResult(
             logits_output=logits_output,


### PR DESCRIPTION
## Motivation

DFLASH self-fenced its `req_to_token` writes with a `verify_done` event — a CPU-blocking `cudaEventSynchronize` (~2.1ms x 37/profile), the largest remaining sync in the dflash overlap loop.

Now that seq_lens CPU values relay through the FutureMap (`publish_ready`, #29232), `verify_done`'s only remaining duty is the WAR fence (schedule writes `req_to_token`; the previous forward reads it). That fence is already provided by the scheduler's global `_apply_war_barrier` — dflash was just excluded from it via `and not is_dflash()`.

## Changes

- Remove the `verify_done` field and its record in all 3 forward paths (prefill / idle / decode).
- Remove the `verify_done.synchronize()` / `plan_stream.wait_event(verify_done)` gates in `prepare_for_decode`.
- Drop `and not is_dflash()` from `_war_barrier_enabled` so dflash flows through `_apply_war_barrier`.

## WAR ordering: before -> after

**Before** — dflash self-fenced the over-alloc write on its own `verify_done` event (recorded after the verify forward):

```
verify_done  (recorded after the verify forward completes)
   │
   ▼
plan_stream.wait_event(verify_done)            prepare_for_decode   (dflash self-fence -- REMOVED)
   │
   ▼
over-alloc writes req_to_token (plan stream)
```

**After** — the over-alloc write is ordered behind the previous forward through the scheduler's global barrier:

```
forward reads req_to_token  (forward stream)
   │  this PR publishes no read_done -> barrier takes the coarse branch
   ▼
schedule_stream.wait_stream(forward_stream)    scheduler.py:1510  (_apply_war_barrier, called at loop top :1564)
   │
   ▼
plan_stream.wait_stream(schedule_stream)       dflash_info_v2.py:188  (prepare_for_decode)
   │
   ▼
over-alloc writes req_to_token (plan stream)   dflash_info_v2.py:218
```

`prepare_for_decode` already does `plan_stream.wait_stream(schedule_stream)` (to see the scheduler's filter/merge writes), so the plan-stream over-alloc write inherits the barrier's dependency transitively — no explicit plan-stream wait is added.

Coarse `wait_stream(forward_stream)` waits for the full forward (same as the old `verify_done.synchronize()`) but is device-side, so it does not block the CPU thread. A follow-up (#29541) publishes a fine-grained `read_done` event so `_apply_war_barrier` takes the `wait_event(read_done)` branch (`scheduler.py:1507`) instead, waiting only until `req_to_token` has been read.

## Dependencies

Depends on #29232 (merged). Independent of #29343 (fa3).





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28316317922](https://github.com/sgl-project/sglang/actions/runs/28316317922)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28316317857](https://github.com/sgl-project/sglang/actions/runs/28316317857)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
