### PR TITLE
[cookbook] GLM-5.2 NVFP4 B300: TP8 recipe + 3 strategies

### DIFF
--- a/docs_new/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
@@ -134,4 +134,39 @@ export const benchmarks = [
         ttft_ms: 130174, tpot_ms: 67.12, tokens_per_sec_per_gpu: 589.4 },
     ],
   },
+  // ---- B300 + NVFP4 ----  (8-GPU single node, TP8; nvidia/GLM-5.2-NVFP4 via --quantization modelopt_fp4,
+  // measured on the lmsysorg/sglang:dev-glm52-nvfp4 preview image, flush-cache every run.
+  // tokens_per_sec_per_gpu = total server output tok/s / 8 GPUs (410→51, 1793→224, 1220→153, 1641→205, 3439→430).
+  // aime25 overrides the variant default (87.7 → 89.58, measured on this NVFP4 build); gsm8k inherits the default.)
+  {
+    match: { hw: "b300", variant: "default", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+    sglang_version: "dev-glm52-nvfp4",
+    accuracy: { aime25_pct: 89.58 },
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 196, tpot_ms: 1.86, tokens_per_sec_per_gpu: 51 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 274, tpot_ms: 6.95, tokens_per_sec_per_gpu: 224 },
+    ],
+  },
+  {
+    match: { hw: "b300", variant: "default", quant: "nvfp4", strategy: "balanced", nodes: "single" },
+    sglang_version: "dev-glm52-nvfp4",
+    accuracy: { aime25_pct: 89.58 },
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
+        ttft_ms: 680, tpot_ms: 48.9, tokens_per_sec_per_gpu: 153 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256 },
+        ttft_ms: 3010, tpot_ms: 149, tokens_per_sec_per_gpu: 205 },
+    ],
+  },
+  {
+    match: { hw: "b300", variant: "default", quant: "nvfp4", strategy: "high-throughput", nodes: "single" },
+    sglang_version: "dev-glm52-nvfp4",
+    accuracy: { aime25_pct: 89.58 },
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1024 },
+        ttft_ms: 6370, tpot_ms: 280, tokens_per_sec_per_gpu: 430 },
+    ],
+  },
 ];

--- a/docs_new/src/snippets/configs/zai-org/glm-5.2.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.2.jsx
@@ -614,11 +614,12 @@ sgl-eval run aime25 \\
     },
 
     // ====================================================================
-    // NVFP4 — nvidia/GLM-5.2-NVFP4 (Model Optimizer).
-    // B200: 8-GPU single node, TP8 (low-latency / balanced / high-throughput); balanced &
+    // NVFP4 — nvidia/GLM-5.2-NVFP4 (Model Optimizer). TP8 on B200/B300, TP4 on GB300.
+    // B200/B300: 8-GPU single node, TP8 (low-latency / balanced / high-throughput); balanced &
     // high-throughput add DP-Attention (dp8). low-latency uses MTP 5-1-6, balanced MTP 2-1-3.
-    // B300/GB300: 4-GPU single node, TP4 (the node fits the ~381 GB build); GB300 adds dp4 on
-    // balanced & high-throughput. Blackwell NVFP4 measured on the dev-glm52-nvfp4 preview image.
+    // GB300: 4-GPU single node, TP4 (the node fits the ~381 GB build); GB300 adds dp4 on
+    // balanced & high-throughput; low-latency uses MTP 5-1-6.
+    // Blackwell NVFP4 measured on the dev-glm52-nvfp4 preview image.
     // ====================================================================
     {
       match: { hw: "b200", variant: "default", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
@@ -685,14 +686,14 @@ sgl-eval run aime25 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
-        "--tp 4",
+        "--tp 8",
         "--quantization modelopt_fp4",
         "--speculative-algorithm EAGLE",
         "--speculative-num-steps 5",
         "--speculative-eagle-topk 1",
         "--speculative-num-draft-tokens 6",
         "--chunked-prefill-size 8192",
-        "--mem-fraction-static 0.8",
+        "--mem-fraction-static 0.85",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",
       ],
@@ -703,10 +704,40 @@ sgl-eval run aime25 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
-        "--tp 4",
+        "--tp 8",
+        "--dp 8",
+        "--enable-dp-attention",
         "--quantization modelopt_fp4",
+        // Shorter draft (MTP 2-1-3) than low-latency's 5-1-6: at this concurrency the
+        // verify overhead of a long draft outweighs the accept-length gain.
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 2",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 3",
+        // Two required flags for DP-Attention + MTP here: `decode`-mode spec attention
+        // avoids a CUDA-graph capture deadlock, and max-running 256 lifts the default
+        // ~48-request throttle so DP-Attention can fill all 8 ranks.
+        "--speculative-attention-mode decode",
+        "--max-running-requests 256",
         "--chunked-prefill-size 8192",
-        "--mem-fraction-static 0.8",
+        "--mem-fraction-static 0.85",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b300", variant: "default", quant: "nvfp4", strategy: "high-throughput", nodes: "single" },
+      verified: true,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--tp 8",
+        "--dp 8",
+        "--enable-dp-attention",
+        "--quantization modelopt_fp4",
+        "--max-running-requests 1024",
+        "--chunked-prefill-size 8192",
+        "--mem-fraction-static 0.85",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",
       ],


### PR DESCRIPTION
## Motivation

Update the GLM-5.2 **NVFP4 B300** cookbook entries. They previously shipped the TP4 layout with only `low-latency` + `balanced`. Replace them with the verified single-node **8×B300 TP8** recipe and add the missing `high-throughput` strategy, all measured on the `lmsysorg/sglang:dev-glm52-nvfp4` preview image.

## Changes

`docs_new/src/snippets/configs/zai-org/glm-5.2.jsx` — B300 NVFP4 cells:

- **low-latency** — `tp4 → tp8`, `mem-fraction-static 0.8 → 0.85`, keep full MTP 5-1-6
- **balanced** — `tp8 + dp8 + --enable-dp-attention`, shorter MTP 2-1-3, plus the two flags this path requires: `--speculative-attention-mode decode` (avoids a CUDA-graph capture deadlock) and `--max-running-requests 256` (lifts the default ~48-request throttle so DP-Attention can fill all 8 ranks)
- **high-throughput** (new) — `tp8 + dp8 + --enable-dp-attention`, no MTP, `--max-running-requests 1024`

`docs_new/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx` — fill the matching speed numbers for all three strategies. `tokens_per_sec_per_gpu = total output tok/s ÷ 8 GPUs`. `aime25` overrides to 89.58 on the NVFP4 build (same checkpoint as the GB300 NVFP4 entries); gsm8k inherits the variant default.

| strategy | conc | tok/s/gpu | TTFT | TPOT |
|---|---|---|---|---|
| low-latency | 1 / 16 | 51 / 224 | 196 / 274 ms | 1.86 / 6.95 ms |
| balanced | 64 / 256 | 153 / 205 | 680 / 3010 ms | 48.9 / 149 ms |
| high-throughput | 1024 | 430 | 6370 ms | 280 ms |

## Checklist

- Docs/cookbook-only change; both JSX configs validated via `node --check` + module import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28402970621](https://github.com/sgl-project/sglang/actions/runs/28402970621)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28402970448](https://github.com/sgl-project/sglang/actions/runs/28402970448)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->