### PR TITLE
Fix pythonic signed literal parsing

### DIFF
--- a/python/sglang/srt/function_call/pythonic_detector.py
+++ b/python/sglang/srt/function_call/pythonic_detector.py
@@ -214,6 +214,14 @@ class PythonicDetector(BaseFormatDetector):
             }
         elif isinstance(val, ast.List):
             return [self._get_parameter_value(v) for v in val.elts]
+        elif isinstance(val, ast.UnaryOp) and isinstance(val.op, (ast.UAdd, ast.USub)):
+            operand = self._get_parameter_value(val.operand)
+            if isinstance(operand, bool):
+                raise ValueError("Tool call arguments must be literals")
+            try:
+                return +operand if isinstance(val.op, ast.UAdd) else -operand
+            except TypeError as exc:
+                raise ValueError("Tool call arguments must be literals") from exc
         else:
             raise ValueError("Tool call arguments must be literals")
 

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -260,6 +260,38 @@ class TestPythonicDetector(unittest.TestCase):
         self.assertEqual(params2["query"], "test")
         self.assertEqual(params2["filters"], ["a", "b"])
 
+    def test_detect_and_parse_signed_numeric_arguments(self):
+        """Test parsing pythonic calls with signed numeric literals."""
+        text = (
+            "[get_weather(location='Oslo', temperature=-5, delta=+2), "
+            "search(query='coordinates', bounds=[-1.5, +2.25], "
+            "config={'offset': -3})]"
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(result.normal_text, "")
+        self.assertEqual(len(result.calls), 2)
+
+        params1 = json.loads(result.calls[0].parameters)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(params1["location"], "Oslo")
+        self.assertEqual(params1["temperature"], -5)
+        self.assertEqual(params1["delta"], 2)
+
+        params2 = json.loads(result.calls[1].parameters)
+        self.assertEqual(result.calls[1].name, "search")
+        self.assertEqual(params2["query"], "coordinates")
+        self.assertEqual(params2["bounds"], [-1.5, 2.25])
+        self.assertEqual(params2["config"]["offset"], -3)
+
+    def test_detect_and_parse_rejects_signed_boolean_arguments(self):
+        """Unary operators should not coerce booleans into integers."""
+        text = "[get_weather(location='Oslo', enabled=-True)]"
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(result.normal_text, text)
+        self.assertEqual(result.calls, [])
+
     def test_parse_streaming_partial_nested_brackets(self):
         """Test parsing partial tool calls with nested brackets across chunks."""
         # First chunk with nested brackets but incomplete


### PR DESCRIPTION
## Summary

- parse pythonic tool-call signed numeric literals (`-5`, `+2`, nested signed list/dict values)
- preserve the existing literal-only guard for unsupported unary operands
- add a `TestPythonicDetector` regression covering two calls in the same pythonic list so one signed literal no longer drops the whole batch

## Root Cause

Python parses signed numeric literals as `ast.UnaryOp`, not `ast.Constant`. `PythonicDetector._get_parameter_value` only handled `ast.Constant`, `ast.Dict`, and `ast.List`, so a negative argument raised during parsing. The caller caught the exception and returned no tool calls.

Fixes #27910.

## Validation

- `python3 -m py_compile python/sglang/srt/function_call/pythonic_detector.py test/registered/unit/function_call/test_function_call_parser.py`
- `git diff --check`
- focused local check that loaded the modified `PythonicDetector` with stubbed dependencies and verified two calls survive `temperature=-5`, `delta=+2`, `bounds=[-1.5, +2.25]`, and `config={'offset': -3}`

Not run: full pytest target in this bare environment because pytest and SGLang runtime dependencies such as numpy are not installed.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28346494010](https://github.com/sgl-project/sglang/actions/runs/28346494010)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28346493963](https://github.com/sgl-project/sglang/actions/runs/28346493963)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->