### PR TITLE
Move easydict to optional remote-models extra

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-OCR-2.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-OCR-2.mdx
@@ -30,6 +30,13 @@ For more details, please refer to the [official DeepSeek-OCR-2 repository](https
 
 Please refer to the [official SGLang installation guide](../../../docs/get-started/install) for installation instructions.
 
+DeepSeek-OCR-2 uses remote model code. If you installed SGLang from pip or uv,
+install the remote-models extra before launching:
+
+```bash Command
+uv pip install "sglang[remote-models]"
+```
+
 For SGLang CPU installation, please refer to the [CPU version installation guide](../../../docs/hardware-platforms/cpu_server#installation).
 
 ## 3. Model Deployment

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-OCR.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-OCR.mdx
@@ -26,6 +26,13 @@ For more details, please refer to the [official DeepSeek-OCR repository](https:/
 
 Please refer to the [official SGLang installation guide](../../../docs/get-started/install) for installation instructions.
 
+DeepSeek-OCR uses remote model code. If you installed SGLang from pip or uv,
+install the remote-models extra before launching:
+
+```bash Command
+uv pip install "sglang[remote-models]"
+```
+
 For SGLang CPU installation, please refer to the [CPU version installation guide](../../../docs/hardware-platforms/cpu_server#installation).
 
 ## 3. Model Deployment

--- a/docs_new/docs/get-started/install.mdx
+++ b/docs_new/docs/get-started/install.mdx
@@ -25,6 +25,14 @@ pip install uv
 uv pip install sglang
 ```
 
+Some model repositories loaded with `--trust-remote-code` require optional
+third-party packages. If a remote-code model such as DeepSeek-OCR requires
+`easydict`, install the remote-models extra:
+
+```bash Command
+uv pip install "sglang[remote-models]"
+```
+
 The major version of Cuda is 13 by default. To install sglang under Cuda 12 with pip or uv, please try the following commands:
 ```bash Command
 pip install --upgrade pip

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
   "datasets",
   "decord2 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "distro",
-  "easydict",  # Required by remote model code (e.g. DeepSeek-OCR) loaded via trust_remote_code; validated by transformers 5.4+ check_imports
   "einops",
   "fastapi",
   "flash-attn-4==4.0.0b15",
@@ -121,6 +120,10 @@ ray = [
   "ray[default]>=2.55.1",
 ]
 
+remote-models = [
+  "easydict",  # Required by some trust_remote_code model repos, e.g. DeepSeek-OCR.
+]
+
 tracing = [
   "opentelemetry-api",
   "opentelemetry-exporter-otlp",
@@ -163,6 +166,7 @@ dev = ["sglang[test]"]
 all = [
   "sglang[diffusion]",
   "sglang[http2]",
+  "sglang[remote-models]",
   "sglang[tracing]",
 ]
 

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -23,7 +23,6 @@ dependencies = [
   "build",
   "compressed-tensors",
   "datasets",
-  "easydict",
   "einops",
   "fastapi",
   "gguf",
@@ -98,6 +97,10 @@ tracing = [
   "opentelemetry-exporter-otlp-proto-grpc",
   "opentelemetry-sdk",
 ]
+remote-models = [
+  "easydict",  # Required by some trust_remote_code model repos, e.g. DeepSeek-OCR.
+]
+
 test = [
   "accelerate",
   "expecttest",
@@ -108,7 +111,11 @@ test = [
   "pytest",
   "sentence_transformers",
 ]
-all = []
+all = [
+  "sglang-cpu[diffusion]",
+  "sglang-cpu[remote-models]",
+  "sglang-cpu[tracing]",
+]
 dev = ["sglang[test]"]
 
 [project.urls]

--- a/python/pyproject_npu.toml
+++ b/python/pyproject_npu.toml
@@ -24,7 +24,6 @@ dependencies = [
   "compressed-tensors",
   "datasets",
   "decord2 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
-  "easydict",
   "einops",
   "fastapi",
   "gguf",
@@ -93,6 +92,10 @@ tracing = [
   "opentelemetry-sdk",
 ]
 
+remote-models = [
+  "easydict",  # Required by some trust_remote_code model repos, e.g. DeepSeek-OCR.
+]
+
 test = [
   "accelerate",
   "expecttest",
@@ -108,7 +111,7 @@ test = [
 
 # https://docs.sglang.io/platforms/ascend_npu.html
 srt_npu = []
-all_npu = ["sglang[diffusion]"]
+all_npu = ["sglang[diffusion]", "sglang[remote-models]"]
 dev_npu = ["sglang[all_npu]", "sglang[test]"]
 
 [project.urls]

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -26,7 +26,6 @@ runtime_common = [
   "build",
   "compressed-tensors",
   "datasets",
-  "easydict",
   "einops",
   "fastapi",
   "gguf",
@@ -88,6 +87,10 @@ tracing = [
   "opentelemetry-exporter-otlp",
   "opentelemetry-exporter-otlp-proto-grpc",
   "opentelemetry-sdk",
+]
+
+remote-models = [
+  "easydict",  # Required by some trust_remote_code model repos, e.g. DeepSeek-OCR.
 ]
 
 # HIP (Heterogeneous-computing Interface for Portability) for AMD
@@ -173,10 +176,23 @@ test = [
   "tabulate",
 ]
 
-all_hip = ["sglang[diffusion_hip]", "sglang[srt_hip]", "sglang[tracing]"]
-all_hpu = ["sglang[srt_hpu]"]
-all_musa = ["sglang[diffusion_musa]", "sglang[srt_musa]"]
-all_mps = ["sglang[diffusion_mps]", "sglang[srt_mps]"]
+all_hip = [
+  "sglang[diffusion_hip]",
+  "sglang[remote-models]",
+  "sglang[srt_hip]",
+  "sglang[tracing]",
+]
+all_hpu = ["sglang[remote-models]", "sglang[srt_hpu]"]
+all_musa = [
+  "sglang[diffusion_musa]",
+  "sglang[remote-models]",
+  "sglang[srt_musa]",
+]
+all_mps = [
+  "sglang[diffusion_mps]",
+  "sglang[remote-models]",
+  "sglang[srt_mps]",
+]
 
 dev_hip = ["sglang[all_hip]", "sglang[test]"]
 dev_hpu = ["sglang[all_hpu]", "sglang[test]"]

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -24,7 +24,6 @@ dependencies = [
   "build",
   "compressed-tensors",
   "datasets",
-  "easydict",
   "einops",
   "fastapi",
   "gguf",
@@ -97,6 +96,10 @@ tracing = [
   "opentelemetry-exporter-otlp-proto-grpc",
   "opentelemetry-sdk",
 ]
+remote-models = [
+  "easydict",  # Required by some trust_remote_code model repos, e.g. DeepSeek-OCR.
+]
+
 test = [
   "accelerate",
   "bitsandbytes",
@@ -116,6 +119,7 @@ dev = ["sglang[test]"]
 
 all = [
   "sglang[diffusion]",
+  "sglang[remote-models]",
   "sglang[tracing]",
 ]
 


### PR DESCRIPTION
## Motivation

Fixes #29177.

`easydict` is currently published as an unconditional SGLang dependency, so it
appears in the default `Requires-Dist` metadata even for deployments that never
load model repos requiring it. That creates avoidable LGPL-3.0 license-compliance
friction downstream.

The dependency appears to be needed by some remote model code loaded through
`--trust-remote-code` (for example DeepSeek-OCR), not by SGLang's default runtime
path. Making it opt-in keeps those models supported without forcing every SGLang
installation to pull in `easydict`.

## Modifications

- Move `easydict` from default dependencies to a new `remote-models` optional
  extra in all pyproject variants.
- Include the new extra in the platform `all` extras so broad/dev installs keep
  the previous convenience behavior.
- Document `uv pip install "sglang[remote-models]"` in the install guide and
  DeepSeek-OCR docs for remote-code model repos that need `easydict`.

## Accuracy Tests

N/A. This is a packaging/docs-only change and does not touch model execution or
outputs.

## Speed Tests and Profiling

N/A. This change does not touch runtime execution paths.

## Validation

```bash
git diff --check
```

```bash
python3 - <<'PY'
import pathlib, tomllib
files = [
    pathlib.Path('python/pyproject.toml'),
    pathlib.Path('python/pyproject_cpu.toml'),
    pathlib.Path('python/pyproject_npu.toml'),
    pathlib.Path('python/pyproject_other.toml'),
    pathlib.Path('python/pyproject_xpu.toml'),
]
for path in files:
    data = tomllib.loads(path.read_text())
    deps = data['project']['dependencies']
    optional = data['project']['optional-dependencies']
    assert not any(dep.split(';', 1)[0].strip().split()[0].lower() == 'easydict' for dep in deps), path
    assert optional.get('remote-models') == ['easydict'], (path, optional.get('remote-models'))
print('ok: easydict is only in remote-models extra for all pyproject variants')
PY
```

```bash
python -m pip install --dry-run --no-deps -e python
```

```bash
pre-commit run --files \
  docs/basic_usage/deepseek_ocr.md \
  docs/get_started/install.md \
  docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-OCR-2.mdx \
  docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-OCR.mdx \
  docs_new/docs/get-started/install.mdx \
  python/pyproject.toml \
  python/pyproject_cpu.toml \
  python/pyproject_npu.toml \
  python/pyproject_other.toml \
  python/pyproject_xpu.toml
```

The pip dry-run and pre-commit checks were run in a disposable venv and
completed successfully. I did not run GPU/server validation because this change
is packaging metadata and docs only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). N/A: packaging/docs metadata only.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). N/A: no runtime/output path changes.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28346456410](https://github.com/sgl-project/sglang/actions/runs/28346456410)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28346456360](https://github.com/sgl-project/sglang/actions/runs/28346456360)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->