### PR TITLE
Delay Frozen-KV MTP target pool binding

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -866,9 +866,6 @@ class Scheduler(
     def init_model_worker(self):
         # Load model weights.
         self.init_tp_model_worker()
-        if self.spec_algorithm.is_frozen_kv_mtp():
-            # Frozen-KV MTP draft construction needs the target KV pool.
-            self.init_target_memory_pool()
         self.maybe_init_draft_worker()
 
         # Allocate KV cache pools for all workers.

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -114,16 +114,11 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
             f"{self.speculative_algorithm.name}."
         )
 
-        # Draft attention uses target req_to_token + KV allocator (read-only).
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
-            target_worker.get_memory_pool()
-        )
-
-        target_cfg = target_worker.model_runner.memory_pool_config
-        self.draft_pool_config = MemoryPoolConfig(
-            max_total_num_tokens=64,  # Dummy value
-            max_running_requests=target_cfg.max_running_requests,
-        )
+        # The draft attention backend reads target KV pools, but those pools are
+        # not available until the scheduler finishes target memory profiling.
+        self.req_to_token_pool = None
+        self.token_to_kv_pool_allocator = None
+        self.draft_pool_config = None
 
         self.hot_token_id = None
 
@@ -144,9 +139,9 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
                 moe_dp_rank=moe_dp_rank,
                 nccl_port=nccl_port,
                 is_draft_worker=True,
-                req_to_token_pool=self.req_to_token_pool,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                memory_pool_config=self.draft_pool_config,
+                req_to_token_pool=None,
+                token_to_kv_pool_allocator=None,
+                memory_pool_config=None,
             )
 
         embed, head = self.target_worker.model_runner.model.get_embed_and_head()
@@ -160,8 +155,6 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
             )
 
         self.kv_context: Optional[FrozenKVMTPContext] = None
-        if hasattr(self.draft_model_runner.model, "bind_frozen_kv_context"):
-            self._bind_kv_context()
 
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
@@ -180,22 +173,25 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         req_to_token_pool=None,
         token_to_kv_pool_allocator=None,
     ):
+        if memory_pool_config is None:
+            raise ValueError("target memory pool config is required")
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+        self.draft_pool_config = MemoryPoolConfig(
+            max_total_num_tokens=64,  # Dummy value; Frozen-KV draft owns no KV.
+            max_running_requests=memory_pool_config.max_running_requests,
+        )
+
         # NOTE: call TpModelWorker explicitly -- EagleDraftWorkerBase precedes it in
         # the MRO and its alloc_memory_pool is a no-op stub.
         TpModelWorker.alloc_memory_pool(
             self,
             memory_pool_config=self.draft_pool_config,
-            req_to_token_pool=(
-                req_to_token_pool
-                if req_to_token_pool is not None
-                else self.req_to_token_pool
-            ),
-            token_to_kv_pool_allocator=(
-                token_to_kv_pool_allocator
-                if token_to_kv_pool_allocator is not None
-                else self.token_to_kv_pool_allocator
-            ),
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=token_to_kv_pool_allocator,
         )
+        if hasattr(self.draft_model_runner.model, "bind_frozen_kv_context"):
+            self._bind_kv_context()
 
     def init_attention_backends(self):
         with (
@@ -676,9 +672,6 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
             server_args.speculative_algorithm
         )
 
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
-            target_worker.get_memory_pool()
-        )
         # Match the draft context length to the target (assistant reads target KV).
         server_args.context_length = target_worker.model_runner.model_config.context_len
 

--- a/test/registered/unit/spec/test_frozen_kv_mtp_pool_init.py
+++ b/test/registered/unit/spec/test_frozen_kv_mtp_pool_init.py
@@ -1,0 +1,240 @@
+"""Unit tests for Frozen-KV MTP delayed target-pool binding."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
+from sglang.srt.speculative.frozen_kv_mtp_worker_v2 import (
+    FrozenKVMTPDraftWorker,
+    FrozenKVMTPWorkerV2,
+)
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-large")
+
+
+class _DraftModel:
+    backbone_hidden_size = 16
+
+    def __init__(self):
+        self.embed_and_head = None
+        self.bound_context = None
+        self.build_context_args = None
+
+    def set_embed_and_head(self, embed, head):
+        self.embed_and_head = (embed, head)
+
+    def build_frozen_kv_mtp_context(self, *, target_model, target_token_to_kv_pool):
+        self.build_context_args = (target_model, target_token_to_kv_pool)
+        return object()
+
+    def bind_frozen_kv_context(self, ctx):
+        self.bound_context = ctx
+
+
+def _server_args():
+    return SimpleNamespace(
+        speculative_eagle_topk=1,
+        speculative_num_steps=1,
+        speculative_num_draft_tokens=1,
+        speculative_algorithm="FROZEN_KV_MTP",
+        speculative_adaptive=False,
+        enable_dp_attention=False,
+        device="cpu",
+        page_size=1,
+        context_length=128,
+    )
+
+
+def _target_worker():
+    target_model = MagicMock()
+    target_model.get_embed_and_head.return_value = ("embed", "head")
+    target_runner = SimpleNamespace(
+        model=target_model,
+        model_config=SimpleNamespace(context_len=128),
+        memory_pool_config=None,
+        token_to_kv_pool=object(),
+    )
+    worker = MagicMock()
+    worker.model_runner = target_runner
+    worker.get_memory_pool.side_effect = AssertionError(
+        "target pool should not be read during construction"
+    )
+    return worker
+
+
+def _patch_tp_model_worker():
+    init_calls = []
+    alloc_calls = []
+
+    def fake_init(
+        self,
+        *,
+        server_args,
+        gpu_id,
+        tp_rank,
+        pp_rank,
+        dp_rank,
+        moe_ep_rank,
+        attn_cp_rank,
+        moe_dp_rank,
+        nccl_port,
+        is_draft_worker=False,
+        req_to_token_pool=None,
+        token_to_kv_pool_allocator=None,
+        memory_pool_config=None,
+        **_,
+    ):
+        init_calls.append(
+            {
+                "is_draft_worker": is_draft_worker,
+                "req_to_token_pool": req_to_token_pool,
+                "token_to_kv_pool_allocator": token_to_kv_pool_allocator,
+                "memory_pool_config": memory_pool_config,
+            }
+        )
+        self._model_runner = SimpleNamespace(
+            model=_DraftModel(),
+            tp_group=object(),
+            device="cpu",
+            attn_backend=object(),
+        )
+
+    def fake_alloc(
+        self,
+        memory_pool_config=None,
+        req_to_token_pool=None,
+        token_to_kv_pool_allocator=None,
+    ):
+        alloc_calls.append(
+            {
+                "memory_pool_config": memory_pool_config,
+                "req_to_token_pool": req_to_token_pool,
+                "token_to_kv_pool_allocator": token_to_kv_pool_allocator,
+            }
+        )
+
+    return (
+        patch(
+            "sglang.srt.speculative.frozen_kv_mtp_worker_v2.TpModelWorker.__init__",
+            fake_init,
+        ),
+        patch(
+            "sglang.srt.speculative.frozen_kv_mtp_worker_v2.TpModelWorker.alloc_memory_pool",
+            fake_alloc,
+        ),
+        init_calls,
+        alloc_calls,
+    )
+
+
+def _make_draft_worker(target):
+    return FrozenKVMTPDraftWorker(
+        _server_args(),
+        gpu_id=0,
+        tp_rank=0,
+        dp_rank=None,
+        moe_ep_rank=0,
+        attn_cp_rank=0,
+        moe_dp_rank=0,
+        nccl_port=12345,
+        target_worker=target,
+    )
+
+
+class TestFrozenKVMTPPoolInit(CustomTestCase):
+    def test_draft_worker_constructor_does_not_read_target_pool(self):
+        init_patch, alloc_patch, init_calls, _ = _patch_tp_model_worker()
+        target = _target_worker()
+
+        with init_patch, alloc_patch:
+            worker = _make_draft_worker(target)
+
+        target.get_memory_pool.assert_not_called()
+        self.assertIsNone(worker.req_to_token_pool)
+        self.assertIsNone(worker.token_to_kv_pool_allocator)
+        self.assertIsNone(worker.draft_pool_config)
+        self.assertIsNone(worker.kv_context)
+        self.assertEqual(len(init_calls), 1)
+        self.assertIsNone(init_calls[0]["req_to_token_pool"])
+        self.assertIsNone(init_calls[0]["token_to_kv_pool_allocator"])
+        self.assertIsNone(init_calls[0]["memory_pool_config"])
+        self.assertEqual(
+            worker.draft_model_runner.model.embed_and_head, ("embed", "head")
+        )
+        self.assertIsNone(worker.draft_model_runner.model.bound_context)
+
+    def test_draft_worker_alloc_binds_target_pool_after_target_init(self):
+        init_patch, alloc_patch, _, alloc_calls = _patch_tp_model_worker()
+        target = _target_worker()
+        req_pool = object()
+        allocator = object()
+        target_cfg = MemoryPoolConfig(max_total_num_tokens=1024, max_running_requests=7)
+
+        with init_patch, alloc_patch:
+            worker = _make_draft_worker(target)
+            worker.alloc_memory_pool(
+                memory_pool_config=target_cfg,
+                req_to_token_pool=req_pool,
+                token_to_kv_pool_allocator=allocator,
+            )
+
+        self.assertIs(worker.req_to_token_pool, req_pool)
+        self.assertIs(worker.token_to_kv_pool_allocator, allocator)
+        self.assertEqual(worker.draft_pool_config.max_total_num_tokens, 64)
+        self.assertEqual(worker.draft_pool_config.max_running_requests, 7)
+        self.assertEqual(len(alloc_calls), 1)
+        self.assertIs(alloc_calls[0]["memory_pool_config"], worker.draft_pool_config)
+        self.assertIs(alloc_calls[0]["req_to_token_pool"], req_pool)
+        self.assertIs(alloc_calls[0]["token_to_kv_pool_allocator"], allocator)
+        draft_model = worker.draft_model_runner.model
+        self.assertIs(draft_model.bound_context, worker.kv_context)
+        self.assertEqual(
+            draft_model.build_context_args,
+            (target.model_runner.model, target.model_runner.token_to_kv_pool),
+        )
+
+    def test_draft_worker_alloc_requires_target_pool_config(self):
+        init_patch, alloc_patch, _, alloc_calls = _patch_tp_model_worker()
+        target = _target_worker()
+
+        with init_patch, alloc_patch:
+            worker = _make_draft_worker(target)
+            with self.assertRaisesRegex(ValueError, "target memory pool config"):
+                worker.alloc_memory_pool(memory_pool_config=None)
+
+        self.assertEqual(alloc_calls, [])
+
+    def test_worker_v2_constructor_does_not_read_target_pool(self):
+        target = _target_worker()
+
+        with (
+            patch(
+                "sglang.srt.speculative.frozen_kv_mtp_worker_v2.FrozenKVMTPDraftWorker",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "sglang.srt.speculative.frozen_kv_mtp_worker_v2._get_plan_stream",
+                return_value=(None, None),
+            ),
+        ):
+            FrozenKVMTPWorkerV2(
+                _server_args(),
+                gpu_id=0,
+                tp_rank=0,
+                dp_rank=None,
+                moe_ep_rank=0,
+                attn_cp_rank=0,
+                moe_dp_rank=0,
+                nccl_port=12345,
+                target_worker=target,
+            )
+
+        target.get_memory_pool.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #29021.

Frozen-KV MTP currently has a scheduler-level special case that allocates the
target KV pool before constructing the draft worker. That ordering is only
needed because the draft worker constructor eagerly reads target memory pools
and binds its frozen-KV context before target memory profiling has completed.

The draft attention backend does need read-only target KV access at runtime, but
draft worker construction should not depend on target KV pools.

## Modifications

- Stop reading target memory pools in `FrozenKVMTPDraftWorker.__init__`.
- Move target pool assignment, dummy draft pool config construction, and
  frozen-KV context binding into `FrozenKVMTPDraftWorker.alloc_memory_pool()`.
- Remove the scheduler special case that eagerly initializes target memory pools
  for Frozen-KV MTP before draft worker construction.
- Add focused unit coverage that Frozen-KV MTP can be constructed before target
  pool allocation and then bound through the normal allocation path.

## Accuracy Tests

This change is intended to be output-neutral. It changes when the Frozen-KV MTP
draft worker receives the target KV pool references, not the draft/verify math.

H200 smoke validation generated successfully with the same prompt before and
after the change. The patched run returned HTTP 200 with speculative accept
metrics present (`spec_accept_rate=0.8`, `spec_accept_length=4.0`).

## Speed Tests and Profiling

No speed benchmark was run. This is an initialization-order change; steady-state
decode kernels and scheduler policy are unchanged.

The H200 patched smoke kept CUDA graph enabled (`disable_cuda_graph=false`).

## Validation

```bash
git diff --check
```

```bash
python3 -m py_compile \
  python/sglang/srt/managers/scheduler.py \
  python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py \
  test/registered/unit/spec/test_frozen_kv_mtp_pool_init.py
```

```bash
pre-commit run --files \
  python/sglang/srt/managers/scheduler.py \
  python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py \
  test/registered/unit/spec/test_frozen_kv_mtp_pool_init.py
```

```bash
PYTHONPATH=python python3 -m pytest \
  test/registered/unit/spec/test_frozen_kv_mtp_pool_init.py -q
```

Focused pytest result: `3 passed`.

H200 runtime validation on `lmsysorg/sglang:latest`, base commit `828411e`, one
NVIDIA H200 GPU, model `google/gemma-4-E4B-it`, draft model
`google/gemma-4-E4B-it-assistant`:

- Current main control: server ready; `/generate` returned HTTP 200 with
  speculative accept metrics and CUDA graph enabled.
- Negative control with only the scheduler special case removed: exited before
  readiness at the old construction-time dependency
  (`memory_pool_config` was still `None` when the draft constructor read
  `max_running_requests`).
- Full patch: server ready; `/generate` returned HTTP 200 with
  `spec_accept_rate=0.8`, `spec_accept_length=4.0`, and CUDA graph enabled.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A: no documentation change.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Accuracy/speed are not expected to change; H200 runtime smoke is included above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28342303729](https://github.com/sgl-project/sglang/actions/runs/28342303729)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28342303614](https://github.com/sgl-project/sglang/actions/runs/28342303614)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->