### PR TITLE
Release LoRA usage for aborted waiting-queue requests

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2745,6 +2745,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         }
         del self.rid_to_state[recv_obj.rid]
 
+        # Waiting-queue aborts do not go through _handle_batch_output, so release
+        # the LoRA usage acquired before dispatch once the scheduler confirms
+        # this request is no longer pending.
+        lora_id = getattr(state.obj, "lora_id", None)
+        lora_path = getattr(state.obj, "lora_path", None)
+        if self.server_args.enable_lora and lora_path and lora_id is not None:
+            asyncio.create_task(self.lora_registry.release(lora_id))
+
         state.out_list.append(out)
         state.event.set()
 
@@ -2903,7 +2911,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         else:
             rids = obj.rid
         for rid in rids:
-            self.rid_to_state.pop(rid, None)
+            state = self.rid_to_state.pop(rid, None)
+            if state is None:
+                continue
+            lora_id = getattr(state.obj, "lora_id", None)
+            lora_path = getattr(state.obj, "lora_path", None)
+            if self.server_args.enable_lora and lora_path and lora_id is not None:
+                asyncio.create_task(self.lora_registry.release(lora_id))
 
     def _should_dispatch_to_encoder(
         self, obj: Union[GenerateReqInput, EmbeddingReqInput]

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -244,6 +244,59 @@ class TestRidToStateCleanupOnAbort(CustomTestCase):
             state.out_list[0]["meta_info"]["finish_reason"]["type"], "abort"
         )
 
+    def test_abort_releases_lora_request_usage(self):
+        """Waiting-queue abort should release the LoRA usage counter once."""
+        tm = _make_tokenizer_manager()
+        tm.server_args.enable_lora = True
+        tm.lora_registry = Mock()
+        tm.lora_registry.release = AsyncMock()
+        rid = "abort_lora_rid"
+        state = _make_req_state(rid)
+        state.obj.lora_path = "test-lora"
+        state.obj.lora_id = "lora-0"
+        tm.rid_to_state[rid] = state
+
+        async def drive_abort():
+            tm._handle_abort_req(_make_abort_req(rid))
+            await asyncio.sleep(0)
+
+        asyncio.run(drive_abort())
+
+        self.assertNotIn(rid, tm.rid_to_state)
+        self.assertTrue(state.event.is_set())
+        tm.lora_registry.release.assert_awaited_once_with("lora-0")
+
+    def test_abort_without_lora_does_not_release_usage(self):
+        """Non-LoRA abort cleanup should not touch the LoRA registry."""
+        tm = _make_tokenizer_manager()
+        tm.server_args.enable_lora = True
+        tm.lora_registry = Mock()
+        tm.lora_registry.release = AsyncMock()
+        rid = "abort_no_lora_rid"
+        state = _make_req_state(rid)
+        tm.rid_to_state[rid] = state
+
+        tm._handle_abort_req(_make_abort_req(rid))
+
+        self.assertNotIn(rid, tm.rid_to_state)
+        tm.lora_registry.release.assert_not_awaited()
+
+    def test_abort_without_lora_path_attr_does_not_release_usage(self):
+        """Abort cleanup should tolerate future request objects without lora_path."""
+        tm = _make_tokenizer_manager()
+        tm.server_args.enable_lora = True
+        tm.lora_registry = Mock()
+        tm.lora_registry.release = AsyncMock()
+        rid = "abort_missing_lora_path_rid"
+        state = _make_req_state(rid)
+        del state.obj.lora_path
+        tm.rid_to_state[rid] = state
+
+        tm._handle_abort_req(_make_abort_req(rid))
+
+        self.assertNotIn(rid, tm.rid_to_state)
+        tm.lora_registry.release.assert_not_awaited()
+
 
 class TestRidToStateCleanupOnBatchOutput(CustomTestCase):
     """Test that _handle_batch_output removes rid from rid_to_state on completion."""
@@ -514,6 +567,33 @@ class TestGenerateRequestCleanupOnDispatchFailure(CustomTestCase):
         # All sub-request entries created by _init_req_state are cleaned up.
         for r in rids:
             self.assertNotIn(r, tm.rid_to_state)
+
+    def test_single_failure_after_lora_acquire_releases_usage(self):
+        tm = _make_tm_for_generate()
+        tm.server_args.enable_lora = True
+        tm.lora_registry = Mock()
+        tm.lora_registry.release = AsyncMock()
+        rid = "single_lora_overlen"
+        obj = _make_generate_obj(rid, is_single=True)
+        obj.lora_path = "test-lora"
+        tm._tokenize_one_request = AsyncMock(side_effect=ValueError("input too long"))
+        tm._send_one_request = Mock()
+
+        async def acquire_lora(_):
+            obj.lora_id = "lora-0"
+
+        tm._validate_and_resolve_lora = AsyncMock(side_effect=acquire_lora)
+
+        async def drive():
+            with self.assertRaises(ValueError):
+                await tm.generate_request(obj).__anext__()
+            await asyncio.sleep(0)
+
+        asyncio.run(drive())
+
+        self.assertNotIn(rid, tm.rid_to_state)
+        tm._send_one_request.assert_not_called()
+        tm.lora_registry.release.assert_awaited_once_with("lora-0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #29179.

LoRA requests acquire a LoRA registry usage counter before dispatch. On the
normal completion path, `TokenizerManager._handle_batch_output()` releases that
usage when the request finishes.

The waiting-queue abort path is different: the scheduler echoes an `AbortReq`
back to tokenizer manager, and `TokenizerManager._handle_abort_req()` completes
the original `/generate` waiter directly. Before this PR, that path removed the
request state and notified the waiter, but did not release the LoRA registry
usage counter. A leaked counter can make later LRU unload block in
`wait_for_unload()`, which matches the reported symptom: `/abort_request`
returns 200, health stays OK, queues look empty, but later LoRA generation can
hang.

I reproduced the issue on current main with an H200 validation workload: 13 of
30 LoRA `/generate` calls stayed alive after their matching `/abort_request`
returned 200, and a post-run LoRA generation timed out. The base-only abort
control did not reproduce the hang.

## Modifications

- Release LoRA registry usage in `TokenizerManager._handle_abort_req()` when a
  scheduler-confirmed waiting-queue abort completes a LoRA request.
- Add unit coverage that:
  - a LoRA waiting-queue abort releases the acquired LoRA id exactly once;
  - a non-LoRA abort does not touch the LoRA registry.

## Accuracy Tests

This change does not alter model forward computation, sampling, logits, or
tokenization. It only releases LoRA usage bookkeeping after a scheduler-confirmed
abort.

H200 runtime validation with `Qwen/Qwen2.5-0.5B-Instruct` and generated LoRA
adapters:

- Baseline current main: LoRA abort workload reproduced the hang (`13/30`
  original `/generate` calls still alive after abort 200; post-run LoRA generate
  timed out).
- Patched, LoRA overlap disabled: `0/30` hung after abort, final `/health` 200,
  post-run base generate 200, post-run LoRA generate 200.
- Patched, base-only abort control: `0/12` hung after abort, final `/health`
  200, post-run base generate 200, post-run LoRA generate 200.
- Patched, LoRA overlap enabled: `0/30` hung after abort, final `/health` 200,
  post-run base generate 200, post-run LoRA generate 200.

The validation harness also observes an unrelated `/v1/loads?include=lora`
`slots_total=0` field warning after idle in both patched controls; the
user-visible hang signal is gone.

## Speed Tests and Profiling

No speed benchmark was run. The change only schedules existing LoRA registry
cleanup on a request abort path and should not affect normal generation speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Notes:

- Documentation is not changed because this fixes internal request cleanup.
- Accuracy and speed sections explain why model-output and throughput benchmarks
  are not applicable.

Validation commands:

```bash
git diff --check
python3 -m py_compile \
  python/sglang/srt/managers/tokenizer_manager.py \
  test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
pre-commit run --files \
  python/sglang/srt/managers/tokenizer_manager.py \
  test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
PYTHONPATH=python python3 -m pytest \
  test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py -q
```















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28346530955](https://github.com/sgl-project/sglang/actions/runs/28346530955)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28346530866](https://github.com/sgl-project/sglang/actions/runs/28346530866)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->