### PR TITLE
Fix duplicate 'weight_version' key in /model_info response

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -715,7 +715,6 @@ async def model_info():
         "has_audio_understanding": model_config.is_audio_understandable_model,
         "model_type": getattr(model_config.hf_config, "model_type", None),
         "architectures": getattr(model_config.hf_config, "architectures", None),
-        "weight_version": _global_state.tokenizer_manager.server_args.weight_version,
         # "hf_config": model_config.hf_config.to_dict(),
     }
     embedding_model_spec = getattr(model_config, "embedding_model_spec", None)


### PR DESCRIPTION
## Motivation

The `/model_info` endpoint in `http_server.py` builds its result dict with the
`"weight_version"` key set twice with the identical value. The second entry silently overwrites the first; harmless at runtime
but a redundant duplicate key (flagged by pyflakes: *dictionary key
'weight_version' repeated*).

## Modifications

Remove the redundant `"weight_version"` entry from the `model_info()` result
dict. No behavior change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30608155232](https://github.com/sgl-project/sglang/actions/runs/30608155232)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30608155158](https://github.com/sgl-project/sglang/actions/runs/30608155158)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->