### PR TITLE
Handle host UID/GID collisions in devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,8 +4,37 @@ FROM lmsysorg/sglang:dev
 # NOTE: Replace with your own UID and GID. This is a workaround from https://github.com/microsoft/vscode-remote-release/issues/49#issuecomment-489060908.
 ARG HOST_UID=1003
 ARG HOST_GID=1003
-RUN groupadd -g $HOST_GID devuser && \
-    useradd -m -u $HOST_UID -g $HOST_GID -s /bin/zsh devuser
+RUN set -eux; \
+    if [ "${HOST_UID}" = "0" ] || [ "${HOST_GID}" = "0" ]; then \
+        echo "HOST_UID and HOST_GID must be non-zero" >&2; \
+        exit 1; \
+    fi; \
+    if getent group "${HOST_GID}" >/dev/null; then \
+        target_group="$(getent group "${HOST_GID}" | cut -d: -f1)"; \
+    elif getent group devuser >/dev/null; then \
+        groupmod -g "${HOST_GID}" devuser; \
+        target_group=devuser; \
+    else \
+        groupadd -g "${HOST_GID}" devuser; \
+        target_group=devuser; \
+    fi; \
+    existing_user=""; \
+    if getent passwd "${HOST_UID}" >/dev/null; then \
+        existing_user="$(getent passwd "${HOST_UID}" | cut -d: -f1)"; \
+    fi; \
+    if getent passwd devuser >/dev/null; then \
+        if [ -n "${existing_user}" ] && [ "${existing_user}" != "devuser" ]; then \
+            userdel "${existing_user}"; \
+        fi; \
+        usermod -u "${HOST_UID}" -g "${HOST_GID}" -d /home/devuser -s /bin/zsh devuser; \
+    elif [ -n "${existing_user}" ]; then \
+        usermod -l devuser -u "${HOST_UID}" -g "${HOST_GID}" -d /home/devuser -s /bin/zsh "${existing_user}"; \
+    else \
+        useradd -u "${HOST_UID}" -g "${HOST_GID}" -d /home/devuser -s /bin/zsh devuser; \
+    fi; \
+    mkdir -p /home/devuser; \
+    chown -R devuser:"$(id -gn devuser)" /home/devuser; \
+    echo "devuser uses uid=$(id -u devuser), gid=$(id -g devuser), group=${target_group}"
 
 # Give devuser sudo access
 RUN apt-get update && apt-get install -y sudo && \
@@ -17,11 +46,11 @@ RUN apt-get update && apt-get install -y sudo && \
 RUN cp -r /root/.oh-my-zsh /home/devuser/.oh-my-zsh && \
     cp /root/.zshrc /home/devuser/.zshrc && \
     sed -i 's|/root/.oh-my-zsh|/home/devuser/.oh-my-zsh|g' /home/devuser/.zshrc && \
-    chown -R devuser:devuser /home/devuser/
+    chown -R devuser:"$(id -gn devuser)" /home/devuser/
 
 # Set workspace directory and ownership
 WORKDIR /sgl-workspace/sglang
-RUN chown -R devuser:devuser /sgl-workspace
+RUN chown -R devuser:"$(id -gn devuser)" /sgl-workspace
 
 # Switch to devuser
 USER devuser

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,5 +26,6 @@
     // in the dev docker container. You can remove / comment out these
     // two lines if you prefer to sync code changes manually.
     "workspaceMount": "source=${localWorkspaceFolder},target=/sgl-workspace/sglang,type=bind",
-    "workspaceFolder": "/sgl-workspace/sglang"
+    "workspaceFolder": "/sgl-workspace/sglang",
+    "updateRemoteUserUID": true
 }


### PR DESCRIPTION
## Summary

Fixes #28134.

This makes the devcontainer user/group setup idempotent when the requested host
UID or GID already exists in the `lmsysorg/sglang:dev` base image. The old
Dockerfile always ran `groupadd -g $HOST_GID devuser` and then `useradd -u
$HOST_UID ... devuser`, so common IDs such as UID 1000 or an existing shared GID
could fail before the container finished building.

The new setup:

- rejects `HOST_UID=0` or `HOST_GID=0` before touching root;
- reuses an existing group for `HOST_GID`;
- renames/updates an existing user at `HOST_UID` to `devuser` when needed;
- uses `devuser`'s actual primary group for later ownership fixes;
- explicitly enables `updateRemoteUserUID` in `devcontainer.json`.

Thanks to the reporter in #28134 for narrowing the devcontainer UID/GID
collision and sharing a concrete workaround.

## Validation

- `docker build --build-arg HOST_UID=1000 --build-arg HOST_GID=100 -t sglang-devcontainer-uidgid-test:28134 -f .devcontainer/Dockerfile .`
- `docker run --rm sglang-devcontainer-uidgid-test:28134 ...` confirmed `devuser` is `uid=1000 gid=100(users)` and `/home/devuser` plus `/sgl-workspace` are owned by `devuser:users`.
- `docker build --build-arg HOST_UID=1003 --build-arg HOST_GID=1003 -t sglang-devcontainer-default-test:28134 -f .devcontainer/Dockerfile .`
- `docker run --rm sglang-devcontainer-default-test:28134 ...` confirmed `devuser` is `uid=1003 gid=1003(devuser)` and checked directories are owned by `devuser:devuser`.
- `docker build --build-arg HOST_UID=0 --build-arg HOST_GID=0 ...` fails early with `HOST_UID and HOST_GID must be non-zero`.
- `git diff --check`
















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28346560113](https://github.com/sgl-project/sglang/actions/runs/28346560113)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28346560061](https://github.com/sgl-project/sglang/actions/runs/28346560061)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->