### PR TITLE
Fix infinite loop parsing Gemma4 nested array with bracket in string

### DIFF
--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -88,6 +88,13 @@ def _parse_gemma4_array(arr_str: str) -> list:
             sub_start = i + 1
             i += 1
             while i < n and depth > 0:
+                if arr_str[i : i + len(STRING_DELIM)] == STRING_DELIM:
+                    # Skip over string contents so that '[' / ']' characters
+                    # inside a string element don't affect the bracket depth.
+                    i += len(STRING_DELIM)
+                    next_delim = arr_str.find(STRING_DELIM, i)
+                    i = next_delim + len(STRING_DELIM) if next_delim != -1 else n
+                    continue
                 if arr_str[i] == "[":
                     depth += 1
                 elif arr_str[i] == "]":

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -5225,6 +5225,14 @@ class TestGemma4Detector(unittest.TestCase):
         self.assertIsInstance(result[3], dict)
         self.assertEqual(result[3]["key"], "val")
 
+    def test_parse_gemma4_array_nested_array_with_bracket_in_string(self):
+        # A string element inside a nested array may itself contain '[' or ']'
+        # characters. These must not be counted when tracking bracket depth,
+        # otherwise the nested array is mis-sliced and a stray ']' can make the
+        # parser spin forever. Regression test for that hang/mis-parse.
+        result = _parse_gemma4_array('[<|"|>a]b<|"|>, <|"|>c<|"|>]')
+        self.assertEqual(result, [["a]b", "c"]])
+
     def test_parse_gemma4_value_types(self):
         self.assertIs(_parse_gemma4_value("true"), True)
         self.assertIs(_parse_gemma4_value("false"), False)


### PR DESCRIPTION
## Motivation

`gemma4_detector.py` has four bracket/brace depth-counting loops. Three of
them skip over string-delimited contents (`<|"|>...<|"|>`) so that `[`/`]`/`{`/`}`
characters *inside a string* don't affect the depth count. The nested-array
branch of `_parse_gemma4_array` was the only one that did not.

As a result, a Gemma4 tool call whose argument is a nested array containing a
string element with a `]` (or `[`) inside it closes the array early, mis-slices
it, and leaves a stray `]` that the main loop can neither consume nor skip —
causing an **infinite loop** on model-controlled output, as well as wrong tool
arguments.

## Modifications

- Skip `STRING_DELIM` contents when tracking bracket depth in the nested-array
  branch, mirroring the three sibling depth loops in this file.
- Add a regression test (`test_parse_gemma4_array_nested_array_with_bracket_in_string`)
  that asserts the correct parse and, by terminating, no hang.

## Checklist

- [x] Verified before/after with an isolated repro: current code hangs, patched
      code returns `[["a]b", "c"]]`.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28328136411](https://github.com/sgl-project/sglang/actions/runs/28328136411)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28328136352](https://github.com/sgl-project/sglang/actions/runs/28328136352)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->