### PR TITLE
[Feature] Add --default-chat-template-kwargs server arg

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -171,6 +171,9 @@ class OpenAIServingChat(OpenAIServingBase):
         self.template_manager = template_manager
         self.tool_call_parser = self.tokenizer_manager.server_args.tool_call_parser
         self.reasoning_parser = self.tokenizer_manager.server_args.reasoning_parser
+        self.default_chat_template_kwargs = (
+            self.tokenizer_manager.server_args.default_chat_template_kwargs or {}
+        )
         self._reasoning_detector = None
         if self.reasoning_parser:
             try:
@@ -642,6 +645,15 @@ class OpenAIServingChat(OpenAIServingBase):
         self, request: ChatCompletionRequest, is_multimodal: bool
     ) -> MessageProcessingResult:
         """Process chat messages and apply chat template"""
+        if self.default_chat_template_kwargs:
+            ctk = dict(request.chat_template_kwargs or {})
+            for k, v in self.default_chat_template_kwargs.items():
+                ctk.setdefault(k, v)
+            request.chat_template_kwargs = ctk
+            effort = ctk.get("reasoning_effort")
+            if effort is not None and request.reasoning_effort is None:
+                request.reasoning_effort = effort
+
         # GptOss model needs to keep special tokens for harmony parsing
         if self.is_gpt_oss or self.is_gemma4:
             request.skip_special_tokens = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1042,8 +1042,9 @@ class ServerArgs:
         Optional[Dict[str, Any]],
         Arg(
             help="Default chat template kwargs applied to every request when not "
-            "overridden per-request, e.g. '{\"enable_thinking\": false}' to disable "
-            "thinking server-side. Per-request chat_template_kwargs takes precedence.",
+            "overridden per-request. Keys must match what the model's chat template "
+            "expects (e.g. enable_thinking, thinking, reasoning_effort). Per-request "
+            "chat_template_kwargs takes precedence.",
             type_parser=json.loads,
         ),
     ] = None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1038,6 +1038,15 @@ class ServerArgs:
         "Return number of cached tokens in usage.prompt_tokens_details for each openai request.",
     ] = False
     reasoning_parser: Optional[str] = None
+    default_chat_template_kwargs: A[
+        Optional[Dict[str, Any]],
+        Arg(
+            help="Default chat template kwargs applied to every request when not "
+            "overridden per-request, e.g. '{\"enable_thinking\": false}' to disable "
+            "thinking server-side. Per-request chat_template_kwargs takes precedence.",
+            type_parser=json.loads,
+        ),
+    ] = None
     strip_thinking_cache: A[
         bool,
         "Skip caching reasoning-model output (thinking + answer) in the radix tree on finish; keep only the prompt prefix. Opt-in: changes cache contents.",
@@ -2653,6 +2662,13 @@ class ServerArgs:
         self._handle_ssl_validation()
         # Validate transcription/ASR-specific server args.
         self._handle_asr_validation()
+
+        if self.default_chat_template_kwargs is not None and not isinstance(
+            self.default_chat_template_kwargs, dict
+        ):
+            raise ValueError(
+                "--default-chat-template-kwargs must decode to a JSON object"
+            )
 
         # Handle deprecated arguments.
         self._handle_deprecated_args()

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -45,6 +45,7 @@ class _MockTokenizerManager:
             tool_call_parser="hermes",
             reasoning_parser=None,
             stream_response_default_include_usage=False,
+            default_chat_template_kwargs=None,
         )
         # Mock hf_config for _resolve_chat_encoding_spec check
         mock_hf_config = Mock()
@@ -325,6 +326,54 @@ class ServingChatTestCase(unittest.TestCase):
             adapted, _ = self.chat._convert_to_internal_request(req)
 
         self.assertFalse(adapted.require_reasoning)
+
+    def test_default_chat_template_kwargs_applied_when_request_unset(self):
+        self.template_manager.chat_template_name = None
+        self.template_manager.jinja_template_content_format = "string"
+        self.tm.tokenizer.apply_chat_template.return_value = [1, 2, 3]
+        self.chat.default_chat_template_kwargs = {"enable_thinking": False}
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "What is 2+2?"}],
+        )
+
+        self.chat._process_messages(req, is_multimodal=False)
+
+        kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
+        self.assertIs(kwargs["enable_thinking"], False)
+
+    def test_default_chat_template_kwargs_overridden_per_request(self):
+        self.template_manager.chat_template_name = None
+        self.template_manager.jinja_template_content_format = "string"
+        self.tm.tokenizer.apply_chat_template.return_value = [1, 2, 3]
+        self.chat.default_chat_template_kwargs = {"enable_thinking": False}
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "What is 2+2?"}],
+            chat_template_kwargs={"enable_thinking": True},
+        )
+
+        self.chat._process_messages(req, is_multimodal=False)
+
+        kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
+        self.assertIs(kwargs["enable_thinking"], True)
+
+    def test_default_chat_template_kwargs_mirrors_reasoning_effort(self):
+        self.template_manager.chat_template_name = None
+        self.template_manager.jinja_template_content_format = "string"
+        self.tm.tokenizer.apply_chat_template.return_value = [1, 2, 3]
+        self.chat.default_chat_template_kwargs = {"reasoning_effort": "high"}
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "What is 2+2?"}],
+        )
+
+        self.chat._process_messages(req, is_multimodal=False)
+
+        self.assertEqual(req.reasoning_effort, "high")
 
     def test_kimi_tool_call_keeps_template_default_thinking(self):
         self.template_manager.chat_template_name = None


### PR DESCRIPTION
## Motivation

There is currently no way to disable thinking (or set any chat template kwarg) once at server launch and have it apply to every request by default. Today operators must either:

- pass `chat_template_kwargs={"enable_thinking": false}` on **every** client request, or
- set the `SGLANG_DEFAULT_THINKING` env var, which only covers the `thinking` key (not `enable_thinking` used by Qwen3 / GLM-4.5 / GLM-5.2) and is not a CLI flag.

This adds a `--default-chat-template-kwargs` server arg so a single launch flag (e.g. `--default-chat-template-kwargs '{"enable_thinking": false}'`) makes the default apply to all requests without per-request changes.

## Changes

- `ServerArgs.default_chat_template_kwargs` (CLI `--default-chat-template-kwargs`, JSON dict, `type_parser=json.loads`).
- `OpenAIServingChat` reads it in `__init__` and merges it into `request.chat_template_kwargs` at the top of `_process_messages` with **setdefault** semantics, so per-request `chat_template_kwargs` and `reasoning_effort` (which the protocol validator already folds into `chat_template_kwargs`) still take precedence.
- `_process_messages` is the shared entry point for the OpenAI Chat, Responses, Anthropic, and tokenize paths, so one injection point covers all of them.
- Two unit tests in `test_serving/unit/entrypoints/openai/test_serving_chat.py`: default is applied when the request omits `chat_template_kwargs`, and a per-request value overrides the default.

## Usage

```bash
python -m sglang.launch_server --model-path ... --default-chat-template-kwargs '{"enable_thinking": false}'
```

Precedence: per-request `chat_template_kwargs` > `reasoning_effort` > `--default-chat-template-kwargs` > template default.





























































































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28919966285](https://github.com/sgl-project/sglang/actions/runs/28919966285)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28919966174](https://github.com/sgl-project/sglang/actions/runs/28919966174)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->