### PR TITLE
[SM120] Support GLM DSA serving on RTX PRO 6000

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -251,6 +251,54 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     && rm -rf /tmp/sglang_deps \
     && pip freeze | grep -v "^sglang==" > /sgl-workspace/constraints.txt
 
+# Optional source override for DeepGEMM changes that are not available in a
+# released sgl-deep-gemm wheel yet. Pass DEEPGEMM_SOURCE_REF as an immutable
+# commit hash for reproducible builds. Defaults stay empty, so official builds
+# keep using the pinned package version from python/pyproject.toml.
+ARG DEEPGEMM_SOURCE_REPO
+ARG DEEPGEMM_SOURCE_REF
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ -n "${DEEPGEMM_SOURCE_REPO}" ]; then \
+        rm -rf /tmp/deepgemm_src && \
+        git clone --recursive "${DEEPGEMM_SOURCE_REPO}" /tmp/deepgemm_src && \
+        cd /tmp/deepgemm_src && \
+        if [ -n "${DEEPGEMM_SOURCE_REF}" ]; then \
+            git checkout --detach "${DEEPGEMM_SOURCE_REF}"; \
+        fi && \
+        echo "Using DeepGEMM source commit $(git rev-parse HEAD)" && \
+        git submodule update --init --recursive && \
+        DG_FORCE_BUILD=1 python3 -m pip install --no-build-isolation --no-deps --force-reinstall -v . && \
+        cd /sgl-workspace && \
+        rm -rf /tmp/deepgemm_src; \
+    fi
+
+# Optional source override for FlashInfer changes that are not available in a
+# released flashinfer-python wheel yet. Pass FLASHINFER_SOURCE_REF as an
+# immutable commit hash for reproducible builds. Defaults stay empty, so
+# official builds keep using the pinned package versions from
+# python/pyproject.toml.
+ARG FLASHINFER_SOURCE_REPO
+ARG FLASHINFER_SOURCE_REF
+ARG FLASHINFER_CUDA_ARCH_LIST
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ -n "${FLASHINFER_SOURCE_REPO}" ]; then \
+        rm -rf /tmp/flashinfer_src && \
+        git clone --recursive "${FLASHINFER_SOURCE_REPO}" /tmp/flashinfer_src && \
+        cd /tmp/flashinfer_src && \
+        if [ -n "${FLASHINFER_SOURCE_REF}" ]; then \
+            git checkout --detach "${FLASHINFER_SOURCE_REF}"; \
+        fi && \
+        echo "Using FlashInfer source commit $(git rev-parse HEAD)" && \
+        git submodule update --init --recursive && \
+        python3 -m pip install --upgrade "setuptools>=77,<82" build && \
+        export FLASHINFER_CUDA_ARCH_LIST="${FLASHINFER_CUDA_ARCH_LIST:-12.0f}" && \
+        python3 -m pip install --no-build-isolation --no-deps --force-reinstall -v ".[cu13]" && \
+        python3 -m pip install --no-build-isolation --no-deps --force-reinstall -v ./flashinfer-cubin && \
+        python3 -m pip install --no-build-isolation --no-deps --force-reinstall -v ./flashinfer-jit-cache && \
+        cd /sgl-workspace && \
+        rm -rf /tmp/flashinfer_src; \
+    fi
+
 ########################################################
 # PARALLEL STAGE 2: DeepEP Builder (needs torch_deps)
 ########################################################

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -177,11 +177,53 @@ def get_dsa_index_topk(config: PretrainedConfig) -> int:
     return config.index_topk
 
 
+def _normalize_dsa_indexer_type(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+
+    value = value.strip().lower()
+    if value in ("f", "full", "full_indexer", "full-indexer"):
+        return "F"
+    if value in (
+        "s",
+        "skip",
+        "shared",
+        "share",
+        "skip_topk",
+        "skip-topk",
+        "shared_indexer",
+        "shared-indexer",
+    ):
+        return "S"
+    return None
+
+
+def get_dsa_index_topk_pattern(config) -> Optional[str]:
+    """Return an explicit or checkpoint-derived DSA top-k sharing pattern.
+
+    GLM-5.2 checkpoints may ship ``index_topk_pattern: null`` while carrying
+    the same IndexShare layout in ``indexer_types``. Normalize that metadata so
+    all skip-topk consumers use the checkpoint's layer layout by default.
+    """
+    pattern = _hf_attr(config, "index_topk_pattern")
+    if pattern is not None:
+        return pattern
+
+    indexer_types = _hf_attr(config, "indexer_types")
+    if not indexer_types:
+        return None
+
+    normalized = [_normalize_dsa_indexer_type(value) for value in indexer_types]
+    if any(value is None for value in normalized):
+        return None
+    return "".join(normalized)
+
+
 def dsa_layer_skips_topk(config: PretrainedConfig, layer_id: int) -> bool:
     """Return whether a DSA layer reuses the previous layer's top-k indices."""
     assert is_deepseek_dsa(config)
 
-    pattern = getattr(config, "index_topk_pattern", None)
+    pattern = get_dsa_index_topk_pattern(config)
     if pattern is not None:
         return layer_id < len(pattern) and pattern[layer_id] == "S"
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -75,6 +76,32 @@ if TYPE_CHECKING:
 
 
 _is_hip = is_hip()
+
+
+@lru_cache(maxsize=None)
+def _flashinfer_trtllm_mla_accepts_kwarg(name: str) -> bool:
+    import inspect
+
+    import flashinfer.decode
+
+    signature = inspect.signature(
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla
+    )
+    return name in signature.parameters
+
+
+def _normalize_flashinfer_sparse_mla_page_table(
+    page_table: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    block_tables_i32 = page_table.to(torch.int32)
+    seq_lens = (block_tables_i32 >= 0).sum(dim=-1).to(torch.int32)
+    block_tables = (
+        torch.clamp(block_tables_i32, min=0)
+        .contiguous()
+        .view(page_table.shape[0], 1, -1)
+    )
+    return block_tables, seq_lens
+
 
 if _is_hip:
     from sglang.srt.layers.attention.dsa.triton_kernel import get_valid_kv_indices
@@ -296,7 +323,12 @@ class DSAIndexerMetadata(BaseIndexerMetadata):
 
 
 _DSA_IMPL_T: TypeAlias = Literal[
-    "flashmla_sparse", "flashmla_kv", "fa3", "tilelang", "trtllm"
+    "flashmla_sparse",
+    "flashmla_kv",
+    "flashinfer_sparse_mla",
+    "fa3",
+    "tilelang",
+    "trtllm",
 ]
 
 
@@ -323,6 +355,13 @@ class DeepseekSparseAttnBackend(
         self.real_page_size = model_runner.page_size
         self.num_splits = (
             1 if model_runner.server_args.enable_deterministic_inference else 0
+        )
+        architectures = getattr(
+            model_runner.model_config.hf_config, "architectures", []
+        )
+        model_arch = architectures[0] if architectures else None
+        self.flashinfer_sparse_mla_kv_scale_format = (
+            "arbitrary_fp32" if model_arch == "GlmMoeDsaForCausalLM" else "auto"
         )
         self.use_dsa = is_deepseek_dsa(model_runner.model_config.hf_config)
         assert self.use_dsa, "DSA backend only supports DeepSeek DSA"
@@ -1574,7 +1613,7 @@ class DeepseekSparseAttnBackend(
             else self.dsa_prefill_impl
         )
 
-        if dsa_impl == "trtllm" and not self.use_mha:
+        if dsa_impl in ("trtllm", "flashinfer_sparse_mla") and not self.use_mha:
             return self._forward_trtllm(
                 q,
                 k,
@@ -1590,6 +1629,9 @@ class DeepseekSparseAttnBackend(
                 is_neox,
                 llama_4_scaling,
                 is_prefill=True,
+                flashinfer_backend=(
+                    "sparse" if dsa_impl == "flashinfer_sparse_mla" else "trtllm-gen"
+                ),
             )
 
         if k is not None:
@@ -1800,7 +1842,7 @@ class DeepseekSparseAttnBackend(
         metadata = self.forward_metadata
         assert causal, "DSA is causal only"
 
-        if self.dsa_decode_impl == "trtllm":
+        if self.dsa_decode_impl in ("trtllm", "flashinfer_sparse_mla"):
             return self._forward_trtllm(
                 q,
                 k,
@@ -1815,6 +1857,11 @@ class DeepseekSparseAttnBackend(
                 cos_sin_cache,
                 is_neox,
                 llama_4_scaling,
+                flashinfer_backend=(
+                    "sparse"
+                    if self.dsa_decode_impl == "flashinfer_sparse_mla"
+                    else "trtllm-gen"
+                ),
             )
 
         if k is not None:
@@ -2353,14 +2400,16 @@ class DeepseekSparseAttnBackend(
         is_neox: Optional[bool] = False,
         llama_4_scaling: Optional[torch.Tensor] = None,
         is_prefill: bool = False,
+        flashinfer_backend: str = "trtllm-gen",
     ) -> torch.Tensor:
         """Forward using TRT-LLM sparse MLA kernel."""
         import flashinfer.decode
 
         metadata = self.forward_metadata
+        use_flashinfer_sparse_mla = flashinfer_backend == "sparse"
 
         merge_query = q_rope is not None
-        if self.kv_cache_dtype == torch.float8_e4m3fn:
+        if self.kv_cache_dtype == torch.float8_e4m3fn and not use_flashinfer_sparse_mla:
             # For FP8 path, we quantize the query and rope parts and merge them into a single tensor
             # Note: rope application in deepseek_v2.py:forward_absorb_prepare is skipped for FP8 decode path of this trtllm_mla backend
             assert q_rope is not None, "For FP8 path q_rope should not be None."
@@ -2437,10 +2486,44 @@ class DeepseekSparseAttnBackend(
         batch_size = page_table_1.shape[0]
         _, num_heads, head_dim = q_all.shape
 
-        q = q_all.view(batch_size, 1, num_heads, head_dim)
-        kv = kv_cache.view(-1, 1, self.real_page_size, self.kv_cache_dim)
-        block_tables = page_table_1.unsqueeze(1)
-        seq_lens = metadata.cache_seqlens_int32 if seq_lens is None else seq_lens
+        extra_kwargs = {}
+        if use_flashinfer_sparse_mla:
+            if not _flashinfer_trtllm_mla_accepts_kwarg("kv_scale_format"):
+                raise RuntimeError(
+                    "flashinfer_sparse_mla requires FlashInfer sparse MLA SM120 "
+                    "support with the kv_scale_format argument. Install a "
+                    "FlashInfer build that includes flashinfer-ai/flashinfer#3395."
+                )
+            if q_all.dtype != torch.bfloat16:
+                raise ValueError(
+                    "flashinfer_sparse_mla requires BF16 query input for the "
+                    f"native SM120 sparse MLA kernel, got {q_all.dtype}."
+                )
+            if self.real_page_size != 64:
+                raise ValueError(
+                    "flashinfer_sparse_mla requires page_size=64 for the native "
+                    f"SM120 sparse MLA kernel, got {self.real_page_size}."
+                )
+            if self.kv_cache_dim != 656:
+                raise ValueError(
+                    "flashinfer_sparse_mla requires packed GLM/DSv3.2 FP8 KV "
+                    f"cache rows with 656 bytes per token, got {self.kv_cache_dim}."
+                )
+
+            q = q_all.view(batch_size, 1, num_heads, head_dim)
+            kv = kv_cache.view(torch.uint8).view(
+                -1, 1, self.real_page_size, self.kv_cache_dim
+            )
+            block_tables, seq_lens = _normalize_flashinfer_sparse_mla_page_table(
+                page_table_1
+            )
+            bmm1_scale = float(layer.scaling)
+            extra_kwargs["kv_scale_format"] = self.flashinfer_sparse_mla_kv_scale_format
+        else:
+            q = q_all.view(batch_size, 1, num_heads, head_dim)
+            kv = kv_cache.view(-1, 1, self.real_page_size, self.kv_cache_dim)
+            block_tables = page_table_1.unsqueeze(1)
+            seq_lens = metadata.cache_seqlens_int32 if seq_lens is None else seq_lens
 
         out = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
             query=q,
@@ -2454,8 +2537,9 @@ class DeepseekSparseAttnBackend(
             max_seq_len=metadata.max_seq_len_k,
             sparse_mla_top_k=self.dsa_index_topk,
             bmm1_scale=bmm1_scale,
-            backend="trtllm-gen",
+            backend=flashinfer_backend,
             skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
+            **extra_kwargs,
         )
 
         return out

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -73,6 +73,7 @@ from sglang.srt.utils.custom_op import register_custom_op
 
 logger = logging.getLogger(__name__)
 _SGLANG_EXPERIMENTAL_LORA_OPTI = envs.SGLANG_EXPERIMENTAL_LORA_OPTI.get()
+_TRTLLM_STYLE_DSA_MLA_BACKENDS = {"trtllm"}
 
 if TYPE_CHECKING:
     from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
@@ -958,12 +959,14 @@ class DeepseekMLAForwardMixin:
         self: DeepseekV2AttentionMLA, forward_batch: ForwardBatch
     ) -> bool:
         """
-        Check if we should skip rope and do fused rope+quantize for TRTLLM MLA decode in fp8_e4m3 path.
+        Check if we should skip rope and do fused rope+quantize for TRTLLM-style MLA decode in fp8_e4m3 path.
         """
         if self.current_attention_backend in ("dsa", "nsa"):
             return (
-                get_global_server_args().dsa_decode_backend == "trtllm"
-                or get_global_server_args().dsa_prefill_backend == "trtllm"
+                get_global_server_args().dsa_decode_backend
+                in _TRTLLM_STYLE_DSA_MLA_BACKENDS
+                or get_global_server_args().dsa_prefill_backend
+                in _TRTLLM_STYLE_DSA_MLA_BACKENDS
             ) and get_attn_backend().kv_cache_dtype == torch.float8_e4m3fn
 
         return (

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -110,6 +110,18 @@ _device_sm = get_device_sm()
 
 logger = logging.getLogger(__name__)
 
+
+def _modelopt_fp4_excludes_shared_experts(
+    quant_config: Optional[QuantizationConfig],
+) -> bool:
+    if quant_config is None or quant_config.get_name() != "modelopt_fp4":
+        return False
+    return any(
+        "shared_experts" in pattern
+        for pattern in (getattr(quant_config, "exclude_modules", None) or [])
+    )
+
+
 if _is_npu:
     from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import split_qkv_rmsnorm_rope
 
@@ -1215,6 +1227,11 @@ class Glm4MoeForCausalLM(nn.Module):
             disable_reason = "GLM-4.5 cannot use shared experts fusion optimization under deepep expert parallelism."
         elif self.quant_config and self.quant_config.get_name() == "w4afp8":
             disable_reason = "GLM-4.5 W4AFP8 model uses different quant method for routed experts and shared experts."
+        elif _modelopt_fp4_excludes_shared_experts(self.quant_config):
+            disable_reason = (
+                "GLM ModelOpt FP4 checkpoint excludes shared experts from "
+                "quantization, so they cannot be fused into routed FP4 expert slots."
+            )
 
         if disable_reason is not None:
             get_global_server_args().disable_shared_experts_fusion = True
@@ -1476,6 +1493,19 @@ class Glm4MoeForCausalLM(nn.Module):
 
 class GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM):
     def determine_num_fused_shared_experts(self):
+        if get_global_server_args().disable_shared_experts_fusion:
+            self.num_fused_shared_experts = 0
+            return
+        if _modelopt_fp4_excludes_shared_experts(self.quant_config):
+            get_global_server_args().disable_shared_experts_fusion = True
+            self.num_fused_shared_experts = 0
+            log_info_on_rank0(
+                logger,
+                "GLM ModelOpt FP4 checkpoint excludes shared experts from "
+                "quantization, so they cannot be fused into routed FP4 expert slots. "
+                "Shared experts fusion optimization is disabled.",
+            )
+            return
         super().determine_num_fused_shared_experts("GlmMoeDsaForCausalLM")
 
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -297,6 +297,7 @@ DSA_CHOICES = [
     "flashmla_sparse",
     "flashmla_kv",
     "flashmla_auto",
+    "flashinfer_sparse_mla",
     "fa3",
     "tilelang",
     "aiter",
@@ -2611,6 +2612,8 @@ class ServerArgs:
         # Get GPU memory capacity, which is a common dependency for several configuration steps.
         gpu_mem = get_device_memory_capacity(self.device)
 
+        self._mem_fraction_static_user_set = self.mem_fraction_static is not None
+
         # Handle memory-related, chunked prefill, and CUDA graph batch size configurations.
         self._handle_gpu_memory_settings(gpu_mem)
 
@@ -3567,7 +3570,12 @@ class ServerArgs:
             self.dsa_prefill_backend = "tilelang"
             self.dsa_decode_backend = "tilelang"
         elif kv_cache_dtype == "fp8_e4m3":
-            if major >= 10:
+            if major == 12:
+                if not user_set_prefill:
+                    self.dsa_prefill_backend = "flashinfer_sparse_mla"
+                if not user_set_decode:
+                    self.dsa_decode_backend = "flashinfer_sparse_mla"
+            elif major >= 10:
                 if not user_set_prefill:
                     self.dsa_prefill_backend = "trtllm"
                 if not user_set_decode:
@@ -3606,8 +3614,50 @@ class ServerArgs:
 
         validate_hisparse_kv_cache_dtype(self)
 
+    def _apply_glm_dsa_sm120_cuda_graph_memory_defaults(self):
+        user_set_decode_batch_sizes = (
+            Phase.DECODE,
+            "max_bs",
+        ) in self._cuda_graph_config_locked or (
+            Phase.DECODE,
+            "bs",
+        ) in self._cuda_graph_config_locked
+
+        if (
+            not user_set_decode_batch_sizes
+            and self.cuda_graph_config.decode.backend != Backend.DISABLED
+            and self.cuda_graph_config.decode.max_bs is not None
+            and self.cuda_graph_config.decode.max_bs > 256
+        ):
+            self.cuda_graph_config.decode.max_bs = 256
+            self.cuda_graph_config.decode.bs = (
+                self._generate_decode_cuda_graph_batch_sizes(256)
+            )
+            logger.warning(
+                "Setting decode CUDA graph max_bs to 256 for GLM DSA on SM120 "
+                "to leave enough memory for CUDA graph capture."
+            )
+
+        if (
+            not getattr(
+                self,
+                "_mem_fraction_static_user_set",
+                self.mem_fraction_static is not None,
+            )
+            and not user_set_decode_batch_sizes
+            and self.cuda_graph_config.decode.backend != Backend.DISABLED
+            and self.mem_fraction_static is not None
+            and self.mem_fraction_static > 0.8
+        ):
+            self.mem_fraction_static = 0.8
+            logger.warning(
+                "Capping auto mem_fraction_static at 0.8 for GLM DSA on SM120 "
+                "to leave enough memory for CUDA graph capture."
+            )
+
     def _handle_model_specific_adjustments(self):
         from sglang.srt.configs.model_config import (
+            get_dsa_index_topk_pattern,
             get_mimo_v2_fused_qkv_expected_tp_size,
             is_deepseek_dsa,
         )
@@ -3667,7 +3717,7 @@ class ServerArgs:
                     logger.info("Use dsa attention backend for DeepSeek with DSA.")
 
                 index_topk_freq = getattr(hf_config, "index_topk_freq", 1) or 1
-                index_topk_pattern = getattr(hf_config, "index_topk_pattern", None)
+                index_topk_pattern = get_dsa_index_topk_pattern(hf_config)
                 if self.enable_two_batch_overlap and (
                     index_topk_freq > 1
                     or (index_topk_pattern is not None and "S" in index_topk_pattern)
@@ -3749,6 +3799,8 @@ class ServerArgs:
                     major, _ = torch.cuda.get_device_capability()
                     self._set_default_dsa_kv_cache_dtype(major, self.quantization)
                     self._set_default_dsa_backends(self.kv_cache_dtype, major)
+                    if model_arch == "GlmMoeDsaForCausalLM" and major == 12:
+                        self._apply_glm_dsa_sm120_cuda_graph_memory_defaults()
 
                 if self.enable_prefill_cp:
                     assert (

--- a/scripts/release/bump_flashinfer_version.py
+++ b/scripts/release/bump_flashinfer_version.py
@@ -20,7 +20,8 @@ def read_current_flashinfer_version(repo_root: Path) -> str:
     pyproject = repo_root / "python" / "pyproject.toml"
     content = pyproject.read_text()
     match = re.search(
-        r"flashinfer_python==(\d+\.\d+\.\d+(?:rc\d+|\.post\d+)?)", content
+        r"flashinfer_python(?:\[[^\]]+\])?==(\d+\.\d+\.\d+(?:rc\d+|\.post\d+)?)",
+        content,
     )
     if not match:
         raise ValueError(f"Could not find flashinfer_python version in {pyproject}")
@@ -39,11 +40,15 @@ def replace_flashinfer_version(
 
     name = file_path.name
     if name == "pyproject.toml":
-        new_content = new_content.replace(
-            f"flashinfer_python=={old_version}", f"flashinfer_python=={new_version}"
+        new_content = re.sub(
+            rf"(flashinfer_python(?:\[[^\]]+\])?==){re.escape(old_version)}",
+            rf"\g<1>{new_version}",
+            new_content,
         )
-        new_content = new_content.replace(
-            f"flashinfer_cubin=={old_version}", f"flashinfer_cubin=={new_version}"
+        new_content = re.sub(
+            rf"(flashinfer_cubin==){re.escape(old_version)}",
+            rf"\g<1>{new_version}",
+            new_content,
         )
     elif name == "Dockerfile":
         new_content = re.sub(

--- a/test/manual/test_dsa_alias_cli_registry_env.py
+++ b/test/manual/test_dsa_alias_cli_registry_env.py
@@ -37,6 +37,7 @@ class TestDSAChoicesAndFields(unittest.TestCase):
     def test_dsa_choices_is_canonical(self):
         self.assertIn("fa3", self.DSA_CHOICES)
         self.assertIn("tilelang", self.DSA_CHOICES)
+        self.assertIn("flashinfer_sparse_mla", self.DSA_CHOICES)
 
     def test_nsa_choices_is_alias(self):
         self.assertIs(

--- a/test/registered/unit/configs/test_model_config_dsa.py
+++ b/test/registered/unit/configs/test_model_config_dsa.py
@@ -1,0 +1,66 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.configs.model_config import (
+    dsa_layer_skips_topk,
+    get_dsa_index_topk_pattern,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _make_dsa_config(**overrides):
+    defaults = dict(
+        architectures=["GlmMoeDsaForCausalLM"],
+        index_topk=2048,
+        index_topk_freq=1,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestDsaIndexTopkPattern(CustomTestCase):
+    def test_explicit_index_topk_pattern_takes_precedence(self):
+        config = _make_dsa_config(
+            index_topk_pattern="FSF", indexer_types=["S", "S", "S"]
+        )
+
+        self.assertEqual(get_dsa_index_topk_pattern(config), "FSF")
+        self.assertFalse(dsa_layer_skips_topk(config, 0))
+        self.assertTrue(dsa_layer_skips_topk(config, 1))
+        self.assertFalse(dsa_layer_skips_topk(config, 2))
+
+    def test_derives_index_topk_pattern_from_fs_indexer_types(self):
+        config = _make_dsa_config(index_topk_pattern=None, indexer_types=["F", "S"])
+
+        self.assertEqual(get_dsa_index_topk_pattern(config), "FS")
+        self.assertFalse(dsa_layer_skips_topk(config, 0))
+        self.assertTrue(dsa_layer_skips_topk(config, 1))
+
+    def test_derives_index_topk_pattern_from_word_indexer_types(self):
+        config = _make_dsa_config(
+            index_topk_pattern=None, indexer_types=["full", "shared", "skip_topk"]
+        )
+
+        self.assertEqual(get_dsa_index_topk_pattern(config), "FSS")
+        self.assertFalse(dsa_layer_skips_topk(config, 0))
+        self.assertTrue(dsa_layer_skips_topk(config, 1))
+        self.assertTrue(dsa_layer_skips_topk(config, 2))
+
+    def test_falls_back_to_frequency_when_indexer_types_are_unknown(self):
+        config = _make_dsa_config(
+            index_topk_freq=2,
+            index_skip_topk_offset=1,
+            index_topk_pattern=None,
+            indexer_types=["full", "unknown"],
+        )
+
+        self.assertIsNone(get_dsa_index_topk_pattern(config))
+        self.assertFalse(dsa_layer_skips_topk(config, 0))
+        self.assertTrue(dsa_layer_skips_topk(config, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_deepseek_mla_forward.py
+++ b/test/registered/unit/models/test_deepseek_mla_forward.py
@@ -1,0 +1,76 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention import dsa_backend
+from sglang.srt.models.deepseek_common.attention_forward_methods import forward_mla
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDeepseekMLAForwardPolicy(unittest.TestCase):
+    def _fuse_rope_for_dsa(self, prefill_backend, decode_backend, kv_cache_dtype):
+        server_args = SimpleNamespace(
+            dsa_prefill_backend=prefill_backend,
+            dsa_decode_backend=decode_backend,
+        )
+        attn_backend = SimpleNamespace(kv_cache_dtype=kv_cache_dtype)
+        fake_self = SimpleNamespace(current_attention_backend="dsa")
+        fake_batch = SimpleNamespace()
+
+        with (
+            patch.object(forward_mla, "get_global_server_args", lambda: server_args),
+            patch.object(forward_mla, "get_attn_backend", lambda: attn_backend),
+        ):
+            return forward_mla.DeepseekMLAForwardMixin._fuse_rope_for_trtllm_mla(
+                fake_self, fake_batch
+            )
+
+    def test_flashinfer_sparse_mla_uses_native_bf16_query_path(self):
+        self.assertFalse(
+            self._fuse_rope_for_dsa(
+                "flashinfer_sparse_mla",
+                "flashinfer_sparse_mla",
+                torch.float8_e4m3fn,
+            )
+        )
+
+    def test_trtllm_dsa_backend_uses_fp8_rope_fusion(self):
+        self.assertTrue(
+            self._fuse_rope_for_dsa(
+                "trtllm",
+                "trtllm",
+                torch.float8_e4m3fn,
+            )
+        )
+
+    def test_non_trtllm_style_dsa_backend_does_not_fuse_rope(self):
+        self.assertFalse(
+            self._fuse_rope_for_dsa(
+                "fa3",
+                "fa3",
+                torch.float8_e4m3fn,
+            )
+        )
+
+
+class TestFlashInferSparseMLAPageTable(unittest.TestCase):
+    def test_sparse_mla_lengths_stay_int32(self):
+        page_table = torch.tensor([[10, 11, -1], [7, -1, -1]], dtype=torch.int64)
+
+        block_tables, seq_lens = (
+            dsa_backend._normalize_flashinfer_sparse_mla_page_table(page_table)
+        )
+
+        self.assertEqual(block_tables.dtype, torch.int32)
+        self.assertEqual(seq_lens.dtype, torch.int32)
+        self.assertEqual(tuple(block_tables.shape), (2, 1, 3))
+        self.assertEqual(block_tables.tolist(), [[[10, 11, 0]], [[7, 0, 0]]])
+        self.assertEqual(seq_lens.tolist(), [2, 1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_glm4_moe.py
+++ b/test/registered/unit/models/test_glm4_moe.py
@@ -1,0 +1,57 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.models.glm4_moe import (
+    GlmMoeDsaForCausalLM,
+    _modelopt_fp4_excludes_shared_experts,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _FakeQuantConfig:
+    def __init__(self, name, exclude_modules):
+        self._name = name
+        self.exclude_modules = exclude_modules
+
+    def get_name(self):
+        return self._name
+
+
+class TestGlmSharedExpertFusionPolicy(unittest.TestCase):
+    def test_modelopt_fp4_shared_expert_exclusion_disables_fusion(self):
+        quant_config = _FakeQuantConfig(
+            "modelopt_fp4",
+            ["model.layers.*.mlp.shared_experts.*"],
+        )
+
+        self.assertTrue(_modelopt_fp4_excludes_shared_experts(quant_config))
+
+    def test_modelopt_fp4_without_shared_expert_exclusion_keeps_fusion_available(self):
+        quant_config = _FakeQuantConfig("modelopt_fp4", ["lm_head"])
+
+        self.assertFalse(_modelopt_fp4_excludes_shared_experts(quant_config))
+
+    def test_other_quantization_does_not_trigger_modelopt_fp4_guard(self):
+        quant_config = _FakeQuantConfig(
+            "modelopt_fp8",
+            ["model.layers.*.mlp.shared_experts.*"],
+        )
+
+        self.assertFalse(_modelopt_fp4_excludes_shared_experts(quant_config))
+
+    @patch("sglang.srt.models.glm4_moe.get_global_server_args")
+    def test_glm_dsa_explicit_disable_shared_expert_fusion_sets_zero(self, mock_args):
+        mock_args.return_value = SimpleNamespace(disable_shared_experts_fusion=True)
+        model = object.__new__(GlmMoeDsaForCausalLM)
+        model.quant_config = _FakeQuantConfig("modelopt_fp4", [])
+
+        model.determine_num_fused_shared_experts()
+
+        self.assertEqual(model.num_fused_shared_experts, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -12,6 +12,7 @@ from sglang.srt.layers.cp.base import is_cp_enabled, is_interleave
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     CudaGraphConfig,
+    Phase,
     PhaseConfig,
 )
 from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
@@ -165,6 +166,124 @@ class TestHiSparseDsaBackendPolicy(unittest.TestCase):
 
         self.assertEqual(server_args.dsa_prefill_backend, "flashmla_kv")
         self.assertEqual(server_args.dsa_decode_backend, "flashmla_kv")
+
+    @patch("sglang.srt.server_args.is_hip", return_value=False)
+    def test_dsa_defaults_to_flashinfer_sparse_mla_on_sm120_fp8(self, _mock_is_hip):
+        server_args = ServerArgs(model_path="dummy")
+
+        server_args._set_default_dsa_backends(kv_cache_dtype="fp8_e4m3", major=12)
+
+        self.assertEqual(server_args.dsa_prefill_backend, "flashinfer_sparse_mla")
+        self.assertEqual(server_args.dsa_decode_backend, "flashinfer_sparse_mla")
+
+    @patch("sglang.srt.server_args.is_hip", return_value=False)
+    def test_dsa_sm120_fp8_preserves_user_backend(self, _mock_is_hip):
+        server_args = ServerArgs(
+            model_path="dummy",
+            dsa_prefill_backend="flashmla_kv",
+        )
+
+        server_args._set_default_dsa_backends(kv_cache_dtype="fp8_e4m3", major=12)
+
+        self.assertEqual(server_args.dsa_prefill_backend, "flashmla_kv")
+        self.assertEqual(server_args.dsa_decode_backend, "flashinfer_sparse_mla")
+
+    def test_glm_sm120_dsa_caps_default_decode_cuda_graph_memory(self):
+        server_args = ServerArgs(model_path="dummy")
+        server_args.cuda_graph_config = CudaGraphConfig()
+        server_args.cuda_graph_config.decode.max_bs = 512
+        server_args.cuda_graph_config.decode.bs = (
+            server_args._generate_decode_cuda_graph_batch_sizes(512)
+        )
+        server_args._cuda_graph_config_locked = set()
+        server_args._mem_fraction_static_user_set = False
+        server_args.mem_fraction_static = 0.839
+
+        server_args._apply_glm_dsa_sm120_cuda_graph_memory_defaults()
+
+        self.assertEqual(server_args.cuda_graph_config.decode.backend, Backend.FULL)
+        self.assertEqual(server_args.cuda_graph_config.decode.max_bs, 256)
+        self.assertEqual(max(server_args.cuda_graph_config.decode.bs), 256)
+        self.assertEqual(server_args.mem_fraction_static, 0.8)
+
+    def test_glm_sm120_dsa_preserves_explicit_decode_cuda_graph_backend(self):
+        server_args = ServerArgs(model_path="dummy")
+        server_args.cuda_graph_config = CudaGraphConfig()
+        server_args.cuda_graph_config.decode.backend = Backend.FULL
+        server_args.cuda_graph_config.decode.max_bs = 512
+        server_args.cuda_graph_config.decode.bs = (
+            server_args._generate_decode_cuda_graph_batch_sizes(512)
+        )
+        server_args._cuda_graph_config_locked = {(Phase.DECODE, "backend")}
+        server_args._mem_fraction_static_user_set = False
+        server_args.mem_fraction_static = 0.839
+
+        server_args._apply_glm_dsa_sm120_cuda_graph_memory_defaults()
+
+        self.assertEqual(server_args.cuda_graph_config.decode.backend, Backend.FULL)
+        self.assertEqual(server_args.cuda_graph_config.decode.max_bs, 256)
+        self.assertEqual(max(server_args.cuda_graph_config.decode.bs), 256)
+        self.assertEqual(server_args.mem_fraction_static, 0.8)
+
+    def test_glm_sm120_dsa_preserves_explicit_tc_piecewise_decode_backend(self):
+        server_args = ServerArgs(model_path="dummy")
+        server_args.cuda_graph_config = CudaGraphConfig()
+        server_args.cuda_graph_config.decode.backend = Backend.TC_PIECEWISE
+        server_args.cuda_graph_config.decode.max_bs = 512
+        server_args.cuda_graph_config.decode.bs = (
+            server_args._generate_decode_cuda_graph_batch_sizes(512)
+        )
+        server_args._cuda_graph_config_locked = {(Phase.DECODE, "backend")}
+        server_args._mem_fraction_static_user_set = False
+        server_args.mem_fraction_static = 0.839
+
+        server_args._apply_glm_dsa_sm120_cuda_graph_memory_defaults()
+
+        self.assertEqual(
+            server_args.cuda_graph_config.decode.backend, Backend.TC_PIECEWISE
+        )
+        self.assertEqual(server_args.cuda_graph_config.decode.max_bs, 256)
+        self.assertEqual(max(server_args.cuda_graph_config.decode.bs), 256)
+        self.assertEqual(server_args.mem_fraction_static, 0.8)
+
+    def test_glm_sm120_dsa_preserves_disabled_decode_cuda_graph(self):
+        server_args = ServerArgs(model_path="dummy")
+        server_args.cuda_graph_config = CudaGraphConfig()
+        server_args.cuda_graph_config.decode.backend = Backend.DISABLED
+        server_args.cuda_graph_config.decode.max_bs = 512
+        server_args.cuda_graph_config.decode.bs = (
+            server_args._generate_decode_cuda_graph_batch_sizes(512)
+        )
+        server_args._cuda_graph_config_locked = {(Phase.DECODE, "backend")}
+        server_args._mem_fraction_static_user_set = False
+        server_args.mem_fraction_static = 0.839
+
+        server_args._apply_glm_dsa_sm120_cuda_graph_memory_defaults()
+
+        self.assertEqual(
+            server_args.cuda_graph_config.decode.backend, Backend.DISABLED
+        )
+        self.assertEqual(server_args.cuda_graph_config.decode.max_bs, 512)
+        self.assertEqual(max(server_args.cuda_graph_config.decode.bs), 512)
+        self.assertEqual(server_args.mem_fraction_static, 0.839)
+
+    def test_glm_sm120_dsa_preserves_explicit_decode_cuda_graph(self):
+        server_args = ServerArgs(model_path="dummy")
+        server_args.cuda_graph_config = CudaGraphConfig()
+        server_args.cuda_graph_config.decode.max_bs = 512
+        server_args.cuda_graph_config.decode.bs = (
+            server_args._generate_decode_cuda_graph_batch_sizes(512)
+        )
+        server_args._cuda_graph_config_locked = {(Phase.DECODE, "max_bs")}
+        server_args._mem_fraction_static_user_set = False
+        server_args.mem_fraction_static = 0.839
+
+        server_args._apply_glm_dsa_sm120_cuda_graph_memory_defaults()
+
+        self.assertEqual(server_args.cuda_graph_config.decode.backend, Backend.FULL)
+        self.assertEqual(server_args.cuda_graph_config.decode.max_bs, 512)
+        self.assertEqual(max(server_args.cuda_graph_config.decode.bs), 512)
+        self.assertEqual(server_args.mem_fraction_static, 0.839)
 
     @patch("sglang.srt.server_args.is_hip", return_value=True)
     def test_hisparse_defaults_to_tilelang_on_rocm(self, _mock_is_hip):


### PR DESCRIPTION
## Motivation

Fixes #29562.

This PR adds a native SM120 serving path for GLM DSA / GLM-5.2-NVFP4 on RTX PRO
6000 Blackwell. With the default GLM launch, the patched path starts the TP8
server, captures CUDA graphs, passes `/health`, and completes a minimal
`/generate` request on exact SM120 hardware.

The reporter path had multiple independent blockers:

1. GLM-5.2-NVFP4 ModelOpt metadata excludes `mlp.shared_experts` from FP4
   quantization, but shared-expert fusion remapped those unquantized tensors
   into routed packed FP4 expert slots. That caused the initial `3072` vs
   `6144` loader mismatch.
2. After disabling shared-expert fusion, SGLang still selected `trtllm` DSA
   backends for fp8 KV on SM120. The underlying FlashInfer TRTLLM-gen MLA path
   reports unsupported architecture on SM120.
3. Other DSA backend choices still reached
   `deep_gemm.get_paged_mqa_logits_metadata`, which is unsupported on SM120 in
   the currently pinned `sgl-deep-gemm` wheel.
4. With validated FlashInfer/DeepGEMM source builds, the old decode CUDA graph
   `max_bs=512` default OOMed during graph capture on 96GB RTX PRO 6000. An
   independent `dev-cu13` run also found `full` decode graph capture can hang.
   The current patch keeps SGLang's default `full` decode graph backend for
   consistency with the existing decode path, caps decode `max_bs` at 256 by
   default for this SM120 GLM DSA case, and still lets users explicitly select
   `tc_piecewise` as an alternative decode CUDA graph mode.
5. GLM-5.2-NVFP4 ships `index_topk_pattern: null`; the DSA IndexShare layer
   layout is encoded in `indexer_types`, so SGLang needs to derive the same F/S
   sharing pattern from checkpoint metadata instead of requiring a manual model
   config override.

## Modifications

- `glm4_moe.py`: detect ModelOpt FP4 checkpoints where shared experts are not
  quantized and automatically disable GLM shared-expert fusion for that case.
- `model_config.py`: derive the DSA top-k sharing pattern from
  checkpoint-native `indexer_types` when `index_topk_pattern` is absent,
  preserving explicit pattern precedence and the existing frequency/offset
  fallback.
- `server_args.py`: add `flashinfer_sparse_mla` as a DSA backend choice and
  select it by default for fp8 DSA on SM120. For GLM DSA on SM120, preserve the
  default `full` decode CUDA graph backend, cap the default decode graph
  `max_bs` to 256, and use the derived DSA top-k sharing pattern for the TBO
  guard. Hopper and SM100 paths keep their existing default backend selections.
- `dsa_backend.py`: call FlashInfer sparse MLA with the SM120 contract required
  by the native kernels: BF16 query, packed uint8 KV, page size 64, int32 sparse
  page tables, and `kv_scale_format="arbitrary_fp32"` for GLM.
- `forward_mla.py`: keep TRTLLM-style FP8 RoPE fusion limited to the TRTLLM
  backend so the sparse MLA path uses its own input contract.
- `Dockerfile`: add optional repo+commit source build args for FlashInfer and
  DeepGEMM so the image can use the validated dependency commits before wheels
  are released.

Validated source commits:

- FlashInfer `5f2bdc41f9ffecef9d8ed590e688e7c0f108504f`
  (includes merged SM120 sparse MLA support from
  https://github.com/flashinfer-ai/flashinfer/pull/3395)
- DeepGEMM `2073ddb2814892014c33ef4cd1c7d4c148baf1fe`
  (SM120 support merge)

Released wheel gap checked on SM120:

- `flashinfer-python==0.6.13`, `flashinfer-cubin==0.6.13`, and
  `flashinfer-jit-cache==0.6.13+cu130` import, but the released
  `trtllm_batch_decode_with_kv_cache_mla` signature still lacks
  `kv_scale_format`, so this GLM sparse MLA path needs a FlashInfer source
  build until the next wheel release.
- `sgl-deep-gemm` is still at 0.1.3, so the DeepGEMM SM120 metadata path needs
  the source commit above until a new SGLang DeepGEMM wheel is published.

The Dockerfile source override path pins the validated repos by commit hash:

```bash
--build-arg FLASHINFER_SOURCE_REPO=https://github.com/flashinfer-ai/flashinfer.git
--build-arg FLASHINFER_SOURCE_REF=5f2bdc41f9ffecef9d8ed590e688e7c0f108504f
--build-arg FLASHINFER_CUDA_ARCH_LIST=12.0f
--build-arg DEEPGEMM_SOURCE_REPO=https://github.com/deepseek-ai/DeepGEMM.git
--build-arg DEEPGEMM_SOURCE_REF=2073ddb2814892014c33ef4cd1c7d4c148baf1fe
```

I also validated this repo+commit install sequence on the exact SM120 base
image: DeepGEMM was installed from the pinned GitHub commit as
`deep_gemm 2.5.0+2073ddb`; FlashInfer was installed from the pinned GitHub
commit with `FLASHINFER_CUDA_ARCH_LIST=12.0f`, including `flashinfer-python`,
`flashinfer-cubin`, and `flashinfer-jit-cache` 0.6.13. The final probe printed
`has_kv_scale_format True`,
`deepgemm_metadata_ok Tensor (189, 2) torch.int32 cuda`, and
`repo_commit_install_ok`.

## Accuracy Tests

This PR changes the serving path for a previously unsupported SM120 GLM DSA
configuration. I did not run a full downstream accuracy benchmark such as GSM8K.
The issue-specific accuracy-relevant validation was functional generation on the
exact target hardware:

- default GLM-5.2-NVFP4 TP8 launch reached `/health`
- minimal `/generate` completed with HTTP 200 and 16 completion tokens
- the default backend change is gated to SM120, and focused tests cover the
  SM120 selection path plus existing non-SM120 routing behavior

FlashInfer sparse MLA correctness for the SM120 kernels is covered upstream by
FlashInfer's SM120 sparse MLA test suite in
https://github.com/flashinfer-ai/flashinfer/pull/3395.

## Speed Tests and Profiling

I did not run a throughput benchmark or profiler sweep for this patch. The
performance-relevant validation was that the SM120 path keeps CUDA graphs
enabled:

- old decode CUDA graph `max_bs=512` OOMed during graph capture on 96GB RTX PRO
  6000
- independent `dev-cu13` validation found `full` decode graph capture can hang,
  while `tc_piecewise` decode capture works
- the patched default keeps the `full` decode graph backend for consistency
  with the existing decode path and caps GLM DSA SM120 decode graph `max_bs` to
  256
- explicit `tc_piecewise` remains available as an alternative decode CUDA graph
  mode
- prefill CUDA graph capture completed
- decode CUDA graph capture completed
- FlashInfer autotune completed

## Tests

Exact SM120 hardware:

- 8 x NVIDIA RTX PRO 6000 Blackwell Server Edition
- compute capability SM120
- driver `580.159.03`, CUDA `13.0` host / `13.0.1` container
- base image `lmsysorg/sglang:dev-glm52-nvfp4`
- PyTorch `2.11.0+cu130`

Baseline:

- reporter-style launch failed in the GLM shared-expert fusion loader path with
  the `3072` vs `6144` mismatch
- `--disable-shared-experts-fusion` got past load/KV allocation, then failed in
  `deep_gemm.get_paged_mqa_logits_metadata(...): Unsupported architecture`
- explicit legacy `--dsa-prefill-backend trtllm --dsa-decode-backend trtllm`
  failed with `TllmGenFmhaRunner ... Unsupported architecture`

Patched dependency probe:

```text
torch 2.11.0+cu130
cuda_cap (12, 0)
flashinfer_python 0.6.13
flashinfer-cubin 0.6.13
flashinfer-jit-cache 0.6.13
deep-gemm 2.5.0+2073ddb
deep_gemm 2.5.0+2073ddb
sgl-deep-gemm 0.1.3
has_backend True
has_kv_scale_format True
deepgemm_metadata_ok Tensor (189, 2) torch.int32 cuda
repo_commit_install_ok
```

Patched default launch:

```bash
python3 -m sglang.launch_server \
  --model-path nvidia/GLM-5.2-NVFP4 \
  --tensor-parallel-size 8 \
  --quantization modelopt_fp4 \
  --tool-call-parser glm47 \
  --reasoning-parser glm45 \
  --trust-remote-code \
  --mem-fraction-static 0.8 \
  --host 0.0.0.0 \
  --port 30000
```

Result:

- selected `prefill=flashinfer_sparse_mla`, `decode=flashinfer_sparse_mla`
- auto-disabled incompatible shared-expert fusion
- allocated fp8 KV cache successfully (`368768` tokens/rank, `21.11 GB`/rank)
- FlashInfer autotune completed
- prefill CUDA graph capture completed
- decode CUDA graph capture completed
- `/health` passed
- minimal `/generate` completed with HTTP 200 and 16 completion tokens

Latest SM120 rerun after the `tc_piecewise` decode graph follow-up, on PR head
`cf638d6e6b0b1138128196d2349da18460b06d44`:

- source-pinned dependency image still reports `has_kv_scale_format True` and
  DeepGEMM metadata support
- focused unit checks passed:
  `99 passed, 18 warnings, 10 subtests passed`
- default launch above selected `flashinfer_sparse_mla`
- `cuda_graph_config.decode.backend` defaulted to `tc_piecewise` with
  `max_bs=256`
- all eight ranks loaded `GlmMoeDsaForCausalLM` with `modelopt_fp4` / `NVFP4`
- allocated fp8 KV cache successfully (`368768` tokens/rank, `21.11 GB`/rank)
- prefill CUDA graph capture completed with `backend=tc_piecewise`
- decode CUDA graph capture completed with `backend=tc_piecewise` and
  `bs=[1, 2, 4, ..., 256]`
- `/health` passed
- minimal `/generate` completed with HTTP 200 and 16 completion tokens
- failure grep was clean for `Unsupported architecture`, `TllmGenFmhaRunner`,
  `Traceback`, `OutOfMemory`, `RuntimeError`, `ValueError`, `3072`, and `6144`

Local checks:

```bash
git diff --check
```

```bash
python3 -m py_compile \
  python/sglang/srt/layers/attention/dsa_backend.py \
  python/sglang/srt/server_args.py
python3 scripts/ci/check_registered_tests.py
python3 scripts/ci/check_no_registered_tests_in_package.py
```

Follow-up after independent `dev-cu13` validation of the native path:

```bash
git diff --check
python3 -m py_compile \
  python/sglang/srt/server_args.py \
  test/registered/unit/server_args/test_server_args.py
python3 scripts/ci/check_registered_tests.py
python3 scripts/ci/check_no_registered_tests_in_package.py
```

```bash
PYTHONPATH=python python3 -m pytest \
  test/registered/unit/server_args/test_server_args.py \
  test/registered/unit/models/test_glm4_moe.py \
  test/registered/unit/models/test_deepseek_mla_forward.py -q
# 99 passed, 18 warnings, 10 subtests passed
```

SM120 runtime rerun for the earlier `tc_piecewise` default follow-up:

```bash
python3 -m sglang.launch_server \
  --model-path nvidia/GLM-5.2-NVFP4 \
  --tensor-parallel-size 8 \
  --quantization modelopt_fp4 \
  --tool-call-parser glm47 \
  --reasoning-parser glm45 \
  --trust-remote-code \
  --mem-fraction-static 0.8 \
  --host 0.0.0.0 \
  --port 30000
```

Result: selected `flashinfer_sparse_mla`, defaulted decode CUDA graph backend to
`tc_piecewise`, completed prefill and decode CUDA graph capture, passed
`/health`, returned HTTP 200 for minimal `/generate`, and had a clean failure
grep.

Latest follow-up for GLM-5.2 `indexer_types` metadata and default `full` decode
graph validation, on PR head `005ffc65dc0f72d42a1436c31ef129ed98cccc58`:

- cached GLM-5.2-NVFP4 config has `index_topk_pattern: null` and 78
  `indexer_types` entries describing the `full`/`shared` layer layout
- source-pinned image focused tests passed:
  `97 passed, 18 warnings, 10 subtests passed`
- the default launch above selected `flashinfer_sparse_mla`
- `cuda_graph_config.decode.backend` remained `full` with `max_bs=256`
- prefill CUDA graph capture completed with `backend=tc_piecewise`
- decode CUDA graph capture completed with `backend=full` and
  `bs=[1, 2, 4, ..., 256]`
- `/health` passed
- minimal `/generate` completed with HTTP 200 and 16 completion tokens
- no `index_topk_pattern` override or manual decode backend flag was used
- focused tests cover default `full`, explicit `full`, explicit `tc_piecewise`,
  and explicit disabled decode CUDA graph behavior
- previous explicit `full` checks also passed at `--cuda-graph-max-bs-decode 32`
  and at the PR's automatic `max_bs=256` cap

GitHub Actions:

- `lint` passed on head `cf638d6e6b0b1138128196d2349da18460b06d44`
- the latest amended head `005ffc65dc0f72d42a1436c31ef129ed98cccc58` needs the
  normal GitHub check rerun
- remaining red PR checks are `pr-gate` failures due missing maintainer `run-ci`
  authorization/label, not test job failures

Validation gaps:

- I did not rerun Hopper/H200 or SM100/B200 full-server controls in this patch.
- The backend default change is gated to SM120, and the focused tests cover the
  SM120 selection path plus existing non-SM120 routing behavior.
- Released FlashInfer and `sgl-deep-gemm` wheels still need follow-up releases.
  Until then, the Dockerfile source-pinned build args above are the validated
  way for the SGLang image to carry this path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). `git diff --check` and GitHub `lint` passed.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Focused unit tests were added/updated for GLM fusion, SM120 DSA routing, sparse MLA call contract, DSA `indexer_types` pattern derivation, and non-SM120 routing.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No separate user-facing docs are needed; the PR body documents the source-pinned dependency path and wheel gap.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). See the Accuracy Tests and Speed Tests sections for the issue-specific validation and remaining benchmark gap.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28357834679](https://github.com/sgl-project/sglang/actions/runs/28357834679)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28357834575](https://github.com/sgl-project/sglang/actions/runs/28357834575)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28352062088](https://github.com/sgl-project/sglang/actions/runs/28352062088)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28352061942](https://github.com/sgl-project/sglang/actions/runs/28352061942)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
