### PR TITLE
[Bugfix] Preserve single quotes inside JSON values in Llama32 streaming tool calls

### DIFF
--- a/python/sglang/srt/function_call/llama32_detector.py
+++ b/python/sglang/srt/function_call/llama32_detector.py
@@ -44,6 +44,46 @@ class Llama32Detector(BaseFormatDetector):
             pass
         return text
 
+    def _convert_python_dict_syntax(self, buffer: str) -> str:
+        """Convert Python-dict single-quote syntax to JSON for streaming.
+
+        Only segments *outside* double-quoted JSON string literals are
+        converted, so single quotes that legitimately appear inside a JSON
+        string value (e.g. ``{"text": "tip: 'x'"}``) are left untouched.
+        Rewriting them used to corrupt the tool-call arguments because the
+        ``: '...'`` substitution matched inside the value.
+        """
+
+        def _convert(segment: str) -> str:
+            segment = re.sub(r"'([^']*)':", r'"\1":', segment)
+            segment = re.sub(r":\s*'([^']*)'", r': "\1"', segment)
+            return segment
+
+        out: List[str] = []
+        segment_start = 0
+        in_string = False
+        escaped = False
+        for i, ch in enumerate(buffer):
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif ch == "\\":
+                    escaped = True
+                elif ch == '"':
+                    in_string = False
+                    # Copy the closed string literal verbatim.
+                    out.append(buffer[segment_start : i + 1])
+                    segment_start = i + 1
+            elif ch == '"':
+                # Flush the preceding (convertible) out-of-string segment.
+                out.append(_convert(buffer[segment_start:i]))
+                in_string = True
+                segment_start = i
+        tail = buffer[segment_start:]
+        # An unterminated string at the buffer tail (mid-stream) stays verbatim.
+        out.append(tail if in_string else _convert(tail))
+        return "".join(out)
+
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a Llama 3.2 format tool call."""
         # depending on the prompt format the Llama model may or may not
@@ -118,11 +158,11 @@ class Llama32Detector(BaseFormatDetector):
         """Override to handle Python dict format in streaming."""
         # First try with converted Python dict
         self._buffer += new_text
-        converted_buffer = self._buffer
 
-        # Convert Python dict syntax to JSON
-        converted_buffer = re.sub(r"'([^']*)':", r'"\1":', converted_buffer)
-        converted_buffer = re.sub(r":\s*'([^']*)'", r': "\1"', converted_buffer)
+        # Convert Python dict syntax to JSON. Conversion is skipped inside JSON
+        # string literals so single quotes within an argument value are not
+        # rewritten (which would corrupt the streamed arguments).
+        converted_buffer = self._convert_python_dict_syntax(self._buffer)
 
         # Temporarily replace buffer for parsing
         original_buffer = self._buffer

--- a/test/registered/unit/function_call/test_llama32_detector.py
+++ b/test/registered/unit/function_call/test_llama32_detector.py
@@ -185,6 +185,53 @@ class TestLlama32Detector(CustomTestCase):
         self.assertEqual(params["city"], "Tokyo")
         self.assertEqual(params["unit"], "celsius")
 
+    def test_streaming_single_quote_inside_json_value(self):
+        # A valid JSON argument value that contains a `: '...'` substring must
+        # not be corrupted by the Python-dict -> JSON conversion. Streaming the
+        # call character by character previously rewrote the inner single
+        # quotes and produced invalid JSON, dropping the arguments.
+        note_tool = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="note",
+                    parameters={
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}},
+                        "required": ["text"],
+                    },
+                ),
+            )
+        ]
+        text = '<|python_tag|>{"name": "note", "arguments": {"text": "tip: \'be careful\'"}}'
+        detector = Llama32Detector()
+        all_calls = []
+        for ch in text:
+            all_calls.extend(detector.parse_streaming_increment(ch, note_tool).calls)
+
+        func_calls = [c for c in all_calls if c.name]
+        self.assertEqual(len(func_calls), 1)
+        self.assertEqual(func_calls[0].name, "note")
+        full_params = "".join(c.parameters for c in all_calls if c.parameters)
+        params = json.loads(full_params)
+        self.assertEqual(params["text"], "tip: 'be careful'")
+
+    def test_streaming_python_dict_syntax(self):
+        # Python-dict (single-quoted) output must still convert correctly when
+        # streamed, including when the call is delivered character by character.
+        text = "<|python_tag|>{'name': 'get_weather', 'arguments': {'city': 'Beijing'}}"
+        detector = Llama32Detector()
+        all_calls = []
+        for ch in text:
+            all_calls.extend(detector.parse_streaming_increment(ch, self.tools).calls)
+
+        func_calls = [c for c in all_calls if c.name]
+        self.assertEqual(len(func_calls), 1)
+        self.assertEqual(func_calls[0].name, "get_weather")
+        full_params = "".join(c.parameters for c in all_calls if c.parameters)
+        params = json.loads(full_params)
+        self.assertEqual(params["city"], "Beijing")
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
## Motivation

`Llama32Detector.parse_streaming_increment` converts Python-dict syntax to JSON by running two buffer-wide regex substitutions on every streamed increment:

```python
converted_buffer = re.sub(r"'([^']*)':", r'"\1":', converted_buffer)
converted_buffer = re.sub(r":\s*'([^']*)'", r': "\1"', converted_buffer)
```

The second substitution is not aware of string boundaries, so it also rewrites single quotes that appear **inside a valid JSON string value**. When a Llama 3.2 tool call streams an argument whose value contains a `: '...'` substring, the conversion turns the value into invalid JSON and the arguments are corrupted (or dropped entirely), even though the non-streaming `detect_and_parse` path handles the same output correctly.

Minimal reproduction (model emits valid JSON):

```
<|python_tag|>{"name": "note", "arguments": {"text": "tip: 'be careful'"}}
```

| path | reconstructed `text` arg |
| --- | --- |
| `detect_and_parse` (non-streaming) | `tip: 'be careful'` ✅ |
| streaming | `tip: ` then invalid JSON → `json.loads` raises `Unterminated string` ❌ |

The inner `: 'be careful'` is rewritten to `: "be careful"`, producing `{"text": "tip: "be careful""}`. This affects any argument value containing a colon followed by a quoted phrase — common in natural-language and code arguments.

## Modifications

- Add `Llama32Detector._convert_python_dict_syntax`, which applies the Python-dict → JSON conversion **only to text outside double-quoted JSON string literals** (with backslash-escape handling). Single quotes inside an argument value are now left untouched, while genuine Python-dict output (the case the conversion exists for) still converts correctly, including a value that is still being streamed (an unterminated string at the buffer tail is preserved verbatim).
- Replace the two unconditional `re.sub` calls in `parse_streaming_increment` with a call to the new helper.
- Add regression tests:
  - `test_streaming_single_quote_inside_json_value` — streams the reproduction above character by character and asserts the argument round-trips. Fails on `main` (`JSONDecodeError`), passes here.
  - `test_streaming_python_dict_syntax` — locks in that single-quoted Python-dict output still converts correctly when streamed character by character (previously uncovered in streaming).

The change is confined to `llama32_detector.py`; behavior for plain JSON values and for Python-dict output is unchanged (verified against the existing detector unit tests).

## Accuracy Tests

Not applicable — no model forward / kernel changes. Pure tool-call parsing fix.

## Speed Tests and Profiling

Not applicable — the helper is a single linear pass over the buffer (same order of work as the two `re.sub` calls it replaces).

## Checklist

- [x] Format your code according to pre-commit (black/isort/ruff `F401,F821,UP037` pass).
- [x] Add unit tests (`test/registered/unit/function_call/test_llama32_detector.py`; full file passes).
- [ ] Update documentation — not applicable.
- [ ] Provide accuracy and speed benchmark results — not applicable.
- [x] Follow the SGLang code style guidance.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28333655551](https://github.com/sgl-project/sglang/actions/runs/28333655551)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28333655468](https://github.com/sgl-project/sglang/actions/runs/28333655468)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->