### PR TITLE
fix: replace hardcoded layer_id with mtp_start_layer_idx in Step3p5 MTP

### DIFF
--- a/python/sglang/srt/models/step3p5_mtp.py
+++ b/python/sglang/srt/models/step3p5_mtp.py
@@ -74,7 +74,7 @@ class Step3p5AMultiTokenPredictor(nn.Module):
         self.mtp_start_layer_idx = config.num_hidden_layers
         self.num_mtp_layers = config.num_nextn_predict_layers
 
-        layer_id = 45  # FIXME
+        layer_id = self.mtp_start_layer_idx
 
         self.enorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
         self.hnorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The class 'Step3p5AMultiTokenPredictor' has hardcoded 'layer_id = 45' when creating the MTP decoder block, even though 'self.mtp_start_layer_idx' (which equals 'config.num_hidden_layers') is already computed on the line above and holds the correct value. The hardcoded value works for the current Step3p5 model (45 layers), but would silently assign the wrong KV cache slot if a variant with a different layer count is introduced, causing the MTP block to collide with a main decoder layer's cache slot.

The original author marked this with '# FIXME' in PR #18084.

## Modifications

In 'Step3p5AMultiTokenPredictor.__init__', replace --> layer_id = 45 with --> layer_id = self.mtp_start_layer_idx

## Accuracy Tests

N/A - no changes to model outputs since self.mtp_start_layer_idx == config.num_hidden_layers == 45

## Speed Tests and Profiling

N/A - no performance impact

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28350619992](https://github.com/sgl-project/sglang/actions/runs/28350619992)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28350619881](https://github.com/sgl-project/sglang/actions/runs/28350619881)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->