### PR TITLE
[Test] Add unit tests for srt/kv_canary (#20865)

### DIFF
--- a/test/registered/unit/kv_canary/test_buffer_group.py
+++ b/test/registered/unit/kv_canary/test_buffer_group.py
@@ -1,0 +1,164 @@
+"""Tests for sglang.srt.kv_canary.buffer_group: PoolKind enum and CanaryBufferGroup."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.srt.kv_canary.buffer_group import CanaryBufferGroup, PoolKind
+from sglang.test.test_utils import CustomTestCase
+
+_DEVICE = torch.device("cpu")
+
+# Minimal canary buffer shape: [num_slots, canary_bytes]
+_SHAPE = (10, 16)
+
+
+def _buf():
+    return torch.zeros(*_SHAPE, dtype=torch.uint8, device=_DEVICE)
+
+
+def _make_group(
+    *,
+    kind=PoolKind.FULL,
+    v_head=None,
+    v_tail=None,
+    swa_index_lut=None,
+    kv_offset=0,
+    real_kv_k=(),
+    real_kv_v=(),
+):
+    return CanaryBufferGroup(
+        kind=kind,
+        k_head=_buf(),
+        k_tail=_buf(),
+        v_head=v_head,
+        v_tail=v_tail,
+        real_kv_sources_k=real_kv_k,
+        real_kv_sources_v=real_kv_v,
+        swa_index_lut=swa_index_lut,
+        kv_token_id_vs_position_offset=kv_offset,
+    )
+
+
+class TestPoolKindEnum(CustomTestCase):
+    def test_full_value(self):
+        self.assertEqual(int(PoolKind.FULL), 0)
+
+    def test_swa_value(self):
+        self.assertEqual(int(PoolKind.SWA), 1)
+
+    def test_members_count(self):
+        self.assertEqual(len(list(PoolKind)), 2)
+
+    def test_is_int_enum(self):
+        import enum
+
+        self.assertIsInstance(PoolKind.FULL, int)
+        self.assertTrue(issubclass(PoolKind, enum.IntEnum))
+
+    def test_full_less_than_swa(self):
+        self.assertLess(PoolKind.FULL, PoolKind.SWA)
+
+
+class TestCanaryBufferGroupHasVHalf(CustomTestCase):
+    def test_has_v_half_true_when_v_head_set(self):
+        bg = _make_group(v_head=_buf(), v_tail=_buf())
+        self.assertTrue(bg.has_v_half)
+
+    def test_has_v_half_false_when_v_head_none(self):
+        bg = _make_group(v_head=None, v_tail=None)
+        self.assertFalse(bg.has_v_half)
+
+    def test_has_v_half_false_returns_bool(self):
+        bg = _make_group()
+        self.assertIsInstance(bg.has_v_half, bool)
+
+    def test_has_v_half_true_returns_bool(self):
+        bg = _make_group(v_head=_buf(), v_tail=_buf())
+        self.assertIsInstance(bg.has_v_half, bool)
+
+
+class TestCanaryBufferGroupFields(CustomTestCase):
+    def test_kind_full(self):
+        bg = _make_group(kind=PoolKind.FULL)
+        self.assertEqual(bg.kind, PoolKind.FULL)
+
+    def test_kind_swa(self):
+        bg = _make_group(kind=PoolKind.SWA)
+        self.assertEqual(bg.kind, PoolKind.SWA)
+
+    def test_k_head_stored(self):
+        k = _buf()
+        bg = CanaryBufferGroup(
+            kind=PoolKind.FULL,
+            k_head=k,
+            k_tail=_buf(),
+            v_head=None,
+            v_tail=None,
+            real_kv_sources_k=(),
+            real_kv_sources_v=(),
+            swa_index_lut=None,
+            kv_token_id_vs_position_offset=0,
+        )
+        self.assertIs(bg.k_head, k)
+
+    def test_k_tail_stored(self):
+        t = _buf()
+        bg = CanaryBufferGroup(
+            kind=PoolKind.FULL,
+            k_head=_buf(),
+            k_tail=t,
+            v_head=None,
+            v_tail=None,
+            real_kv_sources_k=(),
+            real_kv_sources_v=(),
+            swa_index_lut=None,
+            kv_token_id_vs_position_offset=0,
+        )
+        self.assertIs(bg.k_tail, t)
+
+    def test_v_head_none_when_not_set(self):
+        bg = _make_group()
+        self.assertIsNone(bg.v_head)
+
+    def test_v_tail_none_when_not_set(self):
+        bg = _make_group()
+        self.assertIsNone(bg.v_tail)
+
+    def test_real_kv_sources_k_empty_tuple(self):
+        bg = _make_group()
+        self.assertEqual(bg.real_kv_sources_k, ())
+
+    def test_real_kv_sources_v_empty_tuple(self):
+        bg = _make_group()
+        self.assertEqual(bg.real_kv_sources_v, ())
+
+    def test_swa_index_lut_none_for_full_group(self):
+        bg = _make_group(kind=PoolKind.FULL, swa_index_lut=None)
+        self.assertIsNone(bg.swa_index_lut)
+
+    def test_swa_index_lut_stored(self):
+        lut = torch.zeros(100, dtype=torch.int64)
+        bg = _make_group(kind=PoolKind.SWA, swa_index_lut=lut)
+        self.assertIs(bg.swa_index_lut, lut)
+
+    def test_kv_token_id_vs_position_offset_zero(self):
+        bg = _make_group(kv_offset=0)
+        self.assertEqual(bg.kv_token_id_vs_position_offset, 0)
+
+    def test_kv_token_id_vs_position_offset_one(self):
+        bg = _make_group(kv_offset=1)
+        self.assertEqual(bg.kv_token_id_vs_position_offset, 1)
+
+    def test_frozen_dataclass_rejects_mutation(self):
+        bg = _make_group()
+        with self.assertRaises((AttributeError, TypeError)):
+            bg.kind = PoolKind.SWA
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/kv_canary/test_capacities.py
+++ b/test/registered/unit/kv_canary/test_capacities.py
@@ -1,0 +1,303 @@
+"""Tests for sglang.srt.kv_canary.capacities: CanaryLaunchCapacities arithmetic and validation."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.kv_canary.capacities import CanaryLaunchCapacities
+from sglang.test.test_utils import CustomTestCase
+
+
+def _sa(
+    cuda_graph_max_bs=0,
+    spec_num_draft_tokens=None,
+    max_prefill_tokens=8192,
+    chunked_prefill_size=None,
+):
+    """Build a minimal server_args SimpleNamespace."""
+    if cuda_graph_max_bs == 0:
+        cuda_graph_config = None
+    else:
+        cuda_graph_config = SimpleNamespace(
+            decode=SimpleNamespace(max_bs=cuda_graph_max_bs)
+        )
+    return SimpleNamespace(
+        cuda_graph_config=cuda_graph_config,
+        speculative_num_draft_tokens=spec_num_draft_tokens,
+        max_prefill_tokens=max_prefill_tokens,
+        chunked_prefill_size=chunked_prefill_size,
+    )
+
+
+class TestVerifyCapacityArithmetic(CustomTestCase):
+    def test_verify_capacity_is_three_times_pool_slot_count(self):
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(),
+            req_to_token_pool_size=512,
+            max_seq_len_per_req=2048,
+            pool_slot_count=100,
+        )
+        self.assertEqual(caps.per_forward_verify_capacity, 300)
+
+    def test_verify_capacity_with_small_pool(self):
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(),
+            req_to_token_pool_size=4,
+            max_seq_len_per_req=64,
+            pool_slot_count=7,
+        )
+        self.assertEqual(caps.per_forward_verify_capacity, 21)
+
+    def test_verify_capacity_with_large_pool(self):
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(),
+            req_to_token_pool_size=4096,
+            max_seq_len_per_req=4096,
+            pool_slot_count=500,
+        )
+        self.assertEqual(caps.per_forward_verify_capacity, 1500)
+
+
+class TestWriteReqCapacityArithmetic(CustomTestCase):
+    def test_req_capacity_equals_pool_when_no_cuda_graph(self):
+        # max_bs = max(0, req_to_token_pool_size)
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(cuda_graph_max_bs=0),
+            req_to_token_pool_size=128,
+            max_seq_len_per_req=1024,
+            pool_slot_count=50,
+        )
+        self.assertEqual(caps.per_forward_write_req_capacity, 128)
+
+    def test_req_capacity_uses_cuda_graph_max_when_larger(self):
+        # max_bs = max(256, 128) = 256
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(cuda_graph_max_bs=256),
+            req_to_token_pool_size=128,
+            max_seq_len_per_req=1024,
+            pool_slot_count=50,
+        )
+        self.assertEqual(caps.per_forward_write_req_capacity, 256)
+
+    def test_req_capacity_uses_pool_when_larger_than_cuda_graph(self):
+        # max_bs = max(32, 512) = 512
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(cuda_graph_max_bs=32),
+            req_to_token_pool_size=512,
+            max_seq_len_per_req=1024,
+            pool_slot_count=50,
+        )
+        self.assertEqual(caps.per_forward_write_req_capacity, 512)
+
+
+class TestWriteEntryCapacityArithmetic(CustomTestCase):
+    def test_chunked_none_gives_inf_limit(self):
+        # chunked_prefill_size=None -> chunked_limit=math.inf
+        # max_extend_tokens_per_forward = min(8192, inf) = 8192
+        # write_entry = max(100*1, 8192) = 8192
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(chunked_prefill_size=None, max_prefill_tokens=8192),
+            req_to_token_pool_size=100,
+            max_seq_len_per_req=2048,
+            pool_slot_count=50,
+        )
+        self.assertEqual(caps.per_forward_write_entry_capacity, 8192)
+
+    def test_chunked_size_limits_extend_tokens(self):
+        # chunked_prefill_size=512, max_prefill_tokens=8192
+        # max_extend_tokens_per_forward = min(8192, 512) = 512
+        # write_entry = max(100*1, 512) = 512
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(chunked_prefill_size=512, max_prefill_tokens=8192),
+            req_to_token_pool_size=100,
+            max_seq_len_per_req=2048,
+            pool_slot_count=50,
+        )
+        self.assertEqual(caps.per_forward_write_entry_capacity, 512)
+
+    def test_spec_tokens_scale_write_entry(self):
+        # spec_num_draft_tokens=4 -> num_tokens_per_bs = max(1, 4) = 4
+        # max_bs = max(256, 128) = 256
+        # chunked_limit = 512
+        # max_extend_tokens_per_forward = min(8192, 512) = 512
+        # write_entry = max(256*4=1024, 512) = 1024
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(
+                cuda_graph_max_bs=256,
+                spec_num_draft_tokens=4,
+                chunked_prefill_size=512,
+                max_prefill_tokens=8192,
+            ),
+            req_to_token_pool_size=128,
+            max_seq_len_per_req=2048,
+            pool_slot_count=50,
+        )
+        self.assertEqual(caps.per_forward_write_entry_capacity, 1024)
+
+    def test_no_spec_tokens_uses_one_per_bs(self):
+        # spec_num_draft_tokens=None -> num_tokens_per_bs=1
+        # max_bs = 64, chunked_prefill_size=32
+        # max_extend = min(8192, 32) = 32
+        # write_entry = max(64*1, 32) = 64
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(
+                cuda_graph_max_bs=64,
+                spec_num_draft_tokens=None,
+                chunked_prefill_size=32,
+                max_prefill_tokens=8192,
+            ),
+            req_to_token_pool_size=1,
+            max_seq_len_per_req=256,
+            pool_slot_count=1,
+        )
+        self.assertEqual(caps.per_forward_write_entry_capacity, 64)
+
+    def test_spec_zero_draft_tokens_treated_as_no_spec(self):
+        # spec_num_draft_tokens=0 -> falsy, num_tokens_per_bs=1
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(
+                spec_num_draft_tokens=0,
+                chunked_prefill_size=32,
+                max_prefill_tokens=8192,
+            ),
+            req_to_token_pool_size=64,
+            max_seq_len_per_req=256,
+            pool_slot_count=1,
+        )
+        # write_entry = max(64*1, 32) = 64
+        self.assertEqual(caps.per_forward_write_entry_capacity, 64)
+
+
+class TestValidationErrors(CustomTestCase):
+    def test_nonpositive_req_to_token_pool_size_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CanaryLaunchCapacities.from_args(
+                server_args=_sa(),
+                req_to_token_pool_size=0,
+                max_seq_len_per_req=2048,
+                pool_slot_count=10,
+            )
+        self.assertIn("req_to_token_pool_size", str(ctx.exception))
+
+    def test_negative_req_to_token_pool_size_raises(self):
+        with self.assertRaises(ValueError):
+            CanaryLaunchCapacities.from_args(
+                server_args=_sa(),
+                req_to_token_pool_size=-1,
+                max_seq_len_per_req=2048,
+                pool_slot_count=10,
+            )
+
+    def test_nonpositive_max_seq_len_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CanaryLaunchCapacities.from_args(
+                server_args=_sa(),
+                req_to_token_pool_size=10,
+                max_seq_len_per_req=0,
+                pool_slot_count=10,
+            )
+        self.assertIn("max_seq_len_per_req", str(ctx.exception))
+
+    def test_nonpositive_pool_slot_count_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CanaryLaunchCapacities.from_args(
+                server_args=_sa(),
+                req_to_token_pool_size=10,
+                max_seq_len_per_req=2048,
+                pool_slot_count=0,
+            )
+        self.assertIn("pool_slot_count", str(ctx.exception))
+
+    def test_negative_cuda_graph_max_bs_raises(self):
+        sa = SimpleNamespace(
+            cuda_graph_config=SimpleNamespace(decode=SimpleNamespace(max_bs=-1)),
+            speculative_num_draft_tokens=None,
+            max_prefill_tokens=8192,
+            chunked_prefill_size=None,
+        )
+        with self.assertRaises(ValueError) as ctx:
+            CanaryLaunchCapacities.from_args(
+                server_args=sa,
+                req_to_token_pool_size=10,
+                max_seq_len_per_req=2048,
+                pool_slot_count=10,
+            )
+        self.assertIn("cuda_graph_max_bs", str(ctx.exception))
+
+    def test_negative_spec_draft_tokens_raises(self):
+        sa = _sa()
+        sa.speculative_num_draft_tokens = -1
+        with self.assertRaises(ValueError) as ctx:
+            CanaryLaunchCapacities.from_args(
+                server_args=sa,
+                req_to_token_pool_size=10,
+                max_seq_len_per_req=2048,
+                pool_slot_count=10,
+            )
+        self.assertIn("speculative_num_draft_tokens", str(ctx.exception))
+
+    def test_nonpositive_max_prefill_tokens_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CanaryLaunchCapacities.from_args(
+                server_args=_sa(max_prefill_tokens=0),
+                req_to_token_pool_size=10,
+                max_seq_len_per_req=2048,
+                pool_slot_count=10,
+            )
+        self.assertIn("max_prefill_tokens", str(ctx.exception))
+
+
+class TestPostInitValidation(CustomTestCase):
+    def test_zero_verify_capacity_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CanaryLaunchCapacities(
+                per_forward_verify_capacity=0,
+                per_forward_write_req_capacity=10,
+                per_forward_write_entry_capacity=10,
+            )
+        self.assertIn("per_forward_verify_capacity", str(ctx.exception))
+
+    def test_zero_write_req_capacity_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CanaryLaunchCapacities(
+                per_forward_verify_capacity=10,
+                per_forward_write_req_capacity=0,
+                per_forward_write_entry_capacity=10,
+            )
+        self.assertIn("per_forward_write_req_capacity", str(ctx.exception))
+
+    def test_zero_write_entry_capacity_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CanaryLaunchCapacities(
+                per_forward_verify_capacity=10,
+                per_forward_write_req_capacity=10,
+                per_forward_write_entry_capacity=0,
+            )
+        self.assertIn("per_forward_write_entry_capacity", str(ctx.exception))
+
+    def test_negative_any_field_raises(self):
+        with self.assertRaises(ValueError):
+            CanaryLaunchCapacities(
+                per_forward_verify_capacity=-1,
+                per_forward_write_req_capacity=10,
+                per_forward_write_entry_capacity=10,
+            )
+
+
+class TestFrozenDataclass(CustomTestCase):
+    def test_is_frozen(self):
+        caps = CanaryLaunchCapacities.from_args(
+            server_args=_sa(),
+            req_to_token_pool_size=10,
+            max_seq_len_per_req=128,
+            pool_slot_count=5,
+        )
+        with self.assertRaises((AttributeError, TypeError)):
+            caps.per_forward_verify_capacity = 999
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/kv_canary/test_config.py
+++ b/test/registered/unit/kv_canary/test_config.py
@@ -1,0 +1,200 @@
+"""Tests for sglang.srt.kv_canary.config: CanaryMode enum and CanaryConfig.from_env."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.jit_kernel.kv_canary.consts import RealKvHashMode
+from sglang.srt.kv_canary.config import CanaryConfig, CanaryMode
+from sglang.test.test_utils import CustomTestCase
+
+_ENV_RING = "SGLANG_KV_CANARY_RING_CAPACITY"
+_ENV_WRITE = "SGLANG_KV_CANARY_ENABLE_WRITE_INPUT_ASSERT"
+_ENV_VERIFY = "SGLANG_KV_CANARY_ENABLE_VERIFY_TOKEN_ASSERT"
+_ENV_STATS = "SGLANG_KV_CANARY_STATS_PRINT_EVERY_N_STEPS"
+
+_ALL_ENV_KEYS = (_ENV_RING, _ENV_WRITE, _ENV_VERIFY, _ENV_STATS)
+
+
+def _make_server_args(mode="none", real_data="PARTIAL", sweep_interval=0):
+    return SimpleNamespace(
+        kv_canary=mode,
+        kv_canary_real_data=real_data,
+        kv_canary_sweep_interval=sweep_interval,
+    )
+
+
+def _clean_env():
+    """Return a copy of os.environ with all kv_canary keys removed."""
+    return {k: v for k, v in os.environ.items() if k not in _ALL_ENV_KEYS}
+
+
+class TestCanaryModeEnum(CustomTestCase):
+    def test_none_value(self):
+        self.assertEqual(CanaryMode.NONE.value, "none")
+
+    def test_log_value(self):
+        self.assertEqual(CanaryMode.LOG.value, "log")
+
+    def test_raise_value(self):
+        self.assertEqual(CanaryMode.RAISE.value, "raise")
+
+    def test_members_count(self):
+        self.assertEqual(len(list(CanaryMode)), 3)
+
+    def test_is_str_subclass(self):
+        self.assertIsInstance(CanaryMode.NONE, str)
+
+
+class TestCanaryConfigFromEnvMode(CustomTestCase):
+    def test_mode_none(self):
+        with patch.dict(os.environ, _clean_env(), clear=True):
+            cfg = CanaryConfig.from_env(_make_server_args(mode="none"))
+        self.assertEqual(cfg.mode, CanaryMode.NONE)
+
+    def test_mode_log(self):
+        with patch.dict(os.environ, _clean_env(), clear=True):
+            cfg = CanaryConfig.from_env(_make_server_args(mode="log"))
+        self.assertEqual(cfg.mode, CanaryMode.LOG)
+
+    def test_mode_raise(self):
+        with patch.dict(os.environ, _clean_env(), clear=True):
+            cfg = CanaryConfig.from_env(_make_server_args(mode="raise"))
+        self.assertEqual(cfg.mode, CanaryMode.RAISE)
+
+    def test_mode_uppercase_is_accepted(self):
+        # from_env calls .lower(), so "NONE" becomes "none" and is valid.
+        with patch.dict(os.environ, _clean_env(), clear=True):
+            cfg = CanaryConfig.from_env(_make_server_args(mode="NONE"))
+        self.assertEqual(cfg.mode, CanaryMode.NONE)
+
+    def test_mode_with_whitespace_stripped(self):
+        with patch.dict(os.environ, _clean_env(), clear=True):
+            cfg = CanaryConfig.from_env(_make_server_args(mode="  log  "))
+        self.assertEqual(cfg.mode, CanaryMode.LOG)
+
+    def test_invalid_mode_raises_value_error(self):
+        with patch.dict(os.environ, _clean_env(), clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                CanaryConfig.from_env(_make_server_args(mode="disabled"))
+        self.assertIn("disabled", str(ctx.exception))
+
+    def test_invalid_mode_warn_raises(self):
+        # "warn" is not a valid mode (valid: none/log/raise).
+        with patch.dict(os.environ, _clean_env(), clear=True):
+            with self.assertRaises(ValueError):
+                CanaryConfig.from_env(_make_server_args(mode="warn"))
+
+    def test_invalid_mode_health_check_raises(self):
+        with patch.dict(os.environ, _clean_env(), clear=True):
+            with self.assertRaises(ValueError):
+                CanaryConfig.from_env(_make_server_args(mode="health_check"))
+
+
+class TestCanaryConfigFromEnvDefaults(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self._patched = patch.dict(os.environ, _clean_env(), clear=True)
+        self._patched.start()
+
+    def tearDown(self):
+        self._patched.stop()
+        super().tearDown()
+
+    def _cfg(self, **kwargs):
+        return CanaryConfig.from_env(_make_server_args(**kwargs))
+
+    def test_default_ring_capacity(self):
+        cfg = self._cfg()
+        self.assertEqual(cfg.ring_capacity, 1024)
+
+    def test_default_enable_write_input_assert(self):
+        cfg = self._cfg()
+        self.assertFalse(cfg.enable_write_input_assert)
+
+    def test_default_enable_verify_token_assert(self):
+        cfg = self._cfg()
+        self.assertFalse(cfg.enable_verify_token_assert)
+
+    def test_default_stats_print_every_n_steps(self):
+        cfg = self._cfg()
+        self.assertEqual(cfg.stats_print_every_n_steps, 100)
+
+    def test_sweep_interval_from_server_args(self):
+        cfg = self._cfg(sweep_interval=7)
+        self.assertEqual(cfg.sweep_interval, 7)
+
+    def test_real_kv_hash_mode_partial(self):
+        cfg = self._cfg(real_data="PARTIAL")
+        self.assertEqual(cfg.real_kv_hash_mode, RealKvHashMode.PARTIAL)
+
+    def test_real_kv_hash_mode_none(self):
+        cfg = self._cfg(real_data="NONE")
+        self.assertEqual(cfg.real_kv_hash_mode, RealKvHashMode.NONE)
+
+    def test_real_kv_hash_mode_all(self):
+        cfg = self._cfg(real_data="ALL")
+        self.assertEqual(cfg.real_kv_hash_mode, RealKvHashMode.ALL)
+
+
+class TestCanaryConfigFromEnvOverrides(CustomTestCase):
+    def test_ring_capacity_from_env(self):
+        env = {**_clean_env(), _ENV_RING: "512"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = CanaryConfig.from_env(_make_server_args())
+        self.assertEqual(cfg.ring_capacity, 512)
+
+    def test_enable_write_input_assert_from_env(self):
+        env = {**_clean_env(), _ENV_WRITE: "1"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = CanaryConfig.from_env(_make_server_args())
+        self.assertTrue(cfg.enable_write_input_assert)
+
+    def test_enable_verify_token_assert_from_env(self):
+        env = {**_clean_env(), _ENV_VERIFY: "1"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = CanaryConfig.from_env(_make_server_args())
+        self.assertTrue(cfg.enable_verify_token_assert)
+
+    def test_stats_print_every_n_steps_from_env(self):
+        env = {**_clean_env(), _ENV_STATS: "50"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = CanaryConfig.from_env(_make_server_args())
+        self.assertEqual(cfg.stats_print_every_n_steps, 50)
+
+
+class TestCanaryConfigFieldAccess(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self._patched = patch.dict(os.environ, _clean_env(), clear=True)
+        self._patched.start()
+        self._cfg = CanaryConfig.from_env(
+            _make_server_args(mode="log", sweep_interval=3)
+        )
+
+    def tearDown(self):
+        self._patched.stop()
+        super().tearDown()
+
+    def test_all_fields_accessible(self):
+        cfg = self._cfg
+        _ = cfg.mode
+        _ = cfg.ring_capacity
+        _ = cfg.sweep_interval
+        _ = cfg.real_kv_hash_mode
+        _ = cfg.enable_write_input_assert
+        _ = cfg.enable_verify_token_assert
+        _ = cfg.stats_print_every_n_steps
+
+    def test_frozen_dataclass_rejects_mutation(self):
+        with self.assertRaises((AttributeError, TypeError)):
+            self._cfg.mode = CanaryMode.NONE
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/kv_canary/test_expected_inputs.py
+++ b/test/registered/unit/kv_canary/test_expected_inputs.py
@@ -1,0 +1,104 @@
+"""Tests for sglang.srt.kv_canary.expected_inputs: ExpectedInputs allocation and slicing."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.srt.kv_canary.expected_inputs import ExpectedInputs
+from sglang.test.test_utils import CustomTestCase
+
+_DEVICE = torch.device("cpu")
+
+
+class TestExpectedInputsAllocate(CustomTestCase):
+    def test_tokens_shape(self):
+        ei = ExpectedInputs.allocate(capacity=8, device=_DEVICE)
+        self.assertEqual(ei.tokens.shape, torch.Size([8]))
+
+    def test_tokens_dtype(self):
+        ei = ExpectedInputs.allocate(capacity=8, device=_DEVICE)
+        self.assertEqual(ei.tokens.dtype, torch.int64)
+
+    def test_positions_shape(self):
+        ei = ExpectedInputs.allocate(capacity=8, device=_DEVICE)
+        self.assertEqual(ei.positions.shape, torch.Size([8]))
+
+    def test_positions_dtype(self):
+        ei = ExpectedInputs.allocate(capacity=8, device=_DEVICE)
+        self.assertEqual(ei.positions.dtype, torch.int64)
+
+    def test_capacity_one(self):
+        ei = ExpectedInputs.allocate(capacity=1, device=_DEVICE)
+        self.assertEqual(ei.tokens.shape, torch.Size([1]))
+        self.assertEqual(ei.positions.shape, torch.Size([1]))
+
+    def test_tokens_and_positions_are_separate_tensors(self):
+        ei = ExpectedInputs.allocate(capacity=4, device=_DEVICE)
+        self.assertIsNot(ei.tokens, ei.positions)
+
+    def test_frozen_dataclass_rejects_mutation(self):
+        ei = ExpectedInputs.allocate(capacity=4, device=_DEVICE)
+        with self.assertRaises((AttributeError, TypeError)):
+            ei.tokens = torch.zeros(4, dtype=torch.int64)
+
+
+class TestExpectedInputsSlice(CustomTestCase):
+    def test_slice_shape(self):
+        ei = ExpectedInputs.allocate(capacity=8, device=_DEVICE)
+        s = ei.slice(3)
+        self.assertEqual(s.tokens.shape, torch.Size([3]))
+        self.assertEqual(s.positions.shape, torch.Size([3]))
+
+    def test_slice_is_view_of_original_tokens(self):
+        ei = ExpectedInputs.allocate(capacity=8, device=_DEVICE)
+        s = ei.slice(3)
+        self.assertEqual(s.tokens.data_ptr(), ei.tokens.data_ptr())
+
+    def test_slice_is_view_of_original_positions(self):
+        ei = ExpectedInputs.allocate(capacity=8, device=_DEVICE)
+        s = ei.slice(3)
+        self.assertEqual(s.positions.data_ptr(), ei.positions.data_ptr())
+
+    def test_slice_zero_returns_empty(self):
+        ei = ExpectedInputs.allocate(capacity=8, device=_DEVICE)
+        s = ei.slice(0)
+        self.assertEqual(s.tokens.numel(), 0)
+        self.assertEqual(s.positions.numel(), 0)
+
+    def test_slice_full_capacity_same_as_original(self):
+        ei = ExpectedInputs.allocate(capacity=5, device=_DEVICE)
+        s = ei.slice(5)
+        self.assertEqual(s.tokens.shape, ei.tokens.shape)
+        self.assertEqual(s.positions.shape, ei.positions.shape)
+
+    def test_slice_data_shared_with_original(self):
+        ei = ExpectedInputs.allocate(capacity=8, device=_DEVICE)
+        ei.tokens.fill_(42)
+        s = ei.slice(3)
+        self.assertEqual(s.tokens.tolist(), [42, 42, 42])
+
+    def test_slice_returns_expected_inputs_instance(self):
+        ei = ExpectedInputs.allocate(capacity=4, device=_DEVICE)
+        s = ei.slice(2)
+        self.assertIsInstance(s, ExpectedInputs)
+
+    def test_slice_dtype_preserved(self):
+        ei = ExpectedInputs.allocate(capacity=4, device=_DEVICE)
+        s = ei.slice(2)
+        self.assertEqual(s.tokens.dtype, torch.int64)
+        self.assertEqual(s.positions.dtype, torch.int64)
+
+    def test_writes_through_slice_visible_in_original(self):
+        ei = ExpectedInputs.allocate(capacity=6, device=_DEVICE)
+        ei.tokens.zero_()
+        s = ei.slice(3)
+        s.tokens.fill_(7)
+        self.assertEqual(ei.tokens[:3].tolist(), [7, 7, 7])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/kv_canary/test_plan_input.py
+++ b/test/registered/unit/kv_canary/test_plan_input.py
@@ -1,0 +1,369 @@
+"""Tests for sglang.srt.kv_canary.plan_input: PlanInput allocation, zeroing, and dispatch."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.kv_canary.plan_input import PlanInput
+from sglang.test.test_utils import CustomTestCase
+
+_DEVICE = torch.device("cpu")
+
+
+def _mode(name):
+    """Return a SimpleNamespace that responds to exactly one ForwardMode predicate."""
+
+    class _M:
+        def is_decode_or_idle(self):
+            return name == "decode"
+
+        def is_target_verify(self):
+            return name == "target_verify"
+
+        def is_draft_extend_v2(self):
+            return name == "draft_extend_v2"
+
+        def is_extend(self):
+            return name == "extend"
+
+        def __repr__(self):
+            return f"MockForwardMode({name!r})"
+
+    return _M()
+
+
+def _unknown_mode():
+    class _U:
+        def is_decode_or_idle(self):
+            return False
+
+        def is_target_verify(self):
+            return False
+
+        def is_draft_extend_v2(self):
+            return False
+
+        def is_extend(self):
+            return False
+
+        def __repr__(self):
+            return "UnknownMode"
+
+    return _U()
+
+
+class TestPlanInputAllocate(CustomTestCase):
+    def test_req_pool_indices_shape(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        self.assertEqual(pi.req_pool_indices.shape, torch.Size([4]))
+
+    def test_req_pool_indices_dtype(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        self.assertEqual(pi.req_pool_indices.dtype, torch.int64)
+
+    def test_prefix_lens_shape(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        self.assertEqual(pi.prefix_lens.shape, torch.Size([4]))
+
+    def test_prefix_lens_dtype(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        self.assertEqual(pi.prefix_lens.dtype, torch.int64)
+
+    def test_extend_seq_lens_shape(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        self.assertEqual(pi.extend_seq_lens.shape, torch.Size([4]))
+
+    def test_extend_seq_lens_dtype(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        self.assertEqual(pi.extend_seq_lens.dtype, torch.int64)
+
+    def test_valid_lens_shape(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        self.assertEqual(
+            pi.req_to_verify_expected_tokens_valid_lens.shape, torch.Size([4])
+        )
+
+    def test_all_tensors_initialised_to_zero(self):
+        pi = PlanInput.allocate(bs_capacity=3, device=_DEVICE)
+        self.assertTrue(pi.req_pool_indices.eq(0).all())
+        self.assertTrue(pi.prefix_lens.eq(0).all())
+        self.assertTrue(pi.extend_seq_lens.eq(0).all())
+        self.assertTrue(pi.req_to_verify_expected_tokens_valid_lens.eq(0).all())
+
+    def test_frozen_dataclass_rejects_mutation(self):
+        pi = PlanInput.allocate(bs_capacity=2, device=_DEVICE)
+        with self.assertRaises((AttributeError, TypeError)):
+            pi.req_pool_indices = torch.zeros(2, dtype=torch.int64)
+
+
+class TestPlanInputZero(CustomTestCase):
+    def test_zero_clears_all_tensors(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        pi.req_pool_indices.fill_(7)
+        pi.prefix_lens.fill_(8)
+        pi.extend_seq_lens.fill_(9)
+        pi.req_to_verify_expected_tokens_valid_lens.fill_(10)
+        pi.zero_()
+        self.assertTrue(pi.req_pool_indices.eq(0).all())
+        self.assertTrue(pi.prefix_lens.eq(0).all())
+        self.assertTrue(pi.extend_seq_lens.eq(0).all())
+        self.assertTrue(pi.req_to_verify_expected_tokens_valid_lens.eq(0).all())
+
+
+class TestPlanInputBatchSizeGuard(CustomTestCase):
+    def test_batch_larger_than_capacity_raises_runtime_error(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.zeros(10, dtype=torch.int32),
+            forward_mode=_mode("decode"),
+            spec_info=None,
+            positions=torch.arange(10, dtype=torch.int64),
+            seq_lens=None,
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        with self.assertRaises(RuntimeError) as ctx:
+            pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertIn("exceeds static capacity", str(ctx.exception))
+
+    def test_batch_equal_to_capacity_is_accepted(self):
+        pi = PlanInput.allocate(bs_capacity=3, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2, 3], dtype=torch.int32),
+            forward_mode=_mode("decode"),
+            spec_info=None,
+            positions=torch.tensor([0, 1, 2], dtype=torch.int64),
+            seq_lens=None,
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)  # must not raise
+
+
+class TestFillFromForwardBatchDecode(CustomTestCase):
+    def test_decode_prefix_lens_from_positions(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([10, 20], dtype=torch.int32),
+            forward_mode=_mode("decode"),
+            spec_info=None,
+            positions=torch.tensor([5, 7], dtype=torch.int64),
+            seq_lens=None,
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(pi.prefix_lens[:2].tolist(), [5, 7])
+
+    def test_decode_extend_seq_lens_all_ones(self):
+        # fill_(1) is applied to the extend_seq_lens[:bs] slice; padding slot stays 0.
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2, 3], dtype=torch.int32),
+            forward_mode=_mode("decode"),
+            spec_info=None,
+            positions=torch.tensor([0, 1, 2], dtype=torch.int64),
+            seq_lens=None,
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(pi.extend_seq_lens[:3].tolist(), [1, 1, 1])
+        self.assertEqual(pi.extend_seq_lens[3].item(), 0)
+
+    def test_decode_req_pool_indices_copied(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([7, 8], dtype=torch.int32),
+            forward_mode=_mode("decode"),
+            spec_info=None,
+            positions=torch.tensor([3, 4], dtype=torch.int64),
+            seq_lens=None,
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(pi.req_pool_indices[:2].tolist(), [7, 8])
+
+    def test_decode_padding_tail_zeroed(self):
+        # bs=2, capacity=4: indices 2 and 3 must remain zero after zero_() + fill.
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        pi.req_pool_indices.fill_(99)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int32),
+            forward_mode=_mode("decode"),
+            spec_info=None,
+            positions=torch.tensor([0, 1], dtype=torch.int64),
+            seq_lens=None,
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(pi.req_pool_indices[2:].tolist(), [0, 0])
+
+
+class TestFillFromForwardBatchTargetVerify(CustomTestCase):
+    def test_target_verify_prefix_lens_from_seq_lens(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2, 3], dtype=torch.int32),
+            forward_mode=_mode("target_verify"),
+            spec_info=SimpleNamespace(draft_token_num=4),
+            positions=None,
+            seq_lens=torch.tensor([10, 20, 30], dtype=torch.int32),
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(pi.prefix_lens[:3].tolist(), [10, 20, 30])
+
+    def test_target_verify_extend_seq_lens_is_draft_token_num(self):
+        # fill_(draft_token_num) applied to extend_seq_lens[:bs] slice; padding slot stays 0.
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2, 3], dtype=torch.int32),
+            forward_mode=_mode("target_verify"),
+            spec_info=SimpleNamespace(draft_token_num=6),
+            positions=None,
+            seq_lens=torch.tensor([10, 20, 30], dtype=torch.int32),
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(pi.extend_seq_lens[:3].tolist(), [6, 6, 6])
+        self.assertEqual(pi.extend_seq_lens[3].item(), 0)
+
+
+class TestFillFromForwardBatchDraftExtendV2(CustomTestCase):
+    def test_draft_extend_v2_prefix_is_seq_minus_extend(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int32),
+            forward_mode=_mode("draft_extend_v2"),
+            spec_info=None,
+            positions=None,
+            seq_lens=torch.tensor([15, 25], dtype=torch.int32),
+            extend_seq_lens=torch.tensor([3, 5], dtype=torch.int32),
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(pi.prefix_lens[:2].tolist(), [12, 20])
+
+    def test_draft_extend_v2_extend_seq_lens_copied(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int32),
+            forward_mode=_mode("draft_extend_v2"),
+            spec_info=None,
+            positions=None,
+            seq_lens=torch.tensor([15, 25], dtype=torch.int32),
+            extend_seq_lens=torch.tensor([3, 5], dtype=torch.int32),
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(pi.extend_seq_lens[:2].tolist(), [3, 5])
+
+
+class TestFillFromForwardBatchExtend(CustomTestCase):
+    def test_extend_prefix_lens_from_extend_prefix_lens(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int32),
+            forward_mode=_mode("extend"),
+            spec_info=None,
+            positions=None,
+            seq_lens=None,
+            extend_seq_lens=torch.tensor([7, 8], dtype=torch.int32),
+            extend_prefix_lens=torch.tensor([100, 200], dtype=torch.int32),
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(pi.prefix_lens[:2].tolist(), [100, 200])
+
+    def test_extend_seq_lens_from_extend_seq_lens(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int32),
+            forward_mode=_mode("extend"),
+            spec_info=None,
+            positions=None,
+            seq_lens=None,
+            extend_seq_lens=torch.tensor([7, 8], dtype=torch.int32),
+            extend_prefix_lens=torch.tensor([100, 200], dtype=torch.int32),
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(pi.extend_seq_lens[:2].tolist(), [7, 8])
+
+
+class TestFillFromForwardBatchUnknownMode(CustomTestCase):
+    def test_unknown_mode_raises_not_implemented(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1], dtype=torch.int32),
+            forward_mode=_unknown_mode(),
+            spec_info=None,
+            positions=None,
+            seq_lens=None,
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        with self.assertRaises(NotImplementedError) as ctx:
+            pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertIn("Unsupported forward mode", str(ctx.exception))
+
+
+class TestFillFromForwardBatchValidLens(CustomTestCase):
+    def test_valid_lens_copied_when_present(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int32),
+            forward_mode=_mode("decode"),
+            spec_info=None,
+            positions=torch.tensor([5, 7], dtype=torch.int64),
+            seq_lens=None,
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=torch.tensor([12, 15], dtype=torch.int32),
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(
+            pi.req_to_verify_expected_tokens_valid_lens[:2].tolist(), [12, 15]
+        )
+
+    def test_valid_lens_stays_zero_when_none(self):
+        pi = PlanInput.allocate(bs_capacity=4, device=_DEVICE)
+        fb = SimpleNamespace(
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int32),
+            forward_mode=_mode("decode"),
+            spec_info=None,
+            positions=torch.tensor([5, 7], dtype=torch.int64),
+            seq_lens=None,
+            extend_seq_lens=None,
+            extend_prefix_lens=None,
+            req_all_ids_lens=None,
+        )
+        pi.fill_from_forward_batch(forward_batch=fb)
+        self.assertEqual(
+            pi.req_to_verify_expected_tokens_valid_lens.tolist(), [0, 0, 0, 0]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/kv_canary/test_state.py
+++ b/test/registered/unit/kv_canary/test_state.py
@@ -1,0 +1,202 @@
+"""Tests for sglang.srt.kv_canary.state: ViolationLog and CanaryDeviceState allocation."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.jit_kernel.kv_canary.consts import VIOLATION_FIELDS, RealKvHashMode
+from sglang.srt.kv_canary.config import CanaryConfig, CanaryMode
+from sglang.srt.kv_canary.state import CanaryDeviceState, ViolationLog
+from sglang.test.test_utils import CustomTestCase
+
+_DEVICE = torch.device("cpu")
+
+
+def _make_config(
+    *,
+    ring_capacity=64,
+    enable_write_input_assert=False,
+    enable_verify_token_assert=False,
+):
+    return CanaryConfig(
+        mode=CanaryMode.NONE,
+        ring_capacity=ring_capacity,
+        sweep_interval=0,
+        real_kv_hash_mode=RealKvHashMode.PARTIAL,
+        enable_write_input_assert=enable_write_input_assert,
+        enable_verify_token_assert=enable_verify_token_assert,
+        stats_print_every_n_steps=100,
+    )
+
+
+class TestViolationLogAllocate(CustomTestCase):
+    def test_violation_ring_shape(self):
+        vl = ViolationLog.allocate(ring_capacity=64, device=_DEVICE)
+        self.assertEqual(vl.violation_ring.shape, torch.Size([64, VIOLATION_FIELDS]))
+
+    def test_violation_ring_uses_violation_fields_const(self):
+        # VIOLATION_FIELDS == 8 per the import
+        self.assertEqual(VIOLATION_FIELDS, 8)
+        vl = ViolationLog.allocate(ring_capacity=1, device=_DEVICE)
+        self.assertEqual(vl.violation_ring.shape[1], VIOLATION_FIELDS)
+
+    def test_violation_ring_dtype(self):
+        vl = ViolationLog.allocate(ring_capacity=16, device=_DEVICE)
+        self.assertEqual(vl.violation_ring.dtype, torch.int64)
+
+    def test_violation_ring_initialised_to_zero(self):
+        vl = ViolationLog.allocate(ring_capacity=4, device=_DEVICE)
+        self.assertTrue(vl.violation_ring.eq(0).all())
+
+    def test_violation_write_index_shape(self):
+        vl = ViolationLog.allocate(ring_capacity=32, device=_DEVICE)
+        self.assertEqual(vl.violation_write_index.shape, torch.Size([1]))
+
+    def test_violation_write_index_dtype(self):
+        vl = ViolationLog.allocate(ring_capacity=32, device=_DEVICE)
+        self.assertEqual(vl.violation_write_index.dtype, torch.int32)
+
+    def test_violation_write_index_initialised_to_zero(self):
+        vl = ViolationLog.allocate(ring_capacity=32, device=_DEVICE)
+        self.assertEqual(int(vl.violation_write_index[0]), 0)
+
+    def test_ring_capacity_one(self):
+        vl = ViolationLog.allocate(ring_capacity=1, device=_DEVICE)
+        self.assertEqual(vl.violation_ring.shape[0], 1)
+
+    def test_zero_ring_capacity_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            ViolationLog.allocate(ring_capacity=0, device=_DEVICE)
+        self.assertIn("ring_capacity", str(ctx.exception))
+
+    def test_negative_ring_capacity_raises(self):
+        with self.assertRaises(ValueError):
+            ViolationLog.allocate(ring_capacity=-5, device=_DEVICE)
+
+    def test_frozen_dataclass_rejects_mutation(self):
+        vl = ViolationLog.allocate(ring_capacity=8, device=_DEVICE)
+        with self.assertRaises((AttributeError, TypeError)):
+            vl.violation_ring = torch.zeros(1)
+
+
+class TestCanaryDeviceStateAllocate(CustomTestCase):
+    def test_kernel_run_counters_shape(self):
+        cfg = _make_config()
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=4)
+        self.assertEqual(state.kernel_run_counters.shape, torch.Size([4]))
+
+    def test_kernel_run_counters_dtype(self):
+        cfg = _make_config()
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=4)
+        self.assertEqual(state.kernel_run_counters.dtype, torch.int64)
+
+    def test_kernel_run_counters_initialised_to_zero(self):
+        cfg = _make_config()
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=3)
+        self.assertTrue(state.kernel_run_counters.eq(0).all())
+
+    def test_slot_run_counters_shape_matches_num_tags(self):
+        cfg = _make_config()
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=7)
+        self.assertEqual(state.slot_run_counters.shape, torch.Size([7]))
+
+    def test_slot_run_counters_dtype(self):
+        cfg = _make_config()
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=2)
+        self.assertEqual(state.slot_run_counters.dtype, torch.int64)
+
+    def test_slot_run_counters_initialised_to_zero(self):
+        cfg = _make_config()
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=2)
+        self.assertTrue(state.slot_run_counters.eq(0).all())
+
+    def test_enable_chain_position_assert_initialised_to_one(self):
+        cfg = _make_config()
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=1)
+        self.assertEqual(int(state.enable_chain_position_assert[0]), 1)
+
+    def test_enable_chain_position_assert_shape(self):
+        cfg = _make_config()
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=1)
+        self.assertEqual(state.enable_chain_position_assert.shape, torch.Size([1]))
+
+    def test_enable_chain_position_assert_dtype(self):
+        cfg = _make_config()
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=1)
+        self.assertEqual(state.enable_chain_position_assert.dtype, torch.int32)
+
+    def test_req_to_verify_expected_tokens_none_when_disabled(self):
+        cfg = _make_config(enable_verify_token_assert=False)
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=2)
+        self.assertIsNone(state.req_to_verify_expected_tokens)
+
+    def test_req_to_verify_expected_tokens_allocated_when_enabled(self):
+        cfg = _make_config(enable_verify_token_assert=True)
+        state = CanaryDeviceState.allocate(
+            config=cfg,
+            device=_DEVICE,
+            num_tags=2,
+            req_to_token_alloc_size=10,
+            max_context_len=20,
+        )
+        self.assertIsNotNone(state.req_to_verify_expected_tokens)
+        self.assertEqual(
+            state.req_to_verify_expected_tokens.shape, torch.Size([10, 20])
+        )
+
+    def test_req_to_verify_expected_tokens_dtype(self):
+        cfg = _make_config(enable_verify_token_assert=True)
+        state = CanaryDeviceState.allocate(
+            config=cfg,
+            device=_DEVICE,
+            num_tags=2,
+            req_to_token_alloc_size=5,
+            max_context_len=8,
+        )
+        self.assertEqual(state.req_to_verify_expected_tokens.dtype, torch.int32)
+
+    def test_missing_alloc_size_raises_when_verify_enabled(self):
+        cfg = _make_config(enable_verify_token_assert=True)
+        with self.assertRaises(ValueError) as ctx:
+            CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=2)
+        self.assertIn("req_to_token_alloc_size", str(ctx.exception))
+
+    def test_missing_max_context_len_raises_when_verify_enabled(self):
+        cfg = _make_config(enable_verify_token_assert=True)
+        with self.assertRaises(ValueError):
+            CanaryDeviceState.allocate(
+                config=cfg,
+                device=_DEVICE,
+                num_tags=2,
+                req_to_token_alloc_size=10,
+            )
+
+    def test_zero_num_tags_raises(self):
+        cfg = _make_config()
+        with self.assertRaises(ValueError) as ctx:
+            CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=0)
+        self.assertIn("num_tags", str(ctx.exception))
+
+    def test_negative_num_tags_raises(self):
+        cfg = _make_config()
+        with self.assertRaises(ValueError):
+            CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=-1)
+
+    def test_violation_log_ring_capacity_matches_config(self):
+        cfg = _make_config(ring_capacity=128)
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=1)
+        self.assertEqual(state.violation_log.violation_ring.shape[0], 128)
+
+    def test_frozen_dataclass_rejects_mutation(self):
+        cfg = _make_config()
+        state = CanaryDeviceState.allocate(config=cfg, device=_DEVICE, num_tags=1)
+        with self.assertRaises((AttributeError, TypeError)):
+            state.kernel_run_counters = torch.zeros(1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/kv_canary/test_sweep_plan_builder.py
+++ b/test/registered/unit/kv_canary/test_sweep_plan_builder.py
@@ -20,17 +20,23 @@ import torch
 
 # ---- Patch sys.modules so that sweep_plan_builder's deep import chain succeeds ----
 # Only install mocks for modules not already loaded (avoids clobbering a real import).
+# Track what we installed so tearDownModule can remove the stubs from sys.modules,
+# preventing pollution if a discovery runner collects multiple files in one process.
+_PATCHED_MODULES: list[str] = []
+
 if "sglang.srt.kv_canary.radix_cache_walker" not in sys.modules:
     _rw_stub = types.ModuleType("sglang.srt.kv_canary.radix_cache_walker")
     _rw_stub.walk_radix_cache_for_canary = (
         None  # sentinel; sweep_plan_builder imports this name
     )
     sys.modules["sglang.srt.kv_canary.radix_cache_walker"] = _rw_stub
+    _PATCHED_MODULES.append("sglang.srt.kv_canary.radix_cache_walker")
 
 if "sglang.srt.mem_cache.base_prefix_cache" not in sys.modules:
     _bpc_stub = types.ModuleType("sglang.srt.mem_cache.base_prefix_cache")
     _bpc_stub.BasePrefixCache = None
     sys.modules["sglang.srt.mem_cache.base_prefix_cache"] = _bpc_stub
+    _PATCHED_MODULES.append("sglang.srt.mem_cache.base_prefix_cache")
 
 # Also ensure VerifyPlan exists on the jit_kernel verify module if not already loaded.
 _JIT_VERIFY = "sglang.jit_kernel.kv_canary.verify"
@@ -38,6 +44,13 @@ if _JIT_VERIFY not in sys.modules:
     _jit_mod = types.ModuleType(_JIT_VERIFY)
     _jit_mod.VerifyPlan = None
     sys.modules[_JIT_VERIFY] = _jit_mod
+    _PATCHED_MODULES.append(_JIT_VERIFY)
+
+
+def tearDownModule() -> None:
+    for mod in _PATCHED_MODULES:
+        sys.modules.pop(mod, None)
+
 
 from sglang.srt.kv_canary.sweep_plan_builder import _swa_translate  # noqa: E402
 from sglang.test.test_utils import CustomTestCase

--- a/test/registered/unit/kv_canary/test_sweep_plan_builder.py
+++ b/test/registered/unit/kv_canary/test_sweep_plan_builder.py
@@ -1,0 +1,132 @@
+"""Tests for sglang.srt.kv_canary.sweep_plan_builder: _swa_translate pure-tensor helper."""
+
+# Import blocker on this machine (macOS + Python 3.11):
+# sweep_plan_builder -> radix_cache_walker -> radix_cache -> memory_pool ->
+# dsa/index_buf_accessor -> quantization -> awq -> moe -> moe_runner/runner.py
+# uses @torch.compile which triggers torch._inductor which fails with:
+#   TypeError: unsupported operand type(s) for |: 'module' and 'type'
+# This is a torch/Python 3.11 version mismatch on macOS. Linux CI should be unaffected.
+# We mock the problematic imports in sys.modules at module level before the import occurs.
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import sys
+import types
+import unittest
+
+import torch
+
+# ---- Patch sys.modules so that sweep_plan_builder's deep import chain succeeds ----
+# Only install mocks for modules not already loaded (avoids clobbering a real import).
+if "sglang.srt.kv_canary.radix_cache_walker" not in sys.modules:
+    _rw_stub = types.ModuleType("sglang.srt.kv_canary.radix_cache_walker")
+    _rw_stub.walk_radix_cache_for_canary = (
+        None  # sentinel; sweep_plan_builder imports this name
+    )
+    sys.modules["sglang.srt.kv_canary.radix_cache_walker"] = _rw_stub
+
+if "sglang.srt.mem_cache.base_prefix_cache" not in sys.modules:
+    _bpc_stub = types.ModuleType("sglang.srt.mem_cache.base_prefix_cache")
+    _bpc_stub.BasePrefixCache = None
+    sys.modules["sglang.srt.mem_cache.base_prefix_cache"] = _bpc_stub
+
+# Also ensure VerifyPlan exists on the jit_kernel verify module if not already loaded.
+_JIT_VERIFY = "sglang.jit_kernel.kv_canary.verify"
+if _JIT_VERIFY not in sys.modules:
+    _jit_mod = types.ModuleType(_JIT_VERIFY)
+    _jit_mod.VerifyPlan = None
+    sys.modules[_JIT_VERIFY] = _jit_mod
+
+from sglang.srt.kv_canary.sweep_plan_builder import _swa_translate  # noqa: E402
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestSwaTranslateEmpty(CustomTestCase):
+    def test_empty_indices_returns_empty(self):
+        indices = torch.tensor([], dtype=torch.int64)
+        lut = torch.tensor([10, 20, 30], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.numel(), 0)
+
+    def test_empty_indices_same_object_returned(self):
+        indices = torch.tensor([], dtype=torch.int64)
+        lut = torch.tensor([10, 20, 30], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertIs(result, indices)
+
+
+class TestSwaTranslateNormal(CustomTestCase):
+    def test_single_element(self):
+        indices = torch.tensor([2], dtype=torch.int64)
+        lut = torch.tensor([10, 20, 30], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.tolist(), [30])
+
+    def test_sequential_lookup(self):
+        indices = torch.tensor([0, 1, 2], dtype=torch.int64)
+        lut = torch.tensor([10, 20, 30], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.tolist(), [10, 20, 30])
+
+    def test_repeated_indices(self):
+        indices = torch.tensor([1, 1, 0], dtype=torch.int64)
+        lut = torch.tensor([100, 200, 300], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.tolist(), [200, 200, 100])
+
+    def test_output_dtype_is_int64(self):
+        indices = torch.tensor([0, 1], dtype=torch.int32)
+        lut = torch.tensor([5, 6, 7], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.dtype, torch.int64)
+
+
+class TestSwaTranslateAnchorPassthrough(CustomTestCase):
+    """Negative indices are anchors and must be returned unchanged (not looked up)."""
+
+    def test_negative_minus_one_is_preserved(self):
+        indices = torch.tensor([-1], dtype=torch.int64)
+        lut = torch.tensor([99, 88, 77], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.tolist(), [-1])
+
+    def test_negative_minus_two_is_preserved(self):
+        indices = torch.tensor([-2], dtype=torch.int64)
+        lut = torch.tensor([99, 88, 77], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.tolist(), [-2])
+
+    def test_mixed_negative_and_positive(self):
+        # [-1, 0, 2] with lut=[10,20,30]: -1 stays -1, 0->10, 2->30
+        indices = torch.tensor([-1, 0, 2], dtype=torch.int64)
+        lut = torch.tensor([10, 20, 30], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.tolist(), [-1, 10, 30])
+
+    def test_all_negative_all_preserved(self):
+        indices = torch.tensor([-1, -3, -7], dtype=torch.int64)
+        lut = torch.tensor([99, 88, 77, 66], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.tolist(), [-1, -3, -7])
+
+    def test_zero_positive_index_maps_correctly(self):
+        # index 0 is NOT an anchor (only < 0 is anchor)
+        indices = torch.tensor([0], dtype=torch.int64)
+        lut = torch.tensor([42], dtype=torch.int64)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.tolist(), [42])
+
+
+class TestSwaTranslateLutDataTypes(CustomTestCase):
+    def test_int32_lut_is_cast_to_int64(self):
+        indices = torch.tensor([0, 1], dtype=torch.int64)
+        lut = torch.tensor([5, 6], dtype=torch.int32)
+        result = _swa_translate(indices=indices, lut=lut)
+        self.assertEqual(result.tolist(), [5, 6])
+        self.assertEqual(result.dtype, torch.int64)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
154 tests covering the srt/kv_canary KV cache verification subsystem.

No server, no GPU, no model loading.
Ref: #20865

## Motivation

Added seven new test files under `test/registered/unit/kv_canary/` covering the pure-logic layer of SGLang's KV cache canary verification system.

`srt/kv_canary/` currently has no dedicated unit tests. The kv_canary subsystem detects KV cache correctness violations at runtime by writing canary tokens into KV cache slots and verifying them on subsequent reads. It covers configuration parsing, capacity arithmetic, device state allocation, sweep plan building, forward-batch input extraction, and buffer group management. Regressions in these files silently disable or misconfigure the verification pipeline.

Two behavioral bugs were caught empirically during test development:

1. `CanaryConfig.from_env()` applies `.lower()` before mode validation — `"NONE"` is accepted, not rejected. The initial assumption was wrong; the test was corrected to assert success.
2. `PlanInput.fill_from_forward_batch()` fills only `[:bs]` elements of `extend_seq_lens`, not the full capacity-sized tensor. Padding slots correctly stay zero. Tests corrected to assert `[:bs]` only.

## Coverage

`config.py` (27 tests):
- `CanaryMode` enum — member count, str subclass, all string values.
- `CanaryConfig.from_env()` — mode=none/log/raise, uppercase accepted, whitespace stripped, invalid mode raises ValueError, health_check/warn modes raise on invalid config.
- Default field values — ring_capacity, stats_print_every_n_steps, enable_verify_token_assert, enable_write_input_assert, real_kv_hash_mode all/none/partial, sweep_interval.
- Env var overrides — each field overridden independently via patched env.
- Frozen dataclass rejects mutation.

`capacities.py` (23 tests):
- `CanaryLaunchCapacities.from_args()` arithmetic — per_forward_verify_capacity = pool_slot_count * 3, verified for small/large pool sizes.
- write_entry_capacity — no spec tokens uses one per bs, spec tokens scale correctly, zero draft tokens treated as no-spec, chunked None gives math.inf limit, chunked size limits extend tokens.
- write_req_capacity — equals pool when no cuda graph, uses cuda_graph_max when larger, uses pool when larger than cuda graph.
- Validation — non-positive pool_slot_count raises, negative cuda_graph_max_bs raises, non-positive max_prefill_tokens raises, non-positive max_seq_len raises, negative spec_draft_tokens raises, negative/zero req_to_token_pool_size raises.
- Post-init validation — zero verify/write_entry/write_req capacity raises.
- Frozen dataclass rejects mutation.

`state.py` (29 tests):
- `ViolationLog.allocate()` — violation_ring shape/dtype/zero-init, write_index shape/dtype/zero-init, ring capacity matches config, zero/negative ring_capacity raises, frozen dataclass rejects mutation, VIOLATION_FIELDS const used.
- `CanaryDeviceState.allocate()` — kernel_run_counters shape/dtype/zero-init, slot_run_counters shape matches num_tags/dtype/zero-init, enable_chain_position_assert shape/dtype/one-init, violation_log ring capacity matches config, req_to_verify_expected_tokens allocated when enabled/None when disabled/dtype correct, missing alloc_size raises when verify enabled, missing max_context_len raises when verify enabled, zero/negative num_tags raises, frozen dataclass rejects mutation.

`sweep_plan_builder.py` (12 tests):
- `_swa_translate()` — empty indices returns same object, sequential lookup, single element, repeated indices, output dtype is int64, int32 LUT cast to int64, negative anchor values preserved as passthrough, mixed negative and positive, -1/-2 preserved.

`expected_inputs.py` (16 tests):
- `ExpectedInputs.allocate()` — tokens/positions shape, dtype, separate tensor objects, capacity=1, frozen dataclass rejects mutation.
- `ExpectedInputs.slice()` — returns ExpectedInputs instance, correct shape, full capacity same as original, zero returns empty, data shared with original (view semantics), writes through slice visible in original, dtype preserved.

`plan_input.py` (25 tests):
- `PlanInput.allocate()` — all tensors zero-init, shape/dtype for extend_seq_lens/prefix_lens/req_pool_indices/valid_lens, frozen dataclass rejects mutation.
- `PlanInput.zero()` — clears all tensors.
- `PlanInput.fill_from_forward_batch()` — DECODE: req_pool_indices copied, prefix_lens from positions, extend_seq_lens all ones, padding tail zeroed; EXTEND: prefix_lens from extend_prefix_lens, extend_seq_lens from extend_seq_lens; TARGET_VERIFY: prefix_lens from seq_lens, extend_seq_lens is draft_token_num; DRAFT_EXTEND_V2: extend_seq_lens copied, prefix = seq - extend; unknown mode raises NotImplementedError; valid_lens copied when present, stays zero when None.
- Batch size guard — equal to capacity accepted, larger than capacity raises RuntimeError.

`buffer_group.py` (22 tests):
- `PoolKind` enum — IntEnum, member count, FULL/SWA values, FULL < SWA ordering.
- `CanaryBufferGroup` fields — kind full/swa, k_head/k_tail stored, v_head/v_tail None when not set, swa_index_lut stored/None for full group, real_kv_sources_k/v empty tuple defaults, kv_token_id_vs_position offset 0/1, frozen dataclass rejects mutation.
- `CanaryBufferGroup.has_v_half` — True when v_head set, False when v_head None, returns bool.

All files registered via:
```python
register_cpu_ci(est_time=5, suite="base-a-test-cpu")
```

## Test plan

```
python3 test/registered/unit/kv_canary/test_config.py -v
```

```
test_all_fields_accessible (__main__.TestCanaryConfigFieldAccess) ... ok
test_frozen_dataclass_rejects_mutation (__main__.TestCanaryConfigFieldAccess) ... ok
test_default_enable_verify_token_assert (__main__.TestCanaryConfigFromEnvDefaults) ... ok
test_default_enable_write_input_assert (__main__.TestCanaryConfigFromEnvDefaults) ... ok
test_default_ring_capacity (__main__.TestCanaryConfigFromEnvDefaults) ... ok
test_default_stats_print_every_n_steps (__main__.TestCanaryConfigFromEnvDefaults) ... ok
test_real_kv_hash_mode_all (__main__.TestCanaryConfigFromEnvDefaults) ... ok
test_real_kv_hash_mode_none (__main__.TestCanaryConfigFromEnvDefaults) ... ok
test_real_kv_hash_mode_partial (__main__.TestCanaryConfigFromEnvDefaults) ... ok
test_sweep_interval_from_server_args (__main__.TestCanaryConfigFromEnvDefaults) ... ok
test_invalid_mode_health_check_raises (__main__.TestCanaryConfigFromEnvMode) ... ok
test_invalid_mode_raises_value_error (__main__.TestCanaryConfigFromEnvMode) ... ok
test_invalid_mode_warn_raises (__main__.TestCanaryConfigFromEnvMode) ... ok
test_mode_log (__main__.TestCanaryConfigFromEnvMode) ... ok
test_mode_none (__main__.TestCanaryConfigFromEnvMode) ... ok
test_mode_raise (__main__.TestCanaryConfigFromEnvMode) ... ok
test_mode_uppercase_is_accepted (__main__.TestCanaryConfigFromEnvMode) ... ok
test_mode_with_whitespace_stripped (__main__.TestCanaryConfigFromEnvMode) ... ok
test_enable_verify_token_assert_from_env (__main__.TestCanaryConfigFromEnvOverrides) ... ok
test_enable_write_input_assert_from_env (__main__.TestCanaryConfigFromEnvOverrides) ... ok
test_ring_capacity_from_env (__main__.TestCanaryConfigFromEnvOverrides) ... ok
test_stats_print_every_n_steps_from_env (__main__.TestCanaryConfigFromEnvOverrides) ... ok
test_is_str_subclass (__main__.TestCanaryModeEnum) ... ok
test_log_value (__main__.TestCanaryModeEnum) ... ok
test_members_count (__main__.TestCanaryModeEnum) ... ok
test_none_value (__main__.TestCanaryModeEnum) ... ok
test_raise_value (__main__.TestCanaryModeEnum) ... ok

----------------------------------------------------------------------
Ran 27 tests in 0.004s
```

```
python3 test/registered/unit/kv_canary/test_capacities.py -v
```

```
test_is_frozen (__main__.TestFrozenDataclass) ... ok
test_negative_any_field_raises (__main__.TestPostInitValidation) ... ok
test_zero_verify_capacity_raises (__main__.TestPostInitValidation) ... ok
test_zero_write_entry_capacity_raises (__main__.TestPostInitValidation) ... ok
test_zero_write_req_capacity_raises (__main__.TestPostInitValidation) ... ok
test_negative_cuda_graph_max_bs_raises (__main__.TestValidationErrors) ... ok
test_negative_req_to_token_pool_size_raises (__main__.TestValidationErrors) ... ok
test_negative_spec_draft_tokens_raises (__main__.TestValidationErrors) ... ok
test_nonpositive_max_prefill_tokens_raises (__main__.TestValidationErrors) ... ok
test_nonpositive_max_seq_len_raises (__main__.TestValidationErrors) ... ok
test_nonpositive_pool_slot_count_raises (__main__.TestValidationErrors) ... ok
test_nonpositive_req_to_token_pool_size_raises (__main__.TestValidationErrors) ... ok
test_verify_capacity_is_three_times_pool_slot_count (__main__.TestVerifyCapacityArithmetic) ... ok
test_verify_capacity_with_large_pool (__main__.TestVerifyCapacityArithmetic) ... ok
test_verify_capacity_with_small_pool (__main__.TestVerifyCapacityArithmetic) ... ok
test_chunked_none_gives_inf_limit (__main__.TestWriteEntryCapacityArithmetic) ... ok
test_chunked_size_limits_extend_tokens (__main__.TestWriteEntryCapacityArithmetic) ... ok
test_no_spec_tokens_uses_one_per_bs (__main__.TestWriteEntryCapacityArithmetic) ... ok
test_spec_tokens_scale_write_entry (__main__.TestWriteEntryCapacityArithmetic) ... ok
test_spec_zero_draft_tokens_treated_as_no_spec (__main__.TestWriteEntryCapacityArithmetic) ... ok
test_req_capacity_equals_pool_when_no_cuda_graph (__main__.TestWriteReqCapacityArithmetic) ... ok
test_req_capacity_uses_cuda_graph_max_when_larger (__main__.TestWriteReqCapacityArithmetic) ... ok
test_req_capacity_uses_pool_when_larger_than_cuda_graph (__main__.TestWriteReqCapacityArithmetic) ... ok

----------------------------------------------------------------------
Ran 23 tests in 0.000s
```

```
python3 test/registered/unit/kv_canary/test_state.py -v
```

```
test_enable_chain_position_assert_dtype (__main__.TestCanaryDeviceStateAllocate) ... ok
test_enable_chain_position_assert_initialised_to_one (__main__.TestCanaryDeviceStateAllocate) ... ok
test_enable_chain_position_assert_shape (__main__.TestCanaryDeviceStateAllocate) ... ok
test_frozen_dataclass_rejects_mutation (__main__.TestCanaryDeviceStateAllocate) ... ok
test_kernel_run_counters_dtype (__main__.TestCanaryDeviceStateAllocate) ... ok
test_kernel_run_counters_initialised_to_zero (__main__.TestCanaryDeviceStateAllocate) ... ok
test_kernel_run_counters_shape (__main__.TestCanaryDeviceStateAllocate) ... ok
test_missing_alloc_size_raises_when_verify_enabled (__main__.TestCanaryDeviceStateAllocate) ... ok
test_missing_max_context_len_raises_when_verify_enabled (__main__.TestCanaryDeviceStateAllocate) ... ok
test_negative_num_tags_raises (__main__.TestCanaryDeviceStateAllocate) ... ok
test_req_to_verify_expected_tokens_allocated_when_enabled (__main__.TestCanaryDeviceStateAllocate) ... ok
test_req_to_verify_expected_tokens_dtype (__main__.TestCanaryDeviceStateAllocate) ... ok
test_req_to_verify_expected_tokens_none_when_disabled (__main__.TestCanaryDeviceStateAllocate) ... ok
test_slot_run_counters_dtype (__main__.TestCanaryDeviceStateAllocate) ... ok
test_slot_run_counters_initialised_to_zero (__main__.TestCanaryDeviceStateAllocate) ... ok
test_slot_run_counters_shape_matches_num_tags (__main__.TestCanaryDeviceStateAllocate) ... ok
test_violation_log_ring_capacity_matches_config (__main__.TestCanaryDeviceStateAllocate) ... ok
test_zero_num_tags_raises (__main__.TestCanaryDeviceStateAllocate) ... ok
test_frozen_dataclass_rejects_mutation (__main__.TestViolationLogAllocate) ... ok
test_negative_ring_capacity_raises (__main__.TestViolationLogAllocate) ... ok
test_ring_capacity_one (__main__.TestViolationLogAllocate) ... ok
test_violation_ring_dtype (__main__.TestViolationLogAllocate) ... ok
test_violation_ring_initialised_to_zero (__main__.TestViolationLogAllocate) ... ok
test_violation_ring_shape (__main__.TestViolationLogAllocate) ... ok
test_violation_ring_uses_violation_fields_const (__main__.TestViolationLogAllocate) ... ok
test_violation_write_index_dtype (__main__.TestViolationLogAllocate) ... ok
test_violation_write_index_initialised_to_zero (__main__.TestViolationLogAllocate) ... ok
test_violation_write_index_shape (__main__.TestViolationLogAllocate) ... ok
test_zero_ring_capacity_raises (__main__.TestViolationLogAllocate) ... ok

----------------------------------------------------------------------
Ran 29 tests in 0.011s
```

```
python3 test/registered/unit/kv_canary/test_sweep_plan_builder.py -v
```

```
test_all_negative_all_preserved (__main__.TestSwaTranslateAnchorPassthrough) ... ok
test_mixed_negative_and_positive (__main__.TestSwaTranslateAnchorPassthrough) ... ok
test_negative_minus_one_is_preserved (__main__.TestSwaTranslateAnchorPassthrough) ... ok
test_negative_minus_two_is_preserved (__main__.TestSwaTranslateAnchorPassthrough) ... ok
test_zero_positive_index_maps_correctly (__main__.TestSwaTranslateAnchorPassthrough) ... ok
test_empty_indices_returns_empty (__main__.TestSwaTranslateEmpty) ... ok
test_empty_indices_same_object_returned (__main__.TestSwaTranslateEmpty) ... ok
test_int32_lut_is_cast_to_int64 (__main__.TestSwaTranslateLutDataTypes) ... ok
test_output_dtype_is_int64 (__main__.TestSwaTranslateNormal) ... ok
test_repeated_indices (__main__.TestSwaTranslateNormal) ... ok
test_sequential_lookup (__main__.TestSwaTranslateNormal) ... ok
test_single_element (__main__.TestSwaTranslateNormal) ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.007s
```

```
python3 test/registered/unit/kv_canary/test_expected_inputs.py -v
```

```
test_capacity_one (__main__.TestExpectedInputsAllocate) ... ok
test_frozen_dataclass_rejects_mutation (__main__.TestExpectedInputsAllocate) ... ok
test_positions_dtype (__main__.TestExpectedInputsAllocate) ... ok
test_positions_shape (__main__.TestExpectedInputsAllocate) ... ok
test_tokens_and_positions_are_separate_tensors (__main__.TestExpectedInputsAllocate) ... ok
test_tokens_dtype (__main__.TestExpectedInputsAllocate) ... ok
test_tokens_shape (__main__.TestExpectedInputsAllocate) ... ok
test_slice_data_shared_with_original (__main__.TestExpectedInputsSlice) ... ok
test_slice_dtype_preserved (__main__.TestExpectedInputsSlice) ... ok
test_slice_full_capacity_same_as_original (__main__.TestExpectedInputsSlice) ... ok
test_slice_is_view_of_original_positions (__main__.TestExpectedInputsSlice) ... ok
test_slice_is_view_of_original_tokens (__main__.TestExpectedInputsSlice) ... ok
test_slice_returns_expected_inputs_instance (__main__.TestExpectedInputsSlice) ... ok
test_slice_shape (__main__.TestExpectedInputsSlice) ... ok
test_slice_zero_returns_empty (__main__.TestExpectedInputsSlice) ... ok
test_writes_through_slice_visible_in_original (__main__.TestExpectedInputsSlice) ... ok

----------------------------------------------------------------------
Ran 16 tests in 0.002s
```

```
python3 test/registered/unit/kv_canary/test_plan_input.py -v
```

```
test_decode_extend_seq_lens_all_ones (__main__.TestFillFromForwardBatchDecode) ... ok
test_decode_padding_tail_zeroed (__main__.TestFillFromForwardBatchDecode) ... ok
test_decode_prefix_lens_from_positions (__main__.TestFillFromForwardBatchDecode) ... ok
test_decode_req_pool_indices_copied (__main__.TestFillFromForwardBatchDecode) ... ok
test_draft_extend_v2_extend_seq_lens_copied (__main__.TestFillFromForwardBatchDraftExtendV2) ... ok
test_draft_extend_v2_prefix_is_seq_minus_extend (__main__.TestFillFromForwardBatchDraftExtendV2) ... ok
test_extend_prefix_lens_from_extend_prefix_lens (__main__.TestFillFromForwardBatchExtend) ... ok
test_extend_seq_lens_from_extend_seq_lens (__main__.TestFillFromForwardBatchExtend) ... ok
test_target_verify_extend_seq_lens_is_draft_token_num (__main__.TestFillFromForwardBatchTargetVerify) ... ok
test_target_verify_prefix_lens_from_seq_lens (__main__.TestFillFromForwardBatchTargetVerify) ... ok
test_unknown_mode_raises_not_implemented (__main__.TestFillFromForwardBatchUnknownMode) ... ok
test_valid_lens_copied_when_present (__main__.TestFillFromForwardBatchValidLens) ... ok
test_valid_lens_stays_zero_when_none (__main__.TestFillFromForwardBatchValidLens) ... ok
test_all_tensors_initialised_to_zero (__main__.TestPlanInputAllocate) ... ok
test_extend_seq_lens_dtype (__main__.TestPlanInputAllocate) ... ok
test_extend_seq_lens_shape (__main__.TestPlanInputAllocate) ... ok
test_frozen_dataclass_rejects_mutation (__main__.TestPlanInputAllocate) ... ok
test_prefix_lens_dtype (__main__.TestPlanInputAllocate) ... ok
test_prefix_lens_shape (__main__.TestPlanInputAllocate) ... ok
test_req_pool_indices_dtype (__main__.TestPlanInputAllocate) ... ok
test_req_pool_indices_shape (__main__.TestPlanInputAllocate) ... ok
test_valid_lens_shape (__main__.TestPlanInputAllocate) ... ok
test_batch_equal_to_capacity_is_accepted (__main__.TestPlanInputBatchSizeGuard) ... ok
test_batch_larger_than_capacity_raises_runtime_error (__main__.TestPlanInputBatchSizeGuard) ... ok
test_zero_clears_all_tensors (__main__.TestPlanInputZero) ... ok

----------------------------------------------------------------------
Ran 25 tests in 0.005s
```

```
python3 test/registered/unit/kv_canary/test_buffer_group.py -v
```

```
test_frozen_dataclass_rejects_mutation (__main__.TestCanaryBufferGroupFields) ... ok
test_k_head_stored (__main__.TestCanaryBufferGroupFields) ... ok
test_k_tail_stored (__main__.TestCanaryBufferGroupFields) ... ok
test_kind_full (__main__.TestCanaryBufferGroupFields) ... ok
test_kind_swa (__main__.TestCanaryBufferGroupFields) ... ok
test_kv_token_id_vs_position_offset_one (__main__.TestCanaryBufferGroupFields) ... ok
test_kv_token_id_vs_position_offset_zero (__main__.TestCanaryBufferGroupFields) ... ok
test_real_kv_sources_k_empty_tuple (__main__.TestCanaryBufferGroupFields) ... ok
test_real_kv_sources_v_empty_tuple (__main__.TestCanaryBufferGroupFields) ... ok
test_swa_index_lut_none_for_full_group (__main__.TestCanaryBufferGroupFields) ... ok
test_swa_index_lut_stored (__main__.TestCanaryBufferGroupFields) ... ok
test_v_head_none_when_not_set (__main__.TestCanaryBufferGroupFields) ... ok
test_v_tail_none_when_not_set (__main__.TestCanaryBufferGroupFields) ... ok
test_has_v_half_false_returns_bool (__main__.TestCanaryBufferGroupHasVHalf) ... ok
test_has_v_half_false_when_v_head_none (__main__.TestCanaryBufferGroupHasVHalf) ... ok
test_has_v_half_true_returns_bool (__main__.TestCanaryBufferGroupHasVHalf) ... ok
test_has_v_half_true_when_v_head_set (__main__.TestCanaryBufferGroupHasVHalf) ... ok
test_full_less_than_swa (__main__.TestPoolKindEnum) ... ok
test_full_value (__main__.TestPoolKindEnum) ... ok
test_is_int_enum (__main__.TestPoolKindEnum) ... ok
test_members_count (__main__.TestPoolKindEnum) ... ok
test_swa_value (__main__.TestPoolKindEnum) ... ok

----------------------------------------------------------------------
Ran 22 tests in 0.001s
```

## Accuracy Tests
N/A — test-only change. No kernel or model-forward code is touched.

## Speed Tests and Profiling
N/A — this PR only adds unit tests and does not affect the inference path.

## Checklist
- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process
Ping Merge Oncalls to start the process. See the PR Merge Process.
Get approvals from CODEOWNERS and other reviewers.
Trigger CI tests with comments or contact authorized users to do so.
Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28338042182](https://github.com/sgl-project/sglang/actions/runs/28338042182)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28338042096](https://github.com/sgl-project/sglang/actions/runs/28338042096)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->