### PR TITLE
Capture routed expert metadata for HashTopK

### DIFF
--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -19,6 +19,7 @@ from sglang.srt.layers.moe.topk import (
     _mask_topk_ids_padded_region,
     _zero_topk_weights_padded_region,
 )
+from sglang.srt.state_capturer.routed_experts import get_global_experts_capturer
 from sglang.srt.utils import is_hip, is_npu
 
 logger = logging.getLogger(__name__)
@@ -59,6 +60,7 @@ class HashTopK(nn.Module):
         self.routed_scaling_factor = routed_scaling_factor
         self.num_fused_shared_experts = num_fused_shared_experts
         self.score_func = scoring_func
+        self.allow_routed_experts_capture = True
         self.tid2eid = nn.Parameter(
             torch.empty(vocab_size, topk - num_fused_shared_experts, dtype=torch.int32),
             requires_grad=False,
@@ -73,6 +75,14 @@ class HashTopK(nn.Module):
                 "HashTopK + apply_routed_scaling_factor_on_output is not supported "
                 "with fused shared experts; pass --disable-shared-experts-fusion."
             )
+
+    def _capture_routed_experts_if_allowed(self, topk_ids: torch.Tensor) -> None:
+        if not self.allow_routed_experts_capture:
+            return
+        if (cap := get_global_experts_capturer()) is not None:
+            if self.layer_id is None:
+                raise RuntimeError("HashTopK routed-experts capture requires layer_id.")
+            cap.capture(layer_id=self.layer_id, topk_indices=topk_ids)
 
     def _init_default_tid2eid(self) -> None:
         topk = self.tid2eid.shape[1]
@@ -197,6 +207,8 @@ class HashTopK(nn.Module):
 
         if self.apply_routed_scaling_factor_on_output:
             topk_weights = topk_weights * self.routed_scaling_factor
+
+        self._capture_routed_experts_if_allowed(topk_ids)
 
         log2phy_prob = None
         if (

--- a/python/sglang/srt/state_capturer/routed_experts.py
+++ b/python/sglang/srt/state_capturer/routed_experts.py
@@ -151,14 +151,16 @@ def extract_routed_experts_from_meta_info(data):
 def disable_routed_experts_capture_for_draft(model: Any) -> None:
     """Opt every draft MoE ``TopK`` out of routed-experts (R3) capture.
 
-    Capture is target-only; a draft ``TopK`` must never write the target's
-    process-global buffer. ``HashTopK`` has no ``topk_config`` and never
-    captures, so it is left untouched.
+    Capture is target-only; draft MoE routers must never write the target's
+    process-global buffer.
     """
     # Lazy import: ``layers.moe.topk`` imports ``get_global_experts_capturer``
     # from this module, so a top-level import here would be circular.
+    from sglang.srt.layers.moe.hash_topk import HashTopK
     from sglang.srt.layers.moe.topk import TopK
 
     for module in model.modules():
         if isinstance(module, TopK):
             module.topk_config.allow_routed_experts_capture = False
+        elif isinstance(module, HashTopK):
+            module.allow_routed_experts_capture = False

--- a/test/registered/unit/layers/moe/test_hash_topk_routed_experts_capture.py
+++ b/test/registered/unit/layers/moe/test_hash_topk_routed_experts_capture.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+import torch
+
+import sglang.srt.layers.moe.hash_topk as hash_topk_module
+import sglang.srt.server_args as server_args_module
+from sglang.srt.layers.moe.hash_topk import HashTopK
+from sglang.srt.state_capturer import routed_experts as routed_experts_module
+from sglang.srt.state_capturer.routed_experts import (
+    disable_routed_experts_capture_for_draft,
+    set_global_experts_capturer,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class FakeCapturer:
+    def __init__(self):
+        self.calls = []
+
+    def capture(self, layer_id: int, topk_indices: torch.Tensor):
+        self.calls.append((layer_id, topk_indices.detach().clone()))
+
+
+class TestHashTopKRoutedExpertsCapture(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self._old_server_args = server_args_module._global_server_args
+        self._old_capturer = routed_experts_module.get_global_experts_capturer()
+        server_args_module.set_global_server_args_for_scheduler(
+            SimpleNamespace(enable_deepep_waterfill=False)
+        )
+        self.capturer = FakeCapturer()
+        set_global_experts_capturer(self.capturer)
+
+    def tearDown(self):
+        set_global_experts_capturer(self._old_capturer)
+        server_args_module.set_global_server_args_for_scheduler(self._old_server_args)
+        super().tearDown()
+
+    def _make_hash_topk(self, layer_id=3):
+        return HashTopK(
+            topk=2,
+            num_experts=5,
+            num_fused_shared_experts=0,
+            vocab_size=8,
+            scoring_func="softmax",
+            layer_id=layer_id,
+        )
+
+    def _run_hash_topk(self, hash_topk, hidden_states, router_logits, input_ids):
+        with hash_topk_module.envs.SGLANG_OPT_USE_FUSED_HASH_TOPK.override(False):
+            return hash_topk(hidden_states, router_logits, input_ids)
+
+    def test_hash_topk_captures_selected_experts(self):
+        hash_topk = self._make_hash_topk()
+        hidden_states = torch.zeros((3, 4), dtype=torch.float32)
+        router_logits = torch.ones((3, 5), dtype=torch.float32)
+        input_ids = torch.tensor([1, 2, 4], dtype=torch.long)
+
+        output = self._run_hash_topk(hash_topk, hidden_states, router_logits, input_ids)
+
+        self.assertEqual(len(self.capturer.calls), 1)
+        layer_id, captured = self.capturer.calls[0]
+        self.assertEqual(layer_id, 3)
+        self.assertTrue(torch.equal(captured, output.topk_ids))
+        expected = torch.tensor([[1, 2], [2, 3], [4, 0]], dtype=torch.int32)
+        self.assertTrue(torch.equal(captured, expected))
+
+    def test_draft_opt_out_disables_hash_topk_capture(self):
+        model = torch.nn.Module()
+        model.hash_topk = self._make_hash_topk()
+
+        disable_routed_experts_capture_for_draft(model)
+        self._run_hash_topk(
+            model.hash_topk,
+            torch.zeros((1, 4), dtype=torch.float32),
+            torch.ones((1, 5), dtype=torch.float32),
+            torch.tensor([1], dtype=torch.long),
+        )
+
+        self.assertEqual(self.capturer.calls, [])
+
+    def test_missing_layer_id_raises_when_capture_is_active(self):
+        hash_topk = self._make_hash_topk(layer_id=None)
+
+        with self.assertRaisesRegex(RuntimeError, "requires layer_id"):
+            self._run_hash_topk(
+                hash_topk,
+                torch.zeros((1, 4), dtype=torch.float32),
+                torch.ones((1, 5), dtype=torch.float32),
+                torch.tensor([1], dtype=torch.long),
+            )
+
+        self.assertEqual(self.capturer.calls, [])


### PR DESCRIPTION
## Motivation

Fixes #29040.

`--enable-return-routed-experts` allocates capture rows for every MoE layer, but
HashTopK hash-router layers never wrote their selected `topk_ids` into the
routed-experts capturer. Those layer rows therefore stayed at their zero
initialization, so the returned `routed_experts` metadata looked like every token
and top-k slot routed to expert 0.

## Modifications

- Add a HashTopK capture hook that writes the selected `topk_ids` to the global
  routed-experts capturer when `layer_id` is available.
- Keep the capture before EPLB logical-to-physical remapping and padded-region
  mutation, matching the regular TopK capture semantics.
- Add a HashTopK draft opt-out flag and wire it into
  `disable_routed_experts_capture_for_draft()`.
- Add registered CPU unit coverage for HashTopK capture and draft opt-out.

## Accuracy Tests

This does not change expert selection, routing weights, MoE kernels, logits, or
sampling behavior. It only fills optional routed-experts metadata when
`--enable-return-routed-experts` is enabled.

## Speed Tests and Profiling

No benchmark run. The new work is gated by the existing optional routed-experts
capturer path; when no capturer is installed it is just a `None` check after
HashTopK routing.

## Validation

- `python3 -m py_compile python/sglang/srt/layers/moe/hash_topk.py python/sglang/srt/state_capturer/routed_experts.py test/registered/unit/layers/moe/test_hash_topk_routed_experts_capture.py`
- `python3 scripts/ci/check_registered_tests.py`
- `git diff --check`
- `PYTHONPATH=python python3 -m pytest test/registered/unit/layers/moe/test_hash_topk_routed_experts_capture.py -q` (`2 passed`, in `lmsysorg/sglang:dev`)
- `pre-commit run --files python/sglang/srt/layers/moe/hash_topk.py python/sglang/srt/state_capturer/routed_experts.py test/registered/unit/layers/moe/test_hash_topk_routed_experts_capture.py` (in `lmsysorg/sglang:dev`)

Validation gap: I did not run the full 4 x H20 `DeepSeek-V4-Flash` benchmark
from the issue. The focused unit test covers the missing HashTopK capture
invariant directly.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A, no docs surface changed.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). N/A, output-neutral metadata hook; see sections above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28342190754](https://github.com/sgl-project/sglang/actions/runs/28342190754)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28342190714](https://github.com/sgl-project/sglang/actions/runs/28342190714)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->