### PR TITLE
ci(amd): consolidate stage-b-test-1-gpu-small-amd 14→6 shards (-14% GPU-min, -33% wall-clock)

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -471,7 +471,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        part: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+        part: [0, 1, 2, 3, 4, 5]
     runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
     steps:
       - name: Checkout code
@@ -493,7 +493,7 @@ jobs:
       - name: Run test
         timeout-minutes: 60
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 2400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 6 --timeout-per-file 2400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   stage-b-test-1-gpu-small-amd-nondeterministic:
     name: ${{ format('stage-b-test-1-gpu-small-amd-nondeterministic (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
@@ -1009,7 +1009,7 @@ jobs:
           stage-name: stage-b-amd
           jobs: |
             [
-              {"prefix": "stage-b-test-1-gpu-small-amd", "expected_count": 14},
+              {"prefix": "stage-b-test-1-gpu-small-amd", "expected_count": 6},
               {"prefix": "stage-b-test-1-gpu-large-amd", "expected_count": 3},
               {"prefix": "stage-b-test-2-gpu-large-amd", "expected_count": 2}
             ]


### PR DESCRIPTION
## Summary

Consolidates `stage-b-test-1-gpu-small-amd` from **14 matrix shards to 6**, saving **~14% GPU-minutes per PR run** and **~33% wall-clock**, with no test coverage change.

## Why 6 (not 8 or 14)

The suite has 108 tests, ~256min total `est_time`. With ~6 concurrent MI325 1-GPU runners observed in practice:

| Shards | GPU-min | Wall-clock | Waves |
|--------|---------|------------|-------|
| **6**  | **292** | **49min** | **1 (zero idle)** |
| 8      | 304     | 76min      | 2 (6+2, 4 idle) |
| 12     | 328     | 55min      | 2 (6+6) |
| 14     | 340     | 73min      | 3 (6+6+2) |

**6 shards is optimal on both axes**: 1 wave at 6 concurrent runners (zero idle), minimal bring-up overhead (6min × 6 = 36min vs 6min × 14 = 84min).

8 shards (a prior revision of this PR) was suboptimal: 2 waves (6+2) with 4 runners idle in wave 2, giving 76min wall-clock — *slower than the 14-shard baseline* (73min).

## Timeout safety

Longest shard at 6 = ~53min (LPT-balanced), under the 60min job timeout and far under the 480min `wait-for-stage-b` gate. Per-file 2400s (40min) timeout is generous (max single-test est = 4.35min).

## Changes

- `.github/workflows/pr-test-amd.yml`: matrix `part` 14→6, `--auto-partition-size` 14→6, `expected_count` 14→6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29337465584](https://github.com/sgl-project/sglang/actions/runs/29337465584)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #29337465077](https://github.com/sgl-project/sglang/actions/runs/29337465077)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->