### PR TITLE
Fix CI caused by https://github.com/sgl-project/sglang/pull/29576

### DIFF
--- a/test/registered/kernels/test_dsa_indexer.py
+++ b/test/registered/kernels/test_dsa_indexer.py
@@ -321,8 +321,8 @@ class TestDSAIndexer(CustomTestCase):
         params.update(kwargs)
 
         torch.set_default_dtype(self.dtype)
-        indexer = Indexer(**params)
-        # Move indexer to CUDA device
+        with torch.device(self.device):
+            indexer = Indexer(**params)
         indexer = indexer.to(device=self.device)
 
         # Convert linear layer weights to bfloat16 (but preserve LayerNorm's float32


### PR DESCRIPTION
Quick fix because of wrong test setup

```
pytest test/registered/kernels/test_dsa_indexer.py
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /sgl-workspace/sglang/test
configfile: pytest.ini
plugins: anyio-4.13.0, typeguard-4.5.2
collected 11 items                                                                                                                                                                                              

test/registered/kernels/test_dsa_indexer.py ...........                                                                                                                                                   [100%]

=============================================================================================== warnings summary ================================================================================================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1434
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================== 11 passed, 17 warnings in 8.54s ========================================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28344520414](https://github.com/sgl-project/sglang/actions/runs/28344520414)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28344520327](https://github.com/sgl-project/sglang/actions/runs/28344520327)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->