### PR TITLE
[NPU][Bugfix] Accept in_capture in Ascend replay metadata

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
@@ -131,6 +131,7 @@ class AscendMambaAttnBackendBase(MambaAttnBackendBase):
         spec_info: Optional[SpecInput],
         seq_lens_cpu: Optional[torch.Tensor],
         num_padding: Optional[int] = None,
+        in_capture: bool = False,
     ):
         # out_graph passes seq_lens_cpu=None at capture; mirror the base guard.
         if seq_lens_cpu is None:


### PR DESCRIPTION
 ## Motivation

  Fix an NPU scheduler startup failure during graph capture for hybrid linear attention. After the ReplaySSM metadata path started
  forwarding `in_capture` into `_replay_metadata`, the Ascend override did not accept that keyword and failed with:

  ```text
  TypeError: AscendMambaAttnBackendBase._replay_metadata() got an unexpected keyword argument 'in_capture'
```

  ## Modifications

  - Add the optional in_capture: bool = False parameter to AscendMambaAttnBackendBase._replay_metadata.
  - Keep the existing Ascend metadata replay behavior unchanged; this only aligns the override signature with the base
    MambaAttnBackendBase call contract.

  ## Accuracy Tests

  N/A. This change only fixes a Python method signature mismatch in the metadata setup path. It does not change model computation,
  attention math, kernel dispatch, or output tensors.

  Local validation:

  python -m py_compile python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
  git diff --check origin/main...HEAD

  Also verified with a minimal AST signature check that AscendMambaAttnBackendBase._replay_metadata accepts in_capture.

  ## Speed Tests and Profiling

```plaintext
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 54        
Successful requests:                     216       
Benchmark duration (s):                  467.72    
Total input tokens:                      756000    
Total input text tokens:                 756000    
Total generated tokens:                  324000    
Total generated tokens (retokenized):    320923    
Request throughput (req/s):              0.46      
Input token throughput (tok/s):          1616.36   
Output token throughput (tok/s):         692.73    
Peak output token throughput (tok/s):    1806.00   
Peak concurrent requests:                61        
Total token throughput (tok/s):          2309.09   
Concurrency:                             45.65     
Accept length:                           3.18      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   98856.37  
Median E2E Latency (ms):                 97978.79  
P90 E2E Latency (ms):                    124065.17 
P95 E2E Latency (ms):                    143389.84 
P99 E2E Latency (ms):                    158894.43 
---------------Time to First Token----------------
Mean TTFT (ms):                          23767.97  
Median TTFT (ms):                        17584.51  
P90 TTFT (ms):                           47317.83  
P95 TTFT (ms):                           48638.98  
P99 TTFT (ms):                           49934.07  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          50.09     
Median TPOT (ms):                        49.90     
P90 TPOT (ms):                           63.18     
P95 TPOT (ms):                           66.43     
P99 TPOT (ms):                           84.10     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           50.09     
Median ITL (ms):                         25.24     
P90 ITL (ms):                            50.23     
P95 ITL (ms):                            61.12     
P99 ITL (ms):                            102.57    
Max ITL (ms):                            24333.16  
==================================================
```

  ## Checklist

  - [ ] Format your code according to the Format code with pre-commit
    (https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).

  - [ ] Add unit tests according to the Run and add unit tests
    (https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).

  - [ ] Update documentation according to Write documentations
    (https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).

  - [ ] Provide accuracy and speed benchmark results according to Test the accuracy
    (https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and Benchmark the speed
    (https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).

  - [ ] Follow the SGLang code style guidance (https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28344694222](https://github.com/sgl-project/sglang/actions/runs/28344694222)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28344694147](https://github.com/sgl-project/sglang/actions/runs/28344694147)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->