### PR TITLE
Fix DSA indexer fused RoPE cache device migration

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -437,9 +437,14 @@ class Indexer(MultiPlatformOp):
         self.scale_fmt = scale_fmt
         self.softmax_scale = self.head_dim**-0.5
 
-        self._indexer_freqs_cis: Optional[torch.Tensor] = None
         if _use_dsa_indexer_fusion:
-            self._indexer_freqs_cis = _shared_indexer_freqs_cis(self.rotary_emb)
+            self.register_buffer(
+                "_indexer_freqs_cis",
+                _shared_indexer_freqs_cis(self.rotary_emb),
+                persistent=False,
+            )
+        else:
+            self._indexer_freqs_cis: Optional[torch.Tensor] = None
 
     @contextlib.contextmanager
     def _with_real_sm_count(self):


### PR DESCRIPTION
## Summary
- register the fused DSA indexer RoPE cache as a non-persistent buffer so module device moves migrate it with the rest of the indexer
- keep the non-fusion path as `None` and keep the cached tensor out of checkpoints

## Root cause
`_indexer_freqs_cis` was stored as a plain tensor attribute. When `Indexer.to(cuda)` is used, that cached RoPE table stays on CPU while the fused K store path passes `torch.view_as_real(_indexer_freqs_cis).flatten(-2)` into the JIT kernel. The resulting `163840 x 64` float32 tensor then fails device matching with expected `cuda:0`.

This was visible in the Base CI failure on #29499, but the failing file/path is not changed by that PR.

## Validation
- `python3 -m py_compile python/sglang/srt/layers/attention/dsa/dsa_indexer.py`
- `git diff --check`
- H200, `lmsysorg/sglang:latest`, Torch `2.11.0+cu130`: `python3 test/registered/kernels/test_dsa_indexer.py` -> 11 tests OK
- Before the patch, the same H200 run reproduced the failure in `test_forward_extend_mode` and `test_forward_decode_mode` with the CPU `163840 x 64` RoPE tensor expected on `cuda:0`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28344917559](https://github.com/sgl-project/sglang/actions/runs/28344917559)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28344917490](https://github.com/sgl-project/sglang/actions/runs/28344917490)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->