### PR TITLE
Require admin auth for /load_lora_adapter_from_tensors

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1430,6 +1430,7 @@ async def load_lora_adapter(
 
 
 @app.api_route("/load_lora_adapter_from_tensors", methods=["POST"])
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
 async def load_lora_adapter_from_tensors(
     obj: Annotated[LoadLoRAAdapterFromTensorsReqInput, Body()], request: Request
 ):


### PR DESCRIPTION
Body:
## Motivation

The `/load_lora_adapter_from_tensors` route was registered without an
`@auth_level` decorator, so the auth middleware treats it as a NORMAL
endpoint — unlike its siblings `/load_lora_adapter` and
`/unload_lora_adapter`, which are `AuthLevel.ADMIN_OPTIONAL`. This lets a
non-admin (or anonymous, under admin-key-only deployments) caller invoke a
privileged model-mutation path that registers caller-supplied adapter
tensors/config into the live LoRA registry.

## Modifications

Add `@auth_level(AuthLevel.ADMIN_OPTIONAL)` so all three LoRA management
routes share the same authorization level. One-line change; no new imports
(`AuthLevel` / `auth_level` are already imported).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28346372127](https://github.com/sgl-project/sglang/actions/runs/28346372127)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28346372020](https://github.com/sgl-project/sglang/actions/runs/28346372020)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->