### PR TITLE
[Spec] Make `build_tree_kernel_efficient` enforce `seq_lens_sum` contract

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -116,7 +116,7 @@ def build_tree_kernel_efficient(
     top_scores_index: torch.Tensor,
     draft_tokens: torch.Tensor,
     seq_lens: torch.Tensor,
-    seq_lens_sum: int,
+    seq_lens_sum: Optional[int],
     topk: int,
     spec_steps: int,
     num_verify_tokens: int,
@@ -132,6 +132,12 @@ def build_tree_kernel_efficient(
     # e.g. for bs=1, tree_mask: num_draft_token, seq_lens_sum + num_draft_token (flattened)
     # where each row indicates the attending pattern of each draft token
     # if use_partial_packed_tree_mask is True, tree_mask: num_draft_token (flattened, packed)
+    #
+    # Protocol: when tree_mask_buf is provided (preallocated), seq_lens_sum is
+    # never read — callers may pass None. When tree_mask_buf is None, the
+    # FULL_MASK path sizes the allocation from seq_lens_sum, so it must be a
+    # concrete int. Assert here so every caller gets the same error instead of
+    # each guarding independently.
     if tree_mask_buf is not None:
         tree_mask = tree_mask_buf
         if tree_mask_mode == TreeMaskMode.QLEN_ONLY:
@@ -158,6 +164,11 @@ def build_tree_kernel_efficient(
             device=device,
         )
     elif tree_mask_mode == TreeMaskMode.FULL_MASK:
+        assert seq_lens_sum is not None, (
+            "FULL_MASK requires seq_lens_sum to size the tree mask when "
+            "tree_mask_buf is None; provide a preallocated tree_mask_buf "
+            "or a concrete seq_lens_sum"
+        )
         tree_mask = torch.full(
             (
                 seq_lens_sum * num_verify_tokens

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -527,19 +527,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             self.target_worker.model_runner.attn_backend.get_verify_buffers_to_fill_after_draft()
         )
 
-        # build_tree_kernel uses seq_lens_sum only to size the (non-preallocated)
-        # tree mask; over-size is safe. Skip per-iter .sum().item() D2H via UB.
-        seq_lens_sum = batch.seq_lens_sum
-        if seq_lens_sum is None:
-            if tree_mask_buf is None:
-                max_context_len = (
-                    self.target_worker.model_runner.attn_backend.max_context_len
-                )
-                seq_lens_sum = batch.seq_lens.shape[0] * max_context_len
-            else:
-                # tree_mask_buf preallocated -> kernel ignores seq_lens_sum.
-                seq_lens_sum = 0
-
         (
             tree_mask,
             position,
@@ -553,7 +540,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             top_scores_index,
             draft_tokens,
             batch.seq_lens,
-            seq_lens_sum,
+            batch.seq_lens_sum,
             self.topk,
             self.speculative_num_steps,
             self.speculative_num_draft_tokens,


### PR DESCRIPTION
## Summary

- Make `build_tree_kernel_efficient` enforce the `seq_lens_sum` contract internally: type signature is now `Optional[int]`, and the FULL_MASK + no-preallocated-buf path asserts `seq_lens_sum is not None`
- Remove the duplicated `seq_lens_sum=None` guard from single-layer eagle (`eagle_worker_v2.py`); both eagle variants now pass `batch.seq_lens_sum` directly

## Background

`seq_lens_sum` is only consumed when `tree_mask_buf is None` (FULL_MASK dynamic allocation path). When `tree_mask_buf` is provided (preallocated), it is ignored. This contract was implicit and enforced inconsistently:

- Single-layer eagle guarded `seq_lens_sum=None` at its call site (#26128)
- Multi-layer eagle did NOT guard, causing `NoneType * int` crash when `seq_lens_sum` is `None`

Moving the contract into `build_tree_kernel_efficient` ensures all callers (current and future) get the same behavior.

## No behavior change for existing backends

This only changes the crash site (from caller-side `NoneType * int` to an assert with a clear message). Backends that provide preallocated `tree_mask_buf` (trtllm_mla, and fa3/fa4 in #29589) are unaffected — they always take the preallocated path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28347219734](https://github.com/sgl-project/sglang/actions/runs/28347219734)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28347219646](https://github.com/sgl-project/sglang/actions/runs/28347219646)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #28347219728](https://github.com/sgl-project/sglang/actions/runs/28347219728)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->