### PR TITLE
Fix Nunchaku FP4 validation and image save output

### DIFF
--- a/python/sglang/multimodal_gen/configs/quantization/nunchaku.py
+++ b/python/sglang/multimodal_gen/configs/quantization/nunchaku.py
@@ -114,12 +114,22 @@ class NunchakuSVDQuantArgs:
         unsupported: list[str] = []
         for i in range(device_count):
             major, minor = torch.cuda.get_device_capability(i)
-            if major == 9:
-                unsupported.append(f"cuda:{i} (SM{major}{minor}, Hopper)")
+            device = f"cuda:{i} (SM{major}{minor})"
+            if self.quantization_precision == "nvfp4":
+                if major not in (10, 12):
+                    unsupported.append(device)
+            elif major == 9:
+                unsupported.append(f"{device}, Hopper")
             elif major not in (8, 12):
-                unsupported.append(f"cuda:{i} (SM{major}{minor})")
+                unsupported.append(device)
 
         if unsupported:
+            if self.quantization_precision == "nvfp4":
+                raise ValueError(
+                    "Nunchaku SVDQuant FP4 is currently only supported on Blackwell GPUs; "
+                    f"Unsupported devices: {', '.join(unsupported)}. "
+                    "Use INT4 weights on this device, or run FP4 on supported Blackwell hardware."
+                )
             raise ValueError(
                 "Nunchaku SVDQuant is currently only supported on Ampere (SM8x) or SM12x GPUs; "
                 f"Unsupported devices: {', '.join(unsupported)}. "

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
@@ -74,6 +74,40 @@ def _parse_extra_container(value: Any) -> dict[str, Any]:
     return {}
 
 
+def _coerce_optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "off"}:
+            return False
+    return bool(value)
+
+
+def _resolve_output_path_for_request(
+    request: ImageGenerationsRequest, server_output_path: str | None
+) -> tuple[str | None, bool]:
+    request_save_output = request.save_output
+    if request_save_output is None:
+        request_save_output = _get_extra_field(request, "save_output")
+    save_output = _coerce_optional_bool(request_save_output)
+    if save_output is None:
+        save_output = True
+
+    request_output_path = request.output_path
+    if request_output_path is None:
+        request_output_path = _get_extra_field(request, "output_path")
+
+    output_path = request_output_path or server_output_path
+    if not save_output:
+        return None, False
+    return output_path, output_path is not None
+
+
 def _read_b64_for_paths(paths: list[str]) -> list[str]:
     """Read and base64-encode each file. Must be called before cloud upload deletes them."""
     result = []
@@ -158,7 +192,11 @@ async def generations(
         else choose_output_image_ext(request.output_format, request.background)
     )
 
-    with temp_dir_if_disabled(server_args.output_path) as output_dir:
+    configured_output_path, is_persistent = _resolve_output_path_for_request(
+        request, server_args.output_path
+    )
+
+    with temp_dir_if_disabled(configured_output_path) as output_dir:
         sampling = build_sampling_params(
             request_id,
             prompt=request.prompt,
@@ -231,9 +269,10 @@ async def generations(
             else None
         )
 
-        cloud_url = await cloud_storage.upload_and_cleanup(save_file_path)
+        cloud_url = None
+        if is_persistent or resp_format == "url":
+            cloud_url = await cloud_storage.upload_and_cleanup(save_file_path)
 
-        is_persistent = server_args.output_path is not None
         await IMAGE_STORE.upsert(
             request_id,
             {

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -49,6 +49,8 @@ class ImageGenerationsRequest(BaseModel):
     negative_prompt: Optional[str] = None
     output_quality: Optional[str] = "default"
     output_compression: Optional[int] = None
+    save_output: Optional[bool] = None
+    output_path: Optional[str] = None
     enable_teacache: Optional[bool] = False
     max_sequence_length: Optional[int] = None
     flow_shift: Optional[float] = None

--- a/python/sglang/multimodal_gen/test/unit/test_nunchaku_quantization_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_nunchaku_quantization_args.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from sglang.multimodal_gen.configs.quantization import nunchaku
+from sglang.multimodal_gen.configs.quantization.nunchaku import NunchakuSVDQuantArgs
+
+
+def _patch_nunchaku_cuda(monkeypatch, capabilities):
+    monkeypatch.setattr(nunchaku.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(nunchaku, "is_nunchaku_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: len(capabilities))
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda i: capabilities[i])
+
+
+def test_nunchaku_nvfp4_rejects_sm89(monkeypatch):
+    _patch_nunchaku_cuda(monkeypatch, [(8, 9)])
+    args = NunchakuSVDQuantArgs(
+        enable_svdquant=True,
+        transformer_weights_path="svdq-fp4_r128-z-image-turbo.safetensors",
+        quantization_precision="nvfp4",
+        quantization_rank=128,
+    )
+
+    with pytest.raises(ValueError, match="SVDQuant FP4"):
+        args._validate()
+
+
+@pytest.mark.parametrize("capability", [(10, 0), (12, 0)])
+def test_nunchaku_nvfp4_allows_blackwell(monkeypatch, capability):
+    _patch_nunchaku_cuda(monkeypatch, [capability])
+    args = NunchakuSVDQuantArgs(
+        enable_svdquant=True,
+        transformer_weights_path="svdq-fp4_r128-z-image-turbo.safetensors",
+        quantization_precision="nvfp4",
+        quantization_rank=128,
+    )
+
+    args._validate()
+
+
+def test_nunchaku_int4_keeps_sm89_support(monkeypatch):
+    _patch_nunchaku_cuda(monkeypatch, [(8, 9)])
+    args = NunchakuSVDQuantArgs(
+        enable_svdquant=True,
+        transformer_weights_path="svdq-int4_r128-z-image-turbo.safetensors",
+        quantization_precision="int4",
+        quantization_rank=128,
+    )
+
+    args._validate()

--- a/python/sglang/multimodal_gen/test/unit/test_openai_image_api.py
+++ b/python/sglang/multimodal_gen/test/unit/test_openai_image_api.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from sglang.multimodal_gen.runtime.entrypoints.openai.image_api import (
+    _resolve_output_path_for_request,
+)
+from sglang.multimodal_gen.runtime.entrypoints.openai.protocol import (
+    ImageGenerationsRequest,
+)
+
+
+def test_image_request_defaults_to_server_output_path():
+    request = ImageGenerationsRequest(prompt="a cat")
+
+    output_path, is_persistent = _resolve_output_path_for_request(request, "outputs/")
+
+    assert output_path == "outputs/"
+    assert is_persistent
+
+
+def test_image_request_save_output_false_uses_temporary_output_path():
+    request = ImageGenerationsRequest(
+        prompt="a cat",
+        response_format="b64_json",
+        save_output=False,
+    )
+
+    output_path, is_persistent = _resolve_output_path_for_request(request, "outputs/")
+
+    assert output_path is None
+    assert not is_persistent
+
+
+def test_image_request_save_output_false_from_extra_body():
+    request = ImageGenerationsRequest(
+        prompt="a cat",
+        response_format="b64_json",
+        extra_body={"save_output": False},
+    )
+
+    output_path, is_persistent = _resolve_output_path_for_request(request, "outputs/")
+
+    assert output_path is None
+    assert not is_persistent
+
+
+def test_image_request_output_path_override():
+    request = ImageGenerationsRequest(prompt="a cat", output_path="custom-output")
+
+    output_path, is_persistent = _resolve_output_path_for_request(request, "outputs/")
+
+    assert output_path == "custom-output"
+    assert is_persistent


### PR DESCRIPTION
## Motivation

Related to #28256. The report has two actionable parts:

- Nunchaku SVDQuant FP4 weights can be inferred from `svdq-fp4_*` filenames and pass SGLang startup validation on non-Blackwell devices, then fail later inside the external Nunchaku CUDA path with a less actionable runtime error.
- The OpenAI-compatible image endpoint accepts extension fields such as `extra_body={"save_output": false}`, but image generation still uses the server default output directory and persists files.

This PR does not make FP4 supported on non-Blackwell GPUs; it makes that unsupported configuration fail earlier with a clearer message and preserves INT4 behavior.

## Modifications

- Reject Nunchaku SVDQuant FP4 on non-Blackwell GPU capabilities during argument validation, while keeping INT4 support for SM8x and allowing FP4 on SM10x/SM12x Blackwell.
- Add `save_output` and `output_path` fields to `ImageGenerationsRequest`.
- Resolve image output paths per request: `save_output=false` uses a temporary output path for response materialization and avoids persistent local output for `b64_json` responses.
- Add focused unit coverage for the Nunchaku capability guard and image output path resolution, including nested `extra_body`.

## Accuracy Tests

Not applicable. This changes validation and response file persistence behavior; it does not change model forward math or generated image contents.

## Speed Tests and Profiling

Not applicable. No request-path compute kernels or scheduling behavior are changed.

## Tests

- `git diff --check`
- On an H200 validation VM using `lmsysorg/sglang:latest`:
  `PYTHONPATH=python python3 -m pytest python/sglang/multimodal_gen/test/unit/test_openai_image_api.py python/sglang/multimodal_gen/test/unit/test_openai_utils.py python/sglang/multimodal_gen/test/unit/test_nunchaku_quantization_args.py -q`
  Result: `13 passed`

Full Nunchaku Z-Image FP4 runtime was not run in this PR validation because the available SGLang container does not include the external `nunchaku` package and the B200 host did not already have the image/model cache. The FP4 change is covered at the SGLang validation boundary with mocked CUDA capabilities.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28348804199](https://github.com/sgl-project/sglang/actions/runs/28348804199)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28348804083](https://github.com/sgl-project/sglang/actions/runs/28348804083)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->