### PR TITLE
Make mem_fraction_static reserve disaggregation-mode aware

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3511,6 +3511,10 @@ class ServerArgs:
                 and decode_cuda_graph_config.backend != Backend.DISABLED
             ):
                 reserved_mem += decode_cuda_graph_config.max_bs * 2
+                # DeepEP all-to-all buffers captured in the decode graph are
+                # not covered by the max_bs term.
+                if self.moe_a2a_backend == "deepep":
+                    reserved_mem += 2 * 1024
             # Some adjustments for large parallel size
             reserved_mem += self.tp_size * self.pp_size / 8 * 1024
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3493,17 +3493,28 @@ class ServerArgs:
         if self.mem_fraction_static is None:
             # Constant meta data (e.g., from attention backend)
             reserved_mem = 512
-            # For activation during large prefill
-            if self.chunked_prefill_size > 0:
+            # For activation slack
+            if self.disaggregation_mode == "decode":
+                # Decode nodes do no prefill; size activation to the decode batch.
+                running_requests = (
+                    self.max_running_requests or decode_cuda_graph_config.max_bs or 1
+                )
+                draft_tokens = self.speculative_num_draft_tokens or 1
+                reserved_mem += max(running_requests * draft_tokens, 2048) * 1.5
+            elif self.chunked_prefill_size > 0:
                 reserved_mem += max(self.chunked_prefill_size, 2048) * 1.5
             else:
                 reserved_mem += max(self.max_prefill_tokens, 2048) * 1.5
-            # For cuda graphs
-            reserved_mem += decode_cuda_graph_config.max_bs * 2
+            # For decode cuda graphs (skip on prefill-only nodes)
+            if (
+                self.disaggregation_mode != "prefill"
+                and decode_cuda_graph_config.backend != Backend.DISABLED
+            ):
+                reserved_mem += decode_cuda_graph_config.max_bs * 2
             # Some adjustments for large parallel size
             reserved_mem += self.tp_size * self.pp_size / 8 * 1024
 
-            if self.enable_dp_attention:
+            if self.enable_dp_attention and self.disaggregation_mode != "prefill":
                 # DP attention needs more padding for some operations
                 reserved_mem += decode_cuda_graph_config.max_bs * self.dp_size * 3
 
@@ -3513,8 +3524,11 @@ class ServerArgs:
                 if decode_cuda_graph_config.max_bs > 300:
                     reserved_mem += decode_cuda_graph_config.max_bs * self.dp_size * 1.5
 
-            # For piecewise cuda graphs
-            if prefill_cuda_graph_config.backend != Backend.DISABLED:
+            # For prefill piecewise cuda graphs (skip on decode-only nodes)
+            if (
+                self.disaggregation_mode != "decode"
+                and prefill_cuda_graph_config.backend != Backend.DISABLED
+            ):
                 if not self.use_mla_backend():
                     # Only calculate the memory overhead for Non-Torch Memory use since the Torch Memory can be reused with Cuda Graph Capture
                     reserved_mem += len(prefill_cuda_graph_config.bs) * 8

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3511,10 +3511,6 @@ class ServerArgs:
                 and decode_cuda_graph_config.backend != Backend.DISABLED
             ):
                 reserved_mem += decode_cuda_graph_config.max_bs * 2
-                # DeepEP all-to-all buffers captured in the decode graph are
-                # not covered by the max_bs term.
-                if self.moe_a2a_backend == "deepep":
-                    reserved_mem += 2 * 1024
             # Some adjustments for large parallel size
             reserved_mem += self.tp_size * self.pp_size / 8 * 1024
 
@@ -3542,6 +3538,15 @@ class ServerArgs:
 
             if gpu_mem is not None and gpu_mem > 60 * 1024:
                 reserved_mem = max(reserved_mem, 10 * 1024)
+
+            # DeepEP all-to-all buffers captured in the decode graph are real
+            # extra allocations, so reserve them on top of the floor.
+            if (
+                self.disaggregation_mode != "prefill"
+                and decode_cuda_graph_config.backend != Backend.DISABLED
+                and self.moe_a2a_backend == "deepep"
+            ):
+                reserved_mem += 2 * 1024
 
             self.mem_fraction_static = (
                 round((gpu_mem - reserved_mem) / gpu_mem, 3)


### PR DESCRIPTION
## Motivation

When `--mem-fraction-static` is not set, SGLang auto-derives it by estimating reserved (non-KV) memory. Today that estimate always includes both prefill activation slack **and** decode/prefill CUDA-graph buffers, regardless of the node's role.

On PD-disaggregated deployments each node runs only one phase, so the other phase's reserve is dead headroom that needlessly shrinks the KV cache:
- A **prefill** node still reserves decode CUDA-graph + DP-attention padding memory it never uses.
- A **decode** node still sizes activation slack to prefill tokens and reserves prefill piecewise-CUDA-graph memory it never uses.

## Modification

Gate the reserve terms in `ServerArgs._handle_gpu_memory_settings` on `self.disaggregation_mode`:

- **Activation slack**: decode nodes size to the decode batch — `max(max_running_requests or decode max_bs or 1) * (speculative_num_draft_tokens or 1)`, floored at 2048, ×1.5 — instead of prefill-token sizing. Prefill / unified keep the existing chunked-prefill / max-prefill sizing.
- **Decode CUDA-graph term** and **DP-attention padding terms**: skipped when `disaggregation_mode == "prefill"` (the decode-graph term is additionally guarded on the decode graph backend being enabled).
- **Prefill piecewise CUDA-graph term**: skipped when `disaggregation_mode == "decode"`.

Net effect:
- decode-only nodes drop prefill activation sizing + prefill CUDA-graph reserve;
- prefill-only nodes drop decode CUDA-graph reserve + DP padding reserve;
- unified (non-disaggregated) behavior is unchanged.

The >60GiB 10GiB floor and all other terms are untouched.

## Checklist

- [x] Format with the existing pre-commit hooks.
- [x] No behavior change for non-disaggregated deployments.





























































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28694459209](https://github.com/sgl-project/sglang/actions/runs/28694459209)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28694459160](https://github.com/sgl-project/sglang/actions/runs/28694459160)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->