### PR TITLE
[Spec] Frozen-KV MTP: delay target KV binding to pool init + reset stale draft out_cache_loc

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -850,9 +850,6 @@ class Scheduler(
     def init_model_worker(self):
         # Load model weights.
         self.init_tp_model_worker()
-        if self.spec_algorithm.is_frozen_kv_mtp():
-            # Frozen-KV MTP draft construction needs the target KV pool.
-            self.init_target_memory_pool()
         self.maybe_init_draft_worker()
 
         # Allocate KV cache pools for all workers.

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -114,16 +114,11 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
             f"{self.speculative_algorithm.name}."
         )
 
-        # Draft attention uses target req_to_token + KV allocator (read-only).
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
-            target_worker.get_memory_pool()
-        )
-
-        target_cfg = target_worker.model_runner.memory_pool_config
-        self.draft_pool_config = MemoryPoolConfig(
-            max_total_num_tokens=64,  # Dummy value
-            max_running_requests=target_cfg.max_running_requests,
-        )
+        # Target pools (read-only) are bound in alloc_memory_pool(), not here, so
+        # the worker can be built before the target pool exists (see #29021).
+        self.req_to_token_pool = None
+        self.token_to_kv_pool_allocator = None
+        self.draft_pool_config: Optional[MemoryPoolConfig] = None
 
         self.hot_token_id = None
 
@@ -144,9 +139,6 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
                 moe_dp_rank=moe_dp_rank,
                 nccl_port=nccl_port,
                 is_draft_worker=True,
-                req_to_token_pool=self.req_to_token_pool,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                memory_pool_config=self.draft_pool_config,
             )
 
         embed, head = self.target_worker.model_runner.model.get_embed_and_head()
@@ -160,8 +152,6 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
             )
 
         self.kv_context: Optional[FrozenKVMTPContext] = None
-        if hasattr(self.draft_model_runner.model, "bind_frozen_kv_context"):
-            self._bind_kv_context()
 
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
@@ -180,22 +170,25 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         req_to_token_pool=None,
         token_to_kv_pool_allocator=None,
     ):
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+
+        self.draft_pool_config = MemoryPoolConfig(
+            max_total_num_tokens=64,  # Dummy value
+            max_running_requests=memory_pool_config.max_running_requests,
+        )
+
         # NOTE: call TpModelWorker explicitly -- EagleDraftWorkerBase precedes it in
         # the MRO and its alloc_memory_pool is a no-op stub.
         TpModelWorker.alloc_memory_pool(
             self,
             memory_pool_config=self.draft_pool_config,
-            req_to_token_pool=(
-                req_to_token_pool
-                if req_to_token_pool is not None
-                else self.req_to_token_pool
-            ),
-            token_to_kv_pool_allocator=(
-                token_to_kv_pool_allocator
-                if token_to_kv_pool_allocator is not None
-                else self.token_to_kv_pool_allocator
-            ),
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=token_to_kv_pool_allocator,
         )
+
+        if hasattr(self.draft_model_runner.model, "bind_frozen_kv_context"):
+            self._bind_kv_context()
 
     def init_attention_backends(self):
         with (
@@ -441,6 +434,9 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         assert forward_batch.capture_hidden_mode == CaptureHiddenMode.LAST
         self._set_positions(forward_batch)
         self._expand_for_topk_draft(forward_batch)
+
+        # Frozen draft never writes KV; None signals fill_from to skip the slot.
+        forward_batch.out_cache_loc = None
 
         can_run_cuda_graph = (
             self.cuda_graph_runner


### PR DESCRIPTION
## Motivation

Two coupled fixes for Frozen-KV MTP, folded into one PR because the `trtllm_mha` + hybrid-SWA path needs **both** to start *and* run. Closes #29021. Supersedes #28264 (folded in here; original author credited as co-author).

### 1. Delay target KV binding until pool init (closes #29021)

While reviewing memory-pool init ordering, Frozen-KV MTP was found to have a scheduler-level special case in `init_model_worker` (`scheduler.py`): it allocated the **target** KV pool *before* constructing the draft worker, unlike every other speculative algorithm.

The special case existed only because `FrozenKVMTPDraftWorker.__init__` eagerly read runtime pool state: it called `target_worker.get_memory_pool()`, derived the dummy `draft_pool_config` from `target_worker.model_runner.memory_pool_config`, and bound the `FrozenKVMTPContext` to `target_worker.model_runner.token_to_kv_pool`. None of those exist until the target pool is allocated.

This is a *fake* construction-time dependency:
- `ModelRunner.__init__` loads weights but does **not** allocate the KV pool — allocation happens only in `alloc_memory_pool()`.
- `EAGLEWorkerV2` already proves the deferred pattern: it constructs its `TpModelWorker` with no pool args and defers all pool/target-dependent binding to `alloc_memory_pool()`.
- The scheduler's `init_memory_pools()` already passes the target `req_to_token_pool` / `token_to_kv_pool_allocator` / `memory_pool_config` into the draft worker's `alloc_memory_pool()`.

### 2. Reset stale `out_cache_loc` on the draft path (supersedes #28264)

The frozen draft never writes KV (it reads the target KV read-only), but the draft `forward_batch` carried the **prefill's** `out_cache_loc` into the draft seed step. That stale, prefill-length `out_cache_loc` was then copied into decode-sized draft buffers, crashing **both** draft execution paths on any prompt longer than the draft decode width:

- eager: `EagerRunner.fill_from` → `output with shape [1] doesn't match the broadcast shape [N]`
- `trtllm_mha` cuda graph: `cuda_graph_swa_out_cache_loc[:n].copy_(...)` → `size of tensor a (max_bs*topk) must match tensor b (N)`

Setting `forward_batch.out_cache_loc = None` after the topk expand fixes both: the eager fill and the `trtllm_mha` SWA write-target both skip the slot when it is `None`, so neither path touches a decode-sized buffer with prefill data.

Without (1) the worker cannot be constructed in the normal order; without (2) the resulting `trtllm_mha` + SWA config crashes at the first long prefill (e.g. server warmup). They are landed together so the path is actually usable.

## Modifications

- **`frozen_kv_mtp_worker_v2.py`**
  - `__init__`: drop the `target_worker.get_memory_pool()` read, the `draft_pool_config` build from the target config, the pool args passed into `TpModelWorker.__init__`, and the eager `_bind_kv_context()` call. The constructor now only loads/configures the draft worker.
  - `alloc_memory_pool()`: bind the target `req_to_token_pool` / `token_to_kv_pool_allocator` from the args the scheduler already passes, build the dummy `draft_pool_config` from the passed `memory_pool_config`, then bind the target KV context.
  - `draft()`: set `forward_batch.out_cache_loc = None` after the topk expand (frozen draft never writes KV).
- **`scheduler.py`** — remove the `is_frozen_kv_mtp()` special case in `init_model_worker`. Frozen-KV MTP now flows through the normal `init_tp_model_worker → maybe_init_draft_worker → init_memory_pools` path.

A dedicated Gemma-4 NVFP4 + `trtllm_mha` frozen-KV MTP regression test will be added in a follow-up.

## Accuracy / Sanity Tests

**Existing GSM8K (triton, gemma-4-E4B, CUDA graph on):** `test_frozen_kv_mtp.py` topk=1/3 pass, accept length unchanged from the eager-binding baseline.

**trtllm_mha + hybrid-SWA + NVFP4 — issue #26957 SWA-fill repro**, `google/gemma-4-31B` NVFP4 target + `-assistant` draft, `--attention-backend trtllm_mha --speculative-algorithm NEXTN`, CUDA graph enabled, 1× B200 (sm_100), `random-input-len 8000 / output 1000 / 80 prompts`:

| Metric | Result |
| --- | --- |
| Successful requests | 80 / 80 |
| Server errors / illegal-memory access | 0 |
| Peak SWA token usage | **1.00 (100% fill)** — past the ~0.83 #26957 trigger |
| Accept length | ~3.1 |
| Total token throughput | ~14.4k tok/s |

The SWA pool was saturated with no `fmhaSm100f*SlidingOrChunkedCausal*` illegal-memory access, confirming the deferred-binding + `out_cache_loc` reset are correct for the trtllm_mha frozen-KV SWA path. (Note: the PR's own CI 31B test exercises the triton backend; the trtllm_mha path is validated here manually.)

## Checklist

- [x] Format code with pre-commit.
- [ ] Add unit tests — existing e2e `test_frozen_kv_mtp.py` (triton) covers the GSM8K path; a dedicated Gemma-4 NVFP4 + `trtllm_mha` test is a TODO follow-up.
- [x] Provide accuracy/sanity results (see above).

🤖 Generated with Claude Code























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28360533167](https://github.com/sgl-project/sglang/actions/runs/28360533167)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28360533015](https://github.com/sgl-project/sglang/actions/runs/28360533015)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->