### PR TITLE
[AMD][CI] Cross-node 1P1D PD-disagg bench CI (mori + mooncake)

### DIFF
--- a/.github/workflows/nightly-pd-amd-crossnode.yml
+++ b/.github/workflows/nightly-pd-amd-crossnode.yml
@@ -1,0 +1,130 @@
+name: Nightly PD-Disagg Cross-Node Bench (AMD MI35x)
+
+# Phase 1: workflow_dispatch only. Run by hand from the GitHub UI after
+# you've SSH'd onto a runner host that has keys + network reach into the two
+# Conductor MI35x nodes (Pensando RoCE fabric). runs-on stays `arc-mi300x-pd`
+# (the future ARC scale set name) so the workflow file doesn't need editing
+# when we cut over.
+#
+# NOTE: Slurm-gated target nodes (pam_slurm_adopt) need an active allocation
+# before the runner can SSH into them.
+#
+# Phase 2: enable the cron stanza once the runner is wired up and the first
+# few manual runs are clean.
+
+on:
+  workflow_dispatch:
+    inputs:
+      prefill_node:
+        description: 'SSH target (user@ip) for prefill node'
+        required: true
+        type: string
+      decode_node:
+        description: 'SSH target (user@ip) for decode node'
+        required: true
+        type: string
+      prefill_ip:
+        description: 'RoCE-routable IP of prefill node'
+        required: true
+        type: string
+      decode_ip:
+        description: 'RoCE-routable IP of decode node'
+        required: true
+        type: string
+      container:
+        description: 'docker container name on both nodes'
+        required: true
+        type: string
+        default: 'mori_bench'
+      remote_workdir:
+        description: 'workdir inside container (cache_bench.py is pushed here)'
+        required: true
+        type: string
+        default: '/sgl-workspace/ci_pd'
+      model_path:
+        description: 'model path inside container (MXFP4 for MI35x/gfx950)'
+        required: false
+        type: string
+        default: '/data/models/DeepSeek-V4-Flash-MXFP4'
+      tp_size:
+        description: 'tensor-parallel size per role'
+        required: false
+        type: string
+        default: '8'
+      transfer_backend:
+        description: 'KV transfer backend (mooncake needs the #27730-bumped image)'
+        required: false
+        type: choice
+        default: 'mori'
+        options:
+          - mori
+          - mooncake
+      bench_conc:
+        description: 'cache_bench --max-concurrency'
+        required: false
+        type: string
+        default: '4'
+      bench_nprompts:
+        required: false
+        type: string
+        default: '32'
+      bench_outlen:
+        required: false
+        type: string
+        default: '200'
+
+  # schedule:
+  #   - cron: '0 7 * * *'   # enable once Phase 2 runner is stable
+
+concurrency:
+  group: nightly-pd-amd-crossnode
+  cancel-in-progress: false
+
+jobs:
+  crossnode-pd:
+    # Phase 1: change to a self-hosted label you can hand-trigger from. The
+    # important thing is that this host has SSH keys for prefill_node /
+    # decode_node and IP reachability to prefill_ip / decode_ip.
+    # Phase 2: once the ARC scale set is up, the label below picks it up.
+    runs-on: [self-hosted, arc-mi300x-pd]
+
+    timeout-minutes: 90
+
+    env:
+      PREFILL_NODE: ${{ inputs.prefill_node }}
+      DECODE_NODE:  ${{ inputs.decode_node }}
+      PREFILL_IP:   ${{ inputs.prefill_ip }}
+      DECODE_IP:    ${{ inputs.decode_ip }}
+      CONTAINER:    ${{ inputs.container }}
+      REMOTE_WORKDIR: ${{ inputs.remote_workdir }}
+      MODEL_PATH:     ${{ inputs.model_path }}
+      TP_SIZE:        ${{ inputs.tp_size }}
+      TRANSFER_BACKEND: ${{ inputs.transfer_backend }}
+      BENCH_CONC:     ${{ inputs.bench_conc }}
+      BENCH_NPROMPTS: ${{ inputs.bench_nprompts }}
+      BENCH_OUTLEN:   ${{ inputs.bench_outlen }}
+
+    steps:
+      - name: Checkout sglang
+        uses: actions/checkout@v4
+
+      - name: Sanity-check SSH to both target nodes
+        run: |
+          for tgt in "$PREFILL_NODE" "$DECODE_NODE"; do
+            ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10 \
+              "$tgt" "echo reachable: \$(hostname); rocm-smi --showid | head -3"
+          done
+
+      - name: Run cross-node 1P1D benchmark
+        run: |
+          export RESULTS_DIR="${GITHUB_WORKSPACE}/results"
+          bash ci_bootstrap/scripts/run_cross_node_pd.sh
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pd-crossnode-${{ github.run_id }}
+          path: results/
+          retention-days: 30
+          if-no-files-found: warn

--- a/ci_bootstrap/README.md
+++ b/ci_bootstrap/README.md
@@ -1,0 +1,142 @@
+# AMD MI35x cross-node PD-disagg CI bootstrap
+
+Draft CI for **cross-node** 1P1D prefill/decode-disaggregated benchmarks on
+AMD MI35x (gfx950) over the AMD **Pensando** RoCE fabric (8× `rdma0..rdma7`,
+netdevs `tw-eth0..7`). Modeled after NV's PR sgl-project/sglang#22461 but
+adapted for our infra (SSH + docker over Conductor nodes; later ARC on K8s).
+
+> **Slurm caveat:** some nodes (e.g. the `mia1-p02-*` pool in `amd-frameworks`)
+> are Slurm-gated by `pam_slurm_adopt` — SSH is refused until you hold an active
+> allocation. Allocate first from a node that has the Slurm client:
+> `salloc -A <account> -p <partition> -w <node> -t 02:00:00 --no-shell`, then SSH.
+> Others (e.g. `mia1-p01-g20`, in the `rccl_dev` reservation) allow direct SSH.
+
+## Layout
+
+```
+.github/workflows/nightly-pd-amd-crossnode.yml        workflow_dispatch + (commented) cron
+ci_bootstrap/
+├── README.md                                         (this file)
+└── scripts/
+    ├── preflight_nodes.sh     env / GPU / RDMA / container / port / IP-reach checks
+    ├── setup_container.sh     start-if-stopped; fail-if-missing (no docker run yet)
+    ├── discover_network.sh    read-only RDMA / netdev dump (pick PREFILL_IP/DECODE_IP)
+    ├── run_cross_node_pd.sh   orchestrator: preflight -> setup -> launch -> bench -> collect
+    ├── prefill_node.sh        runs inside container on prefill node, TP=8 all GPUs
+    ├── decode_node.sh         runs inside container on decode node,  TP=8 all GPUs
+    └── proxy_node.sh          sglang_router PD-disagg proxy
+```
+
+Orchestrator stages (run_cross_node_pd.sh):
+**0** preflight  → **1** setup containers → **2** push role scripts →
+**3** launch prefill+decode → **4** wait ports → **5** launch router →
+**6** run cache_bench.py → **7** collect CSV+logs → **8** teardown
+
+## How it differs from the in-repo 1p1d_bnxt_tp4_mtp/ launchers
+
+The existing `1p1d_bnxt_tp4_mtp/{prefill,decode}_mori_nodp.sh` scripts are
+**co-located 1P1D** on a single 8-GPU box: prefill grabs GPUs 0-3, decode
+grabs 4-7, and the router talks to `0.0.0.0:30025` and `0.0.0.0:30100`.
+
+The CI variants here put each role on **its own node** with all 8 GPUs:
+- `HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7` everywhere
+- `--host $HOST_IP` (RoCE/mgmt-routable, not 0.0.0.0) so the peer node can reach it
+- RDMA devices (`IB_DEVS`) are **auto-discovered** from `ibv_devices` (the rdma*
+  list), overridable via env; `SOCKET_IFNAME` defaults to `eno0` for the gloo/NCCL
+  TCP control plane
+- Router takes `PREFILL_IP` and `DECODE_IP` as env vars and points at remote URLs
+
+## KV transfer backend (`mori` | `mooncake`)
+
+Set `TRANSFER_BACKEND` (env or the `transfer_backend` workflow input) to pick the
+disagg KV path. Default is `mori`.
+
+- `mori` — AMD's native engine, validated path. The `MORI_IO_*` / `SGLANG_MORI_*`
+  QP-tuning vars in the role scripts only apply here.
+- `mooncake` — requires an image carrying the **#27730** mooncake bump
+  (`MOONCAKE_COMMIT=d8f35569`, built with the multi-protocol HIP cmake flags).
+  That bump pulls in **#2346**, the fix for the `deconstruct()` wild-pointer →
+  `ibv_destroy_qp` segfault. Older images ship mooncake `v0.3.7.post2` (e.g. the
+  `...20260623` mi35x image = `b6a841dc`) which **segfaults at QP teardown on
+  disconnect** — runs may complete but the segfault is still in the logs and the
+  path is fragile. Do not run the mooncake leg on a pre-#27730 image.
+
+```bash
+export TRANSFER_BACKEND=mooncake   # rest of the invocation is identical
+bash ci_bootstrap/scripts/run_cross_node_pd.sh
+```
+
+## Two-phase rollout
+
+### Phase 1 — manual trigger (now)
+
+Run from your jumpbox or any host that has SSH keys for the Conductor nodes
+and IP reachability to them. Either:
+
+**(a) From the GitHub UI** once this PR is up: Actions → "Nightly PD-Disagg
+Cross-Node Bench (AMD MI300X)" → Run workflow → fill the inputs. The
+`runs-on: [self-hosted, arc-mi300x-pd]` label needs to resolve to a runner
+you've registered by hand (any laptop with `./run.sh` works for a smoke
+test, since the heavy lifting happens over SSH).
+
+**(b) Locally without GitHub** — same script:
+
+```bash
+# Example: g20 (prefill, direct SSH) + g09 (decode, allocate via Slurm first).
+# Use the eno0 mgmt IPs (10.24.112.x) — the addresses the jump server resolves.
+export PREFILL_NODE=mia1-p01-g20
+export DECODE_NODE=mia1-p02-g09
+export PREFILL_IP=10.24.112.111       # g20 eno0
+export DECODE_IP=10.24.112.140        # g09 eno0
+export CONTAINER=mori_bench
+export REMOTE_WORKDIR=/sgl-workspace/ci_pd
+export MODEL_PATH=/data/models/DeepSeek-V4-Flash-MXFP4
+bash ci_bootstrap/scripts/run_cross_node_pd.sh
+```
+
+Result goes to `./results-<timestamp>/` (CSV + per-role logs).
+
+### Phase 2 — switch to ARC self-hosted runner (later)
+
+Convert one Conductor MI35x node into a K8s worker, join yctseng's ARC
+cluster, create a `RunnerScaleSet` named `arc-mi300x-pd`. Nothing in this
+workflow needs to change — the `runs-on:` label already matches.
+
+## Recommended order on a fresh pair of nodes
+
+```bash
+# 0) allocate any Slurm-gated decode node first (skip for direct-SSH nodes):
+#    ssh mia1-p01-g20 'salloc -A amd-frameworks -p amd-frameworks -w mia1-p02-g09 -t 02:00:00 --no-shell'
+
+# 1) dump per-node RDMA/netdev info (read-only) to confirm the rdma* fabric:
+NODES="mia1-p01-g20 mia1-p02-g09" \
+    bash ci_bootstrap/scripts/discover_network.sh | tee net-discovery.log
+
+# 2) run preflight (IB_DEVS auto-discovers; set it only to pin specific NICs):
+export PREFILL_NODE=mia1-p01-g20 DECODE_NODE=mia1-p02-g09
+export PREFILL_IP=10.24.112.111  DECODE_IP=10.24.112.140
+export CONTAINER=mori_bench
+export REMOTE_WORKDIR=/sgl-workspace/ci_pd
+bash ci_bootstrap/scripts/preflight_nodes.sh
+
+# 3) if preflight is clean, run the full orchestrator:
+bash ci_bootstrap/scripts/run_cross_node_pd.sh
+```
+
+## Open assumptions preflight will check for you
+
+1. SSH reachability of both nodes.
+2. `rocm-smi` is runnable AND not in CPX mode (>8 GPU entries warns).
+3. `/dev/kfd`, `/dev/dri/renderD*`, `/dev/infiniband` populated.
+4. `docker` reachable.
+5. `$CONTAINER` exists on both nodes (and `setup_container.sh` will start it
+   if stopped; fail-loudly if missing).
+6. `$REMOTE_WORKDIR` + `cache_bench.py` present inside the container.
+7. Expected ports (30025/8998 on prefill, 30100/9001 on decode, 8000 on router)
+   are free.
+8. At least one `rdma*` device is present on the host (and, if `IB_DEVS` is set,
+   each requested device exists).
+9. Peer IP is pingable from each node.
+
+If preflight fails: read the FAIL lines, fix them, rerun. Do NOT skip with
+`SKIP_PREFLIGHT=1` on the first manual run.

--- a/ci_bootstrap/install_runner.sh
+++ b/ci_bootstrap/install_runner.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Install a GitHub Actions self-hosted runner on an AMD MI35x Conductor node.
+#
+# Run as the user account that holds the Conductor reservation (no sudo needed).
+# The runner is installed under ~/actions-runner and started via the
+# user-mode `./run.sh` (or nohup) — NOT installed as a systemd service,
+# because we don't have root on Conductor nodes.
+#
+# REQUIRED env vars:
+#   GH_REPO   - e.g. "sgl-project/sglang" (or your fork)
+#   GH_TOKEN  - short-lived registration token from
+#               https://github.com/<repo>/settings/actions/runners/new
+#               (Settings → Actions → Runners → New self-hosted runner)
+#   RUNNER_NAME    - e.g. "amd-mi300x-e06u43"
+#   RUNNER_LABELS  - comma-separated, e.g. "self-hosted,linux,x64,mi300x,pd-cluster"
+#
+# Optional:
+#   RUNNER_VERSION - default 2.321.0
+#   RUNNER_DIR     - default $HOME/actions-runner
+
+set -euo pipefail
+
+: "${GH_REPO:?set GH_REPO=owner/repo}"
+: "${GH_TOKEN:?set GH_TOKEN=<registration token from GitHub UI>}"
+: "${RUNNER_NAME:?set RUNNER_NAME}"
+: "${RUNNER_LABELS:?set RUNNER_LABELS}"
+
+RUNNER_VERSION="${RUNNER_VERSION:-2.321.0}"
+RUNNER_DIR="${RUNNER_DIR:-$HOME/actions-runner}"
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)  RUNNER_ARCH=x64 ;;
+    aarch64) RUNNER_ARCH=arm64 ;;
+    *) echo "unsupported arch: $ARCH"; exit 1 ;;
+esac
+
+TARBALL="actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"
+URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${TARBALL}"
+
+if [ -d "$RUNNER_DIR" ] && [ -f "$RUNNER_DIR/.runner" ]; then
+    echo "Runner already configured at $RUNNER_DIR — aborting (remove first if you want to re-register)"
+    exit 1
+fi
+
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+
+if [ ! -f "$TARBALL" ]; then
+    echo "Downloading $URL"
+    curl -fsSLO "$URL"
+fi
+tar xzf "$TARBALL"
+
+./config.sh \
+    --url "https://github.com/${GH_REPO}" \
+    --token "$GH_TOKEN" \
+    --name "$RUNNER_NAME" \
+    --labels "$RUNNER_LABELS" \
+    --work _work \
+    --unattended \
+    --replace
+
+echo
+echo "Runner configured. Start it with one of:"
+echo "  cd $RUNNER_DIR && ./run.sh                      # foreground"
+echo "  cd $RUNNER_DIR && nohup ./run.sh > runner.log 2>&1 &   # background, dies on logout"
+echo "  cd $RUNNER_DIR && tmux new -d -s gh-runner ./run.sh    # survives logout"
+echo
+echo "If you have sudo, prefer: sudo ./svc.sh install \$USER && sudo ./svc.sh start"

--- a/ci_bootstrap/scripts/cache_bench.py
+++ b/ci_bootstrap/scripts/cache_bench.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Prefix-cache serving benchmark for sglang.
+
+Measures how serving performance scales as a function of the shared-prefix ratio.
+Total input per request is always `total_tokens` (default 70,000).
+The shared prefix (identical across all requests in a batch) grows from 0%
+to 100%, and the unique suffix (fresh random tokens per request) shrinks.
+
+Uses sglang's native /generate endpoint with streaming enabled so TTFT, ITL,
+and TPOT are measured similarly to sglang.bench_serving.
+"""
+
+import argparse
+import asyncio
+import csv
+import json
+import random
+import time
+from dataclasses import dataclass, field
+
+import aiohttp
+import numpy as np
+import requests
+from transformers import AutoTokenizer
+
+
+BENCH_AIOHTTP_TIMEOUT_SECONDS = 600
+BENCH_AIOHTTP_READ_BUFSIZE_BYTES = 10 * 1024**2
+
+
+@dataclass
+class RequestResult:
+    success: bool = False
+    error: str = ""
+    e2e: float = 0.0
+    ttft: float = 0.0
+    itl: list[float] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+    generated_text: str = ""
+
+
+def remove_prefix(text: str, prefix: str) -> str:
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text
+
+
+def percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    return float(np.percentile(values, q))
+
+
+def mean(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return float(np.mean(values))
+
+
+def std(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return float(np.std(values))
+
+
+async def send_request(
+    session: aiohttp.ClientSession,
+    url: str,
+    input_ids: list[int],
+    prompt_len: int,
+    output_len: int,
+    semaphore: asyncio.Semaphore,
+) -> RequestResult:
+    payload = {
+        "input_ids": input_ids,
+        "sampling_params": {
+            "temperature": 0.0,
+            "max_new_tokens": output_len,
+            "ignore_eos": True,
+        },
+        "stream": True,
+    }
+
+    result = RequestResult(input_tokens=prompt_len)
+
+    async with semaphore:
+        st = time.perf_counter()
+        most_recent_timestamp = st
+        last_output_len = 0
+
+        try:
+            async with session.post(url, json=payload) as resp:
+                if resp.status != 200:
+                    body = await resp.text()
+                    result.error = f"HTTP {resp.status}: {body}"
+                    return result
+
+                async for chunk_bytes in resp.content:
+                    chunk_bytes = chunk_bytes.strip()
+                    if not chunk_bytes:
+                        continue
+
+                    chunk = chunk_bytes.decode("utf-8")
+                    chunk = remove_prefix(chunk, "data: ")
+                    chunk = remove_prefix(chunk, "data:")
+
+                    if chunk == "[DONE]":
+                        continue
+
+                    data = json.loads(chunk)
+
+                    # Mirror sglang native streaming behavior:
+                    # only act on chunks that carry text.
+                    if "text" not in data or not data["text"]:
+                        continue
+
+                    timestamp = time.perf_counter()
+                    latency = timestamp - st
+
+                    result.generated_text = data["text"]
+                    current_output_len = data["meta_info"]["completion_tokens"]
+
+                    # First token.
+                    if result.ttft == 0.0:
+                        result.ttft = timestamp - st
+                    else:
+                        # Some chunks may advance multiple tokens; distribute
+                        # the gap evenly across those newly produced tokens.
+                        num_new_tokens = current_output_len - last_output_len
+                        if num_new_tokens == 0:
+                            continue
+
+                        chunk_gap = timestamp - most_recent_timestamp
+                        adjust_itl = chunk_gap / num_new_tokens
+                        result.itl.extend([adjust_itl] * num_new_tokens)
+
+                    most_recent_timestamp = timestamp
+                    last_output_len = current_output_len
+
+                    result.success = True
+                    result.e2e = latency
+                    result.output_tokens = current_output_len
+
+        except Exception as exc:
+            result.error = str(exc)
+
+    return result
+
+
+async def run_batch(
+    base_url: str,
+    prompts: list[dict],
+    output_len: int,
+    max_concurrency: int,
+) -> list[RequestResult]:
+    sem = asyncio.Semaphore(max_concurrency)
+    url = f"{base_url}/generate"
+    timeout = aiohttp.ClientTimeout(total=BENCH_AIOHTTP_TIMEOUT_SECONDS)
+
+    async with aiohttp.ClientSession(
+        timeout=timeout,
+        read_bufsize=BENCH_AIOHTTP_READ_BUFSIZE_BYTES,
+    ) as session:
+        tasks = [
+            asyncio.create_task(
+                send_request(
+                    session=session,
+                    url=url,
+                    input_ids=p["input_ids"],
+                    prompt_len=p["prompt_len"],
+                    output_len=output_len,
+                    semaphore=sem,
+                )
+            )
+            for p in prompts
+        ]
+        return await asyncio.gather(*tasks)
+
+
+def flush_cache(base_url: str) -> None:
+    resp = requests.post(f"{base_url}/flush_cache", timeout=30)
+    resp.raise_for_status()
+
+
+def gen_token_ids(vocab_ids: list[int], token_num: int, rng: random.Random) -> list[int]:
+    """Generate a list of exactly `token_num` random token IDs."""
+    if token_num <= 0:
+        return []
+    return rng.choices(vocab_ids, k=token_num)
+
+
+def build_prompts(
+    vocab_ids: list[int],
+    total_tokens: int,
+    shared_pct: int,
+    num_prompts: int,
+    rng: random.Random,
+) -> list[dict]:
+    prefix_len = total_tokens * shared_pct // 100
+    suffix_len = total_tokens - prefix_len
+
+    shared_prefix = gen_token_ids(vocab_ids, prefix_len, rng)
+
+    prompts = []
+    for _ in range(num_prompts):
+        suffix = gen_token_ids(vocab_ids, suffix_len, rng)
+        input_ids = shared_prefix + suffix
+        prompts.append({"input_ids": input_ids, "prompt_len": len(input_ids)})
+    return prompts
+
+
+def calculate_metrics(results: list[RequestResult], elapsed: float) -> dict:
+    ok = [r for r in results if r.success]
+
+    total_input = sum(r.input_tokens for r in ok)
+    total_output = sum(r.output_tokens for r in ok)
+
+    ttfts_ms = [r.ttft * 1000.0 for r in ok if r.ttft > 0.0]
+    tpots_ms = [
+        ((r.e2e - r.ttft) / (r.output_tokens - 1)) * 1000.0
+        for r in ok
+        if r.output_tokens > 1 and r.e2e >= r.ttft
+    ]
+    itls_ms = [itl * 1000.0 for r in ok for itl in r.itl]
+    e2e_ms = [r.e2e * 1000.0 for r in ok]
+
+    request_throughput = len(ok) / elapsed if elapsed > 0 else 0.0
+    input_throughput = total_input / elapsed if elapsed > 0 else 0.0
+    output_throughput = total_output / elapsed if elapsed > 0 else 0.0
+    total_throughput = (total_input + total_output) / elapsed if elapsed > 0 else 0.0
+    concurrency = (sum(r.e2e for r in ok) / elapsed) if elapsed > 0 else 0.0
+
+    return {
+        "completed": len(ok),
+        "elapsed_s": elapsed,
+        "total_input_tokens": total_input,
+        "total_output_tokens": total_output,
+        "request_throughput_req_s": request_throughput,
+        "input_throughput_tok_s": input_throughput,
+        "output_throughput_tok_s": output_throughput,
+        "total_token_throughput_tok_s": total_throughput,
+        "mean_ttft_ms": mean(ttfts_ms),
+        "median_ttft_ms": percentile(ttfts_ms, 50),
+        "std_ttft_ms": std(ttfts_ms),
+        "p99_ttft_ms": percentile(ttfts_ms, 99),
+        "mean_tpot_ms": mean(tpots_ms),
+        "median_tpot_ms": percentile(tpots_ms, 50),
+        "std_tpot_ms": std(tpots_ms),
+        "p99_tpot_ms": percentile(tpots_ms, 99),
+        "mean_itl_ms": mean(itls_ms),
+        "median_itl_ms": percentile(itls_ms, 50),
+        "std_itl_ms": std(itls_ms),
+        "p95_itl_ms": percentile(itls_ms, 95),
+        "p99_itl_ms": percentile(itls_ms, 99),
+        "max_itl_ms": max(itls_ms) if itls_ms else 0.0,
+        "mean_e2e_latency_ms": mean(e2e_ms),
+        "median_e2e_latency_ms": percentile(e2e_ms, 50),
+        "std_e2e_latency_ms": std(e2e_ms),
+        "p90_e2e_latency_ms": percentile(e2e_ms, 90),
+        "p99_e2e_latency_ms": percentile(e2e_ms, 99),
+        "concurrency": concurrency,
+    }
+
+
+def print_benchmark_result(metrics: dict, tp_size: int) -> None:
+    tpm_per_gpu = (
+        metrics["total_token_throughput_tok_s"] * 60.0 / tp_size if tp_size > 0 else 0.0
+    )
+
+    print("  Benchmark serving result:")
+    print(f"    Successful requests:            {metrics['completed']}")
+    print(f"    Benchmark duration (s):         {metrics['elapsed_s']:.2f}")
+    print(f"    Total input tokens:             {metrics['total_input_tokens']}")
+    print(f"    Total generated tokens:         {metrics['total_output_tokens']}")
+    print(f"    Request throughput (req/s):     {metrics['request_throughput_req_s']:.2f}")
+    print(f"    Input token throughput (tok/s): {metrics['input_throughput_tok_s']:.2f}")
+    print(f"    Output token throughput (tok/s): {metrics['output_throughput_tok_s']:.2f}")
+    print(f"    Total token throughput (tok/s): {metrics['total_token_throughput_tok_s']:.2f}")
+    print(f"    TPM per GPU:                    {tpm_per_gpu:.2f}")
+    print(f"    Concurrency:                    {metrics['concurrency']:.2f}")
+    print(f"    Mean TTFT (ms):                 {metrics['mean_ttft_ms']:.2f}")
+    print(f"    Median TTFT (ms):               {metrics['median_ttft_ms']:.2f}")
+    print(f"    P99 TTFT (ms):                  {metrics['p99_ttft_ms']:.2f}")
+    print(f"    Mean TPOT (ms):                 {metrics['mean_tpot_ms']:.2f}")
+    print(f"    Median TPOT (ms):               {metrics['median_tpot_ms']:.2f}")
+    print(f"    P99 TPOT (ms):                  {metrics['p99_tpot_ms']:.2f}")
+    print(f"    Mean ITL (ms):                  {metrics['mean_itl_ms']:.2f}")
+    print(f"    Median ITL (ms):                {metrics['median_itl_ms']:.2f}")
+    print(f"    P95 ITL (ms):                   {metrics['p95_itl_ms']:.2f}")
+    print(f"    P99 ITL (ms):                   {metrics['p99_itl_ms']:.2f}")
+    print(f"    Max ITL (ms):                   {metrics['max_itl_ms']:.2f}")
+    print(f"    Mean E2E latency (ms):          {metrics['mean_e2e_latency_ms']:.2f}")
+    print(f"    Median E2E latency (ms):        {metrics['median_e2e_latency_ms']:.2f}")
+    print(f"    P90 E2E latency (ms):           {metrics['p90_e2e_latency_ms']:.2f}")
+    print(f"    P99 E2E latency (ms):           {metrics['p99_e2e_latency_ms']:.2f}")
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "--total-tokens",
+        type=int,
+        default=70000,
+        help="Total input tokens per request (shared + unique)",
+    )
+    parser.add_argument("--output-len", type=int, default=200)
+    parser.add_argument("--num-prompts", type=int, default=64)
+    parser.add_argument("--max-concurrency", type=int, default=4)
+    parser.add_argument("--csv-out", default="bench_results.csv")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--model",
+        type=str,
+        required=True,
+        help="Model path or HF repo (used to load tokenizer)",
+    )
+    parser.add_argument(
+        "--pcts",
+        type=str,
+        default="0,10,20,30,40,50,60,70,80,90,92,95,97,99",
+        help="Comma-separated shared-prefix percentages to sweep",
+    )
+    parser.add_argument(
+        "--tp-size",
+        type=int,
+        default=4,
+        help="Tensor parallel size used by the server (for TPM/GPU calc)",
+    )
+    args = parser.parse_args()
+
+    base_url = f"http://{args.host}:{args.port}"
+    pcts = [int(p) for p in args.pcts.split(",")]
+    rng = random.Random(args.seed)
+
+    print(f"Loading tokenizer from {args.model} ...")
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    vocab_ids = list(tokenizer.get_vocab().values())
+    print(f"Tokenizer loaded (vocab_size={len(vocab_ids)})")
+
+    csv_fields = [
+        "shared_prefix_pct",
+        "prefix_len",
+        "suffix_len",
+        "num_prompts",
+        "succeeded",
+        "elapsed_s",
+        "request_throughput_req_s",
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_token_throughput_tok_s",
+        "input_throughput_tok_s",
+        "output_throughput_tok_s",
+        "concurrency",
+        "mean_ttft_ms",
+        "median_ttft_ms",
+        "p99_ttft_ms",
+        "mean_tpot_ms",
+        "median_tpot_ms",
+        "p99_tpot_ms",
+        "mean_itl_ms",
+        "median_itl_ms",
+        "p95_itl_ms",
+        "p99_itl_ms",
+        "max_itl_ms",
+        "mean_e2e_latency_ms",
+        "median_e2e_latency_ms",
+        "p90_e2e_latency_ms",
+        "p99_e2e_latency_ms",
+        "tpm_per_gpu",
+    ]
+
+    with open(args.csv_out, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=csv_fields)
+        writer.writeheader()
+
+    for pct in pcts:
+        prefix_len = args.total_tokens * pct // 100
+        suffix_len = args.total_tokens - prefix_len
+
+        print(f"\n{'=' * 70}")
+        print(
+            f"shared_prefix={pct}%  prefix_len={prefix_len}  "
+            f"suffix_len={suffix_len}  total={prefix_len + suffix_len}"
+        )
+        print(f"{'=' * 70}")
+
+        print("  Flushing KV cache ...")
+        flush_cache(base_url)
+        time.sleep(1)
+
+        print(f"  Building {args.num_prompts} prompts ...")
+        prompts = build_prompts(
+            vocab_ids,
+            args.total_tokens,
+            pct,
+            args.num_prompts,
+            rng,
+        )
+
+        if prefix_len > 0:
+            print(f"  Warming cache with shared prefix ({prefix_len} tokens) ...")
+            warmup_prompt = [{
+                "input_ids": prompts[0]["input_ids"][:prefix_len],
+                "prompt_len": prefix_len,
+            }]
+            warmup_results = await run_batch(base_url, warmup_prompt, 1, 1)
+            if not warmup_results[0].success:
+                raise RuntimeError(f"Warmup failed: {warmup_results[0].error}")
+
+        print(f"  Sending requests (max_concurrency={args.max_concurrency}) ...")
+        t0 = time.perf_counter()
+        results = await run_batch(
+            base_url,
+            prompts,
+            args.output_len,
+            args.max_concurrency,
+        )
+        elapsed = time.perf_counter() - t0
+
+        ok = [r for r in results if r.success]
+        failed = len(results) - len(ok)
+
+        if failed:
+            print(f"  WARNING: {failed}/{len(results)} requests failed")
+            for r in results:
+                if not r.success:
+                    print(f"    {r.error[:160]}")
+
+        if not ok:
+            print("  ERROR: all requests failed, skipping")
+            continue
+
+        metrics = calculate_metrics(results, elapsed)
+        tpm_per_gpu = (
+            metrics["total_token_throughput_tok_s"] * 60.0 / args.tp_size
+            if args.tp_size > 0 else 0.0
+        )
+
+        row = {
+            "shared_prefix_pct": pct,
+            "prefix_len": prefix_len,
+            "suffix_len": suffix_len,
+            "num_prompts": len(results),
+            "succeeded": metrics["completed"],
+            "elapsed_s": f"{metrics['elapsed_s']:.2f}",
+            "request_throughput_req_s": f"{metrics['request_throughput_req_s']:.2f}",
+            "total_input_tokens": metrics["total_input_tokens"],
+            "total_output_tokens": metrics["total_output_tokens"],
+            "total_token_throughput_tok_s": f"{metrics['total_token_throughput_tok_s']:.2f}",
+            "input_throughput_tok_s": f"{metrics['input_throughput_tok_s']:.2f}",
+            "output_throughput_tok_s": f"{metrics['output_throughput_tok_s']:.2f}",
+            "concurrency": f"{metrics['concurrency']:.2f}",
+            "mean_ttft_ms": f"{metrics['mean_ttft_ms']:.2f}",
+            "median_ttft_ms": f"{metrics['median_ttft_ms']:.2f}",
+            "p99_ttft_ms": f"{metrics['p99_ttft_ms']:.2f}",
+            "mean_tpot_ms": f"{metrics['mean_tpot_ms']:.2f}",
+            "median_tpot_ms": f"{metrics['median_tpot_ms']:.2f}",
+            "p99_tpot_ms": f"{metrics['p99_tpot_ms']:.2f}",
+            "mean_itl_ms": f"{metrics['mean_itl_ms']:.2f}",
+            "median_itl_ms": f"{metrics['median_itl_ms']:.2f}",
+            "p95_itl_ms": f"{metrics['p95_itl_ms']:.2f}",
+            "p99_itl_ms": f"{metrics['p99_itl_ms']:.2f}",
+            "max_itl_ms": f"{metrics['max_itl_ms']:.2f}",
+            "mean_e2e_latency_ms": f"{metrics['mean_e2e_latency_ms']:.2f}",
+            "median_e2e_latency_ms": f"{metrics['median_e2e_latency_ms']:.2f}",
+            "p90_e2e_latency_ms": f"{metrics['p90_e2e_latency_ms']:.2f}",
+            "p99_e2e_latency_ms": f"{metrics['p99_e2e_latency_ms']:.2f}",
+            "tpm_per_gpu": f"{tpm_per_gpu:.2f}",
+        }
+
+        with open(args.csv_out, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=csv_fields)
+            writer.writerow(row)
+
+        print_benchmark_result(metrics, args.tp_size)
+
+    print(f"\nResults saved to {args.csv_out}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ci_bootstrap/scripts/decode_node.sh
+++ b/ci_bootstrap/scripts/decode_node.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Cross-node PD: decode role. Runs on the decode node inside its container.
+# Listens on $HOST_IP:30100; reaches prefill at $PREFILL_IP:8998 (bootstrap).
+set -ex
+
+: "${HOST_IP:?HOST_IP required - this nodes RoCE-routable IP}"
+: "${MODEL_PATH:=/data/models/DeepSeek-V4-Flash-MXFP4}"
+: "${TP_SIZE:=8}"
+
+# RDMA NICs: auto-discover the rdma* devices on this node (Pensando RoCE
+# enumerates them as rdma0..rdma7). Override by exporting IB_DEVS.
+IB_DEVS="${IB_DEVS:-$(ibv_devices 2>/dev/null | awk 'NR>2 && $1 ~ /^rdma/ {print $1}' | sort -V | paste -sd,)}"
+: "${IB_DEVS:?could not auto-discover rdma* devices; set IB_DEVS explicitly}"
+
+# Cross-node TCP control plane (gloo/NCCL bootstrap). eno0 is the routable mgmt
+# iface on these nodes; override with SOCKET_IFNAME if different.
+: "${SOCKET_IFNAME:=eno0}"
+
+# KV transfer backend: mori (default) or mooncake.
+# mooncake requires an image with the #27730 mooncake bump (d8f35569, which
+# carries #2346 — the QP-teardown wild-pointer segfault fix). Older images ship
+# mooncake v0.3.7.post2 which segfaults at ibv_destroy_qp on disconnect.
+: "${TRANSFER_BACKEND:=mori}"
+
+if [ "$TRANSFER_BACKEND" = "mori" ]; then
+  # MORI QP caps. Pensando reports max_qp_wr=65535 / max_sge=8 so these defaults
+  # are well within limits; all overridable for tuning.
+  export MORI_IO_XGMI_SCATTER_GATHER_THRESHOLD="${MORI_IO_XGMI_SCATTER_GATHER_THRESHOLD:-4}"
+  export MORI_IO_QP_MAX_SEND_WR="${MORI_IO_QP_MAX_SEND_WR:-4096}"
+  export MORI_IO_QP_MAX_CQE="${MORI_IO_QP_MAX_CQE:-32768}"
+  export MORI_IO_QP_MAX_SGE="${MORI_IO_QP_MAX_SGE:-4}"
+  export SGLANG_MORI_QP_PER_TRANSFER="${SGLANG_MORI_QP_PER_TRANSFER:-4}"
+  export SGLANG_MORI_NUM_WORKERS="${SGLANG_MORI_NUM_WORKERS:-4}"
+fi
+
+export LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+export SGLANG_USE_AITER=1
+export SGLANG_USE_AITER_AR=0
+export SGLANG_USE_AITER_AG=0
+export AITER_ENABLE_EXPERIMENTAL=1
+export AITER_DISABLE_FLYDSL=1
+export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1
+export SGLANG_ENABLE_SPEC_V2=1
+export ROCM_QUICK_REDUCE_QUANTIZATION=NONE
+export SGLANG_AITER_FP8_PREFILL_ATTN=1
+export SGLANG_AITER_MLA_PERSIST=1
+export SGLANG_MOE_PADDING=1
+export SGLANG_SET_CPU_AFFINITY=1
+export SGLANG_ROCM_FUSED_DECODE_MLA=1
+export SGLANG_USE_ROCM700A=1
+
+export NCCL_IB_RETRY_CNT=15
+export NCCL_IB_TIMEOUT=22
+export GLOO_SOCKET_IFNAME="$SOCKET_IFNAME"
+export NCCL_SOCKET_IFNAME="$SOCKET_IFNAME"
+export NCCL_IB_HCA="$IB_DEVS"
+export NCCL_CROSS_NIC=1
+export NCCL_IB_GID_INDEX="${NCCL_IB_GID_INDEX:-1}"
+
+python3 -m sglang.launch_server \
+  --model-path "$MODEL_PATH" \
+  --served-model-name deepseek \
+  --host "$HOST_IP" \
+  --port 30100 \
+  --tensor-parallel-size "$TP_SIZE" \
+  --trust-remote-code \
+  --attention-backend aiter \
+  --disaggregation-mode decode \
+  --disaggregation-transfer-backend "$TRANSFER_BACKEND" \
+  --disaggregation-ib-device "$IB_DEVS" \
+  --disaggregation-bootstrap-port 9001 \
+  --chunked-prefill-size 131072 \
+  --max-prefill-tokens 131072 \
+  --mem-fraction-static 0.9 \
+  --kv-cache-dtype fp8_e4m3 \
+  --max-running-requests 32 \
+  --cuda-graph-max-bs 32 \
+  --context-length 200000 \
+  --stream-interval 30 \
+  --schedule-policy lpm \
+  --watchdog-timeout 10000 \
+  --show-time-cost \
+  --enable-metrics \
+  --enable-cache-report

--- a/ci_bootstrap/scripts/discover_network.sh
+++ b/ci_bootstrap/scripts/discover_network.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# discover_network.sh - dump per-node networking / RDMA info so we can decide
+# whether PREFILL_IP / DECODE_IP should be the SSH-side IP (10.245.x.x) or a
+# separate bnxt/RDMA-side address.
+#
+# Pure read-only. No changes. Output is dumped to stdout; redirect to a file
+# if you want to diff between nodes.
+#
+# Required env: any of NODES="node1 node2 ..." or the standard PREFILL_NODE/
+# DECODE_NODE/ROUTER_NODE trio.
+
+set -uo pipefail
+
+SSH_OPTS=(-o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes)
+
+if [ -z "${NODES:-}" ]; then
+    NODES="${PREFILL_NODE:-} ${DECODE_NODE:-} ${ROUTER_NODE:-}"
+fi
+# de-dup, strip empties
+NODES=$(echo $NODES | tr ' ' '\n' | awk 'NF && !seen[$0]++' | tr '\n' ' ')
+if [ -z "$NODES" ]; then
+    echo "set NODES=\"a@1.2.3.4 b@5.6.7.8\" (or PREFILL_NODE / DECODE_NODE / ROUTER_NODE)" >&2
+    exit 2
+fi
+
+section() { printf '\n--- %s ---\n' "$*"; }
+
+for tgt in $NODES; do
+    echo
+    echo "============================================================"
+    echo "=== node: $tgt"
+    echo "============================================================"
+
+    ssh "${SSH_OPTS[@]}" "$tgt" 'bash -s' <<'REMOTE'
+set +e
+
+section() { printf '\n--- %s ---\n' "$*"; }
+
+section "hostname / uname"
+hostname
+hostname -I
+uname -r
+
+section "ip -br addr"
+ip -br addr
+
+section "ip -br link"
+ip -br link
+
+section "ip route (default)"
+ip route show default
+
+section "rdma link (kernel rdma subsystem)"
+if command -v rdma >/dev/null; then
+    rdma link 2>&1
+else
+    echo "rdma cli not installed"
+fi
+
+section "ibv_devinfo (libibverbs)"
+if command -v ibv_devinfo >/dev/null; then
+    ibv_devinfo 2>&1 | head -200
+else
+    echo "ibv_devinfo not installed"
+fi
+
+section "/sys/class/infiniband"
+if [ -d /sys/class/infiniband ]; then
+    for dev in /sys/class/infiniband/*; do
+        [ -e "$dev" ] || continue
+        d=$(basename "$dev")
+        echo "[$d]"
+        for f in node_guid sys_image_guid fw_ver hca_type board_id; do
+            [ -r "$dev/$f" ] && printf "  %-15s %s\n" "$f" "$(cat $dev/$f)"
+        done
+        # ports + their IPv4 GID-mapped address (RoCE shows IPs in gid_attrs/ndevs)
+        for port in "$dev"/ports/*; do
+            [ -d "$port" ] || continue
+            pnum=$(basename "$port")
+            state=$(cat "$port/state" 2>/dev/null)
+            rate=$(cat "$port/rate" 2>/dev/null)
+            phys=$(cat "$port/phys_state" 2>/dev/null)
+            echo "  port $pnum: state=$state  phys=$phys  rate=$rate"
+            if [ -d "$port/gid_attrs/ndevs" ]; then
+                for gn in "$port/gid_attrs/ndevs"/*; do
+                    [ -r "$gn" ] || continue
+                    nd=$(cat "$gn" 2>/dev/null)
+                    [ -n "$nd" ] || continue
+                    idx=$(basename "$gn")
+                    ipv4=$(ip -4 -br addr show "$nd" 2>/dev/null | awk '{print $3}')
+                    echo "    gid[$idx] -> netdev=$nd  ipv4=$ipv4"
+                done
+            fi
+        done
+    done
+else
+    echo "no /sys/class/infiniband"
+fi
+
+section "RDMA driver modules / dmesg"
+lsmod 2>/dev/null | grep -E '^(ionic|bnxt|mlx5|irdma)' || echo "no known RDMA driver modules matched"
+dmesg 2>/dev/null | grep -iE 'ionic|bnxt_re|mlx5|RoCE' | tail -10 || true
+REMOTE
+
+done

--- a/ci_bootstrap/scripts/prefill_node.sh
+++ b/ci_bootstrap/scripts/prefill_node.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Cross-node PD: prefill role. Runs on the prefill node inside its container.
+# Listens on $HOST_IP:30025 (must be reachable from decode and proxy nodes
+# over the Pensando RoCE fabric).
+set -ex
+
+: "${HOST_IP:?HOST_IP required - this nodes RoCE-routable IP}"
+: "${MODEL_PATH:=/data/models/DeepSeek-V4-Flash-MXFP4}"
+: "${TP_SIZE:=8}"
+
+# RDMA NICs: auto-discover the rdma* devices on this node (Pensando RoCE
+# enumerates them as rdma0..rdma7). Override by exporting IB_DEVS.
+IB_DEVS="${IB_DEVS:-$(ibv_devices 2>/dev/null | awk 'NR>2 && $1 ~ /^rdma/ {print $1}' | sort -V | paste -sd,)}"
+: "${IB_DEVS:?could not auto-discover rdma* devices; set IB_DEVS explicitly}"
+
+# Cross-node TCP control plane (gloo/NCCL bootstrap). eno0 is the routable mgmt
+# iface on these nodes; override with SOCKET_IFNAME if different.
+: "${SOCKET_IFNAME:=eno0}"
+
+# KV transfer backend: mori (default) or mooncake.
+# mooncake requires an image with the #27730 mooncake bump (d8f35569, which
+# carries #2346 — the QP-teardown wild-pointer segfault fix). Older images ship
+# mooncake v0.3.7.post2 which segfaults at ibv_destroy_qp on disconnect.
+: "${TRANSFER_BACKEND:=mori}"
+
+if [ "$TRANSFER_BACKEND" = "mori" ]; then
+  # MORI QP caps. Pensando reports max_qp_wr=65535 / max_sge=8 so these defaults
+  # are well within limits; all overridable for tuning.
+  export MORI_IO_XGMI_SCATTER_GATHER_THRESHOLD="${MORI_IO_XGMI_SCATTER_GATHER_THRESHOLD:-4}"
+  export MORI_IO_QP_MAX_SEND_WR="${MORI_IO_QP_MAX_SEND_WR:-4096}"
+  export MORI_IO_QP_MAX_CQE="${MORI_IO_QP_MAX_CQE:-32768}"
+  export MORI_IO_QP_MAX_SGE="${MORI_IO_QP_MAX_SGE:-4}"
+  export SGLANG_MORI_QP_PER_TRANSFER="${SGLANG_MORI_QP_PER_TRANSFER:-4}"
+  export SGLANG_MORI_NUM_WORKERS="${SGLANG_MORI_NUM_WORKERS:-4}"
+fi
+
+export LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+export SGLANG_USE_AITER=1
+export SGLANG_USE_AITER_AR=0
+export SGLANG_USE_AITER_AG=0
+export AITER_ENABLE_EXPERIMENTAL=1
+export AITER_DISABLE_FLYDSL=1
+export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1
+export SGLANG_ENABLE_SPEC_V2=1
+export ROCM_QUICK_REDUCE_QUANTIZATION=NONE
+export SGLANG_AITER_FP8_PREFILL_ATTN=1
+export SGLANG_AITER_MLA_PERSIST=1
+export SGLANG_MOE_PADDING=1
+export SGLANG_SET_CPU_AFFINITY=1
+export SGLANG_ROCM_FUSED_DECODE_MLA=1
+export SGLANG_USE_ROCM700A=1
+
+export NCCL_IB_RETRY_CNT=15
+export NCCL_IB_TIMEOUT=22
+export GLOO_SOCKET_IFNAME="$SOCKET_IFNAME"
+export NCCL_SOCKET_IFNAME="$SOCKET_IFNAME"
+export NCCL_IB_HCA="$IB_DEVS"
+export NCCL_CROSS_NIC=1
+export NCCL_IB_GID_INDEX="${NCCL_IB_GID_INDEX:-1}"
+
+python3 -m sglang.launch_server \
+  --model-path "$MODEL_PATH" \
+  --served-model-name deepseek \
+  --host "$HOST_IP" \
+  --port 30025 \
+  --tensor-parallel-size "$TP_SIZE" \
+  --trust-remote-code \
+  --attention-backend aiter \
+  --disaggregation-mode prefill \
+  --disaggregation-transfer-backend "$TRANSFER_BACKEND" \
+  --disaggregation-ib-device "$IB_DEVS" \
+  --disaggregation-bootstrap-port 8998 \
+  --load-balance-method round_robin \
+  --chunked-prefill-size 131072 \
+  --max-prefill-tokens 131072 \
+  --mem-fraction-static 0.9 \
+  --kv-cache-dtype fp8_e4m3 \
+  --max-running-requests 32 \
+  --cuda-graph-max-bs 16 \
+  --context-length 200000 \
+  --stream-interval 30 \
+  --schedule-policy lpm \
+  --watchdog-timeout 10000 \
+  --show-time-cost \
+  --enable-metrics \
+  --enable-cache-report

--- a/ci_bootstrap/scripts/preflight_nodes.sh
+++ b/ci_bootstrap/scripts/preflight_nodes.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# preflight_nodes.sh - fail early and clearly on environment issues before
+# the orchestrator burns time launching SGLang.
+#
+# Runs a battery of checks against PREFILL_NODE and DECODE_NODE (SSH-side)
+# plus the docker container expected on each. Every check prints PASS/FAIL/WARN;
+# the script exits non-zero if any FAIL was recorded.
+#
+# Required env (same as run_cross_node_pd.sh):
+#   PREFILL_NODE  DECODE_NODE  PREFILL_IP  DECODE_IP
+#   CONTAINER     REMOTE_WORKDIR
+#
+# Optional:
+#   ROUTER_NODE        (default: PREFILL_NODE)
+#   IB_DEVS            comma-list of RDMA devices to verify (e.g. rdma0,rdma1,...);
+#                      if unset, just asserts >=1 rdma* device is present
+#   PREFILL_PORT       default 30025
+#
+# NOTE: some nodes are Slurm-gated (pam_slurm_adopt). If an SSH check fails with
+# "Connection closed" / "no active jobs on this node", allocate first:
+#   salloc -A <account> -p <partition> -w <node> -t 02:00:00 --no-shell
+#   DECODE_PORT        default 30100
+#   BOOTSTRAP_PORT     default 8998
+#   ROUTER_PORT        default 8000
+#   DECODE_BOOT_PORT   default 9001
+
+set -uo pipefail
+
+: "${PREFILL_NODE:?}"
+: "${DECODE_NODE:?}"
+: "${PREFILL_IP:?}"
+: "${DECODE_IP:?}"
+: "${CONTAINER:?}"
+: "${REMOTE_WORKDIR:?}"
+
+ROUTER_NODE="${ROUTER_NODE:-$PREFILL_NODE}"
+IB_DEVS="${IB_DEVS:-}"
+PREFILL_PORT="${PREFILL_PORT:-30025}"
+DECODE_PORT="${DECODE_PORT:-30100}"
+BOOTSTRAP_PORT="${BOOTSTRAP_PORT:-8998}"
+ROUTER_PORT="${ROUTER_PORT:-8000}"
+DECODE_BOOT_PORT="${DECODE_BOOT_PORT:-9001}"
+
+SSH_OPTS=(-o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes)
+
+FAILS=0
+WARNS=0
+
+pass() { printf '  [PASS] %s\n' "$*"; }
+fail() { printf '  [FAIL] %s\n' "$*"; FAILS=$((FAILS+1)); }
+warn() { printf '  [WARN] %s\n' "$*"; WARNS=$((WARNS+1)); }
+hdr()  { printf '\n=== %s ===\n' "$*"; }
+
+# Run a remote command; capture combined output. Returns the remote exit code.
+rsh() {
+    local tgt="$1"; shift
+    ssh "${SSH_OPTS[@]}" "$tgt" "$@"
+}
+
+# Run inside the container on a node; returns the docker exec exit code.
+in_container() {
+    local tgt="$1" cmd="$2"
+    ssh "${SSH_OPTS[@]}" "$tgt" "docker exec ${CONTAINER} bash -c $(printf '%q' "$cmd")"
+}
+
+# ---------------------------------------------------------------------------
+check_node() {
+    local role="$1" tgt="$2" peer_ip="$3"
+    hdr "$role  ($tgt)"
+
+    # 1. SSH reachability
+    if out=$(rsh "$tgt" 'echo OK; hostname; hostname -I' 2>&1); then
+        pass "ssh OK; remote hostname=$(echo "$out" | sed -n 2p)"
+        echo "         remote IPs: $(echo "$out" | sed -n 3p)"
+    else
+        fail "ssh to $tgt failed: $out"
+        return  # no point running the rest
+    fi
+
+    # 2. rocm-smi + compute partition
+    # Count physical GPUs via VRAM "Total Used" lines (one per device) rather than
+    # --showid, which over-reports on these nodes (XCD/partition rows inflate it).
+    if out=$(rsh "$tgt" 'rocm-smi --showmeminfo vram 2>&1' 2>&1); then
+        gpu_count=$(echo "$out" | grep -cE 'Total Used' || true)
+        if (( gpu_count >= 1 )); then
+            pass "rocm-smi reports $gpu_count GPU(s)"
+            if (( gpu_count > 8 )); then
+                warn "  >8 GPUs means compute-partition (CPX). TP=8 will fail. Need SPX."
+            fi
+        else
+            fail "rocm-smi present but no GPUs visible (amdgpu blacklisted?)"
+        fi
+    else
+        fail "rocm-smi not runnable on host: $out"
+    fi
+    rsh "$tgt" 'rocm-smi --showcomputepartition 2>&1 | head -20' \
+        2>&1 | sed 's/^/         /'
+
+    # 3. /dev/kfd, /dev/dri/renderD*, /dev/infiniband
+    out=$(rsh "$tgt" 'ls -l /dev/kfd 2>&1 | head -1; ls /dev/dri/renderD* 2>/dev/null | wc -l; ls /dev/infiniband 2>/dev/null | tr "\n" " "')
+    echo "$out" | sed 's/^/         /'
+    if echo "$out" | grep -q '/dev/kfd'; then pass "/dev/kfd present"; else fail "/dev/kfd missing"; fi
+    renderd=$(echo "$out" | sed -n 2p)
+    if [ "${renderd:-0}" -gt 0 ]; then
+        pass "/dev/dri/renderD* count = $renderd"
+        if [ "$renderd" -gt 8 ]; then
+            warn "  >8 renderD nodes -> compute-partitioned. Need SPX flip."
+        fi
+    else
+        fail "no /dev/dri/renderD* devices"
+    fi
+    if echo "$out" | sed -n 3p | grep -q '.'; then
+        pass "/dev/infiniband populated"
+    else
+        fail "/dev/infiniband empty or missing"
+    fi
+
+    # 4. docker available
+    if rsh "$tgt" 'docker version --format "client {{.Client.Version}} / server {{.Server.Version}}"' 2>&1; then
+        pass "docker reachable"
+    else
+        fail "docker not available or daemon down"
+    fi
+
+    # 5. container existence + state
+    cstate=$(rsh "$tgt" "docker inspect -f '{{.State.Status}}' ${CONTAINER} 2>/dev/null" || true)
+    if [ -z "$cstate" ]; then
+        fail "container '$CONTAINER' does not exist on $tgt (setup_container.sh will fail loudly)"
+    else
+        echo "         container state: $cstate"
+        case "$cstate" in
+            running) pass "container '$CONTAINER' running" ;;
+            exited|created|paused) warn "container exists but state=$cstate (setup_container.sh will start it)" ;;
+            *) warn "container in unexpected state: $cstate" ;;
+        esac
+    fi
+
+    # 6. REMOTE_WORKDIR inside container (skip if container not running)
+    if [ "$cstate" = "running" ]; then
+        if in_container "$tgt" "test -d $REMOTE_WORKDIR" 2>/dev/null; then
+            pass "REMOTE_WORKDIR=$REMOTE_WORKDIR exists in container"
+        else
+            fail "REMOTE_WORKDIR=$REMOTE_WORKDIR missing in container"
+        fi
+        if in_container "$tgt" "test -f $REMOTE_WORKDIR/cache_bench.py" 2>/dev/null; then
+            pass "cache_bench.py present in REMOTE_WORKDIR"
+        else
+            warn "cache_bench.py NOT in $REMOTE_WORKDIR (orchestrator will fail at benchmark step)"
+        fi
+    fi
+
+    # 7. expected ports free (check INSIDE the container, since that's where sglang binds)
+    if [ "$cstate" = "running" ]; then
+        local pcheck
+        case "$role" in
+            prefill) pcheck="$PREFILL_PORT $BOOTSTRAP_PORT" ;;
+            decode)  pcheck="$DECODE_PORT $DECODE_BOOT_PORT" ;;
+            router)  pcheck="$ROUTER_PORT" ;;
+        esac
+        for p in $pcheck; do
+            if in_container "$tgt" "ss -ltn 2>/dev/null | awk '{print \$4}' | grep -q ':${p}\$'"; then
+                fail "port $p already in use inside container on $tgt"
+            else
+                pass "port $p free inside container"
+            fi
+        done
+    fi
+
+    # 8. RDMA devices present (host side). Pensando RoCE enumerates as rdma0..rdma7.
+    found_devs=$(rsh "$tgt" "ibv_devices 2>/dev/null | awk 'NR>2 && \$1 ~ /^rdma/ {print \$1}' | sort -V | paste -sd,")
+    if [ -n "$found_devs" ]; then
+        ndev=$(echo "$found_devs" | tr ',' '\n' | grep -c .)
+        pass "RDMA devices on host: $found_devs ($ndev)"
+        if [ -n "$IB_DEVS" ]; then
+            for d in ${IB_DEVS//,/ }; do
+                if echo ",$found_devs," | grep -q ",$d,"; then
+                    pass "  requested IB device $d present"
+                else
+                    fail "  requested IB device $d NOT present on $tgt"
+                fi
+            done
+        fi
+    else
+        fail "no rdma* devices found on $tgt (ibv_devices empty) — RoCE fabric down?"
+    fi
+
+    # 9. reachability of PEER ip from this node (ICMP only; service not up yet)
+    if rsh "$tgt" "ping -c 2 -W 2 $peer_ip" >/dev/null 2>&1; then
+        pass "peer IP $peer_ip pingable from $tgt"
+    else
+        fail "peer IP $peer_ip NOT pingable from $tgt"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+hdr "preflight start"
+echo "PREFILL_NODE = $PREFILL_NODE      PREFILL_IP = $PREFILL_IP"
+echo "DECODE_NODE  = $DECODE_NODE       DECODE_IP  = $DECODE_IP"
+echo "ROUTER_NODE  = $ROUTER_NODE"
+echo "CONTAINER    = $CONTAINER"
+echo "REMOTE_WORKDIR = $REMOTE_WORKDIR"
+echo "IB_DEVS      = ${IB_DEVS:-(auto-discover rdma*)}"
+
+check_node prefill "$PREFILL_NODE" "$DECODE_IP"
+check_node decode  "$DECODE_NODE"  "$PREFILL_IP"
+
+# Router-specific check only if router is on a third node
+if [ "$ROUTER_NODE" != "$PREFILL_NODE" ] && [ "$ROUTER_NODE" != "$DECODE_NODE" ]; then
+    check_node router "$ROUTER_NODE" "$PREFILL_IP"
+fi
+
+hdr "preflight summary"
+echo "FAILS=$FAILS  WARNS=$WARNS"
+if [ "$FAILS" -gt 0 ]; then
+    echo "preflight FAILED — fix the items above before running run_cross_node_pd.sh"
+    exit 1
+fi
+if [ "$WARNS" -gt 0 ]; then
+    echo "preflight passed with warnings — review before continuing"
+fi
+echo "preflight OK"

--- a/ci_bootstrap/scripts/proxy_node.sh
+++ b/ci_bootstrap/scripts/proxy_node.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Cross-node PD: router. Runs on any node that can reach both PREFILL_IP
+# and DECODE_IP. Exposes the OpenAI-compatible endpoint on $HOST_IP:8000.
+set -ex
+
+: "${HOST_IP:=0.0.0.0}"
+: "${PREFILL_IP:?PREFILL_IP required}"
+: "${DECODE_IP:?DECODE_IP required}"
+
+# --disable-circuit-breaker: with a single P/D pair there is no failover target,
+# so the breaker only hurts -- a slow large-prefix warmup trips it and the router
+# then 503s ("all circuits open") against a perfectly healthy prefill worker.
+python -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --host "$HOST_IP" \
+  --port 8000 \
+  --policy round_robin \
+  --prefill-policy round_robin \
+  --decode-policy round_robin \
+  --disable-circuit-breaker \
+  --request-timeout-secs 1800 \
+  --prefill "http://${PREFILL_IP}:30025" 8998 \
+  --decode  "http://${DECODE_IP}:30100"

--- a/ci_bootstrap/scripts/run_cross_node_pd.sh
+++ b/ci_bootstrap/scripts/run_cross_node_pd.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Orchestrate a cross-node 1P1D PD benchmark on two AMD MI35x nodes
+# (one prefill, one decode) over the Pensando RoCE fabric, and run a benchmark
+# client against the router.
+#
+# Phase 1 (manual): run this from your jumpbox/laptop. SSH keys must be
+#                   installed on PREFILL_NODE and DECODE_NODE.
+# Phase 2 (GH runner): run this inside an ARC runner pod that has SSH access
+#                      to the two converted Conductor nodes. No script changes
+#                      between phases — only where the script runs.
+#
+# NOTE: Slurm-gated nodes (pam_slurm_adopt) need an active allocation before SSH
+# works. Allocate first, e.g. from a node with the Slurm client:
+#   salloc -A <account> -p <partition> -w <node> -t 02:00:00 --no-shell
+#
+# Env vars (required):
+#   PREFILL_NODE    SSH target (user@ip) for the prefill node
+#   DECODE_NODE     SSH target (user@ip) for the decode node
+#   PREFILL_IP      RoCE-routable IP of PREFILL_NODE (router/decode reach it here)
+#   DECODE_IP       RoCE-routable IP of DECODE_NODE
+#   CONTAINER       docker container name on both nodes (pre-launched, sglang+rocm)
+#   REMOTE_WORKDIR  path inside container where scripts get rsynced
+#
+# Optional:
+#   ROUTER_NODE     where to launch the proxy (default: PREFILL_NODE)
+#   MODEL_PATH      default /data/models/DeepSeek-V4-Flash-MXFP4 (MXFP4; MI35x/gfx950)
+#   TP_SIZE         default 8
+#   TRANSFER_BACKEND  default mori; set "mooncake" for the mooncake KV path
+#                     (needs an image with the #27730 mooncake bump)
+#   BENCH_CONC      default "4"  (max-concurrency for cache_bench)
+#   BENCH_NPROMPTS  default 32
+#   BENCH_OUTLEN    default 200
+#   RESULTS_DIR     local dir for collected artifacts (default ./results-<timestamp>)
+
+set -euo pipefail
+
+: "${PREFILL_NODE:?}"
+: "${DECODE_NODE:?}"
+: "${PREFILL_IP:?}"
+: "${DECODE_IP:?}"
+: "${CONTAINER:?}"
+: "${REMOTE_WORKDIR:?}"
+
+ROUTER_NODE="${ROUTER_NODE:-$PREFILL_NODE}"
+MODEL_PATH="${MODEL_PATH:-/data/models/DeepSeek-V4-Flash-MXFP4}"
+TP_SIZE="${TP_SIZE:-8}"
+# KV transfer backend: mori (default) or mooncake. mooncake needs an image with
+# the #27730 mooncake bump (d8f35569 / #2346 QP-teardown segfault fix).
+TRANSFER_BACKEND="${TRANSFER_BACKEND:-mori}"
+BENCH_CONC="${BENCH_CONC:-4}"
+BENCH_NPROMPTS="${BENCH_NPROMPTS:-32}"
+BENCH_OUTLEN="${BENCH_OUTLEN:-200}"
+TS="$(date +%Y%m%d_%H%M%S)"
+RESULTS_DIR="${RESULTS_DIR:-./results-${TS}}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$RESULTS_DIR"
+
+ssh_opts="-o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes"
+
+stage() { echo; echo "==== [$(date +%T)] $* ===="; }
+
+# ---- 0. Preflight: fail loudly on env issues BEFORE we launch anything -------
+# Skip with SKIP_PREFLIGHT=1 if you need to re-run after a known-acceptable
+# warning (don't make this a habit).
+if [ "${SKIP_PREFLIGHT:-0}" != "1" ]; then
+    stage "preflight"
+    bash "$SCRIPT_DIR/preflight_nodes.sh"
+else
+    stage "preflight SKIPPED (SKIP_PREFLIGHT=1)"
+fi
+
+# ---- 1. Ensure containers are up on every target node -------------------------
+stage "setup containers"
+bash "$SCRIPT_DIR/setup_container.sh"
+
+# ---- 2. Push scripts to both nodes and into their containers ------------------
+# cache_bench.py runs on ROUTER_NODE (stage 6) and is not part of the sglang
+# image, so it must be pushed too. It is data, not an executable -> no chmod.
+stage "push role scripts"
+for pair in "$PREFILL_NODE:prefill_node.sh" "$DECODE_NODE:decode_node.sh" "$ROUTER_NODE:proxy_node.sh"; do
+    tgt="${pair%%:*}"; f="${pair##*:}"
+    scp $ssh_opts "$SCRIPT_DIR/$f" "${tgt}:/tmp/$f"
+    ssh $ssh_opts "$tgt" "docker cp /tmp/$f ${CONTAINER}:${REMOTE_WORKDIR}/$f && \
+                          docker exec ${CONTAINER} chmod +x ${REMOTE_WORKDIR}/$f"
+done
+scp $ssh_opts "$SCRIPT_DIR/cache_bench.py" "${ROUTER_NODE}:/tmp/cache_bench.py"
+ssh $ssh_opts "$ROUTER_NODE" "docker cp /tmp/cache_bench.py ${CONTAINER}:${REMOTE_WORKDIR}/cache_bench.py"
+
+# ---- 3. Launch prefill + decode in detached docker exec, capture logs ---------
+stage "launch prefill on $PREFILL_NODE (HIP all 8 GPUs, listen $PREFILL_IP:30025)"
+ssh $ssh_opts "$PREFILL_NODE" "\
+    docker exec -d -e HOST_IP=${PREFILL_IP} -e MODEL_PATH=${MODEL_PATH} -e TP_SIZE=${TP_SIZE} \
+        -e TRANSFER_BACKEND=${TRANSFER_BACKEND} \
+        -w ${REMOTE_WORKDIR} ${CONTAINER} \
+        bash -c './prefill_node.sh > /tmp/prefill.log 2>&1'"
+
+stage "launch decode on $DECODE_NODE (listen $DECODE_IP:30100)"
+ssh $ssh_opts "$DECODE_NODE" "\
+    docker exec -d -e HOST_IP=${DECODE_IP} -e MODEL_PATH=${MODEL_PATH} -e TP_SIZE=${TP_SIZE} \
+        -e TRANSFER_BACKEND=${TRANSFER_BACKEND} \
+        -w ${REMOTE_WORKDIR} ${CONTAINER} \
+        bash -c './decode_node.sh > /tmp/decode.log 2>&1'"
+
+# ---- 4. Wait for both to be live ----------------------------------------------
+wait_port() {
+    local tgt="$1" ip="$2" port="$3" timeout="${4:-600}"
+    local t=0
+    while ! ssh $ssh_opts "$tgt" "exec 3<>/dev/tcp/${ip}/${port}" 2>/dev/null; do
+        ((t+=5)); sleep 5
+        if (( t >= timeout )); then
+            echo "TIMEOUT waiting for ${ip}:${port}" >&2
+            return 1
+        fi
+    done
+    echo "  -> ${ip}:${port} live after ${t}s"
+}
+stage "wait for prefill 30025 + decode 30100 (up to 10 min each)"
+wait_port "$PREFILL_NODE" "$PREFILL_IP" 30025 600
+wait_port "$DECODE_NODE" "$DECODE_IP" 30100 600
+
+# ---- 5. Launch router on ROUTER_NODE ------------------------------------------
+stage "launch router on $ROUTER_NODE (8000 -> prefill+decode)"
+ssh $ssh_opts "$ROUTER_NODE" "\
+    docker exec -d -e PREFILL_IP=${PREFILL_IP} -e DECODE_IP=${DECODE_IP} \
+        -w ${REMOTE_WORKDIR} ${CONTAINER} \
+        bash -c './proxy_node.sh > /tmp/proxy.log 2>&1'"
+
+stage "wait for router 8000"
+ROUTER_IP="$(ssh $ssh_opts "$ROUTER_NODE" hostname -I | awk '{print $1}')"
+wait_port "$ROUTER_NODE" "$ROUTER_IP" 8000 120
+
+# ---- 6. Run benchmark client (from router node, against 127.0.0.1:8000) -------
+stage "run cache_bench (n=${BENCH_NPROMPTS} outlen=${BENCH_OUTLEN} c=${BENCH_CONC})"
+CSV_REMOTE="${REMOTE_WORKDIR}/bench_crossnode_${TS}.csv"
+LOG_REMOTE="${REMOTE_WORKDIR}/bench_crossnode_${TS}.log"
+ssh $ssh_opts "$ROUTER_NODE" "\
+    docker exec -w ${REMOTE_WORKDIR} ${CONTAINER} \
+        python3 cache_bench.py \
+          --host 127.0.0.1 --port 8000 \
+          --model ${MODEL_PATH} \
+          --total-tokens 70000 --output-len ${BENCH_OUTLEN} \
+          --num-prompts ${BENCH_NPROMPTS} \
+          --pcts 0,20,40,60,80,90,92,95,97,99 \
+          --tp-size ${TP_SIZE} --max-concurrency ${BENCH_CONC} \
+          --csv-out ${CSV_REMOTE} 2>&1 | tee ${LOG_REMOTE}"
+
+# ---- 7. Collect artifacts -----------------------------------------------------
+stage "collect logs + csv into $RESULTS_DIR"
+ssh $ssh_opts "$ROUTER_NODE"  "docker cp ${CONTAINER}:${CSV_REMOTE} /tmp/ && docker cp ${CONTAINER}:${LOG_REMOTE} /tmp/"
+scp $ssh_opts "$ROUTER_NODE:/tmp/$(basename "$CSV_REMOTE")" "$RESULTS_DIR/"
+scp $ssh_opts "$ROUTER_NODE:/tmp/$(basename "$LOG_REMOTE")" "$RESULTS_DIR/"
+for pair in "$PREFILL_NODE:prefill.log" "$DECODE_NODE:decode.log" "$ROUTER_NODE:proxy.log"; do
+    tgt="${pair%%:*}"; f="${pair##*:}"
+    ssh $ssh_opts "$tgt" "docker exec ${CONTAINER} cat /tmp/$f" > "$RESULTS_DIR/${tgt//[@:]/_}_$f" || true
+done
+
+# ---- 8. Tear down servers (best-effort) ---------------------------------------
+stage "teardown sglang processes in containers"
+for tgt in "$PREFILL_NODE" "$DECODE_NODE" "$ROUTER_NODE"; do
+    # sglang renames workers via setproctitle to 'sglang::scheduler/router/detokenizer',
+    # so the launch-command pattern never matches. Use bracket-trick on the proctitle
+    # (the '[s]glang' regex also prevents pkill from matching its own command line).
+    ssh $ssh_opts "$tgt" "docker exec ${CONTAINER} pkill -9 -f '[s]glang' || true"
+done
+
+echo
+echo "DONE. Artifacts in $RESULTS_DIR"
+ls -la "$RESULTS_DIR"

--- a/ci_bootstrap/scripts/setup_container.sh
+++ b/ci_bootstrap/scripts/setup_container.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# setup_container.sh - bring $CONTAINER to running state on each target node.
+#
+# Default policy (conservative):
+#   - if container is running         -> noop (PASS)
+#   - if container exists but stopped -> docker start
+#   - if container does not exist     -> FAIL with clear message
+#
+# With SETUP_CREATE=1 a missing container is created via the canonical
+# `docker run` recipe (explicit ROCm/RDMA devices + caps, least-privilege).
+#
+# Required env: PREFILL_NODE  DECODE_NODE  CONTAINER  (+ optional ROUTER_NODE)
+# SETUP_CREATE=1 also requires: IMAGE  (sglang+rocm image, e.g.
+#   rocm/sgl-dev:v0.5.13.post1-rocm700-mi35x-20260617)
+# Optional (create path): SHM_SIZE (default 32g), DATA_DIR (default /data),
+#   REMOTE_WORKDIR (created inside container if set).
+
+set -uo pipefail
+
+: "${PREFILL_NODE:?}"
+: "${DECODE_NODE:?}"
+: "${CONTAINER:?}"
+ROUTER_NODE="${ROUTER_NODE:-$PREFILL_NODE}"
+
+SETUP_CREATE="${SETUP_CREATE:-0}"
+SHM_SIZE="${SHM_SIZE:-32g}"
+DATA_DIR="${DATA_DIR:-/data}"
+if [ "$SETUP_CREATE" = "1" ]; then
+    : "${IMAGE:?SETUP_CREATE=1 requires IMAGE (sglang+rocm image)}"
+fi
+
+SSH_OPTS=(-o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes)
+FAILS=0
+
+create_container() {
+    local tgt="$1"
+    echo "[INFO] $tgt: creating container '${CONTAINER}' from ${IMAGE}"
+    if ssh "${SSH_OPTS[@]}" "$tgt" "\
+        docker run -d --name ${CONTAINER} \
+          --device=/dev/kfd --device=/dev/dri --device=/dev/infiniband \
+          --network=host --ipc=host --shm-size=${SHM_SIZE} \
+          --ulimit memlock=-1 --ulimit stack=67108864 \
+          --cap-add=SYS_PTRACE --cap-add=IPC_LOCK \
+          --security-opt seccomp=unconfined \
+          --group-add video --group-add render \
+          -v ${DATA_DIR}:${DATA_DIR} \
+          ${IMAGE} sleep infinity" >/dev/null; then
+        if [ -n "${REMOTE_WORKDIR:-}" ]; then
+            ssh "${SSH_OPTS[@]}" "$tgt" \
+                "docker exec ${CONTAINER} mkdir -p ${REMOTE_WORKDIR}" >/dev/null || true
+        fi
+        local state
+        state=$(ssh "${SSH_OPTS[@]}" "$tgt" "docker inspect -f '{{.State.Status}}' ${CONTAINER}")
+        if [ "$state" = "running" ]; then
+            echo "[PASS] $tgt: container created and running"
+            return 0
+        fi
+        echo "[FAIL] $tgt: docker run completed but state=$state"
+    else
+        echo "[FAIL] $tgt: docker run failed"
+    fi
+    FAILS=$((FAILS+1))
+    return 1
+}
+
+ensure_running() {
+    local tgt="$1"
+    local state
+    state=$(ssh "${SSH_OPTS[@]}" "$tgt" \
+        "docker inspect -f '{{.State.Status}}' ${CONTAINER} 2>/dev/null" || true)
+
+    if [ -z "$state" ]; then
+        if [ "$SETUP_CREATE" = "1" ]; then
+            create_container "$tgt"
+            return $?
+        fi
+        cat >&2 <<EOF
+[FAIL] $tgt: container '${CONTAINER}' does not exist.
+       setup_container.sh is conservative by default and will not create it.
+       Either:
+         (a) launch it manually with the canonical docker run command, OR
+         (b) re-run with SETUP_CREATE=1 IMAGE=<sglang+rocm image>
+             to auto-create it.
+EOF
+        FAILS=$((FAILS+1))
+        return 1
+    fi
+
+    case "$state" in
+        running)
+            echo "[PASS] $tgt: container '${CONTAINER}' already running"
+            ;;
+        exited|created|paused)
+            echo "[INFO] $tgt: container '${CONTAINER}' state=$state -> docker start"
+            if ssh "${SSH_OPTS[@]}" "$tgt" "docker start ${CONTAINER}" >/dev/null; then
+                # confirm
+                state=$(ssh "${SSH_OPTS[@]}" "$tgt" "docker inspect -f '{{.State.Status}}' ${CONTAINER}")
+                if [ "$state" = "running" ]; then
+                    echo "[PASS] $tgt: container now running"
+                else
+                    echo "[FAIL] $tgt: docker start completed but state=$state"
+                    FAILS=$((FAILS+1))
+                fi
+            else
+                echo "[FAIL] $tgt: docker start failed"
+                FAILS=$((FAILS+1))
+            fi
+            ;;
+        *)
+            echo "[FAIL] $tgt: container in unexpected state '$state'"
+            FAILS=$((FAILS+1))
+            ;;
+    esac
+}
+
+# De-dup target list (router often == prefill)
+declare -A SEEN
+for tgt in "$PREFILL_NODE" "$DECODE_NODE" "$ROUTER_NODE"; do
+    [ -n "${SEEN[$tgt]:-}" ] && continue
+    SEEN[$tgt]=1
+    ensure_running "$tgt"
+done
+
+if [ "$FAILS" -gt 0 ]; then
+    echo "setup_container FAILED on $FAILS node(s)"
+    exit 1
+fi
+echo "setup_container OK"


### PR DESCRIPTION
## Motivation

Draft CI for **cross-node** 1P1D prefill/decode-disaggregated benchmarks on AMD
MI35x (gfx950) over the AMD Pensando RoCE fabric (`rdma0..rdma7`). Modeled after
the NVIDIA GB200 disaggregation nightly (#22461) but adapted for our infra
(SSH + docker over Conductor nodes; ARC on K8s later).

## What this adds

- `ci_bootstrap/scripts/` — orchestrator (`run_cross_node_pd.sh`) + role scripts
  (prefill/decode/proxy), preflight, network discovery, container setup.
- `.github/workflows/nightly-pd-amd-crossnode.yml` — `workflow_dispatch` (cron
  stanza commented until the runner is wired up).

## KV transfer backend (`mori` | `mooncake`)

Selectable via `TRANSFER_BACKEND` (env or the `transfer_backend` workflow input),
default `mori`. The `MORI_IO_*` / `SGLANG_MORI_*` tuning vars only apply to `mori`.

`mooncake` requires an image carrying the **#27730** mooncake bump
(`MOONCAKE_COMMIT=d8f35569`), which pulls in **#2346** — the fix for the
`deconstruct()` wild-pointer -> `ibv_destroy_qp` segfault. Older images ship
mooncake `v0.3.7.post2` which segfaults at QP teardown on disconnect, so the
mooncake leg must not run on a pre-#27730 image.

## Rollout

- **Phase 1 (now):** `workflow_dispatch`-only; can also be driven entirely by hand
  via `ci_bootstrap/scripts/run_cross_node_pd.sh` from a host with SSH reach into
  the two nodes — no GitHub trigger required to validate.
- **Phase 2 (later):** wire up the self-hosted/ARC runner and enable the cron.

Draft — opening for review while mooncake E2E validation waits on the #27730 image.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28348704483](https://github.com/sgl-project/sglang/actions/runs/28348704483)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28348704342](https://github.com/sgl-project/sglang/actions/runs/28348704342)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->