### PR TITLE
Budget EAGLE/STANDALONE draft KV pool in SWA pool configurators

### DIFF
--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -310,6 +310,16 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
             * kv_size
         )
 
+        # EAGLE/STANDALONE draft KV pool inherits max_total tokens with its
+        # full-attn layers; budget into the full term.
+        self._draft_full_layers_num = 0
+        if (
+            mr.spec_algorithm.is_eagle() or mr.spec_algorithm.is_standalone()
+        ) and not mr.is_draft_worker:
+            draft_layers = getattr(mr, "eagle_draft_num_layers", None)
+            if draft_layers is not None and int(draft_layers) > 0:
+                self._draft_full_layers_num = int(draft_layers)
+
         # Bytes per token of max_total_num_tokens.
         #
         # Hybrid (full_layers > 0): max_total = full_tokens, so cell_size accounts
@@ -320,10 +330,14 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
         # token beyond the sliding window can be evicted. So cell_size = S*ns,
         # with no ratio factor applied.
         if self._full_layers_num == 0:
-            self._cell_size = self._swa_per_token * self._swa_layers_num
+            self._cell_size = (
+                self._swa_per_token * self._swa_layers_num
+                + self._full_per_token * self._draft_full_layers_num
+            )
         else:
             self._cell_size = (
-                self._full_per_token * self._full_layers_num
+                self._full_per_token
+                * (self._full_layers_num + self._draft_full_layers_num)
                 + self._swa_full_tokens_ratio
                 * self._swa_per_token
                 * self._swa_layers_num
@@ -447,7 +461,9 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
         # SWA pool sized tightly from the cap; the rest of the budget goes to full.
         swa_tokens = ceil_align(self._swa_cap, page_size)
         fixed_swa_bytes = swa_tokens * self._swa_per_token * self._swa_layers_num
-        full_cell_size = self._full_per_token * self._full_layers_num
+        full_cell_size = self._full_per_token * (
+            self._full_layers_num + self._draft_full_layers_num
+        )
         full_tokens = (
             int((available_bytes - fixed_swa_bytes) // full_cell_size) // page_size
         ) * page_size


### PR DESCRIPTION
## Summary

- SWA pool configurators (`HybridSWAPoolConfigurator` and `SWAChunkCapPoolConfigurator`) solved `full_tokens` without accounting for the EAGLE/STANDALONE draft pool per-token cost
- The draft pool inherits `max_total_num_tokens` (1:1) with its full-attention layers, so it over-allocated into headroom causing PD decode OOM when SWA + EAGLE3 draft were used together
- Fix: mirror `DefaultPoolConfigurator` by inflating the full per-token cost by the draft layers count in both SWA configurators

## Motivation

`DefaultPoolConfigurator` already budgets EAGLE/STANDALONE draft KV correctly (lines 132-149 in pool_configurator.py). The SWA configurators were missing this adjustment, leading to memory over-commitment and OOM on PD decode workers with hybrid SWA models (e.g. Gemma, Command-R, MiMo) + EAGLE3.

## Test plan

- [ ] Verify no regressions on SWA models without speculative decode (draft_full_layers_num=0, no behavior change)
- [ ] Verify PD decode with SWA + EAGLE3 no longer OOMs

































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28385641522](https://github.com/sgl-project/sglang/actions/runs/28385641522)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #28385641388](https://github.com/sgl-project/sglang/actions/runs/28385641388)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->