### PR TITLE
[AMD][Bugfix] Mamba radix cache: avoid the degenerate single-token (M=1) recompute that corrupts the first token

### DIFF
--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -1125,7 +1125,8 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
                 gf = req.get_fill_ids()
                 input_len = len(gf) if gf else None
             if input_len is not None and (
-                input_len - sum(len(v) for v in value[:best_value_len])
+                0
+                < input_len - sum(len(v) for v in value[:best_value_len])
                 < MIN_SAFE_GDN_EXTEND
             ):
                 retreat_node, retreat_len = last_node, best_value_len

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -1103,6 +1103,49 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         cow_mamba = params.cow_mamba
         req = params.req
 
+        # FIX: tail<2 retreat. A radix HIT that leaves a 1-token recompute (extend_input_len==1) issues a
+        # single-token (M=1) MoE forward. On gfx950 that selects MoE tile block_m=16, whose aiter ck_moe_stage1
+        # GEMM returns NaN for a finite fp8 input (32/64/128 tiles are correct) -> flat logits -> wrong first
+        # token. The GDN/mamba recurrence is bit-exact correct (verified). Retreat to the previous checkpoint
+        # so the recompute is always >=2 tokens (never M=1); the COW restore source and the KV prefix move to
+        # the same earlier boundary in lock-step. Gated on cow_mamba (same condition as the COW stamp below),
+        # so no_buffer/int8 strategies that share this COW path are covered too. Root fix: upstream aiter.
+        MIN_SAFE_GDN_EXTEND = 2  # tail==1 is the degenerate single-token (M=1) extend
+        if (
+            cow_mamba
+            and req is not None
+            and best_value_len > 0
+            and last_node.mamba_value is not None
+        ):
+            fill = getattr(req, "full_untruncated_fill_ids", None)
+            # NOTE empty array("q") (e.g. a PD-disagg decode match before fill_ids is populated) is falsy ->
+            # input_len=None -> we cannot determine the tail -> do NOT retreat (else we'd discard real hits).
+            input_len = len(fill) if fill else None
+            if input_len is None and hasattr(req, "get_fill_ids"):
+                gf = req.get_fill_ids()
+                input_len = len(gf) if gf else None
+            if input_len is not None and (
+                input_len - sum(len(v) for v in value[:best_value_len])
+                < MIN_SAFE_GDN_EXTEND
+            ):
+                retreat_node, retreat_len = last_node, best_value_len
+                while retreat_len > 0:
+                    retreat_node = retreat_node.parent
+                    retreat_len -= 1
+                    if (
+                        retreat_node is not None
+                        and retreat_node.mamba_value is not None
+                    ):
+                        break
+                if (
+                    retreat_len > 0
+                    and retreat_node is not None
+                    and retreat_node.mamba_value is not None
+                ):
+                    last_node, best_value_len = retreat_node, retreat_len
+                else:
+                    last_node, best_value_len = self.root_node, 0
+
         # update time for matched nodes, and make nodes closer to root to be least recently used
         # this allows mamba to evict nodes closer to root first
         node_update = last_node

--- a/test/registered/amd/test_qwen35_radix_tail1_fidelity_mi35x.py
+++ b/test/registered/amd/test_qwen35_radix_tail1_fidelity_mi35x.py
@@ -167,6 +167,20 @@ class TestQwen35RadixTail1FidelityMI35x(CustomTestCase):
             "tail=2 extend should stay 2 (no spurious retreat)",
         )
 
+    def test_tail0_control_perfect_hit_not_retreated(self):
+        # Control: token_len % 64 == 0 -> tail=0 (perfect cache hit, nothing to recompute, no M=1 forward).
+        # Assert the fix does NOT over-trigger on perfect hits: the extend stays 0 (no spurious retreat that
+        # would force recomputing up to a full chunk). Guards the tail==0 regression.
+        prompt, ptok = _build_prompt_of_len_mod(self.base_url, target_mod=0)
+        requests.get(self.base_url + "/flush_cache", timeout=60)
+        _first_token(self.base_url, prompt)  # warm
+        _tok, hit_ptok, hit_cached = _first_token(self.base_url, prompt)  # hit
+        self.assertEqual(
+            hit_ptok - hit_cached,
+            0,
+            "tail=0 perfect cache hit should have 0 extend (must not retreat)",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/amd/test_qwen35_radix_tail1_fidelity_mi35x.py
+++ b/test/registered/amd/test_qwen35_radix_tail1_fidelity_mi35x.py
@@ -1,0 +1,172 @@
+"""Regression test for the mamba-radix single-token-tail cache-fidelity bug (the tail<2 retreat fix).
+
+Bug (pre-fix): with `--mamba-scheduler-strategy extra_buffer` on a hybrid GDN+MoE model, a radix cache
+HIT on a prompt whose token length is == 1 mod 64 restores the nearest GDN checkpoint and recomputes
+exactly one token (extend_input_len == 1). On gfx950 that single-token (M=1) MoE forward selects tile
+block_m=16, whose aiter ck_moe_stage1 GEMM returns NaN -> flat logits -> a wrong, silent first token.
+The GDN/mamba recurrence is bit-exact correct; the corruption is the M=1 MoE tile.
+
+The corruption is reliable (every tail=1 hit) but the specific garbage text varies run-to-run (the
+aiter MoE reduction is non-deterministic, and a flat-logit state flips the argmax), so an
+output-equality assertion is an unreliable gate. This test instead gates on the deterministic
+structural property the fix guarantees: a tail=1 re-send no longer produces a 1-token GDN extend
+(extend_input_len >= 2, or a fresh cached=0). A tail=2 control guards against over-triggering. Standard
+accuracy gates (e.g. GSM8K) do NOT catch the bug (a multi-token answer re-grounds).
+
+VERIFIED on Qwen3.6-35B-A3B-FP8 (TP1) on current main (bug reproduced + fix confirmed).
+"""
+
+import os
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_amd_ci(est_time=1200, suite="nightly-amd-1-gpu-mi35x", nightly=True)
+
+MODEL_PATH = "Qwen3.6-35B-A3B-FP8"  # validated 35B hybrid GDN+MoE (TP1); adjust to the lane's model path
+SERVER_LAUNCH_TIMEOUT = 1800
+TP_SIZE = 1
+CHUNK = (
+    64  # mamba_cache_chunk_size = max(FLA_CHUNK_SIZE=64, page_size); page_size=64 here
+)
+
+
+def _first_token(base_url, prompt):
+    """Greedy first generated token + the prompt token count + cached-token count, via /v1/completions."""
+    r = requests.post(
+        base_url + "/v1/completions",
+        json={
+            "model": MODEL_PATH,
+            "prompt": prompt,
+            "max_tokens": 1,
+            "temperature": 0,
+            "logprobs": 1,
+        },
+        timeout=120,
+    )
+    r.raise_for_status()
+    c = r.json()["choices"][0]
+    usage = r.json().get("usage", {}) or {}
+    cached = (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
+    return c["logprobs"]["tokens"][0], usage.get("prompt_tokens"), cached
+
+
+def _build_prompt_of_len_mod(base_url, target_mod):
+    """Pad a fixed base prompt until its token length % CHUNK == target_mod (so a full re-send leaves
+    tail == (CHUNK - matched) ... specifically target_mod==1 -> tail==1)."""
+    base = (
+        "Context: a deterministic policy passage repeated to build a long, stable shared prefix. "
+        "The assistant must answer strictly from the passage. " * 4
+    )
+    filler = (
+        "Answer concisely and accurately using only the passage above. " * 80
+    ).split()
+    for w in range(len(filler)):
+        p = f"{base}{' '.join(filler[:w])}\nQuestion: what is the policy?\nAnswer:"
+        _, ptok, _ = _first_token(base_url, p)
+        if ptok % CHUNK == target_mod:
+            return p, ptok
+    raise RuntimeError(
+        f"could not build a prompt with token_len % {CHUNK} == {target_mod}"
+    )
+
+
+class TestQwen35RadixTail1FidelityMI35x(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        env = os.environ.copy()
+        env["SGLANG_USE_AITER"] = "1"
+        # Minimal launch; the structural assertion below is deterministic by construction.
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=[
+                "--tp",
+                str(TP_SIZE),
+                "--trust-remote-code",
+                "--attention-backend",
+                "triton",
+                "--mamba-scheduler-strategy",
+                "extra_buffer",
+                "--page-size",
+                "64",
+                "--cuda-graph-max-bs",
+                "64",
+                "--max-running-requests",
+                "64",
+                "--max-queued-requests",
+                "256",
+                "--chunked-prefill-size",
+                "32768",
+                "--max-prefill-tokens",
+                "32768",
+                "--mem-fraction-static",
+                "0.85",
+                "--watchdog-timeout",
+                "1800",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true}',
+            ],
+            env=env,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_tail1_retreat_fires(self):
+        # PRIMARY, DETERMINISTIC gate. The garbage-output symptom comes from the single-token (M=1) MoE
+        # returning NaN (aiter ck_moe_stage1, tile block_m=16 on gfx950); the corruption is reliable but the
+        # specific garbage text varies per process launch (the MoE reduction is non-deterministic, and a
+        # flat-logit state flips the argmax), so an output-equality assertion is an unreliable gate. Instead
+        # assert the fix's ROUTING change, which is data-deterministic: a tail=1 re-send (token_len % 64 == 1)
+        # must no longer yield a 1-token GDN extend -- the tail<2 retreat makes extend_input_len >= 2 (or
+        # fresh, cached=0).
+        prompt, ptok = _build_prompt_of_len_mod(self.base_url, target_mod=1)
+        requests.get(self.base_url + "/flush_cache", timeout=60)
+        _first_token(self.base_url, prompt)  # warm: cache the prefix
+        _hit_tok, hit_ptok, hit_cached = _first_token(
+            self.base_url, prompt
+        )  # re-send (tail=1 without the fix)
+        extend = hit_ptok - hit_cached
+        self.assertGreaterEqual(
+            extend,
+            2,
+            f"tail=1 re-send produced a {extend}-token extend (cached={hit_cached}/{hit_ptok}); the tail<2 "
+            f"retreat did NOT fire -> fix inactive. (Un-fixed code yields extend==1; that single-token MoE "
+            f"forward NaNs and corrupts the first token, and the garbage varies per launch, so output equality "
+            f"cannot gate this -- the retreat firing is the gate.)",
+        )
+
+    def test_tail2_control_still_hits_cache(self):
+        # Control: token_len % 64 == 2 -> tail=2 (already correct, never retreated). Assert the fix did NOT
+        # over-trigger: the cache is still used (cached > 0) and the extend stays 2. Guards the R1/over-trigger regression.
+        prompt, ptok = _build_prompt_of_len_mod(self.base_url, target_mod=2)
+        requests.get(self.base_url + "/flush_cache", timeout=60)
+        _first_token(self.base_url, prompt)  # warm
+        _tok, hit_ptok, hit_cached = _first_token(self.base_url, prompt)  # hit
+        self.assertGreater(
+            hit_cached,
+            0,
+            "tail=2 hit should still use the cache (fix must not over-trigger)",
+        )
+        self.assertEqual(
+            hit_ptok - hit_cached,
+            2,
+            "tail=2 extend should stay 2 (no spurious retreat)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/mem_cache/test_tail1_retreat_logic_cpu.py
+++ b/test/registered/mem_cache/test_tail1_retreat_logic_cpu.py
@@ -40,7 +40,8 @@ def retreat(value, last_node, best_value_len, req, root, cow_mamba=True):
             gf = req.get_fill_ids()
             input_len = len(gf) if gf else None
         if input_len is not None and (
-            input_len - sum(len(v) for v in value[:best_value_len])
+            0
+            < input_len - sum(len(v) for v in value[:best_value_len])
             < MIN_SAFE_GDN_EXTEND
         ):
             rn, rl = last_node, best_value_len
@@ -108,6 +109,13 @@ if __name__ == "__main__":
             "tail=64 (L=192) no retreat",
             n_chunks=2,
             input_len=192,
+            expect_retreat_to_len=2,
+        ),
+        # tail=0 -> perfect cache hit -> NO retreat (bvl unchanged)
+        case(
+            "tail=0 (L=128) no retreat",
+            n_chunks=2,
+            input_len=128,
             expect_retreat_to_len=2,
         ),
         # single checkpoint + tail=1 -> no earlier ckpt -> fresh fallback (bvl=0)

--- a/test/registered/mem_cache/test_tail1_retreat_logic_cpu.py
+++ b/test/registered/mem_cache/test_tail1_retreat_logic_cpu.py
@@ -1,0 +1,147 @@
+"""CPU unit test for the tail<2 retreat DECISION logic (no GPU, no server).
+Mirrors the inline logic in MambaRadixCache._match_post_processor so we can lock the edge cases the GPU
+aggregated run can't reach — especially R1 (an empty full_untruncated_fill_ids, as in PD-disagg decode,
+must NOT retreat). For the upstream PR, extract the inline block into a helper and point this test at it.
+
+Run: /home/onemount/miniconda3/bin/python test_tail1_retreat_logic_cpu.py
+"""
+
+from array import array
+
+CHUNK = 64
+MIN_SAFE_GDN_EXTEND = 2
+
+
+class Node:
+    def __init__(self, parent, end, has_ckpt):
+        self.parent = parent
+        self.end = end
+        self.mamba_value = (
+            end if has_ckpt else None
+        )  # checkpoint slot id (truthy) or None
+
+
+class Req:
+    def __init__(self, fill_ids):
+        self.full_untruncated_fill_ids = array("q", fill_ids)
+
+
+def retreat(value, last_node, best_value_len, req, root, cow_mamba=True):
+    """EXACT mirror of the patched _match_post_processor retreat block (R1+R2+R4)."""
+    if (
+        cow_mamba
+        and req is not None
+        and best_value_len > 0
+        and last_node.mamba_value is not None
+    ):
+        fill = getattr(req, "full_untruncated_fill_ids", None)
+        input_len = len(fill) if fill else None  # R1: empty array("q") -> None -> bail
+        if input_len is None and hasattr(req, "get_fill_ids"):
+            gf = req.get_fill_ids()
+            input_len = len(gf) if gf else None
+        if input_len is not None and (
+            input_len - sum(len(v) for v in value[:best_value_len])
+            < MIN_SAFE_GDN_EXTEND
+        ):
+            rn, rl = last_node, best_value_len
+            while rl > 0:
+                rn = rn.parent
+                rl -= 1
+                if rn is not None and rn.mamba_value is not None:
+                    break
+            if rl > 0 and rn is not None and rn.mamba_value is not None:
+                return rn, rl
+            return root, 0
+    return last_node, best_value_len
+
+
+def make_chain(n_chunks):
+    """root -> ckpt@64 -> ckpt@128 -> ... ; value[i] = 64-token span per node; all chunk-aligned -> all ckpt."""
+    root = Node(None, 0, False)
+    nodes = [root]
+    value = []
+    for i in range(1, n_chunks + 1):
+        nodes.append(Node(nodes[-1], i * CHUNK, True))
+        value.append([0] * CHUNK)
+    return root, nodes, value
+
+
+def case(name, n_chunks, input_len, expect_retreat_to_len, cow_mamba=True, req=True):
+    root, nodes, value = make_chain(n_chunks)
+    last_node, bvl = nodes[-1], n_chunks  # full match on all checkpoint nodes
+    r = Req(list(range(input_len))) if req else None
+    ln, nbvl = retreat(value, last_node, bvl, r, root, cow_mamba)
+    matched = sum(len(v) for v in value[:nbvl])
+    tail = input_len - matched if req else None
+    ok = nbvl == expect_retreat_to_len
+    print(
+        f"  {'PASS' if ok else 'FAIL'}  {name}: best_value_len {bvl}->{nbvl}  matched={matched}  "
+        f"tail_after={tail}  (expected bvl={expect_retreat_to_len})"
+    )
+    return ok
+
+
+if __name__ == "__main__":
+    print("tail<2 retreat decision — CPU edge-case lock:")
+    results = [
+        # full re-send L = k*64 + 1 -> tail_before=1 -> retreat one checkpoint (bvl k -> k-1)
+        case(
+            "tail=1 (L=129=2*64+1) retreats one ckpt",
+            n_chunks=2,
+            input_len=129,
+            expect_retreat_to_len=1,
+        ),
+        case(
+            "tail=1 (L=705=11*64+1) retreats one ckpt",
+            n_chunks=11,
+            input_len=705,
+            expect_retreat_to_len=10,
+        ),
+        # tail=2 -> NO retreat (bvl unchanged) -> cache preserved
+        case(
+            "tail=2 (L=130) no retreat",
+            n_chunks=2,
+            input_len=130,
+            expect_retreat_to_len=2,
+        ),
+        case(
+            "tail=64 (L=192) no retreat",
+            n_chunks=2,
+            input_len=192,
+            expect_retreat_to_len=2,
+        ),
+        # single checkpoint + tail=1 -> no earlier ckpt -> fresh fallback (bvl=0)
+        case(
+            "single ckpt + tail=1 (L=65) -> fresh",
+            n_chunks=1,
+            input_len=65,
+            expect_retreat_to_len=0,
+        ),
+        # R1: empty full_untruncated_fill_ids (disagg decode shape) -> NO retreat despite cow_mamba
+        case(
+            "R1: empty fill_ids (disagg) -> NO retreat",
+            n_chunks=11,
+            input_len=0,
+            expect_retreat_to_len=11,
+        ),
+        # not a mamba COW match -> untouched
+        case(
+            "cow_mamba=False -> untouched",
+            n_chunks=11,
+            input_len=705,
+            expect_retreat_to_len=11,
+            cow_mamba=False,
+        ),
+        case(
+            "req=None -> untouched",
+            n_chunks=11,
+            input_len=705,
+            expect_retreat_to_len=11,
+            req=False,
+        ),
+    ]
+    print(f"\n{sum(results)}/{len(results)} passed")
+    assert all(results), "edge-case lock FAILED"
+    print(
+        "OK — tail=1 retreats, tail>=2 preserved, single-ckpt falls back fresh, empty-fill_ids/non-mamba untouched."
+    )

--- a/test/registered/mem_cache/test_tail1_retreat_logic_cpu.py
+++ b/test/registered/mem_cache/test_tail1_retreat_logic_cpu.py
@@ -3,10 +3,15 @@ Mirrors the inline logic in MambaRadixCache._match_post_processor so we can lock
 aggregated run can't reach — especially R1 (an empty full_untruncated_fill_ids, as in PD-disagg decode,
 must NOT retreat). For the upstream PR, extract the inline block into a helper and point this test at it.
 
-Run: /home/onemount/miniconda3/bin/python test_tail1_retreat_logic_cpu.py
+Run: pytest test/registered/mem_cache/test_tail1_retreat_logic_cpu.py
+(registered to the base-a-test-cpu CI suite via run_suite.py --hw cpu).
 """
 
 from array import array
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 CHUNK = 64
 MIN_SAFE_GDN_EXTEND = 2

--- a/test/registered/mem_cache/test_tail1_retreat_logic_cpu.py
+++ b/test/registered/mem_cache/test_tail1_retreat_logic_cpu.py
@@ -82,72 +82,81 @@ def case(name, n_chunks, input_len, expect_retreat_to_len, cow_mamba=True, req=T
     return ok
 
 
+# Edge cases the aggregated GPU run can't reach; each dict is kwargs for case().
+CASES = [
+    # full re-send L = k*64 + 1 -> tail_before=1 -> retreat one checkpoint (bvl k -> k-1)
+    {
+        "name": "tail=1 (L=129=2*64+1) retreats one ckpt",
+        "n_chunks": 2,
+        "input_len": 129,
+        "expect_retreat_to_len": 1,
+    },
+    {
+        "name": "tail=1 (L=705=11*64+1) retreats one ckpt",
+        "n_chunks": 11,
+        "input_len": 705,
+        "expect_retreat_to_len": 10,
+    },
+    # tail=2 -> NO retreat (bvl unchanged) -> cache preserved
+    {
+        "name": "tail=2 (L=130) no retreat",
+        "n_chunks": 2,
+        "input_len": 130,
+        "expect_retreat_to_len": 2,
+    },
+    {
+        "name": "tail=64 (L=192) no retreat",
+        "n_chunks": 2,
+        "input_len": 192,
+        "expect_retreat_to_len": 2,
+    },
+    # tail=0 -> perfect cache hit -> NO retreat (bvl unchanged)
+    {
+        "name": "tail=0 (L=128) no retreat",
+        "n_chunks": 2,
+        "input_len": 128,
+        "expect_retreat_to_len": 2,
+    },
+    # single checkpoint + tail=1 -> no earlier ckpt -> fresh fallback (bvl=0)
+    {
+        "name": "single ckpt + tail=1 (L=65) -> fresh",
+        "n_chunks": 1,
+        "input_len": 65,
+        "expect_retreat_to_len": 0,
+    },
+    # R1: empty full_untruncated_fill_ids (disagg decode shape) -> NO retreat despite cow_mamba
+    {
+        "name": "R1: empty fill_ids (disagg) -> NO retreat",
+        "n_chunks": 11,
+        "input_len": 0,
+        "expect_retreat_to_len": 11,
+    },
+    # not a mamba COW match -> untouched
+    {
+        "name": "cow_mamba=False -> untouched",
+        "n_chunks": 11,
+        "input_len": 705,
+        "expect_retreat_to_len": 11,
+        "cow_mamba": False,
+    },
+    {
+        "name": "req=None -> untouched",
+        "n_chunks": 11,
+        "input_len": 705,
+        "expect_retreat_to_len": 11,
+        "req": False,
+    },
+]
+
+
+def test_tail1_retreat_edge_cases():
+    """Pytest entry point: every tail<2 retreat edge case must hold."""
+    assert all(case(**c) for c in CASES)
+
+
 if __name__ == "__main__":
     print("tail<2 retreat decision — CPU edge-case lock:")
-    results = [
-        # full re-send L = k*64 + 1 -> tail_before=1 -> retreat one checkpoint (bvl k -> k-1)
-        case(
-            "tail=1 (L=129=2*64+1) retreats one ckpt",
-            n_chunks=2,
-            input_len=129,
-            expect_retreat_to_len=1,
-        ),
-        case(
-            "tail=1 (L=705=11*64+1) retreats one ckpt",
-            n_chunks=11,
-            input_len=705,
-            expect_retreat_to_len=10,
-        ),
-        # tail=2 -> NO retreat (bvl unchanged) -> cache preserved
-        case(
-            "tail=2 (L=130) no retreat",
-            n_chunks=2,
-            input_len=130,
-            expect_retreat_to_len=2,
-        ),
-        case(
-            "tail=64 (L=192) no retreat",
-            n_chunks=2,
-            input_len=192,
-            expect_retreat_to_len=2,
-        ),
-        # tail=0 -> perfect cache hit -> NO retreat (bvl unchanged)
-        case(
-            "tail=0 (L=128) no retreat",
-            n_chunks=2,
-            input_len=128,
-            expect_retreat_to_len=2,
-        ),
-        # single checkpoint + tail=1 -> no earlier ckpt -> fresh fallback (bvl=0)
-        case(
-            "single ckpt + tail=1 (L=65) -> fresh",
-            n_chunks=1,
-            input_len=65,
-            expect_retreat_to_len=0,
-        ),
-        # R1: empty full_untruncated_fill_ids (disagg decode shape) -> NO retreat despite cow_mamba
-        case(
-            "R1: empty fill_ids (disagg) -> NO retreat",
-            n_chunks=11,
-            input_len=0,
-            expect_retreat_to_len=11,
-        ),
-        # not a mamba COW match -> untouched
-        case(
-            "cow_mamba=False -> untouched",
-            n_chunks=11,
-            input_len=705,
-            expect_retreat_to_len=11,
-            cow_mamba=False,
-        ),
-        case(
-            "req=None -> untouched",
-            n_chunks=11,
-            input_len=705,
-            expect_retreat_to_len=11,
-            req=False,
-        ),
-    ]
+    results = [case(**c) for c in CASES]
     print(f"\n{sum(results)}/{len(results)} passed")
     assert all(results), "edge-case lock FAILED"
     print(


### PR DESCRIPTION
## Motivation

On a hybrid Gated-DeltaNet + MoE model (e.g. Qwen3.5/3.6) with the mamba radix prefix cache
(`--mamba-scheduler-strategy extra_buffer`), a cache **hit** on a prompt whose total length is
**≡ 1 (mod 64)** produces a **wrong, silent first generated token**.

**Mechanism.** The mamba radix cache stores the GDN recurrent state only at periodic **checkpoints**
(every `chunk = 64` tokens), so checkpoints land at multiples of 64. On a hit, the engine restores the
**nearest checkpoint** and recomputes the remaining **"tail"** — i.e. the number of tokens past that
checkpoint (`tail = extend_input_len`, the recompute length). When the prompt length is `≡ 1 (mod 64)`,
the nearest checkpoint sits exactly one token back, so the tail is **1** (`extend_input_len == 1`).

**Root cause (localized; the corrupting kernel is upstream aiter).** That single-token (M=1) recompute
issues an M=1 MoE forward, which on gfx950 selects MoE tile `block_m=16`; the aiter `ck_moe_stage1`
GEMM returns **NaN** at that tile for a finite fp8 input (the `32/64/128` tiles are correct) → flat
logits → garbage first token. The GDN/mamba recurrence is **bit-exact correct** (verified). The
precise reason *inside* CK is still under investigation — it reproduces only under the live server's
warmed state, not in an isolated replay (see Related issues) — but the trigger and the fix are
verified. This PR is the **correctness-safe sglang-side mitigation**: it removes the `tail == 1`
trigger so the engine never issues the M=1 MoE, robust even on an un-fixed aiter.

**The defect is the `extra_buffer` mamba-radix path.** Every `tail == 1` cache hit is corrupted —
**24/24 (100%)** of templated re-sends across six diverse prompts — while a `no_buffer` baseline
(which does not cache mamba state) never reaches the path and never corrupts.

The *fact* of corruption is reliable; the *specific* garbage text is **not** bit-stable run-to-run,
**even at temperature 0**. The aiter MoE reduction is itself non-deterministic, and the corrupted
state has near-tied (flat) top logits, so the wrong argmax flips between forwards; a clean state stays
stable because its logit gap is large. The clean, low-noise probe is therefore the **first-token
argmax** (quantified under Accuracy Tests).

**Why it's silent / impact.** Standard evals grade a **final answer** after a long generation that
re-grounds on the correct prompt, and the trigger is rare (~1.5% of prompt lengths), so the bug stays
latent. It bites hardest where the first token is load-bearing and there is no recovery step:

- **Determinism contract broken:** a cached/retried temp-0 re-send of a prompt of length `≡ 1 (mod 64)`
  (`65, 129, 193, …`) returns a *different* first token than the original call (breaks response caches,
  "regenerate = same answer", eval reproducibility).
- **Single-token outputs** (classifier/router/yes-no gate, `max_tokens=1`): the garbage token *is* the
  answer — no recovery.
- **First-token-logprob uses** (logprob reranking, MCQ A/B/C/D): the first-token distribution is
  corrupted (measured — see Accuracy Tests).
- **Structured output / tool calling** (first token is `{`/`[`/a tool name): garbage → parse failure
  (plausible consequence of the measured first-token corruption; not separately harness-tested).

A concrete, replicable example (**AMD MI350X**, Qwen3.6-35B-A3B-FP8, TP1, **temp 0**, thinking off).
This is the **entire request** — a normal 193-token prompt (`= 3×64 + 1`, so `≡ 1 mod 64`):

> **system:** `You are a precise assistant. Answer the user's question with a single word.`
>
> **user:** `I am double-checking a short geography quiz before I submit it. So far I have reviewed`
> `quiz item numbers 1 2 3 4 5 … 38 39. The one fact I still want to confirm is this question: what`
> `is the capital of France? Reply with only the city name, nothing else.`
>
> → templated prompt length = **193 tokens** (`≡ 1 mod 64` — the trigger)

Send it once (cache **miss**), then send the **identical** request again. The second call is a cache
**hit** reporting `cached_tokens = 192` (the nearest checkpoint, `3×64`) — so 192 of 193 tokens are
restored and exactly **one token (the tail) is recomputed**:

| call | cache | `cached_tokens` | recompute tail | output |
|---|---|---|---|---|
| 1st — fresh | miss | 0 | (full prefill) | **`Paris`** ✓ |
| 2nd…5th — identical re-send | **HIT** | **192** | **1** | `niestety, nie mogę odpowiedzieć…` · `\/\/\/\/…` · `svp, please provide the question…` · `ú` — **4/4 wrong, each different** |

Same request, same temp 0 — the only difference is that the second call was served from the cache. The
corruption is reliable (every re-send wrong) yet the garbage differs each time (temp-0 greedy over a
flat-logit state + the non-deterministic MoE — not a sampling effect). With longer generations the
recurrent-state corruption often carries forward through the whole response, not just the first token.

## Modifications

One file, `MambaRadixCache._match_post_processor`
(`python/sglang/srt/mem_cache/mamba_radix_cache.py`). Before the copy-on-write (COW) state-restore
logic: when a hit would leave a recompute tail `< 2`, retreat the matched prefix to the nearest
earlier checkpoint ancestor (tail becomes `chunk + 1 ≥ 2`); if there is no earlier checkpoint, fall
back to a fresh compute (prefix 0). The KV prefix (`value[:best_value_len]`) and the COW restore source
(`last_node.mamba_value`) move to the same boundary **in lock-step**, so KV and mamba state stay
consistent.

```python
MIN_SAFE_GDN_EXTEND = 2  # tail==1 is the degenerate single-token (M=1) extend
# Retreat to the previous GDN checkpoint so the recompute is always >=2 tokens (never M=1), moving the
# KV prefix and the COW restore source to the same boundary in lock-step. Root fix: upstream aiter.
if cow_mamba and req is not None and best_value_len > 0 and last_node.mamba_value is not None:
    fill = getattr(req, "full_untruncated_fill_ids", None)
    # empty array("q") (e.g. a PD-disagg decode match before fill_ids is populated) is falsy ->
    # input_len=None -> we cannot determine the tail -> do NOT retreat (else we'd discard real hits).
    input_len = len(fill) if fill else None
    if input_len is None and hasattr(req, "get_fill_ids"):
        gf = req.get_fill_ids()
        input_len = len(gf) if gf else None
    if input_len is not None and (
        input_len - sum(len(v) for v in value[:best_value_len]) < MIN_SAFE_GDN_EXTEND
    ):
        retreat_node, retreat_len = last_node, best_value_len
        while retreat_len > 0:
            retreat_node = retreat_node.parent
            retreat_len -= 1
            if retreat_node is not None and retreat_node.mamba_value is not None:
                break
        if retreat_len > 0 and retreat_node is not None and retreat_node.mamba_value is not None:
            last_node, best_value_len = retreat_node, retreat_len   # tail becomes chunk+1 (>=2)
        else:
            last_node, best_value_len = self.root_node, 0           # no earlier ckpt -> fresh
```

Design notes:
- **Gated on `cow_mamba`**, not on `enable_mamba_extra_buffer` — i.e. the same condition that guards
  the COW state-restore later in this method. Any strategy that performs the mamba COW restore is
  covered (e.g. int8); a strategy that doesn't set `cow_mamba` (e.g. `no_buffer`, which doesn't cache
  mamba state) never enters the guard, so it is inert there. Correctness-safe in all cases.
- **Bails when input length is unknown** (empty `full_untruncated_fill_ids`, e.g. a PD-disaggregated
  decode match before fill_ids is populated). Treating it as 0 would spuriously retreat every decode
  hit and discard real cache hits.
- **Lock-step KV + mamba:** both downstream uses derive from `(last_node, best_value_len)` — the KV
  slice and the COW source — so they can never desync.
- **Backends / scope.** The *corruption* is confirmed only on **AMD gfx950 + aiter** (cause: the aiter
  `ck_moe_stage1` `block_m=16` GEMM, a ROCm-only Composable Kernel). The *trigger* (`tail == 1`) is
  backend-independent — it comes from the generic `extra_buffer` cache — and whether other backends'
  MoE kernels also mishandle the degenerate M=1 shape is **untested** (we do not claim it is safe
  there). The retreat is therefore applied **unconditionally** on the mamba-COW path, not arch-gated:
  it is a routing-only change, always correct on any backend (worst case ≤ `chunk` extra recompute
  tokens on ~1.5% of full re-sends), and avoids a degenerate single-token shape regardless of vendor.
  If maintainers prefer to limit the change to the only confirmed-affected backend, gating the retreat
  to ROCm is a one-line change.

## Accuracy Tests

**Primary gate — deterministic, by construction.** The fix changes only a routing decision (which
checkpoint to restore from), based on lengths. The test asserts the **structural** property: a
`L ≡ 1 mod 64` re-send no longer produces a 1-token extend (`extend_input_len ≥ 2`, or a fresh
`cached=0`), with a `tail = 2` control that must **still hit the cache** (guards against
over-triggering). Verified on current `main` at `L=705` (`705 = 11×64 + 1` → tail=1, was garbage) and
`L=706` (`= 11×64 + 2` → tail=2, correct).

**Why the fix is correct (decisive isolation).** Build `L ∈ {193,194,195,196}` sharing the **same
checkpoint@192** (`cached=192` for all): `tail=1` (193) is corrupt; `tail=2/3/4` (194/195/196) are
correct. So the stored checkpoint is correct — only the single-token recompute is wrong, and for
`tail ≥ 2` the later recomputed tokens re-ground. The clean correctness probe (per Motivation) is the
**first-token argmax**: on tail=1 hits it matched fresh **0/40** against a **40/40** fresh-vs-fresh
floor before the fix; the retreat removes the path.

**No regression.** For `tail ≥ 2`, fresh, and decode the **code path is unchanged by construction**
(the retreat only fires on `tail < 2`), so those cases are unaffected. Corroborating: GSM8K (n=40) =
**0.95** unchanged, radix cache hits 38/40; cache-HIT vs fresh next-token distributions are within the
MoE non-determinism floor (Jensen-Shannon over top-20 logprobs, temp 0).

**Reproduce:**
```bash
# Server — AMD MI350X / gfx950, Qwen3.6-35B-A3B-FP8, TP1:
python -m sglang.launch_server --model-path <Qwen3.6-35B-A3B-FP8> --tp 1 \
    --mamba-scheduler-strategy extra_buffer --page-size 64 --trust-remote-code
# Client — send the 193-token prompt from Motivation twice (temp 0, enable_thinking=false):
#   1st call  -> cache miss -> "Paris"
#   2nd call  -> cache HIT (cached_tokens=192, tail=1) -> garbage   [bug; fixed by this PR]
# Automated: tests/.../test_qwen35_radix_tail1_fidelity_mi35x.py
```

**Scope of what was executed:** the only backend exercised is **AMD MI350X (gfx950 / ROCm / aiter)** —
validated on **Qwen3.6-35B-A3B-FP8, TP1, current `main` (d282bdd8f1)**; the fail/pass split is verified
at `L=705`/`L=706`. A broader tail sweep (tail=1 fails; tail 2..63 and ≥64 pass) was run on an earlier
container image; its results are consistent with the current-main `L=705`/`L=706` verification but the
full sweep was not re-run on current main. The **397B / TP8** lane is not yet executed, and **no
non-AMD backend was tested** (the fix is applied generically — see the Backends / scope note above).

## Speed Tests and Profiling

Negligible and bounded to the rare trigger: `≤ chunk` (≤64) extra recompute tokens only on a full
re-send whose length is `≡ 1 mod chunk` (~1/64 of lengths); a single-node prompt at that length falls
back to a full recompute for that one request. **Zero** effect on `tail ≥ 2` hits or normal serving.
No kernel changes.

## Checklist

- [x] Format with pre-commit (all hooks pass; black reformatted the 3 changed files)
- [x] Unit tests added (`test_tail1_retreat_logic_cpu.py` — CPU retreat-logic;
  `test_qwen35_radix_tail1_fidelity_mi35x.py` — E2E structural gate)
- [x] Accuracy results provided (no-regression; deterministic correctness gate)
- [x] Documentation (n/a — internal cache routing fix)

## Related issues

The kernel root cause is filed upstream as **ROCm/aiter#4032** — the `ck_moe_stage1` `block_m=16` GEMM
returns NaN at M=1 on gfx950 (clean fp8 input → NaN output). Confirmed in the live server: clamping
`block_size_M ≥ 32` in `aiter/fused_moe.py` drives the tail=1 corruption to 0%, identifying the tile
as the cause. The why-inside-CK is still open (it reproduces only under the live server's warmed state,
not in an isolated replay), which is why this sglang-side trigger removal is the verifiable, shippable
change.



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29419886515](https://github.com/sgl-project/sglang/actions/runs/29419886515)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29419886372](https://github.com/sgl-project/sglang/actions/runs/29419886372)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->