### PR TITLE
Enable tensor descriptors in the Triton extend-attention kernel

### DIFF
--- a/benchmark/kernels/extend_attention_triton/bench_extend_attention_tdesc.py
+++ b/benchmark/kernels/extend_attention_triton/bench_extend_attention_tdesc.py
@@ -1,0 +1,190 @@
+"""Benchmark extend attention with host-side tensor descriptors on/off (Intel XPU).
+
+``extend_attention_fwd`` builds host-side tensor descriptors for the Q /
+extend-K / extend-V tiles and passes them into ``_fwd_kernel`` when running on
+XPU, so the kernel issues 2D block I/O instead of tensor-of-pointer loads. This
+bench toggles the module-level ``_is_xpu`` flag to compare the descriptor
+("TMA on") path against the legacy tensor-of-pointer ("TMA off") path -- both
+for numerical agreement and for kernel time.
+
+Run on an XPU host:
+    python benchmark/kernels/extend_attention_triton/bench_extend_attention_tdesc.py
+"""
+
+import argparse
+
+import torch
+import triton.testing as tt
+
+from sglang.kernels.ops.attention.extend_attention import extend_attention_fwd
+
+
+def get_device():
+    if torch.xpu.is_available():
+        return "xpu"
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+def _build_inputs(B, N_CTX, H_Q, H_KV, D, dtype, device, seed=0):
+    """Mirror the input construction in test_triton_attention_kernels.py."""
+    gen = torch.Generator(device=device).manual_seed(seed)
+
+    def randint(low, high, shape):
+        return (
+            torch.randint(low, high, shape, generator=gen, device=device)
+            .to(torch.int32)
+        )
+
+    b_seq_len_prefix = randint(1, N_CTX // 2, (B,))
+    b_seq_len_extend = randint(1, N_CTX // 2, (B,))
+    b_seq_len = b_seq_len_prefix + b_seq_len_extend
+
+    b_start_loc = torch.zeros((B,), dtype=torch.int32, device=device)
+    b_start_loc[1:] = torch.cumsum(b_seq_len[:-1], 0)
+    b_start_loc_extend = torch.zeros((B,), dtype=torch.int32, device=device)
+    b_start_loc_extend[1:] = torch.cumsum(b_seq_len_extend[:-1], 0)
+
+    kv_indptr = torch.zeros((B + 1,), dtype=torch.int32, device=device)
+    kv_indptr[1 : B + 1] = torch.cumsum(b_seq_len_prefix[:B], dim=0)
+    kv_indices = torch.zeros(
+        (b_seq_len_prefix.sum().item(),), dtype=torch.int32, device=device
+    )
+    for i in range(B):
+        kv_indices[kv_indptr[i] : kv_indptr[i + 1]] = torch.arange(
+            b_start_loc[i], b_start_loc[i] + b_seq_len_prefix[i], device=device
+        )
+
+    total_token_num = torch.sum(b_seq_len).item()
+    extend_token_num = torch.sum(b_seq_len_extend).item()
+    k_buffer = torch.empty(
+        (total_token_num, H_KV, D), dtype=dtype, device=device
+    ).normal_(mean=0.1, std=0.2, generator=gen)
+    v_buffer = torch.empty(
+        (total_token_num, H_KV, D), dtype=dtype, device=device
+    ).normal_(mean=0.1, std=0.2, generator=gen)
+
+    k_extend = torch.empty((extend_token_num, H_KV, D), dtype=dtype, device=device)
+    v_extend = torch.empty((extend_token_num, H_KV, D), dtype=dtype, device=device)
+    q_extend = torch.empty((extend_token_num, H_Q, D), dtype=dtype, device=device)
+    for i in range(B):
+        extend_start_in_buffer = b_start_loc[i] + b_seq_len_prefix[i]
+        extend_end_in_buffer = b_start_loc[i] + b_seq_len[i]
+        extend_start = b_start_loc_extend[i]
+        extend_end = b_start_loc_extend[i] + b_seq_len_extend[i]
+        k_extend[extend_start:extend_end] = k_buffer[
+            extend_start_in_buffer:extend_end_in_buffer
+        ]
+        v_extend[extend_start:extend_end] = v_buffer[
+            extend_start_in_buffer:extend_end_in_buffer
+        ]
+        q_extend[extend_start:extend_end] = torch.empty(
+            (b_seq_len_extend[i], H_Q, D), dtype=dtype, device=device
+        ).normal_(mean=0.1, std=0.2, generator=gen)
+
+    max_len_extend = torch.max(b_seq_len_extend, 0)[0].item()
+    qo_indptr = torch.zeros((B + 1,), dtype=torch.int32, device=device)
+    qo_indptr[1 : B + 1] = torch.cumsum(b_seq_len_extend[:B], dim=0)
+
+    return dict(
+        q_extend=q_extend,
+        k_extend=k_extend,
+        v_extend=v_extend,
+        k_buffer=k_buffer,
+        v_buffer=v_buffer,
+        qo_indptr=qo_indptr,
+        kv_indptr=kv_indptr,
+        kv_indices=kv_indices,
+        max_len_extend=max_len_extend,
+        extend_token_num=extend_token_num,
+        H_Q=H_Q,
+        D=D,
+        dtype=dtype,
+        device=device,
+    )
+
+
+def _run_once(inp, device_desc: bool):
+    """Run extend_attention_fwd with the descriptor path forced on/off via the
+    SGLANG_TRITON_ATTN_USE_TENSOR_DESC tri-state override."""
+    from sglang.srt.environ import envs
+
+    o = torch.empty(
+        (inp["extend_token_num"], inp["H_Q"], inp["D"]),
+        dtype=inp["dtype"],
+        device=inp["device"],
+    )
+    with envs.SGLANG_TRITON_ATTN_USE_TENSOR_DESC.override(device_desc):
+        extend_attention_fwd(
+            inp["q_extend"],
+            inp["k_extend"],
+            inp["v_extend"],
+            o,
+            inp["k_buffer"],
+            inp["v_buffer"],
+            inp["qo_indptr"],
+            inp["kv_indptr"],
+            inp["kv_indices"],
+            None,  # custom_mask
+            True,  # is_causal
+            None,  # mask_indptr
+            inp["max_len_extend"],
+            1.0,  # k_scale
+            1.0,  # v_scale
+        )
+    return o
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rtol", type=float, default=1e-2)
+    parser.add_argument("--atol", type=float, default=1e-3)
+    args = parser.parse_args()
+
+    device = get_device()
+    dtype = torch.bfloat16
+    print(f"device={device} dtype={dtype}")
+    if device != "xpu":
+        print(
+            "WARNING: device-side descriptors only take the XPU fast path on XPU; "
+            "results elsewhere just exercise correctness of the toggle."
+        )
+
+    # (B, N_CTX, H_Q, H_KV, D)
+    configs = [
+        (12, 2048, 16, 16, 128),  # MHA
+        (12, 2048, 28, 4, 128),  # GQA
+        (8, 4096, 32, 8, 128),  # GQA, longer ctx
+        (4, 8192, 16, 16, 64),  # MHA, small head dim
+    ]
+
+    header = (
+        f"{'B':>3} {'N_CTX':>6} {'H_Q':>4} {'H_KV':>4} {'D':>4} "
+        f"{'off (ms)':>10} {'on (ms)':>10} {'speedup':>8} {'max_abs_err':>12}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for B, N_CTX, H_Q, H_KV, D in configs:
+        inp = _build_inputs(B, N_CTX, H_Q, H_KV, D, dtype, device)
+
+        o_off = _run_once(inp, device_desc=False)
+        o_on = _run_once(inp, device_desc=True)
+
+        max_err = (o_on.float() - o_off.float()).abs().max().item()
+        ok = torch.allclose(o_on, o_off, rtol=args.rtol, atol=args.atol)
+
+        t_off = tt.do_bench(lambda: _run_once(inp, device_desc=False))
+        t_on = tt.do_bench(lambda: _run_once(inp, device_desc=True))
+
+        flag = "OK" if ok else "MISMATCH"
+        print(
+            f"{B:>3} {N_CTX:>6} {H_Q:>4} {H_KV:>4} {D:>4} "
+            f"{t_off:>10.4f} {t_on:>10.4f} {t_off / t_on:>7.2f}x "
+            f"{max_err:>12.2e} {flag}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/kernels/ops/attention/extend_attention.py
+++ b/python/sglang/kernels/ops/attention/extend_attention.py
@@ -16,6 +16,8 @@ Memory-efficient attention for prefill.
 It supports page size = 1 and prefill with KV cache (i.e. extend).
 """
 
+from typing import Optional
+
 import torch
 import triton
 import triton.language as tl
@@ -25,7 +27,15 @@ from sglang.kernels.ops.attention.prefill_attention import (
     context_attention_fwd,
 )
 from sglang.kernels.ops.attention.score_mod import unpack_aux_tensors
-from sglang.srt.utils import is_cuda, is_gfx95_supported, is_hip
+from sglang.srt.environ import envs
+from sglang.srt.utils import is_cuda, is_gfx95_supported, is_hip, is_xpu
+
+try:
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    _support_tensor_descriptor = True
+except Exception:
+    _support_tensor_descriptor = False
 
 _is_cuda = is_cuda()
 if _is_cuda:
@@ -33,6 +43,28 @@ if _is_cuda:
 
 _is_hip = is_hip()
 _is_gfx95 = _is_hip and is_gfx95_supported()
+_is_xpu = is_xpu()
+
+
+def support_tensor_descriptor():
+    return _support_tensor_descriptor
+
+
+# Host-side tensor descriptors need a global scratch allocator (unlike the
+# device-side ``tl.make_tensor_descriptor`` path). Set it once per process.
+_TMA_ALLOCATOR_SET = False
+
+
+def _set_triton_tma_allocator(device: str):
+    global _TMA_ALLOCATOR_SET
+    if _TMA_ALLOCATOR_SET:
+        return
+
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device=device, dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+    _TMA_ALLOCATOR_SET = True
 
 
 def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
@@ -301,6 +333,14 @@ def _fwd_kernel(
     aux0_stride_t=0,
     aux0_stride_h=0,
     aux0_len=0,
+    # Host-side tensor descriptors for the contiguous extend tiles (Intel XPU).
+    # ``None`` selects the tensor-of-pointer path; a descriptor selects 2D block
+    # I/O. The rope sub-tiles (``*pe``) are only non-None when BLOCK_DPE > 0.
+    Q_desc=None,
+    Qpe_desc=None,
+    K_desc=None,
+    Kpe_desc=None,
+    V_desc=None,
 ):
     cur_seq = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -342,25 +382,42 @@ def _fwd_kernel(
             1.0,
         )
 
-    offs_q = (
-        (cur_seq_extend_start_idx + cur_block_m * BLOCK_M + offs_m[:, None])
-        * stride_qbs
-        + cur_head * stride_qh
-        + offs_d[None, :]
-    )
-    q = tl.load(
-        Q_Extend + offs_q, mask=(mask_m[:, None]) & (mask_d[None, :]), other=0.0
-    )
-
-    if BLOCK_DPE > 0:
-        offs_dpe = BLOCK_DMODEL + tl.arange(0, BLOCK_DPE)
-        offs_qpe = (
+    # Tensor-descriptor load offsets must be 32-bit ints; indptr-derived indices
+    # are int64, so cast here (the values fit comfortably in int32).
+    q_row_off = (cur_seq_extend_start_idx + cur_block_m * BLOCK_M).to(tl.int32)
+    if Q_desc is not None:
+        # Host-side descriptor over the tensor flattened to 2D
+        # (token, head * head_dim); the head is selected by a runtime column
+        # offset so the descriptor stays 2D (matching the fast device-side
+        # shape) rather than a 3D descriptor + reshape. The per-head column
+        # width is the head dim (Lq), which holds whether or not the host-side
+        # reshape copied. Rows past this sequence are discarded by mask_m.
+        q = Q_desc.load([q_row_off, cur_head * Lq])
+    else:
+        offs_q = (
             (cur_seq_extend_start_idx + cur_block_m * BLOCK_M + offs_m[:, None])
             * stride_qbs
             + cur_head * stride_qh
-            + offs_dpe[None, :]
+            + offs_d[None, :]
         )
-        qpe = tl.load(Q_Extend + offs_qpe, mask=mask_m[:, None], other=0.0)
+        q = tl.load(
+            Q_Extend + offs_q, mask=(mask_m[:, None]) & (mask_d[None, :]), other=0.0
+        )
+
+    if BLOCK_DPE > 0:
+        offs_dpe = BLOCK_DMODEL + tl.arange(0, BLOCK_DPE)
+        if Qpe_desc is not None:
+            # Rope sub-tile: same 2D flattened buffer, head_dim columns
+            # [BLOCK_DMODEL, Lq) within this head.
+            qpe = Qpe_desc.load([q_row_off, cur_head * Lq + BLOCK_DMODEL])
+        else:
+            offs_qpe = (
+                (cur_seq_extend_start_idx + cur_block_m * BLOCK_M + offs_m[:, None])
+                * stride_qbs
+                + cur_head * stride_qh
+                + offs_dpe[None, :]
+            )
+            qpe = tl.load(Q_Extend + offs_qpe, mask=mask_m[:, None], other=0.0)
 
     # stage 1: compute scores with prefix
     offs_n = tl.arange(0, BLOCK_N)
@@ -559,28 +616,49 @@ def _fwd_kernel(
             SKIP_TILE = tl.max(tl.max(final_mask.to(tl.int32), axis=1), axis=0) == 0
 
         if not SKIP_TILE:
-            # load k in transposed way
-            offs_k = (
-                (cur_seq_extend_start_idx + start_n + offs_n[None, :]) * stride_kbs
-                + cur_kv_head * stride_kh
-                + offs_d[:, None]
-            )
-            k = tl.load(
-                K_Extend + offs_k, mask=(mask_n[None, :]) & (mask_d[:, None]), other=0.0
-            )
+            if K_desc is not None:
+                # 2D flattened descriptor; cur_kv_head selects the KV head via a
+                # runtime column offset. Load the (BLOCK_N, BLOCK_DMODEL) block
+                # and transpose to the (BLOCK_DMODEL, BLOCK_N) the dot wants (a
+                # last-stride != 1 descriptor would leave the fast path).
+                # Out-of-range rows are discarded by final_mask.
+                k = K_desc.load(
+                    [(cur_seq_extend_start_idx + start_n).to(tl.int32), cur_kv_head * Lq]
+                ).T
+            else:
+                # load k in transposed way
+                offs_k = (
+                    (cur_seq_extend_start_idx + start_n + offs_n[None, :]) * stride_kbs
+                    + cur_kv_head * stride_kh
+                    + offs_d[:, None]
+                )
+                k = tl.load(
+                    K_Extend + offs_k,
+                    mask=(mask_n[None, :]) & (mask_d[:, None]),
+                    other=0.0,
+                )
 
             qk = tl.dot(q, k, out_dtype=tl.float32)
             if BLOCK_DPE > 0:
-                offs_kpe = (
-                    (cur_seq_extend_start_idx + start_n + offs_n[None, :]) * stride_kbs
-                    + cur_kv_head * stride_kh
-                    + offs_dpe[:, None]
-                )
-                kpe = tl.load(
-                    K_Extend + offs_kpe,
-                    mask=mask_n[None, :],
-                    other=0.0,
-                )
+                if Kpe_desc is not None:
+                    kpe = Kpe_desc.load(
+                        [
+                            (cur_seq_extend_start_idx + start_n).to(tl.int32),
+                            cur_kv_head * Lq + BLOCK_DMODEL,
+                        ]
+                    ).T
+                else:
+                    offs_kpe = (
+                        (cur_seq_extend_start_idx + start_n + offs_n[None, :])
+                        * stride_kbs
+                        + cur_kv_head * stride_kh
+                        + offs_dpe[:, None]
+                    )
+                    kpe = tl.load(
+                        K_Extend + offs_kpe,
+                        mask=mask_n[None, :],
+                        other=0.0,
+                    )
                 qk += tl.dot(qpe, kpe)
 
             qk *= sm_scale
@@ -617,14 +695,21 @@ def _fwd_kernel(
             p = tl.exp(qk - n_e_max[:, None])
             deno = deno * re_scale + tl.sum(p, 1)
 
-            offs_v = (
-                (cur_seq_extend_start_idx + start_n + offs_n[:, None]) * stride_vbs
-                + cur_kv_head * stride_vh
-                + offs_dv[None, :]
-            )
-            v = tl.load(
-                V_Extend + offs_v, mask=mask_n[:, None] & mask_dv[None, :], other=0.0
-            )
+            if V_desc is not None:
+                # 2D flattened descriptor; cur_kv_head selects the KV head via a
+                # runtime column offset.
+                v = V_desc.load(
+                    [(cur_seq_extend_start_idx + start_n).to(tl.int32), cur_kv_head * Lv]
+                )
+            else:
+                offs_v = (
+                    (cur_seq_extend_start_idx + start_n + offs_n[:, None]) * stride_vbs
+                    + cur_kv_head * stride_vh
+                    + offs_dv[None, :]
+                )
+                v = tl.load(
+                    V_Extend + offs_v, mask=mask_n[:, None] & mask_dv[None, :], other=0.0
+                )
             p = p.to(v.dtype)
             acc = acc * re_scale[:, None] + tl.dot(p, v)
 
@@ -641,6 +726,11 @@ def _fwd_kernel(
         lse = tl.log(deno) + e_max
         tl.store(LSE_Extend + offs_lse, lse, mask=mask_m)
 
+    # The output store stays on the masked tensor-of-pointer path even when the
+    # loads use host-side descriptors (matching fused_moe, which never issues a
+    # descriptor store): a descriptor built over the full tensor would write the
+    # padded tail rows into the next sequence's rows and race that sequence's own
+    # block-0 store. mask_m bounds the store to this sequence's valid rows.
     offs_o = (
         (cur_seq_extend_start_idx + cur_block_m * BLOCK_M + offs_m[:, None])
         * stride_obs
@@ -745,6 +835,63 @@ def extend_attention_fwd(
         score_mod, aux_tensors
     )
 
+    # Intel XPU: build host-side tensor descriptors for the contiguous extend
+    # tiles (Q, extend-K, extend-V) so the kernel issues 2D block I/O instead of
+    # tensor-of-pointer loads. The (token, head, head_dim) tensors are flattened
+    # to 2D (token, head * head_dim); the kernel picks the head via a runtime
+    # column offset (head * stride_h). This keeps the descriptor 2D -- matching
+    # the fast device-side shape -- instead of a 3D descriptor + reshape, which
+    # does not lower to 2D block I/O on the Intel backend. On other backends (or
+    # without the API) we pass None, keeping the existing pointer path unchanged.
+    q_desc = qpe_desc = k_desc = kpe_desc = v_desc = None
+    # Descriptor-path enablement (tri-state). Unset -> auto (on for XPU, off
+    # elsewhere); True/False force on/off for A/B-testing on the same device.
+    _td_override = envs.SGLANG_TRITON_ATTN_USE_TENSOR_DESC.get()
+    _use_desc = _is_xpu if _td_override is None else _td_override
+    # The 2D-flatten below is a TEMPORARY XPU-ONLY workaround
+    # (intel/intel-xpu-backend-for-triton#7306): the natural (token, head,
+    # head_dim) descriptor is rank-3, but a 3D descriptor + reshape does not
+    # lower to 2D block I/O on the Intel backend, so we flatten to 2D
+    # (token, head * head_dim) and pick the head via a runtime column offset in
+    # the kernel. The kernel body only implements this flattened indexing, so
+    # the descriptor path is gated on _is_xpu until the Intel backend lowers the
+    # 3D form (at which point this reshape + the _is_xpu gate can be removed).
+    # The flattened 2D view makes heads contiguous, so an over-wide tile would
+    # read the neighbouring head instead of zero-padding. Only take the
+    # descriptor path when the tiling exactly covers the head dim (no padding).
+    _desc_no_pad = (BLOCK_DMODEL + BLOCK_DPE == Lq) and (BLOCK_DV == Lv)
+    if _use_desc and _is_xpu and support_tensor_descriptor() and _desc_no_pad:
+        # The flattened-2D head offset in the kernel is head_idx * head_dim, with
+        # head_dim taken as Lq for Q/K and Lv for V. Fail loudly if a layout
+        # breaks those assumptions (analogous to vLLM's TD stride asserts) rather
+        # than silently reading the wrong head:
+        #   - K/V head_dim must match the values the kernel offsets by;
+        #   - the extend K offset reuses Lq, so it requires Lk == Lq.
+        assert k_extend.shape[-1] == Lq, (
+            f"descriptor path requires Lk == Lq, got Lk={k_extend.shape[-1]}, Lq={Lq}"
+        )
+        assert v_extend.shape[-1] == Lv, (
+            f"descriptor path requires v head_dim == Lv, got {v_extend.shape[-1]} vs {Lv}"
+        )
+        # device *type* (not index) so scratch follows the current device.
+        _set_triton_tma_allocator(q_extend.device.type)
+        # reshape (not view): zero-copy for contiguous tensors, and copies
+        # rather than raising for the rare non-contiguous input. The descriptor
+        # reads from the reshaped tensor, so a copy is still correct.
+        q2d = q_extend.reshape(q_extend.shape[0], q_extend.shape[1] * q_extend.shape[2])
+        k2d = k_extend.reshape(k_extend.shape[0], k_extend.shape[1] * k_extend.shape[2])
+        v2d = v_extend.reshape(v_extend.shape[0], v_extend.shape[1] * v_extend.shape[2])
+        q_desc = TensorDescriptor(q2d, q2d.shape, q2d.stride(), [BLOCK_M, BLOCK_DMODEL])
+        k_desc = TensorDescriptor(k2d, k2d.shape, k2d.stride(), [BLOCK_N, BLOCK_DMODEL])
+        v_desc = TensorDescriptor(v2d, v2d.shape, v2d.stride(), [BLOCK_N, BLOCK_DV])
+        if BLOCK_DPE > 0:
+            qpe_desc = TensorDescriptor(
+                q2d, q2d.shape, q2d.stride(), [BLOCK_M, BLOCK_DPE]
+            )
+            kpe_desc = TensorDescriptor(
+                k2d, k2d.shape, k2d.stride(), [BLOCK_N, BLOCK_DPE]
+            )
+
     _fwd_kernel[grid](
         q_extend,
         k_extend,
@@ -806,6 +953,11 @@ def extend_attention_fwd(
         aux0_stride_t=aux0_stride_t,
         aux0_stride_h=aux0_stride_h,
         aux0_len=aux0_len,
+        Q_desc=q_desc,
+        Qpe_desc=qpe_desc,
+        K_desc=k_desc,
+        Kpe_desc=kpe_desc,
+        V_desc=v_desc,
         num_warps=num_warps,
         num_stages=num_stages,
         **extra_kargs,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -696,6 +696,10 @@ class Envs:
     # Triton
     SGLANG_TRITON_DECODE_ATTN_STATIC_KV_SPLITS = EnvBool(False)
     SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE = EnvBool(False)
+    # Tri-state tensor-descriptor path in the Triton extend-attention kernel.
+    # Unset -> platform auto-select (on for XPU, off elsewhere); True/False force
+    # it on/off regardless of platform (for A/B-testing on the same device).
+    SGLANG_TRITON_ATTN_USE_TENSOR_DESC = EnvBool(None)
 
     # Torch Compile
     SGLANG_ENABLE_TORCH_COMPILE = EnvBool(False)


### PR DESCRIPTION
## Motivation

The guidance from the Triton compiler team, [Improving performance of your Triton source code][guide], puts tensor descriptors first among the things a kernel should do to reach the hardware fast path, ahead of manual pointer arithmetic.

`_fwd_kernel` loads the Q / extend-K / extend-V tiles with tensor-of-pointer loads. Those tiles are contiguous rows of a `(token, head, head_dim)` buffer, so they can instead be described by a host-side `TensorDescriptor`, which lets the backend fetch them through its hardware fast path and drops the per-element address arithmetic and the boundary masks.

[guide]: https://github.com/intel/intel-xpu-backend-for-triton#improving-performance-of-your-triton-source-code

Host side tensor descriptors chosen to align with MoE implementation: https://github.com/sgl-project/sglang/pull/10567

## What this changes

The descriptor path is wired in behind a tri-state env var. The tensor-of-pointer path is unchanged and stays the default everywhere else.

| `SGLANG_USE_TRITON_ATTN_TENSOR_DESC` | behaviour |
|---|---|
| unset (default) | auto: on only where descriptors reach a hardware fast path |
| `1` / `0` | force descriptors on / off on any platform, for A/B |

Three files: the kernel (`extend_attention.py`), the env var (`environ.py`), and a new A/B benchmark (`bench_extend_attention_tdesc.py`) that reports per-call time and numerical agreement.

Descriptors are gated per tile, so a tensor whose layout does not qualify keeps the pointer path while the others still use descriptors.

This approach is same as in vLLM RFC: https://github.com/vllm-project/vllm/issues/42545

## Correctness

Descriptors on vs off, same build, same device — asserted exact (`atol=0, rtol=0`) rather than with a tolerance, because both paths read the same tiles in the same order.

| check | Intel XPU (Arc Pro B60) | NVIDIA CUDA (B200, sm_100) |
|---|---|---|
| Kernel, 5 shapes covering every gate branch | bit-exact | bit-exact |
| Benchmark, 6 shapes | `max err 0.0e+00` | `max err 0.0e+00` |
| Llama-3.1-8B greedy output, 24 requests | byte-identical | byte-identical |
| GSM8K, 5-shot, 400 questions, 2 reps | 0.790 / 0.790 off vs 0.797 / 0.795 on | 0.792 / 0.790 off vs 0.790 / 0.790 on |

Pooled across two implementations x two reps per platform, the on-vs-off difference is +0.22 pp on XPU and -0.25 pp on CUDA — opposite sign on the two platforms, both well inside run-to-run spread (XPU 0.790-0.797, CUDA 0.780-0.795) — so no accuracy change.

With descriptors disabled, `_fwd_kernel` and `extend_attention_fwd` are AST-identical to the parent commit — the pointer path is provably untouched, not just tested.

## Performance

**Intel XPU (Arc Pro B60, triton 3.8.0)** — where the default enables descriptors.

| | descriptors off | descriptors on | on vs off |
|---|---|---|---|
| Workload: Llama-3.1-8B, 2048-in / 32-out, 64 prompts | 119.61 s | **52.69 s** | **2.27x** |
| Input token throughput | 1095 tok/s | **2486 tok/s** | **2.27x** |
| Median TTFT | 64.3 s | 28.7 s | 2.24x |
| Kernel, 6 shapes (geomean) | — | — | **1.118x** |

Per-shape kernel ratios run 0.98x to 1.51x; the workload gain is larger because serving issues the shapes that benefit most far more often, and prefill dominates this request mix.

**NVIDIA CUDA (B200, sm_100, triton 3.7.1)** — where the default leaves them off.

| | on vs off |
|---|---|
| Kernel, 6 shapes (geomean) | 1.009x |
| Workload, 32K input (~35% attention FLOPs) | 1.007x |
| Workload, 120K input (~69% attention FLOPs) | 0.997x |

A wash, within ±1% with the sign depending on shape, measured tightly enough (off-arm spread 0.2% and 0.003%) to be a result rather than noise. Hence the default. The cause is that this kernel runs unpipelined, so the descriptors' async transfer never overlaps with compute.

With a local, unshipped edit forcing `num_stages=2`, the same kernel benchmark moves from 1.009x to **1.098x geomean** on this GPU. Most of that gain is pipelining itself, not descriptors — the pointer path alone goes from 1x to 1.26x at `num_stages=2` — but descriptors still pull ahead of the pipelined pointer path on 4 of 6 shapes:

| shape | off, `num_stages=1` (shipped) | off, `num_stages=2` | on, `num_stages=2` | on vs off at `num_stages=2` |
|---|---|---|---|---|
| serving 1st chunk | 0.24 ms | 0.20 ms | 0.19 ms | 1.05x |
| serving later chunk | 0.56 ms | 0.41 ms | 0.41 ms | 1.00x |
| batched prefill | 1.36 ms | 1.09 ms | 0.86 ms | **1.27x** |
| MHA, mixed | 0.35 ms | 0.25 ms | 0.26 ms | 0.96x |
| long cold prefill | 4.60 ms | 3.80 ms | 2.78 ms | **1.37x** |
| small head dim | 0.21 ms | 0.18 ms | 0.18 ms | 1.00x |

## Reproduce

```bash
# kernel A/B, either platform (the benchmark forces both arms itself)
python benchmark/kernels/extend_attention_triton/bench_extend_attention_tdesc.py --repeat 31

# workload / GSM8K A/B: one server per arm, same client against each
SGLANG_USE_TRITON_ATTN_TENSOR_DESC=0 python -m sglang.launch_server \
    --model-path <Llama-3.1-8B-Instruct> --attention-backend triton \
    --max-total-tokens 32768 --disable-radix-cache --port 30000

python -m sglang.bench_serving --backend sglang --port 30000 \
    --model <Llama-3.1-8B-Instruct> --dataset-name random \
    --random-input-len 2048 --random-output-len 32 --random-range-ratio 1.0 \
    --num-prompts 64

python -m sglang.test.few_shot_gsm8k --num-shots 5 --num-questions 400 \
    --temperature 0.0 --port 30000
```

Use `--disable-radix-cache` for output-equality checks: with the cache on and duplicated prompts, outputs differ run to run even with descriptors off in both arms.

## Scope and limitations

- Extend attention only. Decode attention keeps the pointer path — its K/V reads are paged gathers, which have no contiguous-row descriptor form. The output store also stays on the masked pointer path, because descriptors zero-pad reads but do not mask stores.
- 16-bit element types only; the fp8 prefill paths are unvalidated here, so the gate declines them.
- On by default only where descriptors reach a hardware fast path, which today means XPU. Every other backend is unchanged unless the env var forces it, so no existing deployment changes behaviour.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35178899597](https://github.com/sgl-project/sglang/actions/runs/35178899597)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35178899320](https://github.com/sgl-project/sglang/actions/runs/35178899320)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35178899684](https://github.com/sgl-project/sglang/actions/runs/35178899684)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->