### PR TITLE
Add Qwen3 MoE tests for PP compatibility with CP and DP

### DIFF
--- a/test/registered/pp/test_pp_parallel_compat.py
+++ b/test/registered/pp/test_pp_parallel_compat.py
@@ -68,8 +68,6 @@ class _Qwen3MoePPCompatMixin:
             top_p=0.95,
             top_k=20,
             base_url=self.base_url,
-            host="http://127.0.0.1",
-            port=int(self.base_url.split(":")[-1]),
         )
         metrics = run_eval(args)
         print(f"{metrics=}")

--- a/test/registered/pp/test_pp_parallel_compat.py
+++ b/test/registered/pp/test_pp_parallel_compat.py
@@ -1,0 +1,113 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    kill_process_tree,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=1000, stage="extra-b", runner_config="4-gpu-h100")
+
+QWEN3_MOE_MODEL_PATH = "Qwen/Qwen3-30B-A3B-FP8"
+
+GSM8K_BASELINE_ACCURACY = 0.93
+
+
+class _Qwen3MoePPCompatMixin:
+    """Launch a Qwen3 MoE server combining PP with another parallel strategy and
+    check GSM8K accuracy. Concrete subclasses set ``parallel_args`` (and
+    optionally ``server_env``); this mixin is not a TestCase so it is never
+    collected on its own.
+    """
+
+    model = QWEN3_MOE_MODEL_PATH
+    parallel_args: list = []
+    server_env = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                *cls.parallel_args,
+                "--cuda-graph-max-bs-decode",
+                "32",
+                "--max-running-requests",
+                "32",
+                "--trust-remote-code",
+                "--disable-piecewise-cuda-graph",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true, "num_threads": 64}',
+            ],
+            env=cls.server_env,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            model=self.model,
+            eval_name="gsm8k",
+            num_shots=5,
+            num_examples=200,
+            max_tokens=16000,
+            num_threads=128,
+            repeat=1,
+            temperature=0.6,
+            top_p=0.95,
+            top_k=20,
+            base_url=self.base_url,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreaterEqual(metrics["score"], GSM8K_BASELINE_ACCURACY)
+
+
+class TestQwen3MoePPxCP(_Qwen3MoePPCompatMixin, CustomTestCase):
+    """PP x CP: pp_size=2 x attn_cp_size=2 (tp_size=2, moe_dp_size=1)."""
+
+    parallel_args = [
+        "--tp-size",
+        "2",
+        "--pp-size",
+        "2",
+        "--ep-size",
+        "2",
+        "--attn-cp-size",
+        "2",
+        "--enable-prefill-cp",
+        "--cp-strategy",
+        "zigzag",
+    ]
+    server_env = {"SGLANG_ENABLE_CP_V2": "1"}
+
+
+class TestQwen3MoePPxDP(_Qwen3MoePPCompatMixin, CustomTestCase):
+    """PP x DP: pp_size=2 x dp_size=2 attention (tp_size=2)."""
+
+    parallel_args = [
+        "--tp-size",
+        "2",
+        "--pp-size",
+        "2",
+        "--dp-size",
+        "2",
+        "--enable-dp-attention",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/pp/test_pp_parallel_compat.py
+++ b/test/registered/pp/test_pp_parallel_compat.py
@@ -11,7 +11,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=1000, stage="extra-b", runner_config="4-gpu-h100")
+register_cuda_ci(est_time=600, stage="extra-b", runner_config="4-gpu-h100")
 
 QWEN3_MOE_MODEL_PATH = "Qwen/Qwen3-30B-A3B-FP8"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

We have CI coverage for Pipeline Parallelism (PP) on its own and for Context Parallelism (CP) / DP attention on their own, but no test that exercises PP **composed with** another parallel strategy. Regressions in the cross-strategy
plumbing (e.g. the PP proxy layout interacting with CP-v2 metadata, or with the DP-attention scatter/gather) would currently slip through.

This PR adds a small GSM8K accuracy gate that pins two PP-combined layouts for Qwen3 MoE, so a future change that breaks PP×CP or PP×DP fails CI instead of silently corrupting outputs.

## Modifications

- New file `test/registered/pp/test_pp_parallel_compat.py`, registered to the `extra-b` / `4-gpu-h100` CUDA suite.
- A shared `_Qwen3MoePPCompatMixin` launches a `Qwen/Qwen3-30B-A3B-FP8` server and runs the GSM8K eval (200 examples, thinking-mode sampling `temperature=0.6 / top_p=0.95 / top_k=20`), gating at
  `GSM8K_BASELINE_ACCURACY = 0.93`. The mixin is intentionally not a `TestCase`, so it is never collected on its own.
- Two concrete cases, each using `tp_size × pp_size = 4` GPUs:
  - **`TestQwen3MoePPxCP`** — `pp_size=2 × attn_cp_size=2` (`tp_size=2`,
    `ep_size=2`, zigzag prefill CP via the CP-v2 path, `SGLANG_ENABLE_CP_V2=1`).
  - **`TestQwen3MoePPxDP`** — `pp_size=2 × dp_size=2` DP attention (`tp_size=2`).

The threshold, sampling config, and server flags mirror the existing `test/registered/cp/test_gqa_preill_cp.py` template so the gate stays consistent with the already-validated CP tests.


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28366754495](https://github.com/sgl-project/sglang/actions/runs/28366754495)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28366754374](https://github.com/sgl-project/sglang/actions/runs/28366754374)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->