### PR TITLE
[NPU] Support mlaprolog, fp8 KVcache(only MLA) and ChunkPrefill for A5(950PR/DT) NPU

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -28,7 +28,11 @@ from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.spec_info import SpecInput
-from sglang.srt.utils import get_bool_env_var, get_current_device_stream_fast
+from sglang.srt.utils import (
+    get_bool_env_var,
+    get_current_device_stream_fast,
+    is_npu_before_atlas_a5,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
@@ -40,13 +44,17 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 FULL_ATTENTION_WINDOW = 2147483647
+_is_npu_before_atlas_a5 = is_npu_before_atlas_a5()
 
 
 def _reshape_kv_for_fia_nz(
     tensor: torch.Tensor, num_heads: int, head_dim: int, page_size: int
 ) -> torch.Tensor:
     """Reshapes a tensor for FIA NZ format."""
-    return tensor.view(-1, 1, num_heads * head_dim // 16, page_size, 16)
+    nz_last_dim = 32 if tensor.dtype == torch.float8_e4m3fn else 16
+    return tensor.view(
+        -1, 1, num_heads * head_dim // nz_last_dim, page_size, nz_last_dim
+    )
 
 
 @dataclass
@@ -76,6 +84,9 @@ class ForwardMetadata:
     # prefix cache
     prefix_lens: Optional[torch.Tensor] = None
     flatten_prefix_block_tables: Optional[torch.Tensor] = None
+    prefix_block_tables: Optional[torch.Tensor] = None
+    prefix_seq_lens_npu: Optional[torch.Tensor] = None
+    prefix_seq_starts: Optional[torch.Tensor] = None
 
 
 class AscendAttnMaskBuilder:
@@ -280,6 +291,7 @@ class AscendAttnBackend(AttentionBackend):
         super().__init__()
         self.forward_metadata = None
         self.device = model_runner.device
+        self.fp8_kv_scale = torch.ones(1, dtype=torch.float32, device=self.device)
         self.speculative_step_id = speculative_step_id
         self.speculative_step_offset_npu = torch.tensor(
             speculative_step_id + 1, device="npu"
@@ -318,6 +330,7 @@ class AscendAttnBackend(AttentionBackend):
         self.graph_mode = False
         self.use_fa = get_bool_env_var("ASCEND_USE_FA", "False")
         self.use_fia = get_bool_env_var("ASCEND_USE_FIA", "False")
+        self.kv_cache_dtype = model_runner.server_args.kv_cache_dtype
         self.enable_torch_compile = model_runner.server_args.enable_torch_compile
         self.speculative_num_draft_tokens = (
             model_runner.server_args.speculative_num_draft_tokens
@@ -364,6 +377,157 @@ class AscendAttnBackend(AttentionBackend):
             self.dllm_block_size = self.dllm_config.block_size
 
         self.attn_cp_size = model_runner.attn_cp_size
+
+    def _resolve_fp8_kv_scale(
+        self, fp8_kv_scale: Optional[torch.Tensor], device: torch.device
+    ) -> torch.Tensor:
+        if fp8_kv_scale is None:
+            return self.fp8_kv_scale.to(device=device, dtype=torch.float32)
+        return fp8_kv_scale.reshape(-1).to(device=device, dtype=torch.float32)
+
+    def _load_prefix_kv_cache_A5(
+        self,
+        forward_batch: ForwardBatch,
+        layer: RadixAttention,
+        fp8_kv_scale: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        ckv_cache, k_rope_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
+            layer.layer_id
+        )
+        total_prefix_tokens = int(self.forward_metadata.prefix_lens.sum().item())
+        kv_cached = torch.empty(
+            (
+                total_prefix_tokens,
+                ckv_cache.shape[-2],
+                ckv_cache.shape[-1],
+            ),
+            dtype=ckv_cache.dtype,
+            device=ckv_cache.device,
+        )
+        k_rope_cached = torch.empty(
+            (
+                total_prefix_tokens,
+                k_rope_cache.shape[-2],
+                k_rope_cache.shape[-1],
+            ),
+            dtype=k_rope_cache.dtype,
+            device=k_rope_cache.device,
+        )
+        torch_npu.npu_gather_pa_kv_cache(
+            ckv_cache,
+            k_rope_cache,
+            self.forward_metadata.prefix_block_tables,
+            self.forward_metadata.prefix_seq_lens_npu.contiguous(),
+            seq_offset=self.forward_metadata.prefix_seq_starts,
+            key=kv_cached,
+            value=k_rope_cached,
+        )
+        if self.kv_cache_dtype == "fp8_e4m3":
+            kv_scale = self._resolve_fp8_kv_scale(fp8_kv_scale, kv_cached.device)
+            kv_cached = torch.mul(kv_cached.to(kv_scale.dtype), kv_scale).to(
+                torch.bfloat16
+            )
+        return kv_cached, k_rope_cached
+
+    def forward_extend_prefix_A5(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layer: RadixAttention,
+        fp8_kv_scale: Optional[torch.Tensor] = None,
+    ):
+        num_token_padding = q.shape[0]
+        q, k, v = [
+            data[: forward_batch.num_token_non_padded_cpu] for data in [q, k, v]
+        ]
+        q_nope, q_rope = q.split([layer.v_head_dim, self.qk_rope_head_dim], dim=-1)
+        k_nope, k_rope = k.split([layer.v_head_dim, self.qk_rope_head_dim], dim=-1)
+        num_tokens = q_nope.size(0)
+        attn_output = torch.empty(
+            num_tokens,
+            layer.tp_q_head_num,
+            layer.v_head_dim,
+            dtype=q_nope.dtype,
+            device=q_nope.device,
+        )
+        attn_lse = torch.empty(
+            layer.tp_q_head_num,
+            num_tokens,
+            dtype=torch.float32,
+            device=q_nope.device,
+        )
+
+        actual_seq_lengths = np.array(forward_batch.extend_seq_lens_cpu).cumsum().tolist()
+
+        common_kwargs = {
+            "query_rope": q_rope,
+            "key_rope": k_rope,
+            "num_heads": layer.tp_q_head_num,
+            "num_key_value_heads": layer.tp_k_head_num,
+            "input_layout": "TND",
+            "atten_mask": self.fia_mask,
+            "sparse_mode": 3,
+            "scale": layer.scaling,
+            "antiquant_mode": 0,
+            "antiquant_scale": None,
+            "block_table": None,
+            "block_size": 0,
+            "softmax_lse_flag": True,
+            "actual_seq_lengths": actual_seq_lengths,
+            "actual_seq_lengths_kv": actual_seq_lengths,
+        }
+        attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(
+            q_nope, k_nope, v, **common_kwargs
+        )
+        attn_lse = attn_lse.to(torch.float32)
+        out_list = [
+            attn_output.reshape(num_tokens * layer.tp_q_head_num, layer.v_head_dim)
+        ]
+        lse_list = [attn_lse.reshape(num_tokens * layer.tp_q_head_num)]
+
+        kv_cached, k_rope_cached = self._load_prefix_kv_cache_A5(
+            forward_batch, layer, fp8_kv_scale=fp8_kv_scale
+        )
+
+        assert layer.kv_b_proj is not None
+        kv = layer.kv_b_proj(kv_cached)[0].view(
+            -1, layer.tp_k_head_num, self.qk_nope_head_dim + layer.v_head_dim
+        )
+        k_nope, v = kv.split([self.qk_nope_head_dim, layer.v_head_dim], dim=-1)
+
+        k_rope = k_rope_cached.expand(-1, layer.tp_k_head_num, -1)
+
+        actual_seq_lengths_kv = np.array(self.forward_metadata.prefix_lens).cumsum().tolist()
+        common_kwargs["actual_seq_lengths_kv"] = actual_seq_lengths_kv
+        common_kwargs["key_rope"] = k_rope
+        prefix_attn_output, prefix_attn_lse = torch_npu.npu_fused_infer_attention_score(
+            q_nope, k_nope, v, **common_kwargs
+        )
+        prefix_attn_lse = prefix_attn_lse.to(torch.float32)
+
+        out_list.append(
+            prefix_attn_output.reshape(
+                num_tokens * layer.tp_q_head_num, layer.v_head_dim
+            )
+        )
+        lse_list.append(prefix_attn_lse.reshape(num_tokens * layer.tp_q_head_num))
+        output, _ = torch_npu.npu_attention_update(tuple(lse_list), tuple(out_list), 0)
+        output = output.reshape(-1, layer.tp_q_head_num, layer.v_head_dim)
+
+        if num_token_padding != forward_batch.num_token_non_padded_cpu:
+            output = torch.cat(
+                [
+                    output,
+                    output.new_zeros(
+                        num_token_padding - output.shape[0],
+                        *output.shape[1:],
+                    ),
+                ],
+                dim=0,
+            )
+        return output
 
     def _is_swa_layer(self, layer: RadixAttention) -> bool:
         return (
@@ -488,6 +652,9 @@ class AscendAttnBackend(AttentionBackend):
                 "cpu"
             )
             seq_prefix_lens = self.forward_metadata.prefix_lens.tolist()
+            prefix_block_tables = []
+            prefix_seq_starts = []
+            prefix_token_offset = 0
             self.forward_metadata.flatten_prefix_block_tables = torch.empty(
                 0, dtype=torch.int32
             ).to(self.device)
@@ -498,12 +665,34 @@ class AscendAttnBackend(AttentionBackend):
                 req_prefix_block_tables = (
                     req_indices[:seq_len][:: self.page_size] // self.page_size
                 )
+                prefix_block_tables.append(req_prefix_block_tables.to(torch.int32))
+                prefix_seq_starts.append(prefix_token_offset)
+                prefix_token_offset += seq_len
                 self.forward_metadata.flatten_prefix_block_tables = torch.cat(
                     (
                         self.forward_metadata.flatten_prefix_block_tables,
                         torch.flatten(req_prefix_block_tables),
                     )
                 )
+            max_prefix_pages = max(
+                (table.numel() for table in prefix_block_tables), default=0
+            )
+            self.forward_metadata.prefix_block_tables = torch.zeros(
+                (len(prefix_block_tables), max_prefix_pages),
+                dtype=torch.int32,
+                device=self.device,
+            )
+            for i, table in enumerate(prefix_block_tables):
+                if table.numel() > 0:
+                    self.forward_metadata.prefix_block_tables[i, : table.numel()] = (
+                        table.to(device=self.device, dtype=torch.int32)
+                    )
+            self.forward_metadata.prefix_seq_lens_npu = (
+                self.forward_metadata.prefix_lens.to(device=self.device).int()
+            )
+            self.forward_metadata.prefix_seq_starts = torch.tensor(
+                prefix_seq_starts, dtype=torch.int64, device=self.device
+            )
 
         if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
             self.forward_metadata.swa_out_cache_loc = (
@@ -1088,6 +1277,8 @@ class AscendAttnBackend(AttentionBackend):
         topk_indices: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         slopes: Optional[torch.Tensor] = None,
+        dequant_scale_q_nope: Optional[torch.Tensor] = None,
+        fp8_kv_scale: Optional[torch.Tensor] = None,
     ):
         if is_mla_preprocess_enabled() and self.use_mla:
             # MLAPO and MLAPROLOG do save kv_cache
@@ -1129,6 +1320,8 @@ class AscendAttnBackend(AttentionBackend):
                 q_rope=q_rope,
                 k_rope=k_rope,
                 sinks=sinks,
+                dequant_scale_q_nope=dequant_scale_q_nope,
+                fp8_kv_scale=fp8_kv_scale,
             )
 
         if not self.use_mla:
@@ -1601,6 +1794,25 @@ class AscendAttnBackend(AttentionBackend):
                     -1, layer.tp_q_head_num * layer.v_head_dim
                 )
             else:
+                if not _is_npu_before_atlas_a5:
+                    # This path handles chunked prefill on A5 ascend NPU (950PR/DT).
+                    # We do not reuse the older ATB-based path here because ATB operators are
+                    # deprecated on A5 and should not be the backend for this prefix-cache flow.
+                    # Therefore we keep the historical two-pass structure here:
+                    # 1. run attention for the current chunk;
+                    # 2. load prefix KV from paged cache and manually dequantize FP8 KV with the
+                    #    runtime kv scale before kv_b_proj.
+                    # The manual dequantization is required because the prefix KV must be materialized
+                    # as dense BF16 tensors for kv_b_proj and the follow-up V1 attention path. and by the current
+                    # aclnnFusedInferAttentionScoreV5 document, MLA prefill does not support quantized modes.
+                    return self.forward_extend_prefix_A5(
+                        q,
+                        k,
+                        v,
+                        forward_batch,
+                        layer,
+                        fp8_kv_scale=fp8_kv_scale,
+                    )
                 num_token_padding = q.shape[0]
                 q, k, v = [
                     data[: forward_batch.num_token_non_padded_cpu] for data in [q, k, v]
@@ -1885,6 +2097,8 @@ class AscendAttnBackend(AttentionBackend):
         q_rope: Optional[torch.Tensor] = None,
         k_rope: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
+        dequant_scale_q_nope: Optional[torch.Tensor] = None,
+        fp8_kv_scale: Optional[torch.Tensor] = None,
     ):
         if save_kv_cache:
             if self.use_mla:
@@ -2043,6 +2257,59 @@ class AscendAttnBackend(AttentionBackend):
                 self.speculative_num_draft_tokens,
             )
 
+            if self.kv_cache_dtype == "fp8_e4m3":
+                dequant_scale_q_nope = dequant_scale_q_nope.squeeze(2)
+                q_fp8, dequant_scale_query = q_nope, dequant_scale_q_nope
+                kv_scale = self._resolve_fp8_kv_scale(fp8_kv_scale, q_nope.device)
+                attn_output = torch.empty_like(
+                    q_nope, dtype=torch.bfloat16, device=q_nope.device
+                )
+                softmax_lse = torch.empty(
+                    1, dtype=torch.bfloat16, device=q_nope.device
+                )
+                torch_npu.npu_fused_infer_attention_score_v2.out(
+                    q_fp8,
+                    c_kv_cache,
+                    c_kv_cache,
+                    query_rope=q_rope,
+                    key_rope=k_rope_cache,
+                    num_query_heads=layer.tp_q_head_num,
+                    num_key_value_heads=layer.tp_k_head_num,
+                    input_layout="TND",
+                    softmax_scale=layer.scaling,
+                    block_table=self.forward_metadata.block_tables,
+                    block_size=self.page_size,
+                    actual_seq_qlen=actual_seq_lengths,
+                    actual_seq_kvlen=actual_seq_lengths_kv,
+                    sparse_mode=3,
+                    atten_mask=self.mtp_mask,
+                    dequant_scale_query=dequant_scale_query,
+                    dequant_scale_key=kv_scale,
+                    dequant_scale_value=kv_scale,
+                    key_quant_mode=0,
+                    value_quant_mode=0,
+                    query_quant_mode=3,
+                    out=[attn_output, softmax_lse],
+                )
+                attn_output = attn_output.view(
+                    -1, layer.tp_q_head_num * layer.v_head_dim
+                )
+                if (
+                    not self.graph_mode
+                    and forward_batch.num_token_non_padded_cpu != num_token_padding
+                ):
+                    attn_output = torch.cat(
+                        [
+                            attn_output,
+                            attn_output.new_zeros(
+                                num_token_padding - attn_output.shape[0],
+                                *attn_output.shape[1:],
+                            ),
+                        ],
+                        dim=0,
+                    )
+                return attn_output
+
             if (
                 self.q_head_num_padding is not None
                 and self.q_head_num_padding > self.tp_q_head_num
@@ -2147,6 +2414,8 @@ class AscendAttnBackend(AttentionBackend):
         q_rope: Optional[torch.Tensor] = None,
         k_rope: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
+        dequant_scale_q_nope: Optional[torch.Tensor] = None,
+        fp8_kv_scale: Optional[torch.Tensor] = None,
     ):
         if save_kv_cache:
             if self.use_mla:
@@ -2360,6 +2629,42 @@ class AscendAttnBackend(AttentionBackend):
                     self.forward_metadata.seq_lens_cpu_int.cpu().int().tolist()
                 )
 
+            if self.kv_cache_dtype == "fp8_e4m3":
+                dequant_scale_q_nope = dequant_scale_q_nope.transpose(-1, -2)
+                q_fp8, dequant_scale_query = q_nope, dequant_scale_q_nope
+                kv_scale = self._resolve_fp8_kv_scale(fp8_kv_scale, q_nope.device)
+                output = torch.empty_like(
+                    q_nope, dtype=torch.bfloat16, device=q_nope.device
+                )
+                softmax_lse = torch.empty(
+                    1, dtype=torch.bfloat16, device=q_nope.device
+                )
+                torch_npu.npu_fused_infer_attention_score_v2.out(
+                    q_fp8,
+                    c_kv_cache,
+                    c_kv_cache,
+                    query_rope=q_rope,
+                    key_rope=k_rope_cache,
+                    num_query_heads=self.q_head_num_padding,
+                    num_key_value_heads=layer.tp_k_head_num,
+                    input_layout="BSND",
+                    softmax_scale=layer.scaling,
+                    block_table=self.forward_metadata.block_tables,
+                    block_size=self.page_size,
+                    actual_seq_kvlen=actual_seq_len_kv,
+                    sparse_mode=0,
+                    dequant_scale_query=dequant_scale_query,
+                    dequant_scale_key=kv_scale,
+                    dequant_scale_value=kv_scale,
+                    key_quant_mode=0,
+                    value_quant_mode=0,
+                    query_quant_mode=3,
+                    out=[output, softmax_lse],
+                )
+
+                output = output[:, :, : layer.tp_q_head_num, :]
+                return output.view(-1, layer.tp_q_head_num * self.kv_lora_rank)
+
             workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
                 q_nope,
                 c_kv_cache,
@@ -2417,6 +2722,8 @@ class AscendAttnBackend(AttentionBackend):
         topk_indices: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         slopes: Optional[torch.Tensor] = None,
+        dequant_scale_q_nope: Optional[torch.Tensor] = None,
+        fp8_kv_scale: Optional[torch.Tensor] = None,
     ):
         if is_mla_preprocess_enabled() and self.use_mla:
             # MLAPO does saving kv_cache
@@ -2445,6 +2752,8 @@ class AscendAttnBackend(AttentionBackend):
                 q_rope=q_rope,
                 k_rope=k_rope,
                 sinks=sinks,
+                dequant_scale_q_nope=dequant_scale_q_nope,
+                fp8_kv_scale=fp8_kv_scale,
             )
 
         if not self.use_mla:
@@ -2708,24 +3017,63 @@ class AscendAttnBackend(AttentionBackend):
                     layer.tp_q_head_num,
                     self.qk_rope_head_dim,
                 )
-                attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
-                    q,
-                    kv_c,
-                    kv_c,
-                    query_rope=q_rope,
-                    key_rope=k_pe,
-                    num_heads=layer.tp_q_head_num,
-                    num_key_value_heads=layer.tp_k_head_num,
-                    input_layout="BSND",
-                    atten_mask=None,
-                    sparse_mode=0,
-                    scale=layer.scaling,
-                    antiquant_mode=0,
-                    antiquant_scale=None,
-                    block_table=self.forward_metadata.block_tables,
-                    block_size=self.page_size,
-                    actual_seq_lengths_kv=self.forward_metadata.seq_lens_cpu_int,
-                )
+                if self.kv_cache_dtype == "fp8_e4m3":
+                    dequant_scale_q_nope = dequant_scale_q_nope.transpose(-1, -2)
+                    if self.forward_metadata.seq_lens_cpu_int is None:
+                        actual_seq_len_kv = self.forward_metadata.seq_lens_cpu_list
+                    else:
+                        actual_seq_len_kv = (
+                            self.forward_metadata.seq_lens_cpu_int.cpu().int().tolist()
+                        )
+                    q_fp8, dequant_scale_query = q, dequant_scale_q_nope
+                    kv_scale = self._resolve_fp8_kv_scale(fp8_kv_scale, q.device)
+                    attn_output = torch.empty_like(
+                        q, dtype=torch.bfloat16, device=q.device
+                    )
+                    softmax_lse = torch.empty(
+                        1, dtype=torch.bfloat16, device=q.device
+                    )
+                    torch_npu.npu_fused_infer_attention_score_v2.out(
+                        q_fp8,
+                        kv_c,
+                        kv_c,
+                        query_rope=q_rope,
+                        key_rope=k_pe,
+                        num_query_heads=layer.tp_q_head_num,
+                        num_key_value_heads=layer.tp_k_head_num,
+                        input_layout="BSND",
+                        softmax_scale=layer.scaling,
+                        block_table=self.forward_metadata.block_tables,
+                        block_size=self.page_size,
+                        actual_seq_kvlen=actual_seq_len_kv,
+                        sparse_mode=0,
+                        dequant_scale_query=dequant_scale_query,
+                        dequant_scale_key=kv_scale,
+                        dequant_scale_value=kv_scale,
+                        key_quant_mode=0,
+                        value_quant_mode=0,
+                        query_quant_mode=3,
+                        out=[attn_output, softmax_lse],
+                    )
+                else:
+                    attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
+                        q,
+                        kv_c,
+                        kv_c,
+                        query_rope=q_rope,
+                        key_rope=k_pe,
+                        num_heads=layer.tp_q_head_num,
+                        num_key_value_heads=layer.tp_k_head_num,
+                        input_layout="BSND",
+                        atten_mask=None,
+                        sparse_mode=0,
+                        scale=layer.scaling,
+                        antiquant_mode=0,
+                        antiquant_scale=None,
+                        block_table=self.forward_metadata.block_tables,
+                        block_size=self.page_size,
+                        actual_seq_lengths_kv=self.forward_metadata.seq_lens_cpu_int,
+                    )
             else:
                 assert (
                     self.graph_mode == False

--- a/python/sglang/srt/hardware_backend/npu/attention/mla_preprocess.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/mla_preprocess.py
@@ -10,7 +10,9 @@ from sglang.srt.model_executor.forward_context import (
     get_attn_backend,
     get_token_to_kv_pool,
 )
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import get_bool_env_var
+from sglang.srt.utils import is_npu_before_atlas_a5
 
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -29,6 +31,9 @@ def is_fia_nz() -> bool:
             is_mla_preprocess_enabled()
         ), "SGLANG_USE_FIA_NZ must be enable with SGLANG_NPU_USE_MLAPO"
     return is_fia_nz_
+
+
+_is_npu_before_atlas_a5 = is_npu_before_atlas_a5()
 
 
 def round_up(val: int, align: int) -> int:
@@ -64,6 +69,29 @@ def trans_rope_weight(weight, rope_dim):
     return weight.contiguous()
 
 
+def _quantize_mla_query_for_mxfp8(
+    query: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    query_shape = query.shape
+    x = query.reshape(-1, query_shape[-1]).contiguous()
+    x_mxfp8, x_scale = torch.ops.npu.npu_dynamic_mx_quant(
+        x,
+        axis=1,
+        dst_type=torch.float8_e4m3fn,
+        block_size=32,
+        scale_alg=None,
+    )
+
+    if x_scale.dim() == 3 and x_scale.shape[-1] == 2:
+        x_scale = x_scale.contiguous().reshape(x_scale.shape[0], -1)
+    elif x_scale.dim() != 2:
+        raise RuntimeError(f"Unexpected MLAProlog query scale shape: {x_scale.shape}")
+
+    if x_scale.dtype == torch.uint8:
+        x_scale = x_scale.view(torch.float8_e8m0fnu)
+    return x_mxfp8, x_scale
+
+
 class NPUFusedMLAPreprocess(torch.nn.Module):
     def __init__(
         self,
@@ -79,6 +107,7 @@ class NPUFusedMLAPreprocess(torch.nn.Module):
         qk_rope_head_dim,
         v_head_dim,
         quant_config: Optional["QuantizationConfig"] = None,
+        fak_descale_reciprocal: Optional[torch.Tensor] = None,
     ):
         super().__init__()
         self.qkv_a_proj = fused_qkv_a_proj_with_mqa
@@ -91,6 +120,8 @@ class NPUFusedMLAPreprocess(torch.nn.Module):
         self.quant_config = quant_config
         self.has_preprocess_weights = False
         self.dtype = None
+        self.quant_scale_ckv = None
+        self.runtime_refs = {"fak_descale_reciprocal": fak_descale_reciprocal}
 
         self.q_lora_rank = self.q_b_proj.input_size  # 1536
         self.kv_lora_rank = self.kv_a_layernorm.hidden_size  # 512
@@ -99,9 +130,20 @@ class NPUFusedMLAPreprocess(torch.nn.Module):
         self.qk_rope_head_dim = qk_rope_head_dim  # 64
         self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
         self.v_head_dim = v_head_dim
+        self.kv_cache_dtype = get_global_server_args().kv_cache_dtype
         self.q_b_proj_weight_scale = self.q_b_proj.weight_scale.view(1, -1).to(
             torch.float
-        )
+        ) if hasattr(self.q_b_proj, "weight_scale") else None
+
+    def _get_quant_scale_ckv(self, device: torch.device) -> torch.Tensor:
+        fak_descale_reciprocal = self.runtime_refs.get("fak_descale_reciprocal")
+        if fak_descale_reciprocal is not None:
+            return fak_descale_reciprocal.reshape(-1).to(
+                device=device, dtype=torch.float32
+            )
+        if self.quant_scale_ckv is None or self.quant_scale_ckv.device != device:
+            self.quant_scale_ckv = torch.ones(1, dtype=torch.float32, device=device)
+        return self.quant_scale_ckv
 
     def preprocess_weights(self, hidden_states):
         self.dummy = torch.zeros(
@@ -241,13 +283,54 @@ class NPUFusedMLAPreprocess(torch.nn.Module):
         )
 
     def mlaprolog_preprocess_weight(self):
-        self.qkv_a_proj.weight.data = self.qkv_a_proj.weight.data.transpose(0, 1)
-        qkv_a_proj_weight_q = self.qkv_a_proj.weight.data[:, : self.q_lora_rank].clone()
-        qkv_a_proj_weight_kv = self.qkv_a_proj.weight.data[
-            :, self.q_lora_rank :
-        ].clone()
-        self.q_a_proj_weight = npu_format_cast(qkv_a_proj_weight_q)
-        self.kv_a_proj_weight = npu_format_cast(qkv_a_proj_weight_kv)
+        if hasattr(self.q_b_proj, "weight_scale_original"):
+            self.q_b_proj_weight = npu_format_cast(
+                self.q_b_proj.weight_original.transpose(0, 1).clone()
+            )
+            self.q_b_proj_scale = (
+                self.q_b_proj.weight_scale_original.clone().view(torch.float8_e8m0fnu)
+            )
+        else:
+            self.q_b_proj_weight = npu_format_cast(
+                self.q_b_proj.weight.data.transpose(0, 1).clone()
+            )
+
+        if hasattr(self.qkv_a_proj, "weight_scale_original"):
+            self.qkv_a_proj.weight_original = self.qkv_a_proj.weight_original.transpose(
+                0, 1
+            )
+            qkv_a_proj_weight_q = self.qkv_a_proj.weight_original[
+                :, : self.q_lora_rank
+            ].clone()
+            qkv_a_proj_weight_kv = self.qkv_a_proj.weight_original[
+                :, self.q_lora_rank :
+            ].clone()
+            self.q_a_proj_weight = npu_format_cast(qkv_a_proj_weight_q)
+            self.kv_a_proj_weight = npu_format_cast(qkv_a_proj_weight_kv)
+            self.qkv_a_proj_scale_q = (
+                self.qkv_a_proj.weight_scale_original[: self.q_lora_rank, :]
+                .clone()
+                .view(torch.float8_e8m0fnu)
+            )
+
+            self.qkv_a_proj_scale_kv = (
+                self.qkv_a_proj.weight_scale_original[self.q_lora_rank :, :]
+                .clone()
+                .view(torch.float8_e8m0fnu)
+            )
+        else:
+            self.qkv_a_proj.weight.data = self.qkv_a_proj.weight.data.transpose(0, 1)
+            qkv_a_proj_weight_q = self.qkv_a_proj.weight.data[
+                :, : self.q_lora_rank
+            ].clone()
+            qkv_a_proj_weight_kv = self.qkv_a_proj.weight.data[
+                :, self.q_lora_rank :
+            ].clone()
+            self.q_a_proj_weight = npu_format_cast(qkv_a_proj_weight_q)
+            self.kv_a_proj_weight = npu_format_cast(qkv_a_proj_weight_kv)
+
+        if not hasattr(self.qkv_a_proj, "weight_scale_original"):
+            self.qkv_a_proj.weight.data = self.qkv_a_proj.weight.data.transpose(0, 1)
 
     def get_sin_cos(self, positions):
         cos_sin = self.rotary_emb.cos_sin_cache[positions]
@@ -340,7 +423,18 @@ class NPUFusedMLAPreprocess(torch.nn.Module):
             cache_mode=cache_mode,
         )
 
-        return (q_pe, k_rope, q_nope, k_nope, forward_batch, zero_allocator, positions)
+        return (
+            q_pe,
+            k_rope,
+            q_nope,
+            k_nope,
+            None,
+            forward_batch,
+            zero_allocator,
+            positions,
+            None,
+            None,
+        )
 
     def forward_mlapo(self, positions, hidden_states, forward_batch, zero_allocator):
         input_dtype = hidden_states.dtype
@@ -423,17 +517,72 @@ class NPUFusedMLAPreprocess(torch.nn.Module):
             v_cache,
             q_nope_out,
             k_cache,
+            None,
             forward_batch,
             zero_allocator,
             positions,
+            None,
+            None,
         )
 
     def forward_mlaprolog(self, positions, hidden_states, forward_batch):
+        import torch_npu
         if not self.has_preprocess_weights:
             self.mlaprolog_preprocess_weight()
             self.has_preprocess_weights = True
         self.cos, self.sin = self.get_sin_cos(positions)
         k_cache, v_cache, slot_mapping = self.get_kv_cache_and_cache_idx(forward_batch)
+        if self.kv_cache_dtype == "fp8_e4m3":
+            dequant_scale_w_dq = self.qkv_a_proj_scale_q
+            dequant_scale_w_uq_qr = self.q_b_proj_scale
+            dequant_scale_w_dkv_kr = self.qkv_a_proj_scale_kv
+            x, x_scale = _quantize_mla_query_for_mxfp8(hidden_states)
+            dequant_scale_x = x_scale.view(torch.float8_e8m0fnu)
+            cache_mode = "PA_NZ" if is_fia_nz() else "PA_BSND"
+            mla_prolog_input_args = {
+                "token_x": x,
+                "weight_dq": self.q_a_proj_weight,
+                "weight_uq_qr": self.q_b_proj_weight,
+                "weight_uk": self.w_kc,
+                "weight_dkv_kr": self.kv_a_proj_weight,
+                "rmsnorm_gamma_cq": self.q_a_layernorm.weight,
+                "rmsnorm_gamma_ckv": self.kv_a_layernorm.weight,
+                "rope_sin": self.sin,
+                "rope_cos": self.cos,
+                "kv_cache": k_cache,
+                "kr_cache": v_cache,
+                "cache_index": slot_mapping.to(dtype=torch.int64),
+                "rmsnorm_epsilon_cq": self.q_a_layernorm.variance_epsilon,
+                "rmsnorm_epsilon_ckv": self.kv_a_layernorm.variance_epsilon,
+                "cache_mode": cache_mode,
+                "query_norm_flag": True,
+                "dequant_scale_w_dq": dequant_scale_w_dq,
+                "dequant_scale_w_uq_qr": dequant_scale_w_uq_qr,
+                "dequant_scale_w_dkv_kr": dequant_scale_w_dkv_kr,
+                "weight_quant_mode": 3,
+                "dequant_scale_x": dequant_scale_x,
+                "kv_cache_quant_mode": 1,
+                "query_quant_mode": 1,
+                "kc_scale": 1.0,
+                "qc_qr_scale": 1.0,
+                "quant_scale_ckv": self._get_quant_scale_ckv(hidden_states.device),
+            }
+            q_nope, q_pe, dequant_scale_q_nope, qr, _ = (
+                torch_npu.npu_mla_prolog_v3(**mla_prolog_input_args)
+            )
+            return (
+                q_pe,
+                v_cache,
+                q_nope,
+                k_cache,
+                qr,
+                forward_batch,
+                None,
+                positions,
+                None,
+                dequant_scale_q_nope,
+            )
+
         mla_prolog_input_args = {
             "token_x": hidden_states,
             "weight_dq": self.q_a_proj_weight,
@@ -455,7 +604,7 @@ class NPUFusedMLAPreprocess(torch.nn.Module):
             "weight_quant_mode": 1,  # 0:no quant; 1:uq_qr: quant; 2: weight_dq,weight_uq_qr,weight_dkv_kr: quant
         }
         q_nope, q_pe, dequant_scale_q_nope, qr, dequant_q_norm = (
-            torch.ops.custom.npu_mla_prolog_v3(**mla_prolog_input_args)
+            torch_npu.npu_mla_prolog_v3(**mla_prolog_input_args)
         )
         dequant_q_norm = dequant_q_norm.view(hidden_states.shape[0])
         return (
@@ -465,8 +614,10 @@ class NPUFusedMLAPreprocess(torch.nn.Module):
             k_cache,
             qr,
             forward_batch,
+            None,
             positions,
             dequant_q_norm,
+            None,
         )
 
     def forward(self, positions, hidden_states, forward_batch, zero_allocator):
@@ -481,11 +632,11 @@ class NPUFusedMLAPreprocess(torch.nn.Module):
         _is_mlaprolog = hasattr(self.quant_config, "ignore") and any(
             re.fullmatch(r".*kv_b_proj", l) for l in self.quant_config.ignore
         )
-        if _is_w8a8:
+        if _is_w8a8 and _is_npu_before_atlas_a5:
             return self.forward_mlapo(
                 positions, hidden_states, forward_batch, zero_allocator
             )
-        elif _is_mlaprolog:
+        elif _is_mlaprolog or not _is_npu_before_atlas_a5:
             return self.forward_mlaprolog(positions, hidden_states, forward_batch)
         else:
             return self.forward_absorb_prepare_npu_rms_norm_cache(

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_extend_npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_extend_npu_graph_runner.py
@@ -18,7 +18,8 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from sglang.srt.configs.model_config import is_deepseek_dsa
+from sglang.srt.configs.model_config import AttentionArch, is_deepseek_dsa
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
     EAGLEDraftExtendCudaGraphRunner,
 )
@@ -29,6 +30,10 @@ if TYPE_CHECKING:
 
 class EAGLEDraftExtendNpuGraphRunner(EAGLEDraftExtendCudaGraphRunner):
     def __init__(self, eagle_worker: EagleDraftWorker):
+        self.use_fia_v2 = (
+            eagle_worker.draft_runner.model_config.attention_arch == AttentionArch.MLA
+            and get_global_server_args().kv_cache_dtype == "fp8_e4m3"
+        )
         super().__init__(eagle_worker)
 
     def _cache_loc_dtype(self):
@@ -42,7 +47,11 @@ class EAGLEDraftExtendNpuGraphRunner(EAGLEDraftExtendCudaGraphRunner):
             return self.backend.replay_with_input_update(
                 shape_key,
                 seq_lens=seq_lens,
-                attr_name="actual_seq_lengths_kv",
+                attr_name=(
+                    "actual_seq_kvlen"
+                    if self.use_fia_v2
+                    else "actual_seq_lengths_kv"
+                ),
                 attr_type=[],
             )
         else:

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Dict, Union
 import torch
 
 from sglang.srt.configs.model_config import AttentionArch, is_deepseek_dsa
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
     EAGLEDraftCudaGraphRunner,
 )
@@ -29,12 +30,18 @@ if TYPE_CHECKING:
 
 class EAGLEDraftNpuGraphRunner(EAGLEDraftCudaGraphRunner):
     def __init__(self, eagle_worker: EagleDraftWorker):
+        self.use_fia_v2 = (
+            eagle_worker.draft_runner.model_config.attention_arch == AttentionArch.MLA
+            and get_global_server_args().kv_cache_dtype == "fp8_e4m3"
+        )
         self._init_arch_map()
         super().__init__(eagle_worker)
 
     def _init_arch_map(self):
         self.attr_name: Dict[str, str] = {
-            AttentionArch.MLA: "actual_seq_lengths_kv",
+            AttentionArch.MLA: (
+                "actual_seq_kvlen" if self.use_fia_v2 else "actual_seq_lengths_kv"
+            ),
             AttentionArch.MHA: "context_lens",
         }
         self.attr_type: Dict[str, Union[list, torch.Tensor]] = {

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/multi_layer_eagle_draft_extend_npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/multi_layer_eagle_draft_extend_npu_graph_runner.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.model_executor.cuda_graph_config import cuda_graph_fully_disabled
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.multi_layer_eagle_draft_extend_cuda_graph_runner import (
     MultiLayerEagleDraftExtendCudaGraphRunner,
     MultiLayerEagleMultiStepDraftExtendCudaGraphRunner,
@@ -36,10 +38,19 @@ class MultiLayerEagleDraftExtendNpuGraphRunner(
         seq_lens = self.buffers.seq_lens_cpu[: self.raw_bs].tolist() + [0] * (
             self.bs - self.raw_bs
         )
+        use_fia_v2 = (
+            self.model_runner.model_config.attention_arch == AttentionArch.MLA
+            and get_global_server_args().kv_cache_dtype == "fp8_e4m3"
+        )
+        attr_name = (
+            "actual_seq_kvlen"
+            if use_fia_v2
+            else "actual_seq_lengths_kv"
+        )
         return self.backend.replay_with_input_update(
             shape_key,
             seq_lens=seq_lens,
-            attr_name="actual_seq_kvlen",
+            attr_name=attr_name,
             attr_type=[],
         )
 

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -111,11 +111,16 @@ class NPUGraphRunner(DecodeCudaGraphRunner):
         self.model_runner = model_runner
         self._init_arch_map()
         self.use_fia = get_bool_env_var("ASCEND_USE_FIA", "False")
-        self.if_use_v2 = any(
-            arch
-            in ("MiMoV2ForCausalLM", "MiMoV2FlashForCausalLM", "Step3p5ForCausalLM")
-            for arch in (model_runner.model_config.hf_config.architectures or [])
+        architectures = getattr(model_runner.model_config.hf_config, "architectures", [])
+        if_use_v2 = any(
+            arch in ("MiMoV2ForCausalLM", "MiMoV2FlashForCausalLM", "Step3p5ForCausalLM")
+            for arch in architectures
         )
+        if_use_v2 = if_use_v2 or (
+            model_runner.model_config.attention_arch == AttentionArch.MLA
+            and model_runner.server_args.kv_cache_dtype == "fp8_e4m3"
+        )
+        self.if_use_v2 = if_use_v2
 
     def _init_arch_map(self):
         if self.is_dllm:

--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -313,6 +313,11 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
         self.kv_lora_rank = kv_lora_rank
         self.qk_rope_head_dim = qk_rope_head_dim
         self.index_head_dim = index_head_dim
+        self.k_store_dtype = self.store_dtype
+        self.v_store_dtype = self.store_dtype
+        if self.dtype == torch.float8_e4m3fn:
+            self.k_store_dtype = torch.float8_e4m3fn
+            self.v_store_dtype = torch.bfloat16
 
         self.custom_mem_pool = None
 
@@ -326,7 +331,7 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
                     1,
                     self.kv_lora_rank,
                 ),
-                dtype=self.store_dtype,
+                dtype=self.k_store_dtype,
                 device=self.device,
             )
             self.v_buffer = torch.zeros(
@@ -337,7 +342,7 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
                     1,
                     self.qk_rope_head_dim,
                 ),
-                dtype=self.store_dtype,
+                dtype=self.v_store_dtype,
                 device=self.device,
             )
             self.index_k_buffer = None
@@ -350,7 +355,7 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
                         1,
                         self.index_head_dim,
                     ),
-                    dtype=self.store_dtype,
+                    dtype=self.k_store_dtype,
                     device=self.device,
                 )
 
@@ -390,7 +395,7 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
 
-        if self.store_dtype != self.dtype:
+        if self.k_store_dtype != self.dtype:
             return self.k_buffer[layer_id - self.start_layer].view(self.dtype)
         return self.k_buffer[layer_id - self.start_layer]
 
@@ -398,7 +403,7 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
 
-        if self.store_dtype != self.dtype:
+        if self.v_store_dtype == self.store_dtype and self.store_dtype != self.dtype:
             return self.v_buffer[layer_id - self.start_layer].view(self.dtype)
         return self.v_buffer[layer_id - self.start_layer]
 

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -370,7 +370,11 @@ def forward_mla_core_npu(
         )
         if (
             m.kv_cache_dtype == "fp8_e4m3"
-            and forward_batch.forward_mode.is_decode_or_idle()
+            and (
+                forward_batch.forward_mode.is_decode_or_idle()
+                or forward_batch.forward_mode.is_target_verify()
+                or forward_batch.forward_mode.is_draft_extend_v2()
+            )
         ):
             extra_kwargs["save_kv_cache"] = False
 

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -151,7 +151,9 @@ def forward_mha_prepare_npu(
     v = kv[..., m.qk_nope_head_dim :]
 
     k = m._concat_and_cast_mha_k(k_nope, k_pe, forward_batch)
-    return q, k, v, forward_batch
+    return q, k, v, forward_batch, _get_fp8_kv_runtime_scale(
+        m, "fak_descale_float", q.device
+    )
 
 
 def forward_mha_core_npu(
@@ -160,8 +162,16 @@ def forward_mha_core_npu(
     k: torch.Tensor,
     v: torch.Tensor,
     forward_batch: "ForwardBatch",
+    fp8_kv_scale: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    attn_output = m.attn_mha(q, k, v, forward_batch, save_kv_cache=False)
+    attn_output = m.attn_mha(
+        q,
+        k,
+        v,
+        forward_batch,
+        save_kv_cache=False,
+        fp8_kv_scale=fp8_kv_scale,
+    )
     attn_output = attn_output.reshape(-1, m.num_local_heads * m.v_head_dim)
     output, _ = m.o_proj(attn_output)
     return output

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -25,6 +25,28 @@ if TYPE_CHECKING:
 _use_ag_after_qlora = envs.SGLANG_USE_AG_AFTER_QLORA.get()
 
 
+def _get_fp8_kv_runtime_scale(
+    m: "DeepseekV2AttentionMLA", attr_name: str, device: torch.device
+) -> torch.Tensor | None:
+    if m.kv_cache_dtype != "fp8_e4m3":
+        return None
+
+    scale = getattr(m, attr_name, None)
+    if scale is None:
+        fallback_attr = f"_{attr_name}_fallback"
+        scale = getattr(m, fallback_attr, None)
+        if scale is None:
+            fallback = torch.ones(
+                (1, getattr(m, "num_local_kv_heads", 1)),
+                dtype=torch.float32,
+                device=device,
+            )
+            m.register_buffer(fallback_attr, fallback, persistent=False)
+            scale = getattr(m, fallback_attr)
+
+    return scale.to(device=device, dtype=torch.float32)
+
+
 # region MHA
 def forward_mha_prepare_npu(
     m: "DeepseekV2AttentionMLA",
@@ -90,6 +112,9 @@ def forward_mha_prepare_npu(
         q_pe = q_pe.reshape(B, -1, m.qk_rope_head_dim)
 
         ckv_cache, k_rope_cache = get_token_to_kv_pool().get_kv_buffer(m.layer_id)
+        c_kv_scale = _get_fp8_kv_runtime_scale(
+            m, "fak_descale_reciprocal", q.device
+        )
         _, _, k_pe, kv_a = torch_npu.npu_kv_rmsnorm_rope_cache(
             latent_cache.view(-1, 1, 1, m.kv_lora_rank + m.qk_rope_head_dim),  # bnsd
             m.kv_a_layernorm.weight,
@@ -99,7 +124,7 @@ def forward_mha_prepare_npu(
             k_rope_cache,
             ckv_cache,
             k_rope_scale=None,
-            c_kv_scale=None,
+            c_kv_scale=c_kv_scale,
             k_rope_offset=None,
             c_kv_offset=None,
             epsilon=m.kv_a_layernorm.variance_epsilon,
@@ -167,22 +192,37 @@ def forward_mla_prepare_npu(
                 m.num_local_heads,
                 m.qk_nope_head_dim,
                 m.qk_rope_head_dim,
+                m.v_head_dim,
                 m.quant_config,
+                _get_fp8_kv_runtime_scale(
+                    m, "fak_descale_reciprocal", hidden_states.device
+                ),
             )
+        else:
+            m.mla_preprocess.runtime_refs["fak_descale_reciprocal"] = (
+                _get_fp8_kv_runtime_scale(
+                    m, "fak_descale_reciprocal", hidden_states.device
+                )
+            )
+        preprocess_result = m.mla_preprocess.forward(
+            positions, hidden_states, forward_batch, zero_allocator
+        )
         (
             q_pe,
             k_pe,
             q_nope_out,
             k_nope,
+            _,
             forward_batch,
             zero_allocator,
             positions,
-        ) = m.mla_preprocess.forward(
-            positions, hidden_states, forward_batch, zero_allocator
-        )
+            _,
+            dequant_scale_q_nope,
+        ) = preprocess_result
         topk_indices = None
     else:
         q_lora = None
+        dequant_scale_q_nope = None
         if m.q_lora_rank is not None:
             q, latent_cache = (
                 get_attn_tp_context()
@@ -225,6 +265,51 @@ def forward_mla_prepare_npu(
 
         q_pe, k_pe = m.rotary_emb(positions, q_pe, k_pe)
 
+        if m.kv_cache_dtype == "fp8_e4m3":
+            cos = m.rotary_emb.cos_cached.to(q_nope_out.device)
+            sin = m.rotary_emb.sin_cached.to(q_nope_out.device)
+            q_nope_shape = q_nope_out.shape
+            q_nope_out, dequant_scale_q_nope = torch_npu.npu_dynamic_quant(
+                q_nope_out.reshape(-1, q_nope_shape[-1]),
+                dst_type=torch.float8_e4m3fn,
+            )
+            q_nope_out = q_nope_out.view(q_nope_shape)
+            dequant_scale_q_nope = dequant_scale_q_nope.view(q_nope_shape[:-1]).to(
+                torch.float32
+            )
+
+            fp8_kv_scale = _get_fp8_kv_runtime_scale(
+                m, "fak_descale_float", q_pe.device
+            )
+            q_pe = (q_pe / dequant_scale_q_nope.unsqueeze(-1) / fp8_kv_scale).to(
+                torch.bfloat16
+            )
+
+            ckv_cache, k_rope_cache = get_token_to_kv_pool().get_kv_buffer(m.layer_id)
+            c_kv_scale = _get_fp8_kv_runtime_scale(
+                m, "fak_descale_reciprocal", q_nope_out.device
+            )
+
+            _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
+                latent_cache.view(-1, 1, 1, m.kv_lora_rank + m.qk_rope_head_dim),
+                m.kv_a_layernorm.weight,
+                cos,
+                sin,
+                forward_batch.out_cache_loc.to(torch.int64),
+                k_rope_cache,
+                ckv_cache,
+                k_rope_scale=None,
+                c_kv_scale=c_kv_scale,
+                k_rope_offset=None,
+                c_kv_offset=None,
+                epsilon=m.kv_a_layernorm.variance_epsilon,
+                cache_mode="PA_NZ" if is_fia_nz() else "PA_BNSD",
+                is_output_kv=True,
+            )
+            k_pe = k_pe.reshape(-1, 1, m.qk_rope_head_dim)
+            k_nope = k_nope.reshape(-1, 1, m.kv_lora_rank)
+            dequant_scale_q_nope = dequant_scale_q_nope.unsqueeze(-1)
+
         if dsa_use_prefill_cp(forward_batch):
             # support allgather+rerrange
             k_nope, k_pe = m.rebuild_cp_kv_cache(
@@ -249,6 +334,7 @@ def forward_mla_prepare_npu(
         zero_allocator,
         positions,
         topk_indices,
+        dequant_scale_q_nope,
     )
 
 
@@ -262,7 +348,22 @@ def forward_mla_core_npu(
     zero_allocator: "BumpAllocator",
     positions: torch.Tensor,
     topk_indices: torch.Tensor,
+    dequant_scale_q_nope=None,
 ) -> torch.Tensor:
+    extra_kwargs = {}
+    if topk_indices is not None:
+        extra_kwargs["topk_indices"] = topk_indices
+    if dequant_scale_q_nope is not None:
+        extra_kwargs["dequant_scale_q_nope"] = dequant_scale_q_nope
+        extra_kwargs["fp8_kv_scale"] = _get_fp8_kv_runtime_scale(
+            m, "fak_descale_float", q_pe.device
+        )
+        if (
+            m.kv_cache_dtype == "fp8_e4m3"
+            and forward_batch.forward_mode.is_decode_or_idle()
+        ):
+            extra_kwargs["save_kv_cache"] = False
+
     attn_output = m.attn_mqa(
         q_nope_out,
         k_nope,
@@ -270,7 +371,7 @@ def forward_mla_core_npu(
         forward_batch,
         q_rope=q_pe,
         k_rope=k_pe,
-        **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
+        **extra_kwargs,
     )
 
     attn_output = attn_output.view(-1, m.num_local_heads, m.kv_lora_rank)
@@ -518,8 +619,10 @@ def npu_mla_preprocess(
             k_nope,
             q_lora,
             forward_batch,
+            zero_allocator,
             positions,
             dynamic_scale,
+            _,
         ) = m.mla_preprocess.forward(
             positions, hidden_states, forward_batch, zero_allocator
         )
@@ -535,9 +638,12 @@ def npu_mla_preprocess(
                     k_pe,
                     q_nope_out,
                     k_nope,
+                    _,
                     forward_batch,
                     zero_allocator,
                     positions,
+                    _,
+                    _,
                 ) = m.mla_preprocess.forward(
                     positions, hidden_states, forward_batch, zero_allocator
                 )
@@ -554,9 +660,12 @@ def npu_mla_preprocess(
                 k_pe,
                 q_nope_out,
                 k_nope,
+                _,
                 forward_batch,
                 zero_allocator,
                 positions,
+                _,
+                _,
             ) = m.mla_preprocess.forward(
                 positions, hidden_states, forward_batch, zero_allocator
             )

--- a/python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
@@ -172,6 +172,8 @@ class NPUMXFP8LinearMethod(_NPULinearMethodBase):
         layer.register_parameter("weight", weight)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        layer.weight_original = layer.weight.clone()
+        layer.weight_scale_original = layer.weight_scale.clone()
         weight = layer.weight.data
         if weight.dtype == torch.float8_e4m3fn:
             # Offline (ModelSlim) path: weight is already MXFP8-quantised and

--- a/python/sglang/srt/layers/quantization/modelslim/modelslim.py
+++ b/python/sglang/srt/layers/quantization/modelslim/modelslim.py
@@ -12,9 +12,11 @@ from sglang.srt.hardware_backend.npu.quantization.linear_method_npu import (
 from sglang.srt.layers.quantization.base_config import (
     FusedMoEMethodBase,
     QuantizationConfig,
+    QuantizeMethodBase,
 )
 from sglang.srt.layers.quantization.modelslim.schemes import (
     ModelSlimMXFP8Scheme,
+    ModelSlimQFP8DynamicKVFP8Scheme,
     ModelSlimW4A4Int4,
     ModelSlimW4A4Int4MoE,
     ModelSlimW4A8Int8MoE,
@@ -32,11 +34,28 @@ if TYPE_CHECKING:
     )
     from sglang.srt.layers.quantization.base_config import QuantizeMethodBase
     from sglang.srt.layers.quantization.modelslim.schemes import (
+        ModelSlimKVSchemeBase,
         ModelSlimLinearScheme,
         ModelSlimMoEScheme,
     )
 
 logger = logging.getLogger(__name__)
+
+
+class ModelSlimQFP8DynamicKVFP8Method(QuantizeMethodBase):
+    def __init__(self, scheme: ModelSlimQFP8DynamicKVFP8Scheme):
+        self.scheme = scheme
+
+    def create_weights(self, layer: torch.nn.Module, *args, **kwargs):
+        self.scheme.create_weights(layer, *args, **kwargs)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self.scheme.process_weights_after_loading(layer)
+
+    def apply(self, layer: torch.nn.Module, *args, **kwargs) -> torch.Tensor:
+        raise RuntimeError(
+            "ModelSlimQFP8DynamicKVFP8Method.apply should not be called."
+        )
 
 
 # func refers to RMSNorm.__init__
@@ -155,6 +174,10 @@ class ModelSlimConfig(QuantizationConfig):
         from sglang.srt.layers.linear import LinearBase
         from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 
+        kv_method = self._maybe_get_kv_method(layer, prefix)
+        if kv_method is not None:
+            return kv_method
+
         if isinstance(layer, LinearBase):
             # TODO: we should remove this code and switch to the packed_modules_mapping declared inside the modeling files
             key = "model"
@@ -184,6 +207,29 @@ class ModelSlimConfig(QuantizationConfig):
             layer.scheme = self.get_moe_scheme(layer, prefix)
             return ModelSlimFusedMoEMethod(self)
         return None
+
+    def get_kv_scheme(
+        self, layer: torch.nn.Module, prefix: str, quant_type: str
+    ) -> "ModelSlimKVSchemeBase":
+        del layer
+        if quant_type == "Q_FP8_DYNAMIC_KV_FP8":
+            return ModelSlimQFP8DynamicKVFP8Scheme(
+                quant_config=self.quant_description, prefix=prefix
+            )
+        raise NotImplementedError(
+            f"No ModelSlim KV scheme registered for quant_type={quant_type!r}."
+        )
+
+    def _maybe_get_kv_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> Optional[QuantizeMethodBase]:
+        kv_quant_type = self.quant_description.get(f"{prefix}.quant_type")
+        if kv_quant_type != "Q_FP8_DYNAMIC_KV_FP8":
+            return None
+
+        return ModelSlimQFP8DynamicKVFP8Method(
+            self.get_kv_scheme(layer, prefix, kv_quant_type)
+        )
 
     def get_linear_scheme(
         self, layer: torch.nn.Module, prefix: Optional[str] = None

--- a/python/sglang/srt/layers/quantization/modelslim/schemes/__init__.py
+++ b/python/sglang/srt/layers/quantization/modelslim/schemes/__init__.py
@@ -4,8 +4,13 @@
 # modelslim_mxfp8 imports ModelSlimLinearScheme from this package,
 # so the base class must be imported first.
 # isort: off
-from .modelslim_scheme import ModelSlimLinearScheme, ModelSlimMoEScheme
+from .modelslim_scheme import (
+    ModelSlimKVSchemeBase,
+    ModelSlimLinearScheme,
+    ModelSlimMoEScheme,
+)
 from .modelslim_mxfp8 import ModelSlimMXFP8Scheme
+from .modelslim_q_fp8_dynamic_kv_fp8 import ModelSlimQFP8DynamicKVFP8Scheme
 
 # isort: on
 from .modelslim_w4a4_int4 import ModelSlimW4A4Int4
@@ -17,7 +22,9 @@ from .modelslim_w8a8_int8_moe import ModelSlimW8A8Int8MoE
 __all__ = [
     "ModelSlimLinearScheme",
     "ModelSlimMoEScheme",
+    "ModelSlimKVSchemeBase",
     "ModelSlimMXFP8Scheme",
+    "ModelSlimQFP8DynamicKVFP8Scheme",
     "ModelSlimW8A8Int8",
     "ModelSlimW4A4Int4",
     "ModelSlimW4A4Int4MoE",

--- a/python/sglang/srt/layers/quantization/modelslim/schemes/modelslim_q_fp8_dynamic_kv_fp8.py
+++ b/python/sglang/srt/layers/quantization/modelslim/schemes/modelslim_q_fp8_dynamic_kv_fp8.py
@@ -1,0 +1,98 @@
+import torch
+from torch import nn
+
+from sglang.srt.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from sglang.srt.layers.quantization.modelslim.schemes.modelslim_scheme import (
+    ModelSlimKVSchemeBase,
+)
+
+
+def _modelslim_kv_weight_loader(
+    param: torch.Tensor, loaded_weight: torch.Tensor
+) -> None:
+    if param.numel() == 1 and loaded_weight.numel() == 1:
+        param.data.fill_(loaded_weight.item())
+        return
+
+    loaded_weight = loaded_weight.to(param.dtype)
+    if loaded_weight.shape != param.shape:
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+        if loaded_weight.shape[0] % tp_size != 0:
+            raise ValueError(
+                f"Cannot shard ModelSlim KV weight {tuple(loaded_weight.shape)} "
+                f"across tensor parallel size {tp_size}."
+            )
+        shard_size = loaded_weight.shape[0] // tp_size
+        loaded_weight = loaded_weight.narrow(0, shard_size * tp_rank, shard_size)
+
+    if loaded_weight.shape != param.shape:
+        raise ValueError(
+            f"Attempted to load ModelSlim KV weight {tuple(loaded_weight.shape)} "
+            f"into parameter {tuple(param.shape)}."
+        )
+
+    param.data.copy_(loaded_weight)
+
+
+class ModelSlimQFP8DynamicKVFP8Scheme(ModelSlimKVSchemeBase):
+    def __init__(self, quant_config, prefix: str):
+        self.quant_config = quant_config
+        self.prefix = prefix
+
+    def create_weights(
+        self,
+        layer: nn.Module,
+        num_heads: int,
+        num_kv_heads: int,
+    ) -> None:
+
+        for name in ("fa_q", "fa_k", "fa_v"):
+            if not hasattr(layer, name):
+                setattr(layer, name, nn.Module())
+
+        params = {
+            "fa_q.scale": torch.ones((num_heads, 1), dtype=torch.float32),
+            "fa_k.scale": torch.ones((num_kv_heads, 1), dtype=torch.float32),
+            "fa_v.scale": torch.ones((num_kv_heads, 1), dtype=torch.float32),
+            "fa_q.offset": torch.zeros((num_heads, 1), dtype=torch.float32),
+            "fa_k.offset": torch.zeros((num_kv_heads, 1), dtype=torch.float32),
+            "fa_v.offset": torch.zeros((num_kv_heads, 1), dtype=torch.float32),
+        }
+
+        for name, value in params.items():
+            module_name, param_name = name.rsplit(".", 1)
+            module = getattr(layer, module_name)
+            if hasattr(module, param_name):
+                continue
+            param = nn.Parameter(value, requires_grad=False)
+            param.weight_loader = _modelslim_kv_weight_loader
+            module.register_parameter(param_name, param)
+
+        runtime_params = {
+            "fak_descale_float": torch.ones((1, num_kv_heads), dtype=torch.float32),
+            "fak_descale_reciprocal": torch.ones(
+                (1, num_kv_heads), dtype=torch.float32
+            ),
+        }
+        for name, value in runtime_params.items():
+            if hasattr(layer, name):
+                continue
+            layer.register_parameter(name, nn.Parameter(value, requires_grad=False))
+
+    def process_weights_after_loading(self, layer: nn.Module) -> None:
+        if not hasattr(layer, "fak_descale_float") or not hasattr(
+            layer, "fak_descale_reciprocal"
+        ):
+            raise RuntimeError(
+                f"ModelSlimQFP8DynamicKVFP8Scheme for {self.prefix} has not created weights yet."
+            )
+
+        fa_k_scale = torch.squeeze(layer.fa_k.scale).reshape(1, -1).to(torch.float32)
+        fa_k_descale_reciprocal = torch.reciprocal(fa_k_scale)
+
+        layer.fak_descale_float.data.copy_(fa_k_scale)
+        layer.fak_descale_reciprocal.data.copy_(fa_k_descale_reciprocal)

--- a/python/sglang/srt/layers/quantization/modelslim/schemes/modelslim_scheme.py
+++ b/python/sglang/srt/layers/quantization/modelslim/schemes/modelslim_scheme.py
@@ -13,7 +13,7 @@ from sglang.srt.layers.quantization.base_scheme import BaseLinearScheme, BaseMoE
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
 
-__all__ = ["ModelSlimLinearScheme", "ModelSlimMoEScheme"]
+__all__ = ["ModelSlimLinearScheme", "ModelSlimMoEScheme", "ModelSlimKVSchemeBase"]
 
 
 class ModelSlimLinearScheme(BaseLinearScheme):
@@ -98,4 +98,14 @@ class ModelSlimMoEScheme(BaseMoEScheme):
         :param bias: bias parameter
 
         """
+        raise NotImplementedError
+
+
+class ModelSlimKVSchemeBase:
+    @abstractmethod
+    def create_weights(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @abstractmethod
+    def process_weights_after_loading(self, layer: torch.nn.Module):
         raise NotImplementedError

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -684,6 +684,9 @@ class DeepseekV2WeightLoaderMixin:
                 self_attn.w_vc = bind_or_assign(self_attn.w_vc, w_vc.contiguous())
                 self_attn.use_deep_gemm_bmm = True
 
+            if hasattr(self_attn, "refresh_fa_k_scale_params"):
+                self_attn.refresh_fa_k_scale_params()
+
     @classmethod
     def generate_weight_name_filter(cls, logical_experts_map: Dict[int, List[int]]):
         """

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1748,6 +1748,8 @@ class DeepseekV2AttentionMLA(
         self.w_kc = None
         self.w_vc = None
         self.w_scale = 1.0
+        self.kv_quant_method = None
+        self._init_kv_quant_weights(quant_config, prefix)
 
         self.w_scale_k = None
         self.w_scale_v = None
@@ -1779,6 +1781,26 @@ class DeepseekV2AttentionMLA(
         self.init_mla_forward()
         self.init_mla_fused_rope_rocm_forward()
         self.init_mla_fused_rope_cpu_forward()
+
+    def _init_kv_quant_weights(
+        self, quant_config: Optional[QuantizationConfig], prefix: str
+    ) -> None:
+        if quant_config is None or not _is_npu:
+            return
+
+        self.kv_quant_method = quant_config.get_quant_method(self, prefix=prefix)
+        if self.kv_quant_method is None:
+            return
+
+        self.kv_quant_method.create_weights(
+            self,
+            num_heads=self.num_local_heads,
+            num_kv_heads=1,
+        )
+
+    def refresh_fa_k_scale_params(self) -> None:
+        if self.kv_quant_method is not None:
+            self.kv_quant_method.process_weights_after_loading(self)
 
     def dispatch_attn_forward_method(
         self, forward_batch: ForwardBatch

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -193,6 +193,22 @@ def is_npu() -> bool:
 
 
 @lru_cache(maxsize=1)
+def is_npu_before_atlas_a5() -> bool:
+    if not hasattr(torch, "npu") or not torch.npu.is_available():
+        return False
+
+    get_device_name = getattr(torch.npu, "get_device_name", None)
+    if get_device_name is not None:
+        device_name = get_device_name(0)
+    else:
+        import torch_npu
+
+        device_name = torch_npu.npu.get_device_name(0)
+
+    return not str(device_name).startswith("Ascend950")
+
+
+@lru_cache(maxsize=1)
 def is_host_cpu_x86() -> bool:
     machine = platform.machine().lower()
     return (


### PR DESCRIPTION
## Motivation

This PR adds Ascend NPU support for MLAProlog with FP8 KV cache on Atlas A5 hardware, and enables the required A5 chunk prefill path for MLA attention. The goal is to support ModelSlim `Q_FP8_DYNAMIC_KV_FP8` checkpoints and run DeepSeek-style MLA workloads with FP8 KV cache correctly on A5, while keeping the migration limited to the necessary NPU attention, KV cache, graph metadata, and weight preprocessing paths.

## Modifications

- Added Atlas A5 hardware detection utility for NPU runtime path selection.
- Added ModelSlim KV quantization scheme support for `Q_FP8_DYNAMIC_KV_FP8`, including FA Q/K/V scale parameter registration and post-load runtime scale preparation.
- Preserved original MXFP8 linear weight and scale tensors after loading so MLAProlog preprocessing can consume the original layout/scale metadata.
- Updated DeepSeek MLA initialization and weight loading to create KV quantization parameters and refresh FA-K scale runtime parameters after `kv_b_proj` processing.
- Extended NPU MLA preprocessing to support MLAProlog FP8 KV cache:
  - handles MXFP8 query quantization;
  - prepares original quantized weights and scales for MLAProlog;
  - passes FP8 KV cache quant/dequant scales into `npu_mla_prolog_v3`;
  - standardizes MLA preprocess return values for downstream attention paths.
- Updated NPU DeepSeek MLA attention flow to propagate FP8 KV runtime scales and `dequant_scale_q_nope` into the Ascend attention backend.
- Updated Ascend attention backend for FP8 KV cache MLA decode/graph/MTP paths using `npu_fused_infer_attention_score_v2`.
- Added A5-specific MLA chunk prefill prefix-cache path that materializes prefix KV cache and applies FP8 dequantization before `kv_b_proj`.
- Updated NPU MLA KV memory pool layout so FP8 KV cache stores C-KV and K-Rope with the required dtype handling.
- Updated NPU graph runner v2 selection for MLA FP8 KV cache graph updates.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->