### PR TITLE
Fix ROCm causal Conv3D cat-pad fallback

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/parallel_conv.py
+++ b/python/sglang/multimodal_gen/runtime/layers/parallel_conv.py
@@ -107,7 +107,11 @@ def _can_fuse_causal_conv3d_cat_pad(
     cache_x: torch.Tensor | None,
     padding: list[int],
 ) -> bool:
-    if cache_x is None or fused_causal_conv3d_cat_pad is None:
+    if (
+        cache_x is None
+        or fused_causal_conv3d_cat_pad is None
+        or not current_platform.is_cuda()
+    ):
         return False
     if not x.is_cuda or not x.is_contiguous() or not cache_x.is_contiguous():
         return False

--- a/python/sglang/multimodal_gen/test/unit/test_vae_spatial_parallel_decode.py
+++ b/python/sglang/multimodal_gen/test/unit/test_vae_spatial_parallel_decode.py
@@ -28,6 +28,7 @@ from sglang.multimodal_gen.runtime.layers.parallel_conv import (
     SpatialParallelCausalConv3d,
     SpatialParallelConv2d,
     SpatialParallelConv3d,
+    _can_fuse_causal_conv3d_cat_pad,
     chunk_height_by_sizes,
     split_for_parallel_decode,
 )
@@ -74,6 +75,19 @@ class _DispatchProbeVAE(ParallelTiledVAE):
         raise AssertionError(
             "spatial_shard decode should not use parallel_tiled_decode"
         )
+
+
+class _FakeCudaTensor:
+    def __init__(self, shape, dtype=torch.float16):
+        self.shape = shape
+        self.dtype = dtype
+        self.is_cuda = True
+
+    def dim(self):
+        return len(self.shape)
+
+    def is_contiguous(self):
+        return True
 
 
 class TestVAESpatialParallelDecode(unittest.TestCase):
@@ -289,6 +303,18 @@ class TestVAESpatialParallelDecode(unittest.TestCase):
         self.assertEqual(rank0.shape[-2], 6)
         self.assertEqual(rank1.shape[-2], 4)
         torch.testing.assert_close(torch.cat([rank0, rank1], dim=-2), x)
+
+    def test_causal_conv3d_fusion_disabled_on_non_cuda_platform(self):
+        x = _FakeCudaTensor((1, 2, 3, 4, 4))
+        cache_x = _FakeCudaTensor((1, 2, 1, 4, 4))
+
+        with patch(
+            "sglang.multimodal_gen.runtime.layers.parallel_conv.current_platform.is_cuda",
+            return_value=False,
+        ):
+            self.assertFalse(
+                _can_fuse_causal_conv3d_cat_pad(x, cache_x, [1, 1, 1, 1, 1, 0])
+            )
 
     def test_qwen_decoder_uses_spatial_parallel_components(self):
         with (


### PR DESCRIPTION
## Summary
- keep the causal Conv3D cat/pad fusion eligibility CUDA-platform-only
- let ROCm tensors that report `Tensor.is_cuda == True` use the existing `torch.cat` + `F.pad` fallback
- add a regression test that simulates CUDA-like tensor metadata on a non-CUDA platform

## Why
#29281 made `fused_causal_conv3d_cat_pad` always defined. On ROCm, PyTorch tensors use the CUDA device API and can report `is_cuda == True`, but `parallel_conv.py` only imports the CUDA/Triton fusion implementations when `current_platform.is_cuda()` is true. That allowed `_can_fuse_causal_conv3d_cat_pad` to return true on ROCm and then hit `RuntimeError: causal Conv3D cat/pad fusion is only available on CUDA` instead of falling back.

## Testing
- `git commit` hooks: passed (`check python ast`, `isort`, `ruff`, `black-jupyter`, etc.)
- `PYTHONPYCACHEPREFIX=/tmp/sglang-pyc python3 -m py_compile python/sglang/multimodal_gen/runtime/layers/parallel_conv.py python/sglang/multimodal_gen/test/unit/test_vae_spatial_parallel_decode.py`
- local pytest/unittest not run: this host is missing `pytest`, `torch`, and `orjson`

## CI
- Pending manual AMD multimodal workflow dispatch after PR creation.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28365151301](https://github.com/sgl-project/sglang/actions/runs/28365151301)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28365151065](https://github.com/sgl-project/sglang/actions/runs/28365151065)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->