### PR TITLE
[DSV4][NPU][PD] Support prefill-decode disaggregation for DeepSeek V4 on NPU

### DIFF
--- a/python/sglang/srt/disaggregation/ascend/conn.py
+++ b/python/sglang/srt/disaggregation/ascend/conn.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.typing as npt
 
 from sglang.srt.disaggregation.ascend.transfer_engine import AscendTransferEngine
+from sglang.srt.disaggregation.base.conn import StateType
 from sglang.srt.disaggregation.common.utils import group_concurrent_contiguous
 from sglang.srt.disaggregation.mooncake.conn import (
     MooncakeKVBootstrapServer,
@@ -17,8 +18,26 @@ from sglang.srt.utils.network import get_local_ip_auto
 
 logger = logging.getLogger(__name__)
 
+# DSV4-on-NPU per-pool components; sent via the same _send_kvcache_generic
+# (page-indexed) path as SWA.
+_DSV4_KVCACHE_STATE_TYPES = (
+    StateType.DSV4_SWA,
+    StateType.DSV4_C4,
+    StateType.DSV4_C128,
+    StateType.DSV4_INDEXER,
+    StateType.DSV4_C4_STATE,
+    StateType.DSV4_C128_STATE,
+)
+
 
 class AscendKVManager(MooncakeKVManager):
+    def _is_generic_kvcache_state_type(self, st: StateType) -> bool:
+        # DSV4 per-pool components also use the page-indexed send path.
+        return (
+            super()._is_generic_kvcache_state_type(st)
+            or st in _DSV4_KVCACHE_STATE_TYPES
+        )
+
     def init_engine(self):
         # TransferEngine initialized on ascend.
         local_ip = get_local_ip_auto()

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -22,6 +22,14 @@ class StateType(str, enum.Enum):
     # DeepSeek-V4 unified_kv SWA ring: addressed per-row by ring slot
     # (req_pool_idx * ring_stride + pos % ring_stride), needs its own component.
     SWA_RING = "swa_ring"
+    # DSV4-on-NPU per-pool components (no full-token contiguous space); each
+    # page-indexed on its own pool, registered in this fixed order.
+    DSV4_SWA = "dsv4_swa"
+    DSV4_C4 = "dsv4_c4"
+    DSV4_C128 = "dsv4_c128"
+    DSV4_INDEXER = "dsv4_indexer"
+    DSV4_C4_STATE = "dsv4_c4_state"
+    DSV4_C128_STATE = "dsv4_c128_state"
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1050,22 +1050,38 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 return ring_rows.astype(np.int32)
 
             state_types = self.kv_manager.kv_args.state_types
-            state_indices: Optional[List] = []
-            for st in state_types:
-                if st == StateType.MAMBA:
-                    state_indices.append(_mamba_payload())
-                elif st == StateType.SWA:
-                    state_indices.append(_swa_payload())
-                elif st == StateType.DSA:
-                    state_indices.append(_dsa_payload())
-                elif st == StateType.MINIMAX_INDEX_K:
-                    # Index rows live at the same loc as main KV on the same
-                    # page_size, so reuse the full-seq page-ids.
-                    state_indices.append(_dsa_payload())
-                elif st == StateType.SWA_RING:
-                    state_indices.append(_swa_ring_payload())
-                else:
-                    state_indices.append(None)
+            if hasattr(self.req_to_token_pool, "req_to_token_c4"):
+                # DSV4 on NPU: per-pool dst page indices, produced by the same
+                # shared builder prefill uses so src/dst line up positionally.
+                from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
+                    build_dsv4_kv_transfer_payloads,
+                )
+
+                state_indices: Optional[List] = build_dsv4_kv_transfer_payloads(
+                    self.req_to_token_pool,
+                    decode_req.req.req_pool_idx,
+                    seq_len,
+                    self.token_to_kv_pool_allocator.page_size,
+                    self.scheduler.sliding_window_size,
+                    state_types,
+                )
+            else:
+                state_indices: Optional[List] = []
+                for st in state_types:
+                    if st == StateType.MAMBA:
+                        state_indices.append(_mamba_payload())
+                    elif st == StateType.SWA:
+                        state_indices.append(_swa_payload())
+                    elif st == StateType.DSA:
+                        state_indices.append(_dsa_payload())
+                    elif st == StateType.MINIMAX_INDEX_K:
+                        # Index rows live at the same loc as main KV on the same
+                        # page_size, so reuse the full-seq page-ids.
+                        state_indices.append(_dsa_payload())
+                    elif st == StateType.SWA_RING:
+                        state_indices.append(_swa_ring_payload())
+                    else:
+                        state_indices.append(None)
 
             decode_req.metadata_buffer_index = (
                 self.req_to_metadata_buffer_idx_allocator.alloc()
@@ -1385,6 +1401,24 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 if prefix_len > 0
                 else torch.tensor([-1], dtype=torch.int64, device=device)
             )
+            # DSV4-on-NPU allocator: reserves c4/c128 + tail compress-state pools
+            # as transfer dst; None for non-DSV4 (plain path).
+            dsv4_alloc = (
+                self.token_to_kv_pool_allocator
+                if hasattr(self.token_to_kv_pool_allocator, "c4_attn_allocator")
+                else None
+            )
+            dsv4_kwargs = {}
+            if dsv4_alloc is not None:
+                dsv4_kwargs = dict(
+                    req_pool_indices=torch.tensor(
+                        [req.req_pool_idx], dtype=torch.int64, device=device
+                    ),
+                    dsv4_state_lens=dsv4_alloc.compute_dsv4_state_lens_extend(
+                        [req], [fill_len]
+                    ),
+                    req_to_token_pool=self.req_to_token_pool,
+                )
             if self._uses_swa_tail_prealloc() and prefix_len == 0:
                 # Tail-only SWA allocation: only valid when prefix_len == 0.
                 # When prefix_len > 0 (radix cache hit), we fall back to
@@ -1398,6 +1432,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     last_loc=last_loc,
                     extend_num_tokens=fill_len,
                     swa_tail_len=self._swa_tail_len(fill_len),
+                    **dsv4_kwargs,
                 )
                 req.swa_evicted_seqlen = fill_len - self._swa_tail_len(fill_len)
             else:
@@ -1410,6 +1445,23 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
                     last_loc=last_loc,
                     extend_num_tokens=delta_len,
+                    **dsv4_kwargs,
+                )
+            # Unwrap the DSV4OutCacheLoc bundle: full-pool loc for the base write,
+            # plus the five per-req tables (disagg bypasses the batch hook).
+            if dsv4_alloc is not None and kv_loc is not None:
+                from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
+                    write_dsv4_prealloc_tables,
+                )
+
+                dsv4_bundle = kv_loc
+                kv_loc = dsv4_bundle.out_full_loc
+                write_dsv4_prealloc_tables(
+                    self.req_to_token_pool,
+                    req,
+                    total_prefix_len,
+                    fill_len,
+                    dsv4_bundle,
                 )
 
         assert kv_loc is not None, (

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -923,6 +923,11 @@ class MooncakeKVManager(CommonKVManager):
             f"Received AUX_DATA for bootstrap_room {room} with length:{len(data)}"
         )
 
+    def _is_generic_kvcache_state_type(self, st: "StateType") -> bool:
+        """State types sent via the page-indexed ``_send_kvcache_generic`` path
+        (not the mamba-state path); subclasses extend for hardware components."""
+        return st in (StateType.SWA, StateType.DSA, StateType.SWA_RING)
+
     def maybe_send_extra(
         self,
         req: TransferInfo,
@@ -1001,7 +1006,7 @@ class MooncakeKVManager(CommonKVManager):
                         )
                         or rc
                     )
-            elif st in (StateType.SWA, StateType.DSA, StateType.SWA_RING):
+            elif self._is_generic_kvcache_state_type(st):
                 if (
                     target_rank_registration_info is not None
                     and not self.is_mla_backend
@@ -1827,7 +1832,13 @@ class MooncakeKVReceiver(CommonKVReceiver):
             )
             # Note(shangming): No need to add pp rank here since decode pp size should be equal to prefill pp size or 1
             tp_rank = self.kv_mgr.kv_args.engine_rank
-            kv_item_len = self.kv_mgr.kv_args.kv_item_lens[0]
+            # DSV4-on-NPU has no full-token contiguous KV (kv_item_lens empty),
+            # ships per-pool instead, so report 0.
+            kv_item_len = (
+                self.kv_mgr.kv_args.kv_item_lens[0]
+                if self.kv_mgr.kv_args.kv_item_lens
+                else 0
+            )
             dst_tp_rank = str(tp_rank).encode("ascii")
             dst_attn_tp_size = str(self.kv_mgr.attn_tp_size).encode("ascii")
             dst_kv_item_len = str(kv_item_len).encode("ascii")

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1062,22 +1062,38 @@ class SchedulerDisaggregationPrefillMixin:
             state_types = (
                 self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
             )
-            state_indices = []
-            for st in state_types:
-                if st == StateType.MAMBA:
-                    state_indices.append(_mamba_payload())
-                elif st == StateType.SWA:
-                    state_indices.append(_swa_payload())
-                elif st == StateType.DSA:
-                    state_indices.append(_dsa_payload())
-                elif st == StateType.MINIMAX_INDEX_K:
-                    # Index rows live at the same loc as main KV on the same
-                    # page_size, so reuse the full-seq page-ids.
-                    state_indices.append(_dsa_payload())
-                elif st == StateType.SWA_RING:
-                    state_indices.append(_swa_ring_payload())
-                else:
-                    state_indices.append(None)
+            if hasattr(self.req_to_token_pool, "req_to_token_c4"):
+                # DSV4 on NPU: every component is a per-pool transfer, produced
+                # by the shared builder (same logic as decode → indices align).
+                from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
+                    build_dsv4_kv_transfer_payloads,
+                )
+
+                state_indices = build_dsv4_kv_transfer_payloads(
+                    self.req_to_token_pool,
+                    req.req_pool_idx,
+                    seq_len,
+                    page_size,
+                    self.sliding_window_size,
+                    state_types,
+                )
+            else:
+                state_indices = []
+                for st in state_types:
+                    if st == StateType.MAMBA:
+                        state_indices.append(_mamba_payload())
+                    elif st == StateType.SWA:
+                        state_indices.append(_swa_payload())
+                    elif st == StateType.DSA:
+                        state_indices.append(_dsa_payload())
+                    elif st == StateType.MINIMAX_INDEX_K:
+                        # Index rows live at the same loc as main KV on the same
+                        # page_size, so reuse the full-seq page-ids.
+                        state_indices.append(_dsa_payload())
+                    elif st == StateType.SWA_RING:
+                        state_indices.append(_swa_ring_payload())
+                    else:
+                        state_indices.append(None)
 
         page_indices = kv_to_page_indices(kv_indices, page_size)
         if not req.disagg_kv_sender.should_send_kv_chunk(len(page_indices), last_chunk):

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -655,7 +655,16 @@ def setup_state_kv_args(
     kv_args.state_item_lens = []
     kv_args.state_dim_per_tensor = []
 
-    if isinstance(token_to_kv_pool, MiniMaxSparseKVPool):
+    if hasattr(token_to_kv_pool, "get_dsv4_state_components"):
+        # DSV4-on-NPU: each pool is its own component in a fixed order (prefill
+        # and decode register identically); skips the 2D-only get_state_buf_infos.
+        for name, comp_ptrs, comp_lens, comp_item_lens in (
+            token_to_kv_pool.get_dsv4_state_components()
+        ):
+            append_state_component(
+                kv_args, StateType[name], comp_ptrs, comp_lens, comp_item_lens
+            )
+    elif isinstance(token_to_kv_pool, MiniMaxSparseKVPool):
         if token_to_kv_pool.index_kv_pool is not None:
             raise NotImplementedError(
                 "PD disaggregation for MiniMax sparse layers with index value "

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_allocator.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_allocator.py
@@ -545,6 +545,52 @@ class DSV4NPUTokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             dsv4_state_lens,
         )
 
+    def alloc_extend_swa_tail(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        swa_tail_len: int,
+        *,
+        req_pool_indices: Optional[torch.Tensor] = None,
+        dsv4_state_lens: Optional[DSV4StateLens] = None,
+        req_to_token_pool=None,
+    ) -> Optional[DSV4OutCacheLoc]:
+        """Disagg-decode prealloc variant of :meth:`alloc_extend`: super() does
+        full+swa-tail, then _alloc_c_and_state adds c4/c128(+state) → DSV4OutCacheLoc."""
+        self._cur_req_to_token_pool = req_to_token_pool
+        out_full_loc = super().alloc_extend_swa_tail(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+            swa_tail_len,
+        )
+        if out_full_loc is None:
+            return None
+
+        out_swa_loc = self.translate_loc_from_full_to_swa(out_full_loc)
+        assert out_swa_loc is not None, (
+            "translate_loc_from_full_to_swa returned None — "
+            "full_to_swa_index_mapping not initialized?"
+        )
+        return self._alloc_c_and_state(
+            out_full_loc,
+            out_swa_loc,
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc.dtype,
+            req_pool_indices,
+            dsv4_state_lens,
+        )
+
     def free(
         self,
         free_index: Optional[torch.Tensor] = None,

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_common_hooks.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_common_hooks.py
@@ -111,6 +111,99 @@ def maybe_write_dsv4_extend(
         )
 
 
+def build_dsv4_kv_transfer_payloads(
+    req_to_token_pool,
+    req_pool_idx: int,
+    seq_len: int,
+    page_size: int,
+    window_size: int,
+    state_types,
+):
+    """Per-pool PD-transfer page indices aligned to ``state_types``; prefill (src)
+    and decode (dst) must produce identical lists or KV is silently corrupted."""
+    import numpy as np
+
+    from sglang.srt.disaggregation.base.conn import StateType
+    from sglang.srt.mem_cache.common import kv_to_page_indices
+
+    def pages(table, lo: int, hi: int):
+        if hi <= lo:
+            return np.empty((0,), dtype=np.int32)
+        slots = table[req_pool_idx, lo:hi].cpu().numpy()
+        return kv_to_page_indices(slots, page_size).astype(np.int32)
+
+    def state_pages(table):
+        # Whole prompt span, mirroring the kernel state_block_table
+        # (state_table[req, ::page_size]//page_size); non-tail = skip sentinel page 0.
+        n_pages = (seq_len + page_size - 1) // page_size
+        return pages(table, 0, n_pages * page_size)
+
+    window_start = max(0, seq_len - window_size)
+    window_start = (window_start // page_size) * page_size
+
+    out = []
+    for st in state_types:
+        if st == StateType.DSV4_SWA:
+            out.append(pages(req_to_token_pool.req_to_token_swa, window_start, seq_len))
+        elif st == StateType.DSV4_C4:
+            out.append(pages(req_to_token_pool.req_to_token_c4, 0, seq_len // 4))
+        elif st == StateType.DSV4_C128:
+            out.append(pages(req_to_token_pool.req_to_token_c128, 0, seq_len // 128))
+        elif st == StateType.DSV4_INDEXER:
+            # indexer shares the c4 slot space (written at the c4 loc).
+            out.append(pages(req_to_token_pool.req_to_token_c4, 0, seq_len // 4))
+        elif st == StateType.DSV4_C4_STATE:
+            out.append(state_pages(req_to_token_pool.req_to_token_c4_state))
+        elif st == StateType.DSV4_C128_STATE:
+            out.append(state_pages(req_to_token_pool.req_to_token_c128_state))
+        else:
+            out.append(np.empty((0,), dtype=np.int32))
+    return out
+
+
+def write_dsv4_prealloc_tables(
+    req_to_token_pool,
+    req: Req,
+    prefix_len: int,
+    fill_len: int,
+    bundle,
+) -> None:
+    """Write the five DSV4 per-req tables for one request on the disagg-decode
+    prealloc path (no ScheduleBatch); no-op without bundle / DSV4 tables."""
+    if bundle is None or not hasattr(req_to_token_pool, "write_c4"):
+        return
+    rp = torch.tensor([req.req_pool_idx])
+    pl = torch.tensor([prefix_len])
+    sl = torch.tensor([fill_len])
+
+    _write_per_req_slice(req_to_token_pool.write_swa, rp, pl, sl, bundle.out_swa_loc, ratio=1)
+    _write_per_req_slice(req_to_token_pool.write_c4, rp, pl, sl, bundle.out_c4_loc, ratio=4)
+    _write_per_req_slice(
+        req_to_token_pool.write_c128, rp, pl, sl, bundle.out_c128_loc, ratio=128
+    )
+
+    if bundle.out_c4_state_loc is not None and hasattr(
+        req_to_token_pool, "write_c4_state"
+    ):
+        _write_state_tail_per_req(
+            req_to_token_pool.write_c4_state,
+            rp,
+            [getattr(req, "c4_state_alloc_offset", 0)],
+            sl,
+            bundle.out_c4_state_loc,
+        )
+    if bundle.out_c128_state_loc is not None and hasattr(
+        req_to_token_pool, "write_c128_state"
+    ):
+        _write_state_tail_per_req(
+            req_to_token_pool.write_c128_state,
+            rp,
+            [getattr(req, "c128_state_alloc_offset", 0)],
+            sl,
+            bundle.out_c128_state_loc,
+        )
+
+
 def maybe_write_dsv4_decode(
     batch: ScheduleBatch,
     seq_lens_cpu: torch.Tensor,

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_decode_req_to_token_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_decode_req_to_token_pool.py
@@ -1,0 +1,87 @@
+"""DecodeReqToTokenPool + the five DSV4 per-req tables (swa/c4/c128/c4_state/
+c128_state) the NPU attention and KV-transfer paths need on the decode side."""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.disaggregation.decode import DecodeReqToTokenPool
+from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+
+
+class DSV4NPUDecodeReqToTokenPool(DecodeReqToTokenPool):
+    """DecodeReqToTokenPool + DSV4 swa/c4/c128(+state) per-req tables;
+    see :class:`DSV4NPUReqToTokenPool` for the table semantics."""
+
+    def __init__(
+        self,
+        size: int,
+        max_context_len: int,
+        device: str,
+        enable_memory_saver: bool,
+        pre_alloc_size: int,
+    ):
+        super().__init__(
+            size=size,
+            max_context_len=max_context_len,
+            device=device,
+            enable_memory_saver=enable_memory_saver,
+            pre_alloc_size=pre_alloc_size,
+        )
+
+        memory_saver_adapter = TorchMemorySaverAdapter.create(
+            enable=enable_memory_saver
+        )
+
+        # Allocator back-ref (wired via register_dsv4_allocator) so free(req)
+        # releases c4/c128 pages; None at construction for base clear().
+        self._dsv4_allocator = None
+
+        # (name, columns): swa/state = 1 slot/token, c4/c128 = 1 slot/ratio tokens.
+        # Init zero so unallocated columns map to block 0 (kernel skip sentinel).
+        with memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            for name, cols in (
+                ("req_to_token_swa", max_context_len),
+                ("req_to_token_c4", max(1, max_context_len // 4)),
+                ("req_to_token_c128", max(1, max_context_len // 128)),
+                ("req_to_token_c4_state", max_context_len),
+                ("req_to_token_c128_state", max_context_len),
+            ):
+                setattr(
+                    self,
+                    name,
+                    torch.zeros(
+                        (self._alloc_size, cols),
+                        dtype=torch.int32,
+                        device=device,
+                    ),
+                )
+
+    # Per-pool write helpers, called by mem_cache/common.py after alloc with
+    # slot indices from DSV4OutCacheLoc.
+    def write_swa(self, indices, values: torch.Tensor) -> None:
+        self.req_to_token_swa[indices] = values
+
+    def write_c4(self, indices, values: torch.Tensor) -> None:
+        self.req_to_token_c4[indices] = values
+
+    def write_c128(self, indices, values: torch.Tensor) -> None:
+        self.req_to_token_c128[indices] = values
+
+    def write_c4_state(self, indices, values: torch.Tensor) -> None:
+        self.req_to_token_c4_state[indices] = values
+
+    def write_c128_state(self, indices, values: torch.Tensor) -> None:
+        self.req_to_token_c128_state[indices] = values
+
+    def register_dsv4_allocator(self, allocator) -> None:
+        """Wire the DSV4NPUTokenToKVPoolAllocator ref so ``free(req)`` can
+        release c4/c128 pool pages alongside the req_pool_idx slot."""
+        self._dsv4_allocator = allocator
+
+    def free(self, req):
+        # Release c4/c128 via the allocator (None before register_dsv4_allocator).
+        if self._dsv4_allocator is not None:
+            self._dsv4_allocator.free(req=req, req_to_token_pool=self)
+        super().free(req)

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
@@ -29,7 +29,7 @@ The subclass overrides only:
 from __future__ import annotations
 
 import math
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 import torch_npu
@@ -378,6 +378,73 @@ class DSV4NPUTokenToKVPool(DeepSeekV4TokenToKVPool):
             enable_memory_saver,
             kernel_page_size=self.page_size,
         )
+
+    # PD-disaggregation buffer descriptors. NPU buffers are 4D PA_ND
+    # (num_pages, page_size, 1, dim); buf.nbytes / buf[0].nbytes stay per-page-correct.
+    def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
+        # No full-token contiguous space on NPU; everything ships per-pool via
+        # get_dsv4_state_components(), so the contiguous path is empty.
+        return [], [], []
+
+    def get_dsv4_state_components(
+        self,
+    ) -> List[Tuple[str, List[int], List[int], List[int]]]:
+        """Ordered ``(DSV4_* name, data_ptrs, data_lens, item_lens)`` per pool, in a
+        fixed order so prefill and decode register identically (empty pools skipped)."""
+        components: List[Tuple[str, List[int], List[int], List[int]]] = []
+
+        def kv_entry(bufs):
+            return (
+                [b.data_ptr() for b in bufs],
+                [b.nbytes for b in bufs],
+                [b[0].nbytes for b in bufs],
+            )
+
+        def state_entry(want_ratio: int, include_indexer: bool):
+            ptrs: List[int] = []
+            lens: List[int] = []
+            ilens: List[int] = []
+
+            def add(pool):
+                t = pool.kv_score_buffer.kv_score
+                ptrs.append(t.data_ptr())
+                lens.append(t.nbytes)
+                ilens.append(t[0].nbytes * pool.page_size)
+
+            for ratio, pool in zip(self.compression_ratios, self.compress_state_pools):
+                if pool is not None and ratio == want_ratio:
+                    add(pool)
+            if include_indexer:
+                # indexer compress-state pools are all ratio 4 and share the
+                # c4_state slot space.
+                for pool in self.indexer_compress_state_pools:
+                    if pool is not None:
+                        add(pool)
+            return ptrs, lens, ilens
+
+        # KV pools (4D PA_ND).
+        if self.swa_kv_pool is not None:
+            components.append(("DSV4_SWA", *kv_entry(self.swa_kv_pool.kv_buffer)))
+        if self.c4_kv_pool is not None:
+            components.append(("DSV4_C4", *kv_entry(self.c4_kv_pool.kv_buffer)))
+        if self.c128_kv_pool is not None:
+            components.append(("DSV4_C128", *kv_entry(self.c128_kv_pool.kv_buffer)))
+        if self.c4_indexer_kv_pool is not None:
+            idx_bufs = list(self.c4_indexer_kv_pool.index_k_buffer) + list(
+                self.c4_indexer_kv_pool.index_scale_buffer
+            )
+            components.append(("DSV4_INDEXER", *kv_entry(idx_bufs)))
+
+        # Compress-state pools (paged, flat 2D). c4_state bundles attn-c4-state +
+        # indexer-c4-state (same req_to_token_c4_state slot space).
+        components.append(("DSV4_C4_STATE", *state_entry(4, include_indexer=True)))
+        components.append(
+            ("DSV4_C128_STATE", *state_entry(128, include_indexer=False))
+        )
+
+        # Drop empty components (e.g. a ratio with no layers) so every shipped
+        # component has non-zero item_lens; the set is identical on both sides.
+        return [c for c in components if c[1]]
 
     def get_state_cache(self, layer_id: int, from_indexer: bool) -> torch.Tensor:
         """fp32 ``[block_num, page_size, 2*coff*D]`` view of this layer's

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -270,9 +270,21 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             alloc_full_indices[-swa_tail_len:], alloc_swa_indices
         )
         if swa_tail_len < extend_num_tokens:
-            self.full_to_swa_index_mapping[
-                alloc_full_indices[:-swa_tail_len].to(torch.int64)
-            ] = 0
+            zero_indices = alloc_full_indices[:-swa_tail_len]
+            if _is_npu:
+                # aclnnIndexPut rejects a scalar/int32 value against the int64
+                # mapping; mirror alloc_decode and scatter an int64 zero tensor.
+                torch_npu.npu_scatter_nd_update_(
+                    self.full_to_swa_index_mapping,
+                    zero_indices.to(torch.int64).unsqueeze(-1),
+                    torch.zeros(
+                        zero_indices.numel(),
+                        dtype=self.full_to_swa_index_mapping.dtype,
+                        device=self.full_to_swa_index_mapping.device,
+                    ),
+                )
+            else:
+                self.full_to_swa_index_mapping[zero_indices] = 0
         return alloc_full_indices
 
     def alloc_decode(

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -380,6 +380,22 @@ class ModelRunnerKVCacheMixin:
                         mamba_size=self.server_args.max_mamba_cache_size,
                         start_layer=self.start_layer,
                     )
+                elif _is_npu and is_deepseek_v4(self.model_config.hf_config):
+                    # DSV4 on NPU needs the swa/c4/c128(+state) per-req tables on
+                    # the decode side too; the stock DecodeReqToTokenPool lacks
+                    # them. See dsv4_decode_req_to_token_pool for rationale.
+                    from sglang.srt.hardware_backend.npu.dsv4.dsv4_decode_req_to_token_pool import (
+                        DSV4NPUDecodeReqToTokenPool,
+                    )
+
+                    self.req_to_token_pool = DSV4NPUDecodeReqToTokenPool(
+                        size=max_num_reqs,
+                        max_context_len=self.model_config.context_len
+                        + extra_max_context_len,
+                        device=self.device,
+                        enable_memory_saver=self.server_args.enable_memory_saver,
+                        pre_alloc_size=pre_alloc_size,
+                    )
                 else:
                     self.req_to_token_pool = DecodeReqToTokenPool(
                         size=max_num_reqs,


### PR DESCRIPTION
## Motivation

DeepSeek-V4 on NPU (Ascend) has no single full-token KV space — its KV is split across 6 paged pools (`swa` / `c4` / `c128` / `indexer` / `c4_state` / `c128_state`), each with its own page geometry. The generic prefill-decode (PD) disaggregation path assumes one full-token contiguous space, so it cannot transfer DSV4-on-NPU KV correctly. This PR adapts startup, decode pre-allocation, descriptor registration, and KV transfer to be **per-pool**, enabling PD disaggregation for DeepSeek-V4 on NPU. All changes are gated to the NPU + DSV4 path; CUDA and other models/platforms are unaffected.

## Modifications

- **`mem_cache/allocator/swa.py`** — `alloc_extend_swa_tail` zero-fill writes an int64 value on NPU (`aclnnIndexPut` rejects int32 vs int64 mapping), matching `alloc` / `alloc_extend`.
- **`model_executor/model_runner_kv_cache_mixin.py`** — decode mode selects `DSV4NPUDecodeReqToTokenPool` (the stock `DecodeReqToTokenPool` lacks the 5 DSV4 per-req tables); gated on `disaggregation_mode == "decode"` and NPU and `is_deepseek_v4`.
- **`hardware_backend/npu/dsv4/dsv4_decode_req_to_token_pool.py`** (new) — `DecodeReqToTokenPool` + the 5 DSV4 tables / write helpers / allocator free hook (self-contained; leaves the existing `DSV4NPUReqToTokenPool` untouched).
- **`hardware_backend/npu/dsv4/dsv4_allocator.py`** — `alloc_extend_swa_tail` override so decode pre-alloc also reserves c4/c128 KV and tail compress-state pools (mirrors `alloc_extend`).
- **`hardware_backend/npu/dsv4/dsv4_common_hooks.py`** — `write_dsv4_prealloc_tables` (per-req write for the disagg pre-alloc path that bypasses the batch hook) and `build_dsv4_kv_transfer_payloads` (shared prefill/decode per-pool page indices, so src/dst align positionally).
- **`hardware_backend/npu/dsv4/dsv4_memory_pool.py`** — `get_contiguous_buf_infos` returns empty (no full-token space); `get_dsv4_state_components` reports per-pool buf infos in a fixed order.
- **`disaggregation/base/conn.py`** — add `DSV4_SWA/C4/C128/INDEXER/C4_STATE/C128_STATE` StateTypes.
- **`disaggregation/utils.py`** — `setup_state_kv_args` registers each DSV4 pool as its own component (before the `BaseSWAKVPool` branch to avoid the 2D-assert path).
- **`disaggregation/prefill.py` / `decode.py`** — produce per-pool send/recv indices via the shared builder; non-DSV4 paths keep the original `MAMBA`/`SWA`/`DSA`/`MINIMAX_INDEX_K`/`SWA_RING` loop unchanged.
- **`disaggregation/mooncake/conn.py`** — tolerate empty contiguous `kv_item_lens` and expose a `_is_generic_kvcache_state_type` hook for subclasses to extend.
- **`disaggregation/ascend/conn.py`** — DSV4 send routing lives in `AscendKVManager` (the DSV4 transfer is NPU-only).

## Accuracy Tests

- **Reduced-layer PD** — per-pool KV + compress-state transfer is byte-identical cross-process, and end-to-end output matches a single-process baseline token-for-token.
- **GPQA-Diamond (non-think)** — full model, `temp=1 / top_p=1`, batch=32: **76.26% (198/198, clean, 0 errors)** on Ascend.

## Benchmarking and Profiling

N/A for this PR — the change enables a previously-unsupported transfer path (DSV4-on-NPU PD) rather than altering a CUDA/critical-path hot loop; all additions are gated behind DSV4+NPU checks and are no-ops on every other model/platform. Throughput characterization of DSV4-on-NPU PD is tracked separately.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit) guidance.
- [ ] Add unit tests as outlined in the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests) guidance.
- [ ] Update documentation as needed, as outlined in the [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations) guidance.
- [ ] Provide accuracy and speed benchmark results according to the guidance.
- [ ] Follow the SGLang code style guidance.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28365350148](https://github.com/sgl-project/sglang/actions/runs/28365350148)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28365350027](https://github.com/sgl-project/sglang/actions/runs/28365350027)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->