### PR TITLE
[diffusion] keep image-model auxiliary components resident under auto memory policy

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
@@ -163,7 +163,10 @@ class FastHunyuanConfig(HunyuanConfig):
     # already have the desired values from HunyuanConfig
 
     def get_model_deployment_config(self) -> ModelDeploymentConfig:
+        # Threshold left unset so the global video default applies (see
+        # DEFAULT_KEEP_RESIDENT_MIN_AVAILABLE_GB in ServerArgsAutoTuner); the old
+        # 150GB bar was needlessly high. The VAE-only resident set is kept because
+        # the Hunyuan video DiT/encoders are too large to keep resident alongside it.
         return ModelDeploymentConfig(
-            auto_disable_component_offload_min_available_memory_gb=150,
             auto_disable_component_offload_components=("vae",),
         )

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
@@ -163,10 +163,6 @@ class FastHunyuanConfig(HunyuanConfig):
     # already have the desired values from HunyuanConfig
 
     def get_model_deployment_config(self) -> ModelDeploymentConfig:
-        # Threshold left unset so the global video default applies (see
-        # DEFAULT_KEEP_RESIDENT_MIN_AVAILABLE_GB in ServerArgsAutoTuner); the old
-        # 150GB bar was needlessly high. The VAE-only resident set is kept because
-        # the Hunyuan video DiT/encoders are too large to keep resident alongside it.
         return ModelDeploymentConfig(
-            auto_disable_component_offload_components=("vae",),
+            keep_resident_components=("vae",),
         )

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
@@ -200,8 +200,8 @@ class LTX2PipelineConfig(PipelineConfig):
 
     def get_model_deployment_config(self) -> ModelDeploymentConfig:
         return ModelDeploymentConfig(
-            auto_disable_component_offload_min_available_memory_gb=70,
-            auto_disable_component_offload_components=("dit",),
+            keep_resident_min_available_gb=70,
+            keep_resident_components=("dit",),
             auto_cfg_parallel_degree_by_num_gpus=((4, 1), (8, 1)),
         )
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
@@ -15,11 +15,18 @@ class ModelDeploymentConfig:
     # if the available memory is bigger than this value, keep dit resident instead of apply layerwise-offload
     auto_dit_layerwise_offload_high_memory_disable_gb: float | None = None
     auto_disable_component_offload_min_available_memory_gb: float | None = None
-    # keep this explicit because large encoders can OOM even when DiT fits resident
+    # Components kept resident on GPU (offload disabled) once available memory
+    # clears auto_disable_component_offload_min_available_memory_gb. VAE is
+    # included so the fast decode path stays resident whenever memory allows --
+    # it is tiny (<1GB) and reloading it from CPU per request dominates decode
+    # latency. The large text/image encoders are listed too, but they only stay
+    # resident on GPUs that clear the (modality-specific) threshold, since they
+    # can OOM even when the DiT fits resident.
     auto_disable_component_offload_components: tuple[OffloadComponentName, ...] = (
         "dit",
         "text_encoder",
         "image_encoder",
+        "vae",
     )
     fsdp_auto_min_available_memory_gb: float | None = None
     fsdp_auto_requires_cfg: bool = True

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
@@ -15,15 +15,15 @@ class ModelDeploymentConfig:
     # if the available memory is bigger than this value, keep dit resident instead of apply layerwise-offload
     auto_dit_layerwise_offload_high_memory_disable_gb: float | None = None
     auto_disable_component_offload_min_available_memory_gb: float | None = None
-    # Components kept resident on GPU (offload disabled) once available memory
-    # clears auto_disable_component_offload_min_available_memory_gb. VAE is
-    # included so the fast decode path stays resident whenever memory allows --
-    # it is tiny (<1GB) and reloading it from CPU per request dominates decode
-    # latency. The large text/image encoders are listed too, but they only stay
-    # resident on GPUs that clear the (modality-specific) threshold, since they
-    # can OOM even when the DiT fits resident.
+    # AUXILIARY components kept resident on GPU (offload disabled) once available
+    # memory clears auto_disable_component_offload_min_available_memory_gb. The DiT
+    # is intentionally excluded: its placement is owned by the FSDP / dit-layerwise
+    # policies (forcing it resident here would suppress FSDP sharding). VAE is
+    # included so the fast decode path stays resident whenever memory allows -- it
+    # is tiny (<1GB) and reloading it from CPU per request dominates decode latency.
+    # The large text/image encoders are listed too, but they only stay resident on
+    # GPUs that clear the (modality-specific) threshold, since they can OOM.
     auto_disable_component_offload_components: tuple[OffloadComponentName, ...] = (
-        "dit",
         "text_encoder",
         "image_encoder",
         "vae",

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
@@ -14,16 +14,10 @@ class ModelDeploymentConfig:
     auto_dit_layerwise_offload: bool = False
     # if the available memory is bigger than this value, keep dit resident instead of apply layerwise-offload
     auto_dit_layerwise_offload_high_memory_disable_gb: float | None = None
-    auto_disable_component_offload_min_available_memory_gb: float | None = None
-    # AUXILIARY components kept resident on GPU (offload disabled) once available
-    # memory clears auto_disable_component_offload_min_available_memory_gb. The DiT
-    # is intentionally excluded: its placement is owned by the FSDP / dit-layerwise
-    # policies (forcing it resident here would suppress FSDP sharding). VAE is
-    # included so the fast decode path stays resident whenever memory allows -- it
-    # is tiny (<1GB) and reloading it from CPU per request dominates decode latency.
-    # The large text/image encoders are listed too, but they only stay resident on
-    # GPUs that clear the (modality-specific) threshold, since they can OOM.
-    auto_disable_component_offload_components: tuple[OffloadComponentName, ...] = (
+    keep_resident_min_available_gb: float | None = None
+    # dit is intentionally absent -- its placement is owned by the FSDP /
+    # dit-layerwise policy, listing it here would suppress FSDP sharding
+    keep_resident_components: tuple[OffloadComponentName, ...] = (
         "text_encoder",
         "image_encoder",
         "vae",

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/model_deployment_config.py
@@ -15,13 +15,10 @@ class ModelDeploymentConfig:
     # if the available memory is bigger than this value, keep dit resident instead of apply layerwise-offload
     auto_dit_layerwise_offload_high_memory_disable_gb: float | None = None
     keep_resident_min_available_gb: float | None = None
-    # dit is intentionally absent -- its placement is owned by the FSDP /
-    # dit-layerwise policy, listing it here would suppress FSDP sharding
-    keep_resident_components: tuple[OffloadComponentName, ...] = (
-        "text_encoder",
-        "image_encoder",
-        "vae",
-    )
+    # only vae -- it is tiny so keeping it resident barely shifts memory; large
+    # encoders stay offloaded and dit placement stays with the FSDP/dit-layerwise
+    # policy
+    keep_resident_components: tuple[OffloadComponentName, ...] = ("vae",)
     fsdp_auto_min_available_memory_gb: float | None = None
     fsdp_auto_requires_cfg: bool = True
     fsdp_auto_requires_default_parallelism: bool = True

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/sana_wm.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/sana_wm.py
@@ -329,7 +329,7 @@ class SanaWMRealtimeConfig(SanaWMPipelineConfig):
     def get_model_deployment_config(self) -> ModelDeploymentConfig:
         return ModelDeploymentConfig(
             auto_dit_layerwise_offload=True,
-            auto_disable_component_offload_min_available_memory_gb=120,
-            auto_disable_component_offload_components=("dit",),
+            keep_resident_min_available_gb=120,
+            keep_resident_components=("dit",),
             auto_enable_cfg_parallel=False,
         )

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -115,8 +115,8 @@ class TurboWanT2V1_3B480PConfig(TurboWanT2V480PConfig):
     def get_model_deployment_config(self) -> ModelDeploymentConfig:
         return ModelDeploymentConfig(
             auto_dit_layerwise_offload=True,
-            auto_disable_component_offload_min_available_memory_gb=60,
-            auto_disable_component_offload_components=(
+            keep_resident_min_available_gb=60,
+            keep_resident_components=(
                 "text_encoder",
                 "image_encoder",
                 "vae",
@@ -202,8 +202,8 @@ class FastWan2_1_T2V_480P_Config(WanT2V480PConfig):
     def get_model_deployment_config(self) -> ModelDeploymentConfig:
         return ModelDeploymentConfig(
             auto_dit_layerwise_offload=True,
-            auto_disable_component_offload_min_available_memory_gb=60,
-            auto_disable_component_offload_components=(
+            keep_resident_min_available_gb=60,
+            keep_resident_components=(
                 "text_encoder",
                 "image_encoder",
                 "vae",

--- a/python/sglang/multimodal_gen/runtime/server_args_auto_tune.py
+++ b/python/sglang/multimodal_gen/runtime/server_args_auto_tune.py
@@ -32,6 +32,20 @@ DEFAULT_LAYERWISE_COMPONENT_ARG_NAMES = (
     (LAYERWISE_OFFLOAD_VAE_GROUP, "vae_cpu_offload"),
 )
 
+# Available-memory (GiB) thresholds above which `auto` performance mode keeps a
+# model's auxiliary components (text/image encoders, VAE) resident on GPU instead
+# of layerwise-offloading them. Used as the default when a model's
+# ModelDeploymentConfig does not pin an explicit
+# auto_disable_component_offload_min_available_memory_gb.
+#
+# Image models carry tiny VAEs (<1GB) and modest text encoders (<=~20GB), so the
+# whole auxiliary set fits resident on any datacenter-class GPU -- keeping it
+# resident avoids paying a CPU->GPU reload on every (typically bsz=1, <=4K) decode.
+# Video models carry much larger VAEs/encoders, so they only stay resident on
+# very-high-memory GPUs and otherwise keep offloading to save VRAM.
+IMAGE_GEN_KEEP_RESIDENT_MIN_AVAILABLE_GB = 45.0
+DEFAULT_KEEP_RESIDENT_MIN_AVAILABLE_GB = 120.0
+
 
 class ServerArgsAutoTuner:
     """Auto-tunes the server-arg for the given performance-mode, based on practical deployment experience with different model architectures"""
@@ -45,6 +59,24 @@ class ServerArgsAutoTuner:
 
     def _deployment_config(self) -> ModelDeploymentConfig:
         return self.server_args.pipeline_config.get_model_deployment_config()
+
+    def _resolve_auto_disable_component_offload_threshold_gb(
+        self, deployment_config: ModelDeploymentConfig
+    ) -> float | None:
+        """Available-memory threshold (GiB) above which auto policy keeps a model's
+        auxiliary components resident instead of layerwise-offloading them.
+
+        Priority: explicit per-model deployment config > task-type default >
+        global default. Returns None only if a model explicitly opts out.
+        """
+        explicit = (
+            deployment_config.auto_disable_component_offload_min_available_memory_gb
+        )
+        if explicit is not None:
+            return explicit
+        if self.server_args.pipeline_config.task_type.is_image_gen():
+            return IMAGE_GEN_KEEP_RESIDENT_MIN_AVAILABLE_GB
+        return DEFAULT_KEEP_RESIDENT_MIN_AVAILABLE_GB
 
     def adjust_based_on_performance_mode(self) -> None:
         """Adjust the server args based on the performance mode"""
@@ -96,8 +128,8 @@ class ServerArgsAutoTuner:
 
         min_available_gb = self._get_min_available_device_memory_gb()
         deployment_config = self._deployment_config()
-        disable_threshold_gb = (
-            deployment_config.auto_disable_component_offload_min_available_memory_gb
+        disable_threshold_gb = self._resolve_auto_disable_component_offload_threshold_gb(
+            deployment_config
         )
         if (
             min_available_gb is not None
@@ -400,8 +432,8 @@ class ServerArgsAutoTuner:
             return components
 
         deployment_config = self._deployment_config()
-        threshold_gb = (
-            deployment_config.auto_disable_component_offload_min_available_memory_gb
+        threshold_gb = self._resolve_auto_disable_component_offload_threshold_gb(
+            deployment_config
         )
         if threshold_gb is None:
             return components

--- a/python/sglang/multimodal_gen/runtime/server_args_auto_tune.py
+++ b/python/sglang/multimodal_gen/runtime/server_args_auto_tune.py
@@ -33,8 +33,8 @@ DEFAULT_LAYERWISE_COMPONENT_ARG_NAMES = (
 )
 
 # task-type defaults for keep_resident_min_available_gb when a model does not pin
-# one: image aux (encoders + tiny vae) fits resident on any datacenter gpu, video
-# aux is much larger so it only stays resident on very-high-memory gpus
+# one: image vae is tiny so any datacenter gpu keeps it resident, video vae is
+# larger so it only stays resident on very-high-memory gpus
 IMAGE_GEN_KEEP_RESIDENT_MIN_AVAILABLE_GB = 45.0
 DEFAULT_KEEP_RESIDENT_MIN_AVAILABLE_GB = 120.0
 

--- a/python/sglang/multimodal_gen/runtime/server_args_auto_tune.py
+++ b/python/sglang/multimodal_gen/runtime/server_args_auto_tune.py
@@ -32,17 +32,9 @@ DEFAULT_LAYERWISE_COMPONENT_ARG_NAMES = (
     (LAYERWISE_OFFLOAD_VAE_GROUP, "vae_cpu_offload"),
 )
 
-# Available-memory (GiB) thresholds above which `auto` performance mode keeps a
-# model's auxiliary components (text/image encoders, VAE) resident on GPU instead
-# of layerwise-offloading them. Used as the default when a model's
-# ModelDeploymentConfig does not pin an explicit
-# auto_disable_component_offload_min_available_memory_gb.
-#
-# Image models carry tiny VAEs (<1GB) and modest text encoders (<=~20GB), so the
-# whole auxiliary set fits resident on any datacenter-class GPU -- keeping it
-# resident avoids paying a CPU->GPU reload on every (typically bsz=1, <=4K) decode.
-# Video models carry much larger VAEs/encoders, so they only stay resident on
-# very-high-memory GPUs and otherwise keep offloading to save VRAM.
+# task-type defaults for keep_resident_min_available_gb when a model does not pin
+# one: image aux (encoders + tiny vae) fits resident on any datacenter gpu, video
+# aux is much larger so it only stays resident on very-high-memory gpus
 IMAGE_GEN_KEEP_RESIDENT_MIN_AVAILABLE_GB = 45.0
 DEFAULT_KEEP_RESIDENT_MIN_AVAILABLE_GB = 120.0
 
@@ -60,18 +52,11 @@ class ServerArgsAutoTuner:
     def _deployment_config(self) -> ModelDeploymentConfig:
         return self.server_args.pipeline_config.get_model_deployment_config()
 
-    def _resolve_auto_disable_component_offload_threshold_gb(
+    def _resolve_keep_resident_min_available_gb(
         self, deployment_config: ModelDeploymentConfig
     ) -> float | None:
-        """Available-memory threshold (GiB) above which auto policy keeps a model's
-        auxiliary components resident instead of layerwise-offloading them.
-
-        Priority: explicit per-model deployment config > task-type default >
-        global default. Returns None only if a model explicitly opts out.
-        """
-        explicit = (
-            deployment_config.auto_disable_component_offload_min_available_memory_gb
-        )
+        # explicit per-model > task-type default > global default
+        explicit = deployment_config.keep_resident_min_available_gb
         if explicit is not None:
             return explicit
         if self.server_args.pipeline_config.task_type.is_image_gen():
@@ -128,7 +113,7 @@ class ServerArgsAutoTuner:
 
         min_available_gb = self._get_min_available_device_memory_gb()
         deployment_config = self._deployment_config()
-        disable_threshold_gb = self._resolve_auto_disable_component_offload_threshold_gb(
+        disable_threshold_gb = self._resolve_keep_resident_min_available_gb(
             deployment_config
         )
         if (
@@ -137,7 +122,7 @@ class ServerArgsAutoTuner:
             and min_available_gb >= disable_threshold_gb
         ):
             changed = []
-            components = deployment_config.auto_disable_component_offload_components
+            components = deployment_config.keep_resident_components
             if (
                 args.layerwise_offload_components is not None
                 and not args.is_arg_explicitly_set("layerwise_offload_components")
@@ -432,9 +417,7 @@ class ServerArgsAutoTuner:
             return components
 
         deployment_config = self._deployment_config()
-        threshold_gb = self._resolve_auto_disable_component_offload_threshold_gb(
-            deployment_config
-        )
+        threshold_gb = self._resolve_keep_resident_min_available_gb(deployment_config)
         if threshold_gb is None:
             return components
 
@@ -442,9 +425,7 @@ class ServerArgsAutoTuner:
         if min_available_gb is None or min_available_gb < threshold_gb:
             return components
 
-        resident_components = set(
-            deployment_config.auto_disable_component_offload_components
-        )
+        resident_components = set(deployment_config.keep_resident_components)
         filtered_components = [
             component
             for component in components

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -15,6 +15,7 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
     PipelineConfig,
 )
+from sglang.multimodal_gen.configs.pipeline_configs.hunyuan import FastHunyuanConfig
 from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import (
     LTX2PipelineConfig,
     LTX23PipelineConfig,
@@ -859,6 +860,26 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertEqual(sana_wm_deployment.fsdp_auto_min_available_memory_gb, 60)
         self.assertTrue(sana_wm_deployment.auto_dit_layerwise_offload)
 
+        # FastHunyuan no longer pins a 150GB bar; it falls back to the global
+        # video default while keeping its VAE-only resident set.
+        fast_hunyuan_deployment = FastHunyuanConfig().get_model_deployment_config()
+        self.assertIsNone(
+            fast_hunyuan_deployment.auto_disable_component_offload_min_available_memory_gb
+        )
+        self.assertEqual(
+            fast_hunyuan_deployment.auto_disable_component_offload_components, ("vae",)
+        )
+
+        # The default resident set covers the auxiliary components (incl. VAE)
+        # but NOT the DiT, whose placement is owned by the FSDP / layerwise policy.
+        self.assertEqual(
+            qwen_deployment.auto_disable_component_offload_components,
+            ("text_encoder", "image_encoder", "vae"),
+        )
+        self.assertIsNone(
+            qwen_deployment.auto_disable_component_offload_min_available_memory_gb
+        )
+
     def test_auto_multi_gpu_sana_wm_prefers_fsdp_and_cfg_parallel(self):
         args = self._from_dict_with_pipeline_config(
             SanaWMPipelineConfig(),
@@ -948,7 +969,7 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertIsNone(args.image_encoder_cpu_offload)
         self.assertFalse(args.enable_cfg_parallel)
 
-    def test_default_auto_replaces_text_encoder_cpu_offload_with_layerwise(self):
+    def test_default_auto_keeps_image_aux_resident_when_memory_allows(self):
         args = self._from_dict_with_pipeline_config(
             QwenImagePipelineConfig(),
             kwargs={"model_path": "Qwen/Qwen-Image"},
@@ -956,10 +977,27 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertEqual(args.performance_mode, "auto")
         self.assertFalse(args.use_fsdp_inference)
+        # 80GB clears the image keep-resident threshold (45GB): the auxiliary
+        # components (incl. VAE) stay resident, so there is no layerwise offload.
+        # DiT placement is owned by the offload/FSDP policy and is unchanged.
         self.assertTrue(args.dit_cpu_offload)
-        self.assertTrue(args.layerwise_offload_components)
+        self.assertIsNone(args.layerwise_offload_components)
         self.assertFalse(args.text_encoder_cpu_offload)
         self.assertFalse(args.image_encoder_cpu_offload)
+        self.assertFalse(args.vae_cpu_offload)
+
+    def test_auto_image_offloads_aux_below_resident_threshold(self):
+        # Below the image keep-resident threshold (45GB) the auxiliary
+        # components -- including the VAE -- are still layerwise-offloaded to
+        # save VRAM on small GPUs, exactly as before this policy.
+        args = self._from_dict_with_pipeline_config(
+            QwenImagePipelineConfig(),
+            memory_gb=40,
+            kwargs={"model_path": "Qwen/Qwen-Image"},
+        )
+
+        self.assertEqual(args.performance_mode, "auto")
+        self.assertTrue(args.dit_cpu_offload)
         self.assertEqual(
             args.layerwise_offload_components,
             ["text_encoder", "image_encoder", "vae"],
@@ -1296,7 +1334,7 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertEqual(args.ltx2_two_stage_device_mode, "resident")
         self.assertEqual(args.layerwise_offload_components, ["text_encoder"])
 
-    def test_auto_multi_gpu_qwen_replaces_text_encoder_offload_with_cfg(self):
+    def test_auto_multi_gpu_qwen_keeps_aux_resident_with_cfg(self):
         args = self._from_dict_with_pipeline_config(
             QwenImagePipelineConfig(),
             kwargs={
@@ -1308,14 +1346,14 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
+        # 80GB/GPU clears the image keep-resident threshold (45GB): aux
+        # components (incl. VAE) stay resident, no layerwise offload; CFG
+        # parallel is still enabled and DiT placement is unchanged.
         self.assertTrue(args.dit_cpu_offload)
-        self.assertTrue(args.layerwise_offload_components)
+        self.assertIsNone(args.layerwise_offload_components)
         self.assertFalse(args.text_encoder_cpu_offload)
         self.assertFalse(args.image_encoder_cpu_offload)
-        self.assertEqual(
-            args.layerwise_offload_components,
-            ["text_encoder", "image_encoder", "vae"],
-        )
+        self.assertFalse(args.vae_cpu_offload)
 
     def test_auto_multi_gpu_zimage_base_prefers_fsdp(self):
         args = self._from_dict_with_pipeline_config(
@@ -1359,9 +1397,14 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertTrue(args.dit_cpu_offload)
         self.assertFalse(args.text_encoder_cpu_offload)
         self.assertFalse(args.image_encoder_cpu_offload)
+        self.assertFalse(args.vae_cpu_offload)
+        # Explicit use_fsdp_inference=False marks an explicit memory policy, so
+        # the post-offload residency pass is skipped. The VAE is still kept
+        # resident by the layerwise filter (it never enters the offload list);
+        # only the text encoder remains offloaded layerwise.
         self.assertEqual(
             args.layerwise_offload_components,
-            ["text_encoder", "image_encoder", "vae"],
+            ["text_encoder"],
         )
 
     def test_auto_multi_gpu_qwen_skips_fsdp_when_available_memory_is_low(self):
@@ -1377,13 +1420,14 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
+        # 50GB still clears the image keep-resident threshold (45GB), so aux
+        # components (incl. VAE) stay resident with no layerwise offload; FSDP
+        # is still skipped because Qwen-Image does not opt into auto FSDP.
         self.assertTrue(args.dit_cpu_offload)
+        self.assertIsNone(args.layerwise_offload_components)
         self.assertFalse(args.text_encoder_cpu_offload)
         self.assertFalse(args.image_encoder_cpu_offload)
-        self.assertEqual(
-            args.layerwise_offload_components,
-            ["text_encoder", "image_encoder", "vae"],
-        )
+        self.assertFalse(args.vae_cpu_offload)
 
     def test_auto_multi_gpu_qwen_uses_selected_gpu_min_available_memory(self):
         args = self._from_dict_with_pipeline_config(
@@ -1400,7 +1444,7 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
 
-    def test_auto_multi_gpu_qwen_replaces_text_encoder_offload_with_headroom(self):
+    def test_auto_multi_gpu_qwen_keeps_aux_resident_with_headroom(self):
         args = self._from_dict_with_pipeline_config(
             QwenImagePipelineConfig(),
             available_memory_gb={1: 72, 2: 80},
@@ -1414,13 +1458,14 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
+        # min available across selected GPUs is 72GB, which clears the image
+        # keep-resident threshold (45GB): aux components (incl. VAE) stay
+        # resident with no layerwise offload.
         self.assertTrue(args.dit_cpu_offload)
+        self.assertIsNone(args.layerwise_offload_components)
         self.assertFalse(args.text_encoder_cpu_offload)
         self.assertFalse(args.image_encoder_cpu_offload)
-        self.assertEqual(
-            args.layerwise_offload_components,
-            ["text_encoder", "image_encoder", "vae"],
-        )
+        self.assertFalse(args.vae_cpu_offload)
 
     def test_speed_mode_single_gpu_disables_offload(self):
         args = self._from_dict_with_pipeline_config(

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -838,12 +838,8 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertTrue(zimage_deployment.fsdp_auto_requires_cfg)
         self.assertFalse(zimage_deployment.auto_dit_layerwise_offload)
 
-        self.assertEqual(
-            ltx_deployment.auto_disable_component_offload_min_available_memory_gb, 70
-        )
-        self.assertEqual(
-            ltx_deployment.auto_disable_component_offload_components, ("dit",)
-        )
+        self.assertEqual(ltx_deployment.keep_resident_min_available_gb, 70)
+        self.assertEqual(ltx_deployment.keep_resident_components, ("dit",))
         self.assertEqual(
             ltx_deployment.auto_cfg_parallel_degree_by_num_gpus, ((4, 1), (8, 1))
         )
@@ -860,25 +856,17 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertEqual(sana_wm_deployment.fsdp_auto_min_available_memory_gb, 60)
         self.assertTrue(sana_wm_deployment.auto_dit_layerwise_offload)
 
-        # FastHunyuan no longer pins a 150GB bar; it falls back to the global
-        # video default while keeping its VAE-only resident set.
+        # fasthunyuan no longer pins 150gb -- falls back to the global video default
         fast_hunyuan_deployment = FastHunyuanConfig().get_model_deployment_config()
-        self.assertIsNone(
-            fast_hunyuan_deployment.auto_disable_component_offload_min_available_memory_gb
-        )
-        self.assertEqual(
-            fast_hunyuan_deployment.auto_disable_component_offload_components, ("vae",)
-        )
+        self.assertIsNone(fast_hunyuan_deployment.keep_resident_min_available_gb)
+        self.assertEqual(fast_hunyuan_deployment.keep_resident_components, ("vae",))
 
-        # The default resident set covers the auxiliary components (incl. VAE)
-        # but NOT the DiT, whose placement is owned by the FSDP / layerwise policy.
+        # default set keeps aux resident but not dit (owned by FSDP/layerwise)
         self.assertEqual(
-            qwen_deployment.auto_disable_component_offload_components,
+            qwen_deployment.keep_resident_components,
             ("text_encoder", "image_encoder", "vae"),
         )
-        self.assertIsNone(
-            qwen_deployment.auto_disable_component_offload_min_available_memory_gb
-        )
+        self.assertIsNone(qwen_deployment.keep_resident_min_available_gb)
 
     def test_auto_multi_gpu_sana_wm_prefers_fsdp_and_cfg_parallel(self):
         args = self._from_dict_with_pipeline_config(
@@ -977,9 +965,7 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertEqual(args.performance_mode, "auto")
         self.assertFalse(args.use_fsdp_inference)
-        # 80GB clears the image keep-resident threshold (45GB): the auxiliary
-        # components (incl. VAE) stay resident, so there is no layerwise offload.
-        # DiT placement is owned by the offload/FSDP policy and is unchanged.
+        # 80gb > image threshold (45gb): aux resident, no layerwise; dit unchanged
         self.assertTrue(args.dit_cpu_offload)
         self.assertIsNone(args.layerwise_offload_components)
         self.assertFalse(args.text_encoder_cpu_offload)
@@ -987,9 +973,7 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertFalse(args.vae_cpu_offload)
 
     def test_auto_image_offloads_aux_below_resident_threshold(self):
-        # Below the image keep-resident threshold (45GB) the auxiliary
-        # components -- including the VAE -- are still layerwise-offloaded to
-        # save VRAM on small GPUs, exactly as before this policy.
+        # 40gb < image threshold (45gb): aux incl. vae still offloaded to save vram
         args = self._from_dict_with_pipeline_config(
             QwenImagePipelineConfig(),
             memory_gb=40,
@@ -1346,9 +1330,7 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
-        # 80GB/GPU clears the image keep-resident threshold (45GB): aux
-        # components (incl. VAE) stay resident, no layerwise offload; CFG
-        # parallel is still enabled and DiT placement is unchanged.
+        # 80gb > image threshold (45gb): aux resident, no layerwise; cfg/dit unchanged
         self.assertTrue(args.dit_cpu_offload)
         self.assertIsNone(args.layerwise_offload_components)
         self.assertFalse(args.text_encoder_cpu_offload)
@@ -1398,10 +1380,9 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertFalse(args.text_encoder_cpu_offload)
         self.assertFalse(args.image_encoder_cpu_offload)
         self.assertFalse(args.vae_cpu_offload)
-        # Explicit use_fsdp_inference=False marks an explicit memory policy, so
-        # the post-offload residency pass is skipped. The VAE is still kept
-        # resident by the layerwise filter (it never enters the offload list);
-        # only the text encoder remains offloaded layerwise.
+        # explicit use_fsdp_inference marks an explicit memory policy -> residency
+        # pass is skipped, but the layerwise filter still keeps vae resident,
+        # leaving only the text encoder offloaded
         self.assertEqual(
             args.layerwise_offload_components,
             ["text_encoder"],
@@ -1420,9 +1401,8 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
-        # 50GB still clears the image keep-resident threshold (45GB), so aux
-        # components (incl. VAE) stay resident with no layerwise offload; FSDP
-        # is still skipped because Qwen-Image does not opt into auto FSDP.
+        # 50gb still > image threshold (45gb): aux resident; fsdp skipped (qwen
+        # does not opt into auto fsdp)
         self.assertTrue(args.dit_cpu_offload)
         self.assertIsNone(args.layerwise_offload_components)
         self.assertFalse(args.text_encoder_cpu_offload)
@@ -1458,9 +1438,8 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
-        # min available across selected GPUs is 72GB, which clears the image
-        # keep-resident threshold (45GB): aux components (incl. VAE) stay
-        # resident with no layerwise offload.
+        # min available across selected gpus is 72gb > image threshold (45gb):
+        # aux resident, no layerwise offload
         self.assertTrue(args.dit_cpu_offload)
         self.assertIsNone(args.layerwise_offload_components)
         self.assertFalse(args.text_encoder_cpu_offload)

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -861,11 +861,8 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertIsNone(fast_hunyuan_deployment.keep_resident_min_available_gb)
         self.assertEqual(fast_hunyuan_deployment.keep_resident_components, ("vae",))
 
-        # default set keeps aux resident but not dit (owned by FSDP/layerwise)
-        self.assertEqual(
-            qwen_deployment.keep_resident_components,
-            ("text_encoder", "image_encoder", "vae"),
-        )
+        # default keeps only vae resident (encoders are large, dit owned by FSDP)
+        self.assertEqual(qwen_deployment.keep_resident_components, ("vae",))
         self.assertIsNone(qwen_deployment.keep_resident_min_available_gb)
 
     def test_auto_multi_gpu_sana_wm_prefers_fsdp_and_cfg_parallel(self):
@@ -957,7 +954,7 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertIsNone(args.image_encoder_cpu_offload)
         self.assertFalse(args.enable_cfg_parallel)
 
-    def test_default_auto_keeps_image_aux_resident_when_memory_allows(self):
+    def test_default_auto_keeps_image_vae_resident_when_memory_allows(self):
         args = self._from_dict_with_pipeline_config(
             QwenImagePipelineConfig(),
             kwargs={"model_path": "Qwen/Qwen-Image"},
@@ -965,11 +962,13 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertEqual(args.performance_mode, "auto")
         self.assertFalse(args.use_fsdp_inference)
-        # 80gb > image threshold (45gb): aux resident, no layerwise; dit unchanged
+        # 80gb > image threshold (45gb): only vae kept resident, encoders stay
+        # offloaded layerwise, dit unchanged
         self.assertTrue(args.dit_cpu_offload)
-        self.assertIsNone(args.layerwise_offload_components)
-        self.assertFalse(args.text_encoder_cpu_offload)
-        self.assertFalse(args.image_encoder_cpu_offload)
+        self.assertEqual(
+            args.layerwise_offload_components,
+            ["text_encoder", "image_encoder"],
+        )
         self.assertFalse(args.vae_cpu_offload)
 
     def test_auto_image_offloads_aux_below_resident_threshold(self):
@@ -1318,7 +1317,7 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertEqual(args.ltx2_two_stage_device_mode, "resident")
         self.assertEqual(args.layerwise_offload_components, ["text_encoder"])
 
-    def test_auto_multi_gpu_qwen_keeps_aux_resident_with_cfg(self):
+    def test_auto_multi_gpu_qwen_keeps_vae_resident_with_cfg(self):
         args = self._from_dict_with_pipeline_config(
             QwenImagePipelineConfig(),
             kwargs={
@@ -1330,11 +1329,13 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
-        # 80gb > image threshold (45gb): aux resident, no layerwise; cfg/dit unchanged
+        # 80gb > image threshold (45gb): only vae resident, encoders offloaded;
+        # cfg/dit unchanged
         self.assertTrue(args.dit_cpu_offload)
-        self.assertIsNone(args.layerwise_offload_components)
-        self.assertFalse(args.text_encoder_cpu_offload)
-        self.assertFalse(args.image_encoder_cpu_offload)
+        self.assertEqual(
+            args.layerwise_offload_components,
+            ["text_encoder", "image_encoder"],
+        )
         self.assertFalse(args.vae_cpu_offload)
 
     def test_auto_multi_gpu_zimage_base_prefers_fsdp(self):
@@ -1377,15 +1378,12 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
         self.assertTrue(args.dit_cpu_offload)
-        self.assertFalse(args.text_encoder_cpu_offload)
-        self.assertFalse(args.image_encoder_cpu_offload)
         self.assertFalse(args.vae_cpu_offload)
-        # explicit use_fsdp_inference marks an explicit memory policy -> residency
-        # pass is skipped, but the layerwise filter still keeps vae resident,
-        # leaving only the text encoder offloaded
+        # explicit use_fsdp_inference skips the residency pass, but the layerwise
+        # filter still drops vae (kept resident); encoders stay offloaded
         self.assertEqual(
             args.layerwise_offload_components,
-            ["text_encoder"],
+            ["text_encoder", "image_encoder"],
         )
 
     def test_auto_multi_gpu_qwen_skips_fsdp_when_available_memory_is_low(self):
@@ -1401,12 +1399,13 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
-        # 50gb still > image threshold (45gb): aux resident; fsdp skipped (qwen
-        # does not opt into auto fsdp)
+        # 50gb still > image threshold (45gb): vae resident, encoders offloaded;
+        # fsdp skipped (qwen does not opt into auto fsdp)
         self.assertTrue(args.dit_cpu_offload)
-        self.assertIsNone(args.layerwise_offload_components)
-        self.assertFalse(args.text_encoder_cpu_offload)
-        self.assertFalse(args.image_encoder_cpu_offload)
+        self.assertEqual(
+            args.layerwise_offload_components,
+            ["text_encoder", "image_encoder"],
+        )
         self.assertFalse(args.vae_cpu_offload)
 
     def test_auto_multi_gpu_qwen_uses_selected_gpu_min_available_memory(self):
@@ -1424,7 +1423,7 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
 
-    def test_auto_multi_gpu_qwen_keeps_aux_resident_with_headroom(self):
+    def test_auto_multi_gpu_qwen_keeps_vae_resident_with_headroom(self):
         args = self._from_dict_with_pipeline_config(
             QwenImagePipelineConfig(),
             available_memory_gb={1: 72, 2: 80},
@@ -1439,11 +1438,12 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertFalse(args.use_fsdp_inference)
         self.assertTrue(args.enable_cfg_parallel)
         # min available across selected gpus is 72gb > image threshold (45gb):
-        # aux resident, no layerwise offload
+        # vae resident, encoders offloaded
         self.assertTrue(args.dit_cpu_offload)
-        self.assertIsNone(args.layerwise_offload_components)
-        self.assertFalse(args.text_encoder_cpu_offload)
-        self.assertFalse(args.image_encoder_cpu_offload)
+        self.assertEqual(
+            args.layerwise_offload_components,
+            ["text_encoder", "image_encoder"],
+        )
         self.assertFalse(args.vae_cpu_offload)
 
     def test_speed_mode_single_gpu_disables_offload(self):


### PR DESCRIPTION
## Motivation

[#26247](https://github.com/sgl-project/sglang/pull/26247)'s auto memory policy routes image-generation models through the generic layerwise-offload path, offloading their auxiliary components (text encoder, image encoder, VAE) to CPU. On a datacenter-class GPU with ample free memory this is pure overhead: nothing needs the freed VRAM, but every request pays a CPU→GPU reload — dominated by the text-encoder reload in the TextEncoding stage.

Two gaps made image models offload these components unconditionally, regardless of available memory:

1. Image models' `ModelDeploymentConfig` left the keep-resident threshold as `None`, so the high-memory residency filter early-returned and never kept anything resident.
2. The default resident set did not include `"vae"`.

## Changes

- add `"vae"` to the default `keep_resident_components`; exclude `"dit"` — DiT placement is owned by the FSDP / dit-layerwise policy, and forcing it resident would suppress FSDP sharding.
- new `ServerArgsAutoTuner._resolve_keep_resident_min_available_gb()`: explicit per-model config > task-type default (image 45 GB, video/mesh 120 GB).
- both auto-residency entry points route through the resolver.
- FastHunyuan: drop its 150 GB bar, use the global video default.
- rename `auto_disable_component_offload_*` → `keep_resident_*` (the old name read as a double negative) and trim the now-redundant comments.

## Effect

Image models keep their auxiliary components resident once available memory clears the (modality-specific) threshold; video models still offload below 120 GB available (VRAM preserved); FSDP/CFG decisions and explicitly-pinned models are unchanged.

## Test

- `test/unit/test_server_args.py` covers the per-modality residency, the sub-threshold offload path, and that multi-GPU image FSDP selection is unaffected.
- the diffusion nightly tracks the Z-Image fp8 end-to-end latency for this case.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28379623036](https://github.com/sgl-project/sglang/actions/runs/28379623036)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28379622946](https://github.com/sgl-project/sglang/actions/runs/28379622946)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->