### PR TITLE
[DSV4][NPU][PD] Support prefill-decode disaggregation for DeepSeek V4 on NPU

### DIFF
--- a/python/sglang/srt/disaggregation/ascend/conn.py
+++ b/python/sglang/srt/disaggregation/ascend/conn.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import enum
 import logging
 from typing import List, Tuple
 
@@ -16,6 +17,21 @@ from sglang.srt.disaggregation.mooncake.conn import (
 from sglang.srt.utils.network import get_local_ip_auto
 
 logger = logging.getLogger(__name__)
+
+
+class AscendStateType(str, enum.Enum):
+    """DSV4-on-NPU per-pool PD components, kept out of the cross-hardware
+    StateType enum. Sent via the same page-indexed path as SWA."""
+
+    DSV4_SWA = "dsv4_swa"
+    DSV4_C4 = "dsv4_c4"
+    DSV4_C128 = "dsv4_c128"
+    DSV4_INDEXER = "dsv4_indexer"
+    DSV4_C4_STATE = "dsv4_c4_state"
+    DSV4_C128_STATE = "dsv4_c128_state"
+
+
+_DSV4_KVCACHE_STATE_TYPES = tuple(AscendStateType)
 
 
 class AscendKVManager(MooncakeKVManager):
@@ -42,10 +58,12 @@ class AscendKVManager(MooncakeKVManager):
             self.engine.batch_register(component_ptrs, component_lens)
 
     def get_mla_kv_ptrs_with_pp(
-        self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int]
+        self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int], state_type=None
     ) -> Tuple[List[int], List[int], int]:
         # src_kv_ptrs: k_data, v_data, index_k_data(optional)
         # dst_kv_ptrs: k_data, v_data, index_k_data(optional)
+        # state_type is accepted for parity with the common disaggregation path;
+        # the NPU kv_buf_groups slicing below is state-type agnostic.
         start_layer = self.kv_args.prefill_start_layer
         kv_buf_groups = getattr(self.kv_args, "kv_buf_groups", 1)
         total_kv_layers = getattr(self.kv_args, "total_kv_layers", 0)
@@ -177,6 +195,13 @@ class AscendKVManager(MooncakeKVManager):
             return process_layers(layers_params)
 
         return 0
+
+    def _is_generic_kvcache_state_type(self, st) -> bool:
+        # DSV4 per-pool components also use the page-indexed send path.
+        return (
+            super()._is_generic_kvcache_state_type(st)
+            or st in _DSV4_KVCACHE_STATE_TYPES
+        )
 
 
 class AscendKVSender(MooncakeKVSender):

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -85,12 +85,14 @@ from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
     set_time_batch,
 )
-from sglang.srt.utils import get_num_new_pages
+from sglang.srt.utils import get_num_new_pages, is_npu
 from sglang.srt.utils.network import NetworkAddress
 from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 logger = logging.getLogger(__name__)
+
+_is_npu = is_npu()
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -1062,30 +1064,41 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 )
 
             state_types = self.kv_manager.kv_args.state_types
-            state_indices: Optional[List] = []
             if StateType.C128_STATE in state_types:
                 clear_c128_state = getattr(
                     self.token_to_kv_pool, "clear_c128_req_state", None
                 )
                 if clear_c128_state is not None:
                     clear_c128_state(int(decode_req.req.req_pool_idx))
-            for st in state_types:
-                if st == StateType.MAMBA:
-                    state_indices.append(_mamba_payload())
-                elif st == StateType.SWA:
-                    state_indices.append(_swa_payload())
-                elif st == StateType.DSA:
-                    state_indices.append(_dsa_payload())
-                elif st == StateType.MINIMAX_INDEX_K:
-                    # Index rows live at the same loc as main KV on the same
-                    # page_size, so reuse the full-seq page-ids.
-                    state_indices.append(_dsa_payload())
-                elif st == StateType.SWA_RING:
-                    state_indices.append(_swa_ring_payload())
-                elif st == StateType.C128_STATE:
-                    state_indices.append(_c128_state_payload())
-                else:
-                    state_indices.append(None)
+            # MINIMAX_INDEX_K reuses _dsa_payload: index rows live at the same loc
+            # as main KV on the same page_size.
+            payloads = {
+                StateType.MAMBA: _mamba_payload,
+                StateType.SWA: _swa_payload,
+                StateType.DSA: _dsa_payload,
+                StateType.MINIMAX_INDEX_K: _dsa_payload,
+                StateType.SWA_RING: _swa_ring_payload,
+                StateType.C128_STATE: _c128_state_payload,
+            }
+            if _is_npu and isinstance(
+                self.token_to_kv_pool, DeepSeekV4TokenToKVPool
+            ):
+                from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
+                    dsv4_state_payloads,
+                )
+
+                payloads.update(
+                    dsv4_state_payloads(
+                        self.req_to_token_pool,
+                        decode_req.req.req_pool_idx,
+                        seq_len,
+                        self.token_to_kv_pool_allocator.page_size,
+                        self.scheduler.sliding_window_size,
+                    )
+                )
+            state_indices: Optional[List] = [
+                payloads[st]() if st in payloads else None for st in state_types
+            ]
 
             decode_req.metadata_buffer_index = (
                 self.req_to_metadata_buffer_idx_allocator.alloc()
@@ -1405,6 +1418,23 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 if prefix_len > 0
                 else torch.tensor([-1], dtype=torch.int64, device=device)
             )
+            # kwargs make the DSV4 allocator return a bundle, unwrap reads it.
+            is_dsv4 = _is_npu and isinstance(
+                self.token_to_kv_pool, DeepSeekV4TokenToKVPool
+            )
+            dsv4_kwargs = {}
+            if is_dsv4:
+                from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
+                    dsv4_prealloc_kwargs,
+                )
+
+                dsv4_kwargs = dsv4_prealloc_kwargs(
+                    self.token_to_kv_pool_allocator,
+                    req,
+                    fill_len,
+                    self.req_to_token_pool,
+                    device=device,
+                )
             if self._uses_swa_tail_prealloc() and prefix_len == 0:
                 # Tail-only SWA allocation: only valid when prefix_len == 0.
                 # When prefix_len > 0 (radix cache hit), we fall back to
@@ -1418,6 +1448,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     last_loc=last_loc,
                     extend_num_tokens=fill_len,
                     swa_tail_len=self._swa_tail_len(fill_len),
+                    **dsv4_kwargs,
                 )
                 req.swa_evicted_seqlen = fill_len - self._swa_tail_len(fill_len)
             else:
@@ -1430,6 +1461,15 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
                     last_loc=last_loc,
                     extend_num_tokens=delta_len,
+                    **dsv4_kwargs,
+                )
+            if is_dsv4:
+                from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
+                    dsv4_unwrap_prealloc,
+                )
+
+                kv_loc = dsv4_unwrap_prealloc(
+                    kv_loc, self.req_to_token_pool, req, total_prefix_len, fill_len
                 )
 
         assert kv_loc is not None, (

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -924,6 +924,16 @@ class MooncakeKVManager(CommonKVManager):
             f"Received AUX_DATA for bootstrap_room {room} with length:{len(data)}"
         )
 
+    def _is_generic_kvcache_state_type(self, st: "StateType") -> bool:
+        """State types sent via the page-indexed ``_send_kvcache_generic`` path
+        (not the mamba-state path); subclasses extend for hardware components."""
+        return st in (
+            StateType.SWA,
+            StateType.DSA,
+            StateType.SWA_RING,
+            StateType.C128_STATE,
+        )
+
     def maybe_send_extra(
         self,
         req: TransferInfo,
@@ -1002,12 +1012,7 @@ class MooncakeKVManager(CommonKVManager):
                         )
                         or rc
                     )
-            elif st in (
-                StateType.SWA,
-                StateType.DSA,
-                StateType.SWA_RING,
-                StateType.C128_STATE,
-            ):
+            elif self._is_generic_kvcache_state_type(st):
                 if (
                     target_rank_registration_info is not None
                     and not self.is_mla_backend
@@ -1841,7 +1846,13 @@ class MooncakeKVReceiver(CommonKVReceiver):
             )
             # Note(shangming): No need to add pp rank here since decode pp size should be equal to prefill pp size or 1
             tp_rank = self.kv_mgr.kv_args.engine_rank
-            kv_item_len = self.kv_mgr.kv_args.kv_item_lens[0]
+            # Some pools have no full-token contiguous KV (kv_item_lens empty)
+            # and ship per-pool instead, so report 0.
+            kv_item_len = (
+                self.kv_mgr.kv_args.kv_item_lens[0]
+                if self.kv_mgr.kv_args.kv_item_lens
+                else 0
+            )
             dst_tp_rank = str(tp_rank).encode("ascii")
             dst_attn_tp_size = str(self.kv_mgr.attn_tp_size).encode("ascii")
             dst_kv_item_len = str(kv_item_len).encode("ascii")

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -63,6 +63,7 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
+from sglang.srt.utils import is_npu
 from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 
 if TYPE_CHECKING:
@@ -72,6 +73,8 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
 
 logger = logging.getLogger(__name__)
+
+_is_npu = is_npu()
 
 
 def should_force_retry(req: Req) -> bool:
@@ -1079,24 +1082,36 @@ class SchedulerDisaggregationPrefillMixin:
             state_types = (
                 self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
             )
-            state_indices = []
-            for st in state_types:
-                if st == StateType.MAMBA:
-                    state_indices.append(_mamba_payload())
-                elif st == StateType.SWA:
-                    state_indices.append(_swa_payload())
-                elif st == StateType.DSA:
-                    state_indices.append(_dsa_payload())
-                elif st == StateType.MINIMAX_INDEX_K:
-                    # Index rows live at the same loc as main KV on the same
-                    # page_size, so reuse the full-seq page-ids.
-                    state_indices.append(_dsa_payload())
-                elif st == StateType.SWA_RING:
-                    state_indices.append(_swa_ring_payload())
-                elif st == StateType.C128_STATE:
-                    state_indices.append(_c128_state_payload())
-                else:
-                    state_indices.append(None)
+            # MINIMAX_INDEX_K reuses _dsa_payload: index rows live at the same loc
+            # as main KV on the same page_size.
+            payloads = {
+                StateType.MAMBA: _mamba_payload,
+                StateType.SWA: _swa_payload,
+                StateType.DSA: _dsa_payload,
+                StateType.MINIMAX_INDEX_K: _dsa_payload,
+                StateType.SWA_RING: _swa_ring_payload,
+                StateType.C128_STATE: _c128_state_payload,
+            }
+            if _is_npu and isinstance(
+                self.token_to_kv_pool_allocator.get_kvcache(),
+                DeepSeekV4TokenToKVPool,
+            ):
+                from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
+                    dsv4_state_payloads,
+                )
+
+                payloads.update(
+                    dsv4_state_payloads(
+                        self.req_to_token_pool,
+                        req.req_pool_idx,
+                        seq_len,
+                        page_size,
+                        self.sliding_window_size,
+                    )
+                )
+            state_indices = [
+                payloads[st]() if st in payloads else None for st in state_types
+            ]
 
         page_indices = kv_to_page_indices(kv_indices, page_size)
         if not req.disagg_kv_sender.should_send_kv_chunk(len(page_indices), last_chunk):

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -680,7 +680,16 @@ def setup_state_kv_args(
     kv_args.state_item_lens = []
     kv_args.state_dim_per_tensor = []
 
-    if isinstance(token_to_kv_pool, MiniMaxSparseKVPool):
+    if hasattr(token_to_kv_pool, "get_pd_state_components"):
+        # Pool ships each sub-pool as its own page-indexed component (fixed order
+        # so prefill and decode register identically); skips get_state_buf_infos.
+        for st, comp_ptrs, comp_lens, comp_item_lens in (
+            token_to_kv_pool.get_pd_state_components()
+        ):
+            append_state_component(
+                kv_args, st, comp_ptrs, comp_lens, comp_item_lens
+            )
+    elif isinstance(token_to_kv_pool, MiniMaxSparseKVPool):
         if token_to_kv_pool.index_kv_pool is not None:
             raise NotImplementedError(
                 "PD disaggregation for MiniMax sparse layers with index value "

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_allocator.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_allocator.py
@@ -584,9 +584,32 @@ class DSV4NPUTokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             last_loc,
             extend_num_tokens,
         )
+        return self._wrap_full_alloc(
+            out_full_loc,
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc.dtype,
+            req_pool_indices,
+            dsv4_state_lens,
+        )
+
+    def _wrap_full_alloc(
+        self,
+        out_full_loc,
+        prefix_lens,
+        prefix_lens_cpu,
+        seq_lens,
+        seq_lens_cpu,
+        loc_dtype,
+        req_pool_indices,
+        dsv4_state_lens,
+    ) -> Optional[DSV4OutCacheLoc]:
+        # Shared tail of alloc_extend / alloc_extend_swa_tail: translate the full
+        # loc to swa, then add the c4/c128(+state) pools into a DSV4OutCacheLoc.
         if out_full_loc is None:
             return None
-
         out_swa_loc = self.translate_loc_from_full_to_swa(out_full_loc)
         assert out_swa_loc is not None, (
             "translate_loc_from_full_to_swa returned None — "
@@ -599,7 +622,7 @@ class DSV4NPUTokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             prefix_lens_cpu,
             seq_lens,
             seq_lens_cpu,
-            last_loc.dtype,
+            loc_dtype,
             req_pool_indices,
             dsv4_state_lens,
         )
@@ -627,6 +650,43 @@ class DSV4NPUTokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         return self._alloc_c_and_state(
             out_full_loc,
             out_swa_loc,
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc.dtype,
+            req_pool_indices,
+            dsv4_state_lens,
+        )
+
+    def alloc_extend_swa_tail(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        swa_tail_len: int,
+        *,
+        req_pool_indices: Optional[torch.Tensor] = None,
+        dsv4_state_lens: Optional[DSV4StateLens] = None,
+        req_to_token_pool=None,
+    ) -> Optional[DSV4OutCacheLoc]:
+        """Disagg-decode prealloc variant of :meth:`alloc_extend`: super() does
+        full+swa-tail, then _alloc_c_and_state adds c4/c128(+state) → DSV4OutCacheLoc."""
+        self._cur_req_to_token_pool = req_to_token_pool
+        out_full_loc = super().alloc_extend_swa_tail(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+            swa_tail_len,
+        )
+        return self._wrap_full_alloc(
+            out_full_loc,
             prefix_lens,
             prefix_lens_cpu,
             seq_lens,

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_common_hooks.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_common_hooks.py
@@ -13,13 +13,9 @@ these hooks then:
 Non-DSV4 paths leave ``batch.out_cache_loc_dsv4`` None, so this module is a
 no-op for them.
 
-TODO: the disagg DSV4 path bypasses these hooks — it calls
-``allocator.alloc_extend`` directly then ``req_to_token_pool.write`` without
-going through ``mem_cache/common.py`` (see ``disaggregation/decode.py``). The
-DSV4OutCacheLoc bundle is still produced but never written into the per-req
-tables, so disagg + DSV4 is unsupported here (c-pages leak). Fixing requires
-calling these hooks from disagg's per-req alloc loop, or moving the write
-into the allocator itself.
+The disagg per-req prealloc path does not build a ``ScheduleBatch`` and so
+bypasses the batch hook; it writes the same tables via
+``write_dsv4_prealloc_tables`` (driven by ``dsv4_unwrap_prealloc``).
 """
 
 from __future__ import annotations
@@ -119,6 +115,124 @@ def maybe_write_dsv4_extend(
             req_pool_indices_cpu,
             c128_state_alloc_offsets,
             seq_lens_cpu,
+            bundle.out_c128_state_loc,
+        )
+
+
+def dsv4_state_payloads(req_to_token_pool, req_pool_idx, seq_len, page_size, window_size):
+    """Per-StateType PD-payload builders for DSV4-on-NPU, keyed by ``StateType``.
+
+    Returns ``{}`` for non-DSV4 pools so PD code can ``dict.update`` it
+    unconditionally. prefill (src) and decode (dst) share this builder so their
+    page-index lists line up positionally (a mismatch silently corrupts KV).
+    """
+    if not hasattr(req_to_token_pool, "req_to_token_c4"):
+        return {}
+
+    import numpy as np
+
+    from sglang.srt.disaggregation.ascend.conn import AscendStateType
+    from sglang.srt.mem_cache.common import kv_to_page_indices
+
+    def pages(table, lo, hi):
+        if hi <= lo:
+            return np.empty((0,), dtype=np.int32)
+        slots = table[req_pool_idx, lo:hi].cpu().numpy()
+        return kv_to_page_indices(slots, page_size).astype(np.int32)
+
+    def state_pages(table):
+        # Whole prompt span, mirroring the kernel state_block_table
+        # (state_table[req, ::page_size]//page_size); non-tail = skip sentinel page 0.
+        n_pages = (seq_len + page_size - 1) // page_size
+        return pages(table, 0, n_pages * page_size)
+
+    window_start = (max(0, seq_len - window_size) // page_size) * page_size
+
+    # DSV4_INDEXER shares the c4 slot space (written at the c4 loc).
+    return {
+        AscendStateType.DSV4_SWA: lambda: pages(
+            req_to_token_pool.req_to_token_swa, window_start, seq_len
+        ),
+        AscendStateType.DSV4_C4: lambda: pages(
+            req_to_token_pool.req_to_token_c4, 0, seq_len // 4
+        ),
+        AscendStateType.DSV4_C128: lambda: pages(
+            req_to_token_pool.req_to_token_c128, 0, seq_len // 128
+        ),
+        AscendStateType.DSV4_INDEXER: lambda: pages(
+            req_to_token_pool.req_to_token_c4, 0, seq_len // 4
+        ),
+        AscendStateType.DSV4_C4_STATE: lambda: state_pages(
+            req_to_token_pool.req_to_token_c4_state
+        ),
+        AscendStateType.DSV4_C128_STATE: lambda: state_pages(
+            req_to_token_pool.req_to_token_c128_state
+        ),
+    }
+
+
+def dsv4_prealloc_kwargs(allocator, req, fill_len, req_to_token_pool, *, device):
+    """Extra ``alloc_extend(_swa_tail)`` kwargs for the DSV4 allocator; ``{}`` for
+    non-DSV4 so callers can splat it unconditionally."""
+    if not hasattr(allocator, "c4_attn_allocator"):
+        return {}
+    return dict(
+        req_pool_indices=torch.tensor(
+            [req.req_pool_idx], dtype=torch.int64, device=device
+        ),
+        dsv4_state_lens=allocator.compute_dsv4_state_lens_extend([req], [fill_len]),
+        req_to_token_pool=req_to_token_pool,
+    )
+
+
+def dsv4_unwrap_prealloc(kv_loc, req_to_token_pool, req, prefix_len, fill_len):
+    """Unwrap a DSV4OutCacheLoc bundle to its full-pool loc and write the five
+    per-req tables; a plain tensor (non-DSV4) passes through unchanged."""
+    if kv_loc is None or not hasattr(kv_loc, "out_full_loc"):
+        return kv_loc
+    write_dsv4_prealloc_tables(req_to_token_pool, req, prefix_len, fill_len, kv_loc)
+    return kv_loc.out_full_loc
+
+
+def write_dsv4_prealloc_tables(
+    req_to_token_pool,
+    req: Req,
+    prefix_len: int,
+    fill_len: int,
+    bundle,
+) -> None:
+    """Write the five DSV4 per-req tables for one request on the disagg-decode
+    prealloc path (no ScheduleBatch); no-op without bundle / DSV4 tables."""
+    if bundle is None or not hasattr(req_to_token_pool, "write_c4"):
+        return
+    rp = torch.tensor([req.req_pool_idx])
+    pl = torch.tensor([prefix_len])
+    sl = torch.tensor([fill_len])
+
+    _write_per_req_slice(req_to_token_pool.write_swa, rp, pl, sl, bundle.out_swa_loc, ratio=1)
+    _write_per_req_slice(req_to_token_pool.write_c4, rp, pl, sl, bundle.out_c4_loc, ratio=4)
+    _write_per_req_slice(
+        req_to_token_pool.write_c128, rp, pl, sl, bundle.out_c128_loc, ratio=128
+    )
+
+    if bundle.out_c4_state_loc is not None and hasattr(
+        req_to_token_pool, "write_c4_state"
+    ):
+        _write_state_tail_per_req(
+            req_to_token_pool.write_c4_state,
+            rp,
+            [getattr(req, "c4_state_alloc_offset", 0)],
+            sl,
+            bundle.out_c4_state_loc,
+        )
+    if bundle.out_c128_state_loc is not None and hasattr(
+        req_to_token_pool, "write_c128_state"
+    ):
+        _write_state_tail_per_req(
+            req_to_token_pool.write_c128_state,
+            rp,
+            [getattr(req, "c128_state_alloc_offset", 0)],
+            sl,
             bundle.out_c128_state_loc,
         )
 

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
@@ -29,7 +29,7 @@ The subclass overrides only:
 from __future__ import annotations
 
 import math
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 import torch_npu
@@ -167,6 +167,7 @@ class NPUCompressStatePool(CompressStatePool):
         num_usable_pages = (size + page_size - 1) // page_size
         num_buffer_pages = num_usable_pages + 1
         self._size = num_buffer_pages * page_size
+        self.ratio = ratio
         self.page_size = page_size
         # ring_size=0 marks "not ring-buffered" (paged allocator replaces the
         # parent's ring hashing); kept so downstream hasattr probes don't break.
@@ -387,6 +388,73 @@ class DSV4NPUTokenToKVPool(DeepSeekV4TokenToKVPool):
             enable_memory_saver,
             kernel_page_size=self.page_size,
         )
+
+    def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
+        # No full-token contiguous space on NPU; everything ships per-pool via
+        # get_pd_state_components(), so the contiguous path is empty.
+        return [], [], []
+
+    def get_pd_state_components(
+        self,
+    ) -> List[Tuple[str, List[int], List[int], List[int]]]:
+        """Ordered ``(AscendStateType, data_ptrs, data_lens, item_lens)`` per pool, in a
+        fixed order so prefill and decode register identically (empty pools skipped)."""
+        from sglang.srt.disaggregation.ascend.conn import AscendStateType
+
+        components: List[Tuple[str, List[int], List[int], List[int]]] = []
+
+        def kv_entry(bufs):
+            return (
+                [b.data_ptr() for b in bufs],
+                [b.nbytes for b in bufs],
+                [b[0].nbytes for b in bufs],
+            )
+
+        def state_entry(want_ratio: int, include_indexer: bool):
+            ptrs: List[int] = []
+            lens: List[int] = []
+            ilens: List[int] = []
+
+            def add(pool):
+                t = pool.kv_score_buffer.kv_score
+                ptrs.append(t.data_ptr())
+                lens.append(t.nbytes)
+                ilens.append(t[0].nbytes * pool.page_size)
+
+            for ratio, pool in zip(self.compression_ratios, self.compress_state_pools):
+                if pool is not None and ratio == want_ratio:
+                    add(pool)
+            if include_indexer:
+                # indexer compress-state pools are all ratio 4 and share the
+                # c4_state slot space.
+                for pool in self.indexer_compress_state_pools:
+                    if pool is not None:
+                        add(pool)
+            return ptrs, lens, ilens
+
+        # KV pools (4D PA_ND).
+        if self.swa_kv_pool is not None:
+            components.append((AscendStateType.DSV4_SWA, *kv_entry(self.swa_kv_pool.kv_buffer)))
+        if self.c4_kv_pool is not None:
+            components.append((AscendStateType.DSV4_C4, *kv_entry(self.c4_kv_pool.kv_buffer)))
+        if self.c128_kv_pool is not None:
+            components.append((AscendStateType.DSV4_C128, *kv_entry(self.c128_kv_pool.kv_buffer)))
+        if self.c4_indexer_kv_pool is not None:
+            idx_bufs = list(self.c4_indexer_kv_pool.index_k_buffer) + list(
+                self.c4_indexer_kv_pool.index_scale_buffer
+            )
+            components.append((AscendStateType.DSV4_INDEXER, *kv_entry(idx_bufs)))
+
+        # Compress-state pools (paged, flat 2D). c4_state bundles attn-c4-state +
+        # indexer-c4-state (same req_to_token_c4_state slot space).
+        components.append((AscendStateType.DSV4_C4_STATE, *state_entry(4, include_indexer=True)))
+        components.append(
+            (AscendStateType.DSV4_C128_STATE, *state_entry(128, include_indexer=False))
+        )
+
+        # Drop empty components (e.g. a ratio with no layers) so every shipped
+        # component has non-zero item_lens; the set is identical on both sides.
+        return [c for c in components if c[1]]
 
     def get_state_cache(self, layer_id: int, from_indexer: bool) -> torch.Tensor:
         """fp32 ``[block_num, page_size, 2*coff*D]`` view of this layer's

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_req_to_token_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_req_to_token_pool.py
@@ -35,32 +35,24 @@ from __future__ import annotations
 import torch
 
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.disaggregation.decode import DecodeReqToTokenPool
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 
-class DSV4NPUReqToTokenPool(ReqToTokenPool):
-    """ReqToTokenPool extended with DSV4 SWA + c4/c128 per-req tables.
+class DSV4ReqToTokenTablesMixin:
+    """Shared DSV4-NPU per-req table logic for the prefill/normal pool
+    (:class:`DSV4NPUReqToTokenPool`) and the disagg-decode pool
+    (:class:`DSV4NPUDecodeReqToTokenPool`), which differ only in their base.
 
-    Drop-in replacement for ReqToTokenPool when the model is DeepSeek-V4 on
-    NPU. Selected by ``model_runner_kv_cache_mixin`` based on model arch +
-    device. Non-DSV4 and non-NPU paths continue to use the base class.
-
-    The auxiliary tables are intentionally NOT zeroed on ``clear()``: they are
-    indexed only by active rows (via req_pool_idx) and only each row's
-    ``[:seq_len]`` prefix is read, so stale entries past kv_committed_len are
-    unreachable by the attention metadata builder.
+    Host class must call ``super().__init__(...)`` first (so ``_alloc_size``
+    exists) then ``self._init_dsv4_tables(...)``; ``free`` should call
+    ``self._dsv4_free(req)`` before delegating to the base ``free``.
     """
 
-    def __init__(
-        self,
-        size: int,
-        max_context_len: int,
-        device: str,
-        enable_memory_saver: bool,
-    ):
-        super().__init__(size, max_context_len, device, enable_memory_saver)
-
+    def _init_dsv4_tables(
+        self, max_context_len: int, device: str, enable_memory_saver: bool
+    ) -> None:
         memory_saver_adapter = TorchMemorySaverAdapter.create(
             enable=enable_memory_saver
         )
@@ -91,11 +83,8 @@ class DSV4NPUReqToTokenPool(ReqToTokenPool):
                     ),
                 )
 
-    # ------------------------------------------------------------------
     # Per-pool write helpers, called by mem_cache/common.py after alloc, using
     # slot indices from DSV4OutCacheLoc. Args: (req_pool_idx, token_offset), slot.
-    # ------------------------------------------------------------------
-
     def write_swa(self, indices, values: torch.Tensor) -> None:
         self.req_to_token_swa[indices] = values
 
@@ -113,16 +102,68 @@ class DSV4NPUReqToTokenPool(ReqToTokenPool):
 
     def register_dsv4_allocator(self, allocator) -> None:
         """Wire the DSV4NPUTokenToKVPoolAllocator ref so ``free(req)`` can
-        release c4/c128 pool pages alongside the req_pool_idx slot. This is a
-        one-way ref (pool -> allocator). The reverse direction (the allocator
-        reading these per-req tables for its c-pool / state last_loc lookup) is
-        no longer a stored back-ref: mem_cache/common.py passes this pool into
-        ``alloc_extend`` / ``alloc_decode`` per call instead."""
+        release c4/c128 pool pages alongside the req_pool_idx slot."""
         self._dsv4_allocator = allocator
 
-    def free(self, req):
+    def _dsv4_free(self, req) -> None:
         # Trigger c4/c128 free via the allocator's unified free path. May be None
         # between __init__ and register_dsv4_allocator — defensive None check.
         if self._dsv4_allocator is not None:
             self._dsv4_allocator.free(req=req, req_to_token_pool=self)
+
+
+class DSV4NPUReqToTokenPool(DSV4ReqToTokenTablesMixin, ReqToTokenPool):
+    """ReqToTokenPool extended with DSV4 SWA + c4/c128 per-req tables.
+
+    Drop-in replacement for ReqToTokenPool when the model is DeepSeek-V4 on
+    NPU. Selected by ``model_runner_kv_cache_mixin`` based on model arch +
+    device. Non-DSV4 and non-NPU paths continue to use the base class.
+
+    The auxiliary tables are intentionally NOT zeroed on ``clear()``: they are
+    indexed only by active rows (via req_pool_idx) and only each row's
+    ``[:seq_len]`` prefix is read, so stale entries past kv_committed_len are
+    unreachable by the attention metadata builder.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        max_context_len: int,
+        device: str,
+        enable_memory_saver: bool,
+    ):
+        super().__init__(size, max_context_len, device, enable_memory_saver)
+        self._init_dsv4_tables(max_context_len, device, enable_memory_saver)
+
+    def free(self, req):
+        self._dsv4_free(req)
+        super().free(req)
+
+
+class DSV4NPUDecodeReqToTokenPool(DSV4ReqToTokenTablesMixin, DecodeReqToTokenPool):
+    """DecodeReqToTokenPool with the DSV4 swa/c4/c128(+state) per-req tables.
+
+    The disagg-decode counterpart of DSV4NPUReqToTokenPool; DecodeReqToTokenPool
+    pre-allocates extra req slots for in-flight prefill transfers.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        max_context_len: int,
+        device: str,
+        enable_memory_saver: bool,
+        pre_alloc_size: int,
+    ):
+        super().__init__(
+            size=size,
+            max_context_len=max_context_len,
+            device=device,
+            enable_memory_saver=enable_memory_saver,
+            pre_alloc_size=pre_alloc_size,
+        )
+        self._init_dsv4_tables(max_context_len, device, enable_memory_saver)
+
+    def free(self, req):
+        self._dsv4_free(req)
         super().free(req)

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -279,9 +279,21 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             alloc_full_indices[-swa_tail_len:], alloc_swa_indices
         )
         if swa_tail_len < extend_num_tokens:
-            self.full_to_swa_index_mapping[
-                alloc_full_indices[:-swa_tail_len].to(torch.int64)
-            ] = 0
+            zero_indices = alloc_full_indices[:-swa_tail_len]
+            if _is_npu:
+                # aclnnIndexPut rejects a scalar/int32 value against the int64
+                # mapping; mirror alloc_decode and scatter an int64 zero tensor.
+                torch_npu.npu_scatter_nd_update_(
+                    self.full_to_swa_index_mapping,
+                    zero_indices.to(torch.int64).unsqueeze(-1),
+                    torch.zeros(
+                        zero_indices.numel(),
+                        dtype=self.full_to_swa_index_mapping.dtype,
+                        device=self.full_to_swa_index_mapping.device,
+                    ),
+                )
+            else:
+                self.full_to_swa_index_mapping[zero_indices] = 0
         return alloc_full_indices
 
     def alloc_decode(

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -564,6 +564,20 @@ class ModelRunnerKVCacheMixin:
                         mamba_size=self.server_args.max_mamba_cache_size,
                         start_layer=self.start_layer,
                     )
+                elif _is_npu and is_deepseek_v4(self.model_config.hf_config):
+                    # Decode-side per-req tables the stock pool lacks.
+                    from sglang.srt.hardware_backend.npu.dsv4.dsv4_req_to_token_pool import (
+                        DSV4NPUDecodeReqToTokenPool,
+                    )
+
+                    self.req_to_token_pool = DSV4NPUDecodeReqToTokenPool(
+                        size=max_num_reqs,
+                        max_context_len=self.model_config.context_len
+                        + extra_max_context_len,
+                        device=self.device,
+                        enable_memory_saver=self.server_args.enable_memory_saver,
+                        pre_alloc_size=pre_alloc_size,
+                    )
                 else:
                     self.req_to_token_pool = DecodeReqToTokenPool(
                         size=max_num_reqs,


### PR DESCRIPTION
## Motivation

DeepSeek-V4 on NPU (Ascend) has no single full-token KV space — its KV is split across 6 paged pools (`swa` / `c4` / `c128` / `indexer` / `c4_state` / `c128_state`), each with its own page geometry. The generic prefill-decode (PD) disaggregation path assumes one full-token contiguous space, so it cannot transfer DSV4-on-NPU KV correctly. This PR adapts startup, decode pre-allocation, descriptor registration, and KV transfer to be **per-pool**, enabling PD disaggregation for DeepSeek-V4 on NPU. All changes are gated to the NPU + DSV4 path; CUDA and other models/platforms are unaffected.

## Modifications

- **`mem_cache/allocator/swa.py`** — `alloc_extend_swa_tail` zero-fill writes an int64 value on NPU (`aclnnIndexPut` rejects int32 vs int64 mapping), matching `alloc` / `alloc_extend`.
- **`model_executor/model_runner_kv_cache_mixin.py`** — decode mode selects `DSV4NPUDecodeReqToTokenPool` (the stock `DecodeReqToTokenPool` lacks the 5 DSV4 per-req tables); gated on `disaggregation_mode == "decode"` and NPU and `is_deepseek_v4`.
- **`hardware_backend/npu/dsv4/dsv4_decode_req_to_token_pool.py`** (new) — `DecodeReqToTokenPool` + the 5 DSV4 tables / write helpers / allocator free hook (self-contained; leaves the existing `DSV4NPUReqToTokenPool` untouched).
- **`hardware_backend/npu/dsv4/dsv4_allocator.py`** — `alloc_extend_swa_tail` override so decode pre-alloc also reserves c4/c128 KV and tail compress-state pools (mirrors `alloc_extend`).
- **`hardware_backend/npu/dsv4/dsv4_common_hooks.py`** — `write_dsv4_prealloc_tables` (per-req write for the disagg pre-alloc path that bypasses the batch hook) and `build_dsv4_kv_transfer_payloads` (shared prefill/decode per-pool page indices, so src/dst align positionally).
- **`hardware_backend/npu/dsv4/dsv4_memory_pool.py`** — `get_contiguous_buf_infos` returns empty (no full-token space); `get_dsv4_state_components` reports per-pool buf infos in a fixed order.
- **`disaggregation/base/conn.py`** — add `DSV4_SWA/C4/C128/INDEXER/C4_STATE/C128_STATE` StateTypes.
- **`disaggregation/utils.py`** — `setup_state_kv_args` registers each DSV4 pool as its own component (before the `BaseSWAKVPool` branch to avoid the 2D-assert path).
- **`disaggregation/prefill.py` / `decode.py`** — produce per-pool send/recv indices via the shared builder; non-DSV4 paths keep the original `MAMBA`/`SWA`/`DSA`/`MINIMAX_INDEX_K`/`SWA_RING` loop unchanged.
- **`disaggregation/mooncake/conn.py`** — tolerate empty contiguous `kv_item_lens` and expose a `_is_generic_kvcache_state_type` hook for subclasses to extend.
- **`disaggregation/ascend/conn.py`** — DSV4 send routing lives in `AscendKVManager` (the DSV4 transfer is NPU-only).

## Accuracy Tests

- **Reduced-layer PD** — per-pool KV + compress-state transfer is byte-identical cross-process, and end-to-end output matches a single-process baseline token-for-token.
- **GPQA-Diamond (non-think)** — full model, `temp=1 / top_p=1`, batch=32: **76.26% (198/198, clean, 0 errors)** on Ascend.

## Benchmarking and Profiling

N/A for this PR — the change enables a previously-unsupported transfer path (DSV4-on-NPU PD) rather than altering a CUDA/critical-path hot loop; all additions are gated behind DSV4+NPU checks and are no-ops on every other model/platform. Throughput characterization of DSV4-on-NPU PD is tracked separately.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit) guidance.
- [ ] Add unit tests as outlined in the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests) guidance.
- [ ] Update documentation as needed, as outlined in the [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations) guidance.
- [ ] Provide accuracy and speed benchmark results according to the guidance.
- [ ] Follow the SGLang code style guidance.





































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28777325467](https://github.com/sgl-project/sglang/actions/runs/28777325467)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28777325239](https://github.com/sgl-project/sglang/actions/runs/28777325239)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->