### PR TITLE
[spec] Fix index_share_for_mtp_iteration being a no-op in EAGLE MTP draft

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -430,11 +430,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For hidden states before normal
     return_hidden_states_before_norm: bool = False
 
-    # NSA/DSA indexer-topk reuse across the MTP draft steps. The flag is set per
-    # draft pass; the carried topk tensor itself lives on spec_info
-    # (EagleDraftInput.mtp_topk_indices), which is shared by reference across the
-    # per-step forwards, unlike this batch object which the eager/graph runner
-    # copies (dropping any writeback here).
+    # Gate for reusing the first MTP draft step's indexer topk across steps;
+    # the carried topk lives on spec_info (see EagleDraftInput.mtp_topk_indices).
     reuse_mtp_topk_indices: Optional[bool] = False
 
     # === Forward-derived (built in init_new on the forward stream; FB-owned) ===

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -430,8 +430,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For hidden states before normal
     return_hidden_states_before_norm: bool = False
 
-    # For NSA/DSA topk_indices reuse across forward calls (e.g., EAGLE draft)
-    topk_indices: Optional[torch.Tensor] = None
+    # NSA/DSA indexer-topk reuse across the MTP draft steps. The flag is set per
+    # draft pass; the carried topk tensor itself lives on spec_info
+    # (EagleDraftInput.mtp_topk_indices), which is shared by reference across the
+    # per-step forwards, unlike this batch object which the eager/graph runner
+    # copies (dropping any writeback here).
     reuse_mtp_topk_indices: Optional[bool] = False
 
     # === Forward-derived (built in init_new on the forward stream; FB-owned) ===

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -228,13 +228,13 @@ class DeepseekModelNextN(nn.Module):
                     residual,
                     zero_allocator,
                     prev_topk_indices=(
-                        forward_batch.topk_indices
+                        forward_batch.spec_info.mtp_topk_indices
                         if forward_batch.reuse_mtp_topk_indices
                         else None
                     ),
                 )
                 if forward_batch.reuse_mtp_topk_indices:
-                    forward_batch.topk_indices = topk_indices
+                    forward_batch.spec_info.mtp_topk_indices = topk_indices
 
             if not forward_batch.forward_mode.is_idle():
                 if residual is not None:

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -159,6 +159,13 @@ class EagleDraftInput(SpecInput):
     hidden_states: Optional[torch.Tensor] = None
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 
+    # NSA/DSA indexer topk computed on the first MTP draft step and reused by the
+    # rest (index_share_for_mtp_iteration). Carried here, not on ForwardBatch:
+    # the per-step eager/graph forward runs on a copied ForwardBatch, so a
+    # writeback there is dropped, whereas spec_info is shared by reference across
+    # the draft steps (same path as hidden_states).
+    mtp_topk_indices: Optional[torch.Tensor] = None
+
     # Per-req bonus token (the "+1" target prediction at end of each accept
     # chain); the worker copies it here post-extend for next iter's draft.
     bonus_tokens: torch.Tensor = None

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -159,11 +159,8 @@ class EagleDraftInput(SpecInput):
     hidden_states: Optional[torch.Tensor] = None
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 
-    # NSA/DSA indexer topk computed on the first MTP draft step and reused by the
-    # rest (index_share_for_mtp_iteration). Carried here, not on ForwardBatch:
-    # the per-step eager/graph forward runs on a copied ForwardBatch, so a
-    # writeback there is dropped, whereas spec_info is shared by reference across
-    # the draft steps (same path as hidden_states).
+    # Carried on spec_info, not ForwardBatch: each draft step runs on a copied
+    # ForwardBatch, so a writeback there is dropped (spec_info is shared by ref).
     mtp_topk_indices: Optional[torch.Tensor] = None
 
     # Per-req bonus token (the "+1" target prediction at end of each accept

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -159,8 +159,8 @@ class EagleDraftInput(SpecInput):
     hidden_states: Optional[torch.Tensor] = None
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 
-    # Carried on spec_info, not ForwardBatch: each draft step runs on a copied
-    # ForwardBatch, so a writeback there is dropped (spec_info is shared by ref).
+    # Survives across draft steps: spec_info is shared by reference across the
+    # per-step forwards (each runs on a copied ForwardBatch, dropping writebacks).
     mtp_topk_indices: Optional[torch.Tensor] = None
 
     # Per-req bonus token (the "+1" target prediction at end of each accept

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -612,7 +612,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         scores = None
         if self.index_share_for_mtp_iteration:
             forward_batch.reuse_mtp_topk_indices = True
-            forward_batch.topk_indices = None
+            spec_info.mtp_topk_indices = None
         for i in range(self.speculative_num_steps):
             input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
                 i, topk_p, topk_index, hidden_states, scores, self.topk
@@ -688,7 +688,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             forward_batch.positions.add_(1)
 
         if self.index_share_for_mtp_iteration:
-            forward_batch.topk_indices = None
+            spec_info.mtp_topk_indices = None
             forward_batch.reuse_mtp_topk_indices = False
 
         # Organize the results


### PR DESCRIPTION
## Problem

`index_share_for_mtp_iteration` (#28192) is meant to run the DSA indexer once on the first MTP draft step and reuse its top-k for the remaining steps. It's a silent no-op — the reuse never engages, so every draft step recomputes the indexer.

## Cause

Each draft step forwards on a *copied* ForwardBatch (`load_batch` → `extract_buffer`/`replace`). The write-back in `deepseek_nextn`

```python
forward_batch.topk_indices = topk_indices
```

lands on that per-step copy, while the ForwardBatch the draft loop carries across steps keeps `topk_indices = None`. So `prev_topk_indices` is always None and step 0's selection is never reused.

It went unnoticed because at short context the indexer selects all tokens (ctx < `index_topk`), so reuse and recompute are bit-identical; the paths only diverge once the selection actually prunes.

## Fix

Carry the top-k on `spec_info` (`EagleDraftInput.mtp_topk_indices`), which is shared by reference across the per-step forwards the same way `hidden_states` already is, so the write-back survives. Removes the now-dead `ForwardBatch.topk_indices` field.

Models that don't set the flag are unaffected — the flag (and `topk == 1`) gates the whole path.

## Test

GLM-5.2-FP8 on 4×B300 (EAGLE `topk=1`, `num_steps=5`, `num_draft_tokens=6`). Verified the reuse now engages — step 0 computes the indexer, steps 1–3 reuse it — matching the deterministic-top-k design. On an OpenHands-style long-context agentic workload (~89k ISL, 13-turn) the accept length is neutral with vs without the fix (4.64 vs 4.65), i.e. the change is behavior-preserving for draft quality while removing the redundant per-step indexer recompute and restoring the intended path. Spec decode is lossless regardless — only the draft proposal changes, not target verify.

## Performance

At long context (ISL ≈ 500k) the redundant per-step indexer recompute dominates a draft step. Profiling one draft step:

| reuse | draft step time |
|-------|-----------------|
| ON (this PR) | 2.215 ms |
| OFF (main) | 4.167 ms |

**1.88× faster per draft step** (4.167 → 2.215 ms, ~47% less time) — the indexer now runs once (step 0) and is reused by steps 1–3 instead of recomputed each step. The gain scales with context (indexer cost ∝ sequence length): large at ~500k, smaller at the ~80k agentic regime.

Draft-step profile (reuse ON):

<img width="229" height="617" alt="image" src="https://github.com/user-attachments/assets/be813827-1801-431e-9418-b17602549ef4" />


Draft-step profile (reuse OFF, main):

<img width="236" height="839" alt="image" src="https://github.com/user-attachments/assets/feb7c55c-d518-4ae1-87ab-56a476f63673" />
































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28386073348](https://github.com/sgl-project/sglang/actions/runs/28386073348)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28397012447](https://github.com/sgl-project/sglang/actions/runs/28397012447)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
