### PR TITLE
Redact secret fields from server_info responses

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1234,7 +1234,7 @@ class Engine(EngineScoreMixin, EngineBase):
         )
         return msgspec_to_builtins(
             {
-                **dataclasses.asdict(self.tokenizer_manager.server_args),
+                **self.tokenizer_manager.server_args.to_dict_redacted(),
                 **self._scheduler_init_result.scheduler_infos[0],
                 "internal_states": internal_states,
                 "version": __version__,

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -7,7 +7,6 @@ TokenizerManager's event loop.
 """
 
 import asyncio
-import dataclasses
 import json
 import logging
 from types import SimpleNamespace
@@ -393,7 +392,7 @@ class RuntimeHandle:
         return json.dumps(result, default=str)
 
     def get_server_info(self) -> str:
-        result: Dict[str, Any] = dataclasses.asdict(self.server_args)
+        result: Dict[str, Any] = self.server_args.to_dict_redacted()
         result.update(self.scheduler_info)
         return json.dumps(msgspec_to_builtins(result), default=str)
 

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -761,7 +761,7 @@ async def server_info():
     # server_args.model_config is not serializable but should be excluded by asdict.
     return msgspec_to_builtins(
         {
-            **dataclasses.asdict(server_args),
+            **server_args.to_dict_redacted(),
             **_global_state.scheduler_info,
             "internal_states": internal_states,
             "version": __version__,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8890,6 +8890,14 @@ class ServerArgs:
         else:
             return False
 
+    def to_dict_redacted(self) -> dict:
+        """Return the server arguments with configured secrets masked."""
+        redacted = dataclasses.asdict(self)
+        for field in ("api_key", "admin_api_key", "ssl_keyfile_password"):
+            if redacted.get(field) is not None:
+                redacted[field] = "[REDACTED]"
+        return redacted
+
     def describe_kv_events_publisher(self) -> Optional[dict]:
         """Return a structured description of this server's KV-event
         publisher, or `None` if publishing is disabled / misconfigured.

--- a/test/registered/unit/entrypoints/test_server_info.py
+++ b/test/registered/unit/entrypoints/test_server_info.py
@@ -321,5 +321,49 @@ class TestServerInfoExistingFieldsPreserved(CustomTestCase):
         json.dumps(info)
 
 
+class TestServerInfoRedactsSecrets(CustomTestCase):
+    """Test that server-info responses do not disclose configured secrets."""
+
+    SECRET_FIELDS = ("api_key", "admin_api_key", "ssl_keyfile_password")
+
+    def test_configured_secrets_are_masked(self):
+        args = ServerArgs(
+            model_path="dummy",
+            api_key="sk-normal-secret",
+            admin_api_key="sk-admin-secret",
+            ssl_keyfile_password="tls-password",
+        )
+
+        info = _call_server_info_with(args)
+
+        for field in self.SECRET_FIELDS:
+            self.assertIn(field, info)
+            self.assertEqual(
+                info[field],
+                "[REDACTED]",
+                f"secret field '{field}' must be masked in /server_info",
+            )
+        serialized = json.dumps(info)
+        for secret in ("sk-normal-secret", "sk-admin-secret", "tls-password"):
+            self.assertNotIn(secret, serialized)
+
+    def test_unset_secrets_stay_none(self):
+        args = ServerArgs(model_path="dummy")
+
+        info = _call_server_info_with(args)
+
+        for field in self.SECRET_FIELDS:
+            self.assertIn(field, info)
+            self.assertIsNone(info[field])
+
+    def test_non_secret_fields_are_untouched(self):
+        args = ServerArgs(model_path="dummy", api_key="sk-secret", port=31234)
+
+        info = _call_server_info_with(args)
+
+        self.assertEqual(info["model_path"], "dummy")
+        self.assertEqual(info["port"], 31234)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

The server-info surfaces serialize the full `ServerArgs` straight back to
callers via `dataclasses.asdict(...)`: HTTP `/server_info` (a NORMAL endpoint),
the gRPC bridge `get_server_info`, and the Engine API. `ServerArgs` holds
`api_key`, `admin_api_key`, and `ssl_keyfile_password`, so these secrets are
disclosed to any caller that can reach the endpoint (e.g. a normal-key holder
reading the admin key, or anonymous access under admin-key-only deployments).

## Modifications

- Add `ServerArgs.to_dict_redacted()`, which masks the three secret fields.
- Route all three `get_server_info` paths (HTTP, gRPC, Engine API) through it.
- Add redaction regression tests; the field keys remain present (so existing
  consumers and the "all fields present" guard still pass), only the secret
  value is masked. `None` (unset) is left untouched so "no key configured"
  stays distinguishable.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30608155148](https://github.com/sgl-project/sglang/actions/runs/30608155148)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30608155046](https://github.com/sgl-project/sglang/actions/runs/30608155046)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->