### PR TITLE
Reject API keys in multi-tokenizer mode where auth is not enforced

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8507,6 +8507,13 @@ class ServerArgs:
             self.mm_processor_worker_num >= 0
         ), "Multimodal processor worker num must >= 0"
         assert self.mm_io_worker_num >= 0, "Multimodal I/O worker num must >= 0"
+        if self.tokenizer_worker_num > 1:
+            # Multi-tokenizer workers bypass the HTTP auth middleware.
+            assert not self.api_key and not self.admin_api_key, (
+                "API key authentication (--api-key / --admin-api-key) is not "
+                "supported in multi-tokenizer mode (tokenizer_worker_num > 1). "
+                "Set tokenizer_worker_num=1 to enable API key authentication."
+            )
         self.validate_buckets_rule(
             "--prompt-tokens-buckets", self.prompt_tokens_buckets
         )

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1859,5 +1859,39 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestMultiTokenizerApiKeyRejected(CustomTestCase):
+    """Test API-key validation for multi-tokenizer mode."""
+
+    def test_admin_api_key_rejected_with_multiple_tokenizer_workers(self):
+        args = ServerArgs(
+            model_path="dummy", tokenizer_worker_num=2, admin_api_key="admin"
+        )
+        with self.assertRaisesRegex(AssertionError, "multi-tokenizer mode"):
+            args.check_server_args()
+
+    def test_api_key_rejected_with_multiple_tokenizer_workers(self):
+        args = ServerArgs(model_path="dummy", tokenizer_worker_num=2, api_key="user")
+        with self.assertRaisesRegex(AssertionError, "multi-tokenizer mode"):
+            args.check_server_args()
+
+    def test_empty_keys_allowed_with_multiple_tokenizer_workers(self):
+        args = ServerArgs(
+            model_path="dummy",
+            tokenizer_worker_num=2,
+            api_key="",
+            admin_api_key="",
+        )
+        args.check_server_args()
+
+    def test_keys_allowed_with_single_tokenizer_worker(self):
+        args = ServerArgs(
+            model_path="dummy",
+            tokenizer_worker_num=1,
+            api_key="user",
+            admin_api_key="admin",
+        )
+        args.check_server_args()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

The API-key auth middleware is only installed in single-tokenizer mode
(`tokenizer_worker_num == 1`, see `launch_server`). When
`--tokenizer-worker-num > 1`, a configured `--admin-api-key` (or `--api-key`)
is never wired into the request path, so admin-tagged management routes become
reachable without credentials. The worker init already rejected `api_key`, but
it did not reject `admin_api_key`, and only failed after startup rather than at
config-validation time.

## Modifications

- `ServerArgs.check_server_args()` now rejects a configured `api_key` /
  `admin_api_key` when `tokenizer_worker_num > 1`, failing fast at startup
  with a clear message (set `tokenizer_worker_num=1` to use API-key auth).
- Added `TestMultiTokenizerApiKeyRejected` covering: admin key rejected,
  normal key rejected, and single-worker + both keys allowed.

No changes to model/kernel/forward code or any inference path.

## Accuracy Tests

N/A — this is a startup config-validation change and does not affect model outputs.

## Speed Tests and Profiling

N/A — no change to any inference or scheduling path; the guard runs once during
`check_server_args()` at launch.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30608155713](https://github.com/sgl-project/sglang/actions/runs/30608155713)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30608155603](https://github.com/sgl-project/sglang/actions/runs/30608155603)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->