### PR TITLE
[Diffusion] Reuse shared AlignedVector and tidy jit_kernel/diffusion

### DIFF
--- a/python/sglang/jit_kernel/csrc/diffusion/causal_conv3d_cat_pad.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/causal_conv3d_cat_pad.cuh
@@ -15,6 +15,7 @@
 #include <sgl_kernel/utils.h>   // For RuntimeCheck, div_ceil
 
 #include <sgl_kernel/utils.cuh>  // For LaunchKernel
+#include <sgl_kernel/vec.cuh>    // For device::AlignedVector
 
 #include <cstdint>
 
@@ -41,10 +42,7 @@ __global__ void __launch_bounds__(kBlockSize) cat_pad_flat_kernel(
     int64_t pad_d_left,
     int64_t pad_h_top,
     int64_t pad_w_left) {
-  union Pack {
-    ET elem[kVec];
-    uint4 raw;
-  };
+  using Pack = device::AlignedVector<ET, kVec>;
 
   const int64_t nthreads = static_cast<int64_t>(gridDim.x) * blockDim.x;
   for (int64_t vid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; vid < total_vecs; vid += nthreads) {
@@ -81,7 +79,7 @@ __global__ void __launch_bounds__(kBlockSize) cat_pad_flat_kernel(
           value = SGLANG_LDG(src + iw);
         }
       }
-      pack.elem[i] = value;
+      pack[i] = value;
 
       if (++ow == out_w) {
         ow = 0;
@@ -110,7 +108,7 @@ __global__ void __launch_bounds__(kBlockSize) cat_pad_flat_kernel(
       }
     }
 
-    reinterpret_cast<uint4*>(out)[vid] = pack.raw;
+    pack.store(out, vid);
   }
 }
 

--- a/python/sglang/jit_kernel/csrc/diffusion/residual_gate_add.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/residual_gate_add.cuh
@@ -17,6 +17,7 @@
 
 #include <sgl_kernel/type.cuh>   // For dtype_trait conversions
 #include <sgl_kernel/utils.cuh>  // For LaunchKernel and CUDA dtype aliases
+#include <sgl_kernel/vec.cuh>    // For device::AlignedVector
 
 #include <cstdint>
 
@@ -102,13 +103,6 @@ __device__ __forceinline__ T residual_gate_value(T residual, T update, T gate) {
   return dtype_trait<T>::from(to_float(residual) + to_float(product));
 }
 
-template <typename T>
-union Vec16 {
-  static constexpr int kElems = 16 / sizeof(T);
-  uint4 raw;
-  T elems[kElems];
-};
-
 template <typename T, int kVec>
 __global__ void residual_gate_add_vec_kernel(
     const T* __restrict__ residual,
@@ -116,18 +110,18 @@ __global__ void residual_gate_add_vec_kernel(
     const T* __restrict__ gate,
     T* __restrict__ out,
     int64_t n_vec) {
+  using Vec = device::AlignedVector<T, kVec>;
   const int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
   for (int64_t v = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; v < n_vec; v += stride) {
-    const Vec16<T> r{.raw = reinterpret_cast<const uint4*>(residual)[v]};
-    const Vec16<T> u{.raw = reinterpret_cast<const uint4*>(update)[v]};
-    const Vec16<T> g{.raw = reinterpret_cast<const uint4*>(gate)[v]};
-
-    Vec16<T> o;
+    Vec r, u, g, o;
+    r.load(residual, v);
+    u.load(update, v);
+    g.load(gate, v);
 #pragma unroll
     for (int i = 0; i < kVec; ++i) {
-      o.elems[i] = residual_gate_value(r.elems[i], u.elems[i], g.elems[i]);
+      o[i] = residual_gate_value(r[i], u[i], g[i]);
     }
-    reinterpret_cast<uint4*>(out)[v] = o.raw;
+    o.store(out, v);
   }
 }
 
@@ -139,12 +133,14 @@ __global__ void residual_gate_add_bcast_row_tile_kernel(
     T* __restrict__ out,
     int64_t rows,
     int64_t row_vec) {
+  using Vec = device::AlignedVector<T, kVec>;
   const int64_t col_vec = static_cast<int64_t>(blockIdx.x) * kBcastColsVecPerBlock + threadIdx.x;
   if (col_vec >= row_vec) {
     return;
   }
 
-  const Vec16<T> g{.raw = SGLANG_LDG(reinterpret_cast<const uint4*>(gate) + col_vec)};
+  Vec g;
+  g.load(gate, col_vec);
 
   // Grid-stride over row tiles so the launch stays valid even when the number
   // of row tiles exceeds the gridDim.y hardware limit.
@@ -156,15 +152,14 @@ __global__ void residual_gate_add_bcast_row_tile_kernel(
       const int64_t row = row_base + row_offset;
       if (row < rows) {
         const int64_t v = row * row_vec + col_vec;
-        const Vec16<T> r{.raw = reinterpret_cast<const uint4*>(residual)[v]};
-        const Vec16<T> u{.raw = reinterpret_cast<const uint4*>(update)[v]};
-
-        Vec16<T> o;
+        Vec r, u, o;
+        r.load(residual, v);
+        u.load(update, v);
 #pragma unroll
         for (int i = 0; i < kVec; ++i) {
-          o.elems[i] = residual_gate_value(r.elems[i], u.elems[i], g.elems[i]);
+          o[i] = residual_gate_value(r[i], u[i], g[i]);
         }
-        reinterpret_cast<uint4*>(out)[v] = o.raw;
+        o.store(out, v);
       }
     }
   }

--- a/python/sglang/jit_kernel/csrc/diffusion/timestep_embedding.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/timestep_embedding.cuh
@@ -1,9 +1,12 @@
+#pragma once
+
 #include <sgl_kernel/tensor.h>
 #include <sgl_kernel/utils.h>
 
 #include <sgl_kernel/math.cuh>
 #include <sgl_kernel/type.cuh>
 #include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>  // For device::AlignedVector
 
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
@@ -14,7 +17,11 @@
 #include <cuda_runtime.h>
 #include <type_traits>
 
+namespace sglang_timestep_embedding {
+
 namespace {
+
+constexpr int kVec = 4;  // 16B float vector store
 
 template <bool kFlipSinToCos, typename TIn>
 __global__ void timestep_embedding_kernel(
@@ -24,6 +31,8 @@ __global__ void timestep_embedding_kernel(
     float neg_log_max_period,
     float scale,
     int batch_size) {
+  using Vec = device::AlignedVector<float, kVec>;
+
   int row_idx = static_cast<int>(blockIdx.x * blockDim.y + threadIdx.y);
   if (row_idx >= batch_size) {
     return;
@@ -34,36 +43,29 @@ __global__ void timestep_embedding_kernel(
 
   int half_dim = dim / 2;
   int thread_offset = static_cast<int>(threadIdx.x);
-  while (thread_offset * 4 < half_dim) {
-    float4* top_half;
-    float4* bottom_half;
+  while (thread_offset * kVec < half_dim) {
+    // !flip: output is [sin | cos]; flip: output is [cos | sin].
+    float* cos_dst;
+    float* sin_dst;
     if constexpr (!kFlipSinToCos) {
-      bottom_half = reinterpret_cast<float4*>(output_batch_base_ptr + thread_offset * 4);
-      top_half = reinterpret_cast<float4*>(output_batch_base_ptr + half_dim + thread_offset * 4);
+      sin_dst = output_batch_base_ptr + thread_offset * kVec;
+      cos_dst = output_batch_base_ptr + half_dim + thread_offset * kVec;
     } else {
-      top_half = reinterpret_cast<float4*>(output_batch_base_ptr + thread_offset * 4);
-      bottom_half = reinterpret_cast<float4*>(output_batch_base_ptr + half_dim + thread_offset * 4);
+      cos_dst = output_batch_base_ptr + thread_offset * kVec;
+      sin_dst = output_batch_base_ptr + half_dim + thread_offset * kVec;
     }
 
-    float4 vals;
-    vals.x = scale * t_val * device::math::exp(neg_log_max_period * __int2float_rn(thread_offset * 4 + 0));
-    vals.y = scale * t_val * device::math::exp(neg_log_max_period * __int2float_rn(thread_offset * 4 + 1));
-    vals.z = scale * t_val * device::math::exp(neg_log_max_period * __int2float_rn(thread_offset * 4 + 2));
-    vals.w = scale * t_val * device::math::exp(neg_log_max_period * __int2float_rn(thread_offset * 4 + 3));
-
-    float4 cos_vals;
-    cos_vals.x = device::math::cos(vals.x);
-    cos_vals.y = device::math::cos(vals.y);
-    cos_vals.z = device::math::cos(vals.z);
-    cos_vals.w = device::math::cos(vals.w);
-    *top_half = cos_vals;
-
-    float4 sin_vals;
-    sin_vals.x = device::math::sin(vals.x);
-    sin_vals.y = device::math::sin(vals.y);
-    sin_vals.z = device::math::sin(vals.z);
-    sin_vals.w = device::math::sin(vals.w);
-    *bottom_half = sin_vals;
+    Vec cos_vec;
+    Vec sin_vec;
+#pragma unroll
+    for (int i = 0; i < kVec; ++i) {
+      const float angle =
+          scale * t_val * device::math::exp(neg_log_max_period * __int2float_rn(thread_offset * kVec + i));
+      cos_vec[i] = device::math::cos(angle);
+      sin_vec[i] = device::math::sin(angle);
+    }
+    cos_vec.store(cos_dst);
+    sin_vec.store(sin_dst);
 
     thread_offset += static_cast<int>(blockDim.x);
   }
@@ -118,6 +120,8 @@ inline void launch_timestep_embedding(
   }
 }
 
+}  // namespace
+
 template <typename TIn>
 void timestep_embedding(
     tvm::ffi::TensorView input,
@@ -147,4 +151,4 @@ void timestep_embedding(
   launch_timestep_embedding<TIn>(input, output, dim, flip_sin_to_cos, downscale_freq_shift, scale, max_period);
 }
 
-}  // namespace
+}  // namespace sglang_timestep_embedding

--- a/python/sglang/jit_kernel/diffusion/cutedsl/norm_tanh_mul_add_norm_scale.py
+++ b/python/sglang/jit_kernel/diffusion/cutedsl/norm_tanh_mul_add_norm_scale.py
@@ -10,48 +10,13 @@ from sglang.jit_kernel.diffusion.cutedsl.common.norm_fusion import (
     broadcast_tensor_for_bsfd,
     tensor_slice_for_bsfd,
 )
-from sglang.jit_kernel.diffusion.cutedsl.utils import TORCH_TO_CUTE_DTYPE, WARP_SIZE
+from sglang.jit_kernel.diffusion.cutedsl.utils import (
+    WARP_SIZE,
+    to_cute_arg,
+    to_fake_cute_args,
+)
 
 _COMPILE_CACHE = {}
-
-
-def to_cute_arg(
-    t,
-    *,
-    assume_aligned: Optional[int] = 32,
-    use_32bit_stride: bool = False,
-    enable_tvm_ffi: bool = True,
-):
-    """
-    Convert a Python value into a CuTeDSL value.
-    """
-    if isinstance(t, torch.Tensor):
-        return cute.runtime.from_dlpack(
-            t,
-            assumed_align=assume_aligned,
-            use_32bit_stride=use_32bit_stride,
-            enable_tvm_ffi=enable_tvm_ffi,
-        )
-    if isinstance(t, int):
-        return cutlass.Int32(t)
-    if isinstance(t, float):
-        return cutlass.Float32(t)
-    return t
-
-
-def to_fake_cute_args(t: torch.Tensor):
-    if isinstance(t, torch.Tensor):
-        # Only keep the last dim as compile-time value to maximum compiled kernel reuse
-        # e.g. (1,2,1536):(3027,1536,1) -> (?,?,1536):(?,?,1)
-        D = t.shape[-1]
-        dtype = TORCH_TO_CUTE_DTYPE[t.dtype]
-        shape = (*(cute.sym_int() for _ in range(t.ndim - 1)), D)
-        stride = (*(cute.sym_int(divisibility=D) for _ in range(t.ndim - 1)), 1)
-        fake_t = cute.runtime.make_fake_tensor(
-            dtype, shape, stride, memspace=cute.AddressSpace.gmem, assumed_align=32
-        )
-        return fake_t
-    return to_cute_arg(t)
 
 
 class NormTanhMulAddNormScale:
@@ -166,7 +131,7 @@ class NormTanhMulAddNormScale:
         @cute.jit
         def copy_if(src, dst):
             if cutlass.const_expr(
-                isinstance(src, cute.Tensor) and isinstance(src, cute.Tensor)
+                isinstance(src, cute.Tensor) and isinstance(dst, cute.Tensor)
             ):
                 cute.autovec_copy(src, dst)  # LDG.128
 

--- a/python/sglang/jit_kernel/diffusion/cutedsl/scale_residual_norm_scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/cutedsl/scale_residual_norm_scale_shift.py
@@ -10,48 +10,12 @@ from sglang.jit_kernel.diffusion.cutedsl.common.norm_fusion import (
     broadcast_tensor_for_bsfd,
     tensor_slice_for_bsfd,
 )
-from sglang.jit_kernel.diffusion.cutedsl.utils import TORCH_TO_CUTE_DTYPE, WARP_SIZE
+from sglang.jit_kernel.diffusion.cutedsl.utils import (
+    WARP_SIZE,
+    to_fake_cute_args,
+)
 
 _COMPILE_CACHE = {}
-
-
-def to_cute_arg(
-    t,
-    *,
-    assume_aligned: Optional[int] = 32,
-    use_32bit_stride: bool = False,
-    enable_tvm_ffi: bool = True,
-):
-    """
-    Convert a Python value into a CuTeDSL value.
-    """
-    if isinstance(t, torch.Tensor):
-        return cute.runtime.from_dlpack(
-            t,
-            assumed_align=assume_aligned,
-            use_32bit_stride=use_32bit_stride,
-            enable_tvm_ffi=enable_tvm_ffi,
-        )
-    if isinstance(t, int):
-        return cutlass.Int32(t)
-    if isinstance(t, float):
-        return cutlass.Float32(t)
-    return t
-
-
-def to_fake_cute_args(t: torch.Tensor):
-    if isinstance(t, torch.Tensor):
-        # Only keep the last dim as compile-time value to maximum compiled kernel reuse
-        # e.g. (1,2,1536):(3027,1536,1) -> (?,?,1536):(?,?,1)
-        D = t.shape[-1]
-        dtype = TORCH_TO_CUTE_DTYPE[t.dtype]
-        shape = (*(cute.sym_int() for _ in range(t.ndim - 1)), D)
-        stride = (*(cute.sym_int(divisibility=D) for _ in range(t.ndim - 1)), 1)
-        fake_t = cute.runtime.make_fake_tensor(
-            dtype, shape, stride, memspace=cute.AddressSpace.gmem, assumed_align=32
-        )
-        return fake_t
-    return to_cute_arg(t)
 
 
 class ScaleResidualNormScaleShift:
@@ -234,7 +198,7 @@ def validate_x(t: torch.Tensor, B: int, S: int, D: int):
         raise ValueError(f"Validate failed: not contiguous on dim D.")
 
 
-def validate_weight_bias(t: Optional[torch.Tensor], B: int, S: int, D: int):
+def validate_weight_bias(t: Optional[torch.Tensor], D: int):
     if t is None:
         return
     if t.dtype not in (torch.float16, torch.bfloat16, torch.float32):
@@ -312,8 +276,8 @@ def fused_norm_scale_shift(
     # Tensor Validation
     BSD = x.shape
     validate_x(x, *BSD)
-    validate_weight_bias(weight, *BSD)
-    validate_weight_bias(bias, *BSD)
+    validate_weight_bias(weight, BSD[-1])
+    validate_weight_bias(bias, BSD[-1])
     validate_scale_shift(scale, *BSD)
     validate_scale_shift(shift, *BSD)
 
@@ -399,14 +363,13 @@ def fused_scale_residual_norm_scale_shift(
     validate_x(x, *BSD)
     validate_x(residual, *BSD)
     validate_gate(gate, *BSD)
-    validate_weight_bias(weight, *BSD)
-    validate_weight_bias(bias, *BSD)
+    validate_weight_bias(weight, BSD[-1])
+    validate_weight_bias(bias, BSD[-1])
     validate_scale_shift(scale, *BSD)
     validate_scale_shift(shift, *BSD)
     if norm_type == "layer" or norm_type == "rms":
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
-        # if norm_type == "layer" or norm_type == "rms":
         D = x.shape[-1]
         if D % 256 != 0 or D > 8192:
             raise ValueError(

--- a/python/sglang/jit_kernel/diffusion/cutedsl/utils.py
+++ b/python/sglang/jit_kernel/diffusion/cutedsl/utils.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 import cutlass
+import cutlass.cute as cute
 import torch
 
 WARP_SIZE = 32
@@ -8,3 +11,42 @@ TORCH_TO_CUTE_DTYPE = {
     torch.bfloat16: cutlass.BFloat16,
     torch.float32: cutlass.Float32,
 }
+
+
+def to_cute_arg(
+    t,
+    *,
+    assume_aligned: Optional[int] = 32,
+    use_32bit_stride: bool = False,
+    enable_tvm_ffi: bool = True,
+):
+    """
+    Convert a Python value into a CuTeDSL value.
+    """
+    if isinstance(t, torch.Tensor):
+        return cute.runtime.from_dlpack(
+            t,
+            assumed_align=assume_aligned,
+            use_32bit_stride=use_32bit_stride,
+            enable_tvm_ffi=enable_tvm_ffi,
+        )
+    if isinstance(t, int):
+        return cutlass.Int32(t)
+    if isinstance(t, float):
+        return cutlass.Float32(t)
+    return t
+
+
+def to_fake_cute_args(t: torch.Tensor):
+    if isinstance(t, torch.Tensor):
+        # Only keep the last dim as compile-time value to maximum compiled kernel reuse
+        # e.g. (1,2,1536):(3027,1536,1) -> (?,?,1536):(?,?,1)
+        D = t.shape[-1]
+        dtype = TORCH_TO_CUTE_DTYPE[t.dtype]
+        shape = (*(cute.sym_int() for _ in range(t.ndim - 1)), D)
+        stride = (*(cute.sym_int(divisibility=D) for _ in range(t.ndim - 1)), 1)
+        fake_t = cute.runtime.make_fake_tensor(
+            dtype, shape, stride, memspace=cute.AddressSpace.gmem, assumed_align=32
+        )
+        return fake_t
+    return to_cute_arg(t)

--- a/python/sglang/jit_kernel/diffusion/triton/norm.py
+++ b/python/sglang/jit_kernel/diffusion/triton/norm.py
@@ -38,7 +38,6 @@ def triton_autotune_configs():
         for warp_count in [1, 2, 4, 8, 16, 32]
         if warp_count * warp_size <= max_threads_per_block
     ]
-    # return [triton.Config({}, num_warps=8)]
 
 
 # Copied from flash-attn

--- a/python/sglang/jit_kernel/diffusion/triton/sana_wm_gdn.py
+++ b/python/sglang/jit_kernel/diffusion/triton/sana_wm_gdn.py
@@ -120,18 +120,6 @@ def prepare_rope_tables(
     return rope_cos.contiguous(), rope_sin.contiguous()
 
 
-def _precompute_inv_rms(
-    qkv: torch.Tensor, idx: int, C: int, eps: float = 1e-5
-) -> torch.Tensor:
-    """Compute 1/RMS for one component of QKV over the full C = H*D channel dim.
-
-    qkv: (B, N, 3, H, D); idx: 0=Q, 1=K, 2=V; C: H*D. Returns (B, N) float32.
-    """
-    raw = qkv[:, :, idx].float()  # (B, N, H, D)
-    sq_sum = (raw * raw).sum(dim=(-2, -1))  # (B, N)
-    return torch.rsqrt(sq_sum / C + eps)
-
-
 # =====================================================================
 #  Fused single-pass Q+K inverse-RMS Triton kernel
 # =====================================================================
@@ -182,7 +170,7 @@ def fused_qk_inv_rms(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Single-pass Triton fused Q+K inverse-RMS.
 
-    Replaces two ``_precompute_inv_rms`` scans with one launch that reads each
+    Replaces two separate PyTorch RMS scans with one launch that reads each
     ``(b, n)`` row of ``qkv`` exactly once.
     qkv: (B, N, 3, H, D) contiguous. Returns (q_inv_rms, k_inv_rms), each (B, N) float32.
     """
@@ -230,7 +218,7 @@ def fused_bigdn_func(
     """Bidirectional fused GDN. Returns ``(B, N, H, D)``.
 
     Thin entry point kept for call-site stability; delegates to
-    :func:`fused_bigdn_bidi_chunkwise` from ``fused_gdn_chunkwise``.
+    :func:`fused_bigdn_bidi_chunkwise` from ``sana_wm_gdn_chunkwise``.
     """
     from sglang.jit_kernel.diffusion.triton.sana_wm_gdn_chunkwise import (
         fused_bigdn_bidi_chunkwise,

--- a/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
@@ -224,7 +224,6 @@ def _fused_scale_shift_4d_kernel(
     scale_ptr,
     shift_ptr,
     scale_constant: tl.constexpr,  # scale_constant is either 0 or 1.
-    rows,
     inner_dim,
     seq_len,
     num_frames,
@@ -386,7 +385,6 @@ def fuse_scale_shift_kernel(
             scale_reshaped,
             shift_reshaped,
             scale_constant,
-            rows,
             C,
             L,
             num_frames,

--- a/python/sglang/jit_kernel/timestep_embedding.py
+++ b/python/sglang/jit_kernel/timestep_embedding.py
@@ -18,7 +18,12 @@ def _jit_timestep_embedding_module(dtype: torch.dtype) -> Module:
         "timestep_embedding",
         *args,
         cuda_files=["diffusion/timestep_embedding.cuh"],
-        cuda_wrappers=[("timestep_embedding", f"timestep_embedding<{args}>")],
+        cuda_wrappers=[
+            (
+                "timestep_embedding",
+                f"sglang_timestep_embedding::timestep_embedding<{args}>",
+            )
+        ],
     )
 
 


### PR DESCRIPTION
## Motivation

The KDA-Pilot diffusion native-CUDA fast paths each need a 128-bit vectorized load/store. The first one that landed (`norm_scale_shift`, #27392) already uses the shared `device::AlignedVector` component from `sgl_kernel/vec.cuh`, but the two newer kernels (#29281, #29361) still hand-roll their own local `union`. This PR makes all the diffusion CUDA kernels reuse the shared `AlignedVector` component instead of a per-kernel `union`, and folds in a few small, verified cleanups found while reviewing the rest of `jit_kernel/diffusion/`. No behavior change.

## Modifications

**Native CUDA (`.cuh`) — reuse `device::AlignedVector`:**
- `residual_gate_add`: replace `union Vec16<T>` with `device::AlignedVector<T, kVec>` (`.load()`/`.store()`/`operator[]`).
- `causal_conv3d_cat_pad`: replace `union Pack` with `device::AlignedVector<ET, kVec>` (scattered scalar reads stay scalar `__ldg`; only the vectorized store changes).
- `timestep_embedding`: replace raw `float4` with `AlignedVector<float, 4>`, and add `#pragma once` + a named namespace `sglang_timestep_embedding` to match its siblings (plus the matching wrapper symbol in `timestep_embedding.py`).

**CuTe-DSL / Triton cleanups:**
- Hoist the byte-identical `to_cute_arg` / `to_fake_cute_args` helpers into `cutedsl/utils.py` and import them in both kernel files (removes ~36 duplicated lines).
- Fix a copy-paste guard in `norm_tanh_mul_add_norm_scale` (`isinstance(src, …) and isinstance(src, …)` → `… isinstance(dst, …)`, matching the sibling).
- Delete the dead `_precompute_inv_rms` in `sana_wm_gdn` (superseded by `fused_qk_inv_rms`; no callers).
- Drop the unused `rows` parameter from the `scale_shift` 4D kernel and its call site.
- Drop unused `B, S` args from `validate_weight_bias` (only `D` is used; matches the sibling signature).
- Remove stale commented-out code (`norm.py`, `scale_residual_norm_scale_shift.py`) and fix a stale docstring module name in `sana_wm_gdn`.

## Accuracy Tests

Validated on B200 (`pytest`, all pass):
- `test/registered/jit/diffusion/{test_residual_gate_add, test_causal_conv3d_cat_pad, test_fused_norm_scale_shift, test_qwen_image_modulation}.py`
- `test/registered/jit/test_timestep_embedding.py`

A torch-reference smoke over every touched kernel (the 4 CuTe-DSL modulation entries, the 4D `scale_shift` path, `sana_wm_gdn.fused_qk_inv_rms`, plus a negative test that `validate_weight_bias` still rejects bad shapes) matches within bf16 tolerance.

## Speed Tests and Profiling

Before/after on **B200**, OLD = `union`/`float4`, NEW = `AlignedVector` (`cuda` column from the registered benches; medians).

**`bench_residual_gate_add` — `cuda` µs (neutral):**

| workload | OLD | NEW |
|---|---:|---:|
| ltx2_bcast_s32640_c4096 | 126.35 | 125.97 |
| ltx2_full_s8160_c4096 | 41.64 | 41.65 |
| ideogram4_bcast_s4096_c4608 | 23.23 | 23.27 |
| flux2_bcast_s4608_c3072 | 16.02 | 16.05 |
| flux2_bcast_s512_c3072 | 15.93 | 15.68 |
| ltx2_full_s126_c2048 | 13.98 | 13.94 |

**`bench_causal_conv3d_cat_pad` — `cuda` µs (within noise):**

| case | OLD | NEW |
|---|---:|---:|
| c512_t4_h120_w208_cache1 | 126.98 | 129.02 |
| c512_t4_h120_w208_cache2 | 151.55 | 151.61 |
| c256_t4_h240_w416_cache1 | 230.4 | 232.4 |
| c256_t4_h240_w416_cache2 | 274.40 | 276.48 |

The conv3d numbers wobble <1%. To rule out a real regression I diffed the generated SASS of the bf16 `cat_pad_flat_kernel` (largest shape) for OLD vs NEW:

- **identical instruction count: 1184 vs 1184**
- **1× `STG` (a single 128-bit store) and 8× `LDG`** in both — i.e. `AlignedVector::store` lowers to the same `STG.128` as the old `uint4` union
- **0 local-memory ops (`STL`/`LDL` = 0)** in both — no register spilling
- only difference: a single `IMAD`↔`IADD3` scheduling swap (467/127 vs 468/126)

`ncu` agrees: same DRAM throughput (~18.5%), same SM throughput (~81%), zero local load/store sectors in both. The kernel is SM-issue-bound, so the sub-1% wall-clock difference is compiler-scheduling/measurement noise, not an algorithmic or memory regression.

`timestep_embedding` has no registered bench; it is a tiny vectorized store kernel covered by `test_timestep_embedding.py` (the `float4` → `AlignedVector<float,4>` change keeps a single 128-bit store).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (No new tests — behavior-preserving cleanup covered by existing diffusion unit tests.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28380606742](https://github.com/sgl-project/sglang/actions/runs/28380606742)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28380606530](https://github.com/sgl-project/sglang/actions/runs/28380606530)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->