### PR TITLE
Size FA3 speculative page tables from req_to_token capacity

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -241,13 +241,16 @@ class FlashAttentionBackend(AttentionBackend):
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self.req_to_token_capacity_len = int(self.req_to_token.shape[1])
         self.kv_cache_dtype = model_runner.kv_cache_dtype
         self.kv_cache_dtype_str = model_runner.server_args.kv_cache_dtype
         self.page_size = model_runner.page_size
-        # Static page-table width (upper bound). The device-side page-table build
-        # sizes to this constant, so no runtime host max is needed.
+        # Static page-table width (upper bound). Speculative decoding can
+        # over-allocate KV beyond the model context length, and req_to_token is
+        # sized with that headroom. Metadata that indexes req_to_token must use
+        # the addressable row width, not the semantic model context length.
         self.max_num_pages = (
-            self.max_context_len + self.page_size - 1
+            self.req_to_token_capacity_len + self.page_size - 1
         ) // self.page_size
         # Opt out of the seq_lens_cpu D2H only for dflash (the worker adapted to
         # the GPU-only relay); EAGLE/MTP/standalone/non-spec keep the CPU mirror.
@@ -1768,7 +1771,7 @@ class FlashAttentionBackend(AttentionBackend):
         This creates fixed-size tensors that will be reused during CUDA graph replay
         to avoid memory allocations.
         """
-        max_num_pages = (self.max_context_len + self.page_size - 1) // self.page_size
+        max_num_pages = self.max_num_pages
 
         # This is being used by normal decode and draft decode when topk == 1
         self.decode_cuda_graph_metadata = {
@@ -1786,7 +1789,10 @@ class FlashAttentionBackend(AttentionBackend):
                 device=self.device,
             ),
             "strided_indices": torch.arange(
-                0, self.max_context_len, self.page_size, device=self.device
+                0,
+                self.req_to_token_capacity_len,
+                self.page_size,
+                device=self.device,
             ),
         }
         # Pre-allocate scheduler_metadata buffer for CUDA graph
@@ -1859,7 +1865,7 @@ class FlashAttentionBackend(AttentionBackend):
                 ),
                 "page_table": torch.zeros(
                     max_bs,
-                    self.max_context_len,
+                    max_num_pages,
                     dtype=torch.int32,
                     device=self.device,
                 ),
@@ -1928,7 +1934,10 @@ class FlashAttentionBackend(AttentionBackend):
                     device=self.device,
                 ),
                 "strided_indices": torch.arange(
-                    0, self.max_context_len, self.page_size, device=self.device
+                    0,
+                    self.req_to_token_capacity_len,
+                    self.page_size,
+                    device=self.device,
                 ),
             }
 
@@ -1951,7 +1960,10 @@ class FlashAttentionBackend(AttentionBackend):
                     device=self.device,
                 ),
                 "strided_indices": torch.arange(
-                    0, self.max_context_len, self.page_size, device=self.device
+                    0,
+                    self.req_to_token_capacity_len,
+                    self.page_size,
+                    device=self.device,
                 ),
             }
 
@@ -1986,7 +1998,7 @@ class FlashAttentionBackend(AttentionBackend):
                 ),
                 "page_table": torch.zeros(
                     max_bs,
-                    self.max_context_len,
+                    max_num_pages,
                     dtype=torch.int32,
                     device=self.device,
                 ),
@@ -2037,7 +2049,7 @@ class FlashAttentionBackend(AttentionBackend):
                     ),
                     "page_table": torch.zeros(
                         max_bs * self.speculative_num_draft_tokens,
-                        self.max_context_len,
+                        max_num_pages,
                         dtype=torch.int32,
                         device=self.device,
                     ),


### PR DESCRIPTION
## Motivation

Addresses the latest FA3 page-table crash reported in #29516:

```text
AssertionError: FA3 draft-decode page_table: used 256001 > capacity 256000
```

This is separate from the original Qwen MRoPE draft-extend shape mismatch fixed
by #28464, and separate from the Mamba `extra_buffer` verify crash covered by
#29449.

The root cause here is that FA3 CUDA graph metadata page-table buffers were
sized from the semantic model context length (`model_config.context_len`), while
speculative decoding can address `req_to_token` rows with extra headroom beyond
that semantic context. Near the context boundary, draft decode can therefore
need `seq_len + speculative_step` page-table capacity while still staying inside
the addressable `req_to_token` row.

## Modifications

- Keep `self.max_context_len` as the semantic model context length.
- Add `self.req_to_token_capacity_len` from `req_to_token.shape[1]`.
- Derive FA3 CUDA graph `max_num_pages` from the addressable
  `req_to_token` row width.
- Size FA3 CUDA graph page-table metadata and `strided_indices` from that
  addressable capacity for decode, draft decode, target verify, draft extend,
  and topk speculative metadata.

## Accuracy Tests

This change is metadata-capacity-only: it does not change attention math,
accepted token semantics, or kernels. No accuracy benchmark was run.

## Speed Tests and Profiling

No speed benchmark was run. The runtime metadata build path is unchanged; this
only gives preallocated CUDA graph page-table buffers the same headroom already
present in `req_to_token`. The memory increase is bounded by the existing
`req_to_token` extra context headroom.

## Validation

- `git diff --check`: passed
- `python3 -m py_compile python/sglang/srt/layers/attention/flashattention_backend.py`: passed
- H200 issue-specific trigger anchored on current `origin/main`
  `5169df70f6f5434026a89e33946a9f2af2044a79` with
  `lmsysorg/sglang:latest`:
  - pure base trigger failed as expected with FA3 page-table capacity `64`
    below addressable `req_to_token` capacity `68`;
  - patched trigger passed with all checked FA3 speculative page-table metadata
    buffers sized to `68`.

Validation gaps:

- I did not rerun the reporter's exact H20 + Qwen3.6-35B-A3B-FP8 one-hour
  workload.
- I did not add an upstream CUDA unit test for this metadata sizing invariant;
  the focused H200 trigger was kept as issue-specific validation rather than
  duplicating the implementation in a test.

## Checklist

- [x] Format/code style checked.
- [x] Focused validation performed or test gap explicitly documented.
- [x] Docs update not applicable.
- [x] Accuracy/speed impact explained.
- [x] Follow the SGLang code style guidance.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28383488147](https://github.com/sgl-project/sglang/actions/runs/28383488147)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28383487808](https://github.com/sgl-project/sglang/actions/runs/28383487808)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->