### PR TITLE
[HiSparse] Optimize Quest sparse page selection (Part 2 of 4)

### DIFF
--- a/python/sglang/srt/mem_cache/sparsity/algorithms/base_algorithm.py
+++ b/python/sglang/srt/mem_cache/sparsity/algorithms/base_algorithm.py
@@ -1,10 +1,56 @@
 from abc import ABC, abstractmethod
+from ctypes import c_float
+from dataclasses import dataclass
+from importlib import import_module
+from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
 import torch
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+def load_optional_quest_kernel(module_name: str):
+    """Load an installed Quest kernel; an absent module selects the fallback."""
+    try:
+        spec = find_spec(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name and (
+            exc.name == module_name or module_name.startswith(f"{exc.name}.")
+        ):
+            return None
+        raise
+    if spec is None:
+        return None
+    return import_module(module_name)
+
+
+def _float32_scaled_count(count: int, ratio: float) -> int:
+    """Match a device float32 multiply followed by integer truncation."""
+    count_f32 = c_float(count).value
+    ratio_f32 = c_float(ratio).value
+    return int(c_float(count_f32 * ratio_f32).value)
+
+
+@dataclass
+class _TopKPlan:
+    """Temporary tensors needed by one batched page-selection call."""
+
+    max_num_pages: int
+    physical_pages: torch.Tensor
+    valid_page_mask: torch.Tensor
+    active_mask: torch.Tensor
+    recent_start: torch.Tensor
+    history_page_mask: torch.Tensor
+    k_per_req: torch.Tensor
+    max_k: int
+    score_order_required: bool
+    recent_idx: torch.Tensor
+    recent_valid: torch.Tensor
+    req_pool_indices: torch.Tensor
+    seq_lens: torch.Tensor
+    fixed_capacity: bool
 
 
 class BaseSparseAlgorithm(ABC):
@@ -51,6 +97,16 @@ class BaseSparseAlgorithm(ABC):
             - Look-ahead QCache: Allocate importance scores [num_tokens], eviction mask, and optional pseudo query cache [cache_size, hidden_dim]
         """
         pass
+
+    def begin_forward(
+        self,
+        forward_batch: "ForwardBatch",
+        req_pool_indices: torch.Tensor,
+        sparse_mask: torch.Tensor,
+        device: torch.device,
+        fixed_capacity: bool | int = False,
+    ) -> None:
+        """Prepare optional state shared by sparse layers in one forward."""
 
     def construct_representations(
         self,
@@ -165,6 +221,29 @@ class BaseSparseAlgorithmImpl(BaseSparseAlgorithm):
         self.sparsity_ratio = config.sparse_extra_config.get("sparsity_ratio", 0.7)
         self.num_recent_pages = config.sparse_extra_config.get("num_recent_pages", 4)
         self.page_size = config.page_size
+        self._topk_plan: _TopKPlan | None = None
+        self._topk_plan_forward_batch = None
+
+    def begin_forward(
+        self,
+        forward_batch: "ForwardBatch",
+        req_pool_indices: torch.Tensor,
+        sparse_mask: torch.Tensor,
+        device: torch.device,
+        fixed_capacity: bool | int = False,
+    ) -> None:
+        self._topk_plan = None
+        self._topk_plan_forward_batch = None
+        if not fixed_capacity or self.req_to_token_pool is None:
+            return
+        self._topk_plan = self._build_topk_plan(
+            forward_batch,
+            req_pool_indices,
+            sparse_mask,
+            device,
+            fixed_capacity=fixed_capacity,
+        )
+        self._topk_plan_forward_batch = forward_batch
 
     def initialize_representation_pool(
         self,
@@ -267,14 +346,7 @@ class BaseSparseAlgorithmImpl(BaseSparseAlgorithm):
         sparse_mask: torch.Tensor,
         **kwargs,
     ) -> tuple:
-        """
-        Default TopK retrieval: score-based selection + recent pages.
-        Subclasses can override for query-dependent retrieval.
-
-        TODO:
-            1. Using triton kernel to speed up this function
-            2. Support CUDA Graph
-        """
+        """Select important history pages and retain the recent window."""
         bs, device = queries.shape[0], queries.device
 
         seq_lens_source = kwargs.get("forward_batch", None)
@@ -282,77 +354,538 @@ class BaseSparseAlgorithmImpl(BaseSparseAlgorithm):
             raise ValueError(
                 "forward_batch with seq_lens is required for TopK retrieval"
             )
-        seq_lens = seq_lens_source.seq_lens.to(device)
+        plan = self._topk_plan
+        if (
+            bs == 1
+            and self._get_num_pages_cpu(seq_lens_source, 1) is not None
+            and (plan is None or not plan.fixed_capacity)
+        ):
+            return self._retrieve_topk_single(
+                queries,
+                layer_id,
+                req_pool_indices,
+                sparse_mask,
+                seq_lens_source,
+            )
+
+        if (
+            plan is None
+            or self._topk_plan_forward_batch is not seq_lens_source
+            or plan.req_pool_indices.numel() != bs
+            or plan.seq_lens.device != device
+        ):
+            plan = self._build_topk_plan(
+                seq_lens_source,
+                req_pool_indices,
+                sparse_mask,
+                device,
+            )
+        if plan.max_num_pages <= self.num_recent_pages or plan.max_k <= 0:
+            return self._empty_retrieval(bs, device)
+
+        scores = self._retrieve_page_scores_batched(layer_id, queries, plan)
+        topk_scores, topk_idx = torch.topk(
+            scores,
+            k=plan.max_k,
+            dim=1,
+            sorted=plan.score_order_required,
+        )
+
+        return self._finalize_topk_with_recent(topk_scores, topk_idx, plan, **kwargs)
+
+    def _finalize_topk_with_recent(
+        self,
+        topk_scores: torch.Tensor,
+        topk_idx: torch.Tensor,
+        plan: _TopKPlan,
+        **kwargs,
+    ) -> tuple:
+        """Finalize a batched selection, using optional kernels when available."""
+        if kwargs.get("allow_prepared_metadata", False):
+            direct_result = self._try_finalize_to_flashattention_metadata(
+                topk_scores, topk_idx, plan, kwargs.get("attn_metadata")
+            )
+            if direct_result is not None:
+                return direct_result
+
+        kernel_module = None
+        if topk_scores.is_cuda and torch.version.hip is None:
+            kernel_module = load_optional_quest_kernel(
+                "sglang.srt.mem_cache.sparsity.kernels.quest_finalize"
+            )
+        combined_width = topk_scores.shape[1] + plan.recent_idx.shape[1]
+        kernel_inputs = (
+            topk_scores,
+            topk_idx,
+            plan.k_per_req,
+            plan.recent_idx,
+            plan.recent_valid,
+        )
+        if (
+            kernel_module is not None
+            and combined_width <= kernel_module.QUEST_FINALIZE_MAX_WIDTH
+            and all(tensor.is_contiguous() for tensor in kernel_inputs)
+        ):
+            return kernel_module.quest_finalize_selected_pages(
+                topk_scores,
+                topk_idx,
+                plan.k_per_req,
+                plan.recent_idx,
+                plan.recent_valid,
+            )
+
+        device = topk_scores.device
+        topk_idx = topk_idx.to(torch.long)
+        topk_rank = torch.arange(plan.max_k, device=device, dtype=torch.long)
+        topk_valid = (
+            topk_rank.unsqueeze(0) < plan.k_per_req.unsqueeze(1)
+        ) & torch.isfinite(topk_scores)
+        combined_idx = torch.cat([topk_idx, plan.recent_idx], dim=1)
+        combined_valid = torch.cat([topk_valid, plan.recent_valid], dim=1)
+        return self._finalize_selected_pages(
+            combined_idx, combined_valid, plan.max_num_pages
+        )
+
+    def _try_finalize_to_flashattention_metadata(
+        self,
+        topk_scores: torch.Tensor,
+        topk_idx: torch.Tensor,
+        plan: _TopKPlan,
+        attn_metadata,
+    ) -> tuple | None:
+        if (
+            attn_metadata is None
+            or not topk_scores.is_cuda
+            or torch.version.hip is not None
+            or topk_scores.dtype != torch.float32
+        ):
+            return None
+        required_attrs = ("page_table", "cache_seqlens_int32", "cu_seqlens_k")
+        if not all(hasattr(attn_metadata, attr) for attr in required_attrs):
+            return None
+
+        kernel_module = load_optional_quest_kernel(
+            "sglang.srt.mem_cache.sparsity.kernels.quest_flashattention_metadata"
+        )
+        if kernel_module is None:
+            return None
+
+        combined_width = topk_scores.shape[1] + plan.recent_idx.shape[1]
+        kernel_inputs = (
+            topk_idx,
+            plan.k_per_req,
+            plan.recent_idx,
+            plan.recent_valid,
+            plan.active_mask,
+            plan.seq_lens,
+            plan.req_pool_indices,
+            self.req_to_token_pool.req_to_token,
+        )
+        metadata_tensors = (
+            attn_metadata.page_table,
+            attn_metadata.cache_seqlens_int32,
+            attn_metadata.cu_seqlens_k,
+        )
+        if (
+            combined_width > kernel_module.QUEST_DIRECT_METADATA_MAX_WIDTH
+            or attn_metadata.page_table.shape[0] != topk_scores.shape[0]
+            or attn_metadata.page_table.shape[1] < combined_width
+            or any(
+                not tensor.is_cuda or tensor.device != topk_scores.device
+                for tensor in (*kernel_inputs, *metadata_tensors)
+            )
+            or not all(
+                tensor.is_contiguous()
+                for tensor in (
+                    topk_scores,
+                    topk_idx,
+                    plan.k_per_req,
+                    plan.recent_idx,
+                    plan.recent_valid,
+                )
+            )
+        ):
+            return None
+
+        valid_lengths = torch.empty(
+            topk_scores.shape[0], dtype=torch.int32, device=topk_scores.device
+        )
+        kernel_module.quest_finalize_to_flashattention_metadata_(
+            topk_scores=topk_scores,
+            topk_indices=topk_idx,
+            k_per_req=plan.k_per_req,
+            recent_indices=plan.recent_idx,
+            recent_valid=plan.recent_valid,
+            valid_lengths=valid_lengths,
+            sparse_mask=plan.active_mask,
+            seq_lens=plan.seq_lens,
+            req_pool_indices=plan.req_pool_indices,
+            req_to_token=self.req_to_token_pool.req_to_token,
+            page_table=attn_metadata.page_table,
+            cache_seqlens_int32=attn_metadata.cache_seqlens_int32,
+            cu_seqlens_k=attn_metadata.cu_seqlens_k,
+            page_size=self.page_size,
+            update_lengths=True,
+        )
+        return attn_metadata.page_table[:, :combined_width], valid_lengths, True
+
+    def _retrieve_topk_single(
+        self,
+        queries: torch.Tensor,
+        layer_id: int,
+        req_pool_indices: torch.Tensor,
+        sparse_mask: torch.Tensor,
+        forward_batch: "ForwardBatch",
+    ) -> tuple:
+        """Keep the low-overhead historical path for single-request decode."""
+        device = queries.device
+        sparse_mask_cpu = self._get_bool_mask_cpu(
+            sparse_mask, 1, forward_batch=forward_batch
+        )
+        if sparse_mask_cpu is not None and not sparse_mask_cpu[0]:
+            return self._empty_retrieval(1, device)
+
+        num_pages_cpu = self._get_num_pages_cpu(forward_batch, 1)
+        assert num_pages_cpu is not None
+        num_pages = num_pages_cpu[0]
+        if num_pages <= self.num_recent_pages:
+            return self._empty_retrieval(1, device)
 
         req_to_token = self.req_to_token_pool.req_to_token
-        max_req_tokens = req_to_token.shape[1]
+        page_idx = torch.arange(num_pages, device=device, dtype=torch.long)
+        page_starts = (page_idx * self.page_size).clamp(0, req_to_token.shape[1] - 1)
+        single_req_pool_indices = req_pool_indices.to(device=device, dtype=torch.long)
+        physical_pages = (
+            req_to_token[
+                single_req_pool_indices,
+                page_starts.unsqueeze(0),
+            ].to(torch.long)
+            // self.page_size
+        )
+        scores = self._retrieve_page_scores(
+            layer_id,
+            physical_pages,
+            single_req_pool_indices,
+            queries,
+        )
 
-        per_request_indices = []
-        per_request_lengths = []
+        recent_start = num_pages - self.num_recent_pages
+        history_pages = max(recent_start, 1)
+        k = min(
+            max(_float32_scaled_count(history_pages, self.sparsity_ratio), 1),
+            history_pages,
+        )
+        topk_idx = torch.topk(
+            scores[:, :recent_start], k=k, dim=1, sorted=False
+        ).indices.squeeze(0)
+        recent_idx = torch.arange(
+            recent_start, num_pages, device=device, dtype=torch.long
+        )
+        selected = torch.cat([topk_idx, recent_idx]).sort()[0].to(torch.int32)
+        active_mask = sparse_mask.to(device=device, dtype=torch.bool).reshape(1)
+        out_indices = torch.where(
+            active_mask.unsqueeze(1),
+            selected.unsqueeze(0),
+            torch.full((1, selected.numel()), -1, dtype=torch.int32, device=device),
+        )
+        lengths = torch.where(
+            active_mask,
+            torch.full((1,), selected.numel(), dtype=torch.int32, device=device),
+            torch.zeros(1, dtype=torch.int32, device=device),
+        )
+        return out_indices, lengths
 
-        for i in range(bs):
-            if not sparse_mask[i]:
-                per_request_indices.append(
-                    torch.empty(0, device=device, dtype=torch.int32)
+    def _build_topk_plan(
+        self,
+        forward_batch: "ForwardBatch",
+        req_pool_indices: torch.Tensor,
+        sparse_mask: torch.Tensor,
+        device: torch.device,
+        *,
+        fixed_capacity: bool | int = False,
+    ) -> _TopKPlan:
+        """Vectorize ragged request metadata without retaining forward state."""
+        batch_size = req_pool_indices.numel()
+        seq_lens = forward_batch.seq_lens.to(device=device, dtype=torch.long)
+        req_pool_indices = req_pool_indices.to(device=device, dtype=torch.long)
+        sparse_mask_source = sparse_mask
+        sparse_mask = sparse_mask.to(device=device, dtype=torch.bool)
+        num_pages = (seq_lens + self.page_size - 1) // self.page_size
+
+        num_pages_cpu = (
+            None
+            if fixed_capacity
+            else self._get_num_pages_cpu(forward_batch, batch_size)
+        )
+        sparse_mask_cpu = (
+            self._get_bool_mask_cpu(
+                sparse_mask_source,
+                batch_size,
+                forward_batch=forward_batch,
+            )
+            if num_pages_cpu is not None
+            else None
+        )
+        if fixed_capacity:
+            pool_max_pages = getattr(self, "cuda_graph_max_num_pages", None)
+            if pool_max_pages is None:
+                max_context_len = getattr(
+                    self.req_to_token_pool,
+                    "max_context_len",
+                    self.req_to_token_pool.req_to_token.shape[1],
                 )
-                per_request_lengths.append(0)
-                continue
-
-            num_pages = int((seq_lens[i].item() + self.page_size - 1) // self.page_size)
-            if num_pages <= self.num_recent_pages:
-                per_request_indices.append(
-                    torch.empty(0, device=device, dtype=torch.int32)
+                pool_max_pages = max(
+                    (max_context_len + self.page_size - 1) // self.page_size, 1
                 )
-                per_request_lengths.append(0)
-                continue
+            max_num_pages = (
+                pool_max_pages
+                if isinstance(fixed_capacity, bool)
+                else min(fixed_capacity, pool_max_pages)
+            )
+        else:
+            max_num_pages = (
+                max(num_pages_cpu, default=0)
+                if num_pages_cpu is not None
+                else int(num_pages.max().item()) if batch_size > 0 else 0
+            )
+        page_idx = torch.arange(max_num_pages, device=device, dtype=torch.long)
+        valid_page_mask = page_idx.unsqueeze(0) < num_pages.unsqueeze(1)
 
-            page_idx = torch.arange(num_pages, device=device)
-            page_start_token = req_to_token[
-                req_pool_indices[i],
-                (page_idx * self.page_size).clamp(0, max_req_tokens - 1),
-            ]
-            phys_pages = (page_start_token // self.page_size).unsqueeze(0)
-
-            scores = self._retrieve_page_scores(
-                layer_id,
-                phys_pages,
-                req_pool_indices[i : i + 1],
-                queries[i : i + 1],
+        req_to_token = self.req_to_token_pool.req_to_token
+        if max_num_pages > 0:
+            page_starts = (page_idx * self.page_size).clamp(
+                0, req_to_token.shape[1] - 1
+            )
+            physical_pages = (
+                req_to_token[
+                    req_pool_indices[:, None],
+                    page_starts[None, :],
+                ].to(torch.long)
+                // self.page_size
+            )
+            physical_pages = torch.where(
+                valid_page_mask,
+                physical_pages,
+                torch.full_like(physical_pages, -1),
+            )
+        else:
+            physical_pages = torch.empty(
+                (batch_size, 0), device=device, dtype=torch.long
             )
 
-            recent_start = max(num_pages - self.num_recent_pages, 0)
-            scores = scores.clone()
-            scores[:, recent_start:] = float("-inf")
+        active_mask = sparse_mask & (num_pages > self.num_recent_pages)
+        recent_start = (num_pages - self.num_recent_pages).clamp(min=0)
+        history_page_mask = page_idx.unsqueeze(0) < recent_start.unsqueeze(1)
+        history_pages = recent_start.clamp(min=1)
+        k_per_req = (history_pages.to(torch.float32) * self.sparsity_ratio).to(
+            torch.int32
+        )
+        k_per_req = torch.maximum(k_per_req, torch.ones_like(k_per_req))
+        k_per_req = torch.minimum(k_per_req, history_pages.to(torch.int32))
+        k_per_req = torch.where(active_mask, k_per_req, torch.zeros_like(k_per_req))
 
-            history_pages = max(recent_start, 1)
-            k = max(int(history_pages * self.sparsity_ratio), 1)
-            k = min(k, history_pages)
-            topk_idx = torch.topk(scores, k=k, dim=1, sorted=False)[1].squeeze(0)
-
-            recent_idx = torch.arange(
-                recent_start, recent_start + self.num_recent_pages, device=device
+        if fixed_capacity:
+            history_capacity = max(max_num_pages - self.num_recent_pages, 0)
+            max_k = (
+                min(
+                    max(
+                        _float32_scaled_count(history_capacity, self.sparsity_ratio),
+                        1,
+                    ),
+                    history_capacity,
+                )
+                if history_capacity > 0
+                else 0
             )
-            recent_idx = recent_idx[recent_idx < num_pages]
+            score_order_required = True
+        elif num_pages_cpu is not None:
+            k_per_req_cpu = []
+            for row, count in enumerate(num_pages_cpu):
+                # Without a host mask, size conservatively. Device k_per_req
+                # remains authoritative and zeros inactive rows.
+                is_sparse = (
+                    sparse_mask_cpu[row] if sparse_mask_cpu is not None else True
+                )
+                history_count = max(count - self.num_recent_pages, 0)
+                k_per_req_cpu.append(
+                    min(
+                        max(
+                            _float32_scaled_count(
+                                max(history_count, 1), self.sparsity_ratio
+                            ),
+                            1,
+                        ),
+                        history_count,
+                    )
+                    if is_sparse and history_count > 0
+                    else 0
+                )
+            max_k = max(k_per_req_cpu, default=0)
+            positive_k = {value for value in k_per_req_cpu if value > 0}
+            score_order_required = len(positive_k) > 1
+        else:
+            max_k = int(k_per_req.max().item()) if batch_size > 0 else 0
+            score_order_required = True
 
-            combined = (
-                torch.cat([topk_idx, recent_idx], dim=0).sort()[0].to(torch.int32)
-            )
+        recent_offsets = torch.arange(
+            self.num_recent_pages, device=device, dtype=torch.long
+        )
+        recent_idx = recent_start.unsqueeze(1) + recent_offsets.unsqueeze(0)
+        recent_valid = active_mask.unsqueeze(1) & (recent_idx < num_pages.unsqueeze(1))
+        return _TopKPlan(
+            max_num_pages=max_num_pages,
+            physical_pages=physical_pages,
+            valid_page_mask=valid_page_mask,
+            active_mask=active_mask,
+            recent_start=recent_start,
+            history_page_mask=history_page_mask,
+            k_per_req=k_per_req,
+            max_k=max_k,
+            score_order_required=score_order_required,
+            recent_idx=recent_idx,
+            recent_valid=recent_valid,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            fixed_capacity=bool(fixed_capacity),
+        )
 
-            per_request_indices.append(combined)
-            per_request_lengths.append(int(combined.numel()))
+    @staticmethod
+    def _get_bool_mask_cpu(
+        mask: torch.Tensor,
+        batch_size: int,
+        *,
+        forward_batch=None,
+    ) -> list[bool] | None:
+        if not torch.is_tensor(mask) or mask.numel() != batch_size:
+            raise ValueError("sparse_mask must contain one value per request")
 
-        max_len = max(max(per_request_lengths, default=0), 1)
-        out_indices = torch.full((bs, max_len), -1, dtype=torch.int32, device=device)
-        out_lengths = torch.zeros(bs, dtype=torch.int32, device=device)
+        host_mask = getattr(forward_batch, "sparse_mask_cpu", None)
+        if host_mask is None:
+            if mask.device.type != "cpu":
+                return None
+            host_mask = mask
 
-        for i, selected in enumerate(per_request_indices):
-            length = per_request_lengths[i]
-            if length == 0:
-                continue
-            out_indices[i, :length] = selected
-            out_lengths[i] = length
+        if torch.is_tensor(host_mask):
+            if host_mask.device.type != "cpu" or host_mask.numel() != batch_size:
+                return None
+            values = host_mask.detach().reshape(-1).tolist()
+        else:
+            try:
+                values = list(host_mask)
+            except TypeError:
+                return None
+            if len(values) != batch_size:
+                return None
+        return [bool(value) for value in values]
 
-        return out_indices, out_lengths
+    def _get_num_pages_cpu(
+        self, forward_batch: "ForwardBatch", batch_size: int
+    ) -> list[int] | None:
+        seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+        if seq_lens_cpu is None:
+            return None
+        if torch.is_tensor(seq_lens_cpu):
+            if seq_lens_cpu.device.type != "cpu" or seq_lens_cpu.numel() != batch_size:
+                return None
+            values = seq_lens_cpu.reshape(-1).tolist()
+        else:
+            try:
+                values = list(seq_lens_cpu)
+            except TypeError:
+                return None
+            if len(values) != batch_size:
+                return None
+        return [
+            max((int(value) + self.page_size - 1) // self.page_size, 0)
+            for value in values
+        ]
+
+    def should_update_representations(self, forward_batch: "ForwardBatch") -> bool:
+        """Skip only proven single-token decodes that cannot complete a page."""
+        seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+        if seq_lens_cpu is None:
+            return True
+        if torch.is_tensor(seq_lens_cpu):
+            if seq_lens_cpu.device.type != "cpu":
+                return True
+            values = seq_lens_cpu.reshape(-1).tolist()
+        else:
+            try:
+                values = list(seq_lens_cpu)
+            except TypeError:
+                return True
+
+        batch_size = len(values)
+        if self._may_process_multiple_decode_tokens(forward_batch, batch_size):
+            return True
+        return any(
+            int(seq_len) > 0 and int(seq_len) % self.page_size == 0
+            for seq_len in values
+        )
+
+    @staticmethod
+    def _may_process_multiple_decode_tokens(forward_batch, batch_size: int) -> bool:
+        """Detect known multi-token/speculative layouts and keep the safe path."""
+        if getattr(forward_batch, "spec_info", None) is not None:
+            return True
+
+        extend_seq_lens_cpu = getattr(forward_batch, "extend_seq_lens_cpu", None)
+        if extend_seq_lens_cpu is not None:
+            try:
+                if any(int(length) != 1 for length in extend_seq_lens_cpu):
+                    return True
+            except TypeError:
+                return True
+
+        num_tokens = getattr(forward_batch, "num_token_non_padded_cpu", None)
+        if num_tokens is not None and int(num_tokens) != batch_size:
+            return True
+
+        positions = getattr(forward_batch, "positions", None)
+        if torch.is_tensor(positions) and positions.numel() != batch_size:
+            return True
+
+        return False
+
+    def _retrieve_page_scores_batched(
+        self, layer_id: int, queries: torch.Tensor, plan: _TopKPlan
+    ) -> torch.Tensor:
+        scores = self._retrieve_page_scores(
+            layer_id,
+            plan.physical_pages,
+            plan.req_pool_indices,
+            queries,
+        )
+        score_mask = (
+            plan.active_mask.unsqueeze(1)
+            & plan.valid_page_mask
+            & plan.history_page_mask
+        )
+        return torch.where(score_mask, scores, torch.full_like(scores, float("-inf")))
+
+    @staticmethod
+    def _empty_retrieval(batch_size: int, device: torch.device) -> tuple:
+        return (
+            torch.full((batch_size, 1), -1, dtype=torch.int32, device=device),
+            torch.zeros(batch_size, dtype=torch.int32, device=device),
+        )
+
+    @staticmethod
+    def _finalize_selected_pages(
+        combined_idx: torch.Tensor,
+        combined_valid: torch.Tensor,
+        sentinel: int,
+    ) -> tuple:
+        sortable_idx = torch.where(
+            combined_valid, combined_idx, torch.full_like(combined_idx, sentinel)
+        )
+        sorted_idx = torch.sort(sortable_idx, dim=1)[0].to(torch.int32)
+        out_indices = torch.where(
+            sorted_idx == sentinel,
+            torch.full_like(sorted_idx, -1),
+            sorted_idx,
+        )
+        return out_indices, combined_valid.sum(dim=1).to(torch.int32)
 
     def _initialize_representation_pools(
         self, start_layer: int, end_layer: int, total_num_pages: int

--- a/python/sglang/srt/mem_cache/sparsity/algorithms/quest_algorithm.py
+++ b/python/sglang/srt/mem_cache/sparsity/algorithms/quest_algorithm.py
@@ -13,6 +13,7 @@ import torch
 
 from sglang.srt.mem_cache.sparsity.algorithms.base_algorithm import (
     BaseSparseAlgorithmImpl,
+    load_optional_quest_kernel,
 )
 
 logger = logging.getLogger(__name__)
@@ -21,11 +22,95 @@ logger = logging.getLogger(__name__)
 class QuestAlgorithm(BaseSparseAlgorithmImpl):
     """Quest page-wise sparse attention using bounding-box criticality."""
 
+    supports_fixed_cuda_graph_capacity = True
+
     def __init__(self, config, device: torch.device, **kwargs):
         super().__init__(config, device, **kwargs)
+        self.enable_cuda_graph_retrieval = config.sparse_extra_config.get(
+            "enable_cuda_graph_retrieval", True
+        )
         self.page_k_min = {}
         self.page_k_max = {}
         self.page_valid = {}
+
+    def update_representations(
+        self,
+        layer_id: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        k_buffer: torch.Tensor,
+        forward_batch,
+    ) -> None:
+        if not forward_batch.forward_mode.is_decode():
+            return super().update_representations(
+                layer_id,
+                req_pool_indices,
+                seq_lens,
+                k_buffer,
+                forward_batch,
+            )
+        if not self.should_update_representations(forward_batch):
+            return
+        return self._update_decode_representations(
+            layer_id,
+            req_pool_indices,
+            seq_lens,
+            k_buffer,
+            forward_batch,
+        )
+
+    def _update_decode_representations(
+        self,
+        layer_id: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        k_buffer: torch.Tensor,
+        forward_batch,
+    ) -> None:
+        kernel_module = None
+        if (
+            req_pool_indices.numel() >= 4
+            and k_buffer.is_cuda
+            and torch.version.hip is None
+            and k_buffer.ndim == 3
+            and k_buffer.dtype in (torch.float16, torch.bfloat16, torch.float32)
+            and 0 < self.page_size <= 128
+            and 0 < k_buffer.shape[-1] <= 256
+        ):
+            kernel_module = load_optional_quest_kernel(
+                "sglang.srt.mem_cache.sparsity.kernels.quest_page_update"
+            )
+        if kernel_module is not None:
+            tensors = (
+                req_pool_indices,
+                seq_lens,
+                self.req_to_token_pool.req_to_token,
+                self.states.repr_constructed,
+                self.states.last_constructed_page,
+            )
+            if all(tensor.device == k_buffer.device for tensor in tensors):
+                kernel_module.quest_update_page_representations_(
+                    req_pool_indices,
+                    seq_lens,
+                    self.req_to_token_pool.req_to_token,
+                    k_buffer,
+                    self.states.repr_constructed,
+                    self.states.last_constructed_page,
+                    self.page_k_min[layer_id],
+                    self.page_k_max[layer_id],
+                    self.page_valid[layer_id],
+                    self.page_size,
+                    advance_trackers=layer_id == self.end_layer - 1,
+                )
+                return
+
+        return super().update_representations(
+            layer_id,
+            req_pool_indices,
+            seq_lens,
+            k_buffer,
+            forward_batch,
+        )
 
     def _initialize_representation_pools(
         self, start_layer: int, end_layer: int, total_num_pages: int
@@ -78,25 +163,15 @@ class QuestAlgorithm(BaseSparseAlgorithmImpl):
         tok_start = pg_id * self.page_size
         tok_off = torch.arange(self.page_size, device=device).view(1, 1, -1)
         tok_pos = tok_start.unsqueeze(2) + tok_off
-        tok_mask = (
-            tok_pos
-            < (tok_start + self.page_size).clamp(max=seq_lens.unsqueeze(1)).unsqueeze(2)
-        ) & pg_mask.unsqueeze(2)
 
         phys_tok = req_to_token[
             reqs.view(n, 1, 1).expand(n, max_pages, self.page_size),
             tok_pos.clamp(0, req_to_token.shape[1] - 1),
         ].clamp(0, k_buffer.shape[0] - 1)
 
-        keys = k_buffer[phys_tok].to(torch.float32)
-        mask = tok_mask.unsqueeze(-1).unsqueeze(-1)
-
-        page_min = torch.where(mask, keys, torch.full_like(keys, float("inf"))).amin(
-            dim=2
-        )
-        page_max = torch.where(mask, keys, torch.full_like(keys, float("-inf"))).amax(
-            dim=2
-        )
+        keys = k_buffer[phys_tok].to(self.page_k_min[layer_id].dtype)
+        page_min = keys.amin(dim=2)
+        page_max = keys.amax(dim=2)
 
         phys_pg = (
             req_to_token[
@@ -117,6 +192,32 @@ class QuestAlgorithm(BaseSparseAlgorithmImpl):
         self.page_k_max[layer_id][target_pages] = page_max[idx[:, 0], idx[:, 1]]
         self.page_valid[layer_id][target_pages] = True
 
+    def _optional_score_kernel(self, queries: torch.Tensor):
+        if (
+            not queries.is_cuda
+            or torch.version.hip is not None
+            or not self.page_k_min
+            or next(iter(self.page_k_min.values())).shape[-1] > 256
+        ):
+            return None
+        return load_optional_quest_kernel(
+            "sglang.srt.mem_cache.sparsity.kernels.quest_score"
+        )
+
+    def _retrieve_page_scores_batched(self, layer_id, queries, plan) -> torch.Tensor:
+        kernel_module = self._optional_score_kernel(queries)
+        if kernel_module is not None:
+            return kernel_module.quest_page_scores(
+                queries,
+                self.page_k_min[layer_id],
+                self.page_k_max[layer_id],
+                self.page_valid[layer_id],
+                plan.physical_pages,
+                active_mask=plan.active_mask,
+                history_page_counts=plan.recent_start,
+            )
+        return super()._retrieve_page_scores_batched(layer_id, queries, plan)
+
     def _retrieve_page_scores(
         self,
         layer_id: int,
@@ -124,12 +225,26 @@ class QuestAlgorithm(BaseSparseAlgorithmImpl):
         req_pool_indices: torch.Tensor,
         queries: torch.Tensor,
     ) -> torch.Tensor:
-        # Clamp pages to valid storage range
+        physical_pages = phys_pages
+        kernel_module = self._optional_score_kernel(queries)
+        if kernel_module is not None:
+            return kernel_module.quest_page_scores(
+                queries,
+                self.page_k_min[layer_id],
+                self.page_k_max[layer_id],
+                self.page_valid[layer_id],
+                physical_pages,
+            )
+
+        # Clamp pages to valid storage range for the portable fallback.
         phys_pages_clamped = phys_pages.clamp(0, self.page_k_min[layer_id].shape[0] - 1)
 
-        k_min = self.page_k_min[layer_id][phys_pages_clamped]
-        k_max = self.page_k_max[layer_id][phys_pages_clamped]
-        valid_mask = self.page_valid[layer_id][phys_pages_clamped]
+        k_min = self.page_k_min[layer_id][phys_pages_clamped].to(torch.float32)
+        k_max = self.page_k_max[layer_id][phys_pages_clamped].to(torch.float32)
+        valid_mask = self.page_valid[layer_id][phys_pages_clamped] & (
+            (physical_pages >= 0)
+            & (physical_pages < self.page_k_min[layer_id].shape[0])
+        )
         # Align query shape to KV heads.
         head_dim = k_min.shape[-1]
         if queries.dim() == 2:
@@ -139,7 +254,7 @@ class QuestAlgorithm(BaseSparseAlgorithmImpl):
                     f"Quest query hidden size {hidden} not divisible by head_dim {head_dim}"
                 )
             q_heads = hidden // head_dim
-            q = queries.view(bs, q_heads, head_dim)
+            q = queries.reshape(bs, q_heads, head_dim)
         elif queries.dim() == 3:
             q = queries
         else:

--- a/test/registered/unit/mem_cache/test_quest_algorithm.py
+++ b/test/registered/unit/mem_cache/test_quest_algorithm.py
@@ -1,0 +1,349 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from sglang.srt.mem_cache.sparsity.algorithms.base_algorithm import (
+    BaseSparseAlgorithmImpl,
+    load_optional_quest_kernel,
+)
+from sglang.srt.mem_cache.sparsity.algorithms.quest_algorithm import QuestAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class _ScoreAlgorithm(BaseSparseAlgorithmImpl):
+    def _retrieve_page_scores(self, layer_id, phys_pages, req_pool_indices, queries):
+        del layer_id, req_pool_indices, queries
+        self.score_calls = getattr(self, "score_calls", 0) + 1
+        return phys_pages.to(torch.float32)
+
+    def _finalize_topk_with_recent(self, topk_scores, topk_idx, plan, **kwargs):
+        self.finalize_calls = getattr(self, "finalize_calls", 0) + 1
+        return super()._finalize_topk_with_recent(topk_scores, topk_idx, plan, **kwargs)
+
+
+def _config(**extra):
+    return SimpleNamespace(
+        page_size=4,
+        sparse_extra_config={
+            "sparsity_ratio": 0.5,
+            "num_recent_pages": 2,
+            **extra,
+        },
+    )
+
+
+def _score_algorithm(batch_size: int) -> _ScoreAlgorithm:
+    algorithm = _ScoreAlgorithm(_config(), torch.device("cpu"))
+    algorithm.req_to_token_pool = SimpleNamespace(
+        req_to_token=torch.arange(64, dtype=torch.int64).repeat(batch_size, 1)
+    )
+    return algorithm
+
+
+def _reference_selected(seq_len: int, sparse: bool) -> list[int]:
+    num_pages = (seq_len + 3) // 4
+    if not sparse or num_pages <= 2:
+        return []
+    history_pages = num_pages - 2
+    k = min(max(int(history_pages * 0.5), 1), history_pages)
+    return list(range(history_pages - k, num_pages))
+
+
+def test_batched_retrieval_matches_ragged_per_request_reference():
+    algorithm = _score_algorithm(5)
+    seq_lens = torch.tensor([40, 12, 28, 36, 8], dtype=torch.int64)
+    sparse_mask = torch.tensor([True, True, False, True, True])
+    forward_batch = SimpleNamespace(
+        seq_lens=seq_lens,
+        seq_lens_cpu=seq_lens.tolist(),
+        sparse_mask_cpu=sparse_mask.tolist(),
+    )
+
+    selected, lengths = algorithm.retrieve_topk(
+        queries=torch.zeros((5, 1)),
+        layer_id=0,
+        req_pool_indices=torch.arange(5),
+        sparse_mask=sparse_mask,
+        forward_batch=forward_batch,
+    )
+
+    for row, (seq_len, sparse) in enumerate(zip(seq_lens.tolist(), sparse_mask)):
+        expected = _reference_selected(seq_len, bool(sparse))
+        length = int(lengths[row])
+        assert length == len(expected)
+        assert selected[row, :length].tolist() == expected
+        assert (selected[row, length:] == -1).all()
+    assert algorithm.finalize_calls == 1
+
+
+def test_single_request_uses_host_seq_mirror_and_exact_host_mask():
+    algorithm = _score_algorithm(1)
+    seq_lens = torch.tensor([40], dtype=torch.int64)
+    forward_batch = SimpleNamespace(
+        seq_lens=seq_lens,
+        seq_lens_cpu=[40],
+        sparse_mask_cpu=[True],
+    )
+
+    with patch.object(
+        algorithm,
+        "_build_topk_plan",
+        side_effect=AssertionError("single-request path built a batched plan"),
+    ):
+        selected, lengths = algorithm.retrieve_topk(
+            queries=torch.zeros((1, 1)),
+            layer_id=0,
+            req_pool_indices=torch.tensor([0]),
+            sparse_mask=torch.tensor([True]),
+            forward_batch=forward_batch,
+        )
+
+    assert lengths.tolist() == [6]
+    assert selected.tolist() == [[4, 5, 6, 7, 8, 9]]
+
+    forward_batch.sparse_mask_cpu = [False]
+    selected, lengths = algorithm.retrieve_topk(
+        queries=torch.zeros((1, 1)),
+        layer_id=0,
+        req_pool_indices=torch.tensor([0]),
+        sparse_mask=torch.tensor([False]),
+        forward_batch=forward_batch,
+    )
+    assert algorithm.score_calls == 1
+    assert lengths.tolist() == [0]
+    assert selected.tolist() == [[-1]]
+
+
+def test_single_request_without_host_seq_mirror_uses_batched_fallback():
+    algorithm = _score_algorithm(1)
+    seq_lens = torch.tensor([40], dtype=torch.int64)
+
+    with patch.object(
+        algorithm,
+        "_retrieve_topk_single",
+        side_effect=AssertionError("single-request path read device seq_lens"),
+    ):
+        selected, lengths = algorithm.retrieve_topk(
+            queries=torch.zeros((1, 1)),
+            layer_id=0,
+            req_pool_indices=torch.tensor([0]),
+            sparse_mask=torch.tensor([True]),
+            forward_batch=SimpleNamespace(seq_lens=seq_lens),
+        )
+
+    assert lengths.tolist() == [6]
+    assert selected.tolist() == [[4, 5, 6, 7, 8, 9]]
+
+
+def test_missing_host_mask_never_reads_a_device_scalar():
+    algorithm = _score_algorithm(1)
+    seq_lens = torch.tensor([40], dtype=torch.int64)
+    forward_batch = SimpleNamespace(seq_lens=seq_lens, seq_lens_cpu=[40])
+
+    with (
+        patch.object(algorithm, "_get_bool_mask_cpu", return_value=None),
+        patch.object(
+            torch.Tensor,
+            "item",
+            side_effect=AssertionError("device sparse_mask scalar was read"),
+        ),
+    ):
+        selected, lengths = algorithm.retrieve_topk(
+            queries=torch.zeros((1, 1)),
+            layer_id=0,
+            req_pool_indices=torch.tensor([0]),
+            sparse_mask=torch.tensor([False]),
+            forward_batch=forward_batch,
+        )
+
+    assert algorithm.score_calls == 1
+    assert lengths.tolist() == [0]
+    assert (selected == -1).all()
+
+
+def test_full_page_fast_path_matches_reference():
+    algorithm = QuestAlgorithm(_config(), torch.device("cpu"))
+    assert algorithm.enable_cuda_graph_retrieval
+    assert algorithm.supports_fixed_cuda_graph_capacity
+    algorithm.req_to_token_pool = SimpleNamespace(
+        req_to_token=torch.arange(12, dtype=torch.int64).unsqueeze(0)
+    )
+    algorithm.page_k_min[0] = torch.zeros((3, 1, 2), dtype=torch.float32)
+    algorithm.page_k_max[0] = torch.zeros((3, 1, 2), dtype=torch.float32)
+    algorithm.page_valid[0] = torch.zeros(3, dtype=torch.bool)
+    keys = torch.arange(24, dtype=torch.float32).reshape(12, 1, 2)
+
+    algorithm._compute_page_representations(
+        0, torch.tensor([0]), torch.tensor([12]), 0, torch.tensor([3]), keys
+    )
+    expected = keys.reshape(3, 4, 1, 2)
+    torch.testing.assert_close(algorithm.page_k_min[0], expected.amin(dim=1))
+    torch.testing.assert_close(algorithm.page_k_max[0], expected.amax(dim=1))
+
+
+def test_host_page_boundary_skip_is_conservative_for_multi_token_decode():
+    algorithm = _score_algorithm(1)
+
+    single_token = SimpleNamespace(
+        seq_lens_cpu=[17],
+        num_token_non_padded_cpu=1,
+        positions=torch.tensor([16]),
+        spec_info=None,
+    )
+    assert not algorithm.should_update_representations(single_token)
+
+    page_boundary = SimpleNamespace(
+        seq_lens_cpu=[16],
+        num_token_non_padded_cpu=1,
+        positions=torch.tensor([15]),
+        spec_info=None,
+    )
+    assert algorithm.should_update_representations(page_boundary)
+
+    multi_token = SimpleNamespace(
+        seq_lens_cpu=[18],
+        num_token_non_padded_cpu=3,
+        positions=torch.tensor([15, 16, 17]),
+        spec_info=object(),
+    )
+    assert algorithm.should_update_representations(multi_token)
+
+
+def test_fixed_capacity_plan_is_stable_and_skips_dynamic_single_request_path():
+    algorithm = _score_algorithm(1)
+    algorithm.cuda_graph_max_num_pages = 8
+
+    plans = [
+        algorithm._build_topk_plan(
+            SimpleNamespace(seq_lens=torch.tensor([seq_len])),
+            torch.tensor([0]),
+            torch.tensor([True]),
+            torch.device("cpu"),
+            fixed_capacity=64,
+        )
+        for seq_len in (12, 28)
+    ]
+    assert [plan.max_num_pages for plan in plans] == [8, 8]
+    assert [plan.max_k for plan in plans] == [3, 3]
+    assert [plan.physical_pages.shape for plan in plans] == [(1, 8), (1, 8)]
+    assert all(plan.fixed_capacity for plan in plans)
+
+    forward_batch = SimpleNamespace(seq_lens=torch.tensor([28]))
+    algorithm.begin_forward(
+        forward_batch,
+        torch.tensor([0]),
+        torch.tensor([True]),
+        torch.device("cpu"),
+        fixed_capacity=64,
+    )
+    with patch.object(
+        algorithm,
+        "_retrieve_topk_single",
+        side_effect=AssertionError("fixed path used dynamic single-request retrieval"),
+    ):
+        _, lengths = algorithm.retrieve_topk(
+            queries=torch.zeros((1, 1)),
+            layer_id=0,
+            req_pool_indices=torch.tensor([0]),
+            sparse_mask=torch.tensor([True]),
+            forward_batch=forward_batch,
+        )
+
+    assert algorithm._topk_plan.max_num_pages == 8
+    assert lengths.tolist() == [4]
+
+    algorithm.begin_forward(
+        forward_batch,
+        torch.tensor([0]),
+        torch.tensor([True]),
+        torch.device("cpu"),
+    )
+    assert algorithm._topk_plan is None
+
+
+def test_optional_kernel_discovery_falls_back_but_does_not_hide_import_errors():
+    module = "sglang.srt.mem_cache.sparsity.kernels.quest_missing"
+    assert (
+        load_optional_quest_kernel(
+            "sglang.srt.mem_cache.sparsity.missing_parent.quest_kernel"
+        )
+        is None
+    )
+    with patch(
+        "sglang.srt.mem_cache.sparsity.algorithms.base_algorithm.find_spec",
+        return_value=None,
+    ):
+        assert load_optional_quest_kernel(module) is None
+
+    with (
+        patch(
+            "sglang.srt.mem_cache.sparsity.algorithms.base_algorithm.find_spec",
+            return_value=object(),
+        ),
+        patch(
+            "sglang.srt.mem_cache.sparsity.algorithms.base_algorithm.import_module",
+            side_effect=ImportError("broken provider"),
+        ),
+        pytest.raises(ImportError, match="broken provider"),
+    ):
+        load_optional_quest_kernel(module)
+
+
+def test_present_score_provider_is_dispatched():
+    algorithm = QuestAlgorithm(_config(), torch.device("cpu"))
+    algorithm.page_k_min[0] = torch.zeros((2, 1, 2))
+    algorithm.page_k_max[0] = torch.ones((2, 1, 2))
+    algorithm.page_valid[0] = torch.ones(2, dtype=torch.bool)
+    expected = torch.tensor([[1.0, 2.0]])
+    score = Mock(return_value=expected)
+    plan = SimpleNamespace(
+        physical_pages=torch.tensor([[0, 1]]),
+        active_mask=torch.tensor([True]),
+        recent_start=torch.tensor([2]),
+    )
+
+    with patch.object(
+        algorithm,
+        "_optional_score_kernel",
+        return_value=SimpleNamespace(quest_page_scores=score),
+    ):
+        result = algorithm._retrieve_page_scores_batched(
+            0, torch.zeros((1, 1, 2)), plan
+        )
+
+    assert result is expected
+    score.assert_called_once()
+
+
+def test_direct_metadata_requires_explicit_runtime_opt_in():
+    algorithm = _score_algorithm(1)
+    plan = SimpleNamespace(
+        max_k=1,
+        max_num_pages=2,
+        k_per_req=torch.tensor([1]),
+        recent_idx=torch.tensor([[1]]),
+        recent_valid=torch.tensor([[True]]),
+    )
+    topk_scores = torch.tensor([[1.0]])
+    topk_idx = torch.tensor([[0]])
+    prepared = (torch.tensor([[0, 1]]), torch.tensor([2]), True)
+
+    with patch.object(
+        algorithm, "_try_finalize_to_flashattention_metadata", return_value=prepared
+    ) as direct:
+        eager = algorithm._finalize_topk_with_recent(topk_scores, topk_idx, plan)
+        direct.assert_not_called()
+        captured = algorithm._finalize_topk_with_recent(
+            topk_scores,
+            topk_idx,
+            plan,
+            allow_prepared_metadata=True,
+            attn_metadata=object(),
+        )
+
+    assert len(eager) == 2
+    assert captured is prepared


### PR DESCRIPTION
## Overview

This PR makes Quest page selection cheaper without changing its output contract. It replaces per-request retrieval setup with one batched plan, avoids unnecessary host synchronization, and adds a fast path for complete pages.

## PR series

| Part | PR | Scope |
|---|---|---|
| Part 1 | [#30277](https://github.com/sgl-project/sglang/pull/30277) | Eager runtime integration and portable FA3 metadata fallback |
| Part 2, this PR | [#29666](https://github.com/sgl-project/sglang/pull/29666) | Batched retrieval, host-sync reduction, and full-page fast path |
| Part 3 | [#31790](https://github.com/sgl-project/sglang/pull/31790) | Standalone GPU kernels for page selection and FA3 metadata updates |
| Part 4 | [#31951](https://github.com/sgl-project/sglang/pull/31951) | Breakable CUDA Graph runtime variants and capture/replay |

## What this PR changes

The page-selection flow becomes:

```text
request metadata
  -> build one batched page plan
  -> score history pages
  -> select Top-K pages
  -> merge the recent-page window
  -> return selected_indices and valid_lengths
```

- Build one `_TopKPlan` for a ragged batch instead of repeatedly preparing retrieval tensors inside a Python loop.
- Use reliable CPU mirrors for the low-overhead single-request path. When a mirror is unavailable, use the batched tensor path without reading a device scalar on the host.
- Compute complete-page min/max representations directly with `amin`/`amax`; only the partial tail page needs masked reduction.
- Preserve selected-page ordering, the recent-page window, per-request valid lengths, and conservative multi-token page-boundary updates.
- Reject invalid physical-page indices instead of silently redirecting them to an unrelated KV page.
- Expose compatibility hooks used by Part 3's optional GPU kernels and Part 4's fixed-capacity CUDA Graph planning. This PR does not include those implementations; when they are absent, the existing PyTorch and eager paths remain unchanged.

## Historical performance evidence

The previous stacked implementation observed the following change when the algorithm optimization stage was added:

| Workload | Before, Quest/Dense | After, Quest/Dense | Change | Relative uplift |
|---|---:|---:|---:|---:|
| `8k-c8` | 16.98% | 34.68% | +17.70 pp | +104.24% |
| `32k-c1` | 45.63% | 50.36% | +4.73 pp | +10.37% |
| `32k-c4` | 39.19% | 47.67% | +8.48 pp | +21.64% |

These are archived sequential endpoint deltas from the previous stacked implementation. They show why this algorithm work was retained, but they are not isolated measurements of the current independent PR head. A strict throughput A/B for the current public head remains pending.


## Test Plan

- `test/registered/unit/mem_cache/test_quest_algorithm.py`:
  - Batched retrieval matches the ragged per-request reference.
  - Single-request retrieval uses host sequence lengths and sparse masks when available.
  - Missing host sequence lengths fall back to the batched path.
  - Missing host sparse masks never trigger a device-scalar read.
  - Full-page and partial-page representation paths match the reference.
  - Multi-token decode uses a conservative host page-boundary check.

## Test Result

```text
Split-diff source validation: passed 
Parent/head token equivalence: PASS
```




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30327036585](https://github.com/sgl-project/sglang/actions/runs/30327036585)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30327036553](https://github.com/sgl-project/sglang/actions/runs/30327036553)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->