### PR TITLE
[sglang-miles] Fix post_process_weights deadlock in RL in-place mode

### DIFF
--- a/python/sglang/srt/configs/cohere2_moe.py
+++ b/python/sglang/srt/configs/cohere2_moe.py
@@ -2,6 +2,7 @@
 """Cohere2Moe text config used by the Cohere Command-A Plus checkpoints."""
 
 from dataclasses import dataclass
+
 from transformers.configuration_utils import PreTrainedConfig
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -537,8 +537,16 @@ class TokenizerControlMixin:
     ) -> Tuple[bool, str]:
         """Trigger post-processing hooks for weights after loading."""
         self.auto_create_handle_loop()
-        async with self.model_update_lock.writer_lock:
-            results = await self.post_process_weights_communicator(obj)
+
+        async with self.is_pause_cond:
+            is_paused = self.is_pause
+            if is_paused:
+                results = await self.post_process_weights_communicator(obj)
+
+        if not is_paused:
+            async with self.model_update_lock.writer_lock:
+                results = await self.post_process_weights_communicator(obj)
+
         return FanOutCommunicator.merge_results(results)
 
     async def _unload_lora_adapter_locked(


### PR DESCRIPTION
## Summary

Restore the pause-aware locking behavior for `post_process_weights` on the `sglang-miles-v0.5.13` branch.

This is the `post_process_weights` hunk from the earlier pause-aware deadlock fix in https://github.com/sgl-project/sglang/pull/22754, which appears to have been lost during the v0.5.13 `tokenizer_control_mixin.py` refactor.

`sglang-miles-v0.5.12` skipped `model_update_lock.writer_lock` when the engine was already paused. During the v0.5.13 refactor to `tokenizer_control_mixin.py`, `post_process_weights` became an unconditional writer-lock acquisition. That can deadlock with `pause_generation(mode="in_place")`:

```text
active /generate holds model_update_lock.reader_lock
pause_generation(in_place) preserves the request and pauses progress
post_process_weights waits for writer_lock
continue_generation is only called after post_process_weights
```

The result is that health generation stops making progress and post-load processing can time out.

## Fix

- Check `self.is_pause` under `is_pause_cond`.
- Use `model_update_lock.writer_lock` only when the engine is not paused.
- Use `nullcontext()` while paused, matching the pause-aware behavior from the earlier miles branch.

## Validation

```bash
python3 -m py_compile python/sglang/srt/managers/tokenizer_control_mixin.py
```























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28393955205](https://github.com/sgl-project/sglang/actions/runs/28393955205)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28393954957](https://github.com/sgl-project/sglang/actions/runs/28393954957)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
