### PR TITLE
[sglang-miles] Cherry-pick pause-aware post-process weight locking

### DIFF
--- a/python/sglang/srt/configs/cohere2_moe.py
+++ b/python/sglang/srt/configs/cohere2_moe.py
@@ -2,6 +2,7 @@
 """Cohere2Moe text config used by the Cohere Command-A Plus checkpoints."""
 
 from dataclasses import dataclass
+
 from transformers.configuration_utils import PreTrainedConfig
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -5,7 +5,6 @@ import hashlib
 import logging
 import time
 import uuid
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import fastapi
@@ -544,13 +543,14 @@ class TokenizerControlMixin:
 
         async with self.is_pause_cond:
             is_paused = self.is_pause
+            if is_paused:
+                results = await self.begin_weight_update_communicator(obj)
 
-        lock_context = (
-            self.model_update_lock.writer_lock if not is_paused else nullcontext()
-        )
-        async with lock_context:
-            results = await self.begin_weight_update_communicator(obj)
-            return FanOutCommunicator.merge_results(results)
+        if not is_paused:
+            async with self.model_update_lock.writer_lock:
+                results = await self.begin_weight_update_communicator(obj)
+
+        return FanOutCommunicator.merge_results(results)
 
     async def end_weight_update(
         self: TokenizerManager,
@@ -562,13 +562,14 @@ class TokenizerControlMixin:
 
         async with self.is_pause_cond:
             is_paused = self.is_pause
+            if is_paused:
+                results = await self.end_weight_update_communicator(obj)
 
-        lock_context = (
-            self.model_update_lock.writer_lock if not is_paused else nullcontext()
-        )
-        async with lock_context:
-            results = await self.end_weight_update_communicator(obj)
-            return FanOutCommunicator.merge_results(results)
+        if not is_paused:
+            async with self.model_update_lock.writer_lock:
+                results = await self.end_weight_update_communicator(obj)
+
+        return FanOutCommunicator.merge_results(results)
 
     async def _unload_lora_adapter_locked(
         self: TokenizerManager,


### PR DESCRIPTION
Cherry-picks sgl-project/sglang#29670 onto `sglang-miles`.\n\nOriginal commit: 23d989874bd1d467fac54c7f6d138166736f438b\nCherry-pick commit: 2629867c5bc460bd1802d8c59d36403675ffa1b0\n\nConflict resolution:\n- Adapted the original `post_process_weights` pause-aware locking fix to the refactored `begin_weight_update` / `end_weight_update` APIs currently present on `sglang-miles`.\n- Preserved the original behavior: paused updates run without `model_update_lock.writer_lock` while holding `is_pause_cond`; unpaused updates use the writer lock.\n\nValidation:\n- Cherry-pick commit hooks passed: Python AST, merge-conflict check, isort, ruff, and related pre-commit checks.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28401848370](https://github.com/sgl-project/sglang/actions/runs/28401848370)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28401847995](https://github.com/sgl-project/sglang/actions/runs/28401847995)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->