### PR TITLE
fix(mlx): default prefill_aware_swa=False on MlxModelRunnerStub

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
@@ -85,6 +85,14 @@ class MlxModelRunnerStub(ModelRunner):
     # AttributeError.
     canary_manager = None
 
+    # No prefill-aware SWA on the MLX path. The base ModelRunner derives this in
+    # its full initialize() from `model.is_prefill_aware_swa()`, which this
+    # lightweight override skips (and `_DummyModel` does not implement). The
+    # scheduler reads `model_runner.prefill_aware_swa` unconditionally when
+    # admitting a prefill batch, so default to False as a class attribute to keep
+    # that path working instead of raising AttributeError.
+    prefill_aware_swa = False
+
     def __init__(self, *args, mlx_pool_size: int | None = None, **kwargs):
         self._mlx_pool_size = mlx_pool_size
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary

Fixes #29679. `sglang.launch_server` crashes on Apple Silicon / MLX with:

```
AttributeError: 'MlxModelRunnerStub' object has no attribute 'prefill_aware_swa'
```

regardless of the model, right after the tree cache is initialized.

## Root cause

The scheduler reads `model_runner.prefill_aware_swa` **unconditionally** when admitting a prefill batch (`scheduler.py`):

```python
if self.tp_worker.model_runner.prefill_aware_swa:
    for req in can_run_list:
        req.swa_evict_floor = req.extend_range.end
```

The base `ModelRunner` sets this attribute inside its full `initialize()`:

```python
self.prefill_aware_swa = (
    hasattr(self.model, "is_prefill_aware_swa")
    and self.model.is_prefill_aware_swa()
)
```

`MlxModelRunnerStub` overrides `initialize()` with a lightweight version that skips that derivation, so the attribute is never created. Its `_DummyModel` also does not implement `is_prefill_aware_swa()`, so the correct value on the MLX path is `False`.

## Fix

Default `prefill_aware_swa = False` as a class attribute on `MlxModelRunnerStub`, mirroring the existing `canary_manager = None` handling for other state the lightweight `initialize()` intentionally skips. No behavior change on non-MLX paths.

The MLX runner-init contract test is signature-only, so this is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28406153690](https://github.com/sgl-project/sglang/actions/runs/28406153690)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28406153339](https://github.com/sgl-project/sglang/actions/runs/28406153339)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->