### PR TITLE
[AMD][bugfix] Fix Quark crash on W4A8 ProgressiveSpec (list) configs

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -312,6 +312,11 @@ class QuarkConfig(QuantizationConfig):
         if weight_quant is None or input_quant is None:
             return False
 
+        # Quark quantization config uses a multi-stage (list) spec,
+        # so bail out here instead of calling dict methods on a list in the next check.
+        if not isinstance(weight_quant, dict) or not isinstance(input_quant, dict):
+            return False
+
         # Confirm weight scheme is supported
         is_fp8_dtype = (
             weight_quant.get("dtype") == "fp8_e4m3"
@@ -344,6 +349,13 @@ class QuarkConfig(QuantizationConfig):
             logger.debug(
                 "Quark model is not in MX-FP4 format: "
                 "weight_quant or input_quant not set"
+            )
+            return False
+
+        if not isinstance(weight_quant, dict) or not isinstance(input_quant, dict):
+            logger.debug(
+                "Quark model is not in MX-FP4 format: "
+                "weight_quant or input_quant is a multi-stage (list) spec"
             )
             return False
 
@@ -499,7 +511,11 @@ class QuarkConfig(QuantizationConfig):
         elif self._is_fp8_w8a8(weight_config, input_config):
             return QuarkW8A8FP8MoE(weight_config, input_config)
         else:
-            raise RuntimeError("Unsupported FusedMoe scheme")
+            raise RuntimeError(
+                "Unsupported Quark FusedMoE scheme. "
+                f"Weight config: {weight_config}, "
+                f"Input config: {input_config}"
+            )
 
     def get_scaled_act_names(self) -> List[str]:
         return []


### PR DESCRIPTION
W4A8 checkpoints (e.g. amd/Kimi-K2.5-W4A8) are quantized with Quark's ProgressiveSpec, which serializes the two-stage FP8->INT4 weight pipeline as a list of specs rather than a single dict. The scheme-detection helpers _is_mx_fp4 and _is_fp8_w8a8 assumed a dict and called .get() directly, raising "AttributeError: 'list' object has no attribute 'get'".
## Motivation

W4A8 checkpoints (e.g. amd/Kimi-K2.5-W4A8) are quantized with Quark's ProgressiveSpec, which serializes the two-stage FP8->INT4 weight pipeline as a list of specs rather than a single dict. The scheme-detection helpers _is_mx_fp4 and _is_fp8_w8a8 assumed a dict and called .get() directly, raising "AttributeError: 'list' object has no attribute 'get'".

## Modifications

Guard both helpers against list-typed (multi-stage) specs so detection falls through cleanly, and include the offending configs in the get_moe_scheme "unsupported scheme" error for easier diagnosis.

## Accuracy Tests

N/A

## Speed Tests and Profiling

Patched code: 
File ".../quark/quark.py", line 514, in get_moe_scheme
RuntimeError: Unsupported Quark FusedMoE scheme. Weight config: [{'dtype': 'fp8_e4m3', ...}, {'dtype': 'int4', ...}], Input config: {'dtype': 'fp8_e4m3', 'is_dynamic': True, ...}

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28406695123](https://github.com/sgl-project/sglang/actions/runs/28406695123)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28406694922](https://github.com/sgl-project/sglang/actions/runs/28406694922)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->