### PR TITLE
[Apple Silicon] [CI] Add model-free unit-test workflow on macos-26

### DIFF
--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -1,0 +1,112 @@
+name: PR Test (MLX)
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: pr-test-mlx-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ==================== Model-free MLX unit tests (Apple Silicon) ==================== #
+  mlx-unit-test:
+    # Label-gated, mirroring the repo's run-ci label gate (see pr-test-rust.yml):
+    # on a pull_request the job runs only when the PR carries the 'mlx' label,
+    # and re-fires when that label is added. The leading non-pull_request clause
+    # keeps the job runnable for push / workflow_dispatch events if they are ever
+    # added (the model-requiring half of the MLX suite stays on the self-hosted
+    # Apple Silicon runner and is intentionally excluded here).
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'mlx')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'mlx')
+    runs-on: macos-14
+    timeout-minutes: 45
+    env:
+      SGLANG_IS_IN_CI: true
+      # Hosted runner has no model cache; the selected tests are model-free, so
+      # forbid any HF download to keep that guarantee enforced rather than assumed.
+      HF_HUB_OFFLINE: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Verify Apple Silicon runner
+        run: |
+          echo "uname -m: $(uname -m)"
+          python3 -c "import platform; assert platform.machine()=='arm64', platform.machine(); print('machine:', platform.machine(), 'system:', platform.system())"
+
+      - name: Install dependencies (MLX / srt_mps extra)
+        timeout-minutes: 30
+        run: |
+          python3 -m pip install --upgrade pip
+          # Swap in the Apple Silicon (MLX/MPS) project metadata for this
+          # ephemeral checkout, then install the minimal extra that satisfies the
+          # MLX unit-test imports (mlx, mlx-lm, runtime_common, torch). The heavier
+          # all_mps diffusion chain is not needed for these tests.
+          rm -f python/pyproject.toml
+          mv python/pyproject_other.toml python/pyproject.toml
+          python3 -m pip install -e "python[srt_mps]"
+          python3 -m pip install pytest
+
+      - name: Report MLX / torch versions
+        run: |
+          python3 -c "import mlx.core as mx; print('mlx', mx.__version__)"
+          python3 -c "import torch; print('torch', torch.__version__)"
+
+      - name: Run model-free MLX unit tests
+        timeout-minutes: 15
+        run: |
+          # Model-free MLX unit tests, run directly via pytest (same convention as
+          # the MUSA unit-test jobs). These never load a model: signature-only
+          # contract checks, mocked Metal capture, dummy ServerArgs + patch logic,
+          # and pure quantization-config dict logic.
+          #
+          # Four cases are excluded by name (-k): they are stale against current
+          # upstream/main (they poke internal APIs that were refactored after the
+          # tests landed, and only ever skipped on the ubuntu base-a-test-cpu run,
+          # so the drift went unnoticed). They are model-free but currently red and
+          # need a code fix, tracked separately:
+          #   - test_start_profile_success_with_mock_capture
+          #       (_start_profile returns success=False under mocked capture)
+          #   - test_decode_finalize_does_not_snapshot_auxiliary_state
+          #       (MlxModelRunner._clear_steps now set in __init__, fake runner omits it)
+          #   - test_mlx_scheduler_init_overlap_keeps_future_map_relay
+          #       (decide_needs_cpu_seq_lens now reads server_args.speculative_algorithm)
+          #   - test_finished_request_snapshots_before_release
+          #       (_handle_finished_req renamed to _handle_finish_state_updated_req)
+          # -k matches on test-name keywords, so it is robust to the test/pytest.ini
+          # rootdir (which shifts nodeids and silently breaks path-based --deselect).
+          EXCLUDE="test_start_profile_success_with_mock_capture \
+            or test_decode_finalize_does_not_snapshot_auxiliary_state \
+            or test_mlx_scheduler_init_overlap_keeps_future_map_relay \
+            or test_finished_request_snapshots_before_release"
+          python3 -m pytest -v \
+            test/registered/unit/hardware_backend/mlx/test_runner_init_contract.py \
+            test/registered/unit/hardware_backend/mlx/test_metal_profiler.py \
+            test/registered/unit/hardware_backend/mlx/test_attention_patching.py \
+            "test/registered/unit/hardware_backend/mlx/test_quantization.py::TestMlxQuantizationOverride" \
+            -k "not ($EXCLUDE)"
+
+  # ==================== Finish ==================== #
+  pr-test-mlx-finish:
+    needs: [mlx-unit-test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check dependent job status
+        run: |
+          result="${{ needs.mlx-unit-test.result }}"
+          echo "mlx-unit-test: $result"
+          if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+            echo "The MLX unit-test job failed."
+            exit 1
+          fi
+          echo "All jobs completed successfully"

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -69,28 +69,13 @@ jobs:
         run: |
           # Model-free MLX unit tests via pytest, like MUSA's unit-test jobs
           # (its model and server suites use run_suite.py). None load a model:
-          # signature contracts, mocked Metal capture, dummy ServerArgs patch
-          # logic, and quantization-config dict logic.
-          #
-          # Three cases are excluded (-k): model-free but stale against main, only
-          # ever skipped on ubuntu so the drift went unnoticed. Tracked separately:
-          #   - test_decode_finalize_does_not_snapshot_auxiliary_state
-          #       (MlxModelRunner._clear_steps now set in __init__, fake runner omits it)
-          #   - test_mlx_scheduler_init_overlap_keeps_future_map_relay
-          #       (decide_needs_cpu_seq_lens now reads server_args.speculative_algorithm)
-          #   - test_finished_request_snapshots_before_release
-          #       (_handle_finished_req renamed to _handle_finish_state_updated_req)
-          # -k matches test-name keywords, robust to the pytest.ini rootdir that
-          # shifts nodeids and breaks path-based --deselect.
-          EXCLUDE="test_decode_finalize_does_not_snapshot_auxiliary_state \
-            or test_mlx_scheduler_init_overlap_keeps_future_map_relay \
-            or test_finished_request_snapshots_before_release"
+          # signature contracts, mocked Metal capture, dummy ServerArgs patching,
+          # and quant-config dicts.
           python3 -m pytest -v \
             test/registered/unit/hardware_backend/mlx/test_runner_init_contract.py \
             test/registered/unit/hardware_backend/mlx/test_metal_profiler.py \
             test/registered/unit/hardware_backend/mlx/test_attention_patching.py \
-            "test/registered/unit/hardware_backend/mlx/test_quantization.py::TestMlxQuantizationOverride" \
-            -k "not ($EXCLUDE)"
+            "test/registered/unit/hardware_backend/mlx/test_quantization.py::TestMlxQuantizationOverride"
 
   pr-test-mlx-finish:
     needs: [mlx-unit-test]

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -9,6 +9,9 @@ concurrency:
   group: pr-test-mlx-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ==================== Model-free MLX unit tests (Apple Silicon) ==================== #
   mlx-unit-test:
@@ -23,7 +26,7 @@ jobs:
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'mlx')) ||
       (github.event.action == 'labeled' && github.event.label.name == 'mlx')
     runs-on: macos-14
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       SGLANG_IS_IN_CI: true
       # Hosted runner has no model cache; the selected tests are model-free, so
@@ -37,6 +40,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: 'python/pyproject_other.toml'
 
       - name: Verify Apple Silicon runner
         run: |
@@ -47,6 +52,7 @@ jobs:
         timeout-minutes: 30
         run: |
           python3 -m pip install --upgrade pip
+          test -f python/pyproject_other.toml || { echo "alt pyproject_other.toml missing"; exit 1; }
           # Swap in the Apple Silicon (MLX/MPS) project metadata for this
           # ephemeral checkout, then install the minimal extra that satisfies the
           # MLX unit-test imports (mlx, mlx-lm, runtime_common, torch). The heavier

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -38,8 +38,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: 'pip'
-          cache-dependency-path: 'python/pyproject_other.toml'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'python/pyproject_other.toml'
 
       - name: Verify Apple Silicon runner
         run: |
@@ -49,20 +53,20 @@ jobs:
       - name: Install dependencies (MLX / srt_mps extra)
         timeout-minutes: 30
         run: |
-          python3 -m pip install --upgrade pip
           test -f python/pyproject_other.toml || { echo "alt pyproject_other.toml missing"; exit 1; }
           # Swap in the Apple Silicon project metadata, then install the srt_mps
-          # extra (mlx, mlx-lm, runtime_common, torch). The all_mps diffusion
-          # chain is not needed here.
+          # extra (mlx, mlx-lm, runtime_common, torch) into an isolated uv venv.
+          # The all_mps diffusion chain is not needed here.
           rm -f python/pyproject.toml
           mv python/pyproject_other.toml python/pyproject.toml
-          python3 -m pip install -e "python[srt_mps]"
-          python3 -m pip install pytest
+          uv venv
+          uv pip install -e "python[srt_mps]"
+          uv pip install pytest
 
       - name: Report MLX / torch versions
         run: |
-          python3 -c "import mlx.core as mx; print('mlx', mx.__version__)"
-          python3 -c "import torch; print('torch', torch.__version__)"
+          uv run python -c "import mlx.core as mx; print('mlx', mx.__version__)"
+          uv run python -c "import torch; print('torch', torch.__version__)"
 
       - name: Run model-free MLX unit tests
         timeout-minutes: 15
@@ -71,7 +75,7 @@ jobs:
           # (its model and server suites use run_suite.py). None load a model:
           # signature contracts, mocked Metal capture, dummy ServerArgs patching,
           # and quant-config dicts.
-          python3 -m pytest -v \
+          uv run python -m pytest -v \
             test/registered/unit/hardware_backend/mlx/test_runner_init_contract.py \
             test/registered/unit/hardware_backend/mlx/test_metal_profiler.py \
             test/registered/unit/hardware_backend/mlx/test_attention_patching.py \

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -23,12 +23,15 @@ jobs:
     # Apple Silicon runner and is intentionally excluded here).
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'mlx')) ||
-      (github.event.action == 'labeled' && github.event.label.name == 'mlx')
+      contains(github.event.pull_request.labels.*.name, 'mlx')
     runs-on: macos-14
     timeout-minutes: 60
     env:
       SGLANG_IS_IN_CI: true
+      # use_mlx() gates the MLX backend on this var AND mlx importing. Without it
+      # the profiler patch path takes the MPS branch, so the MLX capture-selection
+      # branch (profiler.py: if use_mlx()) is never exercised by this lane.
+      SGLANG_USE_MLX: 1
       # Hosted runner has no model cache; the selected tests are model-free, so
       # forbid any HF download to keep that guarantee enforced rather than assumed.
       HF_HUB_OFFLINE: 1
@@ -75,13 +78,10 @@ jobs:
           # contract checks, mocked Metal capture, dummy ServerArgs + patch logic,
           # and pure quantization-config dict logic.
           #
-          # Four cases are excluded by name (-k): they are stale against current
-          # upstream/main (they poke internal APIs that were refactored after the
-          # tests landed, and only ever skipped on the ubuntu base-a-test-cpu run,
-          # so the drift went unnoticed). They are model-free but currently red and
-          # need a code fix, tracked separately:
-          #   - test_start_profile_success_with_mock_capture
-          #       (_start_profile returns success=False under mocked capture)
+          # Three cases are excluded by name (-k): stale against current upstream/main
+          # (they poke internal APIs refactored after the tests landed; only ever
+          # skipped on ubuntu base-a-test-cpu, so the drift went unnoticed). Model-free
+          # but red, tracked separately:
           #   - test_decode_finalize_does_not_snapshot_auxiliary_state
           #       (MlxModelRunner._clear_steps now set in __init__, fake runner omits it)
           #   - test_mlx_scheduler_init_overlap_keeps_future_map_relay
@@ -90,8 +90,7 @@ jobs:
           #       (_handle_finished_req renamed to _handle_finish_state_updated_req)
           # -k matches on test-name keywords, so it is robust to the test/pytest.ini
           # rootdir (which shifts nodeids and silently breaks path-based --deselect).
-          EXCLUDE="test_start_profile_success_with_mock_capture \
-            or test_decode_finalize_does_not_snapshot_auxiliary_state \
+          EXCLUDE="test_decode_finalize_does_not_snapshot_auxiliary_state \
             or test_mlx_scheduler_init_overlap_keeps_future_map_relay \
             or test_finished_request_snapshots_before_release"
           python3 -m pytest -v \

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -13,27 +13,22 @@ permissions:
   contents: read
 
 jobs:
-  # ==================== Model-free MLX unit tests (Apple Silicon) ==================== #
   mlx-unit-test:
-    # Label-gated, mirroring the repo's run-ci label gate (see pr-test-rust.yml):
-    # on a pull_request the job runs only when the PR carries the 'mlx' label,
-    # and re-fires when that label is added. The leading non-pull_request clause
-    # keeps the job runnable for push / workflow_dispatch events if they are ever
-    # added (the model-requiring half of the MLX suite stays on the self-hosted
-    # Apple Silicon runner and is intentionally excluded here).
+    # Label-gated on 'mlx', reusing the repo's run-ci label-gate mechanism
+    # (pr-test-rust.yml). The gate keys on the PR's current label set, so any
+    # event on a labeled PR re-runs the tests and a later unrelated label can't
+    # mask a prior result. The non-pull_request clause covers push / dispatch.
     if: |
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'mlx')
-    runs-on: macos-14
+    runs-on: macos-26
     timeout-minutes: 60
     env:
       SGLANG_IS_IN_CI: true
-      # use_mlx() gates the MLX backend on this var AND mlx importing. Without it
-      # the profiler patch path takes the MPS branch, so the MLX capture-selection
-      # branch (profiler.py: if use_mlx()) is never exercised by this lane.
+      # use_mlx() needs this var (and mlx importable); without it the profiler
+      # takes the MPS branch and the MLX capture path goes untested.
       SGLANG_USE_MLX: 1
-      # Hosted runner has no model cache; the selected tests are model-free, so
-      # forbid any HF download to keep that guarantee enforced rather than assumed.
+      # Forbid HF downloads so the model-free guarantee is enforced, not assumed.
       HF_HUB_OFFLINE: 1
     steps:
       - name: Checkout code
@@ -56,10 +51,9 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           test -f python/pyproject_other.toml || { echo "alt pyproject_other.toml missing"; exit 1; }
-          # Swap in the Apple Silicon (MLX/MPS) project metadata for this
-          # ephemeral checkout, then install the minimal extra that satisfies the
-          # MLX unit-test imports (mlx, mlx-lm, runtime_common, torch). The heavier
-          # all_mps diffusion chain is not needed for these tests.
+          # Swap in the Apple Silicon project metadata, then install the srt_mps
+          # extra (mlx, mlx-lm, runtime_common, torch). The all_mps diffusion
+          # chain is not needed here.
           rm -f python/pyproject.toml
           mv python/pyproject_other.toml python/pyproject.toml
           python3 -m pip install -e "python[srt_mps]"
@@ -73,23 +67,21 @@ jobs:
       - name: Run model-free MLX unit tests
         timeout-minutes: 15
         run: |
-          # Model-free MLX unit tests, run directly via pytest (same convention as
-          # the MUSA unit-test jobs). These never load a model: signature-only
-          # contract checks, mocked Metal capture, dummy ServerArgs + patch logic,
-          # and pure quantization-config dict logic.
+          # Model-free MLX unit tests via pytest, like MUSA's unit-test jobs
+          # (its model and server suites use run_suite.py). None load a model:
+          # signature contracts, mocked Metal capture, dummy ServerArgs patch
+          # logic, and quantization-config dict logic.
           #
-          # Three cases are excluded by name (-k): stale against current upstream/main
-          # (they poke internal APIs refactored after the tests landed; only ever
-          # skipped on ubuntu base-a-test-cpu, so the drift went unnoticed). Model-free
-          # but red, tracked separately:
+          # Three cases are excluded (-k): model-free but stale against main, only
+          # ever skipped on ubuntu so the drift went unnoticed. Tracked separately:
           #   - test_decode_finalize_does_not_snapshot_auxiliary_state
           #       (MlxModelRunner._clear_steps now set in __init__, fake runner omits it)
           #   - test_mlx_scheduler_init_overlap_keeps_future_map_relay
           #       (decide_needs_cpu_seq_lens now reads server_args.speculative_algorithm)
           #   - test_finished_request_snapshots_before_release
           #       (_handle_finished_req renamed to _handle_finish_state_updated_req)
-          # -k matches on test-name keywords, so it is robust to the test/pytest.ini
-          # rootdir (which shifts nodeids and silently breaks path-based --deselect).
+          # -k matches test-name keywords, robust to the pytest.ini rootdir that
+          # shifts nodeids and breaks path-based --deselect.
           EXCLUDE="test_decode_finalize_does_not_snapshot_auxiliary_state \
             or test_mlx_scheduler_init_overlap_keeps_future_map_relay \
             or test_finished_request_snapshots_before_release"
@@ -100,7 +92,6 @@ jobs:
             "test/registered/unit/hardware_backend/mlx/test_quantization.py::TestMlxQuantizationOverride" \
             -k "not ($EXCLUDE)"
 
-  # ==================== Finish ==================== #
   pr-test-mlx-finish:
     needs: [mlx-unit-test]
     if: always()


### PR DESCRIPTION
## Motivation
The MLX (Apple Silicon) backend has model-free unit tests, but they run only on the ubuntu `base-a-test-cpu` job, where they skip, leaving the MLX logic untested and drift uncaught. This adds a lane that runs them on a GitHub-hosted macOS runner.

## Modifications
`.github/workflows/pr-test-mlx.yml`, modeled on the MUSA/XPU vendor workflows:
- `mlx-unit-test` on `macos-26`, gated on the `mlx` label  via the repo's run-ci label-gate (`pr-test-rust.yml`): keys on the PR's current label.
- Model-free: `HF_HUB_OFFLINE=1` forbids any HF download (enforced, not assumed); least-privilege `contents: read` token.
- `SGLANG_USE_MLX=1`, so the tests exercise the MLX backend, not the MPS fallback.
- Installs the Apple Silicon extra (`python[srt_mps]`) by swapping in `pyproject_other.toml`, repo's alternate project-metadata file (#20803), for the ephemeral checkout, behind a fail-fast guard.
- Direct `pytest`, the MUSA unit-test convention (model and server suites use `run_suite.py`). No `run_suite` or registration change, so the tests keep skipping cleanly under `base-a-test-cpu` on ubuntu.
- A `pr-test-mlx-finish` gate job aggregates status.

## Accuracy Tests
56 pass on macos-26

- `test_runner_init_contract.py`: signature-only contract guard
- `test_metal_profiler.py`: mocked Metal capture
- `test_attention_patching.py`: dummy ServerArgs, patch/unit logic
- `test_quantization.py::TestMlxQuantizationOverride`: pure quant-config dict logic

## Notes
- Required check: mark `pr-test-mlx-finish` required, not `mlx-unit-test`. The unit job is intentionally skipped on unlabeled PRs; the finish job runs `if: always()` and treats `skipped` as success, so non-MLX PRs never block.
- Label-gated, not `paths:`-filtered: MUSA and XPU lanes gate with `dorny/paths-filter` on vendor paths and run on self-hosted GPU runners. MLX changes cut across `srt/` (`scheduler`, `model_runner`, `attention`, `quant`), where a `paths:` glob would over-trigger or miss refactors that break MLX from shared code. Lane gates on the `mlx` label, an explicit opt-in that lets a maintainer add MLX coverage to any PR on demand.
- The model-requiring tests (`TestMlxQuantization`, which loads Qwen3-0.6B and runs generation) stay on the self-hosted Apple Silicon runner.
- No `HWBackend.MLX` / `run_suite.py` integration; standalone workflow by design, and `run_suite.py` is the graduation path once a self-hosted runner is provisioned.

## Checklist
- [x] Pre-commit (isort, ruff, black, codespell) passes.
- [x] Add unit tests.
- [x] Provide accuracy and speed benchmark results (above).
- [x] CI: needs the `mlx` label and an Apple Silicon runner for the MLX path.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28494190256](https://github.com/sgl-project/sglang/actions/runs/28494190256)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #28507328716](https://github.com/sgl-project/sglang/actions/runs/28507328716)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
