### PR TITLE
[AMD] Fix int8 per-token quant Triton portability + register test for AMD nightly CI

### DIFF
--- a/python/sglang/srt/layers/quantization/int8_kernel.py
+++ b/python/sglang/srt/layers/quantization/int8_kernel.py
@@ -9,9 +9,10 @@ import triton
 import triton.language as tl
 from triton.language.extra import libdevice
 
-from sglang.srt.utils import get_device_name, is_cuda
+from sglang.srt.utils import get_device_name, is_cuda, is_hip
 
 _is_cuda = is_cuda()
+_is_hip = is_hip()
 if _is_cuda:
     # Temporary
     try:
@@ -37,6 +38,7 @@ def _per_token_quant_int8(
     N,
     CAL_SUM: tl.constexpr,
     BLOCK: tl.constexpr,
+    IS_HIP: tl.constexpr,
 ):
     # Adapted from https://github.com/InternLM/lmdeploy/blob/086481ed84b59bee3b8e4274e5fc69620040c048/lmdeploy/pytorch/kernels/cuda/w8a8_triton_kernels.py#L282
     row_id = tl.program_id(0)
@@ -48,7 +50,12 @@ def _per_token_quant_int8(
     absmax = tl.maximum(tl.max(tl.abs(x)), 1e-10)
     scale_x = absmax / 127
     x_q = x * (127 / absmax)
-    x_q = libdevice.round(x_q).to(tl.int8)
+    if IS_HIP:
+        # ROCm Triton dropped the CUDA `tl.extra.cuda.libdevice.*` shim
+        # (`__nv_roundf`); use the backend-agnostic libdevice instead.
+        x_q = libdevice.round(x_q).to(tl.int8)
+    else:
+        x_q = tl.extra.cuda.libdevice.round(x_q).to(tl.int8)
     if CAL_SUM:
         x_sum = tl.sum(x, axis=0)
         tl.store(x_sum_ptr + row_id, x_sum.to(x_sum_ptr.dtype.element_ty))
@@ -81,6 +88,7 @@ def per_token_quant_int8(x, scale_dtype=torch.float32, cal_sum=False):
         N=N,
         CAL_SUM=cal_sum,
         BLOCK=BLOCK,
+        IS_HIP=_is_hip,
         num_warps=num_warps,
         num_stages=1,
     )

--- a/python/sglang/srt/layers/quantization/int8_kernel.py
+++ b/python/sglang/srt/layers/quantization/int8_kernel.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 import triton
 import triton.language as tl
+from triton.language.extra import libdevice
 
 from sglang.srt.utils import get_device_name, is_cuda
 
@@ -47,7 +48,7 @@ def _per_token_quant_int8(
     absmax = tl.maximum(tl.max(tl.abs(x)), 1e-10)
     scale_x = absmax / 127
     x_q = x * (127 / absmax)
-    x_q = tl.extra.cuda.libdevice.round(x_q).to(tl.int8)
+    x_q = libdevice.round(x_q).to(tl.int8)
     if CAL_SUM:
         x_sum = tl.sum(x, axis=0)
         tl.store(x_sum_ptr + row_id, x_sum.to(x_sum_ptr.dtype.element_ty))

--- a/test/registered/quant/test_int8_kernel.py
+++ b/test/registered/quant/test_int8_kernel.py
@@ -8,11 +8,10 @@ from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
 from sglang.srt.layers.moe.topk import TopKConfig, select_experts
 from sglang.srt.layers.quantization.int8_kernel import per_token_quant_int8
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=15, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 
 def native_w8a8_per_token_matmul(A, B, As, Bs, output_dtype=torch.float16):

--- a/test/registered/quant/test_int8_kernel.py
+++ b/test/registered/quant/test_int8_kernel.py
@@ -8,10 +8,11 @@ from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
 from sglang.srt.layers.moe.topk import TopKConfig, select_experts
 from sglang.srt.layers.quantization.int8_kernel import per_token_quant_int8
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=15, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 
 def native_w8a8_per_token_matmul(A, B, As, Bs, output_dtype=torch.float16):


### PR DESCRIPTION
## Summary

Two changes that together unblock the int8 fused-MoE kernel test on AMD (self-contained, independently mergeable):

1. **Portability fix** in `python/sglang/srt/layers/quantization/int8_kernel.py`: `_per_token_quant_int8` called `tl.extra.cuda.libdevice.round`, a CUDA-only Triton intrinsic. AMD's Triton backend rejects it at compile time:
   ```
   RuntimeError: Implicit conversion of CUDA __nv_roundf device function has been dropped;
   please update your source program to use triton.language.extra.<op> to replace triton.language.extra.cuda.<op>
   ```
   The CUDA path is kept **byte-for-byte unchanged** (`tl.extra.cuda.libdevice.round`); only on ROCm/HIP do we use the backend-agnostic `from triton.language.extra import libdevice` / `libdevice.round(...)` (the same portable pattern already used in `layers/triton_ops/softcap.py`). The two are selected by an `IS_HIP: tl.constexpr` branch, so Triton prunes the dead branch at compile time and the CUDA-only intrinsic is never lowered on AMD.

   ```python
   if IS_HIP:
       x_q = libdevice.round(x_q).to(tl.int8)          # ROCm: portable libdevice
   else:
       x_q = tl.extra.cuda.libdevice.round(x_q).to(tl.int8)  # CUDA: unchanged
   ```

2. **Register** `quant/test_int8_kernel.py` to the `nightly-amd-kernel-1-gpu` suite (additive `register_amd_ci`, keeps the existing `register_cuda_ci`).

## Root cause (runtime-confirmed)

The kernel compiled on CUDA but failed at Triton compile on ROCm (gfx950) because `tl.extra.cuda.libdevice.round` maps to the CUDA `__nv_roundf` device function, which the AMD backend dropped. The reference path in the test (`per_token_quant_int8`) hit this first, so every parametrization errored before reaching the correctness assertion.

## Verified on real MI35x (gfx950, per-file `pytest`)

`PYTHONPATH` set to the checkout (shadowing the image), `SGLANG_USE_AITER=1`, on both stacks:

| Test | ROCm 7.0 | ROCm 7.2 |
| --- | --- | --- |
| `quant/test_int8_kernel` (1 test / 32 subtests) | ✅ 1 passed | ✅ 1 passed + 32 subtests |

Numerics match the torch reference within ~3e-3 relative error (threshold 0.05). Before the fix: 32 failed (Triton compile error).

## ✅ Dispatched CI verification (`run_suite` nightly kernel job)

`run_suite.py --hw amd --suite nightly-amd-kernel-1-gpu --nightly`, both `nightly-test-1-gpu-kernel` jobs run `test_int8_kernel` green (`passed: true`, ~29s, not skipped):
- ROCm 7.0 — [Run #28411605827](https://github.com/sgl-project/sglang/actions/runs/28411605827)
- ROCm 7.2 — [Run #28411606573](https://github.com/sgl-project/sglang/actions/runs/28411606573)

## Approach / scope

- Minimal, targeted: one import + a HIP-guarded call-site change in the kernel; one additive registration line in the test. **CUDA path unchanged** (guarded by `IS_HIP` constexpr); NV / MUSA jobs untouched, CUDA registration preserved.
- `nightly-amd-kernel-1-gpu` is already wired in `nightly-test-amd.yml` / `nightly-test-amd-rocm720.yml`, so no workflow changes are needed.
- `collect_tests(sanity_check=True)` + `validate_all_suites` pass; the test is collected into `nightly-amd-kernel-1-gpu`. The file has a `__main__` entry.

## Test plan

- [x] AMD nightly `nightly-amd-kernel-1-gpu` runs the test on ROCm 7.0 and 7.2 (green on both — see runtime table and dispatched CI runs above).
- [x] No change to CUDA behavior (`IS_HIP` constexpr prunes the AMD branch on CUDA; CUDA registration untouched).





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28412208681](https://github.com/sgl-project/sglang/actions/runs/28412208681)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28488652903](https://github.com/sgl-project/sglang/actions/runs/28488652903)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->