### PR TITLE
Size speculative attention metadata from req_to_token capacity

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -24,6 +24,8 @@ from sglang.srt.layers.attention.utils import (
     create_flashinfer_kv_indices_triton,
     create_flashmla_kv_indices_triton,
     get_num_kv_index_blocks_flashmla,
+    get_req_to_token_capacity_len,
+    get_req_to_token_capacity_pages,
 )
 from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
@@ -182,6 +184,8 @@ class AiterAttnBackend(AttentionBackend):
 
         # Parse constants
         self.max_context_len = model_runner.model_config.context_len
+        self.req_to_token_capacity_len = get_req_to_token_capacity_len(model_runner)
+        self.req_to_token_capacity_pages = get_req_to_token_capacity_pages(model_runner)
         self.skip_prefill = skip_prefill
 
         max_bs = model_runner.req_to_token_pool.size
@@ -571,7 +575,7 @@ class AiterAttnBackend(AttentionBackend):
         kv_indptr = spec_info.kv_indptr
         kv_flat = spec_info.kv_indices
         page_size = self.page_size
-        max_blocks = (self.max_context_len + page_size - 1) // page_size
+        max_blocks = self.req_to_token_capacity_pages
 
         swa_slot_mapping = None
         swa_page_table = None
@@ -638,7 +642,7 @@ class AiterAttnBackend(AttentionBackend):
         )
 
         page_size = self.page_size
-        max_blocks = (self.max_context_len + page_size - 1) // page_size
+        max_blocks = self.req_to_token_capacity_pages
 
         swa_slot_mapping = None
         swa_page_table = None
@@ -1399,9 +1403,6 @@ class AiterAttnBackend(AttentionBackend):
             max_bs, dtype=torch.int32, device=self.device
         )
         if kv_indices_buf is None:
-            max_num_blocks_per_seq = (
-                self.max_context_len + self.page_size - 1
-            ) // self.page_size
             # Non-unified AITER CUDA graph paths fill this buffer with flat
             # token-level kv_indices via create_flashinfer_kv_indices_triton
             # (kv_indptr = cumsum(seq_lens)).  Even when the allocator is
@@ -1414,13 +1415,7 @@ class AiterAttnBackend(AttentionBackend):
             # metadata sites + paged_attention_ragged call site + FP8 KV
             # coordination, after which this allocation can revert to
             # per-page (gated on use_mla).
-            # Reserve draft slack: MLA target_verify writes seq_len +
-            # num_draft_tokens per row; without it a near-full sequence
-            # overflows the buffer. Mirrors dsa / flashmla.
-            draft_slack = self.num_draft_tokens or 0
-            buffer_numel = max_bs * (
-                max_num_blocks_per_seq * self.page_size + draft_slack
-            )
+            buffer_numel = max_bs * self.req_to_token_capacity_len
             self.cuda_graph_kv_indices = torch.zeros(
                 (buffer_numel,),
                 dtype=torch.int32,
@@ -1433,9 +1428,7 @@ class AiterAttnBackend(AttentionBackend):
             # Keep a distinct page-table buffer for unified attention.  Sharing
             # cuda_graph_kv_indices with non-unified token indices makes
             # page-table width ambiguous after the token buffer is expanded.
-            max_num_blocks_per_seq = (
-                self.max_context_len + self.page_size - 1
-            ) // self.page_size
+            max_num_blocks_per_seq = self.req_to_token_capacity_pages
             self.cuda_graph_page_table = torch.zeros(
                 (max_bs, max_num_blocks_per_seq),
                 dtype=torch.int32,
@@ -1475,9 +1468,7 @@ class AiterAttnBackend(AttentionBackend):
             self.reduce_partial_map = None
 
         if self.use_sliding_window_kv_pool:
-            max_num_blocks_per_seq = (
-                self.max_context_len + self.page_size - 1
-            ) // self.page_size
+            max_num_blocks_per_seq = self.req_to_token_capacity_pages
             self.cuda_graph_swa_page_table = torch.zeros(
                 (max_bs, max_num_blocks_per_seq),
                 dtype=torch.int32,
@@ -1529,9 +1520,7 @@ class AiterAttnBackend(AttentionBackend):
             if spec_info is None or (
                 self.use_triton_unified_attention and not self.use_mla
             ):
-                max_num_blocks_per_seq = (
-                    self.max_context_len + self.page_size - 1
-                ) // self.page_size
+                max_num_blocks_per_seq = self.req_to_token_capacity_pages
 
                 if not self.use_triton_unified_attention:
                     kv_indptr = self.kv_indptr
@@ -1737,9 +1726,7 @@ class AiterAttnBackend(AttentionBackend):
                 )
             else:
                 if self._use_unified_verify:
-                    max_num_blocks_per_seq = (
-                        self.max_context_len + self.page_size - 1
-                    ) // self.page_size
+                    max_num_blocks_per_seq = self.req_to_token_capacity_pages
                     page_table = self.cuda_graph_page_table[:bs]
 
                     swa_page_table = None
@@ -2792,7 +2779,8 @@ class AiterMultiStepDraftBackend:
         self.device = model_runner.device
         # Cached variables for generate_draft_decode_kv_indices
         self.req_to_token_pool = model_runner.req_to_token_pool
-        self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
+        self.req_to_token_capacity_len = get_req_to_token_capacity_len(model_runner)
+        self.pool_len = self.req_to_token_capacity_len
         self.page_size = model_runner.server_args.page_size
 
     def common_template(
@@ -2801,6 +2789,19 @@ class AiterMultiStepDraftBackend:
         num_seqs = forward_batch.batch_size
         bs = self.topk * num_seqs
         seq_lens_sum = forward_batch.seq_lens_sum
+        if seq_lens_sum is None:
+            seq_lens_sum = num_seqs * self.max_context_len
+
+        required_kv_indices_len = draft_kv_indices_used_len(
+            seq_lens_sum, self.topk, bs, self.speculative_num_steps
+        )
+        assert_buffer_fits(
+            required_kv_indices_len,
+            kv_indices_buffer.shape[1],
+            "EAGLE draft kv_indices row (size max_bs * topk * req_to_token_capacity_len)",
+            bs=bs,
+            seq_lens_sum=seq_lens_sum,
+        )
 
         self.generate_draft_decode_kv_indices[
             (self.speculative_num_steps, num_seqs, self.topk)
@@ -2829,7 +2830,7 @@ class AiterMultiStepDraftBackend:
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         kv_indices_width = draft_kv_indices_buffer_width(
-            forward_batch.batch_size, self.topk, self.max_context_len
+            forward_batch.batch_size, self.topk, self.req_to_token_capacity_len
         )
         kv_indices = torch.empty(
             (self.speculative_num_steps, kv_indices_width),
@@ -2850,7 +2851,7 @@ class AiterMultiStepDraftBackend:
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         kv_indices_width = draft_kv_indices_buffer_width(
-            max_bs, self.topk, self.max_context_len
+            max_bs, self.topk, self.req_to_token_capacity_len
         )
         self.cuda_graph_kv_indices = torch.zeros(
             (self.speculative_num_steps, kv_indices_width),

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -17,7 +17,12 @@ from sglang.srt.layers.attention.triton_ops.metadata import (
 from sglang.srt.layers.attention.triton_ops.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
-from sglang.srt.layers.attention.utils import assert_buffer_fits
+from sglang.srt.layers.attention.utils import (
+    assert_buffer_fits,
+    get_model_context_len,
+    get_req_to_token_capacity_len,
+    get_req_to_token_capacity_pages,
+)
 from sglang.srt.layers.cp.base import CPAttentionBackendKind, get_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.layers.radix_attention import AttentionType
@@ -232,7 +237,7 @@ class FlashAttentionBackend(AttentionBackend):
         self.forward_metadata: FlashAttentionMetadata = None
         # extra metadata for handling speculative decoding topk > 1, extended draft decode and verify
         self.forward_metadata_spec_decode_expand: FlashAttentionMetadata = None
-        self.max_context_len = model_runner.model_config.context_len
+        self.max_context_len = get_model_context_len(model_runner)
         self.device = model_runner.device
         self.decode_cuda_graph_metadata = {}
         self.target_verify_metadata = {}
@@ -241,14 +246,15 @@ class FlashAttentionBackend(AttentionBackend):
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self.req_to_token_capacity_len = get_req_to_token_capacity_len(model_runner)
         self.kv_cache_dtype = model_runner.kv_cache_dtype
         self.kv_cache_dtype_str = model_runner.server_args.kv_cache_dtype
         self.page_size = model_runner.page_size
-        # Static page-table width (upper bound). The device-side page-table build
-        # sizes to this constant, so no runtime host max is needed.
-        self.max_num_pages = (
-            self.max_context_len + self.page_size - 1
-        ) // self.page_size
+        # Static page-table width (upper bound). Speculative decoding can
+        # over-allocate KV beyond the model context length, and req_to_token is
+        # sized with that headroom. Metadata that indexes req_to_token must use
+        # the addressable row width, not the semantic model context length.
+        self.max_num_pages = get_req_to_token_capacity_pages(model_runner)
         # Opt out of the seq_lens_cpu D2H only for dflash (the worker adapted to
         # the GPU-only relay); EAGLE/MTP/standalone/non-spec keep the CPU mirror.
         self.needs_cpu_seq_lens = not SpeculativeAlgorithm.from_string(
@@ -1768,7 +1774,7 @@ class FlashAttentionBackend(AttentionBackend):
         This creates fixed-size tensors that will be reused during CUDA graph replay
         to avoid memory allocations.
         """
-        max_num_pages = (self.max_context_len + self.page_size - 1) // self.page_size
+        max_num_pages = self.max_num_pages
 
         # This is being used by normal decode and draft decode when topk == 1
         self.decode_cuda_graph_metadata = {
@@ -1786,7 +1792,10 @@ class FlashAttentionBackend(AttentionBackend):
                 device=self.device,
             ),
             "strided_indices": torch.arange(
-                0, self.max_context_len, self.page_size, device=self.device
+                0,
+                self.req_to_token_capacity_len,
+                self.page_size,
+                device=self.device,
             ),
         }
         # Pre-allocate scheduler_metadata buffer for CUDA graph
@@ -1859,7 +1868,7 @@ class FlashAttentionBackend(AttentionBackend):
                 ),
                 "page_table": torch.zeros(
                     max_bs,
-                    self.max_context_len,
+                    max_num_pages,
                     dtype=torch.int32,
                     device=self.device,
                 ),
@@ -1928,7 +1937,10 @@ class FlashAttentionBackend(AttentionBackend):
                     device=self.device,
                 ),
                 "strided_indices": torch.arange(
-                    0, self.max_context_len, self.page_size, device=self.device
+                    0,
+                    self.req_to_token_capacity_len,
+                    self.page_size,
+                    device=self.device,
                 ),
             }
 
@@ -1951,7 +1963,10 @@ class FlashAttentionBackend(AttentionBackend):
                     device=self.device,
                 ),
                 "strided_indices": torch.arange(
-                    0, self.max_context_len, self.page_size, device=self.device
+                    0,
+                    self.req_to_token_capacity_len,
+                    self.page_size,
+                    device=self.device,
                 ),
             }
 
@@ -1986,7 +2001,7 @@ class FlashAttentionBackend(AttentionBackend):
                 ),
                 "page_table": torch.zeros(
                     max_bs,
-                    self.max_context_len,
+                    max_num_pages,
                     dtype=torch.int32,
                     device=self.device,
                 ),
@@ -2037,7 +2052,7 @@ class FlashAttentionBackend(AttentionBackend):
                     ),
                     "page_table": torch.zeros(
                         max_bs * self.speculative_num_draft_tokens,
-                        self.max_context_len,
+                        max_num_pages,
                         dtype=torch.int32,
                         device=self.device,
                     ),

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -25,6 +25,7 @@ from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import (
     assert_buffer_fits,
     create_flashinfer_kv_indices_triton,
+    get_req_to_token_capacity_len,
 )
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
@@ -1876,7 +1877,8 @@ class FlashInferMultiStepDraftBackend:
         self.max_context_len = self.attn_backends[0].max_context_len
 
         # Cached variables for generate_draft_decode_kv_indices
-        self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
+        self.req_to_token_capacity_len = get_req_to_token_capacity_len(model_runner)
+        self.pool_len = self.req_to_token_capacity_len
         self.req_to_token_pool = model_runner.req_to_token_pool
 
     def common_template(
@@ -1895,7 +1897,7 @@ class FlashInferMultiStepDraftBackend:
         assert_buffer_fits(
             required_kv_indices_len,
             kv_indices_buffer.shape[1],
-            "EAGLE draft kv_indices row (size max_bs * topk * max_context_len)",
+            "EAGLE draft kv_indices row (size max_bs * topk * req_to_token_capacity_len)",
             bs=bs,
             seq_lens_sum=seq_lens_sum,
         )
@@ -1937,7 +1939,7 @@ class FlashInferMultiStepDraftBackend:
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         kv_indices_width = draft_kv_indices_buffer_width(
-            forward_batch.batch_size, self.topk, self.max_context_len
+            forward_batch.batch_size, self.topk, self.req_to_token_capacity_len
         )
         kv_indices = torch.empty(
             (self.speculative_num_steps, kv_indices_width),
@@ -1958,10 +1960,10 @@ class FlashInferMultiStepDraftBackend:
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         # generate_draft_decode_kv_indices packs topk per-branch sequences per row,
-        # so the row needs the topk factor -- same as the eager init_forward_metadata
-        # (batch_size * topk * max_context_len). Dropping it overflows the buffer.
+        # so the row needs the topk factor and req_to_token's addressable width.
+        # Dropping either under-allocates and overflows the buffer.
         kv_indices_width = draft_kv_indices_buffer_width(
-            max_bs, self.topk, self.max_context_len
+            max_bs, self.topk, self.req_to_token_capacity_len
         )
         self.cuda_graph_kv_indices = torch.zeros(
             (self.speculative_num_steps, kv_indices_width),

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -22,7 +22,10 @@ from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.flashinfer_backend import (
     create_flashinfer_kv_indices_triton,
 )
-from sglang.srt.layers.attention.utils import assert_buffer_fits
+from sglang.srt.layers.attention.utils import (
+    assert_buffer_fits,
+    get_req_to_token_capacity_len,
+)
 from sglang.srt.layers.utils.dcp_utils import (
     DecodeContextParallelMetadata,
     dcp_enabled,
@@ -967,7 +970,8 @@ class FlashInferMLAMultiStepDraftBackend:
 
         # Cached variables for generate_draft_decode_kv_indices
         self.req_to_token_pool = model_runner.req_to_token_pool
-        self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
+        self.req_to_token_capacity_len = get_req_to_token_capacity_len(model_runner)
+        self.pool_len = self.req_to_token_capacity_len
         self.page_size = model_runner.server_args.page_size
 
     def common_template(
@@ -986,7 +990,7 @@ class FlashInferMLAMultiStepDraftBackend:
         assert_buffer_fits(
             required_kv_indices_len,
             kv_indices_buffer.shape[1],
-            "EAGLE draft kv_indices row (size max_bs * topk * max_context_len)",
+            "EAGLE draft kv_indices row (size max_bs * topk * req_to_token_capacity_len)",
             bs=bs,
             seq_lens_sum=seq_lens_sum,
         )
@@ -1021,7 +1025,7 @@ class FlashInferMLAMultiStepDraftBackend:
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         kv_indices_width = draft_kv_indices_buffer_width(
-            forward_batch.batch_size, self.topk, self.max_context_len
+            forward_batch.batch_size, self.topk, self.req_to_token_capacity_len
         )
         kv_indices = torch.zeros(
             (self.speculative_num_steps, kv_indices_width),
@@ -1041,10 +1045,10 @@ class FlashInferMLAMultiStepDraftBackend:
         self.common_template(forward_batch, kv_indices, call_fn)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
-        # Row holds topk per-branch sequences (generate_draft_decode_kv_indices), so
-        # it needs the topk factor, matching the eager init_forward_metadata.
+        # Row holds topk per-branch sequences over req_to_token's addressable
+        # width, matching the eager init_forward_metadata.
         kv_indices_width = draft_kv_indices_buffer_width(
-            max_bs, self.topk, self.max_context_len
+            max_bs, self.topk, self.req_to_token_capacity_len
         )
         self.cuda_graph_kv_indices = torch.zeros(
             (self.speculative_num_steps, kv_indices_width),

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -18,9 +18,11 @@ from sglang.srt.layers.attention.triton_ops.kv_indices import (
 )
 from sglang.srt.layers.attention.triton_ops.metadata import get_num_kv_splits_triton
 from sglang.srt.layers.attention.utils import (
+    assert_buffer_fits,
     cp_lse_ag_out_rs,
     create_triton_kv_indices_for_dcp_triton,
     get_dcp_lens,
+    get_req_to_token_capacity_len,
 )
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
@@ -1764,7 +1766,8 @@ class TritonMultiStepDraftBackend:
         self.device = model_runner.device
         # Cached variables for generate_draft_decode_kv_indices
         self.req_to_token_pool = model_runner.req_to_token_pool
-        self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
+        self.req_to_token_capacity_len = get_req_to_token_capacity_len(model_runner)
+        self.pool_len = self.req_to_token_capacity_len
         self.page_size = model_runner.server_args.page_size
 
     def common_template(
@@ -1783,6 +1786,17 @@ class TritonMultiStepDraftBackend:
             # seq_lens_sum here only slice-clamps a preallocated kv_indices buffer;
             # over-estimate is safe. Use a static UB to skip the per-iter .sum().item() D2H.
             seq_lens_sum = num_seqs * self.max_context_len
+
+        required_kv_indices_len = draft_kv_indices_used_len(
+            seq_lens_sum, self.topk, bs, self.speculative_num_steps
+        )
+        assert_buffer_fits(
+            required_kv_indices_len,
+            kv_indices_buffer.shape[1],
+            "EAGLE draft kv_indices row (size max_bs * topk * req_to_token_capacity_len)",
+            bs=bs,
+            seq_lens_sum=seq_lens_sum,
+        )
 
         generate_draft_decode_kv_indices[
             (self.speculative_num_steps, num_seqs, self.topk)
@@ -1814,7 +1828,7 @@ class TritonMultiStepDraftBackend:
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         kv_indices_width = draft_kv_indices_buffer_width(
-            forward_batch.batch_size, self.topk, self.max_context_len
+            forward_batch.batch_size, self.topk, self.req_to_token_capacity_len
         )
         kv_indices = torch.empty(
             (self.speculative_num_steps, kv_indices_width),
@@ -1835,7 +1849,7 @@ class TritonMultiStepDraftBackend:
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         kv_indices_width = draft_kv_indices_buffer_width(
-            max_bs, self.topk, self.max_context_len
+            max_bs, self.topk, self.req_to_token_capacity_len
         )
         self.cuda_graph_kv_indices = torch.zeros(
             (self.speculative_num_steps, kv_indices_width),

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -22,7 +22,12 @@ from sglang.srt.layers.attention.triton_ops.trtllm_fp8_kv_kernel import (
 from sglang.srt.layers.attention.triton_ops.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
-from sglang.srt.layers.attention.utils import canonicalize_stride
+from sglang.srt.layers.attention.utils import (
+    canonicalize_stride,
+    get_model_context_len,
+    get_req_to_token_capacity_len,
+    get_req_to_token_capacity_pages,
+)
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
@@ -98,7 +103,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         config = model_runner.model_config
 
         # MHA-specific dimensions
-        self.max_context_len = model_runner.model_config.context_len
+        self.max_context_len = get_model_context_len(model_runner)
         self.hidden_size = config.hidden_size
 
         # Runtime parameters
@@ -106,6 +111,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self.q_data_type = model_runner.dtype
         self.page_size = model_runner.page_size
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self.req_to_token_capacity_len = get_req_to_token_capacity_len(model_runner)
+        self.req_to_token_capacity_pages = get_req_to_token_capacity_pages(
+            model_runner
+        )
         self.device = model_runner.device
 
         # Workspace allocation
@@ -140,9 +149,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # Static page-table width (upper bound). The CUDA-graph path builds the
         # page table on-device sized to this constant, so it never reads a runtime
         # max. See _fill_page_table_device.
-        self.max_num_pages = (
-            self.max_context_len + self.page_size - 1
-        ) // self.page_size
+        self.max_num_pages = self.req_to_token_capacity_pages
 
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -1471,3 +1471,20 @@ def assert_buffer_fits(used: int, capacity: int, what: str, **context) -> None:
     assert used <= capacity, f"{what}: used {used} > capacity {capacity}" + (
         f" ({', '.join(f'{k}={v}' for k, v in context.items())})" if context else ""
     )
+
+
+def get_model_context_len(model_runner) -> int:
+    """Semantic model context limit."""
+    return int(model_runner.model_config.context_len)
+
+
+def get_req_to_token_capacity_len(model_runner) -> int:
+    """Addressable req_to_token row width, including speculative headroom."""
+    return int(model_runner.req_to_token_pool.req_to_token.shape[1])
+
+
+def get_req_to_token_capacity_pages(model_runner) -> int:
+    """Page-table width needed to cover req_to_token's addressable row."""
+    capacity_len = get_req_to_token_capacity_len(model_runner)
+    page_size = int(model_runner.page_size)
+    return (capacity_len + page_size - 1) // page_size

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -105,17 +105,19 @@ TREE_SPEC_KERNEL_AVAILABLE = (
 
 
 def draft_kv_indices_buffer_width(
-    num_seqs: int, topk: int, max_context_len: int
+    num_seqs: int, topk: int, req_to_token_capacity_len: int
 ) -> int:
     """Per-step row width of the EAGLE draft-decode kv_indices buffer.
 
-    num_seqs * topk branches each attend up to max_context_len KV slots; the topk
-    factor is mandatory -- dropping it under-allocates and overflows the row (#27338, #27460).
+    num_seqs * topk branches each address up to req_to_token_capacity_len KV
+    slots. This is an addressing capacity, not the semantic model context
+    length. The topk factor is mandatory -- dropping it under-allocates and
+    overflows the row (#27338, #27460).
     """
     assert (
-        num_seqs * topk * max_context_len < 2**31
+        num_seqs * topk * req_to_token_capacity_len < 2**31
     ), "kv_indices flat offset would overflow int32; reduce batch/topk/context"
-    return num_seqs * topk * max_context_len
+    return num_seqs * topk * req_to_token_capacity_len
 
 
 def draft_kv_indices_used_len(


### PR DESCRIPTION
## Motivation

Fixes #29695.

Speculative decoding gives `req_to_token` extra addressable headroom beyond the semantic model context length. Several CUDA graph metadata buffers that index `req_to_token` were still sized from `model_config.context_len`, so near the context boundary those buffers could be narrower than the runtime metadata extent.

The invariant this PR applies is:

```text
metadata/addressing capacity follows req_to_token_pool.req_to_token.shape[1]
semantic committed context limit follows model_config.context_len
```

This is related to #29665, but extends the same principle beyond FA3.

## Modifications

- Add shared helpers for `model_context_len`, `req_to_token_capacity_len`, and `req_to_token_capacity_pages`.
- Size FA3 and TRTLLM MHA speculative page-table CUDA graph metadata from `req_to_token` addressable capacity.
- Size FlashInfer, FlashInfer MLA, Triton, and AITER multi-step draft `kv_indices` rows from `req_to_token` addressable capacity.
- Add host-side capacity guards to Triton and AITER multi-step draft metadata generation, matching the existing FlashInfer guard pattern.
- Keep `model_config.context_len` as the semantic limit for model/kernel context parameters. This patch does not expand committed generation length and does not touch scheduler/admission/accept/commit paths.

## Accuracy Tests

This patch changes metadata buffer sizing and host-side capacity guards only. It does not change attention math, accepted-token semantics, or model output selection.

Functional validation was run with an out-of-tree CUDA repro harness on NVIDIA H200 against upstream main `6bdecb8206b8d066e9cfb4ed6032e5a1e9b14340` and then against this patch.

Baseline signals on upstream main:

```text
trtllm_mha: page-table capacity 64, expected 68
flashinfer: used 136 > capacity 128
flashinfer_mla: used 68 > capacity 64
triton: allocated 128, expected/used 136
aiter: allocated 128, expected/used 136 on shared metadata path
```

Patched signals:

```text
trtllm_mha: page-table capacity 68, expected 68, apply completed
flashinfer: allocated 136, expected/used 136, apply completed
flashinfer_mla: allocated 68, expected/used 68, apply completed
triton: allocated 136, expected/used 136, apply completed
aiter: allocated 136, expected/used 136, apply completed on shared metadata path
```

Local checks:

```bash
git diff --check
python3 -m py_compile \
  python/sglang/srt/layers/attention/utils.py \
  python/sglang/srt/speculative/spec_utils.py \
  python/sglang/srt/layers/attention/flashattention_backend.py \
  python/sglang/srt/layers/attention/flashinfer_backend.py \
  python/sglang/srt/layers/attention/flashinfer_mla_backend.py \
  python/sglang/srt/layers/attention/triton_backend.py \
  python/sglang/srt/layers/attention/aiter_backend.py \
  python/sglang/srt/layers/attention/trtllm_mha_backend.py
```

Validation gap: AITER was validated on the shared Python/Triton metadata path on CUDA/H200. AMD/HIP AITER kernel behavior was not validated.

## Speed Tests and Profiling

Not benchmarked. The runtime changes are allocation sizing and host-side integer capacity guards during metadata preparation; no attention kernel math or scheduling policy is changed.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

Opened as a draft to get maintainer feedback on whether this should stay as one cross-backend metadata-capacity PR or be split by backend family.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28411817684](https://github.com/sgl-project/sglang/actions/runs/28411817684)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28411817572](https://github.com/sgl-project/sglang/actions/runs/28411817572)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->