### PR TITLE
[Anthropic] Fix missing cache_read_input_tokens in streaming responses

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -38,6 +38,7 @@ from sglang.srt.entrypoints.openai.protocol import (
     FunctionResponse,
     LogProbs,
     MessageProcessingResult,
+    PromptTokensDetails,
     ResponseParserProtocol,
     SglExt,
     ToolCall,
@@ -336,6 +337,14 @@ class OpenAIServingChat(OpenAIServingBase):
         """Post-process reasoning and tool_calls before building response."""
         return reasoning_text, tool_calls
 
+    def _continuous_usage_cached_details(
+        self, content: Dict[str, Any]
+    ) -> Optional[PromptTokensDetails]:
+        if not self.tokenizer_manager.server_args.enable_cache_report:
+            return None
+        cached = content["meta_info"].get("cached_tokens", 0)
+        return PromptTokensDetails(cached_tokens=cached) if cached else None
+
     async def _generate_stream_content(
         self,
         content: Dict[str, Any],
@@ -377,6 +386,7 @@ class OpenAIServingChat(OpenAIServingBase):
                         prompt_tokens=prompt_tokens.get(index, 0),
                         reasoning_tokens=reasoning_tokens.get(index, 0),
                         completion_tokens=completion_tokens.get(index, 0),
+                        cached_tokens=self._continuous_usage_cached_details(content),
                     ).model_dump()
 
                 yield build_sse_content(
@@ -422,6 +432,7 @@ class OpenAIServingChat(OpenAIServingBase):
                         prompt_tokens=prompt_tokens.get(index, 0),
                         reasoning_tokens=reasoning_tokens.get(index, 0),
                         completion_tokens=completion_tokens.get(index, 0),
+                        cached_tokens=self._continuous_usage_cached_details(content),
                     ).model_dump()
 
                 yield build_sse_content(
@@ -449,6 +460,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     prompt_tokens=prompt_tokens.get(index, 0),
                     reasoning_tokens=reasoning_tokens.get(index, 0),
                     completion_tokens=completion_tokens.get(index, 0),
+                    cached_tokens=self._continuous_usage_cached_details(content),
                 ).model_dump()
 
             yield build_sse_content(
@@ -1898,6 +1910,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     reasoning_tokens=reasoning_tokens,
+                    cached_tokens=self._continuous_usage_cached_details(content),
                 )
 
             yield f"data: {chunk.model_dump_json()}\n\n"
@@ -1950,6 +1963,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     reasoning_tokens=reasoning_tokens,
+                    cached_tokens=self._continuous_usage_cached_details(content),
                 )
 
             yield f"data: {chunk.model_dump_json()}\n\n"

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -342,8 +342,9 @@ class OpenAIServingChat(OpenAIServingBase):
     ) -> Optional[PromptTokensDetails]:
         if not self.tokenizer_manager.server_args.enable_cache_report:
             return None
-        cached = content["meta_info"].get("cached_tokens", 0)
-        return PromptTokensDetails(cached_tokens=cached) if cached else None
+        return UsageProcessor._details_if_cached(
+            content["meta_info"].get("cached_tokens", 0)
+        )
 
     async def _generate_stream_content(
         self,

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1800,6 +1800,63 @@ class ServingChatTestCase(unittest.TestCase):
             },
         )
 
+    def _collect_continuous_usage(self, cached_tokens):
+        content = {
+            "text": "Hello",
+            "meta_info": {
+                "id": "chatcmpl-cont-usage",
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "cached_tokens": cached_tokens,
+                "finish_reason": {"type": "stop", "matched": None},
+                "output_token_logprobs": None,
+                "output_top_logprobs": None,
+            },
+            "index": 0,
+        }
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+        )
+
+        async def _collect():
+            chunks = []
+            async for chunk in self.chat._generate_stream_content(
+                content=content,
+                index=0,
+                request=req,
+                stream_offsets={},
+                reasoning_parser_dict={},
+                parser_dict={},
+                has_tool_calls={},
+                choice_logprobs=None,
+                finish_reason_type="stop",
+                continuous_usage_stats=True,
+                prompt_tokens={0: 10},
+                reasoning_tokens={0: 0},
+                completion_tokens={0: 2},
+            ):
+                chunks.append(chunk)
+            return chunks
+
+        chunks = get_or_create_event_loop().run_until_complete(_collect())
+        return [c["usage"] for c in self._parse_chunks(chunks) if c.get("usage")]
+
+    def test_continuous_usage_reports_cached_tokens(self):
+        """continuous_usage_stats chunks include cached tokens when cache reporting is on."""
+        self.tm.server_args.enable_cache_report = True
+        usages = self._collect_continuous_usage(cached_tokens=6)
+        self.assertTrue(usages, "continuous_usage_stats attached no usage")
+        self.assertEqual(usages[0]["prompt_tokens_details"]["cached_tokens"], 6)
+
+    def test_continuous_usage_omits_cached_tokens_when_report_disabled(self):
+        """With cache reporting off, continuous_usage_stats must not leak cached tokens."""
+        self.tm.server_args.enable_cache_report = False
+        usages = self._collect_continuous_usage(cached_tokens=6)
+        self.assertTrue(usages, "continuous_usage_stats attached no usage")
+        self.assertIsNone(usages[0].get("prompt_tokens_details"))
+
     # ------------- incremental streaming output tests -------------
     def test_incremental_streaming_output_delta(self):
         """Test that streaming with incremental_streaming_output produces correct deltas.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Streaming chat completions with `continuous_usage_stats` (i.e. `stream_options.include_usage` with per-chunk usage) never populated `prompt_tokens_details.cached_tokens` in the per-chunk `usage`. Only the **non-streaming** path (`UsageProcessor.calculate_response_usage`) and the **final** usage-only chunk (`UsageProcessor.calculate_streaming_usage`) reported cached tokens; the per-chunk `calculate_token_usage(...)` calls in the continuous-usage path were missing the `cached_tokens` argument, so `prompt_tokens_details` was always `None`.

This is harmless on the OpenAI route (clients read the final usage chunk), but it **silently breaks the Anthropic `/v1/messages` streaming route**, which delegates to `OpenAIServingChat` with `continuous_usage_stats=True`:

- The Anthropic adapter builds `message_start.message.usage` from the **first** continuous-usage chunk (`anthropic/serving.py`, `_message_start_event(chunk.usage)`), mapping `prompt_tokens_details.cached_tokens` → `cache_read_input_tokens`.
- The final usage-only chunk is mapped to `message_delta` with `include_input=False`, which intentionally drops the input/cache fields.

So the per-chunk continuous usage is the **only** channel through which `cache_read_input_tokens` can reach an Anthropic streaming client — and it was always empty. As a result, on a prefix-cache hit:

- `cache_read_input_tokens` was missing entirely (the cache benefit was invisible to the client), and
- `input_tokens` was over-reported as the full prompt, because Anthropic `input_tokens = prompt_tokens − cached_tokens` (`_anthropic_input_tokens`).

The non-streaming Anthropic path was already correct; this PR fixes the streaming path.

## Modifications

<!-- Detail the changes made in this pull request. -->

`python/sglang/srt/entrypoints/openai/serving_chat.py`
- Add helper `OpenAIServingChat._continuous_usage_cached_details(content)` that returns atokens=...)` when `enable_cache_report` is on and the chunk carries cached tokens,otherwise `None`. The gating and the "only attach when non-zero" behavior mirror `UsageProcessor._details_if_cached`, keeping plain-text usage `prompt_tokens_details=None` (backward compatible).
- Pass it as `cached_tokens=` to all five per-chunk `calculate_token_usage(...)` continuog delta, plain content delta, trailing-logprobs flush, tool-call normal text, and tool-call argument delta.
- Import `PromptTokensDetails`.

`test/registered/unit/entrypoints/openai/test_serving_chat.py`
- `test_continuous_usage_reports_cached_tokens`: with `enable_cache_report=True`, continuous-usage chunks expose `usage.prompt_tokens_details.cached_tokens`.
- `test_continuous_usage_omits_cached_tokens_when_report_disabled`: with reporting off, `absent (no leak).

**End-to-end verification on a live server** (`Qwen3` MoE FP8, `tp=2`, `--enable-cache-report`): the same ~1098-token prompt sent twice over the Anthropic streaming endpoint, observing `message_start.usage` on
the warm (prefix-cache hit) request:

| Build | `input_tokens` | `cache_read_input_tokens` |
| --- | ---: | ---: |
| Before (this PR reverted) | 1098 | absent / 0 |
| After  (this PR)          | 10   | 1088 |

The cold (first) request reports `input_tokens=1098 / cache_read=0` in both builds, confiche reads when they actually occur. Cross-check: reverting only the source change makes
`test_continuous_usage_reports_cached_tokens` fail, confirming the new test guards the re

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A — this changes usage/token accounting only; model forward and token generation are un unchanged.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A — no hot-path or kernel changes. The added helper is a dict lookup gated by `enable_cache_report`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglangion_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/devde.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](httpsuide/contribution_guide.html#test-the-accuracy) and [Benchmark thespeed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/conte-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.githuwers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_gests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permissi































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28437310181](https://github.com/sgl-project/sglang/actions/runs/28437310181)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28437310100](https://github.com/sgl-project/sglang/actions/runs/28437310100)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->