### PR TITLE
[AMD][DI][CI] Add NIXL KV-transfer leg to MI355X disaggregation nightly [NOT FOR MERGE YET]

### DIFF
--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -88,6 +88,10 @@ res = r.get("resources", {})
 def emit(k, v): print(f"{k}={v}")
 emit("IMAGE", rt["image"])
 emit("ATTN", rt["attention_backend"])
+# KV transfer backend: mori (default) or nixl. nixl (upstream ai-dynamo/nixl +
+# UCX built --with-rocm) ships enabled by default in the mainline mi35x ROCm
+# image, so a nixl recipe runs on a stock nightly image.
+emit("XFER", rt.get("transfer_backend", "mori"))
 emit("IB", rt["ib_devices"])
 emit("PPORT", rt["prefill_port"])
 emit("DPORT", rt["decode_port"])
@@ -125,7 +129,7 @@ eval "$RECIPE_VARS"
 if [[ -n "${IMAGE_OVERRIDE:-}" ]]; then
     IMAGE="$IMAGE_OVERRIDE"
 fi
-echo "recipe: image=$IMAGE attn=$ATTN ib=$IB ptp=$PTP dtp=$DTP concs=$CONCS isl=$ISL osl=$OSL"
+echo "recipe: image=$IMAGE attn=$ATTN xfer=$XFER ib=$IB ptp=$PTP dtp=$DTP concs=$CONCS isl=$ISL osl=$OSL"
 
 # ---------------------------------------------------------------------------
 # Shared NFS scratch (visible to login node + compute nodes). Raw bench output
@@ -173,14 +177,23 @@ DSV4_ENV=(
   -e AITER_BF16_FP8_MOE_BOUND=0 -e SGLANG_DSV4_FP4_EXPERTS=$FP4_EXPERTS
 )
 DSV4_ENV_STR="${DSV4_ENV[*]}"
-MORI_ENV="-e MORI_DISABLE_AUTO_XGMI=1 -e NCCL_IB_HCA=ionic -e NCCL_IB_GID_INDEX=1 -e NCCL_CROSS_NIC=1"
+
+# KV-transfer env, keyed off the recipe's transfer_backend. Both backends drive
+# the same RoCE HCAs (NCCL_IB_HCA=ionic) for the cross-node control plane; only
+# mori needs the MORI-specific XGMI auto-disable toggle.
+NCCL_RDMA_ENV="-e NCCL_IB_HCA=ionic -e NCCL_IB_GID_INDEX=1 -e NCCL_CROSS_NIC=1"
+if [[ "$XFER" == "mori" ]]; then
+    XFER_ENV="-e MORI_DISABLE_AUTO_XGMI=1 $NCCL_RDMA_ENV"
+else
+    XFER_ENV="$NCCL_RDMA_ENV"
+fi
 
 COMMON_FLAGS="--trust-remote-code --tp $PTP --disable-radix-cache \
 --attention-backend $ATTN --max-running-requests $MAXREQ --page-size $PAGE \
 --mem-fraction-static $MEMFRAC --swa-full-tokens-ratio $SWA \
 --chunked-prefill-size $CHUNK --disable-shared-experts-fusion \
 --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4 \
---disaggregation-transfer-backend mori --disaggregation-ib-device $IB"
+--disaggregation-transfer-backend $XFER --disaggregation-ib-device $IB"
 
 DOCKER_COMMON="--rm --network host --ipc host --shm-size 32g --privileged \
 --security-opt seccomp=unconfined \
@@ -194,7 +207,7 @@ cat > "$WORKDIR/prefill.sh" <<EOF
 #!/bin/bash
 docker rm -f mi355x_prefill 2>/dev/null || true
 docker run $DOCKER_COMMON --name mi355x_prefill \
-  -e HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 $MORI_ENV $DSV4_ENV_STR \
+  -e HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 $XFER_ENV $DSV4_ENV_STR \
   $IMAGE python3 -m sglang.launch_server \
   --model-path $MODEL_PATH --host 0.0.0.0 --port $PPORT \
   $COMMON_FLAGS --disaggregation-mode prefill --disaggregation-bootstrap-port $PBOOT
@@ -204,7 +217,7 @@ cat > "$WORKDIR/decode.sh" <<EOF
 #!/bin/bash
 docker rm -f mi355x_decode 2>/dev/null || true
 docker run $DOCKER_COMMON --name mi355x_decode \
-  -e HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 $MORI_ENV $DSV4_ENV_STR \
+  -e HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 $XFER_ENV $DSV4_ENV_STR \
   $IMAGE python3 -m sglang.launch_server \
   --model-path $MODEL_PATH --host 0.0.0.0 --port $DPORT \
   $COMMON_FLAGS --disaggregation-mode decode --disaggregation-bootstrap-port $DBOOT

--- a/scripts/ci/slurm/nightly-configs.yaml
+++ b/scripts/ci/slurm/nightly-configs.yaml
@@ -117,3 +117,73 @@ dsv4pro-fp4-mi355x-sglang:
       search-space:
         - conc-list: [1, 8, 16, 32, 64, 128, 256]
           config_file: scripts/ci/slurm/recipes/mi355x-fp4/dsv4pro/1k1k/1p1d.yaml
+
+# AMD MI355X 2-node 1P1D disaggregation over **NIXL** KV transfer (same four
+# DeepSeek-V4 model x precision combos as the MORI blocks above). The
+# recipe's runtime.transfer_backend=nixl switches launch_mi355x.sh off MORI.
+# NIXL (upstream ai-dynamo/nixl + UCX --with-rocm) is enabled by default in the
+# mainline mi35x image, so these run on a stock nightly image unless it was
+# built --build-arg ENABLE_NIXL=0.
+dsv4flash-fp8-mi355x-nixl-sglang:
+  model: sgl-project/DeepSeek-V4-Flash-FP8
+  model-prefix: dsv4flash
+  model_path: /it-share/model_coverage/models--sgl-project--DeepSeek-V4-Flash-FP8
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d-nixl.yaml
+
+dsv4pro-fp8-mi355x-nixl-sglang:
+  model: sgl-project/DeepSeek-V4-Pro-FP8
+  model-prefix: dsv4pro
+  model_path: /it-share/model_coverage/models--sgl-project--DeepSeek-V4-Pro-FP8
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d-nixl.yaml
+
+dsv4flash-fp4-mi355x-nixl-sglang:
+  model: deepseek-ai/DeepSeek-V4-Flash
+  model-prefix: dsv4flash
+  model_path: /it-share/model_coverage/models--deepseek-ai--DeepSeek-V4-Flash
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d-nixl.yaml
+
+dsv4pro-fp4-mi355x-nixl-sglang:
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4pro
+  model_path: /it-share/model_coverage/models--deepseek-ai--DeepSeek-V4-Pro
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp4/dsv4pro/1k1k/1p1d-nixl.yaml

--- a/scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d-nixl.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d-nixl.yaml
@@ -1,0 +1,60 @@
+# MI355X DeepSeek-V4-Flash (FP4) 2-node 1P1D disaggregation recipe (NIXL KV).
+#
+# Same topology as 1p1d.yaml but transfers KV over NIXL instead of MORI.
+# FP4 enables SGLANG_DSV4_FP4_EXPERTS in launch_mi355x.sh (driven by PRECISION).
+# NIXL (upstream ai-dynamo/nixl + UCX built --with-rocm) is enabled by default in
+# the mainline mi35x ROCm image; only an image built --build-arg ENABLE_NIXL=0
+# lacks it. The workflow's image auto-resolver picks the newest mainline mi35x
+# image, so this just works on a stock nightly image.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime` and `bench`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  attention_backend: dsv4
+  transfer_backend: nixl
+  # RoCE HCAs NIXL uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+  swa_full_tokens_ratio: 0.1
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep
+  # (full GSM8K, 8-shot, accuracy > 0.91). A regression here fails the nightly
+  # even when throughput looks fine ("fast but wrong").
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.91

--- a/scripts/ci/slurm/recipes/mi355x-fp4/dsv4pro/1k1k/1p1d-nixl.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp4/dsv4pro/1k1k/1p1d-nixl.yaml
@@ -1,0 +1,62 @@
+# MI355X DeepSeek-V4-Pro (FP4) 2-node 1P1D disaggregation recipe (NIXL KV).
+#
+# Same topology as 1p1d.yaml but transfers KV over NIXL instead of MORI.
+# FP4 enables SGLANG_DSV4_FP4_EXPERTS in launch_mi355x.sh (driven by PRECISION).
+# NIXL (upstream ai-dynamo/nixl + UCX built --with-rocm) is enabled by default in
+# the mainline mi35x ROCm image; only an image built --build-arg ENABLE_NIXL=0
+# lacks it. The workflow's image auto-resolver picks the newest mainline mi35x
+# image, so this just works on a stock nightly image.
+# Pro mirrors the Flash topology (TP8 1P1D) as a starting point; Pro weights are
+# larger, so mem_fraction_static / max_running_requests may need tuning.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime` and `bench`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  attention_backend: dsv4
+  transfer_backend: nixl
+  # RoCE HCAs NIXL uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+  swa_full_tokens_ratio: 0.1
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep
+  # (full GSM8K, 8-shot, accuracy > 0.91). A regression here fails the nightly
+  # even when throughput looks fine ("fast but wrong").
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.91

--- a/scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d-nixl.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d-nixl.yaml
@@ -1,0 +1,59 @@
+# MI355X DeepSeek-V4-Flash-FP8 2-node 1P1D disaggregation recipe (NIXL KV).
+#
+# Same topology as 1p1d.yaml but transfers KV over NIXL instead of MORI.
+# NIXL (upstream ai-dynamo/nixl + UCX built --with-rocm) is enabled by default in
+# the mainline mi35x ROCm image; only an image built --build-arg ENABLE_NIXL=0
+# lacks it. The workflow's image auto-resolver picks the newest mainline mi35x
+# image, so this just works on a stock nightly image.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime` and `bench`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  attention_backend: dsv4
+  transfer_backend: nixl
+  # RoCE HCAs NIXL uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+  swa_full_tokens_ratio: 0.1
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep
+  # (full GSM8K, 8-shot, accuracy > 0.91). A regression here fails the nightly
+  # even when throughput looks fine ("fast but wrong").
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.91

--- a/scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d-nixl.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d-nixl.yaml
@@ -1,0 +1,61 @@
+# MI355X DeepSeek-V4-Pro-FP8 2-node 1P1D disaggregation recipe (NIXL KV).
+#
+# Same topology as 1p1d.yaml but transfers KV over NIXL instead of MORI.
+# NIXL (upstream ai-dynamo/nixl + UCX built --with-rocm) is enabled by default in
+# the mainline mi35x ROCm image; only an image built --build-arg ENABLE_NIXL=0
+# lacks it. The workflow's image auto-resolver picks the newest mainline mi35x
+# image, so this just works on a stock nightly image.
+# Pro mirrors the Flash topology (TP8 1P1D) as a starting point; Pro weights are
+# larger, so mem_fraction_static / max_running_requests may need tuning.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime` and `bench`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  attention_backend: dsv4
+  transfer_backend: nixl
+  # RoCE HCAs NIXL uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+  swa_full_tokens_ratio: 0.1
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep
+  # (full GSM8K, 8-shot, accuracy > 0.91). A regression here fails the nightly
+  # even when throughput looks fine ("fast but wrong").
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.91


### PR DESCRIPTION
## Summary

Extends the MI355X 1P1D disaggregation nightly (added in #29084) with a **NIXL** KV-transfer backend across all four DeepSeek-V4 model x precision combos (Flash/Pro x FP8/FP4).

- `launch_mi355x.sh` now reads `runtime.transfer_backend` from the recipe (defaults to `mori`) instead of hardcoding `mori`, and only applies the MORI-specific XGMI toggle on the mori path; nixl uses the standard NCCL/RDMA control-plane env.
- 4 new recipes `recipes/mi355x-{fp8,fp4}/dsv4{flash,pro}/1k1k/1p1d-nixl.yaml` (same TP8 1P1D topology + GSM8K accuracy gate as the MORI recipes, with `transfer_backend: nixl`).
- 4 new matrix entries in `nightly-configs.yaml`.

NIXL (upstream ai-dynamo/nixl + UCX built `--with-rocm`) ships enabled by default in the mainline mi35x ROCm image, so these run on a stock nightly image unless it was built `--build-arg ENABLE_NIXL=0`.

## Test plan
- [ ] Trigger the MI355X disagg nightly and confirm the 4 nixl legs come up, pass the GSM8K gate, and emit perf results.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28418320733](https://github.com/sgl-project/sglang/actions/runs/28418320733)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28418320656](https://github.com/sgl-project/sglang/actions/runs/28418320656)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->