### PR TITLE
[CI] Migrate more JIT configs

### DIFF
--- a/test/registered/dcp/test_reduce_scatter_along_dim.py
+++ b/test/registered/dcp/test_reduce_scatter_along_dim.py
@@ -29,7 +29,8 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(
     est_time=120,
-    suite="base-b-kernel-unit-8-gpu-h200",
+    stage="base-b-kernel-unit",
+    runner_config="8-gpu-h200",
 )
 
 # ---------------------------------------------------------------------------

--- a/test/registered/jit/benchmark/bench_dsv3_fused_a_gemm.py
+++ b/test/registered/jit/benchmark/bench_dsv3_fused_a_gemm.py
@@ -20,7 +20,9 @@ from sglang.srt.utils.common import is_sm120_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.utils import is_in_ci
 
-register_cuda_ci(est_time=12, suite="base-b-kernel-benchmark-1-gpu-large")
+register_cuda_ci(
+    est_time=12, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
 
 IS_CI = is_in_ci()
 

--- a/test/registered/jit/benchmark/bench_dsv3_router_gemm.py
+++ b/test/registered/jit/benchmark/bench_dsv3_router_gemm.py
@@ -18,7 +18,9 @@ from sglang.jit_kernel.dsv3_router_gemm import dsv3_router_gemm
 from sglang.jit_kernel.utils import get_jit_cuda_arch, is_hip_runtime
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=5, suite="base-b-kernel-benchmark-1-gpu-large")
+register_cuda_ci(
+    est_time=5, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
 
 # sgl_kernel AOT kernel is specialized for hidden_dim=7168 only.
 SGL_KERNEL_HIDDEN_DIM = 7168

--- a/test/registered/jit/benchmark/bench_sparse_mla_q8kv8_prefill_sm90.py
+++ b/test/registered/jit/benchmark/bench_sparse_mla_q8kv8_prefill_sm90.py
@@ -20,7 +20,9 @@ except ImportError:
     flash_mla_sparse_fwd = None
     HAS_Q16_FLASHMLA = False
 
-register_cuda_ci(est_time=120, suite="base-b-kernel-benchmark-1-gpu-large")
+register_cuda_ci(
+    est_time=120, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
 
 IS_CI = is_in_ci()
 DTYPE_FP8 = torch.float8_e4m3fn

--- a/test/registered/jit/benchmark/bench_symm_mem_all_gather.py
+++ b/test/registered/jit/benchmark/bench_symm_mem_all_gather.py
@@ -37,7 +37,8 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(
     est_time=120,
-    suite="base-b-kernel-benchmark-1-gpu-large",
+    stage="base-b-kernel-benchmark",
+    runner_config="1-gpu-large",
     disabled="requires multi-GPU, self-skips in CI",
 )
 

--- a/test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py
+++ b/test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py
@@ -13,7 +13,8 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(
     est_time=20,
-    suite="base-b-kernel-benchmark-1-gpu-large",
+    stage="base-b-kernel-benchmark",
+    runner_config="1-gpu-large",
     disabled="standalone benchmark",
 )
 

--- a/test/registered/jit/benchmark/diffusion/bench_residual_gate_add.py
+++ b/test/registered/jit/benchmark/diffusion/bench_residual_gate_add.py
@@ -9,7 +9,9 @@ from sglang.jit_kernel.diffusion.triton.scale_shift import fuse_scale_shift_kern
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.utils import is_in_ci
 
-register_cuda_ci(est_time=30, suite="base-b-kernel-benchmark-1-gpu-large")
+register_cuda_ci(
+    est_time=30, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
 
 
 @dataclass(frozen=True)

--- a/test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py
+++ b/test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py
@@ -12,8 +12,8 @@ from sglang.jit_kernel.diffusion.triton.causal_conv3d_pad import (
 from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=45, suite="base-b-kernel-unit-1-gpu-large")
-register_cuda_ci(est_time=45, suite="base-b-kernel-unit-1-gpu-b200")
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16

--- a/test/registered/jit/diffusion/test_ltx2_ada_values.py
+++ b/test/registered/jit/diffusion/test_ltx2_ada_values.py
@@ -6,7 +6,7 @@ import torch
 from sglang.jit_kernel.diffusion.triton.ltx2_ada_values import ltx2_ada_values9
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=8, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=8, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 DEVICE = "cuda"
 

--- a/test/registered/jit/diffusion/test_residual_gate_add.py
+++ b/test/registered/jit/diffusion/test_residual_gate_add.py
@@ -9,8 +9,8 @@ from sglang.jit_kernel.diffusion.residual_gate_add import (
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
-register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-b200")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
 
 
 CASES = [

--- a/test/registered/jit/test_cutedsl_dsv3_fused_a_gemm.py
+++ b/test/registered/jit/test_cutedsl_dsv3_fused_a_gemm.py
@@ -9,7 +9,7 @@ from sglang.jit_kernel.cutedsl_dsv3_fused_a_gemm import dsv3_fused_a_gemm
 from sglang.jit_kernel.utils import get_jit_cuda_arch, is_hip_runtime
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 # hd_in must be a multiple of 256; 6144/7168 cover the real fused-A shapes.
 HD_INS = [6144, 7168]

--- a/test/registered/jit/test_dsv32_indexer_fusion.py
+++ b/test/registered/jit/test_dsv32_indexer_fusion.py
@@ -31,7 +31,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 _is_hip = is_hip()
 
-register_cuda_ci(est_time=45, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=90, suite="nightly-kernel-1-gpu", nightly=True)
 
 HEAD_DIM = 128

--- a/test/registered/jit/test_dsv3_fused_a_gemm.py
+++ b/test/registered/jit/test_dsv3_fused_a_gemm.py
@@ -10,7 +10,7 @@ from sglang.jit_kernel.dsv3_fused_a_gemm import dsv3_fused_a_gemm
 from sglang.jit_kernel.utils import get_jit_cuda_arch, is_hip_runtime
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 # hd_in must be a multiple of 256; 6144/7168 cover the real fused-A shapes.
 HD_INS = [6144, 7168]

--- a/test/registered/jit/test_dsv3_router_gemm.py
+++ b/test/registered/jit/test_dsv3_router_gemm.py
@@ -9,7 +9,7 @@ from sglang.jit_kernel.dsv3_router_gemm import dsv3_router_gemm
 from sglang.jit_kernel.utils import get_jit_cuda_arch, is_hip_runtime
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=37, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=37, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=148, suite="nightly-kernel-1-gpu", nightly=True)
 
 HIDDEN_DIMS = [1024, 4096, 5120, 6144, 7168]

--- a/test/registered/jit/test_silu_and_mul_scaled_fp4_experts_quant_packed.py
+++ b/test/registered/jit/test_silu_and_mul_scaled_fp4_experts_quant_packed.py
@@ -47,7 +47,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 # The NVFP4 expert-quant kernels are Blackwell-only (sm100a), so this runs on
 # the B200 unit suite.
-register_cuda_ci(est_time=20, suite="base-b-kernel-unit-1-gpu-b200")
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
 
 FLOAT8_E4M3_MAX = 448.0
 FLOAT4_E2M1_MAX = 6.0

--- a/test/registered/jit/test_sparse_mla_q8kv8_prefill_sm90.py
+++ b/test/registered/jit/test_sparse_mla_q8kv8_prefill_sm90.py
@@ -9,7 +9,7 @@ import torch
 from sglang.srt.utils import is_sm90_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=120, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=300, suite="nightly-kernel-1-gpu", nightly=True)
 
 

--- a/test/registered/jit/test_symm_mem_all_gather.py
+++ b/test/registered/jit/test_symm_mem_all_gather.py
@@ -34,7 +34,7 @@ from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=240, suite="base-b-kernel-unit-8-gpu-h200")
+register_cuda_ci(est_time=240, stage="base-b-kernel-unit", runner_config="8-gpu-h200")
 register_cuda_ci(est_time=240, suite="nightly-kernel-8-gpu-h200", nightly=True)
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #29066 for a few missed JIT runner configs that were failing CI













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28421542247](https://github.com/sgl-project/sglang/actions/runs/28421542247)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28421542138](https://github.com/sgl-project/sglang/actions/runs/28421542138)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->