### PR TITLE
[CI] Migrate JIT tests missed by #29066 to runner_config registration

### DIFF
--- a/scripts/ci/check_registered_tests.py
+++ b/scripts/ci/check_registered_tests.py
@@ -4,13 +4,18 @@ Pre-commit hook: validate CI registry calls under test/registered/.
 
 1. Every test file must contain a CI registry call (register_cuda_ci,
    register_amd_ci, etc.).
-2. A CUDA test must not register a `{stage}-test-{runner_config}`-shaped suite
-   via the legacy single-string `suite=`: that form is not dispatchable via
-   /rerun-test. Use the modern `stage=`/`runner_config=` form instead -- it
-   resolves to the identical suite (CIRegistry.effective_suite is
-   f"{stage}-test-{runner_config}"), so same stage and same runner, just
-   /rerun-test-able. Legacy `suite=` stays valid for nightly/stress/weekly +
-   AMD/CPU/NPU suites whose names don't follow that shape.
+2. A CUDA test must register its PR-test suite via the modern
+   `stage=`/`runner_config=` form. The legacy single-string `suite=` is reserved
+   for the nightly/stress/weekly families (and for AMD/CPU/NPU suites); any other
+   CUDA `suite=` resolves to a name no PR-test workflow invokes, so the test
+   silently never runs. Two shapes are rejected:
+     a. `{stage}-test-{runner_config}` -- the modern name stuffed back into the
+        legacy form. Reported with the exact stage/runner split to use.
+     b. an older `{stage}-{runner_config}` PR-test name (e.g. the pre-migration
+        `base-b-kernel-unit-1-gpu-large`) -- no longer matches any workflow
+        suite at all.
+   The modern form resolves to the identical suite (CIRegistry.effective_suite
+   is f"{stage}-test-{runner_config}") and is /rerun-test-able.
 
 Reuses ut_parse_one_file() from ci_register.py (AST-based parsing)
 to match the same logic used by run_suite.py's collect_tests().
@@ -26,6 +31,12 @@ import sys
 # modern stage=/runner_config= form produces, so a legacy suite= carrying this
 # shape is always expressible (and should be expressed) the modern way.
 _MODERN_SHAPE = re.compile(r"^(.+)-test-(.+)$")
+
+# The only suite families a CUDA registry may keep on the legacy single-string
+# `suite=` form. Everything else is a PR-test/base stage that must use the
+# modern stage=/runner_config= form (otherwise its effective_suite matches no
+# suite the PR-test workflows invoke, and the test silently never runs).
+_LEGACY_CUDA_PREFIXES = ("nightly", "stress", "weekly")
 
 
 def main() -> int:
@@ -48,7 +59,8 @@ def main() -> int:
         return 0
 
     missing = []
-    legacy_shape = []  # (file, suite, stage, runner_config)
+    legacy_shape = []  # (file, suite, stage, runner_config) -- has a -test- split
+    non_dispatchable = []  # (file, suite) -- legacy CUDA suite no workflow invokes
     for f in files:
         try:
             registries, _has_main_entry = ci_register.ut_parse_one_file(f)
@@ -67,9 +79,15 @@ def main() -> int:
                 and r.runner_config is None
             ):
                 continue
+            # nightly/stress/weekly are the only CUDA suites allowed to stay on
+            # the legacy single-string form.
+            if r.suite.split("-", 1)[0] in _LEGACY_CUDA_PREFIXES:
+                continue
             m = _MODERN_SHAPE.match(r.suite)
             if m:
                 legacy_shape.append((f, r.suite, m.group(1), m.group(2)))
+            else:
+                non_dispatchable.append((f, r.suite))
 
     exit_code = 0
     if missing:
@@ -91,6 +109,21 @@ def main() -> int:
                 f"  {f}\n"
                 f'    suite="{suite}"'
                 f'  ->  stage="{stage}", runner_config="{runner_config}"'
+            )
+        print()
+        exit_code = 1
+    if non_dispatchable:
+        print(
+            'ERROR: CUDA test(s) register a legacy `suite="..."` that is neither a '
+            "nightly/stress/weekly suite nor the modern `stage=`/`runner_config=` "
+            "form. This name matches no suite the PR-test workflows invoke, so the "
+            "test silently never runs. Switch to the modern form:\n"
+        )
+        for f, suite in non_dispatchable:
+            print(
+                f"  {f}\n"
+                f'    suite="{suite}"'
+                f'  ->  stage="...", runner_config="..."'
             )
         print()
         exit_code = 1

--- a/test/registered/dcp/test_reduce_scatter_along_dim.py
+++ b/test/registered/dcp/test_reduce_scatter_along_dim.py
@@ -29,7 +29,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(
     est_time=120,
-    stage="base-b-kernel-unit",
+    stage="extra-b",
     runner_config="8-gpu-h200",
 )
 

--- a/test/registered/dcp/test_reduce_scatter_along_dim.py
+++ b/test/registered/dcp/test_reduce_scatter_along_dim.py
@@ -29,7 +29,8 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(
     est_time=120,
-    suite="base-b-kernel-unit-8-gpu-h200",
+    stage="base-b-kernel-unit",
+    runner_config="8-gpu-h200",
 )
 
 # ---------------------------------------------------------------------------

--- a/test/registered/jit/benchmark/bench_dsv3_fused_a_gemm.py
+++ b/test/registered/jit/benchmark/bench_dsv3_fused_a_gemm.py
@@ -20,7 +20,7 @@ from sglang.srt.utils.common import is_sm120_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.utils import is_in_ci
 
-register_cuda_ci(est_time=12, suite="base-b-kernel-benchmark-1-gpu-large")
+register_cuda_ci(est_time=12, stage="base-b-kernel-benchmark", runner_config="1-gpu-large")
 
 IS_CI = is_in_ci()
 

--- a/test/registered/jit/benchmark/bench_dsv3_fused_a_gemm.py
+++ b/test/registered/jit/benchmark/bench_dsv3_fused_a_gemm.py
@@ -20,7 +20,9 @@ from sglang.srt.utils.common import is_sm120_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.utils import is_in_ci
 
-register_cuda_ci(est_time=12, stage="base-b-kernel-benchmark", runner_config="1-gpu-large")
+register_cuda_ci(
+    est_time=12, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
 
 IS_CI = is_in_ci()
 

--- a/test/registered/jit/benchmark/bench_dsv3_router_gemm.py
+++ b/test/registered/jit/benchmark/bench_dsv3_router_gemm.py
@@ -18,7 +18,7 @@ from sglang.jit_kernel.dsv3_router_gemm import dsv3_router_gemm
 from sglang.jit_kernel.utils import get_jit_cuda_arch, is_hip_runtime
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=5, suite="base-b-kernel-benchmark-1-gpu-large")
+register_cuda_ci(est_time=5, stage="base-b-kernel-benchmark", runner_config="1-gpu-large")
 
 # sgl_kernel AOT kernel is specialized for hidden_dim=7168 only.
 SGL_KERNEL_HIDDEN_DIM = 7168

--- a/test/registered/jit/benchmark/bench_dsv3_router_gemm.py
+++ b/test/registered/jit/benchmark/bench_dsv3_router_gemm.py
@@ -18,7 +18,9 @@ from sglang.jit_kernel.dsv3_router_gemm import dsv3_router_gemm
 from sglang.jit_kernel.utils import get_jit_cuda_arch, is_hip_runtime
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=5, stage="base-b-kernel-benchmark", runner_config="1-gpu-large")
+register_cuda_ci(
+    est_time=5, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
 
 # sgl_kernel AOT kernel is specialized for hidden_dim=7168 only.
 SGL_KERNEL_HIDDEN_DIM = 7168

--- a/test/registered/jit/benchmark/bench_sparse_mla_q8kv8_prefill_sm90.py
+++ b/test/registered/jit/benchmark/bench_sparse_mla_q8kv8_prefill_sm90.py
@@ -20,7 +20,9 @@ except ImportError:
     flash_mla_sparse_fwd = None
     HAS_Q16_FLASHMLA = False
 
-register_cuda_ci(est_time=120, stage="base-b-kernel-benchmark", runner_config="1-gpu-large")
+register_cuda_ci(
+    est_time=120, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
 
 IS_CI = is_in_ci()
 DTYPE_FP8 = torch.float8_e4m3fn

--- a/test/registered/jit/benchmark/bench_sparse_mla_q8kv8_prefill_sm90.py
+++ b/test/registered/jit/benchmark/bench_sparse_mla_q8kv8_prefill_sm90.py
@@ -20,7 +20,7 @@ except ImportError:
     flash_mla_sparse_fwd = None
     HAS_Q16_FLASHMLA = False
 
-register_cuda_ci(est_time=120, suite="base-b-kernel-benchmark-1-gpu-large")
+register_cuda_ci(est_time=120, stage="base-b-kernel-benchmark", runner_config="1-gpu-large")
 
 IS_CI = is_in_ci()
 DTYPE_FP8 = torch.float8_e4m3fn

--- a/test/registered/jit/benchmark/bench_symm_mem_all_gather.py
+++ b/test/registered/jit/benchmark/bench_symm_mem_all_gather.py
@@ -37,7 +37,8 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(
     est_time=120,
-    suite="base-b-kernel-benchmark-1-gpu-large",
+    stage="base-b-kernel-benchmark",
+    runner_config="1-gpu-large",
     disabled="requires multi-GPU, self-skips in CI",
 )
 

--- a/test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py
+++ b/test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py
@@ -13,7 +13,8 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(
     est_time=20,
-    suite="base-b-kernel-benchmark-1-gpu-large",
+    stage="base-b-kernel-benchmark",
+    runner_config="1-gpu-large",
     disabled="standalone benchmark",
 )
 

--- a/test/registered/jit/benchmark/diffusion/bench_residual_gate_add.py
+++ b/test/registered/jit/benchmark/diffusion/bench_residual_gate_add.py
@@ -9,7 +9,9 @@ from sglang.jit_kernel.diffusion.triton.scale_shift import fuse_scale_shift_kern
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.utils import is_in_ci
 
-register_cuda_ci(est_time=30, stage="base-b-kernel-benchmark", runner_config="1-gpu-large")
+register_cuda_ci(
+    est_time=30, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
 
 
 @dataclass(frozen=True)

--- a/test/registered/jit/benchmark/diffusion/bench_residual_gate_add.py
+++ b/test/registered/jit/benchmark/diffusion/bench_residual_gate_add.py
@@ -9,7 +9,7 @@ from sglang.jit_kernel.diffusion.triton.scale_shift import fuse_scale_shift_kern
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.utils import is_in_ci
 
-register_cuda_ci(est_time=30, suite="base-b-kernel-benchmark-1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-benchmark", runner_config="1-gpu-large")
 
 
 @dataclass(frozen=True)

--- a/test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py
+++ b/test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py
@@ -12,8 +12,8 @@ from sglang.jit_kernel.diffusion.triton.causal_conv3d_pad import (
 from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=45, suite="base-b-kernel-unit-1-gpu-large")
-register_cuda_ci(est_time=45, suite="base-b-kernel-unit-1-gpu-b200")
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16

--- a/test/registered/jit/diffusion/test_ltx2_ada_values.py
+++ b/test/registered/jit/diffusion/test_ltx2_ada_values.py
@@ -6,7 +6,7 @@ import torch
 from sglang.jit_kernel.diffusion.triton.ltx2_ada_values import ltx2_ada_values9
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=8, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=8, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 DEVICE = "cuda"
 

--- a/test/registered/jit/diffusion/test_residual_gate_add.py
+++ b/test/registered/jit/diffusion/test_residual_gate_add.py
@@ -9,8 +9,8 @@ from sglang.jit_kernel.diffusion.residual_gate_add import (
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
-register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-b200")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
 
 
 CASES = [

--- a/test/registered/jit/test_cutedsl_dsv3_fused_a_gemm.py
+++ b/test/registered/jit/test_cutedsl_dsv3_fused_a_gemm.py
@@ -9,7 +9,7 @@ from sglang.jit_kernel.cutedsl_dsv3_fused_a_gemm import dsv3_fused_a_gemm
 from sglang.jit_kernel.utils import get_jit_cuda_arch, is_hip_runtime
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 # hd_in must be a multiple of 256; 6144/7168 cover the real fused-A shapes.
 HD_INS = [6144, 7168]

--- a/test/registered/jit/test_dsv32_indexer_fusion.py
+++ b/test/registered/jit/test_dsv32_indexer_fusion.py
@@ -31,7 +31,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 _is_hip = is_hip()
 
-register_cuda_ci(est_time=45, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=90, suite="nightly-kernel-1-gpu", nightly=True)
 
 HEAD_DIM = 128

--- a/test/registered/jit/test_dsv3_fused_a_gemm.py
+++ b/test/registered/jit/test_dsv3_fused_a_gemm.py
@@ -10,7 +10,7 @@ from sglang.jit_kernel.dsv3_fused_a_gemm import dsv3_fused_a_gemm
 from sglang.jit_kernel.utils import get_jit_cuda_arch, is_hip_runtime
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 # hd_in must be a multiple of 256; 6144/7168 cover the real fused-A shapes.
 HD_INS = [6144, 7168]

--- a/test/registered/jit/test_dsv3_router_gemm.py
+++ b/test/registered/jit/test_dsv3_router_gemm.py
@@ -9,7 +9,7 @@ from sglang.jit_kernel.dsv3_router_gemm import dsv3_router_gemm
 from sglang.jit_kernel.utils import get_jit_cuda_arch, is_hip_runtime
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=37, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=37, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=148, suite="nightly-kernel-1-gpu", nightly=True)
 
 HIDDEN_DIMS = [1024, 4096, 5120, 6144, 7168]

--- a/test/registered/jit/test_silu_and_mul_scaled_fp4_experts_quant_packed.py
+++ b/test/registered/jit/test_silu_and_mul_scaled_fp4_experts_quant_packed.py
@@ -47,7 +47,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 # The NVFP4 expert-quant kernels are Blackwell-only (sm100a), so this runs on
 # the B200 unit suite.
-register_cuda_ci(est_time=20, suite="base-b-kernel-unit-1-gpu-b200")
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
 
 FLOAT8_E4M3_MAX = 448.0
 FLOAT4_E2M1_MAX = 6.0

--- a/test/registered/jit/test_sparse_mla_q8kv8_prefill_sm90.py
+++ b/test/registered/jit/test_sparse_mla_q8kv8_prefill_sm90.py
@@ -9,7 +9,7 @@ import torch
 from sglang.srt.utils import is_sm90_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=120, suite="base-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=300, suite="nightly-kernel-1-gpu", nightly=True)
 
 

--- a/test/registered/jit/test_symm_mem_all_gather.py
+++ b/test/registered/jit/test_symm_mem_all_gather.py
@@ -34,7 +34,7 @@ from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=240, suite="base-b-kernel-unit-8-gpu-h200")
+register_cuda_ci(est_time=240, stage="base-b-kernel-unit", runner_config="8-gpu-h200")
 register_cuda_ci(est_time=240, suite="nightly-kernel-8-gpu-h200", nightly=True)
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

#29066 migrated the PR-test JIT kernel suites from the legacy `suite=` string to explicit `stage=`/`runner_config=` metadata, and **renamed** those suites to the generated `<stage>-test-<runner_config>` form (note the `-test-` infix that `effective_suite` produces). The `pr-test-jit-kernel.yml` workflow was updated to invoke the renamed suites (`base-b-kernel-unit-test-1-gpu-large`, etc.).

That migration sweep was frozen on #29066's last code commit (2026-06-26), but the PR didn't merge until 2026-06-30. During that ~4-day review window, **9 other JIT-kernel PRs merged to main**, each registering with the old `suite="base-b-kernel-..."` convention. Because the squash merge only applies the recorded diff (it doesn't re-sweep main), those newly-added files were never converted.

As a result, their `effective_suite` stayed in the old no-`-test-` shape (e.g. `base-b-kernel-unit-1-gpu-large`) and **no longer matches any suite the workflow invokes — so they were silently dropped from PR CI.**

## Fix

**1. Migrate the missed registrations** to `stage=`/`runner_config=`. Nightly/AMD registrations (e.g. `nightly-kernel-1-gpu`) are intentionally left on the legacy `suite=` form — that's still the supported shape for suites that don't follow `{stage}-test-{runner_config}`.

⚠️ The **three B200 registrations** additionally pointed at the now-removed `1-gpu-b200` runner; they're repointed at the standardized `4-gpu-b200` used by every other migrated B200 test (the only B200 job the workflow defines).

**2. Close the validator hole that allowed this.** `scripts/ci/check_registered_tests.py` (the `check-registered-tests` pre-commit hook, also enforced in `lint.yml`) only rejected legacy `suite=` of the `{stage}-test-{runner_config}` shape — it matched names containing `-test-`, so the *old* dead shape (`base-b-kernel-unit-1-gpu-large`, no `-test-`) slipped through. Tighten it: a CUDA registry may keep the legacy single-string `suite=` **only** for the nightly/stress/weekly families; any other CUDA `suite=` must use the modern form. This fails a non-dispatchable suite name at pre-commit/CI regardless of merge ordering, so a stale PR can no longer reintroduce this bug.

**3. Re-home a mis-categorized test the guard surfaced.** `test/registered/dcp/test_reduce_scatter_along_dim.py` registered `base-b-kernel-unit-8-gpu-h200` — but it isn't a kernel test: it checks `GroupCoordinator.reduce_scatter_along_dim` (a `parallel_state` device-comm wrapper) against `torch.distributed.reduce_scatter_tensor`, with no `jit_kernel`/`sgl_kernel` import. #29066 missed it because it lives outside `test/registered/jit/`, and it was silently dropped too. Moved it to `stage="extra-b"` / `runner_config="8-gpu-h200"` — same 8×H200 runner, but the correct workflow (`pr-test-extra.yml`), matching its `dcp/` sibling `test_dsv31_dcp8_gsm8k.py` and the `cp/pp/ep` distributed-test convention.

### JIT files migrated, by resolved suite

**`base-b-kernel-unit` / `1-gpu-large`**
- `test/registered/jit/test_dsv3_router_gemm.py` (#21531)
- `test/registered/jit/test_dsv3_fused_a_gemm.py` (#27397)
- `test/registered/jit/test_cutedsl_dsv3_fused_a_gemm.py` (#27397)
- `test/registered/jit/test_dsv32_indexer_fusion.py` (#27705)
- `test/registered/jit/test_sparse_mla_q8kv8_prefill_sm90.py` (#25751)
- `test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py` (#29281)
- `test/registered/jit/diffusion/test_residual_gate_add.py` (#29361)
- `test/registered/jit/diffusion/test_ltx2_ada_values.py` (#29390)

**`base-b-kernel-unit` / `8-gpu-h200`**
- `test/registered/jit/test_symm_mem_all_gather.py` (#29223)

**`base-b-kernel-unit` / `4-gpu-b200`** (was the removed `1-gpu-b200`)
- `test/registered/jit/test_silu_and_mul_scaled_fp4_experts_quant_packed.py` (#18612)
- `test/registered/jit/diffusion/test_causal_conv3d_cat_pad.py` (#29281)
- `test/registered/jit/diffusion/test_residual_gate_add.py` (#29361)

**`base-b-kernel-benchmark` / `1-gpu-large`**
- `test/registered/jit/benchmark/bench_dsv3_fused_a_gemm.py` (#27397)
- `test/registered/jit/benchmark/bench_dsv3_router_gemm.py` (#21531)
- `test/registered/jit/benchmark/bench_sparse_mla_q8kv8_prefill_sm90.py` (#25751)
- `test/registered/jit/benchmark/bench_symm_mem_all_gather.py` (#29223)
- `test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py` (#29281)
- `test/registered/jit/benchmark/diffusion/bench_residual_gate_add.py` (#29361)

### Re-homed (not a kernel test)
- `test/registered/dcp/test_reduce_scatter_along_dim.py` (#14194): `base-b-kernel-unit-8-gpu-h200` → `extra-b` / `8-gpu-h200`

## Test plan
- `python3 scripts/ci/check_registered_tests.py` → exit 0 on the full tree.
- Regression-checked the strengthened guard: reintroducing an old-shape `base-…` suite makes it exit 1 with the offending file listed.
- Parsed each edited file via `ut_parse_one_file` and confirmed `effective_suite` resolves to the suites the workflows invoke (`base-b-kernel-*-test-*` for the JIT files; `extra-b-test-8-gpu-h200` for the re-homed comm test), while nightly registrations are unchanged.
- `/rerun-test test/registered/jit/*` to exercise the re-dispatched 1-gpu/b200 JIT tests on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28424359118](https://github.com/sgl-project/sglang/actions/runs/28424359118)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28424358988](https://github.com/sgl-project/sglang/actions/runs/28424358988)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->