### PR TITLE
[Bugfix][ModelLoader] fix fastsafetensors multi-node device + configurable bbuf/threads

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -577,6 +577,8 @@ class DefaultModelLoader(BaseModelLoader):
             if self.load_config.load_format == LoadFormat.FASTSAFETENSORS:
                 weights_iterator = fastsafetensors_weights_iterator(
                     hf_weights_files,
+                    bbuf_size_kb=server_args.weight_loader_fastsafetensors_bbuf_size_kb,
+                    max_threads=server_args.weight_loader_fastsafetensors_max_threads,
                 )
             elif use_multithread:
                 weights_iterator = buffered_multi_thread_safetensors_weights_iterator(

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -966,6 +966,8 @@ def safetensors_weights_iterator(
 
 def fastsafetensors_weights_iterator(
     hf_weights_files: List[str],
+    bbuf_size_kb: int = 16 * 1024,
+    max_threads: int = 16,
 ) -> Generator[Tuple[str, torch.Tensor], None, None]:
     """
     Iterate over the weights in the model safetensor files
@@ -981,12 +983,7 @@ def fastsafetensors_weights_iterator(
     else:
         pg = SingleGroup()
 
-    try:
-        rank = pg.rank()
-    except Exception:
-        rank = 0
-
-    device = torch.device(f"cuda:{rank}")
+    device = torch.device(f"cuda:{torch.cuda.current_device()}")
 
     weight_files_sub_lists = [
         hf_weights_files[i : i + pg.size()]
@@ -1003,7 +1000,12 @@ def fastsafetensors_weights_iterator(
         disable=False,
         bar_format=_BAR_FORMAT,
     ):
-        loader = SafeTensorsFileLoader(pg, device)
+        loader = SafeTensorsFileLoader(
+            pg,
+            device,
+            bbuf_size_kb=bbuf_size_kb,
+            max_threads=max_threads,
+        )
         rank_file_map = {i: [f] for i, f in enumerate(f_list)}
         loader.add_filenames(rank_file_map)
         try:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2440,6 +2440,14 @@ class ServerArgs:
         bool,
         "Call posix_fadvise(DONTNEED) on each safetensors shard after loading it.",
     ] = False
+    weight_loader_fastsafetensors_bbuf_size_kb: A[
+        int,
+        "Bounce buffer size in KB for fastsafetensors loader (default: 16384 = 16MB).",
+    ] = 16 * 1024
+    weight_loader_fastsafetensors_max_threads: A[
+        int,
+        "Max threads for fastsafetensors loader (default: 16).",
+    ] = 16
     remote_instance_weight_loader_seed_instance_ip: A[
         Optional[str],
         "The ip of the seed instance for loading weights from remote instance.",


### PR DESCRIPTION
Problem

     --load-format fastsafetensors has two issues:

     1. Multi-node crash: fastsafetensors_weights_iterator uses pg.rank() (global rank) as CUDA device index. On multi-node TP, global rank exceeds local GPU count (e.g. rank 11 on a 8-GPU node → cuda:11
     does not exist), causing a crash during weight loading.

     2. Hardcoded buffer/thread params: SafeTensorsFileLoader is constructed with default bbuf_size_kb=16384 (16MB) and max_threads=16 with no way to tune them. On high-bandwidth storage (e.g. GPFS), a
     larger bounce buffer and more threads can significantly improve load speed.
     Changes

     1. Device fix: Replace pg.rank() with torch.cuda.current_device(). By the time weight loading runs, the model runner has already set the correct CUDA device for this process. This is correct in both
     single-node and multi-node settings.

     2. Configurable params: Add two CLI args following existing --weight-loader-* naming convention:
        - --weight-loader-fastsafetensors-bbuf-size-kb (default: 16384 = 16MB)
        - --weight-loader-fastsafetensors-max-threads (default: 16)

        These are passed through to SafeTensorsFileLoader(bbuf_size_kb=..., max_threads=...).
     Related

     - #29272 — bug report for the multi-node device crash
     - #26597 — similar fix using env var for nogds; this PR takes a different approach (no env var needed, CLI args for tuning)
     Testing

     Tested on multi-node TP with model weights on GPFS shared storage. cuda:N crash resolved; bbuf_size and max_threads configurable via CLI args.

     Fixes #29272







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28423844643](https://github.com/sgl-project/sglang/actions/runs/28423844643)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28423844545](https://github.com/sgl-project/sglang/actions/runs/28423844545)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->