### PR TITLE
fix: use 64-bit indexing in merge_state_v2 kernel to prevent integer overflow

### DIFF
--- a/sgl-kernel/csrc/attention/merge_attn_states.cu
+++ b/sgl-kernel/csrc/attention/merge_attn_states.cu
@@ -2,6 +2,7 @@
 #include <c10/cuda/CUDAGuard.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <optional>
 
 #include "pytorch_extension_utils.h"
@@ -43,28 +44,30 @@ __global__ void merge_attn_states_kernel(
   const uint pack_size = 16 / sizeof(scalar_t);
   const uint threads_per_head = head_size / pack_size;
 
-  const uint global_idx = blockIdx.x * NUM_THREADS + threadIdx.x;
-  const uint token_head_threads = num_tokens * num_heads * threads_per_head;
+  const int64_t global_idx = static_cast<int64_t>(blockIdx.x) * NUM_THREADS + threadIdx.x;
+  const int64_t token_head_threads = static_cast<int64_t>(num_tokens) * num_heads * threads_per_head;
 
   if (global_idx >= token_head_threads) return;
 
   // global_idx -> token_idx + head_idx + pack_idx
-  const uint token_head_idx = global_idx / threads_per_head;
-  const uint pack_idx = global_idx % threads_per_head;
+  const int64_t token_head_idx = global_idx / threads_per_head;
+  const uint pack_idx = static_cast<uint>(global_idx % threads_per_head);
 
-  const uint token_idx = token_head_idx / num_heads;
-  const uint head_idx = token_head_idx % num_heads;
+  const int64_t token_idx = token_head_idx / num_heads;
+  const uint head_idx = static_cast<uint>(token_head_idx % num_heads);
 
   const uint pack_offset = pack_idx * pack_size;  // (0~15)*8, etc.
-  const uint head_offset = token_idx * num_heads * head_size + head_idx * head_size;
+  const int64_t head_offset =
+      (token_idx * static_cast<int64_t>(num_heads) + head_idx) * static_cast<int64_t>(head_size);
+  const int64_t lse_offset = token_idx * static_cast<int64_t>(num_heads) + head_idx;
   const scalar_t* prefix_head_ptr = prefix_output + head_offset;
   const scalar_t* suffix_head_ptr = suffix_output + head_offset;
   scalar_t* output_head_ptr = output + head_offset;
 
   // float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
   // float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
-  float p_lse = prefix_lse[token_idx * num_heads + head_idx];
-  float s_lse = suffix_lse[token_idx * num_heads + head_idx];
+  float p_lse = prefix_lse[lse_offset];
+  float s_lse = suffix_lse[lse_offset];
   p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
   s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
 
@@ -101,7 +104,7 @@ __global__ void merge_attn_states_kernel(
   // We only need to write to output_lse once per head.
   if (output_lse != nullptr && pack_idx == 0) {
     float out_lse = logf(out_se) + max_lse;
-    output_lse[token_idx * num_heads + head_idx] = out_lse;
+    output_lse[lse_offset] = out_lse;
   }
 }
 
@@ -165,12 +168,15 @@ void merge_attn_states_launcher(
   // Process one pack elements per thread. for float, the
   // pack_size is 4 for half/bf16, the pack_size is 8.
   const uint threads_per_head = head_size / pack_size;
-  const uint total_threads = num_tokens * num_heads * threads_per_head;
+  const int64_t total_threads = static_cast<int64_t>(num_tokens) * num_heads * threads_per_head;
 
   dim3 block(NUM_THREADS);
-  dim3 grid((total_threads + NUM_THREADS - 1) / NUM_THREADS);
-
   const c10::cuda::OptionalCUDAGuard device_guard(prefix_output.device());
+  const int64_t grid_x = (total_threads + NUM_THREADS - 1) / NUM_THREADS;
+  const int64_t max_grid_x = at::cuda::getCurrentDeviceProperties()->maxGridSize[0];
+  TORCH_CHECK(grid_x <= max_grid_x, "merge_attn_states grid.x exceeds device limit: ", grid_x, " > ", max_grid_x);
+  dim3 grid(static_cast<uint>(grid_x));
+
   auto stream = at::cuda::getCurrentCUDAStream();
 
   LAUNCH_MERGE_ATTN_STATES(scalar_t, NUM_THREADS);

--- a/sgl-kernel/tests/test_merge_state_v2.py
+++ b/sgl-kernel/tests/test_merge_state_v2.py
@@ -142,6 +142,24 @@ DTYPES = [torch.half, torch.bfloat16]
 all_case_info: list[tuple] = []
 
 
+def skip_if_not_enough_cuda_memory(required_bytes: int):
+    if not torch.cuda.is_available():
+        pytest.skip(
+            "Currently only support compare triton merge_attn_states "
+            "with custom cuda merge_attn_states kernel"
+        )
+
+    torch.cuda.empty_cache()
+    free_bytes, _ = torch.cuda.mem_get_info()
+    if free_bytes < required_bytes:
+        required_gib = required_bytes / 1024**3
+        free_gib = free_bytes / 1024**3
+        pytest.skip(
+            f"Large merge_state_v2 regression needs {required_gib:.2f} GiB "
+            f"of free GPU memory, but only {free_gib:.2f} GiB is available"
+        )
+
+
 def generate_markdown_table():
     global all_case_info
     table_header = (
@@ -375,6 +393,81 @@ def test_merge_attn_states(
         len(NUM_BATCH_TOKENS) * len(HEAD_SIZES) * len(NUM_QUERY_HEADS) * len(DTYPES)
     ):
         generate_markdown_table()
+
+
+@torch.inference_mode()
+def test_merge_attn_states_large_head_offset_regression():
+    num_heads = 128
+    head_size = 128
+    output_dtype = torch.half
+    first_overflow_token = 2**32 // (num_heads * head_size)
+    num_tokens = first_overflow_token + 8
+    assert first_overflow_token * num_heads * head_size == 2**32
+
+    data_numel = num_tokens * num_heads * head_size
+    lse_numel = num_tokens * num_heads
+    required_bytes = 3 * data_numel * output_dtype.itemsize
+    required_bytes += 3 * lse_numel * torch.float32.itemsize
+    required_bytes = int(required_bytes * 1.1)
+    skip_if_not_enough_cuda_memory(required_bytes)
+
+    try:
+        prefix_output = torch.empty(
+            (num_tokens, num_heads, head_size), dtype=output_dtype, device="cuda"
+        )
+        suffix_output = torch.empty_like(prefix_output)
+        output = torch.empty_like(prefix_output)
+        prefix_lse = torch.empty(
+            (num_tokens, num_heads), dtype=torch.float32, device="cuda"
+        )
+        suffix_lse = torch.empty_like(prefix_lse)
+        output_lse = torch.empty_like(prefix_lse)
+    except torch.cuda.OutOfMemoryError as exc:
+        torch.cuda.empty_cache()
+        pytest.skip(
+            f"Large merge_state_v2 regression could not allocate tensors: {exc}"
+        )
+
+    sample_positions = [
+        (first_overflow_token, 0),
+        (first_overflow_token, 17),
+        (num_tokens - 1, num_heads - 1),
+    ]
+    head_offsets = torch.arange(head_size, dtype=torch.float32, device="cuda")
+
+    for sample_idx, (token_idx, head_idx) in enumerate(sample_positions):
+        prefix_values = 1.0 + sample_idx + head_offsets * 0.01
+        suffix_values = -0.5 - sample_idx + head_offsets * 0.02
+        prefix_output[token_idx, head_idx].copy_(prefix_values.to(output_dtype))
+        suffix_output[token_idx, head_idx].copy_(suffix_values.to(output_dtype))
+        prefix_lse[token_idx, head_idx] = 0.25 + sample_idx
+        suffix_lse[token_idx, head_idx] = -0.75 + sample_idx * 0.5
+        output[token_idx, head_idx].fill_(-123.0)
+        output_lse[token_idx, head_idx] = -123.0
+
+    output, output_lse = merge_state_v2(
+        prefix_output, prefix_lse, suffix_output, suffix_lse, output, output_lse
+    )
+    torch.cuda.synchronize()
+
+    for token_idx, head_idx in sample_positions:
+        p_lse = prefix_lse[token_idx, head_idx]
+        s_lse = suffix_lse[token_idx, head_idx]
+        max_lse = torch.maximum(p_lse, s_lse)
+        p_se = torch.exp(p_lse - max_lse)
+        s_se = torch.exp(s_lse - max_lse)
+        out_se = p_se + s_se
+        expected = prefix_output[token_idx, head_idx].float() * (
+            p_se / out_se
+        ) + suffix_output[token_idx, head_idx].float() * (s_se / out_se)
+        expected_lse = torch.log(out_se) + max_lse
+
+        torch.testing.assert_close(
+            output[token_idx, head_idx].float(), expected, atol=1e-3, rtol=1e-3
+        )
+        torch.testing.assert_close(
+            output_lse[token_idx, head_idx], expected_lse, atol=1e-5, rtol=1e-5
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`merge_state_v2` (the `merge_attn_states_kernel` in `sgl-kernel/csrc/attention/merge_attn_states.cu`) computes flattened element offsets and the total thread count in 32-bit `uint`. For large-batch / long-sequence workloads these products exceed `2^32 - 1` and wrap, so the kernel reads and writes the wrong addresses and silently produces incorrect merge results.

As reported in #29597, with `num_heads=128`, `head_size=128`, `num_tokens=262152`:

```
head_offset = token_idx * num_heads * head_size = 4294967296 > 2^32 - 1
```

The same overflow class affects `num_tokens * num_heads * threads_per_head` (the launcher's total thread count and the kernel's bounds check) and the `global_idx` derived from `blockIdx.x`.

## Modifications

- Promote the overflow-prone index arithmetic in `merge_attn_states_kernel` from 32-bit `uint` to `int64_t`: `global_idx`, `token_head_threads`, the `head_offset` pointer offset, and the flattened LSE index `token_idx * num_heads + head_idx`. Operands are cast before the multiplications so the products are formed in 64-bit. `pack_idx` and `head_idx` are cast back to `uint` for the small per-head computations.
- The kernel's public template signature is unchanged (`num_tokens` / `num_heads` / `head_size` stay as-is), so no Python wiring changes.
- In `merge_attn_states_launcher`, compute `total_threads` in 64-bit and guard the grid `x` dimension against the device's `maxGridSize[0]` with a `TORCH_CHECK` before the `dim3` cast, so an over-large launch fails loudly instead of wrapping.

## Accuracy Tests

The existing parametrized `test_merge_attn_states` cases (float16 / bfloat16 across the small shapes) compare the CUDA v2 kernel against the Triton and Torch references and continue to pass unchanged - the type widening does not alter results in the non-overflow regime.

A new regression, `test_merge_attn_states_large_head_offset_regression`, builds a shape whose `token_idx * num_heads * head_size` crosses the `2^32` boundary (`num_heads=128`, `head_size=128`, tokens past `2^32 / (num_heads * head_size)`) and asserts the merged output and LSE at sampled tokens/heads match a Torch reference. It reproduces the wrong-address read on the unfixed kernel and passes after the fix. The large case needs roughly 27 GiB of free device memory, so it skips when CUDA is unavailable or memory is insufficient (via `torch.cuda.mem_get_info`) rather than OOM-ing the runner.

## Speed Tests and Profiling

No performance impact is expected: the change only widens index integer types and adds a one-time launch-bounds check on the host. The hot per-element loop is unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Fixes #29597







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28426567498](https://github.com/sgl-project/sglang/actions/runs/28426567498)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28426567380](https://github.com/sgl-project/sglang/actions/runs/28426567380)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->