### PR TITLE
[CP] Fix FP8 MLA RoPE for CP prefill on Blackwell

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -49,7 +49,11 @@ from sglang.srt.layers.attention.utils import (
     mla_quantize_and_rope_for_fp8,
     seqlens_expand_triton,
 )
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import (
+    ForwardBatch,
+    ForwardMode,
+    compute_position_torch,
+)
 from sglang.srt.utils import (
     get_bool_env_var,
     is_cuda,
@@ -98,6 +102,32 @@ else:
         flash_attn_varlen_func,
         flash_attn_with_kvcache,
     )
+
+
+def _get_cp_gathered_k_pos_ids(
+    forward_batch: ForwardBatch, q_len: int, k_len: int
+) -> Optional[torch.Tensor]:
+    if q_len == k_len:
+        return None
+    positions = getattr(forward_batch, "positions", None)
+    if positions is not None and positions.numel() == k_len:
+        return positions
+    if (
+        forward_batch.extend_prefix_lens is None
+        or forward_batch.extend_seq_lens is None
+    ):
+        return None
+
+    k_pos_ids, _ = compute_position_torch(
+        forward_batch.extend_prefix_lens,
+        forward_batch.extend_seq_lens,
+    )
+    if k_pos_ids.shape[0] != k_len:
+        raise ValueError(
+            "Unable to build gathered K RoPE positions for FP8 MLA: expected "
+            f"{k_len} positions, got {k_pos_ids.shape[0]}"
+        )
+    return k_pos_ids
 
 
 def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tensor:
@@ -1678,6 +1708,7 @@ class DeepseekSparseAttnBackend(
         cos_sin_cache: Optional[torch.Tensor] = None,
         is_neox: Optional[bool] = False,
         llama_4_scaling: Optional[torch.Tensor] = None,
+        q_pos_ids: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
         causal = not layer.is_cross_attention
@@ -1708,6 +1739,7 @@ class DeepseekSparseAttnBackend(
                 cos_sin_cache,
                 is_neox,
                 llama_4_scaling,
+                q_pos_ids,
                 is_prefill=True,
             )
 
@@ -1913,6 +1945,7 @@ class DeepseekSparseAttnBackend(
         cos_sin_cache: Optional[torch.Tensor] = None,
         is_neox: Optional[bool] = False,
         llama_4_scaling: Optional[torch.Tensor] = None,
+        q_pos_ids: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
         causal = not layer.is_cross_attention
@@ -1934,6 +1967,7 @@ class DeepseekSparseAttnBackend(
                 cos_sin_cache,
                 is_neox,
                 llama_4_scaling,
+                q_pos_ids,
             )
 
         if k is not None:
@@ -2471,6 +2505,7 @@ class DeepseekSparseAttnBackend(
         cos_sin_cache: Optional[torch.Tensor] = None,
         is_neox: Optional[bool] = False,
         llama_4_scaling: Optional[torch.Tensor] = None,
+        q_pos_ids: Optional[torch.Tensor] = None,
         is_prefill: bool = False,
     ) -> torch.Tensor:
         """Forward using TRT-LLM sparse MLA kernel."""
@@ -2488,16 +2523,24 @@ class DeepseekSparseAttnBackend(
                 cos_sin_cache is not None
             ), "For FP8 path cos_sin_cache should not be None."
 
+            k = k.squeeze(1)
+            k_rope = k_rope.squeeze(1)
+            k_pos_ids = _get_cp_gathered_k_pos_ids(
+                forward_batch, q_rope.shape[0], k_rope.shape[0]
+            )
+            if q_pos_ids is None:
+                q_pos_ids = forward_batch.positions
             q, k, k_rope = mla_quantize_and_rope_for_fp8(
                 q,
                 q_rope,
-                k.squeeze(1),
-                k_rope.squeeze(1),
-                forward_batch.positions,
+                k,
+                k_rope,
+                q_pos_ids,
                 cos_sin_cache,
                 is_neox,
                 self.kv_lora_rank,
                 self.qk_rope_head_dim,
+                k_pos_ids=k_pos_ids,
             )
             merge_query = False
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -52,8 +52,8 @@ from sglang.srt.layers.attention.utils import (
 from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
-    compute_position_torch,
 )
+from sglang.srt.model_executor.triton_ops.position import compute_position_triton
 from sglang.srt.utils import (
     get_bool_env_var,
     is_cuda,
@@ -118,9 +118,16 @@ def _get_cp_gathered_k_pos_ids(
     ):
         return None
 
-    k_pos_ids, _ = compute_position_torch(
+    extend_seq_lens_cpu = getattr(forward_batch, "extend_seq_lens_cpu", None)
+    extend_seq_lens_sum = (
+        sum(extend_seq_lens_cpu)
+        if extend_seq_lens_cpu is not None
+        else int(forward_batch.extend_seq_lens.sum().item())
+    )
+    k_pos_ids, _ = compute_position_triton(
         forward_batch.extend_prefix_lens,
         forward_batch.extend_seq_lens,
+        extend_seq_lens_sum,
     )
     if k_pos_ids.shape[0] != k_len:
         raise ValueError(
@@ -128,6 +135,24 @@ def _get_cp_gathered_k_pos_ids(
             f"{k_len} positions, got {k_pos_ids.shape[0]}"
         )
     return k_pos_ids
+
+
+def _get_cp_local_q_pos_ids(
+    forward_batch: ForwardBatch, q_pos_ids: Optional[torch.Tensor], q_len: int
+) -> Optional[torch.Tensor]:
+    if q_pos_ids is None:
+        q_pos_ids = getattr(forward_batch, "positions", None)
+    if q_pos_ids is None or q_pos_ids.numel() == q_len:
+        return q_pos_ids
+    if can_dsa_prefill_cp_round_robin_split(forward_batch):
+        local_q_pos_ids = dsa_cp_round_robin_split_data(q_pos_ids)
+        if local_q_pos_ids.numel() == q_len:
+            return local_q_pos_ids
+
+    raise ValueError(
+        "Unable to build local Q RoPE positions for FP8 MLA: expected "
+        f"{q_len} positions, got {q_pos_ids.numel()}"
+    )
 
 
 def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tensor:
@@ -2528,8 +2553,9 @@ class DeepseekSparseAttnBackend(
             k_pos_ids = _get_cp_gathered_k_pos_ids(
                 forward_batch, q_rope.shape[0], k_rope.shape[0]
             )
-            if q_pos_ids is None:
-                q_pos_ids = forward_batch.positions
+            q_pos_ids = _get_cp_local_q_pos_ids(
+                forward_batch, q_pos_ids, q_rope.shape[0]
+            )
             q, k, k_rope = mla_quantize_and_rope_for_fp8(
                 q,
                 q_rope,

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -43,7 +43,6 @@ from sglang.srt.layers.attention.triton_ops.pad import (
 from sglang.srt.layers.attention.triton_ops.rope_cache import (
     fused_qk_rope_reshape_and_cache as fused_qk_rope_reshape_and_cache,
 )
-from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
 from sglang.srt.utils import is_cuda
 
 _is_cuda = is_cuda()
@@ -135,7 +134,7 @@ def mla_quantize_and_rope_for_fp8(
     q_len, num_heads = q_rope.shape[0], q_rope.shape[1]
 
     if k_pos_ids is not None:
-        return _mla_quantize_and_rope_for_fp8_torch(
+        return _mla_quantize_and_rope_for_fp8_triton(
             q_nope,
             q_rope,
             k_nope,
@@ -199,7 +198,216 @@ def mla_quantize_and_rope_for_fp8(
     return q_out, k_nope_out, k_rope_out
 
 
-def _mla_quantize_and_rope_for_fp8_torch(
+@triton.jit
+def _copy_fp8_strided_kernel(
+    src,
+    dst,
+    n_elements,
+    src_stride_t: tl.constexpr,
+    src_stride_h: tl.constexpr,
+    src_stride_d: tl.constexpr,
+    dst_stride_t: tl.constexpr,
+    dst_stride_h: tl.constexpr,
+    dst_stride_d: tl.constexpr,
+    dst_dim_offset: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    dim = offsets % HEAD_DIM
+    head = (offsets // HEAD_DIM) % NUM_HEADS
+    token = offsets // (HEAD_DIM * NUM_HEADS)
+
+    values = tl.load(
+        src + token * src_stride_t + head * src_stride_h + dim * src_stride_d,
+        mask=mask,
+    )
+    tl.store(
+        dst
+        + token * dst_stride_t
+        + head * dst_stride_h
+        + (dst_dim_offset + dim) * dst_stride_d,
+        values,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _rope_fp8_strided_kernel(
+    src,
+    dst,
+    pos_ids,
+    cos_sin_cache,
+    n_elements,
+    src_stride_t: tl.constexpr,
+    src_stride_h: tl.constexpr,
+    src_stride_d: tl.constexpr,
+    dst_stride_t: tl.constexpr,
+    dst_stride_h: tl.constexpr,
+    dst_stride_d: tl.constexpr,
+    dst_dim_offset: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HALF_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    IS_NEOX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    rot_dim = offsets % HALF_DIM
+    head = (offsets // HALF_DIM) % NUM_HEADS
+    token = offsets // (HALF_DIM * NUM_HEADS)
+
+    pos = tl.load(pos_ids + token, mask=mask, other=0).to(tl.int64)
+    cos = tl.load(cos_sin_cache + pos * ROPE_DIM + rot_dim, mask=mask, other=1.0)
+    sin = tl.load(
+        cos_sin_cache + pos * ROPE_DIM + HALF_DIM + rot_dim,
+        mask=mask,
+        other=0.0,
+    )
+
+    if IS_NEOX:
+        dim_0 = rot_dim
+        dim_1 = rot_dim + HALF_DIM
+    else:
+        dim_0 = rot_dim * 2
+        dim_1 = dim_0 + 1
+
+    src_base = src + token * src_stride_t + head * src_stride_h
+    x_0 = tl.load(src_base + dim_0 * src_stride_d, mask=mask).to(tl.bfloat16)
+    x_1 = tl.load(src_base + dim_1 * src_stride_d, mask=mask).to(tl.bfloat16)
+    cos = cos.to(tl.bfloat16)
+    sin = sin.to(tl.bfloat16)
+
+    out_0 = ((x_0 * cos).to(tl.bfloat16) - (x_1 * sin).to(tl.bfloat16)).to(tl.bfloat16)
+    out_1 = ((x_1 * cos).to(tl.bfloat16) + (x_0 * sin).to(tl.bfloat16)).to(tl.bfloat16)
+
+    dst_base = (
+        dst + token * dst_stride_t + head * dst_stride_h + dst_dim_offset * dst_stride_d
+    )
+    tl.store(dst_base + dim_0 * dst_stride_d, out_0, mask=mask)
+    tl.store(dst_base + dim_1 * dst_stride_d, out_1, mask=mask)
+
+
+def _get_3d_strides(tensor: torch.Tensor) -> tuple[int, int, int, int, int]:
+    if tensor.dim() == 2:
+        return tensor.shape[0], 1, tensor.stride(0), 0, tensor.stride(1)
+    if tensor.dim() == 3:
+        return tensor.shape[0], tensor.shape[1], *tensor.stride()
+    raise ValueError(f"Expected a 2D or 3D tensor, got shape {tuple(tensor.shape)}")
+
+
+def _copy_fp8_strided(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    head_dim: int,
+    dst_dim_offset: int = 0,
+) -> None:
+    num_tokens, num_heads, src_stride_t, src_stride_h, src_stride_d = _get_3d_strides(
+        src
+    )
+    _, dst_num_heads, dst_stride_t, dst_stride_h, dst_stride_d = _get_3d_strides(dst)
+    if dst_num_heads != num_heads:
+        raise ValueError(
+            f"Source and destination head counts must match: {num_heads} vs {dst_num_heads}"
+        )
+    if src.shape[-1] < head_dim or dst.shape[-1] < dst_dim_offset + head_dim:
+        raise ValueError(
+            "FP8 copy dimensions exceed source or destination shape: "
+            f"src={tuple(src.shape)}, dst={tuple(dst.shape)}, head_dim={head_dim}, "
+            f"dst_dim_offset={dst_dim_offset}"
+        )
+
+    n_elements = num_tokens * num_heads * head_dim
+    if n_elements == 0:
+        return
+    block_size = 1024
+    _copy_fp8_strided_kernel[(triton.cdiv(n_elements, block_size),)](
+        src,
+        dst,
+        n_elements,
+        src_stride_t,
+        src_stride_h,
+        src_stride_d,
+        dst_stride_t,
+        dst_stride_h,
+        dst_stride_d,
+        dst_dim_offset,
+        NUM_HEADS=num_heads,
+        HEAD_DIM=head_dim,
+        BLOCK_SIZE=block_size,
+    )
+
+
+def _rope_fp8_strided(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    pos_ids: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    qk_rope_head_dim: int,
+    dst_dim_offset: int = 0,
+) -> None:
+    pos_ids = pos_ids.flatten()
+    if pos_ids.device != src.device:
+        pos_ids = pos_ids.to(device=src.device)
+    if pos_ids.shape[0] != src.shape[0]:
+        raise ValueError(
+            "RoPE position count must match token count, got "
+            f"{pos_ids.shape[0]} positions for {src.shape[0]} tokens"
+        )
+    if qk_rope_head_dim % 2 != 0:
+        raise ValueError(f"RoPE dimension must be even, got {qk_rope_head_dim}")
+
+    num_tokens, num_heads, src_stride_t, src_stride_h, src_stride_d = _get_3d_strides(
+        src
+    )
+    _, dst_num_heads, dst_stride_t, dst_stride_h, dst_stride_d = _get_3d_strides(dst)
+    if dst_num_heads != num_heads:
+        raise ValueError(
+            f"Source and destination head counts must match: {num_heads} vs {dst_num_heads}"
+        )
+    if (
+        src.shape[-1] < qk_rope_head_dim
+        or dst.shape[-1] < dst_dim_offset + qk_rope_head_dim
+    ):
+        raise ValueError(
+            "RoPE dimensions exceed source or destination shape: "
+            f"src={tuple(src.shape)}, dst={tuple(dst.shape)}, "
+            f"qk_rope_head_dim={qk_rope_head_dim}, dst_dim_offset={dst_dim_offset}"
+        )
+
+    half_dim = qk_rope_head_dim // 2
+    n_elements = num_tokens * num_heads * half_dim
+    if n_elements == 0:
+        return
+    block_size = 256
+    _rope_fp8_strided_kernel[(triton.cdiv(n_elements, block_size),)](
+        src,
+        dst,
+        pos_ids,
+        cos_sin_cache,
+        n_elements,
+        src_stride_t,
+        src_stride_h,
+        src_stride_d,
+        dst_stride_t,
+        dst_stride_h,
+        dst_stride_d,
+        dst_dim_offset,
+        NUM_HEADS=num_heads,
+        HALF_DIM=half_dim,
+        ROPE_DIM=qk_rope_head_dim,
+        IS_NEOX=is_neox,
+        BLOCK_SIZE=block_size,
+    )
+
+
+def _mla_quantize_and_rope_for_fp8_triton(
     q_nope: torch.Tensor,
     q_rope: torch.Tensor,
     k_nope: torch.Tensor,
@@ -220,36 +428,29 @@ def _mla_quantize_and_rope_for_fp8_torch(
         dtype=attn_dtype,
     )
 
-    q_out[..., :kv_lora_rank] = q_nope.to(attn_dtype)
-    q_out[..., kv_lora_rank:] = _apply_rope_for_fp8_quantize(
-        q_rope, q_pos_ids, cos_sin_cache, is_neox
-    ).to(attn_dtype)
-    k_nope_out = k_nope.to(attn_dtype)
-    k_rope_out = _apply_rope_for_fp8_quantize(
-        k_rope, k_pos_ids, cos_sin_cache, is_neox
-    ).to(attn_dtype)
+    k_nope_out = k_nope.new_empty(k_nope.shape, dtype=attn_dtype)
+    k_rope_out = k_rope.new_empty(k_rope.shape, dtype=attn_dtype)
+
+    _copy_fp8_strided(q_nope, q_out, kv_lora_rank)
+    _copy_fp8_strided(k_nope, k_nope_out, kv_lora_rank)
+    _rope_fp8_strided(
+        q_rope,
+        q_out,
+        q_pos_ids,
+        cos_sin_cache,
+        is_neox,
+        qk_rope_head_dim,
+        dst_dim_offset=kv_lora_rank,
+    )
+    _rope_fp8_strided(
+        k_rope,
+        k_rope_out,
+        k_pos_ids,
+        cos_sin_cache,
+        is_neox,
+        qk_rope_head_dim,
+    )
     return q_out, k_nope_out, k_rope_out
-
-
-def _apply_rope_for_fp8_quantize(
-    rope: torch.Tensor,
-    pos_ids: torch.Tensor,
-    cos_sin_cache: torch.Tensor,
-    is_neox: bool,
-) -> torch.Tensor:
-    pos_ids = pos_ids.flatten()
-    if pos_ids.shape[0] != rope.shape[0]:
-        raise ValueError(
-            "RoPE position count must match token count, got "
-            f"{pos_ids.shape[0]} positions for {rope.shape[0]} tokens"
-        )
-    if pos_ids.device != cos_sin_cache.device or pos_ids.dtype != torch.int64:
-        pos_ids = pos_ids.to(device=cos_sin_cache.device, dtype=torch.int64)
-    cos_sin = cos_sin_cache.index_select(0, pos_ids)
-    cos, sin = cos_sin.chunk(2, dim=-1)
-    if rope.dim() == 2:
-        return apply_rotary_emb(rope.unsqueeze(1), cos, sin, is_neox).squeeze(1)
-    return apply_rotary_emb(rope, cos, sin, is_neox)
 
 
 def concat_mla_absorb_q_general(q_nope, q_rope):

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -43,6 +43,7 @@ from sglang.srt.layers.attention.triton_ops.pad import (
 from sglang.srt.layers.attention.triton_ops.rope_cache import (
     fused_qk_rope_reshape_and_cache as fused_qk_rope_reshape_and_cache,
 )
+from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
 from sglang.srt.utils import is_cuda
 
 _is_cuda = is_cuda()
@@ -96,40 +97,66 @@ def mla_quantize_and_rope_for_fp8(
     is_neox: bool,
     kv_lora_rank: int,
     qk_rope_head_dim: int,
+    k_pos_ids: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    import flashinfer.rope
-
     """Quantize and apply RoPE for FP8 attention path.
 
-        This function handles the FP8 quantization and RoPE application for MLA attention.
-        It takes separate query/key nope and rope components, applies RoPE to the rope parts,
-        quantizes all components to FP8, and merges the query components into a single tensor.
+    This function handles the FP8 quantization and RoPE application for MLA attention.
+    It takes separate query/key nope and rope components, applies RoPE to the rope parts,
+    quantizes all components to FP8, and merges the query components into a single tensor.
 
-        Args:
-            q_nope: Query no-position-encoding component [seq_len, num_heads, kv_lora_rank]
-                - expected dtype: torch.bfloat16
-            q_rope: Query RoPE component [seq_len, num_heads, qk_rope_head_dim]
-                - expected dtype: torch.bfloat16
-            k_nope: Key no-position-encoding component [seq_len, num_heads, kv_lora_rank]
-                - expected dtype: torch.bfloat16
-            k_rope: Key RoPE component [seq_len, num_heads, qk_rope_head_dim]
-                - expected dtype: torch.bfloat16
-            pos_ids: Position indices for each token
-                - expected dtype: torch.int64 or torch.int32
-            cos_sin_cache: Precomputed cosine/sine cache for RoPE
-                - expected dtype: matches q_/k_ input dtype (torch.bfloat16)
-            is_neox: Whether to use NeoX-style RoPE (interleaved) or GPT-style (half rotation)
-            kv_lora_rank: Dimension of the no-position-encoding component
-            qk_rope_head_dim: Dimension of the RoPE component
+    Args:
+        q_nope: Query no-position-encoding component [seq_len, num_heads, kv_lora_rank]
+            - expected dtype: torch.bfloat16
+        q_rope: Query RoPE component [seq_len, num_heads, qk_rope_head_dim]
+            - expected dtype: torch.bfloat16
+        k_nope: Key no-position-encoding component [seq_len, num_heads, kv_lora_rank]
+            - expected dtype: torch.bfloat16
+        k_rope: Key RoPE component [seq_len, num_heads, qk_rope_head_dim]
+            - expected dtype: torch.bfloat16
+        pos_ids: Position indices for each token
+            - expected dtype: torch.int64 or torch.int32
+        cos_sin_cache: Precomputed cosine/sine cache for RoPE
+            - expected dtype: matches q_/k_ input dtype (torch.bfloat16)
+        is_neox: Whether to use NeoX-style RoPE (interleaved) or GPT-style (half rotation)
+        kv_lora_rank: Dimension of the no-position-encoding component
+        qk_rope_head_dim: Dimension of the RoPE component
+        k_pos_ids: Optional separate key positions. This is needed by
+            prefill CP paths where q_rope is rank-local but k_rope has
+            been all-gathered and reranged back to the full token order.
 
-        Returns:
-            tuple: (merged_q_out, k_nope_out, k_rope_out) quantized to FP8
-                - merged_q_out: [seq_len, num_heads, kv_lora_rank + qk_rope_head_dim], dtype=torch.float8_e4m3fn
-                - k_nope_out:   [seq_len, num_heads, kv_lora_rank], dtype=torch.float8_e4m3fn
-                - k_rope_out:   [seq_len, num_heads, qk_rope_head_dim], dtype=torch.float8_e4m3fn
-        """
+    Returns:
+        tuple: (merged_q_out, k_nope_out, k_rope_out) quantized to FP8
+            - merged_q_out: [seq_len, num_heads, kv_lora_rank + qk_rope_head_dim], dtype=torch.float8_e4m3fn
+            - k_nope_out:   [seq_len, num_heads, kv_lora_rank], dtype=torch.float8_e4m3fn
+            - k_rope_out:   [seq_len, num_heads, qk_rope_head_dim], dtype=torch.float8_e4m3fn
+    """
     attn_dtype = torch.float8_e4m3fn
     q_len, num_heads = q_rope.shape[0], q_rope.shape[1]
+
+    if k_pos_ids is not None:
+        return _mla_quantize_and_rope_for_fp8_torch(
+            q_nope,
+            q_rope,
+            k_nope,
+            k_rope,
+            pos_ids,
+            k_pos_ids,
+            cos_sin_cache,
+            is_neox,
+            kv_lora_rank,
+            qk_rope_head_dim,
+            attn_dtype,
+        )
+
+    if q_rope.shape[0] != k_rope.shape[0]:
+        raise ValueError(
+            "mla_quantize_and_rope_for_fp8 requires k_pos_ids when q_rope and "
+            f"k_rope have different token counts: {q_rope.shape[0]} vs "
+            f"{k_rope.shape[0]}"
+        )
+
+    import flashinfer.rope
 
     # Allocate output tensors with FP8 dtype
     # Query output will contain merged nope + rope components
@@ -170,6 +197,59 @@ def mla_quantize_and_rope_for_fp8(
     )
 
     return q_out, k_nope_out, k_rope_out
+
+
+def _mla_quantize_and_rope_for_fp8_torch(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    q_pos_ids: torch.Tensor,
+    k_pos_ids: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    attn_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    q_len, num_heads = q_rope.shape[0], q_rope.shape[1]
+    q_out = q_rope.new_empty(
+        q_len,
+        num_heads,
+        kv_lora_rank + qk_rope_head_dim,
+        dtype=attn_dtype,
+    )
+
+    q_out[..., :kv_lora_rank] = q_nope.to(attn_dtype)
+    q_out[..., kv_lora_rank:] = _apply_rope_for_fp8_quantize(
+        q_rope, q_pos_ids, cos_sin_cache, is_neox
+    ).to(attn_dtype)
+    k_nope_out = k_nope.to(attn_dtype)
+    k_rope_out = _apply_rope_for_fp8_quantize(
+        k_rope, k_pos_ids, cos_sin_cache, is_neox
+    ).to(attn_dtype)
+    return q_out, k_nope_out, k_rope_out
+
+
+def _apply_rope_for_fp8_quantize(
+    rope: torch.Tensor,
+    pos_ids: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> torch.Tensor:
+    pos_ids = pos_ids.flatten()
+    if pos_ids.shape[0] != rope.shape[0]:
+        raise ValueError(
+            "RoPE position count must match token count, got "
+            f"{pos_ids.shape[0]} positions for {rope.shape[0]} tokens"
+        )
+    if pos_ids.device != cos_sin_cache.device or pos_ids.dtype != torch.int64:
+        pos_ids = pos_ids.to(device=cos_sin_cache.device, dtype=torch.int64)
+    cos_sin = cos_sin_cache.index_select(0, pos_ids)
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    if rope.dim() == 2:
+        return apply_rotary_emb(rope.unsqueeze(1), cos, sin, is_neox).squeeze(1)
+    return apply_rotary_emb(rope, cos, sin, is_neox)
 
 
 def concat_mla_absorb_q_general(q_nope, q_rope):

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -671,6 +671,8 @@ class DeepseekMLAForwardMixin:
                         "is_neox": self.rotary_emb.is_neox_style,
                         "llama_4_scaling": llama_4_scaling,
                     }
+                    if self.current_attention_backend in ("dsa", "nsa"):
+                        extra_args["q_pos_ids"] = positions
                 if fusion_plan is not None:
                     bmm_attention_fn = (
                         bcg_mla_bmm_then_unified_attention

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -671,7 +671,10 @@ class DeepseekMLAForwardMixin:
                         "is_neox": self.rotary_emb.is_neox_style,
                         "llama_4_scaling": llama_4_scaling,
                     }
-                    if self.current_attention_backend in ("dsa", "nsa"):
+                    if (
+                        self.current_attention_backend in ("dsa", "nsa")
+                        and forward_batch.forward_mode.is_extend()
+                    ):
                         extra_args["q_pos_ids"] = positions
                 if fusion_plan is not None:
                     bmm_attention_fn = (

--- a/test/registered/unit/layers/test_mla_fp8_rope.py
+++ b/test/registered/unit/layers/test_mla_fp8_rope.py
@@ -29,15 +29,6 @@ class TestMlaFp8Rope(CustomTestCase):
         num_heads = 3
         kv_lora_rank = 4
         qk_rope_head_dim = 8
-        is_neox = True
-
-        torch.manual_seed(0)
-        q_nope = torch.randn(q_len, num_heads, kv_lora_rank, dtype=dtype, device=device)
-        q_rope = torch.randn(
-            q_len, num_heads, qk_rope_head_dim, dtype=dtype, device=device
-        )
-        k_nope = torch.randn(k_len, kv_lora_rank, dtype=dtype, device=device)
-        k_rope = torch.randn(k_len, qk_rope_head_dim, dtype=dtype, device=device)
 
         freqs = (
             torch.arange(10, dtype=torch.float32, device=device).unsqueeze(1)
@@ -52,42 +43,67 @@ class TestMlaFp8Rope(CustomTestCase):
         q_pos_ids = torch.tensor([4, 7], dtype=torch.int64, device=device)
         k_pos_ids = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64, device=device)
 
-        q_out, k_nope_out, k_rope_out = mla_quantize_and_rope_for_fp8(
-            q_nope,
-            q_rope,
-            k_nope,
-            k_rope,
-            q_pos_ids,
-            cos_sin_cache,
-            is_neox,
-            kv_lora_rank,
-            qk_rope_head_dim,
-            k_pos_ids=k_pos_ids,
-        )
+        for is_neox in (True, False):
+            with self.subTest(is_neox=is_neox):
+                torch.manual_seed(0)
+                q_nope = torch.randn(
+                    q_len, num_heads, kv_lora_rank, dtype=dtype, device=device
+                )
+                q_rope = torch.randn(
+                    q_len, num_heads, qk_rope_head_dim, dtype=dtype, device=device
+                )
+                k_nope = torch.randn(k_len, kv_lora_rank, dtype=dtype, device=device)
+                k_rope = torch.randn(
+                    k_len, qk_rope_head_dim, dtype=dtype, device=device
+                )
 
-        expected_q = torch.empty(
-            q_len,
-            num_heads,
-            kv_lora_rank + qk_rope_head_dim,
-            dtype=fp8_dtype,
-            device=device,
-        )
-        expected_q[..., :kv_lora_rank] = q_nope.to(fp8_dtype)
-        expected_q[..., kv_lora_rank:] = _apply_rope(
-            q_rope, q_pos_ids, cos_sin_cache, is_neox
-        ).to(fp8_dtype)
-        expected_k_nope = k_nope.to(fp8_dtype)
-        expected_k_rope = _apply_rope(k_rope, k_pos_ids, cos_sin_cache, is_neox).to(
-            fp8_dtype
-        )
+                q_out, k_nope_out, k_rope_out = mla_quantize_and_rope_for_fp8(
+                    q_nope,
+                    q_rope,
+                    k_nope,
+                    k_rope,
+                    q_pos_ids,
+                    cos_sin_cache,
+                    is_neox,
+                    kv_lora_rank,
+                    qk_rope_head_dim,
+                    k_pos_ids=k_pos_ids,
+                )
 
-        torch.testing.assert_close(q_out.float(), expected_q.float(), rtol=0, atol=0)
-        torch.testing.assert_close(
-            k_nope_out.float(), expected_k_nope.float(), rtol=0, atol=0
-        )
-        torch.testing.assert_close(
-            k_rope_out.float(), expected_k_rope.float(), rtol=0, atol=0
-        )
+                expected_q = torch.empty(
+                    q_len,
+                    num_heads,
+                    kv_lora_rank + qk_rope_head_dim,
+                    dtype=fp8_dtype,
+                    device=device,
+                )
+                expected_q[..., :kv_lora_rank] = q_nope.to(fp8_dtype)
+                expected_q[..., kv_lora_rank:] = _apply_rope(
+                    q_rope, q_pos_ids, cos_sin_cache, is_neox
+                ).to(fp8_dtype)
+                expected_k_nope = k_nope.to(fp8_dtype)
+                expected_k_rope = _apply_rope(
+                    k_rope, k_pos_ids, cos_sin_cache, is_neox
+                ).to(fp8_dtype)
+
+                torch.testing.assert_close(
+                    q_out[..., :kv_lora_rank].float(),
+                    expected_q[..., :kv_lora_rank].float(),
+                    rtol=0,
+                    atol=0,
+                )
+                torch.testing.assert_close(
+                    k_nope_out.float(), expected_k_nope.float(), rtol=0, atol=0
+                )
+                torch.testing.assert_close(
+                    q_out[..., kv_lora_rank:].float(),
+                    expected_q[..., kv_lora_rank:].float(),
+                    rtol=0,
+                    atol=0.25,
+                )
+                torch.testing.assert_close(
+                    k_rope_out.float(), expected_k_rope.float(), rtol=0, atol=0.25
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/test_mla_fp8_rope.py
+++ b/test/registered/unit/layers/test_mla_fp8_rope.py
@@ -1,0 +1,94 @@
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.utils import mla_quantize_and_rope_for_fp8
+from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+
+def _apply_rope(x, pos_ids, cos_sin_cache, is_neox):
+    cos_sin = cos_sin_cache.index_select(0, pos_ids)
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    if x.dim() == 2:
+        return apply_rotary_emb(x.unsqueeze(1), cos, sin, is_neox).squeeze(1)
+    return apply_rotary_emb(x, cos, sin, is_neox)
+
+
+class TestMlaFp8Rope(CustomTestCase):
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+    def test_mismatched_q_k_lengths_use_separate_k_positions(self):
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+        fp8_dtype = torch.float8_e4m3fn
+        q_len = 2
+        k_len = 5
+        num_heads = 3
+        kv_lora_rank = 4
+        qk_rope_head_dim = 8
+        is_neox = True
+
+        torch.manual_seed(0)
+        q_nope = torch.randn(q_len, num_heads, kv_lora_rank, dtype=dtype, device=device)
+        q_rope = torch.randn(
+            q_len, num_heads, qk_rope_head_dim, dtype=dtype, device=device
+        )
+        k_nope = torch.randn(k_len, kv_lora_rank, dtype=dtype, device=device)
+        k_rope = torch.randn(k_len, qk_rope_head_dim, dtype=dtype, device=device)
+
+        freqs = (
+            torch.arange(10, dtype=torch.float32, device=device).unsqueeze(1)
+            * torch.arange(
+                1, qk_rope_head_dim // 2 + 1, dtype=torch.float32, device=device
+            ).unsqueeze(0)
+            / 100.0
+        )
+        cos_sin_cache = torch.cat([torch.cos(freqs), torch.sin(freqs)], dim=-1).to(
+            dtype
+        )
+        q_pos_ids = torch.tensor([4, 7], dtype=torch.int64, device=device)
+        k_pos_ids = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64, device=device)
+
+        q_out, k_nope_out, k_rope_out = mla_quantize_and_rope_for_fp8(
+            q_nope,
+            q_rope,
+            k_nope,
+            k_rope,
+            q_pos_ids,
+            cos_sin_cache,
+            is_neox,
+            kv_lora_rank,
+            qk_rope_head_dim,
+            k_pos_ids=k_pos_ids,
+        )
+
+        expected_q = torch.empty(
+            q_len,
+            num_heads,
+            kv_lora_rank + qk_rope_head_dim,
+            dtype=fp8_dtype,
+            device=device,
+        )
+        expected_q[..., :kv_lora_rank] = q_nope.to(fp8_dtype)
+        expected_q[..., kv_lora_rank:] = _apply_rope(
+            q_rope, q_pos_ids, cos_sin_cache, is_neox
+        ).to(fp8_dtype)
+        expected_k_nope = k_nope.to(fp8_dtype)
+        expected_k_rope = _apply_rope(k_rope, k_pos_ids, cos_sin_cache, is_neox).to(
+            fp8_dtype
+        )
+
+        torch.testing.assert_close(q_out.float(), expected_q.float(), rtol=0, atol=0)
+        torch.testing.assert_close(
+            k_nope_out.float(), expected_k_nope.float(), rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            k_rope_out.float(), expected_k_rope.float(), rtol=0, atol=0
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the FP8 MLA RoPE+quantize path when prefill context parallelism makes Q rank-local while K has been all-gathered back to the global/padded token layout.

The FlashInfer `mla_rope_quantize_fp8` fused path assumes Q and K have the same token count. With CP prefill, that assumption breaks: Q uses CP-split local positions while K is rebuilt from the gathered KV cache. This PR keeps the fused fast path for matching Q/K lengths and adds Triton kernels for the mismatched CP case with separate Q and K position tensors, using the old torch implementation as the unit-test reference.

## Changes

- Add an optional `k_pos_ids` path to `mla_quantize_and_rope_for_fp8`.
- Replace the CP fallback with Triton copy/RoPE kernels that write FP8 outputs directly.
- Thread CP-split Q positions from `forward_mla.py` into the DSA TRT-LLM FP8 extend path only.
- Build gathered-K RoPE positions in `dsa_backend.py` with `compute_position_triton` and derive local Q positions for CP.
- Add a CUDA regression test for mismatched Q/K token counts, with torch eager RoPE as the reference.

## Validation

- `python3 -m py_compile python/sglang/srt/layers/attention/utils.py python/sglang/srt/layers/attention/dsa_backend.py python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py test/registered/unit/layers/test_mla_fp8_rope.py && git diff --check`
- On `baizhou-dev` / B300: `PYTHONPATH=/tmp/sglang-glm-opt-triton/python python3 -m pytest -q test/registered/unit/layers/test_mla_fp8_rope.py` -> `1 passed, 21 warnings, 2 subtests passed in 11.77s`.
- On `baizhou-dev` / B300 microbenchmark, shape `q_len=1024`, `k_len=8192`, `heads=16`, `nope=512`, `rope=64`: Triton `0.044 ms`, torch reference `0.117 ms`, `2.64x` speedup; no-RoPE FP8 copy exact, RoPE max diff `0.25` FP8-bin-adjacent.
- On `baizhou-dev` / 8xB300, launched `nvidia/GLM-5.2-NVFP4` with `--kv-cache-dtype fp8_e4m3`, `--tp 8`, prefill CP interleave, and `flashinfer_trtllm`.
- Short `/v1/completions` probe returned HTTP 200 with `prompt_tokens=1`; long repro prompt (`"Hello " * 12000`, `max_tokens=1`) returned HTTP 200 with `prompt_tokens=12001`.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28437454174](https://github.com/sgl-project/sglang/actions/runs/28437454174)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28437454079](https://github.com/sgl-project/sglang/actions/runs/28437454079)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->