### PR TITLE
[AMD] Fix DSA draft-extend metadata on HIP gpu-only path

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -1835,8 +1835,13 @@ class Indexer(MultiPlatformOp):
             # creates a Dynamo shape guard. These graph modes never have empty
             # batches.
             if not in_piecewise_or_breakable_cuda_graph:
-                assert forward_batch.seq_lens_cpu is not None
-                if len(forward_batch.seq_lens_cpu) == 0:
+                if forward_batch.seq_lens_cpu is not None:
+                    batch_is_empty = len(forward_batch.seq_lens_cpu) == 0
+                else:
+                    # GPU-only draft-extend can intentionally omit CPU mirrors;
+                    # metadata keeps the real pre-pad batch shape without a sync.
+                    batch_is_empty = metadata.get_seqlens_int32().shape[0] == 0
+                if batch_is_empty:
                     # this seems b/c max-pad, no worries?
                     # if x.shape[0] != 0:
                     #     print(

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -731,14 +731,15 @@ class DeepseekSparseAttnBackend(
                 page_table, repeats=self.speculative_num_draft_tokens, dim=0
             )
         elif forward_batch.forward_mode.is_draft_extend_v2():
+            # AMD gpu-only draft-extend does not keep prefix CPU mirrors; DSA only
+            # needs the fixed per-request extend lengths for this metadata path.
             assert (
-                forward_batch.extend_seq_lens_cpu is not None
-                and forward_batch.extend_seq_lens is not None
-                and forward_batch.extend_prefix_lens_cpu is not None
-            ), "All of them must not be None"
-
+                forward_batch.extend_seq_lens is not None
+            ), "extend_seq_lens must not be None"
             extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
-            assert forward_batch.extend_seq_lens is not None
+            if extend_seq_lens_cpu is None:
+                extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
+                forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
 
             max_seqlen_q = 1
             cu_seqlens_q = torch.arange(


### PR DESCRIPTION
## Summary
- Fixes the AMD DSA draft-extend v2 eager path by removing two invalid CPU mirror requirements on the gpu-only HIP path.
- DSA metadata now synthesizes fixed draft extend lengths when `extend_seq_lens_cpu` is absent, and the DSA indexer empty-batch guard uses metadata shape when `seq_lens_cpu` is intentionally absent.

## CI evidence
- Regression started after #29413 enabled DSA draft-extend CUDA graph support.
- The failing jobs are AMD-only MI35x DeepSeek-V3.2 MTP nightly accuracy/perf jobs on both ROCm tracks; NVIDIA sister jobs pass.
- On AMD, DSA draft-extend graph support is not enabled by the #29413 allowlist, so the flow falls back to eager draft-extend metadata and indexer paths.

## Root cause
- `ForwardBatch.init_new` leaves CPU mirrors unset on the gpu-only draft-extend path to avoid per-iteration D2H sync.
- The first failing assert required `extend_prefix_lens_cpu` in DSA draft-extend v2 metadata even though this mode only needs fixed per-request extend lengths.
- After that was relaxed, verification exposed the next eager indexer assert requiring `seq_lens_cpu` only to detect empty batches; paged DSA topk for draft-extend reads lengths from metadata instead.

## Fix
- In `dsa_backend.py`, keep requiring device `extend_seq_lens`, but synthesize fixed `extend_seq_lens_cpu` from `speculative_num_draft_tokens` when the CPU mirror is missing.
- In `dsa_indexer.py`, preserve the existing empty-batch return path, but fall back to `metadata.get_seqlens_int32().shape[0] == 0` when `forward_batch.seq_lens_cpu` is intentionally absent.

## Testing
- Local analysis: the diff is limited to the DSA draft-extend eager HIP gpu-only CPU mirror assumptions seen in CI logs.
- `python3 -m py_compile python/sglang/srt/layers/attention/dsa_backend.py`: passed
- `python3 -m py_compile python/sglang/srt/layers/attention/dsa/dsa_indexer.py python/sglang/srt/layers/attention/dsa_backend.py`: passed
- `git diff --check`: passed
- Commit hooks: passed, including python AST, isort, ruff legacy alias, black-jupyter, codespell, and CI registry checks

## Targeted Verification
- Previous dispatch reached past the original `dsa_backend.py` assertion and exposed `dsa_indexer.py:1838`.
- Nightly Test (AMD): https://github.com/sgl-project/sglang/actions/runs/28454404229
- Nightly Test (AMD ROCm 7.2): https://github.com/sgl-project/sglang/actions/runs/28454404432