### PR TITLE
[Quantization] Add blockwise_fp8 online weight quantization

### DIFF
--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
 BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "fp8": Fp8Config,
     "mxfp8": Fp8Config,
+    "blockwise_fp8": Fp8Config,
     "blockwise_int8": BlockInt8Config,
     "modelopt": ModelOptFp8Config,  # Auto-detect, defaults to FP8
     "modelopt_fp8": ModelOptFp8Config,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -157,6 +157,7 @@ class Fp8Config(QuantizationConfig):
         packed_modules_mapping: Optional[Dict[str, List[str]]] = None,
         use_mxfp8: bool = False,
         is_fp4_experts: bool = False,
+        blockwise_fp8: bool = False,
     ) -> None:
         super().__init__()
         # DSV4 mxfp4-packed (True) vs converted FP8 (False); injected by
@@ -179,8 +180,11 @@ class Fp8Config(QuantizationConfig):
             )
         self.packed_modules_mapping = packed_modules_mapping or {}
         self.use_mxfp8 = use_mxfp8
+        self.blockwise_fp8 = blockwise_fp8
+        if blockwise_fp8 and weight_block_size is None:
+            weight_block_size = [128, 128]
         if weight_block_size is not None:
-            if not is_checkpoint_fp8_serialized:
+            if not is_checkpoint_fp8_serialized and not blockwise_fp8:
                 raise ValueError(
                     f"The block-wise quantization only supports fp8-serialized checkpoint for now."
                 )
@@ -352,6 +356,7 @@ class Fp8LinearMethod(LinearMethodBase):
             self.use_marlin = force_marlin or auto_enable
 
         self.use_mxfp8 = getattr(self.quant_config, "use_mxfp8", False)
+        self.blockwise_fp8 = getattr(self.quant_config, "blockwise_fp8", False)
         self.block_quant = (
             self.use_mxfp8 or self.quant_config.weight_block_size is not None
         )
@@ -506,6 +511,24 @@ class Fp8LinearMethod(LinearMethodBase):
             else:
                 layer.register_parameter("input_scale", None)
 
+    def _quantize_blockwise_fp8_weights(self, layer: Module) -> None:
+        from sglang.srt.layers.quantization.fp8_utils import quant_weight_sf_fp32
+
+        weight_data = layer.weight.data
+        if weight_data.dtype != torch.bfloat16:
+            weight_data = weight_data.to(torch.bfloat16)
+        qweight, scale = quant_weight_sf_fp32(weight_data, [128, 128])
+        layer.weight.data = qweight
+        layer.weight.requires_grad_(False)
+        if hasattr(layer, "weight_scale_inv") and layer.weight_scale_inv is not None:
+            layer.weight_scale_inv.data = scale
+        else:
+            layer.register_parameter(
+                "weight_scale_inv", Parameter(scale, requires_grad=False)
+            )
+        layer.weight_scale_inv.format_ue8m0 = False
+        layer.input_scale = None
+
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
         # If ROCm, normalize the weights and scales to e4m3fnuz
         if _is_fp8_fnuz:
@@ -536,6 +559,9 @@ class Fp8LinearMethod(LinearMethodBase):
             self._process_mxfp8_linear_weight_scale(layer)
             return
         else:
+            if self.blockwise_fp8 and not self.is_checkpoint_fp8_serialized:
+                self._quantize_blockwise_fp8_weights(layer)
+
             # Requantize block scales to UE8M0 when DeepGEMM is the active runner.
             use_deepgemm_runner = (
                 self.w8a8_block_fp8_linear
@@ -856,6 +882,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     def __init__(self, quant_config: Fp8Config):
         self.quant_config = quant_config
         self.use_mxfp8 = getattr(self.quant_config, "use_mxfp8", False)
+        self.blockwise_fp8 = getattr(self.quant_config, "blockwise_fp8", False)
         self.block_quant = (
             self.use_mxfp8 or self.quant_config.weight_block_size is not None
         )
@@ -1155,6 +1182,49 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w13_input_scale = None
             layer.w2_input_scale = None
 
+    def _quantize_blockwise_fp8_moe_weights(self, layer: Module) -> None:
+        from sglang.srt.layers.quantization.fp8_utils import quant_weight_sf_fp32
+
+        # w13_weight: bf16 (E, 2*inter, hidden); w2_weight: bf16 (E, hidden, inter).
+        # Quantize per-expert to avoid OOM from flattening all experts at once.
+        num_experts = layer.w13_weight.shape[0]
+        w13_q_all = w13_s_all = w2_q_all = w2_s_all = None
+        for e in range(num_experts):
+            w13_data = layer.w13_weight.data[e]
+            if w13_data.dtype != torch.bfloat16:
+                w13_data = w13_data.to(torch.bfloat16)
+            w2_data = layer.w2_weight.data[e]
+            if w2_data.dtype != torch.bfloat16:
+                w2_data = w2_data.to(torch.bfloat16)
+            w13_q, w13_s = quant_weight_sf_fp32(w13_data, [128, 128])
+            w2_q, w2_s = quant_weight_sf_fp32(w2_data, [128, 128])
+            if w13_q_all is None:
+                w13_q_all = torch.empty(
+                    layer.w13_weight.shape, dtype=w13_q.dtype, device=w13_q.device
+                )
+                w2_q_all = torch.empty(
+                    layer.w2_weight.shape, dtype=w2_q.dtype, device=w2_q.device
+                )
+                w13_s_all = torch.empty(
+                    (num_experts, *w13_s.shape), dtype=w13_s.dtype, device=w13_s.device
+                )
+                w2_s_all = torch.empty(
+                    (num_experts, *w2_s.shape), dtype=w2_s.dtype, device=w2_s.device
+                )
+            w13_q_all[e].copy_(w13_q)
+            w2_q_all[e].copy_(w2_q)
+            w13_s_all[e].copy_(w13_s)
+            w2_s_all[e].copy_(w2_s)
+
+        layer.w13_weight.data = w13_q_all
+        layer.w2_weight.data = w2_q_all
+        layer.w13_weight_scale_inv.data = w13_s_all
+        layer.w2_weight_scale_inv.data = w2_s_all
+        layer.w13_weight_scale_inv.format_ue8m0 = False
+        layer.w2_weight_scale_inv.format_ue8m0 = False
+        layer.w13_input_scale = None
+        layer.w2_input_scale = None
+
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
         # AMD FP4 experts: use aiter's native MXFP4 MoE path
         if _use_aiter and self.is_fp4_expert:
@@ -1320,6 +1390,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             # Check if MoE will actually use DeepGEMM runner
             will_use_deepgemm = self.is_deepgemm_moe_runner_backend_enabled()
+
+            if (
+                self.blockwise_fp8
+                and not self.quant_config.is_checkpoint_fp8_serialized
+            ):
+                self._quantize_blockwise_fp8_moe_weights(layer)
 
             if self.is_fp4_expert:
                 if get_moe_runner_backend().is_marlin():

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1367,6 +1367,32 @@ def quant_weight_ue8m0(
     return out_w, out_s
 
 
+def quant_weight_sf_fp32(
+    weight_dequant: torch.Tensor,
+    weight_block_size: List[int],
+):
+    assert weight_block_size == [128, 128]
+    assert (
+        weight_dequant.dtype == torch.bfloat16
+    ), f"{weight_dequant.dtype=} {weight_dequant.shape=}"
+
+    *batch_dims, n, k = weight_dequant.shape
+
+    weight_dequant_flat = weight_dequant.view((-1, k))
+    out_w_flat, out_s_flat = per_block_no_cast_to_fp8(weight_dequant_flat)
+
+    out_w = out_w_flat.view((*batch_dims, n, k))
+    out_s = out_s_flat.view(
+        (
+            *batch_dims,
+            ceil_div(n, weight_block_size[0]),
+            ceil_div(k, weight_block_size[1]),
+        )
+    )
+
+    return out_w, out_s
+
+
 def transform_scale_ue8m0_inplace(param, mn):
     param.data = transform_scale_ue8m0(param.data, mn=mn)
 
@@ -1500,6 +1526,22 @@ def per_block_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
 # COPIED FROM DeepGEMM
 def ceil_to_ue8m0(x: torch.Tensor):
     return torch.pow(2.0, torch.ceil(torch.log2(x.abs())))
+
+
+def per_block_no_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    m, n = x.shape
+    x_padded = torch.zeros(
+        (ceil_align(m, 128), ceil_align(n, 128)), dtype=x.dtype, device=x.device
+    )
+    x_padded[:m, :n] = x
+    x_view = x_padded.view(-1, 128, x_padded.size(1) // 128, 128)
+    x_amax = x_view.abs().float().amax(dim=(1, 3), keepdim=True).clamp(1e-4)
+    sf = x_amax / 448.0
+    x_scaled = (x_view * (1.0 / sf)).to(torch.float8_e4m3fn)
+    return x_scaled.view_as(x_padded)[:m, :n].contiguous(), sf.view(
+        x_view.size(0), x_view.size(2)
+    )
 
 
 def channel_quant_to_tensor_quant(

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -296,6 +296,8 @@ def get_quant_config(
     if not possible_config_filenames:
         if model_config.quantization == "mxfp8":
             return Fp8Config(use_mxfp8=True, is_checkpoint_fp8_serialized=False)
+        if model_config.quantization == "blockwise_fp8":
+            return Fp8Config(blockwise_fp8=True, is_checkpoint_fp8_serialized=False)
         if model_config.quantization == "quark_mxfp4":
             return quant_cls(
                 online_scheme=model_config.quantization,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -142,6 +142,7 @@ LOAD_FORMAT_CHOICES = [
 QUANTIZATION_CHOICES = [
     "awq",
     "fp8",  # MOE + linear online quantization.
+    "blockwise_fp8",  # 128x128 per-block FP8 online quantization (MoE + linear).
     "mxfp8",  # MOE + linear online quantization.
     "gptq",
     "marlin",

--- a/test/registered/unit/layers/quantization/test_blockwise_fp8_quant.py
+++ b/test/registered/unit/layers/quantization/test_blockwise_fp8_quant.py
@@ -1,0 +1,113 @@
+"""CPU tests for blockwise FP8 online weight quantization helpers."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.fp8_utils import (
+    per_block_no_cast_to_fp8,
+    quant_weight_sf_fp32,
+)
+from sglang.srt.utils.common import ceil_div
+from sglang.test.test_utils import CustomTestCase
+
+BLOCK_SIZE = [128, 128]
+
+
+def _dequant_blocks(q: torch.Tensor, sf: torch.Tensor) -> torch.Tensor:
+    """Reconstruct the (padded) tensor from fp8 values and per-block fp32 scales."""
+    m, n = q.shape
+    pm = ceil_div(m, 128) * 128
+    pn = ceil_div(n, 128) * 128
+    q_padded = torch.zeros((pm, pn), dtype=torch.float32)
+    q_padded[:m, :n] = q.float()
+    q_view = q_padded.view(pm // 128, 128, pn // 128, 128)
+    sf_view = sf.view(pm // 128, 1, pn // 128, 1)
+    deq = (q_view * sf_view).view(pm, pn)
+    return deq[:m, :n]
+
+
+class TestPerBlockNoCastToFp8(CustomTestCase):
+    def test_output_dtype_and_scale_shape_aligned(self):
+        x = torch.randn(256, 512, dtype=torch.bfloat16)
+        q, sf = per_block_no_cast_to_fp8(x)
+
+        self.assertEqual(q.dtype, torch.float8_e4m3fn)
+        self.assertEqual(q.shape, x.shape)
+        self.assertEqual(sf.dtype, torch.float32)
+        self.assertEqual(sf.shape, (2, 4))
+        self.assertTrue(q.is_contiguous())
+
+    def test_scale_shape_unaligned_dims(self):
+        # 200 -> 2 blocks of 128, 300 -> 3 blocks of 128
+        x = torch.randn(200, 300, dtype=torch.bfloat16)
+        q, sf = per_block_no_cast_to_fp8(x)
+
+        self.assertEqual(q.shape, (200, 300))
+        self.assertEqual(sf.shape, (2, 3))
+
+    def test_scale_matches_per_block_amax(self):
+        x = torch.randn(128, 128, dtype=torch.bfloat16)
+        _, sf = per_block_no_cast_to_fp8(x)
+
+        expected = x.abs().float().amax().clamp(1e-4) / 448.0
+        self.assertEqual(sf.shape, (1, 1))
+        self.assertTrue(torch.allclose(sf.flatten(), expected.flatten(), atol=1e-6))
+
+    def test_roundtrip_dequant_accuracy(self):
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, dtype=torch.bfloat16)
+        q, sf = per_block_no_cast_to_fp8(x)
+
+        deq = _dequant_blocks(q, sf)
+        # fp8 e4m3 has ~2 decimal digits of precision; per-block scaling keeps
+        # relative error bounded. Compare against the bf16 reference.
+        ref = x.float()
+        rel = (deq - ref).abs() / ref.abs().clamp(min=1e-2)
+        self.assertLess(rel.mean().item(), 0.1)
+
+    def test_zero_block_clamped(self):
+        x = torch.zeros(128, 128, dtype=torch.bfloat16)
+        q, sf = per_block_no_cast_to_fp8(x)
+
+        # amax is clamped to 1e-4, so scale is 1e-4 / 448 (non-zero, finite).
+        self.assertTrue(torch.isfinite(sf).all())
+        self.assertGreater(sf.min().item(), 0.0)
+        self.assertTrue((q.float() == 0).all())
+
+
+class TestQuantWeightSfFp32(CustomTestCase):
+    def test_2d_weight(self):
+        n, k = 256, 384
+        w = torch.randn(n, k, dtype=torch.bfloat16)
+        out_w, out_s = quant_weight_sf_fp32(w, BLOCK_SIZE)
+
+        self.assertEqual(out_w.dtype, torch.float8_e4m3fn)
+        self.assertEqual(out_w.shape, (n, k))
+        self.assertEqual(out_s.shape, (ceil_div(n, 128), ceil_div(k, 128)))
+
+    def test_3d_weight_batch_dims_preserved(self):
+        e, n, k = 4, 256, 512
+        w = torch.randn(e, n, k, dtype=torch.bfloat16)
+        out_w, out_s = quant_weight_sf_fp32(w, BLOCK_SIZE)
+
+        self.assertEqual(out_w.shape, (e, n, k))
+        self.assertEqual(out_s.shape, (e, ceil_div(n, 128), ceil_div(k, 128)))
+
+    def test_rejects_non_bf16(self):
+        w = torch.randn(128, 128, dtype=torch.float16)
+        with self.assertRaises(AssertionError):
+            quant_weight_sf_fp32(w, BLOCK_SIZE)
+
+    def test_rejects_unsupported_block_size(self):
+        w = torch.randn(128, 128, dtype=torch.bfloat16)
+        with self.assertRaises(AssertionError):
+            quant_weight_sf_fp32(w, [128, 256])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Motivation

  Currently the block-wise FP8 path (`weight_block_size`) only supports **fp8-serialized checkpoints**. To run a model that ships as **bf16** with 128x128 per-block FP8, users have to pre-convert and re-serialize the checkpoint offline.

  This PR adds a `blockwise_fp8` quantization method that performs 128x128 per-block FP8 (E4M3) **online** weight quantization directly from a bf16 checkpoint, for both linear and MoE layers — no offline conversion step required. It is selected via `--quantization blockwise_fp8`.

  ## Modifications

  - **`fp8_utils.py`**
    - `per_block_no_cast_to_fp8`: pads to a 128x128 grid, computes per-block `amax/448` fp32 scales (clamped to `1e-4`), casts the weight to `float8_e4m3fn`. Unlike `per_block_cast_to_fp8`, the scale is kept as raw fp32 (no UE8M0 cast), so the triton runner can consume it directly.
    - `quant_weight_sf_fp32`: thin wrapper that flattens batch dims, quantizes, and reshapes the scale to `(*batch, ceil_div(n,128), ceil_div(k,128))`.
  - **`fp8.py`**
    - `Fp8Config`: new `blockwise_fp8` flag. When set and `weight_block_size` is `None`, it defaults to `[128, 128]`; the "fp8-serialized checkpoint only" guard is relaxed for this path.
    - `Fp8LinearMethod._quantize_blockwise_fp8_weights`: quantizes the bf16 linear weight in `process_weights_after_loading_block_quant`.
    - `Fp8MoEMethod._quantize_blockwise_fp8_moe_weights`: quantizes `w13_weight` / `w2_weight` **per-expert** to avoid the OOM from flattening all experts at once.
    - Both set `format_ue8m0 = False`; the existing DeepGEMM UE8M0 requant path is unchanged and still applies on top when DeepGEMM is the active runner.
  - **Registration**: add `"blockwise_fp8"` to `BASE_QUANTIZATION_METHODS`  (`quantization/__init__.py`), to `get_quant_config` (`weight_utils.py`, returns `Fp8Config(blockwise_fp8=True, is_checkpoint_fp8_serialized=False)`), and to `QUANTIZATION_CHOICES` (`server_args.py`).
  - **Tests**: add CPU unit tests for the pure tensor helpers  (`test/registered/unit/layers/quantization/test_blockwise_fp8_quant.py`).

  ## Accuracy Test

  Unit tests cover the quantization helpers (output dtype, per-block scale shape for both 128-aligned and unaligned dims, scale == per-block `amax/448`, zero-block clamping, round-trip dequant relative error, and batch-dim preservation for the 3-D MoE case):

  test/registered/unit/layers/quantization/test_blockwise_fp8_quant.py 9 passed

  <!-- TODO: add an end-to-end accuracy comparison (e.g. GSM8K / MMLU) of a bf16 model loaded with --quantization blockwise_fp8 vs the bf16 baseline on your target hardware before merge. -->

  ## Benchmark

  <!-- TODO: optionally add throughput/latency numbers on your target GPU. -->

  ## Checklist

  - [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation as needed, including docstrings or example tutorials.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28428976792](https://github.com/sgl-project/sglang/actions/runs/28428976792)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28428976541](https://github.com/sgl-project/sglang/actions/runs/28428976541)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->