### PR TITLE
[PD] Fix prefill DP rank routing under plain DP (non-DP-attention)

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -135,6 +135,14 @@ class CommonKVManager(BaseKVManager):
         self.system_dp_rank = (
             self.kv_args.system_dp_rank if self.kv_args.system_dp_rank else 0
         )
+        # Effective DP rank along the DP dimension that bootstrap_room hashes
+        # over. Under plain DP (enable_dp_attention=False) attn_dp_rank is a
+        # constant 0 for every subprocess, so we fall back to system_dp_rank
+        # which is the real per-process DP rank. Mirrors the dispatch in
+        # KVBootstrapServer.register at the bottom of this file.
+        self.effective_dp_rank = (
+            self.attn_dp_rank if self.system_dp_size == 1 else self.system_dp_rank
+        )
         self.pp_size = server_args.pp_size
         self.pp_rank = self.kv_args.pp_rank
         self.local_ip = get_local_ip_auto()
@@ -781,7 +789,7 @@ class CommonKVSender(BaseKVSender):
             if self.kv_mgr.server_args.load_balance_method != "follow_bootstrap_room":
                 self._register_prefill_dp_rank()
             elif (
-                self.kv_mgr.attn_dp_rank
+                self.kv_mgr.effective_dp_rank
                 != self.bootstrap_room % self.kv_mgr.server_args.dp_size
             ):
                 # follow_bootstrap_room was overridden by external routed_dp_rank
@@ -791,7 +799,7 @@ class CommonKVSender(BaseKVSender):
                     self.kv_mgr.record_failure(
                         self.bootstrap_room,
                         f"follow_bootstrap_room conflict: dispatched to dp_rank "
-                        f"{self.kv_mgr.attn_dp_rank} but bootstrap_room "
+                        f"{self.kv_mgr.effective_dp_rank} but bootstrap_room "
                         f"{self.bootstrap_room} implies dp_rank "
                         f"{self.bootstrap_room % self.kv_mgr.server_args.dp_size}. "
                         f"Set SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK=1 "
@@ -805,7 +813,7 @@ class CommonKVSender(BaseKVSender):
         url = f"http://{self.bootstrap_server_url}/register_dp_rank"
         payload = {
             "bootstrap_room": self.bootstrap_room,
-            "dp_rank": self.kv_mgr.attn_dp_rank,
+            "dp_rank": self.kv_mgr.effective_dp_rank,
         }
         try:
             response = requests.post(url, json=payload, timeout=5)

--- a/test/registered/unit/disaggregation/test_effective_dp_rank.py
+++ b/test/registered/unit/disaggregation/test_effective_dp_rank.py
@@ -1,0 +1,178 @@
+"""Unit tests for srt/disaggregation/common/conn — CommonKVSender DP rank routing.
+
+These tests cover the follow_bootstrap_room conflict check and the
+_register_prefill_dp_rank payload, which under plain DP must use the
+per-process system_dp_rank rather than attn_dp_rank (which is the rank
+*inside* the attention DP group and is constant 0 when DP attention is off).
+
+See also: PR #22901 (which introduced the conflict check) and the bug where
+every DP subprocess saw attn_dp_rank=0 and either rejected ~half of all
+requests (default LB) or registered every request as dp_rank=0 (with the
+SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK=1 workaround).
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.conn import CommonKVManager, CommonKVSender
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_manager_mock(
+    *,
+    attn_dp_rank: int,
+    system_dp_rank: int,
+    enable_dp_attention: bool,
+    dp_size: int,
+    load_balance_method: str = "follow_bootstrap_room",
+):
+    """Build a CommonKVManager-spec mock with the rank fields driven directly.
+
+    effective_dp_rank is computed exactly as CommonKVManager.__init__ does so
+    that calling the real CommonKVSender.__init__ exercises the source code.
+    """
+    mgr = MagicMock(spec=CommonKVManager)
+    mgr.attn_dp_rank = attn_dp_rank
+    mgr.system_dp_rank = system_dp_rank
+    mgr.system_dp_size = 1 if enable_dp_attention else dp_size
+    mgr.effective_dp_rank = (
+        mgr.attn_dp_rank if mgr.system_dp_size == 1 else mgr.system_dp_rank
+    )
+    mgr.is_dummy_cp_rank = False
+    mgr.server_args = MagicMock()
+    mgr.server_args.dp_size = dp_size
+    mgr.server_args.load_balance_method = load_balance_method
+    return mgr
+
+
+class TestEffectiveDpRankComputation(CustomTestCase):
+    """The effective_dp_rank assigned in CommonKVManager.__init__ must equal
+    system_dp_rank under plain DP (system_dp_size > 1) and attn_dp_rank under
+    DP attention (system_dp_size==1)."""
+
+    def test_plain_dp_uses_system_dp_rank(self):
+        mgr = _make_manager_mock(
+            attn_dp_rank=0, system_dp_rank=1, enable_dp_attention=False, dp_size=2
+        )
+        self.assertEqual(mgr.effective_dp_rank, 1)
+
+    def test_dp_attention_uses_attn_dp_rank(self):
+        mgr = _make_manager_mock(
+            attn_dp_rank=1, system_dp_rank=0, enable_dp_attention=True, dp_size=2
+        )
+        self.assertEqual(mgr.effective_dp_rank, 1)
+
+    def test_dp_size_one_collapses_to_zero(self):
+        mgr = _make_manager_mock(
+            attn_dp_rank=0, system_dp_rank=0, enable_dp_attention=False, dp_size=1
+        )
+        self.assertEqual(mgr.effective_dp_rank, 0)
+
+
+class TestFollowBootstrapRoomConflictCheck(CustomTestCase):
+    """The conflict check in CommonKVSender.__init__ must compare the *effective*
+    DP rank (= system_dp_rank under plain DP) against bootstrap_room % dp_size,
+    not attn_dp_rank (which is constant 0 under plain DP).
+
+    We construct a real CommonKVSender with a mocked manager so the actual
+    __init__ source is exercised. attn_dp_rank and effective_dp_rank are set
+    to *different* values so the choice between them is observable.
+    """
+
+    def _build_sender(self, mgr, bootstrap_room):
+        sender = CommonKVSender(
+            mgr=mgr,
+            bootstrap_addr="127.0.0.1:8765",
+            bootstrap_room=bootstrap_room,
+            dest_tp_ranks=[0],
+            pp_rank=0,
+        )
+        return sender
+
+    def test_dp1_with_room_implying_dp1_does_not_fail(self):
+        """A DP1 subprocess receives a request whose room%dp_size==1.  Under
+        the fix, effective_dp_rank=1 matches and the request passes through.
+        Before the fix, attn_dp_rank=0 != 1 and the request was rejected."""
+        mgr = _make_manager_mock(
+            attn_dp_rank=0,
+            system_dp_rank=1,
+            enable_dp_attention=False,
+            dp_size=2,
+        )
+        self._build_sender(mgr, bootstrap_room=43)  # 43 % 2 == 1
+        mgr.record_failure.assert_not_called()
+        statuses = [c.args[1] for c in mgr.update_status.call_args_list]
+        self.assertNotIn(KVPoll.Failed, statuses)
+
+    def test_dp0_with_room_implying_dp1_fails_with_correct_rank_in_message(self):
+        """A genuine routing conflict (room%2==1 dispatched to DP0) is still
+        flagged after the fix.  The error message must report the actual
+        dispatched DP rank (0 here), not always 0."""
+        mgr = _make_manager_mock(
+            attn_dp_rank=0,
+            system_dp_rank=0,
+            enable_dp_attention=False,
+            dp_size=2,
+        )
+        self._build_sender(mgr, bootstrap_room=43)
+        mgr.record_failure.assert_called_once()
+        msg = mgr.record_failure.call_args[0][1]
+        self.assertIn("dispatched to dp_rank 0", msg)
+        self.assertIn("implies dp_rank 1", msg)
+        statuses = [c.args[1] for c in mgr.update_status.call_args_list]
+        self.assertIn(KVPoll.Failed, statuses)
+
+    def test_dp_attention_rank_match(self):
+        """With DP attention on, effective_dp_rank == attn_dp_rank.  A DP-rank-1
+        worker getting a room%2==1 request must pass through without rejection."""
+        mgr = _make_manager_mock(
+            attn_dp_rank=1,
+            system_dp_rank=0,
+            enable_dp_attention=True,
+            dp_size=2,
+        )
+        self._build_sender(mgr, bootstrap_room=99)  # 99 % 2 == 1
+        mgr.record_failure.assert_not_called()
+
+
+class TestRegisterPrefillDpRankPayload(CustomTestCase):
+    """The /register_dp_rank payload must carry the per-process effective DP
+    rank, not attn_dp_rank.  Otherwise every DP subprocess registers as
+    dp_rank=0 and the decode side always queries DP0's port."""
+
+    @patch("sglang.srt.disaggregation.common.conn.requests.post")
+    def test_payload_uses_effective_dp_rank(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        mgr = _make_manager_mock(
+            attn_dp_rank=0,
+            system_dp_rank=1,
+            enable_dp_attention=False,
+            dp_size=2,
+            # Non-default LB drives the sender into _register_prefill_dp_rank
+            load_balance_method="round_robin",
+        )
+        CommonKVSender(
+            mgr=mgr,
+            bootstrap_addr="127.0.0.1:8765",
+            bootstrap_room=12345,
+            dest_tp_ranks=[0],
+            pp_rank=0,
+        )
+
+        mock_post.assert_called_once()
+        payload = mock_post.call_args[1]["json"]
+        self.assertEqual(payload["bootstrap_room"], 12345)
+        # Must be the effective rank (1), not attn_dp_rank (0).
+        self.assertEqual(payload["dp_rank"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_effective_dp_rank.py
+++ b/test/registered/unit/disaggregation/test_effective_dp_rank.py
@@ -25,53 +25,22 @@ from sglang.test.test_utils import CustomTestCase
 
 def _make_manager_mock(
     *,
-    attn_dp_rank: int,
-    system_dp_rank: int,
-    enable_dp_attention: bool,
+    effective_dp_rank: int,
     dp_size: int,
     load_balance_method: str = "follow_bootstrap_room",
 ):
-    """Build a CommonKVManager-spec mock with the rank fields driven directly.
+    """Build a CommonKVManager-spec mock with the fields CommonKVSender reads.
 
-    effective_dp_rank is computed exactly as CommonKVManager.__init__ does so
-    that calling the real CommonKVSender.__init__ exercises the source code.
+    `effective_dp_rank` is provided directly so the test fixture does not
+    re-derive what the source under test computes.
     """
     mgr = MagicMock(spec=CommonKVManager)
-    mgr.attn_dp_rank = attn_dp_rank
-    mgr.system_dp_rank = system_dp_rank
-    mgr.system_dp_size = 1 if enable_dp_attention else dp_size
-    mgr.effective_dp_rank = (
-        mgr.attn_dp_rank if mgr.system_dp_size == 1 else mgr.system_dp_rank
-    )
+    mgr.effective_dp_rank = effective_dp_rank
     mgr.is_dummy_cp_rank = False
     mgr.server_args = MagicMock()
     mgr.server_args.dp_size = dp_size
     mgr.server_args.load_balance_method = load_balance_method
     return mgr
-
-
-class TestEffectiveDpRankComputation(CustomTestCase):
-    """The effective_dp_rank assigned in CommonKVManager.__init__ must equal
-    system_dp_rank under plain DP (system_dp_size > 1) and attn_dp_rank under
-    DP attention (system_dp_size==1)."""
-
-    def test_plain_dp_uses_system_dp_rank(self):
-        mgr = _make_manager_mock(
-            attn_dp_rank=0, system_dp_rank=1, enable_dp_attention=False, dp_size=2
-        )
-        self.assertEqual(mgr.effective_dp_rank, 1)
-
-    def test_dp_attention_uses_attn_dp_rank(self):
-        mgr = _make_manager_mock(
-            attn_dp_rank=1, system_dp_rank=0, enable_dp_attention=True, dp_size=2
-        )
-        self.assertEqual(mgr.effective_dp_rank, 1)
-
-    def test_dp_size_one_collapses_to_zero(self):
-        mgr = _make_manager_mock(
-            attn_dp_rank=0, system_dp_rank=0, enable_dp_attention=False, dp_size=1
-        )
-        self.assertEqual(mgr.effective_dp_rank, 0)
 
 
 class TestFollowBootstrapRoomConflictCheck(CustomTestCase):
@@ -80,8 +49,7 @@ class TestFollowBootstrapRoomConflictCheck(CustomTestCase):
     not attn_dp_rank (which is constant 0 under plain DP).
 
     We construct a real CommonKVSender with a mocked manager so the actual
-    __init__ source is exercised. attn_dp_rank and effective_dp_rank are set
-    to *different* values so the choice between them is observable.
+    __init__ source is exercised.
     """
 
     def _build_sender(self, mgr, bootstrap_room):
@@ -98,12 +66,7 @@ class TestFollowBootstrapRoomConflictCheck(CustomTestCase):
         """A DP1 subprocess receives a request whose room%dp_size==1.  Under
         the fix, effective_dp_rank=1 matches and the request passes through.
         Before the fix, attn_dp_rank=0 != 1 and the request was rejected."""
-        mgr = _make_manager_mock(
-            attn_dp_rank=0,
-            system_dp_rank=1,
-            enable_dp_attention=False,
-            dp_size=2,
-        )
+        mgr = _make_manager_mock(effective_dp_rank=1, dp_size=2)
         self._build_sender(mgr, bootstrap_room=43)  # 43 % 2 == 1
         mgr.record_failure.assert_not_called()
         statuses = [c.args[1] for c in mgr.update_status.call_args_list]
@@ -113,12 +76,7 @@ class TestFollowBootstrapRoomConflictCheck(CustomTestCase):
         """A genuine routing conflict (room%2==1 dispatched to DP0) is still
         flagged after the fix.  The error message must report the actual
         dispatched DP rank (0 here), not always 0."""
-        mgr = _make_manager_mock(
-            attn_dp_rank=0,
-            system_dp_rank=0,
-            enable_dp_attention=False,
-            dp_size=2,
-        )
+        mgr = _make_manager_mock(effective_dp_rank=0, dp_size=2)
         self._build_sender(mgr, bootstrap_room=43)
         mgr.record_failure.assert_called_once()
         msg = mgr.record_failure.call_args[0][1]
@@ -130,12 +88,7 @@ class TestFollowBootstrapRoomConflictCheck(CustomTestCase):
     def test_dp_attention_rank_match(self):
         """With DP attention on, effective_dp_rank == attn_dp_rank.  A DP-rank-1
         worker getting a room%2==1 request must pass through without rejection."""
-        mgr = _make_manager_mock(
-            attn_dp_rank=1,
-            system_dp_rank=0,
-            enable_dp_attention=True,
-            dp_size=2,
-        )
+        mgr = _make_manager_mock(effective_dp_rank=1, dp_size=2)
         self._build_sender(mgr, bootstrap_room=99)  # 99 % 2 == 1
         mgr.record_failure.assert_not_called()
 
@@ -152,9 +105,7 @@ class TestRegisterPrefillDpRankPayload(CustomTestCase):
         mock_post.return_value = mock_response
 
         mgr = _make_manager_mock(
-            attn_dp_rank=0,
-            system_dp_rank=1,
-            enable_dp_attention=False,
+            effective_dp_rank=1,
             dp_size=2,
             # Non-default LB drives the sender into _register_prefill_dp_rank
             load_balance_method="round_robin",


### PR DESCRIPTION
CommonKVSender used attn_dp_rank in two places where the per-process system_dp_rank is required.  Under plain DP (--dp-size N without --enable-dp-attention) get_attention_dp_rank() returns 0 on every DP subprocess, so:

* the follow_bootstrap_room conflict check (default LB) rejected every request that landed on a DP rank > 0 and ~half of those landing on DP0, with the fingerprint "dispatched to dp_rank 0 but bootstrap_room X implies dp_rank Y" where the dispatched rank is always 0;

* the SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK=1 workaround registered every DP subprocess to the bootstrap server as dp_rank=0, so the decode side only ever queried DP0's rank_port and most requests timed out with bootstrap info stale / RDMA handshake errors.

Expose effective_dp_rank on CommonKVManager (= attn_dp_rank when system_dp_size==1, else system_dp_rank), mirroring the dispatch already in KVBootstrapServer.register, and use it at both sender sites.

Verified on H20 with MiMo-7B-RL, prefill --dp-size 2 + decode + mini_lb, 16 concurrent requests: before, conflict=8 (all "dispatched 0" / all DP1) and 8/16 succeed; after, conflict=0 and 16/16 succeed with prefill batches landing on DP0 and DP1.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

  Fixes #29725.

  `CommonKVSender` used `attn_dp_rank` in two places where the per-process `system_dp_rank` is required.  Under plain DP (`--dp-size N` without `--enable-dp-attention`) `get_attention_dp_rank()` returns 0 on every DP subprocess, so:

  * the `follow_bootstrap_room` conflict check (default LB) rejected every request that landed on a DP rank > 0 and ~half of those landing on DP0, with the fingerprint `dispatched to dp_rank 0 but bootstrap_room X implies dp_rank Y` where the dispatched rank is always 0;

  * the `SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK=1` workaround registered every DP subprocess to the bootstrap server as `dp_rank=0`, so the decode side only ever queried DP0's `rank_port` and most requests timed out with bootstrap-info-stale / RDMA handshake errors.

  PR #22901 introduced the consistency check; the field choice was the regression.
## Modifications

  * Expose `effective_dp_rank` on `CommonKVManager` (= `attn_dp_rank` when `system_dp_size == 1`, else `system_dp_rank`), mirroring the dispatch already in `KVBootstrapServer.register` (`conn.py:1310-1314`).
  * Use `effective_dp_rank` at both sender sites:
    * the `follow_bootstrap_room` conflict check in `CommonKVSender.__init__`,
    * the `_register_prefill_dp_rank` HTTP payload.
  * Add unit tests in
  `test/registered/unit/disaggregation/test_effective_dp_rank.py` covering the conflict-check branch and the registration payload, both for plain DP and for DP attention.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
  Not applicable — this PR only changes which DP-rank field is used for KV transfer routing; it does not touch model forward code or kernels.


## Speed Tests and Profiling

  Not applicable for the same reason.  E2E verification on H20 with MiMo-7B-RL, prefill `--dp-size 2` + decode + `mini_lb`, 16 concurrent requests:

| Metric | Before fix | After fix |
  | --- | --- | --- |
  | `follow_bootstrap_room conflict` log lines | 8 | 0 |
  | `Prefill bootstrap failed` log lines | 8 | 0 |
  | Successful responses (out of 16) | 8 / 16 | 16 / 16 |
  | Which DP failed | all DP1 (DP0 coincidentally matched) | none |
  | DP scheduling distribution | DP0 only (DP1 always rejected) | DP0 + DP1 |

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28430629948](https://github.com/sgl-project/sglang/actions/runs/28430629948)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28430629802](https://github.com/sgl-project/sglang/actions/runs/28430629802)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->