### PR TITLE
fix: use system DP rank for prefill sender

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -781,7 +781,9 @@ class CommonKVSender(BaseKVSender):
             prefill_dp_rank = self._prefill_dp_rank()
             if self.kv_mgr.server_args.load_balance_method != "follow_bootstrap_room":
                 self._register_prefill_dp_rank()
-            elif prefill_dp_rank != self.bootstrap_room % self.kv_mgr.server_args.dp_size:
+            elif (
+                prefill_dp_rank != self.bootstrap_room % self.kv_mgr.server_args.dp_size
+            ):
                 # follow_bootstrap_room was overridden by external routed_dp_rank
                 if envs.SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK.get():
                     self._register_prefill_dp_rank()

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -778,12 +778,10 @@ class CommonKVSender(BaseKVSender):
 
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
         if self.kv_mgr.server_args.dp_size > 1:
+            prefill_dp_rank = self._prefill_dp_rank()
             if self.kv_mgr.server_args.load_balance_method != "follow_bootstrap_room":
                 self._register_prefill_dp_rank()
-            elif (
-                self.kv_mgr.attn_dp_rank
-                != self.bootstrap_room % self.kv_mgr.server_args.dp_size
-            ):
+            elif prefill_dp_rank != self.bootstrap_room % self.kv_mgr.server_args.dp_size:
                 # follow_bootstrap_room was overridden by external routed_dp_rank
                 if envs.SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK.get():
                     self._register_prefill_dp_rank()
@@ -791,7 +789,7 @@ class CommonKVSender(BaseKVSender):
                     self.kv_mgr.record_failure(
                         self.bootstrap_room,
                         f"follow_bootstrap_room conflict: dispatched to dp_rank "
-                        f"{self.kv_mgr.attn_dp_rank} but bootstrap_room "
+                        f"{prefill_dp_rank} but bootstrap_room "
                         f"{self.bootstrap_room} implies dp_rank "
                         f"{self.bootstrap_room % self.kv_mgr.server_args.dp_size}. "
                         f"Set SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK=1 "
@@ -800,12 +798,19 @@ class CommonKVSender(BaseKVSender):
                     self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
                     return
 
+    def _prefill_dp_rank(self):
+        return (
+            self.kv_mgr.attn_dp_rank
+            if self.kv_mgr.system_dp_size == 1
+            else self.kv_mgr.system_dp_rank
+        )
+
     def _register_prefill_dp_rank(self):
         """Register this request's prefill dp_rank to the bootstrap server."""
         url = f"http://{self.bootstrap_server_url}/register_dp_rank"
         payload = {
             "bootstrap_room": self.bootstrap_room,
-            "dp_rank": self.kv_mgr.attn_dp_rank,
+            "dp_rank": self._prefill_dp_rank(),
         }
         try:
             response = requests.post(url, json=payload, timeout=5)

--- a/test/registered/unit/disaggregation/test_register_to_bootstrap.py
+++ b/test/registered/unit/disaggregation/test_register_to_bootstrap.py
@@ -231,6 +231,100 @@ class TestRegisterToBootstrap(CustomTestCase):
         self.assertNotIn("[::]", url_used)
         self.assertIn("[::1]", url_used)
 
+    def test_sender_follow_bootstrap_room_uses_system_dp_rank_for_plain_dp(self):
+        from sglang.srt.disaggregation.common.conn import CommonKVSender
+
+        mgr = self._make_manager()
+        mgr.attn_dp_rank = 0
+        mgr.system_dp_size = 2
+        mgr.system_dp_rank = 1
+        mgr.server_args.dp_size = 2
+
+        CommonKVSender(
+            mgr,
+            bootstrap_addr="127.0.0.1:8765",
+            bootstrap_room=3,
+            dest_tp_ranks=[0],
+            pp_rank=0,
+        )
+
+        mgr.record_failure.assert_not_called()
+
+    def test_sender_follow_bootstrap_room_rejects_wrong_plain_dp_rank(self):
+        from sglang.srt.disaggregation.common.conn import CommonKVSender, KVPoll
+
+        mgr = self._make_manager()
+        mgr.attn_dp_rank = 0
+        mgr.system_dp_size = 2
+        mgr.system_dp_rank = 1
+        mgr.server_args.dp_size = 2
+
+        CommonKVSender(
+            mgr,
+            bootstrap_addr="127.0.0.1:8765",
+            bootstrap_room=2,
+            dest_tp_ranks=[0],
+            pp_rank=0,
+        )
+
+        mgr.record_failure.assert_called_once()
+        self.assertIn("dispatched to dp_rank 1", mgr.record_failure.call_args[0][1])
+        mgr.update_status.assert_any_call(2, KVPoll.Failed)
+
+    @patch("sglang.srt.disaggregation.common.conn.requests.post")
+    def test_sender_register_dp_rank_uses_system_dp_rank_for_plain_dp(self, mock_post):
+        from sglang.srt.disaggregation.common.conn import CommonKVSender
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        mgr = self._make_manager()
+        mgr.attn_dp_rank = 0
+        mgr.system_dp_size = 2
+        mgr.system_dp_rank = 1
+        mgr.server_args.dp_size = 2
+        mgr.server_args.load_balance_method = "round_robin"
+
+        CommonKVSender(
+            mgr,
+            bootstrap_addr="127.0.0.1:8765",
+            bootstrap_room=3,
+            dest_tp_ranks=[0],
+            pp_rank=0,
+        )
+
+        payload = mock_post.call_args[1]["json"]
+        self.assertEqual(payload["dp_rank"], 1)
+
+    @patch("sglang.srt.disaggregation.common.conn.requests.post")
+    def test_sender_register_dp_rank_keeps_attention_rank_for_dp_attention(
+        self, mock_post
+    ):
+        from sglang.srt.disaggregation.common.conn import CommonKVSender
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        mgr = self._make_manager()
+        mgr.attn_dp_rank = 2
+        mgr.system_dp_size = 1
+        mgr.system_dp_rank = 0
+        mgr.server_args.dp_size = 4
+        mgr.server_args.load_balance_method = "round_robin"
+
+        CommonKVSender(
+            mgr,
+            bootstrap_addr="127.0.0.1:8765",
+            bootstrap_room=6,
+            dest_tp_ranks=[0],
+            pp_rank=0,
+        )
+
+        payload = mock_post.call_args[1]["json"]
+        self.assertEqual(payload["dp_rank"], 2)
+
     def _make_manager(self, dist_init_addr=None):
         """Create a lightweight mock manager that has the attributes needed
         by register_to_bootstrap, without going through CommonKVManager.__init__
@@ -259,6 +353,7 @@ class TestRegisterToBootstrap(CustomTestCase):
         mgr.system_dp_rank = 0
         mgr.local_ip = "127.0.0.1"
         mgr.rank_port = 12345
+        mgr.is_dummy_cp_rank = False
 
         mgr.kv_args = MagicMock()
         mgr.kv_args.page_size = 16
@@ -266,6 +361,7 @@ class TestRegisterToBootstrap(CustomTestCase):
         mgr.server_args = MagicMock()
         mgr.server_args.kv_cache_dtype = "auto"
         mgr.server_args.load_balance_method = "follow_bootstrap_room"
+        mgr.server_args.dp_size = 1
 
         return mgr
 


### PR DESCRIPTION
Fixes #29725.

Plain DP has a separate system DP rank, while the attention DP rank stays at 0. This uses the same DP rank selection as bootstrap registration when the prefill sender checks `follow_bootstrap_room` and registers `dp_rank`.

Tests:
- `python -m py_compile python/sglang/srt/disaggregation/common/conn.py test/registered/unit/disaggregation/test_register_to_bootstrap.py`
- `python -m ruff check python/sglang/srt/disaggregation/common/conn.py test/registered/unit/disaggregation/test_register_to_bootstrap.py --ignore E402`
- `git diff --check`













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->