### PR TITLE
[Spec Decode] Add cuLA KVBuffer backend for Lightning Attention

### DIFF
--- a/benchmark/lightning_cula/bench_state_layout.py
+++ b/benchmark/lightning_cula/bench_state_layout.py
@@ -1,0 +1,147 @@
+"""Operator-level benchmark: seg_la kv vs vk state layout.
+
+Compares ``seg_la_fwd(state_layout="kv")`` vs ``"vk"`` for PREFILL and
+DECODE paths on Ling-2.6-flash dims (H=HV=8, D=128).  Sweeps (B, S)
+configs and prints a per-path, per-config timing table.
+
+Columns:  path, B, S, H, D, layout, ms, ratio
+"""
+
+import argparse
+
+import torch
+
+from sglang.srt.layers.attention.linear.seg_la import SegLaMeta, seg_la_fwd
+
+
+def _bench(fn, iters=50, warmup=10):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters  # ms/iter
+
+
+def make_inputs(B, S, H, D):
+    total = B * S
+    q = torch.randn(total, H, D, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(total, H, D, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(total, H, D, device="cuda", dtype=torch.bfloat16)
+    decay = (0.3 * torch.arange(1, H + 1, device="cuda", dtype=torch.float32) / H).view(
+        H, 1, 1
+    )
+    return q, k, v, decay
+
+
+def make_closure(B, S, H, D, q, k, v, decay, scale, layout):
+    s = torch.zeros(B, H, D, D, device="cuda", dtype=torch.float32)
+    if layout == "vk":
+        s = s.transpose(-1, -2).contiguous()
+    q_offsets = torch.arange(0, B * S + 1, S, device="cuda", dtype=torch.int32)
+    meta = SegLaMeta(
+        batch_size=B,
+        max_q_length=S,
+        q_offsets=q_offsets,
+        s_offsets=torch.arange(B, device="cuda", dtype=torch.int32),
+        q_lengths=torch.full((B,), S, device="cuda", dtype=torch.int32),
+        s_scales=torch.zeros(B, device="cuda", dtype=torch.int32),
+    )
+
+    def run():
+        seg_la_fwd(q, k, v, s, decay, meta, softmax_scale=scale, state_layout=layout)
+
+    return run
+
+
+def make_decode_closure(B, H, D, q, k, v, decay, scale, layout):
+    s = torch.randn(B, H, D, D, device="cuda", dtype=torch.float32)
+    if layout == "vk":
+        s = s.transpose(-1, -2).contiguous()
+    q_offsets = torch.arange(0, B + 1, 1, device="cuda", dtype=torch.int32)
+    meta = SegLaMeta(
+        batch_size=B,
+        max_q_length=1,
+        q_offsets=q_offsets,
+        s_offsets=torch.arange(B, device="cuda", dtype=torch.int32),
+        q_lengths=torch.ones(B, device="cuda", dtype=torch.int32),
+        s_scales=torch.ones(B, device="cuda", dtype=torch.int32),
+    )
+
+    def run():
+        seg_la_fwd(q, k, v, s, decay, meta, softmax_scale=scale, state_layout=layout)
+
+    return run
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--H", type=int, default=8)
+    ap.add_argument("--D", type=int, default=128)
+    ap.add_argument("--iters", type=int, default=50)
+    args = ap.parse_args()
+    H, D = args.H, args.D
+    scale = D**-0.5
+
+    header = f"{'path':>8} {'B':>4} {'S':>6} {'tokens':>8} {'H':>3} {'D':>4} {'layout':>5} {'ms':>11} {'ratio':>8}"
+    print(
+        f"seg_la state_layout bench | H={H} D={D} | "
+        f"{torch.cuda.get_device_name(0)} "
+        f"sm_{torch.cuda.get_device_properties(0).major}"
+        f"{torch.cuda.get_device_properties(0).minor}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    # ------- PREFILL -------
+    for B, S in [
+        (1, 256),
+        (1, 1024),
+        (1, 4096),
+        (4, 512),
+        (8, 1024),
+        (16, 512),
+        (1, 8192),
+    ]:
+        torch.manual_seed(0)
+        q, k, v, decay = make_inputs(B, S, H, D)
+        t_kv = _bench(
+            make_closure(B, S, H, D, q, k, v, decay, scale, "kv"), iters=args.iters
+        )
+        t_vk = _bench(
+            make_closure(B, S, H, D, q, k, v, decay, scale, "vk"), iters=args.iters
+        )
+        ratio = t_vk / t_kv if t_kv > 0 else float("nan")
+        print(
+            f"{'PREFILL':>8} {B:>4} {S:>6} {B * S:>8} {H:>3} {D:>4} {'kv':>5} {t_kv:>11.4f} {'--':>8}"
+        )
+        print(
+            f"{'PREFILL':>8} {B:>4} {S:>6} {B * S:>8} {H:>3} {D:>4} {'vk':>5} {t_vk:>11.4f} {ratio:>7.2f}x"
+        )
+
+    # ------- DECODE -------
+    for B in [1, 32, 128, 256]:
+        torch.manual_seed(1)
+        q, k, v, decay = make_inputs(B, 1, H, D)
+        t_kv = _bench(
+            make_decode_closure(B, H, D, q, k, v, decay, scale, "kv"), iters=args.iters
+        )
+        t_vk = _bench(
+            make_decode_closure(B, H, D, q, k, v, decay, scale, "vk"), iters=args.iters
+        )
+        ratio = t_vk / t_kv if t_kv > 0 else float("nan")
+        print(
+            f"{'DECODE':>8} {B:>4} {1:>6} {B:>8} {H:>3} {D:>4} {'kv':>5} {t_kv:>11.4f} {'--':>8}"
+        )
+        print(
+            f"{'DECODE':>8} {B:>4} {1:>6} {B:>8} {H:>3} {D:>4} {'vk':>5} {t_vk:>11.4f} {ratio:>7.2f}x"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -96,6 +96,10 @@ default = true
 [project.optional-dependencies]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
+# cuLA Lightning-Attention KVBuffer backend (linear_backend="cula"). Requires
+# Python 3.12+, CUDA 12.9+, and Blackwell (sm100) GPUs. Install from source:
+#   pip install -e https://github.com/inclusionAI/cuLA.git --no-build-isolation
+cula = ["cuda-linear-attention"]
 diffusion = [
   "addict==2.4.0",
   "av==16.1.0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -99,7 +99,6 @@ runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
 # cuLA Lightning-Attention KVBuffer backend (linear_backend="cula"). Requires
 # Python 3.12+, CUDA 12.9+, and Blackwell (sm100) GPUs. Install from source:
 #   pip install -e https://github.com/inclusionAI/cuLA.git --no-build-isolation
-cula = ["cuda-linear-attention"]
 diffusion = [
   "addict==2.4.0",
   "av==16.1.0",

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -205,6 +205,7 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
         mamba_size: int = None,
         start_layer: int = None,
         speculative_eagle_topk: Optional[int] = None,
+        linear_backend: str = "seg_la",
     ):
         DecodeReqToTokenPool.__init__(
             self,
@@ -249,6 +250,7 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
             enable_mamba_extra_buffer=self.enable_mamba_extra_buffer,
             speculative_num_draft_tokens=speculative_num_draft_tokens,
             speculative_eagle_topk=speculative_eagle_topk,
+            linear_backend=linear_backend,
         )
 
     def clear(self):

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1077,37 +1077,45 @@ class HybridLinearAttnBackend(AttentionBackend):
             )
 
     def _cula_commit(self, last_correct_step_indices: torch.Tensor):
-        from sglang.srt.layers.attention.linear.cula_entry import cula_commit
+        from sglang.srt.layers.attention.linear.cula_entry import cula_commit_fused
 
         request_number = last_correct_step_indices.shape[0]
+        if request_number == 0:
+            return
         cache_indices = self.linear_attn_backend.forward_metadata.mamba_cache_indices[
             :request_number
         ]
         mamba_caches = (
             self.linear_attn_backend.req_to_token_pool.get_speculative_mamba2_params_all_layers()
         )
-        accepted_len = (last_correct_step_indices + 1).clamp(min=0).to(torch.int32)
+        accepted_len = (last_correct_step_indices + 1).clamp(min=0)
+        if accepted_len.dtype != torch.int32:
+            accepted_len = accepted_len.to(torch.int32)
         T = mamba_caches.draft_k.shape[2]
-        mamba_layer_ids = list(
-            self.linear_attn_backend.req_to_token_pool.mamba_map.keys()
-        )
-        decay_slopes = self.linear_attn_backend.tp_slope
-        mamba_map = self.linear_attn_backend.req_to_token_pool.mamba_map
-        # Gather the active slots for ALL layers in two launches instead of
-        # per-layer advanced indexing inside the loop (28 gathers -> 1).
-        dk_all = mamba_caches.draft_k[:, cache_indices]  # [L, B, T, H, K]
-        dv_all = mamba_caches.draft_v[:, cache_indices]  # [L, B, T, HV, V]
-        for layer_id in mamba_layer_ids:
-            layer_idx = mamba_map[layer_id]
-            cula_commit(
-                dk_all[layer_idx],
-                dv_all[layer_idx],
-                mamba_caches.temporal[layer_idx],
-                cache_indices,
-                accepted_len,
-                decay_slopes[layer_id],
-                T,
+        # Per-layer decay slopes stacked to [L, H] (cached; tp_slope is fixed).
+        decay_all = getattr(self, "_cula_decay_all", None)
+        if decay_all is None:
+            mamba_layer_ids = list(
+                self.linear_attn_backend.req_to_token_pool.mamba_map.keys()
             )
+            decay_all = torch.stack(
+                [
+                    self.linear_attn_backend.tp_slope[lid].view(-1).contiguous()
+                    for lid in mamba_layer_ids
+                ]
+            )
+            self._cula_decay_all = decay_all
+        # Single fused launch: advances ALL layers' temporal state in place,
+        # reading draft_k/draft_v pool-indexed (no gather, no per-layer loop).
+        cula_commit_fused(
+            mamba_caches.draft_k,
+            mamba_caches.draft_v,
+            mamba_caches.temporal,
+            cache_indices,
+            accepted_len,
+            decay_all,
+            T,
+        )
 
 
 class ShortConvHybridAttnBackend(HybridLinearAttnBackend):

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1014,7 +1014,20 @@ class HybridLinearAttnBackend(AttentionBackend):
         mamba_steps_to_track: Optional[torch.Tensor],
         model,
     ):
-        """Update mamba states after MTP verify via a fused gather-scatter kernel."""
+        """
+        Update mamba states after MTP verify using fully fused Triton kernel.
+
+        This replaces the original advanced indexing operations with a single fused
+        gather-scatter kernel that also handles masking internally, avoiding:
+        - index_elementwise_kernel from tensor[bool_mask]
+        - index_select kernel launches
+        - nonzero kernel launches
+        """
+        linear_backend = getattr(self.linear_attn_backend, "linear_backend", "seg_la")
+        if linear_backend == "cula":
+            self._cula_commit(last_correct_step_indices)
+            return
+
         request_number = last_correct_step_indices.shape[0]
 
         state_indices_tensor = (
@@ -1061,6 +1074,39 @@ class HybridLinearAttnBackend(AttentionBackend):
                 intermediate_conv_window_cache,
                 mamba_track_indices,
                 mamba_steps_to_track,
+            )
+
+    def _cula_commit(self, last_correct_step_indices: torch.Tensor):
+        from sglang.srt.layers.attention.linear.cula_entry import cula_commit
+
+        request_number = last_correct_step_indices.shape[0]
+        cache_indices = self.linear_attn_backend.forward_metadata.mamba_cache_indices[
+            :request_number
+        ]
+        mamba_caches = (
+            self.linear_attn_backend.req_to_token_pool.get_speculative_mamba2_params_all_layers()
+        )
+        accepted_len = (last_correct_step_indices + 1).clamp(min=0).to(torch.int32)
+        T = mamba_caches.draft_k.shape[2]
+        mamba_layer_ids = list(
+            self.linear_attn_backend.req_to_token_pool.mamba_map.keys()
+        )
+        decay_slopes = self.linear_attn_backend.tp_slope
+        mamba_map = self.linear_attn_backend.req_to_token_pool.mamba_map
+        # Gather the active slots for ALL layers in two launches instead of
+        # per-layer advanced indexing inside the loop (28 gathers -> 1).
+        dk_all = mamba_caches.draft_k[:, cache_indices]  # [L, B, T, H, K]
+        dv_all = mamba_caches.draft_v[:, cache_indices]  # [L, B, T, HV, V]
+        for layer_id in mamba_layer_ids:
+            layer_idx = mamba_map[layer_id]
+            cula_commit(
+                dk_all[layer_idx],
+                dv_all[layer_idx],
+                mamba_caches.temporal[layer_idx],
+                cache_indices,
+                accepted_len,
+                decay_slopes[layer_id],
+                T,
             )
 
 

--- a/python/sglang/srt/layers/attention/linear/cula_entry.py
+++ b/python/sglang/srt/layers/attention/linear/cula_entry.py
@@ -10,7 +10,7 @@ try:
     )
 
     CULA_AVAILABLE = True
-except ImportError:
+except (ImportError, OSError):
     CULA_AVAILABLE = False
 
 
@@ -32,15 +32,6 @@ def _as_bf16(t: torch.Tensor) -> torch.Tensor:
     """
     if t.dtype != torch.bfloat16:
         return t.to(torch.bfloat16).contiguous()
-    return t.contiguous()
-
-
-def _as_contiguous(t: torch.Tensor) -> torch.Tensor:
-    """Ensure contiguous without dtype cast. cuLA's decode/verify kernels compute
-    in fp32/TF32 (SMEM is fp32, MMA is TF32) and accept fp32 q/k/v natively, so we
-    pass Ling's fp32 q/k/v straight through — no fp32->bf16 cast, which would add 3
-    cast kernels/layer/step that dominated the graph-replay cost.
-    """
     return t.contiguous()
 
 
@@ -94,10 +85,12 @@ def cula_decode(q, k, v, temporal, cache_indices, decay, scale, out):
     # cuLA decode computes in fp32 (element-wise recurrence); pass q/k/v through
     # in their native dtype (fp32 at runtime) — casting to bf16 would only add
     # cast kernels that the kernel re-converts to fp32 internally.
-    q, k, v = _as_contiguous(q), _as_contiguous(k), _as_contiguous(v)
+    if not (q.is_contiguous() and k.is_contiguous() and v.is_contiguous()):
+        q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
     # Caller must pass a bf16 output buffer; a dtype-dependent re-allocation here
     # would silently swap the buffer baked into a captured CUDA graph.
     assert out.dtype == torch.bfloat16, "cula_decode out must be bf16"
+    assert cache_indices.dtype == torch.int32, "cache_indices must be int32"
     HEAD_DIM = q.shape[-1]
     V_DIM = v.shape[-1]
     pool_size = temporal.shape[0]
@@ -115,7 +108,7 @@ def cula_decode(q, k, v, temporal, cache_indices, decay, scale, out):
         stride_v=v.stride(0),
         stride_s=temporal_3d.stride(0),
         stride_o=out.stride(0),
-        s_offsets=cache_indices.to(torch.int32),
+        s_offsets=cache_indices,
         decay_scales=decay.view(-1),
         HEAD_DIM=HEAD_DIM,
         K_SPLIT_DIM=HEAD_DIM,
@@ -136,7 +129,7 @@ def cula_verify(
         decay: [H, 1, 1] fp32 positive slopes
         scale: float softmax scale
         T: int draft_token_num
-        out: [B*T, HV, V] bf16 preallocated output
+        out: [B*T, HV, V] fp32 preallocated output
         k_buf, v_buf: [pool_size, T, H, K] / [pool_size, T, HV, V] fp32 draft
             buffers. When provided, the kernel writes k/v into them (fused,
             write_kv=True) so the caller does NOT need separate scatter kernels.
@@ -144,6 +137,7 @@ def cula_verify(
         out reshaped to [B*T, HV, V]
     """
     _check_cula()
+    output_dtype = v.dtype
     # cuLA verify kernel loads q/k into fp32 registers (autovec_copy requires
     # matching bit-width). At runtime Ling feeds fp32 (fp32 rotary) -> no cast.
     # For non-fp32 inputs (test kit bf16), cast to fp32 (defensive, not hot path).
@@ -151,9 +145,10 @@ def cula_verify(
         q = q.to(torch.float32).contiguous()
         k = k.to(torch.float32).contiguous()
         v = v.to(torch.float32).contiguous()
-    else:
-        q, k, v = _as_contiguous(q), _as_contiguous(k), _as_contiguous(v)
-    assert out.dtype == torch.bfloat16, "cula_verify out must be bf16"
+    elif not (q.is_contiguous() and k.is_contiguous() and v.is_contiguous()):
+        q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
+    assert out.dtype == torch.float32, "cula_verify out must be fp32"
+    assert cache_indices.dtype == torch.int32, "cache_indices must be int32"
     B = cache_indices.shape[0]
     H = q.shape[1]
     K = q.shape[2]
@@ -170,13 +165,13 @@ def cula_verify(
         temporal,
         out4,
         decay.view(-1),
-        cache_indices.to(torch.int32),
+        cache_indices,
         scale,
         T,
         k_buf=k_buf,
         v_buf=v_buf,
     )
-    return out
+    return out if out.dtype == output_dtype else out.to(output_dtype)
 
 
 def cula_commit(draft_k, draft_v, temporal, cache_indices, accepted_len, decay, T):
@@ -192,13 +187,15 @@ def cula_commit(draft_k, draft_v, temporal, cache_indices, accepted_len, decay, 
         T: int draft_token_num
     """
     _check_cula()
+    assert cache_indices.dtype == torch.int32, "cache_indices must be int32"
+    assert accepted_len.dtype == torch.int32, "accepted_len must be int32"
     linear_attention_state_update_kvbuffer(
         draft_k,
         draft_v,
         temporal,
         decay.view(-1),
-        cache_indices.to(torch.int32),
-        accepted_len.to(torch.int32),
+        cache_indices,
+        accepted_len,
         T,
     )
 
@@ -218,12 +215,14 @@ def cula_commit_fused(
         T: int draft_token_num
     """
     _check_cula()
+    assert cache_indices.dtype == torch.int32, "cache_indices must be int32"
+    assert accepted_len.dtype == torch.int32, "accepted_len must be int32"
     linear_attention_state_update_kvbuffer_fused(
         draft_k,
         draft_v,
         temporal,
         decay_all,
-        cache_indices.to(torch.int32),
-        accepted_len.to(torch.int32),
+        cache_indices,
+        accepted_len,
         T,
     )

--- a/python/sglang/srt/layers/attention/linear/cula_entry.py
+++ b/python/sglang/srt/layers/attention/linear/cula_entry.py
@@ -1,0 +1,229 @@
+import torch
+
+try:
+    from cula.lightning import (
+        lightning_attn_fwd_varlen,
+        linear_attention_decode,
+        linear_attention_state_update_kvbuffer,
+        linear_attention_state_update_kvbuffer_fused,
+        linear_attention_verify_kvbuffer,
+    )
+
+    CULA_AVAILABLE = True
+except ImportError:
+    CULA_AVAILABLE = False
+
+
+def _check_cula():
+    if not CULA_AVAILABLE:
+        raise ImportError(
+            "cuLA is required for linear_backend='cula'. "
+            "Install it from https://github.com/inclusionAI/cuLA:\n"
+            "  git clone https://github.com/inclusionAI/cuLA.git\n"
+            "  pip install -e cuLA --no-build-isolation\n"
+            "Requirements: Python 3.12+, CUDA 12.9+, PyTorch 2.9.1+."
+        )
+
+
+def _as_bf16(t: torch.Tensor) -> torch.Tensor:
+    """Cast to contiguous bf16. Unused on the live cula path now (the kernels
+    compute in fp32/TF32 internally and accept fp32 q/k/v directly — see
+    cula_decode/cula_verify); kept for cula_prefill and as a helper.
+    """
+    if t.dtype != torch.bfloat16:
+        return t.to(torch.bfloat16).contiguous()
+    return t.contiguous()
+
+
+def _as_contiguous(t: torch.Tensor) -> torch.Tensor:
+    """Ensure contiguous without dtype cast. cuLA's decode/verify kernels compute
+    in fp32/TF32 (SMEM is fp32, MMA is TF32) and accept fp32 q/k/v natively, so we
+    pass Ling's fp32 q/k/v straight through — no fp32->bf16 cast, which would add 3
+    cast kernels/layer/step that dominated the graph-replay cost.
+    """
+    return t.contiguous()
+
+
+# Kept as the entry point for a future all-cuLA prefill path. The current
+# linear_backend="cula" routes prefill through the seg_la kernel family with
+# [v,k] state layout (see lightning_backend.py) so only decode/verify/commit
+# use cuLA; this wrapper is therefore not on the live call path today.
+def cula_prefill(q, k, v, temporal, cache_indices, cu_seqlens, decay, scale):
+    """Prefill via cuLA varlen Lightning Attention.
+
+    Args:
+        q, k, v: [total_tokens, H, D] bf16 packed
+        temporal: [pool_size, H, V, K] fp32 V-major state pool (per-layer slice)
+        cache_indices: [N] int32 indices into pool
+        cu_seqlens: [N+1] int32 cumulative seq lens
+        decay: [H, 1, 1] fp32 positive slopes
+        scale: float softmax scale
+    Returns:
+        o: [total_tokens, H, D] bf16
+    """
+    _check_cula()
+    q, k, v = _as_bf16(q), _as_bf16(k), _as_bf16(v)
+    total_tokens = q.shape[0]
+    o, _ = lightning_attn_fwd_varlen(
+        q.unsqueeze(0),
+        k.unsqueeze(0),
+        v.unsqueeze(0),
+        decay.view(-1),
+        cu_seqlens,
+        scale=scale,
+        state_pool=temporal,
+        initial_state_indices=cache_indices.to(torch.int32),
+    )
+    return o.squeeze(0)
+
+
+def cula_decode(q, k, v, temporal, cache_indices, decay, scale, out):
+    """Single-token decode via cuLA.
+
+    Args:
+        q, k, v: [B, H, D] bf16
+        temporal: [pool_size, HV, V, K] fp32 V-major state pool (per-layer slice)
+        cache_indices: [B] int32 indices into pool
+        decay: [H, 1, 1] fp32 positive slopes
+        scale: float softmax scale
+        out: [B, H, D] bf16 preallocated output
+    Returns:
+        out: [B, H, D] bf16
+    """
+    _check_cula()
+    # cuLA decode computes in fp32 (element-wise recurrence); pass q/k/v through
+    # in their native dtype (fp32 at runtime) — casting to bf16 would only add
+    # cast kernels that the kernel re-converts to fp32 internally.
+    q, k, v = _as_contiguous(q), _as_contiguous(k), _as_contiguous(v)
+    # Caller must pass a bf16 output buffer; a dtype-dependent re-allocation here
+    # would silently swap the buffer baked into a captured CUDA graph.
+    assert out.dtype == torch.bfloat16, "cula_decode out must be bf16"
+    HEAD_DIM = q.shape[-1]
+    V_DIM = v.shape[-1]
+    pool_size = temporal.shape[0]
+    HV = temporal.shape[1]
+    temporal_3d = temporal.view(pool_size * HV, temporal.shape[2], temporal.shape[3])
+    linear_attention_decode(
+        q,
+        k,
+        v,
+        temporal_3d,
+        out,
+        softmax_scale=scale,
+        stride_q=q.stride(0),
+        stride_k=k.stride(0),
+        stride_v=v.stride(0),
+        stride_s=temporal_3d.stride(0),
+        stride_o=out.stride(0),
+        s_offsets=cache_indices.to(torch.int32),
+        decay_scales=decay.view(-1),
+        HEAD_DIM=HEAD_DIM,
+        K_SPLIT_DIM=HEAD_DIM,
+        V_SPLIT_DIM=V_DIM,
+    )
+    return out
+
+
+def cula_verify(
+    q, k, v, temporal, cache_indices, decay, scale, T, out, k_buf=None, v_buf=None
+):
+    """Parallel verify via cuLA KVBuffer.
+
+    Args:
+        q, k, v: [B*T, H, D] fp32 packed (uniform T per request)
+        temporal: [pool_size, HV, V, K] fp32 V-major state pool (per-layer slice)
+        cache_indices: [B] int32 indices into pool
+        decay: [H, 1, 1] fp32 positive slopes
+        scale: float softmax scale
+        T: int draft_token_num
+        out: [B*T, HV, V] bf16 preallocated output
+        k_buf, v_buf: [pool_size, T, H, K] / [pool_size, T, HV, V] fp32 draft
+            buffers. When provided, the kernel writes k/v into them (fused,
+            write_kv=True) so the caller does NOT need separate scatter kernels.
+    Returns:
+        out reshaped to [B*T, HV, V]
+    """
+    _check_cula()
+    # cuLA verify kernel loads q/k into fp32 registers (autovec_copy requires
+    # matching bit-width). At runtime Ling feeds fp32 (fp32 rotary) -> no cast.
+    # For non-fp32 inputs (test kit bf16), cast to fp32 (defensive, not hot path).
+    if q.dtype != torch.float32:
+        q = q.to(torch.float32).contiguous()
+        k = k.to(torch.float32).contiguous()
+        v = v.to(torch.float32).contiguous()
+    else:
+        q, k, v = _as_contiguous(q), _as_contiguous(k), _as_contiguous(v)
+    assert out.dtype == torch.bfloat16, "cula_verify out must be bf16"
+    B = cache_indices.shape[0]
+    H = q.shape[1]
+    K = q.shape[2]
+    HV = v.shape[1]
+    V = v.shape[2]
+    q4 = q.view(B, T, H, K)
+    k4 = k.view(B, T, H, K)
+    v4 = v.view(B, T, HV, V)
+    out4 = out.view(B, T, HV, V)
+    linear_attention_verify_kvbuffer(
+        q4,
+        k4,
+        v4,
+        temporal,
+        out4,
+        decay.view(-1),
+        cache_indices.to(torch.int32),
+        scale,
+        T,
+        k_buf=k_buf,
+        v_buf=v_buf,
+    )
+    return out
+
+
+def cula_commit(draft_k, draft_v, temporal, cache_indices, accepted_len, decay, T):
+    """Commit accepted state via cuLA KVBuffer state_update.
+
+    Args:
+        draft_k: [B, T, H, K] bf16
+        draft_v: [B, T, HV, V] bf16
+        temporal: [pool_size, HV, V, K] fp32 state pool
+        cache_indices: [B] int32 indices into pool
+        accepted_len: [B] int32 in [0, T]
+        decay: [H, 1, 1] fp32 positive slopes
+        T: int draft_token_num
+    """
+    _check_cula()
+    linear_attention_state_update_kvbuffer(
+        draft_k,
+        draft_v,
+        temporal,
+        decay.view(-1),
+        cache_indices.to(torch.int32),
+        accepted_len.to(torch.int32),
+        T,
+    )
+
+
+def cula_commit_fused(
+    draft_k, draft_v, temporal, cache_indices, accepted_len, decay_all, T
+):
+    """Layer-fused commit: advance ALL mamba layers' state in one kernel launch.
+
+    Args:
+        draft_k: [L, pool_size, T, H, K] fp32
+        draft_v: [L, pool_size, T, HV, V] fp32
+        temporal: [L, pool_size, HV, V, K] fp32 V-major state pool (written in place)
+        cache_indices: [B] int32 indices into pool
+        accepted_len: [B] int32 in [0, T]
+        decay_all: [L, H] fp32 per-layer positive slopes
+        T: int draft_token_num
+    """
+    _check_cula()
+    linear_attention_state_update_kvbuffer_fused(
+        draft_k,
+        draft_v,
+        temporal,
+        decay_all,
+        cache_indices.to(torch.int32),
+        accepted_len.to(torch.int32),
+        T,
+    )

--- a/python/sglang/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sglang/srt/layers/attention/linear/lightning_backend.py
@@ -39,6 +39,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
 
     def __init__(self, model_runner: ModelRunner):
         super().__init__(model_runner)
+        self._server_args = model_runner.server_args
         # seg_la processes draft tokens as a chain -- it has no parent-indices
         # plumbing for tree-shaped drafts, so spec v2 tree verify (topk > 1) would
         # commit wrong mamba states silently. Fail fast instead of mis-decoding.
@@ -89,8 +90,139 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             self.linear_backend = (
                 "seg_la"  # reuse all existing seg_la branches unchanged
             )
+        elif self.linear_backend == "cula":
+            # cuLA's state pool is V-major [v,k]; prefill reuses the seg_la
+            # kernel family with the [v,k] layout so the state it writes is
+            # directly consumable by cuLA's decode/verify/commit kernels.
+            self.seg_la_state_layout = "vk"
         logger.info(
             f"linear_backend for linear attention in hybrid_linear_backend: {self.linear_backend}"
+        )
+
+        if self.linear_backend == "cula":
+            self.head_dim = (
+                model_runner.model_config.hf_config.head_dim
+                if hasattr(model_runner.model_config.hf_config, "head_dim")
+                else (
+                    model_runner.model_config.hf_config.hidden_size
+                    // model_runner.model_config.hf_config.num_attention_heads
+                )
+            )
+            self.num_heads = total_num_heads // (
+                model_runner.tp_size if hasattr(model_runner, "tp_size") else 1
+            )
+
+    def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
+        super().init_cuda_graph_state(max_bs, max_num_tokens)
+        if self.linear_backend == "cula":
+            self._warmup_cula_kernels(max_bs, max_num_tokens)
+
+    def _warmup_cula_kernels(self, max_bs: int, max_num_tokens: int):
+        from sglang.srt.layers.attention.linear.cula_entry import (
+            cula_commit_fused,
+            cula_decode,
+            cula_verify,
+        )
+
+        draft_token_num = max_num_tokens // max_bs
+        decay = self.tp_slope[0]
+        scale = self.head_dim**-0.5
+        temporal = self.req_to_token_pool.mamba_pool.mamba_cache.temporal[0]
+        # Fused commit operates on the full per-layer state pool. Set up the
+        # layer-fused warmup tensors once (bs-independent): real temporal_full
+        # (3.8GB, not copyable) + small dummy draft buffers + stacked decay.
+        temporal_full = self.req_to_token_pool.mamba_pool.mamba_cache.temporal
+        num_layers = temporal_full.shape[0]
+        pool_size = temporal_full.shape[1]
+        mamba_layer_ids = list(self.req_to_token_pool.mamba_map.keys())
+        decay_all = torch.stack(
+            [self.tp_slope[lid].view(-1).contiguous() for lid in mamba_layer_ids]
+        )
+        dummy_dk_pool = torch.zeros(
+            (num_layers, pool_size, draft_token_num, self.num_heads, self.head_dim),
+            device=self.device,
+            dtype=torch.float32,
+        )
+        dummy_dv_pool = torch.zeros_like(dummy_dk_pool)
+        # decode and verify both take fp32 q/k/v natively (kernels compute in
+        # fp32/TF32). cute.compile bakes the dtype seen at first call, so warmup
+        # dtype MUST match runtime dtype (fp32 for both).
+        decode_dtype = torch.float32
+        verify_dtype = torch.float32
+        out_dtype = torch.bfloat16
+
+        # decode is CUDA-graphed -> sparse warmup suffices. verify + commit use
+        # sym_int() for B (one compile covers all B) -> sparse warmup is enough.
+        decode_warmup = sorted(
+            bs for bs in {1, 2, 4, 8, 16, 32, 33, 64, max_bs} if bs <= max_bs
+        )
+        eager_warmup = [1, 32]  # trigger the single compile for verify + commit
+
+        for bs in decode_warmup:
+            dummy_q = torch.zeros(
+                (bs, self.num_heads, self.head_dim),
+                device=self.device,
+                dtype=decode_dtype,
+            )
+            dummy_out = torch.zeros(
+                (bs, self.num_heads, self.head_dim), device=self.device, dtype=out_dtype
+            )
+            dummy_idx = torch.zeros(bs, dtype=torch.int32, device=self.device)
+            cula_decode(
+                dummy_q, dummy_q, dummy_q, temporal, dummy_idx, decay, scale, dummy_out
+            )
+        if draft_token_num > 1:
+            for bs in eager_warmup:
+                total = bs * draft_token_num
+                dummy_qv = torch.zeros(
+                    (total, self.num_heads, self.head_dim),
+                    device=self.device,
+                    dtype=verify_dtype,
+                )
+                dummy_outv = torch.zeros(
+                    (total, self.num_heads, self.head_dim),
+                    device=self.device,
+                    dtype=out_dtype,
+                )
+                dummy_idx = torch.zeros(bs, dtype=torch.int32, device=self.device)
+                # Warm the write_kv=True variant (runtime uses fused draft writes).
+                # k_buf/v_buf are per-layer pool-indexed [pool, T, H, K] fp32 slices.
+                cula_verify(
+                    dummy_qv,
+                    dummy_qv,
+                    dummy_qv,
+                    temporal,
+                    dummy_idx,
+                    decay,
+                    scale,
+                    draft_token_num,
+                    dummy_outv,
+                    k_buf=dummy_dk_pool[0],
+                    v_buf=dummy_dv_pool[0],
+                )
+                # Fused commit: one launch for ALL layers. draft_k/v dummies are
+                # pool-indexed (bs-independent, allocated once); only h0_indices/
+                # accepted_len vary with bs. Writes garbage into temporal_full slot
+                # 0, zeroed back after the loop.
+                dummy_acc = torch.full(
+                    (bs,), draft_token_num, dtype=torch.int32, device=self.device
+                )
+                cula_commit_fused(
+                    dummy_dk_pool,
+                    dummy_dv_pool,
+                    temporal_full,
+                    dummy_idx,
+                    dummy_acc,
+                    decay_all,
+                    draft_token_num,
+                )
+        # Restore the state pool to its initial zeros (fused-commit warmup wrote
+        # garbage into the active slots).
+        temporal_full.zero_()
+        torch.cuda.synchronize()
+        logger.info(
+            f"cuLA kernel warmup complete (decode={len(decode_warmup)} bs, "
+            f"eager verify+commit={len(eager_warmup)} bs)"
         )
 
     def init_forward_metadata_out_graph(
@@ -337,6 +469,43 @@ class LightningAttentionBackend(MambaAttnBackendBase):
                 ),
                 intermediate_state_indices=intermediate_state_indices,
             )
+        elif self.linear_backend == "cula":
+            from sglang.srt.layers.attention.linear.cula_entry import cula_verify
+
+            decay = self.tp_slope[layer_id]
+            scale = layer.head_dim**-0.5
+            if forward_batch.forward_mode.is_target_verify():
+                T = forward_batch.spec_info.draft_token_num
+                # cula_verify accepts fp32 q/k/v natively and fuses the draft_k/v
+                # writes (write_kv=True) -- no separate scatter kernels. draft_k/v
+                # are per-layer [pool, T, H, K] / [pool, T, HV, V] fp32 buffers.
+                out = torch.empty_like(v, dtype=torch.bfloat16)
+                o = cula_verify(
+                    q,
+                    k,
+                    v,
+                    ssm_states,
+                    cache_indices,
+                    decay,
+                    scale,
+                    T,
+                    out,
+                    k_buf=mamba_cache_params.draft_k,
+                    v_buf=mamba_cache_params.draft_v,
+                )
+            else:
+                # Prefill via the seg_la kernel family with [v,k] state layout
+                # (self.seg_la_state_layout == "vk" for cula), so the state
+                # written here matches cuLA's V-major state pool.
+                o = self._linear_attention_entry(
+                    q,
+                    k,
+                    v,
+                    ssm_states,
+                    cache_indices,
+                    metadata,
+                    layer,
+                )
         else:
             raise ValueError(
                 f"linear backend: {self.linear_backend} is not support for now"
@@ -383,6 +552,15 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             o = self._linear_attention_entry(
                 q, k, v, ssm_states, cache_indices, metadata, layer
             )
+        elif self.linear_backend == "cula":
+            from sglang.srt.layers.attention.linear.cula_entry import cula_decode
+
+            decay = self.tp_slope[layer_id]
+            scale = layer.head_dim**-0.5
+            # Pass q/k/v through in native dtype (fp32); cula_decode computes in
+            # fp32 internally. Pre-allocated bf16 out so no graph re-alloc.
+            out = torch.empty_like(v, dtype=torch.bfloat16)
+            o = cula_decode(q, k, v, ssm_states, cache_indices, decay, scale, out)
         else:
             raise ValueError(
                 f"linear backend: {self.linear_backend} is not support for now"

--- a/python/sglang/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sglang/srt/layers/attention/linear/lightning_backend.py
@@ -78,6 +78,17 @@ class LightningAttentionBackend(MambaAttnBackendBase):
         self.linear_backend = getattr(
             model_runner.model_config.hf_config, "linear_backend", "seg_la"
         )
+        # seg_la_vk: same kernel family with [v,k] state layout for all kernels.
+        # The state pool is square (H,D,D) — inner k/v ordering is kernel-internal.
+        # The MTP scatter is a layout-agnostic whole-slot copy, so as long as every
+        # seg_la kernel (including mtp's intermediate_ssm write) uses [v,k], the
+        # path is end-to-end self-consistent with no memory_pool / scatter changes.
+        self.seg_la_state_layout = "kv"
+        if self.linear_backend == "seg_la_vk":
+            self.seg_la_state_layout = "vk"
+            self.linear_backend = (
+                "seg_la"  # reuse all existing seg_la branches unchanged
+            )
         logger.info(
             f"linear_backend for linear attention in hybrid_linear_backend: {self.linear_backend}"
         )
@@ -266,6 +277,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             caches=temp_cache,
             cache_indices=intermediate_state_indices,
             decouple=True,
+            state_layout=self.seg_la_state_layout,
         )
         return hidden
 

--- a/python/sglang/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sglang/srt/layers/attention/linear/lightning_backend.py
@@ -128,22 +128,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
         decay = self.tp_slope[0]
         scale = self.head_dim**-0.5
         temporal = self.req_to_token_pool.mamba_pool.mamba_cache.temporal[0]
-        # Fused commit operates on the full per-layer state pool. Set up the
-        # layer-fused warmup tensors once (bs-independent): real temporal_full
-        # (3.8GB, not copyable) + small dummy draft buffers + stacked decay.
         temporal_full = self.req_to_token_pool.mamba_pool.mamba_cache.temporal
-        num_layers = temporal_full.shape[0]
-        pool_size = temporal_full.shape[1]
-        mamba_layer_ids = list(self.req_to_token_pool.mamba_map.keys())
-        decay_all = torch.stack(
-            [self.tp_slope[lid].view(-1).contiguous() for lid in mamba_layer_ids]
-        )
-        dummy_dk_pool = torch.zeros(
-            (num_layers, pool_size, draft_token_num, self.num_heads, self.head_dim),
-            device=self.device,
-            dtype=torch.float32,
-        )
-        dummy_dv_pool = torch.zeros_like(dummy_dk_pool)
         # decode and verify both take fp32 q/k/v natively (kernels compute in
         # fp32/TF32). cute.compile bakes the dtype seen at first call, so warmup
         # dtype MUST match runtime dtype (fp32 for both).
@@ -157,6 +142,11 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             bs for bs in {1, 2, 4, 8, 16, 32, 33, 64, max_bs} if bs <= max_bs
         )
         eager_warmup = [1, 32]  # trigger the single compile for verify + commit
+        pool_size = temporal.shape[0]
+
+        def dummy_cache_indices(bs: int) -> torch.Tensor:
+            # Prefer distinct warmup slots, but stay in-bounds for tiny test pools.
+            return torch.arange(bs, dtype=torch.int32, device=self.device) % pool_size
 
         for bs in decode_warmup:
             dummy_q = torch.zeros(
@@ -167,11 +157,23 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             dummy_out = torch.zeros(
                 (bs, self.num_heads, self.head_dim), device=self.device, dtype=out_dtype
             )
-            dummy_idx = torch.zeros(bs, dtype=torch.int32, device=self.device)
+            dummy_idx = dummy_cache_indices(bs)
             cula_decode(
                 dummy_q, dummy_q, dummy_q, temporal, dummy_idx, decay, scale, dummy_out
             )
         if draft_token_num > 1:
+            # Fused commit operates on the full per-layer state pool. Reuse the
+            # preallocated draft buffers to avoid duplicating a large fp32 pool
+            # during warmup; runtime verify overwrites active slots before commit.
+            mamba_layer_ids = list(self.req_to_token_pool.mamba_map.keys())
+            decay_all = torch.stack(
+                [self.tp_slope[lid].view(-1).contiguous() for lid in mamba_layer_ids]
+            )
+            mamba_caches = (
+                self.req_to_token_pool.get_speculative_mamba2_params_all_layers()
+            )
+            dummy_dk_pool = mamba_caches.draft_k
+            dummy_dv_pool = mamba_caches.draft_v
             for bs in eager_warmup:
                 total = bs * draft_token_num
                 dummy_qv = torch.zeros(
@@ -182,9 +184,9 @@ class LightningAttentionBackend(MambaAttnBackendBase):
                 dummy_outv = torch.zeros(
                     (total, self.num_heads, self.head_dim),
                     device=self.device,
-                    dtype=out_dtype,
+                    dtype=torch.float32,
                 )
-                dummy_idx = torch.zeros(bs, dtype=torch.int32, device=self.device)
+                dummy_idx = dummy_cache_indices(bs)
                 # Warm the write_kv=True variant (runtime uses fused draft writes).
                 # k_buf/v_buf are per-layer pool-indexed [pool, T, H, K] fp32 slices.
                 cula_verify(
@@ -202,8 +204,8 @@ class LightningAttentionBackend(MambaAttnBackendBase):
                 )
                 # Fused commit: one launch for ALL layers. draft_k/v dummies are
                 # pool-indexed (bs-independent, allocated once); only h0_indices/
-                # accepted_len vary with bs. Writes garbage into temporal_full slot
-                # 0, zeroed back after the loop.
+                # accepted_len vary with bs. Writes garbage into temporal_full warmup
+                # slots, zeroed back after the loop.
                 dummy_acc = torch.full(
                     (bs,), draft_token_num, dtype=torch.int32, device=self.device
                 )
@@ -479,7 +481,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
                 # cula_verify accepts fp32 q/k/v natively and fuses the draft_k/v
                 # writes (write_kv=True) -- no separate scatter kernels. draft_k/v
                 # are per-layer [pool, T, H, K] / [pool, T, HV, V] fp32 buffers.
-                out = torch.empty_like(v, dtype=torch.bfloat16)
+                out = torch.empty(v.shape, dtype=torch.float32, device=v.device)
                 o = cula_verify(
                     q,
                     k,
@@ -559,7 +561,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             scale = layer.head_dim**-0.5
             # Pass q/k/v through in native dtype (fp32); cula_decode computes in
             # fp32 internally. Pre-allocated bf16 out so no graph re-alloc.
-            out = torch.empty_like(v, dtype=torch.bfloat16)
+            out = torch.empty(v.shape, dtype=torch.bfloat16, device=v.device)
             o = cula_decode(q, k, v, ssm_states, cache_indices, decay, scale, out)
         else:
             raise ValueError(

--- a/python/sglang/srt/layers/attention/linear/seg_la.py
+++ b/python/sglang/srt/layers/attention/linear/seg_la.py
@@ -226,6 +226,7 @@ def seg_la_p_kernel(
     V_SPLIT_DIM: tl.constexpr,
     BLOCK: tl.constexpr,
     EVEN: tl.constexpr,
+    VK: tl.constexpr,
 ):
     bid = tl.program_id(0)
     hid = tl.program_id(1)
@@ -279,15 +280,26 @@ def seg_la_p_kernel(
         + vid * V_SPLIT_DIM
         + (offs_b[:, None] * H * HEAD_DIM + offs_v[None, :])
     )
-    s_ptrs = (
-        S
-        + s_offset * stride_s
-        + hid * HEAD_DIM * HEAD_DIM
-        + kid * HEAD_DIM * K_SPLIT_DIM
-        + vid * V_SPLIT_DIM
-        + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
-    )
-    state = tl.load(s_ptrs, mask=s_scale > 0).to(tl.float32)
+    if VK:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + vid * HEAD_DIM * V_SPLIT_DIM
+            + kid * K_SPLIT_DIM
+            + (offs_v[:, None] * HEAD_DIM + offs_k[None, :])
+        )
+        state = tl.trans(tl.load(s_ptrs, mask=s_scale > 0)).to(tl.float32)
+    else:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
+        state = tl.load(s_ptrs, mask=s_scale > 0).to(tl.float32)
 
     for n in range(0, q_length, BLOCK):
         n = tl.multiple_of(n, BLOCK)
@@ -340,7 +352,10 @@ def seg_la_p_kernel(
                 mask=(n + offs_b)[:, None] < q_length,
             )
 
-    tl.store(s_ptrs, state.to(S.dtype.element_ty))
+    if VK:
+        tl.store(s_ptrs, tl.trans(state).to(S.dtype.element_ty))
+    else:
+        tl.store(s_ptrs, state.to(S.dtype.element_ty))
 
 
 # used for speculative
@@ -368,6 +383,7 @@ def seg_la_s_kernel(
     V_SPLIT_DIM: tl.constexpr,
     BLOCK: tl.constexpr,
     EVEN: tl.constexpr,
+    VK: tl.constexpr,
 ):
     bid = tl.program_id(0)
     hid = tl.program_id(1)
@@ -421,15 +437,26 @@ def seg_la_s_kernel(
         + vid * V_SPLIT_DIM
         + (offs_b[:, None] * H * HEAD_DIM + offs_v[None, :])
     )
-    s_ptrs = (
-        S
-        + s_offset * stride_s
-        + hid * HEAD_DIM * HEAD_DIM
-        + kid * HEAD_DIM * K_SPLIT_DIM
-        + vid * V_SPLIT_DIM
-        + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
-    )
-    state = tl.load(s_ptrs, mask=s_scale > 0).to(tl.float32)
+    if VK:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + vid * HEAD_DIM * V_SPLIT_DIM
+            + kid * K_SPLIT_DIM
+            + (offs_v[:, None] * HEAD_DIM + offs_k[None, :])
+        )
+        state = tl.trans(tl.load(s_ptrs, mask=s_scale > 0)).to(tl.float32)
+    else:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
+        state = tl.load(s_ptrs, mask=s_scale > 0).to(tl.float32)
 
     if EVEN:
         q = tl.load(q_ptrs).to(tl.float32)
@@ -497,6 +524,7 @@ def seg_la_d_kernel(
     HEAD_DIM: tl.constexpr,
     K_SPLIT_DIM: tl.constexpr,
     V_SPLIT_DIM: tl.constexpr,
+    VK: tl.constexpr,
 ):
     bid = tl.program_id(0)
     hid = tl.program_id(1)
@@ -528,22 +556,36 @@ def seg_la_d_kernel(
         + vid * V_SPLIT_DIM
         + (offs_v)
     )
-    s_ptrs = (
-        S
-        + s_offset * stride_s
-        + hid * HEAD_DIM * HEAD_DIM
-        + kid * HEAD_DIM * K_SPLIT_DIM
-        + vid * V_SPLIT_DIM
-        + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
-    )
+    if VK:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + vid * HEAD_DIM * V_SPLIT_DIM
+            + kid * K_SPLIT_DIM
+            + (offs_v[:, None] * HEAD_DIM + offs_k[None, :])
+        )
+    else:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
     state = tl.load(s_ptrs).to(tl.float32)
 
     k = tl.load(k_ptrs).to(tl.float32)
     v = tl.load(v_ptrs).to(tl.float32)
     q = tl.load(q_ptrs).to(tl.float32) * softmax_scale
 
-    state = state * tl.exp(decay_scale) + k[:, None] * v
-    o = tl.sum(q[:, None] * state, axis=0)
+    if VK:
+        state = state * tl.exp(decay_scale) + v[:, None] * k[None, :]
+        o = tl.sum(q[None, :] * state, axis=1)
+    else:
+        state = state * tl.exp(decay_scale) + k[:, None] * v
+        o = tl.sum(q[:, None] * state, axis=0)
 
     tl.store(out_ptrs, o.to(Out.dtype.element_ty))
     tl.store(s_ptrs, state.to(S.dtype.element_ty))
@@ -572,6 +614,7 @@ def seg_la_mtp_kernel(
     HEAD_DIM: tl.constexpr,
     K_SPLIT_DIM: tl.constexpr,
     V_SPLIT_DIM: tl.constexpr,
+    VK: tl.constexpr,
 ):
     bid = tl.program_id(0)
     hid = tl.program_id(1)
@@ -604,33 +647,61 @@ def seg_la_mtp_kernel(
         + (offs_v)
     )
     # (bs, qo_heads, d, d)
-    s_ptrs = (
-        S
-        + s_offset * stride_s
-        + hid * HEAD_DIM * HEAD_DIM
-        + kid * HEAD_DIM * K_SPLIT_DIM
-        + vid * V_SPLIT_DIM
-        + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
-    )
+    if VK:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + vid * HEAD_DIM * V_SPLIT_DIM
+            + kid * K_SPLIT_DIM
+            + (offs_v[:, None] * HEAD_DIM + offs_k[None, :])
+        )
+    else:
+        s_ptrs = (
+            S
+            + s_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
     state = tl.load(s_ptrs).to(tl.float32)
     # (bs, step, kv_heads, d, d)
     cache_indices = tl.load(cache_indices + bid)
-    c_ptrs = (
-        CACHES
-        + cache_indices * stride_c
-        + hid * HEAD_DIM * HEAD_DIM
-        + kid * HEAD_DIM * K_SPLIT_DIM
-        + vid * V_SPLIT_DIM
-        + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
-    )
+    # Under VK, intermediate_ssm is written in [v,k] — the same layout as temporal —
+    # so fused_mamba_state_scatter_with_mask (a layout-agnostic whole-slot copy)
+    # commits [v,k] → [v,k] and stays consistent. The c_ptrs swap is mandatory:
+    # forgetting it would silently corrupt state on MTP commit.
+    if VK:
+        c_ptrs = (
+            CACHES
+            + cache_indices * stride_c
+            + hid * HEAD_DIM * HEAD_DIM
+            + vid * HEAD_DIM * V_SPLIT_DIM
+            + kid * K_SPLIT_DIM
+            + (offs_v[:, None] * HEAD_DIM + offs_k[None, :])
+        )
+    else:
+        c_ptrs = (
+            CACHES
+            + cache_indices * stride_c
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
 
     for i in range(step):
         q = tl.load(q_ptrs).to(tl.float32) * softmax_scale
         k = tl.load(k_ptrs).to(tl.float32)
         v = tl.load(v_ptrs).to(tl.float32)
 
-        state = state * decay_scale + k[:, None] * v
-        o = tl.sum(q[:, None] * state, axis=0)
+        if VK:
+            state = state * decay_scale + v[:, None] * k[None, :]
+            o = tl.sum(q[None, :] * state, axis=1)
+        else:
+            state = state * decay_scale + k[:, None] * v
+            o = tl.sum(q[:, None] * state, axis=0)
 
         tl.store(out_ptrs, o.to(Out.dtype.element_ty))
         tl.store(c_ptrs, state.to(CACHES.dtype.element_ty))
@@ -665,7 +736,14 @@ def seg_la_fwd(
     cache_indices=None,
     softmax_scale=None,
     decouple=False,
+    state_layout: str = "kv",
 ):
+    assert state_layout in (
+        "kv",
+        "vk",
+    ), f"Unsupported seg_la state_layout: {state_layout}"
+    VK = state_layout == "vk"
+
     length, qo_heads, HEAD_DIM = q.shape
     _, kv_heads, _ = k.shape
     bs = meta.batch_size
@@ -720,6 +798,7 @@ def seg_la_fwd(
                 HEAD_DIM=HEAD_DIM,
                 K_SPLIT_DIM=K_SPLIT_DIM,
                 V_SPLIT_DIM=V_SPLIT_DIM,
+                VK=VK,
                 num_warps=num_warps,
                 num_stages=num_stages,
             )
@@ -753,6 +832,7 @@ def seg_la_fwd(
                 V_SPLIT_DIM=V_SPLIT_DIM,
                 BLOCK=BLOCK,
                 EVEN=EVEN,
+                VK=VK,
                 num_warps=num_warps,
                 num_stages=num_stages,
             )
@@ -784,6 +864,7 @@ def seg_la_fwd(
                 V_SPLIT_DIM=V_SPLIT_DIM,
                 BLOCK=BLOCK,
                 EVEN=EVEN,
+                VK=VK,
                 num_warps=num_warps,
                 num_stages=num_stages,
             )
@@ -842,6 +923,7 @@ def seg_la_fwd(
             HEAD_DIM=HEAD_DIM,
             K_SPLIT_DIM=K_SPLIT_DIM,
             V_SPLIT_DIM=V_SPLIT_DIM,
+            VK=VK,
             num_warps=num_warps,
             num_stages=num_stages,
         )

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -621,6 +621,9 @@ class KVCacheConfigurator:
             enable_overlap_schedule=not self.server_args.disable_overlap_schedule,
             mamba_size=self.server_args.max_mamba_cache_size,
             start_layer=self.layer_info.start_layer,
+            linear_backend=getattr(
+                self.model_config.hf_config, "linear_backend", "seg_la"
+            ),
         )
         return req_to_token_pool
 
@@ -1583,9 +1586,17 @@ class KVCacheConfigurator:
         assert config is not None
 
         has_spec_dec = not self.spec_algorithm.is_none()
+        linear_backend = getattr(
+            self.model_config.hf_config, "linear_backend", "seg_la"
+        )
         if has_spec_dec:
             assert server_args.speculative_num_draft_tokens is not None
             assert server_args.max_running_requests is not None
+        cula_draft_kv_cache_per_slot = (
+            self._cula_draft_kv_cache_per_slot()
+            if has_spec_dec and linear_backend == "cula"
+            else None
+        )
 
         if server_args.max_mamba_cache_size is not None:
             # Use explicitly set max_mamba_cache_size
@@ -1596,16 +1607,21 @@ class KVCacheConfigurator:
             )
             # Reserve intermediate memory based on capped max_num_reqs
             if has_spec_dec:
-                ratio = self._calculate_mamba_ratio()
-                capped_reqs = min(
-                    server_args.max_running_requests // self.ps.attn_dp_size,
-                    server_args.max_mamba_cache_size // ratio,
-                )
-                intermediate_size = (
-                    config.mamba2_cache_params.mamba_cache_per_req
-                    * capped_reqs
-                    * server_args.speculative_num_draft_tokens
-                )
+                if cula_draft_kv_cache_per_slot is not None:
+                    intermediate_size = (
+                        cula_draft_kv_cache_per_slot * server_args.max_mamba_cache_size
+                    )
+                else:
+                    ratio = self._calculate_mamba_ratio()
+                    capped_reqs = min(
+                        server_args.max_running_requests // self.ps.attn_dp_size,
+                        server_args.max_mamba_cache_size // ratio,
+                    )
+                    intermediate_size = (
+                        config.mamba2_cache_params.mamba_cache_per_req
+                        * capped_reqs
+                        * server_args.speculative_num_draft_tokens
+                    )
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
         elif (
             server_args.disable_radix_cache
@@ -1619,22 +1635,25 @@ class KVCacheConfigurator:
             )
             # Reserve intermediate memory based on capped max_num_reqs
             if has_spec_dec:
-                intermediate_size = (
-                    config.mamba2_cache_params.mamba_cache_per_req
-                    * server_args.max_mamba_cache_size
-                    * server_args.speculative_num_draft_tokens
-                )
+                if cula_draft_kv_cache_per_slot is not None:
+                    intermediate_size = (
+                        cula_draft_kv_cache_per_slot * server_args.max_mamba_cache_size
+                    )
+                else:
+                    intermediate_size = (
+                        config.mamba2_cache_params.mamba_cache_per_req
+                        * server_args.max_mamba_cache_size
+                        * server_args.speculative_num_draft_tokens
+                    )
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
         else:
             # Use ratio-based calculation to auto-fit available memory
             assert config.mamba2_cache_params.mamba_cache_per_req > 0
             per_req = config.mamba2_cache_params.mamba_cache_per_req
 
-            # Solve jointly for max_mamba_cache_size accounting for intermediate memory.
-            # The mamba budget (from the ratio split) must cover both:
-            #   1. main mamba state: max_mamba_cache_size * per_req
-            #   2. intermediate states: (max_mamba_cache_size / ratio) * D * per_req
-            # So: max_mamba_cache_size * per_req * (1 + D/ratio) = mamba_budget_bytes
+            # Solve jointly for max_mamba_cache_size accounting for speculative
+            # auxiliary buffers. seg_la keeps the old max-request-indexed
+            # intermediate states; cuLA keeps pool-indexed fp32 draft K/V.
             mamba_budget = (
                 total_rest_memory
                 * server_args.mamba_full_memory_ratio
@@ -1643,22 +1662,36 @@ class KVCacheConfigurator:
             mamba_budget_bytes = mamba_budget * (1 << 30)
 
             if has_spec_dec:
-                ratio = self._calculate_mamba_ratio()
-                D = server_args.speculative_num_draft_tokens
-                # Joint solve: main_state + intermediate = mamba_budget
-                server_args.override(
-                    "mamba_pool.memory_budget_spec",
-                    max_mamba_cache_size=int(
-                        mamba_budget_bytes // (per_req * (1 + D / ratio))
-                    ),
-                )
-                # Intermediate memory is included in mamba_budget, subtract it
-                # so the return value only has main_state subtracted from total
-                capped_reqs = min(
-                    server_args.max_running_requests // self.ps.attn_dp_size,
-                    server_args.max_mamba_cache_size // ratio,
-                )
-                intermediate_size = per_req * capped_reqs * D
+                if cula_draft_kv_cache_per_slot is not None:
+                    # cuLA draft K/V buffers are pool-indexed by mamba cache
+                    # slot, so they scale with max_mamba_cache_size.
+                    server_args.override(
+                        "mamba_pool.memory_budget_spec",
+                        max_mamba_cache_size=int(
+                            mamba_budget_bytes
+                            // (per_req + cula_draft_kv_cache_per_slot)
+                        ),
+                    )
+                    intermediate_size = (
+                        cula_draft_kv_cache_per_slot * server_args.max_mamba_cache_size
+                    )
+                else:
+                    ratio = self._calculate_mamba_ratio()
+                    D = server_args.speculative_num_draft_tokens
+                    # Joint solve: main_state + intermediate = mamba_budget
+                    server_args.override(
+                        "mamba_pool.memory_budget_spec",
+                        max_mamba_cache_size=int(
+                            mamba_budget_bytes // (per_req * (1 + D / ratio))
+                        ),
+                    )
+                    # Intermediate memory is included in mamba_budget, subtract it
+                    # so the return value only has main_state subtracted from total
+                    capped_reqs = min(
+                        server_args.max_running_requests // self.ps.attn_dp_size,
+                        server_args.max_mamba_cache_size // ratio,
+                    )
+                    intermediate_size = per_req * capped_reqs * D
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
             else:
                 server_args.override(
@@ -1688,6 +1721,25 @@ class KVCacheConfigurator:
             / (1 << 30)
         )
         return total_rest_memory - mamba_state_memory
+
+    def _cula_draft_kv_cache_per_slot(self) -> int:
+        """Bytes per mamba cache slot for cuLA KVBuffer draft K/V buffers."""
+        cache_params = self.mambaish_config.mamba2_cache_params
+        num_layers = len(
+            [
+                i
+                for i in cache_params.layers
+                if self.layer_info.start_layer <= i < self.layer_info.end_layer
+            ]
+        )
+        hidden_groups, key_dim, value_dim = cache_params.shape.temporal
+        draft_tokens = self.server_args.speculative_num_draft_tokens
+        return (
+            num_layers
+            * draft_tokens
+            * (hidden_groups * key_dim + hidden_groups * value_dim)
+            * torch.float32.itemsize
+        )
 
 
 def calculate_mla_kv_cache_dim(

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -672,6 +672,9 @@ class KVCacheConfigurator:
             enable_linear_replayssm=self.server_args.enable_linear_replayssm,
             linear_replayssm_cache_len=self.server_args.linear_replayssm_cache_len,
             mamba_envelope_layout=self.server_args.enable_page_major_kv_layout,
+            linear_backend=getattr(
+                self.model_config.hf_config, "linear_backend", "seg_la"
+            ),
         )
         return req_to_token_pool
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -352,6 +352,11 @@ class MambaPool:
         intermediate_ssm: torch.Tensor
         intermediate_conv_window: List[torch.Tensor]
 
+    @dataclass(frozen=True, kw_only=True)
+    class CulaSpeculativeState(State):
+        draft_k: torch.Tensor
+        draft_v: torch.Tensor
+
     def __init__(
         self,
         *,
@@ -366,6 +371,7 @@ class MambaPool:
         enable_linear_replayssm: bool = False,
         linear_replayssm_cache_len: int = 16,
         envelope_layout: bool = False,
+        linear_backend: str = "seg_la",
     ):
         conv_state_shape = cache_params.shape.conv
         temporal_state_shape = cache_params.shape.temporal
@@ -381,6 +387,7 @@ class MambaPool:
         self.debug_memory_pool = envs.SGLANG_DEBUG_MEMORY_POOL.get()
         self.enable_linear_replayssm = enable_linear_replayssm
         self.linear_replayssm_cache_len = linear_replayssm_cache_len
+        self.linear_backend = linear_backend
 
         # for disagg with nvlink
         self.enable_custom_mem_pool, self.custom_mem_pool, _ = (
@@ -489,107 +496,141 @@ class MambaPool:
                 )
 
             if speculative_num_draft_tokens is not None:
-                if _is_npu:
+                if self.linear_backend == "cula":
+                    temporal_state = temporal_state.transpose(-1, -2).contiguous()
+                    HV, Kd, Vd = temporal_state_shape
+                    T = speculative_num_draft_tokens
+                    H = HV
+                    # draft_k/draft_v are indexed by the global mamba cache slot id
+                    # (mamba_cache_indices), which ranges over the `size`-based mamba
+                    # pool — NOT the spec_state_size (== max_num_reqs) pool. They must
+                    # therefore match the `temporal` state pool's leading dim (size + 1);
+                    # using spec_state_size + 1 here under-sizes the buffer and lets a
+                    # cache slot id >= spec_state_size+1 index out of bounds.
+                    draft_k = torch.zeros(
+                        (num_mamba_layers, size + 1, T, H, Kd),
+                        dtype=torch.bfloat16,
+                        device=device,
+                    )
+                    draft_v = torch.zeros(
+                        (num_mamba_layers, size + 1, T, HV, Vd),
+                        dtype=torch.bfloat16,
+                        device=device,
+                    )
+                    self.mamba_cache = self.CulaSpeculativeState(
+                        conv=conv_state,
+                        temporal=temporal_state,
+                        draft_k=draft_k,
+                        draft_v=draft_v,
+                    )
+                    logger.info(
+                        f"Mamba Cache (cula) allocated. "
+                        f"temporal V-major {tuple(temporal_state.shape)}, "
+                        f"draft_kv size: {(get_tensor_size_bytes(draft_k) + get_tensor_size_bytes(draft_v)) / GB:.3f}GB"
+                    )
+                elif _is_npu:
                     temporal_state = temporal_state.transpose(-1, -2)
                     temporal_state_shape = (
                         *temporal_state_shape[:-2],
                         temporal_state_shape[-1],
                         temporal_state_shape[-2],
                     )
-                # Cache intermediate SSM states per draft token during target verify
-                # Shape: [num_layers, size + 1, speculative_num_draft_tokens, HV, K, V]
-                intermediate_ssm_state_cache = torch.zeros(
-                    size=(
-                        num_mamba_layers,
-                        spec_state_size + 1,
-                        speculative_num_draft_tokens,
-                        temporal_state_shape[0],
-                        temporal_state_shape[1],
-                        temporal_state_shape[2],
-                    ),
-                    dtype=ssm_dtype,
-                    device="cuda",
-                )
-                # Cache intermediate conv windows (last K-1 inputs) per draft token
-                # during target verify.
-                #
-                # On CUDA (Triton conv kernel + Triton scatter) we use a
-                # *deduplicated sliding-window* layout: consecutive draft tokens'
-                # (K-1)-wide windows overlap by (K-2), so instead of D separate
-                # [dim, K-1] windows we store one shared [dim, D+K-2] buffer per
-                # (layer, slot) and expose an overlapping `as_strided` view of
-                # logical shape [num_layers, size+1, draft_tokens, dim, K-1] where
-                # step `t`'s window is the slice shared[..., :, t:t+K-1]. This
-                # halves the conv-intermediate footprint (D*(K-1) -> D+K-2 columns)
-                # with no numerical change: both the conv kernel write (idempotent
-                # overlapping stores) and `fused_conv_window_scatter_with_mask`
-                # consume the view through its strides.
-                #
-                # Dedup the sliding-window conv-intermediate only when it is safe:
-                # CUDA + a linear draft chain (topk <= 1). NPU/CPU and EAGLE tree
-                # verify (topk > 1) keep the dense layout -- see
-                # `conv_window_dedup_enabled` for the full rationale. The
-                # `fused_conv_window_scatter_with_mask` scatter is layout-agnostic,
-                # so the dense fallback reads correctly through the same code path.
-                dedup_conv_window = conv_window_dedup_enabled(
-                    _is_npu, _is_cpu, speculative_eagle_topk
-                )
-                self._intermediate_conv_window_phys = []
-                if dedup_conv_window:
-                    intermediate_conv_window_cache = []
-                    for conv_shape in conv_state_shape:
-                        conv_dim, win = conv_shape  # win == conv_kernel - 1 == K-1
-                        shared_win = (
-                            speculative_num_draft_tokens + win - 1
-                        )  # D + (K-1) - 1
-                        phys = torch.zeros(
-                            size=(
-                                num_mamba_layers,
-                                spec_state_size + 1,
-                                conv_dim,
-                                shared_win,
-                            ),
-                            dtype=conv_dtype,
-                            device="cuda",
+                if self.linear_backend != "cula":
+                    # Cache intermediate SSM states per draft token during target verify
+                    # Shape: [num_layers, size + 1, speculative_num_draft_tokens, HV, K, V]
+                    intermediate_ssm_state_cache = torch.zeros(
+                        size=(
+                            num_mamba_layers,
+                            spec_state_size + 1,
+                            speculative_num_draft_tokens,
+                            temporal_state_shape[0],
+                            temporal_state_shape[1],
+                            temporal_state_shape[2],
+                        ),
+                        dtype=ssm_dtype,
+                        device="cuda",
+                    )
+                    # Cache intermediate conv windows (last K-1 inputs) per draft token
+                    # during target verify.
+                    #
+                    # On CUDA (Triton conv kernel + Triton scatter) we use a
+                    # *deduplicated sliding-window* layout: consecutive draft tokens'
+                    # (K-1)-wide windows overlap by (K-2), so instead of D separate
+                    # [dim, K-1] windows we store one shared [dim, D+K-2] buffer per
+                    # (layer, slot) and expose an overlapping `as_strided` view of
+                    # logical shape [num_layers, size+1, draft_tokens, dim, K-1] where
+                    # step `t`'s window is the slice shared[..., :, t:t+K-1]. This
+                    # halves the conv-intermediate footprint (D*(K-1) -> D+K-2 columns)
+                    # with no numerical change: both the conv kernel write (idempotent
+                    # overlapping stores) and `fused_conv_window_scatter_with_mask`
+                    # consume the view through its strides.
+                    #
+                    # Dedup the sliding-window conv-intermediate only when it is safe:
+                    # CUDA + a linear draft chain (topk <= 1). NPU/CPU and EAGLE tree
+                    # verify (topk > 1) keep the dense layout -- see
+                    # `conv_window_dedup_enabled` for the full rationale. The
+                    # `fused_conv_window_scatter_with_mask` scatter is layout-agnostic,
+                    # so the dense fallback reads correctly through the same code path.
+                    dedup_conv_window = conv_window_dedup_enabled(
+                        _is_npu, _is_cpu, speculative_eagle_topk
+                    )
+                    self._intermediate_conv_window_phys = []
+                    if dedup_conv_window:
+                        intermediate_conv_window_cache = []
+                        for conv_shape in conv_state_shape:
+                            conv_dim, win = conv_shape  # win == conv_kernel - 1 == K-1
+                            shared_win = (
+                                speculative_num_draft_tokens + win - 1
+                            )  # D + (K-1) - 1
+                            phys = torch.zeros(
+                                size=(
+                                    num_mamba_layers,
+                                    spec_state_size + 1,
+                                    conv_dim,
+                                    shared_win,
+                                ),
+                                dtype=conv_dtype,
+                                device="cuda",
+                            )
+                            # view[l, s, step, d, w] = phys[l, s, d, step + w]
+                            view = phys.as_strided(
+                                (
+                                    phys.shape[0],
+                                    phys.shape[1],
+                                    speculative_num_draft_tokens,
+                                    conv_dim,
+                                    win,
+                                ),
+                                (
+                                    phys.stride(0),
+                                    phys.stride(1),
+                                    phys.stride(3),  # step -> shared-win axis
+                                    phys.stride(2),  # dim
+                                    phys.stride(3),  # win -> shared-win axis
+                                ),
+                            )
+                            self._intermediate_conv_window_phys.append(phys)
+                            intermediate_conv_window_cache.append(view)
+                    else:
+                        # Original dense layout (NPU/CPU, or EAGLE tree verify): one
+                        # [dim, K-1] window per draft token.
+                        intermediate_conv_window_cache = [
+                            torch.zeros(
+                                size=(
+                                    num_mamba_layers,
+                                    spec_state_size + 1,
+                                    speculative_num_draft_tokens,
+                                    conv_shape[0],
+                                    conv_shape[1],
+                                ),
+                                dtype=conv_dtype,
+                                device="cuda",
+                            )
+                            for conv_shape in conv_state_shape
+                        ]
+                        self._intermediate_conv_window_phys = (
+                            intermediate_conv_window_cache
                         )
-                        # view[l, s, step, d, w] = phys[l, s, d, step + w]
-                        view = phys.as_strided(
-                            (
-                                phys.shape[0],
-                                phys.shape[1],
-                                speculative_num_draft_tokens,
-                                conv_dim,
-                                win,
-                            ),
-                            (
-                                phys.stride(0),
-                                phys.stride(1),
-                                phys.stride(3),  # step -> shared-win axis (stride 1)
-                                phys.stride(2),  # dim
-                                phys.stride(3),  # win -> shared-win axis (stride 1)
-                            ),
-                        )
-                        self._intermediate_conv_window_phys.append(phys)
-                        intermediate_conv_window_cache.append(view)
-                else:
-                    # Original dense layout (NPU/CPU, or EAGLE tree verify): one
-                    # [dim, K-1] window per draft token.
-                    # Shape: [num_layers, size+1, draft_tokens, dim, K-1]
-                    intermediate_conv_window_cache = [
-                        torch.zeros(
-                            size=(
-                                num_mamba_layers,
-                                spec_state_size + 1,
-                                speculative_num_draft_tokens,
-                                conv_shape[0],
-                                conv_shape[1],
-                            ),
-                            dtype=conv_dtype,
-                            device="cuda",
-                        )
-                        for conv_shape in conv_state_shape
-                    ]
-                    self._intermediate_conv_window_phys = intermediate_conv_window_cache
                 self.mamba_cache = self.SpeculativeState(
                     conv=conv_state,
                     temporal=temporal_state,
@@ -660,8 +701,10 @@ class MambaPool:
             self.mem_usage = mem_usage_bytes / GB
             self.num_mamba_layers = num_mamba_layers
 
-    def get_speculative_mamba2_params_all_layers(self) -> SpeculativeState:
-        assert isinstance(self.mamba_cache, self.SpeculativeState)
+    def get_speculative_mamba2_params_all_layers(self):
+        assert isinstance(
+            self.mamba_cache, (self.SpeculativeState, self.CulaSpeculativeState)
+        )
         return self.mamba_cache
 
     def mamba2_layer_cache(self, layer_id: int):
@@ -838,6 +881,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         enable_linear_replayssm: bool = False,
         linear_replayssm_cache_len: int = 16,
         mamba_envelope_layout: bool = False,
+        linear_backend: str = "seg_la",
     ):
         super().__init__(
             size=size,
@@ -864,6 +908,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
             enable_linear_replayssm=enable_linear_replayssm,
             linear_replayssm_cache_len=linear_replayssm_cache_len,
             mamba_envelope_layout=mamba_envelope_layout,
+            linear_backend=linear_backend,
         )
 
     def _init_mamba_pool(
@@ -879,6 +924,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         enable_linear_replayssm: bool = False,
         linear_replayssm_cache_len: int = 16,
         mamba_envelope_layout: bool = False,
+        linear_backend: str = "seg_la",
     ):
         self.mamba_pool = MambaPool(
             size=mamba_size,
@@ -892,6 +938,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
             enable_linear_replayssm=enable_linear_replayssm,
             linear_replayssm_cache_len=linear_replayssm_cache_len,
             envelope_layout=mamba_envelope_layout,
+            linear_backend=linear_backend,
         )
         self.mamba_allocator = MambaSlotAllocator(
             size=mamba_size,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -634,25 +634,25 @@ class MambaPool:
                         self._intermediate_conv_window_phys = (
                             intermediate_conv_window_cache
                         )
-                self.mamba_cache = self.SpeculativeState(
-                    conv=conv_state,
-                    temporal=temporal_state,
-                    intermediate_ssm=intermediate_ssm_state_cache,
-                    intermediate_conv_window=intermediate_conv_window_cache,
-                    replayssm_d=replayssm_d,
-                    replayssm_k=replayssm_k,
-                    replayssm_g=replayssm_g,
-                )
-                logger.info(
-                    f"Mamba Cache is allocated. "
-                    f"max_mamba_cache_size: {size}, "
-                    f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
-                    f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
-                    f"intermediate_ssm_state_cache size: {get_tensor_size_bytes(intermediate_ssm_state_cache) / GB:.2f}GB "
-                    # Report the deduplicated PHYSICAL conv-window buffers (the view
-                    # over-reports its logical, un-deduplicated size).
-                    f"intermediate_conv_window_cache size: {get_tensor_size_bytes(self._intermediate_conv_window_phys) / GB:.2f}GB "
-                )
+                    self.mamba_cache = self.SpeculativeState(
+                        conv=conv_state,
+                        temporal=temporal_state,
+                        intermediate_ssm=intermediate_ssm_state_cache,
+                        intermediate_conv_window=intermediate_conv_window_cache,
+                        replayssm_d=replayssm_d,
+                        replayssm_k=replayssm_k,
+                        replayssm_g=replayssm_g,
+                    )
+                    logger.info(
+                        f"Mamba Cache is allocated. "
+                        f"max_mamba_cache_size: {size}, "
+                        f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
+                        f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
+                        f"intermediate_ssm_state_cache size: {get_tensor_size_bytes(intermediate_ssm_state_cache) / GB:.2f}GB "
+                        # Report the deduplicated PHYSICAL conv-window buffers (the view
+                        # over-reports its logical, un-deduplicated size).
+                        f"intermediate_conv_window_cache size: {get_tensor_size_bytes(self._intermediate_conv_window_phys) / GB:.2f}GB "
+                    )
             else:
                 self.mamba_cache = self.State(
                     conv=conv_state,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -507,14 +507,17 @@ class MambaPool:
                     # therefore match the `temporal` state pool's leading dim (size + 1);
                     # using spec_state_size + 1 here under-sizes the buffer and lets a
                     # cache slot id >= spec_state_size+1 index out of bounds.
+                    # fp32: the cuLA verify/commit kernels compute in fp32 and now load
+                    # q/k natively as fp32, so the draft buffers stay fp32 end-to-end
+                    # (no fp32<->bf16 cast on the sglang side).
                     draft_k = torch.zeros(
                         (num_mamba_layers, size + 1, T, H, Kd),
-                        dtype=torch.bfloat16,
+                        dtype=torch.float32,
                         device=device,
                     )
                     draft_v = torch.zeros(
                         (num_mamba_layers, size + 1, T, HV, Vd),
-                        dtype=torch.bfloat16,
+                        dtype=torch.float32,
                         device=device,
                     )
                     self.mamba_cache = self.CulaSpeculativeState(
@@ -786,14 +789,20 @@ class MambaPool:
     def get_contiguous_buf_infos(self):
         """
         Get buffer info for RDMA registration.
-        Only returns conv and temporal state buffers, excluding intermediate buffers
-        used for speculative decoding (intermediate_ssm, intermediate_conv_window).
+        Only returns persistent conv and temporal state buffers, excluding
+        speculative-only buffers (intermediate_ssm, intermediate_conv_window,
+        draft_k, draft_v).
         """
         state_tensors = []
         for field in vars(self.mamba_cache):
             # Skip intermediate buffers used only for speculative decoding
             # These buffers have different size (spec_state_size + 1) and should not be transferred
-            if field in ("intermediate_ssm", "intermediate_conv_window"):
+            if field in (
+                "intermediate_ssm",
+                "intermediate_conv_window",
+                "draft_k",
+                "draft_v",
+            ):
                 continue
             # Skip GDN ReplaySSM ring buffers: they are derived/transient decode
             # scratch, not part of the persistent transferable state.
@@ -838,6 +847,8 @@ class MambaPool:
                 "replayssm_d",
                 "replayssm_k",
                 "replayssm_g",
+                "draft_k",
+                "draft_v",
             ):
                 continue
             value = getattr(self.mamba_cache, field)

--- a/python/sglang/test/kits/attention_unittest/attention_methods/lightning_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/lightning_attention.py
@@ -62,6 +62,7 @@ class LightningAttentionCase:
     page_size: int
     prefix_lens: tuple[int, ...]
     extend_lens: tuple[int, ...] = ()
+    linear_backend: str = "seg_la"
 
     @property
     def batch_size(self) -> int:
@@ -198,6 +199,8 @@ class TinyLightningModelConfig:
             num_attention_heads=num_heads,
             num_hidden_layers=num_hidden_layers,
             linear_backend=linear_backend,
+            head_dim=head_dim,
+            hidden_size=num_heads * head_dim,
         )
         self.hf_config.get_text_config = lambda: self.hf_config
         self.hf_text_config = self.hf_config
@@ -302,6 +305,7 @@ class MockLightningModelRunner(ModelRunner):
             enable_mamba_extra_buffer=False,
             speculative_num_draft_tokens=speculative_num_draft_tokens or None,
             enable_overlap_schedule=False,
+            linear_backend=model_config.hf_config.linear_backend,
         )
         max_token_loc = case.page_size + pool_batch_size * max_context_len
         self.token_to_kv_pool = MHATokenToKVPool(
@@ -552,6 +556,7 @@ def build_lightning_attention_fixture(
         head_dim=head_dim,
         context_len=max_context_len,
         num_hidden_layers=num_hidden_layers,
+        linear_backend=case.linear_backend,
     )
     runner = MockLightningModelRunner(
         case=case,
@@ -765,6 +770,8 @@ def run_lightning_attention_case(
         loc_layout=loc_layout,
     )
     initial_ssm_states = _ssm_states(fixture).clone()
+    if case.linear_backend == "cula":
+        initial_ssm_states = initial_ssm_states.transpose(-1, -2).contiguous()
     actual = run_lightning_fixture_eager(fixture)
     expected = _pure_torch_lightning_reference(fixture, initial_ssm_states)
 
@@ -784,8 +791,13 @@ def run_lightning_attention_case(
 
 
 def _clone_lightning_cache(fixture: LightningAttentionFixture):
-    """Snapshot the SSM state for CG capture/replay isolation."""
-    return _ssm_states(fixture).clone()
+    """Snapshot the SSM state for CG capture/replay isolation.
+    For cula (V-major layout), transpose to K-major so the pure-Python
+    reference (which uses torch.outer → [K,V]) computes correctly."""
+    state = _ssm_states(fixture).clone()
+    if fixture.case.linear_backend == "cula":
+        state = state.transpose(-1, -2).contiguous()
+    return state
 
 
 def _restore_lightning_cache(

--- a/test/manual/lightning/test_seg_la_vk_e2e_parity.py
+++ b/test/manual/lightning/test_seg_la_vk_e2e_parity.py
@@ -1,0 +1,252 @@
+"""E2E parity test: seg_la vs seg_la_vk on a real Ling / Bailing-MoE-Linear model.
+
+This test is **USER-RUN** — it needs a real checkpoint + GPUs + time.
+Claude authored it; the user executes it.
+
+Loads the same model twice (sequentially to save memory) — baseline with
+default ``linear_backend`` (``"seg_la"``) and override
+``json_model_override_args='{"linear_backend":"seg_la_vk"}'``.  Greedy-decodes
+a fixed prompt set (single, batched, long) and asserts **identical token ids**.
+Also runs a spec variant (NEXTN) to cover the MTP+scatter path.
+
+Usage::
+    MODEL=/root/.cache/modelscope/hub/models/inclusionAI/Ling-2___6-flash
+    python3 test/manual/lightning/test_seg_la_vk_e2e_parity.py --model-path "$MODEL" --tp-size 4
+
+Passing this test is the gate that confirms ``seg_la_vk`` is end-to-end
+correct with no ``memory_pool.py`` / scatter changes needed.
+"""
+
+import argparse
+import sys
+
+import torch
+
+from sglang import Engine
+
+PROMPTS = [
+    "The capital of France is",
+    "Explain the key differences between linear attention and standard self-attention in one paragraph.",
+    "Write a Python function to compute Fibonacci numbers recursively.",
+    "In 2019, the European Space Agency launched",
+    "A recipe for chocolate chip cookies:",
+]
+
+# Longer prompt to exercise prefill chunking
+LONG_PROMPT = (
+    "The theory of general relativity, proposed by Albert Einstein in 1915, "
+    "fundamentally changed our understanding of gravity. Instead of viewing gravity "
+    "as a force between masses, Einstein described it as the curvature of spacetime "
+    "caused by mass and energy. This revolutionary framework has been confirmed by "
+    "numerous experiments and observations over the past century, including the "
+    "precession of Mercury's orbit, the bending of starlight during solar eclipses, "
+    "and the recent detection of gravitational waves by LIGO. Describe the core "
+    "principles of general relativity and its major experimental confirmations:"
+)
+
+
+def _build_engine(
+    model_path: str,
+    tp_size: int,
+    extra_args: dict,
+    spec: bool = False,
+    model_impl: str = "auto",
+):
+    """Build an sglang.Engine with the given overrides."""
+    kwargs = dict(
+        model_path=model_path,
+        tp_size=tp_size,
+        model_impl=model_impl,
+        trust_remote_code=True,
+        mem_fraction_static=0.75,
+        max_running_requests=64,
+        log_level="error",
+    )
+    if extra_args:
+        kwargs["json_model_override_args"] = _to_json_str(extra_args)
+    if spec:
+        kwargs.update(
+            speculative_algorithm="NEXTN",
+            speculative_num_steps=3,
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=4,
+            mamba_scheduler_strategy="extra_buffer",
+        )
+    return Engine(**kwargs)
+
+
+def _to_json_str(d: dict) -> str:
+    import json
+
+    return json.dumps(d)
+
+
+def _greedy_generate(engine: Engine, prompts: list, max_tokens: int = 64):
+    """Greedy (temperature=0) generate and return list of token-id lists."""
+    try:
+        outputs = engine.generate(
+            prompts,
+            sampling_params={"temperature": 0.0, "max_new_tokens": max_tokens},
+        )
+    except Exception:
+        # Fallback: generate one-by-one if batched generate fails
+        outputs = []
+        for p in prompts:
+            outputs.append(
+                engine.generate(
+                    p,
+                    sampling_params={"temperature": 0.0, "max_new_tokens": max_tokens},
+                )
+            )
+    tokens = []
+    for out in outputs:
+        if hasattr(out, "output_ids"):
+            tokens.append(out.output_ids)
+        elif isinstance(out, dict):
+            tokens.append(out.get("output_ids", []))
+        else:
+            raise TypeError(f"Unexpected output type: {type(out)}")
+    return tokens
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-path", required=True)
+    ap.add_argument("--tp-size", type=int, default=4)
+    ap.add_argument(
+        "--model-impl",
+        type=str,
+        default="auto",
+        help="Model implementation backend, e.g. 'auto' or 'modelscope'",
+    )
+    ap.add_argument("--max-tokens", type=int, default=64)
+    ap.add_argument(
+        "--skip-spec", action="store_true", help="Skip speculative decoding test"
+    )
+    args = ap.parse_args()
+
+    torch.cuda.empty_cache()
+
+    # ---- Baseline: seg_la (kv, default) ----
+    print("=== Loading baseline (seg_la / kv) ===", flush=True)
+    engine_kv = _build_engine(
+        args.model_path,
+        args.tp_size,
+        model_impl=args.model_impl,
+        extra_args={},
+        spec=False,
+    )
+    try:
+        prompts = list(PROMPTS) + [LONG_PROMPT]
+        kv_tokens = _greedy_generate(engine_kv, prompts, args.max_tokens)
+
+        # Also test batched (first 3 prompts together)
+        kv_batch = _greedy_generate(
+            engine_kv, [PROMPTS[0], PROMPTS[1], PROMPTS[2]], args.max_tokens
+        )
+        print(
+            f"  baseline generated {sum(len(t) for t in kv_tokens)} total tokens",
+            flush=True,
+        )
+    finally:
+        engine_kv.shutdown()
+        del engine_kv
+        torch.cuda.empty_cache()
+
+    # ---- Override: seg_la_vk ----
+    print("=== Loading override (seg_la_vk / vk) ===", flush=True)
+    engine_vk = _build_engine(
+        args.model_path,
+        args.tp_size,
+        model_impl=args.model_impl,
+        extra_args={"linear_backend": "seg_la_vk"},
+        spec=False,
+    )
+    try:
+        prompts = list(PROMPTS) + [LONG_PROMPT]
+        vk_tokens = _greedy_generate(engine_vk, prompts, args.max_tokens)
+        vk_batch = _greedy_generate(
+            engine_vk, [PROMPTS[0], PROMPTS[1], PROMPTS[2]], args.max_tokens
+        )
+        print(
+            f"  override generated {sum(len(t) for t in vk_tokens)} total tokens",
+            flush=True,
+        )
+    finally:
+        engine_vk.shutdown()
+        del engine_vk
+        torch.cuda.empty_cache()
+
+    # ---- Assert identical ----
+    all_ok = True
+    for i, (kv_tok, vk_tok) in enumerate(
+        zip(kv_tokens + kv_batch, vk_tokens + vk_batch)
+    ):
+        if kv_tok != vk_tok:
+            print(f"\nFAIL: prompt group {i}: tokens differ!", flush=True)
+            print(
+                f"  kv ({len(kv_tok)}): {kv_tok[:20]}{'...' if len(kv_tok) > 20 else ''}",
+                flush=True,
+            )
+            print(
+                f"  vk ({len(vk_tok)}): {vk_tok[:20]}{'...' if len(vk_tok) > 20 else ''}",
+                flush=True,
+            )
+            all_ok = False
+    if all_ok:
+        print(
+            "\nPASS: all prompts produce identical token ids (seg_la == seg_la_vk)",
+            flush=True,
+        )
+
+    # ---- Spec variant (NEXTN → MTP + scatter) ----
+    if not args.skip_spec:
+        torch.cuda.empty_cache()
+        print("\n=== Loading baseline (seg_la + spec) ===", flush=True)
+        engine_kv_spec = _build_engine(
+            args.model_path,
+            args.tp_size,
+            model_impl=args.model_impl,
+            extra_args={},
+            spec=True,
+        )
+        try:
+            kv_spec_tokens = _greedy_generate(
+                engine_kv_spec, list(PROMPTS), args.max_tokens
+            )
+        finally:
+            engine_kv_spec.shutdown()
+            del engine_kv_spec
+            torch.cuda.empty_cache()
+
+        print("=== Loading override (seg_la_vk + spec) ===", flush=True)
+        engine_vk_spec = _build_engine(
+            args.model_path,
+            args.tp_size,
+            model_impl=args.model_impl,
+            extra_args={"linear_backend": "seg_la_vk"},
+            spec=True,
+        )
+        try:
+            vk_spec_tokens = _greedy_generate(
+                engine_vk_spec, list(PROMPTS), args.max_tokens
+            )
+        finally:
+            engine_vk_spec.shutdown()
+            del engine_vk_spec
+            torch.cuda.empty_cache()
+
+        for i, (kv_tok, vk_tok) in enumerate(zip(kv_spec_tokens, vk_spec_tokens)):
+            if kv_tok != vk_tok:
+                print(f"\nFAIL (spec): prompt {i}: tokens differ!", flush=True)
+                all_ok = False
+        if all(
+            kv_spec_tokens[i] == vk_spec_tokens[i] for i in range(len(kv_spec_tokens))
+        ):
+            print("PASS (spec): all prompts produce identical token ids", flush=True)
+
+    sys.exit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/attention/unittests/lightning/test_cula.py
+++ b/test/registered/attention/unittests/lightning/test_cula.py
@@ -1,0 +1,148 @@
+import sys
+import unittest
+from pathlib import Path
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sglang.srt.layers.attention.linear.cula_entry import CULA_AVAILABLE
+from sglang.test.kits.attention_unittest.attention_methods.lightning_attention import (
+    LightningAttentionCase,
+    run_lightning_attention_case,
+)
+from sglang.test.kits.attention_unittest.runner_modes.speculative_target_verify_runner import (
+    run_lightning_eagle_verify_case,
+)
+
+register_cuda_ci(est_time=300, suite="base-b-test-4-gpu-b200")
+
+
+@unittest.skipUnless(
+    CULA_AVAILABLE, "cuLA not installed (pip install cuda-linear-attention)"
+)
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestCulaLightningBackendCorrectness(CustomTestCase):
+    """Lightning attention backend correctness with linear_backend='cula'.
+
+    Mirrors the triton test structure but exercises the cuLA kernel path.
+    The reference computation is backend-agnostic (pure-Python seg_la recurrence),
+    so any output mismatch means the cuLA adapter conventions are wrong.
+    """
+
+    CASES = (
+        LightningAttentionCase(
+            name="cula_extend_page_size_1",
+            backend="triton",
+            linear_backend="cula",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=2,
+            page_size=1,
+            prefix_lens=(2, 4),
+            extend_lens=(3, 1),
+        ),
+        LightningAttentionCase(
+            name="cula_extend_zero_prefix_exact_page",
+            backend="triton",
+            linear_backend="cula",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=2,
+            page_size=16,
+            prefix_lens=(0,),
+            extend_lens=(16,),
+        ),
+        LightningAttentionCase(
+            name="cula_extend_two_request_page16",
+            backend="triton",
+            linear_backend="cula",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=2,
+            page_size=16,
+            prefix_lens=(0, 0),
+            extend_lens=(16, 16),
+        ),
+        LightningAttentionCase(
+            name="cula_decode_bsz1_no_prefix",
+            backend="triton",
+            linear_backend="cula",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=2,
+            page_size=16,
+            prefix_lens=(0,),
+        ),
+        LightningAttentionCase(
+            name="cula_decode_bsz1_nonzero_prefix",
+            backend="triton",
+            linear_backend="cula",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=2,
+            page_size=16,
+            prefix_lens=(7,),
+        ),
+    )
+
+    EAGLE_VERIFY_CASES = (
+        (
+            LightningAttentionCase(
+                name="cula_eagle_verify_chain",
+                backend="triton",
+                linear_backend="cula",
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                num_heads=2,
+                page_size=16,
+                prefix_lens=(4, 7),
+                extend_lens=(3, 3),
+            ),
+            1,
+            "eagle",
+        ),
+        (
+            LightningAttentionCase(
+                name="cula_frozen_kv_mtp_verify_chain",
+                backend="triton",
+                linear_backend="cula",
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                num_heads=2,
+                page_size=16,
+                prefix_lens=(4, 7),
+                extend_lens=(3, 3),
+            ),
+            1,
+            "frozen_kv_mtp",
+        ),
+    )
+
+    def test_projected_lightning_attention_cases(self):
+        for case in self.CASES:
+            with self.subTest(case=case.name, linear_backend=case.linear_backend):
+                try:
+                    run_lightning_attention_case(self, case)
+                except RuntimeError as e:
+                    if "Only Blackwell GPUs" in str(e):
+                        self.skipTest(f"cuLA prefill requires SM100+: {e}")
+                    raise
+
+    def test_runner_mode_eagle_verify_cases(self):
+        for case, topk, spec_kind in self.EAGLE_VERIFY_CASES:
+            with self.subTest(
+                case=case.name,
+                linear_backend=case.linear_backend,
+                topk=topk,
+                spec_kind=spec_kind,
+            ):
+                try:
+                    run_lightning_eagle_verify_case(
+                        self, case, topk=topk, spec_kind=spec_kind
+                    )
+                except RuntimeError as e:
+                    if "Only Blackwell GPUs" in str(e):
+                        self.skipTest(f"cuLA prefill requires SM100+: {e}")
+                    raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/attention/unittests/lightning/test_cula.py
+++ b/test/registered/attention/unittests/lightning/test_cula.py
@@ -19,7 +19,7 @@ from sglang.test.kits.attention_unittest.runner_modes.speculative_target_verify_
     run_lightning_eagle_verify_case,
 )
 
-register_cuda_ci(est_time=300, suite="base-b-test-4-gpu-b200")
+register_cuda_ci(est_time=300, stage="base-b", runner_config="4-gpu-b200")
 
 
 @unittest.skipUnless(

--- a/test/registered/attention/unittests/lightning/test_cula_equivalence.py
+++ b/test/registered/attention/unittests/lightning/test_cula_equivalence.py
@@ -16,6 +16,7 @@ from sglang.test.test_utils import CustomTestCase
 try:
     from cula.lightning import (
         linear_attention_state_update_kvbuffer,
+        linear_attention_state_update_kvbuffer_fused,
         linear_attention_verify_kvbuffer,
     )
 
@@ -23,7 +24,7 @@ try:
 except ImportError:
     CULA_AVAILABLE = False
 
-register_cuda_ci(est_time=120, suite="base-b-test-4-gpu-b200")
+register_cuda_ci(est_time=120, stage="base-b", runner_config="4-gpu-b200")
 
 
 def _skip_if_no_gpu():
@@ -93,9 +94,11 @@ class TestCulaKernelCorrectness(CustomTestCase):
         scale = D**-0.5
         decay = 0.3 * torch.arange(H, device="cuda", dtype=torch.float32) / H
 
-        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
-        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
-        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        # fp32 q/k/v: the cuLA verify kernel now loads q/k into fp32 registers
+        # natively (no bf16 cast), matching the runtime path (Ling fp32 rotary).
+        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
+        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
+        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
         state_kmajor = (
             torch.randn(B, H, D, D, device="cuda", dtype=torch.float32) * 0.01
         )
@@ -106,7 +109,7 @@ class TestCulaKernelCorrectness(CustomTestCase):
         # cuLA
         pool_idx = torch.arange(B, device="cuda", dtype=torch.int32)
         s_cula = state_kmajor.transpose(-1, -2).contiguous()
-        out_cula = torch.zeros(B, T, H, D, device="cuda", dtype=torch.bfloat16)
+        out_cula = torch.zeros(B, T, H, D, device="cuda", dtype=torch.float32)
         linear_attention_verify_kvbuffer(
             q.view(B, T, H, D),
             k.view(B, T, H, D),
@@ -136,9 +139,9 @@ class TestCulaKernelCorrectness(CustomTestCase):
         scale = D**-0.5
         decay = 0.3 * torch.arange(H, device="cuda", dtype=torch.float32) / H
 
-        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
-        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
-        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
+        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
+        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
         state_kmajor = (
             torch.randn(B, H, D, D, device="cuda", dtype=torch.float32) * 0.01
         )
@@ -181,9 +184,9 @@ class TestCulaKernelCorrectness(CustomTestCase):
         scale = D**-0.5
         decay = 0.3 * torch.arange(H, device="cuda", dtype=torch.float32) / H
 
-        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
-        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
-        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
+        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
+        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
         state_kmajor = (
             torch.randn(B, H, D, D, device="cuda", dtype=torch.float32) * 0.01
         )
@@ -226,9 +229,9 @@ class TestCulaKernelCorrectness(CustomTestCase):
         scale = D**-0.5
         decay = 0.3 * torch.arange(H, device="cuda", dtype=torch.float32) / H
 
-        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
-        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
-        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
+        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
+        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.float32)
         state_kmajor = (
             torch.randn(B, H, D, D, device="cuda", dtype=torch.float32) * 0.01
         )
@@ -249,6 +252,72 @@ class TestCulaKernelCorrectness(CustomTestCase):
         )
         self.assertTrue(
             torch.equal(s_cula, s_snapshot), "L=0 must leave state unchanged"
+        )
+
+    # ------------------------------------------------------------------
+    # Fused commit kernel: all-layer update matches per-layer reference
+    # ------------------------------------------------------------------
+    def test_cula_commit_fused_matches_pytorch(self):
+        _skip_if_no_gpu()
+        LAYERS, B, T, H, D = 3, 3, 4, 4, 128
+        torch.manual_seed(2026)
+        scale = D**-0.5
+        accepted_len = torch.tensor([T, 2, 0], device="cuda", dtype=torch.int32)
+        pool_idx = torch.arange(B, device="cuda", dtype=torch.int32)
+
+        k = torch.randn(LAYERS, B, T, H, D, device="cuda", dtype=torch.float32)
+        v = torch.randn(LAYERS, B, T, H, D, device="cuda", dtype=torch.float32)
+        state_kmajor = (
+            torch.randn(LAYERS, B, H, D, D, device="cuda", dtype=torch.float32) * 0.01
+        )
+        decay_all = torch.stack(
+            [
+                0.3
+                * (layer_idx + 1)
+                * torch.arange(H, device="cuda", dtype=torch.float32)
+                / H
+                for layer_idx in range(LAYERS)
+            ]
+        )
+
+        ref_layers = []
+        q_dummy = torch.zeros(B * T, H, D, device="cuda", dtype=torch.float32)
+        for layer_idx in range(LAYERS):
+            _, _, inter = _torch_la_mtp_ref(
+                q_dummy,
+                k[layer_idx].view(B * T, H, D),
+                v[layer_idx].view(B * T, H, D),
+                state_kmajor[layer_idx],
+                decay_all[layer_idx],
+                scale,
+                T,
+            )
+            ref = state_kmajor[layer_idx].clone()
+            for batch_idx, length in enumerate(accepted_len.tolist()):
+                if length > 0:
+                    ref[batch_idx] = inter[batch_idx, length - 1]
+            ref_layers.append(ref)
+        ref_state_kmajor = torch.stack(ref_layers)
+
+        s_cula = state_kmajor.transpose(-1, -2).contiguous()
+        linear_attention_state_update_kvbuffer_fused(
+            k,
+            v,
+            s_cula,
+            decay_all,
+            pool_idx,
+            accepted_len,
+            T,
+        )
+        cula_state_kmajor = s_cula.transpose(-1, -2).contiguous()
+
+        rel = (cula_state_kmajor - ref_state_kmajor).pow(2).mean().sqrt() / (
+            ref_state_kmajor.abs().max() + 1e-8
+        )
+        self.assertLess(
+            rel.item(),
+            1e-3,
+            f"fused commit state mismatch vs pytorch ref: {rel:.5f}",
         )
 
 

--- a/test/registered/attention/unittests/lightning/test_cula_equivalence.py
+++ b/test/registered/attention/unittests/lightning/test_cula_equivalence.py
@@ -1,0 +1,256 @@
+"""L1 operator correctness: cuLA verify/commit vs pure PyTorch reference.
+
+No model load required — tests the cuLA adapter conventions (layout, decay sign,
+scale, off-by-one) by running the same random (q, k, v, h0) through the cuLA
+CUDA kernels and a pure-PyTorch recurrent reference, then asserting outputs
+and committed state match within numerical tolerance.
+"""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+try:
+    from cula.lightning import (
+        linear_attention_state_update_kvbuffer,
+        linear_attention_verify_kvbuffer,
+    )
+
+    CULA_AVAILABLE = True
+except ImportError:
+    CULA_AVAILABLE = False
+
+register_cuda_ci(est_time=120, suite="base-b-test-4-gpu-b200")
+
+
+def _skip_if_no_gpu():
+    if not torch.cuda.is_available():
+        raise unittest.SkipTest("CUDA required")
+
+
+# ---------------------------------------------------------------------------
+# Pure PyTorch reference for multi-token Lightning Attention (MTP verify)
+# ---------------------------------------------------------------------------
+def _torch_la_mtp_ref(q, k, v, state_kmajor, decay, scale, T):
+    """Pure PyTorch recurrent Lightning Attention.
+
+    Args:
+        q, k: [B*T, H, D] bf16 packed token-major
+        v:    [B*T, HV, D] bf16
+        state_kmajor: [B, HV, D, D] fp32 K-major initial state
+        decay: [H] fp32 positive slopes
+        scale: float
+        T: int draft_token_num
+    Returns:
+        out:       [B*T, HV, D] bf16 all-T verify output
+        state_new: [B, HV, D, D] fp32 state after T recurrent steps
+        inter:     [B, T, HV, D, D] fp32 per-step intermediate states
+    """
+    B = q.shape[0] // T
+    H = q.shape[1]
+    HV = v.shape[1]
+    D = q.shape[2]
+
+    q_f = q.view(B, T, H, D).float() * scale
+    k_f = k.view(B, T, H, D).float()
+    v_f = v.view(B, T, HV, D).float()
+
+    # Repeat decay per q-head to match HV (grouped linear attention)
+    decay_per_q = torch.exp(-decay.float())
+    decay_per_hv = decay_per_q.repeat_interleave(HV // H).view(1, HV, 1, 1)
+
+    state = state_kmajor.float().clone()
+    out = torch.zeros(B, T, HV, D, dtype=torch.bfloat16, device=q.device)
+    inter = torch.zeros(B, T, HV, D, D, dtype=torch.float32, device=q.device)
+
+    for t in range(T):
+        q_t = q_f[:, t].repeat_interleave(HV // H, dim=1)  # [B, HV, D]
+        k_t = k_f[:, t].repeat_interleave(HV // H, dim=1)  # [B, HV, D]
+        v_t = v_f[:, t]  # [B, HV, D]
+        state = state * decay_per_hv + k_t.unsqueeze(-1) * v_t.unsqueeze(-2)
+        out[:, t] = torch.einsum("bhk,bhkv->bhv", q_t, state).bfloat16()
+        inter[:, t] = state.clone()
+
+    return out.view(B * T, HV, D), state, inter
+
+
+@unittest.skipUnless(
+    CULA_AVAILABLE, "cuLA not installed (pip install cuda-linear-attention)"
+)
+class TestCulaKernelCorrectness(CustomTestCase):
+    """Validate cuLA verify/commit kernels against pure PyTorch reference."""
+
+    # ------------------------------------------------------------------
+    # Verify kernel: output matches PyTorch recurrent reference
+    # ------------------------------------------------------------------
+    def test_cula_verify_matches_pytorch(self):
+        _skip_if_no_gpu()
+        B, T, H, D = 2, 4, 4, 128
+        torch.manual_seed(0)
+        scale = D**-0.5
+        decay = 0.3 * torch.arange(H, device="cuda", dtype=torch.float32) / H
+
+        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        state_kmajor = (
+            torch.randn(B, H, D, D, device="cuda", dtype=torch.float32) * 0.01
+        )
+
+        # Reference
+        o_ref, _, _ = _torch_la_mtp_ref(q, k, v, state_kmajor, decay, scale, T)
+
+        # cuLA
+        pool_idx = torch.arange(B, device="cuda", dtype=torch.int32)
+        s_cula = state_kmajor.transpose(-1, -2).contiguous()
+        out_cula = torch.zeros(B, T, H, D, device="cuda", dtype=torch.bfloat16)
+        linear_attention_verify_kvbuffer(
+            q.view(B, T, H, D),
+            k.view(B, T, H, D),
+            v.view(B, T, H, D),
+            s_cula,
+            out_cula,
+            decay,
+            pool_idx,
+            scale,
+            T,
+        )
+
+        rel = (out_cula.float() - o_ref.view(B, T, H, D).float()).pow(
+            2
+        ).mean().sqrt() / (o_ref.float().abs().max() + 1e-8)
+        self.assertLess(
+            rel.item(), 1e-2, f"verify output mismatch vs pytorch ref: {rel:.5f}"
+        )
+
+    # ------------------------------------------------------------------
+    # Commit kernel: full accept state matches reference after T steps
+    # ------------------------------------------------------------------
+    def test_cula_commit_full_accept(self):
+        _skip_if_no_gpu()
+        B, T, H, D = 2, 4, 4, 128
+        torch.manual_seed(42)
+        scale = D**-0.5
+        decay = 0.3 * torch.arange(H, device="cuda", dtype=torch.float32) / H
+
+        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        state_kmajor = (
+            torch.randn(B, H, D, D, device="cuda", dtype=torch.float32) * 0.01
+        )
+
+        # Reference state after T steps
+        _, ref_state_kmajor, _ = _torch_la_mtp_ref(
+            q, k, v, state_kmajor, decay, scale, T
+        )
+
+        # cuLA commit (full accept)
+        pool_idx = torch.arange(B, device="cuda", dtype=torch.int32)
+        s_cula = state_kmajor.transpose(-1, -2).contiguous()
+        accepted_len = torch.full((B,), T, device="cuda", dtype=torch.int32)
+        linear_attention_state_update_kvbuffer(
+            k.view(B, T, H, D),
+            v.view(B, T, H, D),
+            s_cula,
+            decay,
+            pool_idx,
+            accepted_len,
+            T,
+        )
+        cula_state_kmajor = s_cula.transpose(-1, -2).contiguous()
+
+        rel = (cula_state_kmajor - ref_state_kmajor).pow(2).mean().sqrt() / (
+            ref_state_kmajor.abs().max() + 1e-8
+        )
+        self.assertLess(
+            rel.item(), 1e-3, f"commit state mismatch vs pytorch ref: {rel:.5f}"
+        )
+
+    # ------------------------------------------------------------------
+    # Commit kernel: partial accept state matches reference at step L
+    # ------------------------------------------------------------------
+    def test_cula_commit_partial_accept(self):
+        _skip_if_no_gpu()
+        B, T, H, D = 2, 4, 4, 128
+        L = 2
+        torch.manual_seed(123)
+        scale = D**-0.5
+        decay = 0.3 * torch.arange(H, device="cuda", dtype=torch.float32) / H
+
+        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        state_kmajor = (
+            torch.randn(B, H, D, D, device="cuda", dtype=torch.float32) * 0.01
+        )
+
+        # Reference intermediate state at step L (partial accept)
+        _, _, inter = _torch_la_mtp_ref(q, k, v, state_kmajor, decay, scale, T)
+        ref_state_at_L = inter[:, L - 1]  # [B, HV, D, D]
+
+        # cuLA commit (partial accept)
+        pool_idx = torch.arange(B, device="cuda", dtype=torch.int32)
+        s_cula = state_kmajor.transpose(-1, -2).contiguous()
+        accepted_len = torch.full((B,), L, device="cuda", dtype=torch.int32)
+        linear_attention_state_update_kvbuffer(
+            k.view(B, T, H, D),
+            v.view(B, T, H, D),
+            s_cula,
+            decay,
+            pool_idx,
+            accepted_len,
+            T,
+        )
+        cula_state_kmajor = s_cula.transpose(-1, -2).contiguous()
+
+        rel = (cula_state_kmajor - ref_state_at_L).pow(2).mean().sqrt() / (
+            ref_state_at_L.abs().max() + 1e-8
+        )
+        self.assertLess(
+            rel.item(),
+            1e-3,
+            f"partial commit (L={L}) state mismatch vs pytorch ref: {rel:.5f}",
+        )
+
+    # ------------------------------------------------------------------
+    # Commit kernel: zero accept (L=0) — state unchanged
+    # ------------------------------------------------------------------
+    def test_cula_commit_zero_accept(self):
+        _skip_if_no_gpu()
+        B, T, H, D = 2, 4, 4, 128
+        torch.manual_seed(99)
+        scale = D**-0.5
+        decay = 0.3 * torch.arange(H, device="cuda", dtype=torch.float32) / H
+
+        q = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(B * T, H, D, device="cuda", dtype=torch.bfloat16)
+        state_kmajor = (
+            torch.randn(B, H, D, D, device="cuda", dtype=torch.float32) * 0.01
+        )
+
+        pool_idx = torch.arange(B, device="cuda", dtype=torch.int32)
+        s_cula = state_kmajor.transpose(-1, -2).contiguous()
+        s_snapshot = s_cula.clone()
+        accepted_len = torch.zeros(B, device="cuda", dtype=torch.int32)
+
+        linear_attention_state_update_kvbuffer(
+            k.view(B, T, H, D),
+            v.view(B, T, H, D),
+            s_cula,
+            decay,
+            pool_idx,
+            accepted_len,
+            T,
+        )
+        self.assertTrue(
+            torch.equal(s_cula, s_snapshot), "L=0 must leave state unchanged"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/attention/unittests/lightning/test_seg_la_state_layout.py
+++ b/test/registered/attention/unittests/lightning/test_seg_la_state_layout.py
@@ -1,0 +1,342 @@
+"""Kernel-level correctness test for seg_la state_layout (kv vs vk).
+
+Calls ``seg_la_fwd`` directly (no server, no model), comparing
+``state_layout="kv"`` and ``"vk"`` across prefill (zero / nonzero init),
+decode, spec, and MTP.  The primary assertion is vk == kv (identical by
+construction under refined-B) and, where state is written, vk final state
+== kv final state transposed.
+
+State tensors are passed to the kernel *uncloned* so the in-place state
+write-back is actually verified (not the original inputs).
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.linear.seg_la import SegLaMeta, seg_la_fwd
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase, is_in_amd_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-large")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_decays(H, D, device):
+    """slope ∈ (0.3/H, 0.3) → decay = exp(-slope)."""
+    slope = 0.3 * torch.arange(1, H + 1, device=device, dtype=torch.float32) / H
+    return slope.view(H, 1, 1)
+
+
+def _make_packed_inputs(B, S, H, D, device="cuda", dtype=torch.bfloat16):
+    total = B * S
+    q = torch.randn(total, H, D, device=device, dtype=dtype)
+    k = torch.randn(total, H, D, device=device, dtype=dtype)
+    v = torch.randn(total, H, D, device=device, dtype=dtype)
+    q_offsets = torch.arange(0, total + 1, S, device=device, dtype=torch.int32)
+    return q, k, v, q_offsets
+
+
+def _make_seg_meta(B, S, q_offsets, s_scales_val, s_offsets, mask=None):
+    return SegLaMeta(
+        batch_size=B,
+        max_q_length=S,
+        q_offsets=q_offsets,
+        s_offsets=s_offsets,
+        q_lengths=q_offsets.diff(),
+        s_scales=torch.full(
+            (B,), s_scales_val, device=q_offsets.device, dtype=torch.int32
+        ),
+        mask=mask,
+    )
+
+
+def _new_state(B, H, D, device):
+    """Return a random state pool [B, H, D, D] fp32 in kv layout."""
+    return torch.randn(B, H, D, D, device=device, dtype=torch.float32)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestSegLaStateLayout(CustomTestCase):
+    H = 2
+    D = 128  # decode needs K_SPLIT_DIM=128 → HEAD_DIM=128
+    atol = 5e-2 if is_in_amd_ci() else 3e-2
+    rtol = 5e-2 if is_in_amd_ci() else 3e-2
+
+    def setUp(self):
+        torch.manual_seed(42)
+        torch.cuda.manual_seed_all(42)
+
+    # ---- helpers ----
+    def _run_both_layouts(
+        self,
+        B,
+        S,
+        state_kv,
+        decay,
+        softmax_scale,
+        q,
+        k,
+        v,
+        q_offsets,
+        caches_kv=None,
+        caches_vk=None,
+        cache_indices=None,
+        mask=None,
+        has_init=True,
+    ):
+        """Run seg_la_fwd for kv and vk.
+
+        ``state_kv`` / ``caches_kv`` are passed *uncloned* so the kernel's
+        in-place state write is observable on return. ``has_init`` controls
+        s_scales (1 = read existing state, 0 = zero-init).
+        Returns (o_kv, o_vk, s_kv_final, s_vk_final, caches_kv, caches_vk).
+        """
+        s_offsets = torch.arange(B, device=q.device, dtype=torch.int32)
+        # state_vk is an independent [v,k]-laid-out tensor (transpose + copy).
+        state_vk = state_kv.clone().transpose(-1, -2).contiguous()
+        s_scales_val = 1 if has_init else 0
+
+        meta = _make_seg_meta(B, S, q_offsets, s_scales_val, s_offsets, mask=mask)
+        ci_kv = cache_indices.clone() if cache_indices is not None else None
+        ci_vk = cache_indices.clone() if cache_indices is not None else None
+
+        # kv — kernel writes final state back into state_kv in place
+        o_kv = seg_la_fwd(
+            q,
+            k,
+            v,
+            state_kv,
+            decay,
+            meta,
+            caches=caches_kv,
+            cache_indices=ci_kv,
+            softmax_scale=softmax_scale,
+            state_layout="kv",
+        )
+        # vk — kernel writes final state back into state_vk in place
+        o_vk = seg_la_fwd(
+            q,
+            k,
+            v,
+            state_vk,
+            decay,
+            meta,
+            caches=caches_vk,
+            cache_indices=ci_vk,
+            softmax_scale=softmax_scale,
+            state_layout="vk",
+        )
+        return o_kv, o_vk, state_kv, state_vk, caches_kv, caches_vk
+
+    def _assert_output_match(self, o_kv, o_vk):
+        self.assertTrue(
+            torch.allclose(o_vk, o_kv, atol=self.atol, rtol=self.rtol),
+            f"vk != kv output  max_diff={(o_vk - o_kv).abs().max().item():.6f}",
+        )
+
+    def _assert_state_transpose_match(self, s_kv_final, s_vk_final):
+        """vk final state must equal kv final state transposed (kernel-written)."""
+        s_kv_t = s_kv_final.transpose(-1, -2)
+        self.assertTrue(
+            torch.allclose(s_vk_final, s_kv_t, atol=self.atol, rtol=self.rtol),
+            f"state: vk != kv.transpose  max_diff={(s_vk_final - s_kv_t).abs().max().item():.6f}",
+        )
+
+    # ---- PREFILL ----
+    def test_prefill_zero_init_vsplit32(self):
+        """bs=2 → V_SPLIT_DIM=32; s_scales=0 (zero state init)."""
+        B, S, H, D = 2, 64, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = torch.zeros(B, H, D, D, device=q.device, dtype=torch.float32)
+
+        o_kv, o_vk, skv, svk, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            has_init=False,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        self._assert_state_transpose_match(skv, svk)
+
+    def test_prefill_zero_init_vsplit64(self):
+        """bs=4 → V_SPLIT_DIM=64; s_scales=0."""
+        B, S, H, D = 4, 64, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = torch.zeros(B, H, D, D, device=q.device, dtype=torch.float32)
+
+        o_kv, o_vk, skv, svk, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            has_init=False,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        self._assert_state_transpose_match(skv, svk)
+
+    def test_prefill_nonzero_init(self):
+        """s_scales=1 with random state — exercises tl.trans on prefill load."""
+        B, S, H, D = 2, 64, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = _new_state(B, H, D, q.device)
+
+        o_kv, o_vk, skv, svk, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            has_init=True,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        self._assert_state_transpose_match(skv, svk)
+
+    # ---- DECODE ----
+    def test_decode_vsplit32(self):
+        """bs ≤ 128 → V_SPLIT_DIM=32."""
+        B, S, H, D = 64, 1, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = _new_state(B, H, D, q.device)
+
+        o_kv, o_vk, skv, svk, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            has_init=True,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        self._assert_state_transpose_match(skv, svk)
+
+    def test_decode_vsplit64(self):
+        """bs > 128 → V_SPLIT_DIM=64."""
+        B, S, H, D = 256, 1, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = _new_state(B, H, D, q.device)
+
+        o_kv, o_vk, skv, svk, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            has_init=True,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        self._assert_state_transpose_match(skv, svk)
+
+    # ---- SPEC ----
+    def test_spec_chain(self):
+        """Speculative decode: chain mask, spec writes no state (read-only).
+
+        s_scales=1 so the VK tl.trans-on-load path is exercised.
+        """
+        B, S, H, D = 2, 16, self.H, self.D
+        q, k, v, q_offsets = _make_packed_inputs(B, S, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = _new_state(B, H, D, q.device)
+        mask = torch.tril(torch.ones(B, S, S, device=q.device, dtype=torch.int32))
+
+        o_kv, o_vk, _, _, _, _ = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            mask=mask,
+            has_init=True,
+        )
+        # Spec does NOT write back state; compare outputs only.
+        self._assert_output_match(o_kv, o_vk)
+
+    # ---- MTP ----
+    def test_mtp_chain(self):
+        """MTP path: caches/intermediate_ssm with step=4 tokens per request.
+
+        Ensures both s_ptrs and c_ptrs are swapped consistently — the MTP
+        scatter (layout-agnostic whole-slot copy) stays correct.
+        """
+        step = 4
+        B = step
+        H, D = self.H, self.D
+        S = step
+        q, k, v, q_offsets = _make_packed_inputs(B, step, H, D)
+        decay = _make_decays(H, D, q.device)
+        scale = D**-0.5
+        state_kv = _new_state(B, H, D, q.device)
+
+        # Sentinel init so unwritten slots stay distinguishable; kernel writes
+        # real values. caches_vk is an independent [v,k] tensor.
+        caches_kv = torch.full(
+            (B, step, H, D, D), -1.0, device=q.device, dtype=torch.float32
+        )
+        caches_vk = caches_kv.clone().transpose(-1, -2).contiguous()
+        cache_indices = torch.arange(B, device=q.device, dtype=torch.int32)
+
+        o_kv, o_vk, _, _, caches_kv, caches_vk = self._run_both_layouts(
+            B,
+            S,
+            state_kv,
+            decay,
+            scale,
+            q,
+            k,
+            v,
+            q_offsets,
+            caches_kv=caches_kv,
+            caches_vk=caches_vk,
+            cache_indices=cache_indices,
+            has_init=True,
+        )
+        self._assert_output_match(o_kv, o_vk)
+        # MTP writes to caches, not state; caches_vk == transpose(caches_kv).
+        self._assert_state_transpose_match(caches_kv, caches_vk)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This PR adds an optional cuLA KVBuffer backend for Lightning Attention in Ling-2.6-flash speculative decoding.

Linear-attention serving is IO-sensitive: the recurrent decode path reads and writes a large per-request state on every token, and speculative verification can require temporary state for each draft token. The KVBuffer paper ([arXiv:2605.19049](https://arxiv.org/abs/2605.19049), "KVBuffer: IO-aware Serving for Linear Attention") describes a serving design that buffers recent K/V and verifies speculative draft tokens in parallel, then commits only the accepted prefix into the linear-attention state. In particular, Figure 2 in the paper illustrates the speculative-decoding pattern targeted here: buffer draft K/V, compute verification outputs from the initial state plus buffered K/V, and update the state once after acceptance.

<img width="1672" height="834" alt="image" src="https://github.com/user-attachments/assets/425f5ca4-5b13-43bc-816c-f4fb4fc44f3e" />

<p align="center">
  <em>Figure 2 from KVBuffer: IO-aware Serving for Linear Attention (arXiv:2605.19049), showing speculative verification with buffered draft K/V and a single accepted-prefix state update.</em>
</p>

This SGLang integration exposes that path through `linear_backend="cula"`:

- Prefill remains on the existing `seg_la` kernel family, but writes the state in `[v, k]` layout so it is compatible with cuLA's V-major KVBuffer.
- Decode uses cuLA's single-token Lightning Attention decode kernel.
- Target verify uses cuLA KVBuffer verify and writes draft K/V directly into pool-indexed draft buffers.
- Commit uses a fused cuLA state-update kernel to advance all Lightning Attention layers after acceptance.

cuLA remains an optional source dependency. This PR intentionally does not add a PyPI extra because the backend requires a source install of cuLA with a compatible Python/CUDA/PyTorch stack.

## Scope

Supported in this PR:

- Ling-2.6-flash / Lightning Attention path.
- `linear_backend="cula"` with speculative decoding (`NEXTN`, 4 draft tokens).
- fp32 cuLA KVBuffer verify/commit contract.
- `[v, k]` state layout support in `seg_la`, covered independently by layout parity tests.

Not in scope for this first version:

- General cuLA support for every linear-attention model family.
- cuLA + Mamba prefix-cache extra-buffer tracking.
- Packaging cuLA as an SGLang optional dependency.

## Modifications

- Add `linear_backend="cula"` routing in the Lightning Attention backend.
- Add `seg_la` `[v, k]` state layout support so prefill can produce the V-major state layout expected by cuLA.
- Add cuLA wrappers for decode, verify, and fused commit.
- Allocate cuLA-specific speculative Mamba cache buffers:
  - fp32 temporal state in V-major layout
  - fp32 draft K/V buffers indexed by Mamba cache slot
- Use cuLA KVBuffer verify to write draft K/V directly, avoiding separate draft K/V scatter kernels.
- Use layer-fused cuLA commit to update all Lightning Attention layers after accepted-token selection.
- Account for cuLA draft K/V memory in `max_mamba_cache_size` calculation.
- Keep cuLA import optional and tolerate missing shared-library dependencies during import-time availability checks.
- Add focused correctness tests for cuLA verify/commit, the cuLA Lightning Attention backend, and `seg_la` KV/VK state-layout parity.

## Accuracy Tests

Focused tests:

```text
14 passed
```

GSM8K, 300 questions, 5-shot, high client parallelism:

| Backend | Accuracy | Invalid | Latency (s) | Output tok/s |
|---|---:|---:|---:|---:|
| `seg_la` | 0.8223 | 0.0047 | 11.676 | 3149.19 |
| `cula` | 0.8190 | 0.0020 | 11.041 | 3251.99 |

AIME2024 local JSONL, no extra buffer, 10 repeats, stochastic sampling (`temperature=0.6`, `top_p=0.95`, `num_tries=1`, `max_new_tokens=32768`):

| Backend | Mean accuracy | Accuracy stdev | Mean correct | Extraction errors | Output tok/s |
|---|---:|---:|---:|---:|---:|
| `seg_la` | 0.810 | 0.039 | 24.30/30 | 0 | 2317.36 |
| `cula` | 0.800 | 0.061 | 24.00/30 | 0 | 2352.11 |

Takeaway: cuLA is accuracy-parity with `seg_la` on both GSM8K and AIME2024 smoke tests.

## Speed Tests and Profiling

Only `linear_backend` changes between `seg_la` and `cula`; the shared server and benchmark parameters are listed in the appendix.

Test environment:

- Hardware: 4x H200
- Model: Ling-2.6-flash
- Tensor parallelism: TP=4
- Speculative decoding: `NEXTN`, 4 draft tokens

### ShareGPT Concurrency Test

Raw serving metrics:

| Max concurrency | Backend | Output tok/s | Req/s | Realized concurrency | Accept len | Median TTFT (ms) | Median TPOT (ms) |
|---:|---|---:|---:|---:|---:|---:|---:|
| 8 | `seg_la` | 1705.53 | 1.67 | 7.98 | 3.06 | 93.27 | 4.54 |
| 8 | `cula` | 1734.45 | 1.69 | 7.98 | 3.06 | 93.01 | 4.45 |
| 16 | `seg_la` | 2649.49 | 2.59 | 15.92 | 3.05 | 98.04 | 5.84 |
| 16 | `cula` | 2698.68 | 2.64 | 15.92 | 3.04 | 97.31 | 5.78 |
| 32 | `seg_la` | 3842.24 | 3.75 | 31.73 | 3.04 | 105.39 | 8.07 |
| 32 | `cula` | 3957.60 | 3.86 | 31.78 | 3.03 | 104.44 | 7.80 |
| 64 | `seg_la` | 5503.74 | 5.37 | 62.96 | 3.03 | 115.32 | 11.21 |
| 64 | `cula` | 5648.04 | 5.52 | 62.90 | 3.03 | 112.67 | 10.94 |

Delta vs `seg_la`:

| Max concurrency | Output tok/s uplift | Median TPOT change |
|---:|---:|---:|
| 8 | +1.70% | -1.98% |
| 16 | +1.86% | -1.10% |
| 32 | +3.00% | -3.39% |
| 64 | +2.62% | -2.47% |

Takeaway: on ShareGPT, cuLA shows a small but consistent throughput and TPOT improvement as serving concurrency increases, with comparable realized concurrency and accept length.

### Random 256/1024 Fixed-Server Concurrency Sweep

Raw serving metrics:

| Max concurrency | Backend | Output tok/s | Median TTFT (ms) | Median TPOT (ms) |
|---:|---|---:|---:|---:|
| 8 | `seg_la` | 1595.42 | 92.68 | 4.75 |
| 8 | `cula` | 1626.89 | 92.31 | 4.66 |
| 16 | `seg_la` | 2370.44 | 97.61 | 6.42 |
| 16 | `cula` | 2408.02 | 97.06 | 6.37 |
| 32 | `seg_la` | 3259.96 | 105.16 | 9.38 |
| 32 | `cula` | 3359.73 | 104.02 | 9.14 |
| 64 | `seg_la` | 4443.55 | 117.27 | 13.71 |
| 64 | `cula` | 4585.81 | 114.34 | 13.18 |

Delta vs `seg_la`:

| Max concurrency | Output tok/s uplift | Median TPOT change |
|---:|---:|---:|
| 8 | +1.97% | -1.89% |
| 16 | +1.59% | -0.78% |
| 32 | +3.06% | -2.56% |
| 64 | +3.20% | -3.87% |

Takeaway: the synthetic long-decode workload shows the same direction. The measured gain is modest, but repeatable across the tested concurrency range.

## Checklist

- [x] Format code according to the SGLang pre-commit workflow.
- [x] Add focused unit tests for new backend/layout behavior.
- [ ] Update documentation if maintainers want a user-facing cuLA backend page.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow SGLang code style guidance.

## Appendix: Commands and Parameters

Shared server parameters:

```bash
--tp-size 4
--mem-fraction-static 0.75
--max-running-requests 128
--max-mamba-cache-size 512
--speculative-algorithm NEXTN
--speculative-num-steps 3
--speculative-eagle-topk 1
--speculative-num-draft-tokens 4
--json-model-override-args '{"linear_backend": "<seg_la|cula>"}'
```

Focused tests:

```bash
python -m pytest \
  test/registered/attention/unittests/lightning/test_cula_equivalence.py \
  test/registered/attention/unittests/lightning/test_cula.py \
  test/registered/attention/unittests/lightning/test_seg_la_state_layout.py \
  -q
```

GSM8K:

```bash
python -m sglang.test.few_shot_gsm8k \
  --num-questions 300 \
  --num-shots 5 \
  --parallel 128 \
  --port "${PORT}"
```

AIME2024:

```bash
python -m sglang.test.run_eval \
  --eval-name aime2024 \
  --num-examples 30 \
  --num-tries 1 \
  --temperature 0.6 \
  --top-p 0.95 \
  --max-new-tokens 32768 \
  --port "${PORT}"
```

ShareGPT concurrency test:

```bash
python -m sglang.bench_serving \
  --backend sglang-oai \
  --host "${HOST}" \
  --port "${PORT}" \
  --model "${SERVED_MODEL_NAME}" \
  --tokenizer "${MODEL_PATH}" \
  --dataset-name sharegpt \
  --dataset-path "${SHAREGPT_JSON}" \
  --num-prompts 1024 \
  --request-rate inf \
  --max-concurrency <8|16|32|64> \
  --sharegpt-output-len 1024 \
  --extra-request-body '{"ignore_eos": true}'
```

Random fixed-server concurrency sweep:

```bash
python -m sglang.bench_serving \
  --backend sglang-oai \
  --host "${HOST}" \
  --port "${PORT}" \
  --model "${MODEL_PATH}" \
  --served-model-name "${SERVED_MODEL_NAME}" \
  --tokenizer "${MODEL_PATH}" \
  --dataset-name random \
  --num-prompts 1024 \
  --random-input-len 256 \
  --random-output-len 1024 \
  --request-rate inf \
  --max-concurrency <8|16|32|64> \
  --seed 1 \
  --extra-request-body '{"ignore_eos": true}'
```

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29318681896](https://github.com/sgl-project/sglang/actions/runs/29318681896)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29318681696](https://github.com/sgl-project/sglang/actions/runs/29318681696)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
