### PR TITLE
fix(docker): Install distro and other missing runtime Python deps

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -862,6 +862,14 @@ COPY --from=framework_final /usr/src/gdrdrv-2.5.1 /usr/src/gdrdrv-2.5.1
 # Fix DeepEP IBGDA symlink in runtime
 RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libmlx5.so.1 /usr/lib/$(uname -m)-linux-gnu/libmlx5.so
 
+# Install missing runtime Python dependencies required by packages already present in the image.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install -c /sgl-workspace/constraints.txt \
+    cryptography \
+    distro \
+    pyjwt \
+    pyparsing
+
 WORKDIR /sgl-workspace/sglang
 
 # Keep build provenance at the end so metadata changes do not invalidate build layers.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -564,6 +564,14 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     termplotlib \
     "runai-model-streamer[s3,gcs,azure]>=0.15.7"
 
+# Install system-provided Python packages into pip site-packages for runtime.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install --ignore-installed -c /sgl-workspace/constraints.txt \
+    cryptography \
+    distro \
+    pyjwt \
+    pyparsing
+
 # Optional ai-dynamo nightly for Dynamo + SGLang integration testing. Gated by
 # INSTALL_DYNAMO so it lands only in the dev image (release-docker-dev.yml sets
 # it), not the version-tagged release/runtime images. Empty DYNAMO_VERSION
@@ -861,14 +869,6 @@ COPY --from=framework_final /usr/src/gdrdrv-2.5.1 /usr/src/gdrdrv-2.5.1
 
 # Fix DeepEP IBGDA symlink in runtime
 RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libmlx5.so.1 /usr/lib/$(uname -m)-linux-gnu/libmlx5.so
-
-# Install missing runtime Python dependencies required by packages already present in the image.
-RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install -c /sgl-workspace/constraints.txt \
-    cryptography \
-    distro \
-    pyjwt \
-    pyparsing
 
 WORKDIR /sgl-workspace/sglang
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Fixes #29650.

### Problem

The `lmsysorg/sglang:latest-cu130-runtime` Docker image still fails to start with the following error:
```
  File ".../sglang/srt/entrypoints/openai/protocol.py", line 36, in <module>
    from openai.types.responses import (
  ...
  File ".../openai/_base_client.py", line 36, in <module>
    import distro
ModuleNotFoundError: No module named 'distro'
```
PR #25817 already added `distro` to `pyproject.toml`, which fixes the package metadata. This PR focuses on the Docker runtime image, where `distro` is still absent from the final image and can still raise the `ModuleNotFoundError` reported in #29650.

This is not limited to `distro`. When running `pip check` on `lmsysorg/sglang:latest-cu130-runtime`: 
```
docker run --rm --entrypoint python3 lmsysorg/sglang:latest-cu130-runtime -m pip check
```
The output was:
```
openai 2.6.1 requires distro, which is not installed.
sglang 0.5.14 requires distro, which is not installed.
msal 1.37.0 requires cryptography, which is not installed.
msal 1.37.0 requires pyjwt, which is not installed.
azure-identity 1.25.3 requires cryptography, which is not installed.
nixl 1.3.0 requires nixl-cu12, which is not installed.
google-auth 2.55.1 requires cryptography, which is not installed.
anthropic 0.112.0 requires distro, which is not installed.
matplotlib 3.11.0 requires pyparsing, which is not installed.
azure-storage-blob 12.30.0 requires cryptography, which is not installed.
moviepy 2.2.1 has requirement pillow<12.0,>=9.2.0, but you have pillow 12.2.0.
```

To compare the runtime image with the non-runtime image, I also ran `pip check` on `lmsysorg/sglang:latest-cu130`: 
```
docker run --rm --entrypoint python3 lmsysorg/sglang:latest-cu130 -m pip check
```
The output was: 
```
nixl 1.3.0 requires nixl-cu12, which is not installed.
moviepy 2.2.1 has requirement pillow<12.0,>=9.2.0, but you have pillow 12.2.0.
```

Comparing the two, the packages missing only from the runtime image are `distro`, `cryptography`, `pyjwt`, and `pyparsing`. The `nixl` and `moviepy`/`pillow` lines appear in both images, so they are pre-existing and unrelated. The missing `distro` is what raises the `ModuleNotFoundError` above.

These Python dependencies appear to be provided by the system Python (apt packages under `/usr/lib/python3/dist-packages`). Because they are already importable from there, `pip install` during the build treats them as already satisfied and never installs a copy into the pip site (`/usr/local/lib/python3.12/dist-packages`). The runtime Docker image copies only the pip site-packages directory, not the system site, so these packages are dropped.

## Modifications

Fix `docker/Dockerfile`.

Install the missing runtime Python dependencies into the framework image's pip site-packages directory using the existing `/sgl-workspace/constraints.txt`, so they are copied into the final runtime image.

This PR does not copy `/usr/lib/python3/dist-packages` into the runtime image because the system Python directory contains many packages that SGLang does not need (e.g. `blinker`, `dbus-python`, `httplib2`, `launchpadlib`).

This PR also intentionally leaves the existing `nixl-cu12` and `moviepy`/`pillow` `pip check` reports unchanged, because they are present in both the runtime and non-runtime images and are separate package-policy issues.

## Test

After fixing `docker/Dockerfile` and rebuilding the image, `pip check` reports only the two pre-existing issues:
```
nixl 1.3.0 requires nixl-cu12, which is not installed.
moviepy 2.2.1 has requirement pillow<12.0,>=9.2.0, but you have pillow 12.2.0.
```
and `python3 -c "from sglang.srt.entrypoints.openai.protocol import *"` no longer raises `ModuleNotFoundError`.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28443613471](https://github.com/sgl-project/sglang/actions/runs/28443613471)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28443613277](https://github.com/sgl-project/sglang/actions/runs/28443613277)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->