### PR TITLE
[Bugfix] uninitialized output race in gptq_gemm kernel

### DIFF
--- a/sgl-kernel/csrc/gemm/gptq/gptq_kernel.cu
+++ b/sgl-kernel/csrc/gemm/gptq/gptq_kernel.cu
@@ -246,11 +246,12 @@ __global__ void gemm_half_q_half_gptq_4bit_kernel(
     }
   }
 
+  // Sync before the early return
+  __syncthreads();
+
   // Output is zeroed on the host (see gptq_gemm); zeroing here would race the
   // cross-block atomicAdd accumulation
   if (n >= size_n) return;
-
-  __syncthreads();
 
   // Find initial group
   int groupsize = size_k / groups;
@@ -373,11 +374,12 @@ __global__ void gemm_half_q_half_gptq_2bit_kernel(
     }
   }
 
+  // Sync before the early return
+  __syncthreads();
+
   // Output is zeroed on the host (see gptq_gemm); zeroing here would race the
   // cross-block atomicAdd accumulation
   if (n >= size_n) return;
-
-  __syncthreads();
 
   // Find initial group
   int groupsize = size_k / groups;
@@ -489,11 +491,12 @@ __global__ void gemm_half_q_half_gptq_3bit_kernel(
     }
   }
 
+  // Sync before the early return
+  __syncthreads();
+
   // Output is zeroed on the host (see gptq_gemm); zeroing here would race the
   // cross-block atomicAdd accumulation
   if (n >= size_n) return;
-
-  __syncthreads();
 
   // Find initial group
   int groupsize = size_k / groups;
@@ -608,11 +611,12 @@ __global__ void gemm_half_q_half_gptq_8bit_kernel(
     }
   }
 
+  // Sync before the early return
+  __syncthreads();
+
   // Output is zeroed on the host (see gptq_gemm); zeroing here would race the
   // cross-block atomicAdd accumulation
   if (n >= size_n) return;
-
-  __syncthreads();
 
   // Find initial group
   int groupsize = size_k / groups;

--- a/sgl-kernel/csrc/gemm/gptq/gptq_kernel.cu
+++ b/sgl-kernel/csrc/gemm/gptq/gptq_kernel.cu
@@ -246,13 +246,9 @@ __global__ void gemm_half_q_half_gptq_4bit_kernel(
     }
   }
 
-  // Zero output
+  // Output is zeroed on the host (see gptq_gemm); zeroing here would race the
+  // cross-block atomicAdd accumulation
   if (n >= size_n) return;
-
-  if (blockIdx.z == 0) {
-    for (int m = 0; m < m_count; m++)
-      *((uint64_t*)c_.item_ptr(offset_m + m, n)) = 0;
-  }
 
   __syncthreads();
 
@@ -377,13 +373,9 @@ __global__ void gemm_half_q_half_gptq_2bit_kernel(
     }
   }
 
-  // Zero output
+  // Output is zeroed on the host (see gptq_gemm); zeroing here would race the
+  // cross-block atomicAdd accumulation
   if (n >= size_n) return;
-
-  if (blockIdx.z == 0) {
-    for (int m = 0; m < m_count; m++)
-      *((uint64_t*)c_.item_ptr(offset_m + m, n)) = 0;
-  }
 
   __syncthreads();
 
@@ -497,13 +489,9 @@ __global__ void gemm_half_q_half_gptq_3bit_kernel(
     }
   }
 
-  // Zero output
+  // Output is zeroed on the host (see gptq_gemm); zeroing here would race the
+  // cross-block atomicAdd accumulation
   if (n >= size_n) return;
-
-  if (blockIdx.z == 0) {
-    for (int m = 0; m < m_count; m++)
-      *((uint64_t*)c_.item_ptr(offset_m + m, n)) = 0;
-  }
 
   __syncthreads();
 
@@ -620,13 +608,9 @@ __global__ void gemm_half_q_half_gptq_8bit_kernel(
     }
   }
 
-  // Zero output
+  // Output is zeroed on the host (see gptq_gemm); zeroing here would race the
+  // cross-block atomicAdd accumulation
   if (n >= size_n) return;
-
-  if (blockIdx.z == 0) {
-    for (int m = 0; m < m_count; m++)
-      *((uint64_t*)c_.item_ptr(offset_m + m, n)) = 0;
-  }
 
   __syncthreads();
 
@@ -1275,10 +1259,8 @@ __global__ void gemm_half_q_half_alt_4bit_kernel(
     deq2[val][off] = __halves2half2(__int2half_rn(val & 0xF), __int2half_rn(val >> 4));
   }
 
-  if (blockIdx.z == 0) {
-    for (int m = 0; m < b_end; m++)
-      mul[(b + m) * width + w] = __int2half_rn(0);
-  }
+  // Output is zeroed on the host (see gptq_gemm); zeroing here would race the
+  // cross-block atomicAdd accumulation
   __syncthreads();
 
   int i = width * h + w;
@@ -1357,10 +1339,8 @@ __global__ void gemm_half_q_half_alt_8bit_kernel(
     }
   }
 
-  if (blockIdx.z == 0) {
-    for (int m = 0; m < b_end; m++)
-      mul[(b + m) * width + w] = __int2half_rn(0);
-  }
+  // Output is zeroed on the host (see gptq_gemm); zeroing here would race the
+  // cross-block atomicAdd accumulation
   __syncthreads();
 
   int i = width * h + w;
@@ -1918,7 +1898,9 @@ torch::Tensor gptq_gemm(
     int64_t bit) {
   const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
   auto options = torch::TensorOptions().dtype(a.dtype()).device(a.device());
-  at::Tensor c = torch::empty({a.size(0), b_q_weight.size(1)}, options);
+  // Must be zeros, not empty: z-blocks atomicAdd K-slice partials into the same
+  // output element with no cross-block sync, so it must be pre-zeroed
+  at::Tensor c = torch::zeros({a.size(0), b_q_weight.size(1)}, options);
   at::Tensor temp_dq = torch::empty({b_q_weight.size(0) * 32 / bit, b_q_weight.size(1)}, options);
 
   sglang::gptq::gemm_half_q_half_cuda(

--- a/sgl-kernel/tests/test_gptq_kernel_zero_init.py
+++ b/sgl-kernel/tests/test_gptq_kernel_zero_init.py
@@ -7,6 +7,7 @@ K >> BLOCK_KN_SIZE (gridDim.z > 1) to surface a missing zero-init.
 """
 
 import sys
+
 import pytest
 import torch
 from sgl_kernel import gptq_gemm

--- a/sgl-kernel/tests/test_gptq_kernel_zero_init.py
+++ b/sgl-kernel/tests/test_gptq_kernel_zero_init.py
@@ -82,7 +82,7 @@ def _dequantize_4bit(b_q_weight, b_gptq_qzeros, b_gptq_scales, K, N, group_size)
 
 
 @pytest.mark.parametrize("M", [1, 8])
-@pytest.mark.parametrize("N", [2048, 4096])
+@pytest.mark.parametrize("N", [2048, 4096, 11008])  # 11008 is not a multiple of 512
 @pytest.mark.parametrize("K", [2048, 4096])
 def test_gptq_gemm_output_zero_init(M, N, K):
     if not torch.cuda.is_available():

--- a/sgl-kernel/tests/test_gptq_kernel_zero_init.py
+++ b/sgl-kernel/tests/test_gptq_kernel_zero_init.py
@@ -101,10 +101,20 @@ def test_gptq_gemm_output_zero_init(M, N, K):
         b_q_weight, b_gptq_qzeros, b_gptq_scales, K, N, group_size
     )
 
-    # Repeat: the race is nondeterministic, so several trials make it reliable
+    # fp32 ground truth: matmul over the (fp16-representable) dequantized weights.
+    # Compared with an fp16-appropriate tolerance -- outputs here are O(100) and
+    # accumulate over K up to 4096, so a tight fp16-noise-floor tolerance (e.g.
+    # 4e-2) false-fails on a correct kernel. A missing zero-init, on the other
+    # hand, leaks the poisoned allocator bytes into the output and blows the
+    # error up by orders of magnitude (well past any sane tolerance), so this
+    # still catches the bug it is meant to guard.
+    rtol, atol = 2e-2, 1.0
+
+    # Repeat: the cross-block atomicAdd ordering is nondeterministic, so several
+    # trials make a missing zero-init reliable to surface
     for _ in range(20):
         a = torch.randn(M, K, dtype=dtype, device=device)
-        c_ref = torch.matmul(a, b_dequant)
+        c_ref = torch.matmul(a.float(), b_dequant.float())
 
         _poison_allocator(device, dtype, M * N)
         c_out = gptq_gemm(
@@ -112,7 +122,7 @@ def test_gptq_gemm_output_zero_init(M, N, K):
         )
 
         assert not torch.isnan(c_out).any(), "gptq_gemm produced NaNs"
-        torch.testing.assert_close(c_ref, c_out, rtol=4e-2, atol=4e-2)
+        torch.testing.assert_close(c_out.float(), c_ref, rtol=rtol, atol=atol)
 
 
 if __name__ == "__main__":

--- a/sgl-kernel/tests/test_gptq_kernel_zero_init.py
+++ b/sgl-kernel/tests/test_gptq_kernel_zero_init.py
@@ -7,7 +7,6 @@ K >> BLOCK_KN_SIZE (gridDim.z > 1) to surface a missing zero-init.
 """
 
 import sys
-
 import pytest
 import torch
 from sgl_kernel import gptq_gemm
@@ -101,17 +100,10 @@ def test_gptq_gemm_output_zero_init(M, N, K):
         b_q_weight, b_gptq_qzeros, b_gptq_scales, K, N, group_size
     )
 
-    # fp32 ground truth: matmul over the (fp16-representable) dequantized weights.
-    # Compared with an fp16-appropriate tolerance -- outputs here are O(100) and
-    # accumulate over K up to 4096, so a tight fp16-noise-floor tolerance (e.g.
-    # 4e-2) false-fails on a correct kernel. A missing zero-init, on the other
-    # hand, leaks the poisoned allocator bytes into the output and blows the
-    # error up by orders of magnitude (well past any sane tolerance), so this
-    # still catches the bug it is meant to guard.
+    # Loose tolerance for fp16 accumulation noise; a missing zero-init leaks the
+    # poison bytes and overshoots it by orders of magnitude, so the bug is caught.
     rtol, atol = 2e-2, 1.0
 
-    # Repeat: the cross-block atomicAdd ordering is nondeterministic, so several
-    # trials make a missing zero-init reliable to surface
     for _ in range(20):
         a = torch.randn(M, K, dtype=dtype, device=device)
         c_ref = torch.matmul(a.float(), b_dequant.float())
@@ -126,4 +118,4 @@ def test_gptq_gemm_output_zero_init(M, N, K):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-v"]))
+    sys.exit(pytest.main([__file__]))

--- a/sgl-kernel/tests/test_gptq_kernel_zero_init.py
+++ b/sgl-kernel/tests/test_gptq_kernel_zero_init.py
@@ -1,0 +1,119 @@
+"""Test for the gptq_gemm uninitialized-output accumulation race.
+
+The quantized gptq_gemm path accumulates K-slice partials into the output via
+atomicAdd across gridDim.z blocks, so the output must be zero-initialized. This
+test fills the allocator with non-zero bytes before each call and uses
+K >> BLOCK_KN_SIZE (gridDim.z > 1) to surface a missing zero-init.
+"""
+
+import sys
+
+import pytest
+import torch
+from sgl_kernel import gptq_gemm
+
+from sglang.srt.layers.quantization.utils import pack_cols, pack_rows
+
+
+def _poison_allocator(device, dtype, numel):
+    # Free non-zero blocks so a later torch::empty of the same size reuses them
+    for _ in range(4):
+        junk = torch.full((numel,), 12345.0, dtype=dtype, device=device)
+        del junk
+    torch.cuda.synchronize()
+
+
+def _build_4bit_gptq_weight(K, N, group_size, dtype, device):
+    assert K % group_size == 0
+    num_groups = K // group_size
+
+    b_fp = torch.randn(K, N, dtype=dtype, device=device)
+    g_idx = torch.tensor(
+        [i // group_size for i in range(K)], dtype=torch.int32, device=device
+    )
+    b_grouped = b_fp.reshape(num_groups, group_size, N)
+
+    b_max = torch.max(b_grouped, dim=1, keepdim=True)[0]
+    b_min = torch.min(b_grouped, dim=1, keepdim=True)[0]
+    scales = ((b_max - b_min) / (2**4 - 1)).clamp(min=1e-6)
+    zeros_float = (-b_min / scales).round()
+
+    q_b = (b_grouped / scales + zeros_float).round().clamp(0, 2**4 - 1).to(torch.uint8)
+    q_zeros_unpacked = (zeros_float.to(torch.uint8) - 1).reshape(num_groups, N)
+
+    b_q_weight = pack_rows(q_b.reshape(K, N), 4, K, N)
+    b_gptq_qzeros = pack_cols(q_zeros_unpacked, 4, num_groups, N)
+    b_gptq_scales = scales.squeeze(1)
+    return b_q_weight, b_gptq_qzeros, b_gptq_scales, g_idx
+
+
+def _dequantize_4bit(b_q_weight, b_gptq_qzeros, b_gptq_scales, K, N, group_size):
+    pack_factor = 32 // 4
+    unpacked_w = torch.empty(
+        b_q_weight.shape[0] * pack_factor,
+        b_q_weight.shape[1],
+        dtype=torch.uint8,
+        device=b_q_weight.device,
+    )
+    for i in range(pack_factor):
+        unpacked_w[i::pack_factor, :] = (b_q_weight >> (i * 4)) & 0x0F
+
+    unpacked_z = torch.empty(
+        b_gptq_qzeros.shape[0],
+        b_gptq_qzeros.shape[1] * pack_factor,
+        dtype=torch.uint8,
+        device=b_gptq_qzeros.device,
+    )
+    for i in range(pack_factor):
+        unpacked_z[:, i::pack_factor] = (b_gptq_qzeros >> (i * 4)) & 0x0F
+    unpacked_z = (unpacked_z + 1).to(b_gptq_scales.dtype)
+
+    scale_zeros = unpacked_z * b_gptq_scales
+    current_g_idx = torch.tensor(
+        [i // group_size for i in range(K)],
+        dtype=torch.int32,
+        device=b_q_weight.device,
+    )
+    scale_mat = b_gptq_scales[current_g_idx]
+    scale_zeros_mat = scale_zeros[current_g_idx]
+    return (unpacked_w.to(b_gptq_scales.dtype) * scale_mat - scale_zeros_mat).reshape(
+        K, N
+    )
+
+
+@pytest.mark.parametrize("M", [1, 8])
+@pytest.mark.parametrize("N", [2048, 4096])
+@pytest.mark.parametrize("K", [2048, 4096])
+def test_gptq_gemm_output_zero_init(M, N, K):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    device = "cuda"
+    dtype = torch.float16
+    group_size = 128
+    bit = 4
+    use_shuffle = False
+
+    b_q_weight, b_gptq_qzeros, b_gptq_scales, g_idx = _build_4bit_gptq_weight(
+        K, N, group_size, dtype, device
+    )
+    b_dequant = _dequantize_4bit(
+        b_q_weight, b_gptq_qzeros, b_gptq_scales, K, N, group_size
+    )
+
+    # Repeat: the race is nondeterministic, so several trials make it reliable
+    for _ in range(20):
+        a = torch.randn(M, K, dtype=dtype, device=device)
+        c_ref = torch.matmul(a, b_dequant)
+
+        _poison_allocator(device, dtype, M * N)
+        c_out = gptq_gemm(
+            a, b_q_weight, b_gptq_qzeros, b_gptq_scales, g_idx, use_shuffle, bit
+        )
+
+        assert not torch.isnan(c_out).any(), "gptq_gemm produced NaNs"
+        torch.testing.assert_close(c_ref, c_out, rtol=4e-2, atol=4e-2)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
`gptq_gemm` allocated its GEMM output with `torch::empty` (uninitialized) and relied on an in-kernel zero-store that runs only in `blockIdx.z == 0` blocks, guarded by an intra-block `__syncthreads()`. The quantized (non-reconstruct) path launches the kernel with `gridDim.z = ceil(K / BLOCK_KN_SIZE) > 1`, and every z-block accumulates its K-slice partial into the same output element via `atomicAdd` (the output index ignores `blockIdx.z`). With no cross-block synchronization this is a data race

This matches how vLLM's equivalent kernel (`csrc/quantization/gptq/q_gemm.cu`) is written: it allocates `c` with `torch::zeros` and the in-kernel `// Zero output` is just a comment. 

Fixes #29748

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28451186464](https://github.com/sgl-project/sglang/actions/runs/28451186464)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28451185936](https://github.com/sgl-project/sglang/actions/runs/28451185936)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->