### PR TITLE
Remove transformers 5.12.1 dead-code workarounds

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -453,8 +453,6 @@ class ModelConfig:
         # Verify quantization
         self._verify_quantization()
 
-        self._verify_transformers_version()
-
         # Verify dual-chunk attention config
         self._verify_dual_chunk_attention_config()
 
@@ -915,19 +913,6 @@ class ModelConfig:
         if "IQuestLoopCoderForCausalLM" in self.hf_config.architectures:
             loop_num = getattr(self.hf_text_config, "loop_num", 1)
             self.num_attention_layers = int(self.num_hidden_layers * int(loop_num))
-        if "HrmTextForCausalLM" in self.hf_config.architectures:
-            # Compute KV slot count explicitly: native 5.9.0 configs inflate
-            # num_hidden_layers to this in __post_init__, but non-native ones
-            # may carry the raw per-stack count.
-            H_cycles = self.hf_text_config.H_cycles
-            L_cycles = self.hf_text_config.L_cycles
-            num_layers_per_stack = (
-                getattr(self.hf_text_config, "num_layers_per_stack", None)
-                or self.num_hidden_layers
-            )
-            self.num_attention_layers = (
-                int(num_layers_per_stack) * H_cycles * (L_cycles + 1)
-            )
         if "WhisperForConditionalGeneration" in self.hf_config.architectures:
             # Whisper has unique layer ID scheme:
             # - Encoder self-attention: 0 to encoder_layers-1 (no KV cache)
@@ -1445,46 +1430,6 @@ class ModelConfig:
                 self.hf_config.dual_chunk_attention_config[
                     "sparse_attention_enabled"
                 ] = True
-
-    def _verify_transformers_version(self):
-        import transformers
-        from packaging import version
-
-        tf_version_str = getattr(transformers, "__version__", None)
-        if tf_version_str is None:
-            return
-
-        vision_config = getattr(self.hf_config, "vision_config", None)
-        is_glm_46vmoe = "glm-4.6v" in self.model_path.lower() or (
-            vision_config is not None
-            and getattr(vision_config, "model_type", None) == "glm4v_moe_vision"
-            # The vision config model type for GLM-4.5v is 'glm4v_moe',
-            # while for GLM-4.6v, it is 'glm4v_moe_vision'.
-        )
-        needs_tf_v5 = is_glm_46vmoe
-        # Older transformers lacks the native hrm_text config, so it silently
-        # falls back to TransformersForCausalLM and loads fused weights as junk.
-        architectures = getattr(self.hf_config, "architectures", []) or []
-        is_hrm_text = getattr(self.hf_config, "model_type", None) == "hrm_text" or (
-            "HrmTextForCausalLM" in architectures
-        )
-        if is_hrm_text and version.parse(tf_version_str) < version.parse("5.9.0"):
-            raise ValueError(
-                f"HRM-Text (model type {self.hf_config.model_type!r}) requires "
-                f"transformers >= 5.9.0, but {tf_version_str} is installed. "
-                "Please upgrade transformers."
-            )
-
-        tf_version = version.parse(tf_version_str)
-        required_version = version.parse("5.0.0dev0")
-
-        if tf_version < required_version:
-            if needs_tf_v5:
-                raise ValueError(
-                    f"Transformers version {tf_version_str} is not supported for model {self.model_path} "
-                    f"or model type {self.hf_config.model_type}. "
-                    "Please upgrade transformers to >= 5.0.0."
-                )
 
     def _get_hf_eos_token_id(self) -> Optional[Set[int]]:
         eos_ids = getattr(self.hf_config, "eos_token_id", None)

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -6,29 +6,20 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import nn
-from transformers import activations
+from transformers.activations import PytorchGELUTanh
 
 from sglang.srt.configs.kimi_k25 import KimiK25Config, KimiK25VisionConfig
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
+from sglang.srt.layers.attention.vision import VisionAttention
 from sglang.srt.layers.conv import Conv2dLayer
+from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
+from sglang.srt.layers.quantization.quark.quark import QuarkConfig
 from sglang.srt.managers.mm_utils import (
     MultiModalityDataPaddingPatternMultimodalTokens,
     general_mm_embed_routine,
 )
-
-try:
-    from transformers.activations import PytorchGELUTanh
-except ImportError:
-    from transformers.activations import GELUTanh
-
-    activations.PytorchGELUTanh = GELUTanh
-    PytorchGELUTanh = GELUTanh
-
-from sglang.srt.layers.attention.vision import VisionAttention
-from sglang.srt.layers.linear import ReplicatedLinear
-from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
-from sglang.srt.layers.quantization.quark.quark import QuarkConfig
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,


### PR DESCRIPTION
## Summary

Now that `transformers` is pinned to `5.12.1` (#29393), several version-guarded shims are unreachable dead code. This PR removes them.

### `ModelConfig._verify_transformers_version` (removed)
Both `raise` branches are never triggered under the pin:
- `is_hrm_text and tf < 5.9.0` — hrm_text needs native config added in 5.9.0; pin is 5.12.1.
- `tf < 5.0.0dev0` (glm-4.6v) — pin is 5.12.1.

The whole method and its call site are dead. `import transformers` / `from packaging import version` were function-local, so removal is clean.

### `HrmTextForCausalLM` `num_attention_layers` branch (removed, added in #27887)
Native `HrmTextConfig.__post_init__` already inflates `num_hidden_layers`:

```python
if self.num_layers_per_stack is None:
    self.num_layers_per_stack = self.num_hidden_layers
    self.num_hidden_layers = self.num_layers_per_stack * self.H_cycles * (self.L_cycles + 1)
```

So `num_attention_layers = num_hidden_layers` (the default) equals the explicit `num_layers_per_stack * H_cycles * (L_cycles + 1)` the branch computed. Verified on `sapientinc/HRM-Text-1B`: after `AutoConfig.from_pretrained`, `num_hidden_layers=128`, `num_layers_per_stack=16`, `H=2`, `L=3` → `16*2*4=128`.

### `kimi_k25.py` `PytorchGELUTanh` try/except (removed)
`PytorchGELUTanh` is an alias of `GELUTanh` in transformers 5.x, so the import always succeeds; the `except` branch also referenced an unimported `activations` module (latent `NameError`).

## Verification

e2e on H200 (`hrm-tf-cleanup` devbox, transformers 5.12.1, sglang editable from main + this change):

- `sapientinc/HRM-Text-1B` served (triton backend, cuda-graph/radix/chunked-prefill disabled per `model_specific_adjustment`).
- `AutoConfig.from_pretrained("sapientinc/HRM-Text-1B")` → `num_hidden_layers=128` (= `num_layers_per_stack * H_cycles * (L_cycles+1)`), confirming the deleted branch's value matches the default.
- 4/4 prompts `finish_reason=stop` with coherent, factually correct output (Tokyo / Rayleigh scattering / 25×4=100 / photosynthesis), matching the 2026-06-23 forward-correctness baseline. No no-EOS runaway.

`pre-commit` (isort / ruff / black / clang-format) passes.

## Note

The remaining transformers workarounds in `hf_transformers_patches.py` and `tokenizer.py` were checked against 5.12.1 upstream and are **not** touched — they patch bugs still present in 5.12.1 (e.g. `PilBackend.process_image` still calls `.numpy()` on CUDA tensors, `standardize_rope_params` still accesses `max_position_embeddings` unguarded) or handle remote-code / v5-API compat.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28445959705](https://github.com/sgl-project/sglang/actions/runs/28445959705)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28445959562](https://github.com/sgl-project/sglang/actions/runs/28445959562)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->