### PR TITLE
[AMD] Stop rocm720 pr auto-runs

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -16,14 +16,14 @@ on:
   #     - "sgl-kernel/**"
   #     - ".github/workflows/pr-test-amd-rocm720.yml"
   #     - "docker/rocm.Dockerfile"
-  pull_request:
-    paths:
-      - "python/**"
-      - "scripts/ci/**"
-      - "test/**"
-      - "sgl-kernel/**"
-      - ".github/workflows/pr-test-amd-rocm720.yml"
-      - "docker/rocm.Dockerfile"
+  # pull_request:
+  #   paths:
+  #     - "python/**"
+  #     - "scripts/ci/**"
+  #     - "test/**"
+  #     - "sgl-kernel/**"
+  #     - ".github/workflows/pr-test-amd-rocm720.yml"
+  #     - "docker/rocm.Dockerfile"
   workflow_dispatch:
     inputs:
       target_stage_select:
@@ -115,21 +115,17 @@ env:
   DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
 
 concurrency:
-  # When called via workflow_call with run_all_tests=true, use a unique group per run to
-  # avoid collisions with direct schedule/workflow_dispatch triggers. We use run_all_tests
-  # (not github.event_name) to detect this, because github.event_name inherits from the caller.
-  # Manual dispatch runs also get unique groups so they never cancel each other.
-  group: pr-test-amd-rocm720-${{ (inputs.run_all_tests || github.event_name == 'workflow_dispatch') && format('full-{0}', github.run_id) || inputs.pr_head_sha || inputs.ref || github.ref }}
-  cancel-in-progress: ${{ !inputs.run_all_tests && github.event_name != 'workflow_call' && github.event_name != 'workflow_dispatch' }}
+  # Scheduled and manual full runs use unique groups so they never cancel each other.
+  # PR cancellation is kept only for pull_request events if this trigger is re-enabled.
+  group: pr-test-amd-rocm720-${{ github.event_name == 'schedule' && format('schedule-{0}', github.run_id) || (inputs.run_all_tests || github.event_name == 'workflow_dispatch') && format('full-{0}', github.run_id) || inputs.pr_head_sha || inputs.ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   call-gate:
-    # Runs on PRs (pr-gate.yml enforces the run-ci label / blocks drafts), the daily
-    # '30 17 * * *' cron, workflow_dispatch and workflow_call. It is skipped only on the
-    # 6h ('0 */6 * * *') cron, which cascades a skip to check-changes and every existing
-    # test job, so that cron runs the two dsv4 jobs only. On PRs the existing jobs are
-    # additionally kept off via the change-detection guard in check-changes, so only the
-    # dsv4 jobs run there -- and only when this gate passes (they `needs` it).
+    # Runs on the daily '30 17 * * *' cron, workflow_dispatch and workflow_call.
+    # It is skipped only on the 6h ('0 */6 * * *') cron, which cascades a skip
+    # to check-changes and every existing test job so that cron runs the two
+    # dsv4 jobs only.
     if: github.event.schedule != '0 */6 * * *'
     uses: ./.github/workflows/pr-gate.yml
     secrets: inherit
@@ -183,9 +179,7 @@ jobs:
       - name: Detect file changes
         id: filter
         uses: dorny/paths-filter@v3
-        # On pull_request only the dsv4 jobs run; skip change detection on PRs so the
-        # per-stage outputs stay 'false' and the existing test jobs are gated off.
-        if: steps.run-mode.outputs.run_all_tests != 'true' && github.event_name != 'pull_request'
+        if: steps.run-mode.outputs.run_all_tests != 'true'
         with:
           filters: |
             main_package:
@@ -1141,12 +1135,10 @@ jobs:
             -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-large-8-gpu-mi35x-disaggregation-amd --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   # =============================================== DeepSeek-V4 (MI35x, 8-GPU) ====================================================
-  # On `pull_request` and the 6h ('0 */6 * * *') cron these are the ONLY jobs that run;
-  # they also run on the daily cron alongside the full suite. On PRs they run only when
-  # call-gate succeeds, i.e. the PR carries the run-ci label (and is not a draft), so
-  # they are gated just like every other PR test job. On PR they hard-fail (a failure
-  # blocks merge); on any scheduled run they pass --continue-on-error. They stay
-  # selectable via workflow_dispatch / run on workflow_call full runs.
+  # On the 6h ('0 */6 * * *') cron these are the only jobs that run; they also
+  # run on the daily cron alongside the full suite. Scheduled runs pass
+  # --continue-on-error. They stay selectable via workflow_dispatch / run on
+  # workflow_call full runs.
   dsv4-flash-fp4-fp8-amd-rocm720:
     needs: [call-gate]
     if: |


### PR DESCRIPTION
## Summary
- Comment out the `pull_request` trigger for `pr-test-amd-rocm720.yml` so the workflow does not auto-run on every matching PR.
- Keep the PR trigger block in place as comments so it can be re-enabled later.
- Give scheduled ROCm 7.2 runs unique concurrency groups and only allow cancellation for `pull_request` events, preventing schedule runs from cancelling each other.
- Refresh comments that still described PR behavior.

## Testing
- `git diff --check`
- Verified the active `pull_request` trigger is absent, the commented block remains, schedule/workflow_dispatch/workflow_call remain enabled, and schedule concurrency uses `github.run_id`.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28457066015](https://github.com/sgl-project/sglang/actions/runs/28457066015)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28457064738](https://github.com/sgl-project/sglang/actions/runs/28457064738)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->