### PR TITLE
[Model] Support Qwen3.5 NVFP4 V2 mixed quantization

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1156,7 +1156,9 @@ class ModelConfig:
         quant_algo = json_quant_configs.get("quant_algo", None)
 
         if quant_algo == "MIXED_PRECISION":
-            quantized_layers = json_quant_configs.get("quantized_layers", {})
+            # MIXED_PRECISION is also used by legacy W4A8 checkpoints. ModelOpt
+            # mixed checkpoints identify their NVFP4 modules in the layer map.
+            quantized_layers = json_quant_configs.get("quantized_layers") or {}
             has_modelopt_nvfp4_layers = any(
                 str(layer_info.get("quant_algo", "")).upper() == "NVFP4"
                 for layer_info in quantized_layers.values()

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1156,9 +1156,17 @@ class ModelConfig:
         quant_algo = json_quant_configs.get("quant_algo", None)
 
         if quant_algo == "MIXED_PRECISION":
+            quantized_layers = json_quant_configs.get("quantized_layers", {})
+            has_modelopt_nvfp4_layers = any(
+                str(layer_info.get("quant_algo", "")).upper() == "NVFP4"
+                for layer_info in quantized_layers.values()
+                if isinstance(layer_info, dict)
+            )
             architectures = getattr(self.hf_config, "architectures", []) or []
-            if getattr(self.hf_config, "model_type", None) == "nemotron_h" or any(
-                arch.startswith("NemotronH") for arch in architectures
+            if (
+                has_modelopt_nvfp4_layers
+                or getattr(self.hf_config, "model_type", None) == "nemotron_h"
+                or any(arch.startswith("NemotronH") for arch in architectures)
             ):
                 return {"quant_method": "modelopt_mixed", "quant_algo": quant_algo}
             return {"quant_method": "w4afp8", "quant_algo": quant_algo}

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -638,6 +638,31 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
 
         self.assertEqual(result["quant_method"], "modelopt_mixed")
 
+    def test_nvfp4_layer_metadata_uses_modelopt_mixed(self):
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.hf_config = MagicMock()
+        model_config.hf_config.model_type = "qwen3_5_moe"
+        model_config.hf_config.architectures = ["Qwen3_5MoeForConditionalGeneration"]
+
+        result = model_config._parse_modelopt_quant_config(
+            {
+                "quantization": {
+                    "quant_algo": "MIXED_PRECISION",
+                    "quantized_layers": {
+                        "model.language_model.layers.0.linear_attn.out_proj": {
+                            "quant_algo": "FP8"
+                        },
+                        "model.language_model.layers.0.mlp.experts": {
+                            "quant_algo": "NVFP4",
+                            "group_size": 16,
+                        },
+                    },
+                }
+            }
+        )
+
+        self.assertEqual(result["quant_method"], "modelopt_mixed")
+
     def test_mixed_precision_override_does_not_hijack_w4afp8(self):
         self.assertIsNone(
             ModelOptMixedPrecisionConfig.override_quantization_method(
@@ -686,6 +711,81 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         self.assertEqual(
             quant_config._resolve_quant_algo("model.layers.2.mixer.qkv_proj"),
             "FP8",
+        )
+
+    def test_qwen35_nvfp4_v2_layer_resolution(self):
+        quant_config = ModelOptMixedPrecisionConfig.from_config(
+            {
+                "quant_algo": "MIXED_PRECISION",
+                "kv_cache_scheme": {"type": "float", "num_bits": 8},
+                "quantized_layers": {
+                    "model.language_model.layers.0.linear_attn.in_proj_qkv": {
+                        "quant_algo": "FP8"
+                    },
+                    "model.language_model.layers.0.linear_attn.in_proj_z": {
+                        "quant_algo": "FP8"
+                    },
+                    "model.language_model.layers.0.mlp.experts": {
+                        "quant_algo": "NVFP4",
+                        "group_size": 16,
+                    },
+                    "model.language_model.layers.0.mlp.shared_expert.gate_proj": {
+                        "quant_algo": "FP8"
+                    },
+                    "model.language_model.layers.0.mlp.shared_expert.up_proj": {
+                        "quant_algo": "FP8"
+                    },
+                    "model.language_model.layers.3.self_attn.q_proj": {
+                        "quant_algo": "FP8"
+                    },
+                    "model.language_model.layers.3.self_attn.k_proj": {
+                        "quant_algo": "FP8"
+                    },
+                    "model.language_model.layers.3.self_attn.v_proj": {
+                        "quant_algo": "FP8"
+                    },
+                },
+                "packed_modules_mapping": {
+                    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+                    "gate_up_proj": ["gate_proj", "up_proj"],
+                    "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+                },
+            }
+        )
+
+        self.assertEqual(quant_config.kv_cache_quant_algo, "FP8")
+        self.assertEqual(
+            quant_config._resolve_quant_algo(
+                "model.language_model.layers.0.linear_attn.in_proj_qkvz"
+            ),
+            "FP8",
+        )
+        self.assertEqual(
+            quant_config._resolve_quant_algo(
+                "model.language_model.layers.0.mlp.experts"
+            ),
+            "NVFP4",
+        )
+        self.assertEqual(
+            quant_config._resolve_quant_algo(
+                "model.language_model.layers.0.mlp.shared_expert.gate_up_proj"
+            ),
+            "FP8",
+        )
+        self.assertEqual(
+            quant_config._resolve_quant_algo(
+                "model.language_model.layers.3.self_attn.qkv_proj"
+            ),
+            "FP8",
+        )
+        self.assertIsNone(
+            quant_config._resolve_quant_algo(
+                "model.language_model.layers.0.linear_attn.in_proj_ba"
+            )
+        )
+        self.assertIsNone(quant_config._resolve_quant_algo("lm_head"))
+        self.assertIsNone(
+            quant_config._resolve_quant_algo("mtp.layers.0.mlp.experts")
         )
 
 

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -798,15 +798,11 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
             )
         )
         self.assertIsNone(
-            quant_config._resolve_quant_algo(
-                "model.language_model.layers.0.mlp.gate"
-            )
+            quant_config._resolve_quant_algo("model.language_model.layers.0.mlp.gate")
         )
         self.assertIsNone(quant_config._resolve_quant_algo("model.visual.blocks.0"))
         self.assertIsNone(quant_config._resolve_quant_algo("lm_head"))
-        self.assertIsNone(
-            quant_config._resolve_quant_algo("mtp.layers.0.mlp.experts")
-        )
+        self.assertIsNone(quant_config._resolve_quant_algo("mtp.layers.0.mlp.experts"))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -725,6 +725,9 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
                     "model.language_model.layers.0.linear_attn.in_proj_z": {
                         "quant_algo": "FP8"
                     },
+                    "model.language_model.layers.0.linear_attn.out_proj": {
+                        "quant_algo": "FP8"
+                    },
                     "model.language_model.layers.0.mlp.experts": {
                         "quant_algo": "NVFP4",
                         "group_size": 16,
@@ -762,6 +765,12 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         )
         self.assertEqual(
             quant_config._resolve_quant_algo(
+                "model.language_model.layers.0.linear_attn.out_proj"
+            ),
+            "FP8",
+        )
+        self.assertEqual(
+            quant_config._resolve_quant_algo(
                 "model.language_model.layers.0.mlp.experts"
             ),
             "NVFP4",
@@ -783,6 +792,17 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
                 "model.language_model.layers.0.linear_attn.in_proj_ba"
             )
         )
+        self.assertIsNone(
+            quant_config._resolve_quant_algo(
+                "model.language_model.layers.0.linear_attn.conv1d"
+            )
+        )
+        self.assertIsNone(
+            quant_config._resolve_quant_algo(
+                "model.language_model.layers.0.mlp.gate"
+            )
+        )
+        self.assertIsNone(quant_config._resolve_quant_algo("model.visual.blocks.0"))
         self.assertIsNone(quant_config._resolve_quant_algo("lm_head"))
         self.assertIsNone(
             quant_config._resolve_quant_algo("mtp.layers.0.mlp.experts")


### PR DESCRIPTION
## Motivation

Support [`nvidia/Qwen3.5-397B-A17B-NVFP4-V2`](https://huggingface.co/nvidia/Qwen3.5-397B-A17B-NVFP4-V2), which uses per-tensor FP8 linears and NVFP4 routed experts.


## Modifications

- Route `MIXED_PRECISION` configs containing NVFP4 layers to `modelopt_mixed`, while preserving the legacy W4AFP8 fallback.
- Add coverage for Qwen3.5 packed GDN/attention projections, shared/routed experts, FP8 KV cache, and unquantized modules.

## Accuracy Tests

Validated revision `8f590eae8f10bf55d9a46f79ea0280bde435c9f8` on 4×B200 with TP=4:

- 15/15 relevant unit tests passed.
- All 26 checkpoint shards loaded successfully; FP8 KV cache and CUDA graphs initialized.
- 6/6 short text requests had deterministic greedy outputs.
- A 16,388-token prompt and a multimodal request completed successfully.
- No traceback, missing quantized parameters, NaN, or runtime errors.

- SGLang `run_eval` GSM8K (5-shot, 1,314 scored examples, thinking enabled, `max_tokens=16384`, `temperature=0`, `top_p=0.95`): **97.41% (1280/1314)** in 24.2 minutes.

## Speed Tests and Profiling

N/A. This PR only changes quantization routing and tests.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation is required.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28461584650](https://github.com/sgl-project/sglang/actions/runs/28461584650)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28461584352](https://github.com/sgl-project/sglang/actions/runs/28461584352)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
