### PR TITLE
[DLLM] Add GFusion and EBSampling

### DIFF
--- a/docs/docs/supported-models/diffusion_language_models.mdx
+++ b/docs/docs/supported-models/diffusion_language_models.mdx
@@ -5,7 +5,7 @@ Diffusion language models have shown promise for non-autoregressive text generat
 
 ## Example Launch Command
 
-SGLang supports different DLLM algorithms such as `LowConfidence` and `JointThreshold`.
+SGLang supports different DLLM algorithms such as `LowConfidence`, `JointThreshold`, and `EBSampling`.
 
 ```bash Command
 python3 -m sglang.launch_server \
@@ -63,6 +63,21 @@ max_post_edit_steps: 16
 # 2-gram repetition penalty (default 0).
 # An empirical value of 3 is often sufficient to mitigate most repetitions.
 penalty_lambda: 0
+```
+
+EBSampling Config:
+
+```yaml Config
+# Entropy budget for revealing masked tokens within a block each step.
+# The single lowest-entropy token is always revealed. Additional tokens are
+# revealed while the running (cumulative) entropy prefix stays within gamma.
+# - Higher values: reveal more tokens per step, faster but potentially lower quality
+# - Lower values: reveal fewer tokens per step, slower but higher quality
+# Range: >= 0.0
+gamma: 0.15
+
+# Default: 32, for LLaDA2MoeModelLM
+block_size: 32
 ```
 
 ## Example Client Code Snippet
@@ -146,6 +161,11 @@ Below the supported models are summarized in a table.
       <td><strong>DiffusionGemma</strong></td>
       <td><code>google/diffusiongemma-26B-A4B-it</code></td>
       <td>Uniform-state (renoising) block-diffusion multimodal (text + image) MoE, 25.2B total / 3.8B active, served with the <code>Gemma4Renoise</code> sampler.</td>
+    </tr>
+    <tr>
+      <td><strong>GFusion</strong></td>
+      <td><code>ai-sage/GFusion-10B-A1.8B</code></td>
+      <td>MLA-based (DeepSeek-V3-style) MoE diffusion language model, 10B total / 1.8B active. Requires the <code>fa3</code> or <code>triton</code> attention backend.
     </tr>
   </tbody>
 </table>

--- a/docs/docs/supported-models/diffusion_language_models.mdx
+++ b/docs/docs/supported-models/diffusion_language_models.mdx
@@ -165,7 +165,7 @@ Below the supported models are summarized in a table.
     <tr>
       <td><strong>GFusion</strong></td>
       <td><code>ai-sage/GFusion-10B-A1.8B</code></td>
-      <td>MLA-based (DeepSeek-V3-style) MoE diffusion language model, 10B total / 1.8B active. Requires the <code>fa3</code> or <code>triton</code> attention backend.
+      <td>MLA-based (DeepSeek-V3-style) MoE diffusion language model, 10B total / 1.8B active. Requires the <code>fa3</code> or <code>triton</code> attention backend.</td>
     </tr>
   </tbody>
 </table>

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -547,6 +547,7 @@ def _kimi_k3_moe_runner_overrides(server_args: Any, hf_config: Any) -> dict:
 
 
 @_register_for(
+    "GFusionForDiffusionLM",
     "DeepseekV3ForCausalLM",
     "DeepseekV32ForCausalLM",
     "KimiK25ForConditionalGeneration",
@@ -1660,6 +1661,7 @@ def _dsa_split_backend_resolution(view: Any) -> dict:
 # Keep in sync with the DeepSeek family list on _deepseek_family_overrides.
 _DEEPSEEK_FAMILY_ARCHS = frozenset(
     {
+        "GFusionForDiffusionLM",
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
         "KimiK25ForConditionalGeneration",
@@ -1706,7 +1708,10 @@ def _deepseek_moe_quant_resolution(view: Any) -> dict:
             # models that share the same architecture class (e.g.
             # Moonlight-16B-A3B) are purely BF16.  Check the actual
             # safetensors header instead of assuming FP8 by arch name.
-            if quant_method is None and model_arch in ["DeepseekV3ForCausalLM"]:
+            if quant_method is None and model_arch in [
+                "DeepseekV3ForCausalLM",
+                "GFusionForDiffusionLM",
+            ]:
                 from sglang.srt.utils.common import has_fp8_weights_in_checkpoint
 
                 if has_fp8_weights_in_checkpoint(view.model_path):
@@ -1860,6 +1865,7 @@ def _sparse_head_overlap_disable(view: Any) -> dict:
 # sync with the model-side fusion implementations.
 _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
     {
+        "GFusionForDiffusionLM",
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
         "GptOssForCausalLM",
@@ -2516,6 +2522,33 @@ def _gguf_quantization(view: Any) -> dict:
 @register_post_process
 def _dllm_attention_backend(view: Any) -> dict:
     if view.dllm_algorithm is None:
+        return {}
+    model_arch = view.get_model_config().hf_config.architectures[0]
+    if model_arch == "GFusionForDiffusionLM":
+        if is_npu():
+            raise ValueError("GFusion does not support the ascend attention backend.")
+        supported_backends = {"triton"} if is_hip() else {"fa3", "triton"}
+        configured_backends = {
+            backend
+            for backend in (
+                view.attention_backend,
+                view.prefill_attention_backend,
+                view.decode_attention_backend,
+            )
+            if backend is not None
+        }
+        unsupported_backends = configured_backends - supported_backends
+        if unsupported_backends:
+            raise ValueError(
+                "GFusion only supports the following attention backends: "
+                f"{sorted(supported_backends)}; got {sorted(unsupported_backends)}."
+            )
+        if not configured_backends:
+            attention_backend = "triton" if is_hip() else "fa3"
+            logger.info(
+                f"Attention backend is set to {attention_backend} for GFusion."
+            )
+            return {"attention_backend": attention_backend}
         return {}
     if is_hip():
         if view.attention_backend not in ["triton", "aiter"]:

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2529,7 +2529,13 @@ def _dllm_attention_backend(view: Any) -> dict:
             raise ValueError("GFusion only supports CUDA and HIP GPUs.")
         supported_backends = {"triton"} if is_hip() else {"fa3", "triton"}
         if view.is_attention_backend_not_set():
-            attention_backend = "triton" if is_hip() else "fa3"
+            # Keep the hardware-aware default (FA3 on Hopper, Triton on older
+            # CUDA). HIP/unsupported defaults fall back to Triton.
+            attention_backend = (
+                view.attention_backend
+                if view.attention_backend in supported_backends
+                else "triton"
+            )
             logger.info(f"Attention backend is set to {attention_backend} for GFusion.")
             return {"attention_backend": attention_backend}
         unsupported_backends = set(attention_backends_of(view)) - supported_backends

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2530,9 +2530,7 @@ def _dllm_attention_backend(view: Any) -> dict:
         supported_backends = {"triton"} if is_hip() else {"fa3", "triton"}
         if view.is_attention_backend_not_set():
             attention_backend = "triton" if is_hip() else "fa3"
-            logger.info(
-                f"Attention backend is set to {attention_backend} for GFusion."
-            )
+            logger.info(f"Attention backend is set to {attention_backend} for GFusion.")
             return {"attention_backend": attention_backend}
         unsupported_backends = set(attention_backends_of(view)) - supported_backends
         if unsupported_backends:

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2525,30 +2525,21 @@ def _dllm_attention_backend(view: Any) -> dict:
         return {}
     model_arch = view.get_model_config().hf_config.architectures[0]
     if model_arch == "GFusionForDiffusionLM":
-        if is_npu():
-            raise ValueError("GFusion does not support the ascend attention backend.")
+        if not is_cuda() and not is_hip():
+            raise ValueError("GFusion only supports CUDA and HIP GPUs.")
         supported_backends = {"triton"} if is_hip() else {"fa3", "triton"}
-        configured_backends = {
-            backend
-            for backend in (
-                view.attention_backend,
-                view.prefill_attention_backend,
-                view.decode_attention_backend,
-            )
-            if backend is not None
-        }
-        unsupported_backends = configured_backends - supported_backends
-        if unsupported_backends:
-            raise ValueError(
-                "GFusion only supports the following attention backends: "
-                f"{sorted(supported_backends)}; got {sorted(unsupported_backends)}."
-            )
-        if not configured_backends:
+        if view.is_attention_backend_not_set():
             attention_backend = "triton" if is_hip() else "fa3"
             logger.info(
                 f"Attention backend is set to {attention_backend} for GFusion."
             )
             return {"attention_backend": attention_backend}
+        unsupported_backends = set(attention_backends_of(view)) - supported_backends
+        if unsupported_backends:
+            raise ValueError(
+                "GFusion only supports the following attention backends: "
+                f"{sorted(supported_backends)}; got {sorted(unsupported_backends)}."
+            )
         return {}
     if is_hip():
         if view.attention_backend not in ["triton", "aiter"]:

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -107,7 +107,7 @@ def is_deepseek_dsa(config) -> bool:
     return (
         _hf_arch(config)
         in (
-            "GFusionModelLM",
+            "GFusionForDiffusionLM",
             "DeepseekV3ForCausalLM",
             "DeepseekV32ForCausalLM",
             "DeepseekV3ForCausalLMNextN",
@@ -268,7 +268,6 @@ class ModelConfig:
         disable_hybrid_swa_memory: bool = False,
         model_config_parser: str = "auto",
         speculative_algorithm: Optional[str] = None,
-        dllm_algorithm: Optional[str] = None,
     ) -> None:
         # Parse args
         self.model_path = model_path
@@ -282,7 +281,6 @@ class ModelConfig:
         self.is_multi_layer_eagle = is_multi_layer_eagle
         self.disable_hybrid_swa_memory = disable_hybrid_swa_memory
         self.model_config_parser = model_config_parser
-        self.dllm_algorithm = dllm_algorithm
 
         # Validate quantize_and_serve configuration
         self._validate_quantize_and_serve_config()
@@ -360,9 +358,6 @@ class ModelConfig:
 
         # Config draft model
         self._config_draft_model()
-
-        # Config diffusion LLM (dLLM) model
-        self._config_dllm_model()
 
         # DSV4 expert layout: env (default True = mxfp4) applies only to V4.
         # Other FP8 MoE models (for example DeepSeek V3.2) must keep the normal
@@ -577,21 +572,8 @@ class ModelConfig:
             disable_hybrid_swa_memory=server_args.disable_hybrid_swa_memory,
             model_config_parser=server_args.model_config_parser,
             speculative_algorithm=server_args.speculative_algorithm,
-            dllm_algorithm=server_args.dllm_algorithm,
             **kwargs,
         )
-
-    def _config_dllm_model(self):
-        # GFusion diffusion checkpoints declare "GFusionForDiffusionLM"; when
-        # running under a dLLM algorithm, remap them onto SGLang's DeepSeek-MLA
-        # based implementation registered as "GFusionModelLM".
-        if (
-            self.dllm_algorithm is not None
-            and self.hf_config.architectures[0] == "GFusionForDiffusionLM"
-        ):
-            self.hf_config.architectures[0] = "GFusionModelLM"
-            if getattr(self.hf_text_config, "architectures", None) is not None:
-                self.hf_text_config.architectures[0] = "GFusionModelLM"
 
     def _config_draft_model(self):
         is_draft_model = self.is_draft_model
@@ -844,7 +826,7 @@ class ModelConfig:
         # FIXME: temporary special judge for MLA architecture
         if (
             "DeepseekV2ForCausalLM" in self.hf_config.architectures
-            or "GFusionModelLM" in self.hf_config.architectures
+            or "GFusionForDiffusionLM" in self.hf_config.architectures
             or "DeepseekV32ForCausalLM" in self.hf_config.architectures
             or "DeepseekV3ForCausalLM" in self.hf_config.architectures
             or "DeepseekV3ForCausalLMNextN" in self.hf_config.architectures

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -107,6 +107,7 @@ def is_deepseek_dsa(config) -> bool:
     return (
         _hf_arch(config)
         in (
+            "GFusionModelLM",
             "DeepseekV3ForCausalLM",
             "DeepseekV32ForCausalLM",
             "DeepseekV3ForCausalLMNextN",
@@ -267,6 +268,7 @@ class ModelConfig:
         disable_hybrid_swa_memory: bool = False,
         model_config_parser: str = "auto",
         speculative_algorithm: Optional[str] = None,
+        dllm_algorithm: Optional[str] = None,
     ) -> None:
         # Parse args
         self.model_path = model_path
@@ -280,6 +282,7 @@ class ModelConfig:
         self.is_multi_layer_eagle = is_multi_layer_eagle
         self.disable_hybrid_swa_memory = disable_hybrid_swa_memory
         self.model_config_parser = model_config_parser
+        self.dllm_algorithm = dllm_algorithm
 
         # Validate quantize_and_serve configuration
         self._validate_quantize_and_serve_config()
@@ -357,6 +360,9 @@ class ModelConfig:
 
         # Config draft model
         self._config_draft_model()
+
+        # Config diffusion LLM (dLLM) model
+        self._config_dllm_model()
 
         # DSV4 expert layout: env (default True = mxfp4) applies only to V4.
         # Other FP8 MoE models (for example DeepSeek V3.2) must keep the normal
@@ -571,8 +577,21 @@ class ModelConfig:
             disable_hybrid_swa_memory=server_args.disable_hybrid_swa_memory,
             model_config_parser=server_args.model_config_parser,
             speculative_algorithm=server_args.speculative_algorithm,
+            dllm_algorithm=server_args.dllm_algorithm,
             **kwargs,
         )
+
+    def _config_dllm_model(self):
+        # GFusion diffusion checkpoints declare "GFusionForDiffusionLM"; when
+        # running under a dLLM algorithm, remap them onto SGLang's DeepSeek-MLA
+        # based implementation registered as "GFusionModelLM".
+        if (
+            self.dllm_algorithm is not None
+            and self.hf_config.architectures[0] == "GFusionForDiffusionLM"
+        ):
+            self.hf_config.architectures[0] = "GFusionModelLM"
+            if getattr(self.hf_text_config, "architectures", None) is not None:
+                self.hf_text_config.architectures[0] = "GFusionModelLM"
 
     def _config_draft_model(self):
         is_draft_model = self.is_draft_model
@@ -825,6 +844,7 @@ class ModelConfig:
         # FIXME: temporary special judge for MLA architecture
         if (
             "DeepseekV2ForCausalLM" in self.hf_config.architectures
+            or "GFusionModelLM" in self.hf_config.architectures
             or "DeepseekV32ForCausalLM" in self.hf_config.architectures
             or "DeepseekV3ForCausalLM" in self.hf_config.architectures
             or "DeepseekV3ForCausalLMNextN" in self.hf_config.architectures

--- a/python/sglang/srt/dllm/algorithm/eb_sampling.py
+++ b/python/sglang/srt/dllm/algorithm/eb_sampling.py
@@ -1,0 +1,105 @@
+from typing import List, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.dllm.algorithm.base import DllmAlgorithm
+from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+class EBSampling(DllmAlgorithm):
+    def __init__(
+        self,
+        config: DllmConfig,
+    ):
+        super().__init__(config)
+        self.gamma = config.algorithm_config.get("gamma", 0.0)
+        if self.gamma < 0:
+            raise ValueError("EBSampling requires a non-negative gamma threshold.")
+
+    def run(
+        self,
+        model_runner: ModelRunner,
+        forward_batch: ForwardBatch,
+    ) -> Tuple[Union[LogitsProcessorOutput, torch.Tensor], List[torch.Tensor], bool]:
+        batch_size = forward_batch.batch_size
+        start_list = []
+        mask_index = forward_batch.input_ids == self.mask_id
+
+        if not mask_index.any():
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            return out.logits_output, [], out.can_run_graph
+
+        for block_id in range(batch_size):
+            block_start = block_id * self.block_size
+            block_end = block_start + self.block_size
+            block_input_ids = forward_batch.input_ids[block_start:block_end]
+            block_mask_index = block_input_ids == self.mask_id
+            start = self.block_size - torch.sum(block_mask_index).item()
+            start_list.append(start)
+
+        for _ in range(1, self.block_size + 1):
+            mask_index = forward_batch.input_ids == self.mask_id
+            if not mask_index.any():
+                break
+
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
+            assert batch_size == forward_batch.input_ids.shape[0] // self.block_size
+
+            for batch_id in range(batch_size):
+                curr_block_start = batch_id * self.block_size
+                curr_block_end = curr_block_start + self.block_size
+                block_input_ids = forward_batch.input_ids[
+                    curr_block_start:curr_block_end,
+                ]
+                block_mask_index = block_input_ids == self.mask_id
+                if not block_mask_index.any():
+                    continue
+
+                curr_logits = logits_output.full_logits[
+                    curr_block_start:curr_block_end,
+                ]
+                x = torch.argmax(curr_logits, dim=-1)
+
+                masked_positions = torch.nonzero(
+                    block_mask_index, as_tuple=False
+                ).flatten()
+                masked_logits = curr_logits[masked_positions]
+                masked_log_probs = F.log_softmax(masked_logits, dim=-1)
+                masked_probs = masked_log_probs.exp()
+                masked_entropies = -(masked_probs * masked_log_probs).sum(dim=-1)
+
+                sort_index = torch.argsort(masked_entropies, dim=0)
+                sorted_positions = masked_positions[sort_index]
+                sorted_entropies = masked_entropies[sort_index]
+
+                reveal_count = 1
+                entropy_budget = 0.0
+                for entropy in sorted_entropies[:-1]:
+                    entropy_budget += float(entropy.item())
+                    if entropy_budget <= self.gamma:
+                        reveal_count += 1
+                    else:
+                        break
+
+                transfer_positions = sorted_positions[:reveal_count]
+                transfer_index = torch.zeros_like(block_mask_index)
+                transfer_index[transfer_positions] = True
+
+                block_input_ids[transfer_index] = x[transfer_index]
+
+        out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+        logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
+        next_token_ids = torch.reshape(forward_batch.input_ids, (batch_size, -1))
+        next_token_ids_list = [
+            next_token_ids[i, start_list[i] :] for i in range(batch_size)
+        ]
+
+        return logits_output, next_token_ids_list, can_run_cuda_graph
+
+
+Algorithm = EBSampling

--- a/python/sglang/srt/dllm/algorithm/eb_sampling.py
+++ b/python/sglang/srt/dllm/algorithm/eb_sampling.py
@@ -16,7 +16,7 @@ class EBSampling(DllmAlgorithm):
         config: DllmConfig,
     ):
         super().__init__(config)
-        self.gamma = config.algorithm_config.get("gamma", 0.0)
+        self.gamma = config.algorithm_config.get("gamma", 0.15)
         if self.gamma < 0:
             raise ValueError("EBSampling requires a non-negative gamma threshold.")
 
@@ -26,6 +26,7 @@ class EBSampling(DllmAlgorithm):
         forward_batch: ForwardBatch,
     ) -> Tuple[Union[LogitsProcessorOutput, torch.Tensor], List[torch.Tensor], bool]:
         batch_size = forward_batch.batch_size
+        assert batch_size == forward_batch.input_ids.shape[0] // self.block_size
         start_list = []
         mask_index = forward_batch.input_ids == self.mask_id
 
@@ -47,8 +48,7 @@ class EBSampling(DllmAlgorithm):
                 break
 
             out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
-            logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
-            assert batch_size == forward_batch.input_ids.shape[0] // self.block_size
+            logits_output = out.logits_output
 
             for batch_id in range(batch_size):
                 curr_block_start = batch_id * self.block_size

--- a/python/sglang/srt/dllm/algorithm/eb_sampling.py
+++ b/python/sglang/srt/dllm/algorithm/eb_sampling.py
@@ -86,7 +86,9 @@ class EBSampling(DllmAlgorithm):
                 # while the running entropy budget stays within gamma.
                 reveal_mask = torch.zeros_like(sorted_entropies, dtype=torch.bool)
                 reveal_mask[0] = True
-                reveal_mask[1:] = torch.cumsum(sorted_entropies[:-1], dim=0) <= self.gamma
+                reveal_mask[1:] = (
+                    torch.cumsum(sorted_entropies[:-1], dim=0) <= self.gamma
+                )
                 transfer_positions = sorted_positions[reveal_mask]
                 transfer_index = torch.zeros_like(block_mask_index)
                 transfer_index[transfer_positions] = True

--- a/python/sglang/srt/dllm/algorithm/eb_sampling.py
+++ b/python/sglang/srt/dllm/algorithm/eb_sampling.py
@@ -63,6 +63,11 @@ class EBSampling(DllmAlgorithm):
                 curr_logits = logits_output.full_logits[
                     curr_block_start:curr_block_end,
                 ]
+                # Never select or score the mask token itself: suppress it before
+                # both candidate selection and the entropy computation.
+                if 0 <= self.mask_id < curr_logits.shape[-1]:
+                    curr_logits = curr_logits.clone()
+                    curr_logits[..., self.mask_id] = torch.finfo(curr_logits.dtype).min
                 x = torch.argmax(curr_logits, dim=-1)
 
                 masked_positions = torch.nonzero(
@@ -77,16 +82,12 @@ class EBSampling(DllmAlgorithm):
                 sorted_positions = masked_positions[sort_index]
                 sorted_entropies = masked_entropies[sort_index]
 
-                reveal_count = 1
-                entropy_budget = 0.0
-                for entropy in sorted_entropies[:-1]:
-                    entropy_budget += float(entropy.item())
-                    if entropy_budget <= self.gamma:
-                        reveal_count += 1
-                    else:
-                        break
-
-                transfer_positions = sorted_positions[:reveal_count]
+                # Always reveal the lowest-entropy token, then extend the prefix
+                # while the running entropy budget stays within gamma.
+                reveal_mask = torch.zeros_like(sorted_entropies, dtype=torch.bool)
+                reveal_mask[0] = True
+                reveal_mask[1:] = torch.cumsum(sorted_entropies[:-1], dim=0) <= self.gamma
+                transfer_positions = sorted_positions[reveal_mask]
                 transfer_index = torch.zeros_like(block_mask_index)
                 transfer_index[transfer_positions] = True
 

--- a/python/sglang/srt/dllm/algorithm/eb_sampling.py
+++ b/python/sglang/srt/dllm/algorithm/eb_sampling.py
@@ -1,13 +1,11 @@
-from typing import List, Tuple, Union
+from typing import Any, List
 
 import torch
 import torch.nn.functional as F
 
 from sglang.srt.dllm.algorithm.base import DllmAlgorithm
 from sglang.srt.dllm.config import DllmConfig
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.model_executor.model_runner import ModelRunner
 
 
 class EBSampling(DllmAlgorithm):
@@ -20,89 +18,58 @@ class EBSampling(DllmAlgorithm):
         if self.gamma < 0:
             raise ValueError("EBSampling requires a non-negative gamma threshold.")
 
-    def run(
+    def step(
         self,
-        model_runner: ModelRunner,
         forward_batch: ForwardBatch,
-    ) -> Tuple[Union[LogitsProcessorOutput, torch.Tensor], List[torch.Tensor], bool]:
+        full_logits: torch.Tensor,
+        _states: List[Any],
+    ) -> List[bool]:
         batch_size = forward_batch.batch_size
         assert batch_size == forward_batch.input_ids.shape[0] // self.block_size
-        start_list = []
-        mask_index = forward_batch.input_ids == self.mask_id
+        done = []
 
-        if not mask_index.any():
-            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
-            return out.logits_output, [], out.can_run_graph
-
-        for block_id in range(batch_size):
-            block_start = block_id * self.block_size
+        for batch_id in range(batch_size):
+            block_start = batch_id * self.block_size
             block_end = block_start + self.block_size
             block_input_ids = forward_batch.input_ids[block_start:block_end]
             block_mask_index = block_input_ids == self.mask_id
-            start = self.block_size - torch.sum(block_mask_index).item()
-            start_list.append(start)
+            if not block_mask_index.any():
+                done.append(True)
+                continue
 
-        for _ in range(1, self.block_size + 1):
-            mask_index = forward_batch.input_ids == self.mask_id
-            if not mask_index.any():
-                break
+            curr_logits = full_logits[block_start:block_end]
+            # Never select or score the mask token itself: suppress it before
+            # both candidate selection and the entropy computation.
+            if 0 <= self.mask_id < curr_logits.shape[-1]:
+                curr_logits = curr_logits.clone()
+                curr_logits[..., self.mask_id] = torch.finfo(curr_logits.dtype).min
+            x = torch.argmax(curr_logits, dim=-1)
 
-            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
-            logits_output = out.logits_output
+            masked_positions = torch.nonzero(
+                block_mask_index, as_tuple=False
+            ).flatten()
+            masked_logits = curr_logits[masked_positions]
+            masked_log_probs = F.log_softmax(masked_logits, dim=-1)
+            masked_probs = masked_log_probs.exp()
+            masked_entropies = -(masked_probs * masked_log_probs).sum(dim=-1)
 
-            for batch_id in range(batch_size):
-                curr_block_start = batch_id * self.block_size
-                curr_block_end = curr_block_start + self.block_size
-                block_input_ids = forward_batch.input_ids[
-                    curr_block_start:curr_block_end,
-                ]
-                block_mask_index = block_input_ids == self.mask_id
-                if not block_mask_index.any():
-                    continue
+            sort_index = torch.argsort(masked_entropies, dim=0)
+            sorted_positions = masked_positions[sort_index]
+            sorted_entropies = masked_entropies[sort_index]
 
-                curr_logits = logits_output.full_logits[
-                    curr_block_start:curr_block_end,
-                ]
-                # Never select or score the mask token itself: suppress it before
-                # both candidate selection and the entropy computation.
-                if 0 <= self.mask_id < curr_logits.shape[-1]:
-                    curr_logits = curr_logits.clone()
-                    curr_logits[..., self.mask_id] = torch.finfo(curr_logits.dtype).min
-                x = torch.argmax(curr_logits, dim=-1)
+            # Always reveal the lowest-entropy token, then extend the prefix
+            # while the running entropy budget stays within gamma.
+            reveal_mask = torch.zeros_like(sorted_entropies, dtype=torch.bool)
+            reveal_mask[0] = True
+            reveal_mask[1:] = torch.cumsum(sorted_entropies[:-1], dim=0) <= self.gamma
+            transfer_positions = sorted_positions[reveal_mask]
+            transfer_index = torch.zeros_like(block_mask_index)
+            transfer_index[transfer_positions] = True
 
-                masked_positions = torch.nonzero(
-                    block_mask_index, as_tuple=False
-                ).flatten()
-                masked_logits = curr_logits[masked_positions]
-                masked_log_probs = F.log_softmax(masked_logits, dim=-1)
-                masked_probs = masked_log_probs.exp()
-                masked_entropies = -(masked_probs * masked_log_probs).sum(dim=-1)
+            block_input_ids[transfer_index] = x[transfer_index]
+            done.append(False)
 
-                sort_index = torch.argsort(masked_entropies, dim=0)
-                sorted_positions = masked_positions[sort_index]
-                sorted_entropies = masked_entropies[sort_index]
-
-                # Always reveal the lowest-entropy token, then extend the prefix
-                # while the running entropy budget stays within gamma.
-                reveal_mask = torch.zeros_like(sorted_entropies, dtype=torch.bool)
-                reveal_mask[0] = True
-                reveal_mask[1:] = (
-                    torch.cumsum(sorted_entropies[:-1], dim=0) <= self.gamma
-                )
-                transfer_positions = sorted_positions[reveal_mask]
-                transfer_index = torch.zeros_like(block_mask_index)
-                transfer_index[transfer_positions] = True
-
-                block_input_ids[transfer_index] = x[transfer_index]
-
-        out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
-        logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
-        next_token_ids = torch.reshape(forward_batch.input_ids, (batch_size, -1))
-        next_token_ids_list = [
-            next_token_ids[i, start_list[i] :] for i in range(batch_size)
-        ]
-
-        return logits_output, next_token_ids_list, can_run_cuda_graph
+        return done
 
 
 Algorithm = EBSampling

--- a/python/sglang/srt/dllm/algorithm/eb_sampling.py
+++ b/python/sglang/srt/dllm/algorithm/eb_sampling.py
@@ -45,9 +45,7 @@ class EBSampling(DllmAlgorithm):
                 curr_logits[..., self.mask_id] = torch.finfo(curr_logits.dtype).min
             x = torch.argmax(curr_logits, dim=-1)
 
-            masked_positions = torch.nonzero(
-                block_mask_index, as_tuple=False
-            ).flatten()
+            masked_positions = torch.nonzero(block_mask_index, as_tuple=False).flatten()
             masked_logits = curr_logits[masked_positions]
             masked_log_probs = F.log_softmax(masked_logits, dim=-1)
             masked_probs = masked_log_probs.exp()

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -37,7 +37,7 @@ class DllmConfig:
             "LLaDA2MoeModelLM": {"block_size": 32, "mask_id": 156895},
             "SDARForCausalLM": {"block_size": 4, "mask_id": 151669},
             "SDARMoeForCausalLM": {"block_size": 4, "mask_id": 151669},
-            "GFusionModelLM": {"block_size": 32, "mask_id": 128170},
+            "GFusionForDiffusionLM": {"block_size": 32, "mask_id": 128170},
         }
 
         arch = model_config.hf_config.architectures[0]

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -37,6 +37,7 @@ class DllmConfig:
             "LLaDA2MoeModelLM": {"block_size": 32, "mask_id": 156895},
             "SDARForCausalLM": {"block_size": 4, "mask_id": 151669},
             "SDARMoeForCausalLM": {"block_size": 4, "mask_id": 151669},
+            "GFusionModelLM": {"block_size": 32, "mask_id": 128170},
         }
 
         arch = model_config.hf_config.architectures[0]

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -935,8 +935,9 @@ class FlashAttentionBackend(AttentionBackend):
                     )
 
         elif forward_batch.forward_mode.is_dllm_extend():
-            # dLLM decodes a fixed-size block of masked tokens per request with
-            # bidirectional attention over the whole cached sequence.
+            # The page table below is built at token granularity (no // page_size),
+            # which is only correct at page_size=1 (enforced in _handle_dllm_inference).
+            assert self.page_size == 1, "fa3 dLLM extend requires page_size=1."
             dllm_block_size = self._get_dllm_block_size(
                 batch_size=batch_size, num_tokens=forward_batch.input_ids.shape[0]
             )

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -935,9 +935,11 @@ class FlashAttentionBackend(AttentionBackend):
                     )
 
         elif forward_batch.forward_mode.is_dllm_extend():
-            # The page table below is built at token granularity (no // page_size),
-            # which is only correct at page_size=1 (enforced in _handle_dllm_inference).
-            assert self.page_size == 1, "fa3 dLLM extend requires page_size=1."
+            # dLLM decodes a fixed-size block of masked tokens per request with
+            # bidirectional attention over the whole cached sequence. The page
+            # table is built at token granularity here and strided to page indices
+            # by the shared `page_size > 1` conversion below (same as every other
+            # mode), so page_size == block_size (block-aligned radix cache) works.
             dllm_block_size = self._get_dllm_block_size(
                 batch_size=batch_size, num_tokens=forward_batch.input_ids.shape[0]
             )

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -17,6 +17,7 @@ from sglang.kernels.ops.kvcache.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
 from sglang.srt.configs.model_config import AttentionArch
+from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.unified_mem_hooks import unified_mla_hooks
 from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_verify_mask
@@ -190,6 +191,7 @@ class FlashAttentionBackend(AttentionBackend):
         # sub-pools keep the strided envelope layout FA3 cannot read at all.
         self._unified_hooks = unified_mla_hooks(model_runner.token_to_kv_pool_allocator)
         self._unified_dense = self._unified_hooks.enabled and self.use_mla
+        self.dllm_config = DllmConfig.from_server_args(model_runner.server_args)
         self.skip_prefill = skip_prefill
         self.attn_cp_size = model_runner.ps.attn_cp_size
         self._verify_mask = None
@@ -629,6 +631,16 @@ class FlashAttentionBackend(AttentionBackend):
             m.max_seq_len_k = self.max_context_len
         self.forward_metadata = m
 
+    def _get_dllm_block_size(
+        self, batch_size: Optional[int] = None, num_tokens: Optional[int] = None
+    ) -> int:
+        """Number of query tokens per dLLM block (== block_size)."""
+        if num_tokens is not None and batch_size is not None and batch_size > 0:
+            return num_tokens // batch_size
+        if self.dllm_config is not None:
+            return self.dllm_config.block_size
+        raise ValueError("dLLM block size requested for a non-dLLM batch.")
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize forward metadata hence all layers in the forward pass can reuse it."""
         metadata = FlashAttentionMetadata()
@@ -922,6 +934,28 @@ class FlashAttentionBackend(AttentionBackend):
                         metadata, metadata_expand
                     )
 
+        elif forward_batch.forward_mode.is_dllm_extend():
+            # dLLM decodes a fixed-size block of masked tokens per request with
+            # bidirectional attention over the whole cached sequence.
+            dllm_block_size = self._get_dllm_block_size(
+                batch_size=batch_size, num_tokens=forward_batch.input_ids.shape[0]
+            )
+            metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
+            metadata.max_seq_len_q = dllm_block_size
+            metadata.max_seq_len_k = seq_lens_cpu.max().item()
+            metadata.cu_seqlens_q = torch.arange(
+                0,
+                batch_size * dllm_block_size + 1,
+                dllm_block_size,
+                dtype=torch.int32,
+                device=device,
+            )
+            metadata.cu_seqlens_k = torch.nn.functional.pad(
+                torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
+            )
+            metadata.page_table = self.req_to_token_pool.req_to_token[
+                forward_batch.req_pool_indices, : metadata.max_seq_len_k
+            ]
         elif forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed(
             include_draft_extend_v2=True
         ):
@@ -2346,6 +2380,33 @@ class FlashAttentionBackend(AttentionBackend):
                     ),
                 }
 
+        # dLLM extend metadata (bidirectional block decode under cuda graph)
+        if self.dllm_config is not None:
+            self.dllm_extend_metadata = {
+                "cache_seqlens": torch.zeros(
+                    max_bs, dtype=torch.int32, device=self.device
+                ),
+                "cu_seqlens_q": torch.arange(
+                    0,
+                    max_bs * self.dllm_config.block_size + 1,
+                    step=self.dllm_config.block_size,
+                    dtype=torch.int32,
+                    device=self.device,
+                ),
+                "cu_seqlens_k": torch.zeros(
+                    max_bs + 1, dtype=torch.int32, device=self.device
+                ),
+                "page_table": torch.zeros(
+                    max_bs,
+                    max_num_pages,
+                    dtype=torch.int32,
+                    device=self.device,
+                ),
+                "strided_indices": torch.arange(
+                    0, self.max_context_len, self.page_size, device=self.device
+                ),
+            }
+
         # Only allocate encoder metadata for encoder-decoder models
         if self.is_encoder_decoder:
             self.encoder_metadata = {
@@ -2564,6 +2625,21 @@ class FlashAttentionBackend(AttentionBackend):
                 ]
                 metadata.swa_out_cache_loc = self.swa_out_cache_loc_buf[:num_tokens]
             self.draft_extend_metadata[bs] = metadata
+
+        elif forward_mode.is_dllm_extend():
+            dllm_block_size = self._get_dllm_block_size(bs, num_tokens)
+            metadata.cache_seqlens_int32 = self.dllm_extend_metadata["cache_seqlens"][
+                :bs
+            ]
+            metadata.max_seq_len_q = dllm_block_size
+            # cu_seqlens_q is the fixed [0, block, 2*block, ...] arange; bind the
+            # slice here and never refill it at replay.
+            metadata.cu_seqlens_q = self.dllm_extend_metadata["cu_seqlens_q"][: bs + 1]
+            metadata.cu_seqlens_k = self.dllm_extend_metadata["cu_seqlens_k"][
+                : (bs + 1)
+            ]
+            metadata.page_table = self.dllm_extend_metadata["page_table"][:bs, :]
+            self.dllm_extend_metadata[bs] = metadata
 
         if encoder_lens is not None:
             encoder_bs = encoder_lens.numel()
@@ -2988,11 +3064,30 @@ class FlashAttentionBackend(AttentionBackend):
                 )
             metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
 
+        elif forward_mode.is_dllm_extend():
+            metadata = self.dllm_extend_metadata[bs]
+            metadata.cache_seqlens_int32.copy_(seq_lens)
+            metadata.max_seq_len_q = self._get_dllm_block_size(batch_size=bs)
+            metadata.max_seq_len_k = self._host_max_seq_len(seq_lens_cpu, seq_lens)
+            # cu_seqlens_q already bound to the fixed block arange in capture.
+            metadata.cu_seqlens_k[1:].copy_(
+                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
+            )
+            max_seq_pages = (
+                metadata.max_seq_len_k + self.page_size - 1
+            ) // self.page_size
+            page_indices = self.req_to_token[
+                req_pool_indices[:, None],
+                self.dllm_extend_metadata["strided_indices"][:max_seq_pages],
+            ]
+            page_indices //= self.page_size
+            metadata.page_table[:, :max_seq_pages].copy_(page_indices)
+
         else:
             raise ValueError(
                 f"FA3 `_apply_cuda_graph_metadata` only supports the modes the "
                 f"full cuda-graph runner captures (decode / idle / target_verify "
-                f"/ draft_extend / draft_extend_v2). Got {forward_mode=}. "
+                f"/ draft_extend / draft_extend_v2 / dllm_extend). Got {forward_mode=}. "
                 f"Piecewise / breakable capture must route through "
                 f"`init_forward_metadata(fb)` (the eager entry) instead of "
                 f"`init_forward_metadata_out_graph(fb, in_capture=True)`."

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -19,6 +19,7 @@ from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
+from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_verify_mask
@@ -301,6 +302,10 @@ class TritonAttnBackend(AttentionBackend):
         # Tree-mask scratch is fetched from the target backend only.
         self.is_draft_runner = model_runner.is_draft_worker
 
+        # dLLM (diffusion) config; None for non-diffusion models. Used to size
+        # the fixed per-request query block for DLLM_EXTEND cuda-graph capture.
+        self.dllm_config = DllmConfig.from_server_args(model_runner.server_args)
+
     def get_num_kv_splits(
         self,
         num_kv_splits: torch.Tensor,
@@ -527,6 +532,34 @@ class TritonAttnBackend(AttentionBackend):
             window_num_kv_splits,
             window_kv_offsets,
         )
+
+    def _update_dllm_buffers(
+        self,
+        bs: int,
+        seq_lens: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+    ):
+        """Fill QO + KV cuda-graph buffers for DLLM_EXTEND mode.
+
+        The dLLM block is a fixed-size (block_size) span of query tokens that
+        attends bidirectionally over the cached prefix. The block's own K/V are
+        supplied to the extend kernel as the extend part, so the KV buffer
+        covers only the prefix (``seq_lens - block_size``) — matching the eager
+        DLLM_EXTEND path.
+        """
+        block_size = self.dllm_config.block_size
+        qo_indptr = self.qo_indptr[: bs + 1]
+        qo_indptr[: bs + 1] = torch.arange(
+            0,
+            (1 + bs) * block_size,
+            step=block_size,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        kv_indptr = self._fill_kv_indptr_and_indices(
+            bs, seq_lens - block_size, req_pool_indices, self.cuda_graph_kv_indices
+        )
+        return qo_indptr, kv_indptr
 
     def _update_draft_extend_buffers(
         self,
@@ -1134,6 +1167,27 @@ class TritonAttnBackend(AttentionBackend):
                 swa_out_cache_loc=swa_out_cache_loc,
                 out_cache_loc_full_physical=out_cache_loc_full_physical,
             )
+        elif forward_mode.is_dllm_extend():
+            # dLLM block: fixed block_size query tokens, bidirectional over the
+            # cached prefix (causal=False set in forward_extend for ENCODER_ONLY
+            # layers), no custom mask.
+            return ForwardMetadata(
+                attn_logits=None,
+                attn_lse=None,
+                max_extend_len=self.dllm_config.block_size,
+                num_kv_splits=None,
+                kv_indptr=self.kv_indptr[: bs + 1],
+                kv_indices=self.cuda_graph_kv_indices,
+                qo_indptr=self.qo_indptr[: bs + 1],
+                custom_mask=None,
+                mask_indptr=None,
+                window_kv_indptr=self.window_kv_indptr,
+                window_kv_indices=None,
+                window_num_kv_splits=None,
+                window_kv_offsets=None,
+                swa_out_cache_loc=swa_out_cache_loc,
+                out_cache_loc_full_physical=out_cache_loc_full_physical,
+            )
         elif forward_mode.is_draft_extend_v2():
             return ForwardMetadata(
                 attn_logits=None,
@@ -1193,6 +1247,8 @@ class TritonAttnBackend(AttentionBackend):
             self._update_target_verify_buffers(
                 bs, seq_lens, req_pool_indices, spec_info
             )
+        elif forward_mode.is_dllm_extend():
+            self._update_dllm_buffers(bs, seq_lens, req_pool_indices)
         elif forward_mode.is_draft_extend_v2():
             self._update_draft_extend_buffers(
                 bs, seq_lens, req_pool_indices, forward_mode, spec_info

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -120,6 +120,11 @@ def handle_attention_flashinfer(attn, forward_batch):
 
 
 def handle_attention_fa3(attn, forward_batch):
+    # dLLM decoding runs bidirectional attention over each block; use absorbed
+    # MLA so the fa3 dLLM-extend metadata (per-block cu_seqlens) is honored
+    # instead of the causal MHA chunked-prefix path.
+    if forward_batch.forward_mode.is_dllm_extend():
+        return _dispatch_mla_subtype(attn, forward_batch)
     # when deterministic inference is enabled, use MLA
     if get_exec().deterministic.enable_deterministic_inference:
         return _dispatch_mla_subtype(attn, forward_batch)
@@ -193,6 +198,12 @@ def handle_attention_dsa(attn, forward_batch):
 
 
 def handle_attention_triton(attn, forward_batch):
+    # dLLM decodes a fixed-size bidirectional block via absorbed MLA. Route it
+    # explicitly before the extend/prefix checks below, which read
+    # extend_prefix_lens_cpu (None during dLLM cuda-graph capture).
+    if forward_batch.forward_mode.is_dllm_extend():
+        return _dispatch_mla_subtype(attn, forward_batch)
+
     if is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph():
         return AttnForwardMethod.MLA
 

--- a/python/sglang/srt/models/gfusion.py
+++ b/python/sglang/srt/models/gfusion.py
@@ -14,37 +14,23 @@
 
 """Inference-only GFusion model.
 
-GFusion reuses the DeepSeekV3/DeepSeekV2 MLA implementation and weight loading
-path, but switches the attention layers to bidirectional attention for dLLM
-decoding and returns full logits for all positions.
+GFusion reuses the DeepSeekV3/DeepSeekV2 MLA implementation and weight-loading
+path unchanged; it only switches the attention layers to bidirectional
+attention for dLLM decoding and returns full logits for every position.
 """
 
 from typing import Optional
 
-from torch import nn
 from transformers import PretrainedConfig
 
-from sglang.srt.configs.model_config import is_deepseek_dsa
-from sglang.srt.distributed import get_pp_group
-from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
-from sglang.srt.layers.communicator import get_attn_tp_context
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.layers.utils import PPMissingLayer
-from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
-from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
-from sglang.srt.models.deepseek_v2 import (
-    DeepseekV2ForCausalLM,
-    DeepseekV2Model,
-    DeepseekV2MoE,
-)
-from sglang.srt.runtime_context import get_parallel
-from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import LazyValue, add_prefix
+from sglang.srt.models.deepseek_v2 import DeepseekV2ForCausalLM
 
 
-class GFusionModel(DeepseekV2Model):
+class GFusionForDiffusionLM(DeepseekV2ForCausalLM):
     def __init__(
         self,
         config: PretrainedConfig,
@@ -52,92 +38,15 @@ class GFusionModel(DeepseekV2Model):
         prefix: str = "",
     ) -> None:
         super().__init__(config=config, quant_config=quant_config, prefix=prefix)
-        self._enable_bidirectional_attention()
-
-    def _enable_bidirectional_attention(self) -> None:
-        for layer in self.layers:
+        # dLLM decoding: bidirectional (non-causal) attention over each block and
+        # logits for every position in the block.
+        for layer in self.model.layers:
             if isinstance(layer, PPMissingLayer):
                 continue
             layer.self_attn.attn_mqa.attn_type = AttentionType.ENCODER_ONLY
             layer.self_attn.attn_mha.attn_type = AttentionType.ENCODER_ONLY
 
-
-class GFusionModelLM(DeepseekV2ForCausalLM):
-    packed_modules_mapping = {}
-
-    def __init__(
-        self,
-        config: PretrainedConfig,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
-    ) -> None:
-        nn.Module.__init__(self)
-        self.fuse_qkv_a_proj = (
-            hasattr(config, "q_lora_rank") and config.q_lora_rank is not None
-        )
-        if self.fuse_qkv_a_proj:
-            self.packed_modules_mapping["fused_qkv_a_proj_with_mqa"] = [
-                "q_a_proj",
-                "kv_a_proj_with_mqa",
-            ]
-
-        if quant_config is not None:
-            quant_config.update_packed_modules_mapping(self.packed_modules_mapping)
-
-        self.pp_group = get_pp_group()
-        self.config = config
-        self.tp_size = get_parallel().tp_size
-        self.quant_config = quant_config
-        self.determine_num_fused_shared_experts()
-        self.use_dsa = is_deepseek_dsa(config)
-        self.model = GFusionModel(
-            config, quant_config, prefix=add_prefix("model", prefix)
-        )
-
-        if self.pp_group.is_last_rank:
-            if self.pp_group.world_size == 1 and config.tie_word_embeddings:
-                self.lm_head = self.model.embed_tokens
-            else:
-                self.lm_head = ParallelLMHead(
-                    config.vocab_size,
-                    config.hidden_size,
-                    quant_config=quant_config,
-                    prefix=add_prefix("lm_head", prefix),
-                    use_attn_tp_group=get_global_server_args().enable_dp_lm_head,
-                )
-        else:
-            self.lm_head = PPMissingLayer()
         self.logits_processor = LogitsProcessor(config, return_full_logits=True)
 
-        self._routed_experts_weights_of_layer = LazyValue(
-            lambda: {
-                layer_id: layer.mlp.get_moe_weights()
-                for layer_id, layer in enumerate(self.model.layers)
-                if isinstance(layer.mlp, DeepseekV2MoE)
-            }
-        )
-        self.capture_aux_hidden_states = False
 
-        self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
-        self.mla_enable_prefill_cp = (
-            is_prefill_context_parallel_enabled() and not is_deepseek_dsa(config)
-        )
-        if self.dsa_enable_prefill_cp or self.mla_enable_prefill_cp:
-            self.cp_rank = get_parallel().attn_cp_rank
-            self.cp_size = get_parallel().attn_cp_size
-        else:
-            self.cp_rank = self.cp_size = None
-
-        q_lora_rank = config.q_lora_rank if hasattr(config, "q_lora_rank") else None
-        get_attn_tp_context().init_context(q_lora_rank, is_deepseek_dsa(config))
-
-    def determine_num_fused_shared_experts(self, architecture: Optional[str] = None):
-        if architecture is None:
-            architectures = getattr(self.config, "architectures", None) or [
-                "GFusionModelLM"
-            ]
-            architecture = architectures[0]
-        return super().determine_num_fused_shared_experts(architecture=architecture)
-
-
-EntryClass = GFusionModelLM
+EntryClass = GFusionForDiffusionLM

--- a/python/sglang/srt/models/gfusion.py
+++ b/python/sglang/srt/models/gfusion.py
@@ -31,6 +31,8 @@ from sglang.srt.models.deepseek_v2 import DeepseekV2ForCausalLM
 
 
 class GFusionForDiffusionLM(DeepseekV2ForCausalLM):
+    packed_modules_mapping = {}
+
     def __init__(
         self,
         config: PretrainedConfig,

--- a/python/sglang/srt/models/gfusion.py
+++ b/python/sglang/srt/models/gfusion.py
@@ -1,0 +1,143 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Inference-only GFusion model.
+
+GFusion reuses the DeepSeekV3/DeepSeekV2 MLA implementation and weight loading
+path, but switches the attention layers to bidirectional attention for dLLM
+decoding and returns full logits for all positions.
+"""
+
+from typing import Optional
+
+from torch import nn
+from transformers import PretrainedConfig
+
+from sglang.srt.configs.model_config import is_deepseek_dsa
+from sglang.srt.distributed import get_pp_group
+from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
+from sglang.srt.layers.communicator import get_attn_tp_context
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+from sglang.srt.models.deepseek_v2 import (
+    DeepseekV2ForCausalLM,
+    DeepseekV2Model,
+    DeepseekV2MoE,
+)
+from sglang.srt.runtime_context import get_parallel
+from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils import LazyValue, add_prefix
+
+
+class GFusionModel(DeepseekV2Model):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(config=config, quant_config=quant_config, prefix=prefix)
+        self._enable_bidirectional_attention()
+
+    def _enable_bidirectional_attention(self) -> None:
+        for layer in self.layers:
+            if isinstance(layer, PPMissingLayer):
+                continue
+            layer.self_attn.attn_mqa.attn_type = AttentionType.ENCODER_ONLY
+            layer.self_attn.attn_mha.attn_type = AttentionType.ENCODER_ONLY
+
+
+class GFusionModelLM(DeepseekV2ForCausalLM):
+    packed_modules_mapping = {}
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        nn.Module.__init__(self)
+        self.fuse_qkv_a_proj = (
+            hasattr(config, "q_lora_rank") and config.q_lora_rank is not None
+        )
+        if self.fuse_qkv_a_proj:
+            self.packed_modules_mapping["fused_qkv_a_proj_with_mqa"] = [
+                "q_a_proj",
+                "kv_a_proj_with_mqa",
+            ]
+
+        if quant_config is not None:
+            quant_config.update_packed_modules_mapping(self.packed_modules_mapping)
+
+        self.pp_group = get_pp_group()
+        self.config = config
+        self.tp_size = get_parallel().tp_size
+        self.quant_config = quant_config
+        self.determine_num_fused_shared_experts()
+        self.use_dsa = is_deepseek_dsa(config)
+        self.model = GFusionModel(
+            config, quant_config, prefix=add_prefix("model", prefix)
+        )
+
+        if self.pp_group.is_last_rank:
+            if self.pp_group.world_size == 1 and config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    quant_config=quant_config,
+                    prefix=add_prefix("lm_head", prefix),
+                    use_attn_tp_group=get_global_server_args().enable_dp_lm_head,
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+        self.logits_processor = LogitsProcessor(config, return_full_logits=True)
+
+        self._routed_experts_weights_of_layer = LazyValue(
+            lambda: {
+                layer_id: layer.mlp.get_moe_weights()
+                for layer_id, layer in enumerate(self.model.layers)
+                if isinstance(layer.mlp, DeepseekV2MoE)
+            }
+        )
+        self.capture_aux_hidden_states = False
+
+        self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
+        self.mla_enable_prefill_cp = (
+            is_prefill_context_parallel_enabled() and not is_deepseek_dsa(config)
+        )
+        if self.dsa_enable_prefill_cp or self.mla_enable_prefill_cp:
+            self.cp_rank = get_parallel().attn_cp_rank
+            self.cp_size = get_parallel().attn_cp_size
+        else:
+            self.cp_rank = self.cp_size = None
+
+        q_lora_rank = config.q_lora_rank if hasattr(config, "q_lora_rank") else None
+        get_attn_tp_context().init_context(q_lora_rank, is_deepseek_dsa(config))
+
+    def determine_num_fused_shared_experts(self, architecture: Optional[str] = None):
+        if architecture is None:
+            architectures = getattr(self.config, "architectures", None) or [
+                "GFusionModelLM"
+            ]
+            architecture = architectures[0]
+        return super().determine_num_fused_shared_experts(architecture=architecture)
+
+
+EntryClass = GFusionModelLM

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5107,6 +5107,7 @@ class ServerArgs:
 
         if model_arch in [
             "DeepseekV3ForCausalLM",
+            "GFusionModelLM",
             "DeepseekV32ForCausalLM",
             "KimiK25ForConditionalGeneration",
             "MistralLarge3ForCausalLM",
@@ -7829,6 +7830,7 @@ class ServerArgs:
                     is_deepseek_model = model_arch in [
                         "DeepseekV2ForCausalLM",
                         "DeepseekV3ForCausalLM",
+                        "GFusionModelLM",
                         "DeepseekV32ForCausalLM",
                         "MistralLarge3ForCausalLM",
                         "PixtralForConditionalGeneration",
@@ -7999,9 +8001,13 @@ class ServerArgs:
     def _handle_dllm_inference(self):
         if self.dllm_algorithm is None:
             return
-        # On AMD/HIP, disable cuda graph for DLLM (the attention_backend
-        # resolution moved to the pipeline: arg_groups/overrides.py
-        # _dllm_attention_backend, invoked below at its legacy slot).
+        if self.speculative_algorithm is not None:
+            raise ValueError(
+                "Diffusion LLM inference does not support speculative decoding. "
+                "--dllm-algorithm cannot be used together with --speculative-algorithm."
+            )
+        # On AMD/HIP, disable cuda graph for DLLM (the attention backend
+        # resolution moved to the pipeline in arg_groups/overrides.py).
         if is_hip():
             if (
                 self.cuda_graph_config.decode.backend != Backend.DISABLED

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8001,11 +8001,6 @@ class ServerArgs:
     def _handle_dllm_inference(self):
         if self.dllm_algorithm is None:
             return
-        if self.speculative_algorithm is not None:
-            raise ValueError(
-                "Diffusion LLM inference does not support speculative decoding. "
-                "--dllm-algorithm cannot be used together with --speculative-algorithm."
-            )
         # On AMD/HIP, disable cuda graph for DLLM (the attention backend
         # resolution moved to the pipeline in arg_groups/overrides.py).
         if is_hip():

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5107,7 +5107,7 @@ class ServerArgs:
 
         if model_arch in [
             "DeepseekV3ForCausalLM",
-            "GFusionModelLM",
+            "GFusionForDiffusionLM",
             "DeepseekV32ForCausalLM",
             "KimiK25ForConditionalGeneration",
             "MistralLarge3ForCausalLM",
@@ -7830,7 +7830,7 @@ class ServerArgs:
                     is_deepseek_model = model_arch in [
                         "DeepseekV2ForCausalLM",
                         "DeepseekV3ForCausalLM",
-                        "GFusionModelLM",
+                        "GFusionForDiffusionLM",
                         "DeepseekV32ForCausalLM",
                         "MistralLarge3ForCausalLM",
                         "PixtralForConditionalGeneration",

--- a/test/registered/dllm/test_gfusion.py
+++ b/test/registered/dllm/test_gfusion.py
@@ -1,0 +1,88 @@
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=500, stage="base-b", runner_config="1-gpu-large")
+
+import unittest
+from types import SimpleNamespace
+from typing import List, Optional
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+class TestGFusion(CustomTestCase):
+    extra_args: Optional[List[str]] = None  # None marks the abstract base
+
+    @classmethod
+    def setUpClass(cls):
+        if cls.extra_args is None:
+            raise unittest.SkipTest("Skip the abstract base test class")
+
+        cls.model = "ai-sage/GFusion-10B-A1.8B"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "fa3",
+                "--dllm-algorithm",
+                "EBSampling",
+                "--mem-fraction-static",
+                "0.85",
+                "--max-running-requests",
+                "32",
+                "--cuda-graph-bs",
+                "1",
+                "2",
+                "4",
+                "8",
+                "16",
+                "24",
+                "32",
+                *cls.extra_args,
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        metrics = run_eval(
+            SimpleNamespace(
+                base_url=self.base_url,
+                model=self.model,
+                eval_name="mmlu",
+                api="chat",
+                max_tokens=512,
+                num_examples=200,
+                num_threads=64,
+            )
+        )
+        print(f"{type(self).__name__} mmlu={metrics['score']:.4f}")
+        self.assertGreater(metrics["score"], 0.65)
+
+
+class TestGFusionPageSize1NoRadix(TestGFusion):
+    extra_args = ["--page-size", "1", "--disable-radix-cache"]
+
+
+class TestGFusionPageSizeBlockNoRadix(TestGFusion):
+    extra_args = ["--page-size", "32", "--disable-radix-cache"]
+
+
+class TestGFusionRadixCache(TestGFusion):
+    extra_args = []
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/dllm/test_gfusion.py
+++ b/test/registered/dllm/test_gfusion.py
@@ -36,6 +36,7 @@ class TestGFusion(CustomTestCase):
                 "fa3",
                 "--dllm-algorithm",
                 "EBSampling",
+                "--no-dllm-fdfo",
                 "--mem-fraction-static",
                 "0.85",
                 "--max-running-requests",


### PR DESCRIPTION
## Motivation

This PR adds support for a new diffusion LLM (dLLM) model and a new dLLM decoding algorithm.

**GFusion** (`ai-sage/GFusion-10B-A1.8B`) is a Mixture-of-Experts diffusion language model built on the DeepSeek-V3 **MLA** architecture (10B total / 1.8B active parameters). Since it reuses DeepSeek-V3's MLA blocks and weight layout, the model itself is a thin subclass. The real change is adapting the MLA attention backends to run the DLLM_EXTEND (bidirectional block-decode) forward mode.

**EBSampling** (entropy-bounded sampling) is a new, model-agnostic dLLM decoding algorithm. Instead of revealing tokens whose confidence exceeds a fixed threshold (as `LowConfidence` does), it reveals the lowest-entropy masked token in each block and then keeps revealing tokens while the running cumulative-entropy prefix stays within a budget `gamma`. This lets it commit more tokens per forward pass at matched output quality.

## Modifications

**New model** — `models/gfusion.py`: `GFusionForDiffusionLM`, a `DeepseekV2ForCausalLM` subclass that reuses MLA, only flipping attention to `AttentionType.ENCODER_ONLY` and setting `return_full_logits=True`. `dllm/config.py` registers the GFusion arch defaults (`block_size=32`, `mask_id=128170`).

**New dLLM algorithm** — `dllm/algorithm/eb_sampling.py`: `EBSampling` suppresses the mask token before argmax/entropy, then reveals the prefix of lowest-entropy masked tokens whose cumulative entropy stays within `gamma` (vectorized, `gamma=0.15` default).

**`DLLM_EXTEND` for the MLA attention backends** — previously only flashinfer handled dLLM extend, but its MLA kernel rejects GFusion's `v_head_dim=192`, so fa3/triton are required:
- `flashattention_backend.py` — `DLLM_EXTEND` metadata for **fa3** (eager + cuda-graph capture/replay): fixed per-block `cu_seqlens_q`, prefix `cu_seqlens_k`, page table strided by the shared `page_size > 1` conversion.
- `triton_backend.py` — equivalent QO/KV buffers and cuda-graph metadata for **triton**.
- `models/deepseek_common/attention_backend_handler.py` — route `DLLM_EXTEND` to absorbed MLA for fa3/triton, bypassing the causal MHA chunked-prefix path (which reads `extend_prefix_lens_cpu`).

**Plumbing** — `configs/model_config.py` and `server_args.py` register `GFusionForDiffusionLM` in the DeepSeek MLA arch lists (MLA / FP8-detection / DP), and `server_args.py` allows `fa3`/`triton` under cuda graph for dLLM.

**Tests & docs**
- `test/registered/dllm/test_gfusion.py` — E2E generative-MMLU accuracy tests;
- `docs_new/docs/supported-models/diffusion_language_models.mdx` — documented the `EBSampling` algorithm + config and added GFusion to the supported-models table.

## Accuracy Tests

GFusion-10B-A1.8B (`EBSampling` `gamma=0.15`, fa3) vs. the published model card:

| Benchmark             | SGLang (this PR) | Model card |
| --------------------- | ---------------- | ---------- |
| MMLU (generative)     | **0.737**        | 73.38      |
| MATH-500              | **0.676**        | 68.08      |

Metric values are within the range expected for a generative (non-few-shot-loglikelihood) protocol.

**CI test** launches GFusion on fa3 backend + EBSampling and runs generative MMLU (`num_examples=200`):

| Config (subclass)                | `page_size` | radix cache | MMLU@200 |
| -------------------------------- | ----------- | ----------- | -------- |
| `TestGFusionPageSize1NoRadix`    | 1           | disabled    | ✅ pass   |
| `TestGFusionPageSizeBlockNoRadix`| 32 (=block) | disabled    | ✅ pass   |
| `TestGFusionRadixCache`          | 32 (default)| enabled     | ✅ pass   |

The `0.65` threshold sits far above a corrupted/mis-templated run (`0.25`), so it gates real regressions without flaking on concurrency-induced score drift (runs at `num_threads=64` result in `0.72-0.75`).

## Speed Tests and Profiling

### EBSampling vs LowConfidence throughput

Output-token throughput (tok/s) for GFusion on fa3 (8×H100), measured with `sglang.bench_serving` on ShareGPT, greedy decoding. Generated-token counts were **identical across all six configs**, so these are pure decode-speed comparisons:

| Algorithm      | Setting      | Concurrency 1 (single-user) | Concurrency 32 |
| -------------- | ------------ | --------------------------- | -------------- |
| LowConfidence  | thr = 0.95   | 342.6                       | 1002.5         |
| LowConfidence  | thr = 0.90   | 370.6                       | 1026.3         |
| LowConfidence  | thr = 0.85   | 393.6                       | 1046.3         |
| **EBSampling** | gamma = 0.35 | 270.2                       | 1046.5         |
| **EBSampling** | gamma = 0.50 | 292.2                       | 1100.4         |
| **EBSampling** | gamma = 0.70 | 313.6                       | **1161.4**     |

### EBSampling generalizes beyond GFusion

To motivate EBSampling as a general dLLM decoder (not just for GFusion), we benchmarked it against the existing `LowConfidence` algorithm on **LLaDA2.0-mini-preview** (flashinfer, `page_size=32` + radix, 8×H100).

Throughput is measured with `sglang.bench_serving` on ShareGPT (300 prompts, concurrency 32) and quality is measured on GSM8K benchmark.

| Algorithm    | Setting     | GSM8K  | Throughput @ conc 32 (tok/s) |
| ------------ | ----------- | ----- | ------------------ |
| LowConfidence| thr = 0.95  | 0.840 | 647                |
| LowConfidence| thr = 0.90  | 0.820 | 658                |
| LowConfidence| thr = 0.85  | 0.815  | 674                |
| **EBSampling** | gamma = 0.35 | 0.840 | 673                |
| **EBSampling** | gamma = 0.50 | 0.835 | 709                |
| **EBSampling** | gamma = 0.70 | 0.820 | 716                |

At **matched GSM8K quality, EBSampling is ~4–8% faster**.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — `test/registered/dllm/test_gfusion.py` (page_size × radix matrix, generative MMLU).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — `docs_new/docs/supported-models/diffusion_language_models.mdx` (EBSampling + GFusion).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31064986061](https://github.com/sgl-project/sglang/actions/runs/31064986061)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31064985862](https://github.com/sgl-project/sglang/actions/runs/31064985862)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->