### PR TITLE
[LPLB] Replace hand-written cholesky with cuSolverDx::posv for IPM

### DIFF
--- a/python/sglang/jit_kernel/csrc/lplb/ipm.cuh
+++ b/python/sglang/jit_kernel/csrc/lplb/ipm.cuh
@@ -27,6 +27,7 @@
 
 #include <cstdint>
 #include <cublasdx.hpp>
+#include <cusolverdx.hpp>
 
 namespace {
 
@@ -42,75 +43,37 @@ struct ipm_smem {
   float r[NV];
   float d[NV];
   float alpha;
+  int solve_status;
   bool avail_flag;
 };
 
-// In-place Cholesky factorization a = L L^T (lower triangle), no external
-// linkage. Replaces cuSolverDx::posv to keep the kernel self-contained
-// under sglang's tvm-ffi load_jit (which uses plain c++ for the final
-// link step and so cannot satisfy cuSolverDx's device-link requirement).
-//
-// For the typical LPLB shape (N <= 32) the algorithm is dwarfed by the
-// cuBLASDx GEMMs.
-template <int N, int BLOCK_DIM>
-__device__ __forceinline__ void cholesky_factor(float a[N][N]) {
-  const int tid = threadIdx.x;
-  for (int k = 0; k < N; k++) {
-    if (tid == 0) {
-      // Clamp the pivot away from zero before sqrtf. Numerical drift in
-      // the IPM iterations can push a[k][k] slightly negative on
-      // otherwise-PSD matrices, which would produce NaN and propagate
-      // through the rest of the solve. The convergence check at the end
-      // of the kernel writes 0.5 on non-convergence regardless.
-      a[k][k] = sqrtf(fmaxf(a[k][k], 1e-12f));
-    }
-    __syncthreads();
-    const float pivot = a[k][k];
-    for (int i = k + 1 + tid; i < N; i += BLOCK_DIM) {
-      a[i][k] /= pivot;
-    }
-    __syncthreads();
-    // Schur complement: a[i][j] -= a[i][k] * a[j][k] for j>k, i>=j
-    for (int idx = tid; idx < N * N; idx += BLOCK_DIM) {
-      const int i = idx / N, j = idx % N;
-      if (j > k && i >= j && i < N) {
-        a[i][j] -= a[i][k] * a[j][k];
-      }
-    }
-    __syncthreads();
+template <int N, int SM_VER, int BLOCK_DIM>
+__device__ __forceinline__ void posv_solve(float a[N][N], float b[N], int* status) {
+  if (threadIdx.x == 0) {
+    *status = 0;
   }
-}
+  __syncthreads();
 
-// Solve L L^T x = b in-place on b, where L is the lower triangle of a
-// (filled by `cholesky_factor`). Forward then back substitution; both
-// run on a single thread because N is small and the inner loops have
-// loop-carried dependencies that don't parallelize cheaply.
-template <int N, int BLOCK_DIM>
-__device__ __forceinline__ void cholesky_apply(const float a[N][N], float b[N]) {
-  const int tid = threadIdx.x;
-  if (tid == 0) {
-    for (int i = 0; i < N; i++) {
-      float s = b[i];
-      for (int j = 0; j < i; j++) {
-        s -= a[i][j] * b[j];
-      }
-      b[i] = s / a[i][i];
-    }
-    for (int i = N - 1; i >= 0; i--) {
-      float s = b[i];
-      for (int j = i + 1; j < N; j++) {
-        s -= a[j][i] * b[j];
-      }
-      b[i] = s / a[i][i];
+  using Posv = decltype(cusolverdx::Size<N, N, 1>() +
+                        cusolverdx::Function<cusolverdx::function::posv>() +
+                        cusolverdx::Precision<float>() +
+                        cusolverdx::Type<cusolverdx::type::real>() +
+                        cusolverdx::FillMode<cusolverdx::fill_mode::lower>() +
+                        cusolverdx::Arrangement<cusolverdx::row_major, cusolverdx::col_major>() +
+                        cusolverdx::SM<SM_VER>() +
+                        cusolverdx::Block() +
+                        cusolverdx::BlockDim<BLOCK_DIM>() +
+                        cusolverdx::BatchesPerBlock<1>());
+
+  Posv().execute(a[0], /*runtime_lda=*/N, b, /*runtime_ldb=*/N, status);
+  __syncthreads();
+
+  if (*status != 0) {
+    for (int i = threadIdx.x; i < N; i += BLOCK_DIM) {
+      b[i] = __int_as_float(0x7fffffff);
     }
   }
   __syncthreads();
-}
-
-template <int N, int SM_VER, int BLOCK_DIM>
-__device__ __forceinline__ void cholesky_solve(float a[N][N], float b[N]) {
-  cholesky_factor<N, BLOCK_DIM>(a);
-  cholesky_apply<N, BLOCK_DIM>(a, b);
 }
 
 template <int M, int N, int K, int SM_VER, int BLOCK_DIM>
@@ -182,7 +145,7 @@ __global__ void ipm_solve_kernel(
 
     matmul_NT<NC, NC, NV, SM_VER, BLOCK_DIM>(ax2[0], a[0], ax2a[0]);
     matmul_NT<NC, 1, NV, SM_VER, BLOCK_DIM>(ax2[0], c, ax2c);
-    cholesky_solve<NC, SM_VER, BLOCK_DIM>(ax2a, ax2c);
+    posv_solve<NC, SM_VER, BLOCK_DIM>(ax2a, ax2c, &smem->solve_status);
     matmul_NN<1, NV, NC, SM_VER, BLOCK_DIM>(ax2c, a[0], r);
 
     if (tid < 32) {

--- a/python/sglang/jit_kernel/lplb/cuda_solver.py
+++ b/python/sglang/jit_kernel/lplb/cuda_solver.py
@@ -20,6 +20,7 @@ import torch
 from sglang.jit_kernel.utils import (
     cache_once,
     get_jit_cuda_arch,
+    get_mathdx_cusolverdx_link_inputs,
     load_jit,
     make_cpp_args,
 )
@@ -46,16 +47,17 @@ def _ipm_module(
 ) -> Module:
     """JIT-compile the IPM kernel for one shape. Cached for the process lifetime."""
     args = make_cpp_args(nc, nv, block_dim, sm_ver, num_iters)
-    # The kernel uses cuBLASDx (header-only) for the GEMMs and a hand-written
-    # block-level Cholesky for the POSV. No -rdc=true / static-lib linkage
-    # required, so sglang's tvm-ffi load_jit handles the build with the
-    # default flags.
+    # The kernel uses cuBLASDx for the GEMMs and cuSolverDx POSV for the
+    # Cholesky solve. cuSolverDx requires relocatable device code plus an
+    # nvcc device-link step against the MathDx cuSolverDx LTO/fatbin artifact.
     return load_jit(
         "lplb_ipm",
         *args,
         cuda_files=["lplb/ipm.cuh"],
         cuda_wrappers=[("ipm_solve", f"ipm_solve<{args}>")],
         extra_dependencies=["mathdx"],
+        cuda_device_link=True,
+        cuda_device_link_inputs=get_mathdx_cusolverdx_link_inputs(),
     )
 
 
@@ -87,8 +89,7 @@ def solve_ipm(
 ) -> torch.Tensor:
     """Run the fused single-SM IPM kernel.
 
-    cuBLASDx GEMMs + hand-written block Cholesky, dispatched per the
-    module docstring.
+    cuBLASDx GEMMs + cuSolverDx POSV, dispatched per the module docstring.
 
     Args:
         A: Constraint matrix, shape ``(NC, NV)``, float32, on CUDA.

--- a/python/sglang/jit_kernel/lplb/torch_solver.py
+++ b/python/sglang/jit_kernel/lplb/torch_solver.py
@@ -4,12 +4,13 @@ Solves: min c^T x  subject to  Ax = b, x >= 0
 using a barrier (interior point) method with 5 iterations.
 
 The fused kernel lives in ``cuda_solver`` (CUDA C++ via ``load_jit``,
-backed by header-only cuBLASDx + a hand-written block Cholesky). This
+backed by cuBLASDx GEMMs + cuSolverDx POSV). This
 module is the public-facing import surface for callers (``LPLBSolver``)
 and resolves/caches the backend on first use.
 
-LPLB requires Hopper-class hardware and Math-DX cuBLASDx headers. If
-either is missing, ``warmup`` and ``solve_ipm`` raise — there is no
+LPLB requires Hopper-class hardware and a Math-DX install with cuBLASDx
+headers plus the cuSolverDx device-link artifact. If either is missing,
+``warmup`` and ``solve_ipm`` raise — there is no
 silent fallback.
 """
 
@@ -56,7 +57,7 @@ def _init_fused_backend() -> None:
     except ImportError as e:
         logger.info(
             f"LPLB fused solver disabled: {e}. "
-            "Install Math-DX cuBLASDx via `pip install nvidia-mathdx` "
+            "Install a full Math-DX distribution with cuBLASDx/cuSolverDx "
             "or set MATHDX_HOME to an extracted archive."
         )
         return
@@ -75,8 +76,8 @@ def _unavailable_reason() -> str:
     if cap[0] < 9:
         return f"GPU SM {cap[0]}.{cap[1]} < 9.0 (requires Hopper or newer)"
     return (
-        "Math-DX cuBLASDx headers not found — install via "
-        "`pip install nvidia-mathdx` or set MATHDX_HOME"
+        "Math-DX cuBLASDx/cuSolverDx headers or cuSolverDx device-link "
+        "artifact not found — set MATHDX_HOME to a full Math-DX archive"
     )
 
 
@@ -104,8 +105,8 @@ def solve_ipm(
     """Barrier-method Interior Point solver for standard-form LP.
 
     Dispatches to the JIT-compiled CUDA C++ kernel (Hopper+ GPU with
-    Math-DX cuBLASDx headers, reachable via ``nvidia-mathdx`` PyPI
-    package or ``MATHDX_HOME``). Raises if the fused backend is
+    Math-DX cuBLASDx/cuSolverDx headers and cuSolverDx device-link
+    artifact, reachable via ``MATHDX_HOME``). Raises if the fused backend is
     unavailable or the inputs aren't on CUDA in float32.
 
     Args:
@@ -158,9 +159,9 @@ def solve_ipm_torch_reference(
           x    *= 1 - alpha * d
       write 0.5 everywhere on non-convergence.
 
-    NOT bit-equivalent to the kernel: the kernel factors the KKT system
-    with a hand-written block Cholesky while this uses
-    ``torch.linalg.solve`` (LU). The two agree to a small tolerance
+    NOT bit-equivalent to the kernel: the kernel factors/solves the KKT
+    system with cuSolverDx POSV while this uses ``torch.linalg.solve`` (LU).
+    The two agree to a small tolerance
     (the numerical difference being the whole point of the comparison
     test). This function is never on the production path — the fused
     kernel is the only LP solver at runtime.

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -203,6 +203,198 @@ def _jit_build_dir_name(module_name: str) -> str:
     return f"{module_name}__arch_{arch}__tvmffi_{_tvm_ffi_version()}"
 
 
+def _hash_string_list(values: List[str]) -> str:
+    """Short stable digest for external JIT inputs not covered by source hash.
+
+    ``_local_jit_source_hash`` only tracks ``#include``'d kernel sources.
+    Device-link inputs (e.g. ``libcusolverdx.fatbin``) are linked binaries,
+    not included headers, so they need a separate cache-key component.
+    """
+    digest = hashlib.sha256()
+    for value in values:
+        digest.update(value.encode())
+        digest.update(b"\0")
+    return digest.hexdigest()[:16]
+
+
+def _append_unique(values: List[str], extra_values: List[str]) -> List[str]:
+    """Return ``values`` with any missing entries from ``extra_values`` appended."""
+    result = list(values)
+    for value in extra_values:
+        if value not in result:
+            result.append(value)
+    return result
+
+
+def _ninja_escape_path(path: str) -> str:
+    """Escape ``:`` for Ninja build rules (Ninja treats it as a separator)."""
+    return path.replace(":", "$:")
+
+
+_CUDA_GENCODE_RE = re.compile(r"-gencode=arch=compute_([0-9]+[a-z]?),code=sm_\1")
+
+
+def _enable_cuda_lto_in_ninja(ninja_source: str) -> str:
+    """Make tvm-ffi's CUDA compile rule produce LTO-capable RDC objects.
+
+    tvm-ffi emits ``-gencode=arch=compute_XX,code=sm_XX``, which builds a
+    normal fatbin object.  Device-link against MathDx prebuilt fatbins
+    (``nvcc -dlink -dlto``) requires ``-arch=sm_XX -dlto`` so ``cuda_0.o``
+    is relocatable and LTO-mergeable with ``libcusolverdx.fatbin``.
+    """
+    lines = []
+    replaced_cuda_flags = False
+    for line in ninja_source.splitlines():
+        if line.startswith("cuda_cflags = "):
+            line, num_replacements = _CUDA_GENCODE_RE.subn(r"-arch=sm_\1", line)
+            if num_replacements == 0:
+                raise RuntimeError(
+                    "Unexpected tvm-ffi Ninja layout: missing CUDA gencode flag"
+                )
+            tokens = line.split()
+            if "-dlto" not in tokens:
+                tokens.append("-dlto")
+            line = " ".join(tokens)
+            replaced_cuda_flags = True
+        lines.append(line)
+    if not replaced_cuda_flags:
+        raise RuntimeError("Unexpected tvm-ffi Ninja layout: missing cuda_cflags")
+    return "\n".join(lines) + "\n"
+
+
+def _inject_cuda_device_link(
+    ninja_source: str,
+    module_name: str,
+    cuda_device_link_inputs: List[str],
+) -> str:
+    """Add an nvcc -dlink stage to tvm-ffi's generated Ninja graph.
+
+    tvm-ffi's ``load_inline`` compiles CUDA to ``cuda_0.o`` then host-links
+    directly to ``.so``.  cuSolverDx POSV needs an intermediate step that
+    merges our RDC object with MathDx device code.  We patch the generated
+    ``build.ninja`` because tvm-ffi exposes no device-link hook (layout is
+    assumed stable — see RuntimeError checks below).
+    """
+    escaped_inputs = " ".join(
+        _ninja_escape_path(path) for path in cuda_device_link_inputs
+    )
+    device_link_block = "\n".join(
+        [
+            f"cuda_device_link_inputs = {escaped_inputs}",
+            "",
+            "rule device_link_cuda",
+            "  command = $nvcc -dlink -dlto $cuda_cflags $in $cuda_device_link_inputs -o $out",
+            "",
+            f"build cuda_device_link.o: device_link_cuda cuda_0.o | {escaped_inputs}",
+            "",
+        ]
+    )
+
+    if "\nrule link\n" not in ninja_source:
+        raise RuntimeError("Unexpected tvm-ffi Ninja layout: missing link rule")
+    ninja_source = ninja_source.replace(
+        "\nrule link\n", f"\n{device_link_block}\nrule link\n", 1
+    )
+
+    link_prefix = f"build {module_name}.so: link "
+    lines = []
+    replaced = False
+    for line in ninja_source.splitlines():
+        if line.startswith(link_prefix):
+            line = f"{line} cuda_device_link.o"
+            replaced = True
+        lines.append(line)
+    if not replaced:
+        raise RuntimeError(
+            "Unexpected tvm-ffi Ninja layout: missing shared library target"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _load_inline_with_cuda_device_link(
+    module_name: str,
+    *,
+    cpp_sources: List[str],
+    cuda_sources: List[str],
+    extra_cflags: List[str],
+    extra_cuda_cflags: List[str],
+    extra_ldflags: List[str],
+    extra_include_paths: List[str],
+    build_directory: str,
+    cuda_device_link_inputs: List[str],
+) -> Module:
+    """JIT-compile like ``load_inline``, but with CUDA device-link support.
+
+    Build pipeline: nvcc (``-rdc=true``, LTO flags) → ``cuda_0.o`` →
+    ``nvcc -dlink -dlto`` + external fatbin → ``cuda_device_link.o`` →
+    host link (``-lcudadevrt``) → ``.so``.  Mirrors tvm-ffi internals
+    because the public API has no device-link entry point.
+    """
+    if os.name == "nt":
+        raise NotImplementedError("CUDA device-link JIT is only supported on Unix.")
+    if not cuda_sources:
+        raise ValueError("CUDA device-link JIT requires CUDA sources.")
+    if not cuda_device_link_inputs:
+        raise ValueError("CUDA device-link JIT requires device-link inputs.")
+
+    from tvm_ffi import load_module
+    from tvm_ffi.cpp.extension import (
+        _decorate_with_tvm_ffi,
+        _generate_ninja_build,
+        _maybe_write,
+        build_ninja,
+    )
+    from tvm_ffi.utils import FileLock
+
+    build_dir = pathlib.Path(build_directory).expanduser().resolve()
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    resolved_link_inputs = [
+        str(pathlib.Path(path).expanduser().resolve()) for path in cuda_device_link_inputs
+    ]
+    missing_inputs = [
+        path for path in resolved_link_inputs if not pathlib.Path(path).is_file()
+    ]
+    if missing_inputs:
+        raise RuntimeError(
+            "CUDA device-link input(s) not found: " + ", ".join(missing_inputs)
+        )
+
+    cpp_source = _decorate_with_tvm_ffi("\n".join(cpp_sources), {})
+    cuda_source = _decorate_with_tvm_ffi("\n".join(cuda_sources), {})
+    cpp_file = str((build_dir / "main.cpp").resolve())
+    cuda_file = str((build_dir / "cuda.cu").resolve())
+
+    # -rdc=true: relocatable device code required for nvcc -dlink.
+    # -lcudadevrt: CUDA device runtime needed when linking RDC objects.
+    cuda_cflags = _append_unique(extra_cuda_cflags, ["-rdc=true"])
+    ldflags = _append_unique(extra_ldflags, ["-lcudadevrt"])
+
+    with FileLock(str(build_dir / "lock")):
+        if cpp_sources:
+            _maybe_write(cpp_file, cpp_source)
+        _maybe_write(cuda_file, cuda_source)
+
+        ninja_source = _generate_ninja_build(
+            name=module_name,
+            extra_cflags=extra_cflags,
+            extra_cuda_cflags=cuda_cflags,
+            extra_ldflags=ldflags,
+            extra_include_paths=extra_include_paths,
+            cpp_files=[cpp_file] if cpp_sources else [],
+            cuda_files=[cuda_file],
+            backend="cuda",
+        )
+        ninja_source = _enable_cuda_lto_in_ninja(ninja_source)
+        ninja_source = _inject_cuda_device_link(
+            ninja_source, module_name, resolved_link_inputs
+        )
+        _maybe_write(str(build_dir / "build.ninja"), ninja_source)
+        build_ninja(str(build_dir))
+
+    return load_module(str((build_dir / f"{module_name}.so").resolve()))
+
+
 def load_jit(
     *args: str,
     cpp_files: List[str] | None = None,
@@ -214,6 +406,8 @@ def load_jit(
     extra_ldflags: List[str] | None = None,
     extra_include_paths: List[str] | None = None,
     extra_dependencies: List[str] | None = None,
+    cuda_device_link: bool = False,
+    cuda_device_link_inputs: List[str] | None = None,
     build_directory: str | None = None,
     header_only: bool = True,
 ) -> Module:
@@ -243,6 +437,17 @@ def load_jit(
     :type extra_include_paths: List[str] | None
     :param extra_dependencies: Extra dependencies for the JIT module, e.g., cutlass.
     :type extra_dependencies: List[str] | None
+    :param cuda_device_link: Opt-in nvcc device-link stage for libraries
+        (e.g. cuSolverDx) that ship precompiled device code rather than
+        header-only kernels.  Default ``False`` keeps the simple
+        compile-and-host-link path used by all other JIT modules.
+    :type cuda_device_link: bool
+    :param cuda_device_link_inputs: LTO/fatbin paths passed to ``nvcc -dlink``
+        (typically ``libcusolverdx.fatbin`` from
+        :func:`get_mathdx_cusolverdx_link_inputs`).  Hashed into
+        ``module_name`` so cached ``.so`` files are not reused across
+        Math-DX upgrades or different link inputs.
+    :type cuda_device_link_inputs: List[str] | None
     :param build_directory: The build directory for JIT compilation.
     :type build_directory: str | None
     :param header_only: Whether the module is header-only.
@@ -260,6 +465,7 @@ def load_jit(
     extra_cuda_cflags = extra_cuda_cflags or []
     extra_ldflags = extra_ldflags or []
     extra_include_paths = extra_include_paths or []
+    cuda_device_link_inputs = cuda_device_link_inputs or []
 
     cpp_files = [str((KERNEL_PATH / "csrc" / f).resolve()) for f in cpp_files]
     cuda_files = [str((KERNEL_PATH / "csrc" / f).resolve()) for f in cuda_files]
@@ -272,6 +478,16 @@ def load_jit(
     module_name = "sgl_kernel_jit_" + "_".join(str(arg) for arg in args)
     if cpp_files or cuda_files:
         module_name += "_" + _local_jit_source_hash(cpp_files + cuda_files)
+    if cuda_device_link:
+        if is_hip_runtime():
+            raise NotImplementedError("CUDA device-link JIT is not supported on ROCm.")
+        if not cuda_files:
+            raise ValueError("cuda_device_link=True requires at least one CUDA source.")
+        cuda_device_link_inputs = [
+            str(pathlib.Path(path).expanduser().resolve())
+            for path in cuda_device_link_inputs
+        ]
+        module_name += "_cuda_dlink_" + _hash_string_list(cuda_device_link_inputs)
 
     # A built .so under a deterministic dir is content-addressed: load it
     # directly to skip ninja, whose mtime check rebuilds every CI run (pip
@@ -304,6 +520,20 @@ def load_jit(
         cuda_sources = [f'#include "{path}"' for path in cuda_files]
         cuda_sources += [_make_wrapper(tup) for tup in cuda_wrappers]
         with _jit_compile_context():
+            # cuSolverDx needs the alternate build; everything
+            # else stays on tvm-ffi's standard load_inline path.
+            if cuda_device_link:
+                return _load_inline_with_cuda_device_link(
+                    module_name,
+                    cpp_sources=cpp_sources,
+                    cuda_sources=cuda_sources,
+                    extra_cflags=DEFAULT_CFLAGS + extra_cflags,
+                    extra_cuda_cflags=_get_default_target_flags() + extra_cuda_cflags,
+                    extra_ldflags=DEFAULT_LDFLAGS + extra_ldflags,
+                    extra_include_paths=DEFAULT_INCLUDE + extra_include_paths,
+                    build_directory=build_directory,
+                    cuda_device_link_inputs=cuda_device_link_inputs,
+                )
             return load_inline(
                 module_name,
                 cpp_sources=cpp_sources,
@@ -315,6 +545,12 @@ def load_jit(
                 build_directory=build_directory,
             )
     else:
+        # Non-header-only modules use tvm_ffi.cpp.load(); device-link
+        # patching is implemented only for the header-only load_inline path.
+        if cuda_device_link:
+            raise NotImplementedError(
+                "cuda_device_link=True is currently supported only for header-only JIT modules."
+            )
         assert cpp_wrappers is None and cuda_wrappers is None
         with _jit_compile_context():
             return load(
@@ -519,6 +755,50 @@ def get_mathdx_include_paths() -> List[str]:
     return [str(p) for p in candidates]
 
 
+@cache_once
+def get_mathdx_cusolverdx_link_inputs() -> List[str]:
+    """Locate cuSolverDx device-link inputs for nvcc -dlink.
+
+    cuBLASDx is header-only for the IPM GEMMs, but cuSolverDx POSV pulls in
+    device code from the MathDx distribution. Use the cuSolverDx fatbin here:
+    the final host link is still tvm-ffi's normal c++ shared-library link.
+    The nvidia-mathdx Python wheel may provide headers without the cuSolverDx
+    database/fatbin artifacts, so fail before launching a long JIT build when
+    the install is incomplete.
+    """
+    root = get_mathdx_root()
+    if root is None:
+        raise RuntimeError(
+            "Cannot find NVIDIA Math-DX. Install a full Math-DX distribution "
+            "or set MATHDX_HOME to an extracted Math-DX archive root."
+        )
+
+    include = root / "include"
+    required_headers = [
+        include / "cusolverdx.hpp",
+        include / "cusolverdx" / "database" / "cholesky.cuh",
+        include / "cusolverdx" / "database" / "trs.cuh",
+    ]
+    missing_headers = [str(path) for path in required_headers if not path.is_file()]
+
+    fatbins = sorted(root.rglob("libcusolverdx.fatbin"))
+
+    if missing_headers or not fatbins:
+        problems = []
+        if missing_headers:
+            problems.append("missing headers: " + ", ".join(missing_headers))
+        if not fatbins:
+            problems.append("missing libcusolverdx.fatbin")
+        raise RuntimeError(
+            "Incomplete Math-DX cuSolverDx installation at "
+            f"{root}: {'; '.join(problems)}. Set MATHDX_HOME to a full "
+            "Math-DX archive that contains cuSolverDx database headers and "
+            "libcusolverdx.fatbin."
+        )
+
+    return [str(fatbins[0])]
+
+
 @register_dependency("cutlass")
 def get_cutlass_include_paths() -> List[str]:
     include_paths: List[str] = []
@@ -567,4 +847,5 @@ __all__ = [
     "get_jit_cuda_arch",
     "is_arch_support_pdl",
     "register_dependency",
+    "get_mathdx_cusolverdx_link_inputs",
 ]

--- a/test/registered/eplb/test_lplb_distributed.py
+++ b/test/registered/eplb/test_lplb_distributed.py
@@ -125,7 +125,7 @@ def test_dispatch_probability_matches_torch_reference():
 def test_solve_ipm_matches_torch_reference():
     """The fused CUDA IPM kernel and the pure-torch reference should agree to
     a small tolerance on a *real* LPLB LP. They are NOT bit-equivalent — the
-    kernel factors the KKT system with a hand-written block Cholesky while the
+    kernel factors/solves the KKT system with cuSolverDx POSV while the
     reference uses torch.linalg.solve (LU) — so we compare with allclose and
     print the max abs difference (the numerical-difference number the review
     asked about).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
SGLang's IPM kernel (ipm.cuh) was adapted from DeepSeek-AI/LPLB’s minilp.cu, which uses cuBLASDx GEMMs + cuSolverDx POSV. Currently a hand-written Cholesky function is used in SGLang because cuSolverDx requires relocatable device code (RDC) + nvcc device-link, while SGLang’s standard load_jit → load_inline path only does compile-then-host-link.
This MR adds the build infrastructure to support nvcc device link so cuSolverDx functions can be used. 

Original JIT kernel:
```
ipm.cuh  →  nvcc  →  cuda_0.o  →  
                     g++ link  →  module.so. (header-only, no -rdc, no -dlink)
```

This MR: LPLB IPM with cuSolverDx:
```
ipm.cuh  →  nvcc (-rdc -dlto -arch=sm_XX)  →  cuda_0.o (RDC/LTO)  →
                    nvcc -dlink -dlto + libcusolverdx.fatbin  →  cuda_device_link.o
                   g++ link cuda_device_link.o + host link  →  module.so
```

## Modifications

<!-- Detail the changes made in this pull request. -->

- python/sglang/jit_kernel/csrc/lplb/ipm.cuh
    - Remove hand-written `cholesky_factor`, `cholesky_apply`, `cholesky_solve`
    - Add `posv_solve` using cuSolverDx POSV
    - Add `solve_status` to shared memory; fill B with NaN on non-zero status

- python/sglang/jit_kernel/utils.py
    - Add opt-in `cuda_device_link `/`cuda_device_link_inputs` parameters to load_jit
    - Add `_load_inline_with_cuda_device_link`: mirrors tvm-ffi `load_inline` internals, patches generated Ninja to insert `nvcc -dlink -dlto`
    - Add `_enable_cuda_lto_in_ninja`, `_inject_cuda_device_link`, helpers for cache keying for tvm-ffi and flag handling
    - Add `get_mathdx_cusolverdx_link_inputs()` to locate `libcusolverdx.fatbin` 
    - Hash device-link inputs into module_name so cached `.so` files are not reused across Math-DX upgrades

- python/sglang/jit_kernel/lplb/cuda_solver.py
    - Enable device-link when JIT-compiling the IPM module: `cuda_device_link=True`, `cuda_device_link_inputs=get_mathdx_cusolverdx_link_inputs()`

- python/sglang/jit_kernel/lplb/torch_solver.py
    - Update docs/error messages: full Math-DX distribution with cuSolverDx headers and fatbin required (PyPI nvidia-mathdx wheel may be headers-only)

- test/registered/eplb/test_lplb_distributed.py
    - Update comment: kernel now uses cuSolverDx POSV (still compared against torch LU reference)

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

`nvidia-mathdx` Python package only supports 25.06 MathDx and headers only.  This MR requires full Math-DX package via MATHDX_HOME containing:
    - cuSolverDx headers (cusolverdx.hpp, cublasdx.hpp)
    - libcusolverdx.fatbin

on H100:
```
dorisp@ipp2-1603:~/local/MathDx/sglang$ MATHDX_HOME=~/local/install/nvidia-mathdx-26.03.0-cuda13/nvidia/mathdx/26.03 PYTHONPATH=python pytest test/registered/eplb/test_lplb_distributed.py::test_solve_ipm_matches_torch_reference -s
======================================================================= test session starts ========================================================================
platform linux -- Python 3.12.9, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/scratch.dorisp_sw/MathDx/sglang/test
configfile: pytest.ini
plugins: anyio-4.8.0
collected 1 item

test/registered/eplb/test_lplb_distributed.py
[ipm-compare] converged=True  max|cuda-torch|=2.854e-05  cuda=[0.2181, 0.1986, 0.1986, 0.0, 0.0003, 0.5002, 0.0]  torch=[0.2181, 0.1986, 0.1986, 0.0, 0.0003, 0.5002, 0.0]

================================================================== 1 passed, 5 warnings in 51.35s ==================================================================
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Profiled on NVIDIA H100, Python 3.12.9, torch 2.11.0+cu130, with:

  ```bash
  PYTHONPATH=python python -m pytest \
    test/registered/eplb/test_lplb_distributed.py::test_solve_ipm_matches_torch_reference \
    -s --durations=0 --durations-min=0
```

 On H100, the fused solver matches the torch reference:

  max|cuda-torch| = 2.854e-05

  Focused CUDA-synchronized timings after JIT warmup:

  fused cuda_solve_ipm:          ~0.009 ms
  torch IPM reference:           ~1.93 ms
  production LPLBSolver._solve:  ~0.0165 ms

  I also instrumented the fused IPM kernel around the cusolverdx::posv call. Across the 5 IPM iterations, posv takes ~467 ns per call, or ~2.3 us total, roughly 25% of the fused cuda_solve_ipm runtime.

  The fused IPM solve itself is therefore in the single-digit microsecond range after warmup. Full pytest wall time is dominated by Python import/startup overhead, not solver runtime.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28471691496](https://github.com/sgl-project/sglang/actions/runs/28471691496)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28471691134](https://github.com/sgl-project/sglang/actions/runs/28471691134)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->