### PR TITLE
[AMD] Enable EAGLE for GLM5.2-MXFP4

### DIFF
--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -68,6 +68,53 @@ _is_cuda = is_cuda()
 _is_npu = is_npu()
 
 
+# ----------------------------------------------------------------------------
+# AMD quark (GLM-5.2-MXFP4) NextN/MTP handling — kept separate from the common
+# nextn logic below. The quark checkpoint keeps the whole MTP layer in bf16 by
+# listing it in the quark `exclude` (keyed by full module name,
+# e.g. "model.layers.<N>.eh_proj"). Two consequences the common path must honor,
+# both gated on quant_config being quark:
+#   * eh_proj must be built with its layer-indexed prefix so quark's per-module
+#     exclude check resolves (a bare "eh_proj" prefix never matches).
+#   * the whole nextn draft must be built unquantized when that layer is excluded.
+# ----------------------------------------------------------------------------
+def _is_quark(quant_config: Optional[QuantizationConfig]) -> bool:
+    return quant_config is not None and quant_config.get_name() == "quark"
+
+
+def nextn_eh_proj_prefix(
+    quant_config: Optional[QuantizationConfig], config: PretrainedConfig, prefix: str
+) -> str:
+    """eh_proj weight-loader prefix. For quark, use the checkpoint's layer-indexed
+    name so the per-module `exclude` resolves and eh_proj stays bf16; otherwise the
+    bare name. (Prefix only drives the quant-method lookup; the param name comes
+    from the module path.)"""
+    if _is_quark(quant_config):
+        return add_prefix(f"layers.{config.num_hidden_layers}.eh_proj", prefix)
+    return add_prefix("eh_proj", prefix)
+
+
+def resolve_nextn_quant_config(
+    quant_config: Optional[QuantizationConfig],
+    config: PretrainedConfig,
+    hf_to_sglang_mapper,
+) -> Optional[QuantizationConfig]:
+    """Return the quant_config the nextn draft should build with. For quark, if the
+    MTP layer is in the `exclude` list (GLM-5.2-MXFP4 keeps it bf16), return None so
+    the whole draft is unquantized. Probes the concrete model.layers.<N>.eh_proj
+    module because should_ignore_layer matches full module names — a bare layer
+    prefix never matches."""
+    if not _is_quark(quant_config):
+        return quant_config
+    from sglang.srt.layers.quantization.quark.utils import should_ignore_layer
+
+    ckpt_prefix = f"model.layers.{config.num_hidden_layers}.eh_proj"
+    mapped_prefix = hf_to_sglang_mapper._map_name(ckpt_prefix)
+    if should_ignore_layer(mapped_prefix, quant_config.exclude_layers):
+        return None
+    return quant_config
+
+
 class DeepseekModelNextN(nn.Module):
 
     def __init__(
@@ -104,13 +151,13 @@ class DeepseekModelNextN(nn.Module):
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-        if quant_config is not None and quant_config.get_name() == "quark":
+        if _is_quark(quant_config):
             self.eh_proj = ReplicatedLinear(
                 2 * config.hidden_size,
                 config.hidden_size,
                 bias=False,
                 quant_config=quant_config,
-                prefix=add_prefix("eh_proj", prefix),
+                prefix=nextn_eh_proj_prefix(quant_config, config, prefix),
             )
         else:
             self.eh_proj = nn.Linear(
@@ -301,17 +348,9 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             self.cp_rank = None
             self.cp_size = None
 
-        nextn_quant_config = quant_config
-        # For quark, if the MTP layer is listed in exclude_layers, set quant_config to None.
-        if nextn_quant_config is not None and nextn_quant_config.get_name() == "quark":
-            from sglang.srt.layers.quantization.quark.utils import (
-                should_ignore_layer,
-            )
-
-            ckpt_prefix = f"model.layers.{config.num_hidden_layers}"
-            mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
-            if should_ignore_layer(mapped_prefix, nextn_quant_config.exclude_layers):
-                nextn_quant_config = None
+        nextn_quant_config = resolve_nextn_quant_config(
+            quant_config, config, self.hf_to_sglang_mapper
+        )
 
         self.model = DeepseekModelNextN(
             config, nextn_quant_config, prefix=add_prefix("model", prefix)


### PR DESCRIPTION
## Motivation

EAGLE / MTP speculative decoding fails on quark-quantized DeepSeek-Sparse-Attention
(DSA) checkpoints — e.g. `amd/GLM-5.2-MXFP4` (`GlmMoeDsaForCausalLM`, one nextn
layer). The base model serves fine, but enabling `--speculative-algorithm EAGLE`
crashes during draft weight load and again at the first decode batch. Three
independent bugs in the nextn / DSA draft path are responsible.

## Modifications

1. **`deepseek_nextn.py` — quark `eh_proj` exclude match.** The nextn `eh_proj`
   was built with the bare `"eh_proj"` prefix, so the quark per-module exclude
   (keyed `model.layers.<N>.eh_proj`) never matched and `eh_proj` was MXFP4 (uint8)
   while the checkpoint keeps it bf16 → `param.shape != loaded_weight.shape` at
   load. Use the layer-indexed prefix (as `bailing_moe_nextn` already does). The
   param name is set by the module path, so it is unaffected — only the
   quant-method lookup changes.

2. **`deepseek_nextn.py` — fully-excluded MTP layer detection.** The all-or-nothing
   "is this MTP layer excluded from quant" check probed the bare `model.layers.<N>`
   prefix, which `should_ignore_layer` does not match against the specific exclude
   entries, so the MTP experts (and `eh_proj`) stayed quantized vs the bf16
   checkpoint. Probe a concrete excluded module (`model.layers.<N>.eh_proj`) so the
   fully-excluded MTP layer builds bf16 (`nextn_quant_config=None`).

3. **`base_spec_worker.py` / `dsa_backend.py` — DSA draft-extend CPU mirrors.** The
   gpu_only draft-extend fast path leaves `forward_batch.seq_lens_cpu` and the
   `extend_*_cpu` mirrors `None`, but DSA's indexer / topk / sparse-attention paths
   read them throughout, so EAGLE MTP crashed at the first decode batch
   (`AssertionError` in the indexer and `dsa_backend.init_forward_metadata`). For a
   DSA draft model, materialize the CPU seq-len mirror so the CPU-mirror path
   populates `extend_seq_lens_cpu` / `extend_prefix_lens_cpu`; non-DSA drafts keep
   the gpu_only fast path. The `draft_extend_v2` branch now asserts only the fields
   it actually consumes.

NVIDIA is unaffected.

## Accuracy Tests

`amd/GLM-5.2-MXFP4`, TP4, MI355X (gfx950), `fp8_e4m3` KV, GSM8K 200q, temperature 0.
Before this PR EAGLE does not load, so there is no baseline spec row.

| EAGLE (num-steps / topk / draft-tokens) | GSM8K |
|---|---|
| 1 / 1 / 2 (balanced) | 0.935 |
| 5 / 1 / 6 (low-latency) | 0.950 |

## Speed Benchmarks

Not applicable.


## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/accuracy_eval.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and want the PR to be merged, please leave your approval as the GitHub Bot's `[Review and Merge Process]` is enabled.











































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28751906328](https://github.com/sgl-project/sglang/actions/runs/28751906328)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28751906291](https://github.com/sgl-project/sglang/actions/runs/28751906291)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->