### PR TITLE
[AMD] Register 3 unit mem_cache + utils tests for stage-b-test-1-gpu-small-amd

### DIFF
--- a/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
@@ -14,10 +14,11 @@ from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=15, stage="stage-b", runner_config="1-gpu-small-amd")
 
 PAGE_SIZE = 2
 

--- a/test/registered/unit/mem_cache/test_store_cache_4d.py
+++ b/test/registered/unit/mem_cache/test_store_cache_4d.py
@@ -21,7 +21,7 @@ import unittest
 
 import torch
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 _HAS_CUDA = torch.cuda.is_available()
 # The set_kv_buffer integration test needs SharedMHATokenToKVPool, which only
@@ -31,6 +31,7 @@ _HAS_SHARED_POOL = (
 )
 
 register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=30, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 def _legacy_advanced_indexing_write(

--- a/test/registered/unit/mem_cache/test_store_cache_4d.py
+++ b/test/registered/unit/mem_cache/test_store_cache_4d.py
@@ -21,7 +21,7 @@ import unittest
 
 import torch
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 
 _HAS_CUDA = torch.cuda.is_available()
 # The set_kv_buffer integration test needs SharedMHATokenToKVPool, which only
@@ -31,7 +31,6 @@ _HAS_SHARED_POOL = (
 )
 
 register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=30, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 def _legacy_advanced_indexing_write(

--- a/test/registered/unit/mem_cache/test_triton_kernel_layout.py
+++ b/test/registered/unit/mem_cache/test_triton_kernel_layout.py
@@ -28,7 +28,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 _HAS_CUDA = torch.cuda.is_available()
 
 register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=30, stage="stage-b", runner_config="1-gpu-small-amd")
+register_amd_ci(est_time=5, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 @unittest.skipUnless(_HAS_CUDA, "Triton kernels require CUDA")

--- a/test/registered/unit/mem_cache/test_triton_kernel_layout.py
+++ b/test/registered/unit/mem_cache/test_triton_kernel_layout.py
@@ -23,11 +23,12 @@ import unittest
 
 import torch
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 _HAS_CUDA = torch.cuda.is_available()
 
 register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=30, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 @unittest.skipUnless(_HAS_CUDA, "Triton kernels require CUDA")

--- a/test/registered/unit/utils/test_common.py
+++ b/test/registered/unit/utils/test_common.py
@@ -8,10 +8,11 @@ from sglang.srt.utils.common import (
     get_device_sm_nvidia_smi,
     get_nvidia_driver_version_str,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=5, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")


### PR DESCRIPTION
## Motivation

These tests already run on NVIDIA per-commit CI (`base-b-test-1-gpu-small`) but are not registered for AMD. They are CPU-only or use plain `torch` ops /Triton kernels that are already the primary AMD code paths, so adding `register_amd_ci(...)` next to the existing `register_cuda_ci(...)` is sufficient — no ROCm-specific code changes are required.

## Registered files

| File | AMD `est_time` | Why it is safe on AMD |
|---|---|---|
| `unit/utils/test_common.py` | 5 | `flatten_arrays_to_int64_tensor` over `("cpu", "cuda")` (ROCm maps `"cuda"` → HIP); the `nvidia-smi` helpers are exercised purely via monkey-patched `subprocess.run` (success + fallback paths), so no GPU/NVIDIA tooling is touched. |
| `unit/mem_cache/test_triton_kernel_layout.py` | 5 | Parity test for the Triton `decode_attention_fwd` / `extend_attention_fwd` kernels — the Triton attention backend is the primary AMD path. AMD `est_time` set to the measured 5s (CUDA estimate is 30s). |
| `unit/mem_cache/test_hiradix_cache_unit.py` | 15 | Host-side HiRadix cache event bookkeeping over a small `MHATokenToKVPool` + gloo process group; no NVIDIA-specific kernels. |

Each `register_amd_ci` mirrors the sibling `register_cuda_ci`'s shape, mapping `base-b` → `stage-b-test-1-gpu-small-amd`
(`stage="stage-b", runner_config="1-gpu-small-amd"`). `register_cuda_ci` is left unchanged.

### Dropped candidates

- `unit/utils/test_weight_checker.py` / `test_weight_checker_comparator.py` —
  their fp8 fixtures call `transform_scale_ue8m0`, which imports `deep_gemm`
  (CUDA-only, absent from the AMD CI venv).
- `unit/mem_cache/test_store_cache_4d.py` — passes on the mi3xx lane but fails
  on **rocm720**: the `store_cache_4d` Triton kernel hits a ROCm 7.2.0 Triton
  AMDGPU compiler-pass failure
  (`TritonAMDGPUCanonicalizePointers` → `PassManager::run failed`). Kept
  CUDA-only rather than registering a rocm720-red test.

## Verification

Local AST collection (`collect_tests` from `python/sglang/test/ci/ci_register.py`):
the AMD `stage-b-test-1-gpu-small-amd` suite grows **112 → 115** (+3), all three
files resolve to `stage-b-test-1-gpu-small-amd` with a runnable
`if __name__ == "__main__":` block.

## CI results

Fresh runs on the final 3-file revision (commit `4de74e266b`) — all three
registered files pass on **both** AMD lanes:

- mi3xx `stage-b-test-1-gpu-small-amd`:
  https://github.com/sgl-project/sglang/actions/runs/28499323400 — **success**,
  all 14 partitions green.
- rocm720 `stage-b-test-1-gpu-small-amd-rocm720`:
  https://github.com/sgl-project/sglang/actions/runs/28499324488 — the 3 files
  pass; the only stage-b failures are pre-existing, unrelated tests
  (`profiling/test_start_profile.py`, `scheduler/test_priority_scheduling.py`,
  `vlm/test_vision_chunked_prefill.py`).

| File | mi3xx | rocm720 |
|---|---|---|
| `unit/utils/test_common.py` | pass | pass |
| `unit/mem_cache/test_triton_kernel_layout.py` | pass | pass |
| `unit/mem_cache/test_hiradix_cache_unit.py` | pass | pass |

(The earlier 4-file revision's runs
[mi3xx](https://github.com/sgl-project/sglang/actions/runs/28479072389) /
[rocm720](https://github.com/sgl-project/sglang/actions/runs/28479074188) are
what surfaced the `store_cache_4d` rocm720 Triton compiler bug, now dropped.)

## Test plan

- [x] AMD `stage-b-test-1-gpu-small-amd` (mi3xx) passes on the three registered files.
- [x] AMD rocm720 lane passes on the three registered files.
- [ ] NVIDIA per-commit CI stays green (no change to `register_cuda_ci`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28479048409](https://github.com/sgl-project/sglang/actions/runs/28479048409)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28479053960](https://github.com/sgl-project/sglang/actions/runs/28479053960)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
