### PR TITLE
fix: drop stale mxfp4 marlin scales after repack

### DIFF
--- a/python/sglang/srt/layers/quantization/marlin_utils_fp4.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils_fp4.py
@@ -225,6 +225,13 @@ def _get_optional_param(layer: torch.nn.Module, *names: str) -> torch.Tensor | N
     return None
 
 
+def _discard_mxfp4_marlin_repack_inputs(layer: torch.nn.Module) -> None:
+    for name in ("w13_weight_scale_inv", "w2_weight_scale_inv"):
+        value = getattr(layer, name, None)
+        if isinstance(value, torch.nn.Parameter):
+            delattr(layer, name)
+
+
 def deinterleave_moe_mxfp4_w13_for_marlin(layer: torch.nn.Module) -> None:
     """Convert GPT-OSS interleaved w13 rows to Marlin's contiguous halves.
 
@@ -398,6 +405,8 @@ def prepare_moe_mxfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
         layer.w2_weight_bias = torch.nn.Parameter(
             _permute_bias(w2_bias_data), requires_grad=False
         )
+
+    _discard_mxfp4_marlin_repack_inputs(layer)
 
 
 def prepare_moe_nvfp4_layer_for_marlin(layer: torch.nn.Module) -> None:


### PR DESCRIPTION
## Motivation

MXFP4 Marlin MoE repacks the original FP4 expert weights and scale tensors into Marlin-specific layouts during model loading. After repack, inference uses the newly assigned `w13_weight_scale` and `w2_weight_scale` parameters.

However, the original loader-created `w13_weight_scale_inv` and `w2_weight_scale_inv` parameters remained registered on the layer even though they were no longer read by the Marlin forward path. For large MXFP4 MoE checkpoints, this leaves a significant amount of stale GPU weight memory resident after model loading.

In a DeepSeek-V4-Pro TP16/DP8 run with `--moe-runner-backend marlin`, this stale memory reduced the DSV4 KV pool capacity substantially:

```text
baseline before this patch:
Load weight end ... mem usage=79.05 GB
DSV4 memory calculation ... available_bytes=4.97 GB, full_token=277504

after this patch:
Load weight end ... mem usage=67.57 GB
DSV4 memory calculation ... available_bytes=16.45 GB, full_token=918272
```

This corresponds to about `11.48 GB/GPU` less final weight memory in that configuration.

## Modifications

- Add a small cleanup helper for MXFP4 Marlin MoE repack inputs.
- Delete stale `w13_weight_scale_inv` and `w2_weight_scale_inv` parameters after Marlin repack has produced the runtime `w13_weight_scale` and `w2_weight_scale` tensors.
- Keep the cleanup scoped to MXFP4 Marlin MoE repack; other MXFP4/FP8/FlashInfer paths are unchanged.

## Accuracy Tests

Full accuracy evaluation was not run because this patch does not change the kernel, scale values, repacked tensors, or model forward computation. It only removes old `_scale_inv` parameters after the new Marlin scale parameters have already been materialized and registered.

Smoke test on a real DeepSeek-V4-Pro TP16/DP8 deployment:

```text
/health: HTTP 200
/v1/models: HTTP 200
/v1/completions: HTTP 200
```

The completion smoke test used:

```text
model=/data/models/DeepSeek-V4-Pro
prompt="1+1="
max_tokens=4
temperature=0
```

## Speed Tests and Profiling

No throughput/latency benchmark was run because the patch does not alter runtime compute. The expected performance impact is memory-only: it reduces resident weight memory after MXFP4 Marlin repack and increases the memory available for KV cache.

Memory A/B result from the same DeepSeek-V4-Pro TP16/DP8 command:

```text
baseline weight memory: 79.05 GB/GPU
patched weight memory:  67.57 GB/GPU
delta:                  11.48 GB/GPU

baseline DSV4 full_token: 277504
patched DSV4 full_token:  918272
delta:                   +640768 tokens
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Notes for checklist items:

- Unit test: no new unit test was added because the change is a post-repack parameter ownership cleanup and requires CUDA/Marlin model loading to exercise end-to-end.
- Documentation: no user-facing documentation update is needed.
- Accuracy/speed: full eval and throughput benchmark are not required for this non-compute cleanup; real deployment smoke and memory A/B are included above.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28491064213](https://github.com/sgl-project/sglang/actions/runs/28491064213)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28491064123](https://github.com/sgl-project/sglang/actions/runs/28491064123)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->