### PR TITLE
fix(radix_cache): sync kv_committed_len before release to retain deco…

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -851,6 +851,16 @@ class SchedulerBatchResultProcessor:
                     if get_global_server_args().enable_mamba_extra_buffer_lazy()
                     else True
                 )
+                # Ensure decode output tokens' KV is included in radix cache.
+                # During decode, kv_committed_len may lag behind the actual
+                # number of committed KV entries. Sync it to the full decode
+                # length (excluding the just-sampled last token which has no
+                # KV entry). Use max() to avoid lowering the value when overlap
+                # scheduling has already pre-incremented it for the next step.
+                req.kv_committed_len = max(
+                    req.kv_committed_len,
+                    len(req.origin_input_ids) + len(req.output_ids) - 1,
+                )
                 release_kv_cache(req, self.tree_cache, is_insert=is_insert)
 
             req.time_stats.set_completion_time()


### PR DESCRIPTION
…de KV

During multi-turn conversations, decode output tokens' KV was not being cached in the radix tree because kv_committed_len did not reflect the full sequence length (prefill + decode) at the time cache_finished_req was called. This caused second-round requests to only hit the system prompt prefix (~3184 tokens) instead of reusing all prior KV.

Fix: explicitly sync kv_committed_len to the actual committed KV length (len(origin_input_ids) + len(output_ids) - 1, excluding the just-sampled last token which has no KV computed) right before release_kv_cache in the normal decode finish path. Use max() to avoid regressing the value when overlap scheduling has already pre-incremented it for the next batch.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28492218491](https://github.com/sgl-project/sglang/actions/runs/28492218491)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28492218420](https://github.com/sgl-project/sglang/actions/runs/28492218420)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->