### PR TITLE
[multimodal] Add SM120 Triton attention backend

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/base.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/base.py
@@ -30,6 +30,7 @@ class DiTArchConfig(ArchConfig):
             AttentionBackendEnum.FA,
             AttentionBackendEnum.AITER,
             AttentionBackendEnum.AITER_SAGE,
+            AttentionBackendEnum.SM120_TRITON_ATTN,
             AttentionBackendEnum.TORCH_SDPA,
             AttentionBackendEnum.VIDEO_SPARSE_ATTN,
             AttentionBackendEnum.SPARSE_VIDEO_GEN_2_ATTN,

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/sm120_triton_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/sm120_triton_attn.py
@@ -1,0 +1,103 @@
+import torch
+
+from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
+    AttentionBackend,
+    AttentionImpl,
+    AttentionMetadata,
+)
+from sglang.multimodal_gen.runtime.layers.attention.backends.sdpa import SDPAImpl
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+from sglang.srt.layers.attention.triton_ops.extend_attention import (
+    extend_attention_fwd,
+)
+
+
+class SM120TritonAttentionBackend(AttentionBackend):
+    accept_output_buffer: bool = True
+
+    @staticmethod
+    def get_supported_head_sizes() -> list[int]:
+        return [32, 64, 96, 128, 160, 192, 224, 256]
+
+    @staticmethod
+    def get_enum() -> AttentionBackendEnum:
+        return AttentionBackendEnum.SM120_TRITON_ATTN
+
+    @staticmethod
+    def get_impl_cls() -> type["SM120TritonAttentionImpl"]:
+        return SM120TritonAttentionImpl
+
+
+class SM120TritonAttentionImpl(AttentionImpl):
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        causal: bool,
+        softmax_scale: float,
+        num_kv_heads: int | None = None,
+        prefix: str = "",
+        **extra_impl_args,
+    ) -> None:
+        self.causal = causal
+        self.softmax_scale = softmax_scale
+        self.sdpa_impl = SDPAImpl(
+            num_heads=num_heads,
+            head_size=head_size,
+            causal=causal,
+            softmax_scale=softmax_scale,
+            num_kv_heads=num_kv_heads,
+            prefix=prefix,
+            **extra_impl_args,
+        )
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+    ) -> torch.Tensor:
+        if (
+            query.device.type != "cuda"
+            or query.shape[1] != key.shape[1]
+            or key.shape[1] != value.shape[1]
+        ):
+            return self.sdpa_impl.forward(query, key, value, attn_metadata)
+
+        batch_size, seq_len, _, _ = query.shape
+        q = query.reshape(batch_size * seq_len, query.shape[2], query.shape[3])
+        k = key.reshape(batch_size * seq_len, key.shape[2], key.shape[3])
+        v = value.reshape(batch_size * seq_len, value.shape[2], value.shape[3])
+        out = torch.empty_like(q)
+        qo_indptr = torch.arange(
+            0,
+            (batch_size + 1) * seq_len,
+            seq_len,
+            dtype=torch.int32,
+            device=query.device,
+        )
+        kv_indptr = torch.zeros(
+            (batch_size + 1,), dtype=torch.int32, device=query.device
+        )
+        kv_indices = torch.empty((0,), dtype=torch.int64, device=query.device)
+        extend_attention_fwd(
+            q,
+            k,
+            v,
+            out,
+            k,
+            v,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            custom_mask=None,
+            is_causal=self.causal,
+            mask_indptr=None,
+            max_len_extend=seq_len,
+            k_scale=1.0,
+            v_scale=1.0,
+            sm_scale=self.softmax_scale,
+            skip_prefix=True,
+        )
+        return out.reshape_as(query)

--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -337,6 +337,12 @@ class CudaPlatformBase(Platform):
             return "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SparseLinearAttentionBackend"
         elif selected_backend == AttentionBackendEnum.SAGE_SLA_ATTN:
             return "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SageSparseLinearAttentionBackend"
+        elif selected_backend == AttentionBackendEnum.SM120_TRITON_ATTN:
+            if not cls.is_sm120():
+                raise ValueError(
+                    "sm120_triton_attn is only supported on SM12.x CUDA GPUs."
+                )
+            return "sglang.multimodal_gen.runtime.layers.attention.backends.sm120_triton_attn.SM120TritonAttentionBackend"
         elif selected_backend == AttentionBackendEnum.FA2:
             from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2 import (  # noqa: F401
                 FlashAttention2Backend,

--- a/python/sglang/multimodal_gen/runtime/platforms/interface.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/interface.py
@@ -36,6 +36,7 @@ class AttentionBackendEnum(enum.Enum):
     VMOBA_ATTN = enum.auto()
     AITER = enum.auto()
     AITER_SAGE = enum.auto()
+    SM120_TRITON_ATTN = enum.auto()
     SLA_ATTN = enum.auto()
     SAGE_SLA_ATTN = enum.auto()
     LASER_ATTN = enum.auto()

--- a/python/sglang/multimodal_gen/test/single_test_file/test_sm120_triton_attention_perf.py
+++ b/python/sglang/multimodal_gen/test/single_test_file/test_sm120_triton_attention_perf.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import torch
 
@@ -71,7 +72,7 @@ class TestSM120TritonAttentionPerf(unittest.TestCase):
         sdpa_ms = self._bench_cuda_ms(
             lambda: sdpa_impl.forward(query, key, value, None)
         )
-        print(
+        bench_message = (
             "SM120_TRITON_ATTN_BENCH "
             f"shape=({batch_size},{seq_len},{num_heads},{head_size}) "
             f"dtype={dtype} "
@@ -79,6 +80,8 @@ class TestSM120TritonAttentionPerf(unittest.TestCase):
             f"torch_sdpa_ms={sdpa_ms:.3f} "
             f"speedup={sdpa_ms / sm120_ms:.3f}x"
         )
+        print(bench_message, flush=True)
+        warnings.warn(bench_message, RuntimeWarning, stacklevel=1)
 
     @staticmethod
     def _bench_cuda_ms(fn, warmup: int = 5, repeats: int = 20) -> float:

--- a/python/sglang/multimodal_gen/test/single_test_file/test_sm120_triton_attention_perf.py
+++ b/python/sglang/multimodal_gen/test/single_test_file/test_sm120_triton_attention_perf.py
@@ -1,0 +1,100 @@
+import unittest
+
+import torch
+
+
+def _is_sm120_cuda_available() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12
+
+
+class TestSM120TritonAttentionPerf(unittest.TestCase):
+    @unittest.skipUnless(
+        _is_sm120_cuda_available(),
+        "sm120_triton_attn is only supported on SM12.x CUDA GPUs",
+    )
+    def test_sm120_triton_attention_matches_sdpa_and_benchmarks(self):
+        from sglang.multimodal_gen.runtime.layers.attention.backends.sdpa import (
+            SDPAImpl,
+        )
+        from sglang.multimodal_gen.runtime.layers.attention.backends.sm120_triton_attn import (
+            SM120TritonAttentionImpl,
+        )
+
+        torch.manual_seed(0)
+        torch.cuda.manual_seed_all(0)
+        torch.cuda.set_device(0)
+
+        batch_size = 1
+        seq_len = 1024
+        num_heads = 24
+        head_size = 128
+        softmax_scale = head_size**-0.5
+        dtype = torch.bfloat16
+        device = torch.device("cuda")
+
+        query = torch.randn(
+            batch_size, seq_len, num_heads, head_size, device=device, dtype=dtype
+        )
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+
+        sm120_impl = SM120TritonAttentionImpl(
+            num_heads=num_heads,
+            head_size=head_size,
+            causal=False,
+            softmax_scale=softmax_scale,
+        )
+        sdpa_impl = SDPAImpl(
+            num_heads=num_heads,
+            head_size=head_size,
+            causal=False,
+            softmax_scale=softmax_scale,
+        )
+
+        for _ in range(3):
+            sm120_impl.forward(query, key, value, None)
+            sdpa_impl.forward(query, key, value, None)
+        torch.cuda.synchronize()
+
+        sm120_output = sm120_impl.forward(query, key, value, None)
+        sdpa_output = sdpa_impl.forward(query, key, value, None)
+        torch.testing.assert_close(
+            sm120_output.float(),
+            sdpa_output.float(),
+            atol=5e-2,
+            rtol=5e-2,
+        )
+
+        sm120_ms = self._bench_cuda_ms(
+            lambda: sm120_impl.forward(query, key, value, None)
+        )
+        sdpa_ms = self._bench_cuda_ms(
+            lambda: sdpa_impl.forward(query, key, value, None)
+        )
+        print(
+            "SM120_TRITON_ATTN_BENCH "
+            f"shape=({batch_size},{seq_len},{num_heads},{head_size}) "
+            f"dtype={dtype} "
+            f"sm120_triton_attn_ms={sm120_ms:.3f} "
+            f"torch_sdpa_ms={sdpa_ms:.3f} "
+            f"speedup={sdpa_ms / sm120_ms:.3f}x"
+        )
+
+    @staticmethod
+    def _bench_cuda_ms(fn, warmup: int = 5, repeats: int = 20) -> float:
+        for _ in range(warmup):
+            fn()
+        torch.cuda.synchronize()
+
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(repeats):
+            fn()
+        end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) / repeats
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_sm120_triton_attention_backend.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sm120_triton_attention_backend.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.multimodal_gen.configs.models.dits.base import DiTConfig
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+from sglang.multimodal_gen.runtime.platforms.cuda import CudaPlatformBase
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+
+
+class TestSM120TritonAttentionBackend(unittest.TestCase):
+    def test_cli_name_is_normalized(self):
+        self.assertEqual(
+            ServerArgs._normalize_attention_backend_name("sm120_triton_attn"),
+            "sm120_triton_attn",
+        )
+
+    def test_dit_configs_allow_backend(self):
+        self.assertIn(
+            AttentionBackendEnum.SM120_TRITON_ATTN,
+            DiTConfig().arch_config._supported_attention_backends,
+        )
+
+    def test_cuda_selector_accepts_backend_on_sm120(self):
+        with patch.object(CudaPlatformBase, "is_sm120", return_value=True):
+            self.assertEqual(
+                CudaPlatformBase.get_attn_backend_cls_str(
+                    AttentionBackendEnum.SM120_TRITON_ATTN,
+                    head_size=128,
+                    dtype=torch.bfloat16,
+                ),
+                "sglang.multimodal_gen.runtime.layers.attention.backends.sm120_triton_attn.SM120TritonAttentionBackend",
+            )
+
+    def test_cuda_selector_rejects_backend_off_sm120(self):
+        with patch.object(CudaPlatformBase, "is_sm120", return_value=False):
+            with self.assertRaisesRegex(ValueError, "SM12.x"):
+                CudaPlatformBase.get_attn_backend_cls_str(
+                    AttentionBackendEnum.SM120_TRITON_ATTN,
+                    head_size=128,
+                    dtype=torch.bfloat16,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
Diffusion currently falls back to Torch SDPA on SM120 consumer Blackwell GPUs because FlashAttention is unavailable in this build. This PR exposes an explicit `sm120_triton_attn` backend that reuses SRT's Triton extend-attention kernel path and its SM120 block-size tuning.

## Changes
- Add `AttentionBackendEnum.SM120_TRITON_ATTN` and wire it through CUDA backend selection with an SM12.x hardware guard.
- Allow DiT configs to opt into `sm120_triton_attn`.
- Add a diffusion attention backend wrapper using `extend_attention_fwd(skip_prefix=True)` for dense self-attention and Torch SDPA fallback for non-CUDA or cross-attention cases.
- Add unit coverage for CLI/backend selection and a 5090-only benchmark test that compares `sm120_triton_attn` with `torch_sdpa`.

## Validation
- `pre-commit run --files python/sglang/multimodal_gen/configs/models/dits/base.py python/sglang/multimodal_gen/runtime/platforms/cuda.py python/sglang/multimodal_gen/runtime/platforms/interface.py python/sglang/multimodal_gen/runtime/layers/attention/backends/sm120_triton_attn.py python/sglang/multimodal_gen/test/single_test_file/test_sm120_triton_attention_perf.py python/sglang/multimodal_gen/test/unit/test_sm120_triton_attention_backend.py`
- 5090 availability passed on rerun `28492645908`, job `84452380959`: `1 passed, 21 warnings in 11.44s`.
- 5090 benchmark rerun `28493302466` failed during checkout because it used an old SHA, so I reran the measurements on a real 5090 devbox at PR head `2d5afdee1a571c9855232b4d5f66f1be4b7ff2d0`.
- Environment: `NVIDIA GeForce RTX 5090`, driver `580.105.08`, `torch 2.11.0+cu130`.
- FlashAttention check: `from flash_attn import flash_attn_func` failed on this image; requesting `fa` on SM120 is expected to fall back to `torch_sdpa`.

### 5090 micro attention benchmark

BF16 dense self-attention, non-causal, head_dim=128. `speedup_vs_sdpa < 1` means `sm120_triton_attn` is slower than Torch SDPA.

| shape `(B,S,H,D)` | `sm120_triton_attn` ms | `torch_sdpa` ms | speedup vs SDPA | max abs diff vs SDPA | mean abs diff vs SDPA | p99 abs diff vs SDPA |
|---|---:|---:|---:|---:|---:|---:|
| `(1,512,24,128)` | 0.063 | 0.039 | 0.62x | 0.001953 | 7.53e-05 | 0.000488 |
| `(1,1024,24,128)` | 0.137 | 0.111 | 0.81x | 0.001953 | 8.15e-05 | 0.000488 |
| `(1,2048,24,128)` | 0.433 | 0.322 | 0.74x | 0.000977 | 6.10e-05 | 0.000488 |
| `(1,4096,24,128)` | 1.669 | 1.055 | 0.63x | 0.000977 | 4.47e-05 | 0.000244 |
| `(1,8192,24,128)` | 7.028 | 4.171 | 0.59x | 0.000488 | 3.24e-05 | 0.000244 |
| `(1,2048,40,128)` | 0.685 | 0.430 | 0.63x | 0.001953 | 6.10e-05 | 0.000488 |
| `(1,4096,40,128)` | 2.734 | 1.691 | 0.62x | 0.000977 | 4.47e-05 | 0.000244 |
| `(1,8192,40,128)` | 12.672 | 6.695 | 0.53x | 0.000977 | 3.24e-05 | 0.000244 |

Small-shape math-SDPA reference:

| shape `(B,S,H,D)` | SDPA math ms | `sm120` mean abs diff vs math | `torch_sdpa` mean abs diff vs math |
|---|---:|---:|---:|
| `(1,512,24,128)` | 0.208 | 8.37e-05 | 7.91e-05 |
| `(1,1024,24,128)` | 0.888 | 6.09e-05 | 6.06e-05 |
| `(1,2048,24,128)` | 3.627 | 4.43e-05 | 4.41e-05 |

### 5090 Z-Image server benchmark

Command shape: `zimage_image_t2i`, `1024x1024`, 9 denoise steps, `SGLANG_GEN_BASELINE=1`, `SGLANG_SKIP_CONSISTENCY=1`.

| backend | e2e ms | avg denoise ms | median denoise ms | transformer backend selected |
|---|---:|---:|---:|---|
| `torch_sdpa` | 2512.72 | 245.10 | 271.67 | `torch_sdpa` |
| `sm120_triton_attn` | 2709.41 | 267.21 | 295.55 | `sm120_triton_attn` |

Image-level comparison between the two generated JPG outputs with identical prompt/seed: SSIM `0.9475`, PSNR `25.87`, mean absolute pixel diff `3.54`.

Conclusion from the 5090 measurements: this implementation is numerically close to Torch SDPA at the attention-output level, but it is slower than Torch SDPA across the tested dense-attention shapes and also slower in the Z-Image end-to-end server case.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28493301151](https://github.com/sgl-project/sglang/actions/runs/28493301151)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28493301074](https://github.com/sgl-project/sglang/actions/runs/28493301074)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
