### PR TITLE
Split diffusion perf baselines by GPU platform

### DIFF
--- a/python/sglang/multimodal_gen/test/scripts/gen_perf_baselines.py
+++ b/python/sglang/multimodal_gen/test/scripts/gen_perf_baselines.py
@@ -42,7 +42,7 @@ def _all_cases() -> list[DiffusionTestCase]:
 def _baseline_path() -> Path:
     import sglang.multimodal_gen.test.server.testcase_configs as cfg
 
-    return Path(cfg.__file__).with_name("perf_baselines.json")
+    return cfg.get_perf_baseline_path()
 
 
 def _openai_client(port: int) -> OpenAI:

--- a/python/sglang/multimodal_gen/test/server/perf_baselines/5090.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines/5090.json
@@ -1,0 +1,106 @@
+{
+    "metadata": {
+        "model": "Diffusion Server",
+        "hardware": "CI RTX 5090 pool",
+        "description": "Reference numbers captured from real 5090 CI runner history (PR 29791 run 28492141274, job 84450974283).",
+        "last_updated": "2026-07-01"
+    },
+    "tolerances": {
+        "long_term": {
+            "e2e": 0.15,
+            "denoise_stage": 0.1,
+            "non_denoise_stage": 0.5,
+            "denoise_step": 0.25,
+            "denoise_agg": 0.15
+        },
+        "pr_test": {
+            "e2e": 0.25,
+            "denoise_stage": 0.25,
+            "non_denoise_stage": 0.8,
+            "denoise_step": 0.3,
+            "denoise_agg": 0.2
+        }
+    },
+    "improvement_reporting": {
+        "threshold": 0.2
+    },
+    "sampling": {
+        "step_fractions": [
+            0.0,
+            0.2,
+            0.4,
+            0.6,
+            0.8,
+            1.0
+        ]
+    },
+    "scenarios": {
+        "flux_2_klein_base_image_t2i": {
+            "stages_ms": {
+                "DecodingStage": 18.19,
+                "DenoisingStage": 18213.48,
+                "ImageVAEEncodingStage": 0.01,
+                "InputValidationStage": 0.08,
+                "LatentPreparationStage": 4.87,
+                "TextEncodingStage": 104.46,
+                "TimestepPreparationStage": 142.18
+            },
+            "denoise_step_ms": {
+                "0": 219.58,
+                "10": 359.79,
+                "20": 361.55,
+                "29": 361.99,
+                "39": 362.57,
+                "49": 362.89
+            },
+            "expected_e2e_ms": 18641.09,
+            "expected_avg_denoise_ms": 357.93,
+            "expected_median_denoise_ms": 361.8,
+            "estimated_full_test_time_s": 94.0
+        },
+        "wan2_1_t2v_1.3b": {
+            "stages_ms": {
+                "DecodingStage": 1202.43,
+                "DenoisingStage": 21452.59,
+                "InputValidationStage": 0.09,
+                "LatentPreparationStage": 0.23,
+                "TextEncodingStage": 1210.22,
+                "TimestepPreparationStage": 3.91
+            },
+            "denoise_step_ms": {
+                "0": 480.39,
+                "10": 426.11,
+                "20": 427.32,
+                "29": 428.09,
+                "39": 428.04,
+                "49": 422.31
+            },
+            "expected_e2e_ms": 23877.73,
+            "expected_avg_denoise_ms": 428.74,
+            "expected_median_denoise_ms": 427.94,
+            "estimated_full_test_time_s": 160.9
+        },
+        "zimage_image_t2i": {
+            "stages_ms": {
+                "DecodingStage": 7.11,
+                "DenoisingStage": 2229.48,
+                "InputValidationStage": 0.04,
+                "LatentPreparationStage": 0.17,
+                "TextEncodingStage": 252.73,
+                "TimestepPreparationStage": 38.57
+            },
+            "denoise_step_ms": {
+                "0": 39.34,
+                "2": 277.35,
+                "3": 267.94,
+                "5": 279.01,
+                "6": 273.01,
+                "8": 275.12
+            },
+            "expected_e2e_ms": 2533.95,
+            "expected_avg_denoise_ms": 246.97,
+            "expected_median_denoise_ms": 273.01,
+            "estimated_full_test_time_s": 329.8
+        }
+    }
+}

--- a/python/sglang/multimodal_gen/test/server/perf_baselines/b200.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines/b200.json
@@ -1,0 +1,79 @@
+{
+    "metadata": {
+        "model": "Diffusion Server",
+        "hardware": "CI B200 pool",
+        "description": "Reference estimates for B200-only diffusion cases, split out from the shared diffusion baseline file.",
+        "last_updated": "2026-07-01"
+    },
+    "tolerances": {
+        "long_term": {
+            "e2e": 0.15,
+            "denoise_stage": 0.1,
+            "non_denoise_stage": 0.5,
+            "denoise_step": 0.25,
+            "denoise_agg": 0.15
+        },
+        "pr_test": {
+            "e2e": 0.25,
+            "denoise_stage": 0.25,
+            "non_denoise_stage": 0.8,
+            "denoise_step": 0.3,
+            "denoise_agg": 0.2
+        }
+    },
+    "improvement_reporting": {
+        "threshold": 0.2
+    },
+    "sampling": {
+        "step_fractions": [
+            0.0,
+            0.2,
+            0.4,
+            0.6,
+            0.8,
+            1.0
+        ]
+    },
+    "scenarios": {
+        "flux1_modelopt_nvfp4_t2i": {
+            "stages_ms": {},
+            "denoise_step_ms": {},
+            "expected_e2e_ms": 0.0,
+            "expected_avg_denoise_ms": 0.0,
+            "expected_median_denoise_ms": 0.0,
+            "estimated_full_test_time_s": 71.2
+        },
+        "flux2_modelopt_nvfp4_t2i": {
+            "stages_ms": {},
+            "denoise_step_ms": {},
+            "expected_e2e_ms": 0.0,
+            "expected_avg_denoise_ms": 0.0,
+            "expected_median_denoise_ms": 0.0,
+            "estimated_full_test_time_s": 592.3
+        },
+        "qwen_image_2512_modelopt_nvfp4_t2i": {
+            "stages_ms": {},
+            "denoise_step_ms": {},
+            "expected_e2e_ms": 0.0,
+            "expected_avg_denoise_ms": 0.0,
+            "expected_median_denoise_ms": 0.0,
+            "estimated_full_test_time_s": 120.0
+        },
+        "wan22_modelopt_nvfp4_t2v": {
+            "stages_ms": {},
+            "denoise_step_ms": {},
+            "expected_e2e_ms": 0.0,
+            "expected_avg_denoise_ms": 0.0,
+            "expected_median_denoise_ms": 0.0,
+            "estimated_full_test_time_s": 181.8
+        },
+        "ideogram4_nvfp4_t2i": {
+            "stages_ms": {},
+            "denoise_step_ms": {},
+            "expected_e2e_ms": 0.0,
+            "expected_avg_denoise_ms": 0.0,
+            "expected_median_denoise_ms": 0.0,
+            "estimated_full_test_time_s": 300.0
+        }
+    }
+}

--- a/python/sglang/multimodal_gen/test/server/perf_baselines/h100.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines/h100.json
@@ -2829,38 +2829,6 @@
             "expected_avg_denoise_ms": 0.0,
             "expected_median_denoise_ms": 0.0,
             "estimated_full_test_time_s": 73.7
-        },
-        "flux1_modelopt_nvfp4_t2i": {
-            "stages_ms": {},
-            "denoise_step_ms": {},
-            "expected_e2e_ms": 0.0,
-            "expected_avg_denoise_ms": 0.0,
-            "expected_median_denoise_ms": 0.0,
-            "estimated_full_test_time_s": 71.2
-        },
-        "flux2_modelopt_nvfp4_t2i": {
-            "stages_ms": {},
-            "denoise_step_ms": {},
-            "expected_e2e_ms": 0.0,
-            "expected_avg_denoise_ms": 0.0,
-            "expected_median_denoise_ms": 0.0,
-            "estimated_full_test_time_s": 592.3
-        },
-        "qwen_image_2512_modelopt_nvfp4_t2i": {
-            "stages_ms": {},
-            "denoise_step_ms": {},
-            "expected_e2e_ms": 0.0,
-            "expected_avg_denoise_ms": 0.0,
-            "expected_median_denoise_ms": 0.0,
-            "estimated_full_test_time_s": 120.0
-        },
-        "wan22_modelopt_nvfp4_t2v": {
-            "stages_ms": {},
-            "denoise_step_ms": {},
-            "expected_e2e_ms": 0.0,
-            "expected_avg_denoise_ms": 0.0,
-            "expected_median_denoise_ms": 0.0,
-            "estimated_full_test_time_s": 181.8
         }
     }
 }

--- a/python/sglang/multimodal_gen/test/server/test_server_common.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_common.py
@@ -41,6 +41,7 @@ from sglang.multimodal_gen.test.server.testcase_configs import (
     PerformanceSummary,
     ScenarioConfig,
     get_model_task_type_for_server_args,
+    get_perf_baseline_path,
 )
 from sglang.multimodal_gen.test.test_utils import (
     SGL_TEST_FILES_CI_DATA_REVISION,
@@ -244,7 +245,7 @@ def diffusion_server(case: DiffusionTestCase) -> ServerContext:
             logger.error(
                 f'\n{"=" * 60}\n'
                 f'Add "estimated_full_test_time_s" to scenario "{case.id}":\n\n'
-                f"File: python/sglang/multimodal_gen/test/server/perf_baselines.json\n\n"
+                f"File: {get_perf_baseline_path()}\n\n"
                 f'    "{case.id}": {{\n'
                 f"        ...\n"
                 f'        "estimated_full_test_time_s": {_measured_full_time:.1f}\n'
@@ -456,7 +457,7 @@ class DiffusionServerBase:
                 self._dump_baseline_for_testcase(case, summary, missing_scenario)
                 if missing_scenario:
                     pytest.fail(
-                        f"Testcase '{case.id}' not found in perf_baselines.json"
+                        f"Testcase '{case.id}' not found in {get_perf_baseline_path()}"
                     )
                 return
 
@@ -567,7 +568,7 @@ class DiffusionServerBase:
                 )
         action = "add" if missing_scenario else "update"
         output = f"""
-{action} this baseline in the "scenarios" section of perf_baselines.json:
+{action} this baseline in the "scenarios" section of {get_perf_baseline_path()}:
 
 "{case.id}": {json.dumps(baseline, indent=4)}
 

--- a/python/sglang/multimodal_gen/test/server/testcase_configs.py
+++ b/python/sglang/multimodal_gen/test/server/testcase_configs.py
@@ -12,7 +12,7 @@ pytest python/sglang/multimodal_gen/test/server/test_server_1_gpu.py -k qwen_ima
 To add a new testcase:
 1. add your testcase with case-id: `my_new_test_case_id` to `ONE_GPU_CASES`, `ONE_GPU_MODELOPT_FP8_CASES`, `ONE_GPU_B200_CASES`, or `TWO_GPU_CASES`
 2. run `SGLANG_GEN_BASELINE=1 pytest -s python/sglang/multimodal_gen/test/server/ -k my_new_test_case_id`
-3. insert or override the corresponding scenario in `scenarios` section of perf_baselines.json with the output baseline of step-2
+3. insert or override the corresponding scenario in the platform JSON under `perf_baselines/`
 
 
 """
@@ -33,6 +33,7 @@ from sglang.multimodal_gen.registry import (
     get_model_info,
     get_pipeline_config_classes,
 )
+from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.perf_logger import RequestPerfRecord
 
 
@@ -657,6 +658,57 @@ MODELOPT_WAN22_NVFP4_MODEL = "nvidia/Wan2.2-T2V-A14B-Diffusers-NVFP4"
 MODELOPT_NVFP4_B200_ENV_VARS = {}
 MODELOPT_WAN22_NVFP4_B200_ENV_VARS = {}
 
+PERF_BASELINE_PLATFORM_ENV = "SGLANG_DIFFUSION_PERF_BASELINE_PLATFORM"
+PERF_BASELINE_DIR = Path(__file__).with_name("perf_baselines")
+PERF_BASELINE_FILE_BY_PLATFORM = {
+    "h100": "h100.json",
+    "b200": "b200.json",
+    "5090": "5090.json",
+}
+PERF_BASELINE_PLATFORM_ALIASES = {
+    "sm90": "h100",
+    "hopper": "h100",
+    "h100": "h100",
+    "sm100": "b200",
+    "blackwell": "b200",
+    "b200": "b200",
+    "sm120": "5090",
+    "rtx5090": "5090",
+    "5090": "5090",
+}
+
+
+def _normalize_perf_baseline_platform(platform: str) -> str:
+    normalized = platform.strip().lower().replace("_", "-")
+    normalized = normalized.replace("-", "")
+    if normalized not in PERF_BASELINE_PLATFORM_ALIASES:
+        valid = ", ".join(sorted(PERF_BASELINE_FILE_BY_PLATFORM))
+        raise ValueError(
+            f"Invalid diffusion perf baseline platform {platform!r}. "
+            f"Expected one of: {valid}"
+        )
+    return PERF_BASELINE_PLATFORM_ALIASES[normalized]
+
+
+def get_perf_baseline_platform() -> str:
+    override = os.getenv(PERF_BASELINE_PLATFORM_ENV)
+    if override:
+        return _normalize_perf_baseline_platform(override)
+    if current_platform.is_sm120():
+        return "5090"
+    if current_platform.is_blackwell():
+        return "b200"
+    return "h100"
+
+
+def get_perf_baseline_path(platform: str | None = None) -> Path:
+    baseline_platform = (
+        _normalize_perf_baseline_platform(platform)
+        if platform is not None
+        else get_perf_baseline_platform()
+    )
+    return PERF_BASELINE_DIR / PERF_BASELINE_FILE_BY_PLATFORM[baseline_platform]
+
 
 def _make_modelopt_ci_case(
     case_id: str,
@@ -694,7 +746,7 @@ def _with_default_num_gpus(
 
 # Load global configuration
 BASELINE_CONFIG = (
-    BaselineConfig.load(Path(__file__).with_name("perf_baselines.json"))
+    BaselineConfig.load(get_perf_baseline_path())
     .update(Path(__file__).parent / "ascend" / "perf_baselines_npu.json")
     .update(Path(__file__).parent / "musa" / "perf_baselines_musa.json")
 )

--- a/scripts/ci/utils/diffusion/diffusion_case_parser.py
+++ b/scripts/ci/utils/diffusion/diffusion_case_parser.py
@@ -42,7 +42,8 @@ DEFAULT_EST_TIME_SECONDS = 300.0
 STARTUP_OVERHEAD_SECONDS = 120.0
 
 # Paths relative to repository root
-BASELINE_REL_PATH = "python/sglang/multimodal_gen/test/server/perf_baselines.json"
+BASELINE_REL_PATH = "python/sglang/multimodal_gen/test/server/perf_baselines"
+BASELINE_PLATFORM_ORDER = ("h100", "b200", "5090")
 RUN_SUITE_REL_PATH = "python/sglang/multimodal_gen/test/run_suite.py"
 
 USE_NPU_CONFIGS = os.getenv("USE_NPU_CONFIGS", "0").lower() in ("1", "true")
@@ -345,28 +346,43 @@ class RunSuiteVisitor(ast.NodeVisitor):
         return result
 
 
+def _iter_baseline_paths(baseline_path: Path) -> List[Path]:
+    if baseline_path.is_file():
+        return [baseline_path]
+    if not baseline_path.is_dir():
+        return []
+
+    ordered_paths = [
+        baseline_path / f"{platform}.json" for platform in BASELINE_PLATFORM_ORDER
+    ]
+    ordered_paths.extend(
+        path
+        for path in sorted(baseline_path.glob("*.json"))
+        if path not in ordered_paths
+    )
+    return [path for path in ordered_paths if path.exists()]
+
+
 def load_baselines(baseline_path: Path) -> Dict[str, float]:
     """
-    Load performance baselines from JSON file.
+    Load performance baselines from a JSON file or platform baseline directory.
 
     Returns:
         Dictionary mapping case_id to estimated time in seconds.
     """
-    if not baseline_path.exists():
-        return {}
-
-    with open(baseline_path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-
     baselines = {}
-    scenarios = data.get("scenarios", {})
+    for path in _iter_baseline_paths(baseline_path):
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
 
-    for case_id, scenario in scenarios.items():
-        if scenario.get("estimated_full_test_time_s") is not None:
-            baselines[case_id] = scenario["estimated_full_test_time_s"]
-        else:
-            expected_e2e_ms = scenario.get("expected_e2e_ms", 0)
-            baselines[case_id] = expected_e2e_ms / 1000.0 + STARTUP_OVERHEAD_SECONDS
+        scenarios = data.get("scenarios", {})
+        for case_id, scenario in scenarios.items():
+            if scenario.get("estimated_full_test_time_s") is not None:
+                est_time = scenario["estimated_full_test_time_s"]
+            else:
+                expected_e2e_ms = scenario.get("expected_e2e_ms", 0)
+                est_time = expected_e2e_ms / 1000.0 + STARTUP_OVERHEAD_SECONDS
+            baselines.setdefault(case_id, est_time)
 
     return baselines
 
@@ -443,7 +459,7 @@ def collect_diffusion_suites(
     Args:
         case_config_path: Path to case config (resolved from run_suite.py)
         run_suite_path: Path to run_suite.py
-        baseline_path: Path to perf_baselines.json
+        baseline_path: Path to perf_baselines/ or a single baseline JSON file
 
     Returns:
         Dictionary mapping suite name to DiffusionSuiteInfo.


### PR DESCRIPTION
## Summary
- move diffusion perf baselines into `test/server/perf_baselines/` with `h100.json`, `b200.json`, and `5090.json`
- select the runtime baseline file from the detected GPU platform, with `SGLANG_DIFFUSION_PERF_BASELINE_PLATFORM` as an override
- keep CI case-parser estimates compatible with the platform baseline directory

## 5090 baseline source
- real CI history from PR #29791: [run `28492141274`, job `84450974283`](https://github.com/sgl-project/sglang/actions/runs/28492141274/job/84450974283?pr=29791), runner `5090-d-runner-3`
- added the 5090 cases that produced perf data in that job: `flux_2_klein_base_image_t2i`, `wan2_1_t2v_1.3b`, `zimage_image_t2i`
- did not add `turbo_wan2_1_t2v_1.3b` or `flux_image_t2i_layerwise_cpu_offload_5090` because that run did not produce usable perf metrics for them

## Test Plan
- `python -m json.tool python/sglang/multimodal_gen/test/server/perf_baselines/h100.json`
- `python -m json.tool python/sglang/multimodal_gen/test/server/perf_baselines/b200.json`
- `python -m json.tool python/sglang/multimodal_gen/test/server/perf_baselines/5090.json`
- parser smoke test for `load_baselines(Path("python/sglang/multimodal_gen/test/server/perf_baselines"))`
- `pre-commit run --files python/sglang/multimodal_gen/test/scripts/gen_perf_baselines.py python/sglang/multimodal_gen/test/server/testcase_configs.py python/sglang/multimodal_gen/test/server/test_server_common.py scripts/ci/utils/diffusion/diffusion_case_parser.py python/sglang/multimodal_gen/test/server/perf_baselines/h100.json python/sglang/multimodal_gen/test/server/perf_baselines/b200.json python/sglang/multimodal_gen/test/server/perf_baselines/5090.json`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28493977998](https://github.com/sgl-project/sglang/actions/runs/28493977998)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28493977893](https://github.com/sgl-project/sglang/actions/runs/28493977893)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
