### PR TITLE
[Feature] Reuse OpenAI preprocessing for tokenize endpoints

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -89,7 +89,6 @@ from sglang.srt.entrypoints.openai.protocol import (
     ModelList,
     ResponsesRequest,
     ScoringRequest,
-    TokenizeRequest,
     V1RerankReqInput,
 )
 from sglang.srt.entrypoints.openai.serving_classify import OpenAIServingClassify
@@ -309,7 +308,9 @@ async def lifespan(fast_api_app: FastAPI):
         _global_state.tokenizer_manager, _global_state.template_manager
     )
     fast_api_app.state.openai_serving_tokenize = OpenAIServingTokenize(
-        _global_state.tokenizer_manager, _global_state.template_manager
+        _global_state.tokenizer_manager,
+        fast_api_app.state.openai_serving_chat,
+        fast_api_app.state.openai_serving_completion,
     )
     fast_api_app.state.openai_serving_detokenize = OpenAIServingDetokenize(
         _global_state.tokenizer_manager
@@ -1604,6 +1605,34 @@ async def openai_v1_chat_completions(
 
 
 @app.post(
+    "/v1/chat/tokenize",
+    response_class=ORJSONResponse,
+    dependencies=[Depends(validate_json_request)],
+)
+async def openai_v1_chat_tokenize(request: ChatCompletionRequest, raw_request: Request):
+    """OpenAI-compatible chat tokenization endpoint."""
+    return await raw_request.app.state.openai_serving_tokenize.handle_chat_request(
+        request, raw_request
+    )
+
+
+@app.post(
+    "/v1/completions/tokenize",
+    response_class=ORJSONResponse,
+    dependencies=[Depends(validate_json_request)],
+)
+async def openai_v1_completions_tokenize(
+    request: CompletionRequest, raw_request: Request
+):
+    """OpenAI-compatible text completion tokenization endpoint."""
+    return (
+        await raw_request.app.state.openai_serving_tokenize.handle_completions_request(
+            request, raw_request
+        )
+    )
+
+
+@app.post(
     "/v1/embeddings",
     response_class=ORJSONResponse,
     dependencies=[Depends(validate_json_request)],
@@ -1638,7 +1667,9 @@ async def openai_v1_classify(request: ClassifyRequest, raw_request: Request):
     dependencies=[Depends(validate_json_request)],
     include_in_schema=False,
 )
-async def openai_v1_tokenize(request: TokenizeRequest, raw_request: Request):
+async def openai_v1_tokenize(
+    request: Annotated[Dict[str, Any], Body()], raw_request: Request
+):
     """OpenAI-compatible tokenization endpoint."""
     return await raw_request.app.state.openai_serving_tokenize.handle_request(
         request, raw_request

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -95,7 +95,6 @@ from sglang.srt.entrypoints.openai.protocol import (
     ModelList,
     ResponsesRequest,
     ScoringRequest,
-    TokenizeRequest,
     V1RerankReqInput,
 )
 from sglang.srt.entrypoints.openai.serving_classify import OpenAIServingClassify
@@ -324,7 +323,9 @@ async def lifespan(fast_api_app: FastAPI):
         _global_state.tokenizer_manager, _global_state.template_manager
     )
     fast_api_app.state.openai_serving_tokenize = OpenAIServingTokenize(
-        _global_state.tokenizer_manager, _global_state.template_manager
+        _global_state.tokenizer_manager,
+        fast_api_app.state.openai_serving_chat,
+        fast_api_app.state.openai_serving_completion,
     )
     fast_api_app.state.openai_serving_detokenize = OpenAIServingDetokenize(
         _global_state.tokenizer_manager
@@ -1748,6 +1749,34 @@ async def openai_v1_chat_completions(
 
 
 @app.post(
+    "/v1/chat/tokenize",
+    response_class=ORJSONResponse,
+    dependencies=[Depends(validate_json_request)],
+)
+async def openai_v1_chat_tokenize(request: ChatCompletionRequest, raw_request: Request):
+    """OpenAI-compatible chat tokenization endpoint."""
+    return await raw_request.app.state.openai_serving_tokenize.handle_chat_request(
+        request, raw_request
+    )
+
+
+@app.post(
+    "/v1/completions/tokenize",
+    response_class=ORJSONResponse,
+    dependencies=[Depends(validate_json_request)],
+)
+async def openai_v1_completions_tokenize(
+    request: CompletionRequest, raw_request: Request
+):
+    """OpenAI-compatible text completion tokenization endpoint."""
+    return (
+        await raw_request.app.state.openai_serving_tokenize.handle_completions_request(
+            request, raw_request
+        )
+    )
+
+
+@app.post(
     "/v1/embeddings",
     response_class=ORJSONResponse,
     dependencies=[Depends(validate_json_request)],
@@ -1782,7 +1811,9 @@ async def openai_v1_classify(request: ClassifyRequest, raw_request: Request):
     dependencies=[Depends(validate_json_request)],
     include_in_schema=False,
 )
-async def openai_v1_tokenize(request: TokenizeRequest, raw_request: Request):
+async def openai_v1_tokenize(
+    request: Annotated[Dict[str, Any], Body()], raw_request: Request
+):
     """OpenAI-compatible tokenization endpoint."""
     return await raw_request.app.state.openai_serving_tokenize.handle_request(
         request, raw_request

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1228,7 +1228,7 @@ class TokenizeRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     model: str = DEFAULT_MODEL_NAME
-    prompt: Optional[Union[str, List[str]]] = None
+    prompt: Optional[Union[List[int], List[List[int]], str, List[str]]] = None
     messages: Optional[List[ChatCompletionMessageParam]] = None
     tools: Optional[List[Tool]] = Field(default=None, examples=[None])
     tool_choice: Optional[Union[ToolChoice, Literal["auto", "required", "none"]]] = (

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1469,7 +1469,7 @@ class TokenizeRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     model: str = DEFAULT_MODEL_NAME
-    prompt: Optional[Union[str, List[str]]] = None
+    prompt: Optional[Union[List[int], List[List[int]], str, List[str]]] = None
     messages: Optional[List[ChatCompletionMessageParam]] = None
     tools: Optional[List[Tool]] = Field(default=None, examples=[None])
     tool_choice: Optional[Union[ToolChoice, Literal["auto", "required", "none"]]] = (

--- a/python/sglang/srt/entrypoints/openai/serving_tokenize.py
+++ b/python/sglang/srt/entrypoints/openai/serving_tokenize.py
@@ -1,6 +1,6 @@
 import logging
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Union
 
 from fastapi import HTTPException, Request
 from pydantic import ValidationError

--- a/python/sglang/srt/entrypoints/openai/serving_tokenize.py
+++ b/python/sglang/srt/entrypoints/openai/serving_tokenize.py
@@ -1,10 +1,14 @@
 import logging
 from http import HTTPStatus
-from typing import List, Optional, Union
+from typing import Any, Dict, Union
 
-from fastapi import Request
+from fastapi import HTTPException, Request
+from pydantic import ValidationError
 
+from sglang.srt.entrypoints.openai.encoding_dsv32 import DS32EncodingError
 from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    CompletionRequest,
     DetokenizeRequest,
     DetokenizeResponse,
     ErrorResponse,
@@ -13,6 +17,8 @@ from sglang.srt.entrypoints.openai.protocol import (
 )
 from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.srt.entrypoints.openai.serving_completions import OpenAIServingCompletion
+from sglang.srt.observability.req_time_stats import monotonic_time
 
 logger = logging.getLogger(__name__)
 
@@ -20,13 +26,15 @@ logger = logging.getLogger(__name__)
 class OpenAIServingTokenize(OpenAIServingBase):
     """Handler for /v1/tokenize requests"""
 
-    def __init__(self, tokenizer_manager, template_manager=None):
+    def __init__(
+        self,
+        tokenizer_manager,
+        chat_serving: OpenAIServingChat,
+        completion_serving: OpenAIServingCompletion,
+    ):
         super().__init__(tokenizer_manager)
-        self.chat_serving: Optional[OpenAIServingChat] = (
-            OpenAIServingChat(tokenizer_manager, template_manager)
-            if template_manager is not None
-            else None
-        )
+        self.chat_serving = chat_serving
+        self.completion_serving = completion_serving
 
     def _request_id_prefix(self) -> str:
         return "tok-"
@@ -36,83 +44,144 @@ class OpenAIServingTokenize(OpenAIServingBase):
     ) -> tuple[TokenizeRequest, TokenizeRequest]:
         return request, request
 
-    async def _handle_non_streaming_request(
-        self,
-        adapted_request: TokenizeRequest,
-        request: TokenizeRequest,
-        raw_request: Request,
+    def _validate_request(self, _: TokenizeRequest) -> Union[str, None]:
+        return None
+
+    async def handle_request(
+        self, request: Union[TokenizeRequest, Dict[str, Any]], raw_request: Request
     ) -> Union[TokenizeResponse, ErrorResponse]:
         try:
-            tokenizer = self.tokenizer_manager.tokenizer
-            max_model_len = getattr(tokenizer, "model_max_length", -1)
-
-            if request.messages is not None:
-                token_ids = self._tokenize_chat_request(request)
-                tokens = token_ids
-                count = len(token_ids)
-            elif isinstance(request.prompt, str):
-                token_ids = tokenizer.encode(
-                    request.prompt,
-                    add_special_tokens=request.add_special_tokens,
-                )
-                tokens = token_ids
-                count = len(token_ids)
-            elif isinstance(request.prompt, list):
-                token_ids_list = [
-                    tokenizer.encode(
-                        text, add_special_tokens=request.add_special_tokens
-                    )
-                    for text in request.prompt
-                ]
-                tokens = token_ids_list
-                count = [len(ids) for ids in token_ids_list]
-            else:
+            body = self._request_to_dict(request)
+            has_messages = body.get("messages") is not None
+            has_prompt = body.get("prompt") is not None
+            if has_messages == has_prompt:
                 return self.create_error_response(
-                    f"Invalid prompt type: {type(request.prompt)}. Expected str or List[str]."
+                    "Exactly one of 'prompt' or 'messages' must be provided."
                 )
 
-            return TokenizeResponse(
-                tokens=tokens, count=count, max_model_len=max_model_len
+            if has_messages:
+                body.pop("prompt", None)
+                body.pop("add_special_tokens", None)
+                chat_request = ChatCompletionRequest.model_validate(body)
+                return await self.handle_chat_request(chat_request, raw_request)
+
+            body.pop("messages", None)
+            for field_name in (
+                "tools",
+                "tool_choice",
+                "reasoning_effort",
+                "continue_final_message",
+                "chat_template_kwargs",
+                "add_special_tokens",
+            ):
+                body.pop(field_name, None)
+            completion_request = CompletionRequest.model_validate(body)
+            return await self.handle_completions_request(
+                completion_request, raw_request
             )
-        except ValueError as e:
-            return self.create_error_response(str(e))
         except Exception as e:
-            logger.error("Error during tokenization", exc_info=True)
-            return self.create_error_response(
-                f"Internal server error during tokenization: {e}",
-                err_type="InternalServerError",
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
+            return self._create_exception_response(e)
 
-    def _tokenize_chat_request(self, request: TokenizeRequest) -> List[int]:
-        if self.chat_serving is None:
-            raise ValueError("Chat template tokenization requires a template manager.")
-
-        chat_request = request.to_chat_completion_request()
-        validation_error = self.chat_serving._validate_request(chat_request)
-        if validation_error:
-            raise ValueError(validation_error)
-
-        is_multimodal = self.tokenizer_manager.model_config.is_multimodal
-        processed_messages = self.chat_serving._process_messages(
-            chat_request, is_multimodal
+    async def handle_chat_request(
+        self, request: ChatCompletionRequest, raw_request: Request
+    ) -> Union[TokenizeResponse, ErrorResponse]:
+        return await self._handle_tokenize_request(
+            self.chat_serving, request, raw_request
         )
 
-        prompt_ids = processed_messages.prompt_ids
-        if isinstance(prompt_ids, list) and (
-            prompt_ids or not processed_messages.prompt
-        ):
-            return prompt_ids
-        if isinstance(prompt_ids, str):
-            return self.tokenizer_manager.tokenizer.encode(
-                prompt_ids, add_special_tokens=False
+    async def handle_completions_request(
+        self, request: CompletionRequest, raw_request: Request
+    ) -> Union[TokenizeResponse, ErrorResponse]:
+        return await self._handle_tokenize_request(
+            self.completion_serving, request, raw_request
+        )
+
+    async def _handle_tokenize_request(
+        self,
+        serving: Union[OpenAIServingChat, OpenAIServingCompletion],
+        request: Union[ChatCompletionRequest, CompletionRequest],
+        raw_request: Request,
+    ) -> Union[TokenizeResponse, ErrorResponse]:
+        received_time = monotonic_time()
+        try:
+            error_msg = serving._validate_request(request)
+            if error_msg:
+                return self.create_error_response(error_msg)
+
+            self._log_openai_request(request, raw_request)
+            adapted_request, _ = serving._convert_to_internal_request(
+                request, raw_request
             )
-        if processed_messages.prompt:
-            return self.tokenizer_manager.tokenizer.encode(
-                processed_messages.prompt, add_special_tokens=False
+            adapted_request.received_time = received_time
+            token_ids = await self.tokenizer_manager.tokenize_request(
+                adapted_request, raw_request
+            )
+            return self._create_tokenize_response(token_ids)
+        except Exception as e:
+            return self._create_exception_response(e)
+
+    def _request_to_dict(
+        self, request: Union[TokenizeRequest, Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        if isinstance(request, dict):
+            return dict(request)
+
+        data = request.model_dump(exclude_none=True)
+        extra = getattr(request, "__pydantic_extra__", None)
+        if extra:
+            data.update(extra)
+        return data
+
+    def _log_openai_request(
+        self,
+        request: Union[ChatCompletionRequest, CompletionRequest],
+        raw_request: Request,
+    ):
+        request_logger = self.tokenizer_manager.request_logger
+        if request_logger.log_requests and request_logger.log_requests_level >= 2:
+            request_logger.log_openai_received_request(request, request=raw_request)
+
+    def _create_tokenize_response(
+        self, tokens: Union[list[int], list[list[int]]]
+    ) -> TokenizeResponse:
+        count: Union[int, list[int]]
+        if tokens and isinstance(tokens[0], list):
+            count = [len(token_ids) for token_ids in tokens]
+        else:
+            count = len(tokens)
+
+        return TokenizeResponse(
+            tokens=tokens,
+            count=count,
+            max_model_len=self._get_max_model_len(),
+        )
+
+    def _get_max_model_len(self) -> int:
+        tokenizer = self.tokenizer_manager.tokenizer
+        max_model_len = getattr(tokenizer, "model_max_length", -1)
+        if not isinstance(max_model_len, int):
+            model_config = getattr(self.tokenizer_manager, "model_config", None)
+            max_model_len = getattr(model_config, "context_len", -1)
+        return max_model_len if isinstance(max_model_len, int) else -1
+
+    def _create_exception_response(self, e: Exception):
+        if isinstance(e, HTTPException):
+            return self.create_error_response(
+                message=e.detail, err_type=str(e.status_code), status_code=e.status_code
+            )
+        if isinstance(e, (ValueError, ValidationError, DS32EncodingError)):
+            return self.create_error_response(
+                message=str(e),
+                err_type="BadRequest",
+                status_code=HTTPStatus.BAD_REQUEST,
             )
 
-        raise ValueError("Failed to render chat messages into token ids.")
+        logger.exception(f"Error during tokenization: {e}")
+        return self.create_error_response(
+            f"Internal server error during tokenization: {e}",
+            err_type="InternalServerError",
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
 
 
 class OpenAIServingDetokenize(OpenAIServingBase):

--- a/python/sglang/srt/entrypoints/openai/serving_tokenize.py
+++ b/python/sglang/srt/entrypoints/openai/serving_tokenize.py
@@ -1,10 +1,14 @@
 import logging
 from http import HTTPStatus
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Union
 
-from fastapi import Request
+from fastapi import HTTPException, Request
+from pydantic import ValidationError
 
+from sglang.srt.entrypoints.openai.encoding_dsv32 import DS32EncodingError
 from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    CompletionRequest,
     DetokenizeRequest,
     DetokenizeResponse,
     ErrorResponse,
@@ -13,6 +17,8 @@ from sglang.srt.entrypoints.openai.protocol import (
 )
 from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.srt.entrypoints.openai.serving_completions import OpenAIServingCompletion
+from sglang.srt.observability.req_time_stats import monotonic_time
 
 logger = logging.getLogger(__name__)
 
@@ -20,13 +26,15 @@ logger = logging.getLogger(__name__)
 class OpenAIServingTokenize(OpenAIServingBase):
     """Handler for /v1/tokenize requests"""
 
-    def __init__(self, tokenizer_manager, template_manager=None):
+    def __init__(
+        self,
+        tokenizer_manager,
+        chat_serving: OpenAIServingChat,
+        completion_serving: OpenAIServingCompletion,
+    ):
         super().__init__(tokenizer_manager)
-        self.chat_serving: Optional[OpenAIServingChat] = (
-            OpenAIServingChat(tokenizer_manager, template_manager)
-            if template_manager is not None
-            else None
-        )
+        self.chat_serving = chat_serving
+        self.completion_serving = completion_serving
 
     def _request_id_prefix(self) -> str:
         return "tok-"
@@ -36,88 +44,156 @@ class OpenAIServingTokenize(OpenAIServingBase):
     ) -> tuple[TokenizeRequest, TokenizeRequest]:
         return request, request
 
-    async def _handle_non_streaming_request(
-        self,
-        adapted_request: TokenizeRequest,
-        request: TokenizeRequest,
-        raw_request: Request,
+    def _validate_request(self, _: TokenizeRequest) -> Union[str, None]:
+        return None
+
+    async def handle_request(
+        self, request: Union[TokenizeRequest, Dict[str, Any]], raw_request: Request
     ) -> Union[TokenizeResponse, ErrorResponse]:
         try:
-            tokenizer = self.tokenizer_manager.tokenizer
-            max_model_len = getattr(tokenizer, "model_max_length", -1)
-            # ORJSON accepts signed negative and unsigned positive 64-bit integers.
-            if isinstance(max_model_len, int) and not (
-                -(2**63) <= max_model_len < 2**64
-            ):
-                max_model_len = self.tokenizer_manager.model_config.context_len
-
-            if request.messages is not None:
-                token_ids = self._tokenize_chat_request(request)
-                tokens = token_ids
-                count = len(token_ids)
-            elif isinstance(request.prompt, str):
-                token_ids = tokenizer.encode(
-                    request.prompt,
-                    add_special_tokens=request.add_special_tokens,
-                )
-                tokens = token_ids
-                count = len(token_ids)
-            elif isinstance(request.prompt, list):
-                token_ids_list = [
-                    tokenizer.encode(
-                        text, add_special_tokens=request.add_special_tokens
-                    )
-                    for text in request.prompt
-                ]
-                tokens = token_ids_list
-                count = [len(ids) for ids in token_ids_list]
-            else:
+            body = self._request_to_dict(request)
+            has_messages = body.get("messages") is not None
+            has_prompt = body.get("prompt") is not None
+            if has_messages == has_prompt:
                 return self.create_error_response(
-                    f"Invalid prompt type: {type(request.prompt)}. Expected str or List[str]."
+                    "Exactly one of 'prompt' or 'messages' must be provided."
                 )
 
-            return TokenizeResponse(
-                tokens=tokens, count=count, max_model_len=max_model_len
+            if has_messages:
+                body.pop("prompt", None)
+                body.pop("add_special_tokens", None)
+                chat_request = ChatCompletionRequest.model_validate(body)
+                return await self.handle_chat_request(chat_request, raw_request)
+
+            body.pop("messages", None)
+            if body.pop("add_special_tokens", True) is False:
+                prompt = body["prompt"]
+                tokenizer = self.tokenizer_manager.tokenizer
+                if isinstance(prompt, str):
+                    body["prompt"] = tokenizer.encode(prompt, add_special_tokens=False)
+                elif prompt and isinstance(prompt[0], str):
+                    body["prompt"] = [
+                        tokenizer.encode(text, add_special_tokens=False)
+                        for text in prompt
+                    ]
+            for field_name in (
+                "tools",
+                "tool_choice",
+                "reasoning_effort",
+                "continue_final_message",
+                "chat_template_kwargs",
+            ):
+                body.pop(field_name, None)
+            completion_request = CompletionRequest.model_validate(body)
+            return await self.handle_completions_request(
+                completion_request, raw_request
             )
-        except ValueError as e:
-            return self.create_error_response(str(e))
         except Exception as e:
-            logger.error("Error during tokenization", exc_info=True)
-            return self.create_error_response(
-                f"Internal server error during tokenization: {e}",
-                err_type="InternalServerError",
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
+            return self._create_exception_response(e)
 
-    def _tokenize_chat_request(self, request: TokenizeRequest) -> List[int]:
-        if self.chat_serving is None:
-            raise ValueError("Chat template tokenization requires a template manager.")
-
-        chat_request = request.to_chat_completion_request()
-        validation_error = self.chat_serving._validate_request(chat_request)
-        if validation_error:
-            raise ValueError(validation_error)
-
-        is_multimodal = self.tokenizer_manager.model_config.is_multimodal
-        processed_messages = self.chat_serving._process_messages(
-            chat_request, is_multimodal
+    async def handle_chat_request(
+        self, request: ChatCompletionRequest, raw_request: Request
+    ) -> Union[TokenizeResponse, ErrorResponse]:
+        return await self._handle_tokenize_request(
+            self.chat_serving, request, raw_request
         )
 
-        prompt_ids = processed_messages.prompt_ids
-        if isinstance(prompt_ids, list) and (
-            prompt_ids or not processed_messages.prompt
-        ):
-            return prompt_ids
-        if isinstance(prompt_ids, str):
-            return self.tokenizer_manager.tokenizer.encode(
-                prompt_ids, add_special_tokens=False
+    async def handle_completions_request(
+        self, request: CompletionRequest, raw_request: Request
+    ) -> Union[TokenizeResponse, ErrorResponse]:
+        return await self._handle_tokenize_request(
+            self.completion_serving, request, raw_request
+        )
+
+    async def _handle_tokenize_request(
+        self,
+        serving: Union[OpenAIServingChat, OpenAIServingCompletion],
+        request: Union[ChatCompletionRequest, CompletionRequest],
+        raw_request: Request,
+    ) -> Union[TokenizeResponse, ErrorResponse]:
+        received_time = monotonic_time()
+        try:
+            error_msg = serving._validate_request(request)
+            if error_msg:
+                return self.create_error_response(error_msg)
+
+            self._log_openai_request(request, raw_request)
+            adapted_request, _ = serving._convert_to_internal_request(
+                request, raw_request
             )
-        if processed_messages.prompt:
-            return self.tokenizer_manager.tokenizer.encode(
-                processed_messages.prompt, add_special_tokens=False
+            adapted_request.received_time = received_time
+            token_ids = await self.tokenizer_manager.tokenize_request(
+                adapted_request, raw_request
+            )
+            return self._create_tokenize_response(token_ids)
+        except Exception as e:
+            return self._create_exception_response(e)
+
+    def _request_to_dict(
+        self, request: Union[TokenizeRequest, Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        if isinstance(request, dict):
+            return dict(request)
+
+        data = request.model_dump(exclude_none=True)
+        extra = getattr(request, "__pydantic_extra__", None)
+        if extra:
+            data.update(extra)
+        return data
+
+    def _log_openai_request(
+        self,
+        request: Union[ChatCompletionRequest, CompletionRequest],
+        raw_request: Request,
+    ):
+        request_logger = self.tokenizer_manager.request_logger
+        if request_logger.log_requests and request_logger.log_requests_level >= 2:
+            request_logger.log_openai_received_request(request, request=raw_request)
+
+    def _create_tokenize_response(
+        self, tokens: Union[list[int], list[list[int]]]
+    ) -> TokenizeResponse:
+        count: Union[int, list[int]]
+        if tokens and isinstance(tokens[0], list):
+            count = [len(token_ids) for token_ids in tokens]
+        else:
+            count = len(tokens)
+
+        return TokenizeResponse(
+            tokens=tokens,
+            count=count,
+            max_model_len=self._get_max_model_len(),
+        )
+
+    def _get_max_model_len(self) -> int:
+        tokenizer = self.tokenizer_manager.tokenizer
+        max_model_len = getattr(tokenizer, "model_max_length", -1)
+        # ORJSON accepts signed negative and unsigned positive 64-bit integers.
+        if not isinstance(max_model_len, int) or not (
+            -(2**63) <= max_model_len < 2**64
+        ):
+            model_config = getattr(self.tokenizer_manager, "model_config", None)
+            max_model_len = getattr(model_config, "context_len", -1)
+        return max_model_len if isinstance(max_model_len, int) else -1
+
+    def _create_exception_response(self, e: Exception):
+        if isinstance(e, HTTPException):
+            return self.create_error_response(
+                message=e.detail, err_type=str(e.status_code), status_code=e.status_code
+            )
+        if isinstance(e, (ValueError, ValidationError, DS32EncodingError)):
+            return self.create_error_response(
+                message=str(e),
+                err_type="BadRequest",
+                status_code=HTTPStatus.BAD_REQUEST,
             )
 
-        raise ValueError("Failed to render chat messages into token ids.")
+        logger.exception(f"Error during tokenization: {e}")
+        return self.create_error_response(
+            f"Internal server error during tokenization: {e}",
+            err_type="InternalServerError",
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
 
 
 class OpenAIServingDetokenize(OpenAIServingBase):

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -597,16 +597,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         obj.normalize_batch_and_arguments()
         self._set_default_priority(obj)
 
-        if isinstance(obj, GenerateReqInput) and obj.routed_dp_rank is not None:
-            dp_size = self.server_args.dp_size
-            if dp_size <= 1 and obj.routed_dp_rank == 0:
-                logger.debug(
-                    f"routed_dp_rank={obj.routed_dp_rank} is ignored because dp_size={dp_size}"
-                )
-            elif obj.routed_dp_rank < 0 or obj.routed_dp_rank >= dp_size:
-                raise ValueError(
-                    f"routed_dp_rank={obj.routed_dp_rank} out of range [0, {dp_size})"
-                )
+        self._validate_routed_dp_rank(obj)
 
         self._init_req_state(obj, request)
         try:
@@ -644,6 +635,68 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             # path are left untouched (pop is a no-op).
             self._discard_pending_req_states(obj)
             raise
+
+    def _validate_routed_dp_rank(self, obj: Union[GenerateReqInput, EmbeddingReqInput]):
+        if isinstance(obj, GenerateReqInput) and obj.routed_dp_rank is not None:
+            dp_size = self.server_args.dp_size
+            if dp_size <= 1 and obj.routed_dp_rank == 0:
+                logger.debug(
+                    f"routed_dp_rank={obj.routed_dp_rank} is ignored because dp_size={dp_size}"
+                )
+            elif obj.routed_dp_rank < 0 or obj.routed_dp_rank >= dp_size:
+                raise ValueError(
+                    f"routed_dp_rank={obj.routed_dp_rank} out of range [0, {dp_size})"
+                )
+
+    async def tokenize_request(
+        self,
+        obj: GenerateReqInput,
+        request: Optional[fastapi.Request] = None,
+    ) -> Union[List[int], List[List[int]]]:
+        """Tokenize a generation request without dispatching it to the scheduler."""
+        self.auto_create_handle_loop()
+
+        obj.normalize_batch_and_arguments()
+        self._set_default_priority(obj)
+        self._validate_routed_dp_rank(obj)
+
+        state_initialized = False
+        self._init_req_state(obj, request)
+        state_initialized = True
+        try:
+            if self.server_args.language_only:
+                self._handle_epd_disaggregation_encode_request(obj)
+
+            self.request_logger.log_received_request(obj, self.tokenizer, request)
+
+            async with self.is_pause_cond:
+                await self.is_pause_cond.wait_for(lambda: not self.is_pause)
+
+            async with self.model_update_lock.reader_lock:
+                await self._validate_and_resolve_lora(obj)
+
+                if obj.is_single:
+                    tokenized_obj = await self._tokenize_one_request(obj)
+                    return list(tokenized_obj.input_ids)
+
+                batch_size = obj.batch_size
+                if getattr(obj, "parallel_sample_num", 1) == 1 and (
+                    self._should_use_batch_tokenization(batch_size, obj)
+                ):
+                    tokenized_objs = await self._batch_tokenize_and_process(
+                        batch_size, obj
+                    )
+                else:
+                    tokenized_objs = await asyncio.gather(
+                        *(self._tokenize_one_request(obj[i]) for i in range(batch_size))
+                    )
+
+                return [
+                    list(tokenized_obj.input_ids) for tokenized_obj in tokenized_objs
+                ]
+        finally:
+            if state_initialized:
+                self._discard_pending_req_states(obj)
 
     def _detect_input_format(
         self, texts: Union[str, List[str]], is_cross_encoder: bool

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -793,16 +793,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 "--enable-strict-thinking"
             )
 
-        if isinstance(obj, GenerateReqInput) and obj.routed_dp_rank is not None:
-            dp_size = self.elastic_worker_count
-            if dp_size <= 1 and obj.routed_dp_rank == 0:
-                logger.debug(
-                    f"routed_dp_rank={obj.routed_dp_rank} is ignored because dp_size={dp_size}"
-                )
-            elif obj.routed_dp_rank < 0 or obj.routed_dp_rank >= dp_size:
-                raise ValueError(
-                    f"routed_dp_rank={obj.routed_dp_rank} out of range [0, {dp_size})"
-                )
+        self._validate_routed_dp_rank(obj)
 
         self._init_req_state(obj, request)
         request_rids = {obj.rid} if obj.is_single else set(obj.rid)
@@ -843,6 +834,81 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             # cleanup.
             self._release_req_states_on_failure(request_rids)
             raise
+
+    def _validate_routed_dp_rank(self, obj: Union[GenerateReqInput, EmbeddingReqInput]):
+        if isinstance(obj, GenerateReqInput) and obj.routed_dp_rank is not None:
+            dp_size = self.elastic_worker_count
+            if dp_size <= 1 and obj.routed_dp_rank == 0:
+                logger.debug(
+                    f"routed_dp_rank={obj.routed_dp_rank} is ignored because dp_size={dp_size}"
+                )
+            elif obj.routed_dp_rank < 0 or obj.routed_dp_rank >= dp_size:
+                raise ValueError(
+                    f"routed_dp_rank={obj.routed_dp_rank} out of range [0, {dp_size})"
+                )
+
+    async def tokenize_request(
+        self,
+        obj: GenerateReqInput,
+        request: Optional[fastapi.Request] = None,
+    ) -> Union[List[int], List[List[int]]]:
+        """Tokenize a generation request without dispatching it to the scheduler."""
+        self.auto_create_handle_loop()
+
+        obj.normalize_batch_and_arguments()
+        self._set_default_priority(obj)
+        if (
+            obj.max_thinking_tokens is not None
+            and not get_serving().enable_strict_thinking
+        ):
+            raise ValueError(
+                "max_thinking_tokens requires the server to be launched with "
+                "--enable-strict-thinking"
+            )
+        self._validate_routed_dp_rank(obj)
+
+        state_initialized = False
+        lora_acquired = False
+        self._init_req_state(obj, request)
+        state_initialized = True
+        request_rids = {obj.rid} if obj.is_single else set(obj.rid)
+        try:
+            if get_disagg().language_only:
+                self._handle_epd_disaggregation_encode_request(obj)
+
+            self.request_logger.log_received_request(obj, self.tokenizer, request)
+
+            async with self.is_pause_cond:
+                await self.is_pause_cond.wait_for(lambda: not self.is_pause)
+
+            async with self.model_update_lock.reader_lock:
+                await self._validate_and_resolve_lora(obj)
+                lora_acquired = self.enable_lora and bool(obj.lora_path)
+
+                if obj.is_single:
+                    tokenized_obj = await self._tokenize_one_request(obj)
+                    return list(tokenized_obj.input_ids)
+
+                batch_size = obj.batch_size
+                if getattr(obj, "parallel_sample_num", 1) == 1 and (
+                    self._should_use_batch_tokenization(batch_size, obj)
+                ):
+                    tokenized_objs = await self._batch_tokenize_and_process(
+                        batch_size, obj
+                    )
+                else:
+                    tokenized_objs = await asyncio.gather(
+                        *(self._tokenize_one_request(obj[i]) for i in range(batch_size))
+                    )
+
+                return [
+                    list(tokenized_obj.input_ids) for tokenized_obj in tokenized_objs
+                ]
+        finally:
+            if state_initialized:
+                self._release_req_states_on_failure(request_rids)
+            if lora_acquired:
+                await self.lora_registry.release(obj.lora_id)
 
     def _detect_input_format(
         self, texts: Union[str, List[str]], is_cross_encoder: bool

--- a/test/registered/openai_server/basic/test_openai_server.py
+++ b/test/registered/openai_server/basic/test_openai_server.py
@@ -346,6 +346,124 @@ class TestOpenAIServer(CustomTestCase):
             for parallel_sample_num in [1, 2]:
                 self.run_chat_completion_stream(logprobs, parallel_sample_num)
 
+    def test_chat_tokenize_matches_chat_completion_prompt_tokens(self):
+        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
+        messages = [
+            {"role": "system", "content": "You are a concise assistant."},
+            {"role": "user", "content": "Name one city in France."},
+        ]
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": 0,
+        }
+
+        tokenize_response = requests.post(
+            self.base_url + "/chat/tokenize",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            json=payload,
+        )
+        self.assertEqual(tokenize_response.status_code, 200, tokenize_response.text)
+        tokenize_body = tokenize_response.json()
+
+        completion = client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=0,
+            max_tokens=1,
+        )
+
+        self.assertEqual(tokenize_body["count"], completion.usage.prompt_tokens)
+        self.assertEqual(len(tokenize_body["tokens"]), tokenize_body["count"])
+
+    def test_completions_tokenize_matches_completion_prompt_tokens(self):
+        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
+        prompt = "The capital of France is"
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "temperature": 0,
+        }
+
+        tokenize_response = requests.post(
+            self.base_url + "/completions/tokenize",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            json=payload,
+        )
+        self.assertEqual(tokenize_response.status_code, 200, tokenize_response.text)
+        tokenize_body = tokenize_response.json()
+
+        completion = client.completions.create(
+            model=self.model,
+            prompt=prompt,
+            temperature=0,
+            max_tokens=1,
+        )
+
+        self.assertEqual(tokenize_body["count"], completion.usage.prompt_tokens)
+        self.assertEqual(len(tokenize_body["tokens"]), tokenize_body["count"])
+
+    def test_tokenize_dispatches_and_rejects_ambiguous_body(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        chat_payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        completion_payload = {
+            "model": self.model,
+            "prompt": "hello",
+        }
+
+        chat_tokenize = requests.post(
+            self.base_url + "/chat/tokenize",
+            headers=headers,
+            json=chat_payload,
+        )
+        generic_chat_tokenize = requests.post(
+            self.base_url + "/tokenize",
+            headers=headers,
+            json=chat_payload,
+        )
+        self.assertEqual(chat_tokenize.status_code, 200, chat_tokenize.text)
+        self.assertEqual(
+            generic_chat_tokenize.status_code, 200, generic_chat_tokenize.text
+        )
+        self.assertEqual(chat_tokenize.json(), generic_chat_tokenize.json())
+
+        completions_tokenize = requests.post(
+            self.base_url + "/completions/tokenize",
+            headers=headers,
+            json=completion_payload,
+        )
+        generic_completions_tokenize = requests.post(
+            self.base_url + "/tokenize",
+            headers=headers,
+            json=completion_payload,
+        )
+        self.assertEqual(
+            completions_tokenize.status_code, 200, completions_tokenize.text
+        )
+        self.assertEqual(
+            generic_completions_tokenize.status_code,
+            200,
+            generic_completions_tokenize.text,
+        )
+        self.assertEqual(
+            completions_tokenize.json(), generic_completions_tokenize.json()
+        )
+
+        ambiguous = requests.post(
+            self.base_url + "/tokenize",
+            headers=headers,
+            json={
+                "model": self.model,
+                "prompt": "hello",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        self.assertEqual(ambiguous.status_code, 400, ambiguous.text)
+        self.assertIn("Exactly one", ambiguous.json()["message"])
+
     def test_regex(self):
         client = openai.Client(api_key=self.api_key, base_url=self.base_url)
 

--- a/test/registered/openai_server/basic/test_openai_server.py
+++ b/test/registered/openai_server/basic/test_openai_server.py
@@ -449,6 +449,124 @@ class TestOpenAIServer(CustomTestCase, AnthropicMessagesMixin):
             for parallel_sample_num in [1, 2]:
                 self.run_chat_completion_stream(logprobs, parallel_sample_num)
 
+    def test_chat_tokenize_matches_chat_completion_prompt_tokens(self):
+        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
+        messages = [
+            {"role": "system", "content": "You are a concise assistant."},
+            {"role": "user", "content": "Name one city in France."},
+        ]
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": 0,
+        }
+
+        tokenize_response = requests.post(
+            self.base_url + "/chat/tokenize",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            json=payload,
+        )
+        self.assertEqual(tokenize_response.status_code, 200, tokenize_response.text)
+        tokenize_body = tokenize_response.json()
+
+        completion = client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=0,
+            max_tokens=1,
+        )
+
+        self.assertEqual(tokenize_body["count"], completion.usage.prompt_tokens)
+        self.assertEqual(len(tokenize_body["tokens"]), tokenize_body["count"])
+
+    def test_completions_tokenize_matches_completion_prompt_tokens(self):
+        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
+        prompt = "The capital of France is"
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "temperature": 0,
+        }
+
+        tokenize_response = requests.post(
+            self.base_url + "/completions/tokenize",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            json=payload,
+        )
+        self.assertEqual(tokenize_response.status_code, 200, tokenize_response.text)
+        tokenize_body = tokenize_response.json()
+
+        completion = client.completions.create(
+            model=self.model,
+            prompt=prompt,
+            temperature=0,
+            max_tokens=1,
+        )
+
+        self.assertEqual(tokenize_body["count"], completion.usage.prompt_tokens)
+        self.assertEqual(len(tokenize_body["tokens"]), tokenize_body["count"])
+
+    def test_tokenize_dispatches_and_rejects_ambiguous_body(self):
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        chat_payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        completion_payload = {
+            "model": self.model,
+            "prompt": "hello",
+        }
+
+        chat_tokenize = requests.post(
+            self.base_url + "/chat/tokenize",
+            headers=headers,
+            json=chat_payload,
+        )
+        generic_chat_tokenize = requests.post(
+            self.base_url + "/tokenize",
+            headers=headers,
+            json=chat_payload,
+        )
+        self.assertEqual(chat_tokenize.status_code, 200, chat_tokenize.text)
+        self.assertEqual(
+            generic_chat_tokenize.status_code, 200, generic_chat_tokenize.text
+        )
+        self.assertEqual(chat_tokenize.json(), generic_chat_tokenize.json())
+
+        completions_tokenize = requests.post(
+            self.base_url + "/completions/tokenize",
+            headers=headers,
+            json=completion_payload,
+        )
+        generic_completions_tokenize = requests.post(
+            self.base_url + "/tokenize",
+            headers=headers,
+            json=completion_payload,
+        )
+        self.assertEqual(
+            completions_tokenize.status_code, 200, completions_tokenize.text
+        )
+        self.assertEqual(
+            generic_completions_tokenize.status_code,
+            200,
+            generic_completions_tokenize.text,
+        )
+        self.assertEqual(
+            completions_tokenize.json(), generic_completions_tokenize.json()
+        )
+
+        ambiguous = requests.post(
+            self.base_url + "/tokenize",
+            headers=headers,
+            json={
+                "model": self.model,
+                "prompt": "hello",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        self.assertEqual(ambiguous.status_code, 400, ambiguous.text)
+        self.assertIn("Exactly one", ambiguous.json()["message"])
+
     def test_regex(self):
         client = openai.Client(api_key=self.api_key, base_url=self.base_url)
 

--- a/test/registered/unit/entrypoints/openai/test_serving_tokenize.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_tokenize.py
@@ -1,0 +1,181 @@
+"""Unit tests for OpenAI-compatible tokenize serving."""
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+import asyncio
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from fastapi import Request
+
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    CompletionRequest,
+)
+from sglang.srt.entrypoints.openai.serving_tokenize import OpenAIServingTokenize
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+class _MockTokenizerManager:
+    def __init__(self, token_ids):
+        self.server_args = SimpleNamespace(tokenizer_metrics_allowed_custom_labels=None)
+        self.tokenizer = SimpleNamespace(model_max_length=4096)
+        self.request_logger = SimpleNamespace(
+            log_requests=False,
+            log_requests_level=0,
+            log_openai_received_request=Mock(),
+        )
+        self.tokenize_request = AsyncMock(return_value=token_ids)
+
+
+def _raw_request():
+    raw = Mock(spec=Request)
+    raw.headers = {}
+    return raw
+
+
+def _generate_req(input_ids=None):
+    return GenerateReqInput(input_ids=input_ids or [1, 2], sampling_params={})
+
+
+class TestOpenAIServingTokenize(CustomTestCase):
+    def _make_serving(self, token_ids):
+        tokenizer_manager = _MockTokenizerManager(token_ids)
+        chat_serving = Mock()
+        completion_serving = Mock()
+        chat_serving._validate_request.return_value = None
+        completion_serving._validate_request.return_value = None
+        chat_serving._convert_to_internal_request.return_value = (
+            _generate_req([1, 2]),
+            None,
+        )
+        completion_serving._convert_to_internal_request.return_value = (
+            _generate_req([3, 4]),
+            None,
+        )
+        serving = OpenAIServingTokenize(
+            tokenizer_manager=tokenizer_manager,
+            chat_serving=chat_serving,
+            completion_serving=completion_serving,
+        )
+        return serving, tokenizer_manager, chat_serving, completion_serving
+
+    def test_chat_tokenize_uses_chat_conversion_path(self):
+        serving, tokenizer_manager, chat_serving, completion_serving = (
+            self._make_serving([11, 12])
+        )
+        raw = _raw_request()
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        response = asyncio.run(serving.handle_chat_request(request, raw))
+
+        self.assertEqual(response.tokens, [11, 12])
+        self.assertEqual(response.count, 2)
+        self.assertEqual(response.max_model_len, 4096)
+        chat_serving._validate_request.assert_called_once_with(request)
+        chat_serving._convert_to_internal_request.assert_called_once_with(request, raw)
+        tokenizer_manager.tokenize_request.assert_awaited_once_with(
+            chat_serving._convert_to_internal_request.return_value[0], raw
+        )
+        completion_serving._convert_to_internal_request.assert_not_called()
+
+    def test_completions_tokenize_returns_batch_counts(self):
+        serving, tokenizer_manager, chat_serving, completion_serving = (
+            self._make_serving([[21], [22, 23]])
+        )
+        raw = _raw_request()
+        request = CompletionRequest(model="x", prompt=["a", "b"])
+
+        response = asyncio.run(serving.handle_completions_request(request, raw))
+
+        self.assertEqual(response.tokens, [[21], [22, 23]])
+        self.assertEqual(response.count, [1, 2])
+        completion_serving._validate_request.assert_called_once_with(request)
+        completion_serving._convert_to_internal_request.assert_called_once_with(
+            request, raw
+        )
+        tokenizer_manager.tokenize_request.assert_awaited_once_with(
+            completion_serving._convert_to_internal_request.return_value[0], raw
+        )
+        chat_serving._convert_to_internal_request.assert_not_called()
+
+    def test_generic_tokenize_dispatches_messages_to_chat(self):
+        serving, _, _, _ = self._make_serving([31])
+        raw = _raw_request()
+        serving.handle_chat_request = AsyncMock(return_value="chat-response")
+        serving.handle_completions_request = AsyncMock()
+
+        response = asyncio.run(
+            serving.handle_request(
+                {"model": "x", "messages": [{"role": "user", "content": "hi"}]},
+                raw,
+            )
+        )
+
+        self.assertEqual(response, "chat-response")
+        serving.handle_chat_request.assert_awaited_once()
+        chat_request = serving.handle_chat_request.await_args.args[0]
+        self.assertIsInstance(chat_request, ChatCompletionRequest)
+        serving.handle_completions_request.assert_not_called()
+
+    def test_generic_tokenize_dispatches_prompt_to_completions(self):
+        serving, _, _, _ = self._make_serving([41])
+        raw = _raw_request()
+        serving.handle_chat_request = AsyncMock()
+        serving.handle_completions_request = AsyncMock(
+            return_value="completion-response"
+        )
+
+        response = asyncio.run(
+            serving.handle_request({"model": "x", "prompt": "hello"}, raw)
+        )
+
+        self.assertEqual(response, "completion-response")
+        serving.handle_completions_request.assert_awaited_once()
+        completion_request = serving.handle_completions_request.await_args.args[0]
+        self.assertIsInstance(completion_request, CompletionRequest)
+        serving.handle_chat_request.assert_not_called()
+
+    def test_generic_tokenize_rejects_ambiguous_body(self):
+        serving, _, _, _ = self._make_serving([51])
+        raw = _raw_request()
+
+        response = asyncio.run(
+            serving.handle_request(
+                {
+                    "model": "x",
+                    "prompt": "hello",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                raw,
+            )
+        )
+
+        self.assertEqual(response.status_code, 400)
+        body = json.loads(response.body)
+        self.assertIn("Exactly one", body["message"])
+
+    def test_generic_tokenize_rejects_missing_input(self):
+        serving, _, _, _ = self._make_serving([61])
+        raw = _raw_request()
+
+        response = asyncio.run(serving.handle_request({"model": "x"}, raw))
+
+        self.assertEqual(response.status_code, 400)
+        body = json.loads(response.body)
+        self.assertIn("Exactly one", body["message"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/entrypoints/openai/test_serving_tokenize.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_tokenize.py
@@ -1,0 +1,210 @@
+"""Unit tests for OpenAI-compatible tokenize serving."""
+
+import asyncio
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from fastapi import Request
+
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.entrypoints.openai.protocol import (  # noqa: E402
+    ChatCompletionRequest,
+    CompletionRequest,
+)
+from sglang.srt.entrypoints.openai.serving_tokenize import (  # noqa: E402
+    OpenAIServingTokenize,
+)
+from sglang.srt.managers.io_struct import GenerateReqInput  # noqa: E402
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+class _MockTokenizerManager:
+    def __init__(self, token_ids):
+        self.server_args = SimpleNamespace(tokenizer_metrics_allowed_custom_labels=None)
+        self.tokenizer = SimpleNamespace(
+            model_max_length=4096,
+            encode=Mock(return_value=[71, 72]),
+        )
+        self.request_logger = SimpleNamespace(
+            log_requests=False,
+            log_requests_level=0,
+            log_openai_received_request=Mock(),
+        )
+        self.tokenize_request = AsyncMock(return_value=token_ids)
+
+
+def _raw_request():
+    raw = Mock(spec=Request)
+    raw.headers = {}
+    return raw
+
+
+def _generate_req(input_ids=None):
+    return GenerateReqInput(input_ids=input_ids or [1, 2], sampling_params={})
+
+
+class TestOpenAIServingTokenize(CustomTestCase):
+    def _make_serving(self, token_ids):
+        tokenizer_manager = _MockTokenizerManager(token_ids)
+        chat_serving = Mock()
+        completion_serving = Mock()
+        chat_serving._validate_request.return_value = None
+        completion_serving._validate_request.return_value = None
+        chat_serving._convert_to_internal_request.return_value = (
+            _generate_req([1, 2]),
+            None,
+        )
+        completion_serving._convert_to_internal_request.return_value = (
+            _generate_req([3, 4]),
+            None,
+        )
+        serving = OpenAIServingTokenize(
+            tokenizer_manager=tokenizer_manager,
+            chat_serving=chat_serving,
+            completion_serving=completion_serving,
+        )
+        return serving, tokenizer_manager, chat_serving, completion_serving
+
+    def test_chat_tokenize_uses_chat_conversion_path(self):
+        serving, tokenizer_manager, chat_serving, completion_serving = (
+            self._make_serving([11, 12])
+        )
+        raw = _raw_request()
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        response = asyncio.run(serving.handle_chat_request(request, raw))
+
+        self.assertEqual(response.tokens, [11, 12])
+        self.assertEqual(response.count, 2)
+        self.assertEqual(response.max_model_len, 4096)
+        chat_serving._validate_request.assert_called_once_with(request)
+        chat_serving._convert_to_internal_request.assert_called_once_with(request, raw)
+        tokenizer_manager.tokenize_request.assert_awaited_once_with(
+            chat_serving._convert_to_internal_request.return_value[0], raw
+        )
+        completion_serving._convert_to_internal_request.assert_not_called()
+
+    def test_completions_tokenize_returns_batch_counts(self):
+        serving, tokenizer_manager, chat_serving, completion_serving = (
+            self._make_serving([[21], [22, 23]])
+        )
+        raw = _raw_request()
+        request = CompletionRequest(model="x", prompt=["a", "b"])
+
+        response = asyncio.run(serving.handle_completions_request(request, raw))
+
+        self.assertEqual(response.tokens, [[21], [22, 23]])
+        self.assertEqual(response.count, [1, 2])
+        completion_serving._validate_request.assert_called_once_with(request)
+        completion_serving._convert_to_internal_request.assert_called_once_with(
+            request, raw
+        )
+        tokenizer_manager.tokenize_request.assert_awaited_once_with(
+            completion_serving._convert_to_internal_request.return_value[0], raw
+        )
+        chat_serving._convert_to_internal_request.assert_not_called()
+
+    def test_generic_tokenize_dispatches_messages_to_chat(self):
+        serving, _, _, _ = self._make_serving([31])
+        raw = _raw_request()
+        serving.handle_chat_request = AsyncMock(return_value="chat-response")
+        serving.handle_completions_request = AsyncMock()
+
+        response = asyncio.run(
+            serving.handle_request(
+                {"model": "x", "messages": [{"role": "user", "content": "hi"}]},
+                raw,
+            )
+        )
+
+        self.assertEqual(response, "chat-response")
+        serving.handle_chat_request.assert_awaited_once()
+        chat_request = serving.handle_chat_request.await_args.args[0]
+        self.assertIsInstance(chat_request, ChatCompletionRequest)
+        serving.handle_completions_request.assert_not_called()
+
+    def test_generic_tokenize_dispatches_prompt_to_completions(self):
+        serving, _, _, _ = self._make_serving([41])
+        raw = _raw_request()
+        serving.handle_chat_request = AsyncMock()
+        serving.handle_completions_request = AsyncMock(
+            return_value="completion-response"
+        )
+
+        response = asyncio.run(
+            serving.handle_request({"model": "x", "prompt": "hello"}, raw)
+        )
+
+        self.assertEqual(response, "completion-response")
+        serving.handle_completions_request.assert_awaited_once()
+        completion_request = serving.handle_completions_request.await_args.args[0]
+        self.assertIsInstance(completion_request, CompletionRequest)
+        serving.handle_chat_request.assert_not_called()
+
+    def test_generic_tokenize_preserves_add_special_tokens_false(self):
+        serving, tokenizer_manager, _, _ = self._make_serving([41])
+        raw = _raw_request()
+        serving.handle_completions_request = AsyncMock(
+            return_value="completion-response"
+        )
+
+        response = asyncio.run(
+            serving.handle_request(
+                {
+                    "model": "x",
+                    "prompt": "hello",
+                    "add_special_tokens": False,
+                },
+                raw,
+            )
+        )
+
+        self.assertEqual(response, "completion-response")
+        tokenizer_manager.tokenizer.encode.assert_called_once_with(
+            "hello", add_special_tokens=False
+        )
+        completion_request = serving.handle_completions_request.await_args.args[0]
+        self.assertEqual(completion_request.prompt, [71, 72])
+
+    def test_generic_tokenize_rejects_ambiguous_body(self):
+        serving, _, _, _ = self._make_serving([51])
+        raw = _raw_request()
+
+        response = asyncio.run(
+            serving.handle_request(
+                {
+                    "model": "x",
+                    "prompt": "hello",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                raw,
+            )
+        )
+
+        self.assertEqual(response.status_code, 400)
+        body = json.loads(response.body)
+        self.assertIn("Exactly one", body["message"])
+
+    def test_generic_tokenize_rejects_missing_input(self):
+        serving, _, _, _ = self._make_serving([61])
+        raw = _raw_request()
+
+        response = asyncio.run(serving.handle_request({"model": "x"}, raw))
+
+        self.assertEqual(response.status_code, 400)
+        body = json.loads(response.body)
+        self.assertIn("Exactly one", body["message"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -14,6 +14,7 @@ Covers:
 
 import asyncio
 import unittest
+from array import array
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import msgspec
@@ -397,6 +398,11 @@ class _DummyAsyncCM:
         return False
 
 
+class _TokenizedGenerateObj:
+    def __init__(self, input_ids):
+        self.input_ids = array("q", input_ids)
+
+
 def _make_tm_for_generate() -> TokenizerManager:
     """Augment the mocked TokenizerManager with what generate_request needs."""
     tm = _make_tokenizer_manager()
@@ -514,6 +520,81 @@ class TestGenerateRequestCleanupOnDispatchFailure(CustomTestCase):
         # All sub-request entries created by _init_req_state are cleaned up.
         for r in rids:
             self.assertNotIn(r, tm.rid_to_state)
+
+
+class TestTokenizeRequestWithoutGeneration(CustomTestCase):
+    def test_single_request_returns_ids_without_dispatch_and_cleans_state(self):
+        tm = _make_tm_for_generate()
+        rid = "single_tokenize"
+        obj = _make_generate_obj(rid, is_single=True)
+        tm._tokenize_one_request = AsyncMock(
+            return_value=_TokenizedGenerateObj([7, 8, 9])
+        )
+        tm._send_one_request = Mock()
+        tm._send_batch_request = Mock()
+
+        token_ids = asyncio.run(tm.tokenize_request(obj))
+
+        self.assertEqual(token_ids, [7, 8, 9])
+        tm._tokenize_one_request.assert_awaited_once_with(obj)
+        tm._send_one_request.assert_not_called()
+        tm._send_batch_request.assert_not_called()
+        self.assertNotIn(rid, tm.rid_to_state)
+
+    def test_batch_request_returns_ids_without_dispatch_and_cleans_state(self):
+        tm = _make_tm_for_generate()
+        rids = ["batch_tokenize_0", "batch_tokenize_1"]
+        obj = _make_generate_obj(list(rids), is_single=False)
+        obj.batch_size = len(rids)
+        sub_objs = []
+        for rid in rids:
+            sub_obj = _make_generate_obj(rid, is_single=True)
+            sub_objs.append(sub_obj)
+        obj.__getitem__.side_effect = lambda i: sub_objs[i]
+        tm._should_use_batch_tokenization = Mock(return_value=False)
+        tm._tokenize_one_request = AsyncMock(
+            side_effect=[
+                _TokenizedGenerateObj([1, 2]),
+                _TokenizedGenerateObj([3, 4, 5]),
+            ]
+        )
+        tm._send_one_request = Mock()
+        tm._send_batch_request = Mock()
+
+        token_ids = asyncio.run(tm.tokenize_request(obj))
+
+        self.assertEqual(token_ids, [[1, 2], [3, 4, 5]])
+        self.assertEqual(tm._tokenize_one_request.await_count, 2)
+        tm._send_one_request.assert_not_called()
+        tm._send_batch_request.assert_not_called()
+        for rid in rids:
+            self.assertNotIn(rid, tm.rid_to_state)
+
+    def test_batch_request_uses_batch_tokenization_without_dispatch(self):
+        tm = _make_tm_for_generate()
+        rids = ["batch_encode_tokenize_0", "batch_encode_tokenize_1"]
+        obj = _make_generate_obj(list(rids), is_single=False)
+        obj.batch_size = len(rids)
+        tm._should_use_batch_tokenization = Mock(return_value=True)
+        tm._batch_tokenize_and_process = AsyncMock(
+            return_value=[
+                _TokenizedGenerateObj([10, 11]),
+                _TokenizedGenerateObj([12]),
+            ]
+        )
+        tm._tokenize_one_request = AsyncMock()
+        tm._send_one_request = Mock()
+        tm._send_batch_request = Mock()
+
+        token_ids = asyncio.run(tm.tokenize_request(obj))
+
+        self.assertEqual(token_ids, [[10, 11], [12]])
+        tm._batch_tokenize_and_process.assert_awaited_once_with(len(rids), obj)
+        tm._tokenize_one_request.assert_not_called()
+        tm._send_one_request.assert_not_called()
+        tm._send_batch_request.assert_not_called()
+        for rid in rids:
+            self.assertNotIn(rid, tm.rid_to_state)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -15,6 +15,7 @@ Covers:
 
 import asyncio
 import unittest
+from array import array
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import msgspec
@@ -468,6 +469,11 @@ class _DummyAsyncCM:
         return False
 
 
+class _TokenizedGenerateObj:
+    def __init__(self, input_ids):
+        self.input_ids = array("q", input_ids)
+
+
 def _make_tm_for_generate(case) -> TokenizerManager:
     """Augment the mocked TokenizerManager with what generate_request needs."""
     tm = _make_tokenizer_manager(case)
@@ -495,6 +501,8 @@ def _make_generate_obj(rid, is_single):
     obj.external_trace_header = None
     obj.bootstrap_room = None
     obj.max_thinking_tokens = None
+    obj.lora_path = None
+    obj.lora_id = None
     obj.normalize_batch_and_arguments = Mock()
     if not is_single:
         obj.__getitem__.side_effect = lambda i: Mock()
@@ -801,6 +809,100 @@ class TestDisconnectAfterDispatchAbortsRequest(CustomTestCase):
         aborts = [m for m in sent if isinstance(m, AbortReq) and m.rid == rid]
         self.assertTrue(aborts, "disconnect must send an AbortReq to the scheduler")
         self.assertIn(rid, tm.rid_to_state)
+
+
+class TestTokenizeRequestWithoutGeneration(CustomTestCase):
+    def test_single_request_returns_ids_without_dispatch_and_cleans_state(self):
+        tm = _make_tm_for_generate(self)
+        rid = "single_tokenize"
+        obj = _make_generate_obj(rid, is_single=True)
+        tm._tokenize_one_request = AsyncMock(
+            return_value=_TokenizedGenerateObj([7, 8, 9])
+        )
+        tm._send_one_request = Mock()
+        tm._send_batch_request = Mock()
+
+        token_ids = asyncio.run(tm.tokenize_request(obj))
+
+        self.assertEqual(token_ids, [7, 8, 9])
+        tm._tokenize_one_request.assert_awaited_once_with(obj)
+        tm._send_one_request.assert_not_called()
+        tm._send_batch_request.assert_not_called()
+        self.assertNotIn(rid, tm.rid_to_state)
+
+    def test_lora_reference_is_released_after_tokenization(self):
+        tm = _make_tm_for_generate(self)
+        tm.enable_lora = True
+        tm.lora_registry = MagicMock()
+        tm.lora_registry.release = AsyncMock()
+        rid = "lora_tokenize"
+        obj = _make_generate_obj(rid, is_single=True)
+        obj.lora_path = "adapter"
+        obj.lora_id = "adapter-id"
+        tm._tokenize_one_request = AsyncMock(
+            return_value=_TokenizedGenerateObj([7, 8, 9])
+        )
+
+        token_ids = asyncio.run(tm.tokenize_request(obj))
+
+        self.assertEqual(token_ids, [7, 8, 9])
+        tm.lora_registry.release.assert_awaited_once_with("adapter-id")
+        self.assertNotIn(rid, tm.rid_to_state)
+
+    def test_batch_request_returns_ids_without_dispatch_and_cleans_state(self):
+        tm = _make_tm_for_generate(self)
+        rids = ["batch_tokenize_0", "batch_tokenize_1"]
+        obj = _make_generate_obj(list(rids), is_single=False)
+        obj.batch_size = len(rids)
+        sub_objs = []
+        for rid in rids:
+            sub_obj = _make_generate_obj(rid, is_single=True)
+            sub_objs.append(sub_obj)
+        obj.__getitem__.side_effect = lambda i: sub_objs[i]
+        tm._should_use_batch_tokenization = Mock(return_value=False)
+        tm._tokenize_one_request = AsyncMock(
+            side_effect=[
+                _TokenizedGenerateObj([1, 2]),
+                _TokenizedGenerateObj([3, 4, 5]),
+            ]
+        )
+        tm._send_one_request = Mock()
+        tm._send_batch_request = Mock()
+
+        token_ids = asyncio.run(tm.tokenize_request(obj))
+
+        self.assertEqual(token_ids, [[1, 2], [3, 4, 5]])
+        self.assertEqual(tm._tokenize_one_request.await_count, 2)
+        tm._send_one_request.assert_not_called()
+        tm._send_batch_request.assert_not_called()
+        for rid in rids:
+            self.assertNotIn(rid, tm.rid_to_state)
+
+    def test_batch_request_uses_batch_tokenization_without_dispatch(self):
+        tm = _make_tm_for_generate(self)
+        rids = ["batch_encode_tokenize_0", "batch_encode_tokenize_1"]
+        obj = _make_generate_obj(list(rids), is_single=False)
+        obj.batch_size = len(rids)
+        tm._should_use_batch_tokenization = Mock(return_value=True)
+        tm._batch_tokenize_and_process = AsyncMock(
+            return_value=[
+                _TokenizedGenerateObj([10, 11]),
+                _TokenizedGenerateObj([12]),
+            ]
+        )
+        tm._tokenize_one_request = AsyncMock()
+        tm._send_one_request = Mock()
+        tm._send_batch_request = Mock()
+
+        token_ids = asyncio.run(tm.tokenize_request(obj))
+
+        self.assertEqual(token_ids, [[10, 11], [12]])
+        tm._batch_tokenize_and_process.assert_awaited_once_with(len(rids), obj)
+        tm._tokenize_one_request.assert_not_called()
+        tm._send_one_request.assert_not_called()
+        tm._send_batch_request.assert_not_called()
+        for rid in rids:
+            self.assertNotIn(rid, tm.rid_to_state)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

SGLang already exposes `/v1/tokenize`, but its direct encoding path does not necessarily match the request preprocessing used by `/v1/chat/completions` and `/v1/completions`. This PR adds dedicated tokenize routes and returns the prompt token IDs produced by those same OpenAI conversion and tokenizer-manager paths, without running scheduler forward execution.

## Modifications

- Add `/v1/chat/tokenize` and `/v1/completions/tokenize`.
- Dispatch `/v1/tokenize` to the chat or completions path based on `messages` versus `prompt`, with an explicit error for ambiguous or missing input.
- Reuse the existing endpoint validation and `_convert_to_internal_request()` implementations before tokenization.
- Add `TokenizerManager.tokenize_request()` to run normal tokenizer-side preprocessing and validation without sending a request to the scheduler.
- Clean up tokenizer request state, encoder waiters, and acquired LoRA references on completion or failure.
- Preserve the existing `add_special_tokens=False` behavior on generic prompt tokenization by converting that prompt to input IDs before the completions preprocessing path.
- Accept pre-tokenized prompt IDs in `TokenizeRequest`.
- Add registered unit coverage for serving dispatch, conversion reuse, lifecycle cleanup, LoRA release, no-forward behavior, batch tokenization, and compatibility behavior. Add server tests comparing tokenize counts with actual chat/completion prompt usage.

## Validation

Passed locally on current `main`:

- Focused CPU/import-stub tests: `37 passed` (plus 3 subtests)
- Ruff format check on all seven changed files
- Ruff checks on the changed serving module and focused unit tests, plus tokenizer-manager checks with the file's existing `E402` exception excluded
- Python compile checks
- `git diff --check`

The registered server tests were added but were not run locally because this macOS environment does not provide the required GPU/model-serving setup. Native test collection also requires Triton, so the focused local run used an import-only Triton stub; it is not GPU or full server E2E evidence.

The repository-wide registered-test taxonomy checker is currently blocked by four unrelated violations already present on `main` (`test_fp4_moe_methods.py`, `test_npu_mxfp8_linear.py`, `test_npu_arch35_capability.py`, and `test_xpu_memory_saver.py`).

## Accuracy and performance

Not applicable. The change does not modify model execution or inference kernels.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34210498960](https://github.com/sgl-project/sglang/actions/runs/34210498960)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34210498629](https://github.com/sgl-project/sglang/actions/runs/34210498629)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34210498939](https://github.com/sgl-project/sglang/actions/runs/34210498939)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->