### PR TITLE
[AMD] ci: register page-major Qwen3.5-4B GDN-hybrid test on extra-a 1-gpu-large-amd

### DIFF
--- a/test/registered/page_major/test_page_major_qwen_hybrid.py
+++ b/test/registered/page_major/test_page_major_qwen_hybrid.py
@@ -18,11 +18,15 @@ import unittest
 from types import SimpleNamespace
 from urllib.parse import urlparse
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 from sglang.test.test_utils import DEFAULT_HYBRID_GDN_SMALL_MODEL_NAME_FOR_TEST
 
 register_cuda_ci(est_time=300, stage="extra-a", runner_config="1-gpu-large")
+# AMD: all-triton backends (attention / linear-attn / mamba); the GDN triton
+# kernels are already AMD-proven at the unit level (attention/unittests/gdn/
+# test_triton.py on stage-b-*-amd). No flashinfer/fa/mxfp4/quant.
+register_amd_ci(est_time=300, stage="extra-a", runner_config="1-gpu-large-amd")
 
 
 class TestPageMajorQwenHybrid(DefaultServerBase):


### PR DESCRIPTION
## Summary

Registers `test/registered/page_major/test_page_major_qwen_hybrid.py` for AMD (`extra-a-test-1-gpu-large-amd`).

It launches Qwen3.5-4B (a GDN / linear-attention / mamba hybrid) with `--enable-page-major-kv-layout` on **all-triton** backends (`--attention-backend triton --linear-attn-backend triton --mamba-backend triton`) and asserts GSM8K accuracy ≥ 0.80 (baseline ~0.86, so real margin). No FlashInfer/FA3/FA4, no mxfp4, no quant kernels.

Why this is ROCm-viable: the GDN / linear-attn triton kernels are already AMD-proven per-commit (`attention/unittests/gdn/test_triton.py` runs on `stage-b-*-amd`), and the gate is a forgiving accuracy check. Picked from an extra-tier gap audit as the one cleanly-addable candidate (its `page_major/test_page_major_gpt_oss.py` sibling stays CUDA-only — gpt-oss mxfp4).

Verifying on both AMD lanes; drop the `register_amd_ci` line if it trips (no register-and-skip). `register_cuda_ci` unchanged.

## Test plan

Verifying on both AMD extra lanes (dispatched via `pr-test-amd-extra.yml`, branch rebased onto current `main`; baseline on `main` is green for both `1-gpu-large-amd` and `1-gpu-small-amd`, so these results are attributable):

- [ ] `extra-a-test-1-gpu-large-amd` (mi325) green — [run 28554775031](https://github.com/sgl-project/sglang/actions/runs/28554775031)
- [ ] `extra-a-test-1-gpu-large-amd-rocm720` green — [run 28554781526](https://github.com/sgl-project/sglang/actions/runs/28554781526)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28554777621](https://github.com/sgl-project/sglang/actions/runs/28554777621)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28554777554](https://github.com/sgl-project/sglang/actions/runs/28554777554)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->