### PR TITLE
feat: early validation for Ascend FIA page_size alignment

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6875,6 +6875,15 @@ class ServerArgs:
                 not self.enable_mixed_chunk
             ), "enable_mixed_chunk is required for speculative decoding"
 
+        # Check page_size alignment for Ascend FIA attention backend
+        if self.device == "npu" and self.attention_backend == "ascend":
+            if self.page_size % 16 != 0:
+                raise ValueError(
+                    f"Ascend FIA attention requires page_size to be aligned to 16, "
+                    f"but got page_size={self.page_size}. "
+                    f"Please set --page-size to a multiple of 16 (e.g. 16, 128, 256)."
+                )
+
         # Check chunked prefill
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).
         # Skip validation if disaggregation mode is decode.

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1300,5 +1300,55 @@ class TestSamplingBackendTokenOracleEnvGate(CustomTestCase):
         self.assertEqual(parsed.sampling_backend, "token_oracle")
 
 
+class TestAscendPageSizeAlignment(CustomTestCase):
+    """Ascend FIA attention backend requires page_size aligned to 16.
+
+    check_server_args() should raise ValueError when device=npu,
+    attention_backend=ascend, and page_size is not divisible by 16.
+    """
+
+    def _make_args(self, device="npu", attention_backend="ascend", page_size=1):
+        args = ServerArgs(model_path="dummy")
+        args.device = device
+        args.attention_backend = attention_backend
+        args.page_size = page_size
+        return args
+
+    def test_page_size_1_raises(self):
+        args = self._make_args(page_size=1)
+        with self.assertRaisesRegex(ValueError, "aligned to 16"):
+            args.check_server_args()
+
+    def test_page_size_8_raises(self):
+        args = self._make_args(page_size=8)
+        with self.assertRaisesRegex(ValueError, "aligned to 16"):
+            args.check_server_args()
+
+    def test_page_size_15_raises(self):
+        args = self._make_args(page_size=15)
+        with self.assertRaisesRegex(ValueError, "aligned to 16"):
+            args.check_server_args()
+
+    def test_page_size_16_passes(self):
+        args = self._make_args(page_size=16)
+        args.check_server_args()
+
+    def test_page_size_128_passes(self):
+        args = self._make_args(page_size=128)
+        args.check_server_args()
+
+    def test_page_size_256_passes(self):
+        args = self._make_args(page_size=256)
+        args.check_server_args()
+
+    def test_non_npu_device_skips_validation(self):
+        args = self._make_args(device="cuda", page_size=1)
+        args.check_server_args()
+
+    def test_non_ascend_backend_skips_validation(self):
+        args = self._make_args(attention_backend="flashinfer", page_size=1)
+        args.check_server_args()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

When `device=npu` and `attention_backend=ascend`, the Ascend FIA op requires `page_size` to be divisible by 16. Passing an unaligned value (e.g. `--page-size 1`) currently reaches the FIA op and produces a cryptic `block_size should aligned to 16 ... ret is -1` from the runtime. This PR adds an early `ValueError` in `check_server_args()` so users see a clear, actionable message at startup.

Fixes #25169.

## Changes

- `python/sglang/srt/server_args.py` — 9 lines: `check_server_args()` validation for `device=npu` + `attention_backend=ascend` + `page_size % 16 != 0`
- `test/registered/unit/server_args/test_server_args.py` — 50 lines: `TestAscendPageSizeAlignment` with 8 test cases (3 rejects, 3 accept, 2 skip-conditions)

## Test plan

- [x] `test_page_size_1_raises` — page_size=1 → ValueError including "aligned to 16"
- [x] `test_page_size_8_raises` — page_size=8 → ValueError
- [x] `test_page_size_15_raises` — page_size=15 → ValueError
- [x] `test_page_size_16_passes` — page_size=16 passes
- [x] `test_page_size_128_passes` — page_size=128 passes (Ascend NPU default)
- [x] `test_page_size_256_passes` — page_size=256 passes
- [x] `test_non_npu_device_skips_validation` — device=cuda + page_size=1 passes (no false positive)
- [x] `test_non_ascend_backend_skips_validation` — backend=flashinfer + page_size=1 passes (no false positive)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28499318007](https://github.com/sgl-project/sglang/actions/runs/28499318007)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28499317816](https://github.com/sgl-project/sglang/actions/runs/28499317816)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->