### PR TITLE
Fix UnifiedRadixCache HiCache load-back readiness

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2473,6 +2473,20 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             return self.cache_controller.start_loading()
         return 0
 
+    def is_load_back_event_done(self, consumer_index: int) -> bool:
+        """Return True after the local load-back event is complete."""
+        if consumer_index < 0 or self.cache_controller is None:
+            return True
+
+        finish_event = self.cache_controller.layer_done_counter.events[
+            consumer_index
+        ].finish_event
+        if not finish_event.query():
+            return False
+
+        self.loading_check()
+        return True
+
     # ---- Query / Inspection APIs ----
     # These APIs exist for compatibility with other RadixTree implementations.
     # TODO: simplify and consolidate in a future refactor.

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -630,6 +630,40 @@ class TestUnifiedRadixCacheKVEvents(CustomTestCase):
         self.assertCountEqual([e.block_hashes[0] for e in restored_gpu], stored_hashes)
 
 
+class TestUnifiedRadixCacheLoadBackEvents(CustomTestCase):
+    def test_is_load_back_event_done_waits_for_pending_event(self):
+        tree = object.__new__(UnifiedRadixCache)
+        finish_event = mock.Mock()
+        finish_event.query.return_value = False
+        tree.cache_controller = mock.Mock()
+        tree.cache_controller.layer_done_counter.events = [
+            mock.Mock(finish_event=finish_event)
+        ]
+        tree.loading_check = mock.Mock()
+
+        self.assertFalse(tree.is_load_back_event_done(0))
+        tree.loading_check.assert_not_called()
+
+    def test_is_load_back_event_done_polls_completed_loads(self):
+        tree = object.__new__(UnifiedRadixCache)
+        finish_event = mock.Mock()
+        finish_event.query.return_value = True
+        tree.cache_controller = mock.Mock()
+        tree.cache_controller.layer_done_counter.events = [
+            mock.Mock(finish_event=finish_event)
+        ]
+        tree.loading_check = mock.Mock()
+
+        self.assertTrue(tree.is_load_back_event_done(0))
+        tree.loading_check.assert_called_once_with()
+
+    def test_is_load_back_event_done_treats_no_consumer_as_done(self):
+        tree = object.__new__(UnifiedRadixCache)
+        tree.cache_controller = None
+
+        self.assertTrue(tree.is_load_back_event_done(-1))
+
+
 class UnifiedRadixCacheSuite:
 
     cfg: CacheConfig


### PR DESCRIPTION
## Motivation

Fixes #29812.

`DecodeHiCacheMixin` waits on `tree_cache.is_load_back_event_done(...)` before advancing local restore state. `HiRadixCache` implements this hook, but `UnifiedRadixCache` did not, so decode-side HiCache restore could skip the wait/poll path when unified radix cache is enabled.

## Modifications

- Add `UnifiedRadixCache.is_load_back_event_done`, matching the existing HiRadixCache readiness behavior.
- Treat invalid/no local consumers as done and call `loading_check()` once the local finish event is complete.
- Add unit coverage for pending, completed, and no-consumer readiness cases.

## Accuracy Tests

Not applicable; this changes HiCache event readiness plumbing and does not affect model output math.

## Speed Tests and Profiling

Not run; no inference hot-path computation changes.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28500432152](https://github.com/sgl-project/sglang/actions/runs/28500432152)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28500432046](https://github.com/sgl-project/sglang/actions/runs/28500432046)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->