### PR TITLE
fix(openai): return 400 for negative token ids in /v1/detokenize

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_tokenize.py
+++ b/python/sglang/srt/entrypoints/openai/serving_tokenize.py
@@ -144,6 +144,10 @@ class OpenAIServingDetokenize(OpenAIServingBase):
                     return self.create_error_response(
                         "Invalid input: 'tokens' must be a list of integers."
                     )
+                if not all(t >= 0 for t in request.tokens):
+                    return self.create_error_response(
+                        "Invalid input: 'tokens' must be non-negative integers."
+                    )
                 tokens_to_decode = [int(t) for t in request.tokens]
                 text = tokenizer.decode(
                     tokens_to_decode, skip_special_tokens=request.skip_special_tokens
@@ -159,6 +163,10 @@ class OpenAIServingDetokenize(OpenAIServingBase):
                     if not all(isinstance(t, int) for t in token_list):
                         return self.create_error_response(
                             f"Invalid input: Sublist in 'tokens' must contain only integers. Found: {token_list}"
+                        )
+                    if not all(t >= 0 for t in token_list):
+                        return self.create_error_response(
+                            f"Invalid input: Sublist in 'tokens' must contain only non-negative integers. Found: {token_list}"
                         )
                     decoded_text = tokenizer.decode(
                         [int(t) for t in token_list],

--- a/test/registered/openai_server/validation/test_request_length_validation.py
+++ b/test/registered/openai_server/validation/test_request_length_validation.py
@@ -169,6 +169,19 @@ class TestRequestLengthValidation(CustomTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_detokenize_negative_token_id(self):
+        # A negative id would otherwise reach the HF tokenizer and raise an
+        # OverflowError that is misclassified as a 500.
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        for tokens in ([-1], [[1], [-1]]):
+            response = requests.post(
+                f"{self.base_url}/v1/detokenize",
+                headers=headers,
+                json={"tokens": tokens},
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("non-negative", response.text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

## Motivation

`/v1/detokenize` only checks that `tokens` entries are integers. A negative id is passed to the HF tokenizer, whose Rust `decode` raises `OverflowError` ("out of range integral type conversion attempted"); that is misclassified as **HTTP 500** because the error string lacks "decode".

```bash
curl -s -o /dev/null -w "%{http_code}\n" -X POST localhost:30000/v1/detokenize \
  -d '{"tokens":[-1]}'
# main: 500   this PR: 400
```

## Modifications

In `OpenAIServingDetokenize`, reject negative ids up front (before `tokenizer.decode`) in both the flat-list and list-of-lists branches, via the existing `create_error_response` (HTTP 400), next to the existing integer-type checks.

## Testing

Real-server E2E against `/v1/detokenize` (real fast tokenizer), before vs after:

<details>
<summary>End-to-end before/after</summary>

```
CTRL  tokens=[1,2]            main 200   fix 200
tokens=[-1]                   main 500 ("out of range integral type conversion attempted")   fix 400 ("'tokens' must be non-negative integers.")
tokens=[[1],[-1]]             main 500   fix 400 ("Sublist ... must contain only non-negative integers. Found: [-1]")
```

</details>

A real-server case `test_detokenize_negative_token_id` added to `test/registered/openai_server/validation/test_request_length_validation.py` (the OpenAI admission-validation suite) sends `[-1]` and `[[1], [-1]]` to `/v1/detokenize` and asserts a 400. It passes against a running server on the fix; the 500 on main is shown in the E2E above. `ruff`/`black`/`isort` clean.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28500445829](https://github.com/sgl-project/sglang/actions/runs/28500445829)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28500445603](https://github.com/sgl-project/sglang/actions/runs/28500445603)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->