### PR TITLE
Experiment with sync DSV4 weight loading

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1352,6 +1352,7 @@ jobs:
           echo "## SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton" >> github_summary.md
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
+            -e SGLANG_DSV4_DISABLE_ASYNC_WEIGHT_LOAD=1 \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
@@ -1364,6 +1365,7 @@ jobs:
           echo "## SGLANG_HACK_FLASHMLA_BACKEND=triton" >> github_summary.md
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e SGLANG_HACK_FLASHMLA_BACKEND=triton \
+            -e SGLANG_DSV4_DISABLE_ASYNC_WEIGHT_LOAD=1 \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -842,6 +842,8 @@ class Envs:
     SGLANG_FIX_MTP_HC_HIDDEN = EnvBool(False)
     # ====================================================================
 
+    # Disable the DeepSeek V4 async per-tensor weight-loader thread pool.
+    SGLANG_DSV4_DISABLE_ASYNC_WEIGHT_LOAD = EnvBool(False)
     # Set False when using FP4-to-FP8 converted DeepSeek V4 checkpoint.
     SGLANG_DSV4_FP4_EXPERTS = EnvBool(True)
     # Default reasoning_effort for dsv4 chat encoder when request doesn't set it.

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2209,6 +2209,14 @@ class DeepseekV4ForCausalLM(nn.Module):
         def auto_weight_loader(module):
             return getattr(module, "weight_loader", default_weight_loader)
 
+        disable_async_weight_load = envs.SGLANG_DSV4_DISABLE_ASYNC_WEIGHT_LOAD.get()
+        if disable_async_weight_load:
+            log_info_on_rank0(
+                logger,
+                "DeepSeek V4 async weight loading disabled by "
+                "SGLANG_DSV4_DISABLE_ASYNC_WEIGHT_LOAD.",
+            )
+
         if is_nextn:
             nextn_layer_prefix = f"model.layers.{nextn_layer_id}"
             nextn_spec_weight_names_out_of_layer = [
@@ -2233,7 +2241,9 @@ class DeepseekV4ForCausalLM(nn.Module):
             weight_names = []
             for name, loaded_weight in weights:
                 try:
-                    use_async_loading = should_async_load(loaded_weight)
+                    use_async_loading = (
+                        not disable_async_weight_load
+                    ) and should_async_load(loaded_weight)
 
                     name = self.remap_weight_name_to_dpsk_hf_format(
                         name,


### PR DESCRIPTION
## Summary
- Adds an experimental `SGLANG_DSV4_DISABLE_ASYNC_WEIGHT_LOAD` switch to run DeepSeek V4 per-tensor weight loaders synchronously.
- Enables the switch only for the MI35x ROCm 7.2 DeepSeek-V4-Pro nightly experiment job.

## Root Cause / Hypothesis
- Recent CI logs show HF cache hits, so the remaining ~2100s `Load weight end` tail is not model download.
- Py-spy repeatedly shows `_load_w13` / `_load_w2` blocked in `copy_` / `c10::hip::memcpy_and_sync` / `pthread_mutex_lock`, while most ranks wait at `monitored_barrier`.
- The DeepSeek V4 loader currently submits CPU tensor weight loaders to an unbounded `ThreadPoolExecutor`, which can issue many concurrent H2D copies per rank. This experiment disables that async copy path to test whether the TP0/TP7 slow tail is HIP copy contention.

## Testing
- Local cheap checks: `python3 -m py_compile python/sglang/srt/environ.py python/sglang/srt/models/deepseek_v4.py` passed.
- Commit hooks passed, including YAML, Python AST, ruff, and workflow job-name checks.
- Dispatched workflow: pending.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28501850979](https://github.com/sgl-project/sglang/actions/runs/28501850979)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28501850766](https://github.com/sgl-project/sglang/actions/runs/28501850766)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->