### PR TITLE
perf: use torch.empty for HiCache dummy read buffers to skip a memset

### DIFF
--- a/benchmark/hicache/bench_dummy_page_alloc.py
+++ b/benchmark/hicache/bench_dummy_page_alloc.py
@@ -1,0 +1,115 @@
+"""Microbenchmark for the HiCache non-zero-copy prefetch dummy-page allocation.
+
+HF3FS / EIC non-zero-copy prefetch prepares one dummy read buffer per page and per
+batch (all pages of a batch are alive at once), e.g.
+
+    [host_pool.get_dummy_flat_data_page() for _ in range(page_num)]
+
+(storage/hf3fs/storage_hf3fs.py, storage/eic/eic_storage.py). The buffer is fully
+overwritten by the storage read before use, so any zero-fill is wasted.
+
+This bench reproduces that per-batch pattern and compares:
+
+    zeros : torch.zeros(shape, pin_memory=True)   # current — alloc + memset
+    empty : torch.empty(shape, pin_memory=True)   # proposed — alloc only
+    reuse : one preallocated (page_num, *shape) pinned buffer, one view per slot
+
+It reports the STEADY-STATE per-batch time (after warmup), which is what production
+sees. The gap between `empty` and `reuse` reflects how much PyTorch's pinned host
+caching allocator already reuses freed blocks (i.e. how little a hand-written
+reusable bounce buffer would add on top of the simple zeros->empty change).
+
+Notes / caveats:
+  - Measures MHA-shaped bf16 pages only, not every changed pool type.
+  - Measures buffer-prep cost only, not end-to-end storage prefetch latency.
+
+Run:  python benchmark/hicache/bench_dummy_page_alloc.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import torch
+
+DTYPE = torch.bfloat16
+
+# (label, layer_num, page_size, kv_heads, head_dim, page_num)
+CONFIGS = [
+    ("Qwen2.5-7B  ps=64", 28, 64, 4, 128, 64),
+    ("Qwen2.5-7B  ps=16", 28, 16, 4, 128, 64),
+]
+WARMUP = 3  # unmeasured batches to reach pinned-allocator steady state
+MEASURE = 10  # measured batches, averaged
+
+
+def page_shape(layer_num, page_size, kv_heads, head_dim):
+    # MHA host-pool dummy page: (2, layer_num, page_size, head_num, head_dim)
+    return (2, layer_num, page_size, kv_heads, head_dim)
+
+
+def _alloc_batch(shape, page_num, mode, prealloc):
+    if mode == "reuse":
+        return [prealloc[i] for i in range(page_num)]
+    if mode == "zeros":
+        return [
+            torch.zeros(shape, dtype=DTYPE, pin_memory=True) for _ in range(page_num)
+        ]
+    return [torch.empty(shape, dtype=DTYPE, pin_memory=True) for _ in range(page_num)]
+
+
+def _touch(pages):
+    # Emulate the storage read landing in the buffer so nothing is optimized away
+    # and the buffers stay alive for the whole batch (like the real list-comp).
+    for p in pages:
+        p.view(-1)[0] = 1
+
+
+def bench_steady_ms(shape, page_num, mode, prealloc=None):
+    for _ in range(WARMUP):
+        pages = _alloc_batch(shape, page_num, mode, prealloc)
+        _touch(pages)
+        del pages
+    times = []
+    for _ in range(MEASURE):
+        t0 = time.perf_counter()
+        pages = _alloc_batch(shape, page_num, mode, prealloc)
+        _touch(pages)
+        times.append((time.perf_counter() - t0) * 1e3)  # ms
+        del pages
+    return sum(times) / len(times)
+
+
+def main():
+    print(
+        f"torch {torch.__version__}  (pinned host caching allocator active by default)\n"
+    )
+    header = (
+        f"{'config':<20} {'page MB':>8} {'batch MB':>9} {'mode':>6} "
+        f"{'steady ms':>11} {'steady/page us':>15}"
+    )
+    print(header)
+    print("-" * len(header))
+    for label, layer_num, page_size, kv_heads, head_dim, page_num in CONFIGS:
+        shape = page_shape(layer_num, page_size, kv_heads, head_dim)
+        numel = 1
+        for s in shape:
+            numel *= s
+        page_mb = numel * 2 / 1e6
+        for mode in ("zeros", "empty", "reuse"):
+            prealloc = (
+                torch.empty((page_num,) + shape, dtype=DTYPE, pin_memory=True)
+                if mode == "reuse"
+                else None
+            )
+            steady = bench_steady_ms(shape, page_num, mode, prealloc)
+            print(
+                f"{label:<20} {page_mb:>8.2f} {page_mb*page_num:>9.0f} {mode:>6} "
+                f"{steady:>11.3f} {steady/page_num*1e3:>15.1f}"
+            )
+            del prealloc
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -458,7 +458,7 @@ class MHATokenToKVPoolHost(HostKVCache):
         return data_page
 
     def get_dummy_flat_data_page(self) -> torch.Tensor:
-        return torch.zeros(
+        return torch.empty(
             (2, self.layer_num, self.page_size, self.head_num, self.head_dim),
             dtype=self.dtype,
             device=self.device,
@@ -890,7 +890,7 @@ class MHATokenToKOnlyPoolHost(HostKVCache):
         return data_page
 
     def get_dummy_flat_data_page(self) -> torch.Tensor:
-        return torch.zeros(
+        return torch.empty(
             (self.layer_num, self.page_size, self.head_num, self.head_dim),
             dtype=self.dtype,
             device=self.device,
@@ -1603,7 +1603,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         return data_page
 
     def get_dummy_flat_data_page(self) -> torch.Tensor:
-        return torch.zeros(
+        return torch.empty(
             (
                 self.layer_num,
                 self.page_size,
@@ -2192,7 +2192,7 @@ class MambaPoolHost(HostKVCache):
         return data_page.flatten() if flat else data_page
 
     def get_dummy_flat_data_page(self) -> torch.Tensor:
-        return torch.zeros(
+        return torch.empty(
             self.page_size * self.size_per_token,
             dtype=torch.uint8,
             device=self.device,
@@ -2690,7 +2690,7 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         return data_page.flatten() if flat else data_page
 
     def get_dummy_flat_data_page(self):
-        return torch.zeros(
+        return torch.empty(
             (self.layer_num, self.item_bytes),
             dtype=self.dtype,
             device=self.device,
@@ -3053,7 +3053,7 @@ class DeepSeekV4StateHostPool(HostKVCache):
         return data_page.flatten() if flat else data_page
 
     def get_dummy_flat_data_page(self):
-        return torch.zeros(
+        return torch.empty(
             (self.layer_num, self.state_page_bytes),
             dtype=self.dtype,
             device=self.device,
@@ -3545,7 +3545,7 @@ class DSAIndexerPoolHost(HostKVCache):
         return data_page
 
     def get_dummy_flat_data_page(self) -> torch.Tensor:
-        return torch.zeros(
+        return torch.empty(
             (self.layer_num, self.indexer_page_stride_size),
             dtype=self.indexer_dtype,
             device=self.device,

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -198,8 +198,9 @@ class HostKVCache(abc.ABC):
     @abc.abstractmethod
     def get_dummy_flat_data_page(self) -> torch.Tensor:
         """
-        Get a dummy flat data page from the host memory pool.
-        This is used for prefetching or initializing empty pages.
+        Get a dummy flat data page shaped like one host page, for use as a scratch
+        read buffer (e.g. non-zero-copy prefetch). The contents are uninitialized:
+        callers must fully overwrite the buffer before reading from it.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The non-zero-copy HF3FS/EIC prefetch path allocates one dummy read buffer per page via get_dummy_flat_data_page(). These buffers are fully overwritten by the storage read before use, so the zero-fill from torch.zeros is wasted work.

## Modifications

get_dummy_xxx() methods use torch.empty instead

## Accuracy Tests



## Speed Tests and Profiling

added a micro bench 
Steady-state per-batch buffer-prep time (Qwen2.5-7B host page, bf16, `page_num=64`), measured with `benchmark/hicache/bench_dummy_page_alloc.py`:

| config | zeros (current) | empty (this PR) | speedup |
|---|---|---|---|
| page_size=64 (235 MB/batch) | 15.7 ms | 0.15 ms | ~108x |
| page_size=16 (59 MB/batch) | 0.84 ms | 0.14 ms | ~6x |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28640926727](https://github.com/sgl-project/sglang/actions/runs/28640926727)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28640926599](https://github.com/sgl-project/sglang/actions/runs/28640926599)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->