### PR TITLE
ci: upload MI355X disagg logs

### DIFF
--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -148,6 +148,34 @@ jobs:
           SLURM_EXCLUDE: mia1-p01-g20
         run: bash scripts/ci/slurm/launch_mi355x.sh
 
+      - name: Pack logs
+        if: always()
+        run: |
+          LOG_DIR="$HOME/.mi355x_ci/${MATRIX_CONFIG_NAME}"
+          LOG_BUNDLE="${GITHUB_WORKSPACE}/${RESULT_FILENAME}_logs.tar.gz"
+          if [ ! -d "$LOG_DIR" ]; then
+            echo "WARN: log directory not found: $LOG_DIR"
+            exit 0
+          fi
+
+          mapfile -d '' LOG_FILES < <(
+            find "$LOG_DIR" -maxdepth 1 -type f \
+              \( -name '*.log' -o -name 'server_exit_*' -o -name 'bench_exit' \) \
+              -printf '%P\0' | sort -z
+          )
+          if [ "${#LOG_FILES[@]}" -eq 0 ]; then
+            echo "WARN: no log files found in $LOG_DIR"
+            exit 0
+          fi
+
+          STAGING_DIR="$(mktemp -d)"
+          trap 'rm -rf "$STAGING_DIR"' EXIT
+          for log_file in "${LOG_FILES[@]}"; do
+            cp -a "$LOG_DIR/$log_file" "$STAGING_DIR/$log_file" || true
+          done
+          tar czf "$LOG_BUNDLE" -C "$STAGING_DIR" .
+          echo "Packed ${#LOG_FILES[@]} log file(s) -> $LOG_BUNDLE"
+
       - name: Process results
         if: always()
         run: |
@@ -169,6 +197,15 @@ jobs:
         with:
           name: mi355x-${{ matrix.config.name }}-${{ github.run_id }}
           path: ${{ github.workspace }}/*.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-mi355x-${{ matrix.config.name }}-${{ github.run_id }}
+          path: ${{ github.workspace }}/*_logs.tar.gz
           retention-days: 30
           if-no-files-found: warn
 

--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -196,16 +196,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mi355x-${{ matrix.config.name }}-${{ github.run_id }}
-          path: ${{ github.workspace }}/*.json
-          retention-days: 30
-          if-no-files-found: warn
-
-      - name: Upload logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs-mi355x-${{ matrix.config.name }}-${{ github.run_id }}
-          path: ${{ github.workspace }}/*_logs.tar.gz
+          path: |
+            ${{ github.workspace }}/*.json
+            ${{ github.workspace }}/*_logs.tar.gz
           retention-days: 30
           if-no-files-found: warn
 

--- a/scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d-mtp.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d-mtp.yaml
@@ -34,7 +34,7 @@ runtime:
   page_size: 256
   max_running_requests: 256
   chunked_prefill_size: 8192
-  swa_full_tokens_ratio: 0.1
+  swa_full_tokens_ratio: 0.2
 
 # MTP / EAGLE speculative decoding (NextN head from the base model). Applied to
 # both prefill and decode. Flags mirror

--- a/scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d-mtp.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d-mtp.yaml
@@ -34,7 +34,7 @@ runtime:
   page_size: 256
   max_running_requests: 256
   chunked_prefill_size: 8192
-  swa_full_tokens_ratio: 0.2
+  swa_full_tokens_ratio: 0.3
 
 # MTP / EAGLE speculative decoding (NextN head from the base model). Applied to
 # both prefill and decode. Flags mirror


### PR DESCRIPTION
## Summary
- PR #29784 writes MI355X disagg bench/server logs under `$HOME/.mi355x_ci/${MATRIX_CONFIG_NAME}`, but the workflow only uploaded result JSON files.
- Add an `always()` log packaging step and a separate log artifact upload so each matrix leg keeps the full `bench.log`, per-node `prefill_*.log` / `decode_*.log`, and exit markers.

## Testing
- Local analysis: the pack step runs after the benchmark step regardless of success/failure and before artifact upload, using the same `MATRIX_CONFIG_NAME` scratch directory as `launch_mi355x.sh`.
- Local cheap checks: workflow YAML parsed with PyYAML; MI355X matrix generation passed; the pack snippet produced a tarball containing sample log files and exit markers.
- Commit hooks: `check yaml`, duplicate workflow job-name validation, and other pre-commit hooks passed during commit.

## Verification Plan
- Dispatch `nightly-amd-mi355x-disagg.yml` with `configs=dsv4pro-fp8-1k1k-1p1d-mtp` so only the `dsv4pro-fp8-mi355x-mtp-sglang` / `sgl-project/DeepSeek-V4-Pro-FP8` matrix leg runs.















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28525089444](https://github.com/sgl-project/sglang/actions/runs/28525089444)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28525089335](https://github.com/sgl-project/sglang/actions/runs/28525089335)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->