### PR TITLE
Fix GLM-DSA raw config restoration

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -52,6 +52,8 @@ def _apply_deepseek_ocr_overrides(config, model):
 
 
 def _restore_glm_moe_dsa_raw_config_fields(config, raw_config):
+    if not raw_config:
+        return
     for key in (
         "head_dim",
         "index_head_dim",

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -51,6 +51,31 @@ def _apply_deepseek_ocr_overrides(config, model):
     config._name_or_path = model
 
 
+def _restore_glm_moe_dsa_raw_config_fields(config, raw_config):
+    for key in (
+        "head_dim",
+        "index_head_dim",
+        "index_n_heads",
+        "index_share_for_mtp_iteration",
+        "index_skip_topk_offset",
+        "index_topk",
+        "index_topk_freq",
+        "index_topk_pattern",
+        "indexer_rope_interleave",
+        "indexer_types",
+        "kv_lora_rank",
+        "q_lora_rank",
+        "qk_head_dim",
+        "qk_nope_head_dim",
+        "qk_rope_head_dim",
+        "rope_interleave",
+        "rope_parameters",
+        "v_head_dim",
+    ):
+        if key in raw_config:
+            setattr(config, key, raw_config[key])
+
+
 @register_model_config_parser("hf")
 class HfModelConfigParser(ModelConfigParserBase):
     def parse(
@@ -66,6 +91,18 @@ class HfModelConfigParser(ModelConfigParserBase):
             revision=revision,
             **kwargs,
         )
+
+        raw_glm_moe_dsa_config = None
+        if (
+            config.architectures is not None
+            and config.architectures[0] == "GlmMoeDsaForCausalLM"
+        ):
+            from transformers import PretrainedConfig
+
+            raw_glm_moe_dsa_config, _ = PretrainedConfig.get_config_dict(
+                model, revision=revision, **kwargs
+            )
+            _restore_glm_moe_dsa_raw_config_fields(config, raw_glm_moe_dsa_config)
 
         if (
             config.architectures is not None
@@ -124,6 +161,9 @@ class HfModelConfigParser(ModelConfigParserBase):
                 _apply_deepseek_ocr_overrides(config, model)
             else:
                 config._name_or_path = model
+
+        if raw_glm_moe_dsa_config is not None:
+            _restore_glm_moe_dsa_raw_config_fields(config, raw_glm_moe_dsa_config)
 
         if isinstance(model, str) and config.model_type == "internvl_chat":
             for key, val in config.llm_config.__dict__.items():

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -7,6 +7,7 @@ context length, GGUF detection, etc.) that don't require actual model files.
 import tempfile
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from transformers import PretrainedConfig
 
@@ -589,6 +590,73 @@ class TestPatchNemotronHPattern(unittest.TestCase):
             self.assertEqual(result, ["mamba", "moe", "attention"])
         except ImportError:
             self.skipTest("NemotronHConfig not available in this transformers version")
+
+
+# ---------------------------------------------------------------------------
+# HfModelConfigParser
+# ---------------------------------------------------------------------------
+
+
+class TestHfModelConfigParser(unittest.TestCase):
+    def test_glm_moe_dsa_restores_raw_config_after_registry_reload(self):
+        from sglang.srt.utils.hf_transformers import config as hf_config_module
+
+        raw_config = {
+            "architectures": ["GlmMoeDsaForCausalLM"],
+            "head_dim": 192,
+            "index_head_dim": 128,
+            "kv_lora_rank": 512,
+            "model_type": "glm_moe_dsa",
+            "q_lora_rank": 2048,
+            "qk_head_dim": 256,
+            "qk_nope_head_dim": 192,
+            "qk_rope_head_dim": 64,
+            "v_head_dim": 256,
+        }
+
+        def make_clobbered_config():
+            cfg = PretrainedConfig()
+            cfg.architectures = ["GlmMoeDsaForCausalLM"]
+            cfg.model_type = "glm_moe_dsa"
+            cfg.qk_head_dim = 256
+            cfg.qk_nope_head_dim = 192
+            cfg.qk_rope_head_dim = 192
+            cfg.v_head_dim = 192
+            return cfg
+
+        initial_config = make_clobbered_config()
+        registry_config = make_clobbered_config()
+
+        class RegistryConfig:
+            @staticmethod
+            def from_pretrained(model, revision=None):
+                return registry_config
+
+        with (
+            patch.object(
+                hf_config_module.AutoConfig,
+                "from_pretrained",
+                return_value=initial_config,
+            ),
+            patch(
+                "transformers.PretrainedConfig.get_config_dict",
+                return_value=(raw_config, {}),
+            ),
+            patch.dict(
+                hf_config_module._CONFIG_REGISTRY,
+                {"glm_moe_dsa": RegistryConfig},
+            ),
+        ):
+            config = hf_config_module.HfModelConfigParser().parse(
+                "fake-model", trust_remote_code=False
+            )
+
+        self.assertIs(config, registry_config)
+        self.assertEqual(config.qk_rope_head_dim, 64)
+        self.assertEqual(config.qk_head_dim, 256)
+        self.assertEqual(config.v_head_dim, 256)
+        self.assertEqual(config.kv_lora_rank, 512)
+        self.assertEqual(config.q_lora_rank, 2048)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

GLM-5.2-FP8 can fail to load on current SGLang because Hugging Face config parsing clobbers raw GLM-DSA shape fields. In the failing run, `qk_rope_head_dim` was parsed as `192` instead of the raw `64`, so SGLang constructed `model.layers.13.self_attn.fused_qkv_a_proj_with_mqa.weight` as `(2752, 6144)` while the checkpoint contains `(2624, 6144)`.

This affects the normal `AutoConfig.from_pretrained` path. Existing deployment code only restored raw GLM-DSA fields in a legacy fallback path, and upstream main did not have the restore helper in this parser.

## Reproduction

Hardware / model:

- B200 x8
- `zai-org/GLM-5.2-FP8`
- tensor parallel: `--tp 8`
- SGLang current deployment baseline: `75445db7dddeb583b695c459053cdc82896c6cf6`
- Known-good control: `sglang==0.5.13.post1`

Failing command shape:

```bash
python -m sglang.launch_server \
  --model-path zai-org/GLM-5.2-FP8 \
  --tp 8 \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 5 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 6 \
  --mem-fraction-static 0.8 \
  --cuda-graph-max-bs 32 \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --enable-hierarchical-cache \
  --hicache-ratio 2 \
  --hicache-size 100 \
  --hicache-write-policy write_through \
  --enable-metrics \
  --enable-mfu-metrics \
  --host 0.0.0.0 \
  --port 10100
```

Observed failure before this fix:

```text
AssertionError: param.shape=torch.Size([2752, 6144]) loaded_weight.shape=torch.Size([2624, 6144])
```

The raw checkpoint config has:

```text
q_lora_rank=2048
kv_lora_rank=512
qk_nope_head_dim=192
qk_rope_head_dim=64
v_head_dim=256
```

The checkpoint tensor shape is therefore `2048 + 512 + 64 = 2624` rows. Current parsing produced `qk_rope_head_dim=192`, incorrectly constructing `2048 + 512 + 192 = 2752` rows.

## Fix

Restore raw GLM-DSA config fields immediately after initial HF config parsing and again after SGLang reloads the config from `_CONFIG_REGISTRY`, since the registry reload can overwrite the first restoration.

This keeps the correction in config normalization rather than adding a weight-loader shape special case.

## Validation

- Added unit coverage for the GLM-DSA parser path where both initial `AutoConfig` and registry reload return clobbered fields.
- `py_compile` passed for the edited files.
- `ruff check` passed for the edited files.
- `ruff format --check` passed for the edited files.
- On B200-03 with the full reproduction command above, patched current SGLang:
  - parsed `qk_rope_head_dim=64`, `v_head_dim=256`, `kv_lora_rank=512`, `q_lora_rank=2048`;
  - completed weight load for all TP ranks;
  - entered DeepGEMM warmup with the corrected `N=2624, K=6144` fused shape;
  - reached `/health` 200;
  - returned a successful `/v1/chat/completions` response.

Note: local pytest collection was not run in this Deployment workspace because its system Python has an incompatible Transformers install for this checkout. The targeted runtime smoke was run in the SGLang deployment venv instead.












<sub>✨ Presented to you with <a href=" ">Mind Lab</a > — A Lab for Experiential Intelligence.</sub>










<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28511596736](https://github.com/sgl-project/sglang/actions/runs/28511596736)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28511596516](https://github.com/sgl-project/sglang/actions/runs/28511596516)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->