### PR TITLE
feat: integrate hpc-ops attention and MoE backends

### DIFF
--- a/benchmark/kernels/bench_attention_backends.py
+++ b/benchmark/kernels/bench_attention_backends.py
@@ -1,0 +1,879 @@
+"""Benchmark HPC attention backend against Triton, FlashInfer, and FA3.
+
+Similar to vLLM PR #46020's attention benchmark, this script measures raw kernel
+execution time for various batch sizes and sequence lengths.
+
+Usage:
+    python3 benchmark/kernels/bench_attention_backends.py
+    python3 benchmark/kernels/bench_attention_backends.py --backends hpc triton flashinfer
+    python3 benchmark/kernels/bench_attention_backends.py --repeats 100
+"""
+
+import argparse
+import math
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import torch
+
+# ── Config ──────────────────────────────────────────────────────────────────
+
+HEAD_DIM = 128
+NUM_Q_HEADS = 32
+NUM_KV_HEADS = 8  # GQA ratio = 4
+PAGE_SIZE = 64
+DTYPE = torch.bfloat16
+DEVICE = "cuda"
+
+SM_SCALE = 1.0 / math.sqrt(HEAD_DIM)
+
+# Max KV cache size (tokens).  Enough for 64 × 8k = 512k tokens.
+MAX_KV_TOKENS = 512 * 1024
+NUM_PAGES = MAX_KV_TOKENS // PAGE_SIZE
+
+WARMUP_ITERS = 10
+DEFAULT_REPEATS = 50
+
+
+# ── Batch spec parsing ──────────────────────────────────────────────────────
+
+@dataclass
+class BatchSpec:
+    """Parsed batch specification.
+
+    For decode/extend: ``num_reqs`` requests, each with ``new_tokens`` new Q
+    tokens and ``cached_kv`` cached KV tokens.
+    For prefill: ``num_reqs=1`` request with ``new_tokens`` tokens and
+    ``cached_kv=0``.
+    For mixed: ``prefill_specs`` + ``decode_specs`` lists.
+    """
+    name: str
+    batch_type: str  # "prefill" | "decode" | "extend" | "spec-decode" | "mixed"
+    batch_size: int
+    # Simple specs
+    num_reqs: int = 1
+    new_tokens: int = 0
+    cached_kv: int = 0
+    # Mixed specs
+    prefill_reqs: List[Tuple[int, int]] = field(default_factory=list)  # (new_tokens, cached_kv)
+    decode_reqs: List[Tuple[int, int]] = field(default_factory=list)  # (new_tokens, cached_kv)
+
+    @property
+    def total_q_tokens(self) -> int:
+        if self.batch_type == "mixed":
+            return sum(n for n, _ in self.prefill_reqs) + sum(n for n, _ in self.decode_reqs)
+        return self.num_reqs * self.new_tokens
+
+
+def parse_batch_specs() -> List[BatchSpec]:
+    """Define batch specs matching the vLLM PR #46020 table."""
+    specs = []
+
+    # Prefill (1 request, N tokens, no cached KV)
+    for n, label in [(512, "q512"), (2048, "q2k"), (4096, "q4k"), (8192, "q8k")]:
+        specs.append(BatchSpec(
+            name=label, batch_type="prefill", batch_size=1,
+            num_reqs=1, new_tokens=n, cached_kv=0,
+        ))
+
+    # Extend (1 request, 1k new tokens, 2k cached)
+    specs.append(BatchSpec(
+        name="q1ks2k", batch_type="extend", batch_size=1,
+        num_reqs=1, new_tokens=1024, cached_kv=2048,
+    ))
+
+    # Extend (2 requests, 1k new tokens each, 4k cached each)
+    specs.append(BatchSpec(
+        name="2q1ks4k", batch_type="extend", batch_size=2,
+        num_reqs=2, new_tokens=1024, cached_kv=4096,
+    ))
+
+    # Decode (N requests, 1 new token each, K cached)
+    for n, k, label in [
+        (8, 1024, "8q1s1k"),
+        (16, 2048, "16q1s2k"),
+        (32, 1024, "32q1s1k"),
+        (64, 4096, "64q1s4k"),
+    ]:
+        specs.append(BatchSpec(
+            name=label, batch_type="decode", batch_size=n,
+            num_reqs=n, new_tokens=1, cached_kv=k,
+        ))
+
+    # Spec-decode (N requests, M new tokens each, K cached)
+    for n, m, k, label in [
+        (8, 8, 4096, "8q8s4k"),
+        (16, 2, 1024, "16q2s1k"),
+        (16, 4, 1024, "16q4s1k"),
+        (16, 8, 1024, "16q8s1k"),
+        (32, 4, 2048, "32q4s2k"),
+    ]:
+        specs.append(BatchSpec(
+            name=label, batch_type="spec-decode", batch_size=n,
+            num_reqs=n, new_tokens=m, cached_kv=k,
+        ))
+
+    # Mixed (prefill + decode)
+    specs.append(BatchSpec(
+        name="2q2k_8q1s1k", batch_type="mixed", batch_size=10,
+        prefill_reqs=[(2048, 0)],
+        decode_reqs=[(1, 1024)] * 8,
+    ))
+    specs.append(BatchSpec(
+        name="4q1k_16q1s2k", batch_type="mixed", batch_size=20,
+        prefill_reqs=[(1024, 0)],
+        decode_reqs=[(1, 2048)] * 16,
+    ))
+    specs.append(BatchSpec(
+        name="2q4k_32q1s1k", batch_type="mixed", batch_size=34,
+        prefill_reqs=[(4096, 0)],
+        decode_reqs=[(1, 1024)] * 32,
+    ))
+
+    return specs
+
+
+# ── KV cache & input preparation ────────────────────────────────────────────
+
+@dataclass
+class AttentionInputs:
+    """Prepared inputs for a batch spec, shared across backends."""
+    # Q: [total_q_tokens, num_q_heads, head_dim]
+    q: torch.Tensor
+    # K/V new: [total_new_kv_tokens, num_kv_heads, head_dim]
+    k_new: torch.Tensor
+    v_new: torch.Tensor
+    # Paged KV cache: [num_pages, page_size, num_kv_heads, head_dim]
+    k_cache: torch.Tensor
+    v_cache: torch.Tensor
+    # Block table (page indices): [bs, max_blocks] int32 — used by HPC and FA3
+    block_table: torch.Tensor
+    # Sequence lengths (total KV tokens including new): [bs] int32
+    seq_lens: torch.Tensor
+    # For extend: cu_seqlens_q [bs+1] int32, max_seqlens_q int
+    cu_seqlens_q: Optional[torch.Tensor] = None
+    max_seqlens_q: int = 0
+    # For triton: kv_indptr [bs+1], kv_indices [total_tokens] — TOKEN indices
+    triton_kv_indptr: Optional[torch.Tensor] = None
+    triton_kv_indices: Optional[torch.Tensor] = None
+    # For flashinfer: kv_indptr [bs+1], kv_indices [total_pages] — PAGE indices
+    fi_kv_indptr: Optional[torch.Tensor] = None
+    fi_kv_indices: Optional[torch.Tensor] = None
+    fi_kv_last_page_len: Optional[torch.Tensor] = None
+    # Batch info
+    batch_size: int = 0
+    total_q_tokens: int = 0
+    is_decode: bool = False
+
+
+def prepare_inputs(spec: BatchSpec) -> AttentionInputs:
+    """Prepare dummy inputs for a batch spec."""
+    if spec.batch_type == "mixed":
+        return _prepare_mixed_inputs(spec)
+    return _prepare_simple_inputs(spec)
+
+
+def _prepare_simple_inputs(spec: BatchSpec) -> AttentionInputs:
+    """Prepare inputs for non-mixed batch specs."""
+    bs = spec.num_reqs
+    new_tokens = spec.new_tokens
+    cached_kv = spec.cached_kv
+    total_q = bs * new_tokens
+    total_kv = bs * cached_kv + total_q  # cached + new
+
+    # Allocate paged KV cache
+    num_pages_needed = (total_kv + PAGE_SIZE - 1) // PAGE_SIZE
+    k_cache = torch.randn(
+        max(num_pages_needed, NUM_PAGES), PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM,
+        dtype=DTYPE, device=DEVICE,
+    )
+    v_cache = torch.randn_like(k_cache)
+
+    # Q
+    q = torch.randn(total_q, NUM_Q_HEADS, HEAD_DIM, dtype=DTYPE, device=DEVICE)
+
+    # New K/V
+    k_new = torch.randn(total_q, NUM_KV_HEADS, HEAD_DIM, dtype=DTYPE, device=DEVICE)
+    v_new = torch.randn_like(k_new)
+
+    # Block table: [bs, max_blocks] — page indices for HPC and FA3
+    # Pages are allocated contiguously per request
+    max_seq_len = cached_kv + new_tokens
+    max_blocks = (max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
+    block_table = torch.zeros(bs, max_blocks, dtype=torch.int32, device=DEVICE)
+    page_offset = 0
+    for i in range(bs):
+        for j in range(max_blocks):
+            block_table[i, j] = page_offset + j
+        page_offset += max_blocks
+
+    # Sequence lengths (total KV tokens including new)
+    seq_lens = torch.full((bs,), max_seq_len, dtype=torch.int32, device=DEVICE)
+
+    # For triton: kv_indptr and kv_indices — TOKEN indices
+    # Token indices must be consistent with page assignments:
+    #   token_index = page_index * PAGE_SIZE + offset_within_page
+    triton_kv_indices_list = []
+    triton_kv_indptr = [0]
+    for i in range(bs):
+        base_page = int(block_table[i, 0].item())
+        for j in range(max_seq_len):
+            # token index = base_page * PAGE_SIZE + j
+            triton_kv_indices_list.append(base_page * PAGE_SIZE + j)
+        triton_kv_indptr.append(len(triton_kv_indices_list))
+    triton_kv_indices = torch.tensor(triton_kv_indices_list, dtype=torch.int32, device=DEVICE)
+    triton_kv_indptr = torch.tensor(triton_kv_indptr, dtype=torch.int32, device=DEVICE)
+
+    # For flashinfer: kv_indptr and kv_indices — PAGE indices
+    fi_kv_indices_list = []
+    fi_kv_indptr = [0]
+    for i in range(bs):
+        for j in range(max_blocks):
+            fi_kv_indices_list.append(int(block_table[i, j].item()))
+        fi_kv_indptr.append(len(fi_kv_indices_list))
+    fi_kv_indices = torch.tensor(fi_kv_indices_list, dtype=torch.int32, device=DEVICE)
+    fi_kv_indptr = torch.tensor(fi_kv_indptr, dtype=torch.int32, device=DEVICE)
+
+    # For flashinfer: kv_last_page_len — number of valid tokens in last page
+    last_page_len = max_seq_len % PAGE_SIZE
+    if last_page_len == 0:
+        last_page_len = PAGE_SIZE
+    fi_kv_last_page_len = torch.full((bs,), last_page_len, dtype=torch.int32, device=DEVICE)
+
+    # For extend: cu_seqlens_q
+    cu_seqlens_q = None
+    max_q = new_tokens
+    if spec.batch_type != "decode":
+        cu_seqlens_q = torch.zeros(bs + 1, dtype=torch.int32, device=DEVICE)
+        for i in range(bs):
+            cu_seqlens_q[i + 1] = (i + 1) * new_tokens
+        cu_seqlens_q = cu_seqlens_q.to(torch.int32)
+        max_q = new_tokens
+    else:
+        max_q = 1
+
+    return AttentionInputs(
+        q=q, k_new=k_new, v_new=v_new,
+        k_cache=k_cache, v_cache=v_cache,
+        block_table=block_table, seq_lens=seq_lens,
+        cu_seqlens_q=cu_seqlens_q, max_seqlens_q=max_q,
+        triton_kv_indptr=triton_kv_indptr, triton_kv_indices=triton_kv_indices,
+        fi_kv_indptr=fi_kv_indptr, fi_kv_indices=fi_kv_indices,
+        fi_kv_last_page_len=fi_kv_last_page_len,
+        batch_size=bs, total_q_tokens=total_q,
+        is_decode=(spec.batch_type == "decode"),
+    )
+
+
+def _prepare_mixed_inputs(spec: BatchSpec) -> AttentionInputs:
+    """Prepare inputs for mixed batch specs (prefill + decode requests)."""
+    all_reqs = []  # (new_tokens, cached_kv)
+    all_reqs.extend(spec.prefill_reqs)
+    all_reqs.extend(spec.decode_reqs)
+
+    bs = len(all_reqs)
+    total_q = sum(n for n, _ in all_reqs)
+
+    # Max sequence length across all requests
+    max_seq_len = max(n + c for n, c in all_reqs)
+    max_blocks = (max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
+
+    # Allocate KV cache
+    total_kv = sum(n + c for n, c in all_reqs)
+    num_pages_needed = (total_kv + PAGE_SIZE - 1) // PAGE_SIZE
+    k_cache = torch.randn(
+        max(num_pages_needed, NUM_PAGES), PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM,
+        dtype=DTYPE, device=DEVICE,
+    )
+    v_cache = torch.randn_like(k_cache)
+
+    # Q
+    q = torch.randn(total_q, NUM_Q_HEADS, HEAD_DIM, dtype=DTYPE, device=DEVICE)
+    k_new = torch.randn(total_q, NUM_KV_HEADS, HEAD_DIM, dtype=DTYPE, device=DEVICE)
+    v_new = torch.randn_like(k_new)
+
+    # Block table — page indices
+    block_table = torch.zeros(bs, max_blocks, dtype=torch.int32, device=DEVICE)
+    page_offset = 0
+    seq_lens_list = []
+    blocks_per_req = []
+    for i, (nt, ck) in enumerate(all_reqs):
+        sl = nt + ck
+        seq_lens_list.append(sl)
+        req_blocks = (sl + PAGE_SIZE - 1) // PAGE_SIZE
+        blocks_per_req.append(req_blocks)
+        for j in range(max_blocks):
+            block_table[i, j] = page_offset + j if j < req_blocks else 0
+        page_offset += req_blocks
+
+    seq_lens = torch.tensor(seq_lens_list, dtype=torch.int32, device=DEVICE)
+
+    # Triton: kv_indptr / kv_indices — TOKEN indices
+    # Token indices must be consistent with page assignments
+    triton_kv_indices_list = []
+    triton_kv_indptr = [0]
+    for i, (nt, ck) in enumerate(all_reqs):
+        sl = nt + ck
+        base_page = int(block_table[i, 0].item())
+        for j in range(sl):
+            triton_kv_indices_list.append(base_page * PAGE_SIZE + j)
+        triton_kv_indptr.append(len(triton_kv_indices_list))
+
+    triton_kv_indices = torch.tensor(triton_kv_indices_list, dtype=torch.int32, device=DEVICE)
+    triton_kv_indptr = torch.tensor(triton_kv_indptr, dtype=torch.int32, device=DEVICE)
+
+    # FlashInfer: kv_indptr / kv_indices — PAGE indices
+    fi_kv_indices_list = []
+    fi_kv_indptr = [0]
+    for i in range(bs):
+        rb = blocks_per_req[i]
+        for j in range(rb):
+            fi_kv_indices_list.append(int(block_table[i, j].item()))
+        fi_kv_indptr.append(len(fi_kv_indices_list))
+    fi_kv_indices = torch.tensor(fi_kv_indices_list, dtype=torch.int32, device=DEVICE)
+    fi_kv_indptr = torch.tensor(fi_kv_indptr, dtype=torch.int32, device=DEVICE)
+
+    # FlashInfer: kv_last_page_len
+    fi_last_page_len_list = []
+    for sl in seq_lens_list:
+        lpl = sl % PAGE_SIZE
+        if lpl == 0:
+            lpl = PAGE_SIZE
+        fi_last_page_len_list.append(lpl)
+    fi_kv_last_page_len = torch.tensor(fi_last_page_len_list, dtype=torch.int32, device=DEVICE)
+
+    # cu_seqlens_q
+    cu_seqlens_q = torch.zeros(bs + 1, dtype=torch.int32, device=DEVICE)
+    offset = 0
+    for i, (nt, _) in enumerate(all_reqs):
+        offset += nt
+        cu_seqlens_q[i + 1] = offset
+
+    max_q = max(n for n, _ in all_reqs)
+
+    return AttentionInputs(
+        q=q, k_new=k_new, v_new=v_new,
+        k_cache=k_cache, v_cache=v_cache,
+        block_table=block_table, seq_lens=seq_lens,
+        cu_seqlens_q=cu_seqlens_q, max_seqlens_q=max_q,
+        triton_kv_indptr=triton_kv_indptr, triton_kv_indices=triton_kv_indices,
+        fi_kv_indptr=fi_kv_indptr, fi_kv_indices=fi_kv_indices,
+        fi_kv_last_page_len=fi_kv_last_page_len,
+        batch_size=bs, total_q_tokens=total_q,
+        is_decode=False,
+    )
+
+
+# ── Timing utilities ────────────────────────────────────────────────────────
+
+def benchmark_kernel(fn, warmup=WARMUP_ITERS, repeats=DEFAULT_REPEATS):
+    """Benchmark a kernel function using CUDA events."""
+    # Warmup
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    # Measure
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+
+    times = []
+    for _ in range(repeats):
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    # Return median in seconds
+    times.sort()
+    return times[len(times) // 2] / 1000.0
+
+
+# ── Backend implementations ─────────────────────────────────────────────────
+
+def bench_hpc(inputs: AttentionInputs, repeats: int) -> float:
+    """Benchmark HPC attention backend."""
+    import hpc
+
+    o = torch.empty(
+        inputs.total_q_tokens, NUM_Q_HEADS, HEAD_DIM,
+        dtype=DTYPE, device=DEVICE,
+    )
+
+    if inputs.is_decode:
+        # Decode path
+        def fn():
+            hpc.attention_decode_bf16(
+                q=inputs.q.view(inputs.batch_size, NUM_Q_HEADS, HEAD_DIM),
+                kcache=inputs.k_cache,
+                vcache=inputs.v_cache,
+                block_ids=inputs.block_table,
+                num_seq_kvcache=inputs.seq_lens,
+                mtp=0,
+                new_kv_included=True,
+                splitk=True,
+                output=o,
+            )
+    else:
+        # Prefill/extend path
+        def fn():
+            hpc.attention_with_kvcache_prefill_bf16(
+                q=inputs.q.view(-1, NUM_Q_HEADS, HEAD_DIM),
+                kcache=inputs.k_cache,
+                vcache=inputs.v_cache,
+                cu_seqlens_q=inputs.cu_seqlens_q,
+                block_ids=inputs.block_table,
+                seqlens_kvcache=inputs.seq_lens,
+                max_seqlens_q=inputs.max_seqlens_q,
+                output=o,
+            )
+
+    return benchmark_kernel(fn, repeats=repeats)
+
+
+def bench_triton(inputs: AttentionInputs, repeats: int) -> float:
+    """Benchmark Triton attention backend."""
+    from sglang.srt.layers.attention.triton_ops.decode_attention import (
+        decode_attention_fwd,
+    )
+    from sglang.srt.layers.attention.triton_ops.extend_attention import (
+        extend_attention_fwd,
+    )
+
+    # KV buffer in 3D NHD format for triton
+    k_buffer = inputs.k_cache.view(-1, NUM_KV_HEADS, HEAD_DIM)
+    v_buffer = inputs.v_cache.view(-1, NUM_KV_HEADS, HEAD_DIM)
+
+    if inputs.is_decode:
+        # Decode path
+        # Compute max_kv_splits based on max sequence length (split_tile=256)
+        max_seq_len = int(inputs.seq_lens.max().item())
+        split_tile_size = 256
+        max_kv_splits = max(1, (max_seq_len + split_tile_size - 1) // split_tile_size)
+        # Cap at 128 to limit buffer size
+        max_kv_splits = min(max_kv_splits, 128)
+        num_kv_splits = torch.full(
+            (inputs.batch_size,), max_kv_splits, dtype=torch.int32, device=DEVICE,
+        )
+
+        # attn_logits: [bs, num_heads, max_kv_splits, v_head_dim]
+        # attn_lse: [bs, num_heads, max_kv_splits]
+        attn_logits = torch.empty(
+            inputs.batch_size, NUM_Q_HEADS, max_kv_splits, HEAD_DIM,
+            dtype=torch.float32, device=DEVICE,
+        )
+        attn_lse = torch.empty(
+            inputs.batch_size, NUM_Q_HEADS, max_kv_splits,
+            dtype=torch.float32, device=DEVICE,
+        )
+        o = torch.empty(
+            inputs.batch_size, NUM_Q_HEADS, HEAD_DIM,
+            dtype=DTYPE, device=DEVICE,
+        )
+
+        q_3d = inputs.q.view(inputs.batch_size, NUM_Q_HEADS, HEAD_DIM)
+
+        def fn():
+            decode_attention_fwd(
+                q=q_3d,
+                k_buffer=k_buffer,
+                v_buffer=v_buffer,
+                o=o,
+                kv_indptr=inputs.triton_kv_indptr,
+                kv_indices=inputs.triton_kv_indices,
+                attn_logits=attn_logits,
+                attn_lse=attn_lse,
+                num_kv_splits=num_kv_splits,
+                max_kv_splits=max_kv_splits,
+                sm_scale=SM_SCALE,
+                k_scale=1.0,
+                v_scale=1.0,
+                page_size=PAGE_SIZE,
+            )
+    else:
+        # Extend/prefill path
+        o = torch.empty(
+            inputs.total_q_tokens, NUM_Q_HEADS, HEAD_DIM,
+            dtype=DTYPE, device=DEVICE,
+        )
+        max_extend_len = inputs.max_seqlens_q
+
+        def fn():
+            extend_attention_fwd(
+                q_extend=inputs.q.view(-1, NUM_Q_HEADS, HEAD_DIM),
+                k_extend=inputs.k_new,
+                v_extend=inputs.v_new,
+                o_extend=o,
+                k_buffer=k_buffer,
+                v_buffer=v_buffer,
+                qo_indptr=inputs.cu_seqlens_q,
+                kv_indptr=inputs.triton_kv_indptr,
+                kv_indices=inputs.triton_kv_indices,
+                custom_mask=None,
+                is_causal=True,
+                mask_indptr=None,
+                max_len_extend=max_extend_len,
+                k_scale=1.0,
+                v_scale=1.0,
+                sm_scale=SM_SCALE,
+                page_size=PAGE_SIZE,
+            )
+
+    return benchmark_kernel(fn, repeats=repeats)
+
+
+def bench_flashinfer(inputs: AttentionInputs, repeats: int) -> float:
+    """Benchmark FlashInfer attention backend."""
+    import flashinfer
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=DEVICE)
+
+    # Paged KV cache: [num_pages, 2, page_size, num_kv_heads, head_dim]
+    # FlashInfer expects interleaved K/V stacked along dim 1
+    paged_kv_cache = torch.stack(
+        [inputs.k_cache, inputs.v_cache], dim=1
+    ).contiguous()  # [num_pages, 2, page_size, num_kv_heads, head_dim]
+
+    # Use begin_forward (newer API) or plan (older API).
+    # Decode wrapper: accepts data_type=, q_data_type=
+    # Prefill wrapper: accepts kv_data_type=, q_data_type= (NOT data_type=)
+    def _call_plan(wrapper, *args, **kwargs):
+        for method_name in ("begin_forward", "plan"):
+            method = getattr(wrapper, method_name, None)
+            if method is None:
+                continue
+            try:
+                method(*args, **kwargs)
+                return
+            except TypeError:
+                continue
+        raise RuntimeError("FlashInfer wrapper plan/begin_forward failed")
+
+    if inputs.is_decode:
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            workspace_buffer, "NHD"
+        )
+        _call_plan(
+            wrapper,
+            inputs.fi_kv_indptr,
+            inputs.fi_kv_indices,
+            inputs.fi_kv_last_page_len,
+            NUM_Q_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            data_type=DTYPE,
+            q_data_type=DTYPE,
+        )
+
+        def fn():
+            return wrapper.forward(
+                inputs.q.view(inputs.batch_size, NUM_Q_HEADS, HEAD_DIM),
+                paged_kv_cache,
+                sm_scale=SM_SCALE,
+            )
+    else:
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            workspace_buffer, "NHD"
+        )
+        # Prefill wrapper uses kv_data_type instead of data_type
+        _call_plan(
+            wrapper,
+            inputs.cu_seqlens_q,
+            inputs.fi_kv_indptr,
+            inputs.fi_kv_indices,
+            inputs.fi_kv_last_page_len,
+            NUM_Q_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            q_data_type=DTYPE,
+            kv_data_type=DTYPE,
+        )
+
+        def fn():
+            return wrapper.forward(
+                inputs.q.view(-1, NUM_Q_HEADS, HEAD_DIM),
+                paged_kv_cache,
+                causal=True,
+                sm_scale=SM_SCALE,
+            )
+
+    return benchmark_kernel(fn, repeats=repeats)
+
+
+def bench_fa3(inputs: AttentionInputs, repeats: int) -> float:
+    """Benchmark FlashAttention v3 backend."""
+    try:
+        from sgl_kernel.flash_attn import (
+            flash_attn_varlen_func,
+            flash_attn_with_kvcache,
+        )
+    except ImportError:
+        try:
+            from flash_attn import (
+                flash_attn_varlen_func,
+                flash_attn_with_kvcache,
+            )
+        except ImportError:
+            print("  [SKIP] flash_attn not available")
+            return float("inf")
+
+    # FA3 uses [num_pages, page_size, num_kv_heads, head_dim] for k_cache/v_cache
+    k_cache = inputs.k_cache.contiguous()
+    v_cache = inputs.v_cache.contiguous()
+
+    if inputs.is_decode:
+        # Decode path: flash_attn_with_kvcache
+        # FA3 expects q: [batch_size, seqlen_q, num_heads, head_size] (4D)
+        q_4d = inputs.q.view(inputs.batch_size, 1, NUM_Q_HEADS, HEAD_DIM)
+        # FA3 expects page_table as [bs, max_pages] int32
+        # and cache_seqlens as [bs] int32
+        cache_seqlens = inputs.seq_lens
+
+        def fn():
+            flash_attn_with_kvcache(
+                q=q_4d,
+                k_cache=k_cache,
+                v_cache=v_cache,
+                page_table=inputs.block_table,
+                cache_seqlens=cache_seqlens,
+                cu_seqlens_q=None,
+                max_seqlen_q=1,
+                softmax_scale=SM_SCALE,
+                causal=True,
+            )
+    else:
+        # Prefill/extend path
+        o = torch.empty(
+            inputs.total_q_tokens, NUM_Q_HEADS, HEAD_DIM,
+            dtype=DTYPE, device=DEVICE,
+        )
+        q_3d = inputs.q.view(-1, NUM_Q_HEADS, HEAD_DIM)
+
+        # For pure prefill (no cached KV), use flash_attn_varlen_func
+        # For extend, use flash_attn_with_kvcache with cu_seqlens_q
+        if inputs.cu_seqlens_q is not None and inputs.seq_lens.max().item() > inputs.max_seqlens_q:
+            # Extend path
+            def fn():
+                flash_attn_with_kvcache(
+                    q=q_3d,
+                    k_cache=k_cache,
+                    v_cache=v_cache,
+                    page_table=inputs.block_table,
+                    cache_seqlens=inputs.seq_lens,
+                    cu_seqlens_q=inputs.cu_seqlens_q,
+                    max_seqlen_q=inputs.max_seqlens_q,
+                    softmax_scale=SM_SCALE,
+                    causal=True,
+                )
+        else:
+            # Pure prefill path
+            cu_seqlens_k = inputs.cu_seqlens_q.clone()
+
+            def fn():
+                flash_attn_varlen_func(
+                    q=q_3d,
+                    k=inputs.k_new,
+                    v=inputs.v_new,
+                    cu_seqlens_q=inputs.cu_seqlens_q,
+                    cu_seqlens_k=cu_seqlens_k,
+                    max_seqlen_q=inputs.max_seqlens_q,
+                    max_seqlen_k=inputs.max_seqlens_q,
+                    softmax_scale=SM_SCALE,
+                    causal=True,
+                )
+
+    return benchmark_kernel(fn, repeats=repeats)
+
+
+def bench_trtllm_mha(inputs: AttentionInputs, repeats: int) -> float:
+    """Benchmark TensorRT-LLM MHA backend."""
+    try:
+        from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
+    except ImportError:
+        print("  [SKIP] trtllm_mha not available")
+        return float("inf")
+
+    print("  [SKIP] trtllm_mha requires full server context (not standalone benchmarkable)")
+    return float("inf")
+
+
+# ── Backend registry ────────────────────────────────────────────────────────
+
+BACKENDS = {
+    "hpc": bench_hpc,
+    "triton": bench_triton,
+    "flashinfer": bench_flashinfer,
+    "fa3": bench_fa3,
+    "trtllm_mha": bench_trtllm_mha,
+}
+
+BACKEND_DISPLAY = {
+    "hpc": "HPC_ATTN",
+    "triton": "TRITON_ATTN",
+    "flashinfer": "FLASHINFER",
+    "fa3": "FLASH_ATTN",
+    "trtllm_mha": "TRTLLM_MHA",
+}
+
+
+# ── Table generation ────────────────────────────────────────────────────────
+
+def format_table(results: Dict[str, Dict[str, float]], specs: List[BatchSpec],
+                 backend_names: List[str]) -> str:
+    """Generate a comparison table like the vLLM PR."""
+    display_names = [BACKEND_DISPLAY.get(b, b) for b in backend_names]
+
+    # Build all rows first, then compute column widths dynamically
+    # Each backend gets two columns: "Time (s)" and "vs Best"
+    col_labels = []
+    for name in display_names:
+        col_labels.append(f"{name} Time (s)")
+        col_labels.append("vs Best")
+
+    # Collect row data
+    row_data = []
+    for spec in specs:
+        times = []
+        for b in backend_names:
+            t = results.get(spec.name, {}).get(b, float("inf"))
+            times.append(t)
+        best = min(times)
+
+        row = [spec.name, spec.batch_type, str(spec.batch_size)]
+        for t in times:
+            if t == float("inf"):
+                row.append("N/A")
+                row.append("N/A")
+            else:
+                pct = (t / best) * 100 if best > 0 else 0
+                row.append(f"{t:.6f}")
+                row.append(f"{pct:.1f}%")
+        row_data.append(row)
+
+    # Column headers
+    headers = ["Batch Spec", "Type", "Batch Size"] + col_labels
+
+    # Compute column widths from headers and data
+    num_cols = len(headers)
+    col_widths = [0] * num_cols
+    for i in range(num_cols):
+        col_widths[i] = len(headers[i])
+        for row in row_data:
+            if i < len(row):
+                col_widths[i] = max(col_widths[i], len(row[i]))
+
+    # Pad width = max content width
+    def fmt_cell(text, width, align="left"):
+        if align == "right":
+            return f" {text:>{width}} "
+        if align == "center":
+            total = width - len(text)
+            left = total // 2
+            right = total - left
+            return f" {' ' * left}{text}{' ' * right} "
+        return f" {text:<{width}} "
+
+    # Build table
+    lines = []
+
+    # Header row
+    header_cells = []
+    for i, h in enumerate(headers):
+        header_cells.append(fmt_cell(h, col_widths[i], "center"))
+    lines.append("|" + "|".join(header_cells) + "|")
+
+    # Separator row
+    sep_cells = []
+    for i in range(num_cols):
+        sep_cells.append("-" * (col_widths[i] + 2))
+    lines.append("|" + "|".join(sep_cells) + "|")
+
+    # Data rows
+    for row in row_data:
+        cells = []
+        for i in range(num_cols):
+            val = row[i] if i < len(row) else ""
+            align = "center" if i >= 3 else "left"
+            cells.append(fmt_cell(val, col_widths[i], align))
+        lines.append("|" + "|".join(cells) + "|")
+
+    return "\n".join(lines)
+
+
+# ── Main ────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark attention backends (HPC vs Triton vs FlashInfer vs FA3)"
+    )
+    parser.add_argument(
+        "--backends", nargs="+", default=["hpc", "triton", "flashinfer", "fa3"],
+        choices=list(BACKENDS.keys()),
+        help="Backends to benchmark",
+    )
+    parser.add_argument(
+        "--repeats", type=int, default=DEFAULT_REPEATS,
+        help="Number of timing iterations per benchmark",
+    )
+    parser.add_argument(
+        "--specs", nargs="+", default=None,
+        help="Specific batch specs to run (default: all)",
+    )
+    args = parser.parse_args()
+
+    print(f"Attention Backend Benchmark")
+    print(f"  Device: {torch.cuda.get_device_name()}")
+    print(f"  Config: head_dim={HEAD_DIM}, num_q_heads={NUM_Q_HEADS}, "
+          f"num_kv_heads={NUM_KV_HEADS}, page_size={PAGE_SIZE}, dtype={DTYPE}")
+    print(f"  Backends: {', '.join(args.backends)}")
+    print(f"  Warmup: {WARMUP_ITERS} iters, Measure: {args.repeats} iters")
+    print()
+
+    specs = parse_batch_specs()
+    if args.specs:
+        specs = [s for s in specs if s.name in args.specs]
+
+    results: Dict[str, Dict[str, float]] = {}
+
+    for spec in specs:
+        print(f"Preparing {spec.name} ({spec.batch_type}, bs={spec.batch_size})...", end=" ", flush=True)
+        inputs = prepare_inputs(spec)
+        print(f"q_tokens={inputs.total_q_tokens}")
+
+        results[spec.name] = {}
+        for backend in args.backends:
+            display = BACKEND_DISPLAY.get(backend, backend)
+            print(f"  Benchmarking {display}...", end=" ", flush=True)
+            try:
+                t = BACKENDS[backend](inputs, args.repeats)
+                results[spec.name][backend] = t
+                if t == float("inf"):
+                    print("SKIP")
+                else:
+                    print(f"{t:.6f}s")
+            except Exception as e:
+                results[spec.name][backend] = float("inf")
+                print(f"ERROR: {e}")
+
+        # Free memory
+        del inputs
+        torch.cuda.empty_cache()
+
+    print()
+    print("=" * 120)
+    print("Results:")
+    print("=" * 120)
+    print()
+    table = format_table(results, specs, args.backends)
+    print(table)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/bench_attention_backends.py
+++ b/benchmark/kernels/bench_attention_backends.py
@@ -11,9 +11,6 @@ Usage:
 
 import argparse
 import math
-import os
-import sys
-import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
@@ -40,6 +37,7 @@ DEFAULT_REPEATS = 50
 
 # ── Batch spec parsing ──────────────────────────────────────────────────────
 
+
 @dataclass
 class BatchSpec:
     """Parsed batch specification.
@@ -50,6 +48,7 @@ class BatchSpec:
     ``cached_kv=0``.
     For mixed: ``prefill_specs`` + ``decode_specs`` lists.
     """
+
     name: str
     batch_type: str  # "prefill" | "decode" | "extend" | "spec-decode" | "mixed"
     batch_size: int
@@ -58,13 +57,19 @@ class BatchSpec:
     new_tokens: int = 0
     cached_kv: int = 0
     # Mixed specs
-    prefill_reqs: List[Tuple[int, int]] = field(default_factory=list)  # (new_tokens, cached_kv)
-    decode_reqs: List[Tuple[int, int]] = field(default_factory=list)  # (new_tokens, cached_kv)
+    prefill_reqs: List[Tuple[int, int]] = field(
+        default_factory=list
+    )  # (new_tokens, cached_kv)
+    decode_reqs: List[Tuple[int, int]] = field(
+        default_factory=list
+    )  # (new_tokens, cached_kv)
 
     @property
     def total_q_tokens(self) -> int:
         if self.batch_type == "mixed":
-            return sum(n for n, _ in self.prefill_reqs) + sum(n for n, _ in self.decode_reqs)
+            return sum(n for n, _ in self.prefill_reqs) + sum(
+                n for n, _ in self.decode_reqs
+            )
         return self.num_reqs * self.new_tokens
 
 
@@ -74,22 +79,40 @@ def parse_batch_specs() -> List[BatchSpec]:
 
     # Prefill (1 request, N tokens, no cached KV)
     for n, label in [(512, "q512"), (2048, "q2k"), (4096, "q4k"), (8192, "q8k")]:
-        specs.append(BatchSpec(
-            name=label, batch_type="prefill", batch_size=1,
-            num_reqs=1, new_tokens=n, cached_kv=0,
-        ))
+        specs.append(
+            BatchSpec(
+                name=label,
+                batch_type="prefill",
+                batch_size=1,
+                num_reqs=1,
+                new_tokens=n,
+                cached_kv=0,
+            )
+        )
 
     # Extend (1 request, 1k new tokens, 2k cached)
-    specs.append(BatchSpec(
-        name="q1ks2k", batch_type="extend", batch_size=1,
-        num_reqs=1, new_tokens=1024, cached_kv=2048,
-    ))
+    specs.append(
+        BatchSpec(
+            name="q1ks2k",
+            batch_type="extend",
+            batch_size=1,
+            num_reqs=1,
+            new_tokens=1024,
+            cached_kv=2048,
+        )
+    )
 
     # Extend (2 requests, 1k new tokens each, 4k cached each)
-    specs.append(BatchSpec(
-        name="2q1ks4k", batch_type="extend", batch_size=2,
-        num_reqs=2, new_tokens=1024, cached_kv=4096,
-    ))
+    specs.append(
+        BatchSpec(
+            name="2q1ks4k",
+            batch_type="extend",
+            batch_size=2,
+            num_reqs=2,
+            new_tokens=1024,
+            cached_kv=4096,
+        )
+    )
 
     # Decode (N requests, 1 new token each, K cached)
     for n, k, label in [
@@ -98,10 +121,16 @@ def parse_batch_specs() -> List[BatchSpec]:
         (32, 1024, "32q1s1k"),
         (64, 4096, "64q1s4k"),
     ]:
-        specs.append(BatchSpec(
-            name=label, batch_type="decode", batch_size=n,
-            num_reqs=n, new_tokens=1, cached_kv=k,
-        ))
+        specs.append(
+            BatchSpec(
+                name=label,
+                batch_type="decode",
+                batch_size=n,
+                num_reqs=n,
+                new_tokens=1,
+                cached_kv=k,
+            )
+        )
 
     # Spec-decode (N requests, M new tokens each, K cached)
     for n, m, k, label in [
@@ -111,36 +140,56 @@ def parse_batch_specs() -> List[BatchSpec]:
         (16, 8, 1024, "16q8s1k"),
         (32, 4, 2048, "32q4s2k"),
     ]:
-        specs.append(BatchSpec(
-            name=label, batch_type="spec-decode", batch_size=n,
-            num_reqs=n, new_tokens=m, cached_kv=k,
-        ))
+        specs.append(
+            BatchSpec(
+                name=label,
+                batch_type="spec-decode",
+                batch_size=n,
+                num_reqs=n,
+                new_tokens=m,
+                cached_kv=k,
+            )
+        )
 
     # Mixed (prefill + decode)
-    specs.append(BatchSpec(
-        name="2q2k_8q1s1k", batch_type="mixed", batch_size=10,
-        prefill_reqs=[(2048, 0)],
-        decode_reqs=[(1, 1024)] * 8,
-    ))
-    specs.append(BatchSpec(
-        name="4q1k_16q1s2k", batch_type="mixed", batch_size=20,
-        prefill_reqs=[(1024, 0)],
-        decode_reqs=[(1, 2048)] * 16,
-    ))
-    specs.append(BatchSpec(
-        name="2q4k_32q1s1k", batch_type="mixed", batch_size=34,
-        prefill_reqs=[(4096, 0)],
-        decode_reqs=[(1, 1024)] * 32,
-    ))
+    specs.append(
+        BatchSpec(
+            name="2q2k_8q1s1k",
+            batch_type="mixed",
+            batch_size=10,
+            prefill_reqs=[(2048, 0)],
+            decode_reqs=[(1, 1024)] * 8,
+        )
+    )
+    specs.append(
+        BatchSpec(
+            name="4q1k_16q1s2k",
+            batch_type="mixed",
+            batch_size=20,
+            prefill_reqs=[(1024, 0)],
+            decode_reqs=[(1, 2048)] * 16,
+        )
+    )
+    specs.append(
+        BatchSpec(
+            name="2q4k_32q1s1k",
+            batch_type="mixed",
+            batch_size=34,
+            prefill_reqs=[(4096, 0)],
+            decode_reqs=[(1, 1024)] * 32,
+        )
+    )
 
     return specs
 
 
 # ── KV cache & input preparation ────────────────────────────────────────────
 
+
 @dataclass
 class AttentionInputs:
     """Prepared inputs for a batch spec, shared across backends."""
+
     # Q: [total_q_tokens, num_q_heads, head_dim]
     q: torch.Tensor
     # K/V new: [total_new_kv_tokens, num_kv_heads, head_dim]
@@ -187,8 +236,12 @@ def _prepare_simple_inputs(spec: BatchSpec) -> AttentionInputs:
     # Allocate paged KV cache
     num_pages_needed = (total_kv + PAGE_SIZE - 1) // PAGE_SIZE
     k_cache = torch.randn(
-        max(num_pages_needed, NUM_PAGES), PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM,
-        dtype=DTYPE, device=DEVICE,
+        max(num_pages_needed, NUM_PAGES),
+        PAGE_SIZE,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        dtype=DTYPE,
+        device=DEVICE,
     )
     v_cache = torch.randn_like(k_cache)
 
@@ -224,7 +277,9 @@ def _prepare_simple_inputs(spec: BatchSpec) -> AttentionInputs:
             # token index = base_page * PAGE_SIZE + j
             triton_kv_indices_list.append(base_page * PAGE_SIZE + j)
         triton_kv_indptr.append(len(triton_kv_indices_list))
-    triton_kv_indices = torch.tensor(triton_kv_indices_list, dtype=torch.int32, device=DEVICE)
+    triton_kv_indices = torch.tensor(
+        triton_kv_indices_list, dtype=torch.int32, device=DEVICE
+    )
     triton_kv_indptr = torch.tensor(triton_kv_indptr, dtype=torch.int32, device=DEVICE)
 
     # For flashinfer: kv_indptr and kv_indices — PAGE indices
@@ -241,7 +296,9 @@ def _prepare_simple_inputs(spec: BatchSpec) -> AttentionInputs:
     last_page_len = max_seq_len % PAGE_SIZE
     if last_page_len == 0:
         last_page_len = PAGE_SIZE
-    fi_kv_last_page_len = torch.full((bs,), last_page_len, dtype=torch.int32, device=DEVICE)
+    fi_kv_last_page_len = torch.full(
+        (bs,), last_page_len, dtype=torch.int32, device=DEVICE
+    )
 
     # For extend: cu_seqlens_q
     cu_seqlens_q = None
@@ -256,14 +313,22 @@ def _prepare_simple_inputs(spec: BatchSpec) -> AttentionInputs:
         max_q = 1
 
     return AttentionInputs(
-        q=q, k_new=k_new, v_new=v_new,
-        k_cache=k_cache, v_cache=v_cache,
-        block_table=block_table, seq_lens=seq_lens,
-        cu_seqlens_q=cu_seqlens_q, max_seqlens_q=max_q,
-        triton_kv_indptr=triton_kv_indptr, triton_kv_indices=triton_kv_indices,
-        fi_kv_indptr=fi_kv_indptr, fi_kv_indices=fi_kv_indices,
+        q=q,
+        k_new=k_new,
+        v_new=v_new,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        block_table=block_table,
+        seq_lens=seq_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        max_seqlens_q=max_q,
+        triton_kv_indptr=triton_kv_indptr,
+        triton_kv_indices=triton_kv_indices,
+        fi_kv_indptr=fi_kv_indptr,
+        fi_kv_indices=fi_kv_indices,
         fi_kv_last_page_len=fi_kv_last_page_len,
-        batch_size=bs, total_q_tokens=total_q,
+        batch_size=bs,
+        total_q_tokens=total_q,
         is_decode=(spec.batch_type == "decode"),
     )
 
@@ -285,8 +350,12 @@ def _prepare_mixed_inputs(spec: BatchSpec) -> AttentionInputs:
     total_kv = sum(n + c for n, c in all_reqs)
     num_pages_needed = (total_kv + PAGE_SIZE - 1) // PAGE_SIZE
     k_cache = torch.randn(
-        max(num_pages_needed, NUM_PAGES), PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM,
-        dtype=DTYPE, device=DEVICE,
+        max(num_pages_needed, NUM_PAGES),
+        PAGE_SIZE,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        dtype=DTYPE,
+        device=DEVICE,
     )
     v_cache = torch.randn_like(k_cache)
 
@@ -322,7 +391,9 @@ def _prepare_mixed_inputs(spec: BatchSpec) -> AttentionInputs:
             triton_kv_indices_list.append(base_page * PAGE_SIZE + j)
         triton_kv_indptr.append(len(triton_kv_indices_list))
 
-    triton_kv_indices = torch.tensor(triton_kv_indices_list, dtype=torch.int32, device=DEVICE)
+    triton_kv_indices = torch.tensor(
+        triton_kv_indices_list, dtype=torch.int32, device=DEVICE
+    )
     triton_kv_indptr = torch.tensor(triton_kv_indptr, dtype=torch.int32, device=DEVICE)
 
     # FlashInfer: kv_indptr / kv_indices — PAGE indices
@@ -343,7 +414,9 @@ def _prepare_mixed_inputs(spec: BatchSpec) -> AttentionInputs:
         if lpl == 0:
             lpl = PAGE_SIZE
         fi_last_page_len_list.append(lpl)
-    fi_kv_last_page_len = torch.tensor(fi_last_page_len_list, dtype=torch.int32, device=DEVICE)
+    fi_kv_last_page_len = torch.tensor(
+        fi_last_page_len_list, dtype=torch.int32, device=DEVICE
+    )
 
     # cu_seqlens_q
     cu_seqlens_q = torch.zeros(bs + 1, dtype=torch.int32, device=DEVICE)
@@ -355,19 +428,28 @@ def _prepare_mixed_inputs(spec: BatchSpec) -> AttentionInputs:
     max_q = max(n for n, _ in all_reqs)
 
     return AttentionInputs(
-        q=q, k_new=k_new, v_new=v_new,
-        k_cache=k_cache, v_cache=v_cache,
-        block_table=block_table, seq_lens=seq_lens,
-        cu_seqlens_q=cu_seqlens_q, max_seqlens_q=max_q,
-        triton_kv_indptr=triton_kv_indptr, triton_kv_indices=triton_kv_indices,
-        fi_kv_indptr=fi_kv_indptr, fi_kv_indices=fi_kv_indices,
+        q=q,
+        k_new=k_new,
+        v_new=v_new,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        block_table=block_table,
+        seq_lens=seq_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        max_seqlens_q=max_q,
+        triton_kv_indptr=triton_kv_indptr,
+        triton_kv_indices=triton_kv_indices,
+        fi_kv_indptr=fi_kv_indptr,
+        fi_kv_indices=fi_kv_indices,
         fi_kv_last_page_len=fi_kv_last_page_len,
-        batch_size=bs, total_q_tokens=total_q,
+        batch_size=bs,
+        total_q_tokens=total_q,
         is_decode=False,
     )
 
 
 # ── Timing utilities ────────────────────────────────────────────────────────
+
 
 def benchmark_kernel(fn, warmup=WARMUP_ITERS, repeats=DEFAULT_REPEATS):
     """Benchmark a kernel function using CUDA events."""
@@ -395,13 +477,17 @@ def benchmark_kernel(fn, warmup=WARMUP_ITERS, repeats=DEFAULT_REPEATS):
 
 # ── Backend implementations ─────────────────────────────────────────────────
 
+
 def bench_hpc(inputs: AttentionInputs, repeats: int) -> float:
     """Benchmark HPC attention backend."""
     import hpc
 
     o = torch.empty(
-        inputs.total_q_tokens, NUM_Q_HEADS, HEAD_DIM,
-        dtype=DTYPE, device=DEVICE,
+        inputs.total_q_tokens,
+        NUM_Q_HEADS,
+        HEAD_DIM,
+        dtype=DTYPE,
+        device=DEVICE,
     )
 
     if inputs.is_decode:
@@ -418,6 +504,7 @@ def bench_hpc(inputs: AttentionInputs, repeats: int) -> float:
                 splitk=True,
                 output=o,
             )
+
     else:
         # Prefill/extend path
         def fn():
@@ -457,22 +544,35 @@ def bench_triton(inputs: AttentionInputs, repeats: int) -> float:
         # Cap at 128 to limit buffer size
         max_kv_splits = min(max_kv_splits, 128)
         num_kv_splits = torch.full(
-            (inputs.batch_size,), max_kv_splits, dtype=torch.int32, device=DEVICE,
+            (inputs.batch_size,),
+            max_kv_splits,
+            dtype=torch.int32,
+            device=DEVICE,
         )
 
         # attn_logits: [bs, num_heads, max_kv_splits, v_head_dim]
         # attn_lse: [bs, num_heads, max_kv_splits]
         attn_logits = torch.empty(
-            inputs.batch_size, NUM_Q_HEADS, max_kv_splits, HEAD_DIM,
-            dtype=torch.float32, device=DEVICE,
+            inputs.batch_size,
+            NUM_Q_HEADS,
+            max_kv_splits,
+            HEAD_DIM,
+            dtype=torch.float32,
+            device=DEVICE,
         )
         attn_lse = torch.empty(
-            inputs.batch_size, NUM_Q_HEADS, max_kv_splits,
-            dtype=torch.float32, device=DEVICE,
+            inputs.batch_size,
+            NUM_Q_HEADS,
+            max_kv_splits,
+            dtype=torch.float32,
+            device=DEVICE,
         )
         o = torch.empty(
-            inputs.batch_size, NUM_Q_HEADS, HEAD_DIM,
-            dtype=DTYPE, device=DEVICE,
+            inputs.batch_size,
+            NUM_Q_HEADS,
+            HEAD_DIM,
+            dtype=DTYPE,
+            device=DEVICE,
         )
 
         q_3d = inputs.q.view(inputs.batch_size, NUM_Q_HEADS, HEAD_DIM)
@@ -494,11 +594,15 @@ def bench_triton(inputs: AttentionInputs, repeats: int) -> float:
                 v_scale=1.0,
                 page_size=PAGE_SIZE,
             )
+
     else:
         # Extend/prefill path
         o = torch.empty(
-            inputs.total_q_tokens, NUM_Q_HEADS, HEAD_DIM,
-            dtype=DTYPE, device=DEVICE,
+            inputs.total_q_tokens,
+            NUM_Q_HEADS,
+            HEAD_DIM,
+            dtype=DTYPE,
+            device=DEVICE,
         )
         max_extend_len = inputs.max_seqlens_q
 
@@ -554,9 +658,7 @@ def bench_flashinfer(inputs: AttentionInputs, repeats: int) -> float:
         raise RuntimeError("FlashInfer wrapper plan/begin_forward failed")
 
     if inputs.is_decode:
-        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
-            workspace_buffer, "NHD"
-        )
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, "NHD")
         _call_plan(
             wrapper,
             inputs.fi_kv_indptr,
@@ -576,6 +678,7 @@ def bench_flashinfer(inputs: AttentionInputs, repeats: int) -> float:
                 paged_kv_cache,
                 sm_scale=SM_SCALE,
             )
+
     else:
         wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
             workspace_buffer, "NHD"
@@ -647,17 +750,24 @@ def bench_fa3(inputs: AttentionInputs, repeats: int) -> float:
                 softmax_scale=SM_SCALE,
                 causal=True,
             )
+
     else:
         # Prefill/extend path
         o = torch.empty(
-            inputs.total_q_tokens, NUM_Q_HEADS, HEAD_DIM,
-            dtype=DTYPE, device=DEVICE,
+            inputs.total_q_tokens,
+            NUM_Q_HEADS,
+            HEAD_DIM,
+            dtype=DTYPE,
+            device=DEVICE,
         )
         q_3d = inputs.q.view(-1, NUM_Q_HEADS, HEAD_DIM)
 
         # For pure prefill (no cached KV), use flash_attn_varlen_func
         # For extend, use flash_attn_with_kvcache with cu_seqlens_q
-        if inputs.cu_seqlens_q is not None and inputs.seq_lens.max().item() > inputs.max_seqlens_q:
+        if (
+            inputs.cu_seqlens_q is not None
+            and inputs.seq_lens.max().item() > inputs.max_seqlens_q
+        ):
             # Extend path
             def fn():
                 flash_attn_with_kvcache(
@@ -671,6 +781,7 @@ def bench_fa3(inputs: AttentionInputs, repeats: int) -> float:
                     softmax_scale=SM_SCALE,
                     causal=True,
                 )
+
         else:
             # Pure prefill path
             cu_seqlens_k = inputs.cu_seqlens_q.clone()
@@ -694,12 +805,16 @@ def bench_fa3(inputs: AttentionInputs, repeats: int) -> float:
 def bench_trtllm_mha(inputs: AttentionInputs, repeats: int) -> float:
     """Benchmark TensorRT-LLM MHA backend."""
     try:
-        from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
+        import importlib
+
+        importlib.util.find_spec("sglang.srt.layers.attention.trtllm_mha_backend")
     except ImportError:
         print("  [SKIP] trtllm_mha not available")
         return float("inf")
 
-    print("  [SKIP] trtllm_mha requires full server context (not standalone benchmarkable)")
+    print(
+        "  [SKIP] trtllm_mha requires full server context (not standalone benchmarkable)"
+    )
     return float("inf")
 
 
@@ -724,8 +839,12 @@ BACKEND_DISPLAY = {
 
 # ── Table generation ────────────────────────────────────────────────────────
 
-def format_table(results: Dict[str, Dict[str, float]], specs: List[BatchSpec],
-                 backend_names: List[str]) -> str:
+
+def format_table(
+    results: Dict[str, Dict[str, float]],
+    specs: List[BatchSpec],
+    backend_names: List[str],
+) -> str:
     """Generate a comparison table like the vLLM PR."""
     display_names = [BACKEND_DISPLAY.get(b, b) for b in backend_names]
 
@@ -808,29 +927,38 @@ def format_table(results: Dict[str, Dict[str, float]], specs: List[BatchSpec],
 
 # ── Main ────────────────────────────────────────────────────────────────────
 
+
 def main():
     parser = argparse.ArgumentParser(
         description="Benchmark attention backends (HPC vs Triton vs FlashInfer vs FA3)"
     )
     parser.add_argument(
-        "--backends", nargs="+", default=["hpc", "triton", "flashinfer", "fa3"],
+        "--backends",
+        nargs="+",
+        default=["hpc", "triton", "flashinfer", "fa3"],
         choices=list(BACKENDS.keys()),
         help="Backends to benchmark",
     )
     parser.add_argument(
-        "--repeats", type=int, default=DEFAULT_REPEATS,
+        "--repeats",
+        type=int,
+        default=DEFAULT_REPEATS,
         help="Number of timing iterations per benchmark",
     )
     parser.add_argument(
-        "--specs", nargs="+", default=None,
+        "--specs",
+        nargs="+",
+        default=None,
         help="Specific batch specs to run (default: all)",
     )
     args = parser.parse_args()
 
     print(f"Attention Backend Benchmark")
     print(f"  Device: {torch.cuda.get_device_name()}")
-    print(f"  Config: head_dim={HEAD_DIM}, num_q_heads={NUM_Q_HEADS}, "
-          f"num_kv_heads={NUM_KV_HEADS}, page_size={PAGE_SIZE}, dtype={DTYPE}")
+    print(
+        f"  Config: head_dim={HEAD_DIM}, num_q_heads={NUM_Q_HEADS}, "
+        f"num_kv_heads={NUM_KV_HEADS}, page_size={PAGE_SIZE}, dtype={DTYPE}"
+    )
     print(f"  Backends: {', '.join(args.backends)}")
     print(f"  Warmup: {WARMUP_ITERS} iters, Measure: {args.repeats} iters")
     print()
@@ -842,7 +970,11 @@ def main():
     results: Dict[str, Dict[str, float]] = {}
 
     for spec in specs:
-        print(f"Preparing {spec.name} ({spec.batch_type}, bs={spec.batch_size})...", end=" ", flush=True)
+        print(
+            f"Preparing {spec.name} ({spec.batch_type}, bs={spec.batch_size})...",
+            end=" ",
+            flush=True,
+        )
         inputs = prepare_inputs(spec)
         print(f"q_tokens={inputs.total_q_tokens}")
 

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -337,3 +337,10 @@ def create_intel_xpu_backend(runner):
     from sglang.srt.layers.attention.xpu_backend import XPUAttentionBackend
 
     return XPUAttentionBackend(runner)
+
+
+@register_attention_backend("hpc")
+def create_hpc_backend(runner):
+    from sglang.srt.layers.attention.hpc_backend import HpcAttnBackend
+
+    return HpcAttnBackend(runner)

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -45,9 +45,7 @@ def create_flashinfer_backend(runner):
                 or not runner.plan_stream_for_flashinfer
             ):
                 runner.plan_stream_for_flashinfer = torch.cuda.Stream()
-        return FlashInferAttnBackend(
-            runner, init_new_workspace=runner.init_new_workspace
-        )
+        return FlashInferAttnBackend(runner, init_new_workspace=runner.init_new_workspace)
     else:
         from sglang.srt.layers.attention.flashinfer_mla_backend import (
             FlashInferMLAAttnBackend,
@@ -139,9 +137,7 @@ def create_dsv4_backend(runner):
             DeepseekV4HipRadixBackend,
         )
 
-        logger.info(
-            "Using DeepseekV4HipRadixBackend for compressed attention backend (HIP)."
-        )
+        logger.info("Using DeepseekV4HipRadixBackend for compressed attention backend (HIP).")
         return DeepseekV4HipRadixBackend(runner)
     else:
         from sglang.srt.layers.attention.deepseek_v4_backend import (
@@ -200,8 +196,7 @@ def create_flashattention_v3_backend(runner):
         return FlashAttentionBackend(runner)
     else:
         assert major == 3 and minor >= 1, (
-            "FlashAttention v3 Backend requires MP>=31. "
-            "Please use `--attention-backend triton`."
+            "FlashAttention v3 Backend requires MP>=31. " "Please use `--attention-backend triton`."
         )
         from sglang.srt.hardware_backend.musa.attention import (
             MusaFlashAttentionBackend,
@@ -300,7 +295,7 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
                 assert (
                     runner.server_args.attention_backend == "ascend"
                 ), "ascend backend is the only supported backend on NPU for hybrid GDN models, use --attention-backend ascend to specify the backend."
-            logger.info(f"Using hybrid linear attention backend for hybrid GDN models.")
+            logger.info("Using hybrid linear attention backend for hybrid GDN models.")
             linear_attn_backend = GDNAttnBackend(runner)
         elif runner.mamba2_config is not None:
             linear_attn_backend = Mamba2AttnBackend(runner)
@@ -325,9 +320,7 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
             full_attn_layers = [0]
         else:
             full_attn_layers = cfg.full_attention_layer_ids
-        return HybridLinearAttnBackend(
-            full_attn_backend, linear_attn_backend, full_attn_layers
-        )
+        return HybridLinearAttnBackend(full_attn_backend, linear_attn_backend, full_attn_layers)
 
     return full_attn_backend
 

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -45,7 +45,9 @@ def create_flashinfer_backend(runner):
                 or not runner.plan_stream_for_flashinfer
             ):
                 runner.plan_stream_for_flashinfer = torch.cuda.Stream()
-        return FlashInferAttnBackend(runner, init_new_workspace=runner.init_new_workspace)
+        return FlashInferAttnBackend(
+            runner, init_new_workspace=runner.init_new_workspace
+        )
     else:
         from sglang.srt.layers.attention.flashinfer_mla_backend import (
             FlashInferMLAAttnBackend,
@@ -137,7 +139,9 @@ def create_dsv4_backend(runner):
             DeepseekV4HipRadixBackend,
         )
 
-        logger.info("Using DeepseekV4HipRadixBackend for compressed attention backend (HIP).")
+        logger.info(
+            "Using DeepseekV4HipRadixBackend for compressed attention backend (HIP)."
+        )
         return DeepseekV4HipRadixBackend(runner)
     else:
         from sglang.srt.layers.attention.deepseek_v4_backend import (
@@ -196,7 +200,8 @@ def create_flashattention_v3_backend(runner):
         return FlashAttentionBackend(runner)
     else:
         assert major == 3 and minor >= 1, (
-            "FlashAttention v3 Backend requires MP>=31. " "Please use `--attention-backend triton`."
+            "FlashAttention v3 Backend requires MP>=31. "
+            "Please use `--attention-backend triton`."
         )
         from sglang.srt.hardware_backend.musa.attention import (
             MusaFlashAttentionBackend,
@@ -320,7 +325,9 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
             full_attn_layers = [0]
         else:
             full_attn_layers = cfg.full_attention_layer_ids
-        return HybridLinearAttnBackend(full_attn_backend, linear_attn_backend, full_attn_layers)
+        return HybridLinearAttnBackend(
+            full_attn_backend, linear_attn_backend, full_attn_layers
+        )
 
     return full_attn_backend
 

--- a/python/sglang/srt/layers/attention/hpc_backend.py
+++ b/python/sglang/srt/layers/attention/hpc_backend.py
@@ -1,0 +1,470 @@
+"""HPC-ops Attention Backend for SGLang.
+
+Integrates Tencent's hpc-ops paged attention kernels into SGLang's attention
+backend framework. Supports:
+
+  * **BF16** KV cache — ``hpc.attention_with_kvcache_prefill_bf16`` / ``hpc.attention_decode_bf16``
+  * **FP8** KV cache — ``hpc.attention_with_kvcache_prefill_fp8`` / ``hpc.attention_decode_fp8``
+
+Constraints:
+  * SM90+ (Hopper / H20)
+  * head_dim == 128
+  * page_size should match hpc-ops block_size (recommended 64)
+  * KV cache layout must be NHD (not vectorized_5d)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.runtime_context import get_parallel
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+logger = logging.getLogger(__name__)
+
+# FP8 E4M3 max representable value
+_FP8_E4M3_MAX = 448.0
+
+
+@dataclass
+class HpcForwardMetadata:
+    """Metadata required by the HPC attention kernels."""
+
+    # Block table: [bs, max_blocks], int32
+    block_ids: torch.Tensor
+    # KV cache sequence lengths: [bs], int32
+    seqlens_kvcache: torch.Tensor
+    # Cumulative Q lengths (prefill only): [bs + 1], int32
+    cu_seqlens_q: Optional[torch.Tensor]
+    # Max Q length (prefill only)
+    max_seqlens_q: Optional[int]
+    # Batch size
+    bs: int
+    # Whether new KV was already written (affects seqlens_kvcache)
+    new_kv_included: bool
+
+
+class HpcAttnBackend(AttentionBackend):
+    """Attention backend using Tencent hpc-ops kernels."""
+
+    # HPC backend reads seq_lens on CPU for metadata building
+    needs_cpu_seq_lens: bool = True
+
+    def __init__(self, model_runner: ModelRunner):
+        super().__init__()
+        try:
+            import hpc  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "hpc-ops package is not installed. "
+                "Please install it from https://github.com/Tencent/hpc-ops"
+            ) from e
+
+        from sglang.srt.configs.model_config import AttentionArch
+
+        if model_runner.model_config.attention_arch == AttentionArch.MLA:
+            raise ValueError("HPC attention backend does not support MLA models.")
+
+        self.device = model_runner.device
+        self.req_to_token_pool = model_runner.req_to_token_pool
+        self.token_to_kv_pool = model_runner.token_to_kv_pool
+
+        # Model config
+        self.num_heads = (
+            model_runner.model_config.num_attention_heads
+            // get_parallel().attn_tp_size
+        )
+        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
+            get_parallel().attn_tp_size
+        )
+        self.head_dim = model_runner.model_config.head_dim
+        self.v_head_dim = model_runner.model_config.v_head_dim
+        if self.v_head_dim == -1:
+            self.v_head_dim = self.head_dim
+
+        # Check constraints
+        if self.head_dim != 128:
+            raise ValueError(
+                f"HPC attention backend requires head_dim=128, got {self.head_dim}"
+            )
+
+        if self.v_head_dim != self.head_dim:
+            raise ValueError(
+                f"HPC attention backend requires v_head_dim == head_dim, "
+                f"got v_head_dim={self.v_head_dim}, head_dim={self.head_dim}"
+            )
+
+        major, _ = torch.cuda.get_device_capability(model_runner.gpu_id)
+        if major < 9:
+            raise ValueError(
+                f"HPC attention backend requires SM90+ (Hopper), got SM{major}x"
+            )
+
+        # Page size and KV cache dtype
+        self.page_size = model_runner.server_args.page_size or 1
+        if self.page_size != 64:
+            logger.warning(
+                f"HPC attention backend is optimized for page_size=64, "
+                f"got page_size={self.page_size}. "
+                f"Performance may be degraded."
+            )
+
+        self.kv_cache_dtype = model_runner.server_args.kv_cache_dtype
+        self.use_fp8 = self.kv_cache_dtype in ("fp8_e4m3", "fp8_e5m2")
+
+        self.max_context_len = model_runner.model_config.context_len
+        self.max_blocks = (self.max_context_len + self.page_size - 1) // self.page_size
+
+        self.forward_metadata: Optional[HpcForwardMetadata] = None
+
+    def _get_paged_kv_cache(self, layer: RadixAttention):
+        """Get KV cache in hpc-ops paged format: [num_blocks, block_size, num_kv_heads, head_dim]."""
+        k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+        v_buffer = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
+
+        if k_buffer.ndim == 3:
+            # NHD layout: (total_slots, head_num, head_dim)
+            kcache = k_buffer.view(-1, self.page_size, self.num_kv_heads, self.head_dim)
+            vcache = v_buffer.view(-1, self.page_size, self.num_kv_heads, self.v_head_dim)
+        elif k_buffer.ndim == 5:
+            raise ValueError(
+                "HPC attention backend does not support vectorized_5d KV cache layout. "
+                "Please use NHD layout (set SGLANG_KV_CACHE_LAYOUT=nhd or equivalent)."
+            )
+        else:
+            raise ValueError(
+                f"Unexpected KV cache buffer ndim: {k_buffer.ndim}"
+            )
+
+        return kcache, vcache
+
+    def _build_block_ids(
+        self, req_pool_indices: torch.Tensor, seq_lens: torch.Tensor, bs: int
+    ) -> torch.Tensor:
+        """Build the block table [bs, max_blocks] from SGLang's req_to_token.
+
+        For request *i* and block *j*:
+            block_ids[i, j] = req_to_token[req_pool_indices[i], j * page_size] // page_size
+        """
+        device = seq_lens.device
+        max_seq_len = int(seq_lens[:bs].max().item()) if bs > 0 else 1
+        max_blocks = (max_seq_len + self.page_size - 1) // self.page_size
+        max_blocks = min(max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size)
+
+        # Index req_to_token with req_pool_indices
+        token_table = self.req_to_token_pool.req_to_token[req_pool_indices[:bs]]
+
+        # Get first token of each block: indices 0, page_size, 2*page_size, ...
+        block_starts = torch.arange(
+            0, max_blocks * self.page_size, self.page_size, device=device, dtype=torch.int32
+        )
+        # token_table[:, block_starts] -> [bs, max_blocks]
+        block_ids = (token_table[:, block_starts] // self.page_size).to(torch.int32)
+
+        return block_ids
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        """Build metadata for the current forward batch (eager path)."""
+        bs = forward_batch.batch_size
+        seq_lens = forward_batch.seq_lens
+        req_pool_indices = forward_batch.req_pool_indices
+        device = seq_lens.device
+
+        block_ids = self._build_block_ids(req_pool_indices, seq_lens, bs)
+
+        if forward_batch.forward_mode.is_decode_or_idle():
+            # Decode: KV cache already includes new tokens (we save before attention)
+            seqlens_kvcache = seq_lens[:bs].to(torch.int32)
+            cu_seqlens_q = None
+            max_seqlens_q = None
+            new_kv_included = True
+        else:
+            # Extend / prefill
+            extend_seq_lens = forward_batch.extend_seq_lens[:bs]
+            cu_seqlens_q = torch.zeros(
+                bs + 1, dtype=torch.int32, device=device
+            )
+            cu_seqlens_q[1:] = torch.cumsum(extend_seq_lens, dim=0).to(torch.int32)
+
+            # After saving KV, total cache length = seq_lens
+            seqlens_kvcache = seq_lens[:bs].to(torch.int32)
+            max_seqlens_q = (
+                int(extend_seq_lens.max().item()) if bs > 0 else 1
+            )
+            new_kv_included = True
+
+        self.forward_metadata = HpcForwardMetadata(
+            block_ids=block_ids,
+            seqlens_kvcache=seqlens_kvcache,
+            cu_seqlens_q=cu_seqlens_q,
+            max_seqlens_q=max_seqlens_q,
+            bs=bs,
+            new_kv_included=new_kv_included,
+        )
+
+    def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
+        """Pre-allocate static buffers for CUDA graph capture/replay."""
+        self.cuda_graph_block_ids = torch.zeros(
+            (max_bs, self.max_blocks), dtype=torch.int32, device=self.device
+        )
+        self.cuda_graph_cu_seqlens_q = torch.zeros(
+            (max_bs + 1,), dtype=torch.int32, device=self.device
+        )
+        self.cuda_graph_seqlens_kvcache = torch.zeros(
+            (max_bs,), dtype=torch.int32, device=self.device
+        )
+
+    def init_forward_metadata_out_graph(
+        self, forward_batch: ForwardBatch, in_capture: bool = False
+    ):
+        """Fill pre-allocated CUDA graph buffers for the current batch."""
+        bs = forward_batch.batch_size
+        seq_lens = forward_batch.seq_lens
+        req_pool_indices = forward_batch.req_pool_indices
+
+        # Build block_ids into pre-allocated buffer
+        block_ids = self._build_block_ids(req_pool_indices, seq_lens, bs)
+        max_blocks = block_ids.shape[1]
+        self.cuda_graph_block_ids[:bs, :max_blocks] = block_ids
+        # Zero out unused blocks
+        if max_blocks < self.max_blocks:
+            self.cuda_graph_block_ids[:bs, max_blocks:] = 0
+
+        if forward_batch.forward_mode.is_decode_or_idle():
+            self.cuda_graph_seqlens_kvcache[:bs] = seq_lens[:bs].to(torch.int32)
+            cu_seqlens_q = None
+            max_seqlens_q = None
+            new_kv_included = True
+        else:
+            extend_seq_lens = forward_batch.extend_seq_lens[:bs]
+            self.cuda_graph_cu_seqlens_q[0] = 0
+            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(
+                extend_seq_lens, dim=0
+            ).to(torch.int32)
+            cu_seqlens_q = self.cuda_graph_cu_seqlens_q[: bs + 1]
+
+            self.cuda_graph_seqlens_kvcache[:bs] = seq_lens[:bs].to(torch.int32)
+            max_seqlens_q = (
+                int(extend_seq_lens.max().item()) if bs > 0 else 1
+            )
+            new_kv_included = True
+
+        self.forward_metadata = HpcForwardMetadata(
+            # Use full-width slice (contiguous); the kernel relies on
+            # num_seq_kvcache to determine the valid block count per request.
+            block_ids=self.cuda_graph_block_ids[:bs],
+            seqlens_kvcache=self.cuda_graph_seqlens_kvcache[:bs],
+            cu_seqlens_q=cu_seqlens_q,
+            max_seqlens_q=max_seqlens_q,
+            bs=bs,
+            new_kv_included=new_kv_included,
+        )
+
+    def get_cuda_graph_seq_len_fill_value(self):
+        """Seq lens are padded with 1 (valid single-token decode)."""
+        return 1
+
+    def _save_kv_cache(self, k, v, layer, forward_batch, save_kv_cache):
+        """Save new K/V tensors into the paged KV cache."""
+        if not save_kv_cache or k is None or v is None:
+            return
+
+        if layer.k_scale is not None:
+            self.token_to_kv_pool.set_kv_buffer(
+                layer,
+                forward_batch.out_cache_loc,
+                k,
+                v,
+                layer.k_scale,
+                layer.v_scale,
+            )
+        else:
+            self.token_to_kv_pool.set_kv_buffer(
+                layer,
+                forward_batch.out_cache_loc,
+                k,
+                v,
+            )
+
+    def forward_decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+        **kwargs,
+    ):
+        """Decode attention using hpc-ops kernels."""
+        import hpc
+        from hpc import QuantType
+
+        md = self.forward_metadata
+        bs = md.bs
+
+        # Save new KV to paged cache first
+        self._save_kv_cache(k, v, layer, forward_batch, save_kv_cache)
+
+        # Get paged KV cache
+        kcache, vcache = self._get_paged_kv_cache(layer)
+
+        # Reshape Q: [num_tokens, num_heads, head_dim]
+        # For decode, num_tokens == bs (1 token per request)
+        q_3d = q.view(-1, self.num_heads, self.head_dim)
+
+        # Output: [num_tokens, num_heads, v_head_dim]
+        o = torch.empty(
+            q_3d.shape[0], self.num_heads, self.v_head_dim,
+            dtype=q.dtype, device=q.device,
+        )
+
+        if self.use_fp8:
+            # Compute per-head per-batch Q scale
+            q_max = q_3d.abs().amax(dim=-1)  # [bs, num_heads]
+            qscale = (q_max / _FP8_E4M3_MAX).clamp(min=1e-12).to(torch.float32)
+
+            # K/V scales are per-tensor
+            kscale = torch.tensor(
+                [layer.k_scale_float if layer.k_scale_float else 1.0],
+                dtype=torch.float32,
+                device=self.device,
+            )
+            vscale = torch.tensor(
+                [layer.v_scale_float if layer.v_scale_float else 1.0],
+                dtype=torch.float32,
+                device=self.device,
+            )
+
+            hpc.attention_decode_fp8(
+                q=q_3d,
+                kcache=kcache,
+                vcache=vcache,
+                block_ids=md.block_ids,
+                num_seq_kvcache=md.seqlens_kvcache,
+                qscale=qscale,
+                kscale=kscale,
+                vscale=vscale,
+                mtp=0,
+                new_kv_included=md.new_kv_included,
+                quant_type=QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+                splitk=True,
+                output=o,
+            )
+        else:
+            hpc.attention_decode_bf16(
+                q=q_3d,
+                kcache=kcache,
+                vcache=vcache,
+                block_ids=md.block_ids,
+                num_seq_kvcache=md.seqlens_kvcache,
+                mtp=0,
+                new_kv_included=md.new_kv_included,
+                splitk=True,
+                output=o,
+            )
+
+        # Return [num_tokens, num_heads * head_dim]
+        return o.reshape(-1, self.num_heads * self.v_head_dim)
+
+    def forward_extend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+        **kwargs,
+    ):
+        """Prefill / extend attention using hpc-ops kernels."""
+        import hpc
+        from hpc import QuantType
+
+        md = self.forward_metadata
+        bs = md.bs
+
+        # Save new KV to paged cache first
+        self._save_kv_cache(k, v, layer, forward_batch, save_kv_cache)
+
+        # Get paged KV cache
+        kcache, vcache = self._get_paged_kv_cache(layer)
+
+        # Reshape Q: [total_seq, num_heads, head_dim]
+        q_3d = q.view(-1, self.num_heads, self.head_dim)
+
+        # Output: [total_seq, num_heads, v_head_dim]
+        o = torch.empty(
+            q_3d.shape[0], self.num_heads, self.v_head_dim,
+            dtype=q.dtype, device=q.device,
+        )
+
+        if self.use_fp8:
+            # Quantize Q to FP8 and compute per-token-per-head scales
+            q_max = q_3d.abs().amax(dim=-1)  # [total_seq, num_heads]
+            q_scale_flat = (q_max / _FP8_E4M3_MAX).clamp(min=1e-12).to(torch.float32)
+            q_fp8 = (q_3d / q_scale_flat.unsqueeze(-1)).to(torch.float8_e4m3fn)
+
+            # Reshape q_scale to [bs, num_heads, max_seqlens_q_pad]
+            max_q = md.max_seqlens_q
+            max_q_pad = ((max_q + 15) // 16) * 16  # Pad to 16
+            qscale = torch.zeros(
+                bs, self.num_heads, max_q_pad, dtype=torch.float32, device=self.device
+            )
+            cu_q = md.cu_seqlens_q
+            for i in range(bs):
+                start = int(cu_q[i].item())
+                end = int(cu_q[i + 1].item())
+                seq_i = end - start
+                if seq_i > 0:
+                    qscale[i, :, :seq_i] = q_scale_flat[start:end].t()
+
+            # K/V scales are per-tensor
+            kscale = torch.tensor(
+                [layer.k_scale_float if layer.k_scale_float else 1.0],
+                dtype=torch.float32,
+                device=self.device,
+            )
+            vscale = torch.tensor(
+                [layer.v_scale_float if layer.v_scale_float else 1.0],
+                dtype=torch.float32,
+                device=self.device,
+            )
+
+            hpc.attention_with_kvcache_prefill_fp8(
+                q=q_fp8,
+                kcache=kcache,
+                vcache=vcache,
+                qscale=qscale,
+                kscale=kscale,
+                vscale=vscale,
+                cu_seqlens_q=cu_q,
+                block_ids=md.block_ids,
+                seqlens_kvcache=md.seqlens_kvcache,
+                max_seqlens_q=max_q,
+                quant_type=QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+                output=o,
+            )
+        else:
+            hpc.attention_with_kvcache_prefill_bf16(
+                q=q_3d,
+                kcache=kcache,
+                vcache=vcache,
+                cu_seqlens_q=md.cu_seqlens_q,
+                block_ids=md.block_ids,
+                seqlens_kvcache=md.seqlens_kvcache,
+                max_seqlens_q=md.max_seqlens_q,
+                output=o,
+            )
+
+        # Return [num_tokens, num_heads * v_head_dim]
+        return o.reshape(-1, self.num_heads * self.v_head_dim)

--- a/python/sglang/srt/layers/attention/hpc_backend.py
+++ b/python/sglang/srt/layers/attention/hpc_backend.py
@@ -80,12 +80,9 @@ class HpcAttnBackend(AttentionBackend):
 
         # Model config
         self.num_heads = (
-            model_runner.model_config.num_attention_heads
-            // get_parallel().attn_tp_size
+            model_runner.model_config.num_attention_heads // get_parallel().attn_tp_size
         )
-        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
-            get_parallel().attn_tp_size
-        )
+        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(get_parallel().attn_tp_size)
         self.head_dim = model_runner.model_config.head_dim
         self.v_head_dim = model_runner.model_config.v_head_dim
         if self.v_head_dim == -1:
@@ -93,9 +90,7 @@ class HpcAttnBackend(AttentionBackend):
 
         # Check constraints
         if self.head_dim != 128:
-            raise ValueError(
-                f"HPC attention backend requires head_dim=128, got {self.head_dim}"
-            )
+            raise ValueError(f"HPC attention backend requires head_dim=128, got {self.head_dim}")
 
         if self.v_head_dim != self.head_dim:
             raise ValueError(
@@ -105,9 +100,7 @@ class HpcAttnBackend(AttentionBackend):
 
         major, _ = torch.cuda.get_device_capability(model_runner.gpu_id)
         if major < 9:
-            raise ValueError(
-                f"HPC attention backend requires SM90+ (Hopper), got SM{major}x"
-            )
+            raise ValueError(f"HPC attention backend requires SM90+ (Hopper), got SM{major}x")
 
         # Page size and KV cache dtype
         self.page_size = model_runner.server_args.page_size or 1
@@ -141,9 +134,7 @@ class HpcAttnBackend(AttentionBackend):
                 "Please use NHD layout (set SGLANG_KV_CACHE_LAYOUT=nhd or equivalent)."
             )
         else:
-            raise ValueError(
-                f"Unexpected KV cache buffer ndim: {k_buffer.ndim}"
-            )
+            raise ValueError(f"Unexpected KV cache buffer ndim: {k_buffer.ndim}")
 
         return kcache, vcache
 
@@ -190,16 +181,12 @@ class HpcAttnBackend(AttentionBackend):
         else:
             # Extend / prefill
             extend_seq_lens = forward_batch.extend_seq_lens[:bs]
-            cu_seqlens_q = torch.zeros(
-                bs + 1, dtype=torch.int32, device=device
-            )
+            cu_seqlens_q = torch.zeros(bs + 1, dtype=torch.int32, device=device)
             cu_seqlens_q[1:] = torch.cumsum(extend_seq_lens, dim=0).to(torch.int32)
 
             # After saving KV, total cache length = seq_lens
             seqlens_kvcache = seq_lens[:bs].to(torch.int32)
-            max_seqlens_q = (
-                int(extend_seq_lens.max().item()) if bs > 0 else 1
-            )
+            max_seqlens_q = int(extend_seq_lens.max().item()) if bs > 0 else 1
             new_kv_included = True
 
         self.forward_metadata = HpcForwardMetadata(
@@ -247,15 +234,13 @@ class HpcAttnBackend(AttentionBackend):
         else:
             extend_seq_lens = forward_batch.extend_seq_lens[:bs]
             self.cuda_graph_cu_seqlens_q[0] = 0
-            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(
-                extend_seq_lens, dim=0
-            ).to(torch.int32)
+            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(extend_seq_lens, dim=0).to(
+                torch.int32
+            )
             cu_seqlens_q = self.cuda_graph_cu_seqlens_q[: bs + 1]
 
             self.cuda_graph_seqlens_kvcache[:bs] = seq_lens[:bs].to(torch.int32)
-            max_seqlens_q = (
-                int(extend_seq_lens.max().item()) if bs > 0 else 1
-            )
+            max_seqlens_q = int(extend_seq_lens.max().item()) if bs > 0 else 1
             new_kv_included = True
 
         self.forward_metadata = HpcForwardMetadata(
@@ -310,7 +295,6 @@ class HpcAttnBackend(AttentionBackend):
         from hpc import QuantType
 
         md = self.forward_metadata
-        bs = md.bs
 
         # Save new KV to paged cache first
         self._save_kv_cache(k, v, layer, forward_batch, save_kv_cache)
@@ -324,8 +308,11 @@ class HpcAttnBackend(AttentionBackend):
 
         # Output: [num_tokens, num_heads, v_head_dim]
         o = torch.empty(
-            q_3d.shape[0], self.num_heads, self.v_head_dim,
-            dtype=q.dtype, device=q.device,
+            q_3d.shape[0],
+            self.num_heads,
+            self.v_head_dim,
+            dtype=q.dtype,
+            device=q.device,
         )
 
         if self.use_fp8:
@@ -404,8 +391,11 @@ class HpcAttnBackend(AttentionBackend):
 
         # Output: [total_seq, num_heads, v_head_dim]
         o = torch.empty(
-            q_3d.shape[0], self.num_heads, self.v_head_dim,
-            dtype=q.dtype, device=q.device,
+            q_3d.shape[0],
+            self.num_heads,
+            self.v_head_dim,
+            dtype=q.dtype,
+            device=q.device,
         )
 
         if self.use_fp8:

--- a/python/sglang/srt/layers/attention/hpc_backend.py
+++ b/python/sglang/srt/layers/attention/hpc_backend.py
@@ -82,7 +82,9 @@ class HpcAttnBackend(AttentionBackend):
         self.num_heads = (
             model_runner.model_config.num_attention_heads // get_parallel().attn_tp_size
         )
-        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(get_parallel().attn_tp_size)
+        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
+            get_parallel().attn_tp_size
+        )
         self.head_dim = model_runner.model_config.head_dim
         self.v_head_dim = model_runner.model_config.v_head_dim
         if self.v_head_dim == -1:
@@ -90,7 +92,9 @@ class HpcAttnBackend(AttentionBackend):
 
         # Check constraints
         if self.head_dim != 128:
-            raise ValueError(f"HPC attention backend requires head_dim=128, got {self.head_dim}")
+            raise ValueError(
+                f"HPC attention backend requires head_dim=128, got {self.head_dim}"
+            )
 
         if self.v_head_dim != self.head_dim:
             raise ValueError(
@@ -100,7 +104,9 @@ class HpcAttnBackend(AttentionBackend):
 
         major, _ = torch.cuda.get_device_capability(model_runner.gpu_id)
         if major < 9:
-            raise ValueError(f"HPC attention backend requires SM90+ (Hopper), got SM{major}x")
+            raise ValueError(
+                f"HPC attention backend requires SM90+ (Hopper), got SM{major}x"
+            )
 
         # Page size and KV cache dtype
         self.page_size = model_runner.server_args.page_size or 1
@@ -127,7 +133,9 @@ class HpcAttnBackend(AttentionBackend):
         if k_buffer.ndim == 3:
             # NHD layout: (total_slots, head_num, head_dim)
             kcache = k_buffer.view(-1, self.page_size, self.num_kv_heads, self.head_dim)
-            vcache = v_buffer.view(-1, self.page_size, self.num_kv_heads, self.v_head_dim)
+            vcache = v_buffer.view(
+                -1, self.page_size, self.num_kv_heads, self.v_head_dim
+            )
         elif k_buffer.ndim == 5:
             raise ValueError(
                 "HPC attention backend does not support vectorized_5d KV cache layout. "
@@ -153,7 +161,9 @@ class HpcAttnBackend(AttentionBackend):
         device = seq_lens.device
         max_seq_len = int(seq_lens_cpu[:bs].max().item()) if bs > 0 else 1
         max_blocks = (max_seq_len + self.page_size - 1) // self.page_size
-        max_blocks = min(max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size)
+        max_blocks = min(
+            max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size
+        )
 
         # Index req_to_token with req_pool_indices
         token_table = self.req_to_token_pool.req_to_token[req_pool_indices[:bs]]
@@ -246,9 +256,9 @@ class HpcAttnBackend(AttentionBackend):
         else:
             extend_seq_lens = forward_batch.extend_seq_lens[:bs]
             self.cuda_graph_cu_seqlens_q[0] = 0
-            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(extend_seq_lens, dim=0).to(
-                torch.int32
-            )
+            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(
+                extend_seq_lens, dim=0
+            ).to(torch.int32)
             cu_seqlens_q = self.cuda_graph_cu_seqlens_q[: bs + 1]
 
             self.cuda_graph_seqlens_kvcache[:bs] = seq_lens[:bs].to(torch.int32)

--- a/python/sglang/srt/layers/attention/hpc_backend.py
+++ b/python/sglang/srt/layers/attention/hpc_backend.py
@@ -82,9 +82,7 @@ class HpcAttnBackend(AttentionBackend):
         self.num_heads = (
             model_runner.model_config.num_attention_heads // get_parallel().attn_tp_size
         )
-        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
-            get_parallel().attn_tp_size
-        )
+        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(get_parallel().attn_tp_size)
         self.head_dim = model_runner.model_config.head_dim
         self.v_head_dim = model_runner.model_config.v_head_dim
         if self.v_head_dim == -1:
@@ -92,9 +90,7 @@ class HpcAttnBackend(AttentionBackend):
 
         # Check constraints
         if self.head_dim != 128:
-            raise ValueError(
-                f"HPC attention backend requires head_dim=128, got {self.head_dim}"
-            )
+            raise ValueError(f"HPC attention backend requires head_dim=128, got {self.head_dim}")
 
         if self.v_head_dim != self.head_dim:
             raise ValueError(
@@ -104,12 +100,14 @@ class HpcAttnBackend(AttentionBackend):
 
         major, _ = torch.cuda.get_device_capability(model_runner.gpu_id)
         if major < 9:
-            raise ValueError(
-                f"HPC attention backend requires SM90+ (Hopper), got SM{major}x"
-            )
+            raise ValueError(f"HPC attention backend requires SM90+ (Hopper), got SM{major}x")
 
         # Page size and KV cache dtype
-        self.page_size = model_runner.server_args.page_size or 1
+        self.page_size = (
+            model_runner.server_args.page_size
+            or getattr(model_runner, "page_size", None)
+            or 1
+        )
         if self.page_size != 64:
             logger.warning(
                 f"HPC attention backend is optimized for page_size=64, "
@@ -133,9 +131,7 @@ class HpcAttnBackend(AttentionBackend):
         if k_buffer.ndim == 3:
             # NHD layout: (total_slots, head_num, head_dim)
             kcache = k_buffer.view(-1, self.page_size, self.num_kv_heads, self.head_dim)
-            vcache = v_buffer.view(
-                -1, self.page_size, self.num_kv_heads, self.v_head_dim
-            )
+            vcache = v_buffer.view(-1, self.page_size, self.num_kv_heads, self.v_head_dim)
         elif k_buffer.ndim == 5:
             raise ValueError(
                 "HPC attention backend does not support vectorized_5d KV cache layout. "
@@ -161,9 +157,7 @@ class HpcAttnBackend(AttentionBackend):
         device = seq_lens.device
         max_seq_len = int(seq_lens_cpu[:bs].max().item()) if bs > 0 else 1
         max_blocks = (max_seq_len + self.page_size - 1) // self.page_size
-        max_blocks = min(
-            max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size
-        )
+        max_blocks = min(max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size)
 
         # Index req_to_token with req_pool_indices
         token_table = self.req_to_token_pool.req_to_token[req_pool_indices[:bs]]
@@ -256,9 +250,9 @@ class HpcAttnBackend(AttentionBackend):
         else:
             extend_seq_lens = forward_batch.extend_seq_lens[:bs]
             self.cuda_graph_cu_seqlens_q[0] = 0
-            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(
-                extend_seq_lens, dim=0
-            ).to(torch.int32)
+            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(extend_seq_lens, dim=0).to(
+                torch.int32
+            )
             cu_seqlens_q = self.cuda_graph_cu_seqlens_q[: bs + 1]
 
             self.cuda_graph_seqlens_kvcache[:bs] = seq_lens[:bs].to(torch.int32)
@@ -342,6 +336,9 @@ class HpcAttnBackend(AttentionBackend):
             q_max = q_3d.abs().amax(dim=-1)  # [bs, num_heads]
             qscale = (q_max / _FP8_E4M3_MAX).clamp(min=1e-12).to(torch.float32)
 
+            # Quantize Q to FP8
+            q_fp8 = (q_3d / qscale.unsqueeze(-1)).to(torch.float8_e4m3fn)
+
             # K/V scales are per-tensor (cached on layer to avoid per-step allocation)
             if not hasattr(layer, "hpc_kscale_tensor"):
                 layer.hpc_kscale_tensor = torch.tensor(
@@ -359,7 +356,7 @@ class HpcAttnBackend(AttentionBackend):
             vscale = layer.hpc_vscale_tensor
 
             hpc.attention_decode_fp8(
-                q=q_3d,
+                q=q_fp8,
                 kcache=kcache,
                 vcache=vcache,
                 block_ids=md.block_ids,

--- a/python/sglang/srt/layers/attention/hpc_backend.py
+++ b/python/sglang/srt/layers/attention/hpc_backend.py
@@ -82,7 +82,9 @@ class HpcAttnBackend(AttentionBackend):
         self.num_heads = (
             model_runner.model_config.num_attention_heads // get_parallel().attn_tp_size
         )
-        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(get_parallel().attn_tp_size)
+        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
+            get_parallel().attn_tp_size
+        )
         self.head_dim = model_runner.model_config.head_dim
         self.v_head_dim = model_runner.model_config.v_head_dim
         if self.v_head_dim == -1:
@@ -90,7 +92,9 @@ class HpcAttnBackend(AttentionBackend):
 
         # Check constraints
         if self.head_dim != 128:
-            raise ValueError(f"HPC attention backend requires head_dim=128, got {self.head_dim}")
+            raise ValueError(
+                f"HPC attention backend requires head_dim=128, got {self.head_dim}"
+            )
 
         if self.v_head_dim != self.head_dim:
             raise ValueError(
@@ -100,7 +104,9 @@ class HpcAttnBackend(AttentionBackend):
 
         major, _ = torch.cuda.get_device_capability(model_runner.gpu_id)
         if major < 9:
-            raise ValueError(f"HPC attention backend requires SM90+ (Hopper), got SM{major}x")
+            raise ValueError(
+                f"HPC attention backend requires SM90+ (Hopper), got SM{major}x"
+            )
 
         # Page size and KV cache dtype
         self.page_size = (
@@ -131,7 +137,9 @@ class HpcAttnBackend(AttentionBackend):
         if k_buffer.ndim == 3:
             # NHD layout: (total_slots, head_num, head_dim)
             kcache = k_buffer.view(-1, self.page_size, self.num_kv_heads, self.head_dim)
-            vcache = v_buffer.view(-1, self.page_size, self.num_kv_heads, self.v_head_dim)
+            vcache = v_buffer.view(
+                -1, self.page_size, self.num_kv_heads, self.v_head_dim
+            )
         elif k_buffer.ndim == 5:
             raise ValueError(
                 "HPC attention backend does not support vectorized_5d KV cache layout. "
@@ -157,7 +165,9 @@ class HpcAttnBackend(AttentionBackend):
         device = seq_lens.device
         max_seq_len = int(seq_lens_cpu[:bs].max().item()) if bs > 0 else 1
         max_blocks = (max_seq_len + self.page_size - 1) // self.page_size
-        max_blocks = min(max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size)
+        max_blocks = min(
+            max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size
+        )
 
         # Index req_to_token with req_pool_indices
         token_table = self.req_to_token_pool.req_to_token[req_pool_indices[:bs]]
@@ -250,9 +260,9 @@ class HpcAttnBackend(AttentionBackend):
         else:
             extend_seq_lens = forward_batch.extend_seq_lens[:bs]
             self.cuda_graph_cu_seqlens_q[0] = 0
-            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(extend_seq_lens, dim=0).to(
-                torch.int32
-            )
+            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(
+                extend_seq_lens, dim=0
+            ).to(torch.int32)
             cu_seqlens_q = self.cuda_graph_cu_seqlens_q[: bs + 1]
 
             self.cuda_graph_seqlens_kvcache[:bs] = seq_lens[:bs].to(torch.int32)

--- a/python/sglang/srt/layers/attention/hpc_backend.py
+++ b/python/sglang/srt/layers/attention/hpc_backend.py
@@ -82,7 +82,9 @@ class HpcAttnBackend(AttentionBackend):
         self.num_heads = (
             model_runner.model_config.num_attention_heads // get_parallel().attn_tp_size
         )
-        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(get_parallel().attn_tp_size)
+        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
+            get_parallel().attn_tp_size
+        )
         self.head_dim = model_runner.model_config.head_dim
         self.v_head_dim = model_runner.model_config.v_head_dim
         if self.v_head_dim == -1:
@@ -90,7 +92,9 @@ class HpcAttnBackend(AttentionBackend):
 
         # Check constraints
         if self.head_dim != 128:
-            raise ValueError(f"HPC attention backend requires head_dim=128, got {self.head_dim}")
+            raise ValueError(
+                f"HPC attention backend requires head_dim=128, got {self.head_dim}"
+            )
 
         if self.v_head_dim != self.head_dim:
             raise ValueError(
@@ -100,7 +104,9 @@ class HpcAttnBackend(AttentionBackend):
 
         major, _ = torch.cuda.get_device_capability(model_runner.gpu_id)
         if major < 9:
-            raise ValueError(f"HPC attention backend requires SM90+ (Hopper), got SM{major}x")
+            raise ValueError(
+                f"HPC attention backend requires SM90+ (Hopper), got SM{major}x"
+            )
 
         # Page size and KV cache dtype
         self.page_size = model_runner.server_args.page_size or 1
@@ -127,7 +133,9 @@ class HpcAttnBackend(AttentionBackend):
         if k_buffer.ndim == 3:
             # NHD layout: (total_slots, head_num, head_dim)
             kcache = k_buffer.view(-1, self.page_size, self.num_kv_heads, self.head_dim)
-            vcache = v_buffer.view(-1, self.page_size, self.num_kv_heads, self.v_head_dim)
+            vcache = v_buffer.view(
+                -1, self.page_size, self.num_kv_heads, self.v_head_dim
+            )
         elif k_buffer.ndim == 5:
             raise ValueError(
                 "HPC attention backend does not support vectorized_5d KV cache layout. "
@@ -149,14 +157,20 @@ class HpcAttnBackend(AttentionBackend):
         device = seq_lens.device
         max_seq_len = int(seq_lens[:bs].max().item()) if bs > 0 else 1
         max_blocks = (max_seq_len + self.page_size - 1) // self.page_size
-        max_blocks = min(max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size)
+        max_blocks = min(
+            max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size
+        )
 
         # Index req_to_token with req_pool_indices
         token_table = self.req_to_token_pool.req_to_token[req_pool_indices[:bs]]
 
         # Get first token of each block: indices 0, page_size, 2*page_size, ...
         block_starts = torch.arange(
-            0, max_blocks * self.page_size, self.page_size, device=device, dtype=torch.int32
+            0,
+            max_blocks * self.page_size,
+            self.page_size,
+            device=device,
+            dtype=torch.int32,
         )
         # token_table[:, block_starts] -> [bs, max_blocks]
         block_ids = (token_table[:, block_starts] // self.page_size).to(torch.int32)
@@ -234,9 +248,9 @@ class HpcAttnBackend(AttentionBackend):
         else:
             extend_seq_lens = forward_batch.extend_seq_lens[:bs]
             self.cuda_graph_cu_seqlens_q[0] = 0
-            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(extend_seq_lens, dim=0).to(
-                torch.int32
-            )
+            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(
+                extend_seq_lens, dim=0
+            ).to(torch.int32)
             cu_seqlens_q = self.cuda_graph_cu_seqlens_q[: bs + 1]
 
             self.cuda_graph_seqlens_kvcache[:bs] = seq_lens[:bs].to(torch.int32)

--- a/python/sglang/srt/layers/attention/hpc_backend.py
+++ b/python/sglang/srt/layers/attention/hpc_backend.py
@@ -82,9 +82,7 @@ class HpcAttnBackend(AttentionBackend):
         self.num_heads = (
             model_runner.model_config.num_attention_heads // get_parallel().attn_tp_size
         )
-        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
-            get_parallel().attn_tp_size
-        )
+        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(get_parallel().attn_tp_size)
         self.head_dim = model_runner.model_config.head_dim
         self.v_head_dim = model_runner.model_config.v_head_dim
         if self.v_head_dim == -1:
@@ -92,9 +90,7 @@ class HpcAttnBackend(AttentionBackend):
 
         # Check constraints
         if self.head_dim != 128:
-            raise ValueError(
-                f"HPC attention backend requires head_dim=128, got {self.head_dim}"
-            )
+            raise ValueError(f"HPC attention backend requires head_dim=128, got {self.head_dim}")
 
         if self.v_head_dim != self.head_dim:
             raise ValueError(
@@ -104,9 +100,7 @@ class HpcAttnBackend(AttentionBackend):
 
         major, _ = torch.cuda.get_device_capability(model_runner.gpu_id)
         if major < 9:
-            raise ValueError(
-                f"HPC attention backend requires SM90+ (Hopper), got SM{major}x"
-            )
+            raise ValueError(f"HPC attention backend requires SM90+ (Hopper), got SM{major}x")
 
         # Page size and KV cache dtype
         self.page_size = model_runner.server_args.page_size or 1
@@ -133,9 +127,7 @@ class HpcAttnBackend(AttentionBackend):
         if k_buffer.ndim == 3:
             # NHD layout: (total_slots, head_num, head_dim)
             kcache = k_buffer.view(-1, self.page_size, self.num_kv_heads, self.head_dim)
-            vcache = v_buffer.view(
-                -1, self.page_size, self.num_kv_heads, self.v_head_dim
-            )
+            vcache = v_buffer.view(-1, self.page_size, self.num_kv_heads, self.v_head_dim)
         elif k_buffer.ndim == 5:
             raise ValueError(
                 "HPC attention backend does not support vectorized_5d KV cache layout. "
@@ -147,7 +139,11 @@ class HpcAttnBackend(AttentionBackend):
         return kcache, vcache
 
     def _build_block_ids(
-        self, req_pool_indices: torch.Tensor, seq_lens: torch.Tensor, bs: int
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        bs: int,
     ) -> torch.Tensor:
         """Build the block table [bs, max_blocks] from SGLang's req_to_token.
 
@@ -155,11 +151,9 @@ class HpcAttnBackend(AttentionBackend):
             block_ids[i, j] = req_to_token[req_pool_indices[i], j * page_size] // page_size
         """
         device = seq_lens.device
-        max_seq_len = int(seq_lens[:bs].max().item()) if bs > 0 else 1
+        max_seq_len = int(seq_lens_cpu[:bs].max().item()) if bs > 0 else 1
         max_blocks = (max_seq_len + self.page_size - 1) // self.page_size
-        max_blocks = min(
-            max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size
-        )
+        max_blocks = min(max_blocks, self.req_to_token_pool.req_to_token.shape[1] // self.page_size)
 
         # Index req_to_token with req_pool_indices
         token_table = self.req_to_token_pool.req_to_token[req_pool_indices[:bs]]
@@ -184,7 +178,9 @@ class HpcAttnBackend(AttentionBackend):
         req_pool_indices = forward_batch.req_pool_indices
         device = seq_lens.device
 
-        block_ids = self._build_block_ids(req_pool_indices, seq_lens, bs)
+        block_ids = self._build_block_ids(
+            req_pool_indices, seq_lens, forward_batch.seq_lens_cpu, bs
+        )
 
         if forward_batch.forward_mode.is_decode_or_idle():
             # Decode: KV cache already includes new tokens (we save before attention)
@@ -200,7 +196,7 @@ class HpcAttnBackend(AttentionBackend):
 
             # After saving KV, total cache length = seq_lens
             seqlens_kvcache = seq_lens[:bs].to(torch.int32)
-            max_seqlens_q = int(extend_seq_lens.max().item()) if bs > 0 else 1
+            max_seqlens_q = max(forward_batch.extend_seq_lens_cpu[:bs]) if bs > 0 else 1
             new_kv_included = True
 
         self.forward_metadata = HpcForwardMetadata(
@@ -233,7 +229,9 @@ class HpcAttnBackend(AttentionBackend):
         req_pool_indices = forward_batch.req_pool_indices
 
         # Build block_ids into pre-allocated buffer
-        block_ids = self._build_block_ids(req_pool_indices, seq_lens, bs)
+        block_ids = self._build_block_ids(
+            req_pool_indices, seq_lens, forward_batch.seq_lens_cpu, bs
+        )
         max_blocks = block_ids.shape[1]
         self.cuda_graph_block_ids[:bs, :max_blocks] = block_ids
         # Zero out unused blocks
@@ -248,13 +246,13 @@ class HpcAttnBackend(AttentionBackend):
         else:
             extend_seq_lens = forward_batch.extend_seq_lens[:bs]
             self.cuda_graph_cu_seqlens_q[0] = 0
-            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(
-                extend_seq_lens, dim=0
-            ).to(torch.int32)
+            self.cuda_graph_cu_seqlens_q[1 : bs + 1] = torch.cumsum(extend_seq_lens, dim=0).to(
+                torch.int32
+            )
             cu_seqlens_q = self.cuda_graph_cu_seqlens_q[: bs + 1]
 
             self.cuda_graph_seqlens_kvcache[:bs] = seq_lens[:bs].to(torch.int32)
-            max_seqlens_q = int(extend_seq_lens.max().item()) if bs > 0 else 1
+            max_seqlens_q = max(forward_batch.extend_seq_lens_cpu[:bs]) if bs > 0 else 1
             new_kv_included = True
 
         self.forward_metadata = HpcForwardMetadata(
@@ -334,17 +332,21 @@ class HpcAttnBackend(AttentionBackend):
             q_max = q_3d.abs().amax(dim=-1)  # [bs, num_heads]
             qscale = (q_max / _FP8_E4M3_MAX).clamp(min=1e-12).to(torch.float32)
 
-            # K/V scales are per-tensor
-            kscale = torch.tensor(
-                [layer.k_scale_float if layer.k_scale_float else 1.0],
-                dtype=torch.float32,
-                device=self.device,
-            )
-            vscale = torch.tensor(
-                [layer.v_scale_float if layer.v_scale_float else 1.0],
-                dtype=torch.float32,
-                device=self.device,
-            )
+            # K/V scales are per-tensor (cached on layer to avoid per-step allocation)
+            if not hasattr(layer, "hpc_kscale_tensor"):
+                layer.hpc_kscale_tensor = torch.tensor(
+                    [layer.k_scale_float if layer.k_scale_float else 1.0],
+                    dtype=torch.float32,
+                    device=self.device,
+                )
+            kscale = layer.hpc_kscale_tensor
+            if not hasattr(layer, "hpc_vscale_tensor"):
+                layer.hpc_vscale_tensor = torch.tensor(
+                    [layer.v_scale_float if layer.v_scale_float else 1.0],
+                    dtype=torch.float32,
+                    device=self.device,
+                )
+            vscale = layer.hpc_vscale_tensor
 
             hpc.attention_decode_fp8(
                 q=q_3d,
@@ -424,25 +426,32 @@ class HpcAttnBackend(AttentionBackend):
             qscale = torch.zeros(
                 bs, self.num_heads, max_q_pad, dtype=torch.float32, device=self.device
             )
-            cu_q = md.cu_seqlens_q
+            # Use CPU cumulative sum to avoid 2*bs GPU-CPU synchronizations
+            cu_q_cpu = [0]
+            for length in forward_batch.extend_seq_lens_cpu[:bs]:
+                cu_q_cpu.append(cu_q_cpu[-1] + length)
             for i in range(bs):
-                start = int(cu_q[i].item())
-                end = int(cu_q[i + 1].item())
+                start = cu_q_cpu[i]
+                end = cu_q_cpu[i + 1]
                 seq_i = end - start
                 if seq_i > 0:
                     qscale[i, :, :seq_i] = q_scale_flat[start:end].t()
 
-            # K/V scales are per-tensor
-            kscale = torch.tensor(
-                [layer.k_scale_float if layer.k_scale_float else 1.0],
-                dtype=torch.float32,
-                device=self.device,
-            )
-            vscale = torch.tensor(
-                [layer.v_scale_float if layer.v_scale_float else 1.0],
-                dtype=torch.float32,
-                device=self.device,
-            )
+            # K/V scales are per-tensor (cached on layer to avoid per-step allocation)
+            if not hasattr(layer, "hpc_kscale_tensor"):
+                layer.hpc_kscale_tensor = torch.tensor(
+                    [layer.k_scale_float if layer.k_scale_float else 1.0],
+                    dtype=torch.float32,
+                    device=self.device,
+                )
+            kscale = layer.hpc_kscale_tensor
+            if not hasattr(layer, "hpc_vscale_tensor"):
+                layer.hpc_vscale_tensor = torch.tensor(
+                    [layer.v_scale_float if layer.v_scale_float else 1.0],
+                    dtype=torch.float32,
+                    device=self.device,
+                )
+            vscale = layer.hpc_vscale_tensor
 
             hpc.attention_with_kvcache_prefill_fp8(
                 q=q_fp8,
@@ -451,7 +460,7 @@ class HpcAttnBackend(AttentionBackend):
                 qscale=qscale,
                 kscale=kscale,
                 vscale=vscale,
-                cu_seqlens_q=cu_q,
+                cu_seqlens_q=md.cu_seqlens_q,
                 block_ids=md.block_ids,
                 seqlens_kvcache=md.seqlens_kvcache,
                 max_seqlens_q=max_q,

--- a/python/sglang/srt/layers/moe/moe_runner/hpc.py
+++ b/python/sglang/srt/layers/moe/moe_runner/hpc.py
@@ -1,0 +1,156 @@
+"""HPC-ops MoE runner backend.
+
+This module integrates Tencent's hpc-ops fused MoE kernels into SGLang's
+MoE runner framework. It supports two FP8 quantization schemes:
+
+  * **Per-tensor** — ``hpc.fuse_moe`` via :func:`hpc_fuse_moe`
+  * **Block-wise** — ``hpc.fuse_moe_blockwise`` via :func:`hpc_fuse_moe_blockwise`
+
+The backend is registered as a **fused-only** runner (no ``RunnerCore``),
+following the same pattern as ``marlin.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+    RunnerInput,
+    RunnerOutput,
+    register_fused_func,
+)
+from sglang.srt.layers.moe.utils import MoeRunnerBackend
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+
+
+@dataclass
+class HpcRunnerInput(RunnerInput):
+    """Input bundle passed to the HPC runner core (unused in fused path)."""
+
+    hidden_states: torch.Tensor
+    topk_weights: torch.Tensor
+    topk_ids: torch.Tensor
+    router_logits: torch.Tensor
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.HPC
+
+
+@dataclass
+class HpcRunnerOutput(RunnerOutput):
+    """Output bundle returned from the HPC runner core (unused in fused path)."""
+
+    hidden_states: torch.Tensor
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.HPC
+
+
+@dataclass
+class HpcMoeQuantInfo(MoeQuantInfo):
+    """Quantization payload consumed by the HPC MoE backend.
+
+    Supports both per-tensor and block-wise FP8 quantization schemes.
+
+    **Per-tensor fields** (used when ``is_block_quantized is False``):
+        w13_weight: Gate+up expert weights, fp8.
+        w2_weight: Down expert weights, fp8.
+        w13_scale: Per-tensor scale for gate+up GEMM.
+        w2_scale: Per-tensor scale for down GEMM.
+        act_and_mul_scale: Scale at the activation boundary.
+
+    **Block-wise fields** (used when ``is_block_quantized is True``):
+        w13_weight: Gate+up expert weights, fp8.
+        w2_weight: Down expert weights, fp8.
+        w13_weight_scale: Per-block weight scale for gate+up.
+        w2_weight_scale: Per-block weight scale for down.
+        x_scale: Per-block input activation scale.
+    """
+
+    # Common
+    w13_weight: torch.Tensor = None
+    w2_weight: torch.Tensor = None
+    is_block_quantized: bool = False
+
+    # Per-tensor FP8 fields
+    w13_scale: Optional[torch.Tensor] = None
+    w2_scale: Optional[torch.Tensor] = None
+    act_and_mul_scale: Optional[torch.Tensor] = None
+
+    # Block-wise FP8 fields
+    w13_weight_scale: Optional[torch.Tensor] = None
+    w2_weight_scale: Optional[torch.Tensor] = None
+    x_scale: Optional[torch.Tensor] = None
+
+    # EP metadata
+    rank_ep: int = 0
+    num_expert_total: int = -1
+
+    # Optional shared-expert output to add in-place
+    shared_output: Optional[torch.Tensor] = None
+
+
+@register_fused_func("none", "hpc")
+def fused_experts_none_to_hpc(
+    dispatch_output: StandardDispatchOutput,
+    quant_info: HpcMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> StandardCombineInput:
+    """Fused MoE entry point for HPC-ops backend.
+
+    Dispatches to ``hpc.fuse_moe`` (per-tensor) or ``hpc.fuse_moe_blockwise``
+    (block-wise) depending on ``quant_info.is_block_quantized``.
+    """
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+    from sglang.srt.utils.hpc import hpc_fuse_moe, hpc_fuse_moe_blockwise
+
+    hidden_states = dispatch_output.hidden_states
+    topk_output = dispatch_output.topk_output
+    topk_ids = topk_output.topk_ids
+    topk_scale = topk_output.topk_weights
+
+    if quant_info.is_block_quantized:
+        output = hpc_fuse_moe_blockwise(
+            x=hidden_states,
+            x_scale=quant_info.x_scale,
+            gate_up_weight=quant_info.w13_weight,
+            gate_up_weight_scale=quant_info.w13_weight_scale,
+            down_weight=quant_info.w2_weight,
+            down_weight_scale=quant_info.w2_weight_scale,
+            topk_ids=topk_ids,
+            topk_scale=topk_scale,
+            rank_ep=quant_info.rank_ep,
+            num_expert_total=quant_info.num_expert_total,
+            shared_output=quant_info.shared_output,
+        )
+    else:
+        output = hpc_fuse_moe(
+            x=hidden_states,
+            gate_up_weight=quant_info.w13_weight,
+            down_weight=quant_info.w2_weight,
+            gate_up_scale=quant_info.w13_scale,
+            down_scale=quant_info.w2_scale,
+            act_and_mul_scale=quant_info.act_and_mul_scale,
+            topk_ids=topk_ids,
+            topk_scale=topk_scale,
+            rank_ep=quant_info.rank_ep,
+            num_expert_total=quant_info.num_expert_total,
+            use_bf16_mul=True,
+            shared_output=quant_info.shared_output,
+        )
+
+    return StandardCombineInput(
+        hidden_states=output,
+    )

--- a/python/sglang/srt/layers/moe/moe_runner/hpc.py
+++ b/python/sglang/srt/layers/moe/moe_runner/hpc.py
@@ -130,8 +130,10 @@ def fused_experts_none_to_hpc(
         x_reshaped = hidden_states.view(num_seq, -1, block_k)
         x_max = x_reshaped.abs().amax(dim=-1).clamp(min=1e-12)
         x_scale = (x_max / _FP8_E4M3_MAX).to(torch.float32)
-        x_fp8 = (x_reshaped / x_scale.unsqueeze(-1)).to(torch.float8_e4m3fn).view_as(
-            hidden_states
+        x_fp8 = (
+            (x_reshaped / x_scale.unsqueeze(-1))
+            .to(torch.float8_e4m3fn)
+            .view_as(hidden_states)
         )
 
         output = hpc_fuse_moe_blockwise(
@@ -154,9 +156,11 @@ def fused_experts_none_to_hpc(
         if quant_info.act_and_mul_scale is not None:
             x_scale = quant_info.act_and_mul_scale
         else:
-            x_scale = (hidden_states.abs().max() / _FP8_E4M3_MAX).clamp(
-                min=1e-12
-            ).to(torch.float32)
+            x_scale = (
+                (hidden_states.abs().max() / _FP8_E4M3_MAX)
+                .clamp(min=1e-12)
+                .to(torch.float32)
+            )
         x_fp8 = (hidden_states / x_scale).to(torch.float8_e4m3fn)
 
         # GEMM1 dequantization: output = x_fp8 @ w13_fp8 * (x_scale * w13_scale)

--- a/python/sglang/srt/layers/moe/moe_runner/hpc.py
+++ b/python/sglang/srt/layers/moe/moe_runner/hpc.py
@@ -26,6 +26,8 @@ from sglang.srt.layers.moe.moe_runner.base import (
 )
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
 
+_FP8_E4M3_MAX = 448.0
+
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
         StandardCombineInput,
@@ -122,9 +124,19 @@ def fused_experts_none_to_hpc(
     topk_scale = topk_output.topk_weights
 
     if quant_info.is_block_quantized:
+        # Quantize x to FP8 with per-block scaling (dynamic)
+        num_seq, hidden_size = hidden_states.shape
+        block_k = hidden_size // quant_info.w13_weight_scale.shape[-1]
+        x_reshaped = hidden_states.view(num_seq, -1, block_k)
+        x_max = x_reshaped.abs().amax(dim=-1).clamp(min=1e-12)
+        x_scale = (x_max / _FP8_E4M3_MAX).to(torch.float32)
+        x_fp8 = (x_reshaped / x_scale.unsqueeze(-1)).to(torch.float8_e4m3fn).view_as(
+            hidden_states
+        )
+
         output = hpc_fuse_moe_blockwise(
-            x=hidden_states,
-            x_scale=quant_info.x_scale,
+            x=x_fp8,
+            x_scale=x_scale,
             gate_up_weight=quant_info.w13_weight,
             gate_up_weight_scale=quant_info.w13_weight_scale,
             down_weight=quant_info.w2_weight,
@@ -136,13 +148,38 @@ def fused_experts_none_to_hpc(
             shared_output=quant_info.shared_output,
         )
     else:
+        # Per-tensor: quantize x to FP8 dynamically
+        # quant_info.act_and_mul_scale is the model's w13_input_scale (a13_scale)
+        # used for GEMM1 input quantization. If None, compute dynamically.
+        if quant_info.act_and_mul_scale is not None:
+            x_scale = quant_info.act_and_mul_scale
+        else:
+            x_scale = (hidden_states.abs().max() / _FP8_E4M3_MAX).clamp(
+                min=1e-12
+            ).to(torch.float32)
+        x_fp8 = (hidden_states / x_scale).to(torch.float8_e4m3fn)
+
+        # GEMM1 dequantization: output = x_fp8 @ w13_fp8 * (x_scale * w13_scale)
+        combined_gate_up_scale = (quant_info.w13_scale * x_scale).to(torch.float32)
+
+        # HPC kernel's act_and_mul_scale is MULTIPLIED with the activation
+        # (SiLU(gate) * up) BEFORE converting to FP8 (see hpc-ops naive reference).
+        # So it must be the INVERSE of the quantization scale: 1/x_scale.
+        hpc_act_and_mul_scale = (1.0 / x_scale).to(torch.float32)
+
+        # GEMM2 dequantization must compensate for the pre-quantization:
+        #   down_output = (act * hpc_act_and_mul_scale)_fp8 @ w2_fp8 * down_scale
+        # For correct dequant: down_scale = w2_scale / hpc_act_and_mul_scale
+        #                                 = w2_scale * x_scale
+        hpc_down_scale = (quant_info.w2_scale * x_scale).to(torch.float32)
+
         output = hpc_fuse_moe(
-            x=hidden_states,
+            x=x_fp8,
             gate_up_weight=quant_info.w13_weight,
             down_weight=quant_info.w2_weight,
-            gate_up_scale=quant_info.w13_scale,
-            down_scale=quant_info.w2_scale,
-            act_and_mul_scale=quant_info.act_and_mul_scale,
+            gate_up_scale=combined_gate_up_scale,
+            down_scale=hpc_down_scale,
+            act_and_mul_scale=hpc_act_and_mul_scale,
             topk_ids=topk_ids,
             topk_scale=topk_scale,
             rank_ep=quant_info.rank_ep,

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -54,7 +54,10 @@ class MoeRunner:
                 self.runner_core = MarlinLoraRunnerCore(config)
             else:
                 self.runner_core = None  # Marlin only supports fused path
-        elif runner_backend.is_flashinfer_trtllm() or runner_backend.is_flashinfer_trtllm_routed():
+        elif (
+            runner_backend.is_flashinfer_trtllm()
+            or runner_backend.is_flashinfer_trtllm_routed()
+        ):
             self.runner_core = None  # FlashInfer TRT-LLM only supports fused path
         elif runner_backend.is_flashinfer_cutedsl():
             self.runner_core = None  # FlashInfer CuteDSL only supports fused path
@@ -75,7 +78,9 @@ class MoeRunner:
             runner_backend_name = runner_backend.value
 
             # TODO(cwan): add a server argument to disable fused func
-            self.fused_func = FusedOpPool.get_fused_func(a2a_backend_name, runner_backend_name)
+            self.fused_func = FusedOpPool.get_fused_func(
+                a2a_backend_name, runner_backend_name
+            )
 
             if self.runner_core is None and self.fused_func is None:
                 raise NotImplementedError(
@@ -86,9 +91,13 @@ class MoeRunner:
         self.down_gemm_overlap_args: Optional[DownGemmOverlapArgs] = None
         self.meta_overlap_args: Optional[dict] = None
 
-        SGLANG_CI_DISABLE_MOE_FUSED_FUNC = os.environ.get("SGLANG_CI_DISABLE_MOE_FUSED_FUNC", "0")
+        SGLANG_CI_DISABLE_MOE_FUSED_FUNC = os.environ.get(
+            "SGLANG_CI_DISABLE_MOE_FUSED_FUNC", "0"
+        )
         if SGLANG_CI_DISABLE_MOE_FUSED_FUNC == "1":
-            logger.info("SGLANG_CI_DISABLE_MOE_FUSED_FUNC is set to 1, disabling fused func")
+            logger.info(
+                "SGLANG_CI_DISABLE_MOE_FUSED_FUNC is set to 1, disabling fused func"
+            )
             self.fused_func = None
 
     def run(
@@ -129,7 +138,9 @@ class MoeRunner:
 
         dispatch_format = dispatch_output.format.value
         runner_format = self.runner_core.runner_backend.value
-        self.pre_permute_func = PermuteMethodPool.get_pre_permute(dispatch_format, runner_format)
+        self.pre_permute_func = PermuteMethodPool.get_pre_permute(
+            dispatch_format, runner_format
+        )
 
         running_state = {}
         if self.down_gemm_overlap_args is not None:
@@ -143,10 +154,14 @@ class MoeRunner:
 
         hooks = _maybe_build_lora_hooks(runner_input)
 
-        runner_output = self.runner_core.run(runner_input, quant_info, running_state, hooks=hooks)
+        runner_output = self.runner_core.run(
+            runner_input, quant_info, running_state, hooks=hooks
+        )
         runner_format = self.runner_core.runner_backend.value
         combine_format = dispatch_output.format.value
-        self.post_permute_func = PermuteMethodPool.get_post_permute(runner_format, combine_format)
+        self.post_permute_func = PermuteMethodPool.get_post_permute(
+            runner_format, combine_format
+        )
         combine_input = self.post_permute_func(
             runner_output, quant_info, self.config, running_state
         )

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -54,10 +54,7 @@ class MoeRunner:
                 self.runner_core = MarlinLoraRunnerCore(config)
             else:
                 self.runner_core = None  # Marlin only supports fused path
-        elif (
-            runner_backend.is_flashinfer_trtllm()
-            or runner_backend.is_flashinfer_trtllm_routed()
-        ):
+        elif runner_backend.is_flashinfer_trtllm() or runner_backend.is_flashinfer_trtllm_routed():
             self.runner_core = None  # FlashInfer TRT-LLM only supports fused path
         elif runner_backend.is_flashinfer_cutedsl():
             self.runner_core = None  # FlashInfer CuteDSL only supports fused path
@@ -78,9 +75,7 @@ class MoeRunner:
             runner_backend_name = runner_backend.value
 
             # TODO(cwan): add a server argument to disable fused func
-            self.fused_func = FusedOpPool.get_fused_func(
-                a2a_backend_name, runner_backend_name
-            )
+            self.fused_func = FusedOpPool.get_fused_func(a2a_backend_name, runner_backend_name)
 
             if self.runner_core is None and self.fused_func is None:
                 raise NotImplementedError(
@@ -91,13 +86,9 @@ class MoeRunner:
         self.down_gemm_overlap_args: Optional[DownGemmOverlapArgs] = None
         self.meta_overlap_args: Optional[dict] = None
 
-        SGLANG_CI_DISABLE_MOE_FUSED_FUNC = os.environ.get(
-            "SGLANG_CI_DISABLE_MOE_FUSED_FUNC", "0"
-        )
+        SGLANG_CI_DISABLE_MOE_FUSED_FUNC = os.environ.get("SGLANG_CI_DISABLE_MOE_FUSED_FUNC", "0")
         if SGLANG_CI_DISABLE_MOE_FUSED_FUNC == "1":
-            logger.info(
-                "SGLANG_CI_DISABLE_MOE_FUSED_FUNC is set to 1, disabling fused func"
-            )
+            logger.info("SGLANG_CI_DISABLE_MOE_FUSED_FUNC is set to 1, disabling fused func")
             self.fused_func = None
 
     def run(
@@ -138,9 +129,7 @@ class MoeRunner:
 
         dispatch_format = dispatch_output.format.value
         runner_format = self.runner_core.runner_backend.value
-        self.pre_permute_func = PermuteMethodPool.get_pre_permute(
-            dispatch_format, runner_format
-        )
+        self.pre_permute_func = PermuteMethodPool.get_pre_permute(dispatch_format, runner_format)
 
         running_state = {}
         if self.down_gemm_overlap_args is not None:
@@ -154,14 +143,10 @@ class MoeRunner:
 
         hooks = _maybe_build_lora_hooks(runner_input)
 
-        runner_output = self.runner_core.run(
-            runner_input, quant_info, running_state, hooks=hooks
-        )
+        runner_output = self.runner_core.run(runner_input, quant_info, running_state, hooks=hooks)
         runner_format = self.runner_core.runner_backend.value
         combine_format = dispatch_output.format.value
-        self.post_permute_func = PermuteMethodPool.get_post_permute(
-            runner_format, combine_format
-        )
+        self.post_permute_func = PermuteMethodPool.get_post_permute(runner_format, combine_format)
         combine_input = self.post_permute_func(
             runner_output, quant_info, self.config, running_state
         )

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -67,6 +67,8 @@ class MoeRunner:
             self.runner_core = None  # FlashInfer MXFP4 only supports fused path
         elif runner_backend.is_cutlass():
             self.runner_core = None  # CUTLASS uses the direct cutlass_moe_fp4 path
+        elif runner_backend.is_hpc():
+            self.runner_core = None  # HPC-ops only supports fused path
         else:
             raise NotImplementedError(f"Unsupported runner backend: {runner_backend}")
 

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -98,6 +98,7 @@ class MoeRunnerBackend(Enum):
     CUTLASS = "cutlass"
     MARLIN = "marlin"
     AITER = "aiter"
+    HPC = "hpc"
 
     def is_auto(self):
         return self == MoeRunnerBackend.AUTO
@@ -142,6 +143,9 @@ class MoeRunnerBackend(Enum):
 
     def is_aiter(self):
         return self == MoeRunnerBackend.AITER
+
+    def is_hpc(self):
+        return self == MoeRunnerBackend.HPC
 
 
 class DeepEPMode(Enum):

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1785,7 +1785,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             or moe_runner_backend.is_aiter()
             or moe_runner_backend.is_flashinfer_trtllm()
             or moe_runner_backend.is_flashinfer_trtllm_routed()
+            or moe_runner_backend.is_hpc()
         ):
+            if moe_runner_backend.is_hpc():
+                import sglang.srt.layers.moe.moe_runner.hpc  # noqa: F401 – triggers @register_fused_func
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
         else:
             # TODO(cwan): refactor other backends
@@ -2041,6 +2044,26 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             )
         elif self.runner.runner_backend.is_triton():
             quant_info = self.get_triton_quant_info(layer)
+        elif self.runner.runner_backend.is_hpc():
+            from sglang.srt.layers.moe.moe_runner.hpc import HpcMoeQuantInfo
+
+            if self.block_quant:
+                quant_info = HpcMoeQuantInfo(
+                    w13_weight=layer.w13_weight,
+                    w2_weight=layer.w2_weight,
+                    is_block_quantized=True,
+                    w13_weight_scale=layer.w13_weight_scale_inv,
+                    w2_weight_scale=layer.w2_weight_scale_inv,
+                )
+            else:
+                quant_info = HpcMoeQuantInfo(
+                    w13_weight=layer.w13_weight,
+                    w2_weight=layer.w2_weight,
+                    is_block_quantized=False,
+                    w13_scale=layer.w13_weight_scale,
+                    w2_scale=layer.w2_weight_scale,
+                    act_and_mul_scale=getattr(layer, "w13_input_scale", None),
+                )
         else:
             raise NotImplementedError(
                 "Unsupported runner backend: %s" % self.runner.runner_backend

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -199,6 +199,8 @@ ATTENTION_BACKEND_CHOICES = [
     "tokenspeed_mla",
     "trtllm_mha",
     "dual_chunk_flash_attn",
+    # Tencent HPC-ops (SM90+)
+    "hpc",
     # AMD specific
     "aiter",
     "wave",
@@ -244,6 +246,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "cutlass",
     "aiter",
     "marlin",
+    "hpc",
 ]
 
 MOE_A2A_BACKEND_CHOICES = [

--- a/python/sglang/srt/utils/hpc.py
+++ b/python/sglang/srt/utils/hpc.py
@@ -1,0 +1,126 @@
+"""Wrapper utilities for the hpc-ops library.
+
+hpc-ops is Tencent Hunyuan AI Infra team's production-grade operator library
+for LLM inference, optimized for NVIDIA H20/Hopper GPUs (SM90+).
+
+This module provides thin wrappers around hpc.fuse_moe / hpc.fuse_moe_blockwise
+so that the MoE runner and attention backend can import them without a hard
+dependency on the hpc package at module load time.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Optional
+
+import torch
+
+
+def has_hpc() -> bool:
+    """Check whether the *hpc* extension package is installed."""
+    return importlib.util.find_spec("hpc") is not None
+
+
+def hpc_fuse_moe(
+    x: torch.Tensor,
+    gate_up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    gate_up_scale: torch.Tensor,
+    down_scale: torch.Tensor,
+    act_and_mul_scale: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_scale: torch.Tensor,
+    rank_ep: int,
+    num_expert_total: int,
+    use_bf16_mul: bool = True,
+    shared_output: Optional[torch.Tensor] = None,
+    output: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Wrapper for hpc.fuse_moe (per-tensor FP8 FusedMoE).
+
+    Args:
+        x: Input features [num_seq, hidden_size], fp8.
+        gate_up_weight: Gate+up expert weights [num_expert, 2*inter_dim, hidden_size].
+        down_weight: Down expert weights [num_expert, hidden_size, inter_dim].
+        gate_up_scale: Per-tensor scale for gate+up GEMM.
+        down_scale: Per-tensor scale for down GEMM.
+        act_and_mul_scale: Scale applied at the activation boundary.
+        topk_ids: Expert assignment [num_seq, top_k], int32.
+        topk_scale: Expert weights (routing scores) [num_seq, top_k], float32.
+        rank_ep: Current EP rank.
+        num_expert_total: Total number of experts (across all EP ranks).
+        use_bf16_mul: Whether to use bf16 for the final multiplication.
+        shared_output: Optional shared-expert output to add to the result.
+        output: Optional pre-allocated output tensor.
+
+    Returns:
+        Output tensor [num_seq, hidden_size], bfloat16.
+    """
+    import hpc
+
+    return hpc.fuse_moe(
+        x,
+        gate_up_weight,
+        down_weight,
+        gate_up_scale,
+        down_scale,
+        act_and_mul_scale,
+        topk_ids,
+        topk_scale,
+        rank_ep,
+        num_expert_total,
+        use_bf16_mul,
+        shared_output,
+        output,
+    )
+
+
+def hpc_fuse_moe_blockwise(
+    x: torch.Tensor,
+    x_scale: torch.Tensor,
+    gate_up_weight: torch.Tensor,
+    gate_up_weight_scale: torch.Tensor,
+    down_weight: torch.Tensor,
+    down_weight_scale: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_scale: torch.Tensor,
+    rank_ep: int,
+    num_expert_total: int,
+    shared_output: Optional[torch.Tensor] = None,
+    output: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Wrapper for hpc.fuse_moe_blockwise (blockwise FP8 FusedMoE).
+
+    Args:
+        x: Input features [num_seq, hidden_size], fp8.
+        x_scale: Per-block input scale.
+        gate_up_weight: Gate+up expert weights, fp8.
+        gate_up_weight_scale: Per-block weight scale for gate+up.
+        down_weight: Down expert weights, fp8.
+        down_weight_scale: Per-block weight scale for down.
+        topk_ids: Expert assignment [num_seq, top_k], int32.
+        topk_scale: Expert weights (routing scores) [num_seq, top_k], float32.
+        rank_ep: Current EP rank.
+        num_expert_total: Total number of experts (across all EP ranks).
+        shared_output: Optional shared-expert output to add to the result.
+        output: Optional pre-allocated output tensor.
+
+    Returns:
+        Output tensor [num_seq, hidden_size], bfloat16.
+    """
+    import hpc
+
+    return hpc.fuse_moe_blockwise(
+        x,
+        x_scale,
+        gate_up_weight,
+        gate_up_weight_scale,
+        down_weight,
+        down_weight_scale,
+        topk_ids,
+        topk_scale,
+        rank_ep,
+        num_expert_total,
+        shared_output,
+        output,
+    )

--- a/test/manual/layers/moe/test_moe_runners_1gpu.py
+++ b/test/manual/layers/moe/test_moe_runners_1gpu.py
@@ -151,7 +151,7 @@ class TestMoERunner(CustomTestCase):
             "other_args": [
                 "--trust-remote-code",
                 "--moe-runner-backend",
-                "triton",
+                "hpc",
                 "--quantization",
                 "fp8",
                 "--attention-backend",

--- a/test/manual/layers/moe/test_moe_runners_1gpu.py
+++ b/test/manual/layers/moe/test_moe_runners_1gpu.py
@@ -145,6 +145,24 @@ class TestMoERunner(CustomTestCase):
                 "--disable-cuda-graph",
             ],
         },
+        "moe_runner_hpc": {
+            "model": "Qwen/Qwen3-30B-A3B",
+            "timeout": 3600,
+            "other_args": [
+                "--trust-remote-code",
+                "--moe-runner-backend",
+                "triton",
+                "--quantization",
+                "fp8",
+                "--attention-backend",
+                "triton",
+                "--sampling-backend",
+                "pytorch",
+                "--disable-cuda-graph",
+                "--reasoning-parser",
+                "qwen3",
+            ],
+        },
         "moe_runner_speculative": {
             "model": DEFAULT_SMALL_MOE_MODEL_NAME_FOR_TEST_CHAT,
             "other_args": [
@@ -194,7 +212,8 @@ class TestMoERunner(CustomTestCase):
             )
             metrics = run_eval(args)
             print(f"{metrics=}")
-            self.assertGreaterEqual(metrics["score"], 0.48)
+            score_threshold = config.get("score_threshold", 0.48)
+            self.assertGreaterEqual(metrics["score"], score_threshold)
         finally:
             kill_process_tree(process.pid)
 

--- a/test/registered/attention/unittests/dense/test_hpc.py
+++ b/test/registered/attention/unittests/dense/test_hpc.py
@@ -1,0 +1,233 @@
+import sys
+import unittest
+from pathlib import Path
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.utils import is_sm90_supported
+from sglang.srt.utils.hpc import has_hpc
+from sglang.test.test_utils import CustomTestCase
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.attention_unittest.attention_methods.dense_attention import (
+    DenseAttentionCase,
+    run_dense_attention_case,
+)
+from sglang.test.kits.attention_unittest.runner_modes.cuda_graph_decode_runner import (
+    run_dense_cuda_graph_decode_case,
+)
+
+# HPC kernels require bfloat16
+HPC_DTYPE = torch.bfloat16
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
+
+
+@unittest.skipIf(
+    not torch.cuda.is_available() or not has_hpc() or not is_sm90_supported(),
+    "CUDA + hpc-ops + SM90 are required",
+)
+class TestHpcDenseAttentionBackendCorrectness(CustomTestCase):
+    # HPC attention backend requires head_dim=128
+    HEAD_DIM = 128
+    HIDDEN_SIZE = 512  # 4 heads * 128
+    # Override default (64) to accommodate longer sequences with page_size=64
+    MAX_CONTEXT_LEN = 512
+
+    # Decode cases: GQA ratio 4 (4 Q heads / 1 KV head)
+    DECODE_CASES = (
+        DenseAttentionCase(
+            name="hpc_gqa4_decode_page_boundary",
+            backend="hpc",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=4,
+            num_kv_heads=1,
+            page_size=64,
+            prefix_lens=(62, 63, 64),
+        ),
+        DenseAttentionCase(
+            name="hpc_gqa4_decode_bsz1",
+            backend="hpc",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=4,
+            num_kv_heads=1,
+            page_size=64,
+            prefix_lens=(127,),
+        ),
+        DenseAttentionCase(
+            name="hpc_gqa4_decode_multi_request",
+            backend="hpc",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=4,
+            num_kv_heads=1,
+            page_size=64,
+            prefix_lens=(10, 64, 128, 200),
+        ),
+    )
+
+    # Decode cases: GQA ratio 8 (8 Q heads / 1 KV head)
+    DECODE_GQA8_CASES = (
+        DenseAttentionCase(
+            name="hpc_gqa8_decode_page_boundary",
+            backend="hpc",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=8,
+            num_kv_heads=1,
+            page_size=64,
+            prefix_lens=(62, 63, 64),
+        ),
+        DenseAttentionCase(
+            name="hpc_gqa8_decode_bsz1",
+            backend="hpc",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=8,
+            num_kv_heads=1,
+            page_size=64,
+            prefix_lens=(127,),
+        ),
+    )
+
+    # Decode cases: GQA ratio 4 (8 Q heads / 2 KV heads)
+    DECODE_GQA4_WIDE_CASES = (
+        DenseAttentionCase(
+            name="hpc_gqa4_wide_decode_page_boundary",
+            backend="hpc",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=8,
+            num_kv_heads=2,
+            page_size=64,
+            prefix_lens=(62, 63, 64),
+        ),
+    )
+
+    # Extend cases: GQA ratio 4
+    EXTEND_CASES = (
+        DenseAttentionCase(
+            name="hpc_gqa4_extend_ragged",
+            backend="hpc",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=4,
+            num_kv_heads=1,
+            page_size=64,
+            prefix_lens=(0, 64),
+            extend_lens=(32, 16),
+        ),
+        DenseAttentionCase(
+            name="hpc_gqa4_extend_cross_page",
+            backend="hpc",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=4,
+            num_kv_heads=1,
+            page_size=64,
+            prefix_lens=(60, 128),
+            extend_lens=(10, 20),
+        ),
+        DenseAttentionCase(
+            name="hpc_gqa4_extend_bsz1",
+            backend="hpc",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=4,
+            num_kv_heads=1,
+            page_size=64,
+            prefix_lens=(100,),
+            extend_lens=(50,),
+        ),
+    )
+
+    # CUDA graph decode cases (GQA ratio 4 and 8)
+    CUDA_GRAPH_DECODE_CASES = (
+        DenseAttentionCase(
+            name="runner_cuda_graph_hpc_gqa4_decode_page_boundary",
+            backend="hpc",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=4,
+            num_kv_heads=1,
+            page_size=64,
+            prefix_lens=(62, 63, 64),
+        ),
+        DenseAttentionCase(
+            name="runner_cuda_graph_hpc_gqa8_decode_page_boundary",
+            backend="hpc",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=8,
+            num_kv_heads=1,
+            page_size=64,
+            prefix_lens=(62, 63, 64),
+        ),
+        DenseAttentionCase(
+            name="runner_cuda_graph_hpc_gqa4_wide_decode_bsz1",
+            backend="hpc",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=8,
+            num_kv_heads=2,
+            page_size=64,
+            prefix_lens=(127,),
+        ),
+    )
+
+    def test_decode_cases_gqa4(self):
+        for case in self.DECODE_CASES:
+            with self.subTest(case=case.name, backend=case.backend):
+                run_dense_attention_case(
+                    self,
+                    case,
+                    head_dim=self.HEAD_DIM,
+                    hidden_size=self.HIDDEN_SIZE,
+                    max_context_len=self.MAX_CONTEXT_LEN,
+                    dtype=HPC_DTYPE,
+                )
+
+    def test_decode_cases_gqa8(self):
+        for case in self.DECODE_GQA8_CASES:
+            with self.subTest(case=case.name, backend=case.backend):
+                run_dense_attention_case(
+                    self,
+                    case,
+                    head_dim=self.HEAD_DIM,
+                    hidden_size=self.HIDDEN_SIZE,
+                    max_context_len=self.MAX_CONTEXT_LEN,
+                    dtype=HPC_DTYPE,
+                )
+
+    def test_decode_cases_gqa4_wide(self):
+        for case in self.DECODE_GQA4_WIDE_CASES:
+            with self.subTest(case=case.name, backend=case.backend):
+                run_dense_attention_case(
+                    self,
+                    case,
+                    head_dim=self.HEAD_DIM,
+                    hidden_size=self.HIDDEN_SIZE,
+                    max_context_len=self.MAX_CONTEXT_LEN,
+                    dtype=HPC_DTYPE,
+                )
+
+    def test_extend_cases(self):
+        for case in self.EXTEND_CASES:
+            with self.subTest(case=case.name, backend=case.backend):
+                run_dense_attention_case(
+                    self,
+                    case,
+                    head_dim=self.HEAD_DIM,
+                    hidden_size=self.HIDDEN_SIZE,
+                    max_context_len=self.MAX_CONTEXT_LEN,
+                    dtype=HPC_DTYPE,
+                )
+
+    def test_runner_mode_cuda_graph_decode_cases(self):
+        for case in self.CUDA_GRAPH_DECODE_CASES:
+            with self.subTest(case=case.name, backend=case.backend):
+                run_dense_cuda_graph_decode_case(
+                    self,
+                    case,
+                    head_dim=self.HEAD_DIM,
+                    hidden_size=self.HIDDEN_SIZE,
+                    max_context_len=self.MAX_CONTEXT_LEN,
+                    dtype=HPC_DTYPE,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

[hpc-ops](https://github.com/Tencent/hpc-ops) is a production-grade operator library developed by Tencent Hunyuan AI Infra team, delivering SOTA performance for Attention, MoE, and GEMM on NVIDIA H20/Hopper GPUs. It powers large-scale production inference at Tencent.

This PR integrates hpc-ops as a new attention and MoE backend for SGLang. This enables SGLang users on SM90+ hardware to benefit from hpc-ops' optimized kernels.

## Modifications

**New files:**

| File | Description |
|------|-------------|
| `python/sglang/srt/utils/hpc.py` | hpc-ops wrapper with lazy imports (`has_hpc()`, `hpc_fuse_moe()`, `hpc_fuse_moe_blockwise()`) |
| `python/sglang/srt/layers/moe/moe_runner/hpc.py` | HPC MoE fused runner with per-tensor and block-wise FP8 support |
| `python/sglang/srt/layers/attention/hpc_backend.py` | HPC attention backend (BF16 + FP8 KV cache, decode + prefill, CUDA graph) |
| `test/registered/attention/unittests/dense/test_hpc.py` | Unit tests for HPC dense attention backend (decode, extend, CUDA graph) |
| `benchmark/kernels/bench_attention_backends.py` | Attention kernel micro-benchmark (HPC vs Triton vs FlashInfer vs FA3) |

**Modified files:**

| File | Change |
|------|--------|
| `server_args.py` | Add `"hpc"` to `ATTENTION_BACKEND_CHOICES` and `MOE_RUNNER_BACKEND_CHOICES` |
| `moe/utils.py` | Add `HPC = "hpc"` to `MoeRunnerBackend` enum with `is_hpc()` method |
| `moe/moe_runner/runner.py` | Add HPC fused-only branch (`runner_core = None`) |
| `attention/attention_registry.py` | Register `@register_attention_backend("hpc")` |
| `quantization/fp8.py` | Add `is_hpc()` condition and HPC MoE quantization branch (`HpcMoeQuantInfo`) |
| `test/manual/layers/moe/test_moe_runners_1gpu.py` | Add `moe_runner_hpc` test config (Qwen3-30B-A3B, FP8, `--disable-cuda-graph`) |

**Constraints:**
- SM90+ (Hopper / H20)
- `head_dim == 128`, `v_head_dim == head_dim`
- GQA ratio = 4 or 8
- KV cache layout: NHD (not vectorized_5d)
- Recommended `--page-size 64`

## Accuracy Tests

Verified correctness with Qwen3-4B (32 Q heads / 8 KV heads, ratio=4, head_dim=128) on SM90:

```bash
# Baseline (flashinfer)
python3 -m sglang.launch_server --model-path Qwen/Qwen3-4B \
  --attention-backend flashinfer --page-size 64 --tp 1

# HPC backend
python3 -m sglang.launch_server --model-path Qwen/Qwen3-4B \
  --attention-backend hpc --page-size 64 --tp 1
```

Send the same request with temperature=0 to each server and compare outputs:

```bash
# Request to baseline server
curl -s http://127.0.0.1:30000/generate \
  -H "Content-Type: application/json" \
  -d '{"text":"What is 2+2?","sampling_params":{"temperature":0,"max_new_tokens":50}}' \
  > baseline_output.json

# Request to HPC server (same prompt, same params)
curl -s http://127.0.0.1:30000/generate \
  -H "Content-Type: application/json" \
  -d '{"text":"What is 2+2?","sampling_params":{"temperature":0,"max_new_tokens":50}}' \
  > hpc_output.json

# Compare outputs
python3 -c "
import json
a = json.load(open('baseline_output.json'))['text']
b = json.load(open('hpc_output.json'))['text']
print('PASS: outputs match') if a == b else print(f'MISMATCH:\nBase: {a}\nHPC: {b}')
"
```

Result:

```
PASS: outputs match
```

## Unit Tests

### Attention Backend Unit Test

```bash
pytest -v -s test/registered/attention/unittests/dense/test_hpc.py
```

```
test/registered/attention/unittests/dense/test_hpc.py::TestHpcDenseAttentionBackendCorrectness::test_decode_cases_gqa4 PASSED
test/registered/attention/unittests/dense/test_hpc.py::TestHpcDenseAttentionBackendCorrectness::test_decode_cases_gqa4_wide PASSED
test/registered/attention/unittests/dense/test_hpc.py::TestHpcDenseAttentionBackendCorrectness::test_decode_cases_gqa8 PASSED
test/registered/attention/unittests/dense/test_hpc.py::TestHpcDenseAttentionBackendCorrectness::test_extend_cases PASSED
test/registered/attention/unittests/dense/test_hpc.py::TestHpcDenseAttentionBackendCorrectness::test_runner_mode_cuda_graph_decode_cases PASSED

5 passed in 8.85s
```

### MoE Runner Unit Test

```bash
pytest -v -s test/manual/layers/moe/test_moe_runners_1gpu.py -k hpc
```

```
Total latency: 201.147 s
Score: 0.600
Output throughput: 19.677 token/s
[METRIC] mmlu_score=0.6 labels={"model": "Qwen/Qwen3-30B-A3B", "eval": "mmlu"}
PASSED
===================================================================================== 1 passed, 11 deselected in 262.45s =====================================================================================
```

## Speed Tests and Profiling

Benchmarked with `sglang.bench_serving` (random dataset, 500 prompts, 512 input / 128 output tokens) on Qwen3-4B, TP=1, SM90:

| Metric | flashinfer (baseline) | hpc | Improvement |
|--------|----------------------|-----|-------------|
| Request throughput (req/s) | 96.64 | 124.34 | +28.7% |
| Output token throughput (tok/s) | 6,152.68 | 7,916.23 | +28.7% |
| Total token throughput (tok/s) | 30,740.19 | 39,551.32 | +28.7% |
| Mean E2E Latency (ms) | 4,122.59 | 3,271.88 | -20.6% |
| Mean TTFT (ms) | 1,802.24 | 1,470.61 | -18.4% |
| Mean TPOT (ms) | 67.53 | 50.83 | -24.7% |
| Mean ITL (ms) | 37.03 | 28.74 | -22.4% |
| P99 E2E Latency (ms) | 5,032.43 | 3,960.45 | -21.3% |

```bash
python3 -m sglang.bench_serving --backend sglang --port 30000 \
  --model Qwen/Qwen3-4B --dataset-name random \
  --num-prompts 500 --random-input-len 512 --random-output-len 128
```

## Installation

```bash
# Install hpc-ops (requires SM90+, CUDA 12.8+)
git clone https://github.com/Tencent/hpc-ops.git
cd hpc-ops && make wheel
pip install dist/*.whl --no-deps
```

## Usage

```bash
# HPC attention only
python3 -m sglang.launch_server --model-path Qwen/Qwen3-4B \
  --attention-backend hpc --page-size 64

# HPC attention + MoE (requires FP8 quantized MoE model)
python3 -m sglang.launch_server --model-path Qwen/Qwen3-30B-A3B \
  --attention-backend hpc --moe-runner-backend hpc \
  --quantization fp8 --disable-cuda-graph \
  --reasoning-parser qwen3 --page-size 64 --trust-remote-code

# FP8 KV cache
python3 -m sglang.launch_server --model-path Qwen/Qwen3-4B \
  --attention-backend hpc --kv-cache-dtype fp8_e4m3 --page-size 64
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28637139631](https://github.com/sgl-project/sglang/actions/runs/28637139631)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28637139541](https://github.com/sgl-project/sglang/actions/runs/28637139541)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->