### PR TITLE
Fix OpenAI serving benchmark input token accounting

### DIFF
--- a/python/sglang/benchmark/datasets/openai_dataset.py
+++ b/python/sglang/benchmark/datasets/openai_dataset.py
@@ -14,6 +14,7 @@ class OpenAIDataset(BaseDataset):
     dataset_path: str
     num_requests: int
     fixed_output_len: Optional[int]
+    context_len: Optional[int]
 
     @classmethod
     def from_args(cls, args: Namespace) -> "OpenAIDataset":
@@ -21,6 +22,7 @@ class OpenAIDataset(BaseDataset):
             dataset_path=args.dataset_path,
             num_requests=args.num_prompts,
             fixed_output_len=args.sharegpt_output_len,
+            context_len=args.sharegpt_context_len,
         )
 
     def load(
@@ -31,6 +33,7 @@ class OpenAIDataset(BaseDataset):
             num_requests=self.num_requests,
             tokenizer=tokenizer,
             fixed_output_len=self.fixed_output_len,
+            context_len=self.context_len,
         )
 
 
@@ -39,6 +42,7 @@ def sample_openai_requests(
     num_requests: int,
     tokenizer: PreTrainedTokenizerBase,
     fixed_output_len: Optional[int] = None,
+    context_len: Optional[int] = None,
 ) -> List[DatasetRow]:
     """
     Load OpenAI-compatible chat completion requests from a JSONL file.
@@ -75,8 +79,10 @@ def sample_openai_requests(
         if not messages:
             continue
 
+        max_tokens = data.get("max_tokens") or data.get("max_completion_tokens")
+
         # Use max_tokens from the request, or fall back to fixed_output_len
-        output_len = fixed_output_len or data.get("max_tokens", 256)
+        output_len = fixed_output_len or max_tokens or 256
 
         # Extract extra request body parameters (tools, temperature, top_p, etc.)
         extra_body = {k: v for k, v in data.items() if k not in EXCLUDED_FIELDS}
@@ -86,7 +92,7 @@ def sample_openai_requests(
         prompt_len = len(
             tokenizer.apply_chat_template(
                 messages, tokenize=True, add_generation_prompt=True
-            )
+            )["input_ids"]
         )
 
         # If tools are present, we need to add their token count
@@ -96,6 +102,10 @@ def sample_openai_requests(
             tools_str = json.dumps(extra_body["tools"])
             tools_tokens = len(tokenizer.encode(tools_str))
             prompt_len += tools_tokens
+
+        # Skip requests that exceed model's context length
+        if context_len is not None and prompt_len + output_len > context_len:
+            continue
 
         # Pass messages list directly - the serving benchmark handles List[Dict] prompts
         filtered_dataset.append(

--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -296,6 +296,7 @@ async def async_request_openai_completions(
 
         generated_text = ""
         output_len = request_func_input.output_len
+        prompt_len = request_func_input.prompt_len
         ttft = 0.0
         st = time.perf_counter()
         output.start_time = st
@@ -342,7 +343,9 @@ async def async_request_openai_completions(
                                 output_len = (data.get("usage") or {}).get(
                                     "completion_tokens", output_len
                                 )
-
+                                prompt_len = (data.get("usage") or {}).get(
+                                    "prompt_tokens", prompt_len
+                                )
                     output.generated_text = generated_text
                     output.success = True
                     output.latency = latency
@@ -451,6 +454,7 @@ async def async_request_openai_chat_completions(
 
         generated_text = ""
         output_len = request_func_input.output_len
+        prompt_len = request_func_input.prompt_len
         ttft = 0.0
         st = time.perf_counter()
         output.start_time = st
@@ -473,6 +477,9 @@ async def async_request_openai_chat_completions(
                         output.output_len = response_json.get("usage", {}).get(
                             "completion_tokens", output_len
                         )
+                        output.prompt_len = (response_json.get("usage") or {}).get(
+                            "prompt_tokens", request_func_input.prompt_len
+                        )
                         if getattr(args, "cache_report", False):
                             _extract_cache_from_sglext(response_json, output)
                     else:
@@ -493,7 +500,9 @@ async def async_request_openai_chat_completions(
                                 output_len = (data.get("usage") or {}).get(
                                     "completion_tokens", output_len
                                 )
-
+                                prompt_len = (data.get("usage") or {}).get(
+                                    "prompt_tokens", prompt_len
+                                )
                                 if getattr(args, "cache_report", False):
                                     _extract_cache_from_sglext(data, output)
 
@@ -527,6 +536,7 @@ async def async_request_openai_chat_completions(
                         output.success = True
                         output.latency = latency
                         output.output_len = output_len
+                        output.prompt_len = prompt_len
                 else:
                     output.error = (
                         (response.reason or "") + ": " + (await response.text())
@@ -673,6 +683,7 @@ async def async_request_sglang_generate(
 
         generated_text = ""
         output_len = request_func_input.output_len
+        prompt_len = request_func_input.prompt_len
         ttft = 0.0
         st = time.perf_counter()
         output.start_time = st
@@ -941,6 +952,7 @@ class BenchmarkMetrics:
     total_input_text: int
     total_input_vision: int
     total_output: int
+    total_input_client: int
     total_output_retokenized: int
 
     # Throughput (req/s and tok/s)
@@ -1042,6 +1054,7 @@ def calculate_metrics(
     output_lens: List[int] = []
     retokenized_output_lens: List[int] = []
     total_input = 0
+    total_input_client = 0
     total_input_text = 0
     total_input_vision = 0
     completed = 0
@@ -1066,7 +1079,8 @@ def calculate_metrics(
             )
             retokenized_output_lens.append(retokenized_output_len)
             if input_requests is not None:
-                total_input += input_requests[i].prompt_len
+                total_input += outputs[i].prompt_len
+                total_input_client += input_requests[i].prompt_len
                 total_input_text += input_requests[i].text_prompt_len
                 total_input_vision += input_requests[i].vision_prompt_len
             if output_len > 1:
@@ -1166,6 +1180,7 @@ def calculate_metrics(
     metrics = BenchmarkMetrics(
         completed=completed,
         total_input=total_input,
+        total_input_client=total_input_client,
         total_input_text=total_input_text,
         total_input_vision=total_input_vision,
         total_output=sum(output_lens),
@@ -1559,8 +1574,13 @@ async def benchmark(
     )
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
-    print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
-    print("{:<40} {:<10}".format("Total input text tokens:", metrics.total_input_text))
+
+    print(
+        "{:<40} {:<10}".format(
+            "Total input tokens (client):", metrics.total_input_client
+        )
+    )
+    print("{:<40} {:<10}".format("Total input tokens (server):", metrics.total_input))
     if args.dataset_name in ["image", "mmmu"]:
         print(
             "{:<40} {:<10}".format(


### PR DESCRIPTION
## Motivation

  The OpenAI-format serving benchmark currently relies on client-side prompt token estimates for input-token metrics. For
  OpenAI-compatible chat workloads, this can diverge from the server-reported `usage.prompt_tokens` because the server may
  apply its own chat template, tokenizer behavior, tool serialization, or request preprocessing.

  This caused benchmark reports to show only a single `Total input tokens` value based on the dataset-side estimate, making it
  difficult to distinguish:

  - client-side estimated prompt tokens from dataset preprocessing
  - server-side actual prompt tokens returned by the serving endpoint

  There were also two dataset handling gaps for OpenAI-format JSONL inputs:

  - `max_completion_tokens` was not treated the same as `max_tokens` when deriving per-request output length.
  - `sharegpt_context_len` was not propagated to the OpenAI dataset loader, so over-context OpenAI-format requests were not
  filtered consistently.

  ## Modifications

  `serving.py`

  - Capture `usage.prompt_tokens` from OpenAI completions streaming responses.
  - Capture `usage.prompt_tokens` from OpenAI chat completions streaming responses.
  - Capture `usage.prompt_tokens` from OpenAI chat completions non-streaming responses.
  - Store the server-reported prompt length in `RequestFuncOutput.prompt_len`.
  - Add `total_input_client` to `BenchmarkMetrics`.
  - Report input tokens separately as:
    - `Total input tokens (client)`
    - `Total input tokens (server)`

  `openai_dataset.py`

  - Add `context_len` to `OpenAIDataset`.
  - Propagate `args.sharegpt_context_len` into OpenAI-format dataset loading.
  - Treat `max_completion_tokens` as an output-length source, matching OpenAI chat completion request format.
  - Skip OpenAI-format requests whose estimated prompt length plus output length exceeds `context_len`.

  ## Accuracy Tests

  No model forward path or serving behavior changed.

  This change only affects serving benchmark accounting and dataset filtering. The server-side input token metric now uses
  `usage.prompt_tokens` when available, which better reflects the actual request seen by the serving backend.

  ## Speed Tests and Profiling

  No inference throughput impact.

  The additional work is limited to reading `usage.prompt_tokens` from response chunks and carrying one extra aggregate counter
  in benchmark metrics.

  ## Validation

  - Ran Python compile checks for modified files:
    - `python3 -m py_compile python/sglang/benchmark/serving.py python/sglang/benchmark/datasets/openai_dataset.py`
  - Ran pre-commit hooks during commit:
    - AST check
    - trailing whitespace check
    - ruff
    - isort
    - black-jupyter
    - codespell
    - repository policy hooks



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #28510082551](https://github.com/sgl-project/sglang/actions/runs/28510082551)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #28510082254](https://github.com/sgl-project/sglang/actions/runs/28510082254)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->