### PR TITLE
[trtllm_mha] raise on unsupported forward mode in cuda-graph metadata build

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -494,7 +494,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # The device-side build (_fill_page_table_device) sizes to the static
         # max_num_pages and bounds the actual writes by cache_seqlens, so no
         # runtime host max is needed.
-        metadata = None
         if forward_mode.is_decode_or_idle():
             if spec_info is not None:
                 # Draft Decode
@@ -550,6 +549,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             )
             self._fill_page_table_device(
                 metadata, req_pool_indices, metadata.cache_seqlens_int32
+            )
+        else:
+            raise ValueError(
+                "TRTLLM-MHA CUDA graph metadata build got an unsupported forward "
+                f"mode: {forward_mode}"
             )
         self.forward_metadata = metadata
 


### PR DESCRIPTION
## Motivation

`_apply_cuda_graph_metadata` in the TRTLLM-MHA attention backend initialized `metadata = None` and only assigned it in the `is_decode_or_idle` / `is_target_verify` / `is_draft_extend_v2` branches, with no `else`. An unsupported `forward_mode` therefore silently stored `self.forward_metadata = None`, deferring the failure to a confusing later crash (e.g. an `AttributeError` on `None` deep in the attention path) rather than failing at the source.

## Modifications

- Add an explicit `else: raise ValueError(...)` in `_apply_cuda_graph_metadata` so an unsupported `forward_mode` fails loudly with a clear message.
- Drop the now-dead `metadata = None` init (every branch now either assigns `metadata` or raises).

No behavior change for the supported modes — this only converts a silent `None` into an explicit error.

## Original commits

- `cf1361462`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28510243786](https://github.com/sgl-project/sglang/actions/runs/28510243786)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28510243611](https://github.com/sgl-project/sglang/actions/runs/28510243611)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->