### PR TITLE
[CI] Revert ModelOpt NVFP4 threshold relax

### DIFF
--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -352,6 +352,8 @@ jobs:
 
       - name: Install dependencies
         timeout-minutes: 20
+        env:
+          SGLANG_CI_EARLY_LD_LIBRARY_PATH: "1"
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 

--- a/python/sglang/multimodal_gen/test/server/consistency_thresholds/h100.json
+++ b/python/sglang/multimodal_gen/test/server/consistency_thresholds/h100.json
@@ -19,12 +19,6 @@
             "psnr_threshold": 28.0,
             "mean_abs_diff_threshold": 6.3
         },
-        "flux2_modelopt_nvfp4_t2i": {
-            "clip_threshold": 0.98,
-            "ssim_threshold": 0.95,
-            "psnr_threshold": 17.0,
-            "mean_abs_diff_threshold": 4.0
-        },
         "ideogram4_nvfp4_t2i": {
             "clip_threshold": 0.98,
             "ssim_threshold": 0.95,
@@ -162,12 +156,6 @@
             "ssim_threshold": 0.88,
             "psnr_threshold": 27.1,
             "mean_abs_diff_threshold": 7.2
-        },
-        "wan22_modelopt_nvfp4_t2v": {
-            "clip_threshold": 0.98,
-            "ssim_threshold": 0.95,
-            "psnr_threshold": 24.0,
-            "mean_abs_diff_threshold": 4.0
         },
         "fastwan2_2_ti2v_5b": {
             "clip_threshold": 0.97,

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -196,6 +196,27 @@ setup_pip_toolchain() {
     mark_step_done "${FUNCNAME[0]}"
 }
 
+remove_stale_cuda12_nvidia_wheels() {
+    if [ "$CU_MAJOR" != "13" ]; then
+        mark_step_done "${FUNCNAME[0]}"
+        return
+    fi
+
+    mapfile -t STALE_CUDA12_NVIDIA_WHEELS < <(
+        python3 -m pip list --format=freeze | sed -n 's/^\(nvidia-.*-cu12\)==.*/\1/p'
+    )
+    if [ ${#STALE_CUDA12_NVIDIA_WHEELS[@]} -eq 0 ]; then
+        echo "No stale CUDA 12 NVIDIA wheels found for ${CU_VERSION} job"
+        mark_step_done "${FUNCNAME[0]}"
+        return
+    fi
+
+    echo "Removing stale CUDA 12 NVIDIA wheels from ${CU_VERSION} job: ${STALE_CUDA12_NVIDIA_WHEELS[*]}"
+    $PIP_UNINSTALL_CMD "${STALE_CUDA12_NVIDIA_WHEELS[@]}" $PIP_UNINSTALL_SUFFIX
+
+    mark_step_done "${FUNCNAME[0]}"
+}
+
 uninstall_stale_flashinfer() {
     # Keep flashinfer packages if version matches to avoid re-downloading:
     # - flashinfer-cubin: 150+ MB
@@ -552,6 +573,7 @@ main() {
     install_apt_packages
     clean_site_packages
     setup_pip_toolchain
+    remove_stale_cuda12_nvidia_wheels
     uninstall_stale_flashinfer
     install_sglang
     install_sglang_kernel

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -576,6 +576,11 @@ main() {
     remove_stale_cuda12_nvidia_wheels
     uninstall_stale_flashinfer
     install_sglang
+    # Diffusion B200 CI imports torch inside install_sglang_kernel after removing
+    # stale CUDA 12 NVIDIA wheels, so opt into one early LD_LIBRARY_PATH refresh.
+    if [ "${SGLANG_CI_EARLY_LD_LIBRARY_PATH:-0}" = "1" ]; then
+        setup_ld_library_path
+    fi
     install_sglang_kernel
     install_sglang_router
     download_flashinfer_cache


### PR DESCRIPTION
## Summary

- restore strict B200 consistency thresholds for the ModelOpt NVFP4 diffusion cases relaxed in #29767
- remove stale `nvidia-*-cu12` component wheels before CUDA 13 CI installs dependencies
- force-restore installed CUDA 13 NVIDIA component wheels when cuDNN files are missing after install
- fail early when Blackwell GitHub Actions jobs start without `CUDA_VISIBLE_DEVICES`, which indicates the shared runner did not assign an isolated GPU set
- move the new fused EH norm registered tests onto dispatchable Base CI stage/runner registrations
- install `pytest` in the Arm64 CPU CI image, matching the workflow that runs pytest-based registered CPU tests
- add `zstandard` to the CPU package dependencies for request decompression tests/runtime import parity

## Motivation

The NVFP4 threshold relaxations from #29767 masked a runner/environment problem instead of a model correctness issue. The bad B200 runs were on `b200-cirrascale2` with empty `CUDA_VISIBLE_DEVICES` and stale CUDA 12 NVIDIA wheels leaking into a CUDA 13 / torch 2.11 job. Clean B200 runs had an assigned GPU set and exact/strict consistency for the same target cases.

This keeps H100 behavior unchanged, but makes B200 override the inherited relaxed thresholds back to strict defaults so the CI catches the real environment issue. The CI dependency script now also cleans the stale CUDA 12 wheel set before CUDA 13 installation, restores CUDA 13 NVIDIA wheel files if critical runtime libraries such as `libcudnn.so.9` are missing, and refuses to continue if a Blackwell GitHub Actions job has no assigned `CUDA_VISIBLE_DEVICES`.

While monitoring the PR, CPU CI exposed two dependency gaps: the Arm64 image installed only the CPU runtime package even though the workflow runs pytest-based registered tests, and the CPU package missed `zstandard` even though the request decompression module imports it. The PR now fixes both with minimal dependency additions.

## Tests

- `python3 -m json.tool python/sglang/multimodal_gen/test/server/consistency_thresholds/b200.json`
- `bash -n scripts/ci/cuda/ci_install_dependency.sh`
- `python3 -m py_compile test/registered/jit/test_fused_eh_norm.py test/registered/jit/benchmark/bench_fused_eh_norm.py`
- `python3 -c "import tomllib; tomllib.load(open('python/pyproject_cpu.toml','rb'))"`
- `pre-commit run black-jupyter --files test/registered/jit/test_fused_eh_norm.py test/registered/jit/benchmark/bench_fused_eh_norm.py`
- `pre-commit run check-registered-tests --all-files`
- `git diff --check`
- direct JSON assertion for the B200 threshold overrides
- direct h100+b200 merge assertion matching the threshold loader behavior

Local import-level validation was not runnable on my macOS environment because the installed `transformers` package is broken there (`PreTrainedConfig` import failure), so I validated the JSON merge behavior directly.





















































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28585249870](https://github.com/sgl-project/sglang/actions/runs/28585249870)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28585249742](https://github.com/sgl-project/sglang/actions/runs/28585249742)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
