### PR TITLE
Support MOSS-Transcribe-Diarize model and adapter

### DIFF
--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -24,6 +24,7 @@ from sglang.srt.configs.lfm2_vl import Lfm2VlConfig
 from sglang.srt.configs.locate_anything import LocateAnythingConfig
 from sglang.srt.configs.longcat_flash import LongcatFlashConfig
 from sglang.srt.configs.minicpmv4_6 import MiniCPMV4_6Config, MiniCPMV4_6VisionConfig
+from sglang.srt.configs.moss_transcribe_diarize import MossTranscribeDiarizeConfig
 from sglang.srt.configs.nano_nemotron_vl import (
     NemotronH_Nano_Omni_Reasoning_V3_Config,
     NemotronH_Nano_VL_V2_Config,
@@ -75,6 +76,7 @@ __all__ = [
     "LocateAnythingConfig",
     "MiniCPMV4_6Config",
     "MiniCPMV4_6VisionConfig",
+    "MossTranscribeDiarizeConfig",
     "NemotronHConfig",
     "NemotronHPuzzleConfig",
     "NemotronH_Nano_VL_V2_Config",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1703,6 +1703,7 @@ multimodal_model_archs = [
     "Mistral3ForConditionalGeneration",
     "MultiModalityCausalLM",
     "MllamaForConditionalGeneration",
+    "MossTranscribeDiarizeForConditionalGeneration",
     "MossVLForConditionalGeneration",
     "NemotronH_Nano_VL_V2",
     "NemotronH_Nano_Omni_Reasoning_V3",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1777,6 +1777,7 @@ def is_audio_model(model_architectures: List[str]):
     models = [
         "WhisperForConditionalGeneration",
         "Qwen3ASRForConditionalGeneration",
+        "MossTranscribeDiarizeForConditionalGeneration",
     ]
     return any(model in model_architectures for model in models)
 

--- a/python/sglang/srt/configs/moss_transcribe_diarize.py
+++ b/python/sglang/srt/configs/moss_transcribe_diarize.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from transformers import AutoConfig, PretrainedConfig
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+from transformers.models.whisper.configuration_whisper import WhisperConfig
+
+
+class MossTranscribeDiarizeConfig(PretrainedConfig):
+    model_type = "moss_transcribe_diarize"
+    sub_configs = {"text_config": Qwen3Config, "audio_config": WhisperConfig}
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        text_config=None,
+        audio_config=None,
+        audio_token_id: int = 151671,
+        audio_merge_size: int = 4,
+        adaptor_input_dim: int | None = None,
+        tie_word_embeddings: bool = True,
+        **kwargs,
+    ):
+        if text_config is None:
+            text_config = Qwen3Config(
+                vocab_size=151936,
+                hidden_size=1024,
+                intermediate_size=3072,
+                num_hidden_layers=28,
+                num_attention_heads=16,
+                num_key_value_heads=8,
+                head_dim=128,
+                max_position_embeddings=40960,
+                tie_word_embeddings=tie_word_embeddings,
+                rope_theta=1_000_000.0,
+                layer_types=["full_attention"] * 28,
+            )
+        elif isinstance(text_config, dict):
+            text_config = self.sub_configs["text_config"](**text_config)
+
+        if audio_config is None:
+            audio_config = WhisperConfig(
+                num_mel_bins=80,
+                d_model=1024,
+                encoder_layers=24,
+                encoder_attention_heads=16,
+                encoder_ffn_dim=4096,
+                max_source_positions=1500,
+                dropout=0.0,
+                attention_dropout=0.0,
+                activation_dropout=0.0,
+                activation_function="gelu",
+                encoder_layerdrop=0.0,
+                scale_embedding=False,
+            )
+        elif isinstance(audio_config, dict):
+            audio_config = self.sub_configs["audio_config"](**audio_config)
+
+        text_config.tie_word_embeddings = tie_word_embeddings
+        if not getattr(text_config, "layer_types", None):
+            text_config.layer_types = ["full_attention"] * text_config.num_hidden_layers
+
+        self.text_config = text_config
+        self.audio_config = audio_config
+        self.audio_token_id = audio_token_id
+        self.audio_merge_size = audio_merge_size
+        self.adaptor_input_dim = (
+            adaptor_input_dim or audio_config.d_model * audio_merge_size
+        )
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+
+    def get_text_config(self, decoder=False) -> PretrainedConfig:
+        return self.text_config
+
+
+AutoConfig.register("moss_transcribe_diarize", MossTranscribeDiarizeConfig)

--- a/python/sglang/srt/entrypoints/openai/serving_transcription.py
+++ b/python/sglang/srt/entrypoints/openai/serving_transcription.py
@@ -330,7 +330,7 @@ class OpenAIServingTranscription(OpenAIServingBase):
                         request.language = lang
                         logger.info("Auto-detected language: '%s'", lang)
                 else:
-                    visible = cumulative_text
+                    visible = self._adapter.postprocess_text(cumulative_text)
 
                 delta = visible[len(visible_buffer) :]
                 visible_buffer = visible

--- a/python/sglang/srt/entrypoints/openai/transcription_adapters/__init__.py
+++ b/python/sglang/srt/entrypoints/openai/transcription_adapters/__init__.py
@@ -10,6 +10,9 @@ from sglang.srt.entrypoints.openai.transcription_adapters.base import (  # noqa:
 from sglang.srt.entrypoints.openai.transcription_adapters.mimo_v2_asr import (  # noqa: F401
     MiMoV2ASRAdapter,
 )
+from sglang.srt.entrypoints.openai.transcription_adapters.moss_transcribe_diarize import (  # noqa: F401
+    MossTranscribeDiarizeAdapter,
+)
 from sglang.srt.entrypoints.openai.transcription_adapters.qwen3_asr import (  # noqa: F401
     Qwen3ASRAdapter,
 )
@@ -24,4 +27,5 @@ __all__ = [
     "WhisperAdapter",
     "Qwen3ASRAdapter",
     "MiMoV2ASRAdapter",
+    "MossTranscribeDiarizeAdapter",
 ]

--- a/python/sglang/srt/entrypoints/openai/transcription_adapters/moss_transcribe_diarize.py
+++ b/python/sglang/srt/entrypoints/openai/transcription_adapters/moss_transcribe_diarize.py
@@ -15,10 +15,10 @@ from sglang.srt.entrypoints.openai.transcription_adapters.base import (
 
 _SPECIAL_TOKEN_RE = re.compile(r"<\|(?:im_start|im_end|endoftext)\|>")
 _SEGMENT_RE = re.compile(
-    r"\[(?P<start>\d+(?:\.\d+)?)\]\[(?P<speaker>S\d{2,})\]"
+    r"\[(?P<start>\d+(?:\.\d+)?)\]\s*\[(?P<speaker>S\d{2,})\]"
     r"(?P<text>.*?)"
-    r"\[(?P<end>\d+(?:\.\d+)?)\]"
-    r"(?=\s*(?:\[\d+(?:\.\d+)?\]\[S\d{2,}\]|$))",
+    r"\s*\[(?P<end>\d+(?:\.\d+)?)\]"
+    r"(?=\s*(?:\[\d+(?:\.\d+)?\]\s*\[S\d{2,}\]|$))",
     re.DOTALL,
 )
 

--- a/python/sglang/srt/entrypoints/openai/transcription_adapters/moss_transcribe_diarize.py
+++ b/python/sglang/srt/entrypoints/openai/transcription_adapters/moss_transcribe_diarize.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import re
+
+from sglang.srt.entrypoints.openai.protocol import (
+    TranscriptionRequest,
+    TranscriptionSegment,
+    TranscriptionUsage,
+    TranscriptionVerboseResponse,
+)
+from sglang.srt.entrypoints.openai.transcription_adapters.base import (
+    TranscriptionAdapter,
+    register_transcription_adapter,
+)
+
+_SPECIAL_TOKEN_RE = re.compile(r"<\|(?:im_start|im_end|endoftext)\|>")
+_SEGMENT_RE = re.compile(
+    r"\[(?P<start>\d+(?:\.\d+)?)\]\[(?P<speaker>S\d{2,})\]"
+    r"(?P<text>.*?)"
+    r"\[(?P<end>\d+(?:\.\d+)?)\]"
+    r"(?=\s*(?:\[\d+(?:\.\d+)?\]\[S\d{2,}\]|$))",
+    re.DOTALL,
+)
+
+
+@register_transcription_adapter("MossTranscribeDiarize")
+class MossTranscribeDiarizeAdapter(TranscriptionAdapter):
+    def build_sampling_params(self, request: TranscriptionRequest) -> dict:
+        return {
+            "temperature": request.temperature,
+            "max_new_tokens": 2048,
+        }
+
+    def postprocess_text(self, text: str) -> str:
+        return _SPECIAL_TOKEN_RE.sub("", text).strip()
+
+    def build_verbose_response(
+        self,
+        request: TranscriptionRequest,
+        text: str,
+        ret: dict,
+        tokenizer,
+        usage: TranscriptionUsage,
+    ) -> TranscriptionVerboseResponse:
+        return TranscriptionVerboseResponse(
+            language=request.language or "auto",
+            duration=round(request.audio_duration_s, 2),
+            text=text,
+            segments=self._parse_segments(text),
+            usage=usage,
+        )
+
+    @staticmethod
+    def _parse_segments(text: str) -> list[TranscriptionSegment]:
+        segments = []
+        for segment_id, match in enumerate(_SEGMENT_RE.finditer(text)):
+            speaker = match.group("speaker")
+            body = match.group("text").strip()
+            segment_text = f"[{speaker}]{body}" if body else f"[{speaker}]"
+            segments.append(
+                TranscriptionSegment(
+                    id=segment_id,
+                    start=round(float(match.group("start")), 2),
+                    end=round(float(match.group("end")), 2),
+                    text=segment_text,
+                )
+            )
+        return segments

--- a/python/sglang/srt/entrypoints/openai/transcription_adapters/moss_transcribe_diarize.py
+++ b/python/sglang/srt/entrypoints/openai/transcription_adapters/moss_transcribe_diarize.py
@@ -42,11 +42,14 @@ class MossTranscribeDiarizeAdapter(TranscriptionAdapter):
         tokenizer,
         usage: TranscriptionUsage,
     ) -> TranscriptionVerboseResponse:
+        segments = self._parse_segments(text)
+        if not segments:
+            segments = self._build_fallback_segments(text, request.audio_duration_s)
         return TranscriptionVerboseResponse(
             language=request.language or "auto",
             duration=round(request.audio_duration_s, 2),
             text=text,
-            segments=self._parse_segments(text),
+            segments=segments,
             usage=usage,
         )
 
@@ -66,3 +69,23 @@ class MossTranscribeDiarizeAdapter(TranscriptionAdapter):
                 )
             )
         return segments
+
+    @staticmethod
+    def _build_fallback_segments(
+        text: str, audio_duration_s: float
+    ) -> list[TranscriptionSegment]:
+        text = text.strip()
+        if not text:
+            return []
+
+        if not re.match(r"^\[S\d{2,}\]", text):
+            text = f"[S01]{text}"
+
+        return [
+            TranscriptionSegment(
+                id=0,
+                start=0.0,
+                end=round(max(float(audio_duration_s), 0.0), 2),
+                text=text,
+            )
+        ]

--- a/python/sglang/srt/models/moss_transcribe_diarize.py
+++ b/python/sglang/srt/models/moss_transcribe_diarize.py
@@ -112,9 +112,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             raise ValueError(
                 "MOSS-Transcribe-Diarize audio item is missing audio_feature_lengths."
             )
-        audio_feature_lengths = audio_feature_lengths.to(
-            device=device, dtype=torch.long
-        )
+        audio_feature_lengths = audio_feature_lengths.to(device="cpu", dtype=torch.long)
         if audio_feature_lengths.numel() != input_features.shape[0]:
             raise ValueError(
                 "audio_feature_lengths must contain one length per input_features chunk: "
@@ -124,12 +122,10 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         audio_chunk_mapping = getattr(item, "audio_chunk_mapping", None)
         if audio_chunk_mapping is None:
             audio_chunk_mapping = torch.zeros(
-                input_features.shape[0], dtype=torch.long, device=device
+                input_features.shape[0], dtype=torch.long, device="cpu"
             )
         else:
-            audio_chunk_mapping = audio_chunk_mapping.to(
-                device=device, dtype=torch.long
-            )
+            audio_chunk_mapping = audio_chunk_mapping.to(device="cpu", dtype=torch.long)
         if audio_chunk_mapping.numel() != input_features.shape[0]:
             raise ValueError(
                 "audio_chunk_mapping must contain one sample index per input_features chunk: "
@@ -148,15 +144,15 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             forward_batch,
         )
 
-        num_audios = (
-            int(audio_chunk_mapping.max().item()) + 1
-            if audio_chunk_mapping.numel()
-            else 0
-        )
+        audio_feature_lengths_list = audio_feature_lengths.tolist()
+        audio_chunk_mapping_list = audio_chunk_mapping.tolist()
+        num_audios = 0
+        if audio_chunk_mapping_list:
+            num_audios = max(audio_chunk_mapping_list) + 1
         per_audio_chunks = [[] for _ in range(num_audios)]
         merge_size = int(self.config.audio_merge_size)
-        for chunk_idx, token_len in enumerate(audio_feature_lengths.tolist()):
-            sample_idx = int(audio_chunk_mapping[chunk_idx].item())
+        for chunk_idx, token_len in enumerate(audio_feature_lengths_list):
+            sample_idx = audio_chunk_mapping_list[chunk_idx]
             per_audio_chunks[sample_idx].append(
                 whisper_features[
                     chunk_idx : chunk_idx + 1, : int(token_len) * merge_size
@@ -166,6 +162,8 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         adapted = []
         adaptor_dtype = next(self.vq_adaptor.parameters()).dtype
         for parts in per_audio_chunks:
+            if not parts:
+                continue
             feat = torch.cat(parts, dim=1).to(dtype=adaptor_dtype)
             merged = self.time_merge(feat)
             adapted.append(self.vq_adaptor(merged).squeeze(0))

--- a/python/sglang/srt/models/moss_transcribe_diarize.py
+++ b/python/sglang/srt/models/moss_transcribe_diarize.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.configs.moss_transcribe_diarize import MossTranscribeDiarizeConfig
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+from sglang.srt.models.whisper import WhisperEncoder
+from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
+
+
+class VQAdaptor(nn.Module):
+    def __init__(self, input_dim: int, hidden_size: int, norm_eps: float = 1e-6):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(input_dim, hidden_size, bias=True),
+            nn.SiLU(),
+            nn.Linear(hidden_size, hidden_size, bias=True),
+            nn.LayerNorm(hidden_size, eps=norm_eps, bias=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
+
+class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
+    default_bitsandbytes_target_modules = [
+        ".gate_proj.",
+        ".down_proj.",
+        ".up_proj.",
+        ".q_proj.",
+        ".k_proj.",
+        ".v_proj.",
+        ".o_proj.",
+    ]
+    bitsandbytes_stacked_params_mapping = {
+        "q_proj": ("qkv_proj", 0),
+        "k_proj": ("qkv_proj", 1),
+        "v_proj": ("qkv_proj", 2),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+
+    def __init__(
+        self,
+        config: MossTranscribeDiarizeConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.whisper_encoder = WhisperEncoder(config.audio_config, quant_config)
+        self.vq_adaptor = VQAdaptor(
+            input_dim=config.adaptor_input_dim,
+            hidden_size=config.text_config.hidden_size,
+            norm_eps=config.text_config.rms_norm_eps,
+        )
+        self.language_model = Qwen3ForCausalLM(
+            config.text_config,
+            quant_config,
+            prefix=add_prefix("model.language_model", prefix),
+        )
+        self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
+        return self.pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def time_merge(self, features: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, hidden_size = features.shape
+        merge_size = int(self.config.audio_merge_size)
+        trimmed_len = (seq_len // merge_size) * merge_size
+        return features[:, :trimmed_len, :].reshape(
+            batch_size, trimmed_len // merge_size, hidden_size * merge_size
+        )
+
+    def _encode_one_audio_item(
+        self,
+        item: MultimodalDataItem,
+        forward_batch: ForwardBatch,
+    ) -> list[torch.Tensor]:
+        if item.feature is None:
+            raise ValueError(
+                "MOSS-Transcribe-Diarize audio item is missing input_features."
+            )
+
+        device = next(self.whisper_encoder.parameters()).device
+        encoder_dtype = next(self.whisper_encoder.parameters()).dtype
+        input_features = item.feature.to(device=device, dtype=encoder_dtype)
+
+        audio_feature_lengths = getattr(item, "audio_feature_lengths", None)
+        if audio_feature_lengths is None:
+            raise ValueError(
+                "MOSS-Transcribe-Diarize audio item is missing audio_feature_lengths."
+            )
+        audio_feature_lengths = audio_feature_lengths.to(
+            device=device, dtype=torch.long
+        )
+        if audio_feature_lengths.numel() != input_features.shape[0]:
+            raise ValueError(
+                "audio_feature_lengths must contain one length per input_features chunk: "
+                f"got {audio_feature_lengths.numel()} lengths for {input_features.shape[0]} chunks."
+            )
+
+        audio_chunk_mapping = getattr(item, "audio_chunk_mapping", None)
+        if audio_chunk_mapping is None:
+            audio_chunk_mapping = torch.zeros(
+                input_features.shape[0], dtype=torch.long, device=device
+            )
+        else:
+            audio_chunk_mapping = audio_chunk_mapping.to(
+                device=device, dtype=torch.long
+            )
+        if audio_chunk_mapping.numel() != input_features.shape[0]:
+            raise ValueError(
+                "audio_chunk_mapping must contain one sample index per input_features chunk: "
+                f"got {audio_chunk_mapping.numel()} indices for {input_features.shape[0]} chunks."
+            )
+
+        encoder_len = input_features.shape[-1] // 2
+        encoder_position_ids = torch.arange(
+            encoder_len,
+            device=input_features.device,
+            dtype=torch.long,
+        )
+        whisper_features = self.whisper_encoder(
+            input_features,
+            encoder_position_ids,
+            forward_batch,
+        )
+
+        num_audios = (
+            int(audio_chunk_mapping.max().item()) + 1
+            if audio_chunk_mapping.numel()
+            else 0
+        )
+        per_audio_chunks = [[] for _ in range(num_audios)]
+        merge_size = int(self.config.audio_merge_size)
+        for chunk_idx, token_len in enumerate(audio_feature_lengths.tolist()):
+            sample_idx = int(audio_chunk_mapping[chunk_idx].item())
+            per_audio_chunks[sample_idx].append(
+                whisper_features[
+                    chunk_idx : chunk_idx + 1, : int(token_len) * merge_size
+                ]
+            )
+
+        adapted = []
+        adaptor_dtype = next(self.vq_adaptor.parameters()).dtype
+        for parts in per_audio_chunks:
+            feat = torch.cat(parts, dim=1).to(dtype=adaptor_dtype)
+            merged = self.time_merge(feat)
+            adapted.append(self.vq_adaptor(merged).squeeze(0))
+        return adapted
+
+    def get_audio_feature(
+        self,
+        items: List[MultimodalDataItem],
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        audio_embeds = []
+        for item in items:
+            audio_embeds.extend(self._encode_one_audio_item(item, forward_batch))
+        if not audio_embeds:
+            hidden_size = self.config.text_config.hidden_size
+            device = next(self.vq_adaptor.parameters()).device
+            dtype = next(self.vq_adaptor.parameters()).dtype
+            return torch.empty((0, hidden_size), device=device, dtype=dtype)
+        return torch.cat(audio_embeds, dim=0)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        return general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=self.language_model,
+            data_embedding_funcs={
+                Modality.AUDIO: lambda items: self.get_audio_feature(
+                    items,
+                    forward_batch,
+                ),
+            },
+            positions=positions,
+        )
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        whisper_stacked_params_mapping = [
+            ("self_attn.qkv_proj", "self_attn.q_proj", "q"),
+            ("self_attn.qkv_proj", "self_attn.k_proj", "k"),
+            ("self_attn.qkv_proj", "self_attn.v_proj", "v"),
+        ]
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+
+        def load_one(name: str, loaded_weight: torch.Tensor):
+            original_name = name
+            if "rotary_emb.inv_freq" in name:
+                return
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                return
+
+            if name == "lm_head.weight":
+                name = "language_model.lm_head.weight"
+            elif name.startswith("model.language_model."):
+                name = "language_model.model." + name[len("model.language_model.") :]
+            elif name.startswith("model.whisper_encoder."):
+                name = "whisper_encoder." + name[len("model.whisper_encoder.") :]
+            elif name.startswith("model.vq_adaptor."):
+                name = "vq_adaptor." + name[len("model.vq_adaptor.") :]
+
+            if (
+                name == "language_model.model.embed_tokens.weight"
+                and self.config.text_config.tie_word_embeddings
+                and "language_model.lm_head.weight" in params_dict
+            ):
+                param = params_dict["language_model.lm_head.weight"]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+            handled = False
+            if name.startswith("whisper_encoder."):
+                for param_name, weight_name, shard_id in whisper_stacked_params_mapping:
+                    if weight_name not in name:
+                        continue
+                    mapped_name = name.replace(weight_name, param_name)
+                    if mapped_name.endswith(".bias") and mapped_name not in params_dict:
+                        handled = True
+                        break
+                    if mapped_name in params_dict:
+                        param = params_dict[mapped_name]
+                        param.weight_loader(param, loaded_weight, shard_id)
+                        handled = True
+                    break
+
+            if name.startswith("language_model."):
+                for param_name, weight_name, shard_id in stacked_params_mapping:
+                    if weight_name not in name:
+                        continue
+                    mapped_name = name.replace(weight_name, param_name)
+                    if mapped_name.endswith(".bias") and mapped_name not in params_dict:
+                        handled = True
+                        break
+                    if mapped_name in params_dict:
+                        param = params_dict[mapped_name]
+                        param.weight_loader(param, loaded_weight, shard_id)
+                        handled = True
+                    break
+
+            if handled:
+                return
+
+            if name.endswith(".bias") and name not in params_dict:
+                return
+
+            if name in params_dict:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            else:
+                logger.debug("Skipping weight: %s -> %s", original_name, name)
+
+        for name, loaded_weight in weights:
+            load_one(name, loaded_weight)
+            if (
+                name.startswith("model.whisper_encoder.layers.")
+                and ".self_attn.k_proj.weight" in name
+            ):
+                load_one(
+                    name.replace(".k_proj.weight", ".k_proj.bias"),
+                    torch.zeros(
+                        loaded_weight.shape[0],
+                        dtype=loaded_weight.dtype,
+                        device=loaded_weight.device,
+                    ),
+                )
+
+
+EntryClass = MossTranscribeDiarizeForConditionalGeneration

--- a/python/sglang/srt/multimodal/processors/moss_transcribe_diarize.py
+++ b/python/sglang/srt/multimodal/processors/moss_transcribe_diarize.py
@@ -13,6 +13,11 @@ from sglang.srt.multimodal.processors.base_processor import (
 )
 
 AUDIO_PLACEHOLDER = "<|audio_start|><|audio_pad|><|audio_end|>"
+DEFAULT_TRANSCRIBE_DIARIZE_PROMPT = (
+    "请将音频转写为文本，每一段需以起始时间戳和说话人编号"
+    "（[S01]、[S02]、[S03]…）开头，正文为对应的语音内容，"
+    "并在段末标注结束时间戳，以清晰标明该段语音范围。"
+)
 
 
 class MossTranscribeDiarizeMultimodalProcessor(BaseMultimodalProcessor):
@@ -47,6 +52,8 @@ class MossTranscribeDiarizeMultimodalProcessor(BaseMultimodalProcessor):
         input_text = input_text or ""
         if "<|audio_pad|>" in input_text:
             return input_text
+        if not input_text.strip():
+            input_text = DEFAULT_TRANSCRIBE_DIARIZE_PROMPT
 
         messages = [
             {

--- a/python/sglang/srt/multimodal/processors/moss_transcribe_diarize.py
+++ b/python/sglang/srt/multimodal/processors/moss_transcribe_diarize.py
@@ -1,0 +1,126 @@
+import re
+from typing import Union
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Modality, MultimodalProcessorOutput
+from sglang.srt.models.moss_transcribe_diarize import (
+    MossTranscribeDiarizeForConditionalGeneration,
+)
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
+
+AUDIO_PLACEHOLDER = "<|audio_start|><|audio_pad|><|audio_end|>"
+
+
+class MossTranscribeDiarizeMultimodalProcessor(BaseMultimodalProcessor):
+    models = [MossTranscribeDiarizeForConditionalGeneration]
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        self.AUDIO_TOKEN = AUDIO_PLACEHOLDER
+        self.AUDIO_TOKEN_REGEX = re.compile(
+            r"<\|audio_start\|>(?:<\|audio_pad\|>)+<\|audio_end\|>"
+        )
+        tokenizer = self._processor.tokenizer
+        self.audio_start_id = tokenizer.convert_tokens_to_ids("<|audio_start|>")
+        self.audio_token_id = tokenizer.convert_tokens_to_ids("<|audio_pad|>")
+        self.audio_end_id = tokenizer.convert_tokens_to_ids("<|audio_end|>")
+
+        self.mm_tokens = MultimodalSpecialTokens(
+            audio_token=self.AUDIO_TOKEN,
+            audio_token_regex=self.AUDIO_TOKEN_REGEX,
+            audio_token_id=self.audio_token_id,
+        ).build(_processor)
+        self.ATTR_NAME_TO_MODALITY.update(
+            {
+                "audio_feature_lengths": Modality.AUDIO,
+                "audio_chunk_mapping": Modality.AUDIO,
+            }
+        )
+
+    def _build_prompt(self, input_text: Union[str, list, None]) -> str:
+        if isinstance(input_text, list):
+            input_text = self._tokenizer.decode(input_text)
+        input_text = input_text or ""
+        if "<|audio_pad|>" in input_text:
+            return input_text
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "audio", "audio": ""},
+                    {"type": "text", "text": input_text},
+                ],
+            }
+        ]
+        return self._processor.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+    def process_mm_data(
+        self, input_text, images=None, videos=None, audios=None, **kwargs
+    ):
+        if images or videos:
+            raise ValueError("MOSS-Transcribe-Diarize only supports audio inputs.")
+        if not audios:
+            return self._tokenizer(
+                input_text,
+                return_tensors="pt",
+                add_special_tokens=True,
+            )
+
+        if self.audio_config:
+            kwargs.setdefault("audio_kwargs", {}).update(self.audio_config)
+        result = self._processor(
+            text=input_text,
+            audio=audios,
+            return_tensors="pt",
+            **kwargs,
+        )
+        if not self.server_args.keep_mm_feature_on_device:
+            for feature_name in self.FEATURE_NAMES:
+                if feature_name in result and isinstance(
+                    result[feature_name], torch.Tensor
+                ):
+                    result[feature_name] = result[feature_name].to("cpu")
+        return result
+
+    async def process_mm_data_async(
+        self,
+        audio_data=None,
+        input_text=None,
+        request_obj=None,
+        **kwargs,
+    ):
+        if not audio_data:
+            return None
+
+        prompt = self._build_prompt(input_text)
+        sampling_rate = int(self._processor.feature_extractor.sampling_rate)
+        base_output = await self.load_mm_data(
+            prompt=prompt,
+            audio_data=audio_data,
+            multimodal_tokens=self.mm_tokens,
+            audio_sample_rate=sampling_rate,
+        )
+        if base_output is None:
+            return None
+
+        mm_items, input_ids, _ = self.process_and_combine_mm_data(
+            base_output,
+            self.mm_tokens,
+        )
+
+        return MultimodalProcessorOutput(
+            mm_items=mm_items,
+            input_ids=input_ids.tolist(),
+            audio_start_id=self.audio_start_id,
+            audio_token_id=self.audio_token_id,
+            audio_end_id=self.audio_end_id,
+        )

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -43,6 +43,7 @@ from sglang.srt.configs import (
     LongcatFlashConfig,
     MiniCPMV4_6Config,
     MiniCPMV4_6VisionConfig,
+    MossTranscribeDiarizeConfig,
     MultiModalityConfig,
     NemotronH_Nano_Omni_Reasoning_V3_Config,
     NemotronH_Nano_VL_V2_Config,
@@ -112,6 +113,7 @@ _CONFIG_REGISTRY: Dict[str, Type[PretrainedConfig]] = {
         Step3p7Config,
         MiniCPMV4_6Config,
         MiniCPMV4_6VisionConfig,
+        MossTranscribeDiarizeConfig,
     ]
 }
 

--- a/test/registered/unit/entrypoints/openai/test_moss_transcribe_diarize_adapter.py
+++ b/test/registered/unit/entrypoints/openai/test_moss_transcribe_diarize_adapter.py
@@ -1,0 +1,106 @@
+"""Unit tests for the MOSS transcription adapter."""
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+import unittest
+from unittest.mock import Mock
+
+from sglang.srt.entrypoints.openai.protocol import (
+    TranscriptionRequest,
+    TranscriptionUsage,
+)
+from sglang.srt.entrypoints.openai.transcription_adapters import resolve_adapter
+from sglang.srt.entrypoints.openai.transcription_adapters.moss_transcribe_diarize import (
+    MossTranscribeDiarizeAdapter,
+)
+from sglang.srt.multimodal.processors.moss_transcribe_diarize import (
+    DEFAULT_TRANSCRIBE_DIARIZE_PROMPT,
+    MossTranscribeDiarizeMultimodalProcessor,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestMossTranscribeDiarizeAdapter(CustomTestCase):
+    def test_adapter_registered_by_architecture(self):
+        adapter = resolve_adapter(["MossTranscribeDiarizeForConditionalGeneration"])
+        self.assertIsInstance(adapter, MossTranscribeDiarizeAdapter)
+
+    def test_build_sampling_params_uses_transcription_defaults(self):
+        params = MossTranscribeDiarizeAdapter().build_sampling_params(
+            TranscriptionRequest(temperature=0.0)
+        )
+        self.assertEqual(params["temperature"], 0.0)
+        self.assertEqual(params["max_new_tokens"], 2048)
+
+    def test_postprocess_strips_chat_special_tokens(self):
+        text = "[0.00][S01]你好[1.00]<|im_end|>"
+        self.assertEqual(
+            MossTranscribeDiarizeAdapter().postprocess_text(text),
+            "[0.00][S01]你好[1.00]",
+        )
+
+    def test_verbose_response_parses_diarized_timestamp_segments(self):
+        text = "[0.41][S01]有一个人前来买瓜[1.65]" "[12.24][S02]生意行吗你们哥俩[13.82]"
+        resp = MossTranscribeDiarizeAdapter().build_verbose_response(
+            TranscriptionRequest(language=None, audio_duration_s=13.9),
+            text,
+            ret={},
+            tokenizer=Mock(),
+            usage=TranscriptionUsage(seconds=14),
+        )
+
+        self.assertEqual(resp.language, "auto")
+        self.assertEqual(resp.duration, 13.9)
+        self.assertEqual(resp.text, text)
+        self.assertEqual(len(resp.segments), 2)
+        self.assertEqual(resp.segments[0].start, 0.41)
+        self.assertEqual(resp.segments[0].end, 1.65)
+        self.assertEqual(resp.segments[0].text, "[S01]有一个人前来买瓜")
+        self.assertEqual(resp.segments[1].start, 12.24)
+        self.assertEqual(resp.segments[1].end, 13.82)
+        self.assertEqual(resp.segments[1].text, "[S02]生意行吗你们哥俩")
+
+    def test_verbose_response_keeps_empty_segments_when_format_missing(self):
+        resp = MossTranscribeDiarizeAdapter().build_verbose_response(
+            TranscriptionRequest(audio_duration_s=1.0),
+            "[S01]没有时间戳的文本",
+            ret={},
+            tokenizer=Mock(),
+            usage=TranscriptionUsage(seconds=1),
+        )
+        self.assertEqual(resp.segments, [])
+
+
+class TestMossTranscribeDiarizePrompt(CustomTestCase):
+    def test_empty_input_uses_default_transcription_prompt(self):
+        proc = MossTranscribeDiarizeMultimodalProcessor.__new__(
+            MossTranscribeDiarizeMultimodalProcessor
+        )
+        proc._processor = Mock()
+        proc._processor.apply_chat_template = Mock(return_value="rendered prompt")
+
+        self.assertEqual(proc._build_prompt(""), "rendered prompt")
+        messages = proc._processor.apply_chat_template.call_args.args[0]
+        self.assertEqual(
+            messages[0]["content"][1]["text"], DEFAULT_TRANSCRIBE_DIARIZE_PROMPT
+        )
+
+    def test_explicit_prompt_is_preserved(self):
+        proc = MossTranscribeDiarizeMultimodalProcessor.__new__(
+            MossTranscribeDiarizeMultimodalProcessor
+        )
+        proc._processor = Mock()
+        proc._processor.apply_chat_template = Mock(return_value="rendered prompt")
+
+        proc._build_prompt("自定义转写要求")
+        messages = proc._processor.apply_chat_template.call_args.args[0]
+        self.assertEqual(messages[0]["content"][1]["text"], "自定义转写要求")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_moss_transcribe_diarize_adapter.py
+++ b/test/registered/unit/entrypoints/openai/test_moss_transcribe_diarize_adapter.py
@@ -65,6 +65,27 @@ class TestMossTranscribeDiarizeAdapter(CustomTestCase):
         self.assertEqual(resp.segments[1].end, 13.82)
         self.assertEqual(resp.segments[1].text, "[S02]生意行吗你们哥俩")
 
+    def test_verbose_response_parses_segments_with_optional_whitespace(self):
+        text = (
+            "[0.41] [S01] 有一个人前来买瓜 [1.65]\n"
+            "[12.24] [S02] 生意行吗你们哥俩 [13.82]"
+        )
+        resp = MossTranscribeDiarizeAdapter().build_verbose_response(
+            TranscriptionRequest(audio_duration_s=13.9),
+            text,
+            ret={},
+            tokenizer=Mock(),
+            usage=TranscriptionUsage(seconds=14),
+        )
+
+        self.assertEqual(len(resp.segments), 2)
+        self.assertEqual(resp.segments[0].start, 0.41)
+        self.assertEqual(resp.segments[0].end, 1.65)
+        self.assertEqual(resp.segments[0].text, "[S01]有一个人前来买瓜")
+        self.assertEqual(resp.segments[1].start, 12.24)
+        self.assertEqual(resp.segments[1].end, 13.82)
+        self.assertEqual(resp.segments[1].text, "[S02]生意行吗你们哥俩")
+
     def test_verbose_response_keeps_empty_segments_when_format_missing(self):
         resp = MossTranscribeDiarizeAdapter().build_verbose_response(
             TranscriptionRequest(audio_duration_s=1.0),

--- a/test/registered/unit/entrypoints/openai/test_moss_transcribe_diarize_adapter.py
+++ b/test/registered/unit/entrypoints/openai/test_moss_transcribe_diarize_adapter.py
@@ -86,10 +86,34 @@ class TestMossTranscribeDiarizeAdapter(CustomTestCase):
         self.assertEqual(resp.segments[1].end, 13.82)
         self.assertEqual(resp.segments[1].text, "[S02]生意行吗你们哥俩")
 
-    def test_verbose_response_keeps_empty_segments_when_format_missing(self):
+    def test_verbose_response_falls_back_to_full_audio_segment(self):
+        resp = MossTranscribeDiarizeAdapter().build_verbose_response(
+            TranscriptionRequest(audio_duration_s=1.23),
+            "没有时间戳的文本",
+            ret={},
+            tokenizer=Mock(),
+            usage=TranscriptionUsage(seconds=1),
+        )
+        self.assertEqual(len(resp.segments), 1)
+        self.assertEqual(resp.segments[0].id, 0)
+        self.assertEqual(resp.segments[0].start, 0.0)
+        self.assertEqual(resp.segments[0].end, 1.23)
+        self.assertEqual(resp.segments[0].text, "[S01]没有时间戳的文本")
+
+    def test_verbose_response_fallback_preserves_existing_speaker(self):
+        resp = MossTranscribeDiarizeAdapter().build_verbose_response(
+            TranscriptionRequest(audio_duration_s=1.23),
+            "[S02]没有时间戳的文本",
+            ret={},
+            tokenizer=Mock(),
+            usage=TranscriptionUsage(seconds=1),
+        )
+        self.assertEqual(resp.segments[0].text, "[S02]没有时间戳的文本")
+
+    def test_verbose_response_keeps_empty_segments_for_empty_text(self):
         resp = MossTranscribeDiarizeAdapter().build_verbose_response(
             TranscriptionRequest(audio_duration_s=1.0),
-            "[S01]没有时间戳的文本",
+            "   ",
             ret={},
             tokenizer=Mock(),
             usage=TranscriptionUsage(seconds=1),

--- a/test/registered/unit/entrypoints/openai/test_serving_transcription.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_transcription.py
@@ -44,10 +44,12 @@ def _chunk(text: str, finish: str = None) -> dict:
 class _MockTokenizerManager:
     """Minimal mock satisfying OpenAIServingTranscription.__init__ and stream loop."""
 
-    def __init__(self, stream_chunks: List[dict]):
+    def __init__(self, stream_chunks: List[dict], architectures=None):
         self.model_config = Mock()
         self.model_config.hf_config = Mock()
-        self.model_config.hf_config.architectures = ["WhisperForConditionalGeneration"]
+        self.model_config.hf_config.architectures = architectures or [
+            "WhisperForConditionalGeneration"
+        ]
         # Not a real ServerArgs, so base class sets allowed_custom_labels=None.
         # Default tests assume cumulative-text streaming (the sglang upstream
         # default); tests for incremental_streaming_output=True override this.
@@ -303,6 +305,39 @@ class TestStreamingIncrementalOutputMode(CustomTestCase):
         self.assertFalse(any("<|" in d for d in emitted))
         self.assertEqual("".join(emitted), "Hello world")
         self.assertEqual(request.language, "en")
+
+
+class TestStreamingAdapterPostprocess(CustomTestCase):
+    """Non-fused token streaming still applies model-specific text cleanup."""
+
+    def test_moss_special_token_scrubbed_before_delta_slicing(self):
+        chunks = [
+            _chunk("[0.00][S01]你好[1.00]"),
+            _chunk("[0.00][S01]你好[1.00]<|im_end|>", finish="stop"),
+        ]
+        tm = _MockTokenizerManager(
+            chunks,
+            architectures=["MossTranscribeDiarizeForConditionalGeneration"],
+        )
+        serving = OpenAIServingTranscription(tm)
+        request = TranscriptionRequest(
+            model="moss-transcribe-diarize",
+            stream=True,
+        )
+        adapted = GenerateReqInput(text="", modalities=["audio"])
+
+        async def drive():
+            frames = []
+            async for frame in serving._generate_transcription_stream(
+                adapted, request, Mock()
+            ):
+                frames.append(frame)
+            return frames
+
+        frames = get_or_create_event_loop().run_until_complete(drive())
+        deltas = _deltas_from_sse(frames)
+        self.assertEqual(deltas, ["[0.00][S01]你好[1.00]"])
+        self.assertFalse(any("<|" in delta for delta in deltas))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
This pull request adds support for the [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) model, which is a multi-modal model for audio transcription and speaker diarization. This model supports accepting a single audio input of up to approximately 90 minutes in length, and directly generates structured transcription results with timestamps and speaker labels. 
The changes introduce new configuration, model, and adapter classes, and integrate them into the SGLang SRT codebase. Additionally, the transcription streaming logic is updated to support post-processing for this model.

## Modifications
**New model and configuration integration:**

* Added `MossTranscribeDiarizeConfig` for model configuration, including sub-configs for text (Qwen3) and audio (Whisper), and registered it in the model config system (`python/sglang/srt/configs/moss_transcribe_diarize.py`, `python/sglang/srt/configs/__init__.py`) [[1]](diffhunk://#diff-6f7e894b9cc425def5762adb9ee19ca004d8724e7c098ecd13dd0e57e0a44384R1-R75) [[2]](diffhunk://#diff-3a108b54699cc506f7695afa0528651d62691a2ebed6b0dde65508fd1dcd97f3R27) [[3]](diffhunk://#diff-3a108b54699cc506f7695afa0528651d62691a2ebed6b0dde65508fd1dcd97f3R79).
* Implemented the `MossTranscribeDiarizeForConditionalGeneration` model class, including audio encoding, feature merging, and integration with the language model (`python/sglang/srt/models/moss_transcribe_diarize.py`).
* Registered the new model architecture in the model configuration utilities for both generation and audio model detection (`python/sglang/srt/configs/model_config.py`) [[1]](diffhunk://#diff-be7f3f1b02373a39149a134fd553cc61243cbe11d997dc72e319c6123dba4618R1706) [[2]](diffhunk://#diff-be7f3f1b02373a39149a134fd553cc61243cbe11d997dc72e319c6123dba4618R1780).

**Transcription adapter and streaming support:**

* Added a dedicated transcription adapter for the MossTranscribeDiarize model, including segment parsing and post-processing logic, and registered it in the adapter registry (`python/sglang/srt/entrypoints/openai/transcription_adapters/moss_transcribe_diarize.py`, `python/sglang/srt/entrypoints/openai/transcription_adapters/__init__.py`) [[1]](diffhunk://#diff-43ae5d23f37c307d45e6eaabbf2a00060c345161455af0a8d676d47dc9eae26cR1-R68) [[2]](diffhunk://#diff-584d0f001bbb151025631f759eafc98dd9ceca08a7e442c8aa5df83a15582ae8R13-R15) [[3]](diffhunk://#diff-584d0f001bbb151025631f759eafc98dd9ceca08a7e442c8aa5df83a15582ae8R30).
* Updated the transcription streaming logic to use the adapter's `postprocess_text` method when handling cumulative text output (`python/sglang/srt/entrypoints/openai/serving_transcription.py`).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28569778665](https://github.com/sgl-project/sglang/actions/runs/28569778665)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28569778535](https://github.com/sgl-project/sglang/actions/runs/28569778535)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->