### PR TITLE
[diffusion] refactor: refactor cuda attention backend resolver

### DIFF
--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -27,6 +27,30 @@ from sglang.multimodal_gen.utils import import_pynvml
 
 logger = init_logger(__name__)
 
+_AITER_BACKEND_CLS_STR = (
+    "sglang.multimodal_gen.runtime.layers.attention.backends.aiter.AITerBackend"
+)
+_FLASH_ATTN_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn.FlashAttentionBackend"
+_FLASH_ATTN_2_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2.FlashAttention2Backend"
+_SAGE_ATTN_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn.SageAttentionBackend"
+_SAGE_ATTN_3_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3.SageAttention3Backend"
+_SAGE_SLA_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SageSparseLinearAttentionBackend"
+_SDPA_BACKEND_CLS_STR = (
+    "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"
+)
+_SLIDING_TILE_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sliding_tile_attn.SlidingTileAttentionBackend"
+_SLA_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SparseLinearAttentionBackend"
+_SPARSE_VIDEO_GEN_2_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_video_gen_2_attn.SparseVideoGen2AttentionBackend"
+_VIDEO_SPARSE_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn.VideoSparseAttentionBackend"
+_VMOBA_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.vmoba.VMOBAAttentionBackend"
+
+_DIRECT_ATTENTION_BACKEND_CLS_STRS = {
+    AttentionBackendEnum.AITER: _AITER_BACKEND_CLS_STR,
+    AttentionBackendEnum.TORCH_SDPA: _SDPA_BACKEND_CLS_STR,
+    AttentionBackendEnum.SLA_ATTN: _SLA_BACKEND_CLS_STR,
+    AttentionBackendEnum.SAGE_SLA_ATTN: _SAGE_SLA_BACKEND_CLS_STR,
+}
+
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
@@ -216,15 +240,9 @@ class CudaPlatformBase(Platform):
         return free_gpu_memory / (1 << 30)
 
     @classmethod
-    def get_attn_backend_cls_str(
-        cls,
-        selected_backend: AttentionBackendEnum | None,
-        head_size: int,
-        dtype: torch.dtype,
-    ) -> str:
-        target_backend: AttentionBackendEnum | None = None
-        # TODO(will): maybe come up with a more general interface for local attention
-        # if distributed is False, we always try to use Flash attn
+    def _resolve_import_checked_attn_backend(
+        cls, selected_backend: AttentionBackendEnum | None
+    ) -> str | AttentionBackendEnum | None:
         if selected_backend == AttentionBackendEnum.SLIDING_TILE_ATTN:
             try:
                 from st_attn import sliding_tile_attention  # noqa: F401
@@ -233,7 +251,7 @@ class CudaPlatformBase(Platform):
                     SlidingTileAttentionBackend,
                 )
 
-                return "sglang.multimodal_gen.runtime.layers.attention.backends.sliding_tile_attn.SlidingTileAttentionBackend"
+                return _SLIDING_TILE_BACKEND_CLS_STR
             except ImportError as e:
                 logger.error(
                     "Failed to import Sliding Tile Attention backend: %s", str(e)
@@ -241,7 +259,8 @@ class CudaPlatformBase(Platform):
                 raise ImportError(
                     "Sliding Tile Attention backend is not installed. "
                 ) from e
-        elif selected_backend == AttentionBackendEnum.SAGE_ATTN:
+
+        if selected_backend == AttentionBackendEnum.SAGE_ATTN:
             try:
                 from sageattention import sageattn  # noqa: F401
 
@@ -249,27 +268,29 @@ class CudaPlatformBase(Platform):
                     SageAttentionBackend,
                 )
 
-                return "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn.SageAttentionBackend"
+                return _SAGE_ATTN_BACKEND_CLS_STR
             except ImportError as e:
                 logger.info(e)
                 logger.info(
                     "Sage Attention backend is not installed (To install it, run `pip install sageattention==2.2.0 --no-build-isolation`). Falling back to Flash Attention."
                 )
-                target_backend = AttentionBackendEnum.FA
-        elif selected_backend == AttentionBackendEnum.SAGE_ATTN_3:
+                return AttentionBackendEnum.FA
+
+        if selected_backend == AttentionBackendEnum.SAGE_ATTN_3:
             try:
                 from sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3 import (  # noqa: F401
                     SageAttention3Backend,
                 )
 
-                return "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3.SageAttention3Backend"
+                return _SAGE_ATTN_3_BACKEND_CLS_STR
             except ImportError as e:
                 logger.info(e)
                 logger.info(
                     "Sage Attention 3 backend is not installed (To install it, see https://github.com/thu-ml/SageAttention/tree/main/sageattention3_blackwell#installation). Falling back to Torch SDPA."
                 )
-                target_backend = AttentionBackendEnum.TORCH_SDPA
-        elif selected_backend == AttentionBackendEnum.VIDEO_SPARSE_ATTN:
+                return AttentionBackendEnum.TORCH_SDPA
+
+        if selected_backend == AttentionBackendEnum.VIDEO_SPARSE_ATTN:
             try:
                 from vsa import block_sparse_attn  # noqa: F401
 
@@ -277,7 +298,7 @@ class CudaPlatformBase(Platform):
                     VideoSparseAttentionBackend,
                 )
 
-                return "sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn.VideoSparseAttentionBackend"
+                return _VIDEO_SPARSE_BACKEND_CLS_STR
             except ImportError as e:
                 logger.error(
                     "Failed to import Video Sparse Attention backend: %s", str(e)
@@ -285,7 +306,8 @@ class CudaPlatformBase(Platform):
                 raise ImportError(
                     "Video Sparse Attention backend is not installed."
                 ) from e
-        elif selected_backend == AttentionBackendEnum.SPARSE_VIDEO_GEN_2_ATTN:
+
+        if selected_backend == AttentionBackendEnum.SPARSE_VIDEO_GEN_2_ATTN:
             try:
                 from svg.kernels.triton.permute import (  # noqa: F401
                     apply_inverse_permutation_triton,
@@ -302,7 +324,7 @@ class CudaPlatformBase(Platform):
                     SparseVideoGen2AttentionBackend,
                 )
 
-                return "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_video_gen_2_attn.SparseVideoGen2AttentionBackend"
+                return _SPARSE_VIDEO_GEN_2_BACKEND_CLS_STR
             except ImportError as e:
                 logger.error(
                     "Failed to import Sparse Video Gen 2 (SAP) Attention backend: %s",
@@ -313,7 +335,8 @@ class CudaPlatformBase(Platform):
                     "Please install it by following the instructions at "
                     "https://github.com/svg-project/Sparse-VideoGen"
                 ) from e
-        elif selected_backend == AttentionBackendEnum.VMOBA_ATTN:
+
+        if selected_backend == AttentionBackendEnum.VMOBA_ATTN:
             try:
                 from kernel.attn.vmoba_attn.vmoba import moba_attn_varlen  # noqa: F401
 
@@ -321,7 +344,7 @@ class CudaPlatformBase(Platform):
                     VMOBAAttentionBackend,
                 )
 
-                return "sglang.multimodal_gen.runtime.layers.attention.backends.vmoba.VMOBAAttentionBackend"
+                return _VMOBA_BACKEND_CLS_STR
             except ImportError as e:
                 logger.error(
                     "Failed to import Video MoBA Attention backend: %s", str(e)
@@ -329,65 +352,51 @@ class CudaPlatformBase(Platform):
                 raise ImportError(
                     "Video MoBA Attention backend is not installed. "
                 ) from e
-        elif selected_backend == AttentionBackendEnum.AITER:
-            return "sglang.multimodal_gen.runtime.layers.attention.backends.aiter.AITerBackend"
-        elif selected_backend == AttentionBackendEnum.TORCH_SDPA:
-            return "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"
-        elif selected_backend == AttentionBackendEnum.SLA_ATTN:
-            return "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SparseLinearAttentionBackend"
-        elif selected_backend == AttentionBackendEnum.SAGE_SLA_ATTN:
-            return "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SageSparseLinearAttentionBackend"
-        elif selected_backend == AttentionBackendEnum.FA2:
+
+        if selected_backend == AttentionBackendEnum.FA2:
             from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2 import (  # noqa: F401
                 FlashAttention2Backend,
             )
 
-            return "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2.FlashAttention2Backend"
-        elif selected_backend in [
-            AttentionBackendEnum.FA,
-        ]:
-            if cls.is_sm120():
-                logger.info(
-                    "FlashAttention is not supported on SM12.x in this build; falling back to Torch SDPA."
-                )
-                target_backend = AttentionBackendEnum.TORCH_SDPA
-            elif cls.is_blackwell():
-                from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (
-                    set_fa_ver,
-                )
+            return _FLASH_ATTN_2_BACKEND_CLS_STR
 
-                set_fa_ver(4)
-                target_backend = AttentionBackendEnum.FA
-            else:
-                target_backend = AttentionBackendEnum.FA
-        elif selected_backend:
-            raise ValueError(f"Invalid attention backend for {cls.device_name}")
-        else:
-            if cls.is_sm120():
-                # On SM12.x, the sgl-kernel FlashAttention wheels may not include
-                # support yet. Default to Torch SDPA for correctness.
-                logger.info("Defaulting to Torch SDPA backend on SM12.x")
-                target_backend = AttentionBackendEnum.TORCH_SDPA
-            elif cls.is_blackwell():
-                from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (
-                    set_fa_ver,
-                )
+        return None
 
-                set_fa_ver(4)
-                target_backend = AttentionBackendEnum.FA
-            else:
-                target_backend = AttentionBackendEnum.FA
-
-        # Ensure we have a target backend selected before validation/fallback.
-        if target_backend is None:
-            target_backend = AttentionBackendEnum.FA
-
-        if target_backend == AttentionBackendEnum.FA and cls.is_blackwell():
-            from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (
-                set_fa_ver,
+    @classmethod
+    def _resolve_requested_flash_attention_backend(cls) -> AttentionBackendEnum:
+        if cls.is_sm120():
+            logger.info(
+                "FlashAttention is not supported on SM12.x in this build; falling back to Torch SDPA."
             )
+            return AttentionBackendEnum.TORCH_SDPA
+        return AttentionBackendEnum.FA
 
-            set_fa_ver(4)
+    @classmethod
+    def _resolve_default_attn_backend(cls) -> AttentionBackendEnum:
+        if cls.is_sm120():
+            # On SM12.x, the sgl-kernel FlashAttention wheels may not include
+            # support yet. Default to Torch SDPA for correctness.
+            logger.info("Defaulting to Torch SDPA backend on SM12.x")
+            return AttentionBackendEnum.TORCH_SDPA
+        return AttentionBackendEnum.FA
+
+    @classmethod
+    def _set_flash_attention_version_for_blackwell(cls) -> None:
+        if not cls.is_blackwell():
+            return
+
+        from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (
+            set_fa_ver,
+        )
+
+        set_fa_ver(4)
+
+    @classmethod
+    def _resolve_flash_attention_backend_cls_str(
+        cls, target_backend: AttentionBackendEnum, head_size: int, dtype: torch.dtype
+    ) -> str:
+        if target_backend == AttentionBackendEnum.FA:
+            cls._set_flash_attention_version_for_blackwell()
 
         if not cls.has_device_capability(80):
             logger.info("Cannot use FlashAttention backend for Volta and Turing GPUs.")
@@ -398,8 +407,7 @@ class CudaPlatformBase(Platform):
                 "torch.float16 or torch.bfloat16."
             )
             target_backend = AttentionBackendEnum.TORCH_SDPA
-        # FlashAttn is valid for the model, checking if the package is
-        # installed.
+
         if target_backend == AttentionBackendEnum.FA:
             try:
                 from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (  # noqa: F401
@@ -423,9 +431,38 @@ class CudaPlatformBase(Platform):
                 target_backend = AttentionBackendEnum.TORCH_SDPA
 
         if target_backend == AttentionBackendEnum.TORCH_SDPA:
-            return "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"
+            return _SDPA_BACKEND_CLS_STR
 
-        return "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn.FlashAttentionBackend"
+        return _FLASH_ATTN_BACKEND_CLS_STR
+
+    @classmethod
+    def get_attn_backend_cls_str(
+        cls,
+        selected_backend: AttentionBackendEnum | None,
+        head_size: int,
+        dtype: torch.dtype,
+    ) -> str:
+        direct_backend_cls_str = _DIRECT_ATTENTION_BACKEND_CLS_STRS.get(
+            selected_backend
+        )
+        if direct_backend_cls_str is not None:
+            return direct_backend_cls_str
+
+        resolved_backend = cls._resolve_import_checked_attn_backend(selected_backend)
+        if isinstance(resolved_backend, str):
+            return resolved_backend
+        if isinstance(resolved_backend, AttentionBackendEnum):
+            target_backend = resolved_backend
+        elif selected_backend == AttentionBackendEnum.FA:
+            target_backend = cls._resolve_requested_flash_attention_backend()
+        elif selected_backend:
+            raise ValueError(f"Invalid attention backend for {cls.device_name}")
+        else:
+            target_backend = cls._resolve_default_attn_backend()
+
+        return cls._resolve_flash_attention_backend_cls_str(
+            target_backend, head_size, dtype
+        )
 
     @classmethod
     def get_device_communicator_cls(cls) -> str:

--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -27,22 +27,9 @@ from sglang.multimodal_gen.utils import import_pynvml
 
 logger = init_logger(__name__)
 
-_AITER_BACKEND_CLS_STR = (
-    "sglang.multimodal_gen.runtime.layers.attention.backends.aiter.AITerBackend"
-)
-_FLASH_ATTN_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn.FlashAttentionBackend"
-_FLASH_ATTN_2_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2.FlashAttention2Backend"
-_SAGE_ATTN_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn.SageAttentionBackend"
-_SAGE_ATTN_3_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3.SageAttention3Backend"
-_SAGE_SLA_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SageSparseLinearAttentionBackend"
 _SDPA_BACKEND_CLS_STR = (
     "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"
 )
-_SLIDING_TILE_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sliding_tile_attn.SlidingTileAttentionBackend"
-_SLA_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SparseLinearAttentionBackend"
-_SPARSE_VIDEO_GEN_2_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_video_gen_2_attn.SparseVideoGen2AttentionBackend"
-_VIDEO_SPARSE_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn.VideoSparseAttentionBackend"
-_VMOBA_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.vmoba.VMOBAAttentionBackend"
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
@@ -103,7 +90,9 @@ class _DirectCudaAttentionBackendResolver(_CudaAttentionBackendResolver):
 
 class _AITerAttentionBackendResolver(_DirectCudaAttentionBackendResolver):
     backend = AttentionBackendEnum.AITER
-    backend_cls_str = _AITER_BACKEND_CLS_STR
+    backend_cls_str = (
+        "sglang.multimodal_gen.runtime.layers.attention.backends.aiter.AITerBackend"
+    )
 
 
 class _TorchSDPAAttentionBackendResolver(_DirectCudaAttentionBackendResolver):
@@ -113,12 +102,12 @@ class _TorchSDPAAttentionBackendResolver(_DirectCudaAttentionBackendResolver):
 
 class _SparseLinearAttentionBackendResolver(_DirectCudaAttentionBackendResolver):
     backend = AttentionBackendEnum.SLA_ATTN
-    backend_cls_str = _SLA_BACKEND_CLS_STR
+    backend_cls_str = "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SparseLinearAttentionBackend"
 
 
 class _SageSparseLinearAttentionBackendResolver(_DirectCudaAttentionBackendResolver):
     backend = AttentionBackendEnum.SAGE_SLA_ATTN
-    backend_cls_str = _SAGE_SLA_BACKEND_CLS_STR
+    backend_cls_str = "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SageSparseLinearAttentionBackend"
 
 
 class _SlidingTileAttentionBackendResolver(_CudaAttentionBackendResolver):
@@ -133,7 +122,7 @@ class _SlidingTileAttentionBackendResolver(_CudaAttentionBackendResolver):
                 SlidingTileAttentionBackend,
             )
 
-            return _SLIDING_TILE_BACKEND_CLS_STR
+            return "sglang.multimodal_gen.runtime.layers.attention.backends.sliding_tile_attn.SlidingTileAttentionBackend"
         except ImportError as e:
             logger.error("Failed to import Sliding Tile Attention backend: %s", str(e))
             raise ImportError(
@@ -153,7 +142,7 @@ class _SageAttentionBackendResolver(_CudaAttentionBackendResolver):
                 SageAttentionBackend,
             )
 
-            return _SAGE_ATTN_BACKEND_CLS_STR
+            return "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn.SageAttentionBackend"
         except ImportError as e:
             logger.info(e)
             logger.info(
@@ -172,7 +161,7 @@ class _SageAttention3BackendResolver(_CudaAttentionBackendResolver):
                 SageAttention3Backend,
             )
 
-            return _SAGE_ATTN_3_BACKEND_CLS_STR
+            return "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3.SageAttention3Backend"
         except ImportError as e:
             logger.info(e)
             logger.info(
@@ -193,7 +182,7 @@ class _VideoSparseAttentionBackendResolver(_CudaAttentionBackendResolver):
                 VideoSparseAttentionBackend,
             )
 
-            return _VIDEO_SPARSE_BACKEND_CLS_STR
+            return "sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn.VideoSparseAttentionBackend"
         except ImportError as e:
             logger.error("Failed to import Video Sparse Attention backend: %s", str(e))
             raise ImportError("Video Sparse Attention backend is not installed.") from e
@@ -220,7 +209,7 @@ class _SparseVideoGen2AttentionBackendResolver(_CudaAttentionBackendResolver):
                 SparseVideoGen2AttentionBackend,
             )
 
-            return _SPARSE_VIDEO_GEN_2_BACKEND_CLS_STR
+            return "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_video_gen_2_attn.SparseVideoGen2AttentionBackend"
         except ImportError as e:
             logger.error(
                 "Failed to import Sparse Video Gen 2 (SAP) Attention backend: %s",
@@ -245,7 +234,7 @@ class _VMOBAAttentionBackendResolver(_CudaAttentionBackendResolver):
                 VMOBAAttentionBackend,
             )
 
-            return _VMOBA_BACKEND_CLS_STR
+            return "sglang.multimodal_gen.runtime.layers.attention.backends.vmoba.VMOBAAttentionBackend"
         except ImportError as e:
             logger.error("Failed to import Video MoBA Attention backend: %s", str(e))
             raise ImportError("Video MoBA Attention backend is not installed. ") from e
@@ -260,7 +249,7 @@ class _FlashAttention2BackendResolver(_CudaAttentionBackendResolver):
             FlashAttention2Backend,
         )
 
-        return _FLASH_ATTN_2_BACKEND_CLS_STR
+        return "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2.FlashAttention2Backend"
 
 
 class _FlashAttentionBackendResolver(_CudaAttentionBackendResolver):
@@ -504,7 +493,7 @@ class CudaPlatformBase(Platform):
         if target_backend == AttentionBackendEnum.TORCH_SDPA:
             return _SDPA_BACKEND_CLS_STR
 
-        return _FLASH_ATTN_BACKEND_CLS_STR
+        return "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn.FlashAttentionBackend"
 
     @classmethod
     def get_attn_backend_cls_str(

--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -44,13 +44,6 @@ _SPARSE_VIDEO_GEN_2_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.atte
 _VIDEO_SPARSE_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn.VideoSparseAttentionBackend"
 _VMOBA_BACKEND_CLS_STR = "sglang.multimodal_gen.runtime.layers.attention.backends.vmoba.VMOBAAttentionBackend"
 
-_DIRECT_ATTENTION_BACKEND_CLS_STRS = {
-    AttentionBackendEnum.AITER: _AITER_BACKEND_CLS_STR,
-    AttentionBackendEnum.TORCH_SDPA: _SDPA_BACKEND_CLS_STR,
-    AttentionBackendEnum.SLA_ATTN: _SLA_BACKEND_CLS_STR,
-    AttentionBackendEnum.SAGE_SLA_ATTN: _SAGE_SLA_BACKEND_CLS_STR,
-}
-
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
@@ -90,6 +83,216 @@ def with_nvml_context(fn: Callable[_P, _R]) -> Callable[_P, _R]:
             pynvml.nvmlShutdown()
 
     return wrapper
+
+
+class _CudaAttentionBackendResolver:
+    backend: AttentionBackendEnum
+
+    @classmethod
+    def resolve(cls, platform) -> str | AttentionBackendEnum:
+        raise NotImplementedError
+
+
+class _DirectCudaAttentionBackendResolver(_CudaAttentionBackendResolver):
+    backend_cls_str: str
+
+    @classmethod
+    def resolve(cls, platform) -> str:
+        return cls.backend_cls_str
+
+
+class _AITerAttentionBackendResolver(_DirectCudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.AITER
+    backend_cls_str = _AITER_BACKEND_CLS_STR
+
+
+class _TorchSDPAAttentionBackendResolver(_DirectCudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.TORCH_SDPA
+    backend_cls_str = _SDPA_BACKEND_CLS_STR
+
+
+class _SparseLinearAttentionBackendResolver(_DirectCudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.SLA_ATTN
+    backend_cls_str = _SLA_BACKEND_CLS_STR
+
+
+class _SageSparseLinearAttentionBackendResolver(_DirectCudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.SAGE_SLA_ATTN
+    backend_cls_str = _SAGE_SLA_BACKEND_CLS_STR
+
+
+class _SlidingTileAttentionBackendResolver(_CudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.SLIDING_TILE_ATTN
+
+    @classmethod
+    def resolve(cls, platform) -> str:
+        try:
+            from st_attn import sliding_tile_attention  # noqa: F401
+
+            from sglang.multimodal_gen.runtime.layers.attention.backends.sliding_tile_attn import (  # noqa: F401
+                SlidingTileAttentionBackend,
+            )
+
+            return _SLIDING_TILE_BACKEND_CLS_STR
+        except ImportError as e:
+            logger.error("Failed to import Sliding Tile Attention backend: %s", str(e))
+            raise ImportError(
+                "Sliding Tile Attention backend is not installed. "
+            ) from e
+
+
+class _SageAttentionBackendResolver(_CudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.SAGE_ATTN
+
+    @classmethod
+    def resolve(cls, platform) -> str | AttentionBackendEnum:
+        try:
+            from sageattention import sageattn  # noqa: F401
+
+            from sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn import (  # noqa: F401
+                SageAttentionBackend,
+            )
+
+            return _SAGE_ATTN_BACKEND_CLS_STR
+        except ImportError as e:
+            logger.info(e)
+            logger.info(
+                "Sage Attention backend is not installed (To install it, run `pip install sageattention==2.2.0 --no-build-isolation`). Falling back to Flash Attention."
+            )
+            return AttentionBackendEnum.FA
+
+
+class _SageAttention3BackendResolver(_CudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.SAGE_ATTN_3
+
+    @classmethod
+    def resolve(cls, platform) -> str | AttentionBackendEnum:
+        try:
+            from sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3 import (  # noqa: F401
+                SageAttention3Backend,
+            )
+
+            return _SAGE_ATTN_3_BACKEND_CLS_STR
+        except ImportError as e:
+            logger.info(e)
+            logger.info(
+                "Sage Attention 3 backend is not installed (To install it, see https://github.com/thu-ml/SageAttention/tree/main/sageattention3_blackwell#installation). Falling back to Torch SDPA."
+            )
+            return AttentionBackendEnum.TORCH_SDPA
+
+
+class _VideoSparseAttentionBackendResolver(_CudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.VIDEO_SPARSE_ATTN
+
+    @classmethod
+    def resolve(cls, platform) -> str:
+        try:
+            from vsa import block_sparse_attn  # noqa: F401
+
+            from sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn import (  # noqa: F401
+                VideoSparseAttentionBackend,
+            )
+
+            return _VIDEO_SPARSE_BACKEND_CLS_STR
+        except ImportError as e:
+            logger.error("Failed to import Video Sparse Attention backend: %s", str(e))
+            raise ImportError("Video Sparse Attention backend is not installed.") from e
+
+
+class _SparseVideoGen2AttentionBackendResolver(_CudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.SPARSE_VIDEO_GEN_2_ATTN
+
+    @classmethod
+    def resolve(cls, platform) -> str:
+        try:
+            from svg.kernels.triton.permute import (  # noqa: F401
+                apply_inverse_permutation_triton,
+                permute_tensor_by_labels_triton,
+            )
+            from svg.kmeans_utils import (  # noqa: F401
+                batch_kmeans_Euclid,
+                density_calculation,
+                dynamic_block_sparse_fwd_flashinfer,
+                identify_dynamic_map,
+            )
+
+            from sglang.multimodal_gen.runtime.layers.attention.backends.sparse_video_gen_2_attn import (  # noqa: F401
+                SparseVideoGen2AttentionBackend,
+            )
+
+            return _SPARSE_VIDEO_GEN_2_BACKEND_CLS_STR
+        except ImportError as e:
+            logger.error(
+                "Failed to import Sparse Video Gen 2 (SAP) Attention backend: %s",
+                str(e),
+            )
+            raise ImportError(
+                "Sparse Video Gen 2 (SAP) Attention backend is not installed. "
+                "Please install it by following the instructions at "
+                "https://github.com/svg-project/Sparse-VideoGen"
+            ) from e
+
+
+class _VMOBAAttentionBackendResolver(_CudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.VMOBA_ATTN
+
+    @classmethod
+    def resolve(cls, platform) -> str:
+        try:
+            from kernel.attn.vmoba_attn.vmoba import moba_attn_varlen  # noqa: F401
+
+            from sglang.multimodal_gen.runtime.layers.attention.backends.vmoba import (  # noqa: F401
+                VMOBAAttentionBackend,
+            )
+
+            return _VMOBA_BACKEND_CLS_STR
+        except ImportError as e:
+            logger.error("Failed to import Video MoBA Attention backend: %s", str(e))
+            raise ImportError("Video MoBA Attention backend is not installed. ") from e
+
+
+class _FlashAttention2BackendResolver(_CudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.FA2
+
+    @classmethod
+    def resolve(cls, platform) -> str:
+        from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2 import (  # noqa: F401
+            FlashAttention2Backend,
+        )
+
+        return _FLASH_ATTN_2_BACKEND_CLS_STR
+
+
+class _FlashAttentionBackendResolver(_CudaAttentionBackendResolver):
+    backend = AttentionBackendEnum.FA
+
+    @classmethod
+    def resolve(cls, platform) -> AttentionBackendEnum:
+        if platform.is_sm120():
+            logger.info(
+                "FlashAttention is not supported on SM12.x in this build; falling back to Torch SDPA."
+            )
+            return AttentionBackendEnum.TORCH_SDPA
+        return AttentionBackendEnum.FA
+
+
+_CUDA_ATTENTION_BACKEND_RESOLVERS = {
+    resolver.backend: resolver
+    for resolver in (
+        _AITerAttentionBackendResolver,
+        _TorchSDPAAttentionBackendResolver,
+        _SparseLinearAttentionBackendResolver,
+        _SageSparseLinearAttentionBackendResolver,
+        _SlidingTileAttentionBackendResolver,
+        _SageAttentionBackendResolver,
+        _SageAttention3BackendResolver,
+        _VideoSparseAttentionBackendResolver,
+        _SparseVideoGen2AttentionBackendResolver,
+        _VMOBAAttentionBackendResolver,
+        _FlashAttention2BackendResolver,
+        _FlashAttentionBackendResolver,
+    )
+}
 
 
 class CudaPlatformBase(Platform):
@@ -240,138 +443,6 @@ class CudaPlatformBase(Platform):
         return free_gpu_memory / (1 << 30)
 
     @classmethod
-    def _resolve_import_checked_attn_backend(
-        cls, selected_backend: AttentionBackendEnum | None
-    ) -> str | AttentionBackendEnum | None:
-        if selected_backend == AttentionBackendEnum.SLIDING_TILE_ATTN:
-            try:
-                from st_attn import sliding_tile_attention  # noqa: F401
-
-                from sglang.multimodal_gen.runtime.layers.attention.backends.sliding_tile_attn import (  # noqa: F401
-                    SlidingTileAttentionBackend,
-                )
-
-                return _SLIDING_TILE_BACKEND_CLS_STR
-            except ImportError as e:
-                logger.error(
-                    "Failed to import Sliding Tile Attention backend: %s", str(e)
-                )
-                raise ImportError(
-                    "Sliding Tile Attention backend is not installed. "
-                ) from e
-
-        if selected_backend == AttentionBackendEnum.SAGE_ATTN:
-            try:
-                from sageattention import sageattn  # noqa: F401
-
-                from sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn import (  # noqa: F401
-                    SageAttentionBackend,
-                )
-
-                return _SAGE_ATTN_BACKEND_CLS_STR
-            except ImportError as e:
-                logger.info(e)
-                logger.info(
-                    "Sage Attention backend is not installed (To install it, run `pip install sageattention==2.2.0 --no-build-isolation`). Falling back to Flash Attention."
-                )
-                return AttentionBackendEnum.FA
-
-        if selected_backend == AttentionBackendEnum.SAGE_ATTN_3:
-            try:
-                from sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3 import (  # noqa: F401
-                    SageAttention3Backend,
-                )
-
-                return _SAGE_ATTN_3_BACKEND_CLS_STR
-            except ImportError as e:
-                logger.info(e)
-                logger.info(
-                    "Sage Attention 3 backend is not installed (To install it, see https://github.com/thu-ml/SageAttention/tree/main/sageattention3_blackwell#installation). Falling back to Torch SDPA."
-                )
-                return AttentionBackendEnum.TORCH_SDPA
-
-        if selected_backend == AttentionBackendEnum.VIDEO_SPARSE_ATTN:
-            try:
-                from vsa import block_sparse_attn  # noqa: F401
-
-                from sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn import (  # noqa: F401
-                    VideoSparseAttentionBackend,
-                )
-
-                return _VIDEO_SPARSE_BACKEND_CLS_STR
-            except ImportError as e:
-                logger.error(
-                    "Failed to import Video Sparse Attention backend: %s", str(e)
-                )
-                raise ImportError(
-                    "Video Sparse Attention backend is not installed."
-                ) from e
-
-        if selected_backend == AttentionBackendEnum.SPARSE_VIDEO_GEN_2_ATTN:
-            try:
-                from svg.kernels.triton.permute import (  # noqa: F401
-                    apply_inverse_permutation_triton,
-                    permute_tensor_by_labels_triton,
-                )
-                from svg.kmeans_utils import (  # noqa: F401
-                    batch_kmeans_Euclid,
-                    density_calculation,
-                    dynamic_block_sparse_fwd_flashinfer,
-                    identify_dynamic_map,
-                )
-
-                from sglang.multimodal_gen.runtime.layers.attention.backends.sparse_video_gen_2_attn import (  # noqa: F401
-                    SparseVideoGen2AttentionBackend,
-                )
-
-                return _SPARSE_VIDEO_GEN_2_BACKEND_CLS_STR
-            except ImportError as e:
-                logger.error(
-                    "Failed to import Sparse Video Gen 2 (SAP) Attention backend: %s",
-                    str(e),
-                )
-                raise ImportError(
-                    "Sparse Video Gen 2 (SAP) Attention backend is not installed. "
-                    "Please install it by following the instructions at "
-                    "https://github.com/svg-project/Sparse-VideoGen"
-                ) from e
-
-        if selected_backend == AttentionBackendEnum.VMOBA_ATTN:
-            try:
-                from kernel.attn.vmoba_attn.vmoba import moba_attn_varlen  # noqa: F401
-
-                from sglang.multimodal_gen.runtime.layers.attention.backends.vmoba import (  # noqa: F401
-                    VMOBAAttentionBackend,
-                )
-
-                return _VMOBA_BACKEND_CLS_STR
-            except ImportError as e:
-                logger.error(
-                    "Failed to import Video MoBA Attention backend: %s", str(e)
-                )
-                raise ImportError(
-                    "Video MoBA Attention backend is not installed. "
-                ) from e
-
-        if selected_backend == AttentionBackendEnum.FA2:
-            from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2 import (  # noqa: F401
-                FlashAttention2Backend,
-            )
-
-            return _FLASH_ATTN_2_BACKEND_CLS_STR
-
-        return None
-
-    @classmethod
-    def _resolve_requested_flash_attention_backend(cls) -> AttentionBackendEnum:
-        if cls.is_sm120():
-            logger.info(
-                "FlashAttention is not supported on SM12.x in this build; falling back to Torch SDPA."
-            )
-            return AttentionBackendEnum.TORCH_SDPA
-        return AttentionBackendEnum.FA
-
-    @classmethod
     def _resolve_default_attn_backend(cls) -> AttentionBackendEnum:
         if cls.is_sm120():
             # On SM12.x, the sgl-kernel FlashAttention wheels may not include
@@ -442,23 +513,17 @@ class CudaPlatformBase(Platform):
         head_size: int,
         dtype: torch.dtype,
     ) -> str:
-        direct_backend_cls_str = _DIRECT_ATTENTION_BACKEND_CLS_STRS.get(
-            selected_backend
-        )
-        if direct_backend_cls_str is not None:
-            return direct_backend_cls_str
-
-        resolved_backend = cls._resolve_import_checked_attn_backend(selected_backend)
-        if isinstance(resolved_backend, str):
-            return resolved_backend
-        if isinstance(resolved_backend, AttentionBackendEnum):
-            target_backend = resolved_backend
-        elif selected_backend == AttentionBackendEnum.FA:
-            target_backend = cls._resolve_requested_flash_attention_backend()
-        elif selected_backend:
-            raise ValueError(f"Invalid attention backend for {cls.device_name}")
-        else:
+        if selected_backend is None:
             target_backend = cls._resolve_default_attn_backend()
+        else:
+            resolver = _CUDA_ATTENTION_BACKEND_RESOLVERS.get(selected_backend)
+            if resolver is None:
+                raise ValueError(f"Invalid attention backend for {cls.device_name}")
+
+            resolved_backend = resolver.resolve(cls)
+            if isinstance(resolved_backend, str):
+                return resolved_backend
+            target_backend = resolved_backend
 
         return cls._resolve_flash_attention_backend_cls_str(
             target_backend, head_size, dtype

--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -441,23 +441,30 @@ class CudaPlatformBase(Platform):
         return AttentionBackendEnum.FA
 
     @classmethod
-    def _set_flash_attention_version_for_blackwell(cls) -> None:
+    def _prepare_flash_attention_for_blackwell(cls) -> bool:
         if not cls.is_blackwell():
-            return
+            return True
 
-        from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (
-            set_fa_ver,
-        )
+        try:
+            from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (
+                set_fa_ver,
+            )
+        except ImportError:
+            logger.info(
+                "Cannot use FlashAttention backend because the "
+                "flash_attn package is not found. "
+                "Make sure that flash_attn was built and installed "
+                "(on by default)."
+            )
+            return False
 
         set_fa_ver(4)
+        return True
 
     @classmethod
     def _resolve_flash_attention_backend_cls_str(
         cls, target_backend: AttentionBackendEnum, head_size: int, dtype: torch.dtype
     ) -> str:
-        if target_backend == AttentionBackendEnum.FA:
-            cls._set_flash_attention_version_for_blackwell()
-
         if not cls.has_device_capability(80):
             logger.info("Cannot use FlashAttention backend for Volta and Turing GPUs.")
             target_backend = AttentionBackendEnum.TORCH_SDPA
@@ -466,6 +473,12 @@ class CudaPlatformBase(Platform):
                 "Cannot use FlashAttention backend for dtype other than "
                 "torch.float16 or torch.bfloat16."
             )
+            target_backend = AttentionBackendEnum.TORCH_SDPA
+
+        if (
+            target_backend == AttentionBackendEnum.FA
+            and not cls._prepare_flash_attention_for_blackwell()
+        ):
             target_backend = AttentionBackendEnum.TORCH_SDPA
 
         if target_backend == AttentionBackendEnum.FA:

--- a/python/sglang/multimodal_gen/test/unit/test_cuda_attention_backend.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cuda_attention_backend.py
@@ -5,9 +5,6 @@ import torch
 from sglang.multimodal_gen.runtime.platforms.cuda import CudaPlatformBase
 from sglang.multimodal_gen.runtime.platforms.interface import AttentionBackendEnum
 
-AITER_BACKEND_CLS_STR = (
-    "sglang.multimodal_gen.runtime.layers.attention.backends.aiter.AITerBackend"
-)
 SDPA_BACKEND_CLS_STR = (
     "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"
 )
@@ -59,7 +56,8 @@ class TestCudaAttentionBackendSelection(unittest.TestCase):
 
     def test_direct_aiter_selection(self):
         self.assertEqual(
-            self.resolve(AttentionBackendEnum.AITER), AITER_BACKEND_CLS_STR
+            self.resolve(AttentionBackendEnum.AITER),
+            "sglang.multimodal_gen.runtime.layers.attention.backends.aiter.AITerBackend",
         )
 
     def test_default_backend_uses_torch_sdpa_on_sm120(self):

--- a/python/sglang/multimodal_gen/test/unit/test_cuda_attention_backend.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cuda_attention_backend.py
@@ -1,0 +1,89 @@
+import unittest
+
+import torch
+
+from sglang.multimodal_gen.runtime.platforms.cuda import CudaPlatformBase
+from sglang.multimodal_gen.runtime.platforms.interface import AttentionBackendEnum
+
+AITER_BACKEND_CLS_STR = (
+    "sglang.multimodal_gen.runtime.layers.attention.backends.aiter.AITerBackend"
+)
+SDPA_BACKEND_CLS_STR = (
+    "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"
+)
+
+
+class FakeCudaPlatform(CudaPlatformBase):
+    is_sm120_device = False
+    is_blackwell_device = False
+    supports_flash_attention = True
+
+    @classmethod
+    def is_sm120(cls):
+        return cls.is_sm120_device
+
+    @classmethod
+    def is_blackwell(cls):
+        return cls.is_blackwell_device
+
+    @classmethod
+    def has_device_capability(
+        cls,
+        capability: tuple[int, int] | int,
+        device_id: int = 0,
+    ) -> bool:
+        return cls.supports_flash_attention
+
+
+class TestCudaAttentionBackendSelection(unittest.TestCase):
+    def setUp(self):
+        FakeCudaPlatform.is_sm120_device = False
+        FakeCudaPlatform.is_blackwell_device = False
+        FakeCudaPlatform.supports_flash_attention = True
+
+    def resolve(
+        self,
+        selected_backend: AttentionBackendEnum | None,
+        dtype: torch.dtype = torch.float16,
+    ) -> str:
+        return FakeCudaPlatform.get_attn_backend_cls_str(
+            selected_backend=selected_backend,
+            head_size=128,
+            dtype=dtype,
+        )
+
+    def test_direct_torch_sdpa_selection(self):
+        self.assertEqual(
+            self.resolve(AttentionBackendEnum.TORCH_SDPA), SDPA_BACKEND_CLS_STR
+        )
+
+    def test_direct_aiter_selection(self):
+        self.assertEqual(
+            self.resolve(AttentionBackendEnum.AITER), AITER_BACKEND_CLS_STR
+        )
+
+    def test_default_backend_uses_torch_sdpa_on_sm120(self):
+        FakeCudaPlatform.is_sm120_device = True
+
+        self.assertEqual(self.resolve(None), SDPA_BACKEND_CLS_STR)
+
+    def test_requested_flash_attention_uses_torch_sdpa_on_sm120(self):
+        FakeCudaPlatform.is_sm120_device = True
+
+        self.assertEqual(self.resolve(AttentionBackendEnum.FA), SDPA_BACKEND_CLS_STR)
+
+    def test_default_backend_falls_back_for_non_flash_attention_dtype(self):
+        self.assertEqual(self.resolve(None, torch.float32), SDPA_BACKEND_CLS_STR)
+
+    def test_default_backend_falls_back_without_flash_attention_capability(self):
+        FakeCudaPlatform.supports_flash_attention = False
+
+        self.assertEqual(self.resolve(None), SDPA_BACKEND_CLS_STR)
+
+    def test_invalid_backend_raises(self):
+        with self.assertRaisesRegex(ValueError, "Invalid attention backend"):
+            self.resolve(AttentionBackendEnum.AITER_SAGE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_cuda_attention_backend.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cuda_attention_backend.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -77,6 +78,18 @@ class TestCudaAttentionBackendSelection(unittest.TestCase):
         FakeCudaPlatform.supports_flash_attention = False
 
         self.assertEqual(self.resolve(None), SDPA_BACKEND_CLS_STR)
+
+    def test_blackwell_falls_back_when_flash_attention_prepare_fails(self):
+        FakeCudaPlatform.is_blackwell_device = True
+
+        with patch.object(
+            FakeCudaPlatform,
+            "_prepare_flash_attention_for_blackwell",
+            return_value=False,
+        ) as prepare_flash_attention:
+            self.assertEqual(self.resolve(None), SDPA_BACKEND_CLS_STR)
+
+        prepare_flash_attention.assert_called_once_with()
 
     def test_invalid_backend_raises(self):
         with self.assertRaisesRegex(ValueError, "Invalid attention backend"):


### PR DESCRIPTION
## Motivation
`CudaPlatformBase.get_attn_backend_cls_str` had accumulated backend class paths, optional import probes, requested/default backend selection, SM120 fallback, Blackwell FA4 setup, and FlashAttention validation in one long branch chain. This makes future backend changes hard to review and easy to regress.

## Changes
- Extract CUDA attention backend class path constants and direct backend mapping.
- Split resolver logic into helpers for import-checked special backends, requested/default FlashAttention selection, Blackwell FA4 setup, and FlashAttention fallback validation.
- Preserve the existing selection behavior, including SM120 -> Torch SDPA fallback and Blackwell FlashAttention v4 setup.
- Add focused unit coverage for direct backend selection, SM120 FA/default fallback, dtype/capability fallback, and invalid backend rejection.

## Validation
- `pre-commit run --files python/sglang/multimodal_gen/runtime/platforms/cuda.py python/sglang/multimodal_gen/test/unit/test_cuda_attention_backend.py`











































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28560796958](https://github.com/sgl-project/sglang/actions/runs/28560796958)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28560796853](https://github.com/sgl-project/sglang/actions/runs/28560796853)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->