### PR TITLE
Build SWA window kv buffers for the EAGLE draft-extend cuda-graph path

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -567,6 +567,25 @@ class TritonAttnBackend(AttentionBackend):
         kv_indptr = self._fill_kv_indptr_and_indices(
             bs, kv_lens, req_pool_indices, self.cuda_graph_kv_indices
         )
+        if self.sliding_window_size is not None and self.sliding_window_size > 0:
+            # Fill the swa-pool window buffers like target_verify does, so the
+            # SWA layers' draft-extend reads the smaller swa K/V buffer with
+            # window indices instead of falling back to the full-pool
+            # kv_indices (which overruns the swa buffer -> OOB read).
+            window_kv_indices = self.cuda_graph_window_kv_indices
+            window_kv_offsets = self.cuda_graph_window_kv_offsets
+            _, window_kv_indices, _, window_kv_offsets[:bs] = (
+                update_sliding_window_buffer(
+                    self.window_kv_indptr,
+                    self.req_to_token,
+                    self.sliding_window_size,
+                    kv_lens,
+                    req_pool_indices,
+                    bs,
+                    token_to_kv_pool=self.token_to_kv_pool,
+                    window_kv_indices=window_kv_indices,
+                )
+            )
         return qo_indptr, kv_indptr, num_tokens_per_req
 
     def init_forward_metadata_out_graph(
@@ -1153,10 +1172,12 @@ class TritonAttnBackend(AttentionBackend):
                 qo_indptr=self.qo_indptr[: bs + 1],
                 custom_mask=None,
                 mask_indptr=None,
-                window_kv_indptr=self.window_kv_indptr,
-                window_kv_indices=None,
-                window_num_kv_splits=None,
-                window_kv_offsets=None,
+                window_kv_indptr=self.window_kv_indptr[: bs + 1] if swa else None,
+                window_kv_indices=self.cuda_graph_window_kv_indices if swa else None,
+                window_num_kv_splits=(
+                    self.cuda_graph_window_num_kv_splits if swa else None
+                ),
+                window_kv_offsets=self.cuda_graph_window_kv_offsets if swa else None,
                 swa_out_cache_loc=swa_out_cache_loc,
                 out_cache_loc_full_physical=out_cache_loc_full_physical,
             )

--- a/test/registered/unit/spec/test_triton_draft_extend_cudagraph_swa_window.py
+++ b/test/registered/unit/spec/test_triton_draft_extend_cudagraph_swa_window.py
@@ -1,0 +1,73 @@
+"""Regression test for the EAGLE draft-extend cuda-graph SWA window buffers.
+
+White-box unit test: it builds a bare ``TritonAttnBackend`` via ``__new__`` and
+stubs only the cuda-graph buffers that ``_build_cuda_graph_forward_metadata``
+reads, so the draft-extend metadata can be exercised on CPU without a captured
+graph or a real model. It is coupled to that method's internals on purpose,
+which is the price of testing the metadata shape in isolation.
+
+The contract under test: on a hybrid sliding-window model the draft-extend
+cuda-graph metadata must expose the swa-pool window buffers (a non-None
+``window_kv_indices``) exactly like target_verify does. When it leaves them
+None the SWA layers fall back to the full-pool kv_indices and read out of
+bounds of the smaller swa K/V buffer. Non-SWA models must keep the window
+fields None.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+BS = 3
+
+
+class TestTritonDraftExtendCudaGraphSWAWindow(CustomTestCase):
+    def _build_backend(self, sliding_window_size):
+        backend = TritonAttnBackend.__new__(TritonAttnBackend)
+        backend.sliding_window_size = sliding_window_size
+        backend.num_draft_tokens = 4
+        backend.speculative_num_steps = 3
+        backend.kv_indptr = torch.zeros(BS + 1, dtype=torch.int32)
+        backend.qo_indptr = torch.zeros(BS + 1, dtype=torch.int32)
+        backend.window_kv_indptr = torch.zeros(BS + 1, dtype=torch.int32)
+        backend.cuda_graph_kv_indices = torch.zeros(16, dtype=torch.int64)
+        backend.cuda_graph_window_kv_indices = torch.zeros(16, dtype=torch.int64)
+        backend.cuda_graph_window_num_kv_splits = torch.zeros(BS, dtype=torch.int32)
+        backend.cuda_graph_window_kv_offsets = torch.zeros(BS, dtype=torch.int32)
+        return backend
+
+    def test_draft_extend_swa_exposes_window_buffers(self):
+        backend = self._build_backend(sliding_window_size=128)
+        md = backend._build_cuda_graph_forward_metadata(
+            BS, ForwardMode.DRAFT_EXTEND_V2, spec_info=None, swa_out_cache_loc=None
+        )
+        # The draft step must be handed the swa-pool window buffers instead of
+        # None, so the SWA layers stay on the swa buffer rather than indexing it
+        # with full-pool locations.
+        self.assertIsNotNone(md.window_kv_indices)
+        self.assertIs(md.window_kv_indices, backend.cuda_graph_window_kv_indices)
+        self.assertIsNotNone(md.window_kv_indptr)
+        self.assertIs(md.window_kv_offsets, backend.cuda_graph_window_kv_offsets)
+        self.assertIsNotNone(md.window_num_kv_splits)
+
+    def test_draft_extend_without_swa_keeps_window_none(self):
+        for size in (None, 0):
+            backend = self._build_backend(sliding_window_size=size)
+            md = backend._build_cuda_graph_forward_metadata(
+                BS, ForwardMode.DRAFT_EXTEND_V2, spec_info=None, swa_out_cache_loc=None
+            )
+            self.assertIsNone(md.window_kv_indices, msg=f"size={size}")
+            self.assertIsNone(md.window_kv_indptr, msg=f"size={size}")
+            self.assertIsNone(md.window_kv_offsets, msg=f"size={size}")
+            self.assertIsNone(md.window_num_kv_splits, msg=f"size={size}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Intermittent GPU memory access fault during EAGLE multi-layer speculative decode on hybrid sliding-window models (a mix of full-attention and SWA layers, e.g. MiMo-V2.5-Pro). It only shows up with cuda graph enabled and only when the SWA kv pool is smaller than the full pool. With `--disable-cuda-graph` the model runs clean, which is the tell that this is a cuda-graph-only metadata bug and not a kernel bug.

Root cause: on hybrid-SWA models the triton backend keeps the SWA layers on a smaller swa kv pool and builds a separate set of window kv buffers (`window_kv_indptr` / `window_kv_indices` and the window offsets) that index that pool. Three of the four buffer-building paths do this: decode cuda graph (`_update_decode_kv_buffers`), target_verify cuda graph (`_update_target_verify_buffers`), and every eager path (`init_forward_metadata` -> `update_sliding_window_buffer`). The EAGLE draft-extend cuda-graph path is the odd one out: `_update_draft_extend_buffers` fills only the full kv buffers, and the `is_draft_extend_v2` branch of `_build_cuda_graph_forward_metadata` hard-codes `window_kv_indices=None` (the decode/verify branches use `... if swa else None`).

So on a hybrid-SWA model the draft step runs the SWA layers with no window indices. `forward_extend` takes the sliding-window branch (the layer has a window size), reads `window_kv_indices` (None), and the captured extend kernel indexes the small swa K/V buffer with full-pool locations, an out-of-bounds read. Under rocgdb the fault lands in the extend kernel (`_fwd_kernel`) on the SWA K-buffer load, and the faulting virtual addresses are foreign to every live `kv_indices` buffer, which is the signature of an OOB read off a too-small buffer rather than a stale/freed pointer.

## Modifications

Build the swa window buffers for draft-extend the same way target_verify already does:

1. `_update_draft_extend_buffers`: after filling the full kv buffers, call `update_sliding_window_buffer` to fill the persistent swa window buffers (`cuda_graph_window_kv_indices` / offsets). The window covers the prefix portion (`kv_lens`), matching how draft-extend builds its full `kv_indices`.
2. `is_draft_extend_v2` branch of `_build_cuda_graph_forward_metadata`: point `window_kv_indptr` / `window_kv_indices` / `window_num_kv_splits` / `window_kv_offsets` at those buffers when `swa` is set, mirroring the verify branch.

Both capture and replay route through `_apply_cuda_graph_metadata` -> `_update_draft_extend_buffers`, so the persistent swa buffers are refilled on every replay and the ForwardMetadata view (built once at capture) keeps pointing at the same address-stable buffers. The new code is gated on `sliding_window_size > 0` and the metadata fields stay None otherwise, so it is a no-op for non-SWA models. Eager is already correct (its extend path calls `update_sliding_window_buffer`), so this change is intentionally cuda-graph-only.

## Accuracy Tests

MiMo-V2.5-Pro on MI300X-class hardware, TP8, default hybrid window sizing, cuda graph on. Before the fix the config faults intermittently (~1 in 3 runs, across all ranks). After the fix, full GSM8K runs clean across 6 consecutive runs, strict-match ~0.963-0.967, in line with the baseline.

## Speed Tests and Profiling

Cuda-graph throughput is preserved (~195 s/pass on the validation config), so there is no need to fall back to `--disable-cuda-graph` (~4x slower on decode) or to the `--swa-full-tokens-ratio 1.0` workaround (which costs ~17% KV headroom). The change is a metadata build on the draft-extend path with no kernel changes, so no per-kernel profiling delta is expected.

Notes for reviewers:
- The same defect exists on the `v0.5.12.post1` release tag but in the pre-refactor shape (separate `init_forward_metadata_capture/replay_cuda_graph` + `update_sliding_window_buffer_cuda_graph`), so a backport to that release needs the older-shape version of this fix, not this diff.
- Deployments hitting this have been carrying a small guard in `forward_extend` that falls back to the full kv buffers when `window_kv_indices` is None. That guard turns the NoneType failure into the OOB read described above, so it is a symptom mask, not a fix, and is intentionally not included here since this PR makes `window_kv_indices` non-None on the draft path.
- Follow-up worth doing separately: a small assertion that SWA forward modes always have a non-None `window_kv_indices` under cuda graph would catch this class of missing-window-build bug early. Also worth a confirmation run on gfx950 (validated on gfx942-class so far).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31189512886](https://github.com/sgl-project/sglang/actions/runs/31189512886)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31189511878](https://github.com/sgl-project/sglang/actions/runs/31189511878)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->