### PR TITLE
[diffusion] Fix CI GT generation import

### DIFF
--- a/python/sglang/multimodal_gen/test/scripts/gen_diffusion_ci_outputs.py
+++ b/python/sglang/multimodal_gen/test/scripts/gen_diffusion_ci_outputs.py
@@ -21,13 +21,13 @@ from sglang.multimodal_gen.test.run_suite import (
     SUITES,
     PartitionItem,
     _maybe_pin_update_weights_model_pair,
-    collect_test_items,
     get_case_est_time,
     get_suite_files_rel,
     parse_partition_plan,
     partition_items_by_lpt,
     run_pytest,
 )
+from sglang.multimodal_gen.test.runner.pytest_runner import collect_test_items
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
## Summary
- import `collect_test_items` from `test.runner.pytest_runner` in `gen_diffusion_ci_outputs.py`
- unblock `diffusion-ci-gt-gen.yml`, which currently fails before GT generation starts

## Context
The current workflow fails during `Generate outputs` with:

```
ImportError: cannot import name `collect_test_items` from `sglang.multimodal_gen.test.run_suite`
```









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28537078136](https://github.com/sgl-project/sglang/actions/runs/28537078136)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28537077963](https://github.com/sgl-project/sglang/actions/runs/28537077963)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->