### PR TITLE
[diffusion] Refresh LTX HQ consistency GT

### DIFF
--- a/python/sglang/multimodal_gen/test/scripts/gen_diffusion_ci_outputs.py
+++ b/python/sglang/multimodal_gen/test/scripts/gen_diffusion_ci_outputs.py
@@ -21,13 +21,13 @@ from sglang.multimodal_gen.test.run_suite import (
     SUITES,
     PartitionItem,
     _maybe_pin_update_weights_model_pair,
-    collect_test_items,
     get_case_est_time,
     get_suite_files_rel,
     parse_partition_plan,
     partition_items_by_lpt,
     run_pytest,
 )
+from sglang.multimodal_gen.test.runner.pytest_runner import collect_test_items
 
 logger = init_logger(__name__)
 

--- a/python/sglang/multimodal_gen/test/server/consistency_thresholds/h100.json
+++ b/python/sglang/multimodal_gen/test/server/consistency_thresholds/h100.json
@@ -278,10 +278,10 @@
             "mean_abs_diff_threshold": 5.5
         },
         "ltx_2_3_hq_pipeline": {
-            "clip_threshold": 0.97,
-            "ssim_threshold": 0.88,
-            "psnr_threshold": 26.3,
-            "mean_abs_diff_threshold": 5.8
+            "clip_threshold": 0.995,
+            "ssim_threshold": 0.995,
+            "psnr_threshold": 50.0,
+            "mean_abs_diff_threshold": 0.5
         },
         "ltx_2_3_two_stage_ti2v_2gpus": {
             "clip_threshold": 0.55,

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "8db1f7d4daddc8db468f8d3710f0fd65ba03e34a"
+SGL_TEST_FILES_CI_DATA_REVISION = "9ec165b301fda67c54b1bb41ce14fe32c099f4cd"
 
 if current_platform.is_npu():
     SGL_TEST_FILES_CI_DATA_REVISION = "670d66a8a290b62c0c3c077b3e9b0f4a4d9a44e7"

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "702d939e23f17b42183329dace60f221d2587056"
+SGL_TEST_FILES_CI_DATA_REVISION = "8db1f7d4daddc8db468f8d3710f0fd65ba03e34a"
 
 if current_platform.is_npu():
     SGL_TEST_FILES_CI_DATA_REVISION = "670d66a8a290b62c0c3c077b3e9b0f4a4d9a44e7"

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -78,6 +78,12 @@ SGL_TEST_FILES_OFFICIAL_CONSISTENCY_GT_CASES = frozenset(
         "ltx_2_3_two_stage_ti2v_2gpus",
     }
 )
+# cases listed here must compare against native SGLang-generated GT
+SGL_TEST_FILES_SGLANG_CONSISTENCY_GT_CASES = frozenset(
+    {
+        "ltx_2_3_hq_pipeline",
+    }
+)
 
 CONSISTENCY_PLATFORM_ENV = "SGLANG_DIFFUSION_CONSISTENCY_PLATFORM"
 CONSISTENCY_THRESHOLD_DIR = (
@@ -1196,6 +1202,8 @@ def _find_remote_consistency_gt_files(
             SGL_TEST_FILES_SGLANG_CONSISTENCY_GT_BASE_ASCEND,
             SGL_TEST_FILES_CONSISTENCY_GT_BASE,
         )
+    elif case_id in SGL_TEST_FILES_SGLANG_CONSISTENCY_GT_CASES:
+        bases = (SGL_TEST_FILES_SGLANG_CONSISTENCY_GT_BASE,)
     elif case_id in SGL_TEST_FILES_OFFICIAL_CONSISTENCY_GT_CASES:
         bases = SGL_TEST_FILES_CONSISTENCY_GT_BASES
     else:

--- a/python/sglang/multimodal_gen/test/unit/test_consistency_metrics.py
+++ b/python/sglang/multimodal_gen/test/unit/test_consistency_metrics.py
@@ -54,6 +54,19 @@ def test_remote_video_gt_candidates_survive_inconclusive_probe(monkeypatch):
     ]
 
 
+def test_ltx_hq_remote_gt_uses_sglang_generated(monkeypatch):
+    monkeypatch.setattr(test_utils, "_remote_file_exists", lambda url: True)
+
+    files = test_utils._find_remote_consistency_gt_files(
+        "ltx_2_3_hq_pipeline",
+        1,
+        is_video=True,
+    )
+
+    assert files
+    assert all("/sglang_generated/" in url for _, url in files)
+
+
 def test_platform_gt_candidates_prefer_platform_then_default(monkeypatch):
     monkeypatch.setenv(test_utils.CONSISTENCY_PLATFORM_ENV, "5090")
 


### PR DESCRIPTION
## Summary
- fix the diffusion GT generation script import after `collect_test_items` moved to `test.runner.pytest_runner`
- refresh `ltx_2_3_hq_pipeline` native CI GT under `sglang_generated` and pin ci-data to `9ec165b301fda67c54b1bb41ce14fe32c099f4cd`
- route `ltx_2_3_hq_pipeline` explicitly through `SGL_TEST_FILES_SGLANG_CONSISTENCY_GT_BASE` via `SGL_TEST_FILES_SGLANG_CONSISTENCY_GT_CASES`
- remove stale `official_generated/ltx_2_3_hq_pipeline_1gpu_frame_{0,mid,last}.png` files from ci-data so official-first lookup paths cannot select 1024x1024 GT
- tighten the H100 consistency threshold for `ltx_2_3_hq_pipeline` to near-exact matching
- add a unit guard that keeps LTX HQ on `sglang_generated` GT

## Validation
- GT generation: https://github.com/sgl-project/sglang/actions/runs/28537086966 (`multimodal-diffusion-gen-1gpu (2)` published ci-data commit `8db1f7d4da`)
- Consistency rerun: https://github.com/sgl-project/sglang/actions/runs/28537663480
- Metrics probe: https://github.com/sgl-project/sglang/actions/runs/28537969669 showed `sim=1.0000`, `ssim=1.0000`, `psnr=inf`, `mean_abs_diff=0.0000` against the refreshed GT
- ci-data cleanup revision `9ec165b301fda67c54b1bb41ce14fe32c099f4cd`: `official_generated` HQ frames are 404; `sglang_generated` HQ frames are 200
- H100 rerun https://github.com/sgl-project/sglang/actions/runs/28560345810 checked out `6f5a4fba28b` and passed consistency for `ltx_2_3_hq_pipeline`; the remaining failure in that run is unrelated performance baseline drift in `LTX2AVDecodingStage`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28666932448](https://github.com/sgl-project/sglang/actions/runs/28666932448)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28666932339](https://github.com/sgl-project/sglang/actions/runs/28666932339)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->