### PR TITLE
Support alternative BF16 GEMM

### DIFF
--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from enum import Enum
 from typing import TYPE_CHECKING, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,10 @@ from sglang.srt.layers.utils import MultiPlatformOp, copy_or_rebind_param
 from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
+    get_device_sm,
     is_cpu,
+    is_cuda,
+    is_flashinfer_available,
     is_hip,
     is_npu,
     set_weight_attrs,
@@ -46,11 +50,13 @@ if TYPE_CHECKING:
         DispatchOutput,
         StandardDispatchOutput,
     )
+    from sglang.srt.server_args import ServerArgs
 
 
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_hip = is_hip()
 _is_cpu = is_cpu()
+_is_cuda = is_cuda()
 _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
@@ -60,6 +66,99 @@ if _use_aiter:
 
 if _is_npu:
     from sglang.srt.hardware_backend.npu.utils import npu_format_cast
+
+
+class Bf16GemmBackend(Enum):
+    """Enum for unquantized BF16 GEMM backend selection."""
+
+    AUTO = "auto"
+    FLASHINFER = "flashinfer"
+
+    def is_auto(self) -> bool:
+        return self == Bf16GemmBackend.AUTO
+
+    def is_flashinfer(self) -> bool:
+        return self == Bf16GemmBackend.FLASHINFER
+
+
+_BF16_GEMM_BACKEND: Optional[Bf16GemmBackend] = None
+mm_bf16_tgv_or_cublaslt = None
+
+
+def initialize_bf16_gemm_config(server_args: ServerArgs) -> None:
+    """Initialize the unquantized BF16 GEMM backend configuration."""
+    global _BF16_GEMM_BACKEND, mm_bf16_tgv_or_cublaslt
+
+    backend = Bf16GemmBackend(server_args.bf16_gemm_backend)
+
+    if backend.is_flashinfer():
+        if not (_is_cuda and is_flashinfer_available()):
+            raise RuntimeError(
+                "FlashInfer BF16 GEMM requested via --bf16-gemm-backend=flashinfer, "
+                "but it's not available. This backend requires an NVIDIA GPU with "
+                "FlashInfer installed."
+            )
+
+        from flashinfer.cute_dsl.utils import is_cute_dsl_available
+        from flashinfer.gemm import mm_bf16
+
+        if not (
+            mm_bf16.is_backend_supported("tgv", get_device_sm())
+            and is_cute_dsl_available()
+        ):
+            raise RuntimeError(
+                "FlashInfer BF16 GEMM requested via --bf16-gemm-backend=flashinfer, "
+                "but it's not supported on this GPU/FlashInfer build. This backend "
+                "requires Blackwell (SM100) GPUs with FlashInfer CuTe DSL support."
+            )
+
+        from flashinfer.gemm.gemm_base import DEFAULT_WORKSPACE_SIZE, bf16_gemm_sm100
+        from flashinfer.utils import _get_cache_buf
+
+        from sglang.jit_kernel.utils import is_arch_support_pdl
+        from sglang.srt.utils.custom_op import register_custom_op_from_extern
+
+        tgv_pdl_enabled = is_arch_support_pdl()
+
+        def _mm_bf16_tgv_or_cublaslt(
+            a: torch.Tensor,
+            b: torch.Tensor,
+            bias: Optional[torch.Tensor],
+        ) -> torch.Tensor:
+            out = torch.empty(
+                (a.shape[0], b.shape[1]), dtype=torch.bfloat16, device=a.device
+            )
+            workspace = _get_cache_buf(
+                "mm_bf16_workspace", DEFAULT_WORKSPACE_SIZE, a.device
+            )
+            runner_names = ["tgv"] if bias is not None else ["tgv", "cublaslt"]
+            bf16_gemm_sm100(a, b, bias, tgv_pdl_enabled, out, workspace, runner_names)
+            return out
+
+        def _mm_bf16_tgv_or_cublaslt_fake(
+            a: torch.Tensor,
+            b: torch.Tensor,
+            bias: Optional[torch.Tensor],
+        ) -> torch.Tensor:
+            return torch.empty(
+                (a.shape[0], b.shape[1]), dtype=torch.bfloat16, device=a.device
+            )
+
+        mm_bf16_tgv_or_cublaslt = register_custom_op_from_extern(
+            _mm_bf16_tgv_or_cublaslt,
+            op_name="mm_bf16_tgv_or_cublaslt",
+            fake_impl=_mm_bf16_tgv_or_cublaslt_fake,
+        )
+
+    _BF16_GEMM_BACKEND = backend
+
+
+def get_bf16_gemm_backend() -> Bf16GemmBackend:
+    """Get the current unquantized BF16 GEMM backend."""
+    global _BF16_GEMM_BACKEND
+    if _BF16_GEMM_BACKEND is None:
+        _BF16_GEMM_BACKEND = Bf16GemmBackend.AUTO
+    return _BF16_GEMM_BACKEND
 
 
 class UnquantizedEmbeddingMethod(QuantizeMethodBase):
@@ -151,6 +250,21 @@ class UnquantizedLinearMethod(LinearMethodBase):
 
         elif _use_aiter and type(layer.weight.data) is torch.Tensor:
             return tgemm.mm(x, layer.weight, bias, otype=x.dtype)
+
+        elif (
+            get_bf16_gemm_backend().is_flashinfer()
+            and x.is_cuda
+            and x.dtype == torch.bfloat16
+            and layer.weight.dtype == torch.bfloat16
+            and (bias is None or bias.dtype == torch.bfloat16)
+        ):
+            x_shapes = x.shape
+            if len(x_shapes) != 2:
+                x = x.view(-1, x_shapes[-1])
+            output = mm_bf16_tgv_or_cublaslt(x, layer.weight.T, bias)
+            if len(x_shapes) != 2:
+                output = output.view(*x_shapes[:-1], -1)
+            return output
 
         return F.linear(x, layer.weight, bias)
 

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -33,10 +33,7 @@ from sglang.srt.layers.utils import MultiPlatformOp, copy_or_rebind_param
 from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
-    get_device_sm,
     is_cpu,
-    is_cuda,
-    is_flashinfer_available,
     is_hip,
     is_npu,
     set_weight_attrs,
@@ -56,7 +53,6 @@ if TYPE_CHECKING:
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_hip = is_hip()
 _is_cpu = is_cpu()
-_is_cuda = is_cuda()
 _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
@@ -92,26 +88,6 @@ def initialize_bf16_gemm_config(server_args: ServerArgs) -> None:
     backend = Bf16GemmBackend(server_args.bf16_gemm_backend)
 
     if backend.is_flashinfer():
-        if not (_is_cuda and is_flashinfer_available()):
-            raise RuntimeError(
-                "FlashInfer BF16 GEMM requested via --bf16-gemm-backend=flashinfer, "
-                "but it's not available. This backend requires an NVIDIA GPU with "
-                "FlashInfer installed."
-            )
-
-        from flashinfer.cute_dsl.utils import is_cute_dsl_available
-        from flashinfer.gemm import mm_bf16
-
-        if not (
-            mm_bf16.is_backend_supported("tgv", get_device_sm())
-            and is_cute_dsl_available()
-        ):
-            raise RuntimeError(
-                "FlashInfer BF16 GEMM requested via --bf16-gemm-backend=flashinfer, "
-                "but it's not supported on this GPU/FlashInfer build. This backend "
-                "requires Blackwell (SM100) GPUs with FlashInfer CuTe DSL support."
-            )
-
         from flashinfer.gemm.gemm_base import DEFAULT_WORKSPACE_SIZE, bf16_gemm_sm100
         from flashinfer.utils import _get_cache_buf
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -80,6 +80,7 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.layers.moe import initialize_moe_config
 from sglang.srt.layers.quantization.fp4_utils import initialize_fp4_gemm_config
 from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
+from sglang.srt.layers.quantization.unquant import initialize_bf16_gemm_config
 from sglang.srt.lora.lora_drainer import LoRADrainer
 from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
@@ -744,9 +745,10 @@ class Scheduler(
         if any(hasattr(config_to_check, attr) for attr in moe_topk_attrs):
             initialize_moe_config(self.server_args)
 
-        # Initialize GEMM-related configuration for FP8 and FP4 backends.
+        # Initialize GEMM-related configuration for FP8, FP4, and BF16 backends.
         initialize_fp8_gemm_config(self.server_args)
         initialize_fp4_gemm_config(self.server_args)
+        initialize_bf16_gemm_config(self.server_args)
 
         # This must be called after initialize_moe_config
         self.require_mlp_sync = require_mlp_sync(self.server_args)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -110,6 +110,7 @@ from sglang.srt.layers.quantization.fp8_kernel import (
 from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
     maybe_fuse_routed_scale_and_shared_add,
 )
+from sglang.srt.layers.quantization.unquant import get_bf16_gemm_backend
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.layers.utils import PPMissingLayer
@@ -1777,6 +1778,7 @@ class DeepseekV2AttentionMLA(
             and self.fused_qkv_a_proj_with_mqa.weight.shape[1] % 256 == 0
             and _is_cuda
             and _device_sm >= 90
+            and not get_bf16_gemm_backend().is_flashinfer()
         )
         self.fused_a_gemm_backend = "auto"
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -278,6 +278,8 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
     "marlin",
 ]
 
+BF16_GEMM_BACKEND_CHOICES = ["auto", "flashinfer"]
+
 RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
 
 RL_ON_POLICY_TARGET_CHOICES = ["fsdp"]
@@ -1456,6 +1458,14 @@ class ServerArgs:
             help="Choose the runner backend for NVFP4 GEMM operations. Options: 'auto' (default; selects flashinfer_cutedsl on SM100, marlin on SM80-SM90, flashinfer_cutlass otherwise (including SM120)), 'cutlass' (SGLang CUTLASS kernel), 'flashinfer_cutlass' (FlashInfer CUTLASS backend), 'flashinfer_cudnn' (FlashInfer cuDNN backend, optimal on CUDA 13+ with cuDNN 9.15+), 'flashinfer_cutedsl' (FlashInfer CuTe DSL backend), 'flashinfer_trtllm' (FlashInfer TensorRT-LLM backend, requires different weight preparation with shuffling), 'marlin' (weight-only W4A16 fallback for SM80+). ",
             cli_name="--fp4-gemm-backend",
             choices=FP4_GEMM_RUNNER_BACKEND_CHOICES,
+        ),
+    ] = "auto"
+    bf16_gemm_backend: A[
+        str,
+        Arg(
+            help="Choose the backend for unquantized BF16 GEMM operations. Options: 'auto' (default; uses cuBLAS via torch.nn.functional.linear), 'flashinfer' (FlashInfer's tgv/cublaslt BF16 GEMM, requires FlashInfer with CuTe DSL support on Blackwell (SM100)).",
+            cli_name="--bf16-gemm-backend",
+            choices=BF16_GEMM_BACKEND_CHOICES,
         ),
     ] = "auto"
     dsa_prefill_backend: A[


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

**Need Flashinfer 0.6.15**
It's thanks to the amazing work in 3281, which has optimized M <= 64 problem size for BF16 GEMM. Needs to merge on that side first
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

When using `--bf16-gemm-backend flashinfer`, autotune between cuBLAS (= same as Torch Linear) vs the new CuteDSL GEMM. The cuBLAS call in Flashinfer vs Torch when using looking at source code appears to be mostly the same.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
SGLANG_FLASHINFER_AUTOTUNE_CACHE=0 sglang serve \
    --trust-remote-code \
    --model-path nvidia/GLM-5.2-NVFP4 \
    --tp 4 \
    --quantization modelopt_fp4 --bf16-gemm-backend flashinfer
```

Before:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 32 --platinum
Loading GSM8K Platinum dataset from HuggingFace...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1209/1209 [01:23<00:00, 14.53it/s]
Accuracy: 0.970
Invalid: 0.000
Latency: 83.208 s
Output throughput: 1463.336 token/s
```

After:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 32 --platinum
Loading GSM8K Platinum dataset from HuggingFace...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1209/1209 [01:34<00:00, 12.75it/s]
Accuracy: 0.962
Invalid: 0.000
Latency: 94.817 s
Output throughput: 1271.971 token/s
```

New DSL kernels being called
<img width="1459" height="657" alt="Screenshot 2026-07-01 at 11 21 52 AM" src="https://github.com/user-attachments/assets/5b3bdc06-f5e7-4267-876a-947a88575267" />

AIME25 of DSL GEMM:
```
== aime25 ==
30 examples x 8 repeats  |  2002.8s  |  2327 tok/s  |  4.7M tokens

* pass@1[avg-of-8]  =  92.08% +/- 2.48% (SEM 0.88%)
  pass@8            =  100.00%
  majority@8        =  96.67%
  no_answer         =  1.67%
  stop_rate         =  97.50%
  truncated_rate    =  0.83%
```

## Speed Tests and Profiling

For example, for BS = 1 (in non-spec decode), the speed will increase from 143.95 TPS to 153.08 TPS (around 6%). We'd need some additional E2E testing for more batch sizes (like target verify num_tokens = 6)

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28539548930](https://github.com/sgl-project/sglang/actions/runs/28539548930)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28539548815](https://github.com/sgl-project/sglang/actions/runs/28539548815)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->