### PR TITLE
Fix capture-mode detection during breakable CUDA graph capture

### DIFF
--- a/python/sglang/srt/model_executor/runner_utils/capture_mode.py
+++ b/python/sglang/srt/model_executor/runner_utils/capture_mode.py
@@ -24,6 +24,10 @@ from typing import Optional
 
 import torch
 
+from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context import (
+    is_in_breakable_cuda_graph,
+)
+
 # Detect whether the current forward pass is in capture mode.
 is_capture_mode = False
 
@@ -33,7 +37,7 @@ _capture_lora_variant: Optional[str] = None
 
 
 def get_is_capture_mode() -> bool:
-    return is_capture_mode
+    return is_capture_mode or is_in_breakable_cuda_graph()
 
 
 def compile_in_capture_mode(func):


### PR DESCRIPTION
### Problem
Prefill's breakable CUDA graph (BCG) captured a `max_num_tokens` (e.g. 4096) EP all-to-all buffer (~2GB) instead of the actual `x.shape[0]` (~512).

### Cause
Prefill BCG capture doesn't enter `model_capture_mode()`, so `get_is_capture_mode()` was `False` during BCG capture. The FlashInfer a2a dispatcher's Case-2 guard (`not get_is_capture_mode()`) then treated capture as live inference and sized the buffer to the static max.

### Fix
`get_is_capture_mode()` also returns `True` when `is_in_breakable_cuda_graph()`, restoring correct capture detection at the source. Empirically validated on gb300x4 (tp4ep4, ep=4, no DP attn): prefill BCG `runtime_max_tokens_per_rank` 4096 -> 512.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28539749835](https://github.com/sgl-project/sglang/actions/runs/28539749835)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #28539748815](https://github.com/sgl-project/sglang/actions/runs/28539748815)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->