### PR TITLE
[Package] Move easydict (LGPL-3.0) to an optional remote-models extra

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
   "datasets",
   "decord2 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "distro",
-  "easydict",  # Required by remote model code (e.g. DeepSeek-OCR) loaded via trust_remote_code; validated by transformers 5.4+ check_imports
   "einops",
   "fastapi",
   "flash-attn-4==4.0.0b15",
@@ -94,6 +93,10 @@ url = "https://pypi.org/simple"
 default = true
 
 [project.optional-dependencies]
+# easydict is LGPL-3.0. It is not imported by sglang itself; it is only needed at
+# runtime by some trust_remote_code models (e.g. DeepSeek-OCR) so transformers' import
+# validation passes. Kept as an opt-in extra so the default install stays Apache-2.0 clean.
+remote-models = ["easydict"]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
 diffusion = [

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -23,7 +23,6 @@ dependencies = [
   "build",
   "compressed-tensors",
   "datasets",
-  "easydict",
   "einops",
   "fastapi",
   "gguf",
@@ -72,6 +71,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# easydict is LGPL-3.0. It is not imported by sglang itself; it is only needed at
+# runtime by some trust_remote_code models (e.g. DeepSeek-OCR) so transformers' import
+# validation passes. Kept as an opt-in extra so the default install stays Apache-2.0 clean.
+remote-models = ["easydict"]
 diffusion = [
   "addict==2.4.0",
   "av==16.1.0",

--- a/python/pyproject_npu.toml
+++ b/python/pyproject_npu.toml
@@ -24,7 +24,6 @@ dependencies = [
   "compressed-tensors",
   "datasets",
   "decord2 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
-  "easydict",
   "einops",
   "fastapi",
   "gguf",
@@ -69,6 +68,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# easydict is LGPL-3.0. It is not imported by sglang itself; it is only needed at
+# runtime by some trust_remote_code models (e.g. DeepSeek-OCR) so transformers' import
+# validation passes. Kept as an opt-in extra so the default install stays Apache-2.0 clean.
+remote-models = ["easydict"]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 diffusion = [
   "addict",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -24,7 +24,6 @@ dependencies = [
   "build",
   "compressed-tensors",
   "datasets",
-  "easydict",
   "einops",
   "fastapi",
   "gguf",
@@ -72,6 +71,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# easydict is LGPL-3.0. It is not imported by sglang itself; it is only needed at
+# runtime by some trust_remote_code models (e.g. DeepSeek-OCR) so transformers' import
+# validation passes. Kept as an opt-in extra so the default install stays Apache-2.0 clean.
+remote-models = ["easydict"]
 diffusion = [
   "addict==2.4.0",
   "av==16.1.0",

--- a/test/registered/unit/tools/test_pyproject_license_extras.py
+++ b/test/registered/unit/tools/test_pyproject_license_extras.py
@@ -92,9 +92,7 @@ class TestPyprojectLicenseExtras(unittest.TestCase):
                 )
 
     def test_other_pyproject_keeps_easydict_in_runtime_common(self):
-        runtime_common = _extract_array(
-            OTHER_PYPROJECT.read_text(), "runtime_common"
-        )
+        runtime_common = _extract_array(OTHER_PYPROJECT.read_text(), "runtime_common")
         self.assertIsNotNone(
             runtime_common, "`runtime_common` extra missing in pyproject_other.toml"
         )

--- a/test/registered/unit/tools/test_pyproject_license_extras.py
+++ b/test/registered/unit/tools/test_pyproject_license_extras.py
@@ -1,0 +1,110 @@
+import importlib.util
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CI_REGISTER_PATH = REPO_ROOT / "python" / "sglang" / "test" / "ci" / "ci_register.py"
+
+# pyproject variants where easydict used to be a non-optional core dependency and
+# has been moved to the opt-in `remote-models` extra. easydict is LGPL-3.0 and is
+# not imported by sglang itself; keeping it out of the default install keeps a
+# plain `pip install sglang` Apache-2.0 clean (issue #29177).
+CORE_DEP_PYPROJECTS = [
+    REPO_ROOT / "python" / "pyproject.toml",
+    REPO_ROOT / "python" / "pyproject_cpu.toml",
+    REPO_ROOT / "python" / "pyproject_npu.toml",
+    REPO_ROOT / "python" / "pyproject_xpu.toml",
+]
+# pyproject_other.toml keeps easydict inside its optional `runtime_common` extra
+# (its core `dependencies` list is already minimal), so it is intentionally exempt.
+OTHER_PYPROJECT = REPO_ROOT / "python" / "pyproject_other.toml"
+
+
+def _load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+register_cpu_ci = _load_module("ci_register", CI_REGISTER_PATH).register_cpu_ci
+register_cpu_ci(est_time=0, suite="base-a-test-cpu")
+
+
+def _extract_array(text, key):
+    """Return the raw text between a top-level ``key = [`` and its matching ``]``.
+
+    Uses a bracket-depth counter so both single-line (``x = ["a"]``) and
+    multi-line arrays are captured. The assignment must start at the beginning
+    of a line so a key nested inside another table is not matched. Parsed as
+    text (no tomllib) to stay compatible with the ``requires-python >= 3.10``
+    floor, matching the other pyproject tests in this directory.
+    """
+    m = re.search(r"(?m)^" + re.escape(key) + r"\s*=\s*\[", text)
+    if not m:
+        return None
+    depth = 1
+    i = m.end()
+    while i < len(text) and depth > 0:
+        c = text[i]
+        if c == "[":
+            depth += 1
+        elif c == "]":
+            depth -= 1
+        i += 1
+    return text[m.end() : i - 1]
+
+
+class TestPyprojectLicenseExtras(unittest.TestCase):
+    """Regression guard for issue #29177 (easydict LGPL-3.0 compliance).
+
+    easydict must never be pulled into a default install; it lives only behind
+    an opt-in extra. These tests fail if a future edit re-adds it as a core
+    dependency.
+    """
+
+    def test_easydict_not_in_core_dependencies(self):
+        for path in CORE_DEP_PYPROJECTS:
+            with self.subTest(pyproject=path.name):
+                core = _extract_array(path.read_text(), "dependencies")
+                self.assertIsNotNone(
+                    core, f"no core `dependencies` array found in {path.name}"
+                )
+                self.assertNotIn(
+                    "easydict",
+                    core,
+                    f"easydict (LGPL-3.0) must not be a core dependency in "
+                    f"{path.name}; use the opt-in `remote-models` extra (issue #29177)",
+                )
+
+    def test_remote_models_extra_provides_easydict(self):
+        for path in CORE_DEP_PYPROJECTS:
+            with self.subTest(pyproject=path.name):
+                extra = _extract_array(path.read_text(), "remote-models")
+                self.assertIsNotNone(
+                    extra, f"`remote-models` extra missing in {path.name}"
+                )
+                self.assertIn(
+                    "easydict",
+                    extra,
+                    f"`remote-models` extra must provide easydict in {path.name}",
+                )
+
+    def test_other_pyproject_keeps_easydict_in_runtime_common(self):
+        runtime_common = _extract_array(
+            OTHER_PYPROJECT.read_text(), "runtime_common"
+        )
+        self.assertIsNotNone(
+            runtime_common, "`runtime_common` extra missing in pyproject_other.toml"
+        )
+        self.assertIn(
+            "easydict",
+            runtime_common,
+            "pyproject_other.toml is expected to keep easydict in its optional "
+            "`runtime_common` extra",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`easydict` is declared as a **non-optional core runtime dependency** of `sglang`, yet it is
**not imported anywhere in the sglang source**. It is only pulled in so that certain
`trust_remote_code` models (e.g. DeepSeek-OCR) pass `transformers`' import validation at
runtime. `easydict` is licensed **LGPL-3.0**, which is more restrictive than sglang's
**Apache-2.0**. Because it is non-optional, every `pip install sglang` inherits LGPL
obligations (including source-disclosure requirements) even when the deployment never touches
a model that needs it. This blocks license clearance for downstream users.

Closes #29177

## Modifications

- Remove `easydict` from the core `[project.dependencies]` list and add a new opt-in
  `remote-models` optional-dependency extra (`remote-models = ["easydict"]`) in:
  - `python/pyproject.toml` — the standard PyPI wheel (the `requires_dist` referenced in the issue)
  - `python/pyproject_cpu.toml`, `python/pyproject_xpu.toml`, `python/pyproject_npu.toml` —
    the platform-variant wheels (swapped in for CPU / Intel XPU / Ascend NPU builds), where
    `easydict` was also a core dependency.
- Users who run remote-code models that require `easydict` install it explicitly:
  `pip install sglang[remote-models]`.
- `python/pyproject_other.toml` is intentionally left unchanged: `easydict` there already
  lives inside the optional `runtime_common` extra, so it is not a non-optional dependency in
  that packaging layout.

Verified that `easydict`/`EasyDict` is imported nowhere under `python/sglang/`, so this is a
packaging-metadata change with **zero runtime-code impact**. All four edited files parse as
valid TOML and expose `optional-dependencies.remote-models == ["easydict"]` with `easydict`
absent from core dependencies.

Note for reviewers: I deliberately did **not** add `remote-models` to the `all` extra, to keep
even `sglang[all]` free of the LGPL dependency by default. Happy to fold it into `all` (or
rename the extra, e.g. `remote-code`) if you prefer.

## Accuracy Tests

N/A — packaging-metadata-only change; no kernel or model forward code is touched, so model
outputs are unaffected.

## Speed Tests and Profiling

N/A — no runtime code path changes; inference speed is unaffected.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: no importable code changed; verified via TOML parsing that `easydict` moved from core deps to the `remote-models` extra in all four files.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — no docs changes required.
- [x] Provide accuracy and speed benchmark results — N/A (see above).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28595652534](https://github.com/sgl-project/sglang/actions/runs/28595652534)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28595650181](https://github.com/sgl-project/sglang/actions/runs/28595650181)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->