### PR TITLE
Add pranjalssh to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1021,6 +1021,13 @@
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
+    "pranjalssh": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "pyc96": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,

--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1025,7 +1025,7 @@
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
         "can_rerun_stage": true,
-        "cooldown_interval_minutes": 0,
+        "cooldown_interval_minutes": 30,
         "reason": "custom override"
     },
     "pyc96": {


### PR DESCRIPTION
Adds `pranjalssh` to `.github/CI_PERMISSIONS.json`, inserted in the correct case-sensitive alphabetical position (between `pranavm-nvidia` and `pyc96`).

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28550138989](https://github.com/sgl-project/sglang/actions/runs/28550138989)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28550138898](https://github.com/sgl-project/sglang/actions/runs/28550138898)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->