### PR TITLE
docs(GLM-5.1): add --enable-aiter-allreduce-fusion to MXFP4 MI355X command

### DIFF
--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.1.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.1.mdx
@@ -184,6 +184,7 @@ SGLANG_DSA_TRITON_PREFILL=1 sglang serve \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
   --disable-custom-all-reduce \
+  --enable-aiter-allreduce-fusion \
   --host 0.0.0.0 \
   --port 30000
 ```


### PR DESCRIPTION
## What
Add `--enable-aiter-allreduce-fusion` to the GLM-5.1 MXFP4 (MI355X / gfx950) `sglang serve` command in the cookbook.

## Why
The aiter allreduce fusion path fuses the TP all-reduce with RMSNorm and improves decode throughput on MI355X. This mirrors the validated benchmark recipe for `amd/GLM-5.1-MXFP4` on MI355X.

## Note
The existing command already passes `--disable-custom-all-reduce` (required because the aiter custom all-reduce kernel deadlocks during EAGLE verify at high concurrency). `--enable-aiter-allreduce-fusion` is the separate fused all-reduce + RMSNorm path and is compatible with that setting. Docs-only change.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28550977398](https://github.com/sgl-project/sglang/actions/runs/28550977398)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28550977335](https://github.com/sgl-project/sglang/actions/runs/28550977335)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->