### PR TITLE
[AMD] Fix EAGLE speculative decoding with DSA backend on gfx950 (MI355X)

### DIFF
--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -153,9 +153,19 @@ class EagleDraftWorkerBase(ABC):
             forward_batch.seq_lens_cpu = forward_batch.seq_lens_cpu + num_draft_tokens
             forward_batch.seq_lens_sum = int(forward_batch.seq_lens_cpu.sum())
         else:
-            # Supply CPU mirror (extend_seq_lens are all num_draft_tokens) so
-            # backend max() reads from list without a per-iter D2H sync.
+            # Supply CPU mirrors so backends that read them (e.g. DSA) can
+            # function without a per-iter D2H sync on the common fields.
             forward_batch.extend_seq_lens_cpu = [num_draft_tokens] * bs
+            # DSA backend asserts extend_prefix_lens_cpu and seq_lens_cpu are
+            # non-None during the eager DRAFT_EXTEND_V2 path even when the
+            # scheduler omits them (needs_cpu_seq_lens=False). ForwardBatch.init_new
+            # intentionally leaves them unset in gpu_only mode; populate here.
+            if forward_batch.extend_prefix_lens_cpu is None:
+                forward_batch.extend_prefix_lens_cpu = (
+                    forward_batch.extend_prefix_lens.tolist()
+                )
+            if forward_batch.seq_lens_cpu is None:
+                forward_batch.seq_lens_cpu = forward_batch.seq_lens.cpu()
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run_graph(
             forward_batch
         )


### PR DESCRIPTION
## Motivation

EAGLE speculative decoding crashes on AMD MI355X (gfx950) when using `--dsa-prefill-backend tilelang --dsa-decode-backend tilelang`. The server starts fine but crashes on the first inference request with:

    AssertionError: All of them must not be None
      dsa_backend.py, in init_forward_metadata (DRAFT_EXTEND_V2 path)

**Root cause:** `DeepseekSparseAttnBackend` correctly sets `needs_cpu_seq_lens=False` to avoid D2H syncs on decode/verify cuda-graph paths. The EAGLE `DRAFT_EXTEND_V2` path runs eagerly (outside a cuda graph) and the DSA backend asserts that `extend_prefix_lens_cpu` and `seq_lens_cpu` are non-None. `ForwardBatch.init_new()` intentionally leaves them unset in `gpu_only` mode; `prepare_for_draft_extend()` already backfills `extend_seq_lens_cpu` in this branch but omits the other two.

## Modifications

In the `gpu_only` branch of `EagleDraftWorkerBase.prepare_for_draft_extend()` (`base_spec_worker.py`), populate the two missing CPU mirrors alongside the existing `extend_seq_lens_cpu` backfill:

- `extend_prefix_lens_cpu = extend_prefix_lens.tolist()` — typed `List[int]`
- `seq_lens_cpu = seq_lens.cpu()` — typed `Optional[torch.Tensor]`

One file changed, 12 lines added.

## Accuracy Tests

GSM8K 8-shot on GLM-5.2-FP8, MI355X TP8, image `rocm/sgl-dev:sglang-0.5.14-rocm720-mi35x-mori-0701`: **~95%** (consistent with non-speculative baseline — EAGLE does not affect output distribution with `accept_threshold=1.0`).

## Speed Tests and Profiling

Hardware: AMD MI355X (gfx950), TP8, GLM-5.2-FP8, ISL~1024, OSL=1024, concurrency=32

| Config | Throughput |
|---|---|
| Baseline (no speculative) | 1299 tok/s |
| EAGLE (steps=3, topk=1, draft-tokens=4) | **1885 tok/s (+45%)** |

Runtime accept stats: ~80% accept rate, ~3.2 mean accept length per step.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28556737178](https://github.com/sgl-project/sglang/actions/runs/28556737178)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28556737060](https://github.com/sgl-project/sglang/actions/runs/28556737060)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->