### PR TITLE
Add forward-pass decode interference metrics

### DIFF
--- a/docs/docs/references/production_metrics.mdx
+++ b/docs/docs/references/production_metrics.mdx
@@ -240,6 +240,176 @@ to generate some requests.
 
 Then you should be able to see the metrics in the Grafana dashboard.
 
+## Forward-Pass Decode Interference Metrics
+
+SGLang exports per-forward-pass histograms for diagnosing whether long prefill
+work co-scheduled with decode work is causing decode-step latency tail spikes.
+
+Two different quantities are exported, under names that keep them apart,
+because only one of them is forward time:
+
+- `sglang:forward_pass_duration_seconds`: Histogram of the duration of a single
+  model forward pass, as measured on the device. The `phase` label is
+  `prefill_only`, `decode_only`, `mixed`, or `other`. With `--pp-size` greater
+  than one the emitting rank is the final pipeline stage, so the value is that
+  stage's forward — a fraction of the full model's per-step device time, not
+  the end-to-end pipeline latency.
+- `sglang:decode_step_latency_seconds`: The same measurement restricted to
+  passes that include decode requests. This approximates the delay active
+  decoding requests experience before the next decode step completes.
+- `sglang:schedule_to_result_latency_seconds`: Histogram of the wall-clock
+  interval from the start of a batch's scheduling decision to the end of its
+  result processing. Under overlap this span also covers the *next* batch's
+  scheduling and launch, so it is an engine-step pipeline latency and must not
+  be read as forward-pass time. It is the right series for "how long did one
+  scheduler iteration take end to end", and it is what shows a regression in
+  scheduling or launch cost that leaves the forward itself untouched.
+
+Labels:
+
+- `phase`: Scheduling phase derived from scheduled prefill token and decode
+  request counts.
+- `prefill_tokens_bucket`: Bucketed scheduled prefill token count for
+  `sglang:forward_pass_duration_seconds` and
+  `sglang:schedule_to_result_latency_seconds`.
+- `co_scheduled_prefill_bucket`: Bucketed scheduled prefill token count for
+  `sglang:decode_step_latency_seconds`.
+- `decode_reqs_bucket`: Bucketed number of scheduled decode requests.
+
+Prefill token buckets are `0`, `1_1k`, `1k_4k`, `4k_16k`, `16k_64k`, and
+`64k_plus`. Decode request buckets are `0`, `1`, `2_4`, `5_8`, `9_16`,
+`17_32`, and `33_plus`.
+
+### Enabling
+
+`sglang:schedule_to_result_latency_seconds` needs only `--enable-metrics`.
+
+The two forward-pass series additionally need the forward device timer, which
+is what gives them a boundary that is the forward pass itself rather than a
+position in the scheduler loop. Start the server with either
+`SGLANG_ENABLE_METRICS_DEVICE_TIMER=1` in the environment or
+`--enable-forward-pass-metrics`; without one of them those two series stay
+empty rather than reporting a scheduler-loop interval under a forward-pass
+name.
+
+All three series are exported from a single canonical scheduler rank
+(attention TP rank 0 on the final pipeline stage), matching the rank the
+forward-pass metrics publisher uses, so no rank fan-out occurs and the queries
+below can aggregate over `le` without a `pp_rank` selector — with `--pp-size`
+set, stages other than the last contribute nothing rather than N samples per
+step. `sglang:schedule_to_result_latency_seconds` samples every engine step.
+The two forward-pass series inherit the publisher's device-timer drain
+semantics: a step whose forward produced no completed device interval is
+skipped, and if the next batch's forward completes before the drain point its
+time is folded into the current sample. Rates stay meaningful; an exact
+one-sample-per-step count does not. This holds
+under `--enable-metrics-for-all-schedulers` too: that flag widens the other
+scheduler metrics to every rank, but these three stay on the canonical rank so
+that one sample still means one engine step. Deployments without pipeline
+parallelism are unaffected.
+
+To check that the metrics are exposed:
+
+```bash
+curl http://localhost:<metrics_port>/metrics | grep -E "decode_step_latency|forward_pass_duration|schedule_to_result_latency"
+```
+
+### Interpretation
+
+These metrics are intentionally not completed-request TPOT. Speculative
+decoding, stream interval, and two-batch-overlap can make "one forward pass
+equals one visible token interval" only approximate.
+
+`sglang:schedule_to_result_latency_seconds` minus
+`sglang:forward_pass_duration_seconds` is the scheduler-side share of an engine
+step. A gap that widens while forward duration stays flat points at scheduling
+or launch cost, not at the model.
+
+### PromQL examples
+
+Decode-only p99:
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (le) (
+    rate(sglang:decode_step_latency_seconds_bucket{
+      phase="decode_only",
+      co_scheduled_prefill_bucket="0"
+    }[1m])
+  )
+)
+```
+
+Mixed long-prefill p99:
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (le, co_scheduled_prefill_bucket) (
+    rate(sglang:decode_step_latency_seconds_bucket{
+      phase="mixed",
+      co_scheduled_prefill_bucket=~"16k_64k|64k_plus"
+    }[1m])
+  )
+)
+```
+
+Compare p99 by prefill bucket:
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (le, co_scheduled_prefill_bucket) (
+    rate(sglang:decode_step_latency_seconds_bucket{
+      phase=~"decode_only|mixed"
+    }[5m])
+  )
+)
+```
+
+Decode steps per second. Note this counts only passes that carried decode
+requests — `decode_step_latency_seconds` skips prefill-only and idle steps — so
+it is decode-step throughput, not engine-step throughput:
+
+```promql
+sum by (co_scheduled_prefill_bucket) (
+  rate(sglang:decode_step_latency_seconds_count[5m])
+)
+```
+
+For engine-step throughput, count the series that samples every step:
+
+```promql
+sum(rate(sglang:schedule_to_result_latency_seconds_count[5m]))
+```
+
+Engine-step p99 including scheduling and launch, to compare against the
+forward-pass p99 above:
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (le) (
+    rate(sglang:schedule_to_result_latency_seconds_bucket{
+      phase=~"decode_only|mixed"
+    }[5m])
+  )
+)
+```
+
+If `sglang:decode_step_latency_seconds` p99 for `phase="mixed"` and
+`co_scheduled_prefill_bucket="16k_64k"` or `"64k_plus"` is repeatedly much
+higher than `phase="decode_only"`, long prefill co-scheduling is likely causing
+decode ITL/TPOT tail spikes. As a practical guide, mixed p99 within 1.2x of
+decode-only p99 is weak interference, repeated 1.5x or higher suggests tuning
+chunked prefill or mixed batching, and repeated 2x or higher suggests prefill
+throttling or prefill/decode disaggregation.
+
+If instead `sglang:schedule_to_result_latency_seconds` p99 rises while
+`sglang:decode_step_latency_seconds` p99 stays flat, the model step is fine and
+the cost is in the scheduler iteration around it.
+
 ## Estimated Performance Metrics (MFU-related)
 
 SGLang exports the following estimated per-GPU counters that can be used to derive

--- a/docs_new/docs/references/production_metrics.mdx
+++ b/docs_new/docs/references/production_metrics.mdx
@@ -240,6 +240,103 @@ to generate some requests.
 
 Then you should be able to see the metrics in the Grafana dashboard.
 
+## Forward-Pass Decode Interference Metrics
+
+SGLang also exports per-forward-pass histograms for diagnosing whether long
+prefill work co-scheduled with decode work is causing decode-step latency tail
+spikes. These metrics are available with `--enable-metrics`.
+
+- `sglang:forward_pass_duration_seconds`: Histogram of every scheduler/model
+  forward pass duration. The `phase` label is `prefill_only`, `decode_only`,
+  `mixed`, or `other`.
+- `sglang:decode_step_latency_seconds`: Histogram of forward pass duration only
+  for passes that include decode requests. This approximates the delay active
+  decoding requests experience before the next decode step completes.
+
+Labels:
+
+- `phase`: Scheduling phase derived from scheduled prefill token and decode
+  request counts.
+- `prefill_tokens_bucket`: Bucketed scheduled prefill token count for
+  `sglang:forward_pass_duration_seconds`.
+- `co_scheduled_prefill_bucket`: Bucketed scheduled prefill token count for
+  `sglang:decode_step_latency_seconds`.
+- `decode_reqs_bucket`: Bucketed number of scheduled decode requests.
+
+Prefill token buckets are `0`, `1_1k`, `1k_4k`, `4k_16k`, `16k_64k`, and
+`64k_plus`. Decode request buckets are `0`, `1`, `2_4`, `5_8`, `9_16`,
+`17_32`, and `33_plus`.
+
+These metrics are intentionally not completed-request TPOT. They measure
+scheduler/model forward pass duration. Speculative decoding, stream interval,
+and two-batch-overlap can make "one forward pass equals one visible token
+interval" only approximate.
+
+To check that the metrics are exposed:
+
+```bash
+curl http://localhost:<metrics_port>/metrics | grep -E "decode_step_latency|forward_pass_duration"
+```
+
+### PromQL examples
+
+Decode-only p99:
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (le) (
+    rate(sglang:decode_step_latency_seconds_bucket{
+      phase="decode_only",
+      co_scheduled_prefill_bucket="0"
+    }[1m])
+  )
+)
+```
+
+Mixed long-prefill p99:
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (le, co_scheduled_prefill_bucket) (
+    rate(sglang:decode_step_latency_seconds_bucket{
+      phase="mixed",
+      co_scheduled_prefill_bucket=~"16k_64k|64k_plus"
+    }[1m])
+  )
+)
+```
+
+Compare p99 by prefill bucket:
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (le, co_scheduled_prefill_bucket) (
+    rate(sglang:decode_step_latency_seconds_bucket{
+      phase=~"decode_only|mixed"
+    }[5m])
+  )
+)
+```
+
+Sample count sanity check:
+
+```promql
+sum by (co_scheduled_prefill_bucket) (
+  rate(sglang:decode_step_latency_seconds_count[5m])
+)
+```
+
+If `sglang:decode_step_latency_seconds` p99 for `phase="mixed"` and
+`co_scheduled_prefill_bucket="16k_64k"` or `"64k_plus"` is repeatedly much
+higher than `phase="decode_only"`, long prefill co-scheduling is likely causing
+decode ITL/TPOT tail spikes. As a practical guide, mixed p99 within 1.2x of
+decode-only p99 is weak interference, repeated 1.5x or higher suggests tuning
+chunked prefill or mixed batching, and repeated 2x or higher suggests prefill
+throttling or prefill/decode disaggregation.
+
 ## Estimated Performance Metrics (MFU-related)
 
 SGLang exports the following estimated per-GPU counters that can be used to derive

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2229,7 +2229,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # not read by ForwardBatch), stale in spec draft window
     req_pool_indices_cpu: torch.Tensor = None  # shape: [b], int64
 
-    # Forward-pass metrics
+    # Forward-pass metrics. Stamped when this batch's scheduling decision
+    # starts, so it bounds the schedule-to-result interval, not the forward
+    # pass itself (the device timer measures that).
     fpm_start_time: float = 0.0
 
     # hicache pointer for synchronizing data loading from CPU to GPU

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2586,7 +2586,10 @@ class Scheduler(
     def get_next_batch_to_run(self) -> Optional[ScheduleBatch]:
         self.process_pending_chunked_abort()
 
-        if self.enable_fpm:
+        collect_forward_pass_timing = (
+            self.enable_fpm or self.metrics_reporter.current_scheduler_metrics_enabled
+        )
+        if collect_forward_pass_timing:
             self._fpm_batch_t0 = time.monotonic()
         self._abort_on_waiting_timeout()
         self._abort_on_running_timeout()
@@ -2708,7 +2711,7 @@ class Scheduler(
 
         if ret:
             set_schedule_time_batch(ret)
-            if self.enable_fpm:
+            if collect_forward_pass_timing:
                 ret.fpm_start_time = self._fpm_batch_t0
 
         return ret
@@ -3453,6 +3456,7 @@ class Scheduler(
             self.batch_result_processor.process_batch_result_idle(batch, result)
 
         self.metrics_reporter.log_batch_result_stats(batch, result)
+        self.metrics_reporter.observe_forward_pass_interference(batch)
 
         # Emit forward pass metrics (every iteration when enabled)
         if self.enable_fpm:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3476,7 +3476,10 @@ class Scheduler(
     ) -> NextBatchPlan:
         self.process_pending_chunked_abort()
 
-        if self.enable_fpm:
+        collect_forward_pass_timing = (
+            self.enable_fpm or self.metrics_reporter.forward_pass_metrics_enabled
+        )
+        if collect_forward_pass_timing:
             self._fpm_batch_t0 = time.monotonic()
         self._abort_on_waiting_timeout()
         self._abort_on_running_timeout(running_batch)
@@ -3615,7 +3618,7 @@ class Scheduler(
 
         if ret:
             set_schedule_time_batch(ret)
-            if self.enable_fpm:
+            if collect_forward_pass_timing:
                 ret.fpm_start_time = self._fpm_batch_t0
 
         return NextBatchPlan(batch_to_run=ret, running_batch=running_batch)
@@ -4548,6 +4551,7 @@ class Scheduler(
         self._record_step_counters(batch, result)
 
         self.metrics_reporter.log_batch_result_stats(batch, result)
+        self.metrics_reporter.observe_forward_pass_interference(batch)
 
         # Emit forward pass metrics (every iteration when enabled)
         if self.enable_fpm:

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -894,6 +894,33 @@ class SchedulerMetricsReporter:
                 balancedness=m.eplb_balancedness.item(),
             )
 
+    def observe_forward_pass_interference(self, batch: ScheduleBatch):
+        if not self.current_scheduler_metrics_enabled or self.metrics_collector is None:
+            return
+        if batch.fpm_start_time <= 0:
+            return
+
+        duration_seconds = max(0.0, time.monotonic() - batch.fpm_start_time)
+        scheduled_requests = self._build_scheduled_request_metrics(batch)
+        prefill_tokens = scheduled_requests.sum_prefill_tokens
+        decode_reqs = scheduled_requests.num_decode_requests
+
+        if prefill_tokens > 0 and decode_reqs > 0:
+            phase = "mixed"
+        elif prefill_tokens > 0:
+            phase = "prefill_only"
+        elif decode_reqs > 0:
+            phase = "decode_only"
+        else:
+            phase = "other"
+
+        self.metrics_collector.observe_forward_pass_interference(
+            duration_seconds=duration_seconds,
+            phase=phase,
+            prefill_tokens=prefill_tokens,
+            decode_reqs=decode_reqs,
+        )
+
     def _emit_forward_pass_metrics(
         self,
         batch: ScheduleBatch,

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -167,6 +167,17 @@ class _SchedulerTimeAccountingSnapshot:
         self.is_idle = is_idle
 
 
+def _forward_pass_phase(prefill_tokens: int, decode_reqs: int) -> str:
+    """Label the scheduling composition of one forward pass."""
+    if prefill_tokens > 0 and decode_reqs > 0:
+        return "mixed"
+    if prefill_tokens > 0:
+        return "prefill_only"
+    if decode_reqs > 0:
+        return "decode_only"
+    return "other"
+
+
 @dataclass(kw_only=True)
 class SchedulerMetricsReporter:
     scheduler: Scheduler
@@ -185,6 +196,18 @@ class SchedulerMetricsReporter:
         )
         self.current_scheduler_metrics_enabled = (
             self.metrics_collector_context.current_scheduler_metrics_enabled
+        )
+        # Per-forward-pass Prometheus series are emitted from the same single
+        # canonical rank FPM uses (attention TP rank 0 on the final PP stage),
+        # so one logical engine step contributes exactly one sample. Without the
+        # PP condition every stage of a pp_size=N deployment exports its own
+        # stage-local timing under the same series, and queries that aggregate
+        # over pp_rank silently blend partial-stage timings and inflate the
+        # sample count N-fold. pp_size == 1 is unaffected.
+        self.forward_pass_metrics_enabled = (
+            self.current_scheduler_metrics_enabled
+            and self.is_stats_logging_rank
+            and self.scheduler.ps.pp_rank == self.scheduler.ps.pp_size - 1
         )
         self.enable_kv_cache_events = (
             self.metrics_collector_context.enable_kv_cache_events
@@ -283,6 +306,7 @@ class SchedulerMetricsReporter:
             )
 
         self._init_fpm()
+        self._init_forward_pass_prometheus_timing()
 
         self.scheduler_status_logger = SchedulerStatusLogger.maybe_create(
             enable_metrics=self.enable_metrics
@@ -354,6 +378,48 @@ class SchedulerMetricsReporter:
                 self.scheduler._fpm_dp_rank,
                 self.scheduler._fpm_uses_device_timer,
             )
+
+    def _init_forward_pass_prometheus_timing(self):
+        """Subscribe the Prometheus forward-pass series to the device timer.
+
+        The device timer brackets the model forward itself, so it is the only
+        source here whose interval is bounded by the batch's own forward. A
+        monotonic clock read from the scheduler loop cannot be: on the steady
+        state overlap path the loop selects and launches batch n+1 before it
+        processes n's result, so any wall interval ending at result processing
+        carries n+1's scheduling and launch work.
+
+        Must run after `_init_fpm`, which installs the timer when FPM is on but
+        the metrics device timer env flag is not.
+        """
+        self._forward_pass_gpu_time_acc = 0.0
+        self._forward_pass_uses_device_timer = False
+        if not self.forward_pass_metrics_enabled:
+            return
+        if self.forward_pass_device_timer is None:
+            return
+
+        def _forward_pass_prometheus_reporter(t, **_kwargs):
+            self._forward_pass_gpu_time_acc += t
+
+        self.forward_pass_device_timer.add_reporter(_forward_pass_prometheus_reporter)
+        self._forward_pass_uses_device_timer = True
+
+    def _take_forward_pass_device_time(self) -> Optional[float]:
+        """Drain and return the device time this batch's forward pass took.
+
+        Returns None when no device-timed forward is available; the caller then
+        exports no forward duration at all rather than substituting a
+        scheduler-loop interval that would carry the next batch's work.
+        """
+        if not self._forward_pass_uses_device_timer:
+            return None
+        self.forward_pass_device_timer._report()
+        elapsed = self._forward_pass_gpu_time_acc
+        self._forward_pass_gpu_time_acc = 0.0
+        if elapsed <= 0.0:
+            return None
+        return elapsed
 
     def _build_scheduled_request_metrics(self, batch: ScheduleBatch):
         from sglang.srt.observability.forward_pass_metrics import (
@@ -1108,6 +1174,59 @@ class SchedulerMetricsReporter:
                     forward_mode=batch.forward_mode.name.lower(),
                     balancedness=balancedness,
                 )
+
+    def observe_forward_pass_interference(self, batch: ScheduleBatch):
+        """Export this batch's two per-step timings as separate metrics.
+
+        They are separate because they measure different things and only one of
+        them is forward time:
+
+        * forward pass duration (and its decode-side view, decode step latency)
+          is the device-timed duration of *this* batch's forward. It stays
+          bounded by that forward on both `event_loop_overlap` branches, so it
+          answers "did co-scheduled prefill stretch the model step".
+        * schedule-to-result latency runs from the start of this batch's
+          scheduling decision to the end of its result processing. Under
+          overlap that span also covers the next batch's scheduling and launch,
+          which is a real pipeline cost worth watching but must never be read
+          as forward time.
+        """
+        if not self.forward_pass_metrics_enabled:
+            return
+
+        # Drain unconditionally once the timer is subscribed: device time left
+        # in the accumulator would be charged to the next batch's sample.
+        forward_seconds = self._take_forward_pass_device_time()
+        if self.metrics_collector is None:
+            return
+
+        schedule_to_result_seconds = (
+            max(0.0, time.monotonic() - batch.fpm_start_time)
+            if batch.fpm_start_time > 0
+            else None
+        )
+        if forward_seconds is None and schedule_to_result_seconds is None:
+            return
+
+        scheduled_requests = self._build_scheduled_request_metrics(batch)
+        prefill_tokens = scheduled_requests.sum_prefill_tokens
+        decode_reqs = scheduled_requests.num_decode_requests
+        phase = _forward_pass_phase(prefill_tokens, decode_reqs)
+
+        if forward_seconds is not None:
+            self.metrics_collector.observe_forward_pass_interference(
+                duration_seconds=forward_seconds,
+                phase=phase,
+                prefill_tokens=prefill_tokens,
+                decode_reqs=decode_reqs,
+            )
+        if schedule_to_result_seconds is not None:
+            self.metrics_collector.observe_schedule_to_result_latency(
+                duration_seconds=schedule_to_result_seconds,
+                phase=phase,
+                prefill_tokens=prefill_tokens,
+                decode_reqs=decode_reqs,
+            )
 
     def _emit_forward_pass_metrics(
         self,

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -156,6 +156,50 @@ class SchedulerStats:
 
 
 ROUTING_KEY_REQ_COUNT_BUCKET_BOUNDS = [1, 2, 3, 5, 7, 10, 20, 50, 100, 200]
+FORWARD_PASS_DURATION_BUCKETS = [
+    0.001,
+    0.002,
+    0.005,
+    0.010,
+    0.020,
+    0.050,
+    0.100,
+    0.200,
+    0.500,
+    1.0,
+    2.0,
+    5.0,
+]
+
+
+def bucket_prefill_tokens(n: int) -> str:
+    if n <= 0:
+        return "0"
+    if n < 1024:
+        return "1_1k"
+    if n < 4096:
+        return "1k_4k"
+    if n < 16384:
+        return "4k_16k"
+    if n < 65536:
+        return "16k_64k"
+    return "64k_plus"
+
+
+def bucket_decode_reqs(n: int) -> str:
+    if n <= 0:
+        return "0"
+    if n == 1:
+        return "1"
+    if n <= 4:
+        return "2_4"
+    if n <= 8:
+        return "5_8"
+    if n <= 16:
+        return "9_16"
+    if n <= 32:
+        return "17_32"
+    return "33_plus"
 
 
 def compute_routing_key_stats(routing_keys: List[Optional[str]]) -> tuple:
@@ -724,6 +768,25 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             buckets=exponential_buckets(start=0.001, width=1.62, length=30),
             labelnames=list(labels.keys()) + ["stage"],
         )
+        self.forward_pass_duration_seconds = Histogram(
+            name="sglang:forward_pass_duration_seconds",
+            documentation=(
+                "Histogram of scheduler/model forward pass duration in seconds."
+            ),
+            labelnames=list(labels.keys())
+            + ["phase", "prefill_tokens_bucket", "decode_reqs_bucket"],
+            buckets=FORWARD_PASS_DURATION_BUCKETS,
+        )
+        self.decode_step_latency_seconds = Histogram(
+            name="sglang:decode_step_latency_seconds",
+            documentation=(
+                "Histogram of scheduler/model forward pass duration in seconds "
+                "for passes that include decode requests."
+            ),
+            labelnames=list(labels.keys())
+            + ["phase", "co_scheduled_prefill_bucket", "decode_reqs_bucket"],
+            buckets=FORWARD_PASS_DURATION_BUCKETS,
+        )
 
         # =================================================================
         # Grammar
@@ -1139,6 +1202,34 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
 
     def observe_queue_time(self, latency: float) -> None:
         self._log_histogram(self.queue_time, latency)
+
+    def observe_forward_pass_interference(
+        self,
+        duration_seconds: float,
+        phase: str,
+        prefill_tokens: int,
+        decode_reqs: int,
+    ) -> None:
+        prefill_tokens_bucket = bucket_prefill_tokens(prefill_tokens)
+        decode_reqs_bucket = bucket_decode_reqs(decode_reqs)
+
+        self.forward_pass_duration_seconds.labels(
+            **self.labels,
+            phase=phase,
+            prefill_tokens_bucket=prefill_tokens_bucket,
+            decode_reqs_bucket=decode_reqs_bucket,
+        ).observe(duration_seconds)
+
+        if decode_reqs <= 0:
+            return
+
+        decode_phase = "mixed" if prefill_tokens > 0 else "decode_only"
+        self.decode_step_latency_seconds.labels(
+            **self.labels,
+            phase=decode_phase,
+            co_scheduled_prefill_bucket=prefill_tokens_bucket,
+            decode_reqs_bucket=decode_reqs_bucket,
+        ).observe(duration_seconds)
 
     def observe_weight_load(self, duration_seconds: float, source: str) -> None:
         # Edge-triggered: engine is paused during the update, so log_stats

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -168,6 +168,50 @@ class SchedulerStats:
 
 
 ROUTING_KEY_REQ_COUNT_BUCKET_BOUNDS = [1, 2, 3, 5, 7, 10, 20, 50, 100, 200]
+FORWARD_PASS_DURATION_BUCKETS = [
+    0.001,
+    0.002,
+    0.005,
+    0.010,
+    0.020,
+    0.050,
+    0.100,
+    0.200,
+    0.500,
+    1.0,
+    2.0,
+    5.0,
+]
+
+
+def bucket_prefill_tokens(n: int) -> str:
+    if n <= 0:
+        return "0"
+    if n < 1024:
+        return "1_1k"
+    if n < 4096:
+        return "1k_4k"
+    if n < 16384:
+        return "4k_16k"
+    if n < 65536:
+        return "16k_64k"
+    return "64k_plus"
+
+
+def bucket_decode_reqs(n: int) -> str:
+    if n <= 0:
+        return "0"
+    if n == 1:
+        return "1"
+    if n <= 4:
+        return "2_4"
+    if n <= 8:
+        return "5_8"
+    if n <= 16:
+        return "9_16"
+    if n <= 32:
+        return "17_32"
+    return "33_plus"
 
 
 def compute_routing_key_stats(routing_keys: List[Optional[str]]) -> tuple:
@@ -748,6 +792,40 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             buckets=exponential_buckets(start=0.001, width=1.62, length=30),
             labelnames=list(labels.keys()) + ["stage"],
         )
+        self.forward_pass_duration_seconds = Histogram(
+            name="sglang:forward_pass_duration_seconds",
+            documentation=(
+                "Histogram of the device-measured duration of a single model "
+                "forward pass in seconds. Bounded by the batch's own forward, "
+                "so it never includes scheduler or launch work."
+            ),
+            labelnames=list(labels.keys())
+            + ["phase", "prefill_tokens_bucket", "decode_reqs_bucket"],
+            buckets=FORWARD_PASS_DURATION_BUCKETS,
+        )
+        self.decode_step_latency_seconds = Histogram(
+            name="sglang:decode_step_latency_seconds",
+            documentation=(
+                "Histogram of the device-measured forward pass duration in "
+                "seconds, restricted to passes that include decode requests."
+            ),
+            labelnames=list(labels.keys())
+            + ["phase", "co_scheduled_prefill_bucket", "decode_reqs_bucket"],
+            buckets=FORWARD_PASS_DURATION_BUCKETS,
+        )
+        self.schedule_to_result_latency_seconds = Histogram(
+            name="sglang:schedule_to_result_latency_seconds",
+            documentation=(
+                "Histogram of the wall-clock interval in seconds from the start "
+                "of a batch's scheduling decision to the end of its result "
+                "processing. In overlap mode this deliberately spans the next "
+                "batch's scheduling and launch, so it is an engine-step "
+                "pipeline latency and not forward pass time."
+            ),
+            labelnames=list(labels.keys())
+            + ["phase", "prefill_tokens_bucket", "decode_reqs_bucket"],
+            buckets=FORWARD_PASS_DURATION_BUCKETS,
+        )
 
         # =================================================================
         # Grammar
@@ -1213,6 +1291,63 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
 
     def observe_queue_time(self, latency: float) -> None:
         self._log_histogram(self.queue_time, latency)
+
+    def observe_forward_pass_interference(
+        self,
+        duration_seconds: float,
+        phase: str,
+        prefill_tokens: int,
+        decode_reqs: int,
+    ) -> None:
+        """Record one forward pass duration and its decode-side view.
+
+        `duration_seconds` must be the duration of the batch's own forward pass
+        (the device timer's interval), not a scheduler-loop interval: these two
+        series are read as "how long did the model take on this pass", so
+        folding scheduling or launch work into them would misattribute engine
+        time to the forward.
+        """
+        prefill_tokens_bucket = bucket_prefill_tokens(prefill_tokens)
+        decode_reqs_bucket = bucket_decode_reqs(decode_reqs)
+
+        self.forward_pass_duration_seconds.labels(
+            **self.labels,
+            phase=phase,
+            prefill_tokens_bucket=prefill_tokens_bucket,
+            decode_reqs_bucket=decode_reqs_bucket,
+        ).observe(duration_seconds)
+
+        if decode_reqs <= 0:
+            return
+
+        decode_phase = "mixed" if prefill_tokens > 0 else "decode_only"
+        self.decode_step_latency_seconds.labels(
+            **self.labels,
+            phase=decode_phase,
+            co_scheduled_prefill_bucket=prefill_tokens_bucket,
+            decode_reqs_bucket=decode_reqs_bucket,
+        ).observe(duration_seconds)
+
+    def observe_schedule_to_result_latency(
+        self,
+        duration_seconds: float,
+        phase: str,
+        prefill_tokens: int,
+        decode_reqs: int,
+    ) -> None:
+        """Record the schedule-to-result interval of one engine step.
+
+        This is the pipeline-level companion of
+        `observe_forward_pass_interference`: it spans from the start of the
+        batch's scheduling decision to the end of its result processing, which
+        under overlap also covers the next batch's scheduling and launch.
+        """
+        self.schedule_to_result_latency_seconds.labels(
+            **self.labels,
+            phase=phase,
+            prefill_tokens_bucket=bucket_prefill_tokens(prefill_tokens),
+            decode_reqs_bucket=bucket_decode_reqs(decode_reqs),
+        ).observe(duration_seconds)
 
     def observe_weight_load(self, duration_seconds: float, source: str) -> None:
         # Edge-triggered: engine is paused during the update, so log_stats

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -85,7 +85,20 @@ class _DummyPublisherThread:
         pass
 
 
-def _make_reporter(scheduler) -> SchedulerMetricsReporter:
+class _CollectingMetricsCollector:
+    def __init__(self):
+        self.forward_pass_interference = []
+
+    def observe_forward_pass_interference(self, **kwargs):
+        self.forward_pass_interference.append(kwargs)
+
+
+def _make_reporter(
+    scheduler,
+    *,
+    metrics_collector=None,
+    current_scheduler_metrics_enabled=False,
+) -> SchedulerMetricsReporter:
     if not hasattr(scheduler, "server_args"):
         scheduler.server_args = types.SimpleNamespace(
             enable_metrics=False,
@@ -109,11 +122,11 @@ def _make_reporter(scheduler) -> SchedulerMetricsReporter:
     if not hasattr(scheduler, "draft_worker"):
         scheduler.draft_worker = None
     context = types.SimpleNamespace(
-        enable_metrics=False,
+        enable_metrics=current_scheduler_metrics_enabled,
         is_stats_logging_rank=True,
-        current_scheduler_metrics_enabled=False,
+        current_scheduler_metrics_enabled=current_scheduler_metrics_enabled,
         enable_kv_cache_events=False,
-        collector=None,
+        collector=metrics_collector,
     )
     return SchedulerMetricsReporter(
         scheduler=scheduler,
@@ -121,7 +134,7 @@ def _make_reporter(scheduler) -> SchedulerMetricsReporter:
         pp_rank=0,
         dp_rank=0,
         metrics_collector_context=context,
-        metrics_collector=None,
+        metrics_collector=metrics_collector,
     )
 
 
@@ -233,6 +246,45 @@ class TestForwardPassMetrics(unittest.TestCase):
         self.assertAlmostEqual(
             self.scheduler._fpm_publisher.metrics[0].wall_time, 0.035, places=4
         )
+
+    def test_prometheus_forward_pass_observation_does_not_require_fpm(self):
+        self.scheduler.enable_fpm = False
+        metrics_collector = _CollectingMetricsCollector()
+        self.reporter = _make_reporter(
+            self.scheduler,
+            metrics_collector=metrics_collector,
+            current_scheduler_metrics_enabled=True,
+        )
+
+        prefill_req = _FakeReq(10, prefix_len=2)
+        decode_req = _FakeReq(8, output_len=3)
+        batch = self._make_batch(
+            forward_mode=_FakeForwardMode(is_mixed=True, is_extend=True),
+            reqs=[prefill_req, decode_req],
+            decoding_reqs=[decode_req],
+            prefill_stats=PrefillStats(
+                log_input_tokens=1200,
+                log_hit_tokens=0,
+                new_token_ratio=1.0,
+                num_running_reqs=types.SimpleNamespace(),
+                num_new_seqs=1,
+            ),
+            seq_lens_cpu=[decode_req.seqlen],
+            fpm_start_time=100.0,
+        )
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic",
+            return_value=100.075,
+        ):
+            self.reporter.observe_forward_pass_interference(batch)
+
+        self.assertEqual(len(metrics_collector.forward_pass_interference), 1)
+        observation = metrics_collector.forward_pass_interference[0]
+        self.assertAlmostEqual(observation["duration_seconds"], 0.075, places=4)
+        self.assertEqual(observation["phase"], "mixed")
+        self.assertEqual(observation["prefill_tokens"], 1200)
+        self.assertEqual(observation["decode_reqs"], 1)
 
     def test_disagg_prefill_queued_metrics(self):
         self.scheduler.disaggregation_mode = DisaggregationMode.PREFILL

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -83,7 +83,54 @@ def _publish_server_args(test, **fields):
     return server_args
 
 
-def _make_reporter(test, scheduler) -> SchedulerMetricsReporter:
+class _CollectingMetricsCollector:
+    def __init__(self):
+        self.forward_pass_interference = []
+        self.schedule_to_result = []
+
+    def observe_forward_pass_interference(self, **kwargs):
+        self.forward_pass_interference.append(kwargs)
+
+    def observe_schedule_to_result_latency(self, **kwargs):
+        self.schedule_to_result.append(kwargs)
+
+    def increment_forward_execution_seconds(self, **kwargs):
+        pass
+
+
+class _FakeDeviceTimer:
+    """CPU stand-in for the CUDA-event device timer.
+
+    `record` queues the device time of one forward segment; `_report` hands the
+    queued values to every registered reporter, which is what the real timer
+    does once the segment's end event completes.
+    """
+
+    def __init__(self, reporter):
+        self._reporters = [reporter]
+        self._pending = []
+
+    def add_reporter(self, reporter):
+        self._reporters.append(reporter)
+
+    def record(self, seconds, category="decode"):
+        self._pending.append((seconds, category))
+
+    def _report(self):
+        pending, self._pending = self._pending, []
+        for seconds, category in pending:
+            for reporter in self._reporters:
+                reporter(t=seconds, category=category)
+
+
+def _make_reporter(
+    test,
+    scheduler,
+    *,
+    metrics_collector=None,
+    current_scheduler_metrics_enabled=False,
+    is_stats_logging_rank=True,
+) -> SchedulerMetricsReporter:
     if not hasattr(scheduler, "server_args"):
         scheduler.server_args = _publish_server_args(
             test,
@@ -108,11 +155,11 @@ def _make_reporter(test, scheduler) -> SchedulerMetricsReporter:
     if not hasattr(scheduler, "draft_worker"):
         scheduler.draft_worker = None
     context = types.SimpleNamespace(
-        enable_metrics=False,
-        is_stats_logging_rank=True,
-        current_scheduler_metrics_enabled=False,
+        enable_metrics=current_scheduler_metrics_enabled,
+        is_stats_logging_rank=is_stats_logging_rank,
+        current_scheduler_metrics_enabled=current_scheduler_metrics_enabled,
         enable_kv_cache_events=False,
-        collector=None,
+        collector=metrics_collector,
     )
     return SchedulerMetricsReporter(
         scheduler=scheduler,
@@ -120,7 +167,7 @@ def _make_reporter(test, scheduler) -> SchedulerMetricsReporter:
         pp_rank=0,
         dp_rank=0,
         metrics_collector_context=context,
-        metrics_collector=None,
+        metrics_collector=metrics_collector,
     )
 
 
@@ -238,6 +285,230 @@ class TestForwardPassMetrics(unittest.TestCase):
         self.assertAlmostEqual(
             self.scheduler._fpm_publisher.metrics[0].wall_time, 0.035, places=4
         )
+
+    def _make_mixed_batch(self, fpm_start_time=100.0):
+        prefill_req = _FakeReq(10, prefix_len=2)
+        decode_req = _FakeReq(8, output_len=3)
+        return self._make_batch(
+            forward_mode=_FakeForwardMode(is_mixed=True, is_extend=True),
+            reqs=[prefill_req, decode_req],
+            decoding_reqs=[decode_req],
+            prefill_stats=PrefillStats(
+                log_input_tokens=1200,
+                log_hit_tokens=0,
+                new_token_ratio=1.0,
+                num_running_reqs=types.SimpleNamespace(),
+                num_new_seqs=1,
+            ),
+            seq_lens_cpu=[decode_req.seqlen],
+            fpm_start_time=fpm_start_time,
+        )
+
+    def _make_device_timed_reporter(self, metrics_collector):
+        """Build a reporter whose forward timing comes from a fake device timer."""
+        self.scheduler.enable_fpm = False
+        with (
+            patch(
+                "sglang.srt.managers.scheduler_components.metrics_reporter.ENABLE_METRICS_DEVICE_TIMER",
+                True,
+            ),
+            patch(
+                "sglang.srt.managers.scheduler_components.metrics_reporter.DeviceTimer",
+                _FakeDeviceTimer,
+            ),
+        ):
+            return _make_reporter(
+                self,
+                self.scheduler,
+                metrics_collector=metrics_collector,
+                current_scheduler_metrics_enabled=True,
+            )
+
+    def test_schedule_to_result_observation_does_not_require_fpm(self):
+        self.scheduler.enable_fpm = False
+        metrics_collector = _CollectingMetricsCollector()
+        self.reporter = _make_reporter(
+            self,
+            self.scheduler,
+            metrics_collector=metrics_collector,
+            current_scheduler_metrics_enabled=True,
+        )
+        batch = self._make_mixed_batch()
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic",
+            return_value=100.075,
+        ):
+            self.reporter.observe_forward_pass_interference(batch)
+
+        self.assertEqual(len(metrics_collector.schedule_to_result), 1)
+        observation = metrics_collector.schedule_to_result[0]
+        self.assertAlmostEqual(observation["duration_seconds"], 0.075, places=4)
+        self.assertEqual(observation["phase"], "mixed")
+        self.assertEqual(observation["prefill_tokens"], 1200)
+        self.assertEqual(observation["decode_reqs"], 1)
+        # No device timer, so there is no interval bounded by this batch's own
+        # forward pass; nothing is exported rather than a loop-bounded stand-in.
+        self.assertEqual(metrics_collector.forward_pass_interference, [])
+
+    def test_forward_duration_excludes_next_batch_scheduling_and_launch(self):
+        """`event_loop_overlap` selects (and on the steady-state branch also
+        launches) batch n+1 before it processes n's result, so a wall interval
+        started at n's selection absorbs n+1's scheduler work. The forward-pass
+        duration must stay pinned to n's own forward; only schedule-to-result
+        latency may grow with that extra work.
+        """
+
+        def run_step(next_batch_overhead: float) -> _CollectingMetricsCollector:
+            metrics_collector = _CollectingMetricsCollector()
+            reporter = self._make_device_timed_reporter(metrics_collector)
+            batch = self._make_mixed_batch(fpm_start_time=100.0)
+            # Batch n's own forward: 10 ms on device.
+            reporter.forward_pass_device_timer.record(0.010)
+            # The loop then picks and launches batch n+1 before popping n's
+            # result off the queue, which is what the extra overhead stands for.
+            with patch(
+                "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic",
+                return_value=100.020 + next_batch_overhead,
+            ):
+                reporter.observe_forward_pass_interference(batch)
+            return metrics_collector
+
+        without_overhead = run_step(0.0)
+        with_overhead = run_step(0.050)
+
+        for metrics_collector in (without_overhead, with_overhead):
+            self.assertEqual(len(metrics_collector.forward_pass_interference), 1)
+
+        # The forward pass took 10 ms in both steps; the next batch's work must
+        # not show up here.
+        self.assertAlmostEqual(
+            without_overhead.forward_pass_interference[0]["duration_seconds"],
+            0.010,
+            places=6,
+        )
+        self.assertAlmostEqual(
+            with_overhead.forward_pass_interference[0]["duration_seconds"],
+            0.010,
+            places=6,
+        )
+
+        # It shows up here instead, under a name that says so.
+        for metrics_collector in (without_overhead, with_overhead):
+            self.assertEqual(len(metrics_collector.schedule_to_result), 1)
+        self.assertAlmostEqual(
+            without_overhead.schedule_to_result[0]["duration_seconds"],
+            0.020,
+            places=6,
+        )
+        self.assertAlmostEqual(
+            with_overhead.schedule_to_result[0]["duration_seconds"],
+            0.070,
+            places=6,
+        )
+
+    def test_prometheus_drain_still_feeds_fpm(self):
+        """Draining the device timer for Prometheus must not starve FPM.
+
+        `observe_forward_pass_interference` calls `DeviceTimer._report()` one
+        statement before `_emit_forward_pass_metrics` runs, so FPM's own
+        accumulator is fed by the same drain. `_report()` fans out to every
+        registered reporter, so both must see the interval — if the drain ever
+        became single-subscriber, FPM would silently read zero GPU time.
+        """
+        metrics_collector = _CollectingMetricsCollector()
+        self.reporter = self._make_device_timed_reporter(metrics_collector)
+
+        # Register an FPM-style accumulator on the same timer, the way
+        # `_init_fpm` does when both FPM and Prometheus metrics are enabled.
+        self.scheduler._fpm_gpu_time_acc = 0.0
+
+        def _fpm_reporter(t, **_kwargs):
+            self.scheduler._fpm_gpu_time_acc += t
+
+        self.reporter.forward_pass_device_timer.add_reporter(_fpm_reporter)
+
+        batch = self._make_mixed_batch()
+        self.reporter.forward_pass_device_timer.record(0.012)
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic",
+            return_value=100.050,
+        ):
+            self.reporter.observe_forward_pass_interference(batch)
+
+        # Prometheus got the forward duration ...
+        self.assertEqual(len(metrics_collector.forward_pass_interference), 1)
+        self.assertAlmostEqual(
+            metrics_collector.forward_pass_interference[0]["duration_seconds"],
+            0.012,
+            places=6,
+        )
+        # ... and FPM saw the same interval from the same drain.
+        self.assertAlmostEqual(self.scheduler._fpm_gpu_time_acc, 0.012, places=6)
+
+    def test_forward_pass_device_time_is_not_carried_into_the_next_batch(self):
+        metrics_collector = _CollectingMetricsCollector()
+        reporter = self._make_device_timed_reporter(metrics_collector)
+
+        reporter.forward_pass_device_timer.record(0.010)
+        with patch(
+            "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic",
+            return_value=100.020,
+        ):
+            reporter.observe_forward_pass_interference(self._make_mixed_batch())
+        # Second step: the device timer reported nothing new, so no forward
+        # duration is exported and the first step's time is not reused.
+        with patch(
+            "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic",
+            return_value=100.030,
+        ):
+            reporter.observe_forward_pass_interference(self._make_mixed_batch())
+
+        self.assertEqual(len(metrics_collector.forward_pass_interference), 1)
+        self.assertEqual(len(metrics_collector.schedule_to_result), 2)
+
+    def test_forward_pass_metrics_emit_from_one_canonical_pp_rank(self):
+        """One logical engine step must produce exactly one sample.
+
+        FPM already gates to attention TP rank 0 on the final PP stage; the
+        Prometheus series follow the same rank, otherwise every stage of a
+        pp_size=N deployment exports its own stage-local timing under the same
+        series name.
+        """
+        cases = [
+            # pp_rank, pp_size, attn_tp_rank, emits
+            (0, 1, 0, True),  # no pipeline parallelism: unchanged
+            (0, 2, 0, False),  # earlier PP stage stays silent
+            (1, 2, 0, True),  # final PP stage is the canonical rank
+            (1, 2, 1, False),  # non-zero attention TP rank stays silent
+            (2, 4, 0, False),
+            (3, 4, 0, True),
+        ]
+        for pp_rank, pp_size, attn_tp_rank, emits in cases:
+            with self.subTest(pp_rank=pp_rank, pp_size=pp_size, attn_tp=attn_tp_rank):
+                self.scheduler.ps = _make_ps(
+                    pp_rank=pp_rank, pp_size=pp_size, attn_tp_rank=attn_tp_rank
+                )
+                metrics_collector = _CollectingMetricsCollector()
+                reporter = _make_reporter(
+                    self,
+                    self.scheduler,
+                    metrics_collector=metrics_collector,
+                    current_scheduler_metrics_enabled=True,
+                    is_stats_logging_rank=attn_tp_rank == 0,
+                )
+                with patch(
+                    "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic",
+                    return_value=100.075,
+                ):
+                    reporter.observe_forward_pass_interference(self._make_mixed_batch())
+
+                observed = len(metrics_collector.forward_pass_interference) + len(
+                    metrics_collector.schedule_to_result
+                )
+                self.assertEqual(observed, 1 if emits else 0)
+                self.assertEqual(reporter.forward_pass_metrics_enabled, emits)
 
     def test_disagg_prefill_queued_metrics_include_compute_waiting_queue(self):
         self.scheduler.disaggregation_mode = DisaggregationMode.PREFILL

--- a/test/registered/unit/observability/test_scheduler_metrics_collector.py
+++ b/test/registered/unit/observability/test_scheduler_metrics_collector.py
@@ -1,0 +1,177 @@
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import types
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.observability.metrics_collector import (
+    SchedulerMetricsCollector,
+    bucket_decode_reqs,
+    bucket_prefill_tokens,
+)
+
+
+class _FakeMetricChild:
+    def __init__(self, parent, labels):
+        self._parent = parent
+        self._labels = labels
+
+    def observe(self, value):
+        self._parent.observations.append((self._labels, value))
+
+    def set(self, value):
+        self._parent.sets.append((self._labels, value))
+
+    def inc(self, value=1):
+        self._parent.incs.append((self._labels, value))
+
+
+class _FakeMetric:
+    def __init__(self, name, documentation="", labelnames=None, **kwargs):
+        self.name = name
+        self.documentation = documentation
+        self.labelnames = list(labelnames or [])
+        self.kwargs = kwargs
+        self.observations = []
+        self.sets = []
+        self.incs = []
+
+    def labels(self, **labels):
+        return _FakeMetricChild(self, labels)
+
+
+class _FakeSchedulerMetricsCollector(SchedulerMetricsCollector):
+    _counter_cls = _FakeMetric
+    _gauge_cls = _FakeMetric
+    _histogram_cls = _FakeMetric
+    _summary_cls = _FakeMetric
+
+
+class _FakeGaugeHistogram:
+    def __init__(self, name, documentation="", labelnames=None, **kwargs):
+        self.name = name
+        self.documentation = documentation
+        self.labelnames = list(labelnames or [])
+        self.kwargs = kwargs
+        self.observations = []
+
+    def set_by_current_observations(self, labels, observations):
+        self.observations.append((labels, observations))
+
+
+def _make_collector():
+    with patch(
+        "sglang.srt.observability.metrics_collector.GaugeHistogram",
+        _FakeGaugeHistogram,
+    ):
+        return _FakeSchedulerMetricsCollector(
+            labels={
+                "model_name": "test-model",
+                "engine_type": "server",
+                "tp_rank": 0,
+                "pp_rank": 0,
+                "moe_ep_rank": 0,
+            },
+            server_args=types.SimpleNamespace(
+                prefill_delayer_max_delay_passes=200,
+                prefill_delayer_forward_passes_buckets=None,
+                prefill_delayer_wait_seconds_buckets=None,
+            ),
+        )
+
+
+class TestSchedulerMetricsCollector(unittest.TestCase):
+    def test_prefill_token_buckets(self):
+        cases = [
+            (-1, "0"),
+            (0, "0"),
+            (1, "1_1k"),
+            (1023, "1_1k"),
+            (1024, "1k_4k"),
+            (4095, "1k_4k"),
+            (4096, "4k_16k"),
+            (16383, "4k_16k"),
+            (16384, "16k_64k"),
+            (65535, "16k_64k"),
+            (65536, "64k_plus"),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(bucket_prefill_tokens(value), expected)
+
+    def test_decode_request_buckets(self):
+        cases = [
+            (-1, "0"),
+            (0, "0"),
+            (1, "1"),
+            (2, "2_4"),
+            (4, "2_4"),
+            (5, "5_8"),
+            (8, "5_8"),
+            (9, "9_16"),
+            (16, "9_16"),
+            (17, "17_32"),
+            (32, "17_32"),
+            (33, "33_plus"),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(bucket_decode_reqs(value), expected)
+
+    def test_prefill_only_does_not_observe_decode_step_latency(self):
+        collector = _make_collector()
+
+        collector.observe_forward_pass_interference(
+            duration_seconds=0.123,
+            phase="prefill_only",
+            prefill_tokens=2048,
+            decode_reqs=0,
+        )
+
+        self.assertEqual(len(collector.forward_pass_duration_seconds.observations), 1)
+        labels, value = collector.forward_pass_duration_seconds.observations[0]
+        self.assertEqual(value, 0.123)
+        self.assertEqual(labels["phase"], "prefill_only")
+        self.assertEqual(labels["prefill_tokens_bucket"], "1k_4k")
+        self.assertEqual(labels["decode_reqs_bucket"], "0")
+        self.assertEqual(len(collector.decode_step_latency_seconds.observations), 0)
+
+    def test_mixed_observes_decode_step_with_prefill_bucket(self):
+        collector = _make_collector()
+
+        collector.observe_forward_pass_interference(
+            duration_seconds=0.250,
+            phase="mixed",
+            prefill_tokens=20000,
+            decode_reqs=6,
+        )
+
+        self.assertEqual(len(collector.forward_pass_duration_seconds.observations), 1)
+        self.assertEqual(len(collector.decode_step_latency_seconds.observations), 1)
+        labels, value = collector.decode_step_latency_seconds.observations[0]
+        self.assertEqual(value, 0.250)
+        self.assertEqual(labels["phase"], "mixed")
+        self.assertEqual(labels["co_scheduled_prefill_bucket"], "16k_64k")
+        self.assertEqual(labels["decode_reqs_bucket"], "5_8")
+
+    def test_decode_only_observes_zero_prefill_bucket(self):
+        collector = _make_collector()
+
+        collector.observe_forward_pass_interference(
+            duration_seconds=0.010,
+            phase="decode_only",
+            prefill_tokens=0,
+            decode_reqs=1,
+        )
+
+        labels, value = collector.decode_step_latency_seconds.observations[0]
+        self.assertEqual(value, 0.010)
+        self.assertEqual(labels["phase"], "decode_only")
+        self.assertEqual(labels["co_scheduled_prefill_bucket"], "0")
+        self.assertEqual(labels["decode_reqs_bucket"], "1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/observability/test_scheduler_metrics_collector.py
+++ b/test/registered/unit/observability/test_scheduler_metrics_collector.py
@@ -1,0 +1,225 @@
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import types
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.observability.metrics_collector import (
+    SchedulerMetricsCollector,
+    bucket_decode_reqs,
+    bucket_prefill_tokens,
+)
+from sglang.srt.runtime_context import get_context
+
+
+class _FakeMetricChild:
+    def __init__(self, parent, labels):
+        self._parent = parent
+        self._labels = labels
+
+    def observe(self, value):
+        self._parent.observations.append((self._labels, value))
+
+    def set(self, value):
+        self._parent.sets.append((self._labels, value))
+
+    def inc(self, value=1):
+        self._parent.incs.append((self._labels, value))
+
+
+class _FakeMetric:
+    def __init__(self, name, documentation="", labelnames=None, **kwargs):
+        self.name = name
+        self.documentation = documentation
+        self.labelnames = list(labelnames or [])
+        self.kwargs = kwargs
+        self.observations = []
+        self.sets = []
+        self.incs = []
+
+    def labels(self, **labels):
+        return _FakeMetricChild(self, labels)
+
+
+class _FakeSchedulerMetricsCollector(SchedulerMetricsCollector):
+    _counter_cls = _FakeMetric
+    _gauge_cls = _FakeMetric
+    _histogram_cls = _FakeMetric
+    _summary_cls = _FakeMetric
+
+
+class _FakeGaugeHistogram:
+    def __init__(self, name, documentation="", labelnames=None, **kwargs):
+        self.name = name
+        self.documentation = documentation
+        self.labelnames = list(labelnames or [])
+        self.kwargs = kwargs
+        self.observations = []
+
+    def set_by_current_observations(self, labels, observations):
+        self.observations.append((labels, observations))
+
+
+def _make_collector():
+    with patch(
+        "sglang.srt.observability.metrics_collector.GaugeHistogram",
+        _FakeGaugeHistogram,
+    ):
+        return _FakeSchedulerMetricsCollector(
+            labels={
+                "model_name": "test-model",
+                "engine_type": "server",
+                "tp_rank": 0,
+                "pp_rank": 0,
+                "moe_ep_rank": 0,
+            },
+            server_args=_published_server_args(),
+        )
+
+
+def _published_server_args():
+    """Install a real config so the collector's runtime-context reads resolve.
+
+    The collector reads several config namespaces (``exec``, ``schedule``, ...)
+    through the runtime context rather than off the passed ``server_args``, and
+    those bags fail closed until something publishes them.
+    """
+    override = get_context().override_server_args(
+        prefill_delayer_max_delay_passes=200,
+        prefill_delayer_forward_passes_buckets=None,
+        prefill_delayer_wait_seconds_buckets=None,
+    )
+    return override.install()
+
+
+class TestSchedulerMetricsCollector(unittest.TestCase):
+    def test_prefill_token_buckets(self):
+        cases = [
+            (-1, "0"),
+            (0, "0"),
+            (1, "1_1k"),
+            (1023, "1_1k"),
+            (1024, "1k_4k"),
+            (4095, "1k_4k"),
+            (4096, "4k_16k"),
+            (16383, "4k_16k"),
+            (16384, "16k_64k"),
+            (65535, "16k_64k"),
+            (65536, "64k_plus"),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(bucket_prefill_tokens(value), expected)
+
+    def test_decode_request_buckets(self):
+        cases = [
+            (-1, "0"),
+            (0, "0"),
+            (1, "1"),
+            (2, "2_4"),
+            (4, "2_4"),
+            (5, "5_8"),
+            (8, "5_8"),
+            (9, "9_16"),
+            (16, "9_16"),
+            (17, "17_32"),
+            (32, "17_32"),
+            (33, "33_plus"),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(bucket_decode_reqs(value), expected)
+
+    def test_prefill_only_does_not_observe_decode_step_latency(self):
+        collector = _make_collector()
+
+        collector.observe_forward_pass_interference(
+            duration_seconds=0.123,
+            phase="prefill_only",
+            prefill_tokens=2048,
+            decode_reqs=0,
+        )
+
+        self.assertEqual(len(collector.forward_pass_duration_seconds.observations), 1)
+        labels, value = collector.forward_pass_duration_seconds.observations[0]
+        self.assertEqual(value, 0.123)
+        self.assertEqual(labels["phase"], "prefill_only")
+        self.assertEqual(labels["prefill_tokens_bucket"], "1k_4k")
+        self.assertEqual(labels["decode_reqs_bucket"], "0")
+        self.assertEqual(len(collector.decode_step_latency_seconds.observations), 0)
+
+    def test_mixed_observes_decode_step_with_prefill_bucket(self):
+        collector = _make_collector()
+
+        collector.observe_forward_pass_interference(
+            duration_seconds=0.250,
+            phase="mixed",
+            prefill_tokens=20000,
+            decode_reqs=6,
+        )
+
+        self.assertEqual(len(collector.forward_pass_duration_seconds.observations), 1)
+        self.assertEqual(len(collector.decode_step_latency_seconds.observations), 1)
+        labels, value = collector.decode_step_latency_seconds.observations[0]
+        self.assertEqual(value, 0.250)
+        self.assertEqual(labels["phase"], "mixed")
+        self.assertEqual(labels["co_scheduled_prefill_bucket"], "16k_64k")
+        self.assertEqual(labels["decode_reqs_bucket"], "5_8")
+
+    def test_schedule_to_result_latency_is_a_separate_series(self):
+        collector = _make_collector()
+
+        collector.observe_schedule_to_result_latency(
+            duration_seconds=0.400,
+            phase="mixed",
+            prefill_tokens=20000,
+            decode_reqs=6,
+        )
+
+        self.assertEqual(
+            len(collector.schedule_to_result_latency_seconds.observations), 1
+        )
+        labels, value = collector.schedule_to_result_latency_seconds.observations[0]
+        self.assertEqual(value, 0.400)
+        self.assertEqual(labels["phase"], "mixed")
+        self.assertEqual(labels["prefill_tokens_bucket"], "16k_64k")
+        self.assertEqual(labels["decode_reqs_bucket"], "5_8")
+        # The engine-step interval must not leak into the forward-pass series.
+        self.assertEqual(len(collector.forward_pass_duration_seconds.observations), 0)
+        self.assertEqual(len(collector.decode_step_latency_seconds.observations), 0)
+
+    def test_forward_pass_observation_does_not_touch_schedule_to_result(self):
+        collector = _make_collector()
+
+        collector.observe_forward_pass_interference(
+            duration_seconds=0.010,
+            phase="mixed",
+            prefill_tokens=20000,
+            decode_reqs=6,
+        )
+
+        self.assertEqual(
+            len(collector.schedule_to_result_latency_seconds.observations), 0
+        )
+
+    def test_decode_only_observes_zero_prefill_bucket(self):
+        collector = _make_collector()
+
+        collector.observe_forward_pass_interference(
+            duration_seconds=0.010,
+            phase="decode_only",
+            prefill_tokens=0,
+            decode_reqs=1,
+        )
+
+        labels, value = collector.decode_step_latency_seconds.observations[0]
+        self.assertEqual(value, 0.010)
+        self.assertEqual(labels["phase"], "decode_only")
+        self.assertEqual(labels["co_scheduled_prefill_bucket"], "0")
+        self.assertEqual(labels["decode_reqs_bucket"], "1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Added `sglang:forward_pass_duration_seconds` for every scheduler/model forward pass, labeled by phase, prefill token bucket, and decode request bucket.
- Added `sglang:decode_step_latency_seconds` for passes that include decode requests, labeled by decode-only vs mixed phase, co-scheduled prefill bucket, and decode request bucket.
- Wired Prometheus observation through the scheduler metrics path so it works with `--enable-metrics` and does not require `--enable-forward-pass-metrics`.
- Added CPU unit coverage for bucket helpers, collector label behavior, and reporter observation independent of FPM.
- Documented interpretation, caveats, validation command, and PromQL examples in `docs_new`.

## Why

The production symptom this targets is: decode requests are streaming normally, then a long prompt/prefill request joins the scheduler batch, and existing decode streams suddenly see a p99 inter-token latency / TPOT spike. Request-level TPOT and ITL metrics are useful for user-visible latency, but they aggregate over a whole request. They do not tell us whether the slow decode token was delayed specifically by a long prefill that was co-scheduled in the same scheduler/model forward pass.

In production, this commonly shows up with mixed traffic:

- A chat workload has many short streaming decode requests already running.
- A retrieval or agent request arrives with a very large prompt, for example a 32k-100k token context assembled from documents, tool traces, or conversation history.
- The scheduler admits that prefill alongside active decode work in a mixed batch.
- Users on unrelated decode streams observe one or more slow token intervals, but the completed-request TPOT metric only says those requests had a bad tail. It does not identify the interfering engine step.

The right diagnostic unit is the scheduler/model forward pass, not the completed request. This PR records the duration of every forward pass and separately records decode-step latency for passes that include decode requests. The labels intentionally stay low-cardinality: phase, bucketed co-scheduled prefill token count, and bucketed decode request count.

With these metrics, operators can compare:

- decode-only p99, where no prefill work was co-scheduled;
- mixed prefill+decode p99;
- mixed p99 grouped by co-scheduled prefill token buckets such as `16k_64k` and `64k_plus`.

A practical production diagnosis becomes possible: if `sglang:decode_step_latency_seconds` p99 for `phase="mixed"` and `co_scheduled_prefill_bucket="16k_64k"` or `"64k_plus"` is repeatedly much higher than `phase="decode_only"`, long prefill co-scheduling is likely contributing to decode ITL/TPOT tails. That gives an actionable signal for tuning chunked prefill, mixed batching, prefill throttling, or prefill/decode disaggregation.

This metric is intentionally not a replacement for completed-request TPOT. It is a forward-pass-level interference signal. Speculative decoding, stream interval, and two-batch-overlap can make one forward pass only an approximation of one visible token interval, so the metric should be interpreted as an engine-step latency proxy.

## Validation

- `git diff -z --name-only --diff-filter=ACMRDTUXB upstream/main...HEAD | xargs -0 python3 scripts/ci/check_no_docs_changes.py`
- `git diff --check upstream/main...HEAD`
- `PYTHONPATH=python:test .venv/bin/python -m py_compile python/sglang/srt/observability/metrics_collector.py python/sglang/srt/managers/scheduler_components/metrics_reporter.py python/sglang/srt/managers/scheduler.py test/registered/unit/observability/test_scheduler_metrics_collector.py test/registered/unit/observability/test_forward_pass_metrics.py`
- `TORCH_COMPILE_DISABLE=1 TORCHDYNAMO_DISABLE=1 PYTHONPATH=python:test .venv/bin/python -m pytest test/registered/unit/observability/test_scheduler_metrics_collector.py test/registered/unit/observability/test_forward_pass_metrics.py -q`

Focused pytest result: `14 passed, 6 warnings, 23 subtests passed`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34147147491](https://github.com/sgl-project/sglang/actions/runs/34147147491)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34147147249](https://github.com/sgl-project/sglang/actions/runs/34147147249)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34147147363](https://github.com/sgl-project/sglang/actions/runs/34147147363)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->