### PR TITLE
[BUG] fix strip streaming empty-string suffix from DSV4 tool arguments

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1989,13 +1989,16 @@ class OpenAIServingChat(OpenAIServingBase):
 
         # Get expected vs actual arguments
         expected_args = detector.prev_tool_call_arr[tool_index].get("arguments", {})
-        expected_call = json.dumps(expected_args, ensure_ascii=False)
+        if isinstance(expected_args, str):
+            expected_call = expected_args
+        else:
+            expected_call = json.dumps(expected_args, ensure_ascii=False)
         actual_call = detector.streamed_args_for_tool[tool_index]
 
         # Check if there are remaining arguments to send
         remaining_call = (
-            expected_call.replace(actual_call, "", 1)
-            if actual_call in expected_call
+            expected_call[len(actual_call) :]
+            if expected_call.startswith(actual_call)
             else ""
         )
 

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -859,6 +859,81 @@ class ServingChatTestCase(unittest.TestCase):
         # Should return None since no completion is needed
         self.assertIsNone(result, "Should return None when no completion is needed")
 
+    def test_unstreamed_tool_args_raw_string_no_completion_needed(self):
+        """Test raw JSON string arguments are not JSON-encoded again at finish."""
+
+        mock_parser = Mock()
+        mock_detector = Mock()
+        mock_detector.prev_tool_call_arr = [
+            {"name": "report_template_recognition_commit", "arguments": "{}"}
+        ]
+        mock_detector.streamed_args_for_tool = ["{}"]
+        mock_parser.detector = mock_detector
+
+        content = {
+            "meta_info": {
+                "id": "chatcmpl-test123",
+            }
+        }
+
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "commit"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "report_template_recognition_commit"},
+                }
+            ],
+        )
+
+        result = self.chat._check_for_unstreamed_tool_args(
+            parser=mock_parser,
+            content=content,
+            request=request,
+            index=0,
+        )
+
+        self.assertIsNone(result, "Should not append encoded quotes")
+
+    def test_unstreamed_tool_args_raw_string_completion(self):
+        """Test remaining raw JSON string arguments are sent at finish."""
+
+        mock_parser = Mock()
+        mock_detector = Mock()
+        mock_detector.prev_tool_call_arr = [
+            {
+                "name": "get_weather",
+                "arguments": '{"location": "San Francisco", "unit": "celsius"}',
+            }
+        ]
+        mock_detector.streamed_args_for_tool = ['{"location": "San Francisco"']
+        mock_parser.detector = mock_detector
+
+        content = {
+            "meta_info": {
+                "id": "chatcmpl-test123",
+            }
+        }
+
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "What's the weather?"}],
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+        )
+
+        result = self.chat._check_for_unstreamed_tool_args(
+            parser=mock_parser,
+            content=content,
+            request=request,
+            index=0,
+        )
+
+        self.assertIsNotNone(result, "Should return chunk with remaining arguments")
+        chunk = json.loads(result[6:])
+        tool_calls = chunk["choices"][0]["delta"]["tool_calls"]
+        self.assertEqual(tool_calls[0]["function"]["arguments"], ', "unit": "celsius"}')
+
     def test_unstreamed_tool_args_no_parser_data(self):
         """Test that no completion chunk is sent when parser has no tool call data."""
 


### PR DESCRIPTION
## Motivation
`_check_for_unstreamed_tool_args` compares the full parsed tool arguments with the arguments that have already been streamed, then sends any remaining suffix at generation finish.

The previous logic always applied `json.dumps()` to the detector's stored `arguments`. This is correct when `arguments` is a Python dict, but some detectors, such as the DeepSeek DSML parser used by DeepSeek v32/v4, store arguments as raw JSON strings. Applying `json.dumps()` again double-encodes those raw strings.

For example, raw arguments `"{}"` became `"\"{}\""`, and the suffix logic could append `\"\"` after `{}`.

Fixes an issue where streamed OpenAI tool call arguments could receive an extra encoded suffix such as `\"\"`, producing invalid arguments like `{}\"\"`.

## Modifications

- Treat string `arguments` as already-serialized raw argument text.
- Keep the existing `json.dumps(..., ensure_ascii=False)` path for dict arguments.
- Compute the remaining suffix only when the already-streamed arguments are a prefix of the expected arguments.
- Add unit tests for raw string tool argument completion behavior.

## Tests

- Added unit coverage for raw JSON string arguments that are already fully
  streamed.
- Added unit coverage for raw JSON string arguments that still require a
  suffix at finish.
- Ran:
  `python3 -m py_compile python/sglang/srt/entrypoints/openai/serving_chat.py test/registered/unit/entrypoints/openai/test_serving_chat.py`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28561950521](https://github.com/sgl-project/sglang/actions/runs/28561950521)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28561950427](https://github.com/sgl-project/sglang/actions/runs/28561950427)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->