### PR TITLE
fix(config): treat v_head_dim=0 as unset when deriving model shapes (deepseek-vl2-tiny warmup crash)

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -709,7 +709,11 @@ class ModelConfig:
             setattr(self.hf_text_config, "head_dim", self.head_dim)
 
         self.v_head_dim = getattr(self.hf_text_config, "v_head_dim", None)
-        if self.v_head_dim is None:
+        if not self.v_head_dim:
+            # Treat 0 the same as unset: MLA-disabled checkpoints (e.g.
+            # deepseek-vl2-tiny, DeepseekV2ForCausalLM with use_mla=False)
+            # zero out the MLA head-dim fields instead of omitting them, and a
+            # 0-width V cache breaks every MHA KV pool sized from this value.
             self.v_head_dim = self.head_dim
             setattr(self.hf_text_config, "v_head_dim", self.v_head_dim)
 

--- a/test/registered/unit/configs/test_model_config_shapes.py
+++ b/test/registered/unit/configs/test_model_config_shapes.py
@@ -51,6 +51,21 @@ class TestModelConfigShapes(CustomTestCase):
         self.assertEqual(text_config.swa_head_dim, 128)
         self.assertEqual(text_config.swa_v_head_dim, 128)
 
+    def test_zero_v_head_dim_falls_back_to_head_dim(self):
+        """MLA-disabled checkpoints (e.g. deepseek-vl2-tiny) declare
+        v_head_dim=0 instead of omitting it; 0 must not size the KV pool."""
+        text_config = _make_text_config(
+            head_dim=None,
+            v_head_dim=0,
+            swa_head_dim=None,
+            swa_v_head_dim=None,
+        )
+
+        model_config = self._derive_shapes(text_config)
+
+        self.assertEqual(model_config.v_head_dim, 128)
+        self.assertEqual(text_config.v_head_dim, 128)
+
     def test_explicit_head_dims_are_preserved(self):
         text_config = _make_text_config(
             head_dim=128,


### PR DESCRIPTION
## Motivation

deepseek-vl2-tiny is completely unusable: the scheduler crashes during warmup with

```
RuntimeError: shape mismatch: value tensor of shape [432, 10, 128] cannot be broadcast to indexing result of shape [432, 10, 0]
```

because the MHA KV pool allocates a zero-width V cache. Full root-cause in #29889: the checkpoint is the MLA-disabled member of the VL2 family (`DeepseekV2ForCausalLM`, `use_mla: false`, supported since #5537) and signals that by zeroing the MLA head-dim fields (`v_head_dim: 0`) instead of omitting them. `_derive_model_shapes` falls back to `head_dim` only on `None`, so the 0 survives into `ModelConfig.v_head_dim`, which model_runner_kv_cache_mixin passes to every MHA pool constructor. Regressed in #28683 (before it, pools were sized from `head_dim`).

## Modifications

- `python/sglang/srt/configs/model_config.py`: treat a falsy `v_head_dim` as unset (fall back to `head_dim` and normalize `hf_text_config`). This mirrors the convention the codebase already applies elsewhere: `_override_v_head_dim_if_zero` in multimodal `common.py` patches `v_head_dim == 0` for DeepseekOCR, confirming 0 is never a valid width.
- `test/registered/unit/configs/test_model_config_shapes.py`: regression test `test_zero_v_head_dim_falls_back_to_head_dim`, following the file's existing harness.

MLA checkpoints are unaffected (they carry nonzero `v_head_dim`), and explicit nonzero values remain preserved (covered by the existing `test_explicit_head_dims_are_preserved`).

## Verification (RTX PRO 6000, SM120, CUDA 13, torch 2.11 cu130)

- Unit, real checkpoint: `ModelConfig(deepseek-vl2-tiny)` now derives `attention_arch=MHA, head_dim=128, v_head_dim=128` (was 0 on main `bac351d`).
- End to end: `python -m sglang.launch_server --model-path deepseek-ai/deepseek-vl2-tiny --tp 1 --attention-backend flashinfer --trust-remote-code --disable-cuda-graph` crashes at warmup on the stock build and, with this fix applied, reaches `/health_generate` 200 and serves multimodal chat completions normally (same machine, before/after).
- `test/registered/unit/configs/test_model_config_shapes.py`: 3 passed.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel if you have any questions.

AI-assisted (Claude Code) under human direction; all verification numbers are from live runs.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28563366937](https://github.com/sgl-project/sglang/actions/runs/28563366937)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28563366859](https://github.com/sgl-project/sglang/actions/runs/28563366859)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->