### PR TITLE
[Platform] Route OOT available-memory queries through current_platform

### DIFF
--- a/docs_new/docs/hardware-platforms/plugin.mdx
+++ b/docs_new/docs/hardware-platforms/plugin.mdx
@@ -70,7 +70,7 @@ Key design points:
 - All methods are **instance methods** (not classmethods), called through the `current_platform` singleton
 - Device operations and factory methods raise `NotImplementedError` by default (fail-fast)
 - Capability flags use safe conservative defaults (`False`/`pass`)
-- Methods are annotated `[Active]` (called by SGLang core) or `[Planned]` (reserved for future migration)
+- Methods are annotated `[Active]` (at least one SGLang core path is routed through `current_platform`) or `[Planned]` (reserved for future migration)
 
 ### Platform Discovery (`current_platform`)
 
@@ -205,6 +205,8 @@ class MyDeviceMixin(DeviceMixin):
     def set_device(self, device) -> None: ...
     def get_device_name(self, device_id=0) -> str: ...
     def get_device_total_memory(self, device_id=0) -> int: ...
+    # Optional direct query; otherwise SRT keeps the legacy derived fallback.
+    def get_available_memory(self, device_id=0) -> tuple[int, int]: ...
     def get_current_memory_usage(self, device=None) -> float: ...
     def get_device_capability(self, device_id=0): ...
     def get_torch_distributed_backend_str(self) -> str: ...
@@ -292,7 +294,7 @@ python -c "from sglang.srt.platforms import current_platform; print(current_plat
 
 #### Device Operations (from DeviceMixin)
 
-> Methods annotated **[Active]** are called by SGLang core through `current_platform` — OOT implementations take effect immediately.
+> Methods annotated **[Active]** have at least one SGLang core path routed through `current_platform` — OOT implementations take effect on those routed paths.
 > Methods annotated **[Planned]** are reserved interfaces — SGLang core still uses hardcoded calls (e.g. `torch.cuda.empty_cache()`). OOT implementations will NOT take effect until the core is migrated in a future PR.
 
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
@@ -362,8 +364,8 @@ python -c "from sglang.srt.platforms import current_platform; print(current_plat
     <tr>
       <td><code>get_available_memory(device_id)</code></td>
       <td><code>raise NotImplementedError</code></td>
-      <td>Planned</td>
-      <td>Return <code>(free_bytes, total_bytes)</code></td>
+      <td><strong>Active</strong></td>
+      <td>Optional OOT override returning <code>(free_bytes, total_bytes)</code>. Without an override, SRT derives free memory from total memory minus current usage.</td>
     </tr>
     <tr>
       <td><code>get_current_memory_usage(device)</code></td>

--- a/python/sglang/srt/platforms/device_mixin.py
+++ b/python/sglang/srt/platforms/device_mixin.py
@@ -18,8 +18,9 @@ Hierarchy example (OOT plugin)::
 
 Method status annotations:
 
-- ``[Active]``  — SGLang core calls this method through ``current_platform``.
-  OOT implementations take effect immediately.
+- ``[Active]``  — SGLang core has at least one path routed through
+  ``current_platform`` for this method. OOT implementations take effect on
+  those routed paths.
 - ``[Planned]`` — Reserved interface. SGLang core still uses hardcoded calls
   (e.g. ``torch.cuda.empty_cache()``). OOT implementations will NOT take
   effect until the core is migrated in a future PR.
@@ -145,8 +146,8 @@ class DeviceMixin:
         return self._enum == PlatformEnum.OOT
 
     # ------------------------------------------------------------------
-    # Active methods — core calls these through current_platform.
-    # OOT implementations take effect immediately.
+    # Active methods — core has at least one current_platform call path.
+    # OOT implementations take effect on the routed paths.
     # ------------------------------------------------------------------
 
     def get_device_total_memory(self, device_id: int = 0) -> int:
@@ -157,6 +158,10 @@ class DeviceMixin:
         self, device: Optional["torch.device"] = None
     ) -> float:
         """[Active] Get current peak memory usage in bytes."""
+        raise NotImplementedError
+
+    def get_available_memory(self, device_id: int = 0) -> tuple[int, int]:
+        """[Active] Return ``(free_bytes, total_bytes)`` on routed paths."""
         raise NotImplementedError
 
     def is_pin_memory_available(self, device=None) -> bool:
@@ -198,12 +203,6 @@ class DeviceMixin:
     def synchronize(self) -> None:
         """[Planned] Synchronize device operations. No-op for CPU-like platforms."""
         pass
-
-    # ---- Memory ----
-
-    def get_available_memory(self, device_id: int = 0) -> tuple[int, int]:
-        """[Planned] Return ``(free_bytes, total_bytes)``."""
-        raise NotImplementedError
 
     # ---- Distributed ----
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -97,6 +97,7 @@ from typing_extensions import Literal
 from sglang.srt.environ import envs
 from sglang.srt.observability.func_timer import enable_func_timer
 from sglang.srt.platforms import current_platform
+from sglang.srt.platforms.device_mixin import DeviceMixin
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils.video_decoder import _BACKEND, VideoDecoderWrapper
 
@@ -524,9 +525,15 @@ def get_available_gpu_memory(
                 "If this is an OOT platform, ensure it is properly registered "
                 "via the 'sglang.platform_plugins' entry point."
             )
-        total_mem = current_platform.get_device_total_memory(gpu_id)
-        used_mem = current_platform.get_current_memory_usage()
-        free_gpu_memory = total_mem - used_mem
+        if (
+            type(current_platform).get_available_memory
+            is not DeviceMixin.get_available_memory
+        ):
+            free_gpu_memory, _ = current_platform.get_available_memory(gpu_id)
+        else:
+            total_mem = current_platform.get_device_total_memory(gpu_id)
+            used_mem = current_platform.get_current_memory_usage()
+            free_gpu_memory = total_mem - used_mem
 
     if distributed:
         tensor = torch.tensor(free_gpu_memory, dtype=torch.float32)

--- a/test/registered/unit/platforms/test_platform_interface.py
+++ b/test/registered/unit/platforms/test_platform_interface.py
@@ -320,6 +320,134 @@ class TestCpuDeviceMixin(CustomTestCase):
         self.assertFalse(base.is_pin_memory_available(device="cpu"))
 
 
+class TestAvailableGpuMemory(CustomTestCase):
+    """Tests for common available-memory helper dispatch through platforms."""
+
+    def test_oot_get_available_gpu_memory_uses_available_memory_override(self):
+        from sglang.srt.utils import common
+
+        class P(SRTPlatform):
+            _enum = PlatformEnum.OOT
+            device_name = "custom"
+            device_type = "custom"
+
+            def __init__(self):
+                self.calls = []
+
+            def get_available_memory(self, device_id=0):
+                self.calls.append(device_id)
+                return (3 * (1 << 30), 10 * (1 << 30))
+
+            def get_device_total_memory(self, device_id=0):
+                raise AssertionError("legacy fallback should not run")
+
+            def get_current_memory_usage(self, device=None):
+                raise AssertionError("legacy fallback should not run")
+
+        platform = P()
+        with patch.object(common, "current_platform", platform):
+            self.assertEqual(common.get_available_gpu_memory("custom", 2), 3.0)
+
+        self.assertEqual(platform.calls, [2])
+
+    def test_oot_get_available_gpu_memory_uses_device_mixin_override(self):
+        from sglang.srt.utils import common
+
+        class M(DeviceMixin):
+            def get_available_memory(self, device_id=0):
+                self.calls.append(device_id)
+                return (4 * (1 << 30), 12 * (1 << 30))
+
+        class P(SRTPlatform, M):
+            _enum = PlatformEnum.OOT
+            device_name = "custom"
+            device_type = "custom"
+
+            def __init__(self):
+                self.calls = []
+
+            def get_device_total_memory(self, device_id=0):
+                raise AssertionError("legacy fallback should not run")
+
+            def get_current_memory_usage(self, device=None):
+                raise AssertionError("legacy fallback should not run")
+
+        platform = P()
+        with patch.object(common, "current_platform", platform):
+            self.assertEqual(common.get_available_gpu_memory("custom", 3), 4.0)
+
+        self.assertEqual(platform.calls, [3])
+
+    def test_oot_get_available_gpu_memory_without_override_uses_legacy_fallback(self):
+        from sglang.srt.utils import common
+
+        class P(SRTPlatform):
+            _enum = PlatformEnum.OOT
+            device_name = "custom"
+            device_type = "custom"
+
+            def __init__(self):
+                self.total_calls = []
+                self.usage_calls = []
+
+            def get_device_total_memory(self, device_id=0):
+                self.total_calls.append(device_id)
+                return 10 * (1 << 30)
+
+            def get_current_memory_usage(self, device=None):
+                self.usage_calls.append(device)
+                return 2 * (1 << 30)
+
+        platform = P()
+        with patch.object(common, "current_platform", platform):
+            self.assertEqual(common.get_available_gpu_memory("custom", 4), 8.0)
+
+        self.assertEqual(platform.total_calls, [4])
+        self.assertEqual(platform.usage_calls, [None])
+
+    def test_oot_get_available_gpu_memory_override_error_propagates(self):
+        from sglang.srt.utils import common
+
+        class P(SRTPlatform):
+            _enum = PlatformEnum.OOT
+            device_name = "custom"
+            device_type = "custom"
+
+            def get_available_memory(self, device_id=0):
+                raise RuntimeError("available memory query failed")
+
+            def get_device_total_memory(self, device_id=0):
+                raise AssertionError("legacy fallback should not run")
+
+            def get_current_memory_usage(self, device=None):
+                raise AssertionError("legacy fallback should not run")
+
+        with patch.object(common, "current_platform", P()):
+            with self.assertRaisesRegex(RuntimeError, "available memory query failed"):
+                common.get_available_gpu_memory("custom", 0)
+
+    def test_oot_get_available_gpu_memory_override_not_implemented_propagates(self):
+        from sglang.srt.utils import common
+
+        class P(SRTPlatform):
+            _enum = PlatformEnum.OOT
+            device_name = "custom"
+            device_type = "custom"
+
+            def get_available_memory(self, device_id=0):
+                raise NotImplementedError("available memory hook is not implemented")
+
+            def get_device_total_memory(self, device_id=0):
+                raise AssertionError("legacy fallback should not run")
+
+            def get_current_memory_usage(self, device=None):
+                raise AssertionError("legacy fallback should not run")
+
+        with patch.object(common, "current_platform", P()):
+            with self.assertRaisesRegex(NotImplementedError, "not implemented"):
+                common.get_available_gpu_memory("custom", 0)
+
+
 class TestPinMemoryAvailability(CustomTestCase):
     """Tests for common pin-memory helper dispatch through platforms."""
 


### PR DESCRIPTION
## Motivation

The OOT branch of `get_available_gpu_memory()` currently derives free memory as `get_device_total_memory(gpu_id) - get_current_memory_usage()`. Because `get_current_memory_usage()` follows platform-specific allocator and accounting semantics, that derived value can differ from a runtime's direct free-memory query. Although `DeviceMixin` already exposes `get_available_memory(device_id)`, OOT platforms cannot currently route that direct free/total query into this helper.

## Modifications

- Route only the OOT branch of `get_available_gpu_memory()` through `current_platform.get_available_memory(gpu_id)` when the active platform overrides the `DeviceMixin` base hook.
- Preserve the existing OOT fallback for platforms without the hook: `get_device_total_memory(gpu_id) - get_current_memory_usage()`.
- Leave the existing CUDA/ROCm, XPU, HPU, CPU, NPU, MUSA, and MPS branches unchanged; OOT `empty_cache` behavior also remains unchanged.
- Mark `get_available_memory(device_id)` as active for OOT available-memory dispatch in `DeviceMixin` and `docs_new`.
- Add fake OOT tests for direct override, documented mixin/MRO override, missing-override fallback, and error propagation.

## Accuracy Tests

N/A. No model forward, kernel, or output changes.

## Speed Tests and Profiling

N/A. Platform helper dispatch only.

## Validation

- `git diff --check origin/main...HEAD`
- `python3 -m py_compile python/sglang/srt/utils/common.py python/sglang/srt/platforms/device_mixin.py test/registered/unit/platforms/test_platform_interface.py`
- Changed-files pre-commit, including AST, isort, Ruff, codespell, merge-conflict, and registered-test checks.
- Black check on all changed Python files.
- Five focused no-hardware behavior checks: direct override, documented mixin/MRO override, legacy fallback, `RuntimeError` propagation, and explicit `NotImplementedError` propagation.
- Full registered platform test collection is delegated to CI after rebase because the local environment does not include the complete SGLang model/quantization dependency set.

## Checklist

- Format/lint done.
- Unit tests added.
- Docs updated in `docs_new` for the active OOT hook.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29475105595](https://github.com/sgl-project/sglang/actions/runs/29475105595)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29475105415](https://github.com/sgl-project/sglang/actions/runs/29475105415)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
