### PR TITLE
fix(config): derive scaling in the KimiVL, MiniCPM3, and DeepseekVL2 MLA branches

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -802,6 +802,19 @@ class ModelConfig:
             self.attention_arch = AttentionArch.MLA
             self.kv_lora_rank = self.hf_config.kv_lora_rank
             self.qk_rope_head_dim = self.hf_config.qk_rope_head_dim
+            self.qk_nope_head_dim = self.hf_config.qk_nope_head_dim
+            self.scaling = 1 / math.sqrt(self.qk_nope_head_dim + self.qk_rope_head_dim)
+            rope_scaling = self.hf_config.rope_scaling
+            if rope_scaling:
+                rope_type = (
+                    rope_scaling.get("rope_type")
+                    or rope_scaling.get("type")
+                    or "default"
+                )
+                if rope_type != "default":
+                    self.scaling = compute_mla_mscale_scaling(
+                        rope_scaling, self.scaling
+                    )
         elif "DeepseekVL2ForCausalLM" in self.hf_config.architectures and getattr(
             self.hf_text_config, "use_mla", True
         ):
@@ -810,6 +823,18 @@ class ModelConfig:
             self.kv_lora_rank = self.hf_text_config.kv_lora_rank
             self.qk_rope_head_dim = self.hf_text_config.qk_rope_head_dim
             self.qk_nope_head_dim = self.hf_text_config.qk_nope_head_dim
+            self.scaling = 1 / math.sqrt(self.qk_nope_head_dim + self.qk_rope_head_dim)
+            rope_scaling = self.hf_text_config.rope_scaling
+            if rope_scaling:
+                rope_type = (
+                    rope_scaling.get("rope_type")
+                    or rope_scaling.get("type")
+                    or "default"
+                )
+                if rope_type != "default":
+                    self.scaling = compute_mla_mscale_scaling(
+                        rope_scaling, self.scaling
+                    )
         elif "KimiVLForConditionalGeneration" in self.hf_config.architectures:
             self.head_dim = 256
             self.attention_arch = AttentionArch.MLA
@@ -817,6 +842,18 @@ class ModelConfig:
             self.qk_rope_head_dim = self.hf_text_config.qk_rope_head_dim
             self.v_head_dim = self.hf_text_config.v_head_dim
             self.qk_nope_head_dim = self.hf_text_config.qk_nope_head_dim
+            self.scaling = 1 / math.sqrt(self.qk_nope_head_dim + self.qk_rope_head_dim)
+            rope_scaling = self.hf_text_config.rope_scaling
+            if rope_scaling:
+                rope_type = (
+                    rope_scaling.get("rope_type")
+                    or rope_scaling.get("type")
+                    or "default"
+                )
+                if rope_type != "default":
+                    self.scaling = compute_mla_mscale_scaling(
+                        rope_scaling, self.scaling
+                    )
         elif "KimiLinearForCausalLM" in self.hf_config.architectures:
             self.head_dim = 72
             self.attention_arch = AttentionArch.MLA

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -992,6 +992,8 @@ class ModelConfig:
             self.attention_arch = AttentionArch.MLA
             self.kv_lora_rank = self.hf_config.kv_lora_rank
             self.qk_rope_head_dim = self.hf_config.qk_rope_head_dim
+            self.qk_nope_head_dim = self.hf_config.qk_nope_head_dim
+            self._init_mla_scaling(getattr(self.hf_config, "rope_scaling", None))
         elif "DeepseekVL2ForCausalLM" in self.hf_config.architectures and getattr(
             self.hf_text_config, "use_mla", True
         ):
@@ -1000,6 +1002,7 @@ class ModelConfig:
             self.kv_lora_rank = self.hf_text_config.kv_lora_rank
             self.qk_rope_head_dim = self.hf_text_config.qk_rope_head_dim
             self.qk_nope_head_dim = self.hf_text_config.qk_nope_head_dim
+            self._init_mla_scaling(getattr(self.hf_text_config, "rope_scaling", None))
         elif "KimiVLForConditionalGeneration" in self.hf_config.architectures:
             self.head_dim = 256
             self.attention_arch = AttentionArch.MLA
@@ -1007,6 +1010,7 @@ class ModelConfig:
             self.qk_rope_head_dim = self.hf_text_config.qk_rope_head_dim
             self.v_head_dim = self.hf_text_config.v_head_dim
             self.qk_nope_head_dim = self.hf_text_config.qk_nope_head_dim
+            self._init_mla_scaling(getattr(self.hf_text_config, "rope_scaling", None))
         elif (
             "KimiLinearForCausalLM" in self.hf_config.architectures
             or "KimiK3LinearForCausalLM" in self.hf_config.architectures

--- a/test/registered/unit/configs/test_model_config_shapes.py
+++ b/test/registered/unit/configs/test_model_config_shapes.py
@@ -1,9 +1,10 @@
 """Unit tests for ModelConfig shape normalization."""
 
+import math
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.configs.model_config import AttentionArch, ModelConfig
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -50,6 +51,30 @@ class TestModelConfigShapes(CustomTestCase):
         self.assertEqual(text_config.v_head_dim, 128)
         self.assertEqual(text_config.swa_head_dim, 128)
         self.assertEqual(text_config.swa_v_head_dim, 128)
+
+    def test_mla_branches_derive_scaling(self):
+        """Every branch that concludes AttentionArch.MLA must also derive
+        scaling: FlashInferMLA reads model_config.scaling at construction and
+        crashes with AttributeError otherwise (gh #29891)."""
+        cases = [
+            ("KimiVLForConditionalGeneration", {}),
+            ("MiniCPM3ForCausalLM", {}),
+            ("DeepseekVL2ForCausalLM", {"use_mla": True}),
+        ]
+        for arch, extra in cases:
+            with self.subTest(arch=arch):
+                text_config = _make_text_config(
+                    architectures=[arch],
+                    kv_lora_rank=512,
+                    qk_nope_head_dim=128,
+                    qk_rope_head_dim=64,
+                    v_head_dim=128,
+                    rope_scaling=None,
+                    **extra,
+                )
+                model_config = self._derive_shapes(text_config)
+                self.assertEqual(model_config.attention_arch, AttentionArch.MLA)
+                self.assertAlmostEqual(model_config.scaling, 1 / math.sqrt(128 + 64))
 
     def test_explicit_head_dims_are_preserved(self):
         text_config = _make_text_config(

--- a/test/registered/unit/configs/test_model_config_shapes.py
+++ b/test/registered/unit/configs/test_model_config_shapes.py
@@ -6,6 +6,7 @@ from sglang.srt.configs.model_config import (
     AttentionArch,
     ModelConfig,
     _quant_config_to_dict,
+    compute_mla_mscale_scaling,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -124,6 +125,37 @@ class TestModelConfigShapes(CustomTestCase):
         quant_config = SimpleNamespace(to_dict=lambda: {"quant_method": "test"})
 
         self.assertEqual(_quant_config_to_dict(quant_config), {"quant_method": "test"})
+
+    def test_mla_branches_derive_scaling(self):
+        base_scaling = 1 / math.sqrt(128 + 64)
+        rope_scaling = {"rope_type": "yarn", "factor": 2.0, "mscale_all_dim": 1.0}
+        cases = [
+            ("KimiVLForConditionalGeneration", {}, base_scaling),
+            ("MiniCPM3ForCausalLM", {}, base_scaling),
+            ("DeepseekVL2ForCausalLM", {"use_mla": True}, base_scaling),
+            (
+                "KimiVLForConditionalGeneration",
+                {"rope_scaling": rope_scaling},
+                compute_mla_mscale_scaling(rope_scaling, base_scaling),
+            ),
+        ]
+
+        for arch, extra, expected_scaling in cases:
+            with self.subTest(arch=arch, rope_scaling=extra.get("rope_scaling")):
+                config_kwargs = dict(
+                    architectures=[arch],
+                    kv_lora_rank=512,
+                    qk_nope_head_dim=128,
+                    qk_rope_head_dim=64,
+                    v_head_dim=128,
+                    rope_scaling=None,
+                )
+                config_kwargs.update(extra)
+                text_config = _make_text_config(**config_kwargs)
+                model_config = self._derive_shapes(text_config)
+
+                self.assertEqual(model_config.attention_arch, AttentionArch.MLA)
+                self.assertAlmostEqual(model_config.scaling, expected_scaling)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Serving Kimi-VL, MiniCPM3, or MLA DeepSeek-VL2 with `--attention-backend flashinfer` can fail during backend construction:

```
AttributeError: 'ModelConfig' object has no attribute 'scaling'
```

These three `ModelConfig._derive_model_shapes` branches select `AttentionArch.MLA` without deriving `scaling`, while the FlashInfer MLA decode and prefill updaters read it unconditionally.

## Current-main rebuild

Rebuilt from upstream main `d07ac32d056e19e6e28366a6e20c2085ad149e70` as signed/DCO head `ffbae96012882c2d0fdaaac89442410f820e16be`.

- Reuse the current shared `ModelConfig._init_mla_scaling` helper for KimiVL, MiniCPM3, and DeepseekVL2 with `use_mla=True`.
- Copy MiniCPM3 `qk_nope_head_dim`, which the shared base formula requires.
- Add focused shape coverage for all three architectures plus non-default YaRN scaling.
- Keep the patch to the existing config implementation and its unit test; no backend, server, or dependency changes.

## Verification refreshed 2026-08-10

- `test/registered/unit/configs/test_model_config_shapes.py`: 3 passed, 15 warnings, 4 subtests passed.
- Independent verification reproduced the missing parent attributes, then confirmed all three fixed branches with absent, explicit-default, and YaRN rope scaling; `DeepseekVL2 use_mla=False` remains MHA.
- Exact-file `isort --check-only`, `py_compile`, and `git diff --check` passed.
- Fresh verifier verdict: `CONFIRMED`, with no claim-relevant findings.

Historical context only: the earlier PR head was exercised end to end with Kimi-VL-A3B-Instruct and FlashInfer on NVIDIA RTX PRO 6000 Blackwell, SM120, 96GB. That full-server run was not rerun after this current-main rebuild and is not part of the refreshed claim.

Fixes #29891

## Checklist

- [x] Reused the current shared helper instead of duplicating scaling logic.
- [x] Added focused regression coverage.
- [x] Kept the current-main rebuild minimal and DCO signed.

AI-assisted by OpenAI Codex under human direction.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33255373669](https://github.com/sgl-project/sglang/actions/runs/33255373669)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33255373466](https://github.com/sgl-project/sglang/actions/runs/33255373466)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33255373547](https://github.com/sgl-project/sglang/actions/runs/33255373547)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->