### PR TITLE
Fix PrefillDelayer deadlock: bound the "all"-branch delay by max_delay_passes

### DIFF
--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -240,10 +240,14 @@ class PrefillDelayer:
             if slot_condition or queue_condition:
                 # When the "max_decode_bs - running_bs < max_prefill_bs" condition is met,
                 # the first merge_batch causes the decoding to fail to reach the maximum batch size.
+                # Bound by max_delay_passes (parity with "mixed"): otherwise a
+                # persistently-true slot_condition delays forever and starves
+                # prefill on every rank until KV drains empty.
+                prev_delayed_count = prev_state.delayed_count if prev_state else 0
                 if self.skip_first_delayer:
                     self.skip_first_delayer = False
                     pass
-                else:
+                elif prev_delayed_count < self._max_delay_passes - 1:
                     next_state = prev_state or _State()
                     next_state = next_state.bump_delayed_count()
                     return _NegotiateOutput(
@@ -251,6 +255,15 @@ class PrefillDelayer:
                         output_allow=False,
                         output_reason="delay",
                         **debug_info,
+                    )
+                else:
+                    # Hit max_delay_passes: stop delaying, allow prefill.
+                    return _NegotiateOutput(
+                        next_state=None,
+                        output_allow=True,
+                        output_reason="wait_timeout",
+                        **debug_info,
+                        **wait_info,
                     )
             exist_previous_wait = prev_state is not None
             return _NegotiateOutput(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2949,7 +2949,12 @@ class Scheduler(
             self.chunked_req is None or len(can_run_list) != 1
         )
 
-        self.max_prefill_bs = max(self.max_prefill_bs, len(can_run_list))
+        # Decaying (not all-time) high-water; feeds only the PrefillDelayer slot
+        # condition (max_running_requests - running < max_prefill_bs). A permanent
+        # high-water lets a one-off burst latch this near max_running_requests,
+        # collapsing the delayer's margin and starving prefill; decaying lets it
+        # fall back to the typical prefill size once bursts stop.
+        self.max_prefill_bs = max(len(can_run_list), self.max_prefill_bs - 1)
         if self.enable_hierarchical_cache:
             # todo (zhiqiang): disable cuda graph execution if hicache loading triggered
             new_batch.hicache_consumer_index = (

--- a/test/registered/scheduler/test_prefill_delayer.py
+++ b/test/registered/scheduler/test_prefill_delayer.py
@@ -253,6 +253,30 @@ _NEGOTIATE_TEST_CASES = [
         # still surface that wait to the histograms.
         expected_wait_forward_passes=2,
     ),
+    # Regression guard: the "all" branch must honor max_delay_passes (it had no
+    # timeout, unlike "mixed", causing a permanent prefill-starvation deadlock).
+    # 1024 - 1000 = 24 < max_prefill_bs (80) keeps slot_condition true every
+    # call; with max_delay_passes=3, call 1 is skip_first, calls 2-3 delay, call
+    # 4 releases via wait_timeout.
+    NegotiateTestCase(
+        name="all_slot_condition_timeout",
+        max_delay_passes=3,
+        token_usage_low_watermark=0.8,
+        calls=[
+            NegotiateCall(
+                prefillable=[True, True, True, True],
+                token_usage=[0.9, 0.9, 0.9, 0.9],
+                running_batch=[1000, 1000, 1000, 1000],
+                max_prefill_bs=[80, 80, 80, 80],
+                max_running_requests=1024,
+            )
+            for _ in range(4)
+        ],
+        expected_allow=True,
+        expected_reason="wait_timeout",
+        # Two delays accumulated before the timeout release.
+        expected_wait_forward_passes=2,
+    ),
     # Queue-based trigger: waiting queue below queue_min = min(running * R,
     # max_prefill_bs) should defer prefill. With R=0.5, running=100 and
     # max_prefill_bs=80, queue_min = min(50, 80) = 50, and queue_len=10 < 50.


### PR DESCRIPTION
## Problem

`PrefillDelayer._negotiate_should_allow_prefill_pure` has two branches that can
return `delay`. The `"mixed"` branch bounds its wait by `max_delay_passes`, but
the `"all"` branch (every DP rank has a prefillable request) has **no such
cap**. When its `slot_condition`

```
max_running_requests - global_running_batch_max < global_max_prefill_bs_max
```

stays persistently true, the `"all"` branch returns `delay` on every scheduler
pass forever.

This becomes a hard deadlock in practice because `max_prefill_bs` is a
monotonic all-time high-water (`scheduler.py`): a one-off burst (e.g. a cold
start with a full queue and prefix-cache hits) can latch it near
`max_running_requests`, collapsing the slot margin to ~0 so `slot_condition` is
true whenever any rank has `running > 0`. With DP-attention lockstep coupling
the decision to the global max, prefill is then starved on **all** ranks — the
running batch drains toward 1/rank and the KV pool sits nearly empty while the
waiting queue grows. It is especially easy to hit when the per-rank
`max_running_requests` is small.

## Fix

- **`prefill_delayer.py`**: bound the `"all"`-branch delay by `max_delay_passes`
  and release via `wait_timeout`, matching the existing `"mixed"` branch. This
  guarantees liveness regardless of what keeps the condition true.
- **`scheduler.py`**: decay `max_prefill_bs` (`max(len(can_run_list),
  max_prefill_bs - 1)`) instead of keeping an all-time high-water, so a one-off
  burst can't permanently collapse the delayer's slot margin. This value only
  feeds the delayer's slot condition. Note: this decay only runs on a
  successful prefill, so the `"all"`-branch timeout above is what first breaks
  an established deadlock; the decay then keeps steady state healthy.
- **test**: add `all_slot_condition_timeout`, asserting the `"all"` branch
  releases via `wait_timeout` at `max_delay_passes` rather than delaying forever.

## Verification

- New unit case + existing `test_prefill_delayer.py` negotiate cases pass.
- Reproduced the deadlock and the recovery on an internal DP-attention setup
  (dp>1) where the per-rank slot budget is small; after the fix the running
  batch no longer collapses to 1 and prefill resumes.

## Original commits

- `395c4ce72`
- `9163f9a61`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28567820013](https://github.com/sgl-project/sglang/actions/runs/28567820013)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28567819934](https://github.com/sgl-project/sglang/actions/runs/28567819934)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->