### PR TITLE
fix(sgl-kernel): fail dsv3_fused_a_gemm loudly when the device smem budget is insufficient

### DIFF
--- a/sgl-kernel/csrc/gemm/dsv3_fused_a_gemm.cu
+++ b/sgl-kernel/csrc/gemm/dsv3_fused_a_gemm.cu
@@ -594,6 +594,22 @@ void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens,
   constexpr int barrier_bytes = (stage_cnt * 16 + 1023) / 1024 * 1024;  // 4096
   constexpr int smem_bytes = ((tile_m * 2 + tile_n * 2) * tile_k * stage_cnt + barrier_bytes + 1023) / 1024 * 1024;
 
+  // The pipeline depth is sized against Hopper's 192 KB shared-memory
+  // budget; on devices with a smaller opt-in limit (99 KB on SM120-class
+  // parts) the launch below can never succeed. Check up front so callers
+  // get an actionable error instead of a bare invalid-argument failure:
+  // SGLang routes such devices to the CuteDSL implementation
+  // (sglang.jit_kernel.fused_a_gemm with backend="auto").
+  size_t const smem_optin = at::cuda::getCurrentDeviceProperties()->sharedMemPerBlockOptin;
+  TORCH_CHECK(
+      static_cast<size_t>(smem_bytes) <= smem_optin,
+      "dsv3_fused_a_gemm needs ",
+      smem_bytes,
+      " bytes of dynamic shared memory but this device's opt-in limit is ",
+      smem_optin,
+      " bytes; use the CuteDSL dsv3 fused-A GEMM on this architecture "
+      "(sglang fused_a_gemm backend=\"auto\" selects it automatically)");
+
   dim3 grid(cta_m_cnt, cta_n_cnt, 1);
   dim3 block_size(256);
   cudaLaunchConfig_t config;
@@ -607,10 +623,10 @@ void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens,
   config.numAttrs = 1;
   config.attrs = attrs;
   if (smem_bytes >= (48 * 1024)) {
-    cudaFuncSetAttribute(
+    CHECK_CUDA_SUCCESS(cudaFuncSetAttribute(
         fused_a_gemm_kernel<batch_size, gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt>,
         cudaFuncAttributeMaxDynamicSharedMemorySize,
-        smem_bytes);
+        smem_bytes));
   }
   cudaLaunchKernelEx(
       &config,

--- a/sgl-kernel/tests/test_dsv3_fused_a_gemm.py
+++ b/sgl-kernel/tests/test_dsv3_fused_a_gemm.py
@@ -6,6 +6,11 @@ import torch.nn.functional as F
 from sgl_kernel import dsv3_fused_a_gemm
 
 
+@pytest.mark.skipif(
+    torch.cuda.get_device_properties(0).shared_memory_per_block_optin < 192 * 1024,
+    reason="dsv3_fused_a_gemm sizes its pipeline against Hopper's 192 KB smem "
+    "budget; devices below that (e.g. SM120, 99 KB) route to the CuteDSL kernel",
+)
 @pytest.mark.parametrize("num_tokens", [1, 8, 15, 16])
 def test_dsv3_fused_a_gemm(num_tokens):
     kHdIn = 7168


### PR DESCRIPTION
## Motivation

Fixes #29897, reworked per @b8zhong's direction there: on SM120 the supported dsv3 fused-A GEMM is the CuteDSL kernel (and `sglang.jit_kernel.fused_a_gemm` with `backend="auto"` already routes SM120 to it), so this PR no longer tries to make the AOT kernel run on SM120.

What remains are the two defects that hold regardless of that policy. The pipeline is sized against Hopper's 192 KB smem budget (197,632-byte request); on devices below that opt-in limit (99 KB on SM120) `cudaFuncSetAttribute` fails, the return value was ignored, and callers who don't know about the CuteDSL path (direct `sgl_kernel.dsv3_fused_a_gemm` users, `backend="aot"`, the sgl-kernel test suite) got a bare `cudaErrorInvalidValue` with no hint that a supported alternative exists.

## Modifications

- Check the computed smem request against the device's opt-in limit before launching, and raise an actionable error that names the CuteDSL path: `dsv3_fused_a_gemm needs 197632 bytes of dynamic shared memory but this device's opt-in limit is 101376 bytes; use the CuteDSL dsv3 fused-A GEMM on this architecture (sglang fused_a_gemm backend="auto" selects it automatically)`. The check uses the same `smem_bytes` the launch uses, so there is no constant to keep in sync.
- `CHECK_CUDA_SUCCESS` on the `cudaFuncSetAttribute` call, so any other misconfiguration fails loudly instead of corrupting the launch.
- Skip `tests/test_dsv3_fused_a_gemm.py` on devices below the 192 KB budget (probe-based, mirroring the gates from #29902).

Hopper is unchanged: the budget constant, pipeline depth, and launch configuration are untouched, and the guard passes trivially there (232,448-byte opt-in limit).

## Verification (RTX PRO 6000, SM120, CUDA 13, torch 2.11.0+cu130)

- Direct calls for both tile variants (num_tokens 1 and 16) now raise the signpost error instead of invalid-argument, and the CUDA context stays healthy afterwards (follow-up ops run normally).
- `tests/test_dsv3_fused_a_gemm.py`: 4 failed on stock -> 4 skipped.
- `pre-commit` (clang-format, isort, black, codespell) clean on both files.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28629342180](https://github.com/sgl-project/sglang/actions/runs/28629342180)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28629342082](https://github.com/sgl-project/sglang/actions/runs/28629342082)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->