### PR TITLE
test(sgl-kernel): gate ue8m0 and flashmla prefill tests on supported architectures

### DIFF
--- a/python/sglang/kernels/aot/tests/test_flashmla.py
+++ b/python/sglang/kernels/aot/tests/test_flashmla.py
@@ -45,6 +45,12 @@ def is_sm90_supported(device=None) -> bool:
     )
 
 
+def is_sm100_supported(device=None) -> bool:
+    return (torch.cuda.get_device_capability(device)[0] == 10) and (
+        torch.version.cuda >= "12.8"
+    )
+
+
 def quantize_k_cache(
     input_k_cache: torch.Tensor,  # (num_blocks, block_size, h_k, d)
     dv: int,
@@ -296,6 +302,10 @@ def reference_torch_decode(
     return out_ref, lse_ref
 
 
+@pytest.mark.skipif(
+    not (is_sm90_supported() or is_sm100_supported()),
+    reason="sparse attention forward kernel is only supported on sm90a and sm100f",
+)
 @pytest.mark.parametrize("s_q", S_Q_PREFILL)
 @pytest.mark.parametrize("kv_topk", KV_TOPK_PREFILL)
 @torch.inference_mode()

--- a/python/sglang/kernels/aot/tests/test_per_token_group_quant_8bit.py
+++ b/python/sglang/kernels/aot/tests/test_per_token_group_quant_8bit.py
@@ -115,8 +115,12 @@ def test_per_token_group_quant_with_column_major(
     )
 
     arch_major, _ = torch.cuda.get_device_capability(torch.cuda.current_device())
-    if flags["scale_ue8m0"] and (arch_major <= 9):
-        pytest.skip("Only Blackwell need ue8m0 fusion")
+    if flags["scale_ue8m0"] and (arch_major != 10):
+        # Pre-Blackwell does not need ue8m0 fusion at all. On sm120/sm121 the sgl-kernel
+        # path itself runs fine, but the reference goes through DeepGEMM's
+        # transform_sf_into_required_layout, which only implements the sm100 SF layouts
+        # ("Unknown SF transformation"), so there is nothing to compare against.
+        pytest.skip("ue8m0 fusion is only exercised on sm100")
         return
 
     if (flags["scale_ue8m0"] and (group_size != 128)) or (


### PR DESCRIPTION
## Motivation

A full `sgl-kernel/tests` sweep on an SM120 machine reports a large block of failures that are not bugs - they are tests exercising paths the running architecture knowingly does not support, with no skip condition. On an RTX PRO 6000 Blackwell against current main that is 242 failures across two families, which is enough noise to bury a real failure. Background and per-family tracebacks in #29900.

## Modifications

Each family gated in its own file's existing idiom:

- `test_per_token_group_quant_8bit.py` - the `scale_ue8m0` parametrizations already skipped pre-Blackwell; narrow that skip to sm100. Worth being precise about why: on sm120 the sgl-kernel path under test actually runs fine, but the *reference* calls DeepGEMM's `transform_sf_into_required_layout`, which only implements the sm100 SF layouts and raises `Assertion error (csrc/apis/layout.hpp:59): Unknown SF transformation` (DeepGEMM declined sm120 upstream in deepseek-ai/DeepGEMM#318). With no reference there is nothing to compare against, so the case is skipped rather than silently dropped.
- `test_flashmla.py` - `test_flashmla_prefill` has no arch gate, unlike the two decode tests in the same file. The kernel rejects the device itself with `Sparse Attention Forward Kernel is only supported on SM90a and SM100f architectures.`, so add the matching `skipif` via an `is_sm100_supported()` helper shaped like the file's existing `is_sm90_supported()`.

Deliberately **not** included: `test_fp8_blockwise_moe.py`. An earlier revision of this PR narrowed its `is_blackwell_supported` guard to sm100, which would have permanently skipped 10 cases on sm120. That family is a real support gap, not an unsupportable one - #28125 adds the sm120/sm121 dispatch and turns exactly those 10 cases green, independently reproduced on two different sm120 parts (RTX PRO 6000 and RTX 6000D). Masking it with a skip would have hidden a fixable gap, so those 10 failures are left visible until #28125 lands. Note #31366 currently proposes that same narrowing.

## Accuracy Test

Not an accuracy change - no kernel or reference behaviour is modified, only which cases run. Measured on an RTX PRO 6000 Blackwell (sm120, CUDA 13.0, torch 2.11.0+cu130) against main `d4801be`:

| file | before | after |
|---|---|---|
| `test_per_token_group_quant_8bit.py` | 222 failed, 1760 passed, 1650 skipped | 0 failed, 1760 passed, 1872 skipped |
| `test_flashmla.py` | 20 failed, 624 skipped | 0 failed, 644 skipped |

Pass counts are identical; only the previously failing cases become skips. To confirm nothing is over-skipped on hardware I do not have, I evaluated both predicates against simulated capabilities: `test_flashmla_prefill` runs on sm90/sm100/sm103 and skips elsewhere, and the ue8m0 cases run on sm100/sm103 only - sm80 and sm90 were already skipped by the pre-existing condition, so no currently-green configuration changes behaviour.

`test_fp8_blockwise_moe.py` still reports its 10 failures on sm120, as intended, until #28125 merges.

## Benchmark

Not a perf change.

## Checklist
- [x] Format with pre-commit
- [x] Add/extend unit tests (this PR only adjusts skip conditions)
- [x] AI assistance was used (Claude) for the sweep and drafting; the gates and the hardware runs above were reviewed and executed by the author on real sm120 silicon.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30532792549](https://github.com/sgl-project/sglang/actions/runs/30532792549)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30532792242](https://github.com/sgl-project/sglang/actions/runs/30532792242)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->