### PR TITLE
[diffusion] fix: fix z-Image online fp8 quantization crash with dit_cpu_offload

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
@@ -357,6 +357,11 @@ class ZImagePipelineConfig(ZImageRolloutPipelineMixin, ImagePipelineConfig):
         Batched prompts use stored text lengths. SP mode builds image caches for
         the local spatial shard.
         """
+        if rotary_emb is None:
+            raise ValueError(
+                "Z-Image transformer has no `rotary_emb`. It likely loaded via the "
+                "native diffusers fallback; check the load logs for the real error."
+            )
 
         def create_coordinate_grid(size, start=None, device=None):
             if start is None:

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -170,6 +170,10 @@ class TransformerLoader(ComponentLoader):
             reduce_dtype=torch.float32,
             output_dtype=None,
             strict=False,
+            defer_cpu_offload_until_after_weight_processing=(
+                component_server_args.dit_cpu_offload
+                and quant_spec.requires_device_weight_processing
+            ),
         )
 
         # post-hooks (e.g., patch scales (nunchaku))

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -85,7 +85,12 @@ class TransformerLoader(ComponentLoader):
         component_server_args = _server_args_for_transformer_component(
             server_args, component_name
         )
-        return component_server_args.transformer_weights_path is not None
+        # Don't let a quantized load quietly fall back to the unquantized native
+        # model. That would drop the requested precision and bury the real error.
+        return (
+            component_server_args.transformer_weights_path is not None
+            or component_server_args.quantization is not None
+        )
 
     def load_customized(
         self, component_model_path: str, server_args: ServerArgs, component_name: str

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -196,6 +196,7 @@ def maybe_load_fsdp_model(
     output_dtype: torch.dtype | None = None,
     pin_cpu_memory: bool = True,
     strict: bool = True,
+    defer_cpu_offload_until_after_weight_processing: bool = False,
 ) -> torch.nn.Module:
     """Load a model with optional FSDP (Fully Sharded Data Parallel) support.
 
@@ -206,6 +207,9 @@ def maybe_load_fsdp_model(
             - Weight loading and casting
         reduce_dtype: Data type for gradient reduction in FSDP mixed precision.
         strict: If True, enforce strict state dict loading (all keys must match).
+        defer_cpu_offload_until_after_weight_processing: If True, keep weights
+            on device until process_weights_after_loading completes, then apply
+            non-FSDP CPU offload.
     """
     # NOTE(will): cast_forward_inputs=True shouldn't be needed as we are
     # manually casting the inputs to the model
@@ -232,6 +236,17 @@ def maybe_load_fsdp_model(
         use_fsdp = False
         logger.info("Disabling FSDP for MPS platform as it's not compatible")
 
+    defer_cpu_offload = bool(
+        cpu_offload and defer_cpu_offload_until_after_weight_processing
+    )
+    if defer_cpu_offload and use_fsdp:
+        logger.warning(
+            "Ignoring deferred CPU offload for FSDP loading; keeping the existing "
+            "FSDP offload policy."
+        )
+        defer_cpu_offload = False
+    load_cpu_offload = cpu_offload and not defer_cpu_offload
+
     if use_fsdp:
         model._pre_fsdp_weight_loader_params = {
             n: p
@@ -251,7 +266,7 @@ def maybe_load_fsdp_model(
         )
         shard_model(
             model,
-            cpu_offload=cpu_offload,
+            cpu_offload=load_cpu_offload,
             reshard_after_forward=True,
             mp_policy=mp_policy,
             mesh=device_mesh,
@@ -280,7 +295,7 @@ def maybe_load_fsdp_model(
         device,
         param_dtype,
         strict=strict,
-        cpu_offload=cpu_offload,
+        cpu_offload=load_cpu_offload,
         param_names_mapping=param_names_mapping_fn,
     )
     if bnb_quant_states:
@@ -301,6 +316,8 @@ def maybe_load_fsdp_model(
             if _is_npu:
                 torch.npu.empty_cache()
     model.post_load_weights()
+    if defer_cpu_offload:
+        model.to("cpu")
 
     for n, p in chain(model.named_parameters(), model.named_buffers()):
         if p.is_meta:

--- a/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
@@ -234,7 +234,11 @@ class _Flux2Nvfp4FallbackAdapter(_TransformerQuantAdapter):
 
 
 class _ModelOptFp8OffloadAdapter(_TransformerQuantAdapter):
-    """Adapter for diffusion ModelOpt FP8 checkpoints."""
+    """Keeps the DiT resident when offload would break FP8-family quant.
+
+    modelopt_fp8 needs it for tensor strides; online quant needs it because
+    the load-time quant kernels are GPU/NPU-only.
+    """
 
     def __init__(
         self,
@@ -255,16 +259,30 @@ class _ModelOptFp8OffloadAdapter(_TransformerQuantAdapter):
 
         quant_name_getter = getattr(type(quant_config), "get_name", None)
         quant_name = quant_name_getter() if callable(quant_name_getter) else None
-        if quant_name != "modelopt_fp8":
+
+        # Online quant runs its weight-quant kernel during load, and that kernel
+        # is GPU/NPU-only. If the DiT sits on the host under dit_cpu_offload the
+        # kernel dies there and the loader quietly falls back to an unquantized
+        # native model.
+        is_online_quant = server_args.quantization is not None
+        if quant_name != "modelopt_fp8" and not is_online_quant:
             return
 
         if server_args.dit_cpu_offload:
             server_args.dit_cpu_offload = False
-            logger.warning(
-                "ModelOpt FP8 diffusion checkpoints currently keep dit_cpu_offload "
-                "disabled. Layerwise DiT offload stays enabled because the runtime "
-                "now preserves the restored FP8 tensor strides.",
-            )
+            if is_online_quant:
+                logger.warning(
+                    "Disabling dit_cpu_offload: online '%s' quantization needs the "
+                    "DiT on device at load time. Use --dit-layerwise-offload to save "
+                    "DiT memory.",
+                    server_args.quantization,
+                )
+            else:
+                logger.warning(
+                    "ModelOpt FP8 diffusion checkpoints currently keep dit_cpu_offload "
+                    "disabled. Layerwise DiT offload stays enabled because the runtime "
+                    "now preserves the restored FP8 tensor strides.",
+                )
 
     def prepare(self) -> None:
         _ModelOptFp8OffloadAdapter._maybe_disable_incompatible_dit_offload_modes(

--- a/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
@@ -122,6 +122,7 @@ class TransformerQuantLoadSpec:
     quant_config: Optional[QuantizationConfig]
     nunchaku_config: Optional[NunchakuConfig]
     param_dtype: Optional[torch.dtype]
+    requires_device_weight_processing: bool = False
     post_load_hooks: list[PostLoadHook] = field(default_factory=list)
 
     @property
@@ -234,11 +235,7 @@ class _Flux2Nvfp4FallbackAdapter(_TransformerQuantAdapter):
 
 
 class _ModelOptFp8OffloadAdapter(_TransformerQuantAdapter):
-    """Keeps the DiT resident when offload would break FP8-family quant.
-
-    modelopt_fp8 needs it for tensor strides; online quant needs it because
-    the load-time quant kernels are GPU/NPU-only.
-    """
+    """Adapter for diffusion ModelOpt FP8 checkpoints."""
 
     def __init__(
         self,
@@ -260,29 +257,16 @@ class _ModelOptFp8OffloadAdapter(_TransformerQuantAdapter):
         quant_name_getter = getattr(type(quant_config), "get_name", None)
         quant_name = quant_name_getter() if callable(quant_name_getter) else None
 
-        # Online quant runs its weight-quant kernel during load, and that kernel
-        # is GPU/NPU-only. If the DiT sits on the host under dit_cpu_offload the
-        # kernel dies there and the loader quietly falls back to an unquantized
-        # native model.
-        is_online_quant = server_args.quantization is not None
-        if quant_name != "modelopt_fp8" and not is_online_quant:
+        if quant_name != "modelopt_fp8":
             return
 
         if server_args.dit_cpu_offload:
             server_args.dit_cpu_offload = False
-            if is_online_quant:
-                logger.warning(
-                    "Disabling dit_cpu_offload: online '%s' quantization needs the "
-                    "DiT on device at load time. Use --dit-layerwise-offload to save "
-                    "DiT memory.",
-                    server_args.quantization,
-                )
-            else:
-                logger.warning(
-                    "ModelOpt FP8 diffusion checkpoints currently keep dit_cpu_offload "
-                    "disabled. Layerwise DiT offload stays enabled because the runtime "
-                    "now preserves the restored FP8 tensor strides.",
-                )
+            logger.warning(
+                "ModelOpt FP8 diffusion checkpoints currently keep dit_cpu_offload "
+                "disabled. Layerwise DiT offload stays enabled because the runtime "
+                "now preserves the restored FP8 tensor strides.",
+            )
 
     def prepare(self) -> None:
         _ModelOptFp8OffloadAdapter._maybe_disable_incompatible_dit_offload_modes(
@@ -498,8 +482,23 @@ def resolve_transformer_quant_load_spec(
         quant_config=quant_config,
         nunchaku_config=nunchaku_config,
         param_dtype=param_dtype,
+        requires_device_weight_processing=_requires_device_weight_processing(
+            quant_config
+        ),
         post_load_hooks=post_load_hooks,
     )
+
+
+def _requires_device_weight_processing(
+    quant_config: Optional[QuantizationConfig],
+) -> bool:
+    """Return whether post-load weight processing needs CUDA/NPU tensors."""
+    quant_name = _get_quant_config_name(quant_config)
+    if quant_name == "fp8":
+        return not getattr(quant_config, "is_checkpoint_fp8_serialized", False)
+    if quant_name == "mxfp4":
+        return not getattr(quant_config, "is_checkpoint_mxfp4_serialized", False)
+    return False
 
 
 def _build_transformer_quant_adapters(

--- a/python/sglang/multimodal_gen/test/unit/test_layerwise_offload.py
+++ b/python/sglang/multimodal_gen/test/unit/test_layerwise_offload.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import torch
 
+from sglang.multimodal_gen.runtime.layers.quantization.fp8 import Fp8Config
 from sglang.multimodal_gen.runtime.layers.quantization.modelopt_quant import (
     ModelOptFp8Config,
 )
@@ -294,6 +295,21 @@ def test_modelopt_fp8_adapter_keeps_layerwise_offload_enabled():
 
     assert server_args.dit_cpu_offload is False
     assert server_args.dit_layerwise_offload is True
+
+
+def test_modelopt_fp8_adapter_does_not_change_online_fp8_offload():
+    server_args = SimpleNamespace(
+        dit_cpu_offload=True,
+        dit_layerwise_offload=False,
+        quantization="fp8",
+    )
+
+    _ModelOptFp8OffloadAdapter._maybe_disable_incompatible_dit_offload_modes(
+        server_args=server_args,
+        quant_config=Fp8Config(),
+    )
+
+    assert server_args.dit_cpu_offload is True
 
 
 def test_layerwise_capability_selects_layerwise_strategy_for_any_component():

--- a/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
@@ -49,6 +49,7 @@ from sglang.multimodal_gen.runtime.layers.linear import UnquantizedLinearMethod
 from sglang.multimodal_gen.runtime.layers.quantization.configs.nunchaku_config import (
     NunchakuConfig,
 )
+from sglang.multimodal_gen.runtime.layers.quantization.fp8 import Fp8Config
 from sglang.multimodal_gen.runtime.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     _prepare_nvfp4_weight_bytes,
@@ -56,6 +57,7 @@ from sglang.multimodal_gen.runtime.layers.quantization.modelopt_quant import (
 from sglang.multimodal_gen.runtime.loader.transformer_load_utils import (
     _filter_duplicate_precision_variant_safetensors,
     _Flux2Nvfp4FallbackAdapter,
+    _requires_device_weight_processing,
     resolve_transformer_quant_load_spec,
     resolve_transformer_safetensors_to_load,
 )
@@ -181,6 +183,14 @@ class TestTransformerQuantHelpers(unittest.TestCase):
         resolved = _filter_duplicate_precision_variant_safetensors(files)
 
         self.assertEqual(resolved, files)
+
+    def test_online_fp8_requires_device_weight_processing(self):
+        self.assertTrue(_requires_device_weight_processing(Fp8Config()))
+        self.assertFalse(
+            _requires_device_weight_processing(
+                Fp8Config(is_checkpoint_fp8_serialized=True)
+            )
+        )
 
     @patch(
         "sglang.multimodal_gen.runtime.loader.transformer_load_utils.build_nvfp4_config_from_safetensors_list",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`sglang generate --model-path Tongyi-MAI/Z-Image-Turbo --quantization fp8` crashes with `TypeError: 'NoneType' object is not callable` in `zimage.py::get_freqs_cis`. Online fp8 for Z-Image-Turbo is a documented "validated" path, so this is a regression.

Cause: the auto memory policy enables `dit_cpu_offload`, leaving DiT weights on CPU. Online fp8 quantizes at load time via a CUDA/NPU-only kernel, which fails on CPU tensors. The loader then silently falls back to a native diffusers model (no `rotary_emb`), and denoising crashes calling `rotary_emb(None)`.

closes #29833

## Modifications

- `transformer_load_utils.py`: disable `dit_cpu_offload` when online quantization is requested (not just `modelopt_fp8`), so the DiT stays on device for the load-time quant kernel. `--dit-layerwise-offload` remains the way to save DiT memory.
- `transformer_loader.py`: a failed quantized load now raises the real error instead of silently falling back to an unquantized native model.
- `zimage.py`: `get_freqs_cis` raises a clear error when `rotary_emb` is `None`.

## Accuracy Tests

Loader fix, not a kernel/forward change. 
Before: crashes on the first denoise step. 
After: loads `ZImageTransformer2DModel (sgl-diffusion version)`, no native fallback, image generated correctly.



## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28709134335](https://github.com/sgl-project/sglang/actions/runs/28709134335)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28709134305](https://github.com/sgl-project/sglang/actions/runs/28709134305)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->