### PR TITLE
docs: add Qwen3.6-27B-NVFP4 variant to cookbook

### DIFF
--- a/docs_new/cookbook/autoregressive/Qwen/Qwen3.6.mdx
+++ b/docs_new/cookbook/autoregressive/Qwen/Qwen3.6.mdx
@@ -57,6 +57,11 @@ Both variants share the same hybrid reasoning, tool-calling, and multimodal inte
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Dense 27B</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Qwen/Qwen3.6-27B-FP8](https://huggingface.co/Qwen/Qwen3.6-27B-FP8)</td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>Qwen3.6-27B (NVFP4)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Dense 27B (Blackwell)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>[nvidia/Qwen3.6-27B-NVFP4](https://huggingface.co/nvidia/Qwen3.6-27B-NVFP4)</td>
+    </tr>
   </tbody>
 </table>
 
@@ -75,6 +80,9 @@ uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=pytho
 
 # Or use Docker (NVIDIA GPUs)
 docker pull lmsysorg/sglang:latest
+
+# For the NVFP4 variant (nvidia/Qwen3.6-27B-NVFP4), use the dedicated dev image
+docker pull lmsysorg/sglang:dev-cu13-dev-qwen36-27b-nvfp4
 ```
 
 For the full Docker setup and other installation methods, please refer to the [official SGLang installation guide](../../../docs/get-started/install).

--- a/docs_new/src/snippets/autoregressive/qwen36-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/qwen36-deployment.jsx
@@ -23,10 +23,19 @@ export const Qwen36Deployment = () => {
     quantization: {
       name: 'quantization',
       title: 'Quantization',
-      items: [
-        { id: 'fp8', label: 'FP8', default: true },
-        { id: 'bf16', label: 'BF16', default: false },
-      ],
+      // NVFP4 is a Blackwell-only, 27B-only checkpoint (nvidia/Qwen3.6-27B-NVFP4);
+      // only surface it when both conditions hold so we never emit an unrunnable command.
+      getDynamicItems: (values) => {
+        const items = [
+          { id: 'fp8', label: 'FP8', default: true },
+          { id: 'bf16', label: 'BF16', default: false },
+        ];
+        const nvfp4Supported = values.modelSize === '27b' && (values.hardware === 'b200' || values.hardware === 'b300');
+        if (nvfp4Supported) {
+          items.push({ id: 'nvfp4', label: 'NVFP4', default: false });
+        }
+        return items;
+      },
     },
     reasoning: {
       name: 'reasoning',
@@ -93,8 +102,8 @@ export const Qwen36Deployment = () => {
       baseName: '27B',
       h100: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
       h200: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-      b200: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-      b300: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
+      b200: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 }, nvfp4: { tp: 1 } },
+      b300: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 }, nvfp4: { tp: 1 } },
       xeon: { bf16: { tp: 6 },           fp8: { tp: 6 } },
     },
   };
@@ -147,7 +156,7 @@ export const Qwen36Deployment = () => {
       }
       return next;
     });
-  }, [values.speculative, values.hardware]);
+  }, [values.speculative, values.hardware, values.modelSize]);
 
   const handleRadioChange = (optionName, value) => {
     setValues((prev) => ({ ...prev, [optionName]: value }));
@@ -159,6 +168,32 @@ export const Qwen36Deployment = () => {
     const hwConfig = sizeConfig?.[hardware]?.[quantization];
     if (!hwConfig) {
       return '# Please select a valid hardware and quantization combination';
+    }
+
+    const adjustedValues = {
+      ...values,
+      mambaCache: speculative === 'enabled' ? 'v2' : values.mambaCache,
+    };
+
+    // NVFP4: nvidia/Qwen3.6-27B-NVFP4 on Blackwell (B200/B300). Follows the exact command
+    // shape from the checkpoint's docs — explicit --tp-size 1, --attention-backend trtllm_mha,
+    // new-style --mamba-radix-cache-strategy, and explicit --host/--port (no --mem-fraction-static
+    // or SGLANG_ENABLE_SPEC_V2 prefix). Reasoning / tool-call parsers still follow their toggles.
+    if (quantization === 'nvfp4') {
+      let cmd = `sglang serve --model-path nvidia/Qwen3.6-${sizeConfig.baseName}-NVFP4`;
+      cmd += ` \\\n  --tp-size ${hwConfig.tp} --attention-backend trtllm_mha`;
+      const reasoningRule = options.reasoning.commandRule(values.reasoning);
+      if (reasoningRule) cmd += ` \\\n  ${reasoningRule}`;
+      const toolcallRule = options.toolcall.commandRule(values.toolcall);
+      if (toolcallRule) cmd += ` \\\n  ${toolcallRule}`;
+      if (speculative === 'enabled') {
+        cmd += ` \\\n  --speculative-algorithm EAGLE --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`;
+      }
+      if (adjustedValues.mambaCache === 'v2') {
+        cmd += ` \\\n  --mamba-radix-cache-strategy extra_buffer`;
+      }
+      cmd += ` \\\n  --host 0.0.0.0 --port 30000`;
+      return cmd;
     }
 
     const quantSuffix = quantization === 'fp8' ? '-FP8' : '';
@@ -176,11 +211,6 @@ export const Qwen36Deployment = () => {
     if (hwConfig.tp > 1) {
       cmd += ` \\\n  --tp ${hwConfig.tp}`;
     }
-
-    const adjustedValues = {
-      ...values,
-      mambaCache: speculative === 'enabled' ? 'v2' : values.mambaCache,
-    };
 
     for (const [key, option] of Object.entries(options)) {
       if (key === 'quantization' || key === 'hardware' || key === 'modelSize') continue;


### PR DESCRIPTION
## Motivation

Add the `nvidia/Qwen3.6-27B-NVFP4` (Blackwell) checkpoint to the Qwen3.6 cookbook page so users can generate deployment commands for the NVFP4 variant.

## Modifications

- **Command generator** (`qwen36-deployment.jsx`): expose an **NVFP4** quantization option, surfaced only for **27B + B200/B300** (NVFP4 is a Blackwell-only, 27B-only checkpoint). It emits the checkpoint's documented command shape — explicit `--tp-size 1`, `--attention-backend trtllm_mha`, new-style `--mamba-radix-cache-strategy`, and explicit `--host`/`--port`. The reasoning and tool-call parsers still follow their existing toggles.
- **Available Models** table: add a `Qwen3.6-27B (NVFP4)` row linking to the HF repo.
- **Installation** section: add the dedicated dev image `lmsysorg/sglang:dev-cu13-dev-qwen36-27b-nvfp4`.

Generated command (B200/B300, MTP on, parsers on):

```
sglang serve --model-path nvidia/Qwen3.6-27B-NVFP4 \
  --tp-size 1 --attention-backend trtllm_mha \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --speculative-algorithm EAGLE --speculative-num-steps 3 \
  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
  --mamba-radix-cache-strategy extra_buffer \
  --host 0.0.0.0 --port 30000
```

## Checklist

- [x] `mint validate` passes (build validation)
- [x] Docs-only change (Mintlify cookbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28571649289](https://github.com/sgl-project/sglang/actions/runs/28571649289)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28571649172](https://github.com/sgl-project/sglang/actions/runs/28571649172)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->