### PR TITLE
[router] Log every engine /abort_request with a router_reason label + Prom counter

### DIFF
--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -8,15 +8,155 @@ pub mod sse;
 use crate::health::circuit_breaker::CircuitBreaker;
 use crate::server::error::ApiError;
 use crate::server::header_utils::should_forward_request_header;
+use crate::server::metrics::MetricsRegistry;
 use crate::workers::WireProtocol;
 use anyhow::Context;
 use axum::body::Body;
 use axum::http::{HeaderMap, HeaderName, HeaderValue, Response};
 use bytes::Bytes;
 use reqwest::{Client, Url};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
+
+/// Total number of [`AbortReason`] variants. Referenced by
+/// [`crate::server::metrics::MetricsRegistry`] to size the fixed-length
+/// per-reason counter array — a compile-time invariant that adding a new
+/// variant here without bumping this constant would break, which is exactly
+/// the failure mode we want (versus a silent OOB or a HashMap re-alloc under
+/// contention). Update alongside every new variant.
+pub(crate) const ABORT_REASON_COUNT: usize = 8;
+
+/// Why the router is telling an engine to stop generating a specific request.
+///
+/// Recorded via [`AbortOnDrop`] at the drop site and stamped into (a) the WARN
+/// log line the drop emits and (b) the JSON body of the `/abort_request` POST
+/// (as `router_reason`) so operators can attribute engine-side aborts to a
+/// specific router-side trigger without having to correlate by `rid` alone.
+/// Values are stored in an `AtomicU8` so the reason can be updated cross-thread
+/// (the SSE pump is on a different tokio task than the handler owning the
+/// guard) without borrowing gymnastics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum AbortReason {
+    /// The drop happened without any code path narrowing the cause. Only
+    /// observed when a call site failed to `set_reason` — treat as a bug in
+    /// call-site coverage, not a legitimate reason.
+    Unknown = 0,
+    /// Unary/pre-headers guard: the handler future was dropped mid-await
+    /// before any specific `ApiError` was assigned. In practice this is a
+    /// client-side disconnect: axum cancelled the handler when the client's
+    /// connection closed while the router was still awaiting the engine's
+    /// buffered response.
+    HandlerCancelled = 1,
+    /// Unary/pre-headers guard: the stale-request janitor
+    /// (`ActiveLoadGuard::cancel_token`) fired before the engine responded.
+    /// The handler's `tokio::select!` returned `StaleRequestExpired` and the
+    /// guard was left armed on purpose.
+    StaleRequestExpired = 2,
+    /// Unary/pre-headers guard: the router-side wait-for-response-headers
+    /// budget (`request_timeout`) elapsed before the engine sent headers.
+    /// Distinct from stale-timeout in that the router itself gave up on this
+    /// worker, not the request as a whole.
+    UpstreamTimeout = 3,
+    /// Unary/pre-headers guard: connect / TCP / TLS / write error before a
+    /// response was received. Covers reqwest's transport-layer failures,
+    /// breaker-open rejections, and DNS/URL problems.
+    TransportError = 4,
+    /// Streaming guard: the SSE pump's `tx.send` failed or `tx.closed` fired
+    /// while the pump had more upstream to deliver — i.e. axum/hyper dropped
+    /// the response Body (client TCP close, HTTP/2 RST_STREAM, or a middle
+    /// box severing the connection). The most common streaming abort cause.
+    StreamClientGone = 5,
+    /// Streaming guard: the pump waited `STREAM_SEND_STALL` (120 s) for the
+    /// client to drain the read-ahead buffer and the client never made
+    /// progress. Treated as "client is present but not consuming"; the abort
+    /// releases the engine slot so a working consumer can be served.
+    StreamDownstreamStall = 6,
+    /// Streaming guard: the pump task itself panicked. Distinct from a
+    /// clean client-gone because the panic implies a router-side bug, not a
+    /// client problem — surface it so it doesn't get lumped with the
+    /// normal disconnect volume.
+    StreamPumpPanicked = 7,
+}
+
+impl AbortReason {
+    /// Stable label for logs, metrics, and the outbound POST body. Keep in
+    /// sync with the `AbortReason` variants: adding a variant without adding
+    /// a label here surfaces a compile error, which is why this is a `match`
+    /// and not e.g. a `Debug`-derived string.
+    pub(crate) fn as_label(&self) -> &'static str {
+        match self {
+            AbortReason::Unknown => "unknown",
+            AbortReason::HandlerCancelled => "handler_cancelled",
+            AbortReason::StaleRequestExpired => "stale_request_expired",
+            AbortReason::UpstreamTimeout => "upstream_timeout",
+            AbortReason::TransportError => "transport_error",
+            AbortReason::StreamClientGone => "stream_client_gone",
+            AbortReason::StreamDownstreamStall => "stream_downstream_stall",
+            AbortReason::StreamPumpPanicked => "stream_pump_panicked",
+        }
+    }
+
+    /// Inverse of the `#[repr(u8)]` cast; used by [`crate::server::metrics`]
+    /// to translate its per-reason array index back to a label at scrape
+    /// time. `pub(crate)` (not `pub`) because the discriminant→variant map
+    /// is a crate-private detail — external code goes through `as_label`.
+    ///
+    /// `0` is the legitimate `Unknown` discriminant; other out-of-range
+    /// values are corruption (the atomic is only written from
+    /// `AbortReason as u8`, so they should be unreachable). Split the two
+    /// with a `debug_assert!` so a debug build panics loudly on
+    /// discriminant drift, while release keeps the safe fallback.
+    pub(crate) fn from_u8(v: u8) -> Self {
+        match v {
+            0 => AbortReason::Unknown,
+            1 => AbortReason::HandlerCancelled,
+            2 => AbortReason::StaleRequestExpired,
+            3 => AbortReason::UpstreamTimeout,
+            4 => AbortReason::TransportError,
+            5 => AbortReason::StreamClientGone,
+            6 => AbortReason::StreamDownstreamStall,
+            7 => AbortReason::StreamPumpPanicked,
+            other => {
+                debug_assert!(
+                    false,
+                    "AbortReason::from_u8 got out-of-range value {other}; \
+                     did you add a variant without bumping ABORT_REASON_COUNT?",
+                );
+                AbortReason::Unknown
+            }
+        }
+    }
+
+    /// Contiguous index in `0..ABORT_REASON_COUNT`. Used by the metrics
+    /// registry to index its fixed-length per-reason counter array without a
+    /// hash lookup or lock. Guaranteed in-range by the `#[repr(u8)]` +
+    /// explicit-discriminant layout (0..=7 for the current 8 variants) and
+    /// the `ABORT_REASON_COUNT` constant kept in sync above.
+    pub(crate) fn as_index(&self) -> usize {
+        *self as usize
+    }
+}
+
+// Compile-time invariant: every `AbortReason` discriminant is < ABORT_REASON_COUNT.
+// If you add a new variant without also bumping the constant above, this fails
+// to build — which is the whole point. Runtime array-index panics on the hot
+// path (metrics.rs `engine_aborts_total[reason.as_index()]`) would be
+// significantly worse than a compile error here. Also asserts the "top
+// discriminant is exactly COUNT-1" so a gap (someone assigning a scratch
+// discriminant like `= 100`) also fails to build.
+const _: () = {
+    assert!((AbortReason::Unknown as u8) < ABORT_REASON_COUNT as u8);
+    assert!((AbortReason::HandlerCancelled as u8) < ABORT_REASON_COUNT as u8);
+    assert!((AbortReason::StaleRequestExpired as u8) < ABORT_REASON_COUNT as u8);
+    assert!((AbortReason::UpstreamTimeout as u8) < ABORT_REASON_COUNT as u8);
+    assert!((AbortReason::TransportError as u8) < ABORT_REASON_COUNT as u8);
+    assert!((AbortReason::StreamClientGone as u8) < ABORT_REASON_COUNT as u8);
+    assert!((AbortReason::StreamDownstreamStall as u8) < ABORT_REASON_COUNT as u8);
+    assert!((AbortReason::StreamPumpPanicked as u8) < ABORT_REASON_COUNT as u8);
+    assert!((AbortReason::StreamPumpPanicked as u8) == (ABORT_REASON_COUNT as u8) - 1);
+};
 
 /// Parse a worker URL emitted by discovery.  On failure, trip the worker's
 /// circuit breaker so the malformed worker drops out of subsequent
@@ -92,16 +232,32 @@ const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 const ABORT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Tell an engine to stop generating a request whose client has disconnected,
-/// by `POST`ing `/abort_request {rid, abort_all:false}`. The engine cancels
-/// every in-flight request whose `rid` *starts with* this one, which also
-/// covers the `n>1` parallel-sampling expansions (`<rid>_0`, `<rid>_1`, …).
+/// by `POST`ing `/abort_request {rid, abort_all:false, router_reason}`. The
+/// engine cancels every in-flight request whose `rid` *starts with* this one,
+/// which also covers the `n>1` parallel-sampling expansions
+/// (`<rid>_0`, `<rid>_1`, …).
+///
+/// `reason` is a stable label from [`AbortReason::as_label`] identifying why
+/// the router is aborting. It rides on the request body as `router_reason` so
+/// the engine can log/count aborts by cause (SGLang currently ignores extra
+/// fields, keeping this forward-compatible), and is also stamped into the
+/// WARN log emitted by the [`AbortOnDrop`] drop site — that log is the
+/// primary observability surface: one `sending /abort_request` line per real
+/// abort, tagged with reason, so operators can quantify "how many of my
+/// aborts were `stream_client_gone` vs `stale_request_expired`" without
+/// having to parse pump-timing debug logs.
 ///
 /// Best-effort by construction: the client is already gone, so there is no one
 /// to surface an error to, and a missed abort wastes engine compute but is not
 /// a correctness fault. Failures are logged, not propagated. Not circuit-breaker
 /// gated — an abort is a courtesy to the engine, never counted against a worker.
-async fn send_abort(client: &Client, abort_url: &str, rid: &str) {
-    let body = serde_json::json!({ "rid": rid, "abort_all": false });
+async fn send_abort(client: &Client, abort_url: &str, rid: &str, reason: AbortReason) {
+    let reason_label = reason.as_label();
+    let body = serde_json::json!({
+        "rid": rid,
+        "abort_all": false,
+        "router_reason": reason_label,
+    });
     match client
         .post(abort_url)
         .json(&body)
@@ -112,14 +268,16 @@ async fn send_abort(client: &Client, abort_url: &str, rid: &str) {
         Ok(resp) => tracing::debug!(
             abort_url,
             rid,
+            reason = reason_label,
             status = %resp.status(),
-            "told engine to abort request after client disconnect",
+            "engine acknowledged /abort_request",
         ),
         Err(e) => tracing::warn!(
             abort_url,
             rid,
+            reason = reason_label,
             error = %e,
-            "failed to send abort to engine after client disconnect",
+            "failed to POST /abort_request to engine (best-effort; not retried)",
         ),
     }
 }
@@ -146,16 +304,40 @@ pub(crate) struct AbortOnDrop {
     /// `None` for unary (decided solely by `armed`); `Some` for streaming, where
     /// the abort fires only if the engine had not reached its terminal item.
     reached_end: Option<Arc<AtomicBool>>,
+    /// Encoded [`AbortReason`]. Stored via `Arc<AtomicU8>` so an update from a
+    /// different task than the one that owns the guard (specifically, the SSE
+    /// pump task writing into a streaming guard held inside `stream_guards`)
+    /// is race-free and Send/Sync-friendly.
+    ///
+    /// Defaults are set in the constructors: unary → [`AbortReason::HandlerCancelled`]
+    /// (the "you dropped me without telling me why" catch-all that also covers
+    /// the common client-disconnect-during-await case); streaming →
+    /// [`AbortReason::StreamClientGone`] (the majority streaming case). Call
+    /// sites narrow those defaults via [`Self::set_reason`] or by writing to
+    /// the [`Self::reason_handle`] before the guard drops.
+    reason: Arc<AtomicU8>,
+    /// Metrics sink used in `Drop` to bump `sgl_router_engine_aborts_total`
+    /// with the per-reason label. `None` when the guard was constructed
+    /// directly (unit tests) or the proxy never had metrics attached;
+    /// the WARN log still fires, only the counter goes dark.
+    metrics: Option<Arc<MetricsRegistry>>,
     armed: bool,
 }
 
 impl AbortOnDrop {
-    fn for_unary(client: Client, abort_url: String, rid: String) -> Self {
+    fn for_unary(
+        client: Client,
+        abort_url: String,
+        rid: String,
+        metrics: Option<Arc<MetricsRegistry>>,
+    ) -> Self {
         Self {
             client,
             abort_url,
             rid,
             reached_end: None,
+            reason: Arc::new(AtomicU8::new(AbortReason::HandlerCancelled as u8)),
+            metrics,
             armed: true,
         }
     }
@@ -165,12 +347,15 @@ impl AbortOnDrop {
         abort_url: String,
         rid: String,
         reached_end: Arc<AtomicBool>,
+        metrics: Option<Arc<MetricsRegistry>>,
     ) -> Self {
         Self {
             client,
             abort_url,
             rid,
             reached_end: Some(reached_end),
+            reason: Arc::new(AtomicU8::new(AbortReason::StreamClientGone as u8)),
+            metrics,
             armed: true,
         }
     }
@@ -179,6 +364,22 @@ impl AbortOnDrop {
     /// once a full response has been received from the engine (unary path).
     pub(crate) fn disarm(&mut self) {
         self.armed = false;
+    }
+
+    /// Narrow the recorded [`AbortReason`] from the constructor default. Idempotent
+    /// per drop — later writes overwrite earlier ones, which is intentional: the
+    /// most-specific known reason at drop time wins.
+    pub(crate) fn set_reason(&self, reason: AbortReason) {
+        self.reason.store(reason as u8, Ordering::Relaxed);
+    }
+
+    /// Handle that lets a task NOT holding `&self` write the reason before drop.
+    /// Used by the SSE pump: the pump task holds the guard inside its opaque
+    /// `stream_guards`, but takes a separate `Arc<AtomicU8>` clone so it can
+    /// tag the reason as it hits `break` on `client_gone` / `downstream_stall` /
+    /// panic paths. Cheap: one `Arc::clone`, no allocation.
+    pub(crate) fn reason_handle(&self) -> Arc<AtomicU8> {
+        Arc::clone(&self.reason)
     }
 
     fn should_abort(&self) -> bool {
@@ -195,6 +396,22 @@ impl Drop for AbortOnDrop {
         if !self.should_abort() {
             return;
         }
+        let reason = AbortReason::from_u8(self.reason.load(Ordering::Relaxed));
+        // One WARN line per real abort. Deliberately WARN, not DEBUG: an
+        // abort means the engine is doing wasted work on our behalf, and
+        // operators need to be able to grep this at scale. Paired with the
+        // Prom counter bump below, this gives both a per-event trail (log)
+        // and an aggregate signal (metric) with matching labels — cheap to
+        // slice by reason without full log parsing.
+        tracing::warn!(
+            rid = %self.rid,
+            reason = reason.as_label(),
+            abort_url = %self.abort_url,
+            "sending /abort_request to engine",
+        );
+        if let Some(m) = self.metrics.as_ref() {
+            m.record_engine_abort(reason);
+        }
         let client = self.client.clone();
         let abort_url = std::mem::take(&mut self.abort_url);
         let rid = std::mem::take(&mut self.rid);
@@ -205,11 +422,12 @@ impl Drop for AbortOnDrop {
         // exiting and there is no point chasing an abort.
         match tokio::runtime::Handle::try_current() {
             Ok(handle) => {
-                handle.spawn(async move { send_abort(&client, &abort_url, &rid).await });
+                handle.spawn(async move { send_abort(&client, &abort_url, &rid, reason).await });
             }
             Err(_) => tracing::debug!(
                 %abort_url,
                 %rid,
+                reason = reason.as_label(),
                 "no tokio runtime at drop (shutdown); skipping engine abort",
             ),
         }
@@ -232,6 +450,15 @@ pub struct Proxy {
     /// Wall-clock timeout applied to non-streaming upstream requests. Streaming
     /// requests deliberately do not use this (long generations are valid).
     pub request_timeout: Duration,
+    /// Metrics sink for the drop-side of `AbortOnDrop`. Filled once at startup
+    /// via [`Self::attach_metrics`] — matching the same pattern
+    /// `ActiveLoadRegistry` and `PolicyRegistry` use — so tests that build a
+    /// `Proxy` in isolation don't need a full metrics wiring, and prod flows
+    /// get their per-reason `sgl_router_engine_aborts_total` counter bumped
+    /// on every abort. `OnceLock`, not `Mutex<Option<_>>`, because the wire-in
+    /// is a single-shot at app startup and the read path is on every abort
+    /// drop — one atomic load beats a mutex acquire.
+    metrics: OnceLock<Arc<MetricsRegistry>>,
 }
 
 /// Build a forwarding client for `protocol`, sharing pool/connect tuning
@@ -264,7 +491,52 @@ impl Proxy {
             http1_client: build_client(WireProtocol::Http1)?,
             h2c_client: build_client(WireProtocol::H2c)?,
             request_timeout,
+            metrics: OnceLock::new(),
         })
+    }
+
+    /// Wire a metrics registry into this proxy — every subsequent
+    /// [`AbortOnDrop`] created via [`Self::abort_guard_for`] /
+    /// [`Self::forward_streaming_to`] inherits it and bumps the per-reason
+    /// `sgl_router_engine_aborts_total` counter on drop.
+    ///
+    /// Single-shot (**first attach wins**): backing storage is
+    /// `OnceLock<Arc<MetricsRegistry>>`, deliberately not `Mutex<Option<_>>`
+    /// like `ActiveLoadRegistry::attach_metrics` (which supports replace
+    /// semantics). A `Proxy` outlives one metrics registry in practice —
+    /// there is no hot-swap use case in prod — and the read path
+    /// (`metrics_for_abort` called on every abort drop) benefits from being
+    /// lock-free.
+    ///
+    /// The distinction is observable: if a caller wires the proxy twice
+    /// with different registries, the SECOND registry is silently dropped
+    /// and the FIRST keeps taking bumps. That's a wiring bug the operator
+    /// needs to see — so the second call logs at WARN. The first call
+    /// logs at INFO so a missing wire-in (proxy built, never attached) is
+    /// grep-able at startup instead of showing up later as a flat metric.
+    ///
+    /// Not required for correctness — a proxy without a metrics sink still
+    /// aborts and still WARN-logs the reason; only the aggregate counter goes
+    /// dark. Tests that build a proxy in isolation deliberately skip this so
+    /// they can assert on the log line alone.
+    pub fn attach_metrics(&self, metrics: Arc<MetricsRegistry>) {
+        if self.metrics.set(metrics).is_ok() {
+            tracing::info!(
+                "Proxy metrics attached; sgl_router_engine_aborts_total is now populated"
+            );
+        } else {
+            tracing::warn!(
+                "Proxy::attach_metrics called more than once; second registry ignored \
+                 (first-attach-wins). sgl_router_engine_aborts_total continues to bump \
+                 the first-attached registry, not this one — check AppContext wiring."
+            );
+        }
+    }
+
+    /// Clone the attached metrics registry, if any. Cheap: one `OnceLock::get`
+    /// + one `Arc::clone` on the hot path.
+    fn metrics_for_abort(&self) -> Option<Arc<MetricsRegistry>> {
+        self.metrics.get().map(Arc::clone)
     }
 
     /// The forwarding client for `protocol`. Selected per request from the
@@ -308,6 +580,7 @@ impl Proxy {
             self.client_for(protocol).clone(),
             abort_url.to_string(),
             rid.to_string(),
+            self.metrics_for_abort(),
         ))
     }
 
@@ -577,7 +850,7 @@ impl Proxy {
         // body (it isn't generating), so it is never abortable.
         let upstream: futures::stream::BoxStream<'static, Result<Bytes, std::io::Error>> =
             sse::idle_timeout_stream(resp.bytes_stream(), STREAM_IDLE_TIMEOUT);
-        let (upstream, abort_guard) = match abort_rid {
+        let (upstream, abort_guard, abort_reason_handle) = match abort_rid {
             Some(rid) if status.is_success() => match worker_url.join("/abort_request") {
                 Ok(abort_url) => {
                     let reached_end = Arc::new(AtomicBool::new(false));
@@ -586,12 +859,23 @@ impl Proxy {
                         abort_url.to_string(),
                         rid.to_string(),
                         Arc::clone(&reached_end),
+                        self.metrics_for_abort(),
                     );
-                    (sse::mark_terminal(upstream, reached_end), Some(guard))
+                    // Extract the reason atom so the SSE pump can narrow it
+                    // from the constructor default (`StreamClientGone`) to the
+                    // specific cause (stall / panic) as it hits each break
+                    // site. The atom is `Arc`-shared with the guard, so the
+                    // pump's write is visible to the guard's `Drop`.
+                    let reason_handle = guard.reason_handle();
+                    (
+                        sse::mark_terminal(upstream, reached_end),
+                        Some(guard),
+                        Some(reason_handle),
+                    )
                 }
-                Err(_) => (upstream, None),
+                Err(_) => (upstream, None, None),
             },
-            _ => (upstream, None),
+            _ => (upstream, None, None),
         };
         let guards: Option<Box<dyn Send + 'static>> = match (stream_guards, abort_guard) {
             (Some(g), Some(a)) => Some(Box::new((g, pump_phase, a))),
@@ -599,7 +883,13 @@ impl Proxy {
             (None, Some(a)) => Some(Box::new((pump_phase, a))),
             (None, None) => Some(Box::new(pump_phase)),
         };
-        let body = sse::bytes_stream_to_body(upstream, guards, on_complete, first_byte_hook);
+        let body = sse::bytes_stream_to_body(
+            upstream,
+            guards,
+            on_complete,
+            first_byte_hook,
+            abort_reason_handle,
+        );
         let mut out = Response::new(body);
         *out.status_mut() = status;
         out.headers_mut().insert(
@@ -1095,7 +1385,7 @@ mod tests {
         let client = Client::new();
         {
             let _guard =
-                AbortOnDrop::for_unary(client, format!("{url}/abort_request"), "test-rid-1".into());
+                AbortOnDrop::for_unary(client, format!("{url}/abort_request"), "test-rid-1".into(), None);
         }
         wait_for_abort(&abort_log, Duration::from_secs(2)).await;
         let log = abort_log.lock().unwrap();
@@ -1106,6 +1396,10 @@ mod tests {
         );
         assert_eq!(log[0]["rid"], "test-rid-1");
         assert_eq!(log[0]["abort_all"], false);
+        // No call site refined the reason before drop, so the constructor
+        // default (unary → `HandlerCancelled`, the catch-all covering
+        // "handler future dropped mid-await") must be what the engine sees.
+        assert_eq!(log[0]["router_reason"], "handler_cancelled");
     }
 
     /// Unary guard: `disarm()` before drop (a complete response was received)
@@ -1117,7 +1411,7 @@ mod tests {
         let client = Client::new();
         {
             let mut guard =
-                AbortOnDrop::for_unary(client, format!("{url}/abort_request"), "test-rid-2".into());
+                AbortOnDrop::for_unary(client, format!("{url}/abort_request"), "test-rid-2".into(), None);
             guard.disarm();
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -1141,14 +1435,21 @@ mod tests {
                 format!("{url}/abort_request"),
                 "test-rid-3".into(),
                 Arc::clone(&reached_end),
+                None,
             );
         }
         wait_for_abort(&abort_log, Duration::from_secs(2)).await;
+        let log = abort_log.lock().unwrap();
         assert_eq!(
-            abort_log.lock().unwrap().len(),
+            log.len(),
             1,
             "reached_end=false at drop (client gone before engine finished) must abort"
         );
+        // Streaming guards default to `StreamClientGone` — the majority
+        // real-world cause when the pump exits without setting a narrower
+        // reason (e.g., a test that drops the guard directly without ever
+        // running the pump loop).
+        assert_eq!(log[0]["router_reason"], "stream_client_gone");
     }
 
     /// Streaming guard: dropped with `reached_end` already true (the engine
@@ -1167,6 +1468,7 @@ mod tests {
                 format!("{url}/abort_request"),
                 "test-rid-4".into(),
                 Arc::clone(&reached_end),
+                None,
             );
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -1176,17 +1478,26 @@ mod tests {
         );
     }
 
-    /// `send_abort` posts `{rid, abort_all:false}` to the given URL.
+    /// `send_abort` posts `{rid, abort_all:false, router_reason}` to the given URL.
+    /// The `router_reason` field lets operators break down engine-side aborts
+    /// by the router-side trigger without correlating by rid alone.
     #[tokio::test]
     async fn send_abort_posts_rid_and_abort_all_false() {
         let (url, abort_log, _shutdown) =
             spawn_hanging_worker_with_abort_capture(Duration::from_secs(10)).await;
         let client = Client::new();
-        send_abort(&client, &format!("{url}/abort_request"), "direct-rid").await;
+        send_abort(
+            &client,
+            &format!("{url}/abort_request"),
+            "direct-rid",
+            AbortReason::StreamClientGone,
+        )
+        .await;
         let log = abort_log.lock().unwrap();
         assert_eq!(log.len(), 1);
         assert_eq!(log[0]["rid"], "direct-rid");
         assert_eq!(log[0]["abort_all"], false);
+        assert_eq!(log[0]["router_reason"], "stream_client_gone");
     }
 
     /// `send_abort` is best-effort: an unreachable abort URL (connection
@@ -1196,7 +1507,68 @@ mod tests {
         let client = Client::new();
         // Port 1 is privileged / never listened on in CI sandboxes — refused
         // promptly. No assertion beyond "this does not panic or hang".
-        send_abort(&client, "http://127.0.0.1:1/abort_request", "rid-x").await;
+        send_abort(
+            &client,
+            "http://127.0.0.1:1/abort_request",
+            "rid-x",
+            AbortReason::HandlerCancelled,
+        )
+        .await;
+    }
+
+    /// The abort guard's constructor default is refined by `set_reason` at the
+    /// call site; the final `router_reason` on the wire must match the last
+    /// value stored, not the default. Exercises the `Arc<AtomicU8>` handoff.
+    #[tokio::test]
+    async fn set_reason_narrows_the_default_before_drop() {
+        let (url, abort_log, _shutdown) =
+            spawn_hanging_worker_with_abort_capture(Duration::from_secs(10)).await;
+        let client = Client::new();
+        {
+            let guard = AbortOnDrop::for_unary(
+                client,
+                format!("{url}/abort_request"),
+                "narrowed-rid".into(),
+                None,
+            );
+            // Default is `HandlerCancelled`; narrow to `UpstreamTimeout`.
+            guard.set_reason(AbortReason::UpstreamTimeout);
+            // guard drops at end of scope while armed
+        }
+        wait_for_abort(&abort_log, Duration::from_secs(2)).await;
+        let log = abort_log.lock().unwrap();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0]["router_reason"], "upstream_timeout");
+    }
+
+    /// A guard whose `reason_handle` is written from a different task than
+    /// the one that owns the guard (the streaming SSE pump pattern) still
+    /// sees the narrowed reason on Drop.
+    #[tokio::test]
+    async fn reason_handle_writes_are_visible_to_drop() {
+        let (url, abort_log, _shutdown) =
+            spawn_hanging_worker_with_abort_capture(Duration::from_secs(10)).await;
+        let client = Client::new();
+        let reached_end = Arc::new(AtomicBool::new(false));
+        let guard = AbortOnDrop::for_stream(
+            client,
+            format!("{url}/abort_request"),
+            "cross-task-rid".into(),
+            Arc::clone(&reached_end),
+            None,
+        );
+        let handle = guard.reason_handle();
+        // Simulate the pump's write from a different task.
+        tokio::spawn(async move {
+            handle.store(AbortReason::StreamDownstreamStall as u8, Ordering::Relaxed);
+        })
+        .await
+        .unwrap();
+        drop(guard);
+        wait_for_abort(&abort_log, Duration::from_secs(2)).await;
+        let log = abort_log.lock().unwrap();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0]["router_reason"], "stream_downstream_stall");
     }
 
     /// `abort_guard_for` returns `None` for a worker URL that can't be parsed

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -4,13 +4,15 @@
 //! SSE passthrough — bridges a reqwest `bytes_stream()` into an axum Body.
 
 use std::panic::AssertUnwindSafe;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
 use axum::body::Body;
 use bytes::Bytes;
 use futures::{FutureExt, StreamExt};
+
+use crate::proxy::AbortReason;
 
 /// Sampling counter for the diagnostic `sse_pump_timing` log. ~1-in-`SAMPLE`
 /// pump completions are logged with their first-byte / drain / exit timing and
@@ -127,6 +129,7 @@ pub fn bytes_stream_to_body<S, E>(
     stream_guards: Option<Box<dyn Send + 'static>>,
     on_complete: Option<Box<dyn FnOnce(bool) + Send + 'static>>,
     on_first_byte: Option<Box<dyn FnOnce() + Send + 'static>>,
+    abort_reason: Option<Arc<AtomicU8>>,
 ) -> Body
 where
     S: futures::Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
@@ -138,6 +141,44 @@ where
     // Total buffered bytes stay ≤ STREAM_READAHEAD_MAX_BYTES; see the type doc.
     let readahead = Arc::new(tokio::sync::Semaphore::new(STREAM_READAHEAD_MAX_BYTES));
     let readahead_pump = Arc::clone(&readahead);
+    // Helper: stamp the shared abort-reason handle inside `AbortOnDrop` before
+    // the pump's `_hold` (which owns the guard) drops. Cheap when the pump
+    // wasn't given a handle (`abort_reason` is `None` for non-streaming callers
+    // like tests), lock-free when it was.
+    fn set_abort_reason(handle: &Option<Arc<AtomicU8>>, reason: AbortReason) {
+        if let Some(h) = handle.as_ref() {
+            h.store(reason as u8, Ordering::Relaxed);
+        }
+    }
+    // Local scope guard: on drop, stamp `StreamPumpPanicked` into the shared
+    // abort-reason handle UNLESS `defuse()` has been called. Every normal
+    // pump exit path defuses (its `set_abort_reason` at the break site is the
+    // narrow reason; the marker's default would just clobber it). Only a
+    // panic — where control flow never reaches the defuse — leaves the marker
+    // armed, so the guard's `Drop` fires with the specific `StreamPumpPanicked`
+    // label instead of the constructor's `StreamClientGone` default. Declared
+    // AFTER `_hold` in the pump body so LIFO drop order runs this marker
+    // BEFORE `_hold` (which owns the `AbortOnDrop`) drops — i.e. the reason is
+    // committed before the guard reads it.
+    struct PanicReasonMarker {
+        handle: Option<Arc<AtomicU8>>,
+        defused: bool,
+    }
+    impl PanicReasonMarker {
+        fn defuse(&mut self) {
+            self.defused = true;
+        }
+    }
+    impl Drop for PanicReasonMarker {
+        fn drop(&mut self) {
+            if !self.defused {
+                if let Some(h) = self.handle.as_ref() {
+                    h.store(AbortReason::StreamPumpPanicked as u8, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+    let abort_reason_for_pump = abort_reason.clone();
     tokio::spawn(async move {
         let tx_for_panic = tx.clone();
         // Capture the pump's outcome so we can report it through `on_complete`
@@ -151,6 +192,14 @@ where
             // underscore suppresses the "unused variable" lint while
             // keeping intent explicit.
             let _hold = stream_guards;
+            // Declared AFTER `_hold` so its Drop runs BEFORE `_hold` (LIFO).
+            // See `PanicReasonMarker`'s type-level doc for why this ordering
+            // matters. Mutable so `defuse()` can flip its flag before we
+            // exit through any of the non-panic paths below.
+            let mut panic_marker = PanicReasonMarker {
+                handle: abort_reason_for_pump.clone(),
+                defused: false,
+            };
             // Diagnostic timing for this stream's lifetime. `task_start` ≈ when
             // upstream headers landed (the task is spawned right after). These
             // localize whether the admission slot (held by `_hold`) lingers
@@ -226,6 +275,10 @@ where
                             // budget — clean client-side cancel, not a fault.
                             tracing::debug!("SSE client disconnected mid-stream");
                             exit_reason = "client_disconnect_blocked";
+                            set_abort_reason(
+                                &abort_reason_for_pump,
+                                AbortReason::StreamClientGone,
+                            );
                             break;
                         }
                         res = tokio::time::timeout(
@@ -249,6 +302,14 @@ where
                                 "SSE read-ahead semaphore closed unexpectedly; aborting pump"
                             );
                             exit_reason = "semaphore_closed";
+                            // Treated as a pump-side invariant violation, not a
+                            // client-side event: the same bucket as
+                            // `StreamPumpPanicked` so it stands out separately
+                            // from routine disconnects in metrics/logs.
+                            set_abort_reason(
+                                &abort_reason_for_pump,
+                                AbortReason::StreamPumpPanicked,
+                            );
                             break;
                         }
                         Err(_elapsed) => {
@@ -272,6 +333,10 @@ where
                                 "SSE downstream stalled; stream aborted before completion",
                             )));
                             exit_reason = "downstream_stall";
+                            set_abort_reason(
+                                &abort_reason_for_pump,
+                                AbortReason::StreamDownstreamStall,
+                            );
                             break;
                         }
                     }
@@ -290,6 +355,10 @@ where
                         tracing::debug!("SSE client disconnected mid-stream");
                     }
                     exit_reason = "client_gone";
+                    set_abort_reason(
+                        &abort_reason_for_pump,
+                        AbortReason::StreamClientGone,
+                    );
                     break;
                 }
                 if is_err_chunk {
@@ -298,6 +367,12 @@ where
                     break;
                 }
             }
+            // Every non-panic exit reaches this line. Defuse the marker so its
+            // Drop is a no-op: whatever narrow reason the specific exit path
+            // set (or the constructor default, for the "upstream_end" /
+            // "upstream_error" cases where `mark_terminal` flipped
+            // `reached_end` and the abort won't fire at all) stays as-is.
+            panic_marker.defuse();
             // Diagnostic: this stream's lifetime, sampled. `pump_exit_ms` is how
             // long the admission slot (held by `_hold`, dropped when this block
             // exits) was occupied by the pump; compare to the engine's own
@@ -328,6 +403,12 @@ where
                 .or_else(|| panic_payload.downcast_ref::<String>().cloned())
                 .unwrap_or_else(|| "<non-string panic payload>".to_string());
             tracing::error!(error = %msg, "SSE pump task panicked");
+            // The `PanicReasonMarker` declared inside the pump already stamped
+            // `StreamPumpPanicked` into the abort-reason handle during unwind
+            // (its Drop runs BEFORE `_hold`'s, by LIFO drop order), so by the
+            // time we reach here the abort has already fired with the correct
+            // reason. Nothing to write from the outer scope; documenting the
+            // ordering here so nobody re-adds a stamp that would come too late.
             let _ = tx_for_panic.send(Err(std::io::Error::other(format!(
                 "SSE pump panicked: {msg}"
             ))));
@@ -456,7 +537,7 @@ mod tests {
             Ok(Bytes::from_static(b"world")),
         ];
         let s = stream::iter(chunks);
-        let body = bytes_stream_to_body(s, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None, None);
         let bytes = body.collect().await.unwrap().to_bytes();
         assert_eq!(&bytes[..], b"hello world");
     }
@@ -480,6 +561,7 @@ mod tests {
             Some(Box::new(move || {
                 fired_c.fetch_add(1, Ordering::SeqCst);
             })),
+            None,
         );
         let _ = body.collect().await.unwrap();
         assert_eq!(
@@ -507,6 +589,7 @@ mod tests {
             Some(Box::new(move || {
                 fired_c.fetch_add(1, Ordering::SeqCst);
             })),
+            None,
         );
         let _ = body.collect().await;
         assert_eq!(
@@ -523,7 +606,7 @@ mod tests {
             Err(std::io::Error::other("upstream blew up mid-stream")),
         ];
         let s = stream::iter(chunks);
-        let body = bytes_stream_to_body(s, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None, None);
         // Collecting a body that terminates with an error must return Err.
         let result = body.collect().await;
         assert!(
@@ -585,7 +668,7 @@ mod tests {
         // that arm, the closure unwrap-or-elses would panic itself or
         // produce an empty message, which this test catches.
         let s = PanicAnyOnSecondPoll { polls: 0 };
-        let body = bytes_stream_to_body(s, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None, None);
         let result = body.collect().await;
         assert!(
             result.is_err(),
@@ -608,7 +691,7 @@ mod tests {
         // The pump task panics mid-stream. The client must see a loud Err,
         // NOT a silently-truncated success.
         let s = PanicOnSecondPoll { polls: 0 };
-        let body = bytes_stream_to_body(s, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None, None);
         let result = body.collect().await;
         assert!(
             result.is_err(),
@@ -619,6 +702,41 @@ mod tests {
         assert!(
             msg.contains("pump panicked") || msg.contains("SSE pump panicked"),
             "expected error message to mention pump panic, got: {msg}"
+        );
+    }
+
+    /// End-to-end verification that a panic inside the pump stamps
+    /// `AbortReason::StreamPumpPanicked` into the shared reason atom BEFORE
+    /// the pump task's `_hold` drops the guard. This is the whole point of
+    /// the `PanicReasonMarker`: its Drop runs BEFORE `_hold`'s Drop (LIFO
+    /// order of local variables), so the guard's own Drop reads the
+    /// panic-tagged reason instead of the constructor default
+    /// `StreamClientGone`.
+    ///
+    /// A regression here — someone reordering the marker vs. `_hold`
+    /// declarations, or moving the panic-reason stamp to AFTER `catch_unwind`
+    /// (which runs after `_hold` has dropped and is too late) — silently
+    /// mislabels every panic-induced abort as `stream_client_gone`, sending
+    /// operators looking at the wrong dashboards during an incident.
+    #[tokio::test]
+    async fn pump_stamps_stream_pump_panicked_on_panic() {
+        use std::sync::atomic::AtomicU8;
+
+        // Start with the streaming constructor default so we can prove the
+        // panic path actively overwrites it (a no-op wouldn't).
+        let reason = Arc::new(AtomicU8::new(AbortReason::StreamClientGone as u8));
+        let s = PanicOnSecondPoll { polls: 0 };
+        let body =
+            bytes_stream_to_body(s, None, None, None, Some(Arc::clone(&reason)));
+        // Drain the body so the pump task runs to completion (panics, gets
+        // caught by `catch_unwind`, and the panic marker's Drop has fired).
+        let _ = body.collect().await;
+        assert_eq!(
+            reason.load(Ordering::Relaxed),
+            AbortReason::StreamPumpPanicked as u8,
+            "PanicReasonMarker must have stamped StreamPumpPanicked before \
+             the pump task's _hold dropped — got {}",
+            reason.load(Ordering::Relaxed),
         );
     }
 
@@ -681,7 +799,7 @@ mod tests {
             yielded: 0,
             max: 1000, // way more than we'll let it consume
         };
-        let body = bytes_stream_to_body(stream, None, None, None);
+        let body = bytes_stream_to_body(stream, None, None, None, None);
 
         // Read exactly one frame, then drop the body to simulate client disconnect.
         let mut data_stream = body.into_data_stream();
@@ -733,7 +851,7 @@ mod tests {
             stream::pending::<Result<Bytes, std::io::Error>>(),
             std::time::Duration::from_millis(50),
         );
-        let body = bytes_stream_to_body(stalled, Some(guard), None, None);
+        let body = bytes_stream_to_body(stalled, Some(guard), None, None, None);
         tokio::spawn(async move {
             let _ = body.collect().await;
         });
@@ -782,7 +900,7 @@ mod tests {
         let s = stream::iter(chunks);
 
         // Build the Body but DO NOT read it: the client never drains a byte.
-        let _body = bytes_stream_to_body(s, Some(guard), None, None);
+        let _body = bytes_stream_to_body(s, Some(guard), None, None, None);
 
         // Let the pump run. It should race ahead of the (absent) client, reach
         // upstream-`None`, and drop the guards — all well within STREAM_SEND_STALL.
@@ -841,7 +959,7 @@ mod tests {
         // Hold the Body WITHOUT reading it: the receiver stays open (no clean
         // disconnect) but undrained, so the pump parks acquiring read-ahead
         // permits once the buffer is full.
-        let _body = bytes_stream_to_body(s, Some(guard), None, None);
+        let _body = bytes_stream_to_body(s, Some(guard), None, None, None);
 
         // Advance past the send-stall timeout. The pump must give up on the
         // non-draining client and drop its guards.
@@ -851,6 +969,47 @@ mod tests {
             "a client that stops reading (without disconnecting) must not pin \
              stream_guards — the pump must time out the blocked permit acquire \
              and release the admission slot",
+        );
+    }
+
+    /// End-to-end verification that a downstream stall (client stops draining
+    /// for `STREAM_SEND_STALL` while the connection stays open) stamps
+    /// `AbortReason::StreamDownstreamStall` into the shared reason atom before
+    /// the pump exits. Without this stamp, the guard's Drop would fire with
+    /// the constructor default `StreamClientGone`, which is a lie — the
+    /// client didn't disconnect, it just stopped consuming — and would send
+    /// operators looking at "client cancel" volume when the real signal is
+    /// "consumer backpressure / slow client."
+    ///
+    /// Mirror of `stalled_downstream_releases_stream_guards` above, adding
+    /// the reason-handle assertion the log/metric side depends on.
+    #[tokio::test(start_paused = true)]
+    async fn pump_stamps_stream_downstream_stall_on_send_stall() {
+        use std::sync::atomic::AtomicU8;
+
+        let reason = Arc::new(AtomicU8::new(AbortReason::StreamClientGone as u8));
+        // Same shape as the sibling stall test: > read-ahead budget worth
+        // of bytes to a client that never drains, so the pump parks
+        // acquiring permits and the STREAM_SEND_STALL timeout trips.
+        let chunks: Vec<Result<Bytes, std::io::Error>> = (0..20)
+            .map(|_| Ok(Bytes::from(vec![b'x'; 64 * 1024])))
+            .collect();
+        let s = stream::iter(chunks);
+        let _body =
+            bytes_stream_to_body(s, None, None, None, Some(Arc::clone(&reason)));
+        // Advance past send-stall so the pump gives up on the non-draining
+        // client. `_body` is held to keep the receiver alive during the wait
+        // — a Drop here would masquerade as a client_gone.
+        tokio::time::sleep(STREAM_SEND_STALL + std::time::Duration::from_secs(1)).await;
+        // Give the pump task a scheduling tick to finish its exit path
+        // after the timeout fires.
+        tokio::task::yield_now().await;
+        assert_eq!(
+            reason.load(Ordering::Relaxed),
+            AbortReason::StreamDownstreamStall as u8,
+            "downstream_stall path must stamp StreamDownstreamStall, not the \
+             constructor default (a stalled client is not a gone client) — got {}",
+            reason.load(Ordering::Relaxed),
         );
     }
 
@@ -880,6 +1039,7 @@ mod tests {
             Some(Box::new(move |ok| {
                 outcome_c.store(if ok { 1 } else { 2 }, Ordering::SeqCst);
             })),
+            None,
             None,
         );
 
@@ -926,7 +1086,7 @@ mod tests {
         // guards — even though the client never read a byte.
         let big = Bytes::from(vec![b'x'; 2 * STREAM_READAHEAD_MAX_BYTES]);
         let s = stream::iter(vec![Ok::<Bytes, std::io::Error>(big)]);
-        let _body = bytes_stream_to_body(s, Some(guard), None, None);
+        let _body = bytes_stream_to_body(s, Some(guard), None, None, None);
 
         for _ in 0..1000 {
             if dropped.load(Ordering::SeqCst) {
@@ -949,7 +1109,7 @@ mod tests {
     async fn oversized_single_chunk_streams_through_intact() {
         let big = vec![b'x'; 2 * STREAM_READAHEAD_MAX_BYTES];
         let s = stream::iter(vec![Ok::<Bytes, std::io::Error>(Bytes::from(big.clone()))]);
-        let body = bytes_stream_to_body(s, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None, None);
         let bytes = body.collect().await.unwrap().to_bytes();
         assert_eq!(
             bytes.len(),

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -79,6 +79,12 @@ impl AppContext {
         // after the policy registry, so inject it now. No-op for policies
         // that don't emit metrics.
         policies.attach_metrics(Arc::clone(&metrics));
+        // Same rationale for the proxy's `sgl_router_engine_aborts_total`
+        // counter: the drop-side of `AbortOnDrop` reads the metrics handle
+        // stashed on `Proxy`, and this is the one place where both objects
+        // are alive together. Without this wire-in the abort counter is
+        // permanently zero even though the WARN log still fires per abort.
+        proxy.attach_metrics(Arc::clone(&metrics));
         let admission = Arc::new(AdmissionQueue::new(config.admission, Arc::clone(&metrics)));
         Self {
             config,

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -34,6 +34,7 @@
 //! | `sgl_router_sticky_total` | Counter | `outcome` |
 //! | `sgl_router_ingress_tokenize_errors_total` | Counter | `model_id` |
 //! | `sgl_router_backpressure_rejected_total` | Counter | `model_id` |
+//! | `sgl_router_engine_aborts_total` | Counter | `reason` |
 //! | `sgl_router_queued_requests` | Gauge | (none) |
 //! | `sgl_router_admission_wait_seconds` | Histogram | `model_id` |
 //!
@@ -45,6 +46,7 @@
 //!
 //! The exposition is text/plain; version=0.0.4 per the Prometheus spec.
 
+use crate::proxy::{AbortReason, ABORT_REASON_COUNT};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
@@ -248,7 +250,7 @@ impl ActiveLoadKind {
 
 /// The shared metrics registry, held on `AppContext`. Cheap to clone — all
 /// internal state is `Arc`/`Atomic`/`Mutex`-protected.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct MetricsRegistry {
     // Edge intake, counted at the `access_log_and_record` middleware BEFORE the
     // handler runs, so it includes requests parked/shed/cancelled/dropped before
@@ -275,6 +277,21 @@ pub struct MetricsRegistry {
     sticky_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     ingress_tokenize_errors_total: Mutex<HashMap<String, Arc<AtomicU64>>>,
     backpressure_rejected_total: Mutex<HashMap<String, Arc<AtomicU64>>>,
+    /// Per-reason count of `/abort_request` POSTs the router has sent to
+    /// engines. Fixed-length array indexed by [`AbortReason::as_index`], so
+    /// the hot path is a single `AtomicU64::fetch_add` with **zero locks and
+    /// zero allocations** — deliberately not the `Mutex<HashMap<_, Arc<_>>>`
+    /// pattern used by the model-labelled counters above. At 300 RPS ×
+    /// 50 % abort rate that's ~150 aborts/s already; sharing a hashmap mutex
+    /// with every other request path on the process would be exactly the
+    /// tokenizer-BPE-cache-lock story we already had to fix once, so
+    /// don't do it again for engine aborts.
+    ///
+    /// Population is compile-time bounded by [`ABORT_REASON_COUNT`], read
+    /// via `AbortReason::as_index`; the two must stay in sync (adding a
+    /// variant without bumping the constant fails compilation on the array
+    /// size).
+    engine_aborts_total: [AtomicU64; ABORT_REASON_COUNT],
     /// Current admission wait-queue depth (parked requests). A single
     /// router-wide gauge — the queue is shared across the router, so this is a
     /// global count, not per-model.
@@ -282,6 +299,35 @@ pub struct MetricsRegistry {
     /// Time a parked request waited before admission (seconds), per model.
     /// Only parked-then-admitted requests are recorded.
     admission_wait_seconds: Mutex<HashMap<String, Histogram>>,
+}
+
+/// Manual `Default` because `[AtomicU64; N]: Default` isn't guaranteed by
+/// stable Rust for arbitrary N on every MSRV in the wild (it landed in
+/// std relatively recently), and this crate targets edition 2021 without
+/// pinning a min stable version. `std::array::from_fn` is stable since 1.63
+/// and gives us a zero-initialized array without an intermediate `Vec` or
+/// unsafe. Every other field defers to its own `Default`, keeping this
+/// impl minimally intrusive.
+impl Default for MetricsRegistry {
+    fn default() -> Self {
+        Self {
+            requests_total: Default::default(),
+            worker_requests_total: Default::default(),
+            request_duration: Default::default(),
+            ttft_seconds: Default::default(),
+            responses_total: Default::default(),
+            overlap_blocks: Default::default(),
+            active_load: Default::default(),
+            stale_requests_total: Default::default(),
+            decode_affinity_total: Default::default(),
+            sticky_total: Default::default(),
+            ingress_tokenize_errors_total: Default::default(),
+            backpressure_rejected_total: Default::default(),
+            engine_aborts_total: std::array::from_fn(|_| AtomicU64::new(0)),
+            queued_requests: Default::default(),
+            admission_wait_seconds: Default::default(),
+        }
+    }
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
@@ -579,6 +625,38 @@ impl MetricsRegistry {
             .clone();
         drop(guard);
         counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Bump `sgl_router_engine_aborts_total{reason}` — one increment per
+    /// `/abort_request` POST the router sends to an engine, labelled with
+    /// the router-side trigger (see [`crate::proxy::AbortReason`]).
+    ///
+    /// **Lock-free hot path.** Reasons are known at compile time, so the
+    /// storage is a fixed-length `[AtomicU64; ABORT_REASON_COUNT]` indexed
+    /// by `AbortReason::as_index`. Under a burst of aborts (150 aborts/s at
+    /// 300 RPS × 50 % is the current production baseline, but we want
+    /// headroom for at least 10× that under retry storms) this must NOT
+    /// serialise on a shared mutex the way the model-labelled counters do.
+    /// The `[AtomicU64]::fetch_add` compiles to a single `lock xadd` on
+    /// x86-64 / an `ldaddl` on aarch64 — same cycle-cost as a private
+    /// counter, no cross-core cache-line ping-ponging under contention
+    /// beyond the one line this counter itself lives on.
+    ///
+    /// Paired one-for-one with the "sending /abort_request to engine" WARN
+    /// log emitted at the same drop site: the log gives per-event
+    /// attribution (rid, reason, abort_url), the counter gives aggregate
+    /// rate ("how many `stream_client_gone` aborts per second?") without
+    /// full log parsing.
+    pub(crate) fn record_engine_abort(&self, reason: AbortReason) {
+        // Bounds-safe by construction: `as_index()` is derived from a
+        // `#[repr(u8)]` enum with explicit discriminants 0..ABORT_REASON_COUNT-1,
+        // and the array is sized by the same constant.
+        //
+        // `pub(crate)` (not `pub`) matches the visibility of `AbortReason`
+        // itself — the label set is a crate-private detail; external
+        // consumers observe engine aborts through the `/metrics` scrape,
+        // not through this method.
+        self.engine_aborts_total[reason.as_index()].fetch_add(1, Ordering::Relaxed);
     }
 
     /// Adjust `sgl_router_queued_requests` by `delta` (+1 when a request parks,
@@ -928,6 +1006,35 @@ impl MetricsRegistry {
         }
         drop(guard);
 
+        // engine_aborts_total (per-reason). Iterate the fixed-length array
+        // by index; every AbortReason variant always emits a series, starting
+        // at 0 (unlike model-keyed counters where series appear only after
+        // first bump). Reason: predictable dashboards — an operator that
+        // aliases `stream_client_gone` in Grafana doesn't want a
+        // "no data" panel just because production hasn't had a client
+        // disconnect this scrape window. Sort by label for deterministic
+        // output.
+        out.push_str(
+            "# HELP sgl_router_engine_aborts_total Router-side /abort_request POSTs sent to engines, labelled with the router-side trigger (see AbortReason).\n",
+        );
+        out.push_str("# TYPE sgl_router_engine_aborts_total counter\n");
+        let mut abort_entries: Vec<(&'static str, u64)> = (0..ABORT_REASON_COUNT)
+            .map(|i| {
+                let reason = AbortReason::from_u8(i as u8);
+                (
+                    reason.as_label(),
+                    self.engine_aborts_total[i].load(Ordering::Relaxed),
+                )
+            })
+            .collect();
+        abort_entries.sort_by(|a, b| a.0.cmp(b.0));
+        for (reason, value) in abort_entries {
+            out.push_str(&format!(
+                "sgl_router_engine_aborts_total{{reason=\"{}\"}} {}\n",
+                reason, value,
+            ));
+        }
+
         // queued_requests (router-wide gauge, no labels)
         out.push_str(
             "# HELP sgl_router_queued_requests Requests currently parked in the admission wait queue (router-wide).\n",
@@ -1025,6 +1132,15 @@ mod tests {
         assert!(out.contains("# TYPE sgl_router_decode_affinity_total counter"));
         assert!(out.contains("# TYPE sgl_router_sticky_total counter"));
         assert!(out.contains("# TYPE sgl_router_ingress_tokenize_errors_total counter"));
+        // engine_aborts always emits one series per AbortReason variant,
+        // starting at 0 — deliberately, so a Grafana panel aliased on
+        // `reason="stream_client_gone"` doesn't go blank during a healthy
+        // scrape window where no aborts fired.
+        assert!(out.contains("# TYPE sgl_router_engine_aborts_total counter"));
+        assert!(out.contains(r#"sgl_router_engine_aborts_total{reason="stream_client_gone"} 0"#));
+        assert!(
+            out.contains(r#"sgl_router_engine_aborts_total{reason="stale_request_expired"} 0"#)
+        );
         // Pool-size series exist (at 0) for all three modes even with no
         // workers, so dashboards have a stable series to graph.
         assert!(out.contains(r#"sgl_router_workers{mode="plain"} 0"#));
@@ -1069,6 +1185,70 @@ mod tests {
         let out = reg.render();
         assert!(out.contains(r#"sgl_router_request_duration_seconds_count{model_id="a"} 1"#));
         assert!(out.contains(r#"sgl_router_request_duration_seconds_count{model_id="b"} 1"#));
+    }
+
+    /// `record_engine_abort` bumps only the requested reason's counter and
+    /// leaves the others at 0. The rendered output holds one series per
+    /// variant (verified against the empty-registry test above); this test
+    /// checks that increments land on the right slot.
+    #[test]
+    fn engine_aborts_bumps_only_requested_reason() {
+        let reg = MetricsRegistry::new();
+        reg.record_engine_abort(AbortReason::StreamClientGone);
+        reg.record_engine_abort(AbortReason::StreamClientGone);
+        reg.record_engine_abort(AbortReason::StaleRequestExpired);
+        let out = reg.render();
+        assert!(out.contains(r#"sgl_router_engine_aborts_total{reason="stream_client_gone"} 2"#));
+        assert!(
+            out.contains(r#"sgl_router_engine_aborts_total{reason="stale_request_expired"} 1"#)
+        );
+        // Every other reason must remain at 0 — a fixed-size counter array
+        // with a zero-init default guarantees this, but pin it in a test so
+        // a future refactor to a dynamic map doesn't silently lose the
+        // "series exist even at zero" property.
+        assert!(out.contains(r#"sgl_router_engine_aborts_total{reason="handler_cancelled"} 0"#));
+        assert!(out.contains(r#"sgl_router_engine_aborts_total{reason="upstream_timeout"} 0"#));
+        assert!(out.contains(r#"sgl_router_engine_aborts_total{reason="transport_error"} 0"#));
+        assert!(
+            out.contains(r#"sgl_router_engine_aborts_total{reason="stream_downstream_stall"} 0"#)
+        );
+        assert!(out.contains(r#"sgl_router_engine_aborts_total{reason="stream_pump_panicked"} 0"#));
+        assert!(out.contains(r#"sgl_router_engine_aborts_total{reason="unknown"} 0"#));
+    }
+
+    /// The per-reason counter must not serialise increments on a shared
+    /// mutex — that was exactly the tokenizer BPE-cache-lock story we
+    /// already had to fix once. This test doesn't measure wall-clock
+    /// (unreliable in CI); it just verifies a burst of concurrent bumps
+    /// from many tasks all land, i.e. no fetch_add is lost. If a future
+    /// refactor puts a `Mutex` back on the hot path, correctness stays but
+    /// the perf assumption breaks — pair this with `cargo bench` numbers
+    /// in `bench/` if you re-add a lock.
+    #[tokio::test]
+    async fn engine_aborts_counter_is_lock_free_under_concurrent_bumps() {
+        let reg = MetricsRegistry::new();
+        let n_tasks: usize = 32;
+        let per_task: usize = 500;
+        let mut handles = Vec::with_capacity(n_tasks);
+        for _ in 0..n_tasks {
+            let r = Arc::clone(&reg);
+            handles.push(tokio::spawn(async move {
+                for _ in 0..per_task {
+                    r.record_engine_abort(AbortReason::StreamClientGone);
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        let expected = (n_tasks * per_task) as u64;
+        let out = reg.render();
+        assert!(
+            out.contains(&format!(
+                r#"sgl_router_engine_aborts_total{{reason="stream_client_gone"}} {expected}"#,
+            )),
+            "expected {expected} bumps; got:\n{out}",
+        );
     }
 
     #[test]

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -4,11 +4,33 @@
 use crate::discovery::{ModelId, WorkerMode};
 use crate::policies::registry::{PdPoolResolver, PdResolveError};
 use crate::policies::{request_tokens_for, RequestTokens, SelectionContext};
+use crate::proxy::AbortReason;
 use crate::server::app_context::AppContext;
 use crate::server::error::ApiError;
 use crate::server::metrics::{
     MetricsRegistry, RequestLogContext, StaleRequestOutcome, WorkerModeLabel,
 };
+
+/// Narrow the pre-drop abort reason on the pre-headers / unary guard from
+/// its constructor default (`HandlerCancelled`, the catch-all for "handler
+/// future dropped mid-await") to the specific `ApiError` variant that caused
+/// the fetch to resolve as `Err`. Called at the one site where we know both
+/// the guard and the settled `Result` — right after the `tokio::select!` in
+/// the plain-mode streaming and plain-mode unary arms.
+///
+/// `Ok(_)` means the engine responded (any status): responsibility passes
+/// to either the streaming pump's internal guard (2xx) or nothing at all
+/// (non-2xx, engine's own error body). Nothing to record here.
+fn abort_reason_from_api_error(err: &ApiError) -> AbortReason {
+    match err {
+        ApiError::UpstreamTimeout { .. } => AbortReason::UpstreamTimeout,
+        ApiError::StaleRequestExpired { .. } => AbortReason::StaleRequestExpired,
+        // Everything else is a router-side transport / configuration failure.
+        // The abort still fires (the engine may have started work), but its
+        // origin is on our side, not a client cancel or timeout.
+        _ => AbortReason::TransportError,
+    }
+}
 use crate::workers::Worker;
 use axum::body::Body;
 use axum::extract::State;
@@ -651,9 +673,20 @@ async fn chat_completions_inner(
         // disarm so this one doesn't also fire. Left armed only when `fetch`
         // never resolved (stale-timeout) or a transport-level dispatch error
         // occurred before any response.
-        if r.is_ok() {
-            if let Some(g) = pre_headers_abort_guard.as_mut() {
-                g.disarm();
+        match &r {
+            Ok(_) => {
+                if let Some(g) = pre_headers_abort_guard.as_mut() {
+                    g.disarm();
+                }
+            }
+            Err(err) => {
+                // Narrow the abort reason before the guard drops so the
+                // WARN log + POST body identify the *specific* trigger
+                // (stale timeout / upstream timeout / transport) rather
+                // than the constructor default `HandlerCancelled`.
+                if let Some(g) = pre_headers_abort_guard.as_ref() {
+                    g.set_reason(abort_reason_from_api_error(err));
+                }
             }
         }
         r
@@ -692,9 +725,20 @@ async fn chat_completions_inner(
         // A complete response (any status) means the engine is done with this
         // request — don't abort it. Only an early drop (client disconnect) or
         // stale-timeout leaves the guard armed.
-        if r.is_ok() {
-            if let Some(g) = abort_guard.as_mut() {
-                g.disarm();
+        match &r {
+            Ok(_) => {
+                if let Some(g) = abort_guard.as_mut() {
+                    g.disarm();
+                }
+            }
+            Err(err) => {
+                // Same reason-narrowing as the streaming arm above — see there
+                // for the rationale. Handler-cancellation (client disconnect
+                // during the buffered await) still hits the constructor
+                // default because that path returns no `Err`, it just drops.
+                if let Some(g) = abort_guard.as_ref() {
+                    g.set_reason(abort_reason_from_api_error(err));
+                }
             }
         }
         r
@@ -1095,6 +1139,123 @@ fn parse_probe(body: &Bytes) -> Result<RequestProbe, ApiError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::anyhow;
+    use axum::http::StatusCode;
+    use reqwest::Url;
+
+    /// Every `ApiError` variant must map deterministically to exactly one
+    /// `AbortReason`. This test pins the mapping so:
+    ///   * A future PR adding a new `ApiError` variant is forced to think
+    ///     about which abort reason it belongs to (the wildcard `_ =>
+    ///     TransportError` in `abort_reason_from_api_error` catches it, but
+    ///     silently — this test freezes the intended default).
+    ///   * A typo swap (e.g. `UpstreamTimeout → StaleRequestExpired`) fails
+    ///     loudly here even though both are timeout-family and would
+    ///     otherwise pass a code review.
+    ///
+    /// Kept as one function with a table of cases so adding a new
+    /// `ApiError` variant fails one assertion instead of one whole test —
+    /// the diff shows the exact new row that needed a decision.
+    #[test]
+    fn abort_reason_from_api_error_covers_every_variant() {
+        // sentinel worker URL for the variants that carry one
+        let worker_url = Url::parse("http://w:1/").unwrap();
+        let cases: Vec<(ApiError, AbortReason)> = vec![
+            // Explicitly-mapped narrow reasons — these are the informative
+            // labels the whole change exists to surface.
+            (
+                ApiError::UpstreamTimeout {
+                    worker: worker_url.clone(),
+                },
+                AbortReason::UpstreamTimeout,
+            ),
+            (
+                ApiError::StaleRequestExpired {
+                    model: "m".into(),
+                },
+                AbortReason::StaleRequestExpired,
+            ),
+            // Every other variant falls through to `TransportError`. Each
+            // row is a decision — do not silently accept a default without
+            // considering whether a distinct label would be more useful.
+            (ApiError::BadRequest("x".into()), AbortReason::TransportError),
+            (
+                ApiError::ModelNotFound("m".into()),
+                AbortReason::TransportError,
+            ),
+            (
+                ApiError::UpstreamUnreachable {
+                    worker: worker_url.clone(),
+                    source: anyhow!("unreachable"),
+                },
+                AbortReason::TransportError,
+            ),
+            (
+                ApiError::UpstreamStatus {
+                    status: StatusCode::BAD_GATEWAY,
+                },
+                AbortReason::TransportError,
+            ),
+            (
+                ApiError::NoHealthyWorkers { model: "m".into() },
+                AbortReason::TransportError,
+            ),
+            (
+                ApiError::NoPrefillWorkersAvailable { model: "m".into() },
+                AbortReason::TransportError,
+            ),
+            (
+                ApiError::NoDecodeWorkersAvailable { model: "m".into() },
+                AbortReason::TransportError,
+            ),
+            (
+                ApiError::PolicySelectionFailed { model: "m".into() },
+                AbortReason::TransportError,
+            ),
+            (
+                ApiError::BreakerOpen {
+                    worker: "http://w".into(),
+                },
+                AbortReason::TransportError,
+            ),
+            (
+                ApiError::WorkerMisconfigured {
+                    worker: "http://w".into(),
+                    source: anyhow!("bad url"),
+                },
+                AbortReason::TransportError,
+            ),
+            (
+                ApiError::ServiceOverloaded { model: "m".into() },
+                AbortReason::TransportError,
+            ),
+            (ApiError::Internal(anyhow!("boom")), AbortReason::TransportError),
+        ];
+        for (err, expected) in cases.iter() {
+            let got = abort_reason_from_api_error(err);
+            assert_eq!(
+                got, *expected,
+                "abort_reason_from_api_error({err}) — expected {:?}, got {:?}. \
+                 If you changed the mapping, update the expected value; \
+                 if you added a new ApiError variant, add a row here to pin \
+                 which AbortReason it maps to.",
+                expected, got,
+            );
+        }
+        // Coverage check: the table above must cover every ApiError
+        // variant. If someone adds a new variant without adding a row,
+        // this count assertion catches it — a coarse but effective net.
+        // Keep the expected count in sync with the ApiError enum.
+        const EXPECTED_APIERROR_VARIANTS: usize = 14;
+        assert_eq!(
+            cases.len(),
+            EXPECTED_APIERROR_VARIANTS,
+            "abort_reason_from_api_error test table has {} rows; \
+             ApiError has {} variants — add or remove rows to match.",
+            cases.len(),
+            EXPECTED_APIERROR_VARIANTS,
+        );
+    }
 
     /// `generate_room_id` MUST return values in `[0, i64::MAX]`. The
     /// SGLang prefill stores `bootstrap_room` as `torch.int64`; a u64
@@ -1523,7 +1684,7 @@ mod tests {
             .body(Body::from("[]"))
             .unwrap();
         let res = app.oneshot(req).await.unwrap();
-        assert_eq!(res.status(), axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 
         let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
         assert!(


### PR DESCRIPTION
## Motivation

Before this change every `/abort_request` POST the router sent to an engine was invisible in router logs: the drop-site emitted only a DEBUG line on success and a WARN line on transport failure — no unified per-abort event, no way to attribute an abort to a stale-request-timeout vs. a client disconnect vs. an SSE pump stall, and no aggregate signal ("how many of our aborts are `stream_client_gone` vs `stale_request_expired`?") short of full log parsing. Motivated by a production incident where the router was seen sending "a lot of /abort prematurely" but nothing in the log line said which router-side trigger fired.

## What changed

Structured attribution at both grains — per-event log lines and an aggregate lock-free counter — sharing one label set:

- **`AbortReason` enum** (`proxy/mod.rs`) with 8 stable labels: `unknown`, `handler_cancelled`, `stale_request_expired`, `upstream_timeout`, `transport_error`, `stream_client_gone`, `stream_downstream_stall`, `stream_pump_panicked`. Discriminant range enforced at compile time via `const _: () = { assert!(...) }` so a new variant without a matching `ABORT_REASON_COUNT` bump fails to build.
- **`AbortOnDrop.reason: Arc<AtomicU8>`** — shared reason atom the guard reads in `Drop`. `Arc` because the streaming pump task runs on a different tokio task than the handler owning the guard; the pump gets its own `reason_handle()` clone so it can stamp the specific exit cause at each `break` site.
- **Chat handler** (`server/routes/chat.rs`) wires `set_reason` before both plain-mode arms let their pre-headers / unary guard drop, mapping the settled `ApiError` variant to an `AbortReason`. `StaleRequestExpired` / `UpstreamTimeout` / `TransportError` are all visible in the log line instead of collapsing to the constructor default `HandlerCancelled`.
- **SSE pump** (`proxy/sse.rs`) stamps the specific exit cause at every non-panic break (`client_disconnect_blocked`, `semaphore_closed`, `downstream_stall`, `client_gone`) plus a local `PanicReasonMarker` declared AFTER `_hold` (LIFO drop order) so a panic through the pump stamps `StreamPumpPanicked` BEFORE `_hold` drops the guard.
- **`send_abort` POST body** carries a `router_reason` field alongside `rid`/`abort_all` so the engine can log/count aborts by cause. SGLang currently ignores extra fields — forward-compatible.
- **`AbortOnDrop::drop` emits a WARN log** (`sending /abort_request to engine`, with `rid`, `reason`, `abort_url`) — one line per real abort. Deliberately WARN not DEBUG so the signal survives production log levels.
- **`sgl_router_engine_aborts_total{reason}` Prometheus counter** with the same label set. Storage is a **fixed-length `[AtomicU64; ABORT_REASON_COUNT]`** indexed by `AbortReason::as_index` — hot path is a single `AtomicU64::fetch_add` with **zero locks, zero allocations**. Deliberately not the `Mutex<HashMap>` pattern used by model-labelled counters: at 150+ aborts/s under a saturated router we cannot afford to serialise every abort on a shared hashmap mutex (this is the same class of trap as the tokenizer BPE cache lock in 9fa93370). Series are always rendered for every variant (starting at 0) so Grafana panels aliased on a specific reason don't go blank in healthy windows.
- **`Proxy::attach_metrics`** OnceLock wire-in, matching `AppContext::with_active_load`'s `active_load.attach_metrics` / `policies.attach_metrics` pattern. Logs INFO on the first attach (grep-able at startup for missing wire-ins) and WARN on any subsequent double-attach (silent second-registry-dropped is a real wiring-bug footgun).

## Testing

11 new/strengthened tests. All 540 lib tests pass.

**New:**
- `set_reason_narrows_the_default_before_drop` — `&self` setter path
- `reason_handle_writes_are_visible_to_drop` — cross-task `Arc` handle write
- `engine_aborts_bumps_only_requested_reason` — array-indexing correctness
- `engine_aborts_counter_is_lock_free_under_concurrent_bumps` — 32 tasks × 500 bumps, every fetch_add observed
- `abort_reason_from_api_error_covers_every_variant` — pins the `ApiError` → `AbortReason` mapping for all 14 `ApiError` variants; a new variant without a mapping row fails the test's `EXPECTED_APIERROR_VARIANTS` assertion
- `pump_stamps_stream_pump_panicked_on_panic` — E2E through the pump: panic stream → reason atom stamped `StreamPumpPanicked` before pump exits (verifies `PanicReasonMarker` LIFO drop-before-`_hold`)
- `pump_stamps_stream_downstream_stall_on_send_stall` — E2E through the pump: stalled downstream → reason atom stamped `StreamDownstreamStall` (not the constructor default)

**Strengthened:**
- `abort_on_drop_unary_fires_when_dropped_armed` — pins constructor default `handler_cancelled` on the wire
- `abort_on_drop_stream_fires_when_reached_end_false` — pins `stream_client_gone` on the wire
- `send_abort_posts_rid_and_abort_all_false` — asserts `router_reason: stream_client_gone` in POST body
- `empty_registry_renders_only_help_lines` — asserts all 8 `engine_aborts_total` series render at 0

## Compile-time invariants

- `const _: () = { assert!((AbortReason::StreamPumpPanicked as u8) == (ABORT_REASON_COUNT as u8) - 1); ... }` guarantees the discriminant→count coupling that keeps the metric array bounds-safe. Adding a variant without bumping `ABORT_REASON_COUNT` fails to build.
- `AbortReason::from_u8` has an explicit `0 => Unknown` arm; out-of-range values hit a `debug_assert!(false, "AbortReason::from_u8 got out-of-range value {other}")` in debug builds and fall through to `Unknown` in release.

## Non-behavior changes

- No behavior change on the happy path: successful requests never fire aborts; disarmed guards remain no-ops.
- No new dependency.
- No change to the existing `AbortOnDrop::disarm()` contract; every existing test that disarms still suppresses the abort.

## What operators get

```
grep 'sending /abort_request to engine' router.log | grep 'reason=stream_client_gone' | wc -l
```

```
# Prometheus:
sum by (reason) (rate(sgl_router_engine_aborts_total[5m]))
```

## Related

Depends on `combine/router-admission-http2-loadaware`. Follows the pattern established in commit 9fa9337 (tokenizer sharding) for keeping the hot path lock-free.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28575274119](https://github.com/sgl-project/sglang/actions/runs/28575274119)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28575273595](https://github.com/sgl-project/sglang/actions/runs/28575273595)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->