### PR TITLE
Fix stale _attn_sink_local cache after RL weight updates

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -406,6 +406,11 @@ class MQALayer(nn.Module):
                 )
 
         self.attn_sink = nn.Parameter(torch.empty(self.n_heads, dtype=torch.float32))
+        # FlashMLA's fp8 sparse decode kernel only specializes h_q for {64, 128}.
+        # Pad the per-rank heads to 64 (not the full n_heads) when they fit, to
+        # dispatch the cheaper decode::head64 variant; attn_sink is sliced to
+        # this rank and padded to match.
+        self.padded_num_heads = 64 if self.n_local_heads <= 64 else self.n_heads
         self._attn_sink_local: Optional[torch.Tensor] = (
             self.attn_sink if attn_tp_size == 1 else None
         )
@@ -488,6 +493,19 @@ class MQALayer(nn.Module):
         # KV cache write is always fused into the K kernel
         # (`_compute_kv_to_cache`), so the legacy "overlap store cache" flag
         # has no effect here -- the fused path is on by default.
+
+    def refresh_attn_sink_cache(self):
+        if self._attn_sink_local is self.attn_sink:
+            return
+        if self._attn_sink_local is None:
+            self._attn_sink_local = self.attn_sink.new_zeros(self.padded_num_heads)
+        self._attn_sink_local[: self.n_local_heads].copy_(
+            self.attn_sink[
+                self.tp_rank
+                * self.n_local_heads : (self.tp_rank + 1)
+                * self.n_local_heads
+            ]
+        )
 
     def _compute_q_a(
         self,
@@ -955,30 +973,17 @@ class MQALayer(nn.Module):
 
         tp_slice, q_padded, q_out = slice(None), None, None
         if self.tp_size > 1:
-            # FlashMLA's fp8 sparse decode kernel only specializes h_q for {64, 128}.
-            # Pad the per-rank heads to 64 (not the full n_heads) when they fit, to
-            # dispatch the cheaper decode::head64 variant; attn_sink is sliced to
-            # this rank and padded to match.
-            padded_num_heads = 64 if self.n_local_heads <= 64 else self.n_heads
             # Only [0:n_local_heads] is written below. Uninitialized padded TP
             # heads inject NaN into attention on gfx942 (fnuz), so zero-init
             # there; other archs tolerate new_empty and skip the per-forward
             # memset.
             if _is_gfx942_supported:
-                q_padded = x.new_zeros(x.shape[0], padded_num_heads, self.head_dim)
+                q_padded = x.new_zeros(x.shape[0], self.padded_num_heads, self.head_dim)
             else:
-                q_padded = x.new_empty(x.shape[0], padded_num_heads, self.head_dim)
+                q_padded = x.new_empty(x.shape[0], self.padded_num_heads, self.head_dim)
             tp_slice = slice(0, self.n_local_heads)
             q_out = q_padded[:, tp_slice, :]
-            if self._attn_sink_local is None:
-                # Build once on the first forward (post weight load); a per-call
-                # rebuild would replay a fill+copy per layer in the decode graph.
-                rank = self.tp_rank
-                sink = self.attn_sink.new_zeros(padded_num_heads)
-                sink[: self.n_local_heads] = self.attn_sink[
-                    rank * self.n_local_heads : (rank + 1) * self.n_local_heads
-                ]
-                self._attn_sink_local = sink
+            assert self._attn_sink_local is not None
 
         if enable_multi_stream:
             # Multi-stream path always fuses cache write into the K kernel,
@@ -2094,6 +2099,7 @@ class DeepseekV4ForCausalLM(nn.Module):
             ):
                 self_attn.indexer.compressor.apply_ape_hotfix()
             layer.refresh_mhc_norm_weight_cache()
+            self_attn.refresh_attn_sink_cache()
 
     @staticmethod
     def remap_weight_name_to_dpsk_hf_format(

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -279,6 +279,7 @@ class DeepseekV4ForCausalLMNextN(DeepseekV4ForCausalLM):
 
     def post_load_weights(self, is_nextn=False, weight_names=None):
         super().post_load_weights(is_nextn=True, weight_names=weight_names)
+        self.model.decoder.self_attn.refresh_attn_sink_cache()
 
 
 EntryClass = [DeepseekV4ForCausalLMNextN]


### PR DESCRIPTION
## Motivation

In `deepseek_v4.py`, when `attn_tp_size > 1`, `MQALayer` lazily builds `_attn_sink_local` on the first forward: a per-rank padded **copy** of the `attn_sink` parameter. This cache is never invalidated afterwards.

For inference-only serving this is fine (weights never change after load). But in RL workflows (`update_weights_*`), the `attn_sink` parameter itself gets updated on every step while the attention kernels keep reading the copy built from the initial checkpoint — the effective attn sink silently stays frozen at its step-0 value for the whole training run. The rollout policy then diverges from the trainer policy with no error and no weight-checker signal (`_attn_sink_local` is a plain attribute, not a param/buffer).

The same applies to the NextN (MTP) draft layer, which uses the same `MQALayer`.

## Modifications

- Add `MQALayer.refresh_attn_sink_cache()`: builds the per-rank padded copy on first call and refreshes it with an in-place `copy_` on subsequent calls. In-place is required because the tensor address is captured by CUDA graphs. No-op when `_attn_sink_local` aliases the parameter (`attn_tp_size == 1`).
- Call it from `DeepseekV4ForCausalLM.post_load_weights` (next to the existing `refresh_mhc_norm_weight_cache`). Every load path ends there — `model.load_weights()` calls it internally, and loaders that bypass `load_weights` (dummy / sharded / remote) call it explicitly via `_post_load_weights` — so both initial load and weight updates go through the same code path.
- Remove the lazy build from `forward` (replaced by an assert): the cache lifecycle is now owned entirely by the load/update path. `padded_num_heads` only depends on init-time constants, so it moves to `__init__`.
- `DeepseekV4ForCausalLMNextN.post_load_weights` refreshes its single decoder layer (the base-class loop early-returns for nextn and only walks `self.model.layers`).

## Checklist

- [x] Format your code with `pre-commit run --all-files`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28576741925](https://github.com/sgl-project/sglang/actions/runs/28576741925)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28576741624](https://github.com/sgl-project/sglang/actions/runs/28576741624)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->