### PR TITLE
[Spec] Add DSpark speculative decoding for Qwen3

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -20,6 +20,7 @@ def _resolve_speculative_algorithm_alias(
     """Resolve CLI speculative algorithm; NEXTN/EAGLE may become FROZEN_KV_MTP for Gemma4 assistant drafts."""
 
     is_gemma4_draft = False
+    is_qwen3_dspark_draft = False
     if speculative_draft_model_path:
         from sglang.srt.utils.hf_transformers_utils import get_config
 
@@ -30,6 +31,9 @@ def _resolve_speculative_algorithm_alias(
         is_gemma4_draft = any(
             arch in ("Gemma4AssistantForCausalLM", "Gemma4UnifiedAssistantForCausalLM")
             for arch in draft_archs
+        )
+        is_qwen3_dspark_draft = any(
+            arch == "Qwen3DSparkDraftModel" for arch in draft_archs
         )
 
     if speculative_algorithm == "EAGLE3" and is_gemma4_draft:
@@ -47,6 +51,13 @@ def _resolve_speculative_algorithm_alias(
             )
             return "FROZEN_KV_MTP"
         return "EAGLE"
+
+    if speculative_algorithm == "DSPARK" and is_qwen3_dspark_draft:
+        logger.info(
+            "Detected Qwen3DSparkDraftModel draft; "
+            "routing --speculative-algorithm DSPARK to DFLASH."
+        )
+        return "DFLASH"
 
     return speculative_algorithm
 
@@ -129,6 +140,14 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
 
 
 def _handle_dflash(server_args: ServerArgs) -> None:
+    if (
+        server_args.speculative_dflash_block_size is None
+        and server_args.speculative_dspark_block_size is not None
+    ):
+        server_args.speculative_dflash_block_size = (
+            server_args.speculative_dspark_block_size
+        )
+
     if server_args.enable_dp_attention:
         raise ValueError(
             "Currently DFLASH speculative decoding does not support dp attention."

--- a/python/sglang/srt/models/qwen3_dspark.py
+++ b/python/sglang/srt/models/qwen3_dspark.py
@@ -1,0 +1,152 @@
+"""Qwen3 DSpark draft model for SGLang (DFLASH backbone + Markov/confidence heads)."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sglang.srt.layers.dp_attention import is_dp_attention_enabled
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.models.dflash import DFlashDraftModel
+from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils import add_prefix
+
+
+class DSparkMarkovHead(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        markov_rank: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.markov_w1 = VocabParallelEmbedding(
+            vocab_size,
+            markov_rank,
+            enable_tp=not is_dp_attention_enabled(),
+            prefix=add_prefix("markov_w1", prefix),
+        )
+        self.markov_w2 = ParallelLMHead(
+            vocab_size,
+            markov_rank,
+            quant_config=quant_config,
+            prefix=add_prefix("markov_w2", prefix),
+            use_attn_tp_group=get_global_server_args().enable_dp_lm_head,
+        )
+
+    def get_prev_embeddings(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.markov_w1(token_ids)
+
+    def project_bias(self, embeddings: torch.Tensor) -> torch.Tensor:
+        return F.linear(embeddings, self.markov_w2.weight)
+
+
+class Qwen3DSparkConfidenceHead(nn.Module):
+    """Match DeepSpec AcceptRatePredictor (Linear with bias)."""
+
+    def __init__(self, input_dim: int) -> None:
+        super().__init__()
+        self.proj = nn.Linear(int(input_dim), 1, bias=True, dtype=torch.float32)
+
+    def forward(
+        self, hidden: torch.Tensor, markov_embed: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        if markov_embed is not None:
+            features = torch.cat([hidden, markov_embed], dim=-1)
+        else:
+            features = hidden
+        return self.proj(features.float()).squeeze(-1)
+
+
+class Qwen3DSparkDraftModel(DFlashDraftModel):
+    """DFlash-style Qwen3 draft backbone with DSpark Markov/confidence heads."""
+
+    def __init__(
+        self,
+        config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(config, quant_config=quant_config, prefix=prefix)
+
+        self.vocab_size = int(config.vocab_size)
+        self.markov_rank = int(getattr(config, "markov_rank", 0))
+        self.mask_token_id = int(getattr(config, "mask_token_id", 0))
+        self.noise_token_id = self.mask_token_id
+
+        hidden_size = int(config.hidden_size)
+        enable_confidence = bool(getattr(config, "enable_confidence_head", False))
+        confidence_with_markov = bool(
+            getattr(config, "confidence_head_with_markov", False)
+        )
+
+        self.lm_head = ParallelLMHead(
+            self.vocab_size,
+            hidden_size,
+            quant_config=quant_config,
+            prefix=add_prefix("lm_head", prefix),
+        )
+
+        if self.markov_rank > 0:
+            self.markov_head = DSparkMarkovHead(
+                self.vocab_size,
+                self.markov_rank,
+                quant_config=quant_config,
+                prefix=add_prefix("markov_head", prefix),
+            )
+        else:
+            self.markov_head = None
+
+        self.confidence_head = None
+        if enable_confidence:
+            input_dim = hidden_size
+            if confidence_with_markov:
+                assert self.markov_head is not None
+                input_dim += self.markov_rank
+            self.confidence_head = Qwen3DSparkConfidenceHead(input_dim)
+
+    @property
+    def num_dspark_layers(self) -> int:
+        return len(self.layers)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        markov_weights = []
+        confidence_weights = []
+        lm_head_weights = []
+        backbone_weights = []
+
+        for name, tensor in weights:
+            if name.startswith("markov_head."):
+                markov_weights.append((name, tensor))
+            elif name.startswith("confidence_head."):
+                confidence_weights.append((name, tensor))
+            elif name.startswith("lm_head."):
+                lm_head_weights.append((name, tensor))
+            elif name.startswith("embed_tokens."):
+                continue
+            else:
+                backbone_weights.append((name, tensor))
+
+        super().load_weights(backbone_weights)
+
+        params = dict(self.named_parameters())
+        for name, loaded in markov_weights + confidence_weights + lm_head_weights:
+            if name not in params:
+                continue
+            param = params[name]
+            loader = getattr(param, "weight_loader", None)
+            if loader is not None:
+                loader(param, loaded)
+            else:
+                param.data.copy_(loaded)
+
+
+EntryClass = Qwen3DSparkDraftModel

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1,11 +1,16 @@
 import logging
 import math
 from copy import deepcopy
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 
-from sglang.srt.distributed import get_tp_group
+from sglang.srt.distributed import (
+    get_tensor_model_parallel_world_size,
+    get_tp_group,
+    tensor_model_parallel_all_gather,
+)
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -37,6 +42,9 @@ from sglang.srt.speculative.triton_ops.cache_locs import assign_extend_cache_loc
 from sglang.srt.speculative.triton_ops.dflash import (
     _compute_dflash_accept_bonus_triton_unchecked,
     _prepare_dflash_draft_block_unchecked,
+)
+from sglang.srt.speculative.triton_ops.dspark import (
+    _compute_dspark_accept_bonus_triton_unchecked,
 )
 from sglang.srt.utils import get_available_gpu_memory, is_cuda, is_hip, is_npu
 
@@ -286,6 +294,28 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._bonus_id_bufs: List[torch.Tensor] = []
         self._out_tokens_bufs: List[torch.Tensor] = []
         self._new_seq_lens_bufs: List[torch.Tensor] = []
+
+        self._use_qwen3_dspark = (
+            getattr(self.draft_model, "markov_head", None) is not None
+            and getattr(self.draft_model, "lm_head", None) is not None
+        )
+        self._draft_confidence: Optional[torch.Tensor] = None
+        self._markov_refine_buffer_cap: int = 0
+        self._markov_candidates_buf: Optional[torch.Tensor] = None
+        self._markov_embeds_buf: Optional[torch.Tensor] = None
+        if self._use_qwen3_dspark:
+            self._draft_vocab_size = int(getattr(self.draft_model, "vocab_size", 0))
+            self._draft_markov_rank = int(getattr(self.draft_model, "markov_rank", 0))
+            self.confidence_threshold = float(
+                getattr(server_args, "speculative_dspark_confidence_threshold", 0.0)
+                or 0.0
+            )
+            if self.tp_rank == 0:
+                logger.info(
+                    "Qwen3 DSpark heads enabled (Markov rank=%s, confidence_threshold=%s).",
+                    self._draft_markov_rank,
+                    self.confidence_threshold,
+                )
 
     @property
     def target_worker(self) -> TpModelWorker:
@@ -692,6 +722,99 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
 
         return int(resolved_id)
+
+    def _ensure_markov_refine_buffers(self, bs: int, device: torch.device) -> None:
+        cap = self._markov_refine_buffer_cap
+        if (
+            cap >= int(bs)
+            and self._markov_candidates_buf is not None
+            and self._markov_embeds_buf is not None
+            and self._markov_candidates_buf.device == device
+            and self._markov_embeds_buf.device == device
+        ):
+            return
+
+        new_cap = max(int(bs), cap * 2 if cap > 0 else int(bs))
+        markov_weight = getattr(
+            self.draft_model.markov_head.markov_w1, "weight", None
+        )
+        markov_dtype = (
+            markov_weight.dtype
+            if markov_weight is not None
+            else self.draft_model.lm_head.weight.dtype
+        )
+        self._markov_candidates_buf = torch.empty(
+            (new_cap, int(self.block_size)), dtype=torch.int64, device=device
+        )
+        self._markov_embeds_buf = torch.empty(
+            (new_cap, int(self.block_size), int(self._draft_markov_rank)),
+            dtype=markov_dtype,
+            device=device,
+        )
+        self._markov_refine_buffer_cap = new_cap
+
+    def _refine_block_markov(
+        self,
+        *,
+        block_hidden: torch.Tensor,
+        bonus_tokens: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        bs = int(block_hidden.shape[0])
+        block_size = int(self.block_size)
+        device = block_hidden.device
+
+        self._ensure_markov_refine_buffers(bs, device)
+        assert self._markov_candidates_buf is not None
+        assert self._markov_embeds_buf is not None
+        candidates = self._markov_candidates_buf[:bs]
+        markov_embeds = self._markov_embeds_buf[:bs]
+
+        markov_head = self.draft_model.markov_head
+        confidence_head = self.draft_model.confidence_head
+        lm_head = self.draft_model.lm_head
+        tp_size = get_tensor_model_parallel_world_size()
+        vocab_size = int(self._draft_vocab_size)
+
+        def _gather_full_vocab(logits_shard: torch.Tensor) -> torch.Tensor:
+            if logits_shard.shape[-1] >= vocab_size:
+                return logits_shard[..., :vocab_size]
+            if tp_size == 1:
+                return logits_shard
+            return tensor_model_parallel_all_gather(logits_shard, dim=-1)[
+                ..., :vocab_size
+            ]
+
+        if bonus_tokens.numel() == bs:
+            first_tokens = bonus_tokens.view(-1).to(torch.int64)
+        else:
+            first_tokens = bonus_tokens[:, 0].to(torch.int64)
+        candidates[:, 0].copy_(first_tokens)
+
+        with torch.inference_mode():
+            base_logits = _gather_full_vocab(F.linear(block_hidden, lm_head.weight))
+            prev_tokens = candidates[:, 0]
+            for i in range(block_size):
+                prev_embed = markov_head.get_prev_embeddings(prev_tokens)
+                markov_embeds[:, i].copy_(prev_embed)
+                bias = _gather_full_vocab(markov_head.project_bias(prev_embed))
+                bias.add_(base_logits[:, i])
+                next_tokens = torch.argmax(bias, dim=-1)
+                if i + 1 < block_size:
+                    candidates[:, i + 1].copy_(next_tokens)
+                prev_tokens = next_tokens
+
+            if confidence_head is not None:
+                confidence = confidence_head(block_hidden, markov_embeds)
+            else:
+                confidence = torch.ones(
+                    (bs, block_size), dtype=torch.float32, device=device
+                )
+
+        return candidates, confidence
+
+    def _confident_prefix(self, confidence: torch.Tensor) -> torch.Tensor:
+        keep = torch.sigmoid(confidence) >= self.confidence_threshold
+        return keep.to(torch.int32).cumprod(dim=1).sum(dim=1)
 
     def _greedy_sample_from_vocab_parallel_head(
         self,
@@ -1543,10 +1666,23 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_out = self.draft_model_runner.forward(forward_batch)
         draft_logits_output = draft_out.logits_output
 
-        if self._draft_sampler is not None and draft_out.can_run_graph:
+        draft_tokens = self._draft_block_tokens_buf[:bs]
+        if self._use_qwen3_dspark:
+            draft_hidden = draft_logits_output.hidden_states
+            if draft_hidden is None:
+                raise RuntimeError("DFLASH draft model returned no hidden states.")
+            draft_hidden = draft_hidden.view(bs, int(self.block_size), -1)
+            draft_tokens, self._draft_confidence = self._refine_block_markov(
+                block_hidden=draft_hidden,
+                bonus_tokens=block_ids[:, 0],
+            )
+        elif self._draft_sampler is not None and draft_out.can_run_graph:
             draft_next = self._draft_sampler.out[
                 : bs * (int(self.block_size) - 1)
             ].view(bs, int(self.block_size) - 1)
+            draft_tokens[:, 0].copy_(block_ids[:, 0])
+            draft_tokens[:, 1:].copy_(draft_next)
+            self._draft_confidence = None
         else:
             draft_hidden = draft_logits_output.hidden_states
             if draft_hidden is None:
@@ -1558,10 +1694,9 @@ class DFlashWorkerV2(BaseSpecWorker):
                 ),
                 lm_head=lm_head,
             ).view(bs, int(self.block_size) - 1)
-
-        draft_tokens = self._draft_block_tokens_buf[:bs]
-        draft_tokens[:, 0].copy_(block_ids[:, 0])
-        draft_tokens[:, 1:].copy_(draft_next)
+            draft_tokens[:, 0].copy_(block_ids[:, 0])
+            draft_tokens[:, 1:].copy_(draft_next)
+            self._draft_confidence = None
 
         # --- 2) Target verify.
         # TARGET_VERIFY uses standard causal masking; custom masks are unnecessary here.
@@ -1645,7 +1780,58 @@ class DFlashWorkerV2(BaseSpecWorker):
             target_predict = torch.argmax(logits_output.next_token_logits, dim=-1).view(
                 bs, int(self.block_size)
             )
-            if self._use_triton_accept_bonus:
+            use_dspark_accept = (
+                self._use_qwen3_dspark and self._draft_confidence is not None
+            )
+            dspark_accept_done = False
+            if use_dspark_accept and self._use_triton_accept_bonus:
+                try:
+                    (
+                        accept_len,
+                        commit_lens,
+                        bonus,
+                        out_tokens,
+                        new_seq_lens,
+                    ) = self._next_accept_bonus_buffers(bs)
+                    _compute_dspark_accept_bonus_triton_unchecked(
+                        candidates=candidates,
+                        target_top1=target_predict,
+                        confidence=self._draft_confidence,
+                        commit_lens_out=commit_lens,
+                        bonus_ids_out=bonus,
+                        out_tokens_out=out_tokens,
+                        prefix_lens=prefix_lens,
+                        new_seq_lens_out=new_seq_lens,
+                        confidence_threshold=self.confidence_threshold,
+                    )
+                    accept_len.copy_(commit_lens - 1)
+                    dspark_accept_done = True
+                except Exception as e:
+                    self._use_triton_accept_bonus = False
+                    logger.warning(
+                        "Qwen3 DSpark Triton accept/bonus failed; falling back to eager path: %s",
+                        e,
+                    )
+            if use_dspark_accept and not dspark_accept_done:
+                match_len, bonus = compute_dflash_correct_drafts_and_bonus(
+                    candidates=candidates,
+                    target_predict=target_predict,
+                )
+                confident_prefix = self._confident_prefix(self._draft_confidence)
+                accept_len = torch.minimum(
+                    match_len.to(torch.int64), confident_prefix.to(torch.int64)
+                )
+                commit_lens = accept_len.to(torch.int32) + 1
+                out_tokens = torch.empty(
+                    (bs, int(self.block_size)), dtype=torch.int64, device=device
+                )
+                if int(self.block_size) > 1:
+                    out_tokens[:, : int(self.block_size) - 1].copy_(candidates[:, 1:])
+                out_tokens[:, int(self.block_size) - 1].fill_(0)
+                out_tokens.scatter_(
+                    1, accept_len.to(torch.int64)[:, None], bonus[:, None]
+                )
+            elif self._use_triton_accept_bonus:
                 try:
                     (
                         accept_len,
@@ -1688,7 +1874,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                     out_tokens.scatter_(
                         1, accept_len.to(torch.int64)[:, None], bonus[:, None]
                     )
-            else:
+            elif not use_dspark_accept:
                 accept_len, bonus = compute_dflash_correct_drafts_and_bonus(
                     candidates=candidates,
                     target_predict=target_predict,

--- a/python/sglang/srt/speculative/triton_ops/dspark.py
+++ b/python/sglang/srt/speculative/triton_ops/dspark.py
@@ -1,0 +1,142 @@
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.speculative.triton_ops.dflash import _pick_num_warps
+
+
+@triton.jit
+def _dspark_accept_bonus_contig_kernel(
+    candidates_ptr,
+    target_top1_ptr,
+    confidence_ptr,
+    commit_lens_out_ptr,
+    bonus_ids_out_ptr,
+    out_tokens_ptr,
+    prefix_lens_ptr,
+    new_seq_lens_out_ptr,
+    candidates_row_stride,
+    target_row_stride,
+    confidence_row_stride,
+    commit_stride,
+    bonus_stride,
+    out_tokens_row_stride,
+    prefix_lens_stride,
+    new_seq_lens_stride,
+    confidence_threshold,
+    block_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_SIZE)
+    row_mask = cols < block_size
+    draft_mask = cols < (block_size - 1)
+
+    candidate_row_ptr = candidates_ptr + row * candidates_row_stride
+    target_row_ptr = target_top1_ptr + row * target_row_stride
+    confidence_row_ptr = confidence_ptr + row * confidence_row_stride
+
+    match_prefix_len = tl.full((), 0, tl.int32)
+    match_live = tl.full((), 1, tl.int32)
+    for col in range(BLOCK_SIZE - 1):
+        in_range = col < (block_size - 1)
+        candidate_id = tl.load(candidate_row_ptr + (col + 1), mask=in_range, other=0)
+        target_id = tl.load(target_row_ptr + col, mask=in_range, other=0)
+        match_i32 = (candidate_id == target_id).to(tl.int32)
+        keep = in_range & (match_live != 0) & (match_i32 != 0)
+        match_prefix_len += keep.to(tl.int32)
+        match_live = tl.where(in_range, match_live & match_i32, match_live)
+
+    confidence_prefix_len = tl.full((), 0, tl.int32)
+    confidence_live = tl.full((), 1, tl.int32)
+    for col in range(BLOCK_SIZE):
+        in_range = col < block_size
+        confidence = tl.load(
+            confidence_row_ptr + col, mask=in_range, other=-3.4028234663852886e38
+        )
+        confident_i32 = (tl.sigmoid(confidence) >= confidence_threshold).to(tl.int32)
+        keep = in_range & (confidence_live != 0) & (confident_i32 != 0)
+        confidence_prefix_len += keep.to(tl.int32)
+        confidence_live = tl.where(
+            in_range, confidence_live & confident_i32, confidence_live
+        )
+
+    accept_len = tl.minimum(match_prefix_len, confidence_prefix_len)
+    commit_len = accept_len + 1
+    bonus_id = tl.load(target_row_ptr + accept_len.to(tl.int64))
+    new_seq_len = tl.load(prefix_lens_ptr + row * prefix_lens_stride) + commit_len
+
+    tl.store(commit_lens_out_ptr + row * commit_stride, commit_len)
+    tl.store(bonus_ids_out_ptr + row * bonus_stride, bonus_id)
+    tl.store(new_seq_lens_out_ptr + row * new_seq_lens_stride, new_seq_len)
+
+    candidate_tail = tl.load(candidate_row_ptr + cols + 1, mask=draft_mask, other=0)
+    out_val = tl.where(draft_mask, candidate_tail, 0)
+    out_val = tl.where(cols == accept_len, bonus_id, out_val)
+    tl.store(
+        out_tokens_ptr + row * out_tokens_row_stride + cols, out_val, mask=row_mask
+    )
+
+
+def _is_row_major_contiguous_2d(x: torch.Tensor) -> bool:
+    return x.ndim == 2 and x.is_contiguous()
+
+
+def _compute_dspark_accept_bonus_triton_unchecked(
+    candidates: torch.Tensor,
+    target_top1: torch.Tensor,
+    confidence: torch.Tensor,
+    commit_lens_out: torch.Tensor,
+    bonus_ids_out: torch.Tensor,
+    out_tokens_out: torch.Tensor,
+    prefix_lens: torch.Tensor,
+    new_seq_lens_out: torch.Tensor,
+    confidence_threshold: float,
+) -> None:
+    batch_size, block_size = candidates.shape
+    if batch_size == 0:
+        return
+
+    if not _is_row_major_contiguous_2d(candidates):
+        raise ValueError("DSPARK Triton accept_bonus requires contiguous candidates.")
+    if not _is_row_major_contiguous_2d(target_top1):
+        raise ValueError("DSPARK Triton accept_bonus requires contiguous target_top1.")
+    if not _is_row_major_contiguous_2d(confidence):
+        raise ValueError("DSPARK Triton accept_bonus requires contiguous confidence.")
+    if not _is_row_major_contiguous_2d(out_tokens_out):
+        raise ValueError("DSPARK Triton accept_bonus requires contiguous out_tokens_out.")
+    if not commit_lens_out.is_contiguous():
+        raise ValueError("DSPARK Triton accept_bonus requires contiguous commit_lens_out.")
+    if not bonus_ids_out.is_contiguous():
+        raise ValueError("DSPARK Triton accept_bonus requires contiguous bonus_ids_out.")
+    if prefix_lens.ndim != 1:
+        raise ValueError("DSPARK Triton accept_bonus requires 1D prefix_lens.")
+    if not new_seq_lens_out.is_contiguous():
+        raise ValueError(
+            "DSPARK Triton accept_bonus requires contiguous new_seq_lens_out."
+        )
+
+    block = triton.next_power_of_2(block_size)
+    num_warps = _pick_num_warps(block)
+    _dspark_accept_bonus_contig_kernel[(batch_size,)](
+        candidates,
+        target_top1,
+        confidence,
+        commit_lens_out,
+        bonus_ids_out,
+        out_tokens_out,
+        prefix_lens,
+        new_seq_lens_out,
+        candidates.stride(0),
+        target_top1.stride(0),
+        confidence.stride(0),
+        commit_lens_out.stride(0),
+        bonus_ids_out.stride(0),
+        out_tokens_out.stride(0),
+        prefix_lens.stride(0),
+        new_seq_lens_out.stride(0),
+        float(confidence_threshold),
+        block_size,
+        BLOCK_SIZE=block,
+        num_warps=num_warps,
+    )

--- a/test/registered/unit/spec/test_qwen3_dspark.py
+++ b/test/registered/unit/spec/test_qwen3_dspark.py
@@ -1,0 +1,34 @@
+import json
+
+import pytest
+
+from sglang.srt.arg_groups.speculative_hook import _resolve_speculative_algorithm_alias
+
+
+@pytest.fixture
+def qwen3_dspark_draft_path(tmp_path):
+    draft_path = tmp_path / "draft"
+    draft_path.mkdir()
+    cfg = {
+        "architectures": ["Qwen3DSparkDraftModel"],
+        "block_size": 7,
+        "hidden_size": 4096,
+        "vocab_size": 151936,
+    }
+    (draft_path / "config.json").write_text(json.dumps(cfg))
+    return str(draft_path)
+
+
+def test_dspark_alias_routes_qwen3_draft_to_dflash(qwen3_dspark_draft_path):
+    assert (
+        _resolve_speculative_algorithm_alias("DSPARK", qwen3_dspark_draft_path)
+        == "DFLASH"
+    )
+    assert (
+        _resolve_speculative_algorithm_alias("DFLASH", qwen3_dspark_draft_path)
+        == "DFLASH"
+    )
+
+
+def test_dspark_without_qwen3_draft_stays_dspark():
+    assert _resolve_speculative_algorithm_alias("DSPARK", None) == "DSPARK"


### PR DESCRIPTION
## Summary
- Add `Qwen3DSparkDraftModel` (DFlash backbone + Markov/confidence heads) for DeepSpec DSpark Qwen3 checkpoints.
- Extend `DFlashWorkerV2` with Markov block refinement and confidence-aware accept (Triton + eager fallback).
- Route `--speculative-algorithm DSPARK` to DFLASH when draft architecture is `Qwen3DSparkDraftModel`.

## Usage
```bash
sglang serve \
  --model-path <target-qwen3> \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path <draft-with-Qwen3DSparkDraftModel-config> \
  --speculative-dspark-block-size <block_size>
```

Draft config should set `"architectures": ["Qwen3DSparkDraftModel"]`.

## Test plan
- [ ] `pytest test/registered/unit/spec/test_qwen3_dspark.py`
- [ ] Serve Qwen3-8B + DSpark draft; verify accept len > 1 and stable throughput

Made with [Cursor](https://cursor.com)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28576537802](https://github.com/sgl-project/sglang/actions/runs/28576537802)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28576537798](https://github.com/sgl-project/sglang/actions/runs/28576537798)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->