### PR TITLE
[Kernel]Fix and Fuse DeepSeek-V4 FP8 wo_a quantization

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/fp8_wo_a_group_major_quant.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/fp8_wo_a_group_major_quant.cuh
@@ -1,0 +1,201 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <cstdint>
+#include <cuda_fp8.h>
+
+namespace {
+
+constexpr float kLocalAbsmaxEps = 1e-10f;
+constexpr uint32_t kVecBytes = 32;
+constexpr uint32_t kFp8E4m3Max = 448;
+
+template <int kThreadsPerSubwarp>
+SGL_DEVICE float group_reduce_max(float val) {
+  static_assert(
+      (kThreadsPerSubwarp & (kThreadsPerSubwarp - 1)) == 0 && kThreadsPerSubwarp <= 16 && kThreadsPerSubwarp >= 1,
+      "kThreadsPerSubwarp must be 1, 2, 4, 8, or 16");
+  constexpr device::warp::mask_t kSub = (device::warp::mask_t{1} << kThreadsPerSubwarp) - 1;
+  const device::warp::mask_t mask = kSub << (kThreadsPerSubwarp * ((threadIdx.x % 32) / kThreadsPerSubwarp));
+  return device::warp::reduce_max<kThreadsPerSubwarp>(val, mask);
+}
+
+SGL_DEVICE float fast_pow2(int x) {
+  const uint32_t bits_x = (x + 127) << 23;
+  return __uint_as_float(bits_x);
+}
+
+SGL_DEVICE int fast_log2_ceil(float x) {
+  const auto bits_x = __float_as_uint(x);
+  const auto exp_x = (bits_x >> 23) & 0xff;
+  const auto man_bits = bits_x & ((1 << 23) - 1);
+  return exp_x - 127 + (man_bits != 0);
+}
+
+SGL_DEVICE float2 fmul2_rn(float2 a, float2 b) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  return __fmul2_rn(a, b);
+#else
+  return {a.x * b.x, a.y * b.y};
+#endif
+}
+
+struct Fp8WoAGroupMajorQuantUe8m0Params {
+  const bf16_t* __restrict__ input;   // [G, T, D], contiguous
+  fp8_e4m3_t* __restrict__ output_q;  // [G, T, D], contiguous
+  int32_t* __restrict__ output_s;     // logical [G, T, scale_inner], strided
+  uint32_t G;
+  uint64_t T;
+  uint32_t D;
+  uint32_t hidden_dim_num_groups;
+  uint64_t total_groups;
+  int64_t scale_stride_g;
+  int64_t scale_stride_t;
+  int64_t scale_stride_s;
+};
+
+template <uint32_t kGroupSize, bool kUsePDL>
+__global__ void
+fp8_wo_a_group_major_quant_ue8m0_kernel(const Fp8WoAGroupMajorQuantUe8m0Params __grid_constant__ params) {
+  constexpr uint32_t kInputVecSize = kVecBytes / sizeof(bf16_t);
+  constexpr uint32_t kInputInt4Size = kVecBytes / sizeof(int4);
+  constexpr uint32_t kThreadsPerSubwarp = kGroupSize / kInputVecSize;
+  constexpr uint32_t kSubwarpsPerBlock = 16;
+  static_assert(kGroupSize % kInputVecSize == 0, "group_size must be divisible by the vector width");
+
+  device::PDLWaitPrimary<kUsePDL>();
+
+  const uint32_t subwarp_id = threadIdx.x / kThreadsPerSubwarp;
+  const uint32_t lane_id = threadIdx.x % kThreadsPerSubwarp;
+  const uint64_t linear_group = static_cast<uint64_t>(blockIdx.x) * kSubwarpsPerBlock + subwarp_id;
+  if (linear_group < params.total_groups) {
+    const uint32_t hidden_group = linear_group % params.hidden_dim_num_groups;
+    const uint64_t token_linear = linear_group / params.hidden_dim_num_groups;
+    const uint64_t t = token_linear % params.T;
+    const uint32_t g = token_linear / params.T;
+    const uint64_t row_offset = (static_cast<uint64_t>(g) * params.T + t) * params.D;
+    const uint64_t group_offset = row_offset + static_cast<uint64_t>(hidden_group) * kGroupSize;
+
+    int4 input_int4[kInputInt4Size];
+    auto* input_vec = reinterpret_cast<bf16_t*>(input_int4);
+
+#pragma unroll
+    for (uint32_t j = 0; j < kInputInt4Size; ++j) {
+      input_int4[j] = reinterpret_cast<const int4*>(params.input + group_offset + lane_id * kInputVecSize)[j];
+    }
+
+    float local_absmax = kLocalAbsmaxEps;
+#pragma unroll
+    for (uint32_t j = 0; j < kInputVecSize; ++j) {
+      const float val = static_cast<float>(input_vec[j]);
+      local_absmax = fmaxf(local_absmax, fabsf(val));
+    }
+    local_absmax = group_reduce_max<kThreadsPerSubwarp>(local_absmax);
+
+    const int exp_scale_inv = fast_log2_ceil(local_absmax / static_cast<float>(kFp8E4m3Max));
+    const float y_scale = fast_pow2(-exp_scale_inv);
+    const float y_scale_inv = fast_pow2(exp_scale_inv);
+    const uint8_t scale_exp = static_cast<uint8_t>(__float_as_uint(y_scale_inv) >> 23);
+
+    if (lane_id == 0) {
+      const uint32_t hidden_idx_packed = hidden_group / 4u;
+      const uint32_t pack_idx = hidden_group % 4u;
+      auto* scale_bytes = reinterpret_cast<uint8_t*>(
+          params.output_s + static_cast<int64_t>(g) * params.scale_stride_g +
+          static_cast<int64_t>(t) * params.scale_stride_t +
+          static_cast<int64_t>(hidden_idx_packed) * params.scale_stride_s);
+      scale_bytes[pack_idx] = scale_exp;
+    }
+
+    const uint32_t remainder = params.hidden_dim_num_groups % 4u;
+    if (remainder != 0 && hidden_group == params.hidden_dim_num_groups - 1u && lane_id < 4u - remainder) {
+      const uint32_t hidden_idx_packed = hidden_group / 4u;
+      const uint32_t pack_idx = hidden_group % 4u;
+      auto* scale_bytes = reinterpret_cast<uint8_t*>(
+          params.output_s + static_cast<int64_t>(g) * params.scale_stride_g +
+          static_cast<int64_t>(t) * params.scale_stride_t +
+          static_cast<int64_t>(hidden_idx_packed) * params.scale_stride_s);
+      scale_bytes[pack_idx + 1u + lane_id] = 0;
+    }
+
+    const float2 y_scale_repeated = {y_scale, y_scale};
+    int4 output_buf;
+    auto* output_buf_ptr = reinterpret_cast<__nv_fp8x2_storage_t*>(&output_buf);
+#pragma unroll
+    for (uint32_t j = 0; j < kInputVecSize; j += 2) {
+      float2 inputx2 = {static_cast<float>(input_vec[j]), static_cast<float>(input_vec[j + 1])};
+      float2 outputx2 = fmul2_rn(inputx2, y_scale_repeated);
+      outputx2.x = fminf(fmaxf(outputx2.x, -static_cast<float>(kFp8E4m3Max)), static_cast<float>(kFp8E4m3Max));
+      outputx2.y = fminf(fmaxf(outputx2.y, -static_cast<float>(kFp8E4m3Max)), static_cast<float>(kFp8E4m3Max));
+      output_buf_ptr[j / 2] = __nv_cvt_float2_to_fp8x2(outputx2, __NV_SATFINITE, __NV_E4M3);
+    }
+    *reinterpret_cast<int4*>(params.output_q + group_offset + lane_id * kInputVecSize) = output_buf;
+  }
+
+  device::PDLTriggerSecondary<kUsePDL>();
+}
+
+template <int64_t kGroupSize, bool kUsePDL>
+struct Fp8WoAGroupMajorQuantUe8m0Kernel {
+  static void
+  run(tvm::ffi::TensorView input,
+      tvm::ffi::TensorView output_q,
+      tvm::ffi::TensorView output_s,
+      int64_t scale_stride_g,
+      int64_t scale_stride_t,
+      int64_t scale_stride_s) {
+    using namespace host;
+    auto device = SymbolicDevice{};
+    auto G = SymbolicSize{"G"};
+    auto T = SymbolicSize{"T"};
+    auto D = SymbolicSize{"D"};
+    auto S = SymbolicSize{"scale_inner"};
+    device.set_options<kDLCUDA>();
+
+    TensorMatcher({G, T, D}).with_dtype<bf16_t>().with_device(device).verify(input);
+    TensorMatcher({G, T, D}).with_dtype<fp8_e4m3_t>().with_device(device).verify(output_q);
+    TensorMatcher({G, T, S}).with_strides({-1, -1, -1}).with_dtype<int32_t>().with_device(device).verify(output_s);
+
+    const uint32_t groups = static_cast<uint32_t>(G.unwrap());
+    const uint64_t tokens = static_cast<uint64_t>(T.unwrap());
+    const uint32_t hidden = static_cast<uint32_t>(D.unwrap());
+    RuntimeCheck(hidden % kGroupSize == 0, "D ", hidden, " not divisible by group_size ", kGroupSize);
+    const uint32_t hidden_dim_num_groups = hidden / static_cast<uint32_t>(kGroupSize);
+    const uint32_t scale_inner = (hidden_dim_num_groups + 3u) / 4u;
+    RuntimeCheck(static_cast<uint32_t>(S.unwrap()) == scale_inner, "scale_inner mismatch");
+
+    constexpr uint32_t kInputVecSize = kVecBytes / sizeof(bf16_t);
+    constexpr uint32_t kThreadsPerSubwarp = static_cast<uint32_t>(kGroupSize) / kInputVecSize;
+    constexpr uint32_t kSubwarpsPerBlock = 16;
+    constexpr uint32_t kThreads = kThreadsPerSubwarp * kSubwarpsPerBlock;
+    const uint64_t total_groups = static_cast<uint64_t>(groups) * tokens * hidden_dim_num_groups;
+    if (total_groups == 0) return;
+    const uint64_t grid_x = (total_groups + kSubwarpsPerBlock - 1u) / kSubwarpsPerBlock;
+    RuntimeCheck(grid_x <= static_cast<uint64_t>(UINT32_MAX), "grid.x exceeds CUDA dim3 range");
+
+    const auto params = Fp8WoAGroupMajorQuantUe8m0Params{
+        .input = static_cast<const bf16_t*>(input.data_ptr()),
+        .output_q = static_cast<fp8_e4m3_t*>(output_q.data_ptr()),
+        .output_s = static_cast<int32_t*>(output_s.data_ptr()),
+        .G = groups,
+        .T = tokens,
+        .D = hidden,
+        .hidden_dim_num_groups = hidden_dim_num_groups,
+        .total_groups = total_groups,
+        .scale_stride_g = scale_stride_g,
+        .scale_stride_t = scale_stride_t,
+        .scale_stride_s = scale_stride_s,
+    };
+    const dim3 grid(static_cast<uint32_t>(grid_x));
+    const dim3 block(kThreads);
+    constexpr auto kernel = fp8_wo_a_group_major_quant_ue8m0_kernel<static_cast<uint32_t>(kGroupSize), kUsePDL>;
+    LaunchKernel(grid, block, device.unwrap()).enable_pdl(kUsePDL)(kernel, params);
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/dsv4/__init__.py
+++ b/python/sglang/jit_kernel/dsv4/__init__.py
@@ -17,6 +17,7 @@ from .elementwise import (
     fused_q_norm_rope,
     fused_rope_inplace,
 )
+from .fp8_wo_a import fp8_wo_a_group_major_quant_ue8m0
 from .gemm import linear_bf16_fp32
 from .moe import (
     hash_topk,
@@ -41,6 +42,7 @@ __all__ = [
     "fused_q_indexer_rope_hadamard_fp4_quant",
     "fused_q_indexer_rope_hadamard_quant",
     "fused_k_norm_rope_flashmla",
+    "fp8_wo_a_group_major_quant_ue8m0",
     "make_name",
     "linear_bf16_fp32",
     "get_paged_mqa_logits_metadata",

--- a/python/sglang/jit_kernel/dsv4/fp8_wo_a.py
+++ b/python/sglang/jit_kernel/dsv4/fp8_wo_a.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple
+
+import torch
+
+from sglang.jit_kernel.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
+from sglang.kernel_api_logging import debug_kernel_api
+from sglang.srt.utils import ceil_align
+from sglang.srt.utils.custom_op import register_custom_op
+
+from .utils import make_name
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_module(group_size: int) -> Module:
+    args = make_cpp_args(group_size, is_arch_support_pdl())
+    return load_jit(
+        make_name("fp8_wo_a_group_major_quant_ue8m0"),
+        *args,
+        cuda_files=["deepseek_v4/fp8_wo_a_group_major_quant.cuh"],
+        cuda_wrappers=[
+            (
+                "run",
+                f"Fp8WoAGroupMajorQuantUe8m0Kernel<{args}>::run",
+            ),
+        ],
+        # Match the per-token-group quant v2 math used by the previous helper.
+        extra_cuda_cflags=["--use_fast_math"],
+    )
+
+
+@register_custom_op(
+    op_name="fp8_wo_a_group_major_quant_ue8m0",
+    mutates_args=["o_fp8", "o_s"],
+)
+def _fp8_wo_a_group_major_quant_ue8m0_custom_op(
+    o_group_major: torch.Tensor,
+    o_fp8: torch.Tensor,
+    o_s: torch.Tensor,
+    group_size: int,
+) -> None:
+    module = _jit_module(group_size)
+    module.run(
+        o_group_major,
+        o_fp8,
+        o_s,
+        int(o_s.stride(0)),
+        int(o_s.stride(1)),
+        int(o_s.stride(2)),
+    )
+
+
+@debug_kernel_api
+def fp8_wo_a_group_major_quant_ue8m0(
+    o_group_major: torch.Tensor,
+    group_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize DeepSeek-V4 wo_a activations in one fused group-major launch.
+
+    ``o_group_major`` is logical ``[G, T, D]``. The returned scale tensor is
+    logical ``[G, T, ceil(D / group_size, 4) / 4]`` with four UE8M0 scale bytes
+    packed per int32 and backed by the TMA-aligned ``[G, scale_inner, aligned_T]``
+    layout expected by DeepGEMM.
+    """
+    assert o_group_major.is_cuda
+    assert o_group_major.dtype == torch.bfloat16
+    assert o_group_major.dim() == 3
+    assert o_group_major.is_contiguous()
+
+    G, T, D = o_group_major.shape
+    assert D % group_size == 0, "D must be divisible by group_size"
+    num_groups = D // group_size
+    scale_inner = ceil_align(num_groups, 4) // 4
+    aligned_t = ceil_align(T, 4)
+
+    o_fp8 = torch.empty_like(o_group_major, dtype=torch.float8_e4m3fn)
+    o_s = torch.empty(
+        (G, scale_inner, aligned_t),
+        device=o_group_major.device,
+        dtype=torch.int32,
+    ).transpose(-1, -2)[:, :T, :]
+    _fp8_wo_a_group_major_quant_ue8m0_custom_op(
+        o_group_major,
+        o_fp8,
+        o_s,
+        int(group_size),
+    )
+    return o_fp8, o_s

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -70,11 +70,6 @@ from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.mhc import mhc_fused_post_pre, npu_hc_pre
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
-from sglang.srt.layers.quantization.fp8_kernel import (
-    fp8_dtype,
-    fp8_max,
-    fp8_min,
-)
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.utils.cp_utils import (
@@ -131,7 +126,6 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
-    ceil_align,
     get_bool_env_var,
     is_gfx95_supported,
     log_info_on_rank0,
@@ -162,40 +156,11 @@ def _fp8_wo_a_group_major_quant_ue8m0_for_deep_gemm(
     backed by the TMA-aligned layout expected by DeepGEMM on SM100. Do not make
     the scale tensor contiguous.
     """
-    from sglang.srt.layers.quantization.fp8_kernel import (
-        sgl_per_token_group_quant_8bit,
+    from sglang.jit_kernel.dsv4 import (
+        fp8_wo_a_group_major_quant_ue8m0,
     )
 
-    G, T, D = o_group_major.shape
-    scale_inner = ceil_align(D // group_size, 4) // 4
-    aligned_t = ceil_align(T, 4)
-    o_fp8 = torch.empty(
-        o_group_major.shape, device=o_group_major.device, dtype=fp8_dtype
-    )
-    o_s = torch.empty(
-        (G, scale_inner, aligned_t),
-        device=o_group_major.device,
-        dtype=torch.int,
-    ).transpose(-1, -2)[:, :T, :]
-
-    # The generic wrapper cannot express this preallocated group-major scale
-    # buffer. Write each group's [T, D] rows into the DeepGEMM TMA layout.
-    for g in range(G):
-        sgl_per_token_group_quant_8bit(
-            o_group_major[g],
-            o_fp8[g],
-            o_s[g],
-            group_size,
-            1e-10,
-            fp8_min,
-            fp8_max,
-            True,
-            False,
-            None,
-            enable_v2=True,
-        )
-
-    return o_fp8, o_s
+    return fp8_wo_a_group_major_quant_ue8m0(o_group_major, group_size=group_size)
 
 
 def _is_fused_mhc_post_pre_enabled() -> bool:

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -70,7 +70,11 @@ from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.mhc import mhc_fused_post_pre, npu_hc_pre
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
-from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
+from sglang.srt.layers.quantization.fp8_kernel import (
+    fp8_dtype,
+    fp8_max,
+    fp8_min,
+)
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.utils.cp_utils import (
@@ -127,6 +131,7 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
+    ceil_align,
     get_bool_env_var,
     is_gfx95_supported,
     log_info_on_rank0,
@@ -144,6 +149,53 @@ logger = logging.getLogger(__name__)
 
 _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
 _MHC_POST_MULT_VALUE = 2.0
+
+
+def _fp8_wo_a_group_major_quant_ue8m0_for_deep_gemm(
+    o_group_major: torch.Tensor,
+    group_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize DeepSeek-V4 wo_a input for DeepGEMM FP8 einsum.
+
+    The input is logical [G, T, D]. The returned scale tensor is logical
+    [G, T, ceil(D / group_size, 4) / 4] with four UE8M0 scales packed per int32,
+    backed by the TMA-aligned layout expected by DeepGEMM on SM100. Do not make
+    the scale tensor contiguous.
+    """
+    from sglang.srt.layers.quantization.fp8_kernel import (
+        sgl_per_token_group_quant_8bit,
+    )
+
+    G, T, D = o_group_major.shape
+    scale_inner = ceil_align(D // group_size, 4) // 4
+    aligned_t = ceil_align(T, 4)
+    o_fp8 = torch.empty(
+        o_group_major.shape, device=o_group_major.device, dtype=fp8_dtype
+    )
+    o_s = torch.empty(
+        (G, scale_inner, aligned_t),
+        device=o_group_major.device,
+        dtype=torch.int,
+    ).transpose(-1, -2)[:, :T, :]
+
+    # The generic wrapper cannot express this preallocated group-major scale
+    # buffer. Write each group's [T, D] rows into the DeepGEMM TMA layout.
+    for g in range(G):
+        sgl_per_token_group_quant_8bit(
+            o_group_major[g],
+            o_fp8[g],
+            o_s[g],
+            group_size,
+            1e-10,
+            fp8_min,
+            fp8_max,
+            True,
+            False,
+            None,
+            enable_v2=True,
+        )
+
+    return o_fp8, o_s
 
 
 def _is_fused_mhc_post_pre_enabled() -> bool:
@@ -1067,15 +1119,14 @@ class MQALayer(nn.Module):
 
             T, G, D = o.shape
             R = self.o_lora_rank
-            o_fp8, o_s = sglang_per_token_group_quant_fp8(
-                o.reshape(T * G, D).contiguous(),
+            o_fp8, o_s = _fp8_wo_a_group_major_quant_ue8m0_for_deep_gemm(
+                o.transpose(0, 1).contiguous(),
                 group_size=128,
-                scale_ue8m0=True,
             )
             output = torch.empty(T, G, R, device=o.device, dtype=torch.bfloat16)
             deep_gemm.fp8_einsum(
                 "bhr,hdr->bhd",
-                (o_fp8.view(T, G, D), o_s.view(T, G, -1)),
+                (o_fp8.transpose(0, 1), o_s.transpose(0, 1)),
                 (self.wo_a.weight.view(G, R, D), self.wo_a.weight_scale_inv.data),
                 output,
                 recipe=(1, 1, 128),

--- a/test/registered/jit/test_deepseek_v4_fp8_wo_a.py
+++ b/test/registered/jit/test_deepseek_v4_fp8_wo_a.py
@@ -2,7 +2,9 @@ import importlib
 import unittest
 
 import torch
+from sgl_kernel import sgl_per_token_group_quant_8bit
 
+from sglang.jit_kernel.utils import should_run_full_tests
 from sglang.srt.utils import get_device_sm
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -68,6 +70,97 @@ class TestDeepSeekV4FP8WoA(CustomTestCase):
         cls.quant_weight_ue8m0 = staticmethod(fp8_utils.quant_weight_ue8m0)
         cls.transform_scale_ue8m0 = staticmethod(fp8_utils.transform_scale_ue8m0)
         cls.block_quant_dequant = staticmethod(fp8_utils.block_quant_dequant)
+
+    def test_fused_group_major_quant_matches_per_group_reference(self):
+        torch.manual_seed(1)
+        torch.cuda.manual_seed_all(1)
+
+        G, T, D = 5, 9, 384
+        group_size = 128
+        device = torch.device("cuda")
+        o_group_major = (
+            torch.randn(G, T, D, device=device, dtype=torch.float32) * 0.25
+        ).to(torch.bfloat16)
+
+        o_fp8, o_s = self.quant_helper(o_group_major, group_size=group_size)
+        scale_inner = (D // group_size + 3) // 4
+        aligned_t = (T + 3) // 4 * 4
+        o_fp8_ref = torch.empty_like(o_fp8)
+        o_s_ref = torch.empty(
+            (G, scale_inner, aligned_t), device=device, dtype=torch.int32
+        ).transpose(-1, -2)[:, :T, :]
+        for g in range(G):
+            sgl_per_token_group_quant_8bit(
+                o_group_major[g],
+                o_fp8_ref[g],
+                o_s_ref[g],
+                group_size,
+                1e-10,
+                float(torch.finfo(torch.float8_e4m3fn).min),
+                float(torch.finfo(torch.float8_e4m3fn).max),
+                True,
+                False,
+                None,
+                enable_v2=True,
+            )
+        torch.cuda.synchronize()
+
+        self.assertEqual(o_fp8.shape, (G, T, D))
+        self.assertEqual(o_s.shape, (G, T, scale_inner))
+        self.assertFalse(o_s.is_contiguous())
+        self.assertTrue(torch.equal(o_fp8.view(torch.int8), o_fp8_ref.view(torch.int8)))
+        self.assertTrue(torch.equal(o_s, o_s_ref))
+
+    def test_fused_group_major_quant_large_token_dimension(self):
+        torch.manual_seed(2)
+        torch.cuda.manual_seed_all(2)
+
+        cases = [
+            # Covers >10k live tokens / large decode batch without using much memory.
+            (1, 10_001, 128),
+            # Covers >10k live tokens with the DeepSeek-V4 wo_a model shape.
+            (16, 10_001, 512),
+        ]
+        if should_run_full_tests():
+            # Exercises 64-bit token indexing for long-context-sized token axes
+            # and group-major offsets with g > 0.
+            cases.append((2, 900_001, 128))
+
+        group_size = 128
+        device = torch.device("cuda")
+        for G, T, D in cases:
+            with self.subTest(G=G, T=T, D=D):
+                o_group_major = (
+                    torch.randn(G, T, D, device=device, dtype=torch.float32) * 0.25
+                ).to(torch.bfloat16)
+
+                o_fp8, o_s = self.quant_helper(o_group_major, group_size=group_size)
+                o_fp8_ref = torch.empty_like(o_fp8)
+                scale_inner = (D // group_size + 3) // 4
+                aligned_t = (T + 3) // 4 * 4
+                o_s_ref = torch.empty(
+                    (G, scale_inner, aligned_t), device=device, dtype=torch.int32
+                ).transpose(-1, -2)[:, :T, :]
+                for g in range(G):
+                    sgl_per_token_group_quant_8bit(
+                        o_group_major[g],
+                        o_fp8_ref[g],
+                        o_s_ref[g],
+                        group_size,
+                        1e-10,
+                        float(torch.finfo(torch.float8_e4m3fn).min),
+                        float(torch.finfo(torch.float8_e4m3fn).max),
+                        True,
+                        False,
+                        None,
+                        enable_v2=True,
+                    )
+                torch.cuda.synchronize()
+
+                self.assertTrue(
+                    torch.equal(o_fp8.view(torch.int8), o_fp8_ref.view(torch.int8))
+                )
+                self.assertTrue(torch.equal(o_s, o_s_ref))
 
     def test_fp8_wo_a_einsum_uses_group_major_activation_scales(self):
         torch.manual_seed(0)

--- a/test/registered/jit/test_deepseek_v4_fp8_wo_a.py
+++ b/test/registered/jit/test_deepseek_v4_fp8_wo_a.py
@@ -1,0 +1,128 @@
+import importlib
+import unittest
+
+import torch
+
+from sglang.srt.utils import get_device_sm
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, suite="base-b-kernel-unit-1-gpu-b200")
+
+
+def _ceil_to_ue8m0(x: torch.Tensor) -> torch.Tensor:
+    return torch.pow(2.0, torch.ceil(torch.log2(x.abs())))
+
+
+def _per_token_group_quant_dequant_ref(
+    x_q: torch.Tensor,
+    x: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """Dequantize FP8 per-token-group activations with logical UE8M0 scales."""
+    *prefix, hidden_size = x.shape
+    x_view = x.float().view(*prefix, hidden_size // group_size, group_size)
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    scale = _ceil_to_ue8m0(x_view.abs().amax(dim=-1).clamp(min=1e-10) / fp8_max)
+    x_q_view = x_q.float().view(*prefix, hidden_size // group_size, group_size)
+    return (x_q_view * scale.unsqueeze(-1)).view_as(x).float()
+
+
+class TestDeepSeekV4FP8WoA(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
+        if get_device_sm() < 100:
+            raise unittest.SkipTest("Test requires CUDA SM 100 or higher")
+
+        try:
+            cls.deep_gemm = importlib.import_module("deep_gemm")
+        except ImportError as exc:
+            raise unittest.SkipTest("deep_gemm is required") from exc
+
+        try:
+            cls.deepseek_v4 = importlib.import_module("sglang.srt.models.deepseek_v4")
+        except ImportError as exc:
+            raise unittest.SkipTest(
+                "DeepSeek-V4 model dependencies are required"
+            ) from exc
+
+        if not hasattr(
+            cls.deepseek_v4, "_fp8_wo_a_group_major_quant_ue8m0_for_deep_gemm"
+        ):
+            raise AssertionError(
+                "DeepSeek-V4 FP8 wo_a DeepGEMM quant helper is missing"
+            )
+
+        try:
+            fp8_utils = importlib.import_module(
+                "sglang.srt.layers.quantization.fp8_utils"
+            )
+        except ImportError as exc:
+            raise unittest.SkipTest("FP8 quantization utilities are required") from exc
+
+        cls.quant_helper = staticmethod(
+            cls.deepseek_v4._fp8_wo_a_group_major_quant_ue8m0_for_deep_gemm
+        )
+        cls.quant_weight_ue8m0 = staticmethod(fp8_utils.quant_weight_ue8m0)
+        cls.transform_scale_ue8m0 = staticmethod(fp8_utils.transform_scale_ue8m0)
+        cls.block_quant_dequant = staticmethod(fp8_utils.block_quant_dequant)
+
+    def test_fp8_wo_a_einsum_uses_group_major_activation_scales(self):
+        torch.manual_seed(0)
+        torch.cuda.manual_seed_all(0)
+
+        T, G, D, R = 5, 2, 256, 256
+        group_size = 128
+        device = torch.device("cuda")
+
+        token_scale = torch.linspace(0.5, 1.5, T, device=device).view(T, 1, 1)
+        group_scale = torch.tensor([0.25, 2.0], device=device).view(1, G, 1)
+        o = (
+            torch.randn(T, G, D, device=device, dtype=torch.float32)
+            * token_scale
+            * group_scale
+            * 0.2
+        ).to(torch.bfloat16)
+        weight = (torch.randn(G, R, D, device=device, dtype=torch.float32) * 0.2).to(
+            torch.bfloat16
+        )
+
+        o_group_major = o.transpose(0, 1).contiguous()
+        o_fp8, o_s = self.quant_helper(o_group_major, group_size=group_size)
+
+        self.assertEqual(o_fp8.shape, (G, T, D))
+        self.assertEqual(o_s.shape, (G, T, 1))
+        self.assertFalse(o_s.is_contiguous())
+
+        weight_fp8, weight_s_raw = self.quant_weight_ue8m0(
+            weight, weight_block_size=[128, 128]
+        )
+        weight_s = self.transform_scale_ue8m0(weight_s_raw, mn=R)
+
+        output = torch.empty(T, G, R, device=device, dtype=torch.bfloat16)
+        self.deep_gemm.fp8_einsum(
+            "bhr,hdr->bhd",
+            (o_fp8.transpose(0, 1), o_s.transpose(0, 1)),
+            (weight_fp8, weight_s),
+            output,
+            recipe=(1, 1, 128),
+        )
+
+        o_dequant = _per_token_group_quant_dequant_ref(
+            o_fp8, o_group_major, group_size=group_size
+        ).transpose(0, 1)
+        weight_dequant = self.block_quant_dequant(
+            weight_fp8,
+            weight_s_raw,
+            block_size=[128, 128],
+            dtype=torch.float32,
+        )
+        ref = torch.einsum("tgd,grd->tgr", o_dequant, weight_dequant).to(torch.bfloat16)
+
+        torch.testing.assert_close(output, ref, atol=1e-1, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #29036. This keeps the original PR branch untouched and adds a fused CUDA JIT kernel for the DeepSeek-V4 `wo_a` FP8 activation quantization path discussed in https://github.com/sgl-project/sglang/pull/29036#discussion_r3504904560.

## Summary

- Add `fp8_wo_a_group_major_quant_ue8m0`, a fused group-major CUDA JIT kernel that writes both FP8 activations and UE8M0 scales in the DeepGEMM TMA-friendly scale layout.
- Replace the Python loop over `sgl_per_token_group_quant_8bit` in `deepseek_v4.py` with the fused helper.
- Add JIT tests that compare bit-exactly against the old per-group reference and cover large/extreme shapes, including `T=900001` and `T=10001` / `G=16` model-shaped batches.

## Validation

Code/local:

- `python3 -m compileall -q test/registered/jit/test_deepseek_v4_fp8_wo_a.py python/sglang/jit_kernel/dsv4/fp8_wo_a.py`
- Commit hooks passed: Python AST, isort, ruff, clang-format, registered-test checks, etc.

B300 JIT/stress tests on `baizhou-dev`:

- `SGLANG_JIT_KERNEL_RUN_FULL_TESTS=true python3 test/registered/jit/test_deepseek_v4_fp8_wo_a.py`: 3 tests passed in 6.576s.
- Helper microbench vs old loop, bit-exact (`q_ok=True`, `s_ok=True`):
  - `G=2, T=900001, D=128`: loop 1.854968 ms, fused 0.145310 ms, 12.766x faster.
  - `G=16, T=10001, D=512`: loop 0.229609 ms, fused 0.049487 ms, 4.640x faster.

Serving validation on `baizhou-dev` 4xB300:

- Server used the requested DeepSeek-V4-Flash command/flags, plus `--cuda-graph-max-bs-decode 64` and port `30001` because the exact uncapped launch stalled during CUDA graph capture on this devbox.
- GSM8K smoke: `/sgl-workspace/logs/fused_fp8_wo_a/gsm8k_smoke/sgl_eval_gsm8k_20260701-211050/metrics.json`
  - 4 examples, score 100%, error 0%, truncated 0%, stop 100%.
- `send_one.py` fused profile: `/sgl-workspace/logs/fused_fp8_wo_a/send_one_fused_bs64_len256_new128-*.trace.json.gz`
  - `--batch-size 64 --random-input-len 256 --max-new-tokens 128 --profile --profile-steps 5`
  - trace contains `sglang::fp8_wo_a_group_major_quant_ue8m0` on all TP ranks; old `per_token_group_quant` events still exist elsewhere in the model as expected.
  - Per TP rank, fused wo_a ranges were ~417 events and ~10.9-11.3 ms total in the captured profile.
- GPQA full run: `/sgl-workspace/logs/fused_fp8_wo_a/gpqa_fused_noprogress/sgl_eval_gpqa_20260702-034409/metrics.json`
  - `n_repeats=16`, 198 examples, `max_tokens=200000`, thinking enabled.
  - `pass@1 = 88.44697%`, `pass@1_sem = 0.26030%`, `pass@16 = 96.96970%`, `majority@16 = 88.63636%`.
  - error 0%, stop 98.327%, truncated 1.673%.
  - This preserves the accuracy gain from #29036; compared to the earlier main-branch aggregate from the PR validation (87.3264% pass@1), this is +1.12 pp.

The unfused server-level `send_one.py` baseline was skipped per follow-up request in the Codex thread.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28578335640](https://github.com/sgl-project/sglang/actions/runs/28578335640)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28578335083](https://github.com/sgl-project/sglang/actions/runs/28578335083)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->