### PR TITLE
feat(parser): resolve special-token suffix at runtime for compatibility

### DIFF
--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -300,7 +300,9 @@ def create_grammar_backend(
         )
 
         reasoning_parser = ReasoningParser(
-            model_type=server_args.reasoning_parser, stream_reasoning=False
+            model_type=server_args.reasoning_parser,
+            stream_reasoning=False,
+            tokenizer=tokenizer,
         )
 
         grammar_backend = ReasonerGrammarBackend(

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1517,7 +1517,11 @@ async def parse_function_call_request(
     A native API endpoint to parse function calls from a text.
     """
     # 1) Initialize the parser based on the request body
-    parser = FunctionCallParser(tools=obj.tools, tool_call_parser=obj.tool_call_parser)
+    parser = FunctionCallParser(
+        tools=obj.tools,
+        tool_call_parser=obj.tool_call_parser,
+        tokenizer=get_global_state().tokenizer_manager.tokenizer,
+    )
 
     # 2) Call the non-stream parsing method (non-stream)
     normal_text, calls = parser.parse_non_stream(obj.text)
@@ -1541,7 +1545,11 @@ async def separate_reasoning_request(
     A native API endpoint to separate reasoning from a text.
     """
     # 1) Initialize the parser based on the request body
-    parser = ReasoningParser(model_type=obj.reasoning_parser, request=request)
+    parser = ReasoningParser(
+        model_type=obj.reasoning_parser,
+        request=request,
+        tokenizer=get_global_state().tokenizer_manager.tokenizer,
+    )
 
     # 2) Call the non-stream parsing method (non-stream)
     if obj.return_blocks:

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -174,7 +174,9 @@ class OpenAIServingChat(OpenAIServingBase):
         if self.reasoning_parser:
             try:
                 rp = ReasoningParser(
-                    model_type=self.reasoning_parser, stream_reasoning=True
+                    model_type=self.reasoning_parser,
+                    stream_reasoning=True,
+                    tokenizer=self.tokenizer_manager.tokenizer,
                 )
                 self._reasoning_detector = rp.detector
             except ValueError as e:
@@ -655,7 +657,11 @@ class OpenAIServingChat(OpenAIServingBase):
             else:
                 tools = [item.model_dump() for item in request.tools]
             if self.tool_call_parser:
-                parser = FunctionCallParser(request.tools, self.tool_call_parser)
+                parser = FunctionCallParser(
+                    request.tools,
+                    self.tool_call_parser,
+                    tokenizer=self.tokenizer_manager.tokenizer,
+                )
                 tool_call_constraint = parser.get_structure_constraint(
                     request.tool_choice,
                     parallel_tool_calls=request.parallel_tool_calls,
@@ -1314,6 +1320,7 @@ class OpenAIServingChat(OpenAIServingBase):
                         stream_reasoning=False,
                         force_reasoning=force_reasoning,
                         request=request,
+                        tokenizer=self.tokenizer_manager.tokenizer,
                     )
                     reasoning_text, text = parser.parse_non_stream(text)
                 except Exception as e:
@@ -1497,7 +1504,9 @@ class OpenAIServingChat(OpenAIServingBase):
         # For required/named: only use parser when structural_tag was used
         # as constraint (mirrors the streaming path). For auto: always try.
         if self.tool_call_parser:
-            parser = FunctionCallParser(tools, self.tool_call_parser)
+            parser = FunctionCallParser(
+                tools, self.tool_call_parser, tokenizer=self.tokenizer_manager.tokenizer
+            )
             should_try_parser = (
                 not is_required or parser.detector.supports_structural_tag()
             )
@@ -1610,6 +1619,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 request.stream_reasoning,
                 is_force_reasoning,
                 request,
+                tokenizer=self.tokenizer_manager.tokenizer,
             )
         reasoning_parser = reasoning_parser_dict[index]
         return reasoning_parser.parse_stream_chunk(delta)
@@ -1854,6 +1864,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     probe = FunctionCallParser(
                         tools=request.tools,
                         tool_call_parser=self.tool_call_parser,
+                        tokenizer=self.tokenizer_manager.tokenizer,
                     )
                     use_native_parser = probe.detector.supports_structural_tag()
                 if use_native_parser:
@@ -1864,6 +1875,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 parser_dict[index] = FunctionCallParser(
                     tools=request.tools,
                     tool_call_parser=self.tool_call_parser,
+                    tokenizer=self.tokenizer_manager.tokenizer,
                 )
 
         parser = parser_dict[index]

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -672,6 +672,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 stream_reasoning=False,
                 force_reasoning=self._is_thinking_enabled_for_request(request),
                 request=request,
+                tokenizer=self.tokenizer_manager.tokenizer,
             )
             reasoning_content, content = reasoning_parser.parse_non_stream(final_output)
         else:
@@ -714,7 +715,11 @@ class OpenAIServingResponses(OpenAIServingChat):
             and self.tool_call_parser
             and request.tool_choice != "none"
         ):
-            parser = FunctionCallParser(chat_tools, self.tool_call_parser)
+            parser = FunctionCallParser(
+                chat_tools,
+                self.tool_call_parser,
+                tokenizer=self.tokenizer_manager.tokenizer,
+            )
             should_try_native = (
                 not is_required or parser.detector.supports_structural_tag()
             )
@@ -1799,14 +1804,22 @@ class OpenAIServingResponses(OpenAIServingChat):
         if chat_tools and request.tool_choice != "none":
             native_supports_structural_tag = False
             if self.tool_call_parser:
-                probe = FunctionCallParser(chat_tools, self.tool_call_parser)
+                probe = FunctionCallParser(
+                    chat_tools,
+                    self.tool_call_parser,
+                    tokenizer=self.tokenizer_manager.tokenizer,
+                )
                 native_supports_structural_tag = (
                     probe.detector.supports_structural_tag()
                 )
             if is_required and not native_supports_structural_tag:
                 tool_parser = JsonArrayParser()
             elif self.tool_call_parser:
-                tool_parser = FunctionCallParser(chat_tools, self.tool_call_parser)
+                tool_parser = FunctionCallParser(
+                    chat_tools,
+                    self.tool_call_parser,
+                    tokenizer=self.tokenizer_manager.tokenizer,
+                )
         reasoning_parser_obj: Optional[ReasoningParser] = None
         if self.reasoning_parser:
             reasoning_parser_obj = ReasoningParser(
@@ -1814,6 +1827,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 stream_reasoning=True,
                 force_reasoning=self._is_thinking_enabled_for_request(request),
                 request=request,
+                tokenizer=self.tokenizer_manager.tokenizer,
             )
 
         current_output_index = -1

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from typing import Dict, List, Literal, Optional, Set, Tuple, Type, Union
 
@@ -89,10 +90,15 @@ class FunctionCallParser:
         "gemma4": Gemma4Detector,
     }
 
-    def __init__(self, tools: List[Tool], tool_call_parser: str):
+    def __init__(self, tools: List[Tool], tool_call_parser: str, tokenizer=None):
         detector_class = self.ToolCallParserEnum.get(tool_call_parser)
         if detector_class:
-            detector = detector_class()
+            kwargs = {}
+            if tokenizer is not None:
+                sig = inspect.signature(detector_class)
+                if "tokenizer" in sig.parameters:
+                    kwargs["tokenizer"] = tokenizer
+            detector = detector_class(**kwargs)
         else:
             raise ValueError(f"Unsupported tool_call_parser: {tool_call_parser}")
 

--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -534,7 +534,7 @@ class HunyuanDetector(BaseFormatDetector):
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(
-            begin=f"{self.bot_token}\n{name}{self.tool_sep_token}",
+            begin=f"{self.bot_token}\n{self.tool_call_start_token}{name}{self.tool_sep_token}",
             end=f"{self.tool_call_end_token}\n{self.eot_token}",
             trigger=self.bot_token,
         )

--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -48,7 +48,7 @@ def resolve_hunyuan_tokens(tokenizer) -> Dict[str, str]:
         except Exception as e:
             logger.warning("Failed to read Hunyuan tokenizer vocab: %s", e)
             vocab = None
-    if vocab:
+    if isinstance(vocab, dict):
         for tok in vocab:
             if not isinstance(tok, str):
                 continue

--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -16,6 +16,48 @@ from sglang.srt.function_call.core_types import (
 logger = logging.getLogger(__name__)
 
 
+# Bare (suffix-less) Hunyuan special tokens. The shipping Hy3 tokenizer appends
+# a shared suffix to each (e.g. ``<tool_calls:opensource>``); resolve the real
+# token string from the vocab at runtime and fall back to these literals.
+_HUNYUAN_TOKEN_NAMES = (
+    "tool_calls",
+    "tool_call",
+    "tool_sep",
+    "arg_key",
+    "arg_value",
+    "think",
+)
+
+_HUNYUAN_TOKEN_RE = re.compile(
+    r"^<(?P<name>" + "|".join(_HUNYUAN_TOKEN_NAMES) + r")(?::[^>]+)?>$"
+)
+
+
+def resolve_hunyuan_tokens(tokenizer) -> Dict[str, str]:
+    """Map bare token names to their real (possibly suffixed) strings in vocab.
+
+    Returns ``{name: token_str}`` for each name found. A bare literal is used
+    when the tokenizer carries no suffixed form, so the same detector serves
+    both the preview (suffix-less) and shipping (suffixed) Hy3 tokenizers.
+    """
+    tokens: Dict[str, str] = {}
+    vocab = None
+    if tokenizer is not None:
+        try:
+            vocab = tokenizer.get_vocab()
+        except Exception as e:
+            logger.warning("Failed to read Hunyuan tokenizer vocab: %s", e)
+            vocab = None
+    if vocab:
+        for tok in vocab:
+            m = _HUNYUAN_TOKEN_RE.match(tok)
+            if m:
+                tokens[m.group("name")] = tok
+    for name in _HUNYUAN_TOKEN_NAMES:
+        tokens.setdefault(name, f"<{name}>")
+    return tokens
+
+
 class HunyuanDetector(BaseFormatDetector):
     """
     Detector for Hunyuan (HYV3) tool call format.
@@ -55,26 +97,49 @@ class HunyuanDetector(BaseFormatDetector):
     _INTEGER_PREFIXES = ("int", "uint", "long", "short", "unsigned")
     _NUMBER_PREFIXES = ("num", "float")
 
-    def __init__(self):
+    def __init__(self, tokenizer=None):
         super().__init__()
 
-        self.bot_token = "<tool_calls>"
-        self.eot_token = "</tool_calls>"
+        t = resolve_hunyuan_tokens(tokenizer)
+        tool_calls = t["tool_calls"]
+        tool_call = t["tool_call"]
+        tool_sep = t["tool_sep"]
+        arg_key = t["arg_key"]
+        arg_value = t["arg_value"]
 
-        self.tool_call_start_token = "<tool_call>"
-        self.tool_call_end_token = "</tool_call>"
-        self.tool_sep_token = "<tool_sep>"
+        def _close(open_tok: str) -> str:
+            return "</" + open_tok[1:] if open_tok.startswith("<") else open_tok
 
-        self.arg_key_start_token = "<arg_key>"
-        self.arg_key_end_token = "</arg_key>"
-        self.arg_value_start_token = "<arg_value>"
-        self.arg_value_end_token = "</arg_value>"
+        self.bot_token = tool_calls
+        self.eot_token = _close(tool_calls)
+        self.tool_call_start_token = tool_call
+        self.tool_call_end_token = _close(tool_call)
+        self.tool_sep_token = tool_sep
+        self.arg_key_start_token = arg_key
+        self.arg_key_end_token = _close(arg_key)
+        self.arg_value_start_token = arg_value
+        self.arg_value_end_token = _close(arg_value)
 
+        tc_end = _close(tool_call)
+        ak_end = _close(arg_key)
+        av_end = _close(arg_value)
         self.tool_call_regex = re.compile(
-            r"<tool_call>(.*?)<tool_sep>(.*?)</tool_call>", re.DOTALL
+            re.escape(tool_call)
+            + r"(.*?)"
+            + re.escape(tool_sep)
+            + r"(.*?)"
+            + re.escape(tc_end),
+            re.DOTALL,
         )
         self.func_args_regex = re.compile(
-            r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>", re.DOTALL
+            re.escape(arg_key)
+            + r"(.*?)"
+            + re.escape(ak_end)
+            + r"\s*"
+            + re.escape(arg_value)
+            + r"(.*?)"
+            + re.escape(av_end),
+            re.DOTALL,
         )
 
         # Streaming state
@@ -467,9 +532,9 @@ class HunyuanDetector(BaseFormatDetector):
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(
-            begin=f"<tool_calls>\n<tool_call>{name}<tool_sep>",
-            end="</tool_call>\n</tool_calls>",
-            trigger="<tool_calls>",
+            begin=f"{self.bot_token}\n{name}{self.tool_sep_token}",
+            end=f"{self.tool_call_end_token}\n{self.eot_token}",
+            trigger=self.bot_token,
         )
 
     def supports_structural_tag(self) -> bool:

--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -50,6 +50,8 @@ def resolve_hunyuan_tokens(tokenizer) -> Dict[str, str]:
             vocab = None
     if vocab:
         for tok in vocab:
+            if not isinstance(tok, str):
+                continue
             m = _HUNYUAN_TOKEN_RE.match(tok)
             if m:
                 tokens[m.group("name")] = tok

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -718,7 +718,9 @@ class Scheduler(
         # Set reasoning_parser and think_end_id if --reasoning_parser is enabled
         if self.server_args.reasoning_parser and self.tokenizer:
             reasoning_parser = ReasoningParser(
-                model_type=self.server_args.reasoning_parser, stream_reasoning=False
+                model_type=self.server_args.reasoning_parser,
+                stream_reasoning=False,
+                tokenizer=self.tokenizer,
             )
             self.model_config.think_end_id = self.tokenizer.encode(
                 reasoning_parser.detector.think_end_token, add_special_tokens=False

--- a/python/sglang/srt/managers/template_detection.py
+++ b/python/sglang/srt/managers/template_detection.py
@@ -47,6 +47,9 @@ class TemplateDetectionContext:
     def has_pattern(self, pattern: str, flags: int = 0) -> bool:
         return re.search(pattern, self.template, flags) is not None
 
+    def has_vocab_pattern(self, pattern: str) -> bool:
+        return any(re.search(pattern, tok) for tok in self.vocab)
+
 
 @dataclass(frozen=True)
 class DetectionRule:
@@ -237,10 +240,17 @@ def _is_deepseek_v4(ctx):
 
 
 def _is_hunyuan(ctx):
-    return (
-        (ctx.has_text("<tool_calls>") or ctx.has_vocab("<tool_calls>"))
-        and (ctx.has_text("<tool_sep>") or ctx.has_vocab("<tool_sep>"))
-    ) or (ctx.has_text("reasoning_effort") and ctx.has_text("interleaved_thinking"))
+    # The shipping Hy3 tokenizer appends a shared suffix to each special token
+    # (e.g. ``<tool_calls:opensource>``), so match the bare or suffixed form.
+    tc = ctx.has_text("<tool_calls>") or ctx.has_vocab_pattern(
+        r"^<tool_calls(?::[^>]+)?>$"
+    )
+    sep = ctx.has_text("<tool_sep>") or ctx.has_vocab_pattern(
+        r"^<tool_sep(?::[^>]+)?>$"
+    )
+    return (tc and sep) or (
+        ctx.has_text("reasoning_effort") and ctx.has_text("interleaved_thinking")
+    )
 
 
 def _is_poolside_v1(ctx):

--- a/python/sglang/srt/managers/template_detection.py
+++ b/python/sglang/srt/managers/template_detection.py
@@ -48,7 +48,8 @@ class TemplateDetectionContext:
         return re.search(pattern, self.template, flags) is not None
 
     def has_vocab_pattern(self, pattern: str) -> bool:
-        return any(re.search(pattern, tok) for tok in self.vocab)
+        compiled = re.compile(pattern)
+        return any(isinstance(tok, str) and compiled.search(tok) for tok in self.vocab)
 
 
 @dataclass(frozen=True)

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1,6 +1,8 @@
+import inspect
 from typing import Dict, List, Optional, Tuple, Type
 
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+from sglang.srt.function_call.hunyuan_detector import resolve_hunyuan_tokens
 from sglang.srt.parser.harmony_parser import HarmonyParser
 
 
@@ -541,13 +543,19 @@ class HunyuanDetector(BaseReasoningFormatDetector):
         force_reasoning: bool = False,
         continue_final_message: bool = False,
         previous_content: str = "",
+        tokenizer=None,
     ):
+        t = resolve_hunyuan_tokens(tokenizer)
+        think_open = t["think"]
+        think_close = (
+            "</" + think_open[1:] if think_open.startswith("<") else think_open
+        )
         super().__init__(
-            "<think>",
-            "</think>",
+            think_open,
+            think_close,
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,
-            tool_start_token="<tool_calls>",
+            tool_start_token=t["tool_calls"],
             continue_final_message=continue_final_message,
             previous_content=previous_content,
         )
@@ -1096,6 +1104,7 @@ class ReasoningParser:
         stream_reasoning: bool = True,
         force_reasoning: Optional[bool] = None,
         request: ChatCompletionRequest = None,
+        tokenizer=None,
     ):
         if not model_type:
             raise ValueError("Model type must be specified")
@@ -1129,6 +1138,11 @@ class ReasoningParser:
         chat_template_kwargs = getattr(request, "chat_template_kwargs", None) or {}
         if chat_template_kwargs.get("force_nonempty_content") is True:
             kwargs["force_nonempty_content"] = True
+
+        if tokenizer is not None:
+            sig = inspect.signature(detector_class)
+            if "tokenizer" in sig.parameters:
+                kwargs["tokenizer"] = tokenizer
 
         self.detector = detector_class(**kwargs)
 

--- a/python/sglang/test/kits/reasoning_kit.py
+++ b/python/sglang/test/kits/reasoning_kit.py
@@ -27,7 +27,7 @@ class ReasoningTokenUsageMixin:
     def init_reasoning_token_verifier(cls):
         assert cls.reasoning_parser_name, "reasoning_parser_name must be set"
         cls.tokenizer = get_tokenizer(cls.model)
-        parser = ReasoningParser(cls.reasoning_parser_name)
+        parser = ReasoningParser(cls.reasoning_parser_name, tokenizer=cls.tokenizer)
         cls.think_end_token_id = cls.tokenizer.convert_tokens_to_ids(
             parser.detector.think_end_token
         )


### PR DESCRIPTION
## Motivation

Some tokenizers append a shared suffix to every special token (e.g. `<tool_calls:TAG>` instead of `<tool_calls>`). The `hunyuan` reasoning/tool-call detectors and the `--tool-call-parser auto` rule hard-coded the bare literals, so both parsing and auto-detection broke on such tokenizers. Resolving the real token strings from the vocab at runtime is preferable to hard-coding a per-model suffix.

## Changes

- `resolve_hunyuan_tokens(tokenizer)`: scan the vocab for the real (possibly suffixed) token strings, falling back to bare literals — one detector serves both suffix-less and suffixed tokenizers.
- Plumb an optional `tokenizer` through `ReasoningParser` / `FunctionCallParser` (via `inspect`, so non-hunyuan detectors are untouched).
- `_is_hunyuan` matches bare or suffixed `tool_calls`/`tool_sep` via regex, so `--tool-call-parser auto` still resolves to `hunyuan`.
- `structure_info` uses the resolved tokens; 16 call-sites pass `tokenizer=`.

## Verification

pre-commit + py_compile pass; `tokenizer=None` reproduces the previous token values exactly (backward compatible); e2e confirms auto-detection, tool-call/reasoning parsing, and stop-rate all work on a suffixed tokenizer.









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28694968273](https://github.com/sgl-project/sglang/actions/runs/28694968273)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28694968200](https://github.com/sgl-project/sglang/actions/runs/28694968200)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->