### PR TITLE
perf(triton): avoid per-step D2H .item() sync in cuda-graph loc translate

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -636,15 +636,28 @@ class TritonAttnBackend(AttentionBackend):
         """
         if self._translate_kv_loc is None:
             return None
-        # Full-attention read path.
-        n_kv = int(self.kv_indptr[bs].item())
+        # Full-attention read path. kv_indptr[bs] == forward_batch.seq_lens_sum;
+        # read the CPU mirror to avoid a per-step D2H `.item()` sync.
+        n_kv = (
+            forward_batch.seq_lens_sum
+            if forward_batch.seq_lens_sum is not None
+            else int(self.kv_indptr[bs].item())
+        )
         if n_kv > 0:
             self.cuda_graph_kv_indices[:n_kv] = self._translate_kv_loc(
                 self.cuda_graph_kv_indices[:n_kv]
             )
-        # SWA window read path (hybrid-SWA unified pools only).
+        # SWA window read path (hybrid-SWA unified pools only). window_kv_indptr[bs]
+        # == sum(min(seq_len, window)); compute it from the CPU seq_lens mirror.
         if self.sliding_window_size is not None and self.sliding_window_size > 0:
-            n_win = int(self.window_kv_indptr[bs].item())
+            if forward_batch.seq_lens_cpu is not None:
+                n_win = int(
+                    forward_batch.seq_lens_cpu[:bs]
+                    .clamp(max=self.sliding_window_size)
+                    .sum()
+                )
+            else:
+                n_win = int(self.window_kv_indptr[bs].item())
             if n_win > 0:
                 self.cuda_graph_window_kv_indices[:n_win] = (
                     self.token_to_kv_pool.translate_loc_from_full_to_swa(

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -636,21 +636,24 @@ class TritonAttnBackend(AttentionBackend):
         """
         if self._translate_kv_loc is None:
             return None
-        # Full-attention read path. kv_indptr[bs] == forward_batch.seq_lens_sum;
-        # read the CPU mirror to avoid a per-step D2H `.item()` sync.
+        # seq_lens_sum is the reliable "mirror present" signal: it is
+        # None-preserving into the replay view, unlike seq_lens_cpu (always a
+        # non-None but stale slice for gpu_only batches). None -> fall back to a
+        # per-step D2H `.item()` on the indptr.
+        have_cpu_mirror = forward_batch.seq_lens_sum is not None
+        # Full-attention read path. kv_indptr[bs] == seq_lens_sum.
         n_kv = (
             forward_batch.seq_lens_sum
-            if forward_batch.seq_lens_sum is not None
+            if have_cpu_mirror
             else int(self.kv_indptr[bs].item())
         )
         if n_kv > 0:
             self.cuda_graph_kv_indices[:n_kv] = self._translate_kv_loc(
                 self.cuda_graph_kv_indices[:n_kv]
             )
-        # SWA window read path (hybrid-SWA unified pools only). window_kv_indptr[bs]
-        # == sum(min(seq_len, window)); compute it from the CPU seq_lens mirror.
+        # SWA window read path. window_kv_indptr[bs] == sum(min(seq_len, window)).
         if self.sliding_window_size is not None and self.sliding_window_size > 0:
-            if forward_batch.seq_lens_cpu is not None:
+            if have_cpu_mirror:
                 n_win = int(
                     forward_batch.seq_lens_cpu[:bs]
                     .clamp(max=self.sliding_window_size)


### PR DESCRIPTION
## Motivation

`_translate_cuda_graph_shared_pool_locs` (unified-pool eager v2p translate, run before `graph.replay()`) read the full-attention and SWA-window read-path lengths via `.item()` on GPU indptr buffers. Each `.item()` forces a device→host sync **on every cuda-graph replay step**, on the critical path.

## Change

Read the CPU mirrors the replay batch already carries instead:

- `n_kv` ← `forward_batch.seq_lens_sum` (== `kv_indptr[bs]`)
- `n_win` ← `forward_batch.seq_lens_cpu[:bs].clamp(max=window).sum()` (== `window_kv_indptr[bs]`)

The `.item()` reads are kept as fallbacks for the `gpu_only` path where `seq_lens_sum` / `seq_lens_cpu` are `None`.

## Correctness

- `kv_indptr[bs]` is the prefix sum of the (padded) per-request KV lengths, which equals `seq_lens_sum`.
- `window_kv_indptr[bs]` is the prefix sum of `min(seq_len, window)`, matching the clamped CPU sum.

No behavior change on the numeric path — only the source of the two integer bounds moves from GPU→CPU sync to an existing CPU tensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28618959069](https://github.com/sgl-project/sglang/actions/runs/28618959069)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28618958973](https://github.com/sgl-project/sglang/actions/runs/28618958973)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->