### PR TITLE
ci: make multi-GPU jit test hangs attributable from the CI log

### DIFF
--- a/python/sglang/jit_kernel/mp.py
+++ b/python/sglang/jit_kernel/mp.py
@@ -168,6 +168,10 @@ def multigpu_launch(
     os.environ[pid_key] = str(os.getpid())
     os.environ.setdefault("OMP_NUM_THREADS", "1")
     os.environ.setdefault("GLOO_SOCKET_IFNAME", "lo")  # single-machine setup
+    # Unbuffered child stdout: when a worker is killed on timeout, pytest's
+    # block-buffered progress output is otherwise lost or flushed out of
+    # order into the CI log, making it impossible to tell which test hung.
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
     signal.signal(signal.SIGINT, signal.default_int_handler)
     runnable: List[int] = []
     for N in sorted(num_gpus):

--- a/python/sglang/jit_kernel/tests/utils.py
+++ b/python/sglang/jit_kernel/tests/utils.py
@@ -43,7 +43,14 @@ def multigpu_pytest_main(
         # CI's run_unittest_files invokes `python3 <file> -f` (legacy
         # unittest failfast). Translate to pytest's `-x` so it survives.
         pytest_args = ["-x" if a == "-f" else a for a in sys.argv[1:]]
-        return pytest.main([file] + pytest_args)
+        # Dump all thread stacks (every rank; stderr is not redirected) if a
+        # single test exceeds half the harness budget, so a hung collective
+        # is attributable from the CI log before the outer timeout kills the
+        # process group. Non-fatal: the test keeps running after the dump.
+        dump_after = (timeout // 2) if timeout else 300
+        return pytest.main(
+            [file, "-o", f"faulthandler_timeout={dump_after}"] + pytest_args
+        )
 
     return multigpu_launch(
         name,


### PR DESCRIPTION
## Motivation

The 2026-07-02 `nightly-test-kernel-8-gpu-h200` run ([28558138686](https://github.com/sgl-project/sglang/actions/runs/28558138686)) hung in `test_custom_all_reduce.py` at nproc=2: 23/24 tests passed, then the last test blocked until the 600s harness timeout killed the process group (baseline for the full sweep on the previous night's pass: ~33s).

Investigation points to a transient machine-level glitch on the H200 host that picked up the job, not a code regression — the job passed the 4 preceding nightlies on 4 different runners, the only commit in the window touching the all-reduce path (#29621) is a behavior-preserving refactor of the VMM path (not exercised in this test config), and the host shows no kernel/GPU errors in the failure window.

What the failure did expose is a diagnostics gap: the CI log carried **no evidence of which test hung or where**. pytest's block-buffered progress dots flushed out of order into the next test's output, and no stack was captured before the kill.

## Modifications

- `multigpu_launch`: set `PYTHONUNBUFFERED=1` for torchrun children so per-test progress output reaches the CI log in real time instead of being lost or reordered when a timed-out worker is killed.
- `multigpu_pytest_main`: enable pytest's built-in `faulthandler_timeout` at half the harness budget (300s at the default 600s). A test stuck past the threshold dumps all thread stacks on every rank (stderr is not redirected in non-rank-0 workers) without killing the run, so a hung collective shows exactly which rank is blocked and where, before the outer timeout fires.

Verified locally that the dump fires non-fatally with the hung test's name and full stack.

## Checklist

- [x] Format your code with pre-commit
- [ ] Add unit tests
- [x] Update documentation as needed











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28580125326](https://github.com/sgl-project/sglang/actions/runs/28580125326)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28580125064](https://github.com/sgl-project/sglang/actions/runs/28580125064)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->