### PR TITLE
fix(eval): extract GSM8K answer from first #### marker, not last number

### DIFF
--- a/python/sglang/test/simple_eval_gsm8k.py
+++ b/python/sglang/test/simple_eval_gsm8k.py
@@ -31,6 +31,20 @@ def get_few_shot_examples(lines, k):
 
 def get_answer_value(answer_str):
     answer_str = answer_str.replace(",", "")
+    # GSM8K answers (both the ground-truth and the few-shot format the model
+    # imitates) end with a `#### <number>` marker. Prefer the number after the
+    # FIRST such marker: it is the answer to the question actually asked.
+    # Instruction-tuned models that don't reliably stop after `####` (e.g.
+    # Mistral/Mixtral) run on and emit further `Question:/#### N` pairs; taking
+    # the last number in the whole string then scores the run-on continuation
+    # instead of the real answer. Fall back to the last number when there is no
+    # `####` marker (models that answer in prose).
+    marker = re.search(r"####\s*(-?\d+\.?\d*)", answer_str)
+    if marker is not None:
+        try:
+            return ast.literal_eval(marker.group(1))
+        except (SyntaxError, ValueError):
+            return INVALID
     numbers = re.findall(r"-?\d+\.?\d*", answer_str)
     if len(numbers) < 1:
         return INVALID


### PR DESCRIPTION
## Motivation

The nightly `nightly-test-text-accuracy-2-gpu-h100` job (`test/registered/eval/test_text_models_gsm8k_eval.py`) has been **red for 4+ months** — since the mgsm→gsm8k eval migration (#21931, 2026-04-07). The persistently failing models are `mistralai/Mistral-7B-Instruct-v0.3`, `mistralai/Mixtral-8x7B-Instruct-v0.1`, and their neuralmagic FP8 variants. Scores have been stable night-over-night (Mistral ~0.41, Mixtral ~0.31), i.e. not a flake and not a recent regression.

## Root cause — answer extraction, not model quality

`get_answer_value()` took the **last** number in the model response. Instruction-tuned models that don't reliably stop after the GSM8K `#### <answer>` marker (Mistral/Mixtral especially) **run on**, emitting further `Question:/Answer:/#### N` pairs that mimic the few-shot prompt. The last number is then parsed from the run-on continuation instead of the real answer.

Measured on `mistralai/Mixtral-8x7B-Instruct-v0.1` (500 examples): **65% of the scored-wrong responses contain a correct answer followed by run-on** that the extractor mis-parsed.

## Fix

Prefer the number after the **first** `####` marker (the answer to the question actually asked); fall back to the last number only when there's no marker (prose answers). Ground-truth GSM8K answers carry a single `####`, so their parse is unchanged.

## Validation (B200 devbox, re-scoring saved eval reports through the patched function)

| Model | before (last-num) | after (first-`####`) | threshold |
|---|---|---|---|
| Mistral-7B-Instruct-v0.3 | 0.434 | **0.560** | 0.47 ✅ now passes |
| Mixtral-8x7B-Instruct-v0.1 | 0.294 | **0.612** | 0.69 ⚠️ still below |

**Implementation-independent:** `mistralai/Mistral-7B-Instruct-v0.3` scores **identically** under the native and `--model-impl transformers` backends (0.434 == 0.434), confirming this is not an sglang model-code regression — it's the eval harness.

## Follow-up (not in this PR)

Mixtral-8x7B still measures 0.612 < its 0.69 threshold even with correct extraction — 0.69 derives from the official 74.4% maj@8 CoT figure, unreachable in this greedy single-shot chat eval. The Mistral/Mixtral thresholds (bf16 + FP8) should be recalibrated to measured values from **one nightly run with this fix applied** (same approach as the gemma recalibration in #27342). Deferred here because responsibly setting all 16 thresholds requires re-measuring the full model set on the nightly 2×H100 config, not a single devbox.

## Checklist

- [x] Format with pre-commit
- [ ] Add unit tests
- [x] Update documentation as needed

🤖 Draft — root-cause fix; threshold recalibration to follow.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28585201889](https://github.com/sgl-project/sglang/actions/runs/28585201889)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28585201654](https://github.com/sgl-project/sglang/actions/runs/28585201654)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->