### PR TITLE
Fix event-loop-blocking `requests.get` in `remote_instance_transfer_engine_info`

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1213,7 +1213,8 @@ async def remote_instance_transfer_engine_info(rank: int = None):
 
     server_args = _global_state.tokenizer_manager.server_args
     try:
-        resp = requests.get(
+        resp = await asyncio.to_thread(
+            requests.get,
             f"{server_args.engine_info_bootstrap_url}/get_transfer_engine_info",
             params={"rank": rank},
             timeout=5,


### PR DESCRIPTION
## Motivation
`/remote_instance_transfer_engine_info` is an `async def` FastAPI handler, but it calls `requests.get(..., timeout=5)` synchronously. That blocks the server's event loop for up to 5 seconds per call (the full request timeout), stalling all other in-flight requests on that worker.

## Modification
Offload the blocking call with `asyncio.to_thread(requests.get, ...)`, so the event loop stays free while the HTTP request is in flight. This matches the `asyncio.to_thread` pattern already used elsewhere in the codebase. Behavior and error handling are otherwise unchanged.

File: `python/sglang/srt/entrypoints/http_server.py`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28585247476](https://github.com/sgl-project/sglang/actions/runs/28585247476)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28585247369](https://github.com/sgl-project/sglang/actions/runs/28585247369)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->