### PR TITLE
fix(nvila): remap vision_tower.vision_model.* weights for flattened SiglipVisionModel

### DIFF
--- a/python/sglang/srt/models/nvila.py
+++ b/python/sglang/srt/models/nvila.py
@@ -210,6 +210,18 @@ class NVILAForConditionalGeneration(nn.Module):
             if name.startswith("llm."):
                 self.llm.load_weights([(name[len("llm.") :], loaded_weight)])
             else:
+                # Newer transformers flattened SiglipVisionModel, dropping the
+                # `vision_model` submodule, so the checkpoint's
+                # `vision_tower.vision_model.*` names no longer match the
+                # module's `vision_tower.*` params. Strip the infix when the
+                # original name is absent but the stripped one exists — a no-op
+                # on transformers versions that still nest `vision_model`.
+                if name not in params_dict:
+                    stripped = name.replace(
+                        "vision_tower.vision_model.", "vision_tower.", 1
+                    )
+                    if stripped in params_dict:
+                        name = stripped
                 param = params_dict[name]
                 weight_loader = getattr(
                     param, "weight_loader", weight_utils.default_weight_loader

--- a/python/sglang/srt/models/nvila_lite.py
+++ b/python/sglang/srt/models/nvila_lite.py
@@ -168,6 +168,18 @@ class NVILALiteForConditionalGeneration(nn.Module):
             if name.startswith("llm."):
                 self.llm.load_weights([(name[len("llm.") :], loaded_weight)])
             else:
+                # Newer transformers flattened SiglipVisionModel, dropping the
+                # `vision_model` submodule, so the checkpoint's
+                # `vision_tower.vision_model.*` names no longer match the
+                # module's `vision_tower.*` params. Strip the infix when the
+                # original name is absent but the stripped one exists — a no-op
+                # on transformers versions that still nest `vision_model`.
+                if name not in params_dict:
+                    stripped = name.replace(
+                        "vision_tower.vision_model.", "vision_tower.", 1
+                    )
+                    if stripped in params_dict:
+                        name = stripped
                 param = params_dict[name]
                 weight_loader = getattr(
                     param, "weight_loader", weight_utils.default_weight_loader


### PR DESCRIPTION
## Motivation

`Efficient-Large-Model/NVILA-8B-hf` and `NVILA-Lite-2B-hf` fail to launch in the nightly VLM eval (`nightly-test-vlm-accuracy-2-gpu-h100`, [run 28558138686](https://github.com/sgl-project/sglang/actions/runs/28558138686/job/84736508522)). The scheduler dies during weight loading:

```
KeyError: 'vision_tower.vision_model.embeddings.patch_embedding.bias'
  File ".../sglang/srt/models/nvila.py", line 213, in load_weights
  File ".../sglang/srt/models/nvila_lite.py", line 171, in load_weights
```

Chronic — reproduces in every nightly back to at least 2026-05-29.

## Root cause

Newer `transformers` **flattened `SiglipVisionModel`**, removing the `vision_model` submodule. The NVILA checkpoints still name their vision weights `vision_tower.vision_model.*`, but the module built from the current transformers now exposes them as `vision_tower.*`. Every one of the 437 vision-tower weights then misses `params_dict`, and `load_weights` raises `KeyError` on the first one processed (`patch_embedding.bias`).

Verified on a B200 devbox against the current container transformers:

```
ckpt vision_tower keys: 437   model vision_tower params: 437
has 'vision_model' infix in ckpt: True
after stripping 'vision_tower.vision_model.' -> 'vision_tower.':
  ckpt-not-in-model: []      model-not-in-ckpt: []      exact match: True
```

## Fix

In `load_weights`, when a name is absent from `params_dict`, retry with the `vision_tower.vision_model.` → `vision_tower.` infix stripped. Guarded on membership, so it's a **no-op** on transformers versions that still nest `vision_model`. Applied to both `nvila.py` and `nvila_lite.py` (identical loaders).

## Validation (B200 devbox, current container transformers)

- **Before:** `KeyError` → scheduler dies → `Server process exited with code -9`.
- **After (NVILA-Lite-2B-hf):** 0 KeyErrors, weights load, CUDA graphs capture, Uvicorn serves. End-to-end image+text inference returns a correct vision-grounded response:
  > *"The image features a stylized logo for a company called SGL. The logo is primarily orange and white, with the letters 'SGL' prominently displayed…"* (1573 image tokens processed)
- **NVILA-8B-hf** shares the identical loader and fails with the identical `KeyError` at `nvila.py:213`, so the same remap covers it.

## Checklist

- [x] Format with pre-commit
- [ ] Add unit tests
- [x] Update documentation as needed

🤖 Draft — validated end-to-end on NVILA-Lite-2B.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28586319378](https://github.com/sgl-project/sglang/actions/runs/28586319378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28586318616](https://github.com/sgl-project/sglang/actions/runs/28586318616)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->