### PR TITLE
docs: Added pending support warning for DiffusionGemma Cookbook

### DIFF
--- a/docs_new/cookbook/autoregressive/Google/DiffusionGemma.mdx
+++ b/docs_new/cookbook/autoregressive/Google/DiffusionGemma.mdx
@@ -5,6 +5,9 @@ metatags:
 tag: NEW
 ---
 
+
+> ⚠️ **Note:** Runtime support for DiffusionGemma is currently pending and is **not yet available** in the latest release (v0.5.14). This documentation is a preview for an upcoming release.
+
 ## 1. Model Introduction
 
 DiffusionGemma is a uniform-state (renoising) block-diffusion language model from Google. An encoder builds causal context, and a decoder denoises a fixed-length bidirectional canvas of `canvas_length` tokens. The `Gemma4Renoise` sampler runs `max_denoising_steps` reverse steps over the canvas, feeding the previous step's logits back as self-conditioning and emitting the greedy argmax of the processed logits.


### PR DESCRIPTION
## Motivation

The documentation for `DiffusionGemma` (#27824) was merged and released in `v0.5.14`, but the actual runtime support (#27823) was closed unmerged. This is causing users (#29904) to encounter an `Unknown diffusion LLM` error when trying to follow the cookbook instructions on the latest release.

## Modifications

Added a warning banner to the top of the `DiffusionGemma` cookbook page clarifying that runtime support is pending and not yet available in `v0.5.14`. This should prevent further confusion and duplicate bug reports while the model implementation is being finalized.

## Checklist
- [x] Documentation only (cookbook); no code changes.








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28590123608](https://github.com/sgl-project/sglang/actions/runs/28590123608)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28590123624](https://github.com/sgl-project/sglang/actions/runs/28590123624)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->