### PR TITLE
Fix shared logits buffer for reduced-vocab draft models

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -981,14 +981,19 @@ class LogitsProcessor(nn.Module):
         self, logits: torch.Tensor, logits_metadata: LogitsMetadata
     ) -> torch.Tensor:
         logits_buffer = logits_metadata.next_token_logits_buffer
-        # The shared logits buffer is keyed by vocab width; skip it when this
-        # model's vocab doesn't match (e.g. hot-vocab draft vs full-vocab target).
-        if logits_buffer is not None and logits_buffer.shape[-1] == self.vocab_size:
+        if logits.shape[-1] > self.vocab_size:
+            logits = logits[:, : self.vocab_size]
+        logits_width = logits.shape[-1]
+        # The shared logits buffer is keyed by vocab width and rows; skip it
+        # when this batch has a different logits shape than the graph buffer.
+        if logits_buffer is not None and tuple(logits_buffer.shape) == tuple(
+            logits.shape
+        ):
             assert logits_buffer.dtype == torch.float
-            logits_buffer.copy_(logits[:, : self.vocab_size])
+            logits_buffer.copy_(logits)
             logits = logits_buffer
         else:
-            logits = logits[:, : self.vocab_size].float()
+            logits = logits.float()
         return logits
 
     def _get_dllm_logits(


### PR DESCRIPTION
**This PR fixes existing speculative-decoding CI failures introduced by #29779 (`Share one logits output buffer across prefill/decode/draft cuda-graph runners`). It does not add a new test because the existing CI tests already capture these regressions.**

## Summary

#29779 started sharing one logits output buffer across CUDA graph runners. That exposed two incompatible-buffer cases:

1. In EAGLE/FR-Spec with `--speculative-token-map`, the draft `lm_head` can be sliced to a hot vocab. The draft runner can still carry the full target `self.vocab_size`, so `_copy_logits_to_buffer` attempted to copy reduced-vocab logits into a full-vocab shared buffer.
2. In standalone speculation, the shared buffer can have a different row count from the computed logits. CI hit a `[1, 128256]` shared buffer with `[8, 128256]` logits.

This PR reuses the shared logits buffer only when the full tensor shape matches the computed logits. Otherwise, it returns a float copy with the correct shape. It also keeps the hot-path optimization suggested in review: logits are sliced only when `logits.shape[-1] > self.vocab_size`.

## Failures

Existing CI failures:

```text
test/registered/spec/eagle/test_spec_eagle_topk.py::TestEagleLlama3TokenMap
RuntimeError: The size of tensor a (128256) must match the size of tensor b (32768) at non-singleton dimension 1
```

```text
test/registered/spec/test_spec_standalone.py
RuntimeError: output with shape [1, 128256] doesn't match the broadcast shape [8, 128256]
```

## Focused Repro

Current main, reduced-vocab width mismatch:

```text
input logits=(1, 32768), shared_buffer=(1, 128256)
RuntimeError: The size of tensor a (128256) must match the size of tensor b (32768) at non-singleton dimension 1
```

Current main, row-count mismatch:

```text
input logits=(8, 128256), shared_buffer=(1, 128256)
RuntimeError: output with shape [1, 128256] doesn't match the broadcast shape [8, 128256]
```

With this PR:

```text
width_mismatch: out_shape=(1, 32768) dtype=torch.float32 reused_buffer=False
row_mismatch: out_shape=(8, 128256) dtype=torch.float32 reused_buffer=False
exact_match: out_shape=(1, 128256) dtype=torch.float32 reused_buffer=True
```

The mismatch cases skip the incompatible shared buffer, while the exact-match case still reuses it.

## Tests

The regressions are covered by the existing CI tests listed above.

Additional focused AIHub B200 validation:

```text
Current main: reproduced both 128256-vs-32768 width mismatch and 1-vs-8 row-count mismatch RuntimeErrors
This PR: width mismatch skipped shared buffer, row mismatch skipped shared buffer, exact match reused shared buffer
```















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28603591856](https://github.com/sgl-project/sglang/actions/runs/28603591856)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28603590192](https://github.com/sgl-project/sglang/actions/runs/28603590192)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
