### PR TITLE
docs: document S3-compatible endpoints with Tigris example

### DIFF
--- a/docs/advanced_features/object_storage.md
+++ b/docs/advanced_features/object_storage.md
@@ -14,7 +14,7 @@ When loading models from object storage, SGLang uses a two-phase approach:
 1. **Amazon S3**: `s3://bucket-name/path/to/model/`
 2. **Google Cloud Storage**: `gs://bucket-name/path/to/model/`
 3. **Azure Blob**: `az://some-azure-container/path/`
-4. **S3 compatible**: `s3://bucket-name/path/to/model/`
+4. **S3-compatible endpoints** (MinIO, Tigris, Cloudflare R2, etc.): `s3://bucket-name/path/to/model/`
 
 ## Quick Start
 
@@ -49,6 +49,22 @@ python -m sglang.launch_server \
   --tp 4 \
   --model-loader-extra-config '{"distributed": true}'
 ```
+
+### S3-Compatible Endpoints
+
+To load a model from an S3-compatible object store, point the streamer at the store's endpoint with `AWS_ENDPOINT_URL`. For example, using [Tigris](https://www.tigrisdata.com):
+
+```bash
+AWS_EC2_METADATA_DISABLED=true \
+AWS_ENDPOINT_URL=https://t3.storage.dev \
+AWS_ACCESS_KEY_ID=tid_your_access_key_id \
+AWS_SECRET_ACCESS_KEY=tsec_your_secret_access_key \
+python -m sglang.launch_server \
+  --model-path s3://my-bucket/models/llama-3-8b/ \
+  --load-format runai_streamer
+```
+
+Tigris uses a single global endpoint and doesn't charge egress fees, so the same `s3://` URI works from every worker and there's no cross-region transfer cost when a model is re-pulled on cold starts or autoscale events. The same pattern works for any S3-compatible store — swap `AWS_ENDPOINT_URL` for the provider's endpoint.
 
 ## Configuration
 

--- a/docs_new/docs/advanced_features/object_storage.mdx
+++ b/docs_new/docs/advanced_features/object_storage.mdx
@@ -18,7 +18,7 @@ When loading models from object storage, SGLang uses a two-phase approach:
 1. **Amazon S3**: `s3://bucket-name/path/to/model/`
 2. **Google Cloud Storage**: `gs://bucket-name/path/to/model/`
 3. **Azure Blob**: `az://some-azure-container/path/`
-4. **S3 compatible**: `s3://bucket-name/path/to/model/`
+4. **S3-compatible endpoints** (MinIO, Tigris, Cloudflare R2, etc.): `s3://bucket-name/path/to/model/`
 
 ## Quick Start
 
@@ -53,6 +53,22 @@ python -m sglang.launch_server \
   --tp 4 \
   --model-loader-extra-config '{"distributed": true}'
 ```
+
+### S3-Compatible Endpoints
+
+To load a model from an S3-compatible object store, point the streamer at the store's endpoint with `AWS_ENDPOINT_URL`. For example, using [Tigris](https://www.tigrisdata.com):
+
+```bash
+AWS_EC2_METADATA_DISABLED=true \
+AWS_ENDPOINT_URL=https://t3.storage.dev \
+AWS_ACCESS_KEY_ID=tid_your_access_key_id \
+AWS_SECRET_ACCESS_KEY=tsec_your_secret_access_key \
+python -m sglang.launch_server \
+  --model-path s3://my-bucket/models/llama-3-8b/ \
+  --load-format runai_streamer
+```
+
+Tigris uses a single global endpoint and doesn't charge egress fees, so the same `s3://` URI works from every worker and there's no cross-region transfer cost when a model is re-pulled on cold starts or autoscale events. The same pattern works for any S3-compatible store — swap `AWS_ENDPOINT_URL` for the provider's endpoint.
 
 ## Configuration
 


### PR DESCRIPTION
## Motivation

`docs/advanced_features/object_storage.md` lists "S3 compatible" as a supported backend (item 4 in the list), but the page never shows how to actually configure a non-AWS endpoint. Readers who want to point at MinIO, Tigris, Cloudflare R2, or another S3-compatible store have to guess `AWS_ENDPOINT_URL` from the upstream Run:ai Model Streamer docs.

## Modifications

`docs/advanced_features/object_storage.md` and `docs_new/docs/advanced_features/object_storage.mdx`:

- Expanded item 4 in **Supported Storage Backends** from `S3 compatible` to `S3-compatible endpoints (for example, MinIO, Tigris, Cloudflare R2)`, so the list surfaces concrete providers.
- Added a new **S3-Compatible Endpoints** subsection under **Quick Start** showing the `AWS_ENDPOINT_URL` pattern with Tigris as the worked example. The framing paragraph ties no-egress to the concrete workloads it affects (cold starts, autoscale re-pulls of model weights), and closes with "swap `AWS_ENDPOINT_URL` for the provider's endpoint" so the pattern generalizes to any S3-compatible store.

Both `docs/` and `docs_new/` are edited to keep the Sphinx page and the Mintlify migration in sync per `docs_new/docs_migration_plan.md`.

## Accuracy Tests

N/A — docs only.

## Speed Tests and Profiling

N/A — docs only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(N/A — docs only)*
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results. *(N/A — docs only)*
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28592277725](https://github.com/sgl-project/sglang/actions/runs/28592277725)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28592277254](https://github.com/sgl-project/sglang/actions/runs/28592277254)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->