### PR TITLE
Fix : fall back to NCCL all-reduce for symm-mem during CUDA graph capture

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -629,6 +629,12 @@ class GroupCoordinator:
             and not should_use_pymscclpp_allreduce
         ):
             self.debug_check_symmetric_mempool(self, {"input": input_}, "all_reduce")
+            # NCCL symmetric-memory all-reduce can corrupt results when captured
+            # and replayed in a CUDA graph on some runtime combinations. Keep
+            # symm-mem for eager execution, but use standard NCCL while capturing.
+            if torch.cuda.is_current_stream_capturing():
+                torch.distributed.all_reduce(input_, group=self.device_group)
+                return input_
             with self.pynccl_comm.change_state(enable=True):
                 self.pynccl_comm.all_reduce(input_)
                 return input_


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When `--enable-symm-mem` is enabled, SGLang routes TP all-reduces through NCCL symmetric-memory all-reduce. In one production/debug configuration, capturing that all-reduce into a CUDA graph caused silent numerical corruption after graph replay.

The corruption was observed on `Qwen/Qwen3.5-397B-A17B-FP8` with TP=8 on H100, EAGLE speculative decoding enabled, and CUDA graph enabled. The corrupted residual was amplified by the target model's GDN/Mamba2 SSM recurrence during speculative verify, then committed into persistent `ssm_states`.

In pod-level probes, workers fell into three groups:

- healthy workers with normal speculative acceptance and coherent output
- degraded speculative workers where `spec_accept_rate` collapsed to 0%, while text generation stayed coherent
- fully degraded workers where `spec_accept_rate` stayed below ~20% and text generation degenerated into repeated tokens / garbage

Once a worker entered a degraded state, it did not recover until process restart.

Related to #16322.

## Modifications

In `GroupCoordinator.all_reduce`, keep the existing symmetric-memory path for eager execution, but fall back to standard NCCL all-reduce while the current CUDA stream is being captured:

```python
if torch.cuda.is_current_stream_capturing():
    torch.distributed.all_reduce(input_, group=self.device_group)
    return input_
```

This is intentionally narrow: it only avoids capturing NCCL symmetric-memory all-reduce into a CUDA graph. Eager symmetric-memory all-reduce remains enabled.

## Accuracy Tests

Reproduced and validated on `Qwen/Qwen3.5-397B-A17B-FP8`, TP=8, H100, EAGLE speculative decoding (`steps=3`, `topk=1`, `draft_tokens=4`), `--enable-symm-mem`, CUDA graph enabled.

Production configuration where workers degraded after several hours:

```bash
sglang serve --model-path Qwen/Qwen3.5-397B-A17B-FP8 \
  --tp 8 \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --mamba-scheduler-strategy extra_buffer \
  --page-size 1 \
  --enable-symm-mem \
  --mem-fraction-static 0.8
```

Failing configuration used for the deterministic debug run:

```bash
sglang serve --model-path Qwen/Qwen3.5-397B-A17B-FP8 \
  --tp 8 \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --mamba-scheduler-strategy no_buffer \
  --disable-radix-cache \
  --disable-overlap-schedule \
  --page-size 1 \
  --enable-symm-mem \
  --mem-fraction-static 0.8
```

Reproduction note:

In the production configuration (`extra_buffer`, overlap scheduling, radix cache enabled), degraded workers usually appeared after several hours of traffic. The debug configuration above was intentionally simplified and hit the failure immediately from the first probe request, which made it useful for isolating the symm-mem/CUDA graph interaction.

In that deterministic debug configuration, I did not observe the "speculative-only" degraded mode. The failing probes had low `spec_accept_rate` around ~10% and consistently produced corrupted / repeated-token text.

For the before/after check, I used the same short deterministic probe set.
After applying this patch, I also ran a 24-hour stress test with the deterministic debug configuration above. 
The service stayed healthy throughout the run: output remained coherent.

Elimination summary:

| Intervention | Symm allocation / pool | Symm all-reduce | Result |
|---|---:|---:|---|
| baseline | on | on | SSM NaN, `spec_accept_rate ~= 0.15`, garbage output |
| fallback for all symm all-reduces | on | off | healthy, `spec_accept_rate ~= 0.78` |
| fallback only while CUDA graph capture is active | on | off in graph | healthy, `spec_accept_rate ~= 0.78` |
| `--enable-symm-mem` disabled | off | off | healthy |
| `--disable-cuda-graph` with symm-mem enabled | on | on, eager only | healthy |

With this patch:

- output stayed coherent
- `spec_accept_rate ~= 0.78`
- `spec_accept_length ~= 3.5`
- no non-finite SSM commit was observed in the debug run

NCCL version note:

The issue reproduced with runtime-loaded NCCL 2.28.9 when `--enable-symm-mem` was enabled. With the same NCCL 2.28.9 runtime, disabling `--enable-symm-mem` avoided the corruption. After moving the runtime-loaded NCCL to 2.30.7, I did not observe the same corruption in the same test setup.

That suggests the underlying issue may be in the NCCL symmetric-memory + CUDA graph interaction. NCCL 2.30.x release notes include relevant fixes around symmetric kernels / coherency and symmetric LL kernel data corruption:

- https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-30-7.html
- https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-30-3.html

This guard is still useful because SGLang deployments can run older or different runtime-loaded NCCL versions. It also avoids relying on a specific NCCL runtime version for correctness.

## Speed Tests and Profiling

I did not run a standalone throughput benchmark. The expected performance impact is limited to CUDA graph capture/replay paths that would otherwise use symmetric-memory all-reduce; eager execution still uses symmetric-memory all-reduce.

This trades the symmetric-memory speedup in captured graphs for correctness in affected NCCL/runtime combinations.

## Scope / Follow-up

This PR does not attempt to fix NCCL symmetric-memory CUDA graph behavior itself. It only avoids capturing the affected `all_reduce` path in SGLang.

I only validated the `all_reduce` path in this reproducer. If symmetric-memory `reduce_scatter` or `all_gather` paths are captured into CUDA graphs in similar configurations, they may need the same kind of guard as a follow-up.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). N/A: requires TP=8 H100 + NCCL symm-mem + CUDA graph capture/replay.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Accuracy results included above; no standalone speed benchmark.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28625160160](https://github.com/sgl-project/sglang/actions/runs/28625160160)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28625160094](https://github.com/sgl-project/sglang/actions/runs/28625160094)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->