### PR TITLE
fix(kimik2): stop end-marker straddle leaking into streamed tool args

### DIFF
--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -316,7 +316,13 @@ class KimiK2Detector(BaseFormatDetector):
                 if end_idx != -1:
                     args_full = buffer[args_start:end_idx]
                 else:
-                    args_full = buffer[args_start:]
+                    # The <|tool_call_end|> marker is not guaranteed to arrive in
+                    # a single increment (special tokens can straddle chunk
+                    # boundaries -- the same reason `_split_pending_start` exists
+                    # for the begin marker). Hold back any trailing fragment that
+                    # could be the start of the end marker so it does not leak
+                    # into the streamed arguments as garbled JSON.
+                    args_full = self._hold_pending_end(buffer[args_start:])
                 argument_diff = args_full[len(self._last_arguments) :]
                 if argument_diff or name_just_resolved:
                     calls.append(
@@ -396,6 +402,19 @@ class KimiK2Detector(BaseFormatDetector):
             if any(t.startswith(tail) for t in candidates):
                 return text[:-n], tail
         return text, ""
+
+    def _hold_pending_end(self, text: str) -> str:
+        """Drop a trailing fragment that could be the start of
+        <|tool_call_end|>. Mirrors `_split_pending_start` for the end marker so a
+        marker split across streaming increments does not leak into the emitted
+        arguments. A held-back fragment is re-examined once more text arrives:
+        it either completes the marker (call finalizes) or diverges (flushed).
+        """
+        marker = self.tool_call_end_token
+        for n in range(min(len(text), len(marker) - 1), 0, -1):
+            if marker.startswith(text[-n:]):
+                return text[:-n]
+        return text
 
     def _resolve_function_name(
         self, function_id: str, tools: List[Tool], function_args: str

--- a/test/registered/unit/function_call/test_kimik2_detector.py
+++ b/test/registered/unit/function_call/test_kimik2_detector.py
@@ -1,0 +1,209 @@
+"""Unit tests for KimiK2Detector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.kimik2_detector import KimiK2Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+SB = "<|tool_calls_section_begin|>"
+SE = "<|tool_calls_section_end|>"
+CB = "<|tool_call_begin|>"
+CE = "<|tool_call_end|>"
+AB = "<|tool_call_argument_begin|>"
+
+
+def _call(name: str, idx: int, args_json: str) -> str:
+    return f"{CB}functions.{name}:{idx}{AB}{args_json}{CE}"
+
+
+def _section(*calls: str) -> str:
+    return SB + "".join(calls) + SE
+
+
+class TestKimiK2Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="write_to_file",
+                    description="Write content to a file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "content": {"type": "string"},
+                        },
+                        "required": ["path", "content"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="execute_command",
+                    description="Run a shell command",
+                    parameters={
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = KimiK2Detector()
+
+    def _run_stream(self, deltas):
+        """Feed ``deltas`` in order; reconstruct per-index {name, args} and the
+        concatenated normal text. A fresh detector isolates request state."""
+        detector = KimiK2Detector()
+        acc = {}
+        normal = []
+        for delta in deltas:
+            res = detector.parse_streaming_increment(delta, self.tools)
+            if res.normal_text:
+                normal.append(res.normal_text)
+            for item in res.calls:
+                entry = acc.setdefault(item.tool_index, {"name": None, "args": ""})
+                if item.name:
+                    entry["name"] = item.name
+                if item.parameters:
+                    entry["args"] += item.parameters
+        return acc, "".join(normal)
+
+    # ==================== has_tool_call ====================
+
+    def test_has_tool_call_true(self):
+        self.assertTrue(
+            self.detector.has_tool_call(_section(_call("execute_command", 0, "{}")))
+        )
+
+    def test_has_tool_call_false(self):
+        self.assertFalse(self.detector.has_tool_call("just some normal assistant text"))
+
+    # ==================== detect_and_parse (non-streaming) ====================
+
+    def test_detect_and_parse_single(self):
+        text = "Let me help. " + _section(
+            _call("execute_command", 0, '{"command": "ls"}')
+        )
+        res = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(res.normal_text, "Let me help. ")
+        self.assertEqual(len(res.calls), 1)
+        self.assertEqual(res.calls[0].name, "execute_command")
+        self.assertEqual(json.loads(res.calls[0].parameters), {"command": "ls"})
+
+    def test_detect_and_parse_multiple(self):
+        text = _section(
+            _call("write_to_file", 0, '{"path": "a.txt", "content": "hi"}'),
+            _call("execute_command", 1, '{"command": "ls"}'),
+        )
+        res = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(
+            [c.name for c in res.calls], ["write_to_file", "execute_command"]
+        )
+        self.assertEqual([c.tool_index for c in res.calls], [0, 1])
+
+    def test_detect_and_parse_nested_braces_not_truncated(self):
+        # Arguments containing literal braces / markdown must survive parsing.
+        args = {"path": "x.md", "content": "# T\n```py\nd={'k': 1}\n```\ndone } { more"}
+        text = _section(_call("write_to_file", 0, json.dumps(args)))
+        res = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(res.calls), 1)
+        self.assertEqual(json.loads(res.calls[0].parameters), args)
+
+    def test_detect_and_parse_no_tool_call(self):
+        res = self.detector.detect_and_parse("no tools here", self.tools)
+        self.assertEqual(res.normal_text, "no tools here")
+        self.assertEqual(res.calls, [])
+
+    # ==================== streaming (marker-aligned increments) ====================
+
+    def test_stream_single_call(self):
+        acc, normal = self._run_stream(
+            [SB, CB, "functions.execute_command:0", AB, '{"command": "ls"}', CE, SE]
+        )
+        self.assertEqual(normal, "")
+        self.assertEqual(acc[0]["name"], "execute_command")
+        self.assertEqual(json.loads(acc[0]["args"]), {"command": "ls"})
+
+    def test_stream_multiple_calls(self):
+        text = _section(
+            _call("write_to_file", 0, '{"path": "a.txt", "content": "hi"}'),
+            _call("execute_command", 1, '{"command": "ls"}'),
+        )
+        acc, _ = self._run_stream([text])
+        self.assertEqual(acc[0]["name"], "write_to_file")
+        self.assertEqual(json.loads(acc[0]["args"]), {"path": "a.txt", "content": "hi"})
+        self.assertEqual(acc[1]["name"], "execute_command")
+        self.assertEqual(json.loads(acc[1]["args"]), {"command": "ls"})
+
+    def test_stream_empty_args(self):
+        acc, _ = self._run_stream([_section(_call("execute_command", 0, "{}"))])
+        self.assertEqual(acc[0]["name"], "execute_command")
+        self.assertEqual(json.loads(acc[0]["args"]), {})
+
+    def test_stream_prefix_text_preserved(self):
+        acc, normal = self._run_stream(
+            [
+                "Sure, doing it now. ",
+                _section(_call("execute_command", 0, '{"command": "ls"}')),
+            ]
+        )
+        self.assertEqual(normal, "Sure, doing it now. ")
+        self.assertEqual(json.loads(acc[0]["args"]), {"command": "ls"})
+
+    # ============ regression: <|tool_call_end|> split across increments ============
+    # A special-token marker is not guaranteed to arrive whole (cf. #25071, which
+    # added the begin-marker holdback). Before the fix, the trailing fragment of a
+    # split <|tool_call_end|> leaked into the streamed arguments as broken JSON.
+
+    def test_stream_end_marker_split_two_pieces(self):
+        acc, normal = self._run_stream(
+            [
+                SB,
+                CB,
+                "functions.execute_command:0",
+                AB,
+                '{"command":',
+                ' "ls"}',
+                "<|tool_call_",  # end marker, piece 1
+                "end|>",  # end marker, piece 2
+                SE,
+            ]
+        )
+        self.assertEqual(acc[0]["name"], "execute_command")
+        # Arguments must be exactly the JSON, with no marker fragment leaked in.
+        self.assertEqual(acc[0]["args"], '{"command": "ls"}')
+        self.assertEqual(json.loads(acc[0]["args"]), {"command": "ls"})
+        self.assertNotIn("tool_call", acc[0]["args"])
+        self.assertEqual(normal, "")
+
+    def test_stream_end_marker_split_many_pieces(self):
+        acc, normal = self._run_stream(
+            [
+                SB + CB + "functions.write_to_file:0" + AB,
+                '{"path": "a.txt", ',
+                '"content": "hello"}',
+                "<|tool",
+                "_call",
+                "_end|>",
+                SE,
+            ]
+        )
+        self.assertEqual(acc[0]["name"], "write_to_file")
+        self.assertEqual(
+            json.loads(acc[0]["args"]), {"path": "a.txt", "content": "hello"}
+        )
+        self.assertNotIn("<|", acc[0]["args"])
+        self.assertEqual(normal, "")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes one of the streaming symptoms tracked in #23363.

`KimiK2Detector.parse_streaming_increment` held back a trailing fragment that could begin the *start* marker (`_split_pending_start`, added in #25071) but applied no such guard to `<|tool_call_end|>`. Special-token markers are not guaranteed to arrive whole in a single streaming increment, so when `<|tool_call_end|>` was split across increments its leading fragment (e.g. `<|tool_call_`) leaked into the streamed tool-call arguments and produced broken JSON for the client.

Realistic reproduction — end marker split at a token boundary:

```
increments: [ "<|tool_calls_section_begin|>", "<|tool_call_begin|>",
              "functions.execute_command:0", "<|tool_call_argument_begin|>",
              '{"command":', ' "ls"}', "<|tool_call_", "end|>",
              "<|tool_calls_section_end|>" ]

emitted arguments before fix: {"command": "ls"}<|tool_call_     <- broken JSON
```

## Modifications

- Add `_hold_pending_end()` to `KimiK2Detector`, mirroring the existing `_split_pending_start` for the end marker. It drops a trailing fragment that could be the start of `<|tool_call_end|>`; the fragment is re-examined on the next increment and either completes the marker (call finalizes) or diverges (flushed as arguments).
- Use it in the args-still-streaming branch (`end_idx == -1`).
- Add the first unit test for this detector, `test/registered/unit/function_call/test_kimik2_detector.py` (12 cases). The two `test_stream_end_marker_split_*` regression tests fail without this fix and pass with it.

The begin marker and the `<|tool_call_argument_begin|>` marker already handle straddling correctly (the header parser waits when the marker is incomplete), so this change is scoped to the end marker only.

## Accuracy Tests

Not applicable — this is a CPU-side streaming parser fix; model forward / kernels are unchanged.

## Speed Tests and Profiling

Not applicable — no impact on the inference hot path.

## Checklist

- [x] Add unit tests according to the Run and add unit tests guide.
- [x] Format your code according to Format code with pre-commit.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29425504434](https://github.com/sgl-project/sglang/actions/runs/29425504434)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29425501331](https://github.com/sgl-project/sglang/actions/runs/29425501331)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->