### PR TITLE
[HiCache] Emit KV cache events for completed L3 storage backups

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -612,6 +612,13 @@ class HiRadixCache(RadixCache):
                 entry = self.ongoing_backup.pop(ack_id, None)
                 if entry is not None:
                     entry.release_host()
+                    # Publish an L3 store event once the whole node reached the
+                    # storage backend, so cache-aware routers can index blocks
+                    # persisted to the shared pool (e.g. Mooncake).
+                    if operation.completed_tokens // self.page_size == len(
+                        operation.hash_value
+                    ):
+                        self._record_store_event(entry, medium=StorageMedium.EXTERNAL)
                 if log_metrics and self.enable_storage_metrics:
                     self.storage_metrics_collector.log_backuped_tokens(
                         operation.completed_tokens

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2163,6 +2163,13 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 if entry is not None:
                     node, lock_params = entry
                     self.dec_host_lock_ref(node, lock_params)
+                    # Publish an L3 store event once the whole node reached the
+                    # storage backend, so cache-aware routers can index blocks
+                    # persisted to the shared pool (e.g. Mooncake).
+                    if operation.completed_tokens // self.page_size == len(
+                        operation.hash_value
+                    ):
+                        self._record_store_event(node, medium=StorageMedium.EXTERNAL)
                 if (
                     log_metrics
                     and self.enable_storage_metrics

--- a/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
@@ -1,12 +1,16 @@
 """Unit tests for srt/mem_cache/hiradix_cache.py KV cache events."""
 
 import os
+import shutil
+import tempfile
+import time
 import unittest
 from array import array
 
 import torch
 
 from sglang.srt.disaggregation.kv_events import BlockStored, StorageMedium
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
@@ -30,16 +34,36 @@ class TestHiRadixCacheKVEvents(CustomTestCase):
             raise unittest.SkipTest("CUDA is required for HiRadixCache tests.")
         os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
         os.environ.setdefault("MASTER_PORT", "29601")
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend="gloo", rank=0, world_size=1)
+        os.environ.setdefault("RANK", "0")
+        os.environ.setdefault("WORLD_SIZE", "1")
+        os.environ.setdefault("LOCAL_RANK", "0")
 
-    def _build_cache(self):
+        from sglang.srt.distributed.parallel_state import (
+            init_distributed_environment,
+            initialize_model_parallel,
+            model_parallel_is_initialized,
+        )
+
+        if not torch.distributed.is_initialized():
+            init_distributed_environment(
+                world_size=1, rank=0, local_rank=0, backend="gloo"
+            )
+        if not model_parallel_is_initialized():
+            initialize_model_parallel(
+                tensor_model_parallel_size=1,
+                expert_model_parallel_size=1,
+                pipeline_model_parallel_size=1,
+                backend="gloo",
+            )
+
+    def _build_cache(self, storage_backend=None):
         server_args = ServerArgs(
             model_path="dummy",
             page_size=PAGE_SIZE,
             hicache_io_backend="direct",
             hicache_mem_layout="layer_first",
             hicache_write_policy="write_through",
+            hicache_storage_backend=storage_backend,
         )
         set_global_server_args_for_scheduler(server_args)
         req_to_token_pool = ReqToTokenPool(
@@ -119,6 +143,37 @@ class TestHiRadixCacheKVEvents(CustomTestCase):
         )
         self.assertIsNone(stored_cpu[0].parent_block_hash)
         self.assertEqual(stored_cpu[1].parent_block_hash, stored_cpu[0].block_hashes[0])
+
+    def test_l3_backup_ack_publishes_external_store_events(self):
+        storage_dir = tempfile.mkdtemp(prefix="hicache_l3_events_")
+        self.addCleanup(shutil.rmtree, storage_dir, ignore_errors=True)
+        with envs.SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR.override(storage_dir):
+            cache, allocator = self._build_cache(storage_backend="file")
+        cache.take_events()
+
+        self._insert(cache, allocator, [1, 2, 3, 4])
+        node = self._leaf_for(cache, [1, 2, 3, 4])
+        backed_up = cache.write_backup(node, write_back=True)
+        self.assertGreater(backed_up, 0)
+
+        # Flush the write-through DMA, then wait for the async L3 backup ack.
+        deadline = time.monotonic() + 20
+        while cache.ongoing_write_through and time.monotonic() < deadline:
+            cache.writing_check(write_back=True)
+            time.sleep(0.01)
+        while cache.ongoing_backup and time.monotonic() < deadline:
+            cache.drain_storage_control_queues()
+            time.sleep(0.01)
+        self.assertFalse(cache.ongoing_backup)
+
+        stored_l3 = [
+            e
+            for e in cache.take_events()
+            if isinstance(e, BlockStored) and e.medium == StorageMedium.EXTERNAL
+        ]
+        self.assertEqual([list(e.token_ids) for e in stored_l3], [[1, 2], [3, 4]])
+        self.assertIsNone(stored_l3[0].parent_block_hash)
+        self.assertEqual(stored_l3[1].parent_block_hash, stored_l3[0].block_hashes[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- codex-pr-description:start -->
SGLang publishes `BlockStored` KV events for L1 (`GPU`) and L2 (`CPU_PINNED`) but never for L3 storage backends, so cache-aware routers cannot see blocks persisted to HiCache storage such as Mooncake. This implements the minimal Phase 1 of #29709: when a backup ack drains and the whole node reached storage, publish a `BlockStored(EXTERNAL)` through the existing event path.

### How This Was Implemented
- In `HiRadixCache._drain_backup` and `UnifiedRadixCache._drain_backup`, after the host protection is released, call the existing `_record_store_event(node, medium=StorageMedium.EXTERNAL)`.
- Gate on full completion (`completed_tokens // page_size == len(hash_value)`): partial batch failures and MLA `backup_skip` ranks (which ack with `completed_tokens == 0`) publish nothing, so events are a safe lower bound — never an over-report of blocks that are not actually in storage.
- Reuses the existing per-page emission, so parent-hash chaining and bigram payloads come for free and L3 events share the medium-invariant block hash with the GPU/CPU chain (consumers can join tiers on it).
- No new fields, helpers, or wire-format changes; `EXTERNAL` covers the shared-pool backends this targets (Mooncake).

<details>
<summary>Walkthrough</summary>

- `python/sglang/srt/mem_cache/hiradix_cache.py` — emit `BlockStored(EXTERNAL)` on full backup ack in `_drain_backup`.
- `python/sglang/srt/mem_cache/unified_radix_cache.py` — same emission in the unified cache's `_drain_backup`.
- `test/registered/unit/mem_cache/test_hiradix_cache_unit.py` — assert `EXTERNAL` events with intact token payload and parent chaining after a real file-backend backup ack.

Scoped out of this PR (tracked in #29709): `BlockRemoved(EXTERNAL)` on storage eviction, per-tier medium mapping for local-disk backends, storage-side/multi-writer publishing, and router tier-awareness. These events are a per-worker, best-effort store log; the prefetch path re-verifies L3 presence via `batch_exists`, so a missed or stale event degrades routing, never correctness.

</details>

### Validation
- `pytest test/registered/unit/mem_cache/test_hiradix_cache_unit.py` — 2 passed (existing L2 split test + new L3 `EXTERNAL` test).
- Full `test/registered/unit/mem_cache/` suite: 1527 passed, no regressions.
- Live e2e on 2x L40S (Qwen2.5-1.5B, `--enable-hierarchical-cache --hicache-storage-backend file --hicache-write-policy write_through --kv-events-config zmq`, ZMQ subscriber): TP=1 yields 18 GPU / 18 CPU_PINNED / 18 EXTERNAL events with 18 unique hashes matching 18 files on disk; TP=2 yields the identical single event stream (no cross-rank duplication) while both ranks wrote their 18 per-rank shard files.
<!-- codex-pr-description:end -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28601012337](https://github.com/sgl-project/sglang/actions/runs/28601012337)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28601011992](https://github.com/sgl-project/sglang/actions/runs/28601011992)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
