### PR TITLE
refactor: make customized_info msgpack-native (drop PickleWrapper)

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -105,9 +105,9 @@ class PickleWrapper(msgspec.Struct, tag=True, array_like=True):
     """Wraps an arbitrary Python object as pickle-serialized bytes for msgpack IPC.
 
     In msgpack mode, fields that carry opaque or non-msgspec-typed payloads
-    (e.g. multimodal inputs, time stats, customized info) are stored as
-    PickleWrapper so the outer struct can still be msgpack-encoded.  In pickle
-    mode (_USE_PICKLE_IPC=True), wrap_as_pickle / unwrap_from_pickle are no-ops
+    (e.g. multimodal inputs, time stats) are stored as PickleWrapper so the
+    outer struct can still be msgpack-encoded.  In pickle mode
+    (_USE_PICKLE_IPC=True), wrap_as_pickle / unwrap_from_pickle are no-ops
     and this class is not used on the wire.
     """
 
@@ -1277,6 +1277,7 @@ TokenIdsLogprobIndices = Optional[List[Optional[List[Optional[List[int]]]]]]
 HiddenStateChunk = List[Optional[Union[float, List[float]]]]
 OutputHiddenStates = Optional[List[Optional[List[HiddenStateChunk]]]]
 CachedTokensDetails = Dict[str, Union[int, str]]
+CustomizedInfo = Optional[Dict[str, List[List[Any]]]]
 # Serialized form of BaseFinishReason.to_json() — all values are primitives.
 FinishReasonDict = Dict[str, Optional[Union[str, int, List[int]]]]
 
@@ -1378,8 +1379,7 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: Optional[List[List[int]]] = None
 
-    # Customized info
-    customized_info: Optional[PickleWrapper] = None
+    customized_info: CustomizedInfo = None
     # Detailed breakdown of cached tokens by source (device/host/storage)
     cached_tokens_details: Optional[List[Optional[CachedTokensDetails]]] = None
     # DP rank of the scheduler that processed each request
@@ -1469,8 +1469,7 @@ class BatchStrOutput(BaseBatchReq, kw_only=True):
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: Optional[List[List[int]]] = None
 
-    # Customized info
-    customized_info: Optional[PickleWrapper] = None
+    customized_info: CustomizedInfo = None
     # Detailed breakdown of cached tokens by source (device/host/storage)
     cached_tokens_details: Optional[List[Optional[CachedTokensDetails]]] = None
     # DP rank of the scheduler that processed each request

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -59,7 +59,7 @@ from sglang.srt.managers.schedule_batch import (
     get_return_hidden_states_mode,
 )
 from sglang.srt.multimodal.mm_utils import has_valid_data
-from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.sampling.sampling_params import CustomParamValue, SamplingParams
 from sglang.srt.utils import ImageData, VideoData
 from sglang.srt.utils.field_validators import validate_optional_list_i64_1d_2d
 from sglang.srt.utils.msgspec_utils import (
@@ -105,9 +105,9 @@ class PickleWrapper(msgspec.Struct, tag=True, array_like=True):
     """Wraps an arbitrary Python object as pickle-serialized bytes for msgpack IPC.
 
     In msgpack mode, fields that carry opaque or non-msgspec-typed payloads
-    (e.g. multimodal inputs, time stats, customized info) are stored as
-    PickleWrapper so the outer struct can still be msgpack-encoded.  In pickle
-    mode (_USE_PICKLE_IPC=True), wrap_as_pickle / unwrap_from_pickle are no-ops
+    (e.g. multimodal inputs, time stats) are stored as PickleWrapper so the
+    outer struct can still be msgpack-encoded.  In pickle mode
+    (_USE_PICKLE_IPC=True), wrap_as_pickle / unwrap_from_pickle are no-ops
     and this class is not used on the wire.
     """
 
@@ -1253,6 +1253,7 @@ TokenIdsLogprobIndices = Optional[List[Optional[List[Optional[List[int]]]]]]
 HiddenStateChunk = List[Optional[Union[float, List[float]]]]
 OutputHiddenStates = Optional[List[Optional[List[HiddenStateChunk]]]]
 CachedTokensDetails = Dict[str, Union[int, str]]
+CustomizedInfo = Optional[Dict[str, List[List[CustomParamValue]]]]
 # Serialized form of BaseFinishReason.to_json() — all values are primitives.
 FinishReasonDict = Dict[str, Optional[Union[str, int, List[int]]]]
 
@@ -1354,8 +1355,7 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: Optional[List[List[int]]] = None
 
-    # Customized info
-    customized_info: Optional[PickleWrapper] = None
+    customized_info: CustomizedInfo = None
     # Detailed breakdown of cached tokens by source (device/host/storage)
     cached_tokens_details: Optional[List[Optional[CachedTokensDetails]]] = None
     # DP rank of the scheduler that processed each request
@@ -1445,8 +1445,7 @@ class BatchStrOutput(BaseBatchReq, kw_only=True):
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: Optional[List[List[int]]] = None
 
-    # Customized info
-    customized_info: Optional[PickleWrapper] = None
+    customized_info: CustomizedInfo = None
     # Detailed breakdown of cached tokens by source (device/host/storage)
     cached_tokens_details: Optional[List[Optional[CachedTokensDetails]]] = None
     # DP rank of the scheduler that processed each request

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -124,7 +124,8 @@ def _extract_field_by_index(
     if field is None:
         return None
 
-    should_wrap_result = field_name in ("customized_info", "time_stats")
+    is_customized_info = field_name == "customized_info"
+    should_wrap_result = field_name == "time_stats"
     if should_wrap_result:
         field = unwrap_from_pickle(field)
         if field is None:
@@ -134,11 +135,17 @@ def _extract_field_by_index(
         new_field = {}
         for k, v in field.items():
             if len(v) > index:
-                new_field[k] = [v[index]] if should_wrap_result else v[index]
+                new_field[k] = (
+                    [v[index]] if is_customized_info or should_wrap_result else v[index]
+                )
+            elif is_customized_info:
+                new_field[k] = [[]]
             else:
                 new_field[k] = [None] if should_wrap_result else None
         if should_wrap_result:
             return wrap_as_pickle(new_field) if new_field else None
+        if is_customized_info:
+            return new_field if new_field else None
         return new_field
 
     if check_length:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     List,
     Optional,
@@ -70,6 +71,25 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
+_CUSTOMIZED_INFO_SCALAR_TYPES = (type(None), bool, int, float, str)
+_USE_PICKLE_IPC = envs.SGLANG_USE_PICKLE_IPC.get()
+
+
+def _is_customized_info_value(value: Any) -> bool:
+    value_type = type(value)
+    if value_type in _CUSTOMIZED_INFO_SCALAR_TYPES:
+        return True
+    if value_type is list:
+        for item in value:
+            if type(item) not in _CUSTOMIZED_INFO_SCALAR_TYPES:
+                return False
+        return True
+    if value_type is dict:
+        for key, item in value.items():
+            if type(key) is not str or type(item) not in _CUSTOMIZED_INFO_SCALAR_TYPES:
+                return False
+        return True
+    return False
 
 
 @dataclass(kw_only=True, slots=True, frozen=True)
@@ -180,9 +200,16 @@ class SchedulerBatchResultProcessor:
             for k, v in logits_output.customized_info.items():
                 if k not in req.customized_info:
                     req.customized_info[k] = []
+                elem = v[i]
+                if not _USE_PICKLE_IPC and not _is_customized_info_value(elem):
+                    raise TypeError(
+                        f"customized_info[{k!r}][{i}] must be a JSON scalar, "
+                        "a list of JSON scalars, or a string-keyed map of JSON "
+                        "scalars for msgpack IPC; "
+                        f"got {type(elem).__name__}"
+                    )
                 # Copy the element so it doesn't retain the entire batch
                 # tensor/array via a view reference.
-                elem = v[i]
                 if isinstance(elem, torch.Tensor):
                     elem = elem.clone()
                 elif hasattr(elem, "copy") and callable(elem.copy):

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     List,
     Optional,
@@ -71,6 +72,25 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
+_CUSTOMIZED_INFO_SCALAR_TYPES = (type(None), bool, int, float, str)
+_USE_PICKLE_IPC = envs.SGLANG_USE_PICKLE_IPC.get()
+
+
+def _is_customized_info_value(value: Any) -> bool:
+    value_type = type(value)
+    if value_type in _CUSTOMIZED_INFO_SCALAR_TYPES:
+        return True
+    if value_type is list:
+        for item in value:
+            if not _is_customized_info_value(item):
+                return False
+        return True
+    if value_type is dict:
+        for key, item in value.items():
+            if type(key) is not str or not _is_customized_info_value(item):
+                return False
+        return True
+    return False
 
 
 @dataclass(kw_only=True, slots=True, frozen=True)
@@ -176,18 +196,34 @@ class SchedulerBatchResultProcessor:
         logits_output: LogitsProcessorOutput,
     ):
         if logits_output is not None and logits_output.customized_info is not None:
-            if req.customized_info is None:
-                req.customized_info = {}
+            if not _USE_PICKLE_IPC:
+                for key in logits_output.customized_info:
+                    if type(key) is not str:
+                        raise TypeError(
+                            f"customized_info[{key!r}] uses a "
+                            f"{type(key).__name__} key; keys must be str for "
+                            "msgpack IPC"
+                        )
+            pending_customized_info = []
             for k, v in logits_output.customized_info.items():
-                if k not in req.customized_info:
-                    req.customized_info[k] = []
+                elem = v[i]
+                if not _USE_PICKLE_IPC and not _is_customized_info_value(elem):
+                    raise TypeError(
+                        f"customized_info[{k!r}][{i}] must contain only JSON "
+                        "scalars, lists, and string-keyed maps for msgpack IPC"
+                    )
                 # Copy the element so it doesn't retain the entire batch
                 # tensor/array via a view reference.
-                elem = v[i]
                 if isinstance(elem, torch.Tensor):
                     elem = elem.clone()
                 elif hasattr(elem, "copy") and callable(elem.copy):
                     elem = elem.copy()
+                pending_customized_info.append((k, elem))
+            if req.customized_info is None:
+                req.customized_info = {}
+            for k, elem in pending_customized_info:
+                if k not in req.customized_info:
+                    req.customized_info[k] = []
                 req.customized_info[k].append(elem)
 
     def process_batch_result_prefill(

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -612,6 +612,7 @@ class _GenerationStreamAccumulator:
         if not (self.rids or is_idle_batch):
             return None
         dp_ranks = [dp_rank] * len(self.rids) if self.rids else None
+        customized_info = self.customized_info or None
         return BatchTokenIDOutput(
             rids=self.rids,
             http_worker_ipcs=self.http_worker_ipcs,
@@ -673,9 +674,7 @@ class _GenerationStreamAccumulator:
             output_hidden_states=self.output_hidden_states,
             routed_experts=self.routed_experts,
             indexer_topk=self.indexer_topk,
-            customized_info=(
-                wrap_as_pickle(self.customized_info) if self.customized_info else None
-            ),
+            customized_info=customized_info,
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
             retraction_counts=self.retraction_counts,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2181,7 +2181,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     ):
         recv_obj.time_stats = unwrap_from_pickle(recv_obj.time_stats)
         if isinstance(recv_obj, (BatchStrOutput, BatchTokenIDOutput)):
-            customized_info = unwrap_from_pickle(recv_obj.customized_info)
+            customized_info = recv_obj.customized_info
         else:
             customized_info = None
         pending_notify: dict[str, ReqState] = {}

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2090,7 +2090,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     ):
         recv_obj.time_stats = unwrap_from_pickle(recv_obj.time_stats)
         if isinstance(recv_obj, (BatchStrOutput, BatchTokenIDOutput)):
-            customized_info = unwrap_from_pickle(recv_obj.customized_info)
+            customized_info = recv_obj.customized_info
         else:
             customized_info = None
         pending_notify: dict[str, ReqState] = {}

--- a/test/registered/unit/managers/test_batch_result_processor_customized_info.py
+++ b/test/registered/unit/managers/test_batch_result_processor_customized_info.py
@@ -1,0 +1,166 @@
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import torch
+
+from sglang.srt.managers.scheduler_components import batch_result_processor
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+_NON_NATIVE_FACTORIES = {
+    "array": lambda: array("i", [1]),
+    "ndarray": lambda: np.array([1], dtype=np.int32),
+    "tensor": lambda: torch.tensor([1], dtype=torch.int32),
+}
+
+
+class TestBatchResultProcessorCustomizedInfo(unittest.TestCase):
+    def setUp(self):
+        self.processor = object.__new__(SchedulerBatchResultProcessor)
+
+    def test_msgpack_rejects_non_native_values(self):
+        for name, factory in _NON_NATIVE_FACTORIES.items():
+            with self.subTest(value=name):
+                req = SimpleNamespace(customized_info=None)
+                logits_output = SimpleNamespace(customized_info={"probe": [factory()]})
+
+                with patch.object(batch_result_processor, "_USE_PICKLE_IPC", False):
+                    with self.assertRaisesRegex(
+                        TypeError,
+                        r"customized_info\['probe'\]\[0\]",
+                    ):
+                        self.processor._maybe_collect_customized_info(
+                            0,
+                            req,
+                            logits_output,
+                        )
+
+    def test_msgpack_accepts_native_values(self):
+        values = (None, True, 1, 0.5, "tag", [1, "x"], {"ok": True})
+        req = SimpleNamespace(customized_info=None)
+        logits_output = SimpleNamespace(
+            customized_info={
+                f"value_{index}": [value] for index, value in enumerate(values)
+            }
+        )
+
+        with patch.object(batch_result_processor, "_USE_PICKLE_IPC", False):
+            self.processor._maybe_collect_customized_info(0, req, logits_output)
+
+        actual = tuple(
+            req.customized_info[f"value_{index}"][0] for index in range(len(values))
+        )
+        self.assertEqual(actual, values)
+        self.assertEqual(
+            tuple(type(value) for value in actual),
+            (type(None), bool, int, float, str, list, dict),
+        )
+
+    def test_msgpack_accepts_nested_native_values(self):
+        values = (
+            {"payload": [1, {"enabled": True, "tags": ["a", None]}]},
+            [1, {"details": {"ratio": 0.25}}, [False]],
+        )
+        req = SimpleNamespace(customized_info=None)
+        logits_output = SimpleNamespace(
+            customized_info={
+                f"value_{index}": [value] for index, value in enumerate(values)
+            }
+        )
+
+        with patch.object(batch_result_processor, "_USE_PICKLE_IPC", False):
+            self.processor._maybe_collect_customized_info(0, req, logits_output)
+
+        actual = tuple(
+            req.customized_info[f"value_{index}"][0] for index in range(len(values))
+        )
+        self.assertEqual(actual, values)
+
+    def test_msgpack_rejects_non_string_outer_key_without_mutating_request(self):
+        req = SimpleNamespace(customized_info=None)
+        logits_output = SimpleNamespace(
+            customized_info={"valid": ["value"], 1: ["value"]}
+        )
+
+        with patch.object(batch_result_processor, "_USE_PICKLE_IPC", False):
+            with self.assertRaisesRegex(
+                TypeError,
+                r"customized_info\[1\].*key.*str.*msgpack IPC",
+            ):
+                self.processor._maybe_collect_customized_info(0, req, logits_output)
+
+        self.assertIsNone(req.customized_info)
+
+    def test_msgpack_rejects_non_native_nested_values(self):
+        values = {
+            "list_leaf": [torch.tensor([1])],
+            "map_leaf": {"value": np.array([1])},
+            "map_key": {1: "value"},
+            "deep_leaf": {"payload": [{"value": array("i", [1])}]},
+        }
+        for name, value in values.items():
+            with self.subTest(value=name):
+                req = SimpleNamespace(customized_info=None)
+                logits_output = SimpleNamespace(customized_info={"probe": [value]})
+
+                with patch.object(batch_result_processor, "_USE_PICKLE_IPC", False):
+                    with self.assertRaises(TypeError):
+                        self.processor._maybe_collect_customized_info(
+                            0,
+                            req,
+                            logits_output,
+                        )
+
+    def test_msgpack_rejects_first_invalid_value_without_mutating_request(self):
+        req = SimpleNamespace(customized_info=None)
+        logits_output = SimpleNamespace(
+            customized_info={"invalid": [{"value": torch.tensor([1])}]}
+        )
+
+        with patch.object(batch_result_processor, "_USE_PICKLE_IPC", False):
+            with self.assertRaises(TypeError):
+                self.processor._maybe_collect_customized_info(0, req, logits_output)
+
+        self.assertIsNone(req.customized_info)
+
+    def test_msgpack_rejects_later_invalid_value_without_mutating_request(self):
+        req = SimpleNamespace(customized_info={"valid": ["previous"]})
+        logits_output = SimpleNamespace(
+            customized_info={
+                "valid": ["next"],
+                "invalid": [{"value": torch.tensor([1])}],
+            }
+        )
+
+        with patch.object(batch_result_processor, "_USE_PICKLE_IPC", False):
+            with self.assertRaises(TypeError):
+                self.processor._maybe_collect_customized_info(0, req, logits_output)
+
+        self.assertEqual(req.customized_info, {"valid": ["previous"]})
+
+    def test_pickle_accepts_non_native_values(self):
+        for name, factory in _NON_NATIVE_FACTORIES.items():
+            with self.subTest(value=name):
+                original = factory()
+                req = SimpleNamespace(customized_info=None)
+                logits_output = SimpleNamespace(customized_info={"probe": [original]})
+
+                with patch.object(batch_result_processor, "_USE_PICKLE_IPC", True):
+                    self.processor._maybe_collect_customized_info(
+                        0,
+                        req,
+                        logits_output,
+                    )
+
+                self.assertIs(type(req.customized_info["probe"][0]), type(original))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_batch_result_processor_customized_info.py
+++ b/test/registered/unit/managers/test_batch_result_processor_customized_info.py
@@ -1,0 +1,103 @@
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import torch
+
+from sglang.srt.managers.scheduler_components import batch_result_processor
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+_NON_NATIVE_FACTORIES = {
+    "array": lambda: array("i", [1]),
+    "ndarray": lambda: np.array([1], dtype=np.int32),
+    "tensor": lambda: torch.tensor([1], dtype=torch.int32),
+}
+
+
+class TestBatchResultProcessorCustomizedInfo(unittest.TestCase):
+    def setUp(self):
+        self.processor = object.__new__(SchedulerBatchResultProcessor)
+
+    def test_msgpack_rejects_non_native_values(self):
+        for name, factory in _NON_NATIVE_FACTORIES.items():
+            with self.subTest(value=name):
+                req = SimpleNamespace(customized_info=None)
+                logits_output = SimpleNamespace(customized_info={"probe": [factory()]})
+
+                with patch.object(batch_result_processor, "_USE_PICKLE_IPC", False):
+                    with self.assertRaisesRegex(
+                        TypeError,
+                        r"customized_info\['probe'\]\[0\]",
+                    ):
+                        self.processor._maybe_collect_customized_info(
+                            0,
+                            req,
+                            logits_output,
+                        )
+
+    def test_msgpack_accepts_native_values(self):
+        values = (None, True, 1, 0.5, "tag", [1, "x"], {"ok": True})
+        req = SimpleNamespace(customized_info=None)
+        logits_output = SimpleNamespace(
+            customized_info={
+                f"value_{index}": [value] for index, value in enumerate(values)
+            }
+        )
+
+        with patch.object(batch_result_processor, "_USE_PICKLE_IPC", False):
+            self.processor._maybe_collect_customized_info(0, req, logits_output)
+
+        actual = tuple(
+            req.customized_info[f"value_{index}"][0] for index in range(len(values))
+        )
+        self.assertEqual(actual, values)
+        self.assertEqual(
+            tuple(type(value) for value in actual),
+            (type(None), bool, int, float, str, list, dict),
+        )
+
+    def test_msgpack_rejects_non_native_nested_values(self):
+        values = {
+            "list_leaf": [torch.tensor([1])],
+            "map_leaf": {"value": np.array([1])},
+            "map_key": {1: "value"},
+        }
+        for name, value in values.items():
+            with self.subTest(value=name):
+                req = SimpleNamespace(customized_info=None)
+                logits_output = SimpleNamespace(customized_info={"probe": [value]})
+
+                with patch.object(batch_result_processor, "_USE_PICKLE_IPC", False):
+                    with self.assertRaises(TypeError):
+                        self.processor._maybe_collect_customized_info(
+                            0,
+                            req,
+                            logits_output,
+                        )
+
+    def test_pickle_accepts_non_native_values(self):
+        for name, factory in _NON_NATIVE_FACTORIES.items():
+            with self.subTest(value=name):
+                original = factory()
+                req = SimpleNamespace(customized_info=None)
+                logits_output = SimpleNamespace(customized_info={"probe": [original]})
+
+                with patch.object(batch_result_processor, "_USE_PICKLE_IPC", True):
+                    self.processor._maybe_collect_customized_info(
+                        0,
+                        req,
+                        logits_output,
+                    )
+
+                self.assertIs(type(req.customized_info["probe"][0]), type(original))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_customized_info_msgpack.py
+++ b/test/registered/unit/managers/test_customized_info_msgpack.py
@@ -1,0 +1,155 @@
+import pickle
+import unittest
+from array import array
+
+import numpy as np
+import torch
+
+from sglang.srt.managers.io_struct import (
+    BatchStrOutput,
+    BatchTokenIDOutput,
+    msgpack_decode,
+    msgpack_encode,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_CUSTOMIZED_INFO = {
+    "probe": [[None, True], [200, 201, 202], [False]],
+    "score": [[0.5, None], [None, None, None], ["tag"]],
+    "details": [[[1, "x"], {"ok": True}], [[], {}, None], [{"ratio": 0.25}]],
+}
+
+_NESTED_CUSTOMIZED_INFO = {
+    "details": [
+        [{"payload": [1, {"enabled": True, "tags": ["a", None]}]}],
+        [[{"score": 0.5}, []]],
+        [{"empty": {"items": []}}],
+    ]
+}
+
+_NON_NATIVE_FACTORIES = {
+    "array": lambda: array("i", [1, 2]),
+    "ndarray": lambda: np.array([1, 2], dtype=np.int32),
+    "tensor": lambda: torch.tensor([1, 2], dtype=torch.int32),
+}
+
+_COMMON_FIELDS = dict(
+    rids=["r0", "r1", "r2"],
+    finished_reasons=[None, None, None],
+    output_ids=None,
+    prompt_tokens=[1, 1, 1],
+    completion_tokens=[2, 3, 1],
+    reasoning_tokens=[0, 0, 0],
+    cached_tokens=[0, 0, 0],
+    input_token_logprobs_val=None,
+    input_token_logprobs_idx=None,
+    output_token_logprobs_val=None,
+    output_token_logprobs_idx=None,
+    input_top_logprobs_val=None,
+    input_top_logprobs_idx=None,
+    output_top_logprobs_val=None,
+    output_top_logprobs_idx=None,
+    input_token_ids_logprobs_val=None,
+    input_token_ids_logprobs_idx=None,
+    output_token_ids_logprobs_val=None,
+    output_token_ids_logprobs_idx=None,
+    output_token_entropy_val=None,
+    output_token_sampling_mask=None,
+    output_token_sampling_logprobs=None,
+    output_hidden_states=None,
+    routed_experts=None,
+    indexer_topk=None,
+    placeholder_tokens_idx=None,
+    placeholder_tokens_val=None,
+)
+
+
+def _make_token_id_output(customized_info):
+    return BatchTokenIDOutput(
+        decoded_texts=["", "", ""],
+        decode_ids=[array("i", [10]), array("i", [20]), array("i", [30])],
+        read_offsets=[0, 0, 0],
+        skip_special_tokens=[True, True, True],
+        spaces_between_special_tokens=[True, True, True],
+        no_stop_trim=[False, False, False],
+        customized_info=customized_info,
+        **_COMMON_FIELDS,
+    )
+
+
+def _make_str_output(customized_info):
+    return BatchStrOutput(
+        output_strs=["a", "b", "c"],
+        customized_info=customized_info,
+        **_COMMON_FIELDS,
+    )
+
+
+class TestCustomizedInfoMsgpack(CustomTestCase):
+    def _round_trip(self, output):
+        return msgpack_decode(msgpack_encode(output))
+
+    def test_batch_token_id_output_round_trips(self):
+        decoded = self._round_trip(_make_token_id_output(_CUSTOMIZED_INFO))
+
+        self.assertIsInstance(decoded, BatchTokenIDOutput)
+        self.assertEqual(decoded.customized_info, _CUSTOMIZED_INFO)
+        self.assertEqual(
+            [
+                type(decoded.customized_info["probe"][0][0]),
+                type(decoded.customized_info["probe"][0][1]),
+                type(decoded.customized_info["probe"][1][0]),
+                type(decoded.customized_info["score"][0][0]),
+                type(decoded.customized_info["score"][2][0]),
+                type(decoded.customized_info["details"][0][0]),
+                type(decoded.customized_info["details"][0][1]),
+            ],
+            [type(None), bool, int, float, str, list, dict],
+        )
+
+    def test_batch_str_output_round_trips(self):
+        decoded = self._round_trip(_make_str_output(_CUSTOMIZED_INFO))
+
+        self.assertIsInstance(decoded, BatchStrOutput)
+        self.assertEqual(decoded.customized_info, _CUSTOMIZED_INFO)
+
+    def test_nested_json_values_round_trip(self):
+        for make in (_make_token_id_output, _make_str_output):
+            with self.subTest(make=make.__name__):
+                decoded = self._round_trip(make(_NESTED_CUSTOMIZED_INFO))
+
+                self.assertEqual(decoded.customized_info, _NESTED_CUSTOMIZED_INFO)
+
+    def test_none_round_trips(self):
+        for make in (_make_token_id_output, _make_str_output):
+            with self.subTest(make=make.__name__):
+                decoded = self._round_trip(make(None))
+
+                self.assertIsNone(decoded.customized_info)
+
+    def test_pickle_preserves_non_native_values(self):
+        for make in (_make_token_id_output, _make_str_output):
+            for name, factory in _NON_NATIVE_FACTORIES.items():
+                with self.subTest(make=make.__name__, value=name):
+                    original = factory()
+                    output = make({"probe": [[original]]})
+
+                    decoded = pickle.loads(
+                        pickle.dumps(output, protocol=pickle.HIGHEST_PROTOCOL)
+                    )
+                    actual = decoded.customized_info["probe"][0][0]
+
+                    self.assertIs(type(actual), type(original))
+                    if isinstance(original, torch.Tensor):
+                        self.assertTrue(torch.equal(actual, original))
+                    elif isinstance(original, np.ndarray):
+                        np.testing.assert_array_equal(actual, original)
+                    else:
+                        self.assertEqual(actual, original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_customized_info_msgpack.py
+++ b/test/registered/unit/managers/test_customized_info_msgpack.py
@@ -1,0 +1,150 @@
+import pickle
+import unittest
+from array import array
+
+import msgspec
+import numpy as np
+import torch
+
+from sglang.srt.managers.io_struct import (
+    BatchStrOutput,
+    BatchTokenIDOutput,
+    msgpack_decode,
+    msgpack_encode,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_CUSTOMIZED_INFO = {
+    "probe": [[None, True], [200, 201, 202], [False]],
+    "score": [[0.5, None], [None, None, None], ["tag"]],
+    "details": [[[1, "x"], {"ok": True}], [[], {}, None], [{"ratio": 0.25}]],
+}
+
+_NON_NATIVE_FACTORIES = {
+    "array": lambda: array("i", [1, 2]),
+    "ndarray": lambda: np.array([1, 2], dtype=np.int32),
+    "tensor": lambda: torch.tensor([1, 2], dtype=torch.int32),
+}
+
+_COMMON_FIELDS = dict(
+    rids=["r0", "r1", "r2"],
+    finished_reasons=[None, None, None],
+    output_ids=None,
+    prompt_tokens=[1, 1, 1],
+    completion_tokens=[2, 3, 1],
+    reasoning_tokens=[0, 0, 0],
+    cached_tokens=[0, 0, 0],
+    input_token_logprobs_val=None,
+    input_token_logprobs_idx=None,
+    output_token_logprobs_val=None,
+    output_token_logprobs_idx=None,
+    input_top_logprobs_val=None,
+    input_top_logprobs_idx=None,
+    output_top_logprobs_val=None,
+    output_top_logprobs_idx=None,
+    input_token_ids_logprobs_val=None,
+    input_token_ids_logprobs_idx=None,
+    output_token_ids_logprobs_val=None,
+    output_token_ids_logprobs_idx=None,
+    output_token_entropy_val=None,
+    output_token_sampling_mask=None,
+    output_token_sampling_logprobs=None,
+    output_hidden_states=None,
+    routed_experts=None,
+    indexer_topk=None,
+    placeholder_tokens_idx=None,
+    placeholder_tokens_val=None,
+)
+
+
+def _make_token_id_output(customized_info):
+    return BatchTokenIDOutput(
+        decoded_texts=["", "", ""],
+        decode_ids=[array("i", [10]), array("i", [20]), array("i", [30])],
+        read_offsets=[0, 0, 0],
+        skip_special_tokens=[True, True, True],
+        spaces_between_special_tokens=[True, True, True],
+        no_stop_trim=[False, False, False],
+        customized_info=customized_info,
+        **_COMMON_FIELDS,
+    )
+
+
+def _make_str_output(customized_info):
+    return BatchStrOutput(
+        output_strs=["a", "b", "c"],
+        customized_info=customized_info,
+        **_COMMON_FIELDS,
+    )
+
+
+class TestCustomizedInfoMsgpack(CustomTestCase):
+    def _round_trip(self, output):
+        return msgpack_decode(msgpack_encode(output))
+
+    def test_batch_token_id_output_round_trips(self):
+        decoded = self._round_trip(_make_token_id_output(_CUSTOMIZED_INFO))
+
+        self.assertIsInstance(decoded, BatchTokenIDOutput)
+        self.assertEqual(decoded.customized_info, _CUSTOMIZED_INFO)
+        self.assertEqual(
+            [
+                type(decoded.customized_info["probe"][0][0]),
+                type(decoded.customized_info["probe"][0][1]),
+                type(decoded.customized_info["probe"][1][0]),
+                type(decoded.customized_info["score"][0][0]),
+                type(decoded.customized_info["score"][2][0]),
+                type(decoded.customized_info["details"][0][0]),
+                type(decoded.customized_info["details"][0][1]),
+            ],
+            [type(None), bool, int, float, str, list, dict],
+        )
+
+    def test_batch_str_output_round_trips(self):
+        decoded = self._round_trip(_make_str_output(_CUSTOMIZED_INFO))
+
+        self.assertIsInstance(decoded, BatchStrOutput)
+        self.assertEqual(decoded.customized_info, _CUSTOMIZED_INFO)
+
+    def test_none_round_trips(self):
+        for make in (_make_token_id_output, _make_str_output):
+            with self.subTest(make=make.__name__):
+                decoded = self._round_trip(make(None))
+
+                self.assertIsNone(decoded.customized_info)
+
+    def test_non_native_values_are_rejected_by_msgpack(self):
+        for make in (_make_token_id_output, _make_str_output):
+            for name, factory in _NON_NATIVE_FACTORIES.items():
+                with self.subTest(make=make.__name__, value=name):
+                    output = make({"probe": [[factory()]]})
+
+                    with self.assertRaises(msgspec.ValidationError):
+                        self._round_trip(output)
+
+    def test_pickle_preserves_non_native_values(self):
+        for make in (_make_token_id_output, _make_str_output):
+            for name, factory in _NON_NATIVE_FACTORIES.items():
+                with self.subTest(make=make.__name__, value=name):
+                    original = factory()
+                    output = make({"probe": [[original]]})
+
+                    decoded = pickle.loads(
+                        pickle.dumps(output, protocol=pickle.HIGHEST_PROTOCOL)
+                    )
+                    actual = decoded.customized_info["probe"][0][0]
+
+                    self.assertIs(type(actual), type(original))
+                    if isinstance(original, torch.Tensor):
+                        self.assertTrue(torch.equal(actual, original))
+                    elif isinstance(original, np.ndarray):
+                        np.testing.assert_array_equal(actual, original)
+                    else:
+                        self.assertEqual(actual, original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -5,7 +5,11 @@ from sglang.test.test_utils import maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.io_struct import BatchStrOutput
+from sglang.srt.managers.io_struct import (
+    BatchStrOutput,
+    unwrap_from_pickle,
+    wrap_as_pickle,
+)
 from sglang.srt.managers.multi_tokenizer_mixin import (
     TokenizerWorker,
     _handle_output_by_index,
@@ -38,9 +42,10 @@ class InvalidServerArgs:
         return NotAWorker
 
 
-def _make_batch_str_output() -> BatchStrOutput:
+def _make_batch_str_output(customized_info=None) -> BatchStrOutput:
     return BatchStrOutput(
         rids=["rid-0", "rid-1"],
+        customized_info=customized_info,
         spec_verify_ct=[0, 0],
         spec_num_correct_drafts=[0, 0],
         spec_correct_drafts_histogram=[[], []],
@@ -104,6 +109,28 @@ class TestMultiTokenizerMixin(unittest.TestCase):
     def test_get_tokenizer_worker_class_rejects_non_worker(self):
         with self.assertRaisesRegex(TypeError, "TokenizerWorker"):
             get_tokenizer_worker_class(InvalidServerArgs())
+
+    def test_batch_str_output_keeps_customized_info_rows(self):
+        output = _make_batch_str_output(
+            customized_info={"probe": [[100], [200, 201]], "short": [[300]]}
+        )
+
+        single_output = _handle_output_by_index(output, 1)
+
+        self.assertEqual(
+            single_output.customized_info,
+            {"probe": [[200, 201]], "short": [[]]},
+        )
+
+    def test_batch_str_output_keeps_time_stats_wrapped(self):
+        output = _make_batch_str_output()
+        output.time_stats = wrap_as_pickle({"probe": [100]})
+
+        single_output = _handle_output_by_index(output, 1)
+
+        self.assertEqual(
+            unwrap_from_pickle(single_output.time_stats), {"probe": [None]}
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_output_streamer_customized_info.py
+++ b/test/registered/unit/managers/test_output_streamer_customized_info.py
@@ -2,7 +2,6 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
-from sglang.srt.managers.io_struct import unwrap_from_pickle
 from sglang.srt.managers.scheduler_components.output_streamer import (
     _GenerationStreamAccumulator,
 )
@@ -10,6 +9,20 @@ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _make_accumulator():
+    return _GenerationStreamAccumulator(
+        return_logprob=False,
+        return_hidden_states=False,
+        return_routed_experts=False,
+        return_indexer_topk=False,
+        spec_algorithm=SpeculativeAlgorithm.NONE,
+        disaggregation_mode=DisaggregationMode.NULL,
+        default_stream_interval=1,
+        default_force_stream_interval=1,
+        get_cached_tokens_details=lambda req: None,
+    )
 
 
 class _FakeReq:
@@ -55,17 +68,7 @@ class _FakeReq:
 
 class TestOutputStreamerCustomizedInfo(unittest.TestCase):
     def test_customized_info_is_padded_for_mixed_batches(self):
-        accumulator = _GenerationStreamAccumulator(
-            return_logprob=False,
-            return_hidden_states=False,
-            return_routed_experts=False,
-            return_indexer_topk=False,
-            spec_algorithm=SpeculativeAlgorithm.NONE,
-            disaggregation_mode=DisaggregationMode.NULL,
-            default_stream_interval=1,
-            default_force_stream_interval=1,
-            get_cached_tokens_details=lambda req: None,
-        )
+        accumulator = _make_accumulator()
 
         accumulator.accept(req=_FakeReq("r0", [10, 11]))
         accumulator.accept(
@@ -78,7 +81,7 @@ class TestOutputStreamerCustomizedInfo(unittest.TestCase):
         accumulator.accept(req=_FakeReq("r2", [30], customized_info={"other": [300]}))
 
         payload = accumulator.to_payload(dp_rank=0, is_idle_batch=False)
-        customized_info = unwrap_from_pickle(payload.customized_info)
+        customized_info = payload.customized_info
 
         self.assertEqual(payload.output_ids, [[10, 11], [20, 21, 22], [30]])
         self.assertEqual(
@@ -88,6 +91,25 @@ class TestOutputStreamerCustomizedInfo(unittest.TestCase):
         self.assertEqual(
             customized_info["other"],
             [[None, None], [None, None, None], [300]],
+        )
+
+    def test_payload_accepts_native_container_values(self):
+        accumulator = _make_accumulator()
+        accumulator.accept(
+            req=_FakeReq(
+                "r0",
+                [10, 11],
+                customized_info={
+                    "probe": [[1, "tag"], {"ok": True}],
+                },
+            )
+        )
+
+        payload = accumulator.to_payload(dp_rank=0, is_idle_batch=False)
+
+        self.assertEqual(
+            payload.customized_info,
+            {"probe": [[[1, "tag"], {"ok": True}]]},
         )
 
 

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -310,6 +310,18 @@ class TestRidToStateCleanupOnBatchOutput(CustomTestCase):
 
         self.assertIn(rid, tm.rid_to_state)
 
+    def test_batch_output_accumulates_unwrapped_customized_info(self):
+        tm = _make_tokenizer_manager()
+        rid = "batch_customized_info_rid"
+        state = _make_req_state(rid)
+        tm.rid_to_state[rid] = state
+        batch_output = _make_batch_str_output(rid)
+        batch_output.customized_info = {"probe": [[1, "tag"]]}
+
+        asyncio.run(tm._handle_batch_output(batch_output))
+
+        self.assertEqual(state.out_list[0]["meta_info"]["probe"], [1, "tag"])
+
 
 class TestInitReqStateDuplicateDetection(CustomTestCase):
     """Test that _init_req_state raises ValueError for duplicate rids."""

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -301,6 +301,18 @@ class TestRidToStateCleanupOnBatchOutput(CustomTestCase):
 
         self.assertIn(rid, tm.rid_to_state)
 
+    def test_batch_output_accumulates_unwrapped_customized_info(self):
+        tm = _make_tokenizer_manager()
+        rid = "batch_customized_info_rid"
+        state = _make_req_state(rid)
+        tm.rid_to_state[rid] = state
+        batch_output = _make_batch_str_output(rid)
+        batch_output.customized_info = {"probe": [[1, "tag"]]}
+
+        asyncio.run(tm._handle_batch_output(batch_output))
+
+        self.assertEqual(state.out_list[0]["meta_info"]["probe"], [1, "tag"])
+
 
 class TestInitReqStateDuplicateDetection(CustomTestCase):
     """Test that _init_req_state raises ValueError for duplicate rids."""


### PR DESCRIPTION
## Motivation

Follow-up to #28688, which moved the IPC dataclasses to `msgspec.Struct` with opt-in msgpack transport. This completes Task 5 of #29465.

`customized_info` on `BatchTokenIDOutput` and `BatchStrOutput` carried per-request, per-token metadata inside `PickleWrapper`. The scheduler already builds a fixed nested row shape, so msgpack mode should transport supported values directly instead of performing a pickle round-trip for every batch output.

Refs #29465

## Modifications

- Define `CustomizedInfo` as the nested per-request row shape used by `BatchTokenIDOutput` and `BatchStrOutput`, with recursively JSON-native values in msgpack mode.
- Validate the complete scheduler update before changing request state. Unsupported leaves and non-string map keys raise a path-specific `TypeError`; pickle mode retains its existing opaque-value and copy behavior.
- Remove the redundant wrap and unwrap steps from the stream accumulator and tokenizer manager.
- Preserve the nested single-request row when multi-tokenizer output is split. A missing request row becomes `[[]]`.
- Cover nested JSON values, atomic rejection of invalid metadata, msgpack and pickle behavior, output streaming, and multi-tokenizer row alignment.

## Accuracy Tests

Not applicable. This changes the representation of an internal IPC field and does not change model output.

## Speed Tests and Profiling

This removes a pickle encode and decode for `customized_info` on each batch output when msgpack IPC is enabled.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31498038623](https://github.com/sgl-project/sglang/actions/runs/31498038623)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31498038444](https://github.com/sgl-project/sglang/actions/runs/31498038444)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
