### PR TITLE
Fix UE8M0 scale rounding for DeepGEMM

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1499,7 +1499,12 @@ def per_block_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
 
 # COPIED FROM DeepGEMM
 def ceil_to_ue8m0(x: torch.Tensor):
-    return torch.pow(2.0, torch.ceil(torch.log2(x.abs())))
+    bits = x.abs().float().view(torch.int32)
+    exp = (bits >> 23) & 0xFF
+    mantissa = bits & 0x7FFFFF
+    exp = exp + (mantissa != 0).to(torch.int32)
+    exp = exp.clamp(1, 254)
+    return (exp << 23).view(torch.float32)
 
 
 def channel_quant_to_tensor_quant(

--- a/test/manual/quant/test_block_fp8_deep_gemm_blackwell.py
+++ b/test/manual/quant/test_block_fp8_deep_gemm_blackwell.py
@@ -46,7 +46,12 @@ def per_block_quant_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
 
 def ceil_to_ue8m0(x: torch.Tensor):
     assert x.view(-1).amax().item() > 0
-    return torch.pow(2.0, torch.ceil(torch.log2(x.abs())))
+    bits = x.abs().float().view(torch.int32)
+    exp = (bits >> 23) & 0xFF
+    mantissa = bits & 0x7FFFFF
+    exp = exp + (mantissa != 0).to(torch.int32)
+    exp = exp.clamp(1, 254)
+    return (exp << 23).view(torch.float32)
 
 
 def per_token_group_quant_mxfp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
## Summary

Fix #29954 by making UE8M0 scale rounding bit-exact with DeepGEMM, as suggested in the issue

## Accuracy Test

```bash
sglang serve \
  --model-path zai-org/GLM-5.2-FP8 \
  --tensor-parallel-size 4 \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 5 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 6
```

```bash
sgl-eval run gsm8k \
  --base-url http://127.0.0.1:30000/v1 \
  --num-threads 48 \
  --max-tokens 64000 \
  --temperature 1.0 \
  --top-p 0.95

Run directory: /root/.sgl_eval/sgl_eval_gsm8k_20260702-153500
gsm8k: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [12:35<00:00,  1.75it/s, acc=97.27%]
== gsm8k ==
1319 examples (single-shot)  |  755.8s  |  1610 tok/s  |  1.2M tokens

* score           =  97.27%
  stop_rate       =  100.00%
  truncated_rate  =  0.00%
  error_rate      =  0.00%

Metrics: /root/.sgl_eval/sgl_eval_gsm8k_20260702-153500/metrics.json
Predictions: /root/.sgl_eval/sgl_eval_gsm8k_20260702-153500  (1 jsonl file(s))
```





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28606459405](https://github.com/sgl-project/sglang/actions/runs/28606459405)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28606459168](https://github.com/sgl-project/sglang/actions/runs/28606459168)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->