### PR TITLE
Fix PDMux prefill commit stream dependency

### DIFF
--- a/python/sglang/srt/multiplex/multiplexing_mixin.py
+++ b/python/sglang/srt/multiplex/multiplexing_mixin.py
@@ -212,7 +212,10 @@ class SchedulerMultiplexMixin:
                             self.running_batch.merge_batch(self.split_prefill_batch)
                         else:
                             self.running_batch = self.split_prefill_batch
-
+                        # FIX: event-based stream dependency
+                        self.prefill_commit_done = torch.cuda.Event()
+                        self.prefill_commit_done.record(prefill_stream)
+                        decode_stream.wait_event(self.prefill_commit_done)
                         self.split_prefill_batch = None
                         wait_prefill_kernel_done = False
                         adjust_stream_group = True


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`--enable-pdmux` can crash with a CUDA device-side assert when a split-prefill batch is committed into an existing running decode batch.

The error looks like:

```text
/pytorch/aten/src/ATen/native/cuda/IndexKernel.cu:113:
Assertion `-sizes[i] <= index && index < sizes[i] && "index out of bounds"` failed.
```

I narrowed this down to a missing `prefill_stream -> decode_stream` dependency after `process_batch_result(self.split_prefill_batch, prefill_result)` and `running_batch.merge_batch(self.split_prefill_batch)`.
`merge_batch()` performs CUDA tensor operations such as `torch.cat` on batch metadata tensors under `prefill_stream`. The Python `running_batch` object is updated immediately, but the GPU-side merged metadata may still be pending on `prefill_stream`. Later, `decode_stream` can consume the merged `running_batch` before those updates complete.
Fixes #29958

## Modifications

This PR records a CUDA event after the split-prefill result is processed and committed into `running_batch`, and makes `decode_stream` wait on that event before consuming the merged `running_batch`.
This avoids using `prefill_stream.synchronize()` or `torch.cuda.synchronize()`, so the fix preserves asynchronous execution and only adds the required cross-stream dependency.

## Accuracy Tests

This change only adds stream ordering between prefill commit and subsequent decode consumption. It does not change model weights, kernels, sampling semantics, or model outputs.
I verified that generation requests complete correctly with PDMux enabled after the fix.
## Speed Tests and Profiling

I compared the following cases on A100 with Qwen2.5-7B:
* PDMux without the fix: crashes with `IndexKernel.cu` device-side assert
* PDMux with `prefill_stream.synchronize()` after `merge_batch()`: stable but uses blocking stream synchronization
* PDMux with this event-based dependency: stable
The event-based fix avoids global or stream-wide CPU blocking synchronization and only makes decode_stream wait for the required prefill commit event.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
