### PR TITLE
[Docs] Use trtllm_mha for Qwen3.6 B300

### DIFF
--- a/docs_new/src/snippets/autoregressive/qwen36-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/qwen36-deployment.jsx
@@ -222,11 +222,8 @@ export const Qwen36Deployment = () => {
       }
     }
 
-    if (hardware === 'b200') {
+    if (hardware === 'b200' || hardware === 'b300') {
       cmd += ` \\\n  --attention-backend trtllm_mha`;
-    }
-    if (hardware === 'b300') {
-      cmd += ` \\\n  --attention-backend flashinfer`;
     }
     if (hwConfig.mem !== undefined) {
       cmd += ` \\\n  --mem-fraction-static ${hwConfig.mem}`;


### PR DESCRIPTION
## Summary

Noticed Qwen3.6 had B300 using `flashinfer` for some reason, so this switches it to `trtllm_mha` like B200











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28607705486](https://github.com/sgl-project/sglang/actions/runs/28607705486)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28607705045](https://github.com/sgl-project/sglang/actions/runs/28607705045)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->