### PR TITLE
[codex] Add CUDA 12.2 compatibility fallbacks

### DIFF
--- a/python/sglang/jit_kernel/nvfp4.py
+++ b/python/sglang/jit_kernel/nvfp4.py
@@ -4,6 +4,7 @@ import os
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import torch
+from packaging import version as pkg_version
 
 from sglang.jit_kernel.utils import cache_once, load_jit, override_jit_cuda_arch
 from sglang.kernel_api_logging import debug_kernel_api
@@ -14,7 +15,22 @@ if TYPE_CHECKING:
 
 
 _FLOAT4_E2M1_MAX = 6.0
-_FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+
+def _get_fp8_e4m3_max() -> float:
+    fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+    if fp8_dtype is None:
+        return 448.0
+    if pkg_version.parse(torch.__version__).release < (2, 3):
+        return 448.0
+    try:
+        return torch.finfo(fp8_dtype).max
+    except RuntimeError:
+        # CUDA 12.2-era PyTorch builds may expose the dtype before finfo support.
+        return 448.0
+
+
+_FLOAT8_E4M3_MAX = _get_fp8_e4m3_max()
 
 
 def _nvfp4_cuda_flags() -> list[str]:

--- a/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
+++ b/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
@@ -1,6 +1,7 @@
 # Adapted from https://github.com/thinking-machines-lab/batch_invariant_ops/blob/main/batch_invariant_ops/batch_invariant_ops.py
 
 import contextlib
+import inspect
 from collections import namedtuple
 from collections.abc import Callable
 from typing import Any, Dict, Tuple
@@ -66,6 +67,17 @@ def _matmul_launch_metadata(
     return ret
 
 
+_TRITON_JIT_SUPPORTS_LAUNCH_METADATA = (
+    "launch_metadata" in inspect.signature(triton.jit).parameters
+)
+
+
+def _triton_jit_with_matmul_metadata(fn):
+    if _TRITON_JIT_SUPPORTS_LAUNCH_METADATA:
+        return triton.jit(launch_metadata=_matmul_launch_metadata)(fn)
+    return triton.jit(fn)
+
+
 @triton.jit
 def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS):
     group_id = tile_id // num_pid_in_group
@@ -76,7 +88,7 @@ def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS):
     return pid_m, pid_n
 
 
-@triton.jit(launch_metadata=_matmul_launch_metadata)
+@_triton_jit_with_matmul_metadata
 def matmul_kernel_persistent(
     a_ptr,
     b_ptr,

--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -1,47 +1,74 @@
-from sglang.srt.configs.afmoe import AfmoeConfig
-from sglang.srt.configs.bailing_hybrid import BailingHybridConfig
-from sglang.srt.configs.chatglm import ChatGLMConfig
-from sglang.srt.configs.cohere2_moe import Cohere2MoeConfig
-from sglang.srt.configs.dbrx import DbrxConfig
-from sglang.srt.configs.deepseekvl2 import DeepseekVL2Config
-from sglang.srt.configs.dots_ocr import DotsOCRConfig
-from sglang.srt.configs.dots_vlm import DotsVLMConfig
-from sglang.srt.configs.exaone import ExaoneConfig
-from sglang.srt.configs.falcon_h1 import FalconH1Config
-from sglang.srt.configs.granitemoehybrid import GraniteMoeHybridConfig
-from sglang.srt.configs.interns2preview import InternS2PreviewConfig
-from sglang.srt.configs.janus_pro import MultiModalityConfig
-from sglang.srt.configs.jet_nemotron import JetNemotronConfig
-from sglang.srt.configs.jet_vlm import JetVLMConfig
-from sglang.srt.configs.kimi_k25 import KimiK25Config
-from sglang.srt.configs.kimi_linear import KimiLinearConfig
-from sglang.srt.configs.kimi_vl import KimiVLConfig
-from sglang.srt.configs.kimi_vl_moonvit import MoonViTConfig
-from sglang.srt.configs.laguna import LagunaConfig
-from sglang.srt.configs.lfm2 import Lfm2Config
-from sglang.srt.configs.lfm2_moe import Lfm2MoeConfig
-from sglang.srt.configs.lfm2_vl import Lfm2VlConfig
-from sglang.srt.configs.locate_anything import LocateAnythingConfig
-from sglang.srt.configs.longcat_flash import LongcatFlashConfig
-from sglang.srt.configs.minicpmv4_6 import MiniCPMV4_6Config, MiniCPMV4_6VisionConfig
-from sglang.srt.configs.nano_nemotron_vl import (
-    NemotronH_Nano_Omni_Reasoning_V3_Config,
-    NemotronH_Nano_VL_V2_Config,
-)
-from sglang.srt.configs.nemotron_h import NemotronHConfig, NemotronHPuzzleConfig
-from sglang.srt.configs.olmo3 import Olmo3Config
-from sglang.srt.configs.qwen3_5 import Qwen3_5Config, Qwen3_5MoeConfig
-from sglang.srt.configs.qwen3_asr import Qwen3ASRConfig
-from sglang.srt.configs.qwen3_next import Qwen3NextConfig
-from sglang.srt.configs.step3_vl import (
-    Step3TextConfig,
-    Step3VisionEncoderConfig,
-    Step3VLConfig,
-)
-from sglang.srt.configs.step3p5 import Step3p5Config
-from sglang.srt.configs.step3p7 import Step3p7Config
-from sglang.srt.configs.unlimited_ocr import UnlimitedVLConfig
-from sglang.srt.configs.zaya import ZayaConfig
+from importlib import import_module
+
+
+_CONFIG_IMPORTS = [
+    ("sglang.srt.configs.afmoe", ("AfmoeConfig",)),
+    ("sglang.srt.configs.bailing_hybrid", ("BailingHybridConfig",)),
+    ("sglang.srt.configs.chatglm", ("ChatGLMConfig",)),
+    ("sglang.srt.configs.cohere2_moe", ("Cohere2MoeConfig",)),
+    ("sglang.srt.configs.dbrx", ("DbrxConfig",)),
+    ("sglang.srt.configs.deepseekvl2", ("DeepseekVL2Config",)),
+    ("sglang.srt.configs.dots_ocr", ("DotsOCRConfig",)),
+    ("sglang.srt.configs.dots_vlm", ("DotsVLMConfig",)),
+    ("sglang.srt.configs.exaone", ("ExaoneConfig",)),
+    ("sglang.srt.configs.falcon_h1", ("FalconH1Config",)),
+    ("sglang.srt.configs.granitemoehybrid", ("GraniteMoeHybridConfig",)),
+    ("sglang.srt.configs.interns2preview", ("InternS2PreviewConfig",)),
+    ("sglang.srt.configs.janus_pro", ("MultiModalityConfig",)),
+    ("sglang.srt.configs.jet_nemotron", ("JetNemotronConfig",)),
+    ("sglang.srt.configs.jet_vlm", ("JetVLMConfig",)),
+    ("sglang.srt.configs.kimi_k25", ("KimiK25Config",)),
+    ("sglang.srt.configs.kimi_linear", ("KimiLinearConfig",)),
+    ("sglang.srt.configs.kimi_vl", ("KimiVLConfig",)),
+    ("sglang.srt.configs.kimi_vl_moonvit", ("MoonViTConfig",)),
+    ("sglang.srt.configs.laguna", ("LagunaConfig",)),
+    ("sglang.srt.configs.lfm2", ("Lfm2Config",)),
+    ("sglang.srt.configs.lfm2_moe", ("Lfm2MoeConfig",)),
+    ("sglang.srt.configs.lfm2_vl", ("Lfm2VlConfig",)),
+    ("sglang.srt.configs.locate_anything", ("LocateAnythingConfig",)),
+    ("sglang.srt.configs.longcat_flash", ("LongcatFlashConfig",)),
+    (
+        "sglang.srt.configs.minicpmv4_6",
+        ("MiniCPMV4_6Config", "MiniCPMV4_6VisionConfig"),
+    ),
+    (
+        "sglang.srt.configs.nano_nemotron_vl",
+        (
+            "NemotronH_Nano_Omni_Reasoning_V3_Config",
+            "NemotronH_Nano_VL_V2_Config",
+        ),
+    ),
+    (
+        "sglang.srt.configs.nemotron_h",
+        ("NemotronHConfig", "NemotronHPuzzleConfig"),
+    ),
+    ("sglang.srt.configs.olmo3", ("Olmo3Config",)),
+    ("sglang.srt.configs.qwen3_5", ("Qwen3_5Config", "Qwen3_5MoeConfig")),
+    ("sglang.srt.configs.qwen3_asr", ("Qwen3ASRConfig",)),
+    ("sglang.srt.configs.qwen3_next", ("Qwen3NextConfig",)),
+    (
+        "sglang.srt.configs.step3_vl",
+        ("Step3TextConfig", "Step3VisionEncoderConfig", "Step3VLConfig"),
+    ),
+    ("sglang.srt.configs.step3p5", ("Step3p5Config",)),
+    ("sglang.srt.configs.step3p7", ("Step3p7Config",)),
+    ("sglang.srt.configs.unlimited_ocr", ("UnlimitedVLConfig",)),
+    ("sglang.srt.configs.zaya", ("ZayaConfig",)),
+]
+
+
+def _try_import_configs(module_name: str, names: tuple[str, ...]) -> None:
+    try:
+        module = import_module(module_name)
+    except (ImportError, ModuleNotFoundError, AttributeError):
+        return
+    for name in names:
+        globals()[name] = getattr(module, name)
+
+
+for _module_name, _names in _CONFIG_IMPORTS:
+    _try_import_configs(_module_name, _names)
+
 
 __all__ = [
     "AfmoeConfig",
@@ -87,3 +114,5 @@ __all__ = [
     "UnlimitedVLConfig",
     "ZayaConfig",
 ]
+
+__all__ = [name for name in __all__ if name in globals()]

--- a/python/sglang/srt/configs/cohere2_moe.py
+++ b/python/sglang/srt/configs/cohere2_moe.py
@@ -1,11 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 """Cohere2Moe text config used by the Cohere Command-A Plus checkpoints."""
 
-from transformers.configuration_utils import PreTrainedConfig
+try:
+    from transformers.configuration_utils import PreTrainedConfig
+except ImportError:
+    from transformers.configuration_utils import PretrainedConfig as PreTrainedConfig
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
 try:
-    from huggingface_hub.dataclasses import strict
+    from huggingface_hub.dataclasses import strict as _hf_strict
+
+    def strict(cls):  # type: ignore[misc]
+        try:
+            return _hf_strict(cls)
+        except Exception:
+            return cls
+
 except ImportError:  # older huggingface_hub
 
     def strict(cls):  # type: ignore[misc]

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -74,7 +74,6 @@ from sglang.srt.mem_cache.common import (
     page_align_floor,
     release_kv_cache,
 )
-from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.memory_pool import (
     HybridReqToTokenPool,
     KVCache,
@@ -97,6 +96,10 @@ if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler
 
 CLIP_MAX_NEW_TOKEN = envs.SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION.get()
+
+
+def _is_deepseek_v4_token_to_kv_pool(token_to_kv_pool) -> bool:
+    return type(token_to_kv_pool).__name__ == "DeepSeekV4TokenToKVPool"
 
 
 def _bootstrap_addr(req: Req) -> str:
@@ -349,7 +352,10 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
     def _uses_swa_tail_prealloc(self) -> bool:
         return (
-            isinstance(self.token_to_kv_pool, (SWAKVPool, DeepSeekV4TokenToKVPool))
+            (
+                isinstance(self.token_to_kv_pool, SWAKVPool)
+                or _is_deepseek_v4_token_to_kv_pool(self.token_to_kv_pool)
+            )
             and self.token_to_kv_pool_allocator.page_size > 1
             and hasattr(self.token_to_kv_pool_allocator, "alloc_extend_swa_tail")
         )
@@ -410,8 +416,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             if self.scheduler.enable_hisparse
             else ["VRAM"] * len(kv_data_ptrs)
         )
-        if self.scheduler.enable_hisparse and isinstance(
-            self.token_to_kv_pool, DeepSeekV4TokenToKVPool
+        if self.scheduler.enable_hisparse and _is_deepseek_v4_token_to_kv_pool(
+            self.token_to_kv_pool
         ):
             device_kv_data_ptrs, device_kv_data_lens, device_kv_item_lens = (
                 self.token_to_kv_pool.get_contiguous_buf_infos()

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -61,7 +61,6 @@ from sglang.srt.mem_cache.common import (
     maybe_cache_unfinished_req,
     release_kv_cache,
 )
-from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
 from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 
@@ -72,6 +71,10 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
 
 logger = logging.getLogger(__name__)
+
+
+def _is_deepseek_v4_token_to_kv_pool(token_to_kv_pool) -> bool:
+    return type(token_to_kv_pool).__name__ == "DeepSeekV4TokenToKVPool"
 
 
 def should_force_retry(req: Req) -> bool:
@@ -196,7 +199,7 @@ class PrefillBootstrapQueue:
             req_to_token_pool=req_to_token_pool,
         )
 
-        if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+        if _is_deepseek_v4_token_to_kv_pool(self.token_to_kv_pool):
             # V4's KVCache is organized by compression-ratio
             # buckets rather than by layer.
             kv_args.mla_compression_ratios = list(

--- a/python/sglang/srt/distributed/device_communicators/pynccl_allocator.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl_allocator.py
@@ -4,14 +4,24 @@ import os
 import tempfile
 import traceback
 from contextlib import nullcontext
+from typing import Any
 
 import torch
-from torch.cuda.memory import (
-    CUDAPluggableAllocator,
-    _cuda_beginAllocateCurrentThreadToPool,
-    _cuda_endAllocateToPool,
-    _cuda_releasePool,
-)
+try:
+    from torch.cuda.memory import CUDAPluggableAllocator
+except ImportError:
+    CUDAPluggableAllocator = None
+
+try:
+    from torch.cuda.memory import (
+        _cuda_beginAllocateCurrentThreadToPool,
+        _cuda_endAllocateToPool,
+        _cuda_releasePool,
+    )
+except ImportError:
+    _cuda_beginAllocateCurrentThreadToPool = None
+    _cuda_endAllocateToPool = None
+    _cuda_releasePool = None
 
 from sglang.srt.distributed.parallel_state import GroupCoordinator
 from sglang.srt.environ import envs
@@ -19,6 +29,25 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils.common import torch_release
 
 after_2_8_0 = torch_release >= (2, 8)
+_PYNCCL_ALLOCATOR_REQUIRED_APIS = (
+    CUDAPluggableAllocator is not None
+    and _cuda_beginAllocateCurrentThreadToPool is not None
+    and _cuda_endAllocateToPool is not None
+    and _cuda_releasePool is not None
+    and hasattr(torch.cuda, "MemPool")
+)
+
+
+def is_pynccl_allocator_supported() -> bool:
+    return _PYNCCL_ALLOCATOR_REQUIRED_APIS
+
+
+def _raise_pynccl_allocator_unsupported() -> None:
+    raise RuntimeError(
+        "NCCL symmetric-memory allocator requires PyTorch CUDA memory-pool APIs "
+        "that are not available in this PyTorch build. Disable symmetric memory "
+        "or use a newer PyTorch build."
+    )
 
 # C++ source for the NCCL allocator plugin
 # Key design:
@@ -182,7 +211,7 @@ def restore_symmetric_memory_context(saved_context):
         saved_context.__enter__()
 
 
-def get_nccl_mem_pool() -> torch.cuda.MemPool:
+def get_nccl_mem_pool() -> Any:
     """
     Get the shared MemPool for all groups.
 
@@ -190,6 +219,8 @@ def get_nccl_mem_pool() -> torch.cuda.MemPool:
     Comm registration is handled at context exit time.
     """
     global _allocator, _mem_pool, _cur_device, _register_func
+    if not is_pynccl_allocator_supported():
+        _raise_pynccl_allocator_unsupported()
     if _allocator is None:
         import torch.utils.cpp_extension
 
@@ -328,6 +359,8 @@ def use_symmetric_memory(group_coordinator: GroupCoordinator, disabled: bool = F
         or disabled
         or group_coordinator.world_size == 1
     )
+    if not disabled and not is_pynccl_allocator_supported():
+        _raise_pynccl_allocator_unsupported()
     return SymmetricMemoryContext(group_coordinator) if not disabled else nullcontext()
 
 

--- a/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
+++ b/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
@@ -12,7 +12,10 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-import torch.distributed._symmetric_memory as symm_mem
+try:
+    import torch.distributed._symmetric_memory as symm_mem
+except ModuleNotFoundError:
+    symm_mem = None
 import triton
 import triton.language as tl
 

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1924,7 +1924,9 @@ def init_distributed_environment(
             "distributed_init_method must be provided when initializing "
             "distributed environment"
         )
-        if timeout is not None:
+        if timeout is None:
+            timeout = timedelta(seconds=1800)
+        else:
             assert isinstance(timeout, (int)), "timeout must be a number"
             assert timeout > 0, "timeout must be positive"
             timeout = timedelta(seconds=timeout)

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -30,6 +30,7 @@ import signal
 import tempfile
 import threading
 import time
+from importlib.metadata import PackageNotFoundError, version
 from typing import (
     Any,
     AsyncIterator,
@@ -1309,11 +1310,20 @@ def _set_envs_and_config(server_args: ServerArgs):
                 "at https://docs.flashinfer.ai/installation.html.",
             )
         if _is_cuda:
-            assert_pkg_version(
-                "sglang-kernel",
-                "0.4.4",
-                "Please reinstall the latest version with `pip install sglang-kernel --force-reinstall`",
-            )
+            try:
+                version("sglang-kernel")
+            except PackageNotFoundError:
+                logger.warning(
+                    "sglang-kernel>=0.4.4 is not installed; CUDA paths that "
+                    "require sgl-kernel AOT ops will fail, but pure PyTorch/JIT "
+                    "fallback paths can still run."
+                )
+            else:
+                assert_pkg_version(
+                    "sglang-kernel",
+                    "0.4.4",
+                    "Please reinstall the latest version with `pip install sglang-kernel --force-reinstall`",
+                )
 
     # Signal handlers can only be registered from the main thread.
     if threading.current_thread() is threading.main_thread():

--- a/python/sglang/srt/entrypoints/openai/transcription_adapters/__init__.py
+++ b/python/sglang/srt/entrypoints/openai/transcription_adapters/__init__.py
@@ -1,3 +1,6 @@
+import importlib
+import logging
+
 # Re-export the public API from base so callers can do:
 #   from ...transcription_adapters import TranscriptionAdapter, register_transcription_adapter
 from sglang.srt.entrypoints.openai.transcription_adapters.base import (  # noqa: F401
@@ -6,22 +9,41 @@ from sglang.srt.entrypoints.openai.transcription_adapters.base import (  # noqa:
     resolve_adapter,
 )
 
-# Import built-in adapters so they self-register via @register_transcription_adapter.
-from sglang.srt.entrypoints.openai.transcription_adapters.mimo_v2_asr import (  # noqa: F401
-    MiMoV2ASRAdapter,
-)
-from sglang.srt.entrypoints.openai.transcription_adapters.qwen3_asr import (  # noqa: F401
-    Qwen3ASRAdapter,
-)
-from sglang.srt.entrypoints.openai.transcription_adapters.whisper import (  # noqa: F401
-    WhisperAdapter,
-)
+logger = logging.getLogger(__name__)
+
+
+def _try_import_adapter(module_name: str, class_name: str):
+    try:
+        module = importlib.import_module(
+            f"sglang.srt.entrypoints.openai.transcription_adapters.{module_name}"
+        )
+    except (ImportError, ModuleNotFoundError, AttributeError) as e:
+        logger.debug("Skipping transcription adapter %s: %s", module_name, e)
+        return None
+
+    adapter_cls = getattr(module, class_name)
+    globals()[class_name] = adapter_cls
+    return adapter_cls
+
+
+# Import built-in adapters so they self-register via @register_transcription_adapter
+# when their optional dependencies are available.
+WhisperAdapter = _try_import_adapter("whisper", "WhisperAdapter")
+Qwen3ASRAdapter = _try_import_adapter("qwen3_asr", "Qwen3ASRAdapter")
+MiMoV2ASRAdapter = _try_import_adapter("mimo_v2_asr", "MiMoV2ASRAdapter")
 
 __all__ = [
     "TranscriptionAdapter",
     "register_transcription_adapter",
     "resolve_adapter",
-    "WhisperAdapter",
-    "Qwen3ASRAdapter",
-    "MiMoV2ASRAdapter",
+]
+
+__all__ += [
+    name
+    for name, adapter_cls in (
+        ("WhisperAdapter", WhisperAdapter),
+        ("Qwen3ASRAdapter", Qwen3ASRAdapter),
+        ("MiMoV2ASRAdapter", MiMoV2ASRAdapter),
+    )
+    if adapter_cls is not None
 ]

--- a/python/sglang/srt/kv_canary/api.py
+++ b/python/sglang/srt/kv_canary/api.py
@@ -5,13 +5,8 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import torch
 
-from sglang.srt.kv_canary.capacities import CanaryLaunchCapacities
 from sglang.srt.kv_canary.config import CanaryConfig, CanaryMode
-from sglang.srt.kv_canary.perturb.config import PerturbConfig
-from sglang.srt.kv_canary.pool_patcher.api import attach_canary_buffers
 from sglang.srt.kv_canary.pool_patcher.utils import wrap_method
-from sglang.srt.kv_canary.runner.canary_manager import CanaryManager
-from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     Phase,
@@ -20,6 +15,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 if TYPE_CHECKING:
+    from sglang.srt.kv_canary.runner.canary_manager import CanaryManager
     from sglang.srt.kv_canary.token_oracle.oracle_manager import TokenOracleManager
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.server_args import ServerArgs
@@ -36,6 +32,12 @@ def install_canary(
     config = CanaryConfig.from_env(server_args)
     if config.mode is CanaryMode.NONE:
         return None
+
+    from sglang.srt.kv_canary.capacities import CanaryLaunchCapacities
+    from sglang.srt.kv_canary.perturb.config import PerturbConfig
+    from sglang.srt.kv_canary.pool_patcher.api import attach_canary_buffers
+    from sglang.srt.kv_canary.runner.canary_manager import CanaryManager
+    from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
 
     assert not check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE), (
         "kv-canary: piecewise cuda graph is not supported by the current "

--- a/python/sglang/srt/kv_canary/pool_patcher/api.py
+++ b/python/sglang/srt/kv_canary/pool_patcher/api.py
@@ -7,11 +7,9 @@ import torch
 
 from sglang.srt.kv_canary.buffer_group import CanaryBufferGroup
 from sglang.srt.kv_canary.config import CanaryConfig
-from sglang.srt.kv_canary.pool_patcher.adapters.dsv4 import attach_dsv4
 from sglang.srt.kv_canary.pool_patcher.adapters.mha import attach_mha
 from sglang.srt.kv_canary.pool_patcher.adapters.swa import attach_swa
 from sglang.srt.kv_canary.pool_patcher.buffer_alloc import resolve_real_kv_read_bytes
-from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.memory_pool import (
     KVCache,
     MHATokenToKVPool,
@@ -27,8 +25,15 @@ _POOL_ATTACHERS: Dict[Type, PoolAttacher] = {
     MHATokenToKVPool: attach_mha,
     MHATokenToKVPoolFP4: attach_mha,
     SWAKVPool: attach_swa,
-    DeepSeekV4TokenToKVPool: attach_dsv4,
 }
+
+try:
+    from sglang.srt.kv_canary.pool_patcher.adapters.dsv4 import attach_dsv4
+    from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+
+    _POOL_ATTACHERS[DeepSeekV4TokenToKVPool] = attach_dsv4
+except (ImportError, ModuleNotFoundError, AttributeError, TypeError):
+    logger.debug("Skipping DeepSeekV4 KV canary pool attacher.")
 
 
 def register_pool_attacher(pool_class: Type, attacher: PoolAttacher) -> None:

--- a/python/sglang/srt/layers/attention/fla/utils.py
+++ b/python/sglang/srt/layers/attention/fla/utils.py
@@ -326,14 +326,20 @@ if torch_release >= (2, 4):
         return device_torch_lib.device(index)
 
 else:
-    assert (
-        device == "cuda"
-    ), "Only cuda device is supported for PyTorch version < 2.4.0."
-    autocast_custom_fwd = device_torch_lib.amp.custom_fwd
-    autocast_custom_bwd = device_torch_lib.amp.custom_bwd
+    if device == "cuda":
+        autocast_custom_fwd = device_torch_lib.amp.custom_fwd
+        autocast_custom_bwd = device_torch_lib.amp.custom_bwd
+    elif torch.cuda.is_available():
+        autocast_custom_fwd = torch.cuda.amp.custom_fwd
+        autocast_custom_bwd = torch.cuda.amp.custom_bwd
+    else:
+        autocast_custom_fwd = lambda fn=None, **_: fn if fn is not None else lambda f: f
+        autocast_custom_bwd = lambda fn=None, **_: fn if fn is not None else lambda f: f
 
     def custom_device_ctx(index: int):
-        return torch.cuda.device(index)
+        if torch.cuda.is_available():
+            return torch.cuda.device(index)
+        return contextlib.nullcontext()
 
 
 device_platform = get_available_device()

--- a/python/sglang/srt/layers/attention/torch_native_backend.py
+++ b/python/sglang/srt/layers/attention/torch_native_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -14,6 +15,55 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+@lru_cache(maxsize=1)
+def _sdpa_supports_enable_gqa() -> bool:
+    q = torch.empty((1, 1, 1, 1), device="cpu")
+    try:
+        scaled_dot_product_attention(q, q, q, enable_gqa=False)
+        return True
+    except TypeError as e:
+        if "enable_gqa" in str(e):
+            return False
+        raise
+
+
+def _scaled_dot_product_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    attn_mask: Optional[torch.Tensor],
+    enable_gqa: bool,
+    scale: Optional[float],
+    is_causal: bool,
+) -> torch.Tensor:
+    if _sdpa_supports_enable_gqa():
+        return scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=attn_mask,
+            enable_gqa=enable_gqa,
+            scale=scale,
+            is_causal=is_causal,
+        )
+
+    if enable_gqa and query.shape[-3] != key.shape[-3]:
+        assert query.shape[-3] % key.shape[-3] == 0
+        repeat_factor = query.shape[-3] // key.shape[-3]
+        key = key.repeat_interleave(repeat_factor, dim=-3)
+        value = value.repeat_interleave(repeat_factor, dim=-3)
+
+    return scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_mask=attn_mask,
+        scale=scale,
+        is_causal=is_causal,
+    )
 
 
 class TorchNativeAttnBackend(AttentionBackend):
@@ -157,7 +207,7 @@ class TorchNativeAttnBackend(AttentionBackend):
                 is_causal = False
 
             per_req_out_redudant = (
-                scaled_dot_product_attention(
+                _scaled_dot_product_attention(
                     per_req_query_redudant.unsqueeze(0),
                     per_req_key.unsqueeze(0),
                     per_req_value.unsqueeze(0),
@@ -259,7 +309,7 @@ class TorchNativeAttnBackend(AttentionBackend):
                 is_causal = False
 
             per_req_out = (
-                scaled_dot_product_attention(
+                _scaled_dot_product_attention(
                     per_req_query.unsqueeze(0),
                     per_req_key.unsqueeze(0),
                     per_req_value.unsqueeze(0),

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -45,6 +45,8 @@ from sglang.srt.utils import (
     is_xpu,
 )
 
+logger = logging.getLogger(__name__)
+
 _is_cuda = is_cuda()
 _is_flashinfer_available = is_flashinfer_available()
 _is_hip = is_hip()
@@ -55,6 +57,7 @@ _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 _is_xpu = is_xpu()
 _flashinfer_layernorm_available = False
+_sgl_kernel_norm_available = False
 
 if _is_cuda or _is_xpu or _is_musa:
     if _is_flashinfer_available:
@@ -86,29 +89,54 @@ if _is_cuda or _is_xpu or _is_musa:
     else:
         _flashinfer_layernorm_available = False
 
-    from sgl_kernel import fused_add_rmsnorm as _sgl_fused_add_rmsnorm
-    from sgl_kernel import gemma_fused_add_rmsnorm as _sgl_gemma_fused_add_rmsnorm
-    from sgl_kernel import gemma_rmsnorm as _sgl_gemma_rmsnorm
-    from sgl_kernel import rmsnorm as _sgl_rmsnorm
+    def _register_sgl_kernel_norm_ops():
+        from sgl_kernel import fused_add_rmsnorm as _sgl_fused_add_rmsnorm
+        from sgl_kernel import gemma_fused_add_rmsnorm as _sgl_gemma_fused_add_rmsnorm
+        from sgl_kernel import gemma_rmsnorm as _sgl_gemma_rmsnorm
+        from sgl_kernel import rmsnorm as _sgl_rmsnorm
 
-    from sglang.srt.utils.custom_op import register_custom_op_from_extern
+        from sglang.srt.utils.custom_op import register_custom_op_from_extern
 
-    rmsnorm = register_custom_op_from_extern(
-        _sgl_rmsnorm, op_name="sgl_rmsnorm", out_shape="input"
-    )
-    fused_add_rmsnorm = register_custom_op_from_extern(
-        _sgl_fused_add_rmsnorm,
-        op_name="sgl_fused_add_rmsnorm",
-        mutates_args=["input", "residual"],
-    )
-    gemma_rmsnorm = register_custom_op_from_extern(
-        _sgl_gemma_rmsnorm, op_name="sgl_gemma_rmsnorm", out_shape="input"
-    )
-    gemma_fused_add_rmsnorm = register_custom_op_from_extern(
-        _sgl_gemma_fused_add_rmsnorm,
-        op_name="sgl_gemma_fused_add_rmsnorm",
-        mutates_args=["input", "residual"],
-    )
+        return (
+            register_custom_op_from_extern(
+                _sgl_rmsnorm, op_name="sgl_rmsnorm", out_shape="input"
+            ),
+            register_custom_op_from_extern(
+                _sgl_fused_add_rmsnorm,
+                op_name="sgl_fused_add_rmsnorm",
+                mutates_args=["input", "residual"],
+            ),
+            register_custom_op_from_extern(
+                _sgl_gemma_rmsnorm, op_name="sgl_gemma_rmsnorm", out_shape="input"
+            ),
+            register_custom_op_from_extern(
+                _sgl_gemma_fused_add_rmsnorm,
+                op_name="sgl_gemma_fused_add_rmsnorm",
+                mutates_args=["input", "residual"],
+            ),
+        )
+
+    if _is_cuda:
+        try:
+            (
+                rmsnorm,
+                fused_add_rmsnorm,
+                gemma_rmsnorm,
+                gemma_fused_add_rmsnorm,
+            ) = _register_sgl_kernel_norm_ops()
+            _sgl_kernel_norm_available = True
+        except ImportError:
+            logger.debug(
+                "sgl_kernel norm ops are unavailable; using native RMSNorm fallbacks."
+            )
+    else:
+        (
+            rmsnorm,
+            fused_add_rmsnorm,
+            gemma_rmsnorm,
+            gemma_fused_add_rmsnorm,
+        ) = _register_sgl_kernel_norm_ops()
+        _sgl_kernel_norm_available = True
 _has_aiter_layer_norm = False
 _has_vllm_rms_norm = False
 if _use_aiter:
@@ -152,8 +180,6 @@ if _is_cuda:
         is_supported_jit_fused_add_rmsnorm_hidden_size,
     )
 
-
-logger = logging.getLogger(__name__)
 
 if _is_npu:
     import torch_npu
@@ -311,6 +337,11 @@ class RMSNorm(MultiPlatformOp):
                 # Fallback: pure-Python HF semantics (already implemented in forward_native).
                 out = self.forward_native(x, None, None)
             if needs_reshape:
+                out = out.reshape(original_shape)
+            return out
+        if not _sgl_kernel_norm_available:
+            out = self.forward_native(x, residual, post_residual_addition)
+            if needs_reshape and residual is None:
                 out = out.reshape(original_shape)
             return out
         if residual is not None:
@@ -691,6 +722,9 @@ class GemmaRMSNorm(MultiPlatformOp):
         residual: Optional[torch.Tensor] = None,
         post_residual_addition: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        if not _sgl_kernel_norm_available:
+            return self.forward_native(x, residual, post_residual_addition)
+
         needs_reshape = x.dim() != 2 and residual is None
         if needs_reshape:
             original_shape = x.shape
@@ -919,6 +953,8 @@ class Gemma4RMSNorm(MultiPlatformOp):
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
         if x.numel() == 0:
             return x
+        if not _sgl_kernel_norm_available:
+            return self.forward_native(x)
         needs_reshape = x.dim() != 2
         if needs_reshape:
             original_shape = x.shape

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -21,7 +21,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
 from torch import nn
 
-from sglang.srt.distributed.device_communicators import triton_symm_mem_ag
 from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import (
     DpPaddingMode,
@@ -33,7 +32,18 @@ from sglang.srt.layers.dp_attention import (
     get_dp_dtype,
     get_dp_hidden_size,
 )
-from sglang.srt.layers.triton_ops.softcap import softcap_inplace_logits as fused_softcap
+try:
+    from sglang.srt.layers.triton_ops.softcap import (
+        softcap_inplace_logits as fused_softcap,
+    )
+except ImportError:
+
+    def fused_softcap(logits: torch.Tensor, final_logit_softcapping: float):
+        logits.copy_(
+            final_logit_softcapping * torch.tanh(logits / final_logit_softcapping)
+        )
+        return logits
+
 from sglang.srt.layers.utils.logprob import (
     InputLogprobsResult,
     get_token_ids_logprobs_chunk,
@@ -67,6 +77,32 @@ _is_cpu = is_cpu()
 # and its [batch * dp_size, vocab] output OOMs under DP attention with a
 # tight mem_fraction_static.
 _in_autotune_dummy_run = False
+
+
+class _TensorParallelAllGatherer:
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        from sglang.srt.distributed import tensor_model_parallel_all_gather
+
+        return tensor_model_parallel_all_gather(x, dim=-1)
+
+
+def _create_logits_gatherer(enabled: bool, skip_entry_sync: bool):
+    if not enabled:
+        return _TensorParallelAllGatherer()
+
+    try:
+        from sglang.srt.distributed.device_communicators import triton_symm_mem_ag
+
+        return triton_symm_mem_ag.MultimemAllGatherer(
+            max_tokens=triton_symm_mem_ag.recommended_max_tokens(
+                include_prefill=False, floor=128
+            ),
+            enabled=True,
+            skip_entry_sync=skip_entry_sync,
+        )
+    except Exception as exc:
+        logger.warning("multimem logits all-gather disabled (%s)", exc)
+        return _TensorParallelAllGatherer()
 
 
 def get_in_autotune_dummy_run() -> bool:
@@ -294,10 +330,7 @@ class LogitsProcessor(nn.Module):
         self.return_full_logits = return_full_logits
         self.enable_mis = get_global_server_args().enable_mis
 
-        self._logits_gatherer = triton_symm_mem_ag.MultimemAllGatherer(
-            max_tokens=triton_symm_mem_ag.recommended_max_tokens(
-                include_prefill=False, floor=128
-            ),
+        self._logits_gatherer = _create_logits_gatherer(
             enabled=self.do_tensor_parallel_all_gather and not self.use_attn_tp_group,
             skip_entry_sync=True,
         )

--- a/python/sglang/srt/layers/moe/__init__.py
+++ b/python/sglang/srt/layers/moe/__init__.py
@@ -1,4 +1,4 @@
-from sglang.srt.layers.moe.moe_runner import MoeRunner, MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
 from sglang.srt.layers.moe.utils import (
     DeepEPMode,
     MoeA2ABackend,
@@ -14,6 +14,15 @@ from sglang.srt.layers.moe.utils import (
     should_use_dp_reduce_scatterv,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
+
+
+def __getattr__(name: str):
+    if name == "MoeRunner":
+        from sglang.srt.layers.moe.moe_runner.runner import MoeRunner
+
+        return MoeRunner
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "DeepEPMode",

--- a/python/sglang/srt/layers/moe/moe_runner/__init__.py
+++ b/python/sglang/srt/layers/moe/moe_runner/__init__.py
@@ -1,4 +1,11 @@
 from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
-from sglang.srt.layers.moe.moe_runner.runner import MoeRunner
+
+
+def __getattr__(name: str):
+    if name == "MoeRunner":
+        from sglang.srt.layers.moe.moe_runner.runner import MoeRunner
+
+        return MoeRunner
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = ["MoeRunnerConfig", "MoeRunner"]

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import builtins
 import inspect
+from importlib import import_module
 from typing import TYPE_CHECKING, Dict, Optional, Type
 
 import torch
@@ -18,40 +19,7 @@ class DummyConfig:
 
 CompressedTensorsConfig = DummyConfig
 
-from sglang.srt.layers.quantization.auto_round import AutoRoundConfig
-from sglang.srt.layers.quantization.awq import AWQConfig, AWQCPUConfig, AWQMarlinConfig
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
-from sglang.srt.layers.quantization.bitsandbytes import BitsAndBytesConfig
-from sglang.srt.layers.quantization.blockwise_int8 import BlockInt8Config
-from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
-    CompressedTensorsConfig,
-)
-from sglang.srt.layers.quantization.fp8 import Fp8Config
-from sglang.srt.layers.quantization.fpgemm_fp8 import FBGEMMFp8Config
-from sglang.srt.layers.quantization.gguf import GGUFConfig
-from sglang.srt.layers.quantization.gptq import (
-    CPUGPTQConfig,
-    GPTQAscendConfig,
-    GPTQConfig,
-    GPTQMarlinConfig,
-)
-from sglang.srt.layers.quantization.mlx import MlxQuantizationConfig
-from sglang.srt.layers.quantization.modelopt_quant import (
-    ModelOptFp4Config,
-    ModelOptFp8Config,
-    ModelOptMixedPrecisionConfig,
-)
-from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
-from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
-from sglang.srt.layers.quantization.mxfp4 import Mxfp4Config
-from sglang.srt.layers.quantization.nvfp4_online import NvFp4OnlineConfig
-from sglang.srt.layers.quantization.petit import PetitNvFp4Config
-from sglang.srt.layers.quantization.qoq import QoQConfig
-from sglang.srt.layers.quantization.quark.quark import QuarkConfig
-from sglang.srt.layers.quantization.quark_int4fp8_moe import QuarkInt4Fp8Config
-from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config
-from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config
-from sglang.srt.layers.quantization.w8a8_int8 import W8A8Int8Config
 from sglang.srt.platforms import current_platform
 from sglang.srt.utils import (
     cpu_has_amx_support,
@@ -68,72 +36,133 @@ _is_mxfp_supported = mxfp_supported()
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.topk import TopKOutput
 
+
+def _try_import_quant_configs(
+    module_name: str,
+    names: tuple[str, ...],
+) -> Dict[str, Type[QuantizationConfig]]:
+    try:
+        module = import_module(module_name)
+    except (ImportError, ModuleNotFoundError, AttributeError, TypeError):
+        return {}
+    return {name: getattr(module, name) for name in names if hasattr(module, name)}
+
+
+_QUANT_CONFIGS: Dict[str, Type[QuantizationConfig]] = {}
+for _module_name, _names in [
+    ("sglang.srt.layers.quantization.auto_round", ("AutoRoundConfig",)),
+    (
+        "sglang.srt.layers.quantization.awq",
+        ("AWQConfig", "AWQCPUConfig", "AWQMarlinConfig"),
+    ),
+    ("sglang.srt.layers.quantization.bitsandbytes", ("BitsAndBytesConfig",)),
+    ("sglang.srt.layers.quantization.blockwise_int8", ("BlockInt8Config",)),
+    (
+        "sglang.srt.layers.quantization.compressed_tensors.compressed_tensors",
+        ("CompressedTensorsConfig",),
+    ),
+    ("sglang.srt.layers.quantization.fp8", ("Fp8Config",)),
+    ("sglang.srt.layers.quantization.fpgemm_fp8", ("FBGEMMFp8Config",)),
+    ("sglang.srt.layers.quantization.gguf", ("GGUFConfig",)),
+    (
+        "sglang.srt.layers.quantization.gptq",
+        ("CPUGPTQConfig", "GPTQAscendConfig", "GPTQConfig", "GPTQMarlinConfig"),
+    ),
+    ("sglang.srt.layers.quantization.mlx", ("MlxQuantizationConfig",)),
+    (
+        "sglang.srt.layers.quantization.modelopt_quant",
+        ("ModelOptFp4Config", "ModelOptFp8Config", "ModelOptMixedPrecisionConfig"),
+    ),
+    ("sglang.srt.layers.quantization.modelslim.modelslim", ("ModelSlimConfig",)),
+    ("sglang.srt.layers.quantization.moe_wna16", ("MoeWNA16Config",)),
+    ("sglang.srt.layers.quantization.mxfp4", ("Mxfp4Config",)),
+    ("sglang.srt.layers.quantization.nvfp4_online", ("NvFp4OnlineConfig",)),
+    ("sglang.srt.layers.quantization.petit", ("PetitNvFp4Config",)),
+    ("sglang.srt.layers.quantization.qoq", ("QoQConfig",)),
+    ("sglang.srt.layers.quantization.quark.quark", ("QuarkConfig",)),
+    ("sglang.srt.layers.quantization.quark_int4fp8_moe", ("QuarkInt4Fp8Config",)),
+    ("sglang.srt.layers.quantization.w4afp8", ("W4AFp8Config",)),
+    ("sglang.srt.layers.quantization.w8a8_fp8", ("W8A8Fp8Config",)),
+    ("sglang.srt.layers.quantization.w8a8_int8", ("W8A8Int8Config",)),
+]:
+    _QUANT_CONFIGS.update(_try_import_quant_configs(_module_name, _names))
+
+CompressedTensorsConfig = _QUANT_CONFIGS.get("CompressedTensorsConfig", DummyConfig)
+
 # Base quantization methods
-BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
-    "fp8": Fp8Config,
-    "mxfp8": Fp8Config,
-    "blockwise_int8": BlockInt8Config,
-    "modelopt": ModelOptFp8Config,  # Auto-detect, defaults to FP8
-    "modelopt_fp8": ModelOptFp8Config,
-    "modelopt_fp4": ModelOptFp4Config,
-    "nvfp4_online": NvFp4OnlineConfig,
-    "modelopt_mixed": ModelOptMixedPrecisionConfig,
-    "w8a8_int8": W8A8Int8Config,
-    "w8a8_fp8": W8A8Fp8Config,
-    "awq": AWQConfig,
-    "awq_marlin": AWQMarlinConfig,
-    "bitsandbytes": BitsAndBytesConfig,
-    "gguf": GGUFConfig,
-    "gptq": GPTQConfig,
-    "gptq_marlin": GPTQMarlinConfig,
-    "moe_wna16": MoeWNA16Config,
-    "compressed-tensors": CompressedTensorsConfig,
-    "qoq": QoQConfig,
-    "w4afp8": W4AFp8Config,
-    "petit_nvfp4": PetitNvFp4Config,
-    "fbgemm_fp8": FBGEMMFp8Config,
-    "quark": QuarkConfig,
-    "quark_mxfp4": QuarkConfig,
-    "auto-round": AutoRoundConfig,
-    "auto-round-int8": W8A8Int8Config,
-    "modelslim": ModelSlimConfig,
-    "quark_int4fp8_moe": QuarkInt4Fp8Config,
-}
+BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {}
+
+
+def _register_quant_method(method: str, config_name: str) -> None:
+    config = _QUANT_CONFIGS.get(config_name)
+    if config is not None:
+        BASE_QUANTIZATION_METHODS[method] = config
+
+
+for _method, _config_name in [
+    ("fp8", "Fp8Config"),
+    ("mxfp8", "Fp8Config"),
+    ("blockwise_int8", "BlockInt8Config"),
+    ("modelopt", "ModelOptFp8Config"),  # Auto-detect, defaults to FP8
+    ("modelopt_fp8", "ModelOptFp8Config"),
+    ("modelopt_fp4", "ModelOptFp4Config"),
+    ("nvfp4_online", "NvFp4OnlineConfig"),
+    ("modelopt_mixed", "ModelOptMixedPrecisionConfig"),
+    ("w8a8_int8", "W8A8Int8Config"),
+    ("w8a8_fp8", "W8A8Fp8Config"),
+    ("awq", "AWQConfig"),
+    ("awq_marlin", "AWQMarlinConfig"),
+    ("bitsandbytes", "BitsAndBytesConfig"),
+    ("gguf", "GGUFConfig"),
+    ("gptq", "GPTQConfig"),
+    ("gptq_marlin", "GPTQMarlinConfig"),
+    ("moe_wna16", "MoeWNA16Config"),
+    ("compressed-tensors", "CompressedTensorsConfig"),
+    ("qoq", "QoQConfig"),
+    ("w4afp8", "W4AFp8Config"),
+    ("petit_nvfp4", "PetitNvFp4Config"),
+    ("fbgemm_fp8", "FBGEMMFp8Config"),
+    ("quark", "QuarkConfig"),
+    ("quark_mxfp4", "QuarkConfig"),
+    ("auto-round", "AutoRoundConfig"),
+    ("auto-round-int8", "W8A8Int8Config"),
+    ("modelslim", "ModelSlimConfig"),
+    ("quark_int4fp8_moe", "QuarkInt4Fp8Config"),
+]:
+    _register_quant_method(_method, _config_name)
 
 
 if is_cpu() or is_cuda() or (_is_mxfp_supported and is_hip()):
-    BASE_QUANTIZATION_METHODS.update(
-        {
-            "mxfp4": Mxfp4Config,
-        }
-    )
+    _register_quant_method("mxfp4", "Mxfp4Config")
 
 
 if is_npu():
-    BASE_QUANTIZATION_METHODS.update(
-        {
-            "gptq": GPTQAscendConfig,
-        }
-    )
+    _register_quant_method("gptq", "GPTQAscendConfig")
 
 
 if is_mps():
-    BASE_QUANTIZATION_METHODS.update(
-        {
-            "mlx_q4": MlxQuantizationConfig,
-            "mlx_q8": MlxQuantizationConfig,
-        }
-    )
+    _register_quant_method("mlx_q4", "MlxQuantizationConfig")
+    _register_quant_method("mlx_q8", "MlxQuantizationConfig")
 
 # subset of above quant methods, supported on CPU
-CPU_QUANTIZATION_METHODS = {
-    "fp8": Fp8Config,
-    "w8a8_int8": W8A8Int8Config,
-    "compressed-tensors": CompressedTensorsConfig,
-    "awq": AWQCPUConfig,
-    "gptq": CPUGPTQConfig,
-    "mxfp4": Mxfp4Config,
-}
+CPU_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {}
+
+
+def _register_cpu_quant_method(method: str, config_name: str) -> None:
+    config = _QUANT_CONFIGS.get(config_name)
+    if config is not None:
+        CPU_QUANTIZATION_METHODS[method] = config
+
+
+for _method, _config_name in [
+    ("fp8", "Fp8Config"),
+    ("w8a8_int8", "W8A8Int8Config"),
+    ("compressed-tensors", "CompressedTensorsConfig"),
+    ("awq", "AWQCPUConfig"),
+    ("gptq", "CPUGPTQConfig"),
+    ("mxfp4", "Mxfp4Config"),
+]:
+    _register_cpu_quant_method(_method, _config_name)
 
 QUANTIZATION_METHODS = {**BASE_QUANTIZATION_METHODS}
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -22,12 +22,6 @@ from sglang.srt.layers.amx_utils import (
     _amx_process_weight_after_loading,
 )
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
-from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
-from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
-from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
-    FlashInferTrtllmFp8MoeQuantInfo,
-)
-from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     get_moe_a2a_backend,
@@ -101,7 +95,13 @@ from sglang.srt.utils import (
 )
 
 if TYPE_CHECKING:
+    from sglang.srt.layers.moe import MoeRunnerConfig
+    from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
+    from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+        FlashInferTrtllmFp8MoeQuantInfo,
+    )
     from sglang.srt.layers.moe.moe_runner.aiter import AiterMoeQuantInfo
+    from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
     from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
     from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config
     from sglang.srt.models.utils import WeightsMapper
@@ -1764,6 +1764,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
+        from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend
+
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
 
@@ -1792,6 +1794,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             pass
 
     def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
+        from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
+
         return TritonMoeQuantInfo(
             w13_weight=layer.w13_weight,
             w2_weight=layer.w2_weight,
@@ -1967,6 +1971,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     .unsqueeze(2)
                     .repeat_interleave(w2_scale_k, dim=2)
                 )
+            from sglang.srt.layers.moe.moe_runner.deep_gemm import (
+                DeepGemmMoeQuantInfo,
+            )
+
             quant_info = DeepGemmMoeQuantInfo(
                 w13_weight=w13_weight,
                 w2_weight=w2_weight,
@@ -1989,6 +1997,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             moe_ep_rank = int(getattr(layer, "moe_ep_rank"))
 
             from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+                FlashInferTrtllmFp8MoeQuantInfo,
                 get_activation_type,
             )
 

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -31,6 +31,7 @@ except:
 from sglang.jit_kernel.utils import is_arch_support_pdl
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.utils import (
+    FP8_E4M3_MAX,
     ceil_align,
     get_bool_env_var,
     get_device_core_count,
@@ -54,8 +55,19 @@ _is_sm100_supported = is_sm100_supported()
 _is_sm120_supported = is_sm120_supported()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
+
+def _missing_sgl_kernel_op(*args, **kwargs):
+    raise ImportError(
+        "This FP8 quantization path requires sgl_kernel, but it is not installed "
+        "for the current PyTorch/CUDA environment."
+    )
+
+
 if _is_cuda or _is_musa:
-    from sgl_kernel import sgl_per_token_quant_fp8
+    try:
+        from sgl_kernel import sgl_per_token_quant_fp8
+    except ImportError:
+        sgl_per_token_quant_fp8 = _missing_sgl_kernel_op
 
     from sglang.jit_kernel.per_tensor_quant_fp8 import (
         per_tensor_quant_fp8 as sgl_per_tensor_quant_fp8,
@@ -67,8 +79,10 @@ if _is_cuda or _is_musa:
 
         enable_sgl_per_token_group_quant_8bit = True
     except ImportError:
-        from sgl_kernel import sgl_per_token_group_quant_fp8
-
+        try:
+            from sgl_kernel import sgl_per_token_group_quant_fp8
+        except ImportError:
+            sgl_per_token_group_quant_fp8 = _missing_sgl_kernel_op
         enable_sgl_per_token_group_quant_8bit = False
 
     from sglang.jit_kernel.per_token_group_quant_8bit import (
@@ -132,7 +146,7 @@ if is_fp8_fnuz():
     fp8_max = 224.0
 else:
     fp8_dtype = torch.float8_e4m3fn
-    fp8_max = torch.finfo(fp8_dtype).max
+    fp8_max = FP8_E4M3_MAX
 fp8_min = -fp8_max
 
 

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -87,6 +87,13 @@ _AITER_GFX95_CK_W8A8_MAX_SAFE_M = {
 _FORCE_CK_W8A8: bool = False
 
 
+def _missing_sgl_kernel_op(*args, **kwargs):
+    raise ImportError(
+        "This FP8 matmul path requires sgl_kernel, but it is not installed "
+        "for the current PyTorch/CUDA environment."
+    )
+
+
 def set_force_ck_w8a8(enabled: bool = True) -> None:
     global _FORCE_CK_W8A8
     _FORCE_CK_W8A8 = enabled
@@ -129,7 +136,11 @@ if _use_aiter:
 
 
 if _is_cuda:
-    from sgl_kernel import fp8_blockwise_scaled_mm, fp8_scaled_mm
+    try:
+        from sgl_kernel import fp8_blockwise_scaled_mm, fp8_scaled_mm
+    except ImportError:
+        fp8_blockwise_scaled_mm = _missing_sgl_kernel_op
+        fp8_scaled_mm = _missing_sgl_kernel_op
 
     from sglang.srt.utils.patch_torch import register_fake_if_exists
 

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -14,15 +14,12 @@ from sglang.srt.layers.amx_utils import (
     CPUQuantMethod,
     _amx_process_weight_after_loading,
 )
-from sglang.srt.layers.moe import (
-    MoeRunner,
+from sglang.srt.layers.moe.utils import (
     MoeRunnerBackend,
-    MoeRunnerConfig,
     get_deepep_mode,
     get_moe_a2a_backend,
     get_moe_runner_backend,
 )
-from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.quantization.base_config import (
     FusedMoEMethodBase,
     LinearMethodBase,
@@ -41,6 +38,8 @@ from sglang.srt.utils import (
 )
 
 if TYPE_CHECKING:
+    from sglang.srt.layers.moe import MoeRunner, MoeRunnerConfig
+    from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
     from sglang.srt.layers.moe.token_dispatcher import (
         CombineInput,
         DispatchOutput,
@@ -394,6 +393,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
+        from sglang.srt.layers.moe import MoeRunner
+
         self.moe_runner_config = moe_runner_config
         if self.use_flashinfer_trtllm_moe:
             backend = (
@@ -531,6 +532,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 )
                 return self._aiter_runner.run(dispatch_output, quant_info)
 
+            from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
+
             quant_info = TritonMoeQuantInfo(
                 w13_weight=layer.w13_weight,
                 w2_weight=layer.w2_weight,
@@ -594,6 +597,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             return StandardCombineInput(hidden_states=output)
 
     def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
+        from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
+
         return TritonMoeQuantInfo(
             w13_weight=layer.w13_weight,
             w2_weight=layer.w2_weight,

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -25,15 +25,31 @@ from sglang.srt.utils.common import (
     is_npu,
 )
 
+
+def _missing_sampling_op(*args, **kwargs):
+    raise ImportError(
+        "FlashInfer/sgl_kernel sampling kernels are not installed for the "
+        "current PyTorch/CUDA environment. Use --sampling-backend pytorch."
+    )
+
+
 if is_cuda():
-    from flashinfer.sampling import (
-        min_p_sampling_from_probs,
-        top_k_top_p_sampling_from_probs,
-    )
-    from sgl_kernel import (
-        top_k_renorm_prob,
-        top_p_renorm_prob,
-    )
+    try:
+        from flashinfer.sampling import (
+            min_p_sampling_from_probs,
+            top_k_top_p_sampling_from_probs,
+        )
+    except ImportError:
+        min_p_sampling_from_probs = _missing_sampling_op
+        top_k_top_p_sampling_from_probs = _missing_sampling_op
+    try:
+        from sgl_kernel import (
+            top_k_renorm_prob,
+            top_p_renorm_prob,
+        )
+    except ImportError:
+        top_k_renorm_prob = _missing_sampling_op
+        top_p_renorm_prob = _missing_sampling_op
 
 if is_musa():
     from sgl_kernel import (

--- a/python/sglang/srt/layers/utils/hash.py
+++ b/python/sglang/srt/layers/utils/hash.py
@@ -4,7 +4,7 @@ import triton.language as tl
 
 
 @triton.jit
-def rotl32(x, r: tl.constexpr) -> tl.uint32:
+def rotl32(x, r: tl.constexpr):
     """
     rotate left 32-bit integer x by r bits
     e.g. x = 01110001, r = 2 -> 11000101
@@ -14,7 +14,7 @@ def rotl32(x, r: tl.constexpr) -> tl.uint32:
 
 
 @triton.jit
-def fmix32(h: tl.uint32) -> tl.uint32:
+def fmix32(h):
     """
     final mix of 32-bit hash value for MurmurHash
     """
@@ -27,16 +27,16 @@ def fmix32(h: tl.uint32) -> tl.uint32:
 
 
 @triton.jit
-def murmur3_mix(h: tl.uint32, k: tl.uint32) -> tl.uint32:
+def murmur3_mix(h, k):
     """
     Mixes a 32-bit key into the hash state.
     """
-    c1: tl.uint32 = 0xCC9E2D51
-    c2: tl.uint32 = 0x1B873593
-    r1: tl.constexpr = 15
-    r2: tl.constexpr = 13
-    mm: tl.uint32 = 5
-    nn: tl.uint32 = 0xE6546B64
+    c1 = 0xCC9E2D51
+    c2 = 0x1B873593
+    r1 = 15
+    r2 = 13
+    mm = 5
+    nn = 0xE6546B64
 
     k = (k * c1) & 0xFFFFFFFF
     k = rotl32(k, r1)
@@ -77,10 +77,10 @@ def murmur_hash32_kernel(
     pos = tl.load(positions_ptr + row_idx).to(tl.uint32)
     col = tl.load(col_indices_ptr + col_offsets, mask=mask, other=0).to(tl.uint32)
 
-    h: tl.uint32 = 0  # hash accumulator
+    h = 0  # hash accumulator
 
     # Process seed_low
-    k: tl.uint32 = (seed & 0xFFFFFFFF).to(tl.uint32)
+    k = (seed & 0xFFFFFFFF).to(tl.uint32)
     h = murmur3_mix(h, k)
 
     # Process seed_high

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -172,19 +172,19 @@ class FutureMap:
         self.publish_ready = None  # lazy device.Event(); only spec_v2 needs it
 
     def _lazy_init_forward_buf(self, payload: RelayPayload):
-        # Local import (see decide_needs_cpu_seq_lens): keep module-level deps leaf.
-        from sglang.srt.speculative.spec_utils import spec_need_hidden_states
-
         self._forward_buf_initialized = True
 
         # Spec extras are gated by spec_algo, not by the payload's shape, so a
         # non-spec stash allocates no extra bufs (only output_tokens_buf).
         self.need_topk = self.spec_algo.is_some() and self.spec_algo.need_topk()
-        self.need_hidden_states = (
-            self.spec_algo.is_some()
-            and spec_need_hidden_states()
-            and payload.hidden_states is not None
-        )
+        self.need_hidden_states = False
+        if self.spec_algo.is_some():
+            # Local import (see decide_needs_cpu_seq_lens): keep module-level deps leaf.
+            from sglang.srt.speculative.spec_utils import spec_need_hidden_states
+
+            self.need_hidden_states = (
+                spec_need_hidden_states() and payload.hidden_states is not None
+            )
 
         if self.need_topk:
             topk_p0 = payload.topk_p[0]

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -38,9 +38,6 @@ from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_in_seq_split
 from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
-from sglang.srt.mem_cache.allocator.hisparse import (
-    DeepSeekV4HiSparseTokenToKVPoolAllocator,
-)
 from sglang.srt.mem_cache.allocator.swa import (
     PureSWATokenToKVPoolAllocator,
     SWATokenToKVPoolAllocator,
@@ -86,6 +83,13 @@ IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD = int(
 
 
 IGNORE_EOS_RESERVE_TOKENS = 1
+
+
+def _is_deepseek_v4_hisparse_allocator(token_to_kv_pool_allocator) -> bool:
+    return (
+        type(token_to_kv_pool_allocator).__name__
+        == "DeepSeekV4HiSparseTokenToKVPoolAllocator"
+    )
 
 
 def match_prefix_for_req(
@@ -487,9 +491,14 @@ class PrefillAdder:
 
         # DeepSeek V4 HiSparse wraps an SWATokenToKVPoolAllocator internally and
         # exposes the full SWA allocator interface.
-        self.is_hybrid_swa = isinstance(
-            self.token_to_kv_pool_allocator,
-            (SWATokenToKVPoolAllocator, DeepSeekV4HiSparseTokenToKVPoolAllocator),
+        self.is_hybrid_swa = (
+            isinstance(
+                self.token_to_kv_pool_allocator,
+                SWATokenToKVPoolAllocator,
+            )
+            or _is_deepseek_v4_hisparse_allocator(
+                self.token_to_kv_pool_allocator,
+            )
         )
         self.is_all_swa = isinstance(
             self.token_to_kv_pool_allocator, PureSWATokenToKVPoolAllocator

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -25,11 +25,14 @@ from collections import deque
 from contextlib import contextmanager, nullcontext
 from functools import partial
 from http import HTTPStatus
-from typing import Any, Deque, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Deque, Dict, List, Optional, Tuple, Union
 
 from sglang.srt.utils.common import suppress_noisy_warnings  # isort: skip
 
 suppress_noisy_warnings()
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
 
 import psutil  # isort: skip
 import setproctitle
@@ -46,9 +49,6 @@ from sglang.srt.disaggregation.decode import (
     DecodePreallocQueue,
     DecodeTransferQueue,
     SchedulerDisaggregationDecodeMixin,
-)
-from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
-    DecodeKVCacheOffloadManager,
 )
 from sglang.srt.disaggregation.encode_receiver import create_mm_receiver
 from sglang.srt.disaggregation.prefill import (
@@ -80,9 +80,6 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.layers.moe import initialize_moe_config
 from sglang.srt.layers.quantization.fp4_utils import initialize_fp4_gemm_config
 from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
-from sglang.srt.lora.lora_drainer import LoRADrainer
-from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
-from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
 from sglang.srt.managers.io_struct import (
     AbortReq,
     ActiveRanksOutput,
@@ -242,7 +239,6 @@ from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import PortArgs, ServerArgs, get_global_server_args
 from sglang.srt.session.session_controller import SessionController
 from sglang.srt.speculative.dflash_utils import validate_dflash_request
-from sglang.srt.speculative.eagle_utils import get_draft_recurrent_hidden_state_spec
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
     DynamicGradMode,
@@ -465,6 +461,10 @@ class Scheduler(
             self.server_args.disaggregation_mode == "decode"
             and self.server_args.disaggregation_decode_enable_offload_kvcache
         ):
+            from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
+                DecodeKVCacheOffloadManager,
+            )
+
             self.decode_offload_manager = DecodeKVCacheOffloadManager(
                 req_to_token_pool=self.req_to_token_pool,
                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
@@ -954,7 +954,7 @@ class Scheduler(
             )
 
     def init_hisparse_coordinator(self) -> None:
-        self.hisparse_coordinator: Optional[HiSparseCoordinator] = None
+        self.hisparse_coordinator: Optional["HiSparseCoordinator"] = None
         if not self.enable_hisparse:
             return
 
@@ -1130,6 +1130,10 @@ class Scheduler(
         )
 
         if self.spec_algorithm.carries_draft_hidden_states():
+            from sglang.srt.speculative.eagle_utils import (
+                get_draft_recurrent_hidden_state_spec,
+            )
+
             # `draft_runner` aliases `draft_runner_list[0]` in the multi-layer
             # worker, so a single accessor covers both shapes.
             draft_runner = self.draft_worker.draft_worker.draft_runner
@@ -1695,6 +1699,8 @@ class Scheduler(
 
     def init_lora_drainer(self) -> None:
         if self.server_args.lora_drain_wait_threshold > 0.0:
+            from sglang.srt.lora.lora_drainer import LoRADrainer
+
             self.lora_drainer = LoRADrainer(
                 self.server_args.max_loras_per_batch,
                 self.server_args.lora_drain_wait_threshold,
@@ -1704,6 +1710,8 @@ class Scheduler(
 
     def init_lora_overlap_loader(self) -> None:
         if self.enable_lora_overlap_loading:
+            from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
+
             self.lora_overlap_loader = LoRAOverlapLoader(
                 self.tp_worker.model_runner.lora_manager
             )

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
 
-from sglang.srt.batch_overlap.two_batch_overlap import TboDPAttentionPreparer
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.distributed.parallel_state import get_tp_group
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
@@ -193,6 +192,8 @@ def prepare_mlp_sync_batch_raw(
     is_extend_in_batch = local_batch.forward_mode.is_extend() if local_batch else False
     if local_batch is not None:
         local_batch.is_extend_in_batch = is_extend_in_batch
+
+    from sglang.srt.batch_overlap.two_batch_overlap import TboDPAttentionPreparer
 
     tbo_preparer = TboDPAttentionPreparer()
     if len(offload_tags) == 0 and (

--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -7,9 +7,6 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
-from sglang.srt.mem_cache.allocator.hisparse import (
-    DeepSeekV4HiSparseTokenToKVPoolAllocator,
-)
 from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
@@ -30,6 +27,12 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _is_swa_chunk_cache_allocator(allocator: Any) -> bool:
+    return isinstance(allocator, SWATokenToKVPoolAllocator) or (
+        allocator.__class__.__name__ == "DeepSeekV4HiSparseTokenToKVPoolAllocator"
+    )
 
 
 class ChunkCache(BasePrefixCache):
@@ -115,13 +118,7 @@ class SWAChunkCache(ChunkCache):
 
     def __init__(self, params: CacheInitParams):
         # DeepSeek V4 HiSparse wraps SWATokenToKVPoolAllocator and exposes the same API.
-        assert isinstance(
-            params.token_to_kv_pool_allocator,
-            (
-                SWATokenToKVPoolAllocator,
-                DeepSeekV4HiSparseTokenToKVPoolAllocator,
-            ),
-        )
+        assert _is_swa_chunk_cache_allocator(params.token_to_kv_pool_allocator)
         super().__init__(params)
 
         self.sliding_window_size = params.sliding_window_size

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -34,6 +34,17 @@ import torch
 import triton
 import triton.language as tl
 
+_FLOAT8_KV_CACHE_DTYPES = tuple(
+    dtype
+    for dtype in (
+        getattr(torch, "float8_e5m2", None),
+        getattr(torch, "float8_e4m3fn", None),
+        getattr(torch, "float8_e4m3fnuz", None),
+    )
+    if dtype is not None
+)
+_PTR_DTYPE = getattr(torch, "uint64", torch.int64)
+
 from sglang.jit_kernel.kvcache import can_use_store_cache, store_cache
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
@@ -1205,7 +1216,7 @@ class KVCache(abc.ABC):
         self.page_size = page_size
         self.dtype = dtype
         self.device = device
-        if dtype in (torch.float8_e5m2, torch.float8_e4m3fn, torch.float8_e4m3fnuz):
+        if dtype in _FLOAT8_KV_CACHE_DTYPES:
             # NOTE: Store as torch.uint8 because Tensor.index_put is not implemented for torch.float8_e5m2
             self.store_dtype = torch.uint8
         else:
@@ -1532,12 +1543,12 @@ class MHATokenToKVPool(KVCache):
 
         self.k_data_ptrs = torch.tensor(
             [x.data_ptr() for x in self.k_buffer],
-            dtype=torch.uint64,
+            dtype=_PTR_DTYPE,
             device=self.device,
         )
         self.v_data_ptrs = torch.tensor(
             [x.data_ptr() for x in self.v_buffer],
-            dtype=torch.uint64,
+            dtype=_PTR_DTYPE,
             device=self.device,
         )
         self.data_ptrs = torch.cat([self.k_data_ptrs, self.v_data_ptrs], dim=0)
@@ -1987,12 +1998,12 @@ class NoOpMHATokenToKVPool(MHATokenToKVPool):
 
         self.k_data_ptrs = torch.tensor(
             [x.data_ptr() for x in self.k_buffer],
-            dtype=torch.uint64,
+            dtype=_PTR_DTYPE,
             device=self.device,
         )
         self.v_data_ptrs = torch.tensor(
             [x.data_ptr() for x in self.v_buffer],
-            dtype=torch.uint64,
+            dtype=_PTR_DTYPE,
             device=self.device,
         )
         self.data_ptrs = torch.cat([self.k_data_ptrs, self.v_data_ptrs], dim=0)
@@ -2279,12 +2290,12 @@ class PageMajorMHATokenToKVPool(MHATokenToKVPool):
         # views np.prod(shape[1:]) would not equal it, so compute it directly.
         self.k_data_ptrs = torch.tensor(
             [x.data_ptr() for x in self.k_buffer],
-            dtype=torch.uint64,
+            dtype=_PTR_DTYPE,
             device=self.device,
         )
         self.v_data_ptrs = torch.tensor(
             [x.data_ptr() for x in self.v_buffer],
-            dtype=torch.uint64,
+            dtype=_PTR_DTYPE,
             device=self.device,
         )
         self.data_ptrs = torch.cat([self.k_data_ptrs, self.v_data_ptrs], dim=0)
@@ -2650,7 +2661,7 @@ class MLATokenToKVPool(KVCache):
 
         self.data_ptrs = torch.tensor(
             [x.data_ptr() for x in self.kv_buffer],
-            dtype=torch.uint64,
+            dtype=_PTR_DTYPE,
             device=self.device,
         )
         if not use_dsa:

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -144,6 +144,8 @@ _CPU_COMPILE_FAKE_OPS: set[str] = set()
 
 def register_cpu_compile_fake(op_name: str):
     _CPU_COMPILE_FAKE_OPS.add(op_name)
+    if not hasattr(torch.library, "register_fake"):
+        return lambda func: func
     return torch.library.register_fake(f"sgl_kernel::{op_name}")
 
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -26,31 +26,14 @@ import threading
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
 from torch import nn
 
 from sglang.jit_kernel.ngram_embedding import update_token_table_decode
-from sglang.srt.configs import (
-    BailingHybridConfig,
-    FalconH1Config,
-    GraniteMoeHybridConfig,
-    InternS2PreviewConfig,
-    JetNemotronConfig,
-    JetVLMConfig,
-    KimiLinearConfig,
-    Lfm2Config,
-    Lfm2MoeConfig,
-    Lfm2VlConfig,
-    NemotronH_Nano_VL_V2_Config,
-    NemotronHConfig,
-    Qwen3_5Config,
-    Qwen3_5MoeConfig,
-    Qwen3NextConfig,
-    ZayaConfig,
-)
+from sglang.srt import configs as srt_configs
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.linear_attn_model_registry import get_linear_attn_config
 from sglang.srt.configs.load_config import LoadConfig, LoadFormat
@@ -112,18 +95,12 @@ from sglang.srt.eplb.lplb_solver import (
     clear_global_lplb_solvers,
     set_global_lplb_solver,
 )
-from sglang.srt.hardware_backend.npu.graph_runner.npu_graph_runner import NPUGraphRunner
-from sglang.srt.hardware_backend.xpu.graph_runner.xpu_graph_runner import XPUGraphRunner
-from sglang.srt.kv_canary.api import install_canary
-from sglang.srt.kv_canary.runner.canary_manager import context_tuple
-from sglang.srt.kv_canary.token_oracle.install import install_token_oracle_from_env
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.attention.attention_registry import (
     ATTENTION_BACKENDS,
     attn_backend_wrapper,
 )
 from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
-from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
 from sglang.srt.layers.cp.utils import (
     get_cp_strategy,
 )
@@ -132,18 +109,13 @@ from sglang.srt.layers.dp_attention import (
     initialize_dp_attention,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.layers.moe.hash_topk import HashTopK
-from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
 from sglang.srt.layers.sampler import create_sampler
 from sglang.srt.layers.torchao_utils import apply_torchao_config_to_model
 from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
-from sglang.srt.lora.lora_manager import LoRAManager
-from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import sanity_check_mm_pad_shift_value
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
-from sglang.srt.model_executor.cpu_graph_runner import CPUGraphRunner
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     Phase,
@@ -166,11 +138,7 @@ from sglang.srt.model_executor.model_runner_kv_cache_mixin import (
     ModelRunnerKVCacheMixin,
 )
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
-from sglang.srt.model_executor.runner import (
-    EagerRunner,
-    PrefillCudaGraphRunner,
-    get_batch_sizes_to_capture,
-)
+from sglang.srt.model_executor.runner.eager_runner import EagerRunner
 from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
 from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     RemoteInstanceWeightLoaderBackend,
@@ -279,12 +247,15 @@ CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS = [
     "tokenspeed_mla",
 ]
 
-TORCH_DTYPE_TO_KV_CACHE_STR = {
-    torch.float8_e4m3fn: "fp8_e4m3",
-    torch.float8_e4m3fnuz: "fp8_e4m3",
-    torch.float8_e5m2: "fp8_e5m2",
-    torch.bfloat16: "bf16",
-}
+TORCH_DTYPE_TO_KV_CACHE_STR = {torch.bfloat16: "bf16"}
+for _torch_dtype_name, _kv_cache_dtype_name in (
+    ("float8_e4m3fn", "fp8_e4m3"),
+    ("float8_e4m3fnuz", "fp8_e4m3"),
+    ("float8_e5m2", "fp8_e5m2"),
+):
+    _torch_dtype = getattr(torch, _torch_dtype_name, None)
+    if _torch_dtype is not None:
+        TORCH_DTYPE_TO_KV_CACHE_STR[_torch_dtype] = _kv_cache_dtype_name
 
 
 def add_mla_attention_backend(backend_name):
@@ -306,6 +277,39 @@ UNBALANCED_MODEL_LOADING_TIMEOUT_S = 480  # leave more time for post data proces
 
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.lora_registry import LoRARef
+
+
+class _UnavailableConfig:
+    pass
+
+
+BailingHybridConfig = getattr(
+    srt_configs, "BailingHybridConfig", _UnavailableConfig
+)
+FalconH1Config = getattr(srt_configs, "FalconH1Config", _UnavailableConfig)
+GraniteMoeHybridConfig = getattr(
+    srt_configs, "GraniteMoeHybridConfig", _UnavailableConfig
+)
+InternS2PreviewConfig = getattr(
+    srt_configs, "InternS2PreviewConfig", _UnavailableConfig
+)
+JetNemotronConfig = getattr(srt_configs, "JetNemotronConfig", _UnavailableConfig)
+JetVLMConfig = getattr(srt_configs, "JetVLMConfig", _UnavailableConfig)
+KimiLinearConfig = getattr(srt_configs, "KimiLinearConfig", _UnavailableConfig)
+Lfm2Config = getattr(srt_configs, "Lfm2Config", _UnavailableConfig)
+Lfm2MoeConfig = getattr(srt_configs, "Lfm2MoeConfig", _UnavailableConfig)
+Lfm2VlConfig = getattr(srt_configs, "Lfm2VlConfig", _UnavailableConfig)
+NemotronH_Nano_VL_V2_Config = getattr(
+    srt_configs, "NemotronH_Nano_VL_V2_Config", _UnavailableConfig
+)
+NemotronHConfig = getattr(srt_configs, "NemotronHConfig", _UnavailableConfig)
+Qwen3_5Config = getattr(srt_configs, "Qwen3_5Config", _UnavailableConfig)
+Qwen3_5MoeConfig = getattr(srt_configs, "Qwen3_5MoeConfig", _UnavailableConfig)
+Qwen3NextConfig = getattr(srt_configs, "Qwen3NextConfig", _UnavailableConfig)
+ZayaConfig = getattr(srt_configs, "ZayaConfig", _UnavailableConfig)
 
 _UNSET: Any = object()
 
@@ -694,6 +698,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         if self.server_args.elastic_ep_backend:
             ElasticEPStateManager.init(self.server_args)
+        from sglang.srt.kv_canary.token_oracle.install import (
+            install_token_oracle_from_env,
+        )
+
         self._token_oracle_manager = install_token_oracle_from_env(
             server_args=server_args,
             vocab_size=self.model_config.vocab_size,
@@ -835,6 +843,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
     def max_decode_logits_rows(self) -> int:
         """Rows the shared logits buffer needs."""
+        from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+            get_batch_sizes_to_capture,
+        )
+
         num_tokens_per_bs = self.decode_num_tokens_per_bs()
         capture_bs, _ = get_batch_sizes_to_capture(self, num_tokens_per_bs)
         return max(capture_bs) * num_tokens_per_bs
@@ -849,6 +861,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Must be called AFTER init_memory_pool so the pool object exists for
         # canary to monkey-patch, and BEFORE init_decode_cuda_graph so warmup
         # forwards captured into the graph see the patched pool methods.
+        from sglang.srt.kv_canary.api import install_canary
+
         self.canary_manager = install_canary(
             server_args=self.server_args,
             model_runner=self,
@@ -1641,6 +1655,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 ) from None
 
     def _prepare_moe_topk(self):
+        if not self.server_args.enable_deepep_waterfill:
+            return
+
+        from sglang.srt.layers.moe.hash_topk import HashTopK
+        from sglang.srt.layers.moe.topk import TopK
+
         balancer_cls = None
         num_prepared = 0
         num_routed_experts = None
@@ -2227,6 +2247,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             return None
 
     def init_lora_manager(self):
+        from sglang.srt.lora.lora_manager import LoRAManager
+
         self.lora_manager = LoRAManager(
             base_model=self.model,
             base_hf_config=self.model_config.hf_config,
@@ -2481,6 +2503,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 self.decode_attn_backend_group.append(self._get_attention_backend())
             self.decode_attn_backend = self.decode_attn_backend_group[0]
         elif self.server_args.enable_two_batch_overlap and not self.is_draft_worker:
+            from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
+
             self.attn_backend = TboAttnBackend.init_new(self._get_attention_backend)
         else:
             self.attn_backend = self._get_attention_backend()
@@ -2641,6 +2665,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         else:
             capture_name = f"{role} decode"
             num_tokens_per_bs = 1
+        from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+            get_batch_sizes_to_capture,
+        )
+
         capture_bs, _ = get_batch_sizes_to_capture(self, num_tokens_per_bs)
         decode_backend = self.server_args.cuda_graph_config.decode.backend
         logger.info(
@@ -2659,12 +2687,23 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
             graph_runners = defaultdict(
                 lambda: DecodeCudaGraphRunner,
-                {
-                    "cpu": CPUGraphRunner,
-                    "npu": NPUGraphRunner,
-                    "xpu": XPUGraphRunner,
-                },
             )
+            if self.device == "cpu":
+                from sglang.srt.model_executor.cpu_graph_runner import CPUGraphRunner
+
+                graph_runners["cpu"] = CPUGraphRunner
+            if self.device == "npu":
+                from sglang.srt.hardware_backend.npu.graph_runner.npu_graph_runner import (
+                    NPUGraphRunner,
+                )
+
+                graph_runners["npu"] = NPUGraphRunner
+            elif self.device == "xpu":
+                from sglang.srt.hardware_backend.xpu.graph_runner.xpu_graph_runner import (
+                    XPUGraphRunner,
+                )
+
+                graph_runners["xpu"] = XPUGraphRunner
             self.decode_cuda_graph_runner = graph_runners[self.device](self)
 
         after_mem = get_available_gpu_memory(self.device, self.gpu_id)
@@ -2828,6 +2867,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             f"Capture {capture_name} CUDA graph begin. "
             f"backend={prefill_backend}, num_tokens={capture_num_tokens}, "
             f"avail mem={before_mem:.2f} GB"
+        )
+
+        from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+            PrefillCudaGraphRunner,
         )
 
         self.prefill_cuda_graph_runner = PrefillCudaGraphRunner(self)
@@ -3000,6 +3043,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         # Step span
         step_span_ctx = profile_range(_build_step_span_name(forward_batch))
+
+        if not self.is_draft_worker and self.canary_manager is not None:
+            from sglang.srt.kv_canary.runner.canary_manager import context_tuple
 
         canary_ctx = (
             context_tuple(

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -24,17 +24,11 @@ from sglang.srt.mem_cache.allocator import (
     PagedTokenToKVPoolAllocator,
     TokenToKVPoolAllocator,
 )
-from sglang.srt.mem_cache.allocator.hisparse import (
-    DeepSeekV4HiSparseTokenToKVPoolAllocator,
-    HiSparseTokenToKVPoolAllocator,
-)
 from sglang.srt.mem_cache.allocator.swa import (
     PureSWATokenToKVPoolAllocator,
     SWATokenToKVPoolAllocator,
 )
 from sglang.srt.mem_cache.common import get_req_to_token_extra_context_len
-from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
-from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
 from sglang.srt.mem_cache.memory_pool import (
     DSATokenToKVPool,
     HybridLinearKVPool,
@@ -683,6 +677,10 @@ class ModelRunnerKVCacheMixin:
                     max_num_reqs=self.max_running_requests,
                 )
             else:
+                from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+                    DeepSeekV4TokenToKVPool,
+                )
+
                 pool_cls = DeepSeekV4TokenToKVPool
                 c4_state_pool_size = self.c4_state_pool_size
                 c128_state_pool_size = self.c128_state_pool_size
@@ -842,16 +840,19 @@ class ModelRunnerKVCacheMixin:
                     end_layer=self.end_layer,
                 )
         elif self.use_mla_backend and is_dsa_model:
-            PoolCls = (
-                HiSparseDSATokenToKVPool if self.enable_hisparse else DSATokenToKVPool
-            )
             pool_kwargs = {}
             if self.enable_hisparse:
+                from sglang.srt.mem_cache.hisparse_memory_pool import (
+                    HiSparseDSATokenToKVPool,
+                )
                 from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 
+                PoolCls = HiSparseDSATokenToKVPool
                 pool_kwargs["host_to_device_ratio"] = parse_hisparse_config(
                     self.server_args
                 ).host_to_device_ratio
+            else:
+                PoolCls = DSATokenToKVPool
             self.token_to_kv_pool = PoolCls(
                 self.max_total_num_tokens,
                 page_size=self.page_size,
@@ -1113,6 +1114,9 @@ class ModelRunnerKVCacheMixin:
                     )
                 else:
                     if self.enable_hisparse:
+                        from sglang.srt.mem_cache.allocator.hisparse import (
+                            HiSparseTokenToKVPoolAllocator,
+                        )
                         from sglang.srt.mem_cache.sparsity import (
                             parse_hisparse_config,
                         )
@@ -1148,6 +1152,10 @@ class ModelRunnerKVCacheMixin:
                         )
 
             if self.enable_hisparse and is_dsv4_model:
+                from sglang.srt.mem_cache.allocator.hisparse import (
+                    DeepSeekV4HiSparseTokenToKVPoolAllocator,
+                )
+
                 assert self.is_hybrid_swa, "DeepSeek V4 HiSparse requires SWA mode."
                 self.token_to_kv_pool_allocator = (
                     DeepSeekV4HiSparseTokenToKVPoolAllocator(

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -31,7 +31,6 @@ from sglang.srt.configs.model_config import (
 from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.mem_cache.common import get_alloc_len_per_decode
-from sglang.srt.mem_cache.deepseek_v4_memory_pool import get_compress_state_ring_size
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
 from sglang.srt.utils.common import (
     ceil_align,
@@ -70,6 +69,16 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
+
+
+def get_compress_state_ring_size(
+    compress_ratio: int, is_speculative: bool = False
+) -> int:
+    from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+        get_compress_state_ring_size as _get_compress_state_ring_size,
+    )
+
+    return _get_compress_state_ring_size(compress_ratio, is_speculative)
 
 
 def _get_dsv4_compress_state_dtype_sizes() -> tuple[int, int]:

--- a/python/sglang/srt/model_executor/runner/__init__.py
+++ b/python/sglang/srt/model_executor/runner/__init__.py
@@ -1,48 +1,18 @@
 """Phase-aware CUDA graph runners.
 
-One concrete runner per phase. Each runner owns its phase-specific
-shape semantics (decode → batch size; prefill → token count) and
-delegates capture/replay mechanics to a pluggable
-BaseCudaGraphBackend chosen via cuda_graph_config.
-
-Public API:
-  - BaseRunner — minimal abstract base shared by the cuda-graph runners
-    and the eager runner (shared __init__ + warmup + abstract
-    can_run_graph/load_batch/execute).
-  - BaseCudaGraphRunner — abstract cuda-graph base; bucket padding +
-    capture-loop scaffolding on top of BaseRunner.
-  - DecodeCudaGraphRunner — concrete decode-phase runner.
-  - PrefillCudaGraphRunner — concrete prefill-phase runner.
-  - EagerRunner — no-cuda-graph runner; runs model.forward live (the
-    eager dual of the cuda-graph runners), mode-dispatched over decode +
-    extend + idle.
-  - Buffer dataclasses, capture-mode flags, the global memory pool,
-    and the DeepEP adapter live in
-    sglang.srt.model_executor.runner_utils; they are
-    re-exported here for the EAGLE / multi-step draft cuda graph
-    runners that were authored against the legacy public surface.
+Keep this package initializer light: many model modules import small runner
+helpers during normal eager execution. CUDA-graph and DeepEP-specific classes
+are loaded lazily so disabled backends do not pull optional kernels at import
+time.
 """
 
-from sglang.srt.model_executor.runner.base_cuda_graph_runner import (  # noqa: F401
-    BaseCudaGraphRunner,
-    freeze_gc,
-    get_batch_sizes_to_capture,
-)
+from importlib import import_module
+
 from sglang.srt.model_executor.runner.base_runner import BaseRunner  # noqa: F401
-from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
-    DecodeCudaGraphRunner,
-)
 from sglang.srt.model_executor.runner.eager_runner import EagerRunner  # noqa: F401
-from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (  # noqa: F401
-    PrefillCudaGraphRunner,
-)
 from sglang.srt.model_executor.runner.shape_key import ShapeKey  # noqa: F401
-from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (  # noqa: F401
-    TCPCG_FAILURE_HINT,
-)
 from sglang.srt.model_executor.runner_utils import (  # noqa: F401
     DecodeInputBuffers,
-    DeepEPCudaGraphRunnerAdapter,
     PrefillInputBuffers,
     _grouped_foreach_copy_,
     _set_capture_lora_variant,
@@ -53,3 +23,39 @@ from sglang.srt.model_executor.runner_utils import (  # noqa: F401
     model_capture_mode,
     set_global_graph_memory_pool,
 )
+
+
+def __getattr__(name: str):
+    if name in {
+        "BaseCudaGraphRunner",
+        "freeze_gc",
+        "get_batch_sizes_to_capture",
+    }:
+        base_cuda_graph_runner = import_module(
+            "sglang.srt.model_executor.runner.base_cuda_graph_runner"
+        )
+
+        return getattr(base_cuda_graph_runner, name)
+    if name == "DecodeCudaGraphRunner":
+        from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+            DecodeCudaGraphRunner,
+        )
+
+        return DecodeCudaGraphRunner
+    if name == "PrefillCudaGraphRunner":
+        from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+            PrefillCudaGraphRunner,
+        )
+
+        return PrefillCudaGraphRunner
+    if name == "DeepEPCudaGraphRunnerAdapter":
+        from sglang.srt.model_executor.runner_utils import DeepEPCudaGraphRunnerAdapter
+
+        return DeepEPCudaGraphRunnerAdapter
+    if name == "TCPCG_FAILURE_HINT":
+        from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+            TCPCG_FAILURE_HINT,
+        )
+
+        return TCPCG_FAILURE_HINT
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 import torch
 
-from sglang.srt.batch_overlap.two_batch_overlap import TboCudaGraphRunnerPlugin
 from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
 from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
@@ -200,7 +199,13 @@ class BaseRunner(ABC):
         self.pp_size = model_runner.server_args.pp_size
         self.attn_tp_size = get_parallel().attn_tp_size
         self.attn_tp_rank = get_parallel().attn_tp_rank
-        self.tbo_plugin = TboCudaGraphRunnerPlugin()
+        self.tbo_plugin = None
+        if model_runner.server_args.enable_two_batch_overlap:
+            from sglang.srt.batch_overlap.two_batch_overlap import (
+                TboCudaGraphRunnerPlugin,
+            )
+
+            self.tbo_plugin = TboCudaGraphRunnerPlugin()
 
     def warmup(self) -> None:
         """Run kernel warmup + autotune once, gated by mr._kernel_warmed_up."""

--- a/python/sglang/srt/model_executor/runner_utils/__init__.py
+++ b/python/sglang/srt/model_executor/runner_utils/__init__.py
@@ -19,10 +19,17 @@ from sglang.srt.model_executor.runner_utils.capture_mode import (  # noqa: F401
     get_is_capture_mode,
     model_capture_mode,
 )
-from sglang.srt.model_executor.runner_utils.deepep_adapter import (  # noqa: F401
-    DeepEPCudaGraphRunnerAdapter,
-)
 from sglang.srt.model_executor.runner_utils.pool import (  # noqa: F401
     get_global_graph_memory_pool,
     set_global_graph_memory_pool,
 )
+
+
+def __getattr__(name: str):
+    if name == "DeepEPCudaGraphRunnerAdapter":
+        from sglang.srt.model_executor.runner_utils.deepep_adapter import (
+            DeepEPCudaGraphRunnerAdapter,
+        )
+
+        return DeepEPCudaGraphRunnerAdapter
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -46,10 +46,6 @@ from sglang.srt.distributed import (
 )
 from sglang.srt.layers.quantization import QuantizationConfig, get_quantization_config
 from sglang.srt.layers.quantization.fp8 import Fp8Config
-from sglang.srt.layers.quantization.modelopt_quant import (
-    ModelOptFp4Config,
-    ModelOptFp8Config,
-)
 from sglang.srt.model_loader.ci_weight_validation import (
     ci_download_with_validation_and_retry,
     ci_validate_and_cleanup_local_snapshot,
@@ -342,8 +338,16 @@ def get_quant_config(
                     )
                 return None
             elif quant_algo == "FP8" or model_config.quantization == "modelopt_fp8":
+                from sglang.srt.layers.quantization.modelopt_quant import (
+                    ModelOptFp8Config,
+                )
+
                 return ModelOptFp8Config.from_config(config)
             elif "FP4" in quant_algo:
+                from sglang.srt.layers.quantization.modelopt_quant import (
+                    ModelOptFp4Config,
+                )
+
                 return ModelOptFp4Config.from_config(config)
         return quant_cls.from_config(config)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -47,7 +47,12 @@ from sglang.srt.distributed.device_communicators.mooncake_transfer_engine import
 )
 from sglang.srt.environ import envs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
-from sglang.srt.layers.attention.fla.chunk_delta_h import CHUNK_SIZE as FLA_CHUNK_SIZE
+try:
+    from sglang.srt.layers.attention.fla.chunk_delta_h import (
+        CHUNK_SIZE as FLA_CHUNK_SIZE,
+    )
+except (ImportError, ModuleNotFoundError):
+    FLA_CHUNK_SIZE = 64
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.model_executor.cuda_graph_config import (
     ALLOWED_BACKENDS_PER_PHASE,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -62,10 +62,11 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_info import EagleVerifyInput
 
 
-if _is_cuda:
-    from sgl_kernel import fast_topk
-elif _is_hip:
-    from sgl_kernel import fast_topk
+if _is_cuda or _is_hip:
+    try:
+        from sgl_kernel import fast_topk
+    except ImportError:
+        from sglang.srt.utils.common import fast_topk
 else:
     from sglang.srt.utils.common import fast_topk
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -72,6 +72,8 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    get_args,
+    get_origin,
 )
 from unittest import SkipTest
 from unittest.case import _ShouldStop
@@ -104,6 +106,52 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 torch_release = pkg_version.parse(torch.__version__).release
+
+
+def _install_torch_get_device_module_compat() -> None:
+    if hasattr(torch, "get_device_module"):
+        return
+
+    def _get_device_module(device: Any = None):
+        if device is None:
+            if torch.cuda.is_available():
+                return torch.cuda
+            if hasattr(torch, "xpu") and torch.xpu.is_available():
+                return torch.xpu
+            if torch.backends.mps.is_available():
+                return torch.mps
+            return torch.cpu
+
+        device = torch.device(device)
+        if device.type == "cuda":
+            return torch.cuda
+        if device.type == "xpu" and hasattr(torch, "xpu"):
+            return torch.xpu
+        if device.type == "mps":
+            return torch.mps
+        if device.type == "cpu":
+            return torch.cpu
+        raise ValueError(f"Unknown device module: {device.type}")
+
+    torch.get_device_module = _get_device_module
+
+
+_install_torch_get_device_module_compat()
+
+
+def _get_fp8_e4m3_max() -> float:
+    fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+    if fp8_dtype is None:
+        return 448.0
+    if torch_release < (2, 3):
+        return 448.0
+    try:
+        return torch.finfo(fp8_dtype).max
+    except RuntimeError:
+        # Older CUDA 12.x PyTorch builds expose torch.float8_e4m3fn but do not
+        # implement finfo for it. Keep import-time platform probing alive; code
+        # paths that actually use FP8 kernels still validate their requirements.
+        return 448.0
 
 
 class Range(NamedTuple):
@@ -145,7 +193,7 @@ if is_hip():
     HIP_FP8_E4M3_FNUZ_MAX = 224.0
     FP8_E4M3_MAX = HIP_FP8_E4M3_FNUZ_MAX
 else:
-    FP8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+    FP8_E4M3_MAX = _get_fp8_e4m3_max()
 
 FP8_E4M3_MIN = -FP8_E4M3_MAX
 
@@ -324,7 +372,7 @@ try:
     is_intel_amx_backend_available = hasattr(
         torch.ops.sgl_kernel, "convert_weight_packed"
     )
-except:
+except Exception:
     is_intel_amx_backend_available = False
 
 try:
@@ -363,7 +411,13 @@ def is_flashinfer_available():
     """
     if not get_bool_env_var("SGLANG_IS_FLASHINFER_AVAILABLE", default="true"):
         return False
-    return importlib.util.find_spec("flashinfer") is not None and is_cuda()
+    if importlib.util.find_spec("flashinfer") is None or not is_cuda():
+        return False
+    try:
+        import flashinfer  # noqa: F401
+    except Exception:
+        return False
+    return True
 
 
 @lru_cache(maxsize=1)
@@ -810,7 +864,7 @@ def set_random_seed(seed: int) -> None:
     torch.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
-    if torch.xpu.is_available():
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
         torch.xpu.manual_seed_all(seed)
 
 
@@ -2229,6 +2283,209 @@ def get_compiler_backend(mode=None) -> str:
 sglang_lib = Library("sglang", "FRAGMENT")  # noqa
 
 
+def _fallback_infer_schema(
+    op_func: Callable,
+    mutates_args: List[str],
+) -> str:
+    def _annotation_name(annotation: Any) -> Optional[str]:
+        return annotation if isinstance(annotation, str) else None
+
+    def _is_tensor_annotation(annotation: Any) -> bool:
+        annotation_name = _annotation_name(annotation)
+        return annotation is torch.Tensor or annotation_name in (
+            "Tensor",
+            "torch.Tensor",
+        )
+
+    def _is_optional_tensor_annotation(annotation: Any) -> bool:
+        annotation_name = _annotation_name(annotation)
+        if annotation_name in (
+            "Optional[Tensor]",
+            "Optional[torch.Tensor]",
+            "typing.Optional[torch.Tensor]",
+            "Union[torch.Tensor, None]",
+            "Union[None, torch.Tensor]",
+            "torch.Tensor | None",
+            "None | torch.Tensor",
+        ):
+            return True
+
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+        if origin is Union and type(None) in args:
+            non_none_args = [arg for arg in args if arg is not type(None)]
+            return len(non_none_args) == 1 and _is_tensor_annotation(non_none_args[0])
+        return False
+
+    def _is_optional_scalar_annotation(
+        annotation: Any,
+        scalar_type: type,
+        scalar_names: tuple[str, ...],
+    ) -> bool:
+        annotation_name = _annotation_name(annotation)
+        if annotation_name in tuple(f"Optional[{name}]" for name in scalar_names) + tuple(
+            f"typing.Optional[{name}]" for name in scalar_names
+        ):
+            return True
+
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+        if origin is Union and type(None) in args:
+            non_none_args = [arg for arg in args if arg is not type(None)]
+            return len(non_none_args) == 1 and non_none_args[0] is scalar_type
+        return False
+
+    def _is_dtype_annotation(annotation: Any) -> bool:
+        annotation_name = _annotation_name(annotation)
+        return annotation is torch.dtype or annotation_name in (
+            "dtype",
+            "torch.dtype",
+        )
+
+    def _is_device_annotation(annotation: Any) -> bool:
+        annotation_name = _annotation_name(annotation)
+        return annotation is torch.device or annotation_name in (
+            "device",
+            "torch.device",
+        )
+
+    def _is_tensor_list_annotation(annotation: Any) -> bool:
+        annotation_name = _annotation_name(annotation)
+        if annotation_name in (
+            "List[Tensor]",
+            "List[torch.Tensor]",
+            "list[Tensor]",
+            "list[torch.Tensor]",
+            "Sequence[Tensor]",
+            "Sequence[torch.Tensor]",
+            "typing.Sequence[torch.Tensor]",
+        ):
+            return True
+
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+        return origin in (list, List) and args and _is_tensor_annotation(args[0])
+
+    def _format_tensor_tuple_return(annotation: Any) -> Optional[str]:
+        annotation_name = _annotation_name(annotation)
+        if annotation_name in (
+            "Tuple[Tensor, Tensor]",
+            "Tuple[torch.Tensor, torch.Tensor]",
+            "tuple[Tensor, Tensor]",
+            "tuple[torch.Tensor, torch.Tensor]",
+            "typing.Tuple[torch.Tensor, torch.Tensor]",
+        ):
+            return "(Tensor, Tensor)"
+
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+        if origin in (tuple, Tuple) and args and all(
+            _is_tensor_annotation(arg) for arg in args
+        ):
+            return f"({', '.join('Tensor' for _ in args)})"
+        return None
+
+    def _format_type(annotation: Any, name: str) -> str:
+        alias = ""
+        if name in mutates_args:
+            alias = f"({chr(ord('a') + mutates_args.index(name))}!)"
+
+        if _is_tensor_annotation(annotation):
+            return f"Tensor{alias}"
+        if _is_tensor_list_annotation(annotation):
+            return f"Tensor[]{alias}"
+        if _is_optional_tensor_annotation(annotation):
+            return f"Tensor?{alias}"
+        if _is_optional_scalar_annotation(annotation, int, ("int",)):
+            return "SymInt?"
+        if _is_optional_scalar_annotation(annotation, float, ("float",)):
+            return "float?"
+        if _is_optional_scalar_annotation(annotation, bool, ("bool",)):
+            return "bool?"
+        if _is_optional_scalar_annotation(annotation, str, ("str",)):
+            return "str?"
+        if _is_dtype_annotation(annotation):
+            return "ScalarType"
+        if _is_optional_scalar_annotation(annotation, torch.dtype, ("torch.dtype",)):
+            return "ScalarType?"
+        if _is_device_annotation(annotation):
+            return "Device"
+        if _is_optional_scalar_annotation(annotation, torch.device, ("torch.device",)):
+            return "Device?"
+        if annotation is int or annotation == "int":
+            return "SymInt"
+        if annotation is float or annotation == "float":
+            return "float"
+        if annotation is bool or annotation == "bool":
+            return "bool"
+        if annotation is str or annotation == "str":
+            return "str"
+        raise TypeError(
+            f"Cannot infer custom op schema for argument {name!r} with "
+            f"annotation {annotation!r} on this PyTorch version."
+        )
+
+    def _format_return(annotation: Any) -> str:
+        if annotation is None or annotation is type(None) or annotation == "None":
+            return "()"
+        if _is_tensor_annotation(annotation):
+            return "Tensor"
+        if _is_tensor_list_annotation(annotation):
+            return "Tensor[]"
+        tensor_tuple_return = _format_tensor_tuple_return(annotation)
+        if tensor_tuple_return is not None:
+            return tensor_tuple_return
+        if _is_dtype_annotation(annotation):
+            return "ScalarType"
+        if _is_device_annotation(annotation):
+            return "Device"
+        if annotation is int or annotation == "int":
+            return "SymInt"
+        if annotation is float or annotation == "float":
+            return "float"
+        if annotation is bool or annotation == "bool":
+            return "bool"
+        raise TypeError(
+            f"Cannot infer custom op return schema for annotation {annotation!r} "
+            "on this PyTorch version."
+        )
+
+    def _format_default(default: Any) -> str:
+        if default is inspect.Parameter.empty:
+            return ""
+        if default is None:
+            return "=None"
+        if isinstance(default, bool):
+            return f"={default}"
+        if isinstance(default, (int, float)):
+            return f"={default}"
+        if isinstance(default, str):
+            return f"={default!r}"
+        return ""
+
+    signature = inspect.signature(op_func)
+    args_schema = []
+    inserted_kw_marker = False
+    for name, param in signature.parameters.items():
+        if param.annotation is inspect.Parameter.empty:
+            raise TypeError(
+                f"Cannot infer custom op schema for argument {name!r} without "
+                "a type annotation."
+            )
+        if param.kind is inspect.Parameter.KEYWORD_ONLY and not inserted_kw_marker:
+            args_schema.append("*")
+            inserted_kw_marker = True
+        args_schema.append(
+            f"{_format_type(param.annotation, name)} {name}"
+            f"{_format_default(param.default)}"
+        )
+
+    if signature.return_annotation is inspect.Signature.empty:
+        raise TypeError("Cannot infer custom op schema without a return annotation.")
+    return_schema = _format_return(signature.return_annotation)
+    return f"({', '.join(args_schema)}) -> {return_schema}"
+
+
 def direct_register_custom_op(
     op_name: str,
     op_func: Callable,
@@ -2279,10 +2536,16 @@ def direct_register_custom_op(
     if hasattr(torch.library, "infer_schema"):
         schema_str = torch.library.infer_schema(op_func, mutates_args=mutates_args)
     else:
-        # for pytorch 2.4
+        # for pytorch 2.4 and older
         import torch._custom_op.impl
 
-        schema_str = torch._custom_op.impl.infer_schema(op_func, mutates_args)
+        try:
+            schema_str = torch._custom_op.impl.infer_schema(op_func, mutates_args)
+        except TypeError:
+            try:
+                schema_str = torch._custom_op.impl.infer_schema(op_func)
+            except (TypeError, ValueError):
+                schema_str = _fallback_infer_schema(op_func, mutates_args)
 
     try:
         my_lib.define(op_name + schema_str)
@@ -2295,7 +2558,7 @@ def direct_register_custom_op(
             my_lib.impl(op_name, op_func, "MUSA")
         else:
             my_lib.impl(op_name, op_func, "CUDA")
-        if fake_impl is not None:
+        if fake_impl is not None and hasattr(my_lib, "_register_fake"):
             my_lib._register_fake(op_name, fake_impl)
     except RuntimeError as error:
         if "Tried to register an operator" in str(error) and "multiple times" in str(

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -21,43 +21,7 @@ from typing import Any, Dict, Optional, Type, Union
 import torch
 from huggingface_hub import snapshot_download
 
-from sglang.srt.configs import (
-    AfmoeConfig,
-    BailingHybridConfig,
-    ChatGLMConfig,
-    DbrxConfig,
-    DeepseekVL2Config,
-    DotsOCRConfig,
-    DotsVLMConfig,
-    ExaoneConfig,
-    FalconH1Config,
-    GraniteMoeHybridConfig,
-    InternS2PreviewConfig,
-    JetNemotronConfig,
-    JetVLMConfig,
-    KimiK25Config,
-    KimiLinearConfig,
-    KimiVLConfig,
-    LagunaConfig,
-    LocateAnythingConfig,
-    LongcatFlashConfig,
-    MiniCPMV4_6Config,
-    MiniCPMV4_6VisionConfig,
-    MultiModalityConfig,
-    NemotronH_Nano_Omni_Reasoning_V3_Config,
-    NemotronH_Nano_VL_V2_Config,
-    NemotronHConfig,
-    NemotronHPuzzleConfig,
-    Olmo3Config,
-    Qwen3_5Config,
-    Qwen3_5MoeConfig,
-    Qwen3NextConfig,
-    Step3p5Config,
-    Step3p7Config,
-    Step3VLConfig,
-)
-from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
-from sglang.srt.configs.internvl import InternVLChatConfig
+from sglang.srt import configs as sgl_configs
 from sglang.srt.utils import get_bool_env_var, logger, lru_cache_frozenset
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 
@@ -77,43 +41,59 @@ from transformers import PretrainedConfig
 _CONFIG_REGISTRY: Dict[str, Type[PretrainedConfig]] = {
     cls.model_type: cls
     for cls in [
-        AfmoeConfig,
-        BailingHybridConfig,
-        ChatGLMConfig,
-        DbrxConfig,
-        ExaoneConfig,
-        DeepseekVL2Config,
-        MultiModalityConfig,
-        KimiVLConfig,
-        LocateAnythingConfig,
-        InternVLChatConfig,
-        LagunaConfig,
-        Step3VLConfig,
-        LongcatFlashConfig,
-        Olmo3Config,
-        KimiLinearConfig,
-        Qwen3NextConfig,
-        FalconH1Config,
-        GraniteMoeHybridConfig,
-        DotsVLMConfig,
-        DotsOCRConfig,
-        NemotronH_Nano_VL_V2_Config,
-        NemotronH_Nano_Omni_Reasoning_V3_Config,
-        NemotronHConfig,
-        NemotronHPuzzleConfig,
-        DeepseekVLV2Config,
-        Qwen3_5Config,
-        Qwen3_5MoeConfig,
-        InternS2PreviewConfig,
-        JetNemotronConfig,
-        JetVLMConfig,
-        KimiK25Config,
-        Step3p5Config,
-        Step3p7Config,
-        MiniCPMV4_6Config,
-        MiniCPMV4_6VisionConfig,
+        getattr(sgl_configs, name, None)
+        for name in (
+            "AfmoeConfig",
+            "BailingHybridConfig",
+            "ChatGLMConfig",
+            "DbrxConfig",
+            "ExaoneConfig",
+            "DeepseekVL2Config",
+            "MultiModalityConfig",
+            "KimiVLConfig",
+            "LocateAnythingConfig",
+            "LagunaConfig",
+            "Step3VLConfig",
+            "LongcatFlashConfig",
+            "Olmo3Config",
+            "KimiLinearConfig",
+            "Qwen3NextConfig",
+            "FalconH1Config",
+            "GraniteMoeHybridConfig",
+            "DotsVLMConfig",
+            "DotsOCRConfig",
+            "NemotronH_Nano_VL_V2_Config",
+            "NemotronH_Nano_Omni_Reasoning_V3_Config",
+            "NemotronHConfig",
+            "NemotronHPuzzleConfig",
+            "Qwen3_5Config",
+            "Qwen3_5MoeConfig",
+            "InternS2PreviewConfig",
+            "JetNemotronConfig",
+            "JetVLMConfig",
+            "KimiK25Config",
+            "Step3p5Config",
+            "Step3p7Config",
+            "MiniCPMV4_6Config",
+            "MiniCPMV4_6VisionConfig",
+        )
     ]
+    if cls is not None
 }
+
+try:
+    from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
+
+    _CONFIG_REGISTRY[DeepseekVLV2Config.model_type] = DeepseekVLV2Config
+except (ImportError, ModuleNotFoundError, AttributeError):
+    pass
+
+try:
+    from sglang.srt.configs.internvl import InternVLChatConfig
+
+    _CONFIG_REGISTRY[InternVLChatConfig.model_type] = InternVLChatConfig
+except (ImportError, ModuleNotFoundError, AttributeError):
+    pass
 
 # DeepSeek V3.2 / V4 reuse the V3 config schema. Subclass the upstream
 # transformers class with each model_type so AutoConfig.register passes its

--- a/python/sglang/srt/utils/patch_torch.py
+++ b/python/sglang/srt/utils/patch_torch.py
@@ -132,7 +132,11 @@ def register_fake_if_exists(op_name):
     def decorator(func):
         namespace, bare_op = op_name.split("::")
         ops_namespace = getattr(torch.ops, namespace, None)
-        if ops_namespace and hasattr(ops_namespace, bare_op):
+        if (
+            ops_namespace
+            and hasattr(ops_namespace, bare_op)
+            and hasattr(torch.library, "register_fake")
+        ):
             torch.library.register_fake(op_name, func)
         return func
 

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -1,20 +1,22 @@
+from __future__ import annotations
+
 import hashlib
 import logging
 import time
-from typing import Dict, Iterable, NamedTuple, Optional, Set
+from typing import TYPE_CHECKING, Dict, Iterable, NamedTuple, Optional, Set
 
 import torch
 import torch.distributed as dist
 from pydantic import BaseModel, ConfigDict
 
 from sglang.srt.managers.mm_utils import tensor_hash
-from sglang.srt.utils.weight_checker_comparator import (
-    CHUNK_NUMEL,
-    ComparableWeight,
-    RawComparable,
-    compare_weights,
-    select_comparable_weight,
-)
+
+if TYPE_CHECKING:
+    from sglang.srt.utils.weight_checker_comparator import ComparableWeight
+
+# Keep in sync with weight_checker_comparator.CHUNK_NUMEL without importing the
+# comparator module during server startup.
+CHUNK_NUMEL = 64 * 1024 * 1024
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +185,8 @@ def _check_tensors(
     actual_tensors: Iterable[CheckEntry],
     allow_quant_error: bool = False,
 ):
+    from sglang.srt.utils.weight_checker_comparator import compare_weights
+
     good_names = []
     error_messages = []
     info_messages = []
@@ -256,6 +260,8 @@ def _random_like(t: torch.Tensor):
 def _build_quantized_set(model) -> Dict[str, QuantizedWeight]:
     """Run the router over the model: {weight_name: QuantizedWeight} for each
     quantized weight; weights absent from the set compare raw."""
+    from sglang.srt.utils.weight_checker_comparator import select_comparable_weight
+
     quantized_set = {}
     for module_name, module in model.named_modules():
         comparable_cls = select_comparable_weight(getattr(module, "quant_method", None))
@@ -279,6 +285,8 @@ def _build_check_entries(
 ) -> Iterable[CheckEntry]:
     """Yields a CheckEntry per weight; quantized weights consume their scale, everything
     else is raw."""
+    from sglang.srt.utils.weight_checker_comparator import RawComparable
+
     skip_compare_names = set(skip_compare_names)
     quantized_set = quantized_set or {}
     scale_names = {qw.scale_name for qw in quantized_set.values()}

--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -28,6 +28,13 @@ enable_language(CUDA)
 find_package(CUDAToolkit REQUIRED)
 set_property(GLOBAL PROPERTY CUDA_SEPARABLE_COMPILATION ON)
 
+if (NOT CUDA_VERSION)
+    if (DEFINED CUDAToolkit_VERSION_MAJOR AND DEFINED CUDAToolkit_VERSION_MINOR)
+        set(CUDA_VERSION "${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}")
+    else()
+        string(REGEX MATCH "^[0-9]+\\.[0-9]+" CUDA_VERSION "${CUDAToolkit_VERSION}")
+    endif()
+endif()
 message(STATUS "Detected CUDA_VERSION=${CUDA_VERSION}")
 if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "13.0")
     message("CUDA_VERSION ${CUDA_VERSION} >= 13.0")
@@ -77,6 +84,17 @@ FetchContent_Declare(
     URL_HASH SHA256=931dfd118f4b6de8c7d98702153c7c03840139170af21a07607693bd9749744d
 )
 FetchContent_Populate(repo-flashinfer)
+set(SGL_KERNEL_FLASHINFER_RENORM "${repo-flashinfer_SOURCE_DIR}/csrc/renorm.cu")
+file(READ "${SGL_KERNEL_FLASHINFER_RENORM}" SGL_KERNEL_FLASHINFER_RENORM_CONTENT)
+if (NOT SGL_KERNEL_FLASHINFER_RENORM_CONTENT MATCHES "#include <optional>")
+    string(REPLACE
+        "#include <flashinfer/sampling.cuh>"
+        "#include <optional>\n\n#include <flashinfer/sampling.cuh>"
+        SGL_KERNEL_FLASHINFER_RENORM_CONTENT
+        "${SGL_KERNEL_FLASHINFER_RENORM_CONTENT}"
+    )
+    file(WRITE "${SGL_KERNEL_FLASHINFER_RENORM}" "${SGL_KERNEL_FLASHINFER_RENORM_CONTENT}")
+endif()
 
 # flash-attention
 FetchContent_Declare(
@@ -85,6 +103,29 @@ FetchContent_Declare(
     URL_HASH SHA256=418b5681584dc3efff496a1cab5ffd58d2728d89dcfe0ea16e6985d6ef35c68c
 )
 FetchContent_Populate(repo-flash-attention)
+set(SGL_KERNEL_FLASH_SPARSE_API "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/flash_sparse_api.cpp")
+file(READ "${SGL_KERNEL_FLASH_SPARSE_API}" SGL_KERNEL_FLASH_SPARSE_API_CONTENT)
+if (NOT SGL_KERNEL_FLASH_SPARSE_API_CONTENT MATCHES "#include <optional>")
+    string(REPLACE
+        "#include <torch/nn/functional.h>"
+        "#include <optional>\n\n#include <torch/nn/functional.h>"
+        SGL_KERNEL_FLASH_SPARSE_API_CONTENT
+        "${SGL_KERNEL_FLASH_SPARSE_API_CONTENT}"
+    )
+endif()
+string(REPLACE
+    "void set_params_alibi(Flash_fwd_params &params, std::optional<at::Tensor> &alibi_slopes_, int batch_size, int num_heads){"
+    "template <typename OptionalTensor>\nvoid set_params_alibi(Flash_fwd_params &params, const OptionalTensor &alibi_slopes_, int batch_size, int num_heads){"
+    SGL_KERNEL_FLASH_SPARSE_API_CONTENT
+    "${SGL_KERNEL_FLASH_SPARSE_API_CONTENT}"
+)
+string(REPLACE
+    "const_cast<std::optional<at::Tensor> &>(alibi_slopes_)"
+    "alibi_slopes_"
+    SGL_KERNEL_FLASH_SPARSE_API_CONTENT
+    "${SGL_KERNEL_FLASH_SPARSE_API_CONTENT}"
+)
+file(WRITE "${SGL_KERNEL_FLASH_SPARSE_API}" "${SGL_KERNEL_FLASH_SPARSE_API_CONTENT}")
 
 # ccache option
 option(ENABLE_CCACHE "Whether to use ccache" ON)
@@ -177,6 +218,12 @@ option(SGL_KERNEL_ENABLE_FA3              "Enable FA3"              ${DEFAULT_SG
 option(SGL_KERNEL_ENABLE_SM90A            "Enable SM90A"            OFF)
 option(SGL_KERNEL_ENABLE_SM100A           "Enable SM100A"           OFF)
 
+set(DEFAULT_SGL_KERNEL_ENABLE_SPATIAL OFF)
+if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.4")
+    set(DEFAULT_SGL_KERNEL_ENABLE_SPATIAL ON)
+endif()
+option(SGL_KERNEL_ENABLE_SPATIAL          "Enable green-context spatial ops" ${DEFAULT_SGL_KERNEL_ENABLE_SPATIAL})
+
 if (SGL_KERNEL_ENABLE_BF16)
     list(APPEND SGL_KERNEL_CUDA_FLAGS
         "-DFLASHINFER_ENABLE_BF16"
@@ -242,6 +289,14 @@ if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_FP4)
     )
 endif()
 
+set(SGL_KERNEL_ENABLE_MXFP8_SM100 OFF)
+if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8")
+    set(SGL_KERNEL_ENABLE_MXFP8_SM100 ON)
+    list(APPEND SGL_KERNEL_CUDA_FLAGS
+        "-DSGL_KERNEL_ENABLE_MXFP8_SM100"
+    )
+endif()
+
 # All source files
 # NOTE: Please sort the filenames alphabetically
 set(SOURCES
@@ -258,8 +313,6 @@ set(SOURCES
     "csrc/elementwise/pos_enc.cu"
     "csrc/elementwise/topk.cu"
     "csrc/expert_specialization/es_fp8_blockwise.cu"
-    "csrc/expert_specialization/es_sm100_mxfp8_blockscaled.cu"
-    "csrc/expert_specialization/es_sm100_mxfp8_blockscaled_group_quant.cu"
 
     "csrc/gemm/awq_kernel.cu"
     "csrc/gemm/bmm_fp8.cu"
@@ -308,6 +361,13 @@ set(SOURCES
     "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src/flash_fwd_sparse_hdim128_fp16_sm80.cu"
     "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/flash_sparse_api.cpp"
 )
+
+if (SGL_KERNEL_ENABLE_MXFP8_SM100)
+    list(APPEND SOURCES
+        "csrc/expert_specialization/es_sm100_mxfp8_blockscaled.cu"
+        "csrc/expert_specialization/es_sm100_mxfp8_blockscaled_group_quant.cu"
+    )
+endif()
 
 set(INCLUDES
     ${repo-cutlass_SOURCE_DIR}/include
@@ -475,16 +535,21 @@ if (SGL_KERNEL_ENABLE_FA3)
     target_compile_definitions(flash_ops PRIVATE ${FLASH_OPS_COMPILE_DEFS})
 endif()
 
-# Build spatial_ops as a separate, optional extension for green contexts
-set(SPATIAL_SOURCES
-    "csrc/spatial/greenctx_stream.cu"
-    "csrc/spatial_extension.cc"
-)
+# Build spatial_ops as a separate, optional extension for green contexts.
+# CUDA green-context driver APIs are not available in CUDA 12.2 headers.
+if (SGL_KERNEL_ENABLE_SPATIAL)
+    set(SPATIAL_SOURCES
+        "csrc/spatial/greenctx_stream.cu"
+        "csrc/spatial_extension.cc"
+    )
 
-Python_add_library(spatial_ops MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI ${SPATIAL_SOURCES})
-target_compile_options(spatial_ops PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${SGL_KERNEL_CUDA_FLAGS}>)
-target_link_libraries(spatial_ops PRIVATE ${TORCH_LIBRARIES} c10 cuda)
-install(TARGETS spatial_ops LIBRARY DESTINATION sgl_kernel)
+    Python_add_library(spatial_ops MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI ${SPATIAL_SOURCES})
+    target_compile_options(spatial_ops PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${SGL_KERNEL_CUDA_FLAGS}>)
+    target_link_libraries(spatial_ops PRIVATE ${TORCH_LIBRARIES} c10 cuda)
+    install(TARGETS spatial_ops LIBRARY DESTINATION sgl_kernel)
+else()
+    message(STATUS "Skipping spatial_ops because CUDA green-context APIs require CUDA >= 12.4")
+endif()
 
 # ============================ Extra Install: FLashMLA ============================= #
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/flashmla.cmake)

--- a/sgl-kernel/cmake/flashmla.cmake
+++ b/sgl-kernel/cmake/flashmla.cmake
@@ -1,4 +1,16 @@
 # flash_mla
+set(DEFAULT_SGL_KERNEL_ENABLE_FLASHMLA OFF)
+if("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.4")
+    set(DEFAULT_SGL_KERNEL_ENABLE_FLASHMLA ON)
+endif()
+option(SGL_KERNEL_ENABLE_FLASHMLA "Enable FlashMLA ops" ${DEFAULT_SGL_KERNEL_ENABLE_FLASHMLA})
+
+# The FlashMLA kernels only work on Hopper and require CUDA 12.4 or later.
+if(NOT SGL_KERNEL_ENABLE_FLASHMLA)
+    message(STATUS "Skipping flashmla_ops because FlashMLA requires CUDA >= 12.4")
+    return()
+endif()
+
 # sm90 dense decode HEAD_DIM_K=512 support (sgl-project/FlashMLA#9, merged).
 FetchContent_Declare(
     repo-flashmla
@@ -26,15 +38,12 @@ set(FLASHMLA_CUDA_FLAGS
 
 set(FLASHMLA_ENABLE_SM100 OFF)
 
-# The FlashMLA kernels only work on hopper and require CUDA 12.4 or later.
-# Only build FlashMLA kernels if we are building for something compatible with
-# sm90a
-if(${CUDA_VERSION} VERSION_GREATER 12.4)
+if("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.4")
     list(APPEND FLASHMLA_CUDA_FLAGS
         "-gencode=arch=compute_90a,code=sm_90a"
     )
 endif()
-if(${CUDA_VERSION} VERSION_GREATER 12.8)
+if("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8")
     list(APPEND FLASHMLA_CUDA_FLAGS
         "-gencode=arch=compute_100a,code=sm_100a"
     )

--- a/sgl-kernel/csrc/allreduce/quick_all_reduce.cu
+++ b/sgl-kernel/csrc/allreduce/quick_all_reduce.cu
@@ -3,6 +3,8 @@
 #include <c10/cuda/CUDAStream.h>
 #include <torch/all.h>
 
+#include <optional>
+
 #ifdef USE_ROCM
 
 #include "quick_all_reduce.h"

--- a/sgl-kernel/csrc/allreduce/quick_all_reduce.h
+++ b/sgl-kernel/csrc/allreduce/quick_all_reduce.h
@@ -2,6 +2,7 @@
 
 #include <hip/hip_runtime.h>
 
+#include <optional>
 #include <vector>
 
 #include "quick_all_reduce.cuh"

--- a/sgl-kernel/csrc/attention/cutlass_mla_kernel.cu
+++ b/sgl-kernel/csrc/attention/cutlass_mla_kernel.cu
@@ -38,6 +38,7 @@ void cutlass_mla_decode(
     torch::Tensor const& seq_lens,
     torch::Tensor const& page_table,
     torch::Tensor const& workspace,
+    double sm_scale,
     int64_t num_kv_splits) {
   TORCH_CHECK(false, "CUDA version must be >= 12.4 for cutlass_mla_decode");
 }

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -15,8 +15,10 @@ limitations under the License.
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <torch/all.h>
 #include <torch/library.h>
+#include <torch/version.h>
 
 #include "sgl_kernel_ops.h"
+#include "sgl_kernel_torch_shim.h"
 
 TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   /*
@@ -77,7 +79,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "rotary_embedding(Tensor positions, Tensor! query,"
       "                 Tensor!? key, int head_size,"
       "                 Tensor cos_sin_cache, bool is_neox) -> ()");
-  m.impl("rotary_embedding", torch::kCUDA, &rotary_embedding);
+  m.impl("rotary_embedding", torch::kCUDA, make_pytorch_shim(&rotary_embedding));
 
   m.def("copy_to_gpu_no_ce(Tensor input, Tensor! output) -> ()");
   m.impl("copy_to_gpu_no_ce", torch::kCUDA, &copy_to_gpu_no_ce);
@@ -88,15 +90,15 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("concat_mla_absorb_q", torch::kCUDA, &concat_mla_absorb_q);
 
   m.def("fast_topk(Tensor score, Tensor indices, Tensor lengths, Tensor? row_starts) -> ()");
-  m.impl("fast_topk", torch::kCUDA, &fast_topk_interface);
+  m.impl("fast_topk", torch::kCUDA, make_pytorch_shim(&fast_topk_interface));
   m.def(
       "fast_topk_transform_fused(Tensor score, Tensor lengths, Tensor dst_page_table, Tensor src_page_table, Tensor "
       "cu_seqlens_q, Tensor? row_starts) -> ()");
-  m.impl("fast_topk_transform_fused", torch::kCUDA, &fast_topk_transform_interface);
+  m.impl("fast_topk_transform_fused", torch::kCUDA, make_pytorch_shim(&fast_topk_transform_interface));
   m.def(
       "fast_topk_transform_ragged_fused(Tensor score, Tensor lengths, Tensor topk_indices_ragged, Tensor "
       "topk_indices_offset, Tensor ? row_starts) -> ()");
-  m.impl("fast_topk_transform_ragged_fused", torch::kCUDA, &fast_topk_transform_ragged_interface);
+  m.impl("fast_topk_transform_ragged_fused", torch::kCUDA, make_pytorch_shim(&fast_topk_transform_ragged_interface));
 
   /*
    * From csrc/gemm
@@ -127,7 +129,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def(
       "sgl_per_token_group_quant_8bit_v2(Tensor input, Tensor! output_q, Tensor! output_s, int group_size,"
       " float eps, float fp8_min, float fp8_max, bool scale_ue8m0, bool fuse_silu_and_mul, Tensor? masked_m) -> ()");
-  m.impl("sgl_per_token_group_quant_8bit_v2", torch::kCUDA, &sgl_per_token_group_quant_8bit_v2);
+  m.impl("sgl_per_token_group_quant_8bit_v2", torch::kCUDA, make_pytorch_shim(&sgl_per_token_group_quant_8bit_v2));
 
   m.def("sgl_per_token_quant_fp8(Tensor input, Tensor! output_q, Tensor! output_s) -> ()");
   m.impl("sgl_per_token_quant_fp8", torch::kCUDA, &sgl_per_token_quant_fp8);
@@ -194,13 +196,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "prepare_moe_input(Tensor topk_ids, Tensor expert_offsets, Tensor? blockscale_offsets, Tensor problem_sizes1,"
       " Tensor problem_sizes2, Tensor input_permutation, Tensor output_permutation, int num_experts, int n, int k) -> "
       "()");
-  m.impl("prepare_moe_input", torch::kCUDA, &prepare_moe_input);
+  m.impl("prepare_moe_input", torch::kCUDA, make_pytorch_shim(&prepare_moe_input));
 
   m.def("shuffle_rows(Tensor input, Tensor dst2src_map, Tensor output) -> ()");
   m.impl("shuffle_rows", torch::kCUDA, &shuffle_rows);
 
   m.def("apply_shuffle_mul_sum(Tensor input, Tensor output, Tensor permutation, Tensor? factors) -> ()");
-  m.impl("apply_shuffle_mul_sum", torch::kCUDA, &apply_shuffle_mul_sum);
+  m.impl("apply_shuffle_mul_sum", torch::kCUDA, make_pytorch_shim(&apply_shuffle_mul_sum));
 
   // DeepSeek-V4 fused norm + rope
   m.def(
@@ -348,17 +350,23 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   /*
    * From FlashInfer
    */
+#if TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 8)
   m.def(
       "bmm_fp8(Tensor A, Tensor B, Tensor! D, Tensor A_scale, Tensor B_scale, Tensor workspace_buffer, "
       "int cublas_handle) -> ()",
       {at::Tag::needs_fixed_stride_order});
+#else
+  m.def(
+      "bmm_fp8(Tensor A, Tensor B, Tensor! D, Tensor A_scale, Tensor B_scale, Tensor workspace_buffer, "
+      "int cublas_handle) -> ()");
+#endif
   m.impl("bmm_fp8", torch::kCUDA, &bmm_fp8);
 
   m.def("top_k_renorm_probs(Tensor probs, Tensor! renorm_probs, Tensor? maybe_top_k_arr, int top_k_val) -> ()");
-  m.impl("top_k_renorm_probs", torch::kCUDA, &top_k_renorm_probs);
+  m.impl("top_k_renorm_probs", torch::kCUDA, make_pytorch_shim(&top_k_renorm_probs));
 
   m.def("top_p_renorm_probs(Tensor probs, Tensor! renorm_probs, Tensor? maybe_top_p_arr, float top_p_val) -> ()");
-  m.impl("top_p_renorm_probs", torch::kCUDA, &top_p_renorm_probs);
+  m.impl("top_p_renorm_probs", torch::kCUDA, make_pytorch_shim(&top_p_renorm_probs));
 
   /*
    * From Sparse Flash Attention
@@ -370,7 +378,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "float p_dropout, float softmax_scale, bool is_causal, "
       "float softcap, bool return_softmax, Generator? gen)"
       "-> Tensor[]");
-  m.impl("fwd_sparse", torch::kCUDA, &flash::mha_fwd_sparse);
+  m.impl("fwd_sparse", torch::kCUDA, make_pytorch_shim(&flash::mha_fwd_sparse));
 
   m.def(
       "varlen_fwd_sparse(Tensor! q, Tensor k, Tensor v, "
@@ -429,7 +437,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def(
       "ggml_dequantize(Tensor W, int type, SymInt m, SymInt n, ScalarType? "
       "dtype) -> Tensor");
-  m.impl("ggml_dequantize", torch::kCUDA, &ggml_dequantize);
+  m.impl("ggml_dequantize", torch::kCUDA, make_pytorch_shim(&ggml_dequantize));
 
   m.def(
       "ggml_mul_mat_vec_a8(Tensor W, Tensor X, int type, SymInt row) "
@@ -467,7 +475,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "Tensor? cache_seqlens_,"
       "Tensor? conv_state_indices,"
       "int pad_slot_id) -> ()");
-  m.impl("causal_conv1d_update", torch::kCUDA, &causal_conv1d_update);
+  m.impl("causal_conv1d_update", torch::kCUDA, make_pytorch_shim(&causal_conv1d_update));
 
   m.def(
       "causal_conv1d_fwd(Tensor! x, Tensor! weight,"
@@ -478,7 +486,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "Tensor? has_initial_state,"
       "bool silu_activation,"
       "int pad_slot_id) -> ()");
-  m.impl("causal_conv1d_fwd", torch::kCUDA, &causal_conv1d_fwd);
+  m.impl("causal_conv1d_fwd", torch::kCUDA, make_pytorch_shim(&causal_conv1d_fwd));
 
   /*
    * From csrc/expert_sepcialization
@@ -488,6 +496,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "stride_a, Tensor stride_b, Tensor stride_d, Tensor problem_sizes, Tensor expert_offsets, Tensor workspace) -> "
       "()");
   m.impl("es_fp8_blockwise_scaled_grouped_mm", &es_fp8_blockwise_scaled_grouped_mm);
+#ifdef SGL_KERNEL_ENABLE_MXFP8_SM100
   m.def(
       "es_sm100_mxfp8_blockscaled_grouped_mm(Tensor a, Tensor b, Tensor sfa, Tensor sfb, Tensor d, Tensor "
       "problem_sizes, Tensor expert_offsets, Tensor blockscale_offsets) -> ()");
@@ -496,6 +505,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "es_sm100_mxfp8_blockscaled_grouped_quant(Tensor input, Tensor problem_sizes, Tensor expert_offsets, Tensor "
       "blockscale_offsets, Tensor quant_output, Tensor scale_factor) -> () ");
   m.impl("es_sm100_mxfp8_blockscaled_grouped_quant", &es_sm100_mxfp8_blockscaled_grouped_quant);
+#endif
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/sgl-kernel/csrc/cutlass_extensions/epilogue/scaled_mm_epilogues_c3x.hpp
+++ b/sgl-kernel/csrc/cutlass_extensions/epilogue/scaled_mm_epilogues_c3x.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "cutlass_extensions/epilogue/broadcast_load_epilogue_c3x.hpp"
 
 /*

--- a/sgl-kernel/csrc/cutlass_extensions/gemm/fp8_gemm_sm90_dispatch.cuh
+++ b/sgl-kernel/csrc/cutlass_extensions/gemm/fp8_gemm_sm90_dispatch.cuh
@@ -548,7 +548,7 @@ void cutlass_scaled_mm_sm90_fp8(
     torch::Tensor const& b,
     torch::Tensor const& a_scales,
     torch::Tensor const& b_scales,
-    std::optional<torch::Tensor> const& bias) {
+    const c10::optional<torch::Tensor>& bias) {
   TORCH_CHECK(a_scales.is_contiguous() && b_scales.is_contiguous());
   if (bias) {
     TORCH_CHECK(bias->dtype() == out.dtype(), "currently bias dtype must match output dtype ", out.dtype());

--- a/sgl-kernel/csrc/elementwise/pos_enc.cu
+++ b/sgl-kernel/csrc/elementwise/pos_enc.cu
@@ -5,6 +5,8 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/all.h>
 
+#include <optional>
+
 #include "utils.h"
 
 template <typename scalar_t, bool IS_NEOX>

--- a/sgl-kernel/csrc/expert_specialization/es_fp8_blockwise.cu
+++ b/sgl-kernel/csrc/expert_specialization/es_fp8_blockwise.cu
@@ -188,6 +188,6 @@ void es_fp8_blockwise_scaled_grouped_mm(
   end_event_1.block(stream);
 #else
   TORCH_CHECK_NOT_IMPLEMENTED(
-      can_implement, "No implemented fp8_blockwise_scaled_grouped_mm for current compute capability: ", sm_version);
+      false, "No implemented fp8_blockwise_scaled_grouped_mm for the current compute capability in this build");
 #endif
 }

--- a/sgl-kernel/csrc/flashmla_extension.cc
+++ b/sgl-kernel/csrc/flashmla_extension.cc
@@ -16,10 +16,13 @@ limitations under the License.
 #include <torch/all.h>
 #include <torch/library.h>
 
+#include <optional>
+
 #include "api/dense_decode.h"
 #include "api/sparse_decode.h"
 #include "api/sparse_fwd.h"
 #include "sgl_kernel_ops.h"
+#include "sgl_kernel_torch_shim.h"
 
 static std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>> sgl_sparse_decode_fwd(
     const at::Tensor& q,
@@ -78,7 +81,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def(
       "get_mla_decoding_metadata(Tensor seqlens_k, int num_q_tokens_per_head_k, int h_k, int? h_q, bool "
       "is_fp8_kvcache, int? topk) -> Tensor[]");
-  m.impl("get_mla_decoding_metadata", torch::kCUDA, &get_mla_decoding_metadata);
+  m.impl("get_mla_decoding_metadata", torch::kCUDA, make_pytorch_shim(&get_mla_decoding_metadata));
 
   m.def("get_mla_decoding_metadata_dense_fp8(Tensor seqlens_k, int num_heads_per_head_k, int num_heads_k) -> Tensor[]");
   m.impl("get_mla_decoding_metadata_dense_fp8", torch::kCUDA, &get_mla_decoding_metadata_dense_fp8);
@@ -89,7 +92,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "Tensor? attn_sink, Tensor? extra_k_cache, Tensor? extra_indices_in_kvcache, Tensor? topk_length, Tensor? "
       "extra_topk_length) "
       "-> Tensor[]");
-  m.impl("fwd_kvcache_mla", torch::kCUDA, &fwd_kvcache_mla);
+  m.impl("fwd_kvcache_mla", torch::kCUDA, make_pytorch_shim(&fwd_kvcache_mla));
 
 #ifdef FLASHMLA_ENABLE_SM100
   m.def(
@@ -103,25 +106,25 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "sparse_decode_fwd(Tensor q, Tensor kv, Tensor indices, Tensor? topk_length, Tensor? attn_sink, "
       "Tensor? tile_scheduler_metadata, Tensor? num_splits, Tensor? extra_kv, Tensor? extra_indices, "
       "Tensor? extra_topk_length, int d_v, float sm_scale) -> (Tensor, Tensor, Tensor?, Tensor?)");
-  m.impl("sparse_decode_fwd", torch::kCUDA, &sgl_sparse_decode_fwd);
+  m.impl("sparse_decode_fwd", torch::kCUDA, make_pytorch_shim(&sgl_sparse_decode_fwd));
 
   m.def(
       "dense_decode_fwd(Tensor q, Tensor kcache, int head_size_v, Tensor seqlens_k, Tensor block_table, float "
       "softmax_scale, bool is_causal, Tensor? tile_scheduler_metadata, Tensor? num_splits) -> (Tensor, Tensor, "
       "Tensor?, "
       "Tensor?)");
-  m.impl("dense_decode_fwd", torch::kCUDA, &sgl_dense_decode_fwd);
+  m.impl("dense_decode_fwd", torch::kCUDA, make_pytorch_shim(&sgl_dense_decode_fwd));
 
   m.def(
       "sparse_prefill_fwd(Tensor q, Tensor kv, Tensor indices, float sm_scale, int d_v, Tensor? attn_sink=None, "
       "Tensor? topk_length=None) -> Tensor[]");
-  m.impl("sparse_prefill_fwd", torch::kCUDA, &sparse_prefill_fwd);
+  m.impl("sparse_prefill_fwd", torch::kCUDA, make_pytorch_shim(&sparse_prefill_fwd));
 
   m.def(
       "fwd_kvcache_mla_fp8(Tensor q, Tensor kcache, int head_size_v, Tensor seqlens_k, Tensor block_table, float "
       "softmax_scale, bool is_causal, Tensor tile_scheduler_metadata, Tensor num_splits, Tensor? descale_q, Tensor? "
       "descale_k) -> Tensor[]");
-  m.impl("fwd_kvcache_mla_fp8", torch::kCUDA, &fwd_kvcache_mla_fp8);
+  m.impl("fwd_kvcache_mla_fp8", torch::kCUDA, make_pytorch_shim(&fwd_kvcache_mla_fp8));
 }
 
 REGISTER_EXTENSION(flashmla_ops)

--- a/sgl-kernel/csrc/gemm/fp8_gemm_kernel.cu
+++ b/sgl-kernel/csrc/gemm/fp8_gemm_kernel.cu
@@ -18,6 +18,8 @@ limitations under the License.
 // https://github.com/NVIDIA/TensorRT-LLM/blob/v0.16.0/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_kernel_template_sm89.h
 // https://github.com/NVIDIA/TensorRT-LLM/blob/v0.16.0/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_kernel_template_sm90.h
 
+#include <optional>
+
 #include <ATen/cuda/CUDAContext.h>
 #include <cudaTypedefs.h>
 #include <cutlass/arch/arch.h>
@@ -558,7 +560,7 @@ struct DeviceGemmFp8RowwiseSm100 {
   static ArgumentType prepare_args(
       torch::Tensor const& a_scales,
       torch::Tensor const& b_scales,
-      std::optional<torch::Tensor> const& bias = std::nullopt) {
+      const c10::optional<torch::Tensor>& bias = c10::nullopt) {
     auto a_args = args_from_tensor<ScaleA, float>(a_scales);
     auto b_args = args_from_tensor<ScaleB, float>(b_scales);
 
@@ -933,7 +935,7 @@ struct DeviceGemmFp8RowwiseSm120 {
   static ArgumentType prepare_args(
       torch::Tensor const& a_scales,
       torch::Tensor const& b_scales,
-      std::optional<torch::Tensor> const& bias = std::nullopt) {
+      const c10::optional<torch::Tensor>& bias = c10::nullopt) {
     auto a_args = args_from_tensor<ScaleA, float>(a_scales);
     auto b_args = args_from_tensor<ScaleB, float>(b_scales);
 

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_v2.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_v2.cu
@@ -2,6 +2,7 @@
 #include <c10/util/Float8_e4m3fn.h>
 
 #include <cmath>
+#include <optional>
 #include <flashinfer/vec_dtypes.cuh>
 
 #include "utils.h"

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -295,10 +295,14 @@ void transfer_kv_launcher(
   void* dst_k_ptr = dst_k.defined() ? dst_k.data_ptr() : nullptr;
   const void* src_v_ptr = IsMLA || !src_v.defined() ? nullptr : src_v.data_ptr();
   void* dst_v_ptr = IsMLA || !dst_v.defined() ? nullptr : dst_v.data_ptr();
-  const uintptr_t* src_k_tbl_ptr = src_k_layers.defined() ? src_k_layers.data_ptr<uintptr_t>() : nullptr;
-  const uintptr_t* dst_k_tbl_ptr = dst_k_layers.defined() ? dst_k_layers.data_ptr<uintptr_t>() : nullptr;
-  const uintptr_t* src_v_tbl_ptr = IsMLA || !src_v_layers.defined() ? nullptr : src_v_layers.data_ptr<uintptr_t>();
-  const uintptr_t* dst_v_tbl_ptr = IsMLA || !dst_v_layers.defined() ? nullptr : dst_v_layers.data_ptr<uintptr_t>();
+  const uintptr_t* src_k_tbl_ptr =
+      src_k_layers.defined() ? reinterpret_cast<const uintptr_t*>(src_k_layers.data_ptr<int64_t>()) : nullptr;
+  const uintptr_t* dst_k_tbl_ptr =
+      dst_k_layers.defined() ? reinterpret_cast<const uintptr_t*>(dst_k_layers.data_ptr<int64_t>()) : nullptr;
+  const uintptr_t* src_v_tbl_ptr =
+      IsMLA || !src_v_layers.defined() ? nullptr : reinterpret_cast<const uintptr_t*>(src_v_layers.data_ptr<int64_t>());
+  const uintptr_t* dst_v_tbl_ptr =
+      IsMLA || !dst_v_layers.defined() ? nullptr : reinterpret_cast<const uintptr_t*>(dst_v_layers.data_ptr<int64_t>());
 
   cudaStream_t torch_current_stream = at::cuda::getCurrentCUDAStream();
   if constexpr (PageHeadLayout) {

--- a/sgl-kernel/csrc/mamba/causal_conv1d.cu
+++ b/sgl-kernel/csrc/mamba/causal_conv1d.cu
@@ -5,6 +5,8 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 
+#include <optional>
+
 #include "causal_conv1d.h"
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>

--- a/sgl-kernel/csrc/moe/prepare_moe_input.cu
+++ b/sgl-kernel/csrc/moe/prepare_moe_input.cu
@@ -4,6 +4,7 @@
 
 #include <flashinfer/vec_dtypes.cuh>
 #include <iostream>
+#include <optional>
 
 #include "cutlass/array.h"
 #include "utils.h"

--- a/sgl-kernel/csrc/quantization/gguf/gguf_kernel.cu
+++ b/sgl-kernel/csrc/quantization/gguf/gguf_kernel.cu
@@ -5,6 +5,8 @@
 #include <cuda_runtime.h>
 #include <torch/all.h>
 
+#include <optional>
+
 // dont use clang-format here, it breaks the include order
 // clang-format off
 #include "utils.h"

--- a/sgl-kernel/include/scalar_type.hpp
+++ b/sgl-kernel/include/scalar_type.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <variant>
+
 // For TORCH_CHECK
 #include <torch/library.h>
 
@@ -36,7 +38,7 @@ class ScalarType {
         signed_(signed_),
         bias(bias),
         finite_values_only(finite_values_only),
-        nan_repr(nan_repr) {};
+        nan_repr(nan_repr){};
 
   static constexpr ScalarType int_(uint8_t size_bits, int32_t bias = 0) {
     return ScalarType(0, size_bits - 1, true, bias);

--- a/sgl-kernel/include/sgl_kernel_torch_shim.h
+++ b/sgl-kernel/include/sgl_kernel_torch_shim.h
@@ -19,6 +19,11 @@ limitations under the License.
 
 #include <torch/library.h>
 
+#include <tuple>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
 /**
  * Unfortunately, the type signatures of the flash_attn ops are not compatible
  * with the PyTorch library bindings. To get around that we use
@@ -53,7 +58,7 @@ template <typename T>
 using pytorch_library_compatible_type_t = typename pytorch_library_compatible_type<T>::type;
 
 template <typename T>
-T convert_from_pytorch_compatible_type(pytorch_library_compatible_type_t<T> arg) {
+decltype(auto) convert_from_pytorch_compatible_type(pytorch_library_compatible_type_t<T> arg) {
   return pytorch_library_compatible_type<T>::convert_from_type(arg);
 }
 
@@ -110,13 +115,96 @@ struct pytorch_library_compatible_type<float> {
   }
 };
 
+template <>
+struct pytorch_library_compatible_type<const bool&> {
+  using type = bool;
+  static bool convert_from_type(bool arg) {
+    return arg;
+  }
+};
+
+// Map `std::optional<T>` -> `c10::optional<pytorch_library_compatible_type_t<T>>`.
+// Older PyTorch dispatcher versions, including the CUDA 12.2 NGC stack, do not
+// box `std::optional` directly for custom ops.
+template <typename T>
+struct pytorch_library_compatible_type<std::optional<T>> {
+  using type = c10::optional<pytorch_library_compatible_type_t<T>>;
+  static std::optional<T> convert_from_type(type arg) {
+    if (!arg.has_value()) {
+      return std::nullopt;
+    }
+    return std::optional<T>(convert_from_pytorch_compatible_type<T>(*arg));
+  }
+};
+
+template <typename T>
+struct pytorch_library_compatible_type<const std::optional<T>&> {
+  using type = const c10::optional<pytorch_library_compatible_type_t<T>>&;
+  static std::optional<T> convert_from_type(type arg) {
+    if (!arg.has_value()) {
+      return std::nullopt;
+    }
+    return std::optional<T>(convert_from_pytorch_compatible_type<T>(*arg));
+  }
+};
+
+template <typename T>
+struct pytorch_library_return_type {
+  using type = T;
+  static T convert_from_type(T arg) {
+    return arg;
+  }
+};
+
+template <typename T>
+using pytorch_library_return_type_t = typename pytorch_library_return_type<T>::type;
+
+template <>
+struct pytorch_library_return_type<void> {
+  using type = void;
+};
+
+template <typename T>
+struct pytorch_library_return_type<std::optional<T>> {
+  using type = c10::optional<pytorch_library_return_type_t<T>>;
+  static type convert_from_type(std::optional<T> arg) {
+    if (!arg.has_value()) {
+      return c10::nullopt;
+    }
+    return pytorch_library_return_type<T>::convert_from_type(std::move(*arg));
+  }
+};
+
+template <typename... Args>
+struct pytorch_library_return_type<std::tuple<Args...>> {
+  using type = std::tuple<pytorch_library_return_type_t<Args>...>;
+
+  template <std::size_t... I>
+  static type convert_from_tuple(std::tuple<Args...> arg, std::index_sequence<I...>) {
+    return type(pytorch_library_return_type<Args>::convert_from_type(std::move(std::get<I>(arg)))...);
+  }
+
+  static type convert_from_type(std::tuple<Args...> arg) {
+    return convert_from_tuple(std::move(arg), std::index_sequence_for<Args...>{});
+  }
+};
+
+template <typename T>
+pytorch_library_return_type_t<T> convert_to_pytorch_compatible_return(T arg) {
+  return pytorch_library_return_type<T>::convert_from_type(std::move(arg));
+}
+
 //
 //  Shim Utils
 //
 
 template <typename Ret, typename... Args>
 auto make_pytorch_shim(Ret (*fun)(Args... args)) {
-  return [fun](pytorch_library_compatible_type_t<Args>... args) {
-    return fun(convert_from_pytorch_compatible_type<Args>(args)...);
+  return [fun](pytorch_library_compatible_type_t<Args>... args) -> pytorch_library_return_type_t<Ret> {
+    if constexpr (std::is_void_v<Ret>) {
+      fun(convert_from_pytorch_compatible_type<Args>(args)...);
+    } else {
+      return convert_to_pytorch_compatible_return<Ret>(fun(convert_from_pytorch_compatible_type<Args>(args)...));
+    }
   };
 }


### PR DESCRIPTION
## Summary
- Add compatibility fallbacks so current `main` can import, build `sgl-kernel` from source, and run on the CUDA 12.2 / PyTorch 2.1 stack shipped by `nvcr.io/nvidia/pytorch:23.10-py3`.
- Fix old-Torch custom-op ABI issues by converting `std::optional`/tuple returns through a PyTorch-compatible shim and guarding newer dispatcher APIs.
- Gate CUDA components that require newer headers/toolkits: FlashMLA and green-context `spatial_ops` require CUDA >= 12.4, and SM100 MXFP8 sources require CUDA >= 12.8.
- Keep accelerated AOT `sgl_kernel` common ops available on H100/CUDA 12.2 while preserving newer paths when their dependencies are present.

## Base
- Upstream main SHA: `d8a4f7a7aa235601322dc3f861c936ddd197a0cf`
- Patch commit: `f9899f5136bedac92407e0296dde4f3d11ade688`

## CUDA 12.2 Environment
- Host: H100 80GB
- Container image: `nvcr.io/nvidia/pytorch:23.10-py3`
- Python: 3.10.12
- Torch: `2.1.0a0+32f93b1`
- `torch.version.cuda`: `12.2`
- NVCC: `cuda_12.2.r12.2/compiler.33191640_0`
- Built wheel: `sglang_kernel-0.4.4-cp310-abi3-linux_x86_64.whl`

## Validation
Static checks:
```bash
git diff --check origin/main
```

AOT wheel build in CUDA 12.2 container:
```bash
cd /data/bbuf/repos/sglang-cuda122-main/sgl-kernel
TORCH_CUDA_ARCH_LIST=9.0 \
CMAKE_POLICY_VERSION_MINIMUM=3.5 \
CMAKE_ARGS="-DSGL_KERNEL_COMPILE_THREADS=1 -DENABLE_BELOW_SM90=OFF -DSGL_KERNEL_ENABLE_FA3=OFF" \
CMAKE_BUILD_PARALLEL_LEVEL=8 MAX_JOBS=8 \
uv build --wheel -Cbuild-dir=build_cuda122 . --verbose --color=never --no-build-isolation
python -m pip install --force-reinstall --no-deps dist/*.whl
```
Observed:
- CMake detected `CUDA_VERSION=12.2`.
- `spatial_ops` skipped because CUDA green-context APIs require CUDA >= 12.4.
- `flashmla_ops` skipped because FlashMLA requires CUDA >= 12.4.
- `sm90/common_ops.abi3.so` and `sm100/common_ops.abi3.so` linked successfully.
- Wheel built successfully.

AOT import and op smoke:
```bash
import torch, sglang, sgl_kernel
print(torch.__version__, torch.version.cuda)
print(sgl_kernel.common_ops.__file__)
```
Observed:
- `torch 2.1.0a0+32f93b1 cuda 12.2`
- `sgl_kernel 0.4.4 /usr/local/lib/python3.10/dist-packages/sgl_kernel/sm90/common_ops.abi3.so`
- Direct CUDA op correctness smoke passed for `rmsnorm`, `silu_and_mul`, and `top_k_renorm_probs` with both `None` and tensor optional-arg paths.
- A single upstream pytest case passed after adding a process-local Torch 2.1 test shim for missing `torch.get_default_device`:
  `sgl-kernel/tests/test_activation.py::test_fused_silu_mul[1-1-128]`.

Qwen2.5-32B model smoke on final head:
```bash
CUDA_VISIBLE_DEVICES=0 HF_HUB_DISABLE_XET=1 PYTHONUNBUFFERED=1 \
python -m sglang.launch_server \
  --model-path Qwen/Qwen2.5-32B-Instruct \
  --host 127.0.0.1 --port 31023 \
  --dtype bfloat16 \
  --attention-backend torch_native \
  --sampling-backend pytorch \
  --grammar-backend none \
  --disable-cuda-graph \
  --disable-radix-cache \
  --context-length 2048 \
  --mem-fraction-static 0.82 \
  --trust-remote-code
```
Observed:
- Local HF snapshot loaded; no model download needed.
- `Load weight end. elapsed=8.71 s, type=Qwen2ForCausalLM, mem usage=61.04 GB`.
- KV cache allocated successfully.
- `/health_generate` returned OK.
- `/generate` returned a normal Chinese response for `用一句话解释 CUDA 12.2 兼容性验证。`, with `completion_tokens=48`, `e2e_latency=1.65s`.
- The scheduler process mapped `/usr/local/lib/python3.10/dist-packages/sgl_kernel/sm90/common_ops.abi3.so`, confirming the AOT common ops path was loaded during the model smoke.
- The validation server was stopped after the smoke; GPU0 was released.

## Notes
- `--sampling-backend pytorch` is used because this clean CUDA 12.2 image does not include the FlashInfer Python package. This PR validates the AOT `sgl_kernel` common-ops path, not FlashInfer sampling.
- `--attention-backend torch_native` is used as the CUDA 12.2-compatible attention path for this environment.
- Full `sgl-kernel/tests/test_sampling.py` collection is blocked in this container by missing `flashinfer.sampling`; the test fixture also expects newer `torch.get_default_device`. Direct AOT op smoke covers the CUDA kernels and old-Torch optional-arg ABI paths relevant to this fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28609423903](https://github.com/sgl-project/sglang/actions/runs/28609423903)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28609423532](https://github.com/sgl-project/sglang/actions/runs/28609423532)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
