### PR TITLE
perf: add dLLM consumer-sufficient TP vocab state

### DIFF
--- a/python/sglang/srt/dllm/algorithm/joint_threshold.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold.py
@@ -4,6 +4,7 @@ import torch.nn.functional as F
 
 from sglang.srt.dllm.algorithm.base import DllmAlgorithm
 from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.dllm.tp_local_vocab_state import argmax_max_prob_from_logits_output
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
@@ -73,24 +74,38 @@ class JointThreshold(DllmAlgorithm):
                 block_end = block_start + self.block_size
 
                 curr_input_ids = forward_batch.input_ids[block_start:block_end]
-                curr_logits = logits_output.full_logits[block_start:block_end]
                 curr_prompt_mask = prompt_masks[i]
 
-                if self.penalty_lambda > 0:
-                    prev_ids = curr_input_ids[:-1]
-                    curr_logits[1:, :].scatter_(
-                        1, prev_ids.unsqueeze(-1), -self.penalty_lambda, reduce="add"
+                if getattr(logits_output, "dllm_vocab_state", None) is not None:
+                    if self.penalty_lambda > 0:
+                        raise RuntimeError(
+                            "JointThreshold with penalty_lambda requires full logits."
+                        )
+                    x, p = argmax_max_prob_from_logits_output(
+                        logits_output,
+                        start=block_start,
+                        end=block_end,
                     )
+                else:
+                    curr_logits = logits_output.full_logits[block_start:block_end]
+                    if self.penalty_lambda > 0:
+                        prev_ids = curr_input_ids[:-1]
+                        curr_logits[1:, :].scatter_(
+                            1,
+                            prev_ids.unsqueeze(-1),
+                            -self.penalty_lambda,
+                            reduce="add",
+                        )
 
-                x = torch.argmax(curr_logits, dim=-1)
-                p = torch.squeeze(
-                    torch.gather(
-                        F.softmax(curr_logits, dim=-1),
-                        dim=-1,
-                        index=torch.unsqueeze(x, -1),
-                    ),
-                    -1,
-                )
+                    x = torch.argmax(curr_logits, dim=-1)
+                    p = torch.squeeze(
+                        torch.gather(
+                            F.softmax(curr_logits, dim=-1),
+                            dim=-1,
+                            index=torch.unsqueeze(x, -1),
+                        ),
+                        -1,
+                    )
 
                 mask_index = curr_input_ids == self.mask_id
                 has_mask = mask_index.any()

--- a/python/sglang/srt/dllm/algorithm/low_confidence.py
+++ b/python/sglang/srt/dllm/algorithm/low_confidence.py
@@ -2,10 +2,10 @@ from typing import List, Tuple, Union
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 
 from sglang.srt.dllm.algorithm.base import DllmAlgorithm
 from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.dllm.tp_local_vocab_state import argmax_max_prob_from_logits_output
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
@@ -65,18 +65,10 @@ class LowConfidence(DllmAlgorithm):
                 block_mask_index = block_input_ids == self.mask_id
                 if torch.sum(block_mask_index).item() == 0:
                     continue
-                curr_logits = logits_output.full_logits[
-                    curr_block_start:curr_block_end,
-                ]
-
-                x = torch.argmax(curr_logits, dim=-1)
-                p = torch.squeeze(
-                    torch.gather(
-                        F.softmax(curr_logits, dim=-1),
-                        dim=-1,
-                        index=torch.unsqueeze(x, -1),
-                    ),
-                    -1,
+                x, p = argmax_max_prob_from_logits_output(
+                    logits_output,
+                    start=curr_block_start,
+                    end=curr_block_end,
                 )
                 x = torch.where(block_mask_index, x, block_input_ids)
                 confidence = torch.where(block_mask_index, p, -np.inf)

--- a/python/sglang/srt/dllm/consumer_state_trace.py
+++ b/python/sglang/srt/dllm/consumer_state_trace.py
@@ -1,0 +1,138 @@
+"""Opt-in runtime trace for diffusion-LLM vocab-state lifecycles."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from typing import Any
+
+import torch
+
+from sglang.srt.dllm.tp_local_vocab_state import VocabState
+from sglang.srt.environ import envs
+
+_TRACE_LOCK = threading.Lock()
+
+
+def tensor_nbytes(tensor: torch.Tensor | None) -> int:
+    if tensor is None:
+        return 0
+    return int(tensor.numel() * tensor.element_size())
+
+
+def vocab_state_nbytes(state: VocabState | None) -> int:
+    if state is None:
+        return 0
+    return (
+        tensor_nbytes(state.max_values)
+        + tensor_nbytes(state.argmax_ids)
+        + tensor_nbytes(state.logsumexp)
+        + tensor_nbytes(state.max_probs)
+    )
+
+
+def compact_tp_gather_bytes(*, rows: int, tp_size: int, packed: bool) -> int:
+    rows = int(rows)
+    tp_size = int(tp_size)
+    if rows <= 0 or tp_size <= 1:
+        return 0
+    if packed:
+        return rows * tp_size * 3 * torch.tensor([], dtype=torch.float32).element_size()
+    return rows * tp_size * (
+        2 * torch.tensor([], dtype=torch.float32).element_size()
+        + torch.tensor([], dtype=torch.int64).element_size()
+    )
+
+
+def emit_consumer_state_trace(record: dict[str, Any]) -> None:
+    path = envs.SGLANG_CONSUMER_STATE_TRACE_JSONL.get()
+    if not path:
+        return
+
+    event = {
+        "schema_version": 1,
+        "timestamp_unix_s": time.time(),
+        "framework": "sglang",
+        **record,
+    }
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    line = json.dumps(event, sort_keys=True, separators=(",", ":"))
+    with _TRACE_LOCK:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+
+def emit_full_vocab_trace(
+    *,
+    component: str,
+    full_logits: torch.Tensor | None,
+    vocab_size: int,
+    tp_size: int,
+    rank: int,
+    consumer_contract: str,
+    fallback_reason: str | None = None,
+) -> None:
+    rows = int(full_logits.shape[0]) if full_logits is not None else 0
+    emit_consumer_state_trace(
+        {
+            "component": component,
+            "path": "full_vocab_materialized",
+            "consumer_contract": consumer_contract,
+            "rank": int(rank),
+            "tp_size": int(tp_size),
+            "rows": rows,
+            "vocab_size": int(vocab_size),
+            "local_vocab_size": int(full_logits.shape[-1])
+            if full_logits is not None and full_logits.ndim > 0
+            else 0,
+            "full_vocab_materialized_bytes": tensor_nbytes(full_logits),
+            "full_vocab_reread_bytes": 0,
+            "compact_state_bytes": 0,
+            "tp_gather_bytes": tensor_nbytes(full_logits) if int(tp_size) > 1 else 0,
+            "fallback_reason": fallback_reason,
+            "exact_replay_status": "runtime_metadata_only",
+        }
+    )
+
+
+def emit_compact_vocab_state_trace(
+    *,
+    component: str,
+    local_logits: torch.Tensor,
+    state: VocabState,
+    vocab_size: int,
+    valid_vocab_size: int,
+    tp_size: int,
+    rank: int,
+    packed_gather: bool,
+    consumer_contract: str,
+) -> None:
+    rows = int(local_logits.shape[0])
+    dtype_bytes = int(local_logits.element_size())
+    avoidable_full_vocab_bytes = rows * int(vocab_size) * dtype_bytes
+    emit_consumer_state_trace(
+        {
+            "component": component,
+            "path": "consumer_sufficient_compact",
+            "consumer_contract": consumer_contract,
+            "rank": int(rank),
+            "tp_size": int(tp_size),
+            "rows": rows,
+            "vocab_size": int(vocab_size),
+            "local_vocab_size": int(valid_vocab_size),
+            "local_vocab_materialized_bytes": tensor_nbytes(local_logits),
+            "full_vocab_materialized_bytes": 0,
+            "full_vocab_reread_bytes": 0,
+            "avoidable_full_vocab_materialized_bytes": avoidable_full_vocab_bytes,
+            "compact_state_bytes": vocab_state_nbytes(state),
+            "tp_gather_bytes": compact_tp_gather_bytes(
+                rows=rows, tp_size=tp_size, packed=packed_gather
+            ),
+            "fallback_reason": None,
+            "exact_replay_status": "runtime_metadata_only",
+        }
+    )

--- a/python/sglang/srt/dllm/tp_local_vocab_kernel.py
+++ b/python/sglang/srt/dllm/tp_local_vocab_kernel.py
@@ -1,0 +1,114 @@
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.dllm.tp_local_vocab_state import VocabState
+
+
+LOCAL_VOCAB_STATE_TRITON_MAX_BLOCK_VOCAB = 131072
+
+
+@triton.jit
+def _local_vocab_state_kernel(
+    logits_ptr,
+    penalty_token_ids_ptr,
+    max_values_ptr,
+    argmax_ids_ptr,
+    logsumexp_ptr,
+    stride_row: tl.constexpr,
+    valid_vocab_size: tl.constexpr,
+    vocab_start: tl.constexpr,
+    penalty_lambda: tl.constexpr,
+    APPLY_PENALTY: tl.constexpr,
+    BLOCK_VOCAB: tl.constexpr,
+):
+    row_id = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_VOCAB)
+    valid = offsets < valid_vocab_size
+    values = tl.load(
+        logits_ptr + row_id * stride_row + offsets,
+        mask=valid,
+        other=-float("inf"),
+    ).to(tl.float32)
+    if APPLY_PENALTY:
+        penalty_token_id = tl.load(penalty_token_ids_ptr + row_id)
+        penalty_offset = penalty_token_id - vocab_start
+        values = values - tl.where(
+            valid & (offsets == penalty_offset),
+            penalty_lambda,
+            0.0,
+        )
+
+    max_value = tl.max(values, axis=0)
+    arg_offsets = tl.min(tl.where(values == max_value, offsets, BLOCK_VOCAB), axis=0)
+    exp_sum = tl.sum(tl.exp(values - max_value), axis=0)
+    logsumexp = max_value + tl.log(exp_sum)
+
+    tl.store(max_values_ptr + row_id, max_value)
+    tl.store(argmax_ids_ptr + row_id, arg_offsets + vocab_start)
+    tl.store(logsumexp_ptr + row_id, logsumexp)
+
+
+def _next_power_of_2(value: int) -> int:
+    return 1 << (int(value) - 1).bit_length()
+
+
+def can_use_local_vocab_state_triton(valid_vocab_size: int) -> bool:
+    return (
+        _next_power_of_2(valid_vocab_size)
+        <= LOCAL_VOCAB_STATE_TRITON_MAX_BLOCK_VOCAB
+    )
+
+
+def local_vocab_state_from_logits_triton(
+    *,
+    local_logits: torch.Tensor,
+    vocab_start: int,
+    valid_vocab_size: int | None = None,
+    penalized_token_ids: torch.Tensor | None = None,
+    penalty_lambda: float = 0.0,
+) -> VocabState:
+    if not local_logits.is_cuda:
+        raise ValueError("local_vocab_state_from_logits_triton requires a CUDA tensor")
+    if local_logits.dim() != 2:
+        raise ValueError("local_logits must be a 2D tensor")
+
+    valid_vocab_size = (
+        local_logits.shape[-1] if valid_vocab_size is None else int(valid_vocab_size)
+    )
+    if valid_vocab_size <= 0 or valid_vocab_size > local_logits.shape[-1]:
+        raise ValueError("valid_vocab_size must be in [1, local_logits.shape[-1]]")
+
+    local_logits = local_logits.contiguous()
+    num_rows = local_logits.shape[0]
+    max_values = torch.empty((num_rows,), device=local_logits.device, dtype=torch.float32)
+    argmax_ids = torch.empty((num_rows,), device=local_logits.device, dtype=torch.long)
+    logsumexp = torch.empty((num_rows,), device=local_logits.device, dtype=torch.float32)
+
+    block_vocab = _next_power_of_2(valid_vocab_size)
+    apply_penalty = penalized_token_ids is not None and penalty_lambda > 0
+    if apply_penalty:
+        penalty_token_ids = penalized_token_ids.to(device=local_logits.device).contiguous()
+    else:
+        penalty_token_ids = torch.empty((num_rows,), device=local_logits.device, dtype=torch.long)
+
+    _local_vocab_state_kernel[(num_rows,)](
+        local_logits,
+        penalty_token_ids,
+        max_values,
+        argmax_ids,
+        logsumexp,
+        local_logits.stride(0),
+        valid_vocab_size,
+        int(vocab_start),
+        float(penalty_lambda),
+        APPLY_PENALTY=apply_penalty,
+        BLOCK_VOCAB=block_vocab,
+        num_warps=8,
+    )
+    return VocabState(
+        max_values=max_values,
+        argmax_ids=argmax_ids,
+        logsumexp=logsumexp,
+        max_probs=torch.exp(max_values - logsumexp),
+    )

--- a/python/sglang/srt/dllm/tp_local_vocab_state.py
+++ b/python/sglang/srt/dllm/tp_local_vocab_state.py
@@ -1,0 +1,167 @@
+from dataclasses import dataclass
+
+import torch
+
+
+FLOAT32_EXACT_INT_LIMIT = 1 << 24
+
+
+@dataclass(frozen=True)
+class VocabState:
+    max_values: torch.Tensor
+    argmax_ids: torch.Tensor
+    logsumexp: torch.Tensor
+    max_probs: torch.Tensor
+
+
+def local_vocab_state_from_logits(
+    *,
+    local_logits: torch.Tensor,
+    vocab_start: int,
+    valid_vocab_size: int | None = None,
+    penalized_token_ids: torch.Tensor | None = None,
+    penalty_lambda: float = 0.0,
+) -> VocabState:
+    if valid_vocab_size is not None:
+        local_logits = local_logits[:, : int(valid_vocab_size)]
+    local_logits = local_logits.float()
+    if penalized_token_ids is not None and penalty_lambda > 0:
+        local_logits = local_logits.clone()
+        local_token_ids = penalized_token_ids.to(device=local_logits.device).long() - int(
+            vocab_start
+        )
+        valid_rows = (local_token_ids >= 0) & (local_token_ids < local_logits.shape[-1])
+        if valid_rows.any():
+            row_ids = torch.arange(local_logits.shape[0], device=local_logits.device)
+            local_logits[row_ids[valid_rows], local_token_ids[valid_rows]] -= float(
+                penalty_lambda
+            )
+    max_values, local_argmax_ids = torch.max(local_logits, dim=-1)
+    logsumexp = torch.logsumexp(local_logits, dim=-1)
+    return VocabState(
+        max_values=max_values,
+        argmax_ids=local_argmax_ids.long() + int(vocab_start),
+        logsumexp=logsumexp,
+        max_probs=torch.exp(max_values - logsumexp),
+    )
+
+
+def can_pack_vocab_ids_as_float32(max_vocab_id_inclusive: int) -> bool:
+    max_vocab_id_inclusive = int(max_vocab_id_inclusive)
+    return 0 <= max_vocab_id_inclusive <= FLOAT32_EXACT_INT_LIMIT
+
+
+def pack_vocab_state_for_tp_gather(state: VocabState) -> torch.Tensor:
+    if state.max_values.dtype != torch.float32:
+        raise ValueError("VocabState.max_values must be torch.float32")
+    if state.logsumexp.dtype != torch.float32:
+        raise ValueError("VocabState.logsumexp must be torch.float32")
+
+    return torch.stack(
+        [
+            state.max_values,
+            state.logsumexp,
+            state.argmax_ids.to(dtype=torch.float32),
+        ],
+        dim=-1,
+    ).contiguous()
+
+
+def merge_gathered_packed_vocab_state(gathered: torch.Tensor) -> VocabState:
+    if gathered.ndim != 3 or gathered.shape[-1] != 3:
+        raise ValueError("gathered packed vocab state must have shape [tp, rows, 3]")
+    if gathered.shape[0] == 0:
+        raise ValueError("merge_gathered_packed_vocab_state requires at least one rank")
+
+    max_values_by_rank = gathered[:, :, 0]
+    logsumexp_by_rank = gathered[:, :, 1]
+    argmax_ids_by_rank = gathered[:, :, 2].long()
+
+    best_values = max_values_by_rank[0]
+    best_ids = argmax_ids_by_rank[0]
+    for rank in range(1, max_values_by_rank.shape[0]):
+        rank_values = max_values_by_rank[rank]
+        rank_ids = argmax_ids_by_rank[rank]
+        use_rank = (rank_values > best_values) | (
+            (rank_values == best_values) & (rank_ids < best_ids)
+        )
+        best_values = torch.where(use_rank, rank_values, best_values)
+        best_ids = torch.where(use_rank, rank_ids, best_ids)
+
+    merged_logsumexp = torch.logsumexp(logsumexp_by_rank, dim=0)
+    return VocabState(
+        max_values=best_values,
+        argmax_ids=best_ids.long(),
+        logsumexp=merged_logsumexp,
+        max_probs=torch.exp(best_values - merged_logsumexp),
+    )
+
+
+def merge_vocab_states(states: list[VocabState]) -> VocabState:
+    if not states:
+        raise ValueError("merge_vocab_states requires at least one local state")
+
+    max_values_by_rank = torch.stack([state.max_values for state in states], dim=0)
+    argmax_ids_by_rank = torch.stack([state.argmax_ids for state in states], dim=0)
+    logsumexp_by_rank = torch.stack([state.logsumexp for state in states], dim=0)
+
+    best_values = max_values_by_rank[0]
+    best_ids = argmax_ids_by_rank[0]
+    for rank in range(1, max_values_by_rank.shape[0]):
+        rank_values = max_values_by_rank[rank]
+        rank_ids = argmax_ids_by_rank[rank]
+        use_rank = (rank_values > best_values) | (
+            (rank_values == best_values) & (rank_ids < best_ids)
+        )
+        best_values = torch.where(use_rank, rank_values, best_values)
+        best_ids = torch.where(use_rank, rank_ids, best_ids)
+
+    merged_logsumexp = torch.logsumexp(logsumexp_by_rank, dim=0)
+    return VocabState(
+        max_values=best_values,
+        argmax_ids=best_ids.long(),
+        logsumexp=merged_logsumexp,
+        max_probs=torch.exp(best_values - merged_logsumexp),
+    )
+
+
+def argmax_max_prob_from_logits_output(
+    logits_output,
+    *,
+    start: int,
+    end: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    vocab_state = getattr(logits_output, "dllm_vocab_state", None)
+    if vocab_state is not None:
+        return vocab_state.argmax_ids[start:end], vocab_state.max_probs[start:end]
+
+    logits = logits_output.full_logits[start:end].float()
+    max_values, argmax_ids = torch.max(logits, dim=-1)
+    max_probs = torch.exp(max_values - torch.logsumexp(logits, dim=-1))
+    return argmax_ids.long(), max_probs
+
+
+def low_confidence_transfer_mask(
+    *,
+    input_ids: torch.Tensor,
+    argmax_ids: torch.Tensor,
+    max_probs: torch.Tensor,
+    mask_id: int,
+    threshold: float,
+) -> torch.Tensor:
+    del argmax_ids
+    mask_index = input_ids == int(mask_id)
+    transfer_index = torch.zeros_like(mask_index, dtype=torch.bool)
+    if not mask_index.any():
+        return transfer_index
+
+    confidence = torch.where(
+        mask_index,
+        max_probs,
+        torch.full_like(max_probs, -torch.inf),
+    )
+    transfer_index = confidence > float(threshold)
+    if not transfer_index.any():
+        select_index = torch.topk(confidence, k=1).indices
+        transfer_index[select_index] = True
+    return transfer_index

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -231,6 +231,9 @@ class Envs:
     SGLANG_DISABLED_MODEL_ARCHS = EnvTuple(tuple())
     SGLANG_PREFETCH_BLOCK_SIZE_MB = EnvInt(16)
     SGLANG_GEMMA_OUT_OF_PLACE_POSITION_MUTATION = EnvBool(False)
+    SGLANG_DLLM_TP_LOCAL_VOCAB = EnvBool(False)
+    SGLANG_DLLM_TP_LOCAL_VOCAB_PACKED_GATHER = EnvBool(True)
+    SGLANG_CONSUMER_STATE_TRACE_JSONL = EnvStr("")
 
     # HTTP server
     # Decompress request bodies tagged with `x-body-compressed`.

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -21,7 +21,24 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
 from torch import nn
 
+from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators import triton_symm_mem_ag
+from sglang.srt.dllm.consumer_state_trace import (
+    emit_compact_vocab_state_trace,
+    emit_full_vocab_trace,
+)
+from sglang.srt.dllm.tp_local_vocab_kernel import (
+    can_use_local_vocab_state_triton,
+    local_vocab_state_from_logits_triton,
+)
+from sglang.srt.dllm.tp_local_vocab_state import (
+    VocabState,
+    can_pack_vocab_ids_as_float32,
+    local_vocab_state_from_logits,
+    merge_gathered_packed_vocab_state,
+    merge_vocab_states,
+    pack_vocab_state_for_tp_gather,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import (
     DpPaddingMode,
@@ -67,6 +84,83 @@ _is_cpu = is_cpu()
 # and its [batch * dp_size, vocab] output OOMs under DP attention with a
 # tight mem_fraction_static.
 _in_autotune_dummy_run = False
+
+
+def _should_pack_dllm_vocab_state_for_gather(max_vocab_id_inclusive: int) -> bool:
+    return envs.SGLANG_DLLM_TP_LOCAL_VOCAB_PACKED_GATHER.get() and (
+        can_pack_vocab_ids_as_float32(int(max_vocab_id_inclusive))
+    )
+
+
+def _global_max_vocab_id_for_dllm_tp_state(
+    lm_head: VocabParallelEmbedding,
+    fallback_vocab_size: int,
+) -> int:
+    vocab_size = getattr(lm_head, "org_vocab_size", fallback_vocab_size)
+    return int(vocab_size) - 1
+
+
+def _tp_rank_for_trace() -> int:
+    try:
+        return int(getattr(get_tp_group(), "rank_in_group", 0))
+    except Exception:
+        return 0
+
+
+def _merge_dllm_vocab_state_across_tp(
+    *,
+    local_state: VocabState,
+    tp_group,
+    tp_size: int,
+    global_max_vocab_id_inclusive: int,
+) -> VocabState:
+    num_rows = local_state.max_values.shape[0]
+
+    if _should_pack_dllm_vocab_state_for_gather(global_max_vocab_id_inclusive):
+        local_packed = pack_vocab_state_for_tp_gather(local_state)
+        gathered_packed = torch.empty(
+            (tp_size * num_rows, 3),
+            device=local_packed.device,
+            dtype=local_packed.dtype,
+        )
+        tp_group.all_gather_into_tensor(gathered_packed, local_packed)
+        return merge_gathered_packed_vocab_state(
+            gathered_packed.view(tp_size, num_rows, 3)
+        )
+
+    gathered_max = torch.empty(
+        (tp_size * num_rows,),
+        device=local_state.max_values.device,
+        dtype=local_state.max_values.dtype,
+    )
+    gathered_arg = torch.empty(
+        (tp_size * num_rows,),
+        device=local_state.argmax_ids.device,
+        dtype=local_state.argmax_ids.dtype,
+    )
+    gathered_lse = torch.empty(
+        (tp_size * num_rows,),
+        device=local_state.logsumexp.device,
+        dtype=local_state.logsumexp.dtype,
+    )
+    tp_group.all_gather_into_tensor(gathered_max, local_state.max_values.contiguous())
+    tp_group.all_gather_into_tensor(gathered_arg, local_state.argmax_ids.contiguous())
+    tp_group.all_gather_into_tensor(gathered_lse, local_state.logsumexp.contiguous())
+
+    gathered_max = gathered_max.view(tp_size, num_rows)
+    gathered_arg = gathered_arg.view(tp_size, num_rows)
+    gathered_lse = gathered_lse.view(tp_size, num_rows)
+    return merge_vocab_states(
+        [
+            VocabState(
+                max_values=gathered_max[rank],
+                argmax_ids=gathered_arg[rank],
+                logsumexp=gathered_lse[rank],
+                max_probs=torch.exp(gathered_max[rank] - gathered_lse[rank]),
+            )
+            for rank in range(tp_size)
+        ]
+    )
 
 
 def get_in_autotune_dummy_run() -> bool:
@@ -121,6 +215,7 @@ class LogitsProcessorOutput:
 
     ## Part 4: Diffusion LLM only.
     full_logits: Optional[torch.Tensor] = None
+    dllm_vocab_state: Optional[Any] = None
 
     ## Part 5: Customized Info
     customized_info: Optional[Dict[str, List[Any]]] = None
@@ -293,6 +388,7 @@ class LogitsProcessor(nn.Module):
 
         self.return_full_logits = return_full_logits
         self.enable_mis = get_global_server_args().enable_mis
+        self._dllm_tp_local_vocab_logged = False
 
         self._logits_gatherer = triton_symm_mem_ag.MultimemAllGatherer(
             max_tokens=triton_symm_mem_ag.recommended_max_tokens(
@@ -996,11 +1092,136 @@ class LogitsProcessor(nn.Module):
         logits_metadata: LogitsMetadata,
     ) -> LogitsProcessorOutput:
         assert self.return_full_logits
+        if self._should_use_dllm_tp_local_vocab(lm_head):
+            return LogitsProcessorOutput(
+                full_logits=None,
+                next_token_logits=None,
+                dllm_vocab_state=self._get_dllm_vocab_state(
+                    hidden_states, lm_head, logits_metadata
+                ),
+            )
         full_logits = self._get_logits(hidden_states, lm_head, logits_metadata)
+        emit_full_vocab_trace(
+            component="sglang.logits_processor._get_dllm_logits",
+            full_logits=full_logits,
+            vocab_size=self.vocab_size,
+            tp_size=int(get_parallel().tp_size),
+            rank=_tp_rank_for_trace(),
+            consumer_contract="dllm_full_logits",
+        )
         return LogitsProcessorOutput(
             full_logits=full_logits,
             next_token_logits=None,
         )
+
+    def _should_use_dllm_tp_local_vocab(self, lm_head: VocabParallelEmbedding) -> bool:
+        if not envs.SGLANG_DLLM_TP_LOCAL_VOCAB.get():
+            return False
+        server_args = get_global_server_args()
+        if getattr(server_args, "dllm_algorithm", None) != "LowConfidence":
+            return False
+        if _is_npu:
+            return False
+        if self.use_attn_tp_group or self.do_tensor_parallel_all_gather_dp_attn:
+            return False
+        if not hasattr(lm_head, "weight"):
+            return False
+        if not hasattr(lm_head, "shard_indices"):
+            return False
+        return int(getattr(lm_head, "num_added_embeddings", 0)) == 0
+
+    def _get_dllm_vocab_state(
+        self,
+        hidden_states: torch.Tensor,
+        lm_head: VocabParallelEmbedding,
+        logits_metadata: LogitsMetadata,
+    ) -> VocabState:
+        hidden_states, _ = self._gather_dp_attn_hidden_states(
+            hidden_states, logits_metadata
+        )
+        local_logits = self._compute_lm_head(hidden_states, lm_head)
+
+        if self.logit_scale is not None:
+            local_logits.mul_(self.logit_scale)
+        local_logits = local_logits.float()
+
+        if self.final_logit_softcapping:
+            if not _is_npu:
+                fused_softcap(local_logits, self.final_logit_softcapping)
+            else:
+                local_logits = self.final_logit_softcapping * torch.tanh(
+                    local_logits / self.final_logit_softcapping
+                )
+
+        if hasattr(lm_head, "shard_indices"):
+            shard = lm_head.shard_indices
+            vocab_start = int(shard.org_vocab_start_index)
+            valid_vocab_size = int(shard.num_org_elements)
+        else:
+            vocab_start = 0
+            valid_vocab_size = int(self.vocab_size)
+        if not self._dllm_tp_local_vocab_logged:
+            self._dllm_tp_local_vocab_logged = True
+            logger.info(
+                "SGLANG_DLLM_TP_LOCAL_VOCAB enabled: local_logits=%s "
+                "vocab_start=%d valid_vocab_size=%d tp_size=%d",
+                tuple(local_logits.shape),
+                vocab_start,
+                valid_vocab_size,
+                int(get_parallel().tp_size),
+            )
+
+        if local_logits.is_cuda and can_use_local_vocab_state_triton(valid_vocab_size):
+            local_state = local_vocab_state_from_logits_triton(
+                local_logits=local_logits,
+                vocab_start=vocab_start,
+                valid_vocab_size=valid_vocab_size,
+            )
+        else:
+            local_state = local_vocab_state_from_logits(
+                local_logits=local_logits,
+                vocab_start=vocab_start,
+                valid_vocab_size=valid_vocab_size,
+            )
+
+        tp_size = int(get_parallel().tp_size)
+        global_max_vocab_id = _global_max_vocab_id_for_dllm_tp_state(
+            lm_head,
+            self.vocab_size,
+        )
+        packed_gather = _should_pack_dllm_vocab_state_for_gather(global_max_vocab_id)
+        if tp_size == 1:
+            emit_compact_vocab_state_trace(
+                component="sglang.logits_processor._get_dllm_vocab_state",
+                local_logits=local_logits,
+                state=local_state,
+                vocab_size=global_max_vocab_id + 1,
+                valid_vocab_size=valid_vocab_size,
+                tp_size=tp_size,
+                rank=_tp_rank_for_trace(),
+                packed_gather=packed_gather,
+                consumer_contract="dllm_low_confidence",
+            )
+            return local_state
+
+        merged_state = _merge_dllm_vocab_state_across_tp(
+            local_state=local_state,
+            tp_group=get_tp_group(),
+            tp_size=tp_size,
+            global_max_vocab_id_inclusive=global_max_vocab_id,
+        )
+        emit_compact_vocab_state_trace(
+            component="sglang.logits_processor._get_dllm_vocab_state",
+            local_logits=local_logits,
+            state=merged_state,
+            vocab_size=global_max_vocab_id + 1,
+            valid_vocab_size=valid_vocab_size,
+            tp_size=tp_size,
+            rank=_tp_rank_for_trace(),
+            packed_gather=packed_gather,
+            consumer_contract="dllm_low_confidence",
+        )
+        return merged_state
 
     def compute_logprobs_for_multi_item_scoring(
         self,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -116,6 +116,17 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 
+def _slice_dllm_vocab_state(vocab_state, num_tokens: int):
+    if vocab_state is None:
+        return None
+    return vocab_state.__class__(
+        max_values=vocab_state.max_values[:num_tokens],
+        argmax_ids=vocab_state.argmax_ids[:num_tokens],
+        logsumexp=vocab_state.logsumexp[:num_tokens],
+        max_probs=vocab_state.max_probs[:num_tokens],
+    )
+
+
 def build_replay_fb_view(
     forward_batch: ForwardBatch,
     buffers: DecodeInputBuffers,
@@ -1054,6 +1065,14 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             return LogitsProcessorOutput(
                 next_token_logits=next_token_logits,
                 full_logits=full_logits,
+                dllm_vocab_state=(
+                    _slice_dllm_vocab_state(
+                        output.dllm_vocab_state,
+                        self.raw_num_token,
+                    )
+                    if self.is_dllm
+                    else None
+                ),
                 hidden_states=(
                     output.hidden_states[: self.raw_num_token]
                     if output.hidden_states is not None

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -37,6 +37,7 @@ import tqdm
 
 from sglang.srt.distributed import get_tensor_model_parallel_rank
 from sglang.srt.distributed.parallel_state import graph_capture
+from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.layers.dp_attention import (
     DpPaddingMode,
     set_dp_buffer_len,
@@ -135,6 +136,52 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 
+def _slice_dllm_vocab_state(vocab_state, num_tokens: int):
+    if vocab_state is None:
+        return None
+    return vocab_state.__class__(
+        max_values=vocab_state.max_values[:num_tokens],
+        argmax_ids=vocab_state.argmax_ids[:num_tokens],
+        logsumexp=vocab_state.logsumexp[:num_tokens],
+        max_probs=vocab_state.max_probs[:num_tokens],
+    )
+
+
+def _slice_optional_tensor(value: Optional[torch.Tensor], num_tokens: int):
+    return value[:num_tokens] if value is not None else None
+
+
+def _slice_prefill_logits_output(
+    output: LogitsProcessorOutput,
+    num_tokens: int,
+    *,
+    is_dllm: bool,
+    is_speculative: bool,
+) -> LogitsProcessorOutput:
+    mm_input_embeds = None
+    if is_speculative and output.mm_input_embeds is not None:
+        mm_input_embeds = output.mm_input_embeds[:num_tokens]
+
+    return LogitsProcessorOutput(
+        next_token_logits=(
+            None
+            if is_dllm
+            else _slice_optional_tensor(output.next_token_logits, num_tokens)
+        ),
+        hidden_states=_slice_optional_tensor(output.hidden_states, num_tokens),
+        full_logits=(
+            _slice_optional_tensor(output.full_logits, num_tokens) if is_dllm else None
+        ),
+        dllm_vocab_state=(
+            _slice_dllm_vocab_state(output.dllm_vocab_state, num_tokens)
+            if is_dllm
+            else None
+        ),
+        customized_info=output.customized_info,
+        mm_input_embeds=mm_input_embeds,
+    )
+
+
 class PrefillCudaGraphRunner(BaseCudaGraphRunner):
     """Prefill-phase CUDA graph runner.
 
@@ -193,6 +240,8 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             )
 
         self.mamba_track_enabled = self._is_mamba_track_enabled()
+        self.dllm_config = DllmConfig.from_server_args(model_runner.server_args)
+        self.is_dllm = self.dllm_config is not None
 
         # --- buffers ---------------------------------------------------
         self.buffers: PrefillInputBuffers = PrefillInputBuffers.create(
@@ -987,21 +1036,11 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                     )
 
             if isinstance(output, LogitsProcessorOutput):
-                # Preserve mm_input_embeds for speculative decoding.
-                mm_input_embeds = None
-                if (
-                    self.model_runner.spec_algorithm.is_speculative()
-                    and output.mm_input_embeds is not None
-                ):
-                    mm_input_embeds = output.mm_input_embeds[: self.raw_num_tokens]
-                return LogitsProcessorOutput(
-                    next_token_logits=output.next_token_logits[: self.raw_num_tokens],
-                    hidden_states=(
-                        output.hidden_states[: self.raw_num_tokens]
-                        if output.hidden_states is not None
-                        else None
-                    ),
-                    mm_input_embeds=mm_input_embeds,
+                return _slice_prefill_logits_output(
+                    output,
+                    self.raw_num_tokens,
+                    is_dllm=self.is_dllm,
+                    is_speculative=self.model_runner.spec_algorithm.is_speculative(),
                 )
             elif isinstance(output, EmbeddingPoolerOutput):
                 return output

--- a/test/srt/dllm/test_tp_local_vocab_state.py
+++ b/test/srt/dllm/test_tp_local_vocab_state.py
@@ -1,0 +1,973 @@
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.dllm.tp_local_vocab_state import (
+    FLOAT32_EXACT_INT_LIMIT,
+    argmax_max_prob_from_logits_output,
+    can_pack_vocab_ids_as_float32,
+    local_vocab_state_from_logits,
+    low_confidence_transfer_mask,
+    merge_gathered_packed_vocab_state,
+    merge_vocab_states,
+    pack_vocab_state_for_tp_gather,
+    VocabState,
+)
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+    _slice_prefill_logits_output,
+)
+
+ENDPOINT_BASELINE_URL_ENV = "SGLANG_DLLM_BASELINE_URL"
+ENDPOINT_TP_LOCAL_URL_ENV = "SGLANG_DLLM_TP_LOCAL_VOCAB_URL"
+ENDPOINT_TP_LOCAL_TRACE_ENV = "SGLANG_DLLM_TP_LOCAL_VOCAB_TRACE_JSONL"
+
+
+def _dense_argmax_and_max_prob(logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    logits = logits.float()
+    max_values, argmax_ids = torch.max(logits, dim=-1)
+    max_probs = torch.exp(max_values - torch.logsumexp(logits, dim=-1))
+    return argmax_ids.long(), max_probs
+
+
+def test_low_confidence_tp_state_matches_dense_logits():
+    torch.manual_seed(0)
+    logits = torch.randn(9, 23, dtype=torch.float32)
+    input_ids = torch.tensor([99, 99, 3, 99, 4, 99, 99, 7, 99], dtype=torch.long)
+    mask_id = 99
+    threshold = 0.19
+
+    dense_argmax_ids, dense_max_probs = _dense_argmax_and_max_prob(logits)
+    dense_transfer = low_confidence_transfer_mask(
+        input_ids=input_ids,
+        argmax_ids=dense_argmax_ids,
+        max_probs=dense_max_probs,
+        mask_id=mask_id,
+        threshold=threshold,
+    )
+
+    shard_sizes = [5, 11, 7]
+    states = []
+    vocab_start = 0
+    for shard_size in shard_sizes:
+        shard_logits = logits[:, vocab_start : vocab_start + shard_size]
+        states.append(
+            local_vocab_state_from_logits(
+                local_logits=shard_logits,
+                vocab_start=vocab_start,
+            )
+        )
+        vocab_start += shard_size
+
+    merged = merge_vocab_states(states)
+    merged_transfer = low_confidence_transfer_mask(
+        input_ids=input_ids,
+        argmax_ids=merged.argmax_ids,
+        max_probs=merged.max_probs,
+        mask_id=mask_id,
+        threshold=threshold,
+    )
+
+    torch.testing.assert_close(merged.max_probs, dense_max_probs)
+    torch.testing.assert_close(merged.logsumexp, torch.logsumexp(logits.float(), dim=-1))
+    assert torch.equal(merged.argmax_ids, dense_argmax_ids)
+    assert torch.equal(merged_transfer, dense_transfer)
+
+
+def test_local_vocab_state_ignores_padded_vocab_entries():
+    dense_logits = torch.tensor(
+        [
+            [0.0, 0.3, -0.2, 0.1, 1.0, 0.9],
+            [1.2, -0.4, 0.5, 0.2, -1.0, 0.7],
+        ],
+        dtype=torch.float32,
+    )
+    dense_argmax_ids, dense_max_probs = _dense_argmax_and_max_prob(dense_logits)
+
+    first_state = local_vocab_state_from_logits(
+        local_logits=dense_logits[:, :4],
+        vocab_start=0,
+    )
+    second_state = local_vocab_state_from_logits(
+        local_logits=torch.cat(
+            [
+                dense_logits[:, 4:],
+                torch.full((dense_logits.shape[0], 3), 1000.0),
+            ],
+            dim=-1,
+        ),
+        vocab_start=4,
+        valid_vocab_size=2,
+    )
+
+    merged = merge_vocab_states([first_state, second_state])
+
+    torch.testing.assert_close(merged.max_probs, dense_max_probs)
+    torch.testing.assert_close(
+        merged.logsumexp,
+        torch.logsumexp(dense_logits.float(), dim=-1),
+    )
+    assert torch.equal(merged.argmax_ids, dense_argmax_ids)
+
+
+def test_joint_threshold_penalty_matches_dense_logits():
+    logits = torch.tensor(
+        [
+            [0.2, 1.0, 0.1, -0.1, 0.0, 0.3, -0.4, 0.6],
+            [0.5, 0.2, 1.4, 0.8, 0.1, 1.7, 0.4, -0.2],
+            [1.3, 0.1, -0.5, 1.6, 0.2, 0.0, 1.5, 0.4],
+            [0.0, 0.7, 0.2, -0.3, 1.9, 0.8, 0.1, 1.8],
+        ],
+        dtype=torch.float32,
+    )
+    penalty_token_ids = torch.tensor([-1, 5, 3, 6], dtype=torch.long)
+    penalty_lambda = 0.75
+
+    dense_penalized = logits.clone()
+    row_ids = torch.arange(logits.shape[0])
+    penalized_rows = penalty_token_ids >= 0
+    dense_penalized[row_ids[penalized_rows], penalty_token_ids[penalized_rows]] -= (
+        penalty_lambda
+    )
+    dense_argmax_ids, dense_max_probs = _dense_argmax_and_max_prob(dense_penalized)
+
+    first_state = local_vocab_state_from_logits(
+        local_logits=logits[:, :3],
+        vocab_start=0,
+        penalized_token_ids=penalty_token_ids,
+        penalty_lambda=penalty_lambda,
+    )
+    second_state = local_vocab_state_from_logits(
+        local_logits=logits[:, 3:6],
+        vocab_start=3,
+        penalized_token_ids=penalty_token_ids,
+        penalty_lambda=penalty_lambda,
+    )
+    third_state = local_vocab_state_from_logits(
+        local_logits=logits[:, 6:],
+        vocab_start=6,
+        penalized_token_ids=penalty_token_ids,
+        penalty_lambda=penalty_lambda,
+    )
+
+    merged = merge_vocab_states([first_state, second_state, third_state])
+
+    torch.testing.assert_close(merged.max_probs, dense_max_probs)
+    torch.testing.assert_close(
+        merged.logsumexp,
+        torch.logsumexp(dense_penalized.float(), dim=-1),
+    )
+    assert torch.equal(merged.argmax_ids, dense_argmax_ids)
+
+
+@pytest.mark.parametrize(
+    ("seed", "rows", "vocab_size", "shard_sizes"),
+    [
+        (0, 1, 7, [2, 3, 2]),
+        (1, 8, 31, [5, 9, 1, 16]),
+        (20260622, 13, 67, [17, 3, 19, 28]),
+    ],
+)
+def test_random_low_confidence_tp_state_matches_dense_with_padding_and_penalty(
+    seed: int,
+    rows: int,
+    vocab_size: int,
+    shard_sizes: list[int],
+):
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    logits = torch.randn(rows, vocab_size, generator=generator, dtype=torch.float32)
+    penalty_token_ids = torch.randint(
+        low=0,
+        high=vocab_size + 1,
+        size=(rows,),
+        generator=generator,
+        dtype=torch.long,
+    ) - 1
+    penalty_lambda = 0.625
+
+    penalized = logits.clone()
+    row_ids = torch.arange(rows)
+    penalized_rows = penalty_token_ids >= 0
+    penalized[row_ids[penalized_rows], penalty_token_ids[penalized_rows]] -= (
+        penalty_lambda
+    )
+    dense_argmax_ids, dense_max_probs = _dense_argmax_and_max_prob(penalized)
+
+    states = []
+    vocab_start = 0
+    for shard_size in shard_sizes:
+        shard_logits = logits[:, vocab_start : vocab_start + shard_size]
+        padded_logits = torch.cat(
+            [
+                shard_logits,
+                torch.full((rows, 3), 10000.0, dtype=torch.float32),
+            ],
+            dim=-1,
+        )
+        states.append(
+            local_vocab_state_from_logits(
+                local_logits=padded_logits,
+                vocab_start=vocab_start,
+                valid_vocab_size=shard_size,
+                penalized_token_ids=penalty_token_ids,
+                penalty_lambda=penalty_lambda,
+            )
+        )
+        vocab_start += shard_size
+
+    merged = merge_vocab_states(states)
+
+    torch.testing.assert_close(merged.max_probs, dense_max_probs)
+    torch.testing.assert_close(
+        merged.logsumexp,
+        torch.logsumexp(penalized.float(), dim=-1),
+    )
+    assert torch.equal(merged.argmax_ids, dense_argmax_ids)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_triton_local_vocab_state_matches_reference_cuda():
+    from sglang.srt.dllm.tp_local_vocab_kernel import (
+        local_vocab_state_from_logits_triton,
+    )
+
+    torch.manual_seed(1)
+    logits = torch.randn(6, 41, device="cuda", dtype=torch.float32)
+    logits[:, 37:] = 1000.0
+
+    actual = local_vocab_state_from_logits_triton(
+        local_logits=logits,
+        vocab_start=17,
+        valid_vocab_size=37,
+    )
+    expected = local_vocab_state_from_logits(
+        local_logits=logits,
+        vocab_start=17,
+        valid_vocab_size=37,
+    )
+
+    torch.testing.assert_close(actual.max_values, expected.max_values)
+    torch.testing.assert_close(actual.max_probs, expected.max_probs)
+    torch.testing.assert_close(actual.logsumexp, expected.logsumexp)
+    assert torch.equal(actual.argmax_ids, expected.argmax_ids)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_triton_local_vocab_state_applies_penalty_cuda():
+    from sglang.srt.dllm.tp_local_vocab_kernel import (
+        local_vocab_state_from_logits_triton,
+    )
+
+    torch.manual_seed(2)
+    logits = torch.randn(5, 29, device="cuda", dtype=torch.float32)
+    penalty_token_ids = torch.tensor([11, -1, 17, 30, 27], device="cuda")
+    penalty_lambda = 0.5
+
+    actual = local_vocab_state_from_logits_triton(
+        local_logits=logits,
+        vocab_start=9,
+        penalized_token_ids=penalty_token_ids,
+        penalty_lambda=penalty_lambda,
+    )
+    expected = local_vocab_state_from_logits(
+        local_logits=logits,
+        vocab_start=9,
+        penalized_token_ids=penalty_token_ids,
+        penalty_lambda=penalty_lambda,
+    )
+
+    torch.testing.assert_close(actual.max_values, expected.max_values)
+    torch.testing.assert_close(actual.max_probs, expected.max_probs)
+    torch.testing.assert_close(actual.logsumexp, expected.logsumexp)
+    assert torch.equal(actual.argmax_ids, expected.argmax_ids)
+
+
+def test_argmax_max_prob_uses_compact_state_without_full_logits():
+    state = VocabState(
+        max_values=torch.tensor([1.0, 2.0, 3.0]),
+        argmax_ids=torch.tensor([7, 8, 9]),
+        logsumexp=torch.tensor([1.5, 2.5, 3.5]),
+        max_probs=torch.tensor([0.5, 0.6, 0.7]),
+    )
+    logits_output = LogitsProcessorOutput(
+        next_token_logits=None,
+        full_logits=None,
+        dllm_vocab_state=state,
+    )
+
+    argmax_ids, max_probs = argmax_max_prob_from_logits_output(
+        logits_output,
+        start=1,
+        end=3,
+    )
+
+    assert torch.equal(argmax_ids, torch.tensor([8, 9]))
+    torch.testing.assert_close(max_probs, torch.tensor([0.6, 0.7]))
+
+
+def test_prefill_cuda_graph_slices_dllm_vocab_state_without_next_logits():
+    state = VocabState(
+        max_values=torch.tensor([1.0, 2.0, 3.0]),
+        argmax_ids=torch.tensor([7, 8, 9]),
+        logsumexp=torch.tensor([1.5, 2.5, 3.5]),
+        max_probs=torch.tensor([0.5, 0.6, 0.7]),
+    )
+    hidden_states = torch.arange(12, dtype=torch.float32).view(3, 4)
+    full_logits = torch.arange(15, dtype=torch.float32).view(3, 5)
+    output = LogitsProcessorOutput(
+        next_token_logits=None,
+        hidden_states=hidden_states,
+        full_logits=full_logits,
+        dllm_vocab_state=state,
+    )
+
+    sliced = _slice_prefill_logits_output(
+        output,
+        2,
+        is_dllm=True,
+        is_speculative=False,
+    )
+
+    assert sliced.next_token_logits is None
+    torch.testing.assert_close(sliced.hidden_states, hidden_states[:2])
+    torch.testing.assert_close(sliced.full_logits, full_logits[:2])
+    torch.testing.assert_close(sliced.dllm_vocab_state.max_values, state.max_values[:2])
+    assert torch.equal(sliced.dllm_vocab_state.argmax_ids, state.argmax_ids[:2])
+    torch.testing.assert_close(sliced.dllm_vocab_state.logsumexp, state.logsumexp[:2])
+    torch.testing.assert_close(sliced.dllm_vocab_state.max_probs, state.max_probs[:2])
+
+
+def test_argmax_max_prob_falls_back_to_full_logits_without_compact_state():
+    logits = torch.tensor(
+        [
+            [0.0, 4.0, 1.0],
+            [2.5, -1.0, 2.5],
+            [-3.0, -2.0, -1.0],
+            [0.1, 0.2, 0.3],
+        ],
+        dtype=torch.float32,
+    )
+    logits_output = LogitsProcessorOutput(
+        next_token_logits=None,
+        full_logits=logits,
+        dllm_vocab_state=None,
+    )
+
+    argmax_ids, max_probs = argmax_max_prob_from_logits_output(
+        logits_output,
+        start=1,
+        end=3,
+    )
+
+    expected_argmax_ids, expected_max_probs = _dense_argmax_and_max_prob(logits[1:3])
+    assert torch.equal(argmax_ids, expected_argmax_ids)
+    torch.testing.assert_close(max_probs, expected_max_probs)
+
+
+def test_merge_vocab_states_tie_breaks_equal_max_values_by_token_id():
+    states = [
+        VocabState(
+            max_values=torch.tensor([5.0, 7.0, 1.0]),
+            argmax_ids=torch.tensor([10, 12, 30]),
+            logsumexp=torch.log(torch.tensor([2.0, 3.0, 5.0])),
+            max_probs=torch.empty(3),
+        ),
+        VocabState(
+            max_values=torch.tensor([5.0, 6.0, 1.0]),
+            argmax_ids=torch.tensor([8, 9, 25]),
+            logsumexp=torch.log(torch.tensor([4.0, 7.0, 11.0])),
+            max_probs=torch.empty(3),
+        ),
+        VocabState(
+            max_values=torch.tensor([4.0, 7.0, 2.0]),
+            argmax_ids=torch.tensor([6, 11, 40]),
+            logsumexp=torch.log(torch.tensor([13.0, 17.0, 19.0])),
+            max_probs=torch.empty(3),
+        ),
+    ]
+
+    merged = merge_vocab_states(states)
+
+    assert torch.equal(merged.argmax_ids, torch.tensor([8, 11, 40]))
+    torch.testing.assert_close(merged.max_values, torch.tensor([5.0, 7.0, 2.0]))
+    torch.testing.assert_close(
+        merged.logsumexp,
+        torch.log(torch.tensor([19.0, 27.0, 35.0])),
+    )
+    torch.testing.assert_close(
+        merged.max_probs,
+        torch.exp(merged.max_values - merged.logsumexp),
+    )
+
+
+def test_can_pack_vocab_ids_as_float32_boundary():
+    assert can_pack_vocab_ids_as_float32(0) is True
+    assert can_pack_vocab_ids_as_float32(FLOAT32_EXACT_INT_LIMIT - 1) is True
+    assert can_pack_vocab_ids_as_float32(FLOAT32_EXACT_INT_LIMIT) is True
+    assert can_pack_vocab_ids_as_float32(-1) is False
+    assert can_pack_vocab_ids_as_float32(FLOAT32_EXACT_INT_LIMIT + 1) is False
+
+
+def test_float32_vocab_id_roundtrip_boundary_documents_guard():
+    exact_id = torch.tensor([FLOAT32_EXACT_INT_LIMIT])
+    inexact_id = torch.tensor([FLOAT32_EXACT_INT_LIMIT + 1])
+
+    assert torch.equal(exact_id.float().long(), exact_id)
+    assert not torch.equal(inexact_id.float().long(), inexact_id)
+
+
+def test_packed_vocab_state_preserves_exact_ids_at_float32_boundary():
+    states = [
+        VocabState(
+            max_values=torch.tensor([1.0, 4.0, 6.0], dtype=torch.float32),
+            argmax_ids=torch.tensor(
+                [FLOAT32_EXACT_INT_LIMIT, 9, FLOAT32_EXACT_INT_LIMIT],
+                dtype=torch.long,
+            ),
+            logsumexp=torch.tensor([2.0, 5.0, 7.0], dtype=torch.float32),
+            max_probs=torch.empty(3, dtype=torch.float32),
+        ),
+        VocabState(
+            max_values=torch.tensor([1.0, 4.0, 5.0], dtype=torch.float32),
+            argmax_ids=torch.tensor(
+                [FLOAT32_EXACT_INT_LIMIT - 1, 7, 11],
+                dtype=torch.long,
+            ),
+            logsumexp=torch.tensor([3.0, 6.0, 6.0], dtype=torch.float32),
+            max_probs=torch.empty(3, dtype=torch.float32),
+        ),
+    ]
+
+    expected = merge_vocab_states(states)
+    gathered = torch.stack([pack_vocab_state_for_tp_gather(state) for state in states])
+    actual = merge_gathered_packed_vocab_state(gathered)
+
+    assert torch.equal(actual.argmax_ids, expected.argmax_ids)
+    assert actual.argmax_ids[0].item() == FLOAT32_EXACT_INT_LIMIT - 1
+    assert actual.argmax_ids[1].item() == 7
+    assert actual.argmax_ids[2].item() == FLOAT32_EXACT_INT_LIMIT
+    torch.testing.assert_close(actual.max_values, expected.max_values)
+    torch.testing.assert_close(actual.logsumexp, expected.logsumexp)
+    torch.testing.assert_close(actual.max_probs, expected.max_probs)
+
+
+def test_packed_vocab_state_merge_matches_legacy_merge_with_tie_break():
+    states = [
+        VocabState(
+            max_values=torch.tensor([5.0, 7.0, -1.0], dtype=torch.float32),
+            argmax_ids=torch.tensor([10, 12, 30]),
+            logsumexp=torch.tensor([5.1, 7.5, 2.0], dtype=torch.float32),
+            max_probs=torch.empty(3),
+        ),
+        VocabState(
+            max_values=torch.tensor([5.0, 6.0, 0.0], dtype=torch.float32),
+            argmax_ids=torch.tensor([8, 9, 25]),
+            logsumexp=torch.tensor([5.2, 6.5, 2.5], dtype=torch.float32),
+            max_probs=torch.empty(3),
+        ),
+        VocabState(
+            max_values=torch.tensor([4.0, 7.0, 1.0], dtype=torch.float32),
+            argmax_ids=torch.tensor([6, 11, 40]),
+            logsumexp=torch.tensor([5.3, 7.7, 3.0], dtype=torch.float32),
+            max_probs=torch.empty(3),
+        ),
+    ]
+
+    expected = merge_vocab_states(states)
+    gathered = torch.stack([pack_vocab_state_for_tp_gather(state) for state in states])
+
+    actual = merge_gathered_packed_vocab_state(gathered)
+
+    assert torch.equal(actual.max_values, expected.max_values)
+    assert torch.equal(actual.logsumexp, expected.logsumexp)
+    assert torch.equal(actual.argmax_ids, expected.argmax_ids)
+    assert actual.argmax_ids[0].item() == 8
+    assert actual.argmax_ids[1].item() == 11
+    torch.testing.assert_close(actual.max_probs, expected.max_probs)
+
+
+def test_pack_vocab_state_requires_float32_state_values():
+    base = VocabState(
+        max_values=torch.tensor([1.0], dtype=torch.float32),
+        argmax_ids=torch.tensor([5]),
+        logsumexp=torch.tensor([1.5], dtype=torch.float32),
+        max_probs=torch.tensor([0.6], dtype=torch.float32),
+    )
+
+    with pytest.raises(ValueError, match="max_values"):
+        pack_vocab_state_for_tp_gather(
+            VocabState(
+                max_values=base.max_values.double(),
+                argmax_ids=base.argmax_ids,
+                logsumexp=base.logsumexp,
+                max_probs=base.max_probs,
+            )
+        )
+
+    with pytest.raises(ValueError, match="logsumexp"):
+        pack_vocab_state_for_tp_gather(
+            VocabState(
+                max_values=base.max_values,
+                argmax_ids=base.argmax_ids,
+                logsumexp=base.logsumexp.double(),
+                max_probs=base.max_probs,
+            )
+        )
+
+
+def test_packed_gather_gate_uses_vocab_upper_bound_and_env():
+    import sglang.srt.layers.logits_processor as logits_processor
+    from sglang.srt.environ import envs
+    from sglang.srt.dllm.tp_local_vocab_kernel import (
+        LOCAL_VOCAB_STATE_TRITON_MAX_BLOCK_VOCAB,
+        can_use_local_vocab_state_triton,
+    )
+
+    assert can_pack_vocab_ids_as_float32(151669)
+    assert not can_pack_vocab_ids_as_float32(FLOAT32_EXACT_INT_LIMIT + 1)
+    assert can_use_local_vocab_state_triton(
+        LOCAL_VOCAB_STATE_TRITON_MAX_BLOCK_VOCAB
+    )
+    assert not can_use_local_vocab_state_triton(
+        LOCAL_VOCAB_STATE_TRITON_MAX_BLOCK_VOCAB + 1
+    )
+
+    with envs.SGLANG_DLLM_TP_LOCAL_VOCAB_PACKED_GATHER.override(True):
+        assert logits_processor._should_pack_dllm_vocab_state_for_gather(151669)
+        assert not logits_processor._should_pack_dllm_vocab_state_for_gather(
+            FLOAT32_EXACT_INT_LIMIT + 1
+        )
+
+    with envs.SGLANG_DLLM_TP_LOCAL_VOCAB_PACKED_GATHER.override(False):
+        assert not logits_processor._should_pack_dllm_vocab_state_for_gather(151669)
+
+
+def test_dllm_vocab_state_tp_merge_uses_rank_uniform_packed_or_legacy_path():
+    from sglang.srt.environ import envs
+    from sglang.srt.layers.logits_processor import _merge_dllm_vocab_state_across_tp
+
+    states = [
+        VocabState(
+            max_values=torch.tensor([2.0, 5.0], dtype=torch.float32),
+            argmax_ids=torch.tensor([12, 40], dtype=torch.long),
+            logsumexp=torch.tensor([3.0, 6.0], dtype=torch.float32),
+            max_probs=torch.empty(2),
+        ),
+        VocabState(
+            max_values=torch.tensor([2.0, 4.0], dtype=torch.float32),
+            argmax_ids=torch.tensor([9, 30], dtype=torch.long),
+            logsumexp=torch.tensor([4.0, 7.0], dtype=torch.float32),
+            max_probs=torch.empty(2),
+        ),
+        VocabState(
+            max_values=torch.tensor([1.0, 6.0], dtype=torch.float32),
+            argmax_ids=torch.tensor([7, 35], dtype=torch.long),
+            logsumexp=torch.tensor([5.0, 8.0], dtype=torch.float32),
+            max_probs=torch.empty(2),
+        ),
+    ]
+
+    class FakeTPGroup:
+        def __init__(self, all_states):
+            self.all_states = all_states
+            self.calls = []
+            self.float_call_index = 0
+
+        def all_gather_into_tensor(self, output, input_tensor):
+            self.calls.append(
+                (tuple(output.shape), tuple(input_tensor.shape), input_tensor.dtype)
+            )
+            if input_tensor.dim() == 2:
+                packed_states = [
+                    pack_vocab_state_for_tp_gather(state)
+                    for state in self.all_states
+                ]
+                output.copy_(torch.cat(packed_states, dim=0))
+                return
+            if input_tensor.dtype == torch.long:
+                output.copy_(torch.cat([state.argmax_ids for state in self.all_states]))
+                return
+
+            values = [state.max_values for state in self.all_states]
+            if self.float_call_index == 1:
+                values = [state.logsumexp for state in self.all_states]
+            output.copy_(torch.cat(values))
+            self.float_call_index += 1
+
+    with envs.SGLANG_DLLM_TP_LOCAL_VOCAB_PACKED_GATHER.override(True):
+        packed_group = FakeTPGroup(states)
+        packed = _merge_dllm_vocab_state_across_tp(
+            local_state=states[0],
+            tp_group=packed_group,
+            tp_size=len(states),
+            global_max_vocab_id_inclusive=151669,
+        )
+        assert len(packed_group.calls) == 1
+        assert packed_group.calls[0][0] == (len(states) * 2, 3)
+
+        legacy_group = FakeTPGroup(states)
+        legacy = _merge_dllm_vocab_state_across_tp(
+            local_state=states[0],
+            tp_group=legacy_group,
+            tp_size=len(states),
+            global_max_vocab_id_inclusive=FLOAT32_EXACT_INT_LIMIT + 1,
+        )
+        assert len(legacy_group.calls) == 3
+
+    torch.testing.assert_close(packed.max_probs, legacy.max_probs)
+    assert torch.equal(packed.max_values, legacy.max_values)
+    assert torch.equal(packed.logsumexp, legacy.logsumexp)
+    assert torch.equal(packed.argmax_ids, legacy.argmax_ids)
+
+
+def test_logits_processor_tp_local_vocab_gate(monkeypatch):
+    import sglang.srt.layers.logits_processor as logits_processor
+    from sglang.srt.environ import envs
+
+    processor = SimpleNamespace(
+        use_attn_tp_group=False,
+        do_tensor_parallel_all_gather_dp_attn=False,
+    )
+    lm_head = SimpleNamespace(weight=torch.empty(1))
+    should_use = logits_processor.LogitsProcessor._should_use_dllm_tp_local_vocab
+
+    monkeypatch.setattr(
+        logits_processor,
+        "get_global_server_args",
+        lambda: SimpleNamespace(dllm_algorithm="LowConfidence"),
+    )
+
+    with envs.SGLANG_DLLM_TP_LOCAL_VOCAB.override(False):
+        assert should_use(processor, lm_head) is False
+
+    with envs.SGLANG_DLLM_TP_LOCAL_VOCAB.override(True):
+        assert should_use(processor, lm_head) is False
+        monkeypatch.setattr(logits_processor, "_is_npu", True)
+        assert should_use(processor, lm_head) is False
+        monkeypatch.setattr(logits_processor, "_is_npu", False)
+
+        monkeypatch.setattr(
+            logits_processor,
+            "get_global_server_args",
+            lambda: SimpleNamespace(dllm_algorithm="JointThreshold"),
+        )
+        assert should_use(processor, lm_head) is False
+
+        monkeypatch.setattr(
+            logits_processor,
+            "get_global_server_args",
+            lambda: SimpleNamespace(dllm_algorithm="LowConfidence"),
+        )
+        assert (
+            should_use(
+                SimpleNamespace(
+                    use_attn_tp_group=True,
+                    do_tensor_parallel_all_gather_dp_attn=False,
+                ),
+                lm_head,
+            )
+            is False
+        )
+        assert (
+            should_use(
+                SimpleNamespace(
+                    use_attn_tp_group=False,
+                    do_tensor_parallel_all_gather_dp_attn=True,
+                ),
+                lm_head,
+            )
+            is False
+        )
+        assert should_use(processor, SimpleNamespace()) is False
+
+        global_added_lm_head = SimpleNamespace(
+            weight=torch.empty(1),
+            num_added_embeddings=2,
+            shard_indices=SimpleNamespace(num_added_elements=0),
+        )
+        clean_lm_head = SimpleNamespace(
+            weight=torch.empty(1),
+            num_added_embeddings=0,
+            shard_indices=SimpleNamespace(num_added_elements=0),
+        )
+        lora_wrapped_lm_head = SimpleNamespace(
+            weight=torch.empty(1),
+            num_added_embeddings=0,
+            base_layer=SimpleNamespace(
+                shard_indices=SimpleNamespace(
+                    org_vocab_start_index=4,
+                    num_org_elements=8,
+                    num_added_elements=0,
+                )
+            ),
+        )
+        assert should_use(processor, global_added_lm_head) is False
+        assert should_use(processor, clean_lm_head) is True
+        assert should_use(processor, lora_wrapped_lm_head) is False
+
+
+def test_dllm_vocab_state_logit_scale_matches_full_logits_dtype_order(monkeypatch):
+    import sglang.srt.layers.logits_processor as logits_processor
+
+    logits = torch.tensor(
+        [[-4.15625, -4.125, -4.0], [1.125, 1.25, 1.375]],
+        dtype=torch.bfloat16,
+    )
+    scale = 2.764019822896123
+    hidden_states = torch.empty(2, 1)
+    processor = SimpleNamespace(
+        vocab_size=3,
+        logit_scale=scale,
+        final_logit_softcapping=None,
+        _dllm_tp_local_vocab_logged=True,
+        _gather_dp_attn_hidden_states=lambda hidden, metadata: (hidden, hidden),
+        _compute_lm_head=lambda hidden, lm_head: logits.clone(),
+    )
+    lm_head = SimpleNamespace(
+        weight=torch.empty(1),
+        shard_indices=SimpleNamespace(org_vocab_start_index=0, num_org_elements=3),
+    )
+
+    monkeypatch.setattr(
+        logits_processor,
+        "get_parallel",
+        lambda: SimpleNamespace(tp_size=1),
+    )
+
+    state = logits_processor.LogitsProcessor._get_dllm_vocab_state(
+        processor,
+        hidden_states,
+        lm_head,
+        SimpleNamespace(),
+    )
+    expected_logits = logits.clone()
+    expected_logits.mul_(scale)
+    expected_state = local_vocab_state_from_logits(
+        local_logits=expected_logits.float(),
+        vocab_start=0,
+        valid_vocab_size=3,
+    )
+
+    torch.testing.assert_close(state.max_values, expected_state.max_values)
+    torch.testing.assert_close(state.max_probs, expected_state.max_probs)
+    torch.testing.assert_close(state.logsumexp, expected_state.logsumexp)
+    assert torch.equal(state.argmax_ids, expected_state.argmax_ids)
+
+
+def test_endpoint_trace_evidence_requires_compact_path_record(tmp_path):
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text(
+        json.dumps(
+            {
+                "framework": "sglang",
+                "path": "full_vocab_materialized",
+                "component": "unit.full",
+            }
+        )
+        + "\n"
+    )
+    with pytest.raises(AssertionError, match="consumer_sufficient_compact"):
+        _assert_compact_trace_evidence(trace_path)
+
+    trace_path.write_text(
+        json.dumps(
+            {
+                "framework": "sglang",
+                "path": "consumer_sufficient_compact",
+                "component": "sglang.logits_processor._get_dllm_vocab_state",
+                "tp_size": 1,
+            }
+        )
+        + "\n"
+    )
+    _assert_compact_trace_evidence(trace_path)
+
+
+def test_dllm_vocab_state_softcap_uses_float32_logits(monkeypatch):
+    import sglang.srt.layers.logits_processor as logits_processor
+
+    logits = torch.tensor([[0.5, 1.5, -2.0]], dtype=torch.bfloat16)
+    hidden_states = torch.empty(1, 1)
+    processor = SimpleNamespace(
+        vocab_size=3,
+        logit_scale=None,
+        final_logit_softcapping=2.0,
+        _dllm_tp_local_vocab_logged=True,
+        _gather_dp_attn_hidden_states=lambda hidden, metadata: (hidden, hidden),
+        _compute_lm_head=lambda hidden, lm_head: logits,
+    )
+
+    def fake_softcap_inplace(values, cap):
+        assert values.dtype == torch.float32
+        values.copy_(cap * torch.tanh(values / cap))
+
+    monkeypatch.setattr(logits_processor, "fused_softcap", fake_softcap_inplace)
+    monkeypatch.setattr(
+        logits_processor,
+        "get_parallel",
+        lambda: SimpleNamespace(tp_size=1),
+    )
+
+    state = logits_processor.LogitsProcessor._get_dllm_vocab_state(
+        processor,
+        hidden_states,
+        SimpleNamespace(weight=torch.empty(1)),
+        SimpleNamespace(),
+    )
+    expected_logits = 2.0 * torch.tanh(logits.float() / 2.0)
+    expected_state = local_vocab_state_from_logits(
+        local_logits=expected_logits,
+        vocab_start=0,
+        valid_vocab_size=3,
+    )
+
+    assert state.max_values.dtype == torch.float32
+    assert state.logsumexp.dtype == torch.float32
+    torch.testing.assert_close(state.max_values, expected_state.max_values)
+    torch.testing.assert_close(state.max_probs, expected_state.max_probs)
+    assert torch.equal(state.argmax_ids, expected_state.argmax_ids)
+
+
+def test_consumer_state_trace_emits_full_and_compact_records(tmp_path):
+    from sglang.srt.dllm.consumer_state_trace import (
+        emit_compact_vocab_state_trace,
+        emit_full_vocab_trace,
+    )
+    from sglang.srt.environ import envs
+
+    trace_path = tmp_path / "trace.jsonl"
+    full_logits = torch.empty(2, 5, dtype=torch.float32)
+    local_logits = torch.empty(2, 3, dtype=torch.bfloat16)
+    state = VocabState(
+        max_values=torch.empty(2, dtype=torch.float32),
+        argmax_ids=torch.empty(2, dtype=torch.int64),
+        logsumexp=torch.empty(2, dtype=torch.float32),
+        max_probs=torch.empty(2, dtype=torch.float32),
+    )
+
+    with envs.SGLANG_CONSUMER_STATE_TRACE_JSONL.override(str(trace_path)):
+        emit_full_vocab_trace(
+            component="unit.full",
+            full_logits=full_logits,
+            vocab_size=5,
+            tp_size=2,
+            rank=1,
+            consumer_contract="full",
+        )
+        emit_compact_vocab_state_trace(
+            component="unit.compact",
+            local_logits=local_logits,
+            state=state,
+            vocab_size=9,
+            valid_vocab_size=3,
+            tp_size=2,
+            rank=1,
+            packed_gather=True,
+            consumer_contract="compact",
+        )
+
+    records = [json.loads(line) for line in trace_path.read_text().splitlines()]
+    assert [record["framework"] for record in records] == ["sglang", "sglang"]
+    assert records[0]["path"] == "full_vocab_materialized"
+    assert records[0]["full_vocab_materialized_bytes"] == 2 * 5 * 4
+    assert records[0]["tp_gather_bytes"] == 2 * 5 * 4
+
+    assert records[1]["path"] == "consumer_sufficient_compact"
+    assert records[1]["local_vocab_materialized_bytes"] == 2 * 3 * 2
+    assert records[1]["avoidable_full_vocab_materialized_bytes"] == 2 * 9 * 2
+    assert records[1]["compact_state_bytes"] == 2 * (4 + 8 + 4 + 4)
+    assert records[1]["tp_gather_bytes"] == 2 * 2 * 3 * 4
+
+
+def _endpoint_url(env_key: str) -> str | None:
+    url = os.environ.get(env_key)
+    if not url:
+        return None
+    return url.rstrip("/")
+
+
+def _assert_compact_trace_evidence(trace_path) -> None:
+    records = []
+    with open(trace_path) as trace_file:
+        for line in trace_file:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+
+    assert any(
+        record.get("framework") == "sglang"
+        and record.get("path") == "consumer_sufficient_compact"
+        and record.get("component") == "sglang.logits_processor._get_dllm_vocab_state"
+        for record in records
+    ), "missing consumer_sufficient_compact endpoint trace evidence"
+
+
+def _post_generate(endpoint: str, prompt: str) -> str:
+    requests = pytest.importorskip("requests")
+    response = requests.post(
+        f"{endpoint}/generate",
+        json={
+            "text": prompt,
+            "sampling_params": {
+                "temperature": 0,
+                "max_new_tokens": 8,
+            },
+        },
+        timeout=60,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if isinstance(payload, dict):
+        if "text" in payload:
+            return payload["text"]
+        if "output" in payload:
+            return payload["output"]
+        return payload["outputs"][0]["text"]
+    return payload[0]["text"]
+
+
+def test_baseline_and_tp_local_vocab_endpoints_match_when_configured():
+    baseline_url = _endpoint_url(ENDPOINT_BASELINE_URL_ENV)
+    tp_local_url = _endpoint_url(ENDPOINT_TP_LOCAL_URL_ENV)
+    tp_local_trace = os.environ.get(ENDPOINT_TP_LOCAL_TRACE_ENV)
+    if not baseline_url or not tp_local_url:
+        pytest.skip(
+            f"set {ENDPOINT_BASELINE_URL_ENV} and {ENDPOINT_TP_LOCAL_URL_ENV} "
+            "to compare already-running endpoints"
+        )
+
+    prompts = [
+        "Name one primary color.",
+        "Complete the sequence: 1, 1, 2, 3,",
+    ]
+
+    for prompt in prompts:
+        assert _post_generate(tp_local_url, prompt) == _post_generate(
+            baseline_url, prompt
+        )
+    if tp_local_trace:
+        _assert_compact_trace_evidence(tp_local_trace)
+
+
+def test_cuda_graph_replay_slice_preserves_compact_vocab_state():
+    from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+        _slice_dllm_vocab_state,
+    )
+
+    state = VocabState(
+        max_values=torch.tensor([1.0, 2.0, 3.0, 4.0]),
+        argmax_ids=torch.tensor([10, 11, 12, 13]),
+        logsumexp=torch.tensor([1.5, 2.5, 3.5, 4.5]),
+        max_probs=torch.tensor([0.6, 0.7, 0.8, 0.9]),
+    )
+
+    sliced = _slice_dllm_vocab_state(state, 2)
+
+    assert sliced is not None
+    torch.testing.assert_close(sliced.max_values, torch.tensor([1.0, 2.0]))
+    assert torch.equal(sliced.argmax_ids, torch.tensor([10, 11]))
+    torch.testing.assert_close(sliced.logsumexp, torch.tensor([1.5, 2.5]))
+    torch.testing.assert_close(sliced.max_probs, torch.tensor([0.6, 0.7]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR adds and hardens a dLLM TP-local vocab state path for SGLang.

For LowConfidence dLLM inference, the logits processor can pass compact consumer-sufficient vocab state instead of materializing / gathering full logits across tensor-parallel ranks. This reduces unnecessary full-vocab communication when the downstream dLLM consumer only needs argmax and confidence state.

This PR also fixes a prefill CUDA graph replay bug for dLLM outputs where `next_token_logits=None` is valid but was sliced unconditionally.

## Modifications

| Area | Change |
| --- | --- |
| Logits processor | Add compact `dllm_vocab_state` path for TP-local vocab consumers |
| TP communication | Avoid full-vocab dense state when compact state is enough |
| dLLM algorithms | Consume compact argmax / confidence state in LowConfidence-compatible paths |
| Prefill CUDA graph | Slice dLLM `full_logits` / `dllm_vocab_state` safely while preserving `next_token_logits=None` |
| Guarding | Default-off env-gated path with dense fallback where compact state is insufficient |
| Tests | Add regression coverage for compact vocab state, packed gather, dense equivalence, endpoint comparison hook, and CUDA graph slicing |

## Accuracy Tests

Focused regression tests passed:

```text
25 passed, 1 skipped, 21 warnings
```

The skipped test is an endpoint-comparison gate that requires already-running baseline and optimized endpoint URLs.

The compact vocab state path is tested against dense logits for argmax and confidence consumers, including padded vocab shards, packed gather, tie-breaking, and logit-scale / softcap ordering. The CUDA graph fix has regression coverage for dLLM outputs with `next_token_logits=None`.

This benchmark is a serving-throughput benchmark, not a downstream task-accuracy evaluation.

## Speed Tests and Profiling

Measured through SGLang endpoints using `vllm bench serve`, TP4, closed-loop load, random input length 30, output length 32, 512 measured prompts, 256 warmups.

Benchmark setup:

| item | value |
| --- | --- |
| server | `python -m sglang.launch_server` OpenAI-compatible endpoint |
| tensor parallelism | TP4 |
| load | closed loop, `--request-rate inf` |
| prompts | 512 measured prompts, 256 warmup prompts |
| random shape | input length 30, output length 32 |
| concurrency | c4, c8, c16, c32 |
| baseline flag | `SGLANG_DLLM_TP_LOCAL_VOCAB=0` |
| optimized flag | `SGLANG_DLLM_TP_LOCAL_VOCAB=1` |
| packed gather flag | `SGLANG_DLLM_TP_LOCAL_VOCAB_PACKED_GATHER=1` |
| algorithm | `LowConfidence` |
| attention / sampling backend | `flashinfer` |

Models:

| family | model |
| --- | --- |
| LLaDA2-flash | `inclusionAI/LLaDA2.0-flash` |
| SDAR-8B | `JetLM/SDAR-8B-Chat` |
| SDAR-30B-A3B | `JetLM/SDAR-30B-A3B-Chat-b32` |

Results:

| model | claim range | result |
| --- | --- | ---: |
| LLaDA2-flash | c8-c32 geomean | 1.049x |
| SDAR-8B | c8-c32 geomean | 1.076x |
| SDAR-30B-A3B | repeated c16/c32 geomean | 1.054x |

Detailed rows:

| model | c4 | c8 | c16 | c32 |
| --- | ---: | ---: | ---: | ---: |
| LLaDA2-flash | 1.014x | 1.030x | 1.056x | 1.061x |
| SDAR-8B | 1.027x | 1.040x | 1.098x | 1.090x |
| SDAR-30B-A3B, repeat n=3 | - | - | 1.046x | 1.061x |

An initial SDAR-30B c32 run showed `1.433x`, but repeat validation did not reproduce it. The repeated c16/c32 row above is the PR claim.

Reproduction:

```bash
export MODEL=JetLM/SDAR-8B-Chat

# baseline endpoint
SGLANG_DLLM_TP_LOCAL_VOCAB=0 \
SGLANG_DLLM_TP_LOCAL_VOCAB_PACKED_GATHER=1 \
python -m sglang.launch_server \
  --model-path "${MODEL}" \
  --trust-remote-code \
  --host 127.0.0.1 \
  --port 8000 \
  --tp-size 4 \
  --dllm-algorithm LowConfidence \
  --attention-backend flashinfer \
  --sampling-backend flashinfer \
  --max-running-requests 32

# optimized endpoint
SGLANG_DLLM_TP_LOCAL_VOCAB=1 \
SGLANG_DLLM_TP_LOCAL_VOCAB_PACKED_GATHER=1 \
python -m sglang.launch_server \
  --model-path "${MODEL}" \
  --trust-remote-code \
  --host 127.0.0.1 \
  --port 8001 \
  --tp-size 4 \
  --dllm-algorithm LowConfidence \
  --attention-backend flashinfer \
  --sampling-backend flashinfer \
  --max-running-requests 32
```

Use the same command shape for `inclusionAI/LLaDA2.0-flash` and
`JetLM/SDAR-30B-A3B-Chat-b32`. The measured LLaDA2-flash and SDAR-30B-A3B
runs additionally used `--cuda-graph-backend-decode=disabled`.

Benchmark both endpoints:

```bash
for PORT in 8000 8001; do
  for C in 4 8 16 32; do
    vllm bench serve \
      --backend openai \
      --base-url "http://127.0.0.1:${PORT}" \
      --endpoint /v1/completions \
      --model "${MODEL}" \
      --served-model-name "${MODEL}" \
      --tokenizer "${MODEL}" \
      --trust-remote-code \
      --dataset-name random \
      --random-input-len 30 \
      --random-output-len 32 \
      --random-range-ratio 0 \
      --num-prompts 512 \
      --num-warmups 256 \
      --request-rate inf \
      --max-concurrency "${C}" \
      --ignore-eos \
      --temperature 0 \
      --seed "$((100000 + C))" \
      --percentile-metrics ttft,tpot,itl,e2el \
      --metric-percentiles 50,90,95,99
  done
done
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
