### PR TITLE
[FIX] Prevent Lightning Attention extra-buffer mamba state corruption

### DIFF
--- a/python/sglang/kernels/ops/attention/linear/seg_la.py
+++ b/python/sglang/kernels/ops/attention/linear/seg_la.py
@@ -221,11 +221,14 @@ def seg_la_p_kernel(
     q_lengths,
     s_scales,
     decay_scales,
+    track_lens,
+    track_state_indices,
     HEAD_DIM: tl.constexpr,
     K_SPLIT_DIM: tl.constexpr,
     V_SPLIT_DIM: tl.constexpr,
     BLOCK: tl.constexpr,
     EVEN: tl.constexpr,
+    TRACK_STATE: tl.constexpr,
 ):
     bid = tl.program_id(0)
     hid = tl.program_id(1)
@@ -241,6 +244,11 @@ def seg_la_p_kernel(
     q_offset = tl.load(q_offsets + bid)
     s_offset = tl.load(s_offsets + bid)
     decay_scale = -tl.load(decay_scales + hid)
+    track_len = 0
+    track_state_offset = -1
+    if TRACK_STATE:
+        track_len = tl.load(track_lens + bid)
+        track_state_offset = tl.load(track_state_indices + bid)
 
     offs_b = tl.arange(0, BLOCK)
     offs_k = tl.arange(0, K_SPLIT_DIM)
@@ -288,6 +296,15 @@ def seg_la_p_kernel(
         + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
     )
     state = tl.load(s_ptrs, mask=s_scale > 0).to(tl.float32)
+    if TRACK_STATE:
+        track_s_ptrs = (
+            S
+            + track_state_offset * stride_s
+            + hid * HEAD_DIM * HEAD_DIM
+            + kid * HEAD_DIM * K_SPLIT_DIM
+            + vid * V_SPLIT_DIM
+            + (offs_k[:, None] * HEAD_DIM + offs_v[None, :])
+        )
 
     for n in range(0, q_length, BLOCK):
         n = tl.multiple_of(n, BLOCK)
@@ -330,6 +347,15 @@ def seg_la_p_kernel(
         o = tl.dot(q, state) * block_decay * softmax_scale + o
 
         state = state * block_decay + tl.dot(k, v)
+        if TRACK_STATE:
+            should_track = (
+                (track_state_offset >= 0) & (track_len > 0) & (n + b == track_len)
+            )
+            tl.store(
+                track_s_ptrs,
+                state.to(S.dtype.element_ty),
+                mask=should_track,
+            )
 
         if EVEN:
             tl.store(out_ptrs + n * H * HEAD_DIM, o.to(Out.dtype.element_ty))
@@ -663,6 +689,8 @@ def seg_la_fwd(
     meta,
     caches=None,
     cache_indices=None,
+    track_lens=None,
+    track_state_indices=None,
     softmax_scale=None,
     decouple=False,
 ):
@@ -779,11 +807,18 @@ def seg_la_fwd(
                 meta.q_lengths,
                 meta.s_scales,
                 decay_scales,
+                track_lens if track_lens is not None else meta.q_lengths,
+                (
+                    track_state_indices
+                    if track_state_indices is not None
+                    else meta.s_offsets
+                ),
                 HEAD_DIM=HEAD_DIM,
                 K_SPLIT_DIM=K_SPLIT_DIM,
                 V_SPLIT_DIM=V_SPLIT_DIM,
                 BLOCK=BLOCK,
                 EVEN=EVEN,
+                TRACK_STATE=track_lens is not None and track_state_indices is not None,
                 num_warps=num_warps,
                 num_stages=num_stages,
             )

--- a/python/sglang/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sglang/srt/layers/attention/linear/lightning_backend.py
@@ -15,8 +15,7 @@ from sglang.srt.layers.attention.linear.linear_metadata import (
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.runtime_context import get_parallel
-from sglang.srt.server_args import get_global_server_args
+from sglang.srt.runtime_context import get_parallel, get_server_args
 
 logger = logging.getLogger(__name__)
 
@@ -299,7 +298,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
         if h_dst is None or h_dst.numel() == 0:
             return None, None
 
-        mamba_cache_chunk_size = get_global_server_args().mamba_cache_chunk_size
+        mamba_cache_chunk_size = get_server_args().mamba_cache_chunk_size
         num_prefills = metadata.num_prefills
         track_mask = forward_batch.mamba_track_mask[:num_prefills]
         extend_lens = forward_batch.extend_seq_lens[:num_prefills]

--- a/python/sglang/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sglang/srt/layers/attention/linear/lightning_backend.py
@@ -16,6 +16,7 @@ from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.runtime_context import get_parallel
+from sglang.srt.server_args import get_global_server_args
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,11 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             forward_batch.forward_mode,
             forward_batch.spec_info,
             forward_batch.seq_lens_cpu if not in_capture else None,
+            num_padding=(
+                0 if in_capture else getattr(forward_batch, "num_padding", None)
+            ),
+            in_capture=in_capture,
+            mamba_track_indices=getattr(forward_batch, "mamba_track_indices", None),
         )
         self.forward_metadata = BailingLinearMetadata.prepare_decode(
             metadata.query_start_loc,
@@ -103,6 +109,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             bs,
             forward_batch.seq_lens,
         )
+        self.forward_metadata.mamba_track_indices = metadata.mamba_track_indices
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         metadata = self._forward_metadata(forward_batch)
@@ -111,6 +118,12 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             metadata.mamba_cache_indices,
             forward_batch,
         )
+        self.forward_metadata.mamba_track_indices = metadata.mamba_track_indices
+        self.forward_metadata.track_ssm_h_src = metadata.track_ssm_h_src
+        self.forward_metadata.track_ssm_h_dst = metadata.track_ssm_h_dst
+        self.forward_metadata.track_ssm_final_src = metadata.track_ssm_final_src
+        self.forward_metadata.track_ssm_final_dst = metadata.track_ssm_final_dst
+        self.forward_metadata.has_mamba_track_mask = metadata.has_mamba_track_mask
 
     @staticmethod
     def _build_slope_tensor(
@@ -244,6 +257,8 @@ class LightningAttentionBackend(MambaAttnBackendBase):
         mask=None,
         temp_cache=None,
         intermediate_state_indices=None,
+        track_lens=None,
+        track_state_indices=None,
     ):
         q_offsets = metadata.query_start_loc
 
@@ -265,9 +280,62 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             meta=seg_meta,
             caches=temp_cache,
             cache_indices=intermediate_state_indices,
+            track_lens=track_lens,
+            track_state_indices=track_state_indices,
             decouple=True,
         )
         return hidden
+
+    def _prepare_seg_la_track_store(self, forward_batch, metadata):
+        if (
+            self.linear_backend != "seg_la"
+            or not metadata.has_mamba_track_mask
+            or metadata.num_prefills == 0
+            or forward_batch.mamba_track_mask is None
+        ):
+            return None, None
+
+        h_dst = metadata.track_ssm_h_dst
+        if h_dst is None or h_dst.numel() == 0:
+            return None, None
+
+        mamba_cache_chunk_size = get_global_server_args().mamba_cache_chunk_size
+        num_prefills = metadata.num_prefills
+        track_mask = forward_batch.mamba_track_mask[:num_prefills]
+        extend_lens = forward_batch.extend_seq_lens[:num_prefills]
+        prefix_lens = forward_batch.extend_prefix_lens[:num_prefills]
+        track_seqlens = forward_batch.mamba_track_seqlens[:num_prefills]
+
+        lens_to_track = track_seqlens - prefix_lens
+        boundary_lens = (
+            lens_to_track // mamba_cache_chunk_size
+        ) * mamba_cache_chunk_size
+        track_rows = (track_mask & (boundary_lens < extend_lens)).nonzero(
+            as_tuple=True
+        )[0]
+        if track_rows.numel() == 0:
+            return None, None
+
+        if h_dst.numel() != track_rows.numel():
+            raise RuntimeError(
+                "seg_la mamba track metadata mismatch: "
+                f"{h_dst.numel()} destination slots for {track_rows.numel()} rows"
+            )
+
+        track_lens = torch.zeros(
+            (metadata.batch_size,),
+            dtype=torch.int32,
+            device=metadata.mamba_cache_indices.device,
+        )
+        track_state_indices = torch.full(
+            (metadata.batch_size,),
+            -1,
+            dtype=h_dst.dtype,
+            device=metadata.mamba_cache_indices.device,
+        )
+        track_lens[track_rows] = boundary_lens[track_rows].to(torch.int32)
+        track_state_indices[track_rows] = h_dst
+        return track_lens, track_state_indices
 
     def forward_extend(
         self,
@@ -310,6 +378,11 @@ class LightningAttentionBackend(MambaAttnBackendBase):
                 if forward_batch.forward_mode.is_target_verify()
                 else None
             )
+            track_lens, track_state_indices = (
+                (None, None)
+                if forward_batch.forward_mode.is_target_verify()
+                else self._prepare_seg_la_track_store(forward_batch, metadata)
+            )
             o = self._linear_attention_entry(
                 q,
                 k,
@@ -324,6 +397,8 @@ class LightningAttentionBackend(MambaAttnBackendBase):
                     else None
                 ),
                 intermediate_state_indices=intermediate_state_indices,
+                track_lens=track_lens,
+                track_state_indices=track_state_indices,
             )
         else:
             raise ValueError(
@@ -335,11 +410,20 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             and forward_batch.mamba_track_mask is not None
         ):
             # save mamba cache for extra buffer
-            mamba_track_mask = forward_batch.mamba_track_mask
-            mamba_track_indices = forward_batch.mamba_track_indices
-            dst_masked = mamba_track_indices[mamba_track_mask]
-            src_masked = metadata.mamba_cache_indices[mamba_track_mask]
-            ssm_states[dst_masked] = ssm_states[src_masked]
+            if self.linear_backend == "seg_la":
+                if (
+                    metadata.track_ssm_final_dst is not None
+                    and metadata.track_ssm_final_dst.numel() > 0
+                ):
+                    ssm_states[metadata.track_ssm_final_dst] = ssm_states[
+                        metadata.track_ssm_final_src
+                    ]
+            else:
+                mamba_track_mask = forward_batch.mamba_track_mask
+                mamba_track_indices = forward_batch.mamba_track_indices
+                dst_masked = mamba_track_indices[mamba_track_mask]
+                src_masked = metadata.mamba_cache_indices[mamba_track_mask]
+                ssm_states[dst_masked] = ssm_states[src_masked]
 
         return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
@@ -375,4 +459,11 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             raise ValueError(
                 f"linear backend: {self.linear_backend} is not support for now"
             )
+
+        self._track_mamba_state_decode(
+            forward_batch,
+            mamba_cache_params.conv[0],
+            ssm_states,
+            cache_indices,
+        )
         return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)

--- a/test/registered/attention/unittests/lightning/test_triton.py
+++ b/test/registered/attention/unittests/lightning/test_triton.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import torch
 
+from sglang.kernels.ops.attention.linear.seg_la import SegLaMeta, seg_la_fwd
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.test_utils import CustomTestCase
 
@@ -155,6 +156,82 @@ class TestTritonLightningBackendCorrectness(CustomTestCase):
                     continue
                 with self.subTest(case=case.name, layout=layout):
                     run_lightning_attention_case(self, case, loc_layout=layout)
+
+    def test_seg_la_prefill_tracks_extra_buffer_state(self):
+        torch.manual_seed(20260703)
+        device = "cuda"
+        dtype = torch.float32
+        batch_size = 1
+        num_heads = 2
+        head_dim = 128
+        extend_len = 96
+        track_len = 64
+        active_slot = 0
+        track_slot = 1
+        untouched_slot = 2
+
+        q = torch.randn(extend_len, num_heads, head_dim, dtype=dtype, device=device)
+        k = torch.randn(extend_len, num_heads, head_dim, dtype=dtype, device=device)
+        v = torch.randn(extend_len, num_heads, head_dim, dtype=dtype, device=device)
+        slopes = torch.tensor([0.5, 0.25], dtype=torch.float32, device=device)
+
+        s = torch.empty(
+            3, num_heads, head_dim, head_dim, dtype=torch.float32, device=device
+        )
+        s[active_slot] = torch.randn_like(s[active_slot]) * 0.05
+        s[track_slot].fill_(12345.0)
+        s[untouched_slot].fill_(54321.0)
+        initial_state = s[active_slot].clone()
+        untouched_state = s[untouched_slot].clone()
+
+        meta = SegLaMeta(
+            batch_size=batch_size,
+            max_q_length=None,
+            q_offsets=torch.tensor([0, extend_len], dtype=torch.int32, device=device),
+            s_offsets=torch.tensor([active_slot], dtype=torch.int32, device=device),
+            q_lengths=torch.tensor([extend_len], dtype=torch.int32, device=device),
+            s_scales=torch.tensor([True], dtype=torch.bool, device=device),
+            mask=None,
+        )
+
+        seg_la_fwd(
+            q=q,
+            k=k,
+            v=v,
+            s=s,
+            decay_scales=slopes,
+            meta=meta,
+            track_lens=torch.tensor([track_len], dtype=torch.int32, device=device),
+            track_state_indices=torch.tensor(
+                [track_slot], dtype=torch.int64, device=device
+            ),
+            decouple=True,
+        )
+
+        expected = initial_state.float()
+        expected_at_track = None
+        decay = torch.exp(-slopes)
+        for token_idx in range(extend_len):
+            for head_idx in range(num_heads):
+                expected[head_idx] = expected[head_idx] * decay[head_idx] + torch.outer(
+                    k[token_idx, head_idx], v[token_idx, head_idx]
+                )
+            if token_idx + 1 == track_len:
+                expected_at_track = expected.clone()
+
+        torch.testing.assert_close(
+            s[track_slot],
+            expected_at_track,
+            atol=3e-2,
+            rtol=3e-2,
+        )
+        torch.testing.assert_close(
+            s[active_slot],
+            expected,
+            atol=3e-2,
+            rtol=3e-2,
+        )
+        torch.testing.assert_close(s[untouched_slot], untouched_state)
 
     def test_runner_mode_cuda_graph_decode_cases(self):
         for case in self.CUDA_GRAPH_CASES:


### PR DESCRIPTION
## Motivation

**When Lightning `seg_la` is used with mamba radix cache `extra_buffer`, repeated serving runs can reuse corrupted mamba state snapshots and cause AIME accuracy to collapse.**

<img width="1600" height="860" alt="aime_accuracy_before_after" src="https://github.com/user-attachments/assets/8f43c7c4-a664-4218-b206-cc5189e78527" />

In SGLang, mamba radix cache must keep the token/KV prefix and the recurrent mamba state aligned. With `extra_buffer`, cached mamba states are stored in extra ping-pong slots managed by `req_to_token_pool`; the active slot continues to hold the running request state. The scheduler decides which mamba boundary should be tracked and passes it to the model forward through `ForwardBatch` fields such as `mamba_track_mask`, `mamba_track_indices`, and `mamba_track_seqlens`.

```text
radix cache node for prefix [0, P)
+-------------------------------------------------------+
| KV/token slot indices                                 |
| mamba state slot  ------------------------------+     |
+-------------------------------------------------|-----+
                                                  |
                                                  v
req_to_token_pool / mamba state slots
+-------------------------------------------------------+
| active slot A: running request state                  |
| extra slot B: cache-owned state for prefix [0, P)     |
| extra slot C: alternate ping-pong track slot          |
+-------------------------------------------------------+

Correct:
  radix prefix [0, P) -> mamba state at P

Buggy Lightning seg_la:
  radix prefix [0, P) -> mamba state after full extend E
```

## Relationship to #29945

The initial version of this PR also treated deferred Mamba COW/clear ordering as a Lightning-specific problem. [#29945](https://github.com/sgl-project/sglang/pull/29945) fixed that ordering globally by moving deferred Mamba pool operations into `ModelRunner._forward_raw`, before forward dispatch. This PR is now based on a `main` that contains #29945 and intentionally does not duplicate COW/clear handling inside the Lightning backend.

The remaining bug fixed here is independent of #29945.

**Wrong state written for an internal tracked boundary.**

`seg_la` did not materialize the intermediate recurrent state needed by an unaligned extend. The scheduler stores the radix entry at `mamba_last_track_seqlen`, the last complete `mamba_cache_chunk_size` boundary. That boundary can be inside the current extend instead of at its end. Before this fix, Lightning could copy the final state of the whole extend into the extra-buffer slot associated with the shorter cached prefix.

The serving failure is then:

- radix cache entry represents a prefix ending at `mamba_last_track_seqlen`
- extra-buffer slot contains a state after later tokens in the same extend
- a later prefix cache hit restores the shorter token/KV prefix with an over-advanced mamba state

This mismatch is hard to see in a single isolated forward. It becomes obvious in repeated end-to-end serving rounds, where radix-cache entries are inserted and reused. With `extra_buffer + seg_la`, AIME accuracy starts normally, then drops sharply as polluted snapshots are reused, and extraction errors appear in later rounds.

## Modifications

This PR restores the mamba extra-buffer contract for Lightning `seg_la`.

- **`python/sglang/srt/layers/attention/linear/lightning_backend.py`**

  Propagates the shared Mamba tracking metadata into the Lightning metadata object.

  For extend batches, prepares the compact tracking metadata that `seg_la` needs: the last complete chunk boundary and the destination extra-buffer slot for each tracked request. Aligned boundaries continue to copy the final active state, while decode tracking reuses the shared base-backend helper.

- **`python/sglang/srt/layers/attention/linear/seg_la.py`**

  Adds optional tracking to the `seg_la` prefill kernel. When an extend crosses a tracked mamba boundary, the kernel writes the tracked boundary state to the extra-buffer slot while keeping the existing final-state write to the active slot unchanged.

- **`test/registered/attention/unittests/lightning/test_triton.py`**

  Adds a focused kernel-level regression test for the unaligned extra-buffer path, including the real serving `int64` track-slot index case.

## Accuracy Tests

> [!NOTE]
> These results were collected with both the deferred COW/clear ordering fix and the Lightning tracked-boundary fix present. On the current base, the ordering fix is provided by #29945; this PR provides the remaining Lightning `seg_la` state-snapshot fix.

The same SGLang server is kept alive across all 10 rounds, so this test exercises radix-cache and mamba extra-buffer reuse instead of isolated single-run accuracy.

**Server command:**

`MODEL_PATH` points to the Ling-2.6-flash checkpoint.

```bash
python -m sglang.launch_server \
  --model-path ${MODEL_PATH} \
  --served-model-name Ling-2.6-flash \
  --tp-size 4 \
  --trust-remote-code \
  --mamba-scheduler-strategy extra_buffer \
  --mem-fraction-static 0.75 \
  --max-running-requests 128 \
  --max-mamba-cache-size 512 \
  --speculative-algorithm NEXTN \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --json-model-override-args '{"linear_backend": "seg_la"}'
```

**AIME command used for each round:**

```bash
python benchmark/reasoning_benchmark/bench_sglang.py \
  --backend srt \
  --data-path Maxwell-Jia/AIME_2024 \
  --question-key Problem \
  --answer-key Answer \
  --num-tries 1 \
  --parallel 256 \
  --result-file results_r${round}.jsonl
```

**Before fix:**

| Metric | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8 | R9 | R10 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Accuracy | 0.80 | 0.70 | 0.73 | 0.73 | 0.67 | 0.70 | 0.13 | 0.03 | 0.10 | 0.07 |
| Extraction errors | 0 | 0 | 0 | 0 | 0 | 0 | 12 | 19 | 14 | 17 |

**After fix:**

| Metric | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8 | R9 | R10 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Accuracy | 0.87 | 0.83 | 0.80 | 0.87 | 0.80 | 0.80 | 0.80 | 0.83 | 0.83 | 0.87 |
| Extraction errors | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29904676178](https://github.com/sgl-project/sglang/actions/runs/29904676178)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29904676139](https://github.com/sgl-project/sglang/actions/runs/29904676139)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->