### PR TITLE
fix(function_call): skip non-object JSON entries in parse_base_json

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -81,6 +81,15 @@ class BaseFormatDetector(ABC):
 
         results = []
         for act in action:
+            if not isinstance(act, dict):
+                # The model emitted valid JSON that is not an object
+                # (e.g. `[1, 2, 3]` or a bare string after the bot token).
+                # Such an element can never describe a tool call, so skip it
+                # instead of crashing on ``act.get(...)``.
+                logger.warning(
+                    f"Skipping non-object tool call entry: {act!r}"
+                )
+                continue
             name = act.get("name")
             if not (name and name in tool_indices):
                 logger.warning(f"Model attempted to call undefined function: {name}")

--- a/test/registered/unit/function_call/test_llama32_detector.py
+++ b/test/registered/unit/function_call/test_llama32_detector.py
@@ -93,6 +93,19 @@ class TestLlama32Detector(CustomTestCase):
         self.assertEqual(len(result.calls), 0)
         self.assertEqual(result.normal_text, "The weather is nice today.")
 
+    def test_non_object_json_does_not_crash(self):
+        # A model may emit valid JSON that is not an object (a bare array,
+        # string or number) after the <|python_tag|> token. This must not
+        # raise AttributeError inside parse_base_json; it should simply
+        # produce no tool calls.
+        for text in (
+            "<|python_tag|>[1, 2, 3]",
+            '<|python_tag|>"hello"',
+            "<|python_tag|>42",
+        ):
+            result = self.detector.detect_and_parse(text, self.tools)
+            self.assertEqual(len(result.calls), 0)
+
     def test_multiple_json_objects(self):
         text = '<|python_tag|>{"name": "get_weather", "arguments": {"city": "Beijing"}};{"name": "search", "arguments": {"query": "restaurants"}}'
         result = self.detector.detect_and_parse(text, self.tools)


### PR DESCRIPTION
## What's broken
`parse_base_json` crashes with `AttributeError` when a model emits valid JSON that is not an object after a tool-call bot token, e.g. `<|python_tag|>[1, 2, 3]`, `<|python_tag|>"hello"`, or `<|python_tag|>42`. Because it's shared base-class code, every detector that calls it (Llama 3.2, Mistral JSON-array, DeepSeek, etc.) is affected, and the non-streaming `detect_and_parse` path does not catch it.

## Why it happens
The loop does `name = act.get("name")` for each decoded element without checking that `act` is a dict. A bare array/string/number element has no `.get`, so it raises `AttributeError` and the whole parse fails.

## Fix
Skip non-`dict` entries (with a warning) before calling `.get`, consistent with the existing "skip undefined function" behavior. Such elements can never describe a tool call, so they're ignored rather than crashing.

## Test
Added `test_non_object_json_does_not_crash` asserting `[1,2,3]` / `"hello"` / `42` after `<|python_tag|>` produce zero calls instead of raising. Fails before, passes after; valid tool-call parsing unchanged.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28617519025](https://github.com/sgl-project/sglang/actions/runs/28617519025)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28617518879](https://github.com/sgl-project/sglang/actions/runs/28617518879)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->