### PR TITLE
Add unit tests for CompilationCounter

### DIFF
--- a/test/registered/unit/compilation/test_compilation_counter.py
+++ b/test/registered/unit/compilation/test_compilation_counter.py
@@ -1,0 +1,95 @@
+"""Unit tests for compilation/compilation_counter.py — no server, no model loading.
+
+Covers ``CompilationCounter``: the dataclass that tracks torch.compile /
+CUDA-graph capture counts, its ``clone()`` deep copy, and the ``expect()``
+context manager that asserts exact per-field deltas across a code block.
+"""
+
+import dataclasses
+import unittest
+
+from sglang.srt.compilation.compilation_counter import (
+    CompilationCounter,
+    compilation_counter,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestDefaultsAndSingleton(CustomTestCase):
+    def test_all_counters_start_at_zero(self):
+        counter = CompilationCounter()
+        for field in dataclasses.fields(counter):
+            self.assertEqual(getattr(counter, field.name), 0, field.name)
+
+    def test_module_singleton_is_a_counter(self):
+        self.assertIsInstance(compilation_counter, CompilationCounter)
+
+
+class TestClone(CustomTestCase):
+    def test_clone_copies_values(self):
+        counter = CompilationCounter()
+        counter.num_graphs_seen = 3
+        self.assertEqual(counter.clone().num_graphs_seen, 3)
+
+    def test_clone_returns_new_instance(self):
+        counter = CompilationCounter()
+        self.assertIsNot(counter.clone(), counter)
+
+    def test_clone_is_independent(self):
+        counter = CompilationCounter()
+        counter.num_graphs_seen = 3
+        clone = counter.clone()
+        clone.num_graphs_seen = 99
+        # Mutating the clone must not touch the original.
+        self.assertEqual(counter.num_graphs_seen, 3)
+
+
+class TestExpect(CustomTestCase):
+    def test_passes_on_exact_delta(self):
+        counter = CompilationCounter()
+        with counter.expect(num_graphs_seen=2):
+            counter.num_graphs_seen += 1
+            counter.num_graphs_seen += 1  # total in-block delta == 2
+
+    def test_raises_on_too_small_delta(self):
+        counter = CompilationCounter()
+        with self.assertRaises(AssertionError):
+            with counter.expect(num_graphs_seen=2):
+                counter.num_graphs_seen += 1  # only +1, expected +2
+
+    def test_raises_when_expecting_no_change_but_changed(self):
+        counter = CompilationCounter()
+        with self.assertRaises(AssertionError):
+            with counter.expect(num_graphs_seen=0):
+                counter.num_graphs_seen += 1
+
+    def test_validates_multiple_fields(self):
+        counter = CompilationCounter()
+        with counter.expect(num_graphs_seen=1, num_backend_compilations=2):
+            counter.num_graphs_seen += 1
+            counter.num_backend_compilations += 2
+
+    def test_no_kwargs_is_noop(self):
+        counter = CompilationCounter()
+        with counter.expect():
+            counter.num_graphs_seen += 5  # unchecked, must not raise
+
+    def test_measures_in_block_delta_not_absolute(self):
+        counter = CompilationCounter()
+        counter.num_graphs_seen += 10  # happens before the block, must not count
+        with counter.expect(num_graphs_seen=1):
+            counter.num_graphs_seen += 1
+
+    def test_assertion_message_names_the_field(self):
+        counter = CompilationCounter()
+        with self.assertRaises(AssertionError) as ctx:
+            with counter.expect(num_graphs_seen=5):
+                counter.num_graphs_seen += 1
+        self.assertIn("num_graphs_seen", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`compilation/compilation_counter.py` (`CompilationCounter`, which tracks torch.compile / CUDA-graph capture counts and provides the `expect()` delta-assertion helper used in compilation tests) had no dedicated unit-test coverage. This adds tests to lock in its behavior, in the spirit of the unit-test-coverage effort in #20865.

## Modifications

Adds `test/registered/unit/compilation/test_compilation_counter.py` covering `CompilationCounter`:

- **Defaults / singleton** — every counter field initializes to `0`; the module-level `compilation_counter` is a `CompilationCounter` instance.
- **`clone()`** — copies values, returns a new instance, and is independent (mutating the clone does not affect the original).
- **`expect(**kwargs)`** — passes when in-block field deltas match exactly; raises `AssertionError` on too-small deltas and on any change when `0` was expected; validates multiple fields at once; is a no-op with no kwargs; measures the in-block delta (not the absolute value); and its failure message names the offending field.

Pure-stdlib logic, CPU-only, no server or model loading; registered to `base-a-test-cpu` via `register_cpu_ci`.

## Test Results

Ran the new cases against the current `CompilationCounter` implementation locally — all pass. No third-party or GPU dependencies, so the suite runs in the `base-a-test-cpu` stage.

## Accuracy Tests

N/A — this PR adds tests only and modifies no model, kernel, or forward-path code, so there are no model outputs to validate.

## Speed Tests and Profiling

N/A — test-only change; no inference-path code is touched, so there is no latency/throughput impact to measure.

## Checklist

- [x] Formatted to the SGLang pre-commit style (black 26.1.0 / isort 7.0.0 conventions).
- [x] Added unit tests (this PR is the unit tests).
- [ ] Update documentation — N/A (test-only).
- [ ] Accuracy/speed benchmarks — N/A (test-only).
- [x] Follows the SGLang code style guidance.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28749185648](https://github.com/sgl-project/sglang/actions/runs/28749185648)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28749185575](https://github.com/sgl-project/sglang/actions/runs/28749185575)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->