### PR TITLE
[Do Not Merge][BCG][2/N] Enable DSV4 prefill BCG: two-pass capture + DSV4-aware mem reserve

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -6,6 +6,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
+    Any,
     Dict,
     List,
     Literal,
@@ -1180,7 +1181,97 @@ class DeepseekV4AttnBackend(
             max_seq_len_override=self.MAX_SEQ_LEN_FOR_CAPTURE,
             use_prefill_cuda_graph=True,
         )
+        self._rehome_capture_metadata_tensors_(
+            self.forward_metadata, len(forward_batch.input_ids)
+        )
         return self.forward_metadata
+
+    def _rehome_capture_metadata_tensors_(self, metadata, num_tokens: int) -> None:
+        """Move large per-token capture metadata tensors into shared
+        max-bucket-size backings, one per field.
+
+        Every BCG prefill bucket stashes its own metadata for replay, and
+        the dominant tensors (e.g. the page table: num_tokens ×
+        MAX_SEQ_LEN_FOR_CAPTURE/64 int32) scale with the token count —
+        50 buckets retaining private copies cost ~2.7 GB at 1M context.
+        Aliasing every bucket's tensor as a [:num_tokens] view of one
+        max-size backing keeps the total at the largest bucket's size.
+        Safe because only one graph replays at a time and
+        refresh_for_breakable_cuda_graph_replay_ copies the live batch's
+        values into these views (in place) before every replay.
+
+        Only standalone tensors (t._base is None) with leading dim ==
+        num_tokens and >= 1 MB are re-homed; views of live buffers keep
+        their aliasing.
+        """
+        if not hasattr(self, "_bcg_metadata_backings"):
+            self._bcg_metadata_backings: Dict[Any, torch.Tensor] = {}
+            prefill_bs = self.model_runner.server_args.cuda_graph_config.prefill.bs
+            self._bcg_backing_max_tokens = max(prefill_bs) if prefill_bs else 0
+
+        max_tokens = self._bcg_backing_max_tokens
+        if num_tokens > max_tokens:
+            return
+
+        visited = set()
+        # Fields may alias one tensor object (e.g. indexer_metadata.page_table
+        # is core_attn_metadata.page_table — the indexer asserts identity), so
+        # every reference to a source tensor must map to the same view.
+        # Values hold (source, view): the source reference keeps the original
+        # tensor alive for the walk so its id() cannot be recycled.
+        replaced: Dict[int, Tuple[torch.Tensor, torch.Tensor]] = {}
+
+        def rehome(t: torch.Tensor, path: str) -> Optional[torch.Tensor]:
+            prior = replaced.get(id(t))
+            if prior is not None:
+                return prior[1]
+            if (
+                t._base is not None
+                or t.dim() < 1
+                or t.shape[0] != num_tokens
+                or t.untyped_storage().size() < (1 << 20)
+                or not t.is_cuda
+                or not t.is_contiguous()
+            ):
+                return None
+            key = (path, tuple(t.shape[1:]), t.dtype)
+            backing = self._bcg_metadata_backings.get(key)
+            if backing is None:
+                backing = torch.empty(
+                    (max_tokens, *t.shape[1:]), dtype=t.dtype, device=t.device
+                )
+                self._bcg_metadata_backings[key] = backing
+            view = backing[:num_tokens]
+            view.copy_(t)
+            replaced[id(t)] = (t, view)
+            return view
+
+        def walk(obj, path: str) -> None:
+            if obj is None or id(obj) in visited:
+                return
+            visited.add(id(obj))
+            container = None
+            if isinstance(obj, dict):
+                container = obj.items()
+            elif isinstance(obj, list):
+                container = enumerate(obj)
+            elif hasattr(obj, "__dict__"):
+                container = vars(obj).items()
+            else:
+                return
+            for name, value in list(container):
+                child_path = f"{path}.{name}"
+                if torch.is_tensor(value):
+                    replacement = rehome(value, child_path)
+                    if replacement is not None:
+                        if isinstance(obj, (dict, list)):
+                            obj[name] = replacement
+                        else:
+                            setattr(obj, name, replacement)
+                elif isinstance(value, (dict, list)) or hasattr(value, "__dict__"):
+                    walk(value, child_path)
+
+        walk(metadata, "metadata")
 
     def prepare_forward_metadata_for_breakable_cuda_graph_replay(
         self,

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -40,6 +40,12 @@ else:
     FP8_DTYPE = torch.float8_e4m3fn
     FP8_MAX = torch.finfo(FP8_DTYPE).max
 
+# Upper bound for the c4-indexer logits scratch (query_rows × max_c4_seq_len
+# × fp32) per kernel call; larger workloads are computed in row slices. Keeps
+# the worst-case-sized scratch out of the BCG prefill graph pool (~4 GiB at
+# 4096 tokens × 1M context) and bounds long-context eager transients.
+_C4_LOGITS_SCRATCH_BUDGET_BYTES = 512 << 20
+
 IndexerQuery: TypeAlias = Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
 
 
@@ -550,19 +556,47 @@ class C4IndexerBackendMixin:
         _use_aiter = envs.SGLANG_OPT_USE_AITER_INDEXER.get() and not use_fp4_indexer
         if _c4sl.dim() == 1 and not _use_tilelang and not _use_aiter:
             _c4sl = _c4sl.unsqueeze(-1)
-        logits = fn(
-            q,
-            c4_indexer_kv_cache,
-            weights,
-            _c4sl,
-            page_table,
-            indexer_metadata.deep_gemm_metadata,
-            indexer_metadata.max_c4_seq_len,
-            False,
+
+        # The logits scratch is query_rows × max_c4_seq_len × fp32. When
+        # max_c4_seq_len is the full context (BCG prefill capture sizes it
+        # worst-case, and genuinely long-context eager prefills approach it),
+        # a 4096-token chunk costs ~4 GiB — recorded into the graph pool
+        # forever under capture. Rows are independent through topk, so
+        # compute in row slices that bound the scratch instead. deep_gemm
+        # paths only; alternate backends keep the single-shot call.
+        chunk_rows = 0
+        _use_deep_gemm = not (
+            is_hip()
+            or _use_tilelang
+            or _use_aiter
+            or envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
         )
+        if _use_deep_gemm:
+            logits_bytes = 4 * query_rows * indexer_metadata.max_c4_seq_len
+            if logits_bytes > _C4_LOGITS_SCRATCH_BUDGET_BYTES:
+                chunk_rows = max(
+                    64,
+                    _C4_LOGITS_SCRATCH_BUDGET_BYTES
+                    // (4 * indexer_metadata.max_c4_seq_len),
+                )
+
+        def _slice_q(start: int, end: int):
+            if use_fp4_indexer:
+                return tuple(part[start:end] for part in q)
+            return q[start:end]
 
         assert indexer_metadata.page_table is core_metadata.page_table
         if self.debug_use_external_c4_sparse_indices:
+            fn(
+                q,
+                c4_indexer_kv_cache,
+                weights,
+                _c4sl,
+                page_table,
+                indexer_metadata.deep_gemm_metadata,
+                indexer_metadata.max_c4_seq_len,
+                False,
+            )
             return
 
         indexer_capturer = get_global_indexer_capturer()
@@ -583,33 +617,64 @@ class C4IndexerBackendMixin:
         elif core_metadata.c4_sparse_raw_indices is not None:
             raw_indices = core_metadata.c4_sparse_raw_indices
 
-        if envs.SGLANG_TOPK_TRANSFORM_512_TORCH.get():
-            topk_transform_512_pytorch_vectorized(
-                logits,
-                c4_seq_lens,
-                page_table,
-                c4_sparse_page_indices,
-                indexer_metadata.c4_page_size,
-                raw_indices,
+        def _logits_then_topk(start: int, end: int, schedule_metadata) -> None:
+            logits = fn(
+                _slice_q(start, end),
+                c4_indexer_kv_cache,
+                weights[start:end],
+                _c4sl[start:end],
+                page_table[start:end],
+                schedule_metadata,
+                indexer_metadata.max_c4_seq_len,
+                False,
             )
-        elif envs.SGLANG_OPT_USE_TOPK_V2.get() and raw_indices is None:
-            topk_transform_512_v2(
-                logits,
-                c4_seq_lens,
-                page_table,
-                c4_sparse_page_indices,
-                indexer_metadata.c4_page_size,
-                indexer_metadata.topk_metadata,
-            )
+            raw = raw_indices[start:end] if raw_indices is not None else None
+            if envs.SGLANG_TOPK_TRANSFORM_512_TORCH.get():
+                topk_transform_512_pytorch_vectorized(
+                    logits,
+                    c4_seq_lens[start:end],
+                    page_table[start:end],
+                    c4_sparse_page_indices[start:end],
+                    indexer_metadata.c4_page_size,
+                    raw,
+                )
+            elif chunk_rows == 0 and envs.SGLANG_OPT_USE_TOPK_V2.get() and raw is None:
+                # topk v2's plan has a global header row over the full batch
+                # and cannot be row-sliced; chunked slices use v1 below.
+                topk_transform_512_v2(
+                    logits,
+                    c4_seq_lens,
+                    page_table,
+                    c4_sparse_page_indices,
+                    indexer_metadata.c4_page_size,
+                    indexer_metadata.topk_metadata,
+                )
+            else:
+                topk_transform_512(
+                    logits,
+                    c4_seq_lens[start:end],
+                    page_table[start:end],
+                    c4_sparse_page_indices[start:end],
+                    indexer_metadata.c4_page_size,
+                    raw,
+                )
+
+        if chunk_rows:
+            import deep_gemm
+
+            # Same builder PagedIndexerMetadata picks below the large-query
+            # threshold; per-slice schedules are rebuilt from the sliced
+            # seq lens (device op, records fine inside graph capture).
+            for start in range(0, query_rows, chunk_rows):
+                end = min(start + chunk_rows, query_rows)
+                schedule = deep_gemm.get_paged_mqa_logits_metadata(
+                    _c4sl[start:end].to(torch.int32),
+                    indexer_metadata.c4_page_size,
+                    deep_gemm.get_num_sms(),
+                )
+                _logits_then_topk(start, end, schedule)
         else:
-            topk_transform_512(
-                logits,
-                c4_seq_lens,
-                page_table,
-                c4_sparse_page_indices,
-                indexer_metadata.c4_page_size,
-                raw_indices,
-            )
+            _logits_then_topk(0, query_rows, indexer_metadata.deep_gemm_metadata)
         if hisparse_coordinator is not None:
             if hisparse_decode:
                 compress_layer_id = token_to_kv_pool.layer_mapping[

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -709,6 +709,40 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             self.model_runner.gpu_id,
             empty_cache=False,
         )
+        # BCG: warm up every shape before capturing any. Warmup transients
+        # (e.g. DSV4's ~4 GB c4-indexer scratch per prefill forward) then
+        # share one cached block in the regular allocator across shapes.
+        # Interleaving warmup with capture instead makes each warmup's
+        # transient coexist with the graph mempool — which retains captured
+        # transients for replay and cannot lend them to eager warmups — so
+        # peak memory becomes pool + warmup rather than max(pool, warmup).
+        two_pass = isinstance(self.backend, BreakableCudaGraphBackend)
+        if two_pass:
+            warmup_range = (
+                tqdm.tqdm(list(reversed(self.capture_num_tokens)))
+                if get_tensor_model_parallel_rank() == 0
+                else reversed(self.capture_num_tokens)
+            )
+            for num_tokens in warmup_range:
+                if get_tensor_model_parallel_rank() == 0:
+                    avail_mem = get_available_gpu_memory(
+                        self.model_runner.device,
+                        self.model_runner.gpu_id,
+                        empty_cache=False,
+                    )
+                    warmup_range.set_description(
+                        f"Warming up num tokens ({num_tokens=} {avail_mem=:.2f} GB)"
+                    )
+                self.capture_one_shape(num_tokens, warmup_only=True)
+                # Release this bucket's transients (freed but cached) before
+                # the next bucket's small long-lived allocations (attn
+                # metadata) land inside the same segments — a segment with
+                # any live tensor can never be returned to the driver, and
+                # the multi-GB warmup segments would stay pinned through
+                # capture.
+                self.device_module.synchronize()
+                self.device_module.empty_cache()
+
         capture_range = (
             tqdm.tqdm(list(reversed(self.capture_num_tokens)))
             if get_tensor_model_parallel_rank() == 0
@@ -724,9 +758,11 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 capture_range.set_description(
                     f"Capturing num tokens ({num_tokens=} {avail_mem=:.2f} GB)"
                 )
-            self.capture_one_shape(num_tokens)
+            self.capture_one_shape(num_tokens, skip_warmup=two_pass)
 
-    def capture_one_shape(self, size: int) -> None:
+    def capture_one_shape(
+        self, size: int, warmup_only: bool = False, skip_warmup: bool = False
+    ) -> None:
         """Per-shape capture: build dummy ForwardBatch + run_once,
         delegate to backend. size is the prefill token count.
         """
@@ -751,6 +787,20 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             post_warmup_hook = None
         else:
             post_warmup_hook = getattr(attn_backend, "on_after_cuda_graph_warmup", None)
+        if warmup_only:
+            assert isinstance(self.backend, BreakableCudaGraphBackend)
+            self.backend.warmup_one(run_once, post_warmup_hook)
+            return
+        if skip_warmup:
+            assert isinstance(self.backend, BreakableCudaGraphBackend)
+            self.backend.capture_one(
+                ShapeKey(size=num_tokens),
+                run_once,
+                dummies=None,
+                post_warmup_hook=post_warmup_hook,
+                skip_warmup=True,
+            )
+            return
         self.backend.capture_one(
             ShapeKey(size=num_tokens),
             run_once,

--- a/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
@@ -103,19 +103,41 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             finally:
                 self._capture_stream = None
 
-    def capture_one(
+    def warmup_one(
         self,
-        shape_key: ShapeKey,
         forward_fn: Callable[[], Any],
-        dummies: Optional[Any] = None,
         post_warmup_hook: Optional[Callable[[], None]] = None,
     ) -> None:
+        """Run the two eager warmup iterations for one shape. The prefill
+        runner calls this for every shape before any capture (see
+        _capture_one_stream): warmup transients (e.g. DSV4's ~4 GB
+        c4-indexer scratch) then live in the regular caching allocator and
+        get reused across shapes, instead of coexisting with the graph
+        mempool, which cannot use regular cached blocks.
+        """
         for _ in range(2):
             self._device_module.synchronize()
             self._tp_group.barrier()
             forward_fn()
             if post_warmup_hook is not None:
                 post_warmup_hook()
+
+    def capture_one(
+        self,
+        shape_key: ShapeKey,
+        forward_fn: Callable[[], Any],
+        dummies: Optional[Any] = None,
+        post_warmup_hook: Optional[Callable[[], None]] = None,
+        skip_warmup: bool = False,
+    ) -> None:
+        if not skip_warmup:
+            self.warmup_one(forward_fn, post_warmup_hook)
+            # Return warmup transients to the driver before recording — the
+            # graph mempool cannot use blocks cached by the regular
+            # allocator, so keeping them reserved ratchets memory up per
+            # bucket until capture OOMs.
+            self._device_module.synchronize()
+            self._device_module.empty_cache()
 
         graph = BreakableCUDAGraph(self.deduped_cuda_graph)
         captured_fn = (

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -948,6 +948,12 @@ class MQALayer(nn.Module):
             envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get()
             and self.alt_streams is not None
             and get_is_capture_mode()
+            # BCG's segmented capture loses the alt-stream fork/join ordering
+            # across segment boundaries: replay races the indexer/kv/compressor
+            # streams against their consumers and corrupts outputs for a
+            # timing-dependent subset of small prefill buckets (8/12/16/48
+            # measured on 4x B200). Full-graph (decode) capture is unaffected.
+            and not is_in_breakable_cuda_graph()
             and x.shape[0] <= self._multi_stream_bs_limit
             and not (self.dsa_enable_prefill_cp and dsa_use_prefill_cp(forward_batch))
             and not (_is_hip and self.compressor is None)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3513,28 +3513,20 @@ class ServerArgs:
                 if prefill_cuda_graph_config.backend == Backend.BREAKABLE and (
                     is_deepseek_v4(self.get_model_config().hf_config)
                 ):
-                    # DSV4's breakable prefill graph records the c4-indexer
-                    # fp32 logits scratch — num_tokens × (context_len / 4)
-                    # elements, i.e. context_len bytes per captured token —
-                    # into the graph pool, where it stays live for replay.
-                    context_len = self.get_model_config().context_len
-                    reserved_mem += (
-                        prefill_cuda_graph_config.max_bs * context_len / (1 << 20)
-                    )
-                    # Each bucket also retains captured attention metadata,
-                    # dominated by its page table: num_tokens × (context_len
-                    # / page_size 64) int32 entries = context_len / 16 bytes
-                    # per token, summed over all capture buckets.
-                    reserved_mem += (
-                        sum(prefill_cuda_graph_config.bs) * context_len / 16 / (1 << 20)
-                    )
-                    # Segment-bridge buffers (~30 MB per bucket), first-capture
-                    # pool overhead, and DeepGEMM JIT workspaces. Measured on
-                    # 4x B200 tp=4: total BCG capture usage is ~9.7 GB, ~3 GB
-                    # above the two modeled terms; without this headroom,
-                    # EAGLE's verify/draft graphs exhaust the remainder and
-                    # runtime allocations (e.g. NCCL buffers) fail.
-                    reserved_mem += 3 * 1024
+                    # DSV4 BCG-specific capture overhead. The graph pool
+                    # itself (dominated by the in-graph c4-indexer logits
+                    # scratch) is the captured form of the prefill
+                    # activations already funded by the chunked-prefill
+                    # activation term above, and per-bucket captured
+                    # metadata is deduplicated into max-bucket-size
+                    # backings by the attention backend — neither needs
+                    # extra reserve. What remains: segment-bridge buffers
+                    # (~30 MB per capture bucket), one-time DeepGEMM JIT
+                    # workspaces (~1.5 GB), and runtime headroom for the
+                    # per-replay static-metadata rebuild + NCCL buffers
+                    # (booting with <1 GB free OOMs on the first real
+                    # prefill). Measured on 4x B200 tp=4.
+                    reserved_mem += len(prefill_cuda_graph_config.bs) * 30 + 1536 + 2048
 
             if gpu_mem is not None and gpu_mem > 60 * 1024:
                 reserved_mem = max(reserved_mem, 10 * 1024)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3519,14 +3519,14 @@ class ServerArgs:
                     # activations already funded by the chunked-prefill
                     # activation term above, and per-bucket captured
                     # metadata is deduplicated into max-bucket-size
-                    # backings by the attention backend — neither needs
-                    # extra reserve. What remains: segment-bridge buffers
-                    # (~30 MB per capture bucket), one-time DeepGEMM JIT
-                    # workspaces (~1.5 GB), and runtime headroom for the
-                    # per-replay static-metadata rebuild + NCCL buffers
-                    # (booting with <1 GB free OOMs on the first real
-                    # prefill). Measured on 4x B200 tp=4.
-                    reserved_mem += len(prefill_cuda_graph_config.bs) * 30 + 1536 + 2048
+                    # backings by the attention backend, and the c4-indexer
+                    # logits scratch is bounded by row-chunking in the
+                    # indexer — none of those need extra reserve. What
+                    # remains: segment-bridge buffers (~30 MB per capture
+                    # bucket) and one-time DeepGEMM JIT workspaces.
+                    # Measured on 4x B200 tp=4; leaves ~4 GB post-capture
+                    # for the per-replay static-metadata rebuild + NCCL.
+                    reserved_mem += len(prefill_cuda_graph_config.bs) * 30 + 1024
 
             if gpu_mem is not None and gpu_mem > 60 * 1024:
                 reserved_mem = max(reserved_mem, 10 * 1024)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3223,11 +3223,13 @@ class ServerArgs:
         rules = [
             # MLA prefill takes a different attn-forward path under BCG.
             ("MLA attention", lambda: self.use_mla_backend()),
-            # DSV4 is BCG-compatible but introduces heavy memory pressure: the
-            # c4 indexer scratch is pinned in the capture pool and OOMs. Disable.
+            # DSV4 target-prefill BCG replay corrupts the hidden states fed
+            # to the spec draft (garbled outputs; reproduces on main with
+            # BCG forced). Plain DSV4 prefill under BCG is bit-correct.
             (
-                "DeepSeek-V4 (heavy capture-pool memory pressure)",
-                lambda: is_deepseek_v4(self.get_model_config().hf_config),
+                "DeepSeek-V4 with speculative decoding",
+                lambda: self.speculative_algorithm is not None
+                and is_deepseek_v4(self.get_model_config().hf_config),
             ),
             # CP all_gather replay size mismatch under BCG.
             ("context parallel (attn_cp_size > 1)", lambda: self.attn_cp_size > 1),
@@ -3505,6 +3507,34 @@ class ServerArgs:
                 else:
                     # For MLA backend the memory overhead is much higher than expected with fa3
                     reserved_mem += 1.5 * 1024
+
+                from sglang.srt.configs.model_config import is_deepseek_v4
+
+                if prefill_cuda_graph_config.backend == Backend.BREAKABLE and (
+                    is_deepseek_v4(self.get_model_config().hf_config)
+                ):
+                    # DSV4's breakable prefill graph records the c4-indexer
+                    # fp32 logits scratch — num_tokens × (context_len / 4)
+                    # elements, i.e. context_len bytes per captured token —
+                    # into the graph pool, where it stays live for replay.
+                    context_len = self.get_model_config().context_len
+                    reserved_mem += (
+                        prefill_cuda_graph_config.max_bs * context_len / (1 << 20)
+                    )
+                    # Each bucket also retains captured attention metadata,
+                    # dominated by its page table: num_tokens × (context_len
+                    # / page_size 64) int32 entries = context_len / 16 bytes
+                    # per token, summed over all capture buckets.
+                    reserved_mem += (
+                        sum(prefill_cuda_graph_config.bs) * context_len / 16 / (1 << 20)
+                    )
+                    # Segment-bridge buffers (~30 MB per bucket), first-capture
+                    # pool overhead, and DeepGEMM JIT workspaces. Measured on
+                    # 4x B200 tp=4: total BCG capture usage is ~9.7 GB, ~3 GB
+                    # above the two modeled terms; without this headroom,
+                    # EAGLE's verify/draft graphs exhaust the remainder and
+                    # runtime allocations (e.g. NCCL buffers) fail.
+                    reserved_mem += 3 * 1024
 
             if gpu_mem is not None and gpu_mem > 60 * 1024:
                 reserved_mem = max(reserved_mem, 10 * 1024)


### PR DESCRIPTION
DSV4 was auto-disabled for breakable prefill CUDA graphs because capture OOMed at the default mem-fraction. Four changes make it fit:

1. Two-pass BCG capture (prefill runner): warm up every bucket before capturing any. Warmup transients (DSV4's ~4 GB c4-indexer logits scratch per forward) then share one cached block in the regular allocator instead of coexisting with the graph mempool, which retains captured transients for replay and cannot lend them to eager warmups. Peak becomes max(pool, warmup) rather than pool + warmup.

2. empty_cache() after each bucket's warmup: releases the multi-GB transient segment before small long-lived attn-metadata allocations land inside it and pin it through capture (a segment with any live tensor is never returned to the driver).

3. Replace the DSV4 Backend.DISABLED rule with DSV4+BCG terms in the auto mem-fraction reserve: context_len bytes per captured token for the in-graph c4-indexer logits scratch, context_len/16 bytes per token summed over buckets for the page-table-dominated captured metadata, plus 3 GB for segment bridges and JIT workspaces (measured total BCG capture usage: ~9.7 GB on 4x B200 tp=4).

4. Keep BCG auto-disabled for DSV4 + speculative decoding: BCG prefill replay corrupts the hidden states fed to the EAGLE draft (garbled outputs). Reproduces on unpatched main with BCG forced, so it is a pre-existing bug, not introduced here; tracked as follow-up.

Validated on 4x B200 tp=4 mxfp4 (DeepSeek-V4-Flash):
- Out-of-box (no flags): auto fraction resolves to 0.899, all 50 buckets capture, GSM8K 200q = 0.970 vs 0.975 eager prefill (noise), eval ~2.4x faster wall-clock (3416 vs 1427 output tok/s).
- CI test_deepseek_v4_flash_fp4_b200.py: all 4 classes pass (EAGLE LowLatency resolves to prefill-disabled, identical to main today; explicit-BCG class exercises the two-pass capture path).
- Control on unpatched main with BCG forced: OOM at capture (4.00 GiB c4-indexer alloc), confirming the before/after.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28634765906](https://github.com/sgl-project/sglang/actions/runs/28634765906)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28634765840](https://github.com/sgl-project/sglang/actions/runs/28634765840)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->