### PR TITLE
[diffusion] fix: slice img_shapes per-sample in rollout response extractor

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
@@ -33,21 +33,29 @@ logger = init_logger(__name__)
 router = APIRouter(prefix="/rollout", tags=["rollout"])
 
 
-def _extract_single_sample_tensor(obj: Any, sample_idx: int, batch_size: int) -> Any:
+def _extract_single_sample_tensor(
+    obj: Any, sample_idx: int, batch_size: int, *, current_key: str | None = None
+) -> Any:
     if isinstance(obj, torch.Tensor):
         if obj.dim() >= 1 and obj.shape[0] == batch_size:
             return obj[sample_idx].contiguous()
         return obj
     if isinstance(obj, dict):
         return {
-            k: _extract_single_sample_tensor(v, sample_idx, batch_size)
+            k: _extract_single_sample_tensor(v, sample_idx, batch_size, current_key=k)
             for k, v in obj.items()
         }
     if isinstance(obj, list):
-        return [_extract_single_sample_tensor(v, sample_idx, batch_size) for v in obj]
+        if current_key == "img_shapes" and len(obj) == batch_size:
+            return [obj[sample_idx]]
+        return [
+            _extract_single_sample_tensor(v, sample_idx, batch_size, current_key=current_key)
+            for v in obj
+        ]
     if isinstance(obj, tuple):
         return tuple(
-            _extract_single_sample_tensor(v, sample_idx, batch_size) for v in obj
+            _extract_single_sample_tensor(v, sample_idx, batch_size, current_key=current_key)
+            for v in obj
         )
     return obj
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
@@ -49,12 +49,16 @@ def _extract_single_sample_tensor(
         if current_key == "img_shapes" and len(obj) == batch_size:
             return [obj[sample_idx]]
         return [
-            _extract_single_sample_tensor(v, sample_idx, batch_size, current_key=current_key)
+            _extract_single_sample_tensor(
+                v, sample_idx, batch_size, current_key=current_key
+            )
             for v in obj
         ]
     if isinstance(obj, tuple):
         return tuple(
-            _extract_single_sample_tensor(v, sample_idx, batch_size, current_key=current_key)
+            _extract_single_sample_tensor(
+                v, sample_idx, batch_size, current_key=current_key
+            )
             for v in obj
         )
     return obj


### PR DESCRIPTION
## Motivation

After the qwen-image cond batch alignment fix (`a9d657bf3`), `pos_cond_kwargs` contains an `img_shapes` list of length `batch_size` (one entry per multi-output sample) instead of length 1. `_extract_single_sample_tensor` recurses into lists element-wise without slicing by `sample_idx`, so each per-sample response carried back the full N-length `img_shapes`, breaking downstream consumers that assume per-sample `img_shapes` is length 1.

## Modifications

Thread the current dict key through the recursion and special-case the `img_shapes` list: when `len == batch_size`, take `obj[sample_idx]` and re-wrap as a length-1 list to preserve the `[(1, H, W)]` shape contract.

- `python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py`: add `current_key` kwarg to `_extract_single_sample_tensor` and handle `img_shapes` per-sample slicing (+12 / -4 lines)

## Accuracy Tests

N/A — this fix restores correct per-sample `img_shapes` extraction; no model forward code is changed.

## Speed Tests and Profiling

N/A — pure Python control-flow change in response extraction, no hot path affected.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28647918989](https://github.com/sgl-project/sglang/actions/runs/28647918989)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28647918920](https://github.com/sgl-project/sglang/actions/runs/28647918920)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->