### PR TITLE
[docs] Multi-node deployment: add PD disaggregation and Apptainer examples for SLURM

### DIFF
--- a/docs_new/docs/references/multi_node_deployment/multi_node.mdx
+++ b/docs_new/docs/references/multi_node_deployment/multi_node.mdx
@@ -10,14 +10,14 @@ metatags:
 ```bash Command
 # replace 172.16.4.52:20000 with your own node ip address and port of the first node
 
-python3 -m sglang.launch_server \
+sglang serve \
   --model-path meta-llama/Meta-Llama-3.1-405B-Instruct \
   --tp 16 \
   --dist-init-addr 172.16.4.52:20000 \
   --nnodes 2 \
   --node-rank 0
 
-python3 -m sglang.launch_server \
+sglang serve \
   --model-path meta-llama/Meta-Llama-3.1-405B-Instruct \
   --tp 16 \
   --dist-init-addr 172.16.4.52:20000 \
@@ -28,7 +28,7 @@ python3 -m sglang.launch_server \
 Note that LLama 405B (fp8) can also be launched on a single node.
 
 ```bash Command
-python -m sglang.launch_server --model-path meta-llama/Meta-Llama-3.1-405B-Instruct-FP8 --tp 8
+sglang serve --model-path meta-llama/Meta-Llama-3.1-405B-Instruct-FP8 --tp 8
 ```
 
 ## DeepSeek V3/R1
@@ -78,9 +78,8 @@ echo "[INFO] NCCL_INIT_ADDR: $NCCL_INIT_ADDR"
 # Launch the model server on each node using SLURM
 srun --ntasks=2 --nodes=2 --output="SLURM_Logs/%x_%j_node$SLURM_NODEID.out" \
     --error="SLURM_Logs/%x_%j_node$SLURM_NODEID.err" \
-    python3 -m sglang.launch_server \
+    sglang serve \
     --model-path "$model" \
-    --grammar-backend "xgrammar" \
     --tp "$tp_size" \
     --dist-init-addr "$NCCL_INIT_ADDR" \
     --nnodes 2 \
@@ -101,3 +100,246 @@ wait
 Then, you can test the server by sending requests following other [documents](../../basic_usage/openai_api_completions).
 
 Thanks for [aflah02](https://github.com/aflah02) for providing the example, based on his [blog post](https://aflah02.substack.com/p/multi-node-llm-inference-with-sglang).
+
+## Prefill-Decode (PD) Disaggregation on SLURM
+
+PD disaggregation splits inference across two sets of nodes: prefill nodes handle prompt processing while decode nodes handle token generation. This improves throughput for high-volume serving.
+
+The default transfer backend is Mooncake, which requires RDMA InfiniBand. Install the engine before submitting the jobs:
+
+```bash
+pip install mooncake-transfer-engine
+```
+
+Replace `<ib-device>` below with your InfiniBand device name (e.g., `mlx5_0`). See the
+[PD Disaggregation guide](/docs/advanced_features/pd_disaggregation) for details on other backends and NVLink transport.
+
+### Prefill job
+
+```bash Command
+#!/bin/bash -l
+
+#SBATCH -o SLURM_Logs/%x_%j_prefill.out
+#SBATCH -e SLURM_Logs/%x_%j_prefill.err
+#SBATCH -D ./
+#SBATCH -J Llama-405B-Prefill
+
+#SBATCH --nodes=2
+#SBATCH --ntasks=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=18
+#SBATCH --mem=224GB
+#SBATCH --partition="<your-partition>"
+#SBATCH --gres=gpu:8
+#SBATCH --time=12:00:00
+
+source ENV_FOLDER/bin/activate
+
+model=meta-llama/Meta-Llama-3.1-405B-Instruct
+tp_size=16
+prefill_port=30000
+bootstrap_port=8998
+
+HEAD_NODE=$(scontrol show hostname "$SLURM_NODELIST" | head -n 1)
+NCCL_INIT_ADDR="${HEAD_NODE}:8000"
+
+srun --ntasks=2 --nodes=2 \
+    --output="SLURM_Logs/%x_%j_prefill_node$SLURM_NODEID.out" \
+    --error="SLURM_Logs/%x_%j_prefill_node$SLURM_NODEID.err" \
+    sglang serve \
+    --model-path "$model" \
+    --disaggregation-mode prefill \
+    --disaggregation-bootstrap-port "$bootstrap_port" \
+    --disaggregation-ib-device <ib-device> \
+    --host 0.0.0.0 \
+    --port "$prefill_port" \
+    --tp "$tp_size" \
+    --dist-init-addr "$NCCL_INIT_ADDR" \
+    --nnodes 2 \
+    --node-rank "$SLURM_NODEID" &
+
+while ! nc -z "$HEAD_NODE" "$prefill_port"; do
+    sleep 1
+    echo "[INFO] Waiting for prefill $HEAD_NODE:$prefill_port"
+done
+
+echo "[INFO] Prefill ready on $HEAD_NODE:$prefill_port"
+
+# Publish the prefill address for the router to discover
+echo "http://${HEAD_NODE}:${prefill_port}" > /shared/pd_prefill_addr.txt
+
+wait
+```
+
+### Decode job
+
+```bash Command
+#!/bin/bash -l
+
+#SBATCH -o SLURM_Logs/%x_%j_decode.out
+#SBATCH -e SLURM_Logs/%x_%j_decode.err
+#SBATCH -D ./
+#SBATCH -J Llama-405B-Decode
+
+#SBATCH --nodes=2
+#SBATCH --ntasks=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=18
+#SBATCH --mem=224GB
+#SBATCH --partition="<your-partition>"
+#SBATCH --gres=gpu:8
+#SBATCH --time=12:00:00
+
+source ENV_FOLDER/bin/activate
+
+model=meta-llama/Meta-Llama-3.1-405B-Instruct
+tp_size=16
+decode_port=30001
+
+HEAD_NODE=$(scontrol show hostname "$SLURM_NODELIST" | head -n 1)
+NCCL_INIT_ADDR="${HEAD_NODE}:8000"
+
+srun --ntasks=2 --nodes=2 \
+    --output="SLURM_Logs/%x_%j_decode_node$SLURM_NODEID.out" \
+    --error="SLURM_Logs/%x_%j_decode_node$SLURM_NODEID.err" \
+    sglang serve \
+    --model-path "$model" \
+    --disaggregation-mode decode \
+    --disaggregation-ib-device <ib-device> \
+    --host 0.0.0.0 \
+    --port "$decode_port" \
+    --tp "$tp_size" \
+    --dist-init-addr "$NCCL_INIT_ADDR" \
+    --nnodes 2 \
+    --node-rank "$SLURM_NODEID" &
+
+while ! nc -z "$HEAD_NODE" "$decode_port"; do
+    sleep 1
+    echo "[INFO] Waiting for decode $HEAD_NODE:$decode_port"
+done
+
+echo "[INFO] Decode ready on $HEAD_NODE:$decode_port"
+
+# Publish the decode address for the router to discover
+echo "http://${HEAD_NODE}:${decode_port}" > /shared/pd_decode_addr.txt
+
+wait
+```
+
+### Router
+
+The router only needs a CPU node — allocate it explicitly via SLURM so it runs alongside the prefill/decode jobs. It reads the addresses published by the prefill and decode jobs from the shared filesystem.
+
+```bash Command
+#!/bin/bash -l
+
+#SBATCH -o SLURM_Logs/%x_%j_router.out
+#SBATCH -e SLURM_Logs/%x_%j_router.err
+#SBATCH -D ./
+#SBATCH -J Llama-405B-Router
+
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=8GB
+#SBATCH --partition="<your-cpu-partition>"
+#SBATCH --time=12:00:00
+
+PREFILL_ADDR=$(cat /shared/pd_prefill_addr.txt)
+DECODE_ADDR=$(cat /shared/pd_decode_addr.txt)
+
+srun python3 -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --prefill "$PREFILL_ADDR" \
+  --decode "$DECODE_ADDR" \
+  --host 0.0.0.0 \
+  --port 8000 &
+
+while ! nc -z localhost 8000; do
+    sleep 1
+    echo "[INFO] Waiting for router on port 8000"
+done
+
+echo "[INFO] Router ready on port 8000"
+wait
+```
+
+Send requests to the router on port 8000:
+
+```bash Command
+curl http://<router-node>:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "default", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+## Working with Container via Apptainer (Singularity) on SLURM
+
+Many HPC clusters prefer Apptainer (Singularity) over Docker. Use `apptainer exec` (or `singularity exec`) with `--nv` for GPU access and `--bind` for model mounts.
+
+Build the SIF image once on the shared filesystem so all nodes can use it:
+
+```bash
+apptainer build /path/to/shared/sglang.sif docker://lmsysorg/sglang:latest
+```
+
+Then replace the `source ENV_FOLDER/bin/activate` step in the SLURM job scripts above with `apptainer exec`:
+
+```bash Command
+#!/bin/bash -l
+
+#SBATCH -o SLURM_Logs/%x_%j_master.out
+#SBATCH -e SLURM_Logs/%x_%j_master.err
+#SBATCH -D ./
+#SBATCH -J Llama-405B-TP16-SGL
+
+#SBATCH --nodes=2
+#SBATCH --ntasks=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=18
+#SBATCH --mem=224GB
+#SBATCH --partition="<your-partition>"
+#SBATCH --gres=gpu:8
+#SBATCH --time=12:00:00
+
+model=/models/meta-llama/Meta-Llama-3.1-405B-Instruct
+tp_size=16
+port=30000
+
+HEAD_NODE=$(scontrol show hostname "$SLURM_NODELIST" | head -n 1)
+NCCL_INIT_ADDR="${HEAD_NODE}:8000"
+
+srun --ntasks=2 --nodes=2 \
+    --output="SLURM_Logs/%x_%j_node$SLURM_NODEID.out" \
+    --error="SLURM_Logs/%x_%j_node$SLURM_NODEID.err" \
+    apptainer exec --nv --bind /path/to/models:/models:ro \
+    /path/to/shared/sglang.sif \
+    sglang serve \
+    --model-path "$model" \
+    --tp "$tp_size" \
+    --dist-init-addr "$NCCL_INIT_ADDR" \
+    --nnodes 2 \
+    --node-rank "$SLURM_NODEID" &
+
+while ! nc -z "$HEAD_NODE" "$port"; do
+    sleep 1
+    echo "[INFO] Waiting for $HEAD_NODE:$port"
+done
+
+echo "[INFO] $HEAD_NODE:$port is ready"
+wait
+```
+
+If your site supports Docker, you can also replace the activation step with `docker run`:
+
+```bash Command
+srun --ntasks=2 --nodes=2 \
+    docker run --rm --gpus all --ipc host --network host \
+    -v /path/to/models:/models:ro \
+    lmsysorg/sglang:latest \
+    sglang serve \
+    --model-path /models/meta-llama/Meta-Llama-3.1-405B-Instruct \
+    --tp 16 \
+    --dist-init-addr "$NCCL_INIT_ADDR" \
+    --nnodes 2 \
+    --node-rank "$SLURM_NODEID" &
+```


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
There is one example of running SGLang on SLURM, but the documentation can use more details. This PR adds more SLURM examples for PD disaggregation (prefill/decode split across separate SLURM jobs) and containerized deployments with Apptainer/Singularity.

contributes to: #3244

## Modifications

<!-- Detail the changes made in this pull request. -->
- **Add PD disaggregation section**. Three sbatch job scripts:
  - Prefill job: `sglang serve --disaggregation-mode prefill` across 2 GPU nodes, writes head node address to `/shared/pd_prefill_addr.txt` so the router can find it automatically.
  - Decode job: `sglang serve --disaggregation-mode decode` across 2 GPU nodes, writes to `/shared/pd_decode_addr.txt`.
  - Router job: CPU-only allocation, reads the prefill and decode addresses from shared files, launches `sglang_router.launch_router`.
- **Add Apptainer/Singularity section**. Full sbatch example with the SIF on shared filesystem, uses `apptainer` (current name for Singularity), plus a `docker run` alternative.

Also, some small updates:
- **Update all commands to `sglang serve`**. Replaces `python3 -m sglang.launch_server` throughout.
- **Remove `--grammar-backend xgrammar`**. It's already the default, no need to specify.

## Tests

**TL;DR:** Verified: `sbatch`/`squeue` job lifecycle, `scontrol show hostname` head-node resolution, health-check loop, end-to-end model inference via curl. Partially verified: Apptainer/Singularity SIF on shared filesystem (CPU only, no `--nv` GPU passthrough tested). Not verified: multi-node NCCL (`--nnodes 2`, `--dist-init-addr`), real InfiniBand/NVSwitch networking.

I don't have access to a real SLURM cluster or H100 GPUs, so I tested the Apptainer workflow on a local Ubuntu PC (AMD Ryzen 7 8845HS, 16 cores, 14 GB RAM) using [giovtorres/slurm-docker-cluster](https://github.com/giovtorres/slurm-docker-cluster). It's a CPU-based SLURM emulator with 2 worker nodes and a shared `/data` volume, similar to how an HPC cluster would use NFS/Lustre for shared storage.

### Cluster state

**`make status`:**

```
=== Containers ===
NAME                 IMAGE                          COMMAND                  SERVICE      CREATED        STATUS                 PORTS
mysql                mariadb:12                     "docker-entrypoint.s…"   mysql        24 hours ago   Up 24 hours (healthy)   3306/tcp
slurm-cpu-worker-1   slurm-docker-cluster:25.11.4   "/usr/local/bin/dock…"   cpu-worker   24 hours ago   Up 24 hours (healthy)   6818/tcp
slurm-cpu-worker-2   slurm-docker-cluster:25.11.4   "/usr/local/bin/dock…"   cpu-worker   24 hours ago   Up About an hour (healthy) 6818/tcp
slurmctld            slurm-docker-cluster:25.11.4   "/usr/local/bin/dock…"   slurmctld    24 hours ago   Up 24 hours (healthy)   6817/tcp, 0.0.0.0:3022->22/tcp
slurmdbd             slurm-docker-cluster:25.11.4   "/usr/local/bin/dock…"   slurmdbd     24 hours ago   Up 24 hours (healthy)   6819/tcp
slurmrestd           slurm-docker-cluster:25.11.4   "/usr/local/bin/dock…"   slurmrestd   24 hours ago   Up 24 hours (healthy)   0.0.0.0:6820->6820/tcp

=== Cluster ===
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
cpu*         up   infinite      2   idle c[1-2]
gpu          up   infinite      0    n/a
```

**`sinfo`:**

```
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
cpu*         up   infinite      2   idle c[1-2]
gpu          up   infinite      0    n/a
```

### Test script

**`slurm-apptainer.sh`** (submitted via `sbatch`):

```bash
#!/bin/bash -l
#SBATCH -o /data/%x_%j_master.out
#SBATCH -e /data/%x_%j_master.err
#SBATCH -J sglang-apptainer
#SBATCH --nodes=1
#SBATCH --ntasks=1
#SBATCH --cpus-per-task=4
#SBATCH --time=00:10:00

PORT=30000
MODEL="Qwen/Qwen2.5-0.5B-Instruct"

trap "echo [INFO] Shutting down...; kill %1 2>/dev/null; wait" EXIT SIGTERM SIGINT

HEAD_NODE=$(scontrol show hostname "$SLURM_NODELIST" | head -n 1)
echo "[INFO] Node $SLURM_NODEID on $HEAD_NODE starting"

apptainer exec --env SGLANG_USE_CPU_ENGINE=1 \
  /data/sglang.sif \
  sglang serve \
  --model-path "$MODEL" \
  --device cpu \
  --host 0.0.0.0 \
  --port "$PORT" &

while ! nc -z localhost "$PORT"; do
  sleep 2
  echo "[INFO] Waiting for localhost:$PORT"
done

echo "[INFO] Server ready on $HEAD_NODE:$PORT"
wait
```

### Steps and results

1. Pull the SIF once to shared storage:

```bash
$ docker exec slurmctld apptainer pull /data/sglang.sif docker://lmsysorg/sglang:latest
INFO:    Using cached SIF image
```

2. Submit the job and check the queue:

```bash
$ docker exec slurmctld sbatch /data/slurm-apptainer.sh
Submitted batch job 15

$ docker exec slurmctld squeue
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
                15       cpu sglang-a     root  R       0:02      1 c1
```

3. The health check loop detected the server (from `/data/sglang-apptainer_15_master.out`):

```
[INFO] Node 0 on c1 starting
[INFO] Waiting for localhost:30000
...
[INFO] Server ready on c1:30000
```

4. The server started and responded to API requests:

```bash
$ docker exec slurm-cpu-worker-1 curl -s http://localhost:30000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{"model":"default","messages":[{"role":"user","content":"Say hello in one word"}]}'

{"id":"e7a092a7...","object":"chat.completion","model":"default","choices":[{"index":0,
"message":{"role":"assistant","content":"Hello."},"finish_reason":"stop"}],
"usage":{"prompt_tokens":34,"completion_tokens":3}}
```

5. Server log confirmed the request was processed (from `sglang-apptainer_15_master.err`):

```
[2026-07-02 22:57:19] The server is fired up and ready to roll!
[2026-07-02 23:03:42] Prefill batch, #new-seq: 1, #new-token: 34, ..., input throughput (token/s): 0.09
```

With the SIF on the shared filesystem, each worker node doesn't need to pull the 12 GB image separately. On a real cluster with GPUs, add `--nv` to `apptainer exec` for GPU passthrough.

### Documentation Rendering
Verified the docs rendered correctly:
<img width="1840" height="1106" alt="Screenshot 2026-07-02 at 6 01 35 PM" src="https://github.com/user-attachments/assets/822fe7bf-5100-4aaa-a433-1bd0db7a0d24" />
<img width="1840" height="1106" alt="Screenshot 2026-07-02 at 5 23 10 PM" src="https://github.com/user-attachments/assets/5aa168e5-c674-4c57-958c-99751cdb90be" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29034642566](https://github.com/sgl-project/sglang/actions/runs/29034642566)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29034641372](https://github.com/sgl-project/sglang/actions/runs/29034641372)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->