### PR TITLE
FlashInfer Backend for MXFP8 Grouped Quantization

### DIFF
--- a/docs_new/docs/advanced_features/quantization.mdx
+++ b/docs_new/docs/advanced_features/quantization.mdx
@@ -312,6 +312,38 @@ Backend selection applies to **blockwise FP8**, **MXFP8** (dense linear), and **
 
 On Blackwell, when FlashInfer is unavailable for NVFP4, the SGLang CUTLASS kernel is used as an automatic fallback. On SM80-SM90, `auto` selects Marlin for NVFP4.
 
+## MXFP8 MoE grouped quantization backend
+
+`--mxfp8-grouped-quant-backend` selects the grouped quantization kernel used by
+CUTLASS MXFP8 MoE paths before the grouped GEMM.
+
+<table>
+  <thead>
+    <tr>
+      <th>Backend</th>
+      <th>Hardware</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>auto</code> (default)</td>
+      <td>SM100</td>
+      <td>Uses the FlashInfer cuTile backend when available, otherwise uses the native sgl-kernel grouped quantization op</td>
+    </tr>
+    <tr>
+      <td><code>flashinfer</code></td>
+      <td>SM100</td>
+      <td>Requires a FlashInfer build with the cuTile MXFP8 grouped quantization kernel</td>
+    </tr>
+    <tr>
+      <td><code>native</code></td>
+      <td>SM100</td>
+      <td>Uses the native sgl-kernel grouped quantization op</td>
+    </tr>
+  </tbody>
+</table>
+
 ## Offline Quantization
 
 To load already quantized models, simply load the model weights and config. **Again, if the model has been quantized offline,

--- a/docs_new/docs/advanced_features/server_arguments.mdx
+++ b/docs_new/docs/advanced_features/server_arguments.mdx
@@ -1441,6 +1441,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>auto</code>, <code>cutlass</code>, <code>flashinfer_cudnn</code>, <code>flashinfer_cutedsl</code>, <code>flashinfer_cutlass</code>, <code>flashinfer_trtllm</code>, <code>marlin</code></td>
     </tr>
         <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--mxfp8-grouped-quant-backend`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the backend for CUTLASS MXFP8 MoE grouped quantization. Options: 'auto' (default, uses FlashInfer when available and native otherwise), 'flashinfer' (requires FlashInfer's migrated cuTile MXFP8 grouped quant kernel), 'native' (SGLang native sgl-kernel op).</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`auto`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>auto</code>, <code>flashinfer</code>, <code>native</code></td>
+    </tr>
+        <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--disable-flashinfer-autotune`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Flashinfer autotune is enabled by default. Set this flag to disable the autotune.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>

--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -74,6 +74,9 @@ from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.moe import initialize_moe_config
 from sglang.srt.layers.quantization.fp4_utils import initialize_fp4_gemm_config
 from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
+from sglang.srt.layers.quantization.mxfp8_grouped_quant import (
+    initialize_mxfp8_grouped_quant_config,
+)
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.scheduler_components.dp_attn import prepare_mlp_sync_batch_raw
 from sglang.srt.mem_cache.base_prefix_cache import EvictParams
@@ -844,6 +847,7 @@ def latency_test(
     initialize_moe_config(server_args)
     initialize_fp8_gemm_config(server_args)
     initialize_fp4_gemm_config(server_args)
+    initialize_mxfp8_grouped_quant_config(server_args)
 
     # Set CPU affinity
     if get_bool_env_var("SGLANG_SET_CPU_AFFINITY"):

--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -13,7 +13,6 @@ if _is_cuda:
         apply_shuffle_mul_sum,
         es_fp8_blockwise_scaled_grouped_mm,
         es_sm100_mxfp8_blockscaled_grouped_mm,
-        es_sm100_mxfp8_blockscaled_grouped_quant,
         fp8_blockwise_scaled_grouped_mm,
         prepare_moe_input,
         shuffle_rows,
@@ -25,6 +24,7 @@ if _is_cuda:
         scaled_fp4_experts_quant,
         silu_and_mul_scaled_fp4_experts_quant_packed,
     )
+    from sglang.srt.layers.quantization.mxfp8_grouped_quant import mxfp8_grouped_quant
 
 
 def cutlass_fused_experts_fp8(
@@ -203,7 +203,7 @@ def cutlass_fused_experts_fp8(
         rep_a1_scales = torch.empty(
             (max_blockscale, k // 32), dtype=torch.uint8, device=device
         )
-        es_sm100_mxfp8_blockscaled_grouped_quant(
+        mxfp8_grouped_quant(
             rep_a,
             problem_sizes1,
             expert_offsets[:-1],
@@ -277,7 +277,7 @@ def cutlass_fused_experts_fp8(
         a2_scale = torch.empty(
             (max_blockscale, n // 32), dtype=torch.uint8, device=device
         )
-        es_sm100_mxfp8_blockscaled_grouped_quant(
+        mxfp8_grouped_quant(
             intermediate,
             problem_sizes2,
             expert_offsets[:-1],

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -68,6 +68,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.marlin_utils_fp8 import prepare_fp8_layer_for_marlin
+from sglang.srt.layers.quantization.mxfp8_grouped_quant import mxfp8_grouped_quant
 from sglang.srt.layers.quantization.unquant import (
     UnquantizedFusedMoEMethod,
     UnquantizedLinearMethod,
@@ -1383,8 +1384,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             raise RuntimeError("MXFP8 MoE quantization requires SM100.")
 
         def _quantize_and_swizzle_with_cutlass_es_kernel(weight: torch.Tensor):
-            from sgl_kernel import es_sm100_mxfp8_blockscaled_grouped_quant
-
             weight = weight.contiguous()
             num_experts, m, k = weight.shape
             assert k % 32 == 0, f"{k=} must be divisible by 32 for MXFP8"
@@ -1413,7 +1412,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 dtype=torch.uint8,
                 device=weight.device,
             )
-            es_sm100_mxfp8_blockscaled_grouped_quant(
+            mxfp8_grouped_quant(
                 weight_flat,
                 problem_sizes,
                 expert_offsets,

--- a/python/sglang/srt/layers/quantization/mxfp8_grouped_quant.py
+++ b/python/sglang/srt/layers/quantization/mxfp8_grouped_quant.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import importlib
+import logging
+from enum import Enum
+from functools import lru_cache
+from typing import TYPE_CHECKING, Callable
+
+import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
+
+_FLASHINFER_KERNEL_MODULE = (
+    "flashinfer.quantization.kernels.cutile.mxfp8_grouped_quantize_cutile"
+)
+_FLASHINFER_KERNEL_NAME = "mxfp8_grouped_quantize_cutile"
+# Import the lightweight cuTile availability check before the kernel module. The
+# kernel imports `cuda.tile` at module load, so probing it directly can fail in
+# environments where FlashInfer is installed without cuTile support.
+_FLASHINFER_CUTILE_MODULE = "flashinfer.cutile"
+_FLASHINFER_AVAILABILITY_NAME = "is_cuda_tile_available"
+
+logger = logging.getLogger(__name__)
+
+
+class Mxfp8GroupedQuantBackend(Enum):
+    """Enum for MXFP8 grouped quantization backend selection."""
+
+    AUTO = "auto"
+    FLASHINFER = "flashinfer"
+    NATIVE = "native"
+
+    def is_auto(self) -> bool:
+        return self == Mxfp8GroupedQuantBackend.AUTO
+
+    def is_flashinfer(self) -> bool:
+        return self == Mxfp8GroupedQuantBackend.FLASHINFER
+
+    def is_native(self) -> bool:
+        return self == Mxfp8GroupedQuantBackend.NATIVE
+
+
+MXFP8_GROUPED_QUANT_BACKEND: Mxfp8GroupedQuantBackend | None = None
+
+
+def initialize_mxfp8_grouped_quant_config(server_args: ServerArgs) -> None:
+    """Initialize MXFP8 grouped quantization configuration from server args."""
+    global MXFP8_GROUPED_QUANT_BACKEND
+    MXFP8_GROUPED_QUANT_BACKEND = Mxfp8GroupedQuantBackend(
+        server_args.mxfp8_grouped_quant_backend
+    )
+
+
+def get_mxfp8_grouped_quant_backend() -> Mxfp8GroupedQuantBackend:
+    """Get the current MXFP8 grouped quantization backend."""
+    global MXFP8_GROUPED_QUANT_BACKEND
+    if MXFP8_GROUPED_QUANT_BACKEND is None:
+        MXFP8_GROUPED_QUANT_BACKEND = Mxfp8GroupedQuantBackend.AUTO
+    return MXFP8_GROUPED_QUANT_BACKEND
+
+
+def _missing_flashinfer_error(detail: str) -> RuntimeError:
+    return RuntimeError(
+        "FlashInfer MXFP8 grouped quantization was requested by "
+        "`--mxfp8-grouped-quant-backend=flashinfer`, but the FlashInfer cuTile "
+        f"backend is unavailable: {detail}. Install a FlashInfer build that "
+        f"provides `{_FLASHINFER_KERNEL_MODULE}.{_FLASHINFER_KERNEL_NAME}` and "
+        f"gates on `{_FLASHINFER_CUTILE_MODULE}.{_FLASHINFER_AVAILABILITY_NAME}` "
+        "(the `cuda.tile` dependency), or use "
+        "`--mxfp8-grouped-quant-backend=native`."
+    )
+
+
+def _is_cuda_tile_available() -> bool:
+    try:
+        module = importlib.import_module(_FLASHINFER_CUTILE_MODULE)
+    except Exception:
+        return False
+
+    checker = getattr(module, _FLASHINFER_AVAILABILITY_NAME, None)
+    if checker is None:
+        return False
+
+    try:
+        return bool(checker())
+    except Exception:
+        return False
+
+
+def is_flashinfer_mxfp8_grouped_quant_available() -> bool:
+    if not _is_cuda_tile_available():
+        return False
+
+    try:
+        module = importlib.import_module(_FLASHINFER_KERNEL_MODULE)
+    except Exception:
+        return False
+
+    return getattr(module, _FLASHINFER_KERNEL_NAME, None) is not None
+
+
+@lru_cache(maxsize=1)
+def _load_flashinfer_mxfp8_grouped_quant() -> Callable[..., None]:
+    if not _is_cuda_tile_available():
+        raise _missing_flashinfer_error(
+            f"`{_FLASHINFER_CUTILE_MODULE}.{_FLASHINFER_AVAILABILITY_NAME}` "
+            "reports `cuda.tile` is not importable"
+        )
+
+    try:
+        module = importlib.import_module(_FLASHINFER_KERNEL_MODULE)
+    except Exception as exc:
+        raise _missing_flashinfer_error(
+            f"failed to import `{_FLASHINFER_KERNEL_MODULE}`"
+        ) from exc
+
+    kernel = getattr(module, _FLASHINFER_KERNEL_NAME, None)
+    if kernel is None:
+        raise _missing_flashinfer_error(f"`{_FLASHINFER_KERNEL_NAME}` is missing")
+
+    return kernel
+
+
+def _flashinfer_mxfp8_grouped_quant(
+    input: torch.Tensor,
+    problem_sizes: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    blockscale_offsets: torch.Tensor,
+    quant_output: torch.Tensor,
+    scale_factor: torch.Tensor,
+) -> None:
+    kernel = _load_flashinfer_mxfp8_grouped_quant()
+    kernel(
+        input,
+        problem_sizes,
+        expert_offsets,
+        blockscale_offsets,
+        quant_output,
+        scale_factor,
+    )
+
+
+def _native_mxfp8_grouped_quant(
+    input: torch.Tensor,
+    problem_sizes: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    blockscale_offsets: torch.Tensor,
+    quant_output: torch.Tensor,
+    scale_factor: torch.Tensor,
+) -> None:
+    from sgl_kernel import es_sm100_mxfp8_blockscaled_grouped_quant
+
+    es_sm100_mxfp8_blockscaled_grouped_quant(
+        input,
+        problem_sizes,
+        expert_offsets,
+        blockscale_offsets,
+        quant_output,
+        scale_factor,
+    )
+
+
+@lru_cache(maxsize=1)
+def _resolve_grouped_quant_impl(
+    backend: Mxfp8GroupedQuantBackend,
+) -> Callable[..., None]:
+    """Resolve the configured backend to a concrete implementation.
+
+    Cached so resolution (and any FlashInfer or cuda.tile import) happens once on
+    the first call rather than at config init, and only for workloads that
+    actually use MXFP8 grouped quantization. `auto` falls back to the native
+    kernel when FlashInfer is unavailable or unusable; an explicit `flashinfer`
+    request raises a clear error instead.
+    """
+    if backend.is_flashinfer():
+        _load_flashinfer_mxfp8_grouped_quant()
+        return _flashinfer_mxfp8_grouped_quant
+
+    if backend.is_auto() and is_flashinfer_mxfp8_grouped_quant_available():
+        return _flashinfer_mxfp8_grouped_quant
+
+    return _native_mxfp8_grouped_quant
+
+
+def mxfp8_grouped_quant(
+    input: torch.Tensor,
+    problem_sizes: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    blockscale_offsets: torch.Tensor,
+    quant_output: torch.Tensor,
+    scale_factor: torch.Tensor,
+) -> None:
+    impl = _resolve_grouped_quant_impl(get_mxfp8_grouped_quant_backend())
+    impl(
+        input,
+        problem_sizes,
+        expert_offsets,
+        blockscale_offsets,
+        quant_output,
+        scale_factor,
+    )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -80,6 +80,9 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.layers.moe import initialize_moe_config
 from sglang.srt.layers.quantization.fp4_utils import initialize_fp4_gemm_config
 from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
+from sglang.srt.layers.quantization.mxfp8_grouped_quant import (
+    initialize_mxfp8_grouped_quant_config,
+)
 from sglang.srt.lora.lora_drainer import LoRADrainer
 from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
@@ -747,6 +750,7 @@ class Scheduler(
         # Initialize GEMM-related configuration for FP8 and FP4 backends.
         initialize_fp8_gemm_config(self.server_args)
         initialize_fp4_gemm_config(self.server_args)
+        initialize_mxfp8_grouped_quant_config(self.server_args)
 
         # This must be called after initialize_moe_config
         self.require_mlp_sync = require_mlp_sync(self.server_args)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -278,6 +278,12 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
     "marlin",
 ]
 
+MXFP8_GROUPED_QUANT_BACKEND_CHOICES = [
+    "auto",
+    "flashinfer",
+    "native",
+]
+
 RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
 
 RL_ON_POLICY_TARGET_CHOICES = ["fsdp"]
@@ -357,6 +363,10 @@ def add_fp8_gemm_runner_backend_choices(choices):
 
 def add_fp4_gemm_runner_backend_choices(choices):
     FP4_GEMM_RUNNER_BACKEND_CHOICES.extend(choices)
+
+
+def add_mxfp8_grouped_quant_backend_choices(choices):
+    MXFP8_GROUPED_QUANT_BACKEND_CHOICES.extend(choices)
 
 
 def add_radix_eviction_policy_choices(choices):
@@ -1464,6 +1474,13 @@ class ServerArgs:
             help="Choose the runner backend for NVFP4 GEMM operations. Options: 'auto' (default; selects flashinfer_cutedsl on SM100, marlin on SM80-SM90, flashinfer_cutlass otherwise (including SM120)), 'cutlass' (SGLang CUTLASS kernel), 'flashinfer_cutlass' (FlashInfer CUTLASS backend), 'flashinfer_cudnn' (FlashInfer cuDNN backend, optimal on CUDA 13+ with cuDNN 9.15+), 'flashinfer_cutedsl' (FlashInfer CuTe DSL backend), 'flashinfer_trtllm' (FlashInfer TensorRT-LLM backend, requires different weight preparation with shuffling), 'marlin' (weight-only W4A16 fallback for SM80+). ",
             cli_name="--fp4-gemm-backend",
             choices=FP4_GEMM_RUNNER_BACKEND_CHOICES,
+        ),
+    ] = "auto"
+    mxfp8_grouped_quant_backend: A[
+        str,
+        Arg(
+            help="Choose the backend for CUTLASS MXFP8 MoE grouped quantization. Options: 'auto' (default, uses FlashInfer when available and native otherwise), 'flashinfer' (requires FlashInfer's migrated cuTile MXFP8 grouped quant kernel), 'native' (SGLang native sgl-kernel op). ",
+            choices=MXFP8_GROUPED_QUANT_BACKEND_CHOICES,
         ),
     ] = "auto"
     dsa_prefill_backend: A[

--- a/sgl-kernel/tests/test_es_mxfp8_blockscaled_moe.py
+++ b/sgl-kernel/tests/test_es_mxfp8_blockscaled_moe.py
@@ -26,9 +26,18 @@ def calc_diff(x, y):
     return 1 - sim
 
 
+def cuda_version_at_least(major: int, minor: int) -> bool:
+    if torch.version.cuda is None:
+        return False
+    version = tuple(int(part) for part in torch.version.cuda.split(".")[:2])
+    return version >= (major, minor)
+
+
 def is_sm100_supported(device=None) -> bool:
-    return (torch.cuda.get_device_capability(device)[0] == 10) and (
-        torch.version.cuda >= "12.8"
+    return (
+        torch.cuda.is_available()
+        and torch.cuda.get_device_capability(device)[0] == 10
+        and cuda_version_at_least(12, 8)
     )
 
 

--- a/test/registered/kernels/test_mxfp8_grouped_quant_flashinfer.py
+++ b/test/registered/kernels/test_mxfp8_grouped_quant_flashinfer.py
@@ -1,0 +1,188 @@
+import random
+import sys
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, suite="nightly-4-gpu-b200", nightly=True)
+
+
+def _cuda_version_at_least(major: int, minor: int) -> bool:
+    if torch.version.cuda is None:
+        return False
+    version = tuple(int(part) for part in torch.version.cuda.split(".")[:2])
+    return version >= (major, minor)
+
+
+# This test validates quantized output with the SM100 CUTLASS grouped GEMM ops.
+# SM120 MXFP8 MoE uses a different GEMM path, and is intentionally excluded.
+if not (
+    torch.cuda.is_available()
+    and torch.cuda.get_device_capability()[0] == 10
+    and _cuda_version_at_least(12, 8)
+):
+    pytest.skip(
+        "FlashInfer MXFP8 grouped quantization requires SM100 with CUDA 12.8+.",
+        allow_module_level=True,
+    )
+
+try:
+    from sgl_kernel import es_sm100_mxfp8_blockscaled_grouped_mm
+except Exception as exc:
+    pytest.skip(f"sgl_kernel is unavailable: {exc}", allow_module_level=True)
+
+from sglang.srt.layers.quantization import mxfp8_grouped_quant
+
+if not mxfp8_grouped_quant.is_flashinfer_mxfp8_grouped_quant_available():
+    pytest.skip(
+        "FlashInfer MXFP8 grouped quantization backend is unavailable.",
+        allow_module_level=True,
+    )
+
+
+def _align(val: int, alignment: int = 128) -> int:
+    return int((val + alignment - 1) // alignment * alignment)
+
+
+def _calc_diff(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    x, y = x.double(), y.double()
+    denominator = (x * x + y * y).sum()
+    sim = 2 * (x * y).sum() / denominator
+    return 1 - sim
+
+
+def _set_flashinfer_backend():
+    mxfp8_grouped_quant.MXFP8_GROUPED_QUANT_BACKEND = (
+        mxfp8_grouped_quant.Mxfp8GroupedQuantBackend.FLASHINFER
+    )
+    mxfp8_grouped_quant._load_flashinfer_mxfp8_grouped_quant.cache_clear()
+
+
+def _reset_backend():
+    mxfp8_grouped_quant.MXFP8_GROUPED_QUANT_BACKEND = None
+    mxfp8_grouped_quant._load_flashinfer_mxfp8_grouped_quant.cache_clear()
+
+
+@pytest.mark.parametrize("num_experts", [8, 16, 32, 64])
+@pytest.mark.parametrize("out_dtype", [torch.half, torch.bfloat16])
+def test_flashinfer_mxfp8_grouped_quant_backend(num_experts, out_dtype):
+    torch.manual_seed(42)
+    torch.cuda.manual_seed_all(42)
+    random.seed(num_experts)
+
+    device = "cuda"
+    alignment = 128
+    n_g = random.randint(1, 64) * alignment
+    k_g = random.randint(1, 64) * alignment
+
+    expert_offset = 0
+    expert_offsets = []
+    aux_expert_offset = 0
+    aux_expert_offsets = []
+    a_blockscale_offset = 0
+    a_blockscale_offsets = []
+    b_blockscale_offset = 0
+    b_blockscale_offsets = []
+    problem_sizes = []
+    aux_problem_sizes = []
+    a_list = []
+    b_list = []
+    ref_d_list = []
+    m_per_expert = []
+
+    for _ in range(num_experts):
+        m_g = random.randint(1, 512)
+        m_per_expert.append(m_g)
+        expert_offsets.append(expert_offset)
+        expert_offset += m_g
+        aux_expert_offsets.append(aux_expert_offset)
+        aux_expert_offset += n_g
+        a_blockscale_offsets.append(a_blockscale_offset)
+        a_blockscale_offset += _align(m_g, 128)
+        b_blockscale_offsets.append(b_blockscale_offset)
+        b_blockscale_offset += n_g
+        problem_sizes.append([m_g, n_g, k_g])
+        aux_problem_sizes.append([n_g, m_g, k_g])
+
+        a = torch.normal(0.0, std=1.0, size=(m_g, k_g), device=device, dtype=out_dtype)
+        b = torch.normal(0.0, std=1.0, size=(n_g, k_g), device=device, dtype=out_dtype)
+
+        a_list.append(a)
+        b_list.append(b)
+        ref_d_list.append(a @ b.T)
+
+    a = torch.concat(a_list, dim=0)
+    b = torch.concat(b_list, dim=0)
+
+    _problem_sizes = torch.tensor(problem_sizes, device=device, dtype=torch.int32)
+    _aux_problem_sizes = torch.tensor(
+        aux_problem_sizes, device=device, dtype=torch.int32
+    )
+    _expert_offsets = torch.tensor(expert_offsets, device=device, dtype=torch.int32)
+    _aux_expert_offsets = torch.tensor(
+        aux_expert_offsets, device=device, dtype=torch.int32
+    )
+    _a_blockscale_offsets = torch.tensor(
+        a_blockscale_offsets, device=device, dtype=torch.int32
+    )
+    _b_blockscale_offsets = torch.tensor(
+        b_blockscale_offsets, device=device, dtype=torch.int32
+    )
+
+    a_quant = torch.zeros_like(a, dtype=torch.float8_e4m3fn, device=device)
+    a_scale_factor = torch.zeros(
+        (a_blockscale_offset, k_g // 32), dtype=torch.uint8, device=device
+    )
+
+    b_quant = torch.zeros_like(b, dtype=torch.float8_e4m3fn, device=device)
+    b_scale_factor = torch.zeros(
+        (num_experts, n_g, k_g // 32), dtype=torch.uint8, device=device
+    )
+
+    _set_flashinfer_backend()
+    try:
+        mxfp8_grouped_quant.mxfp8_grouped_quant(
+            a,
+            _problem_sizes,
+            _expert_offsets,
+            _a_blockscale_offsets,
+            a_quant,
+            a_scale_factor,
+        )
+        mxfp8_grouped_quant.mxfp8_grouped_quant(
+            b,
+            _aux_problem_sizes,
+            _aux_expert_offsets,
+            _b_blockscale_offsets,
+            b_quant,
+            b_scale_factor,
+        )
+    finally:
+        _reset_backend()
+
+    b_quant = b_quant.view(num_experts, n_g, k_g).transpose(1, 2)
+    b_scale_factor = b_scale_factor.view(num_experts, n_g, k_g // 32).transpose(1, 2)
+
+    d = torch.empty((expert_offset, n_g), device=device, dtype=out_dtype)
+    es_sm100_mxfp8_blockscaled_grouped_mm(
+        d,
+        a_quant,
+        b_quant,
+        a_scale_factor,
+        b_scale_factor,
+        _problem_sizes,
+        _expert_offsets,
+        _a_blockscale_offsets,
+    )
+
+    for g, m_g in enumerate(m_per_expert):
+        baseline = ref_d_list[g]
+        actual = d[expert_offsets[g] : expert_offsets[g] + m_g]
+        diff = _calc_diff(actual, baseline)
+        assert diff < 0.001
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/unit/layers/quantization/test_mxfp8_grouped_quant.py
+++ b/test/registered/unit/layers/quantization/test_mxfp8_grouped_quant.py
@@ -1,0 +1,174 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.layers.quantization import mxfp8_grouped_quant as grouped_quant
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestMxfp8GroupedQuantDispatch(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        grouped_quant.MXFP8_GROUPED_QUANT_BACKEND = None
+        grouped_quant._load_flashinfer_mxfp8_grouped_quant.cache_clear()
+        grouped_quant._resolve_grouped_quant_impl.cache_clear()
+
+    def tearDown(self):
+        grouped_quant.MXFP8_GROUPED_QUANT_BACKEND = None
+        grouped_quant._load_flashinfer_mxfp8_grouped_quant.cache_clear()
+        grouped_quant._resolve_grouped_quant_impl.cache_clear()
+        super().tearDown()
+
+    def test_initialize_sets_backend(self):
+        server_args = types.SimpleNamespace(mxfp8_grouped_quant_backend="native")
+
+        grouped_quant.initialize_mxfp8_grouped_quant_config(server_args)
+
+        self.assertTrue(grouped_quant.get_mxfp8_grouped_quant_backend().is_native())
+
+    def test_native_backend_calls_sgl_kernel(self):
+        calls = []
+        fake_sgl_kernel = types.SimpleNamespace(
+            es_sm100_mxfp8_blockscaled_grouped_quant=lambda *args: calls.append(args)
+        )
+        grouped_quant.MXFP8_GROUPED_QUANT_BACKEND = (
+            grouped_quant.Mxfp8GroupedQuantBackend.NATIVE
+        )
+
+        with patch.dict(sys.modules, {"sgl_kernel": fake_sgl_kernel}):
+            grouped_quant.mxfp8_grouped_quant(1, 2, 3, 4, 5, 6)
+
+        self.assertEqual(calls, [(1, 2, 3, 4, 5, 6)])
+
+    def test_flashinfer_backend_calls_flashinfer_kernel(self):
+        calls = []
+        fake_kernel_module = types.SimpleNamespace(
+            mxfp8_grouped_quantize_cutile=lambda *args: calls.append(args),
+        )
+        fake_cutile_module = types.SimpleNamespace(
+            is_cuda_tile_available=lambda: True,
+        )
+        grouped_quant.MXFP8_GROUPED_QUANT_BACKEND = (
+            grouped_quant.Mxfp8GroupedQuantBackend.FLASHINFER
+        )
+
+        fake_modules = {
+            "flashinfer": types.ModuleType("flashinfer"),
+            "flashinfer.cutile": fake_cutile_module,
+            "flashinfer.quantization": types.ModuleType("flashinfer.quantization"),
+            "flashinfer.quantization.kernels": types.ModuleType(
+                "flashinfer.quantization.kernels"
+            ),
+            "flashinfer.quantization.kernels.cutile": types.ModuleType(
+                "flashinfer.quantization.kernels.cutile"
+            ),
+            "flashinfer.quantization.kernels.cutile.mxfp8_grouped_quantize_cutile": fake_kernel_module,
+        }
+        with patch.dict(sys.modules, fake_modules):
+            grouped_quant.mxfp8_grouped_quant(1, 2, 3, 4, 5, 6)
+
+        self.assertEqual(calls, [(1, 2, 3, 4, 5, 6)])
+
+    def test_availability_false_when_symbol_missing(self):
+        # Mismatched FlashInfer build: the kernel module exists but does not
+        # define `mxfp8_grouped_quantize_cutile`.
+        fake_cutile_module = types.SimpleNamespace(
+            is_cuda_tile_available=lambda: True,
+        )
+        fake_kernel_module = types.ModuleType(
+            "flashinfer.quantization.kernels.cutile.mxfp8_grouped_quantize_cutile"
+        )
+
+        fake_modules = {
+            "flashinfer": types.ModuleType("flashinfer"),
+            "flashinfer.cutile": fake_cutile_module,
+            "flashinfer.quantization": types.ModuleType("flashinfer.quantization"),
+            "flashinfer.quantization.kernels": types.ModuleType(
+                "flashinfer.quantization.kernels"
+            ),
+            "flashinfer.quantization.kernels.cutile": types.ModuleType(
+                "flashinfer.quantization.kernels.cutile"
+            ),
+            "flashinfer.quantization.kernels.cutile.mxfp8_grouped_quantize_cutile": fake_kernel_module,
+        }
+        with patch.dict(sys.modules, fake_modules):
+            self.assertFalse(
+                grouped_quant.is_flashinfer_mxfp8_grouped_quant_available()
+            )
+
+    def test_auto_uses_flashinfer_when_available(self):
+        calls = []
+        grouped_quant.MXFP8_GROUPED_QUANT_BACKEND = (
+            grouped_quant.Mxfp8GroupedQuantBackend.AUTO
+        )
+
+        with (
+            patch.object(
+                grouped_quant,
+                "is_flashinfer_mxfp8_grouped_quant_available",
+                return_value=True,
+            ),
+            patch.object(
+                grouped_quant,
+                "_flashinfer_mxfp8_grouped_quant",
+                side_effect=lambda *args: calls.append(("flashinfer", args)),
+            ),
+            patch.object(
+                grouped_quant,
+                "_native_mxfp8_grouped_quant",
+                side_effect=lambda *args: calls.append(("native", args)),
+            ),
+        ):
+            grouped_quant.mxfp8_grouped_quant(1, 2, 3, 4, 5, 6)
+
+        self.assertEqual(calls, [("flashinfer", (1, 2, 3, 4, 5, 6))])
+
+    def test_auto_falls_back_to_native_when_flashinfer_unavailable(self):
+        calls = []
+        grouped_quant.MXFP8_GROUPED_QUANT_BACKEND = (
+            grouped_quant.Mxfp8GroupedQuantBackend.AUTO
+        )
+
+        with (
+            patch.object(
+                grouped_quant,
+                "is_flashinfer_mxfp8_grouped_quant_available",
+                return_value=False,
+            ),
+            patch.object(
+                grouped_quant,
+                "_flashinfer_mxfp8_grouped_quant",
+                side_effect=lambda *args: calls.append(("flashinfer", args)),
+            ),
+            patch.object(
+                grouped_quant,
+                "_native_mxfp8_grouped_quant",
+                side_effect=lambda *args: calls.append(("native", args)),
+            ),
+        ):
+            grouped_quant.mxfp8_grouped_quant(1, 2, 3, 4, 5, 6)
+
+        self.assertEqual(calls, [("native", (1, 2, 3, 4, 5, 6))])
+
+    def test_flashinfer_backend_raises_when_kernel_is_missing(self):
+        grouped_quant.MXFP8_GROUPED_QUANT_BACKEND = (
+            grouped_quant.Mxfp8GroupedQuantBackend.FLASHINFER
+        )
+
+        with (
+            patch.object(
+                grouped_quant.importlib,
+                "import_module",
+                side_effect=ImportError("missing"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "--mxfp8-grouped-quant-backend"),
+        ):
+            grouped_quant.mxfp8_grouped_quant(1, 2, 3, 4, 5, 6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Add support for using FlashInfer’s cuTile MXFP8 grouped quantization kernel in the CUTLASS MXFP8 MoE path.

## Modifications

- Add a lazy MXFP8 grouped quantization backend dispatcher with `auto`, `flashinfer`, and `native` options.
- Route existing MXFP8 grouped quantization call sites through the dispatcher.
- Add server and one-batch benchmark initialization for the new backend option.
- Add CPU unit coverage for backend dispatch and FlashInfer availability handling.
- Add SM100 kernel coverage for the FlashInfer grouped quantization path.
- Document `--mxfp8-grouped-quant-backend`.

## Accuracy Tests

Model: `Qwen/Qwen3-30B-A3B` with `--quantization mxfp8 --moe-runner-backend cutlass` on B200 (SM100), using FlashInfer v0.6.14 prerelease.

few-shot GSM8K (200 questions), varying only `--mxfp8-grouped-quant-backend`:

- `native`: Accuracy 0.930, Invalid 0.005
- `flashinfer`: Accuracy 0.930, Invalid 0.005

FlashInfer matches the native path.

## Speed Tests and Profiling

`bench_one_batch` with batch size 32, input length 1024, output length 512, on B200 after warmup, varying only `--mxfp8-grouped-quant-backend`:

- `native`: prefill 0.211 s; decode 0.01708 s/step (1874 tok/s); total 5499 tok/s
- `flashinfer`: prefill 0.212 s; decode 0.00855 s/step (3744 tok/s); total 10740 tok/s

This is ~2x decode throughput and ~1.95x end-to-end throughput, with prefill unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28631662767](https://github.com/sgl-project/sglang/actions/runs/28631662767)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28631662656](https://github.com/sgl-project/sglang/actions/runs/28631662656)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->