### PR TITLE
fix(mimo-vl): pass padded_context_dim to Qwen2_5_VisionPatchMerger

### DIFF
--- a/python/sglang/srt/models/mimo_vl.py
+++ b/python/sglang/srt/models/mimo_vl.py
@@ -301,6 +301,11 @@ class MiMoVisionTransformer(nn.Module):
         self.merger = Qwen2_5_VisionPatchMerger(
             dim=vision_config.out_hidden_size,
             context_dim=hidden_size,
+            # MiMo-VL's merger MLP is square (intermediate == context_dim * merge**2),
+            # so no dim padding is needed. The Qwen2.5-VL formula num_heads * head_dim
+            # over-sizes it here because MiMo uses qk_channels (64) for head_dim rather
+            # than hidden_size // num_heads, which would mismatch the checkpoint.
+            padded_context_dim=hidden_size,
             spatial_merge_size=spatial_merge_size,
             quant_config=quant_config,
             prefix=add_prefix("merger", prefix),


### PR DESCRIPTION
MiMo-VL crashes at model init on the scheduled 8-GPU H200 run (`base-c-test-8-gpu-h200`):

```
TypeError: Qwen2_5_VisionPatchMerger.__init__() missing 1 required positional argument: 'padded_context_dim'
  File "python/sglang/srt/models/mimo_vl.py", line 301, in __init__
```

#20072 added a required `padded_context_dim` arg to `Qwen2_5_VisionPatchMerger` and updated the `qwen2_5_vl` caller, but `mimo_vl` reuses the same class and was missed, so every MiMo-VL launch fails at init.

Fix: pass `padded_context_dim=num_heads * head_dim` in the `mimo_vl` merger call, matching `qwen2_5_vl`.

### Checklist

- [x] Format with pre-commit
- [ ] Add unit tests
- [x] Update documentation as needed



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28637061857](https://github.com/sgl-project/sglang/actions/runs/28637061857)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28637061797](https://github.com/sgl-project/sglang/actions/runs/28637061797)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->