### PR TITLE
[Spec] Remove the ServerArgs clone + global save/restore hack from DFlashWorkerV2

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -247,9 +247,8 @@ def _handle_dflash(server_args: ServerArgs) -> None:
 def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:
     """Resolve `speculative_draft_attention_backend` to a final, supported value.
 
-    The DFLASH draft worker consumes it through ModelRunner's `is_draft_worker`
-    override (one backend for all draft modes), so the draft TpModelWorker can
-    be constructed from the shared ServerArgs without any per-worker copy.
+    Consumed by ModelRunner's `is_draft_worker` override (one backend for all
+    draft modes).
     """
     from sglang.srt.utils import is_hip
 

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -229,6 +229,8 @@ def _handle_dflash(server_args: ServerArgs) -> None:
                 f"window_size={server_args.speculative_draft_window_size}, block_size={draft_tokens}."
             )
 
+    _resolve_dflash_draft_attention_backend(server_args)
+
     if server_args.max_running_requests is None:
         server_args.max_running_requests = 48
         logger.warning(
@@ -240,6 +242,44 @@ def _handle_dflash(server_args: ServerArgs) -> None:
         logger.warning(
             "Mixed chunked prefill is disabled because of using dflash speculative decoding."
         )
+
+
+def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:
+    """Resolve `speculative_draft_attention_backend` to a final, supported value.
+
+    The DFLASH draft worker consumes it through ModelRunner's `is_draft_worker`
+    override (one backend for all draft modes), so the draft TpModelWorker can
+    be constructed from the shared ServerArgs without any per-worker copy.
+    """
+    from sglang.srt.utils import is_hip
+
+    supported_draft_backends = ("flashinfer", "fa3", "fa4", "triton", "ascend")
+    # Use triton on ROCm (no FlashInfer), flashinfer on CUDA.
+    fallback_backend = "triton" if is_hip() else "flashinfer"
+
+    draft_backend = server_args.speculative_draft_attention_backend
+    if draft_backend is None:
+        draft_backend, _ = server_args.get_attention_backends()
+    if draft_backend is None:
+        draft_backend = fallback_backend
+    elif draft_backend == "trtllm_mha":
+        logger.warning(
+            "DFLASH draft worker does not support 'trtllm_mha' because the "
+            "draft path requires per-layer DFlash attention. Falling back to "
+            "'%s'.",
+            fallback_backend,
+        )
+        draft_backend = fallback_backend
+    elif draft_backend not in supported_draft_backends:
+        logger.warning(
+            "DFLASH draft worker only supports attention_backend in %s for now, "
+            "but got %r. Falling back to '%s'.",
+            supported_draft_backends,
+            draft_backend,
+            fallback_backend,
+        )
+        draft_backend = fallback_backend
+    server_args.speculative_draft_attention_backend = draft_backend
 
 
 def _handle_frozen_kv_mtp(server_args: ServerArgs) -> None:

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -279,6 +279,8 @@ def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:
             fallback_backend,
         )
         draft_backend = fallback_backend
+    # FIXME: avoid overriding server args directly; pass the resolved draft
+    # backend to the draft worker explicitly instead.
     server_args.speculative_draft_attention_backend = draft_backend
 
 

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -483,6 +483,7 @@ class ModelConfig:
         model_path: str = None,
         model_revision: str = None,
         is_draft_model: bool = False,
+        context_length: Optional[int] = None,
         **kwargs,
     ):
         quantization = (
@@ -499,7 +500,11 @@ class ModelConfig:
             model_path=model_path or server_args.model_path,
             trust_remote_code=server_args.trust_remote_code,
             revision=model_revision or server_args.revision,
-            context_length=server_args.context_length,
+            context_length=(
+                context_length
+                if context_length is not None
+                else server_args.context_length
+            ),
             model_override_args=server_args.json_model_override_args,
             is_embedding=server_args.is_embedding,
             enable_multimodal=server_args.enable_multimodal,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -262,9 +262,8 @@ class TpModelWorker(BaseTpWorker):
         self.moe_dp_rank = moe_dp_rank
         # Draft worker: target's resolved MemoryPoolConfig (forwarded to ModelRunner).
         self.memory_pool_config = memory_pool_config
-        # Draft worker: target's effective context length, so the draft
-        # ModelConfig covers the target's position range even when the draft
-        # checkpoint declares a shorter one. None keeps server_args.context_length.
+        # Draft worker: target's effective context length; the draft runs at
+        # absolute target positions. None keeps server_args.context_length.
         self.context_length = context_length
 
         # MTP model runners
@@ -279,9 +278,8 @@ class TpModelWorker(BaseTpWorker):
         self._init_dllm_algorithm()
 
         if server_args.skip_tokenizer_init or self.is_draft_worker:
-            # A draft worker's tokenizer would only duplicate the target's
-            # (tokenizer_path always points at the target model); spec workers
-            # that need a tokenizer use the target worker's.
+            # A draft worker's tokenizer would only duplicate the target's:
+            # tokenizer_path always points at the target model.
             self.tokenizer = self.processor = None
         else:
             if self.model_config.is_multimodal:

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -241,6 +241,7 @@ class TpModelWorker(BaseTpWorker):
         token_to_kv_pool_allocator: Optional[BaseTokenToKVPoolAllocator] = None,
         memory_pool_config: Optional[MemoryPoolConfig] = None,
         is_multi_layer_eagle: bool = False,
+        context_length: Optional[int] = None,
     ):
         # Parse args
         self.server_args = server_args
@@ -261,6 +262,10 @@ class TpModelWorker(BaseTpWorker):
         self.moe_dp_rank = moe_dp_rank
         # Draft worker: target's resolved MemoryPoolConfig (forwarded to ModelRunner).
         self.memory_pool_config = memory_pool_config
+        # Draft worker: target's effective context length, so the draft
+        # ModelConfig covers the target's position range even when the draft
+        # checkpoint declares a shorter one. None keeps server_args.context_length.
+        self.context_length = context_length
 
         # MTP model runners
         self.model_runner_list: List[ModelRunner] = []
@@ -273,7 +278,10 @@ class TpModelWorker(BaseTpWorker):
 
         self._init_dllm_algorithm()
 
-        if server_args.skip_tokenizer_init:
+        if server_args.skip_tokenizer_init or self.is_draft_worker:
+            # A draft worker's tokenizer would only duplicate the target's
+            # (tokenizer_path always points at the target model); spec workers
+            # that need a tokenizer use the target worker's.
             self.tokenizer = self.processor = None
         else:
             if self.model_config.is_multimodal:
@@ -370,6 +378,7 @@ class TpModelWorker(BaseTpWorker):
                 else self.server_args.speculative_draft_model_revision
             ),
             is_draft_model=self.is_draft_worker,
+            context_length=self.context_length,
         )
 
     def _init_model_runner(self):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -528,8 +528,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Model-specific adjustment
         self.model_specific_adjustment()
 
-        # Set the global server_args in the scheduler process
-        self.maybe_init_global_server_args(server_args)
+        # Set the global server_args in the scheduler process. Draft workers
+        # share the scheduler's ServerArgs object, so skip re-publishing to
+        # keep target-derived global state (e.g. use_mla_backend) intact.
+        if not self.is_draft_worker:
+            set_global_server_args_for_scheduler(server_args)
+            # FIXME: hacky set `use_mla_backend`
+            get_global_server_args().use_mla_backend = self.use_mla_backend
 
         # Init OpenMP threads binding for CPU
         if self.device == "cpu":
@@ -616,20 +621,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             model_revision=model_revision,
             is_draft_model=is_draft_model,
         )
-
-    def maybe_init_global_server_args(self, server_args: ServerArgs):
-        """Publish `server_args` as the scheduler-process global (target only).
-
-        Draft workers are constructed from the scheduler's ServerArgs object,
-        so re-publishing would be a no-op at best; skipping it guarantees a
-        draft init can never clobber target-derived global state such as
-        `use_mla_backend`.
-        """
-        if self.is_draft_worker:
-            return
-        set_global_server_args_for_scheduler(server_args)
-        # FIXME: hacky set `use_mla_backend`
-        get_global_server_args().use_mla_backend = self.use_mla_backend
 
     def init_msprobe(self):
         # Init the msprobe

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1129,9 +1129,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
     def model_specific_adjustment(self):
         if self.is_draft_worker:
-            # Serving-wide ServerArgs adjustments are driven by the target
-            # model; a draft (e.g. an MHA drafter on an MLA target) must not
-            # override them.
             return
 
         server_args = self.server_args

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -529,11 +529,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.model_specific_adjustment()
 
         # Set the global server_args in the scheduler process
-        set_global_server_args_for_scheduler(server_args)
-        global_server_args = get_global_server_args()
-
-        # FIXME: hacky set `use_mla_backend`
-        global_server_args.use_mla_backend = self.use_mla_backend
+        self.maybe_init_global_server_args(server_args)
 
         # Init OpenMP threads binding for CPU
         if self.device == "cpu":
@@ -620,6 +616,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             model_revision=model_revision,
             is_draft_model=is_draft_model,
         )
+
+    def maybe_init_global_server_args(self, server_args: ServerArgs):
+        """Publish `server_args` as the scheduler-process global (target only).
+
+        Draft workers are constructed from the scheduler's ServerArgs object,
+        so re-publishing would be a no-op at best; skipping it guarantees a
+        draft init can never clobber target-derived global state such as
+        `use_mla_backend`.
+        """
+        if self.is_draft_worker:
+            return
+        set_global_server_args_for_scheduler(server_args)
+        # FIXME: hacky set `use_mla_backend`
+        get_global_server_args().use_mla_backend = self.use_mla_backend
 
     def init_msprobe(self):
         # Init the msprobe

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -528,9 +528,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Model-specific adjustment
         self.model_specific_adjustment()
 
-        # Set the global server_args in the scheduler process. Draft workers
-        # share the scheduler's ServerArgs object, so skip re-publishing to
-        # keep target-derived global state (e.g. use_mla_backend) intact.
+        # Set the global server_args in the scheduler process (target worker
+        # only, so a draft init cannot clobber target-derived global state).
         if not self.is_draft_worker:
             set_global_server_args_for_scheduler(server_args)
             # FIXME: hacky set `use_mla_backend`

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1128,6 +1128,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
 
     def model_specific_adjustment(self):
+        if self.is_draft_worker:
+            # Serving-wide ServerArgs adjustments are driven by the target
+            # model; a draft (e.g. an MHA drafter on an MLA target) must not
+            # override them.
+            return
+
         server_args = self.server_args
 
         # HRM-Text needs bidirectional prompt attention (prefill), which only the

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1,6 +1,5 @@
 import logging
 import math
-from copy import deepcopy
 from typing import List, Optional
 
 import torch
@@ -15,11 +14,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     compute_position,
 )
-from sglang.srt.server_args import (
-    ServerArgs,
-    get_global_server_args,
-    set_global_server_args_for_scheduler,
-)
+from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
@@ -133,53 +128,14 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._warned_sampling_fallback = False
         self._logged_first_verify = False
 
-        # Draft runner (separate KV cache + attention backend).
-        draft_server_args = deepcopy(server_args)
-        draft_server_args.skip_tokenizer_init = True
-        draft_backend = draft_server_args.speculative_draft_attention_backend
-        supported_draft_backends = ("flashinfer", "fa3", "fa4", "triton", "ascend")
-        if draft_backend is None:
-            draft_backend, _ = draft_server_args.get_attention_backends()
-        if draft_backend is None:
-            # Use triton on ROCm (no FlashInfer), flashinfer on CUDA
-            import torch as _torch
-
-            draft_backend = "triton" if _torch.version.hip else "flashinfer"
-        elif draft_backend == "trtllm_mha":
-            import torch as _torch
-
-            _fb = "triton" if _torch.version.hip else "flashinfer"
-            logger.warning(
-                "DFLASH draft worker does not support 'trtllm_mha' because the "
-                "draft path requires per-layer DFlash attention. Falling back to "
-                "'%s'.",
-                _fb,
-            )
-            draft_backend = _fb
-        elif draft_backend not in supported_draft_backends:
-            import torch as _torch
-
-            _fb = "triton" if _torch.version.hip else "flashinfer"
-            logger.warning(
-                "DFLASH draft worker only supports attention_backend in %s for now, "
-                "but got %r. Falling back to '%s'.",
-                supported_draft_backends,
-                draft_backend,
-                _fb,
-            )
-            draft_backend = _fb
-        # Make the draft worker backend explicit and self-contained (no further overrides).
-        draft_server_args.speculative_draft_attention_backend = None
-        draft_server_args.prefill_attention_backend = None
-        draft_server_args.decode_attention_backend = None
-        draft_server_args.attention_backend = draft_backend
-        # Keep draft context length aligned with the target.
-        draft_server_args.context_length = (
-            target_worker.model_runner.model_config.context_len
-        )
-        saved_server_args = get_global_server_args()
+        # Draft runner (separate KV cache + attention backend). The draft
+        # attention backend was resolved into speculative_draft_attention_backend
+        # by arg_groups.speculative_hook._handle_dflash and is applied through
+        # ModelRunner's is_draft_worker override; the target's effective context
+        # length is forwarded so the draft ModelConfig covers the target's
+        # position range.
         self._draft_worker = TpModelWorker(
-            server_args=draft_server_args,
+            server_args=server_args,
             gpu_id=gpu_id,
             tp_rank=tp_rank,
             moe_ep_rank=moe_ep_rank,
@@ -189,8 +145,8 @@ class DFlashWorkerV2(BaseSpecWorker):
             dp_rank=dp_rank,
             nccl_port=nccl_port,
             is_draft_worker=True,
+            context_length=target_worker.model_runner.model_config.context_len,
         )
-        set_global_server_args_for_scheduler(saved_server_args)
         self.draft_model_runner = self._draft_worker.model_runner
         self._draft_sampler = None
         # Keep the same alias that other spec-v2 workers expose.
@@ -226,7 +182,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         if self.tp_rank == 0:
             logger.info(
                 "Initialized DFLASH draft runner. attention_backend=%s, model=%s, block_size=%s, draft_window_size=%s, compact_cache=%s",
-                getattr(draft_server_args, "attention_backend", None),
+                server_args.speculative_draft_attention_backend,
                 self.draft_model.__class__.__name__,
                 self.block_size,
                 self.draft_window_size,

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -128,12 +128,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._warned_sampling_fallback = False
         self._logged_first_verify = False
 
-        # Draft runner (separate KV cache + attention backend). The draft
-        # attention backend was resolved into speculative_draft_attention_backend
-        # by arg_groups.speculative_hook._handle_dflash and is applied through
-        # ModelRunner's is_draft_worker override; the target's effective context
-        # length is forwarded so the draft ModelConfig covers the target's
-        # position range.
+        # Draft runner (separate KV cache + attention backend).
         self._draft_worker = TpModelWorker(
             server_args=server_args,
             gpu_id=gpu_id,

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -1,6 +1,6 @@
 import logging
 
-from sglang.srt.server_args import ServerArgs, get_global_server_args
+from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import is_blackwell, is_hip, is_musa, is_npu
 
 logger = logging.getLogger(__name__)
@@ -118,7 +118,7 @@ class DraftBackendFactory:
         return DeepseekSparseAttnBackend(self.draft_model_runner, skip_prefill=False)
 
     def _create_flashinfer_decode_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             from sglang.srt.layers.attention.flashinfer_backend import (
                 FlashInferMultiStepDraftBackend,
             )
@@ -193,7 +193,7 @@ class DraftBackendFactory:
         )
 
     def _create_trtllm_mla_decode_backend(self, backend: str = "trtllm-gen"):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             raise ValueError(
                 "trtllm_mla backend requires MLA model (use_mla_backend=True)."
             )
@@ -213,7 +213,7 @@ class DraftBackendFactory:
         return self._create_trtllm_mla_decode_backend(backend="cute-dsl")
 
     def _create_tokenspeed_mla_decode_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             raise ValueError(
                 "tokenspeed_mla backend requires MLA model (use_mla_backend=True)."
             )
@@ -259,7 +259,7 @@ class DraftBackendFactory:
         )
 
     def _create_flashinfer_prefill_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             from sglang.srt.layers.attention.flashinfer_backend import (
                 FlashInferAttnBackend,
             )
@@ -307,7 +307,7 @@ class DraftBackendFactory:
         return TRTLLMHAAttnBackend(self.draft_model_runner, skip_prefill=False)
 
     def _create_trtllm_mla_prefill_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             raise ValueError(
                 "trtllm_mla backend requires MLA model (use_mla_backend=True)."
             )
@@ -317,7 +317,7 @@ class DraftBackendFactory:
         return TRTLLMMLABackend(self.draft_model_runner, skip_prefill=False)
 
     def _create_tokenspeed_mla_prefill_backend(self):
-        if not get_global_server_args().use_mla_backend:
+        if not self.draft_model_runner.use_mla_backend:
             raise ValueError(
                 "tokenspeed_mla backend requires MLA model (use_mla_backend=True)."
             )


### PR DESCRIPTION
## Motivation

`DFlashWorkerV2.__init__` deep-copied `ServerArgs`, mutated the clone (draft attention backend, `skip_tokenizer_init`, `context_length`), and built its draft `TpModelWorker` from it. Since `ModelRunner.__init__` publishes its `server_args` as the scheduler-process global, the clone clobbered the global args, forcing a hacky save/restore around the constructor:

```python
saved_server_args = get_global_server_args()
self._draft_worker = TpModelWorker(server_args=draft_server_args, ...)
set_global_server_args_for_scheduler(saved_server_args)
```

Every other spec worker (EAGLE etc.) passes the scheduler's *same* `ServerArgs` object, making the re-publication a no-op by identity. This PR makes DFLASH follow that pattern by routing each clone-mutation through a proper per-draft mechanism.

## Modifications

- **Draft attention backend**: resolution/fallback moved to `_resolve_dflash_draft_attention_backend` in `arg_groups/speculative_hook.py` (ServerArgs normalization phase), writing the final value into `speculative_draft_attention_backend`. `ModelRunner._get_attention_backend` already applies that field for draft workers (single backend for all draft modes), which is what the old prefill/decode-clearing achieved. A FIXME notes that even this field write should eventually become an explicit parameter.
- **Context length**: new explicit `context_length` parameter on `TpModelWorker` → `ModelConfig.from_server_args` — a target-derived override for draft workers, same category as the existing `memory_pool_config` parameter. DFlash passes the target's `context_len`; `ModelConfig._derive_context_length` already expects this ("Target model's context_length" wording). Follow-up: `eagle_worker_v2.py` / `standalone_worker_v2.py` / `frozen_kv_mtp_worker_v2.py` / `multi_layer_eagle_worker_v2.py` still mutate the shared `server_args.context_length` in place and could migrate to this parameter.
- **Tokenizer**: `TpModelWorker` now skips tokenizer init for draft workers. A draft worker's tokenizer was always a byte-identical duplicate of the target's (`tokenizer_path` points at the target model); DFLASH resolves its mask token via the target tokenizer. Side effect: STANDALONE's draft-vs-target `get_vocab()` comparison silently skips, but it was vacuous (it compared the same tokenizer loaded twice).
- **`ModelRunner`**: the global publication (and the `use_mla_backend` write into it) is gated on `not is_draft_worker`, so a draft init can never clobber target-derived global state (matters for an MHA draft on an MLA target).
- **`DFlashWorkerV2.__init__`**: the deepcopy, backend normalization, and save/restore are deleted; the draft worker is constructed from the shared `server_args` plus `context_length=target.context_len`.

## Accuracy Tests

DFLASH e2e on H200 (`meta-llama/Llama-3.1-8B-Instruct` + `z-lab/LLaMA3.1-8B-Instruct-DFlash-UltraChat`, `SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1` — required on main too, since the draft config derives 40960 < 131072):

```
few_shot_gsm8k --num-questions 200: Accuracy: 0.780  Invalid: 0.000
Decode: accept len: ~3.0, accept rate: ~0.22, cuda graph: True
```

Startup logs confirm behavior parity: draft backend `fa3` applied via the `is_draft_worker` override, draft `max_position_embeddings` overridden to 131072, mask token resolved (128002) through the target tokenizer.

An EAGLE3 smoke test on the same box hits two startup failures that reproduce byte-identically on unmodified `main` (verified via a `main` git worktree): the draft context-length `ValueError` without the env var, and a flashinfer cute-dsl rmsnorm dtype error during cuda-graph capture — both pre-existing, unrelated to this PR; the EAGLE draft-worker construction path through the modified code completes identically to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28633766557](https://github.com/sgl-project/sglang/actions/runs/28633766557)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28633766381](https://github.com/sgl-project/sglang/actions/runs/28633766381)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->