### PR TITLE
Fix device mismatch when mixing JPEG (GPU-decoded) and other type (CP…

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -934,6 +934,28 @@ class BaseMultimodalProcessor(ABC):
             elif modality == Modality.AUDIO:
                 audios[idx] = result
 
+        if images:
+            # Detect whether images are split across CPU and GPU.
+            # If mixed, move all GPU tensors to CPU for consistency.
+            has_gpu = has_cpu = False
+            for img in images:
+                if isinstance(img, torch.Tensor) and img.device.type == "cuda":
+                    has_gpu = True
+                else:
+                    has_cpu = True
+                if has_gpu and has_cpu:
+                    break
+
+            if has_gpu and has_cpu:
+                images = [
+                    (
+                        img.cpu()
+                        if isinstance(img, torch.Tensor) and img.device.type == "cuda"
+                        else img
+                    )
+                    for img in images
+                ]
+
         logger.debug(
             "[load_mm_data(simple)] loaded counts: images=%d, videos=%d, audios=%d",
             len(images),


### PR DESCRIPTION
## Motivation

When a request contains multiple images with mixed formats including JPEG images (e.g., JPEG + PNG), the process_mm_data path in BaseMultimodalProcessor produces a device mismatch error.

### Actual error trace:
```
Traceback (most recent call last): 
  File ".../sglang/srt/entrypoints/openai/serving_base.py", line 122, in handle_request ```
    return await self._handle_non_streaming_request(...)
  File ".../sglang/srt/entrypoints/openai/serving_chat.py", line 1404, in _handle_non_streaming_request
    ret = await self.tokenizer_manager.generate_request(...)
  File ".../sglang/srt/managers/tokenizer_manager.py", line 627, in generate_request
    tokenized_obj = await self._tokenize_one_request(obj)
  File ".../sglang/srt/managers/tokenizer_manager.py", line 873, in _tokenize_one_request
    mm_inputs = await self.mm_processor.process_mm_data_async(...)
  File ".../sglang/srt/multimodal/processors/qwen_vl.py", line 709, in process_mm_data_async
    mm_items, input_ids, ret = self.process_and_combine_mm_data(...)
  File ".../sglang/srt/multimodal/processors/base_processor.py", line 1334, in process_and_combine_mm_data
    collected_items, input_ids, ret = self._process_and_collect_mm_items(...)
  File ".../sglang/srt/multimodal/processors/base_processor.py", line 1197, in _process_and_collect_mm_items
    ret = self.process_mm_data(...)
  File ".../sglang/srt/multimodal/processors/base_processor.py", line 467, in process_mm_data
    result = processor.__call__(...)
  File ".../transformers/models/qwen3_vl/processing_qwen3_vl.py", line 105, in __call__
    image_inputs = self.image_processor(images=images, **output_kwargs["images_kwargs"])
  ...
  File ".../transformers/models/qwen2_vl/image_processing_qwen2_vl.py", line 225, in _preprocess
    pixel_values = torch.cat(processed_images, dim=0)
RuntimeError: Expected all tensors to be on the same device, but got tensors is on cuda:0, different from other tensors on cpu (when checking argument in method wrapper_CUDA_cat)
```

### Root Cause
JPEG images are decoded via nvJPEG on GPU, returning `torch.Tensor` on `cuda:0`. [source code](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/utils/common.py#L951)
Other type images are decoded via PIL on CPU, returning `PIL.Image`
These mixed results are collected into the same images list and passed to `processor.__call__()`. The transformers image processor internally converts `PIL.Image` to tensors on CPU, while JPEG tensors remain on `cuda:0`. The final `torch.cat()` at `image_processing_qwen2_vl.py:225` fails because it cannot concatenate tensors from different devices.

## Modifications

In fast_load_mm_data, after collecting all loaded images, detect if the list contains a mix of GPU tensors and CPU items. If so, move all GPU tensors to CPU to ensure uniform device placement before passing to the processor.


## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28633866120](https://github.com/sgl-project/sglang/actions/runs/28633866120)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28633866045](https://github.com/sgl-project/sglang/actions/runs/28633866045)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->