### PR TITLE
Experiment: AMD DSV4 CPU affinity and NUMA diagnostics

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1357,13 +1357,55 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
+      - name: Dump ROCm NUMA diagnostics
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh bash -s <<'BASH'
+          set -x
+          env | sort | grep -E '^(SGLANG|CUDA|HIP|ROCR|HSA|GPU_ARCHS)=' || true
+          lscpu | grep -E 'NUMA|Socket|Core|Thread|CPU\(s\)' || true
+          numactl --hardware || true
+          if command -v rocm-smi >/dev/null 2>&1; then
+            rocm-smi --showtoponuma --showbus || true
+          fi
+          for p in /sys/class/drm/renderD*/device/numa_node /sys/class/drm/card*/device/numa_node; do
+            [ -e "$p" ] && echo "$p=$(cat "$p")"
+          done
+          python3 - <<'PY'
+          import os
+          import torch
+          from sglang.srt.utils.common import is_cuda, is_cuda_alike, is_hip
+          from sglang.srt.utils import numa_utils
+
+          print(f"torch.version.cuda={torch.version.cuda}")
+          print(f"torch.version.hip={torch.version.hip}")
+          print(f"torch.cuda.is_available()={torch.cuda.is_available()}")
+          print(f"is_cuda()={is_cuda()}")
+          print(f"is_hip()={is_hip()}")
+          print(f"is_cuda_alike()={is_cuda_alike()}")
+          print(f"numa_utils._is_cuda={numa_utils._is_cuda}")
+          print(f"SGLANG_NUMA_BIND_V2={os.environ.get('SGLANG_NUMA_BIND_V2')}")
+          print(f"SGLANG_SET_CPU_AFFINITY={os.environ.get('SGLANG_SET_CPU_AFFINITY')}")
+          print(f"os.sched_getaffinity(0)={sorted(os.sched_getaffinity(0))}")
+          print(f"numa_utils._is_numa_available()={numa_utils._is_numa_available()}")
+          for gpu_id in range(torch.cuda.device_count()):
+              try:
+                  nodes = numa_utils._query_numa_node_for_gpu(gpu_id)
+              except Exception as exc:
+                  nodes = f"error: {type(exc).__name__}: {exc}"
+              print(f"numa_utils._query_numa_node_for_gpu({gpu_id})={nodes}")
+          PY
+          BASH
+
       - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Pro FP8 + FP4, unified_kv_triton)
         timeout-minutes: 480
         run: |
           > github_summary.md  # Clear summary file
-          echo "## SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton" >> github_summary.md
+          echo "## SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton, SGLANG_SET_CPU_AFFINITY=0" >> github_summary.md
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
+            -e SGLANG_SET_CPU_AFFINITY=0 \
+            -e SGLANG_NUMA_BIND_V2=1 \
+            -e SGLANG_CRASH_ON_NUMA_BIND_FAILURE=1 \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
@@ -1373,9 +1415,12 @@ jobs:
         timeout-minutes: 480
         run: |
           > github_summary.md  # Clear summary file
-          echo "## SGLANG_HACK_FLASHMLA_BACKEND=triton" >> github_summary.md
+          echo "## SGLANG_HACK_FLASHMLA_BACKEND=triton, SGLANG_SET_CPU_AFFINITY=0" >> github_summary.md
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e SGLANG_HACK_FLASHMLA_BACKEND=triton \
+            -e SGLANG_SET_CPU_AFFINITY=0 \
+            -e SGLANG_NUMA_BIND_V2=1 \
+            -e SGLANG_CRASH_ON_NUMA_BIND_FAILURE=1 \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true


### PR DESCRIPTION
## Summary
- Test whether the persistent ~2100s DeepSeek-V4-Pro weight-load tail on AMD ROCm 7.2 is caused by the current CPU affinity binding rather than HF cache/download or MoE tensor layout.
- Add a focused ROCm NUMA diagnostics step to capture platform flags, NUMA hardware, ROCm topology, sysfs NUMA nodes, and SGLang NUMA helper state.

## Context
Previous experiments showed the HF cache is hit and slow operations are contiguous CPU -> GPU MoE `copy_` calls. Disabling the top-level async loader did not fix the TP0/TP7 tail. Materializing non-contiguous MoE weights helped some non-tail ranks but TP0/TP7 stayed around ~2100s. The profiling run showed TP0/TP7 repeatedly hit the slow-copy profile cap while src/dst tensors were both contiguous.

## Experiment
- Explicitly run the DeepSeek-V4-Pro ROCm720 nightly job with `SGLANG_SET_CPU_AFFINITY=0`.
- Keep `SGLANG_NUMA_BIND_V2=1` and set `SGLANG_CRASH_ON_NUMA_BIND_FAILURE=1` so binding failures are not silently hidden if the NUMA path is reached.
- Print diagnostics before the test, including `is_cuda()`, `is_hip()`, `is_cuda_alike()`, `numa_utils._is_cuda`, `_is_numa_available()`, `numactl --hardware`, `rocm-smi --showtoponuma --showbus`, and `/sys/class/drm/*/device/numa_node`.

## Expected Signal
- If TP0/TP7 load time drops materially, the current CPU affinity mapping is implicated.
- If load time stays ~2100s but diagnostics show ROCm has `is_hip()=True`, `is_cuda()=False`, and `numa_utils._is_cuda=False`, then SGLang NUMA v2 is likely skipped on ROCm and the next patch should add HIP-aware NUMA binding/querying.
- If the job crashes on NUMA binding, use that failure as proof that current automatic binding is not valid in this container/topology.

## Testing
- `python3 - <<'PY' ... yaml.safe_load(...)` passed for `.github/workflows/nightly-test-amd-rocm720.yml`.
- `bash -n` passed for the new diagnostics step body.
- `git diff --check` passed.
- `pre-commit run --files .github/workflows/nightly-test-amd-rocm720.yml` passed.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28638776017](https://github.com/sgl-project/sglang/actions/runs/28638776017)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28638775908](https://github.com/sgl-project/sglang/actions/runs/28638775908)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->