### PR TITLE
refactor: make time_stats msgpack-native

### DIFF
--- a/python/sglang/multimodal_gen/test/unit/test_disagg_trace.py
+++ b/python/sglang/multimodal_gen/test/unit/test_disagg_trace.py
@@ -157,6 +157,8 @@ class TestDisaggTracePropagation(unittest.TestCase):
         with _srt_trace_server_args():
             ctx = TraceReqContext(rid="test-on", role="server", module_name="request")
             ctx.trace_req_start()
+            ctx.trace_slice_start("dispatch", level=1)
+            ctx.trace_slice_end("dispatch", level=1)
             self.assertTrue(ctx.tracing_enable)
             self.assertFalse(ctx.is_copy)
 
@@ -170,6 +172,8 @@ class TestDisaggTracePropagation(unittest.TestCase):
             self.assertTrue(state.get("tracing_enable"))
             # W3C carrier must be present so downstream roles can nest spans.
             self.assertIn("traceparent", state.get("root_span_context", {}))
+            self.assertEqual(len(state["last_span_context"]["trace_id"]), 32)
+            self.assertEqual(len(state["last_span_context"]["span_id"]), 16)
 
             decoded = _roundtrip_scalar_fields(scalar_fields)
             self.assertEqual(decoded["_trace_state"], state)
@@ -183,6 +187,14 @@ class TestDisaggTracePropagation(unittest.TestCase):
             self.assertEqual(
                 _traceparent_from(rebuilt.root_span_context),
                 state["root_span_context"]["traceparent"],
+            )
+            self.assertEqual(
+                rebuilt.last_span_context.trace_id,
+                int(state["last_span_context"]["trace_id"], 16),
+            )
+            self.assertEqual(
+                rebuilt.last_span_context.span_id,
+                int(state["last_span_context"]["span_id"], 16),
             )
             ctx.trace_req_finish()
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -39,7 +39,6 @@ from sglang.srt.managers.io_struct import (
     TokenizedGenerateReqInput,
     sock_recv,
     sock_send,
-    unwrap_from_pickle,
     wrap_as_pickle,
 )
 from sglang.srt.managers.load_snapshot import create_load_snapshot_reader
@@ -317,12 +316,10 @@ class DataParallelController:
         if refresh_load_budget and self.refresh_load_budget_on_dispatch:
             self.refresh_load_budget()
 
-        time_stats = DPControllerReqTimeStats.new_from_obj(
-            unwrap_from_pickle(req.time_stats)
-        )
+        time_stats = DPControllerReqTimeStats.new_from_obj(req.time_stats)
 
         time_stats.set_dp_dispatch_time()
-        req.time_stats = wrap_as_pickle(time_stats)
+        req.time_stats = time_stats.to_ipc()
         self.dispatching(req)
         req.time_stats = time_stats
         req.time_stats.set_dp_dispatch_finish_time()

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -54,6 +54,11 @@ from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.embed_types import PositionalEmbeds
 from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.multimodal.mm_utils import has_valid_data
+from sglang.srt.observability.req_time_stats import (
+    APIServerReqTimeStats,
+    DPControllerReqTimeStats,
+    SchedulerReqTimeStats,
+)
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.utils import ImageData, VideoData
 from sglang.srt.utils.field_validators import validate_optional_list_i64_1d_2d
@@ -69,6 +74,8 @@ else:
     Image = Any
 
 logger = logging.getLogger(__name__)
+
+RequestTimeStats = Union[APIServerReqTimeStats, DPControllerReqTimeStats]
 
 
 class BaseReq(msgspec.Struct, tag=True, kw_only=True, array_like=True):
@@ -100,7 +107,7 @@ class PickleWrapper(msgspec.Struct, tag=True, array_like=True):
     """Wraps an arbitrary Python object as pickle-serialized bytes for msgpack IPC.
 
     In msgpack mode, fields that carry opaque or non-msgspec-typed payloads
-    (e.g. multimodal inputs, time stats, customized info) are stored as
+    (e.g. multimodal inputs or customized info) are stored as
     PickleWrapper so the outer struct can still be msgpack-encoded.  In pickle
     mode (_USE_PICKLE_IPC=True), wrap_as_pickle / unwrap_from_pickle are no-ops
     and this class is not used on the wire.
@@ -878,18 +885,15 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     multi_item_delimiter_indices: Optional[List[int]] = None
 
     # For observability
-    # Pickled Optional[Union[APIServerReqTimeStats, DPControllerReqTimeStats]]
-    time_stats: Optional[PickleWrapper] = None
+    time_stats: Optional[RequestTimeStats] = None
 
     def wrap_pickle_fields(self):
         self.mm_inputs = wrap_as_pickle(self.mm_inputs)
         self.mm_data_mooncake = wrap_as_pickle(self.mm_data_mooncake)
-        self.time_stats = wrap_as_pickle(self.time_stats)
 
     def unwrap_pickle_fields(self):
         self.mm_inputs = unwrap_from_pickle(self.mm_inputs)
         self.mm_data_mooncake = unwrap_from_pickle(self.mm_data_mooncake)
-        self.time_stats = unwrap_from_pickle(self.time_stats)
 
 
 class BatchTokenizedGenerateReqInput(BaseBatchReq, kw_only=True):
@@ -1166,16 +1170,13 @@ class TokenizedEmbeddingReqInput(BaseReq, kw_only=True):
     multi_item_delimiter_indices: Optional[List[int]] = None
 
     # For observability
-    # Pickled Optional[Union[APIServerReqTimeStats, DPControllerReqTimeStats]]
-    time_stats: Optional[PickleWrapper] = None
+    time_stats: Optional[RequestTimeStats] = None
 
     def wrap_pickle_fields(self):
         self.mm_inputs = wrap_as_pickle(self.mm_inputs)
-        self.time_stats = wrap_as_pickle(self.time_stats)
 
     def unwrap_pickle_fields(self):
         self.mm_inputs = unwrap_from_pickle(self.mm_inputs)
-        self.time_stats = unwrap_from_pickle(self.time_stats)
 
 
 class BatchTokenizedEmbeddingReqInput(BaseBatchReq, kw_only=True):
@@ -1278,8 +1279,7 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     dp_ranks: Optional[List[Optional[int]]] = None
 
     # For observability
-    # Pickled Optional[List[SchedulerReqTimeStats]]
-    time_stats: Optional[PickleWrapper] = None
+    time_stats: Optional[List[SchedulerReqTimeStats]] = None
 
     # Multimodal prompt token counts (image/audio/video). None when not applicable.
     image_tokens: Optional[List[int]] = None
@@ -1360,8 +1360,7 @@ class BatchStrOutput(BaseBatchReq, kw_only=True):
     dp_ranks: Optional[List[Optional[int]]] = None
 
     # For observability
-    # Pickled Optional[List[SchedulerReqTimeStats]]
-    time_stats: Optional[PickleWrapper] = None
+    time_stats: Optional[List[SchedulerReqTimeStats]] = None
 
     # Multimodal prompt token counts (image/audio/video). None when not applicable.
     image_tokens: Optional[List[int]] = None
@@ -1397,8 +1396,7 @@ class BatchEmbeddingOutput(BaseBatchReq, kw_only=True):
     cached_tokens_details: Optional[List[Optional[CachedTokensDetails]]] = None
 
     # For observability
-    # Pickled Optional[List[SchedulerReqTimeStats]]
-    time_stats: Optional[PickleWrapper] = None
+    time_stats: Optional[List[SchedulerReqTimeStats]] = None
 
     # Optional pooled hidden states (pre-head transformer output).
     # Two IPC formats, disambiguated by len vs len(rids):

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -124,7 +124,7 @@ def _extract_field_by_index(
     if field is None:
         return None
 
-    should_wrap_result = field_name in ("customized_info", "time_stats")
+    should_wrap_result = field_name == "customized_info"
     if should_wrap_result:
         field = unwrap_from_pickle(field)
         if field is None:
@@ -261,6 +261,7 @@ def _handle_output_by_index(output, i):
     elif isinstance(output, BatchEmbeddingOutput):
         new_output = BatchEmbeddingOutput(
             rids=[output.rids[i]],
+            time_stats=_extract_field_by_index(output, "time_stats", i),
             finished_reasons=_extract_field_by_index(output, "finished_reasons", i),
             embeddings=_extract_field_by_index(output, "embeddings", i),
             prompt_tokens=_extract_field_by_index(output, "prompt_tokens", i),

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -199,7 +199,7 @@ class SchedulerOutputStreamer:
 
                 # Collect detailed cache breakdown if available
                 cached_tokens_details.append(self.get_cached_tokens_details(req))
-                time_stats.append(req.time_stats)
+                time_stats.append(req.time_stats.to_ipc())
                 retraction_counts.append(req.retraction_count)
 
                 phs = req.pooled_hidden_state
@@ -234,7 +234,7 @@ class SchedulerOutputStreamer:
             BatchEmbeddingOutput(
                 rids=rids,
                 http_worker_ipcs=http_worker_ipcs,
-                time_stats=wrap_as_pickle(time_stats),
+                time_stats=time_stats,
                 finished_reasons=finished_reasons,
                 embeddings=embeddings,
                 prompt_tokens=prompt_tokens,
@@ -414,7 +414,7 @@ class _GenerationStreamAccumulator:
 
         self.retraction_counts.append(req.retraction_count)
 
-        self.time_stats.append(req.time_stats)
+        self.time_stats.append(req.time_stats.to_ipc())
 
         if not self.spec_algorithm.is_none():
             self.spec_verify_ct.append(req.spec_verify_ct)
@@ -567,7 +567,7 @@ class _GenerationStreamAccumulator:
             spec_num_cap_tokens=self.spec_num_cap_tokens,
             spec_correct_drafts_histogram=self.spec_correct_drafts_histogram,
             spec_cap_lens_histogram=self.spec_cap_lens_histogram,
-            time_stats=wrap_as_pickle(self.time_stats),
+            time_stats=self.time_stats,
             finished_reasons=self.finished_reasons,
             decoded_texts=self.decoded_texts,
             decode_ids=self.decode_ids_list,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1371,6 +1371,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         tokenized_obj.time_stats.set_api_server_dispatch_time()
         tokenized_obj = wrap_shm_features(tokenized_obj)
         time_stats = tokenized_obj.time_stats
+        tokenized_obj.time_stats = time_stats.to_ipc() if time_stats else None
         tokenized_obj.wrap_pickle_fields()
         self._dispatch_to_scheduler(tokenized_obj)
         tokenized_obj.time_stats = time_stats
@@ -1386,6 +1387,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         set_time_batch(tokenized_objs, "set_api_server_dispatch_time")
         time_stats = [tokenized_obj.time_stats for tokenized_obj in tokenized_objs]
         for tokenized_obj in tokenized_objs:
+            tokenized_obj.time_stats = (
+                tokenized_obj.time_stats.to_ipc() if tokenized_obj.time_stats else None
+            )
             tokenized_obj.wrap_pickle_fields()
 
         if isinstance(tokenized_objs[0], TokenizedGenerateReqInput):
@@ -1904,7 +1908,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             BatchTokenIDOutput,
         ],
     ):
-        recv_obj.time_stats = unwrap_from_pickle(recv_obj.time_stats)
         if isinstance(recv_obj, (BatchStrOutput, BatchTokenIDOutput)):
             customized_info = unwrap_from_pickle(recv_obj.customized_info)
         else:

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+import msgspec
 from typing_extensions import Self
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
@@ -50,6 +51,12 @@ logger = logging.getLogger(__name__)
 
 # Reduce system time calls by computing time.time() based on calibrated perf_counter() values.
 global_diff_realtime_monotonic = time.time() - time.perf_counter()
+
+
+def _restore_req_time_stats(cls: type, state: Dict[str, Any]) -> Any:
+    obj = cls()
+    obj.__setstate__(state)
+    return obj
 
 
 def calibrate_time_diff():
@@ -221,21 +228,25 @@ class RequestStage:
     ANONYMOUS = RequestStageConfig("")
 
 
-@dataclass
-class ReqTimeStatsBase:
+class ReqTimeStatsBase(
+    msgspec.Struct, tag=True, kw_only=True, dict=True, omit_defaults=True
+):
     enable_metrics: bool = False
-    metrics_collector: Optional[
-        Union[
-            SchedulerMetricsCollector,
-            TokenizerMetricsCollector,
-            EncoderMetricsCollector,
-        ]
-    ] = None
-    trace_ctx: Union[TraceReqContext, TraceNullContext] = field(
-        default_factory=TraceNullContext
-    )
     disagg_mode: DisaggregationMode = DisaggregationMode.NULL
     diff_realtime_monotonic: float = 0.0
+    trace_ctx_state: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self):
+        self.metrics_collector: Optional[
+            Union[
+                SchedulerMetricsCollector,
+                TokenizerMetricsCollector,
+                EncoderMetricsCollector,
+            ]
+        ] = None
+        self.trace_ctx: Union[TraceReqContext, TraceNullContext] = (
+            self._decode_trace_ctx_state(self.trace_ctx_state)
+        )
 
     @classmethod
     def new_from_obj(cls, obj: Optional[ReqTimeStatsBase], *args, **kwargs) -> Self:
@@ -243,14 +254,73 @@ class ReqTimeStatsBase:
         new_obj = cls(*args, **kwargs)
         if obj is None:
             return new_obj
-        for key, value in obj.__dict__.items():
-            if hasattr(new_obj, key):
-                setattr(new_obj, key, value)
+
+        new_fields = {field.name for field in msgspec.structs.fields(type(new_obj))}
+        for field in msgspec.structs.fields(type(obj)):
+            if field.name in new_fields:
+                setattr(new_obj, field.name, getattr(obj, field.name))
+
+        new_obj.metrics_collector = obj.metrics_collector
+        new_obj.trace_ctx = obj.trace_ctx
 
         if new_obj.trace_ctx.tracing_enable:
             new_obj.trace_ctx.rebuild_thread_context()
 
         return new_obj
+
+    @staticmethod
+    def _decode_trace_ctx_state(
+        trace_ctx_state: Optional[Dict[str, Any]],
+    ) -> Union[TraceReqContext, TraceNullContext]:
+        if isinstance(trace_ctx_state, dict) and trace_ctx_state.get("tracing_enable"):
+            trace_ctx_state = ReqTimeStatsBase._decode_trace_ctx_ids(trace_ctx_state)
+            trace_ctx = object.__new__(TraceReqContext)
+            trace_ctx.__setstate__(trace_ctx_state)
+            return trace_ctx
+        return TraceNullContext()
+
+    @staticmethod
+    def _encode_trace_ctx_ids(trace_ctx_state: Dict[str, Any]) -> Dict[str, Any]:
+        trace_ctx_state = trace_ctx_state.copy()
+        last_span_context = trace_ctx_state.get("last_span_context")
+        if isinstance(last_span_context, dict):
+            last_span_context = last_span_context.copy()
+            trace_id = last_span_context.get("trace_id")
+            span_id = last_span_context.get("span_id")
+            if isinstance(trace_id, int):
+                last_span_context["trace_id"] = f"{trace_id:032x}"
+            if isinstance(span_id, int):
+                last_span_context["span_id"] = f"{span_id:016x}"
+            trace_ctx_state["last_span_context"] = last_span_context
+        return trace_ctx_state
+
+    @staticmethod
+    def _decode_trace_ctx_ids(trace_ctx_state: Dict[str, Any]) -> Dict[str, Any]:
+        trace_ctx_state = trace_ctx_state.copy()
+        last_span_context = trace_ctx_state.get("last_span_context")
+        if isinstance(last_span_context, dict):
+            last_span_context = last_span_context.copy()
+            for key in ("trace_id", "span_id"):
+                value = last_span_context.get(key)
+                if isinstance(value, str):
+                    last_span_context[key] = int(value, 16)
+            trace_ctx_state["last_span_context"] = last_span_context
+        return trace_ctx_state
+
+    def _get_trace_ctx_state(self) -> Dict[str, Any]:
+        if self.trace_ctx.tracing_enable:
+            return self._encode_trace_ctx_ids(self.trace_ctx.__getstate__())
+        if self.trace_ctx_state is not None:
+            return self.trace_ctx_state
+        return {"tracing_enable": False}
+
+    def to_ipc(self) -> Self:
+        return type(self)(
+            disagg_mode=self.disagg_mode,
+            enable_metrics=False,
+            trace_ctx_state=self._get_trace_ctx_state(),
+            diff_realtime_monotonic=global_diff_realtime_monotonic,
+        )
 
     def disagg_mode_str(self) -> str:
         if self.disagg_mode == DisaggregationMode.NULL:
@@ -317,17 +387,15 @@ class ReqTimeStatsBase:
     def __getstate__(self) -> object:
         # The object is propagated to other processes via serialization and deserialization methods,
         # requiring the metric collector to be reconfigured.
-        trace_ctx_state = (
-            self.trace_ctx.__getstate__()
-            if self.trace_ctx.tracing_enable
-            else {"tracing_enable": False}
-        )
         return {
             "disagg_mode": self.disagg_mode.value if self.disagg_mode else None,
             "enable_metrics": False,
-            "trace_ctx": trace_ctx_state,
+            "trace_ctx": self._get_trace_ctx_state(),
             "diff_realtime_monotonic": global_diff_realtime_monotonic,
         }
+
+    def __reduce_ex__(self, protocol: int):
+        return _restore_req_time_stats, (type(self), self.__getstate__())
 
     def __setstate__(self, state: object):
         # Reconstruct disagg_mode from string value if needed
@@ -336,23 +404,25 @@ class ReqTimeStatsBase:
             state["disagg_mode"] = DisaggregationMode(disagg_mode_val)
 
         # Reconstruct trace_ctx from serialized dict if needed
-        trace_ctx_state = state.get("trace_ctx")
+        trace_ctx_state = state.pop("trace_ctx", state.get("trace_ctx_state", None))
         if isinstance(trace_ctx_state, dict):
-            if trace_ctx_state.get("tracing_enable"):
-                trace_ctx = object.__new__(TraceReqContext)
-                trace_ctx.__setstate__(trace_ctx_state)
-                state["trace_ctx"] = trace_ctx
-            else:
-                state["trace_ctx"] = TraceNullContext()
+            self.trace_ctx_state = trace_ctx_state
+            self.trace_ctx = self._decode_trace_ctx_state(trace_ctx_state)
 
         for key in state.keys():
-            if key.endswith("time"):
+            if key.endswith("time") and state[key] > 0.0:
                 state[key] = convert_time_cross_thread(
                     state[key],
                     state["diff_realtime_monotonic"],
                     global_diff_realtime_monotonic,
                 )
-        self.__dict__.update(state)
+
+        struct_fields = {field.name for field in msgspec.structs.fields(type(self))}
+        for key, value in state.items():
+            if key == "diff_realtime_monotonic":
+                value = global_diff_realtime_monotonic
+            if key in struct_fields:
+                setattr(self, key, value)
 
     def encode_json(self) -> Dict[str, Any]:
         return self.__getstate__()
@@ -361,7 +431,6 @@ class ReqTimeStatsBase:
         self.__setstate__(state)
 
 
-@dataclass
 class APIServerReqTimeStats(ReqTimeStatsBase):
     # get by time.perf_counter()
     created_time: float = 0.0
@@ -524,7 +593,6 @@ class APIServerReqTimeStats(ReqTimeStatsBase):
         return span_attrs
 
 
-@dataclass
 class DPControllerReqTimeStats(ReqTimeStatsBase):
     # propagated from tokenizer/grpc_server, get by time.perf_counter()
     created_time: float = 0.0
@@ -570,7 +638,6 @@ class DPControllerReqTimeStats(ReqTimeStatsBase):
             )
 
 
-@dataclass
 class SchedulerReqTimeStats(ReqTimeStatsBase):
     """
     Store the timestamps for each stage of a request.
@@ -623,9 +690,31 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
     transfer_speed_gb_s: float = 0.0
     transfer_total_mb: float = 0.0
 
+    def __post_init__(self):
+        super().__post_init__()
+        if (
+            self.diff_realtime_monotonic
+            and self.diff_realtime_monotonic != global_diff_realtime_monotonic
+        ):
+            old_diff = self.diff_realtime_monotonic
+            new_diff = global_diff_realtime_monotonic
+            if self.wait_queue_entry_time > 0.0:
+                self.wait_queue_entry_time = convert_time_cross_thread(
+                    self.wait_queue_entry_time, old_diff, new_diff
+                )
+            if self.forward_entry_time > 0.0:
+                self.forward_entry_time = convert_time_cross_thread(
+                    self.forward_entry_time, old_diff, new_diff
+                )
+            if self.prefill_finished_time > 0.0:
+                self.prefill_finished_time = convert_time_cross_thread(
+                    self.prefill_finished_time, old_diff, new_diff
+                )
+            self.diff_realtime_monotonic = new_diff
+
     def __getstate__(self) -> object:
         # send to detokenizer/tokenizer
-        if not self.enable_metrics:
+        if not self.enable_metrics and not self.diff_realtime_monotonic:
             return {}
 
         state = {
@@ -635,6 +724,16 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
             "diff_realtime_monotonic": global_diff_realtime_monotonic,
         }
         return state
+
+    def to_ipc(self) -> Self:
+        if not self.enable_metrics:
+            return type(self)()
+        return type(self)(
+            wait_queue_entry_time=self.wait_queue_entry_time,
+            forward_entry_time=self.forward_entry_time,
+            prefill_finished_time=self.prefill_finished_time,
+            diff_realtime_monotonic=global_diff_realtime_monotonic,
+        )
 
     def set_scheduler_recv_time(self, ts=None):
         calibrate_time_diff()
@@ -1174,7 +1273,6 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
         return f"{convert_time_to_realtime(perf_counter_time):.3f}"
 
 
-@dataclass
 class EncoderReqTimeStats(ReqTimeStatsBase):
     mm_encode_start_time: float = 0.0
     mm_encode_end_time: float = 0.0

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -237,6 +237,11 @@ class ReqTimeStatsBase(
     trace_ctx_state: Optional[Dict[str, Any]] = None
 
     def __post_init__(self):
+        if self.trace_ctx_state is not None:
+            self.trace_ctx_state = TraceReqContext._normalize_state_for_transport(
+                self.trace_ctx_state
+            )
+
         self.metrics_collector: Optional[
             Union[
                 SchedulerMetricsCollector,
@@ -248,18 +253,32 @@ class ReqTimeStatsBase(
             self._decode_trace_ctx_state(self.trace_ctx_state)
         )
 
+        old_diff = self.diff_realtime_monotonic
+        new_diff = global_diff_realtime_monotonic
+        if old_diff and old_diff != new_diff:
+            for field in msgspec.structs.fields(type(self)):
+                if field.name.endswith("time"):
+                    value = getattr(self, field.name)
+                    if value > 0.0:
+                        setattr(
+                            self,
+                            field.name,
+                            convert_time_cross_thread(value, old_diff, new_diff),
+                        )
+            self.diff_realtime_monotonic = new_diff
+
     @classmethod
     def new_from_obj(cls, obj: Optional[ReqTimeStatsBase], *args, **kwargs) -> Self:
         calibrate_time_diff()
-        new_obj = cls(*args, **kwargs)
         if obj is None:
-            return new_obj
+            return cls(*args, **kwargs)
 
-        new_fields = {field.name for field in msgspec.structs.fields(type(new_obj))}
+        new_fields = {field.name for field in msgspec.structs.fields(cls)}
         for field in msgspec.structs.fields(type(obj)):
             if field.name in new_fields:
-                setattr(new_obj, field.name, getattr(obj, field.name))
+                kwargs[field.name] = getattr(obj, field.name)
 
+        new_obj = cls(*args, **kwargs)
         new_obj.metrics_collector = obj.metrics_collector
         new_obj.trace_ctx = obj.trace_ctx
 
@@ -273,43 +292,14 @@ class ReqTimeStatsBase(
         trace_ctx_state: Optional[Dict[str, Any]],
     ) -> Union[TraceReqContext, TraceNullContext]:
         if isinstance(trace_ctx_state, dict) and trace_ctx_state.get("tracing_enable"):
-            trace_ctx_state = ReqTimeStatsBase._decode_trace_ctx_ids(trace_ctx_state)
             trace_ctx = object.__new__(TraceReqContext)
             trace_ctx.__setstate__(trace_ctx_state)
             return trace_ctx
         return TraceNullContext()
 
-    @staticmethod
-    def _encode_trace_ctx_ids(trace_ctx_state: Dict[str, Any]) -> Dict[str, Any]:
-        trace_ctx_state = trace_ctx_state.copy()
-        last_span_context = trace_ctx_state.get("last_span_context")
-        if isinstance(last_span_context, dict):
-            last_span_context = last_span_context.copy()
-            trace_id = last_span_context.get("trace_id")
-            span_id = last_span_context.get("span_id")
-            if isinstance(trace_id, int):
-                last_span_context["trace_id"] = f"{trace_id:032x}"
-            if isinstance(span_id, int):
-                last_span_context["span_id"] = f"{span_id:016x}"
-            trace_ctx_state["last_span_context"] = last_span_context
-        return trace_ctx_state
-
-    @staticmethod
-    def _decode_trace_ctx_ids(trace_ctx_state: Dict[str, Any]) -> Dict[str, Any]:
-        trace_ctx_state = trace_ctx_state.copy()
-        last_span_context = trace_ctx_state.get("last_span_context")
-        if isinstance(last_span_context, dict):
-            last_span_context = last_span_context.copy()
-            for key in ("trace_id", "span_id"):
-                value = last_span_context.get(key)
-                if isinstance(value, str):
-                    last_span_context[key] = int(value, 16)
-            trace_ctx_state["last_span_context"] = last_span_context
-        return trace_ctx_state
-
     def _get_trace_ctx_state(self) -> Dict[str, Any]:
         if self.trace_ctx.tracing_enable:
-            return self._encode_trace_ctx_ids(self.trace_ctx.__getstate__())
+            return self.trace_ctx.__getstate__()
         if self.trace_ctx_state is not None:
             return self.trace_ctx_state
         return {"tracing_enable": False}
@@ -397,32 +387,40 @@ class ReqTimeStatsBase(
     def __reduce_ex__(self, protocol: int):
         return _restore_req_time_stats, (type(self), self.__getstate__())
 
-    def __setstate__(self, state: object):
-        # Reconstruct disagg_mode from string value if needed
-        disagg_mode_val = state.get("disagg_mode")
-        if isinstance(disagg_mode_val, str):
-            state["disagg_mode"] = DisaggregationMode(disagg_mode_val)
-
-        # Reconstruct trace_ctx from serialized dict if needed
-        trace_ctx_state = state.pop("trace_ctx", state.get("trace_ctx_state", None))
+    def __setstate__(self, state: Dict[str, Any]):
+        trace_ctx_state = state.get("trace_ctx", state.get("trace_ctx_state"))
         if isinstance(trace_ctx_state, dict):
+            trace_ctx_state = TraceReqContext._normalize_state_for_transport(
+                trace_ctx_state
+            )
             self.trace_ctx_state = trace_ctx_state
             self.trace_ctx = self._decode_trace_ctx_state(trace_ctx_state)
 
-        for key in state.keys():
-            if key.endswith("time") and state[key] > 0.0:
-                state[key] = convert_time_cross_thread(
-                    state[key],
-                    state["diff_realtime_monotonic"],
+        struct_fields = {field.name for field in msgspec.structs.fields(type(self))}
+        old_diff = state.get("diff_realtime_monotonic", 0.0)
+        for key, value in state.items():
+            if key not in struct_fields:
+                continue
+
+            if key == "disagg_mode" and isinstance(value, str):
+                value = DisaggregationMode(value)
+            elif key == "trace_ctx_state" and isinstance(trace_ctx_state, dict):
+                value = trace_ctx_state
+            elif key == "diff_realtime_monotonic" and old_diff:
+                value = global_diff_realtime_monotonic
+            elif (
+                key.endswith("time")
+                and value > 0.0
+                and old_diff
+                and old_diff != global_diff_realtime_monotonic
+            ):
+                value = convert_time_cross_thread(
+                    value,
+                    old_diff,
                     global_diff_realtime_monotonic,
                 )
 
-        struct_fields = {field.name for field in msgspec.structs.fields(type(self))}
-        for key, value in state.items():
-            if key == "diff_realtime_monotonic":
-                value = global_diff_realtime_monotonic
-            if key in struct_fields:
-                setattr(self, key, value)
+            setattr(self, key, value)
 
     def encode_json(self) -> Dict[str, Any]:
         return self.__getstate__()
@@ -689,28 +687,6 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
     # other
     transfer_speed_gb_s: float = 0.0
     transfer_total_mb: float = 0.0
-
-    def __post_init__(self):
-        super().__post_init__()
-        if (
-            self.diff_realtime_monotonic
-            and self.diff_realtime_monotonic != global_diff_realtime_monotonic
-        ):
-            old_diff = self.diff_realtime_monotonic
-            new_diff = global_diff_realtime_monotonic
-            if self.wait_queue_entry_time > 0.0:
-                self.wait_queue_entry_time = convert_time_cross_thread(
-                    self.wait_queue_entry_time, old_diff, new_diff
-                )
-            if self.forward_entry_time > 0.0:
-                self.forward_entry_time = convert_time_cross_thread(
-                    self.forward_entry_time, old_diff, new_diff
-                )
-            if self.prefill_finished_time > 0.0:
-                self.prefill_finished_time = convert_time_cross_thread(
-                    self.prefill_finished_time, old_diff, new_diff
-                )
-            self.diff_realtime_monotonic = new_diff
 
     def __getstate__(self) -> object:
         # send to detokenizer/tokenizer

--- a/python/sglang/srt/observability/trace.py
+++ b/python/sglang/srt/observability/trace.py
@@ -358,6 +358,21 @@ class TraceReqContext:
 
         return thread_context
 
+    @staticmethod
+    def _normalize_state_for_transport(state: Dict[str, Any]) -> Dict[str, Any]:
+        state = state.copy()
+        last_span_context = state.get("last_span_context")
+        if isinstance(last_span_context, dict):
+            last_span_context = last_span_context.copy()
+            trace_id = last_span_context.get("trace_id")
+            span_id = last_span_context.get("span_id")
+            if isinstance(trace_id, int):
+                last_span_context["trace_id"] = f"{trace_id:032x}"
+            if isinstance(span_id, int):
+                last_span_context["span_id"] = f"{span_id:016x}"
+            state["last_span_context"] = last_span_context
+        return state
+
     def __getstate__(self) -> Optional[Dict[str, Any]]:
         if not self.tracing_enable:
             return {"tracing_enable": False}
@@ -396,7 +411,7 @@ class TraceReqContext:
                 "trace_id": prev_span_context.trace_id,
             }
 
-        return state
+        return self._normalize_state_for_transport(state)
 
     def __setstate__(self, state: Dict[str, Any]):
         self.__dict__.update(state)
@@ -409,9 +424,15 @@ class TraceReqContext:
         self.pid = threading.get_native_id()
         self.root_span_context = propagate.extract(self.root_span_context)
         if self.last_span_context:
+            trace_id = self.last_span_context["trace_id"]
+            span_id = self.last_span_context["span_id"]
+            if isinstance(trace_id, str):
+                trace_id = int(trace_id, 16)
+            if isinstance(span_id, str):
+                span_id = int(span_id, 16)
             self.last_span_context = trace.span.SpanContext(
-                trace_id=self.last_span_context["trace_id"],
-                span_id=self.last_span_context["span_id"],
+                trace_id=trace_id,
+                span_id=span_id,
                 is_remote=True,
             )
         self.events_cache = []

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1,7 +1,31 @@
 import copy
+import pickle
 import unittest
+from array import array
+from unittest.mock import patch
 
-from sglang.srt.managers.io_struct import GenerateReqInput
+import msgspec
+
+import sglang.srt.observability.req_time_stats as req_time_stats_module
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers import io_struct
+from sglang.srt.managers.io_struct import (
+    BatchEmbeddingOutput,
+    BatchTokenIDOutput,
+    BatchTokenizedEmbeddingReqInput,
+    BatchTokenizedGenerateReqInput,
+    GenerateReqInput,
+    TokenizedEmbeddingReqInput,
+    TokenizedGenerateReqInput,
+    sock_recv,
+    sock_send,
+)
+from sglang.srt.observability.req_time_stats import (
+    APIServerReqTimeStats,
+    DPControllerReqTimeStats,
+    SchedulerReqTimeStats,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import (
     register_amd_ci,
     register_cpu_ci,
@@ -16,6 +40,310 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-large")
 register_amd_ci(est_time=8, suite="stage-b-test-1-gpu-small-amd")
 register_cpu_ci(est_time=8, suite="base-c-test-cpu")
+
+
+class _LoopbackSocket:
+    def send(self, data, flags=0):
+        self.data = data
+
+    def recv(self, flags=0):
+        return self.data
+
+    def send_pyobj(self, obj, flags=0, protocol=None):
+        self.data = pickle.dumps(obj, protocol=protocol)
+
+    def recv_pyobj(self, flags=0):
+        return pickle.loads(self.data)
+
+
+def _transport_round_trip(obj):
+    socket = _LoopbackSocket()
+    sock_send(socket, obj)
+    return sock_recv(socket)
+
+
+def _make_batch_token_id_output(time_stats):
+    return BatchTokenIDOutput(
+        rids=["rid"],
+        http_worker_ipcs=[None],
+        finished_reasons=[None],
+        decoded_texts=[""],
+        decode_ids=[array("i", [1])],
+        read_offsets=[0],
+        output_ids=[array("i", [1])],
+        skip_special_tokens=[True],
+        spaces_between_special_tokens=[True],
+        no_stop_trim=[False],
+        prompt_tokens=[1],
+        reasoning_tokens=[0],
+        completion_tokens=[1],
+        cached_tokens=[0],
+        input_token_logprobs_val=None,
+        input_token_logprobs_idx=None,
+        output_token_logprobs_val=None,
+        output_token_logprobs_idx=None,
+        input_top_logprobs_val=None,
+        input_top_logprobs_idx=None,
+        output_top_logprobs_val=None,
+        output_top_logprobs_idx=None,
+        input_token_ids_logprobs_val=None,
+        input_token_ids_logprobs_idx=None,
+        output_token_ids_logprobs_val=None,
+        output_token_ids_logprobs_idx=None,
+        output_token_entropy_val=None,
+        output_hidden_states=None,
+        routed_experts=None,
+        indexer_topk=None,
+        placeholder_tokens_idx=None,
+        placeholder_tokens_val=None,
+        time_stats=[time_stats],
+    )
+
+
+class TestReqTimeStatsTransport(CustomTestCase):
+    def test_tokenized_request_time_stats_round_trip(self):
+        for use_pickle in (False, True):
+            requests = [
+                (
+                    TokenizedEmbeddingReqInput(
+                        input_text="hello",
+                        input_ids=array("i", [1, 2, 3]),
+                        mm_inputs=None,
+                        token_type_ids=None,
+                        sampling_params=SamplingParams(),
+                        time_stats=APIServerReqTimeStats(
+                            disagg_mode=DisaggregationMode.PREFILL
+                        ).to_ipc(),
+                    ),
+                    BatchTokenizedEmbeddingReqInput,
+                    APIServerReqTimeStats,
+                ),
+                (
+                    TokenizedGenerateReqInput(
+                        input_text="hello",
+                        input_ids=array("i", [1, 2, 3]),
+                        input_embeds=None,
+                        mm_inputs=None,
+                        token_type_ids=None,
+                        sampling_params=SamplingParams(),
+                        return_logprob=False,
+                        logprob_start_len=0,
+                        top_logprobs_num=0,
+                        token_ids_logprob=None,
+                        stream=False,
+                        time_stats=DPControllerReqTimeStats(
+                            disagg_mode=DisaggregationMode.PREFILL
+                        ).to_ipc(),
+                    ),
+                    BatchTokenizedGenerateReqInput,
+                    DPControllerReqTimeStats,
+                ),
+            ]
+
+            for req, batch_type, expected_type in requests:
+                for batched in (False, True):
+                    with self.subTest(
+                        use_pickle=use_pickle,
+                        request_type=type(req).__name__,
+                        batched=batched,
+                    ):
+                        with patch.object(io_struct, "_USE_PICKLE_IPC", use_pickle):
+                            req.wrap_pickle_fields()
+                            payload = batch_type(batch=[req]) if batched else req
+                            decoded = _transport_round_trip(payload)
+                            decoded_req = decoded.batch[0] if batched else decoded
+                            decoded_req.unwrap_pickle_fields()
+
+                        self.assertIsInstance(decoded_req.time_stats, expected_type)
+                        self.assertEqual(
+                            decoded_req.time_stats.disagg_mode,
+                            DisaggregationMode.PREFILL,
+                        )
+                        self.assertFalse(
+                            decoded_req.time_stats.trace_ctx.tracing_enable
+                        )
+
+    def test_tracing_time_stats_with_128_bit_id_round_trip(self):
+        trace_state = {
+            "tracing_enable": True,
+            "last_span_context": {
+                "trace_id": (1 << 127) + 1,
+                "span_id": (1 << 63) + 1,
+            },
+        }
+
+        class FakeTraceContext:
+            tracing_enable = True
+
+            def __getstate__(self):
+                return trace_state
+
+        time_stats = APIServerReqTimeStats()
+        time_stats.trace_ctx = FakeTraceContext()
+        snapshot = time_stats.to_ipc()
+
+        request = TokenizedEmbeddingReqInput(
+            input_text="hello",
+            input_ids=array("i", [1, 2, 3]),
+            mm_inputs=None,
+            token_type_ids=None,
+            sampling_params=SamplingParams(),
+            time_stats=snapshot,
+        )
+
+        for use_pickle in (False, True):
+            with self.subTest(use_pickle=use_pickle):
+                with patch.object(io_struct, "_USE_PICKLE_IPC", use_pickle):
+                    decoded = _transport_round_trip(request)
+
+                encoded_span_context = decoded.time_stats.trace_ctx_state[
+                    "last_span_context"
+                ]
+                self.assertEqual(len(encoded_span_context["trace_id"]), 32)
+                self.assertEqual(len(encoded_span_context["span_id"]), 16)
+
+                decoded_trace_state = APIServerReqTimeStats._decode_trace_ctx_ids(
+                    decoded.time_stats.trace_ctx_state
+                )
+                self.assertEqual(
+                    decoded_trace_state["last_span_context"],
+                    trace_state["last_span_context"],
+                )
+
+    def test_scheduler_time_stats_round_trip_converts_clock(self):
+        with patch.object(
+            req_time_stats_module, "global_diff_realtime_monotonic", 100.0
+        ):
+            time_stats = SchedulerReqTimeStats(
+                enable_metrics=True,
+                wait_queue_entry_time=10.0,
+                forward_entry_time=12.0,
+                prefill_finished_time=14.0,
+            )
+            output = BatchEmbeddingOutput(
+                rids=["rid"],
+                http_worker_ipcs=[None],
+                finished_reasons=[None],
+                embeddings=[1.0],
+                prompt_tokens=[3],
+                cached_tokens=[1],
+                placeholder_tokens_idx=None,
+                placeholder_tokens_val=None,
+                retraction_counts=[0],
+                time_stats=[time_stats.to_ipc()],
+            )
+            sockets = {}
+            for use_pickle in (False, True):
+                with patch.object(io_struct, "_USE_PICKLE_IPC", use_pickle):
+                    socket = _LoopbackSocket()
+                    sock_send(socket, output)
+                    sockets[use_pickle] = socket
+
+        for use_pickle, socket in sockets.items():
+            with self.subTest(use_pickle=use_pickle):
+                with patch.object(
+                    req_time_stats_module, "global_diff_realtime_monotonic", 90.0
+                ), patch.object(io_struct, "_USE_PICKLE_IPC", use_pickle):
+                    decoded = sock_recv(socket)
+
+                decoded_time_stats = decoded.time_stats[0]
+                self.assertIsInstance(decoded_time_stats, SchedulerReqTimeStats)
+                self.assertEqual(decoded_time_stats.wait_queue_entry_time, 20.0)
+                self.assertEqual(decoded_time_stats.forward_entry_time, 22.0)
+                self.assertEqual(decoded_time_stats.prefill_finished_time, 24.0)
+                self.assertEqual(decoded_time_stats.diff_realtime_monotonic, 90.0)
+
+    def test_batch_token_id_output_time_stats_round_trip(self):
+        for use_pickle in (False, True):
+            with self.subTest(use_pickle=use_pickle):
+                output = _make_batch_token_id_output(
+                    SchedulerReqTimeStats(
+                        enable_metrics=True, wait_queue_entry_time=1.0
+                    ).to_ipc()
+                )
+                with patch.object(io_struct, "_USE_PICKLE_IPC", use_pickle):
+                    decoded = _transport_round_trip(output)
+
+                self.assertIsInstance(decoded, BatchTokenIDOutput)
+                self.assertIsInstance(decoded.time_stats[0], SchedulerReqTimeStats)
+                self.assertEqual(decoded.time_stats[0].wait_queue_entry_time, 1.0)
+
+    def test_scheduler_time_stats_omit_defaults(self):
+        snapshot = SchedulerReqTimeStats(
+            enable_metrics=True,
+            wait_queue_entry_time=10.0,
+            forward_entry_time=12.0,
+            prefill_finished_time=14.0,
+        ).to_ipc()
+
+        msgpack_state = msgspec.msgpack.decode(msgspec.msgpack.encode(snapshot))
+        self.assertEqual(
+            set(msgpack_state),
+            {
+                "type",
+                "wait_queue_entry_time",
+                "forward_entry_time",
+                "prefill_finished_time",
+                "diff_realtime_monotonic",
+            },
+        )
+
+        _, restore_args = snapshot.__reduce_ex__(pickle.HIGHEST_PROTOCOL)
+        self.assertEqual(
+            set(restore_args[1]),
+            {
+                "wait_queue_entry_time",
+                "forward_entry_time",
+                "prefill_finished_time",
+                "diff_realtime_monotonic",
+            },
+        )
+
+    def test_scheduler_time_stats_disabled_metrics_snapshot_is_empty(self):
+        time_stats = SchedulerReqTimeStats(
+            wait_queue_entry_time=10.0,
+            forward_entry_time=12.0,
+            prefill_finished_time=14.0,
+        )
+
+        snapshot = time_stats.to_ipc()
+
+        self.assertFalse(snapshot.enable_metrics)
+        self.assertEqual(snapshot.wait_queue_entry_time, 0.0)
+        self.assertEqual(snapshot.forward_entry_time, 0.0)
+        self.assertEqual(snapshot.prefill_finished_time, 0.0)
+        self.assertEqual(
+            msgspec.msgpack.decode(msgspec.msgpack.encode(snapshot)),
+            {"type": "SchedulerReqTimeStats"},
+        )
+
+    def test_new_from_obj_copies_shared_and_runtime_state(self):
+        metrics_collector = object()
+        api_time_stats = APIServerReqTimeStats(
+            enable_metrics=True,
+            disagg_mode=DisaggregationMode.DECODE,
+            diff_realtime_monotonic=1.0,
+            created_time=11.0,
+            api_server_dispatch_time=12.0,
+        )
+        api_time_stats.metrics_collector = metrics_collector
+
+        dp_time_stats = DPControllerReqTimeStats.new_from_obj(api_time_stats)
+        dp_time_stats.dpc_dispatch_time = 13.0
+        dp_time_stats_copy = DPControllerReqTimeStats.new_from_obj(dp_time_stats)
+        scheduler_time_stats = SchedulerReqTimeStats.new_from_obj(dp_time_stats)
+
+        self.assertTrue(scheduler_time_stats.enable_metrics)
+        self.assertEqual(scheduler_time_stats.disagg_mode, DisaggregationMode.DECODE)
+        self.assertEqual(scheduler_time_stats.diff_realtime_monotonic, 1.0)
+        self.assertIs(scheduler_time_stats.metrics_collector, metrics_collector)
+        self.assertIs(scheduler_time_stats.trace_ctx, api_time_stats.trace_ctx)
+        self.assertEqual(dp_time_stats.created_time, 11.0)
+        self.assertEqual(dp_time_stats.api_server_dispatch_time, 12.0)
+        self.assertEqual(dp_time_stats_copy.dpc_dispatch_time, 13.0)
+        self.assertEqual(scheduler_time_stats.created_time, 11.0)
+        self.assertEqual(scheduler_time_stats.api_server_dispatch_time, 12.0)
+        self.assertEqual(scheduler_time_stats.dpc_dispatch_time, 13.0)
 
 
 class TestGenerateReqInputNormalization(CustomTestCase):

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -92,6 +92,8 @@ def _make_batch_token_id_output(time_stats):
         output_token_ids_logprobs_val=None,
         output_token_ids_logprobs_idx=None,
         output_token_entropy_val=None,
+        output_token_sampling_mask=None,
+        output_token_sampling_logprobs=None,
         output_hidden_states=None,
         routed_experts=None,
         indexer_topk=None,

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import msgspec
 
 import sglang.srt.observability.req_time_stats as req_time_stats_module
+import sglang.srt.observability.trace as trace_module
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers import io_struct
 from sglang.srt.managers.io_struct import (
@@ -164,11 +165,13 @@ class TestReqTimeStatsTransport(CustomTestCase):
                         )
 
     def test_tracing_time_stats_with_128_bit_id_round_trip(self):
+        trace_id = (1 << 127) + 1
+        span_id = (1 << 63) + 1
         trace_state = {
             "tracing_enable": True,
             "last_span_context": {
-                "trace_id": (1 << 127) + 1,
-                "span_id": (1 << 63) + 1,
+                "trace_id": f"{trace_id:032x}",
+                "span_id": f"{span_id:016x}",
             },
         }
 
@@ -199,16 +202,82 @@ class TestReqTimeStatsTransport(CustomTestCase):
                 encoded_span_context = decoded.time_stats.trace_ctx_state[
                     "last_span_context"
                 ]
-                self.assertEqual(len(encoded_span_context["trace_id"]), 32)
-                self.assertEqual(len(encoded_span_context["span_id"]), 16)
-
-                decoded_trace_state = APIServerReqTimeStats._decode_trace_ctx_ids(
-                    decoded.time_stats.trace_ctx_state
-                )
                 self.assertEqual(
-                    decoded_trace_state["last_span_context"],
+                    encoded_span_context,
                     trace_state["last_span_context"],
                 )
+
+    def test_legacy_trace_state_relay_is_msgpack_safe(self):
+        trace_id = (1 << 127) + 1
+        span_id = (1 << 63) + 1
+        legacy_trace_state = {
+            "tracing_enable": True,
+            "last_span_context": {
+                "trace_id": trace_id,
+                "span_id": span_id,
+            },
+        }
+
+        with patch.object(trace_module, "opentelemetry_initialized", False):
+            constructed = APIServerReqTimeStats(trace_ctx_state=legacy_trace_state)
+            restored = APIServerReqTimeStats()
+            restored.__setstate__({"trace_ctx_state": legacy_trace_state})
+
+        for source, time_stats in (("constructor", constructed), ("state", restored)):
+            with self.subTest(source=source):
+                encoded = msgspec.msgpack.encode(time_stats.to_ipc())
+                decoded = msgspec.msgpack.decode(encoded)
+                span_context = decoded["trace_ctx_state"]["last_span_context"]
+                self.assertEqual(span_context["trace_id"], f"{trace_id:032x}")
+                self.assertEqual(span_context["span_id"], f"{span_id:016x}")
+
+        self.assertEqual(legacy_trace_state["last_span_context"]["trace_id"], trace_id)
+        self.assertEqual(legacy_trace_state["last_span_context"]["span_id"], span_id)
+
+    def test_time_stats_init_converts_clock_for_all_request_types(self):
+        with patch.object(
+            req_time_stats_module, "global_diff_realtime_monotonic", 90.0
+        ):
+            api_time_stats = APIServerReqTimeStats(
+                created_time=10.0,
+                diff_realtime_monotonic=100.0,
+            )
+            dp_time_stats = DPControllerReqTimeStats(
+                dpc_dispatch_time=10.0,
+                diff_realtime_monotonic=100.0,
+            )
+            empty_time_stats = APIServerReqTimeStats(
+                created_time=0.0,
+                diff_realtime_monotonic=100.0,
+            )
+
+        self.assertEqual(api_time_stats.created_time, 20.0)
+        self.assertEqual(dp_time_stats.dpc_dispatch_time, 20.0)
+        self.assertEqual(empty_time_stats.created_time, 0.0)
+        self.assertEqual(api_time_stats.diff_realtime_monotonic, 90.0)
+        self.assertEqual(dp_time_stats.diff_realtime_monotonic, 90.0)
+        self.assertEqual(empty_time_stats.diff_realtime_monotonic, 90.0)
+
+    def test_time_stats_setstate_converts_clock_without_mutating_state(self):
+        state = {
+            "disagg_mode": DisaggregationMode.DECODE.value,
+            "created_time": 10.0,
+            "trace_ctx": {"tracing_enable": False},
+            "diff_realtime_monotonic": 100.0,
+        }
+        with patch.object(
+            req_time_stats_module, "global_diff_realtime_monotonic", 90.0
+        ):
+            time_stats = APIServerReqTimeStats()
+            time_stats.__setstate__(state)
+
+        self.assertEqual(time_stats.disagg_mode, DisaggregationMode.DECODE)
+        self.assertEqual(time_stats.created_time, 20.0)
+        self.assertEqual(time_stats.diff_realtime_monotonic, 90.0)
+        self.assertEqual(state["disagg_mode"], DisaggregationMode.DECODE.value)
+        self.assertEqual(state["created_time"], 10.0)
+        self.assertIn("trace_ctx", state)
+        self.assertEqual(state["diff_realtime_monotonic"], 100.0)
 
     def test_scheduler_time_stats_round_trip_converts_clock(self):
         with patch.object(
@@ -316,33 +385,45 @@ class TestReqTimeStatsTransport(CustomTestCase):
             msgspec.msgpack.decode(msgspec.msgpack.encode(snapshot)),
             {"type": "SchedulerReqTimeStats"},
         )
+        pickle_snapshot = pickle.loads(pickle.dumps(snapshot))
+        self.assertFalse(pickle_snapshot.enable_metrics)
+        self.assertEqual(pickle_snapshot.wait_queue_entry_time, 0.0)
+        self.assertEqual(pickle_snapshot.forward_entry_time, 0.0)
+        self.assertEqual(pickle_snapshot.prefill_finished_time, 0.0)
+        self.assertEqual(pickle_snapshot.diff_realtime_monotonic, 0.0)
 
     def test_new_from_obj_copies_shared_and_runtime_state(self):
         metrics_collector = object()
-        api_time_stats = APIServerReqTimeStats(
-            enable_metrics=True,
-            disagg_mode=DisaggregationMode.DECODE,
-            diff_realtime_monotonic=1.0,
-            created_time=11.0,
-            api_server_dispatch_time=12.0,
-        )
+        with patch.object(
+            req_time_stats_module, "global_diff_realtime_monotonic", 100.0
+        ):
+            api_time_stats = APIServerReqTimeStats(
+                enable_metrics=True,
+                disagg_mode=DisaggregationMode.DECODE,
+                diff_realtime_monotonic=100.0,
+                created_time=11.0,
+                api_server_dispatch_time=12.0,
+            )
         api_time_stats.metrics_collector = metrics_collector
 
-        dp_time_stats = DPControllerReqTimeStats.new_from_obj(api_time_stats)
-        dp_time_stats.dpc_dispatch_time = 13.0
-        dp_time_stats_copy = DPControllerReqTimeStats.new_from_obj(dp_time_stats)
-        scheduler_time_stats = SchedulerReqTimeStats.new_from_obj(dp_time_stats)
+        with patch.object(
+            req_time_stats_module, "global_diff_realtime_monotonic", 90.0
+        ), patch.object(req_time_stats_module, "calibrate_time_diff"):
+            dp_time_stats = DPControllerReqTimeStats.new_from_obj(api_time_stats)
+            dp_time_stats.dpc_dispatch_time = 13.0
+            dp_time_stats_copy = DPControllerReqTimeStats.new_from_obj(dp_time_stats)
+            scheduler_time_stats = SchedulerReqTimeStats.new_from_obj(dp_time_stats)
 
         self.assertTrue(scheduler_time_stats.enable_metrics)
         self.assertEqual(scheduler_time_stats.disagg_mode, DisaggregationMode.DECODE)
-        self.assertEqual(scheduler_time_stats.diff_realtime_monotonic, 1.0)
+        self.assertEqual(scheduler_time_stats.diff_realtime_monotonic, 90.0)
         self.assertIs(scheduler_time_stats.metrics_collector, metrics_collector)
         self.assertIs(scheduler_time_stats.trace_ctx, api_time_stats.trace_ctx)
-        self.assertEqual(dp_time_stats.created_time, 11.0)
-        self.assertEqual(dp_time_stats.api_server_dispatch_time, 12.0)
+        self.assertEqual(dp_time_stats.created_time, 21.0)
+        self.assertEqual(dp_time_stats.api_server_dispatch_time, 22.0)
         self.assertEqual(dp_time_stats_copy.dpc_dispatch_time, 13.0)
-        self.assertEqual(scheduler_time_stats.created_time, 11.0)
-        self.assertEqual(scheduler_time_stats.api_server_dispatch_time, 12.0)
+        self.assertEqual(scheduler_time_stats.created_time, 21.0)
+        self.assertEqual(scheduler_time_stats.api_server_dispatch_time, 22.0)
         self.assertEqual(scheduler_time_stats.dpc_dispatch_time, 13.0)
 
 

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -1,16 +1,23 @@
 import unittest
+from array import array
 
 from sglang.test.ci.ci_register import register_cpu_ci
-from sglang.test.test_utils import maybe_stub_sgl_kernel
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.io_struct import BatchStrOutput
+from sglang.srt.managers.io_struct import (
+    BatchEmbeddingOutput,
+    BatchStrOutput,
+    msgpack_decode,
+    msgpack_encode,
+)
 from sglang.srt.managers.multi_tokenizer_mixin import (
     TokenizerWorker,
     _handle_output_by_index,
     get_tokenizer_worker_class,
 )
+from sglang.srt.observability.req_time_stats import SchedulerReqTimeStats
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -46,7 +53,7 @@ def _make_batch_str_output() -> BatchStrOutput:
         spec_correct_drafts_histogram=[[], []],
         finished_reasons=[None, {"type": "length"}],
         output_strs=["first", "second"],
-        output_ids=[[1], [2]],
+        output_ids=[array("i", [1]), array("i", [2])],
         prompt_tokens=[10, 20],
         completion_tokens=[1, 2],
         reasoning_tokens=[0, 0],
@@ -79,7 +86,7 @@ def _make_batch_str_output() -> BatchStrOutput:
     )
 
 
-class TestMultiTokenizerMixin(unittest.TestCase):
+class TestMultiTokenizerMixin(CustomTestCase):
     def test_batch_str_output_preserves_cached_tokens_details(self):
         output = _make_batch_str_output()
 
@@ -104,6 +111,45 @@ class TestMultiTokenizerMixin(unittest.TestCase):
     def test_get_tokenizer_worker_class_rejects_non_worker(self):
         with self.assertRaisesRegex(TypeError, "TokenizerWorker"):
             get_tokenizer_worker_class(InvalidServerArgs())
+
+    def test_batch_str_output_preserves_time_stats_after_msgpack(self):
+        output = _make_batch_str_output()
+        output.time_stats = [
+            SchedulerReqTimeStats(
+                enable_metrics=True, wait_queue_entry_time=1.0
+            ).to_ipc(),
+            SchedulerReqTimeStats(
+                enable_metrics=True, wait_queue_entry_time=2.0
+            ).to_ipc(),
+        ]
+
+        decoded = msgpack_decode(msgpack_encode(output))
+        single_output = _handle_output_by_index(decoded, 1)
+
+        self.assertEqual(len(single_output.time_stats), 1)
+        self.assertIsInstance(single_output.time_stats[0], SchedulerReqTimeStats)
+        self.assertEqual(single_output.time_stats[0].wait_queue_entry_time, 2.0)
+
+    def test_batch_embedding_output_preserves_time_stats(self):
+        output = BatchEmbeddingOutput(
+            rids=["rid-0", "rid-1"],
+            finished_reasons=[None, None],
+            embeddings=[[1.0], [2.0]],
+            prompt_tokens=[10, 20],
+            cached_tokens=[3, 4],
+            placeholder_tokens_idx=None,
+            placeholder_tokens_val=None,
+            time_stats=[
+                SchedulerReqTimeStats(wait_queue_entry_time=1.0),
+                SchedulerReqTimeStats(wait_queue_entry_time=2.0),
+            ],
+        )
+
+        single_output = _handle_output_by_index(output, 1)
+
+        self.assertEqual(len(single_output.time_stats), 1)
+        self.assertIsInstance(single_output.time_stats[0], SchedulerReqTimeStats)
+        self.assertEqual(single_output.time_stats[0].wait_queue_entry_time, 2.0)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_output_streamer_customized_info.py
+++ b/test/registered/unit/managers/test_output_streamer_customized_info.py
@@ -6,6 +6,7 @@ from sglang.srt.managers.io_struct import unwrap_from_pickle
 from sglang.srt.managers.scheduler_components.output_streamer import (
     _GenerationStreamAccumulator,
 )
+from sglang.srt.observability.req_time_stats import SchedulerReqTimeStats
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -36,7 +37,7 @@ class _FakeReq:
         self.reasoning_tokens = 0
         self.cached_tokens = 0
         self.retraction_count = 0
-        self.time_stats = None
+        self.time_stats = SchedulerReqTimeStats()
         self.mm_image_tokens = 0
         self.mm_audio_tokens = 0
         self.mm_video_tokens = 0

--- a/test/registered/unit/observability/test_trace.py
+++ b/test/registered/unit/observability/test_trace.py
@@ -1,6 +1,7 @@
 """Unit tests for trace.py — no server, no model loading."""
 
 import os
+import pickle
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -515,6 +516,48 @@ class TestTraceReqContextEnabled(unittest.TestCase):
         ctx2 = TraceReqContext(rid="req-2")
         ctx2.__setstate__(state)
         self.assertIsNotNone(ctx2.last_span_context)
+
+    def test_state_round_trip_with_128_bit_ids(self):
+        trace_id = (1 << 127) + 1
+        span_id = (1 << 63) + 1
+        ctx = mod.TraceReqContext(rid="req-1")
+        ctx.trace_req_start(ts=1000)
+        ctx.last_span_context = otel_trace.SpanContext(
+            trace_id=trace_id,
+            span_id=span_id,
+            is_remote=True,
+        )
+
+        state = ctx.__getstate__()
+        self.assertEqual(state["last_span_context"]["trace_id"], f"{trace_id:032x}")
+        self.assertEqual(state["last_span_context"]["span_id"], f"{span_id:016x}")
+
+        restored = object.__new__(mod.TraceReqContext)
+        restored.__setstate__(state)
+        self.assertEqual(restored.last_span_context.trace_id, trace_id)
+        self.assertEqual(restored.last_span_context.span_id, span_id)
+
+        pickle_restored = pickle.loads(pickle.dumps(ctx))
+        self.assertEqual(pickle_restored.last_span_context.trace_id, trace_id)
+        self.assertEqual(pickle_restored.last_span_context.span_id, span_id)
+        ctx.trace_req_finish(ts=2000)
+
+    def test_setstate_accepts_legacy_integer_ids(self):
+        trace_id = (1 << 127) + 1
+        span_id = (1 << 63) + 1
+        ctx = TraceReqContext(rid="req-1")
+        ctx.trace_req_start(ts=1000)
+        state = ctx.__getstate__()
+        state["last_span_context"] = {
+            "trace_id": trace_id,
+            "span_id": span_id,
+        }
+
+        restored = object.__new__(TraceReqContext)
+        restored.__setstate__(state)
+        self.assertEqual(restored.last_span_context.trace_id, trace_id)
+        self.assertEqual(restored.last_span_context.span_id, span_id)
+        ctx.trace_req_finish(ts=2000)
 
     def test_events_cache_partial_match(self):
         """Events outside the slice time range stay in cache."""


### PR DESCRIPTION
## Motivation
Part of #29465. Task 2

Makes request time_stats msgpack-native by removing their remaining PickleWrapper usage.

## Modifications

- Convert request time stats to tagged msgspec.Struct types and remove their PickleWrapper paths.
- Preserve tracing, cross-process clock conversion, pickle compatibility, and multi-tokenizer output handling.
- Add transport tests for pickle and msgpack across request/output variants, including 128-bit trace IDs and disabled metrics.

Scheduler IPC snapshot with metrics enabled:
- Before: 988 bytes; all 32 fields encoded, including defaults
- After: 153 bytes; only the type tag, three required timestamps, and clock offset encoded

## Accuracy Tests

Not applicable. This changes internal IPC serialization and does not affect model outputs.

## Speed Tests and Profiling

No end-to-end inference benchmark was run because model execution is unchanged. The representative scheduler snapshot above verifies that default fields are omitted from the serialized payload.

## Testing

- `PYTHONPATH=python python3 -m pytest test/registered/unit/observability/test_trace.py test/registered/unit/managers/test_io_struct.py test/registered/unit/managers/test_multi_tokenizer_mixin.py python/sglang/multimodal_gen/test/unit/test_disagg_trace.py -q` (97 passed, 16 subtests passed)
- `pre-commit run --all-files` (passed)
- `git diff --check` (passed)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29791248995](https://github.com/sgl-project/sglang/actions/runs/29791248995)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29791248876](https://github.com/sgl-project/sglang/actions/runs/29791248876)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
