### PR TITLE
[CI] increase XPU container shm-size from default 64MB to 8GB

### DIFF
--- a/scripts/ci/xpu/xpu_ci_start_container.sh
+++ b/scripts/ci/xpu/xpu_ci_start_container.sh
@@ -99,6 +99,7 @@ fi
 
 echo "Launching container: ${CONTAINER_NAME} from ${IMAGE}"
 docker run -dt \
+  --shm-size 8g \
   --group-add 992 \
   ${VIDEO_GID:+--group-add "${VIDEO_GID}"} \
   ${RENDER_GID:+--group-add "${RENDER_GID}"} \


### PR DESCRIPTION
## Motivation

The default Docker `/dev/shm` is 64 MB, which very less to handle VLM models, increase it 8GB for VLM image inference.

## Modifications

Added `--shm-size 8g` to the `docker run` command in `scripts/ci/xpu/xpu_ci_start_container.sh`. This is the single script used by both `pr-test-xpu.yml` and `nightly-test-intel.yml` to start the `ci_sglang_xpu` container.

## Accuracy Tests

No model forward code changed — CI infra fix only.

## Speed Tests and Profiling

No inference path changed.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28640185147](https://github.com/sgl-project/sglang/actions/runs/28640185147)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28646888406](https://github.com/sgl-project/sglang/actions/runs/28646888406)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->