### PR TITLE
[AMD] WIP - Set REQUEST_TIMEOUT=30 for AMD to deflake multimodal tests

### DIFF
--- a/scripts/ci/amd/amd_ci_exec.sh
+++ b/scripts/ci/amd/amd_ci_exec.sh
@@ -22,6 +22,13 @@ declare -A ENV_MAP=(
   # exception.
   [SGLANG_ENABLE_ASYNC_ASSERT]=0
   [SGLANG_USE_AITER]=1
+  # Multimodal preprocessing / media-fetch wait timeout (seconds). Default in code
+  # is 3-10s, which is too tight on AMD CI: the first aiter kernel JIT compile can
+  # block the server long enough that LLaVA image preprocessing hits
+  # asyncio.wait_for() and returns HTTP 500 (e.g. test_vision_chunked_prefill).
+  # Bumping it here is conservative (it only extends how long we wait, never changes
+  # numeric behavior) and stays scoped to AMD CI via docker exec -e.
+  [REQUEST_TIMEOUT]=30
 )
 
 # Conditionally add GPU_ARCHS only for mi35x


### PR DESCRIPTION
## Motivation

The scheduled AMD `PR Test (AMD)` runs have been intermittently failing on
`stage-b-test-1-gpu-small-amd`, most visibly on shard 11 in the last two
scheduled runs (runs `28613048730` and `28630801781`). The failing test is
`test/registered/vlm/test_vision_chunked_prefill.py`.

Root cause (from the job logs): the server's `/generate` returns HTTP 500 for
the larger multi-frame video request, because the LLaVA multimodal preprocessor
times out:

```
File ".../srt/multimodal/processors/llava.py", line 113, in
_process_single_image return await asyncio.wait_for(fut, timeout=timeout) asyncio.exceptions.TimeoutError
```
The client then receives an empty body (`JSONDecodeError: Expecting value`),
retries once, and the job exits 255.
The timeout is `int(os.environ.get("REQUEST_TIMEOUT", "10"))`. On AMD CI the
first `aiter` kernel JIT compile (`mha_batch_prefill_...`, ~77s in the logs)
blocks the server long enough that the default 10s preprocessing timeout is
exceeded — right before the failure we see repeated
`Health check failed. Server couldn't get a response from detokenizer` lines.
This is a flaky/environment issue, not a regression in the test or in
`llava.py` (neither file has had a functional change in months).
## Change
Add `REQUEST_TIMEOUT=30` to the `ENV_MAP` in `scripts/ci/amd/amd_ci_exec.sh`,
which is injected into the CI container via `docker exec -e`. The env is
inherited by `run_suite.py` → per-file test subprocess → `popen_launch_server`
(`os.environ.copy()`) → the server process that reads `REQUEST_TIMEOUT`.
## Scope / Impact
- Scoped to AMD CI only — this script is not used by CUDA / other-platform
  workflows, so no other platform is affected.
- `REQUEST_TIMEOUT` is a shared wait-timeout used by several multimodal
  processors (llava/moss_vl/mimo_audio) and media-download HTTP fetches in
  `utils/common.py`. Raising it only extends how long we wait before giving up;
  it does not change any numeric/inference behavior. Risk is low.
## Notes
This is a mitigation to stabilize CI. The underlying cause is aiter kernel JIT
compilation blocking the server; a proper fix would be to pre-compile / cache
that kernel so tests don't JIT during the run.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828319393](https://github.com/sgl-project/sglang/actions/runs/34828319393)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828318806](https://github.com/sgl-project/sglang/actions/runs/34828318806)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34828319074](https://github.com/sgl-project/sglang/actions/runs/34828319074)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->