### PR TITLE
For hybrid sliding-window (SWA) models the SWA KV pool is small and quickly

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -387,6 +387,11 @@ class Envs:
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)
     # Decode batches between SWA out-of-window evictions.
     SGLANG_SWA_EVICTION_INTERVAL = EnvInt(128)
+    # Persist SWA "islands" (the last window+page live SWA kv) into the radix tree,
+    # for both chunked-prefill and decode stages, so prompt AND generated regions
+    # become prefix-cache reusable. Out-of-window SWA kv is freed; full-layer kv is
+    # retained in tombstone nodes. Default on.
+    SGLANG_SWA_RADIX_CACHE_ISLAND = EnvBool(True)
     # For non-streaming requests, the scheduler still flushes intermediate
     # output batches to the tokenizer manager every N decoded tokens so that
     # `first_token_time`/TTFT can be recorded. Lower this (e.g. to 1) to get

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -23,6 +23,7 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.mem_cache.common import (
     maybe_cache_unfinished_req,
+    page_align_floor,
     release_kv_cache,
 )
 from sglang.srt.server_args import get_global_server_args
@@ -626,6 +627,63 @@ class SchedulerBatchResultProcessor:
             batch.reqs, batch.return_logprob, is_idle_batch=True
         )
 
+    def _maybe_cache_decode_swa_island(self, req: Req) -> None:
+        """Persist a sliding-window 'island' of the decode stream into the radix
+        tree every ``--chunked-prefill-size // 4`` generated tokens, so a later
+        request sharing this (prompt + generation) prefix can also hit the
+        kv-cache inside the decode region, not just the prompt region.
+
+        Mirrors chunked-prefill island creation; SWA-only. Relies on
+        ScheduleBatch._evict_swa having already freed the out-of-window SWA kv,
+        so the insert uses from_decode=True to avoid double-freeing.
+        """
+        if req.finished() or req.is_retracted:
+            return
+        if not envs.SGLANG_SWA_RADIX_CACHE_ISLAND.get():
+            return
+        tree_cache = self.tree_cache
+        if not tree_cache.supports_swa():
+            return
+        # Only SWARadixCache supports the from_decode island insert. SWAChunkCache
+        # (used when radix cache is disabled) also reports supports_swa() but its
+        # cache_unfinished_req has no from_decode path -> skip to avoid a TypeError.
+        if getattr(tree_cache, "is_chunk_cache", lambda: False)():
+            return
+        if getattr(req, "skip_radix_cache_insert", False):
+            return
+        # Island spacing: a quarter of the prefill chunk size (page-multiple).
+        chunked_prefill_size = get_global_server_args().chunked_prefill_size
+        if not chunked_prefill_size or chunked_prefill_size <= 0:
+            return
+        interval = chunked_prefill_size // 4
+        if interval <= 0:
+            return
+        # Fire once every `interval` tokens, at an interval-aligned seqlen.
+        if req.seqlen % interval != 0:
+            return
+        # Only persist COMMITTED, page-aligned KV into the tree. Using
+        # kv_committed_len (not seqlen) drops the in-flight tail token under
+        # overlap scheduling, and page_align_floor drops the last partial/live
+        # page. This matches the boundary cache_finished_req uses (RadixKey
+        # .page_aligned floors too), so the island never registers a live page
+        # the request still owns and writes -- which previously left one page
+        # counted in both available and evictable (pool memory leak at on_idle).
+        insert_len = page_align_floor(req.kv_committed_len, tree_cache.page_size)
+        if insert_len <= req.cache_protected_len:
+            # Nothing new beyond the already-locked prefix; skip to avoid lock churn.
+            return
+        # During decode, get_fill_ids() is limited by extend_range to the last
+        # extend window. Refresh full_untruncated_fill_ids to prompt+generation and
+        # point extend_range at the committed, page-aligned frontier, then restore
+        # it so the rest of decode processing is unaffected.
+        req._refresh_fill_ids()
+        saved_extend_range = req.extend_range
+        req.set_extend_range(0, insert_len)
+        try:
+            tree_cache.cache_unfinished_req(req, from_decode=True)
+        finally:
+            req.extend_range = saved_extend_range
+
     def process_batch_result_decode(
         self,
         batch: ScheduleBatch,
@@ -688,6 +746,11 @@ class SchedulerBatchResultProcessor:
             req.update_finish_state(new_accept_len)
 
             self._handle_finish_state_updated_req(req, batch, result, i, logits_output)
+
+            # Decode-stage SWA island: periodically persist a (window+page) live SWA
+            # island into the radix tree so the decode region becomes prefix-cache
+            # reusable too, mirroring chunked-prefill island creation.
+            self._maybe_cache_decode_swa_island(req)
 
             if req.return_logprob:
                 self._apply_decode_logprobs(

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -490,9 +490,7 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         )
         req.swa_prefix_lock_released = False
 
-    def cache_unfinished_req(
-        self, req: Req, chunked=False, from_decode=False
-    ) -> None:
+    def cache_unfinished_req(self, req: Req, chunked=False, from_decode=False) -> None:
         """Cache request when it is unfinished."""
         if self.disable:
             kv_indices = self.req_to_token_pool.req_to_token[
@@ -1270,9 +1268,7 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
                     # Eager prefill eviction: these newly-allocated SWA slots were
                     # not pre-freed by _evict_swa, so free them here. Full-layer KV
                     # stays in node.value (the tombstone node), preserving reuse.
-                    self.token_to_kv_pool_allocator.free_swa(
-                        value[:swa_tombstone_len]
-                    )
+                    self.token_to_kv_pool_allocator.free_swa(value[:swa_tombstone_len])
                 node = self._add_new_node(
                     node,
                     key[:swa_tombstone_len],

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -422,6 +422,7 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         value = params.value
         prev_prefix_len = params.prev_prefix_len
         swa_evicted_seqlen = params.swa_evicted_seqlen
+        free_swa_on_tombstone = params.free_swa_on_tombstone
 
         key, value = key.maybe_to_bigram_view(self.is_eagle, value)
         key = key.page_aligned(self.page_size)
@@ -431,7 +432,12 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
             value = torch.tensor(key.token_ids[: len(key)], dtype=torch.int64)
 
         prefix_len = self._insert_helper(
-            self.root_node, key, value, prev_prefix_len, swa_evicted_seqlen
+            self.root_node,
+            key,
+            value,
+            prev_prefix_len,
+            swa_evicted_seqlen,
+            free_swa_on_tombstone,
         )
         return InsertResult(prefix_len=prefix_len)
 
@@ -484,7 +490,9 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         )
         req.swa_prefix_lock_released = False
 
-    def cache_unfinished_req(self, req: Req, chunked=False) -> None:
+    def cache_unfinished_req(
+        self, req: Req, chunked=False, from_decode=False
+    ) -> None:
         """Cache request when it is unfinished."""
         if self.disable:
             kv_indices = self.req_to_token_pool.req_to_token[
@@ -506,6 +514,35 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         values = kv_indices[: len(radix_key)].to(dtype=torch.int64, copy=True)
         old_prefix_len = req.cache_protected_len
 
+        # Decide the SWA tombstone frontier + who frees the SWA kv for this insert.
+        eager_swa_evicted_seqlen = 0
+        eager_free_swa_on_tombstone = False
+        if from_decode:
+            # Decode-stage SWA island insert. ScheduleBatch._evict_swa has already
+            # freed this request's out-of-window SWA kv during decode, so we must
+            # NOT free again here (double-free). Reuse req.swa_evicted_seqlen as the
+            # tombstone frontier: [old_prefix_len, swa_evicted_seqlen) become
+            # tombstone nodes (full kv kept, swa already freed) and the live tail
+            # [swa_evicted_seqlen, L) is retained as a non-tombstone island so the
+            # decode region becomes prefix-cache reusable.
+            eager_swa_evicted_seqlen = req.swa_evicted_seqlen
+        elif envs.SGLANG_SWA_RADIX_CACHE_ISLAND.get():
+            # Chunked-prefill SWA island (gated by SGLANG_SWA_RADIX_CACHE_ISLAND).
+            # As each prefill chunk commits, tombstone + free the SWA kv of the tokens
+            # that have fallen outside the sliding window, keeping only the last
+            # (window + page) tokens the next chunk's attention still needs. The
+            # full-layer KV stays in the tombstone nodes, so prefix-cache hits are
+            # unaffected; here free_swa_on_tombstone=True because these SWA slots were
+            # just allocated and not pre-freed by ScheduleBatch._evict_swa.
+            target = (
+                (len(radix_key) - self.sliding_window_size - self.page_size)
+                // self.page_size
+            ) * self.page_size
+            target = max(target, req.swa_evicted_seqlen)
+            if target > old_prefix_len:
+                eager_swa_evicted_seqlen = target
+                eager_free_swa_on_tombstone = True
+
         # Radix Cache takes one ref in memory pool
         # Note: the insert function already frees the overlapped kv_indices
         result = self.insert(
@@ -513,8 +550,14 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
                 key=radix_key,
                 value=values,
                 prev_prefix_len=old_prefix_len,
+                swa_evicted_seqlen=eager_swa_evicted_seqlen,
+                free_swa_on_tombstone=eager_free_swa_on_tombstone,
             )
         )
+        if eager_free_swa_on_tombstone:
+            req.swa_evicted_seqlen = max(
+                req.swa_evicted_seqlen, eager_swa_evicted_seqlen
+            )
         new_prefix_len = result.prefix_len
 
         # The prefix indices could be updated, reuse it
@@ -1096,6 +1139,7 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         value,
         update_kv_after_len: int,
         swa_evicted_seqlen: int = 0,
+        free_swa_on_tombstone: bool = False,
     ) -> int:
         # Update the last access time from root to leaf, so that
         # swa will tombstone the node closer to root first
@@ -1222,6 +1266,13 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
                 and swa_evicted_seqlen < total_prefix_length + len(key)
             ):
                 swa_tombstone_len = swa_evicted_seqlen - total_prefix_length
+                if free_swa_on_tombstone:
+                    # Eager prefill eviction: these newly-allocated SWA slots were
+                    # not pre-freed by _evict_swa, so free them here. Full-layer KV
+                    # stays in node.value (the tombstone node), preserving reuse.
+                    self.token_to_kv_pool_allocator.free_swa(
+                        value[:swa_tombstone_len]
+                    )
                 node = self._add_new_node(
                     node,
                     key[:swa_tombstone_len],


### PR DESCRIPTION
# Support SWA radix cache island (decode + chunked-prefill)

## Summary

For hybrid sliding-window (SWA) models the SWA KV pool is small and quickly
becomes the binding constraint under high concurrency. Today the full-layer KV
of a prefix stays cache-reusable, but the SWA KV of tokens that have slid out of
the window is only reclaimed lazily, so the SWA pool saturates, requests get
**retracted** (evicted and recomputed), and effective concurrency collapses.

This PR persists SWA **"islands"** into the radix tree for both the
**chunked-prefill** and **decode** stages. As a prefill chunk commits (or every
`chunked_prefill_size // 4` generated tokens during decode), the request eagerly
**tombstones + frees** the SWA KV of the tokens outside the sliding window and
keeps only the last `window + page` live SWA tokens. The full-layer KV is
retained in the tombstone nodes, so prompt **and** generated regions stay
prefix-cache reusable, while the SWA pool is kept far from saturation.

Gated by `SGLANG_SWA_RADIX_CACHE_ISLAND` (default **on**).

![island_prefill_decode_stages](https://github.com/user-attachments/assets/847a0da7-9d0a-4c09-a406-fc79996495a6)

## Modifications

- `environ.py`: add `SGLANG_SWA_RADIX_CACHE_ISLAND` (`EnvBool(True)`).
- `mem_cache/swa_radix_cache.py`:
  - plumb `free_swa_on_tombstone` through `insert()` / `_insert_helper`; free the
    SWA slots of newly-created tombstone nodes when the caller has not pre-freed
    them (chunked-prefill path).
  - `cache_unfinished_req(..., from_decode=False)`: compute the SWA tombstone
    frontier -- `req.swa_evicted_seqlen` for the decode path (SWA already freed
    by `ScheduleBatch._evict_swa`, so `free_swa_on_tombstone=False`), or
    `len - window - page` for the chunked-prefill path
    (`free_swa_on_tombstone=True`).
- `managers/scheduler_components/batch_result_processor.py`: add
  `_maybe_cache_decode_swa_island(req)`, called per request in the decode result
  loop. It:
  - skips `SWAChunkCache` (returns `supports_swa()=True` but has no `from_decode`
    path -> would `TypeError`) and `skip_radix_cache_insert` requests;
  - fires every `chunked_prefill_size // 4` tokens;
  - **inserts only `page_align_floor(kv_committed_len)` KV** (drops the in-flight
    tail page -- the leak fix), snapshotting/restoring `extend_range` so the rest
    of decode is unaffected.

## Benchmark

`gemma-4-26B-A4B-it`, radix cache **enabled**, `--swa-full-tokens-ratio 0.1
--mem-fraction-static 0.85 --page-size 32 --attention-backend triton`, single
dedicated H800 (uncontended). Two `random-ids` workloads; for each, both runs are
on the same GPU with identical params and only `SGLANG_SWA_RADIX_CACHE_ISLAND`
differs.

### Workload -- 128 x (8192 in / 1024 out), seed 43

![benchmark](https://github.com/user-attachments/assets/f57df724-865c-4bf1-badb-eb5faf1955fb)

| Metric | ISLAND=0 (baseline) | ISLAND=1 (this PR) | Delta |
|---|---:|---:|---:|
| Successful requests | 128 | 128 | - |
| `pool memory leak detected` | n/a | **0** | ok |
| Benchmark duration (s) | 96.94 | **59.86** | **-38.3%** |
| Request throughput (req/s) | 1.32 | **2.14** | **+62.1%** |
| Output throughput (tok/s) | 640.60 | **1037.47** | **+62.0%** |
| Mean E2E latency (ms) | 48917 | 34778 | -28.9% |
| Mean TTFT (ms) | 32130 | 21983 | -31.6% |
| Mean TPOT (ms) | 52.61 | 27.77 | -47.2% |
| Retractions | 32 | **2** | -30 |
| Peak concurrency (running-req) | 20 | **41** | +105% |
| SWA saturation dwell (log lines with usage >=0.90) | 268 | 58 | -78% |

Both workloads show the same effect (~1.6x throughput, retractions collapse,
~2x concurrency, no leak), confirming the win is not workload-length specific.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28644978469](https://github.com/sgl-project/sglang/actions/runs/28644978469)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28947398293](https://github.com/sgl-project/sglang/actions/runs/28947398293)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->