### PR TITLE
[diffusion] feat: performance_mode=speed enables torch.compile by default

### DIFF
--- a/python/sglang/multimodal_gen/runtime/server_args_auto_tune.py
+++ b/python/sglang/multimodal_gen/runtime/server_args_auto_tune.py
@@ -73,6 +73,17 @@ class ServerArgsAutoTuner:
 
         if args.performance_mode == "speed":
             logger.info("Applying performance_mode=speed")
+            if not args.enable_torch_compile and not args.is_arg_explicitly_set(
+                "enable_torch_compile"
+            ):
+                # speed means fastest: compile by default. An explicit
+                # --enable-torch-compile false still wins (e.g. models where
+                # compile measures slower, like short-step Z-Image runs).
+                args.enable_torch_compile = True
+                logger.info(
+                    "performance_mode=speed enables torch.compile "
+                    "(pass --enable-torch-compile false to opt out)"
+                )
             if args.num_gpus >= 2 and self._can_apply_fsdp_policy(
                 require_memory_headroom=False
             ):

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -1477,6 +1477,40 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertFalse(args.text_encoder_cpu_offload)
         self.assertFalse(args.image_encoder_cpu_offload)
 
+    def test_speed_mode_enables_torch_compile_by_default(self):
+        args = self._from_dict_with_pipeline_config(
+            QwenImagePipelineConfig(),
+            kwargs={
+                "model_path": "Qwen/Qwen-Image",
+                "performance_mode": "speed",
+            },
+        )
+
+        self.assertTrue(args.enable_torch_compile)
+
+    def test_speed_mode_preserves_explicit_torch_compile_off(self):
+        args = self._from_dict_with_pipeline_config(
+            QwenImagePipelineConfig(),
+            kwargs={
+                "model_path": "Qwen/Qwen-Image",
+                "performance_mode": "speed",
+                "enable_torch_compile": False,
+            },
+        )
+
+        self.assertFalse(args.enable_torch_compile)
+
+    def test_auto_mode_leaves_torch_compile_off(self):
+        args = self._from_dict_with_pipeline_config(
+            QwenImagePipelineConfig(),
+            kwargs={
+                "model_path": "Qwen/Qwen-Image",
+                "performance_mode": "auto",
+            },
+        )
+
+        self.assertFalse(args.enable_torch_compile)
+
     def test_memory_mode_wan_uses_layerwise_offload(self):
         args = self._from_dict_with_pipeline_config(
             WanT2V480PConfig(),


### PR DESCRIPTION
## Motivation

`--performance-mode speed` configures GPU-resident execution (offloads off, FSDP/CFG-parallel policy) but leaves `torch.compile` off unless the user *also* passes `--enable-torch-compile`. In practice that split is easy to miss: auditing our cross-framework benchmark found several speed-intent deployments silently running eager DiTs. "speed" should mean fastest-by-default.

## Change

In the auto-tuner's speed branch, enable `torch.compile` when the user has not explicitly set it. An explicit `--enable-torch-compile false` still wins — that override matters in practice: on short-step models the compile overhead can measure *slower* end-to-end (e.g. Z-Image turbo 9-step on H100: 0.79 s eager vs 0.99 s compiled, ABAB ×2), so the opt-out stays first-class and is mentioned in the log line.

```
performance_mode=speed enables torch.compile (pass --enable-torch-compile false to opt out)
```

## Tests

- `test_speed_mode_enables_torch_compile_by_default`
- `test_speed_mode_preserves_explicit_torch_compile_off`
- `test_auto_mode_leaves_torch_compile_off`

(existing speed-mode residency tests unchanged and passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28644396170](https://github.com/sgl-project/sglang/actions/runs/28644396170)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28644395994](https://github.com/sgl-project/sglang/actions/runs/28644395994)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->