### PR TITLE
fix: serialize FanOutCommunicator queueing calls with a lock

### DIFF
--- a/python/sglang/srt/managers/communicator.py
+++ b/python/sglang/srt/managers/communicator.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
-from collections import deque
-from typing import Callable, Deque, Generic, List, Optional, TypeVar
+from typing import Callable, Generic, List, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -31,31 +30,35 @@ class FanOutCommunicator(Generic[T]):
         self._mode = mode
         self._result_event: Optional[asyncio.Event] = None
         self._result_values: Optional[List[T]] = None
-        self._ready_queue: Deque[asyncio.Event] = deque()
+        # Serialize queueing-mode callers. asyncio.Lock is FIFO-fair and atomic, which
+        # avoids the slot-handoff race a hand-rolled ready-queue had: a fresh caller
+        # could observe the just-freed slot (result_event is None and empty queue) and
+        # claim it before a woken waiter resumed, tripping its `assert result_event is
+        # None` and returning a 500 (see test_get_server_info_concurrent).
+        self._lock = asyncio.Lock()
 
         assert mode in ["queueing", "watching"]
 
     async def queueing_call(self, obj: T):
-        ready_event = asyncio.Event()
-        if self._result_event is not None or len(self._ready_queue) > 0:
-            self._ready_queue.append(ready_event)
-            await ready_event.wait()
-            assert self._result_event is None
-            assert self._result_values is None
+        # Shield the in-flight lifecycle from caller cancellation. If the caller is
+        # cancelled (e.g. client disconnect), _call keeps holding the lock until this
+        # request's response is fully received and the state is cleared, so the next
+        # caller cannot overwrite result_event/result_values and receive a stale
+        # response. Preserves the invariant: only one request is in flight at a time.
+        async def _call():
+            async with self._lock:
+                if obj is not None:
+                    self._send(obj)
 
-        if obj is not None:
-            self._send(obj)
+                self._result_event = asyncio.Event()
+                self._result_values = []
+                try:
+                    await self._result_event.wait()
+                    return self._result_values
+                finally:
+                    self._result_event = self._result_values = None
 
-        self._result_event = asyncio.Event()
-        self._result_values = []
-        await self._result_event.wait()
-        result_values = self._result_values
-        self._result_event = self._result_values = None
-
-        if len(self._ready_queue) > 0:
-            self._ready_queue.popleft().set()
-
-        return result_values
+        return await asyncio.shield(_call())
 
     async def watching_call(self, obj):
         if self._result_event is None:

--- a/test/registered/unit/managers/test_fanout_communicator.py
+++ b/test/registered/unit/managers/test_fanout_communicator.py
@@ -1,0 +1,91 @@
+import asyncio
+
+from sglang.srt.managers.communicator import FanOutCommunicator
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+async def _pump_until(predicate, max_ticks=200):
+    for _ in range(max_ticks):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("condition was never reached")
+
+
+async def _pump_until_lock_waiters(comm, count, max_ticks=200):
+    await _pump_until(
+        lambda: len(getattr(comm._lock, "_waiters", None) or ()) >= count,
+        max_ticks=max_ticks,
+    )
+
+
+def test_queueing_call_preserves_fifo_under_slot_steal_ordering():
+    # A fresh caller (C) is scheduled while the previous request's completion is still
+    # handing off to the queued waiter (B) -- i.e. before B resumes. The old
+    # ready-queue handoff let C observe the momentarily-empty slot and claim it before
+    # B, tripping B's `assert _result_event is None` and returning a 500 (see
+    # test_get_server_info_concurrent). The lock makes the handoff atomic and FIFO.
+    async def run():
+        sent = []
+        comm = FanOutCommunicator(send=sent.append, fan_out=1, mode="queueing")
+
+        task_a = asyncio.create_task(comm("A"))
+        await _pump_until(lambda: sent == ["A"])
+        task_b = asyncio.create_task(comm("B"))
+        await _pump_until_lock_waiters(comm, 1)
+
+        # Complete A and let C arrive in the same tick, before A's handoff to B settles.
+        comm.handle_recv("result-A")
+        task_c = asyncio.create_task(comm("C"))
+
+        # Drive to completion, delivering a reply to whoever legitimately holds the slot.
+        for _ in range(200):
+            await asyncio.sleep(0)
+            if comm._result_event is not None and not comm._result_event.is_set():
+                comm.handle_recv("result")
+            if task_a.done() and task_b.done() and task_c.done():
+                break
+
+        results = await asyncio.gather(task_a, task_b, task_c, return_exceptions=True)
+        for name, result in zip("ABC", results):
+            assert not isinstance(
+                result, BaseException
+            ), f"caller {name} failed: {result!r}"
+        # FIFO preserved: B is served before the later-arriving C.
+        assert sent == ["A", "B", "C"], sent
+
+    asyncio.run(run())
+
+
+def test_queueing_call_cancelled_request_does_not_contaminate_next_caller():
+    # If an in-flight caller is cancelled (e.g. client disconnect), its response is
+    # still in flight. The call is shielded so it keeps holding the lock until that
+    # response drains, so the next caller cannot send early and receive the stale
+    # response. Invariant: only one request is in flight at a time.
+    async def run():
+        sent = []
+        comm = FanOutCommunicator(send=sent.append, fan_out=1, mode="queueing")
+
+        task_a = asyncio.create_task(comm("A"))
+        await _pump_until(lambda: sent == ["A"])
+
+        task_a.cancel()
+        try:
+            await task_a
+        except asyncio.CancelledError:
+            pass
+
+        # The next caller must not send while A's response is still in flight.
+        task_b = asyncio.create_task(comm("B"))
+        await _pump_until_lock_waiters(comm, 1)
+        assert sent == ["A"], f"B sent before A's response drained: {sent}"
+
+        # A's response drains -> lock releases -> B may proceed with its own request.
+        comm.handle_recv("result-A")
+        await _pump_until(lambda: sent == ["A", "B"])
+        comm.handle_recv("result-B")
+        assert await task_b == ["result-B"]
+
+    asyncio.run(run())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

https://github.com/sgl-project/sglang/actions/runs/28640926727/job/84937744060?pr=29825 


this ci run reveal a concurrency issue in FanOutCommunicator:
 FanOutCommunicator.queueing_call had a non-atomic handoff between the active caller and the next queued caller.

  Example race:

  1. Request A is in flight.
  2. Request B arrives and waits in _ready_queue.
  3. A receives all responses, clears _result_event, pops B from _ready_queue, and sets B's ready event.
  4. Before B resumes, a new request C arrives.
  5. C sees _result_event is None and _ready_queue is empty, so it takes the slot and sets _result_event for C.
  6. B finally resumes and asserts _result_event is None, but it is now C's event.
  7. AssertionError -> request fails with 500.


## Modifications

fixed it by putting the whole “own the single in-flight slot” section of queueing_call() under one asyncio.Lock. Additionally, the in-flight lifecycle runs under asyncio.shield with a try/finally cleanup, so if the caller is cancelled (e.g. client disconnect) the request drains its response and clears state under the lock before releasing it — the next caller can't overwrite the slot and pick up a stale response. Trade-off: a cancelled call holds the lock until its response arrives; if the scheduler never responds the lock stays held, but that already breaks these calls regardless


## Accuracy Tests

added a test for this senario

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28647815629](https://github.com/sgl-project/sglang/actions/runs/28647815629)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28647815548](https://github.com/sgl-project/sglang/actions/runs/28647815548)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->