### PR TITLE
Avoid blocking EAGLE grammar mask uploads

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1535,7 +1535,9 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
             if vocab_mask is not None:
                 assert verify_input.grammar is not None
-                vocab_mask = vocab_mask.to(verify_input.retrieve_next_token.device)
+                vocab_mask = vocab_mask.to(
+                    verify_input.retrieve_next_token.device, non_blocking=True
+                )
                 # NOTE: otherwise, this vocab mask will be the one from the previous extend stage
                 # and will be applied to produce wrong results
                 batch.sampling_info.vocab_mask = None


### PR DESCRIPTION
## Summary

This changes the EAGLE verify path to upload the constrained-decoding vocabulary mask with `non_blocking=True`.

The mask is consumed later by GPU work on the same CUDA stream, so CUDA stream ordering is sufficient. The previous blocking `.to(device)` forced the Python scheduler thread to wait at the copy site via `cudaStreamSynchronize`.

## Why

When EAGLE speculative decoding is combined with grammar-constrained generation, `generate_token_bitmask` creates a CPU mask and `verify` copies it to the target device before sampling. In profiles this copy shows up as repeated host stalls under:

`eagle_worker_v2.py:verify -> Tensor.to -> aten::_to_copy -> aten::copy_ -> cudaStreamSynchronize`

Using a non-blocking copy avoids synchronizing the host immediately after materializing the mask and lets the later GPU consumer observe the normal stream dependency.

We basically move the sync down the line to the python/sglang/srt/managers/scheduler.py(1549): pop_and_process 
(which may also be a problem for a fully overlapped spec decoding since it is not really overlapped now and the sync point in pop_and_process makes us see the latency from the massive cudaGraphLaunch for verify, more details in https://github.com/sgl-project/sglang/issues/29960)

## Validation

- `python3 -m py_compile python/sglang/srt/speculative/eagle_worker_v2.py`
- Local H200 profiling with EAGLE + constrained decoding:
  - mask-upload `cudaStreamSynchronize`, TP0: ~320 ms total before -> ~0.2 ms after
  - mask-upload `cudaStreamSynchronize`, all 8 TP ranks: ~2.57 s aggregate before -> ~1.6 ms after
- Local latency benchmark on the same long-prompt constrained-decoding workload for GLM-5.1:
  - c1 p50: 1.400 s -> 1.320 s
  - c1 p90: 2.353 s -> 2.165 s
  - c4 p50: 3.305 s -> 3.012 s
  - c4 p90: 6.024 s -> 5.550 s







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28648932041](https://github.com/sgl-project/sglang/actions/runs/28648932041)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28648931997](https://github.com/sgl-project/sglang/actions/runs/28648931997)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->