### PR TITLE
Warn when Dumper may capture CUDA graph outputs

### DIFF
--- a/docs_new/docs/references/nightly_precision_regression.mdx
+++ b/docs_new/docs/references/nightly_precision_regression.mdx
@@ -55,6 +55,16 @@ Baselines are stored locally on disk and synced to a **HuggingFace dataset** so 
 | Dumper infrastructure | `python/sglang/srt/debug_utils/dumper.py` | Captures per-layer hidden states at runtime |
 | CI workflow | `.github/workflows/nightly-test-nvidia.yml` | Schedules the nightly job on 8×H200 |
 
+### Dumper and CUDA Graph
+
+The nightly test launches SGLang with `--disable-cuda-graph`,
+`--disable-piecewise-cuda-graph`, and `--disable-radix-cache` before enabling the
+Dumper through `POST /dumper/configure`. Keep these flags when adapting the
+workflow outside the test harness. The `DUMPER_*` path does not auto-disable
+cuda graph or warmup like the legacy `--debug-tensor-dump-output-folder` path,
+and HTTP configuration can enable dumping after graph capture has already
+happened.
+
 ---
 
 ## What Gets Dumped and Compared

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -237,6 +237,12 @@ class _Dumper:
     Then run the program:
     `DUMPER_ENABLE=1 python ...`
 
+    When using Dumper for precision debugging in SGLang, start the server with
+    `--disable-cuda-graph --skip-server-warmup` before enabling Dumper. Unlike
+    the legacy `--debug-tensor-dump-output-folder` path, `DUMPER_*` does not
+    auto-disable cuda graph or warmup, and HTTP configuration can enable dumping
+    after graph capture has already happened.
+
     Auto-cleanup old dumps before first write:
     `DUMPER_CLEANUP_PREVIOUS=1 python ...`
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -213,6 +213,7 @@ from sglang.srt.utils import (
     is_host_cpu_arm64,
     is_npu,
     log_info_on_rank0,
+    log_warning_on_rank0,
     monkey_patch_p2p_access_check,
     require_gathered_buffer,
     reserve_rope_cache_for_long_sequences,
@@ -308,6 +309,26 @@ UNBALANCED_MODEL_LOADING_TIMEOUT_S = 480  # leave more time for post data proces
 logger = logging.getLogger(__name__)
 
 _UNSET: Any = object()
+
+
+def _warn_if_dumper_may_capture_cuda_graph_outputs(server_args):
+    cuda_graph_config = server_args.cuda_graph_config
+    if cuda_graph_config is None:
+        return
+
+    if (
+        cuda_graph_config.decode.backend == Backend.DISABLED
+        and cuda_graph_config.prefill.backend == Backend.DISABLED
+    ):
+        return
+
+    log_warning_on_rank0(
+        logger,
+        "Dumper is enabled or configurable while cuda graph is still enabled. "
+        "DUMPER_* captures may include cuda-graph-replayed tensors instead of "
+        "fresh eager tensors. For precision debugging, pass --disable-cuda-graph "
+        "and --skip-server-warmup before enabling Dumper.",
+    )
 
 
 def resolve_language_model(model: nn.Module) -> nn.Module:
@@ -1614,6 +1635,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
 
         if dumper.may_enable:
+            _warn_if_dumper_may_capture_cuda_graph_outputs(self.server_args)
             dumper.apply_source_patches()
             dumper.register_non_intrusive_dumper(self.model)
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3149,6 +3149,22 @@ def log_info_on_rank0(logger, msg):
             logger.info(f"{msg} (rank-check failed: {e})")
 
 
+def log_warning_on_rank0(logger, msg):
+    from sglang.srt.distributed import get_tensor_model_parallel_rank
+
+    try:
+        if not torch.distributed.is_initialized():
+            logger.warning(msg)
+        elif get_tensor_model_parallel_rank() == 0:
+            logger.warning(msg)
+    except Exception as e:
+        if torch.distributed.is_initialized():
+            if torch.distributed.get_rank() == 0:
+                logger.warning(f"{msg} (rank-check failed: {e})")
+        else:
+            logger.warning(f"{msg} (rank-check failed: {e})")
+
+
 def log_debug_on_rank0(logger, msg):
     """
     Log a debug message only on tensor model parallel rank 0.


### PR DESCRIPTION
## Summary
- warn when the new Dumper path is enabled/configurable while cuda graph remains enabled
- document that DUMPER_* does not auto-disable cuda graph or warmup like the legacy tensor dump CLI path
- clarify the nightly precision regression workflow keeps cuda graph disabled before enabling Dumper through HTTP

## Motivation
This addresses the low-risk Dumper footgun discussed in #28479 without changing runtime behavior. HTTP configuration can enable Dumper after startup, so this PR warns and documents the requirement instead of mirroring the legacy auto-disable behavior.














<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28649871410](https://github.com/sgl-project/sglang/actions/runs/28649871410)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28649871245](https://github.com/sgl-project/sglang/actions/runs/28649871245)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->