### PR TITLE
Fix kv_b_proj channel scale broadcast when reshape hasn't run yet

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1563,6 +1563,9 @@ def channel_quant_to_tensor_quant(
     x_q_channel: torch.Tensor,
     x_s: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    # x_s may still be 1-D [N] if called before process_weights_after_loading reshapes it
+    if x_s.dim() == 1:
+        x_s = x_s.unsqueeze(-1)
     x_dq_channel = x_q_channel.to(torch.float32) * x_s
     x_q_tensor, scale = (
         scaled_fp8_quant(x_dq_channel)


### PR DESCRIPTION
## Motivation

Loading a Quark FP8 per-channel quantized MLA model (DeepSeek V2/V3, Kimi-K2.5, LongCat-Flash, Bailing MoE) crashes during weight loading with:

```
RuntimeError: The size of tensor a (512) must match the size of tensor b (4096) at non-singleton dimension 1
```

`post_load_weights()` calls `channel_quant_to_tensor_quant(weight, weight_scale)` on `kv_b_proj` at the end of `load_weights()`, before `quant_method.process_weights_after_loading()` has reshaped `weight_scale` from 1-D `[N]` to `[N, 1]`. The 1-D scale then broadcasts against the `[N, K]` weight along the wrong dimension.

## Modifications

- `channel_quant_to_tensor_quant` (`fp8_utils.py`): unsqueeze `x_s` to `[N, 1]` if still 1-D before the multiply. No-op if already 2-D, so no behavior change elsewhere.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28649213945](https://github.com/sgl-project/sglang/actions/runs/28649213945)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28649213714](https://github.com/sgl-project/sglang/actions/runs/28649213714)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->