### PR TITLE
Fix DP sync DSV4 SWA cache loc sizing

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1300,6 +1300,15 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             )
 
         self.out_cache_loc = self._pad_tensor_to_size(self.out_cache_loc, num_tokens)
+        if self.out_cache_loc_dsv4 is not None:
+            if self.out_cache_loc_dsv4.out_swa_loc.shape[0] > num_tokens:
+                self.out_cache_loc_dsv4.out_swa_loc = (
+                    self.out_cache_loc_dsv4.out_swa_loc[:num_tokens]
+                )
+            else:
+                self.out_cache_loc_dsv4.out_swa_loc = self._pad_tensor_to_size(
+                    self.out_cache_loc_dsv4.out_swa_loc, num_tokens
+                )
         if self.encoder_lens is not None:
             self.encoder_lens = self._pad_tensor_to_size(self.encoder_lens, bs)
         self.positions = self._pad_tensor_to_size(self.positions, num_tokens)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DP MLP sync can resize the token-level forward batch metadata to match the synchronized `num_tokens` used for collective communication.

For DSV4 on NPU, `out_cache_loc_dsv4.out_swa_loc` is also token-level metadata: each entry is the SWA KV slot for the corresponding output token. However, it was not resized together with `out_cache_loc`. When DP sync pads or shrinks the batch, `out_swa_loc` can become inconsistent with the synced token count, leaving stale SWA rows or missing padded rows.

This can break the invariant that token-level metadata arrays are aligned by token index.

## Modifications

Resize `out_cache_loc_dsv4.out_swa_loc` in `ForwardBatch._pad_inputs_to_size()` to match `num_tokens`.

- If `out_swa_loc` is longer than `num_tokens`, truncate it.
- If `out_swa_loc` is shorter than `num_tokens`, pad it with zeros using the existing `_pad_tensor_to_size()` helper.
- Only `out_swa_loc` is resized because it is raw-token-level metadata. The compressed DSV4 locations such as `out_c4_loc` and `out_c128_loc` have different granularities and should not be resized by raw `num_tokens`.


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28650710609](https://github.com/sgl-project/sglang/actions/runs/28650710609)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28650710451](https://github.com/sgl-project/sglang/actions/runs/28650710451)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->