### PR TITLE
Fix stale decode offload state on host allocation failure

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -139,7 +139,8 @@ class DecodeKVCacheOffloadManager:
             len(req.origin_input_ids) // self.page_size * self.page_size
         )
         state = self.offloaded_state.get(req.rid)
-        if state is None:
+        is_first_offload = state is None
+        if is_first_offload:
             prefill_hashes = self._compute_prefix_hash(
                 req.origin_input_ids[:prefill_offloaded_len]
             )
@@ -151,7 +152,6 @@ class DecodeKVCacheOffloadManager:
                 inc_len=0,
                 last_hash=last_prefill_hash,
             )
-            self.offloaded_state[req.rid] = state
         incremental_total = len(all_tokens) - state.prefill_len
         incremental_new = incremental_total - state.inc_len
         incremental_aligned_len = (
@@ -183,6 +183,9 @@ class DecodeKVCacheOffloadManager:
         if host_indices is None:
             logger.error(f"Not enough host memory for request {req.rid}")
             return False
+
+        if is_first_offload:
+            self.offloaded_state[req.rid] = state
 
         self._mark_offload_started(req.rid)
         self.ongoing_offload[ack_id] = (

--- a/test/registered/unit/disaggregation/test_decode_kvcache_offload_manager.py
+++ b/test/registered/unit/disaggregation/test_decode_kvcache_offload_manager.py
@@ -1,0 +1,42 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
+    DecodeKVCacheOffloadManager,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDecodeKVCacheOffloadManager(unittest.TestCase):
+    def test_host_write_failure_does_not_create_offload_state(self):
+        manager = DecodeKVCacheOffloadManager.__new__(DecodeKVCacheOffloadManager)
+        req = SimpleNamespace(
+            rid="rid-1",
+            req_pool_idx=0,
+            origin_input_ids=[1, 2, 3, 4],
+            output_ids=[5, 6],
+        )
+        manager.cache_controller = SimpleNamespace(write=lambda **kwargs: None)
+        manager.decode_host_mem_pool = object()
+        manager.page_size = 2
+        manager.offload_stride = 1
+        manager.request_counter = 0
+        manager.offloaded_state = {}
+        manager.ongoing_offload = {}
+        manager.req_to_token_pool = SimpleNamespace(
+            req_to_token=torch.arange(16, dtype=torch.int64).view(1, 16)
+        )
+        manager._compute_prefix_hash = lambda tokens, prior_hash="": ["h"]
+
+        self.assertFalse(manager.offload_kv_cache(req))
+
+        self.assertEqual(manager.ongoing_offload, {})
+        self.assertNotIn("rid-1", manager.offloaded_state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`offloaded_state` is used as the lifecycle marker for decode-side KV offload. Once a request is inserted into `self.offloaded_state`, later finish, idle, progress, and cleanup paths can treat that request as having an active decode offload lifecycle.

However, `offload_kv_cache()` created and inserted the first `OffloadedState` before confirming that the incremental KV write was accepted by the host cache. If `cache_controller.write()` failed, for example because the host KV pool had insufficient memory, the function returned `False` but the request still remained in `self.offloaded_state`.

That leaves an inconsistent state: the request looks partially offloaded to the scheduler/cleanup logic, but there is no accepted host write, no host indices, and no corresponding `ongoing_offload` entry. This can make later lifecycle handling follow the offloaded-request path even though the KV ownership never moved to host.

## Modifications

- Build the first `OffloadedState` locally, but only insert it into `self.offloaded_state` after `cache_controller.write()` succeeds.
- Keep the existing path unchanged for requests that already have an offload state.
- Add a unit test that simulates host write allocation failure and verifies that no `offloaded_state` or `ongoing_offload` entry is created.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28650710609](https://github.com/sgl-project/sglang/actions/runs/28650710609)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28650710451](https://github.com/sgl-project/sglang/actions/runs/28650710451)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->