### PR TITLE
Fix HIP import for 5090 diffusion canary

### DIFF
--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -912,14 +912,15 @@ def _make_5090_flux_layerwise_cpu_offload_case() -> DiffusionTestCase:
     )
 
 
-ONE_GPU_5090_CASES = _select_5090_canary_cases(
-    (
-        "zimage_image_t2i",
-        "flux_2_klein_base_image_t2i",
-        "wan2_1_t2v_1.3b",
-        "turbo_wan2_1_t2v_1.3b",
-    )
+ONE_GPU_5090_CANARY_CASE_IDS = (
+    "zimage_image_t2i",
+    "flux_2_klein_base_image_t2i",
+    "wan2_1_t2v_1.3b",
 )
+if not current_platform.is_hip():
+    ONE_GPU_5090_CANARY_CASE_IDS += ("turbo_wan2_1_t2v_1.3b",)
+
+ONE_GPU_5090_CASES = _select_5090_canary_cases(ONE_GPU_5090_CANARY_CASE_IDS)
 ONE_GPU_5090_CASES.append(_make_5090_flux_layerwise_cpu_offload_case())
 
 


### PR DESCRIPTION
## Summary
- `#29791` added a module-level 5090 diffusion canary list that always included `turbo_wan2_1_t2v_1.3b`.
- That TurboWan case is only registered in `ONE_GPU_CASES` on non-HIP platforms, so AMD/ROCm imports of `gpu_cases.py` failed before any multimodal-gen tests could run.
- Make the 5090 canary id tuple follow the same HIP guard as the TurboWan case registration, while keeping `_select_5090_canary_cases()` strict for unknown ids.

## Testing
- Local analysis: on HIP, `turbo_wan2_1_t2v_1.3b` is absent from `ONE_GPU_CASES`; after this patch it is also absent from `ONE_GPU_5090_CANARY_CASE_IDS`, so the module-level selector no longer sees an impossible case id.
- Local cheap checks:
  - `python3 -m py_compile python/sglang/multimodal_gen/test/server/gpu_cases.py`
  - AST guard check confirming TurboWan is present for non-HIP and omitted for HIP
  - strict selector retention check
  - `git diff --check`
  - commit pre-commit hooks passed
- Dispatched `PR Test (AMD)`: https://github.com/sgl-project/sglang/actions/runs/28652472033
- Dispatched `PR Test ROCm 7.2 (AMD)`: https://github.com/sgl-project/sglang/actions/runs/28652472107

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28652461664](https://github.com/sgl-project/sglang/actions/runs/28652461664)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28652461480](https://github.com/sgl-project/sglang/actions/runs/28652461480)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->