### PR TITLE
[diffusion] CI: fix AMD diffusion CI import

### DIFF
--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -912,14 +912,15 @@ def _make_5090_flux_layerwise_cpu_offload_case() -> DiffusionTestCase:
     )
 
 
-ONE_GPU_5090_CASES = _select_5090_canary_cases(
-    (
-        "zimage_image_t2i",
-        "flux_2_klein_base_image_t2i",
-        "wan2_1_t2v_1.3b",
-        "turbo_wan2_1_t2v_1.3b",
-    )
+ONE_GPU_5090_CANARY_CASE_IDS = (
+    "zimage_image_t2i",
+    "flux_2_klein_base_image_t2i",
+    "wan2_1_t2v_1.3b",
 )
+if not current_platform.is_hip():
+    ONE_GPU_5090_CANARY_CASE_IDS += ("turbo_wan2_1_t2v_1.3b",)
+
+ONE_GPU_5090_CASES = _select_5090_canary_cases(ONE_GPU_5090_CANARY_CASE_IDS)
 ONE_GPU_5090_CASES.append(_make_5090_flux_layerwise_cpu_offload_case())
 
 


### PR DESCRIPTION
## Summary

Fix an AMD diffusion CI import failure by keeping the 5090 canary case-id list aligned with the platform-gated base cases.

On ROCm, `turbo_wan2_1_t2v_1.3b` is intentionally skipped from `ONE_GPU_CASES` because its Triton shared-memory requirement exceeds AMD limits. The 5090 canary list still referenced that case unconditionally during module import, so `run_suite.py` failed before AMD CI could select its actual suite.

This keeps the existing NVIDIA/5090 coverage unchanged while avoiding the unavailable TurboWan case on AMD imports.

## Validation

- `python3 -m py_compile python/sglang/multimodal_gen/test/server/gpu_cases.py`
- `ruff check python/sglang/multimodal_gen/test/server/gpu_cases.py`
- `git diff --check`
- source sanity check for the ROCm-gated 5090 case-id list











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28657036721](https://github.com/sgl-project/sglang/actions/runs/28657036721)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28657036487](https://github.com/sgl-project/sglang/actions/runs/28657036487)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->