### PR TITLE
[Anthropic] Default thinking off when the thinking field is absent

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -594,6 +594,22 @@ class AnthropicServing:
                     "emitted to the client"
                 )
             self.openai_serving_chat.apply_reasoning_enabled(chat_request, enabled)
+        else:
+            # The Anthropic Messages API treats extended thinking as opt-in:
+            # an absent ``thinking`` field means off, regardless of the chat
+            # template's own default (Qwen3 etc. default
+            # ``enable_thinking=True``). Best-effort only: always-on
+            # reasoning models cannot be disabled, so keep them as-is
+            # instead of rejecting the request the way an explicit
+            # ``thinking: disabled`` does.
+            try:
+                self.openai_serving_chat.apply_reasoning_enabled(chat_request, False)
+            except ValueError:
+                logger.warning(
+                    "Anthropic request without a thinking field defaults to "
+                    "thinking off, but the reasoning parser is always-on; "
+                    "leaving reasoning enabled"
+                )
 
         # Claude 4.7 ``output_config``: map ``effort`` onto the OpenAI
         # ``reasoning_effort`` knob. ``xhigh`` collapses to ``max`` because

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -743,6 +743,38 @@ class TestAnthropicServing(unittest.TestCase):
             )
         self.assertIn("display", str(ctx.exception))
 
+    def test_request_without_thinking_defaults_reasoning_off(self):
+        """An absent ``thinking`` field means thinking off (Anthropic default),
+        regardless of the chat template's own default."""
+        serving = self._serving()
+        request = self._anthropic_request(stream=False)
+        serving._convert_to_chat_completion_request(request)
+        self.assertEqual(serving.openai_serving_chat.apply_reasoning_calls, [False])
+
+    def test_request_without_thinking_tolerates_always_on_parser(self):
+        """Default-off is best-effort: an always-on reasoning parser cannot be
+        disabled, so an absent ``thinking`` field must not reject the request
+        the way an explicit ``thinking: disabled`` does."""
+        import logging
+
+        class _AlwaysOnOpenAIServingChat(_FakeOpenAIServingChat):
+            def apply_reasoning_enabled(self, chat_request, enabled):
+                super().apply_reasoning_enabled(chat_request, enabled)
+                if not enabled:
+                    raise ValueError("always-on reasoning cannot be disabled")
+
+        serving = AnthropicServing(_AlwaysOnOpenAIServingChat())
+        request = self._anthropic_request(stream=False)
+        with self.assertLogs(
+            "sglang.srt.entrypoints.anthropic.serving", level=logging.WARNING
+        ) as log:
+            chat_request = serving._convert_to_chat_completion_request(request)
+        self.assertIsNotNone(chat_request)
+        self.assertTrue(
+            any("always-on" in r for r in log.output),
+            f"expected always-on warning: {log.output}",
+        )
+
     def test_request_thinking_disabled_with_budget_is_rejected(self):
         """SDK ``ThinkingConfigDisabledParam`` has no ``budget_tokens`` field."""
         from pydantic import ValidationError


### PR DESCRIPTION
## Motivation

Fixes #26620

The Anthropic Messages API treats extended thinking as **opt-in**: an absent `thinking` field means off. `/v1/messages` only called `apply_reasoning_enabled` when the field was present, so the chat template's own default won — Qwen3 and similar templates default `enable_thinking=True`, so every default request from the Anthropic SDK / Claude Code entered a long `<think>` phase, burning thousands of decode tokens even for trivial prompts.

The explicit `enabled`/`disabled`/`adaptive` translation was already fixed in #25876; when closing the superseded #26621, @hnyls2002 noted "the remaining default-off question (absent thinking field) is tracked in #26620". This PR covers exactly that remaining case.

## Modifications

- `python/sglang/srt/entrypoints/anthropic/serving.py`: when `anthropic_request.thinking` is absent, apply reasoning off. This is best-effort: always-on reasoning parsers cannot be disabled, so those keep reasoning on with a warning instead of rejecting the request the way an explicit `thinking: {"type": "disabled"}` does (which still 400s, unchanged).
- `test/registered/unit/entrypoints/anthropic/test_serving.py`: two new unit tests — absent field defaults reasoning off; absent field on an always-on parser succeeds with a warning instead of erroring.

## Checklist

- Ran the full unit test file on CPU (macOS):

```
$ python -m pytest test/registered/unit/entrypoints/anthropic/test_serving.py
61 passed
```

- `pre-commit run` on the changed files: all hooks pass.

This PR was authored with AI assistance (Claude Code); the diff was reviewed and tests were run locally as described above.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28660801739](https://github.com/sgl-project/sglang/actions/runs/28660801739)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28660801610](https://github.com/sgl-project/sglang/actions/runs/28660801610)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->