### PR TITLE
[diffusion] perf: shard masked/batched text across SP in QwenImage DiT

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -173,6 +173,65 @@ def _pad_shard_text_for_sp_varlen(
     return encoder_hidden_states, freqs_cis, joint_mask, gap_meta
 
 
+def _mask_shard_text_for_sp(
+    encoder_hidden_states: torch.Tensor,
+    freqs_cis: Optional[Tuple[torch.Tensor, torch.Tensor]],
+    text_key_mask: torch.Tensor,
+    image_seq_len: int,
+) -> Tuple[
+    torch.Tensor,
+    Optional[Tuple[torch.Tensor, torch.Tensor]],
+    torch.Tensor,
+    Dict[str, torch.Tensor],
+]:
+    """Shard a *padded, variable-length* text stream across SP ranks.
+
+    Masked counterpart of ``_pad_shard_text_for_sp_varlen``: used when the
+    request carries a per-row text validity mask (batched prompts of different
+    tokenized lengths). The text is right-padded to an SP multiple and evenly
+    sharded so the joint ``[text, image]`` sequence is fully sequence-parallel
+    (``num_replicated_prefix=0``) instead of the text being replicated on every
+    rank and recomputed there.
+
+    Validity is per row (not a single contiguous pad block), so the returned
+    metadata is a full varlen ``cu_seqlens`` mask (via ``build_varlen_mask_meta``)
+    rather than a single ``gap_start``/``gap_end``. Single-request (batch 1)
+    never reaches this path — the pipeline sends no mask when every row is full
+    length — so the single-request path is unchanged.
+    """
+    sp_size = get_sp_world_size()
+    t_real = text_key_mask.shape[1]
+    num_pad = (-t_real) % sp_size
+
+    if num_pad:
+        encoder_hidden_states = F.pad(encoder_hidden_states, (0, 0, 0, num_pad))
+        text_key_mask = F.pad(text_key_mask, (0, num_pad), value=False)
+        if freqs_cis is not None:
+            img_cache, txt_cache = freqs_cis
+            txt_cache = F.pad(txt_cache, (0, 0, 0, num_pad))
+            freqs_cis = (img_cache, txt_cache)
+
+    encoder_hidden_states, freqs_cis = _shard_text_for_sp(
+        encoder_hidden_states, freqs_cis
+    )
+    sp_rank = get_sp_parallel_rank()
+    text_mask_local = torch.chunk(text_key_mask, sp_size, dim=1)[sp_rank]
+
+    image_mask = torch.ones(
+        encoder_hidden_states.shape[0],
+        image_seq_len,
+        dtype=torch.bool,
+        device=encoder_hidden_states.device,
+    )
+    joint_mask = torch.cat([text_mask_local, image_mask], dim=1)
+    return (
+        encoder_hidden_states,
+        freqs_cis,
+        joint_mask,
+        build_varlen_mask_meta(joint_mask),
+    )
+
+
 def _get_qkv_projections(
     attn: "QwenImageCrossAttention", hidden_states, encoder_hidden_states=None
 ):
@@ -1508,18 +1567,43 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
                 device=hidden_states.device, dtype=torch.bool
             )
             batch_size, image_seq_len = hidden_states.shape[:2]
-            image_mask = torch.ones(
-                (batch_size, image_seq_len),
-                dtype=torch.bool,
-                device=hidden_states.device,
-            )
-            joint_mask = torch.cat([encoder_hidden_states_mask, image_mask], dim=1)
-            block_attention_kwargs["attn_mask"] = joint_mask
-            # Precompute varlen metadata once per request so every block reuses
-            # the same cu_seqlens / indices instead of rebuilding.
-            block_attention_kwargs["attn_mask_meta"] = build_varlen_mask_meta(
-                joint_mask
-            )
+            if sp_size > 1 and get_ring_parallel_world_size() == 1:
+                # Batched variable-length text under SP: shard the (masked) text
+                # across ranks instead of replicating it, so the joint sequence
+                # is fully sequence-parallel. The per-row validity is carried in
+                # the sharded joint varlen mask. Same machinery as the uneven
+                # no-mask branch below, just with the request's own text mask.
+                # (batch 1 sends no mask, so the single-request path is untouched;
+                # ring>1 keeps replicating — varlen masked path lacks ring support.)
+                (
+                    encoder_hidden_states,
+                    freqs_cis,
+                    joint_mask,
+                    joint_meta,
+                ) = _mask_shard_text_for_sp(
+                    encoder_hidden_states,
+                    freqs_cis,
+                    encoder_hidden_states_mask,
+                    image_seq_len,
+                )
+                sp_text_sharded = True
+                block_attention_kwargs["attn_mask"] = joint_mask
+                block_attention_kwargs["attn_mask_meta"] = joint_meta
+            else:
+                image_mask = torch.ones(
+                    (batch_size, image_seq_len),
+                    dtype=torch.bool,
+                    device=hidden_states.device,
+                )
+                joint_mask = torch.cat(
+                    [encoder_hidden_states_mask, image_mask], dim=1
+                )
+                block_attention_kwargs["attn_mask"] = joint_mask
+                # Precompute varlen metadata once per request so every block
+                # reuses the same cu_seqlens / indices instead of rebuilding.
+                block_attention_kwargs["attn_mask_meta"] = build_varlen_mask_meta(
+                    joint_mask
+                )
         elif sp_size > 1 and encoder_hidden_states.shape[1] % sp_size == 0:
             # Text divides evenly across SP ranks: plain even shard, no mask.
             encoder_hidden_states, freqs_cis = _shard_text_for_sp(

--- a/python/sglang/multimodal_gen/test/unit/test_qwen_sp_text_shard.py
+++ b/python/sglang/multimodal_gen/test/unit/test_qwen_sp_text_shard.py
@@ -1,0 +1,90 @@
+"""Unit test for masked/batched SP text sharding in the QwenImage DiT.
+
+Exercises ``_mask_shard_text_for_sp`` (used by the masked branch of the
+transformer forward under sequence parallelism) with the SP world-size/rank
+helpers mocked, so no GPU or distributed init is required. Verifies that the
+per-rank text shards + their validity masks reassemble to the original
+padded stream, i.e. every real text token is kept on exactly one rank and all
+padding is masked out.
+"""
+
+from unittest import mock
+
+import torch
+
+from sglang.multimodal_gen.runtime.models.dits import qwen_image as qi
+
+
+def _run_all_ranks(ehs, freqs_cis, key_mask, image_seq_len, sp_size):
+    """Collect (text_shard, joint_mask) from every SP rank."""
+    shards = []
+    for rank in range(sp_size):
+        with mock.patch.object(qi, "get_sp_world_size", return_value=sp_size), \
+             mock.patch.object(qi, "get_sp_parallel_rank", return_value=rank):
+            ehs_r, _, joint_mask, meta = qi._mask_shard_text_for_sp(
+                ehs.clone(), freqs_cis, key_mask.clone(), image_seq_len
+            )
+        shards.append((ehs_r, joint_mask, meta))
+    return shards
+
+
+def test_mask_shard_reassembles_padded_text():
+    torch.manual_seed(0)
+    sp_size = 2
+    b, t_real, dim, image_seq_len = 2, 7, 8, 4  # t_real=7 not divisible by 2
+    ehs = torch.randn(b, t_real, dim)
+    # row 0 valid len 7 (full), row 1 valid len 3 (variable-length batch)
+    key_mask = torch.zeros(b, t_real, dtype=torch.bool)
+    key_mask[0, :7] = True
+    key_mask[1, :3] = True
+
+    shards = _run_all_ranks(ehs, None, key_mask, image_seq_len, sp_size)
+
+    local_txt = shards[0][0].shape[1]
+    assert local_txt == ((t_real + sp_size - 1) // sp_size)  # padded/sp = 4
+    # text shards concatenate back to the padded text (real prefix intact)
+    text_cat = torch.cat([s[0] for s in shards], dim=1)
+    assert torch.allclose(text_cat[:, :t_real], ehs)
+
+    # per-rank joint mask = [text_local_validity | image_ones]
+    text_valid_cat = torch.cat(
+        [s[1][:, : s[0].shape[1]] for s in shards], dim=1
+    )
+    padded_mask = torch.zeros(b, local_txt * sp_size, dtype=torch.bool)
+    padded_mask[:, :t_real] = key_mask
+    assert torch.equal(text_valid_cat, padded_mask)  # exactly the real tokens kept
+
+    for _, joint_mask, _ in shards:
+        assert joint_mask.shape == (b, local_txt + image_seq_len)
+        assert joint_mask[:, local_txt:].all()  # image fully valid
+
+
+def test_even_length_no_padding():
+    sp_size = 2
+    b, t_real, dim, image_seq_len = 1, 8, 4, 2  # divisible
+    ehs = torch.randn(b, t_real, dim)
+    key_mask = torch.ones(b, t_real, dtype=torch.bool)
+    shards = _run_all_ranks(ehs, None, key_mask, image_seq_len, sp_size)
+    assert shards[0][0].shape[1] == 4
+    text_cat = torch.cat([s[0] for s in shards], dim=1)
+    assert torch.allclose(text_cat, ehs)  # no padding, exact split
+    for _, joint_mask, _ in shards:
+        assert joint_mask.all()  # all valid (full text + image)
+
+
+def test_rope_cache_sharded_with_text():
+    sp_size = 2
+    b, t_real, dim, image_seq_len = 1, 6, 4, 2
+    ehs = torch.randn(b, t_real, dim)
+    img_cache = torch.randn(image_seq_len, dim)
+    txt_cache = torch.randn(t_real, dim)
+    key_mask = torch.ones(b, t_real, dtype=torch.bool)
+    for rank in range(sp_size):
+        with mock.patch.object(qi, "get_sp_world_size", return_value=sp_size), \
+             mock.patch.object(qi, "get_sp_parallel_rank", return_value=rank):
+            _, freqs_cis, _, _ = qi._mask_shard_text_for_sp(
+                ehs.clone(), (img_cache, txt_cache), key_mask.clone(), image_seq_len
+            )
+        # txt RoPE cache is sharded to match the text; image cache untouched
+        assert freqs_cis[1].shape[0] == t_real // sp_size
+        assert torch.equal(freqs_cis[0], img_cache)


### PR DESCRIPTION
## Motivation

Under sequence parallelism (Ulysses/SP), the QwenImage transformer already shards the **text** stream across ranks for the no-mask paths (even split, and uneven pad-shard via `_pad_shard_text_for_sp_varlen`), making the joint `[text, image]` sequence fully sequence-parallel. But when a request carries a per-row text validity mask — batched prompts of **different tokenized lengths** — the forward fell into the masked branch, which **replicated the full text on every rank** (`num_replicated_prefix = seq_len_txt`) and recomputed it, leaving the joint sequence only partly sequence-parallel.

This wastes redundant text QKV + text-MLP compute on every SP rank, ×60 blocks, for the batched-serving path.

## Change

Add `_mask_shard_text_for_sp` (masked counterpart of `_pad_shard_text_for_sp_varlen`): right-pad the text to an SP multiple, evenly shard it and its RoPE cache, and carry the per-row validity in a **sharded joint varlen `cu_seqlens` mask** (`build_varlen_mask_meta`), with `num_replicated_prefix = 0`. The masked branch now shards instead of replicating when `sp_size > 1` and `ring == 1`.

It reuses the exact machinery of the already-shipped uneven-pad branch (sharded text + joint varlen mask + `sp_text_sharded=True`) — no new attention path.

## No regression by construction

- **Single-request (batch 1) is byte-for-byte unchanged**: the pipeline sends no text mask when every row is full length, so single-request never enters this branch.
- **`sp_size == 1` and `ring > 1` unchanged**: they keep the replicated path (the varlen masked path has no ring support).
- Consistent with existing behavior: the no-mask SP branch already shards text unconditionally, so this introduces no new sharding-vs-replication policy — it extends the same to the masked case.

## Validation

- **Unit test** (`test_qwen_sp_text_shard.py`, SP helpers mocked, no GPU): per-rank text shards + validity masks reassemble to the padded stream (every real token kept on exactly one rank, padding masked out), RoPE sharded with the text, even-length no-pad case exact.
- **2×H100, Ulysses (sp=2) + dynamic batching (max 2)**, two concurrent prompts of different lengths (→ text mask → this branch): both requests return **valid, distinct** 1024² images (decoded, sensible statistics).

### Note: a pre-existing, orthogonal dynamic-batch+SP log

While validating I saw the server log `Failed to split dynamic batched output cleanly ...` under dynamic-batch + SP. This reproduces **identically on `main` without this change** (baseline test: same log, and both requests still return valid images), so it is pre-existing and orthogonal to this PR — flagging it separately for a maintainer, not fixing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28661500720](https://github.com/sgl-project/sglang/actions/runs/28661500720)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28661500410](https://github.com/sgl-project/sglang/actions/runs/28661500410)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->