### PR TITLE
[router] Add --worker-api-key for introspection and KV-event discovery against api-key workers

### DIFF
--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -45,6 +45,12 @@ pub struct Cli {
     /// as the repo id (download honors `HF_TOKEN` / `HF_HOME`).
     #[arg(long)]
     pub tokenizer_path: Option<String>,
+    /// Api key sent as `Authorization: Bearer <key>` on router-originated
+    /// worker requests (`/server_info` introspection, KV-event discovery),
+    /// for fleets whose workers enforce `--api-key`. Proxied client
+    /// requests still forward the caller's own `authorization` header.
+    #[arg(long)]
+    pub worker_api_key: Option<String>,
     /// Routing policy.
     #[arg(long, value_enum, default_value = "round_robin")]
     pub policy: PolicyKind,
@@ -271,6 +277,7 @@ impl Cli {
             discovery,
             proxy: ProxyConfig {
                 request_timeout_secs: self.request_timeout_secs,
+                worker_api_key: self.worker_api_key,
             },
             active_load: ActiveLoadConfig {
                 stale_request_timeout_secs: self.stale_request_timeout_secs,
@@ -406,6 +413,23 @@ mod tests {
         .unwrap();
         assert_eq!(c.model.id, "Qwen/Qwen3-0.6B");
         assert_eq!(c.model.tokenizer_path, "Qwen/Qwen3-0.6B");
+    }
+
+    /// `--worker-api-key` lands in `proxy.worker_api_key`; absent by default.
+    #[test]
+    fn worker_api_key_flag_parses_into_proxy_config() {
+        let c = into_config(&[
+            "--model-id",
+            "qwen3",
+            "--worker-urls",
+            "http://x:30000",
+            "--worker-api-key",
+            "sk-test",
+        ])
+        .unwrap();
+        assert_eq!(c.proxy.worker_api_key.as_deref(), Some("sk-test"));
+        let c = into_config(&["--model-id", "qwen3", "--worker-urls", "http://x:30000"]).unwrap();
+        assert_eq!(c.proxy.worker_api_key, None);
     }
 
     #[test]

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -415,6 +415,24 @@ mod tests {
         assert_eq!(c.model.tokenizer_path, "Qwen/Qwen3-0.6B");
     }
 
+    /// Keys that cannot form a valid HTTP header value are rejected at
+    /// startup instead of silently producing an unauthenticated client.
+    #[test]
+    fn invalid_worker_api_key_is_rejected() {
+        let err = into_config(&[
+            "--model-id",
+            "qwen3",
+            "--worker-urls",
+            "http://x:30000",
+            "--worker-api-key",
+            "bad
+key",
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("worker-api-key"), "got: {err}");
+    }
+
     /// `--worker-api-key` lands in `proxy.worker_api_key`; absent by default.
     #[test]
     fn worker_api_key_flag_parses_into_proxy_config() {

--- a/experimental/sgl-router/src/config/mod.rs
+++ b/experimental/sgl-router/src/config/mod.rs
@@ -15,6 +15,18 @@ impl Config {
         if self.model.id.is_empty() {
             return Err(anyhow!("model id must be non-empty"));
         }
+        // A key that cannot form a valid HTTP header value would otherwise
+        // silently produce an unauthenticated client at runtime.
+        if let Some(key) = &self.proxy.worker_api_key {
+            if key.is_empty() {
+                return Err(anyhow!("--worker-api-key must be non-empty when set"));
+            }
+            if reqwest::header::HeaderValue::from_str(&format!("Bearer {key}")).is_err() {
+                return Err(anyhow!(
+                    "--worker-api-key contains characters that are not valid in an HTTP header value"
+                ));
+            }
+        }
         match &self.discovery {
             DiscoveryBackend::StaticUrls(s) => {
                 if s.urls.is_empty() {

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -21,12 +21,18 @@ pub struct Config {
 /// Outbound proxy tuning. Default mirrors SGLang's typical prefill /
 /// decode latency budget; e2e tests lower it so per-request failures
 /// trip the circuit breaker within the test's wall-time.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ProxyConfig {
     /// Maximum time to wait for a single upstream HTTP request to
     /// return headers + body. Default 300 s. The circuit breaker
     /// records a failure when this fires.
     pub request_timeout_secs: u64,
+    /// Api key sent as `Authorization: Bearer <key>` on router-originated
+    /// worker requests (`/server_info` introspection and KV-event
+    /// discovery), for fleets whose workers enforce `--api-key`.
+    /// Proxied client requests are unaffected: their inbound
+    /// `authorization` header is forwarded as-is.
+    pub worker_api_key: Option<String>,
 }
 
 pub fn default_proxy_request_timeout_secs() -> u64 {
@@ -37,6 +43,7 @@ impl Default for ProxyConfig {
     fn default() -> Self {
         Self {
             request_timeout_secs: default_proxy_request_timeout_secs(),
+            worker_api_key: None,
         }
     }
 }

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -21,7 +21,7 @@ pub struct Config {
 /// Outbound proxy tuning. Default mirrors SGLang's typical prefill /
 /// decode latency budget; e2e tests lower it so per-request failures
 /// trip the circuit breaker within the test's wall-time.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ProxyConfig {
     /// Maximum time to wait for a single upstream HTTP request to
     /// return headers + body. Default 300 s. The circuit breaker
@@ -37,6 +37,20 @@ pub struct ProxyConfig {
 
 pub fn default_proxy_request_timeout_secs() -> u64 {
     300
+}
+
+// Manual `Debug`: `worker_api_key` is a credential and must never appear in
+// logs or panic output, however `Config` gets printed.
+impl std::fmt::Debug for ProxyConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProxyConfig")
+            .field("request_timeout_secs", &self.request_timeout_secs)
+            .field(
+                "worker_api_key",
+                &self.worker_api_key.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 impl Default for ProxyConfig {

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -105,10 +105,21 @@ async fn main() -> Result<()> {
     // subscribers are ever added.
     let block_size_oracle = sgl_router::policies::kv_events::BlockSizeOracle::new();
     let kv_index = sgl_router::policies::kv_events::KvEventIndex::new_with_http_and_oracle(
-        reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(2))
-            .build()
-            .expect("default http client builds"),
+        {
+            let mut headers = reqwest::header::HeaderMap::new();
+            if let Some(key) = cfg.proxy.worker_api_key.as_deref() {
+                if let Ok(mut v) = reqwest::header::HeaderValue::from_str(&format!("Bearer {key}"))
+                {
+                    v.set_sensitive(true);
+                    headers.insert(reqwest::header::AUTHORIZATION, v);
+                }
+            }
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(2))
+                .default_headers(headers)
+                .build()
+                .expect("default http client builds")
+        },
         Arc::clone(&block_size_oracle),
     );
     let policies = Arc::new(

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -108,11 +108,12 @@ async fn main() -> Result<()> {
         {
             let mut headers = reqwest::header::HeaderMap::new();
             if let Some(key) = cfg.proxy.worker_api_key.as_deref() {
-                if let Ok(mut v) = reqwest::header::HeaderValue::from_str(&format!("Bearer {key}"))
-                {
-                    v.set_sensitive(true);
-                    headers.insert(reqwest::header::AUTHORIZATION, v);
-                }
+                let mut v = reqwest::header::HeaderValue::from_str(&format!("Bearer {key}"))
+                    .expect(
+                        "worker api key must be a valid HTTP header value (validated at startup)",
+                    );
+                v.set_sensitive(true);
+                headers.insert(reqwest::header::AUTHORIZATION, v);
             }
             reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(2))

--- a/experimental/sgl-router/src/workers/introspect.rs
+++ b/experimental/sgl-router/src/workers/introspect.rs
@@ -95,6 +95,23 @@ impl WorkerIntrospector {
         Self { client }
     }
 
+    /// Like [`Self::default`], but attach `Authorization: Bearer <key>`
+    /// as a default header on every introspection request, for fleets
+    /// whose workers enforce `--api-key`.
+    pub fn with_worker_api_key(key: &str) -> Self {
+        let mut headers = reqwest::header::HeaderMap::new();
+        if let Ok(mut v) = reqwest::header::HeaderValue::from_str(&format!("Bearer {key}")) {
+            v.set_sensitive(true);
+            headers.insert(reqwest::header::AUTHORIZATION, v);
+        }
+        let client = reqwest::Client::builder()
+            .timeout(SERVER_INFO_TIMEOUT)
+            .default_headers(headers)
+            .build()
+            .expect("introspector http client builds");
+        Self { client }
+    }
+
     /// Fetch `/server_info` for the worker.  Never returns an error:
     /// any failure is logged at `warn!` and yields a default
     /// `ServerInfo` with both halves `None`. Callers register the

--- a/experimental/sgl-router/src/workers/introspect.rs
+++ b/experimental/sgl-router/src/workers/introspect.rs
@@ -100,10 +100,10 @@ impl WorkerIntrospector {
     /// whose workers enforce `--api-key`.
     pub fn with_worker_api_key(key: &str) -> Self {
         let mut headers = reqwest::header::HeaderMap::new();
-        if let Ok(mut v) = reqwest::header::HeaderValue::from_str(&format!("Bearer {key}")) {
-            v.set_sensitive(true);
-            headers.insert(reqwest::header::AUTHORIZATION, v);
-        }
+        let mut v = reqwest::header::HeaderValue::from_str(&format!("Bearer {key}"))
+            .expect("worker api key must be a valid HTTP header value (validated at startup)");
+        v.set_sensitive(true);
+        headers.insert(reqwest::header::AUTHORIZATION, v);
         let client = reqwest::Client::builder()
             .timeout(SERVER_INFO_TIMEOUT)
             .default_headers(headers)

--- a/experimental/sgl-router/src/workers/manager.rs
+++ b/experimental/sgl-router/src/workers/manager.rs
@@ -69,15 +69,11 @@ pub async fn run_with_config(
     kv_index: Option<Arc<KvEventIndex>>,
     active_load: Option<Arc<ActiveLoadRegistry>>,
 ) {
-    run_with_introspector(
-        rx,
-        registry,
-        cfg,
-        kv_index,
-        active_load,
-        Arc::new(WorkerIntrospector::default()),
-    )
-    .await
+    let introspector = match cfg.as_ref().and_then(|c| c.proxy.worker_api_key.as_deref()) {
+        Some(key) => Arc::new(WorkerIntrospector::with_worker_api_key(key)),
+        None => Arc::new(WorkerIntrospector::default()),
+    };
+    run_with_introspector(rx, registry, cfg, kv_index, active_load, introspector).await
 }
 
 /// Internal entry point used by tests so they can supply a custom


### PR DESCRIPTION
## Motivation

The experimental router (`experimental/sgl-router`) calls each worker's `/server_info` without credentials, from two places: the worker-manager introspection (model ids, PD role) and the `cache_aware_zmq` KV-event discovery. Workers launched with `--api-key` return 401 on `/server_info`, so on a key-protected fleet the workers never join their model pool and the KV-event subscribers are never created; `cache_aware_zmq` silently degrades to min-load.

Inbound proxying is not affected (the client's `authorization` header is forwarded as-is); this is only about the router's own outbound calls.

## Modifications

- New optional `--worker-api-key` flag, stored as `ProxyConfig.worker_api_key` (`Copy` dropped for the `String` field; `Clone` kept).
- `WorkerIntrospector::with_worker_api_key` builds its client with a default `Authorization: Bearer <key>` header (marked sensitive); `run_with_config` selects it when the key is configured, `default()` otherwise.
- The KV-event discovery client built in `main.rs` carries the same default header.
- Proxied client requests are unchanged; per-request `authorization` headers still take precedence over client defaults in reqwest.
- Unit test: `worker_api_key_flag_parses_into_proxy_config`.

Validated against a live five-worker SGLang fleet running with `--api-key`: introspection resolves all workers and all five KV-event subscriptions come up (`kv-events: subscribing` with the right `block_size` and bigram detection); without the flag every `/server_info` call 401s. `cargo test` green (542 passed).

## Accuracy Tests

Not applicable (router-side config/auth only; no model forward changes).

## Speed Tests and Profiling

Not applicable (one default header on two internal HTTP clients).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29837309275](https://github.com/sgl-project/sglang/actions/runs/29837309275)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29837309101](https://github.com/sgl-project/sglang/actions/runs/29837309101)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->