### PR TITLE
Fix multi-tokenizer IPC stamping for batched tokenized requests

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1353,9 +1353,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             tokenized_obj.wrap_pickle_fields()
 
         if isinstance(tokenized_objs[0], TokenizedGenerateReqInput):
-            batch_req = BatchTokenizedGenerateReqInput(batch=tokenized_objs)
+            batch_req = BatchTokenizedGenerateReqInput(
+                batch=tokenized_objs,
+                rids=[tokenized_obj.rid for tokenized_obj in tokenized_objs],
+            )
         else:
-            batch_req = BatchTokenizedEmbeddingReqInput(batch=tokenized_objs)
+            batch_req = BatchTokenizedEmbeddingReqInput(
+                batch=tokenized_objs,
+                rids=[tokenized_obj.rid for tokenized_obj in tokenized_objs],
+            )
 
         self._dispatch_to_scheduler(batch_req)
         for tokenized_obj, time_stat in zip(tokenized_objs, time_stats):
@@ -3154,4 +3160,10 @@ def stamp_http_worker_ipc(obj: Any, ipc_name: str) -> None:
     if isinstance(obj, BaseReq):
         obj.http_worker_ipc = ipc_name
     elif isinstance(obj, BaseBatchReq):
+        if obj.rids is None and hasattr(obj, "batch"):
+            obj.rids = [req.rid for req in obj.batch]
         obj.http_worker_ipcs = [ipc_name] * len(obj.rids)
+        if hasattr(obj, "batch"):
+            for req in obj.batch:
+                if isinstance(req, BaseReq):
+                    req.http_worker_ipc = ipc_name

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -5,8 +5,18 @@ from sglang.test.test_utils import maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.io_struct import BatchStrOutput
+from sglang.srt.managers.io_struct import (
+    BatchStrOutput,
+    BatchTokenizedGenerateReqInput,
+    SamplingParams,
+    TokenizedGenerateReqInput,
+)
 from sglang.srt.managers.multi_tokenizer_mixin import _handle_output_by_index
+from sglang.srt.managers.tokenizer_manager import (
+    TokenizerManager,
+    stamp_http_worker_ipc,
+)
+from sglang.srt.observability.req_time_stats import APIServerReqTimeStats
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -50,7 +60,70 @@ def _make_batch_str_output() -> BatchStrOutput:
     )
 
 
+def _make_tokenized_generate_req(rid: str) -> TokenizedGenerateReqInput:
+    req = TokenizedGenerateReqInput(
+        rid=rid,
+        input_text="",
+        input_ids=[1, 2],
+        input_embeds=None,
+        mm_inputs=None,
+        token_type_ids=None,
+        sampling_params=SamplingParams(),
+        return_logprob=False,
+        logprob_start_len=0,
+        top_logprobs_num=0,
+        token_ids_logprob=None,
+        stream=False,
+    )
+    req.time_stats = APIServerReqTimeStats()
+    return req
+
+
 class TestMultiTokenizerMixin(unittest.TestCase):
+
+    def test_send_batch_request_sets_batch_rids(self):
+        tokenizer_manager = TokenizerManager.__new__(TokenizerManager)
+        dispatched = []
+        tokenizer_manager._dispatch_to_scheduler = dispatched.append
+
+        tokenizer_manager._send_batch_request(
+            [
+                _make_tokenized_generate_req("rid-0"),
+                _make_tokenized_generate_req("rid-1"),
+            ]
+        )
+
+        self.assertEqual(len(dispatched), 1)
+        self.assertEqual(dispatched[0].rids, ["rid-0", "rid-1"])
+
+    def test_stamp_http_worker_ipc_fills_batch_and_child_requests(self):
+        batch = BatchTokenizedGenerateReqInput(
+            batch=[
+                _make_tokenized_generate_req("rid-0"),
+                _make_tokenized_generate_req("rid-1"),
+            ]
+        )
+
+        stamp_http_worker_ipc(batch, "ipc-0")
+
+        self.assertEqual(batch.rids, ["rid-0", "rid-1"])
+        self.assertEqual(batch.http_worker_ipcs, ["ipc-0", "ipc-0"])
+        self.assertEqual(
+            [req.http_worker_ipc for req in batch.batch], ["ipc-0", "ipc-0"]
+        )
+
+    def test_stamp_http_worker_ipc_preserves_existing_batch_rids(self):
+        batch = BatchTokenizedGenerateReqInput(
+            rids=["existing-rid"],
+            batch=[_make_tokenized_generate_req("child-rid")],
+        )
+
+        stamp_http_worker_ipc(batch, "ipc-1")
+
+        self.assertEqual(batch.rids, ["existing-rid"])
+        self.assertEqual(batch.http_worker_ipcs, ["ipc-1"])
+        self.assertEqual(batch.batch[0].http_worker_ipc, "ipc-1")
+
     def test_batch_str_output_preserves_cached_tokens_details(self):
         output = _make_batch_str_output()
 


### PR DESCRIPTION
## Summary

This fixes a multi-tokenizer crash when batched tokenized requests are dispatched to the scheduler.

After the SenderWrapper removal, IPC stamping happens right before scheduler dispatch. For `BatchTokenizedGenerateReqInput` / `BatchTokenizedEmbeddingReqInput`, the batch wrapper could be created without `rids`, causing:

```text
TypeError: object of type 'NoneType' has no len()
```

when I use --tokenizer-worker-num 8 in prefill node of PD.
<img width="1294" height="786" alt="image" src="https://github.com/user-attachments/assets/3158f4ef-dbae-4c9d-a040-d214cea3de2d" />

## Changes
1.Populate rids when constructing batched tokenized generate / embedding requests.
2.Make stamp_http_worker_ipc() infer rids from obj.batch when missing.
3.Stamp http_worker_ipc on each child request inside the batch so scheduler routing remains correct.
4.Add unit coverage for batch rid population and multi-tokenizer IPC stamping.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28665460206](https://github.com/sgl-project/sglang/actions/runs/28665460206)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28665460030](https://github.com/sgl-project/sglang/actions/runs/28665460030)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->