### PR TITLE
perf(logits): drop redundant nonzero host-device sync in chunked input-logprob path

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -732,9 +732,6 @@ class LogitsProcessor(nn.Module):
             )
             global_indices = input_logprob_indices[chunk_mask]
             chunk_indices = global_indices - start_idx
-            # Get the positions in the original array where chunk_mask is True
-            # This is needed to correctly index into extend_input_logprob_token_ids_gpu
-            mask_indices = torch.nonzero(chunk_mask, as_tuple=True)[0]
 
             # Get the logits for this chunk
             chunk_states = pruned_states[start_idx:end_idx]
@@ -808,7 +805,7 @@ class LogitsProcessor(nn.Module):
                 torch.arange(
                     chunk_input_logprobs.shape[0], device=chunk_input_logprobs.device
                 ),
-                logits_metadata.extend_input_logprob_token_ids_gpu[mask_indices],
+                logits_metadata.extend_input_logprob_token_ids_gpu[chunk_mask],
             ]
             input_token_logprobs.append(chunk_input_token_logprobs)
 


### PR DESCRIPTION
## Motivation

Addresses part of #9889 (remove `torch.nonzero()` where it forces a host-device sync).

In `LogitsProcessor.process_input_logprobs_by_chunk`, every chunk iteration executes:

```python
mask_indices = torch.nonzero(chunk_mask, as_tuple=True)[0]
```

solely so it can gather `extend_input_logprob_token_ids_gpu[mask_indices]`. When `chunk_mask` is on CUDA, `torch.nonzero` triggers a **host-device synchronization** — its output length is data-dependent, so the GPU must drain and report the count back to the host, stalling the pipeline on the return-logprob prefill path.

## Modifications

For a 1-D boolean mask, `x[mask.nonzero(as_tuple=True)[0]]` is exactly equivalent to direct boolean indexing `x[mask]`. `extend_input_logprob_token_ids_gpu` is length-N in the same position space as `chunk_mask` (it is indexed 1:1 with the input-logprob rows in the non-chunked path, and built at `forward_batch_info.py`), so we can index it directly with `chunk_mask` and drop the intermediate `mask_indices` tensor entirely.

- Remove the `mask_indices = torch.nonzero(chunk_mask, as_tuple=True)[0]` line.
- Index `extend_input_logprob_token_ids_gpu[chunk_mask]` directly.

This removes one host-device sync (and one temporary tensor) per chunk iteration. The output is **byte-identical** — this is a pure, output-preserving micro-optimization.

Net diff: `+1 / -4` in `python/sglang/srt/layers/logits_processor.py`.

## Accuracy Tests

Output is unchanged by construction (the two indexing forms are provably equivalent for a 1-D boolean mask). The existing input-logprob tests exercise this path and should remain green:

- `test/registered/sampling/test_original_logprobs.py`
- `test/manual/test_logprobs.py`

The chunked branch is reached with chunked prefill enabled and a prompt longer than the chunk size with `return_logprob=True` (e.g. a small `--chunked-prefill-size`).

## Speed Tests and Profiling

Micro-optimization on the return-logprob prefill path: eliminates one `nonzero`-induced host-device sync per chunk iteration. No change to the steady-state decode path.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests. (No new test — output is provably identical; covered by existing logprob tests above.)
- [ ] Update documentation according to Write documentations. (N/A — no user-facing behavior change.)
- [ ] Provide accuracy and speed benchmark results. (N/A — output-preserving refactor.)
- [x] Follow the SGLang code style guidance.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28668148269](https://github.com/sgl-project/sglang/actions/runs/28668148269)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28668148117](https://github.com/sgl-project/sglang/actions/runs/28668148117)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->