### PR TITLE
[PP] Add all_gather_exclude to send/recv_tensor_dict for TP-sharded tensors

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -35,7 +35,7 @@ from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from datetime import timedelta
 from multiprocessing import shared_memory
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 from unittest.mock import patch
 
 import torch
@@ -1448,9 +1448,15 @@ class GroupCoordinator:
         dst: Optional[int] = None,
         all_gather_group: Optional["GroupCoordinator"] = None,
         async_send: bool = False,
+        all_gather_exclude: Optional[Set[str]] = None,
     ) -> Optional[List[P2PWork]]:
         """Send the input tensor dictionary.
         NOTE: `dst` is the local rank of the source rank.
+
+        `all_gather_exclude` lists keys of tensors that are NOT replicated
+        across `all_gather_group` (e.g. TP-sharded tensors). These tensors
+        are sent whole instead of using the send-slice/all-gather
+        optimization, which is only lossless for replicated tensors.
         """
         # Bypass the function if we are using only 1 GPU.
         if self.world_size == 1:
@@ -1482,13 +1488,21 @@ class GroupCoordinator:
         send_func = torch.distributed.isend if async_send else torch.distributed.send
         p2p_works = self.send_object(metadata_list, dst=dst, async_send=async_send)
 
-        for tensor in tensor_list:
+        # Keys of the tensors in `tensor_list`, in matching order.
+        tensor_keys = [
+            key for key, value in metadata_list if isinstance(value, TensorMetadata)
+        ]
+        for key, tensor in zip(tensor_keys, tensor_list):
             if tensor.numel() == 0:
                 # Skip sending empty tensors.
                 continue
 
             # send-allgather: send only a slice, then do allgather.
-            if all_gather_group is not None and tensor.numel() % all_gather_size == 0:
+            if (
+                all_gather_group is not None
+                and tensor.numel() % all_gather_size == 0
+                and (all_gather_exclude is None or key not in all_gather_exclude)
+            ):
                 tensor = tensor.reshape(all_gather_size, -1)[all_gather_rank]
 
             comm_group = metadata_group if tensor.is_cpu else group
@@ -1501,9 +1515,15 @@ class GroupCoordinator:
         self,
         src: Optional[int] = None,
         all_gather_group: Optional["GroupCoordinator"] = None,
+        all_gather_exclude: Optional[Set[str]] = None,
     ) -> Optional[Dict[str, Union[torch.Tensor, Any]]]:
         """Recv the input tensor dictionary.
         NOTE: `src` is the local rank of the source rank.
+
+        `all_gather_exclude` must match the value passed to
+        `send_tensor_dict` on the sending rank: the listed keys are received
+        whole instead of being reassembled with the slice/all-gather
+        optimization.
         """
         # Bypass the function if we are using only 1 GPU.
         if not torch.distributed.is_initialized() or self.world_size == 1:
@@ -1535,6 +1555,7 @@ class GroupCoordinator:
                 use_all_gather = (
                     all_gather_group is not None
                     and tensor.numel() % all_gather_size == 0
+                    and (all_gather_exclude is None or key not in all_gather_exclude)
                 )
 
                 if use_all_gather:

--- a/test/registered/unit/distributed/test_send_tensor_dict_all_gather_exclude.py
+++ b/test/registered/unit/distributed/test_send_tensor_dict_all_gather_exclude.py
@@ -1,0 +1,103 @@
+"""Unit tests for GroupCoordinator.send_tensor_dict / recv_tensor_dict with
+`all_gather_exclude` (issue #30015).
+
+When `all_gather_group` is passed, send/recv_tensor_dict send only a 1/N
+slice of each tensor and reassemble it on the receiver with an all-gather
+across the group. That optimization is only lossless for tensors replicated
+across the all-gather group; a TP-sharded tensor (different data per rank)
+gets reassembled from different ranks' slices into a corrupted tensor.
+`all_gather_exclude` opts such tensors out per key so they are sent whole.
+
+Runs 4 gloo CPU processes with tp=2 pp=2:
+    TP groups: [[0, 1], [2, 3]]    PP groups: [[0, 2], [1, 3]]
+PP stage-0 ranks (0, 1) send to stage-1 ranks (2, 3).
+"""
+
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, find_available_port
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+WORLD_SIZE = 4
+
+
+def _make_group(group_ranks, rank, name):
+    from sglang.srt.distributed.parallel_state import GroupCoordinator
+
+    return GroupCoordinator(
+        group_ranks=group_ranks,
+        local_rank=rank,
+        torch_distributed_backend="gloo",
+        use_pynccl=False,
+        use_pymscclpp=False,
+        use_custom_allreduce=False,
+        use_torch_symm_mem_all_reduce=False,
+        use_hpu_communicator=False,
+        use_xpu_communicator=False,
+        use_npu_communicator=False,
+        use_message_queue_broadcaster=False,
+        group_name=name,
+    )
+
+
+def _worker(rank, port):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.distributed.init_process_group(
+        backend="gloo", rank=rank, world_size=WORLD_SIZE
+    )
+    try:
+        tp = _make_group([[0, 1], [2, 3]], rank, "tp_test")
+        pp = _make_group([[0, 2], [1, 3]], rank, "pp_test")
+        tp_rank = tp.rank_in_group
+        is_sender = pp.rank_in_group == 0
+
+        # Different data per TP rank vs. identical across the TP group.
+        sharded = torch.full((2, 4), float(tp_rank + 1))
+        replicated = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+
+        # Round 1: sharded tensor opted out via all_gather_exclude, replicated
+        # tensor still using the slice/all-gather optimization. Both must
+        # round-trip exactly.
+        if is_sender:
+            pp.send_tensor_dict(
+                {"sharded": sharded, "replicated": replicated, "__msg_type__": "x"},
+                all_gather_group=tp,
+                all_gather_exclude={"sharded"},
+            )
+        else:
+            recv = pp.recv_tensor_dict(
+                all_gather_group=tp, all_gather_exclude={"sharded"}
+            )
+            assert torch.equal(recv["sharded"], sharded), recv["sharded"]
+            assert torch.equal(recv["replicated"], replicated), recv["replicated"]
+            assert recv["__msg_type__"] == "x"
+
+        # Round 2: without the exclude, the sharded tensor is reassembled
+        # from both TP ranks' slices — the documented corruption of #30015.
+        if is_sender:
+            pp.send_tensor_dict({"sharded": sharded}, all_gather_group=tp)
+        else:
+            recv = pp.recv_tensor_dict(all_gather_group=tp)
+            corrupted = torch.tensor([[1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]])
+            assert torch.equal(recv["sharded"], corrupted), recv["sharded"]
+
+        torch.distributed.barrier()
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+class TestSendTensorDictAllGatherExclude(CustomTestCase):
+    def test_all_gather_exclude_round_trip(self):
+        port = find_available_port(23000)
+        mp.spawn(_worker, args=(port,), nprocs=WORLD_SIZE, join=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #30015

With `pp>1` and `tp>1`, `GroupCoordinator.send_tensor_dict` applies the send-1/tp-slice + all-gather-on-receive optimization to **every** tensor in the dict. That is only lossless for tensors replicated across the all-gather group; a TP-sharded tensor (different data per rank) is silently reassembled from *different ranks'* slices into a wrong-but-plausible tensor — exactly as @Hakureirm's model-independent repro shows (`[1,...]` / `[2,...]` senders → both receivers get `[1,1,1,1,2,2,2,2]`).

I reproduced this on CPU (gloo, 4 processes, tp=2 × pp=2) with `GroupCoordinator` directly on current main — same corrupted interleaving — and verified the fix restores exact round-trips.

## Modifications

This implements **option 1 from the issue** (the backward-compatible per-key opt-out; the reporter offered both options and no maintainer preference was posted in the 0-comment thread):

- `python/sglang/srt/distributed/parallel_state.py`: `send_tensor_dict` / `recv_tensor_dict` gain `all_gather_exclude: Optional[Set[str]] = None`. Excluded keys skip the slice/all-gather path and are sent/received whole. Default `None` — zero behavior change for existing callers. The docstrings note the same exclude set must be passed on both sides (the set is not transmitted in metadata).
- `test/registered/unit/distributed/test_send_tensor_dict_all_gather_exclude.py`: registered CPU CI test spawning 4 gloo processes (tp=2/pp=2). Asserts (a) a TP-sharded tensor with `all_gather_exclude={"sharded"}` round-trips exactly, (b) a replicated tensor in the same dict still round-trips via the active optimization, and (c) documents the corrupted reassembly without the exclude — pinning the #30015 behavior.

If maintainers prefer option 2 (opt-in allowlist of `{"hidden_states", "residual"}`), happy to rework — this variant was chosen because it cannot regress perf or behavior for existing models. Wiring a model-side declaration of sharded proxy keys through `scheduler_pp_mixin` is left as a follow-up so this stays a contained, reviewable primitive fix.

## Checklist

- New test: 1 passed (~5s, CPU-only).
- `pytest test/registered/unit/distributed/ -q`: only pre-existing failures (verified identical with the change stashed; `test_vmm_utils.py` needs CUDA bindings).
- `pre-commit run` on changed files: all hooks pass.

This PR was authored with AI assistance (Claude Code); the diff was reviewed and tests were run locally as described above.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28674785172](https://github.com/sgl-project/sglang/actions/runs/28674785172)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28674784982](https://github.com/sgl-project/sglang/actions/runs/28674784982)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->