### PR TITLE
fix: gate DeepGEMM by supported CUDA architectures

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
@@ -14,12 +14,16 @@ _is_cuda = is_cuda()
 _is_musa = is_musa()
 
 
+def _is_deep_gemm_supported_cuda_arch(sm_version: int) -> bool:
+    """Return whether DeepGEMM implements this CUDA architecture family."""
+    return sm_version // 10 in (9, 10)
+
+
 def _compute_enable_deep_gemm():
     sm_version = get_device_sm()
-    if (_is_cuda and sm_version < 90) or (_is_musa and sm_version < 31):
+    if _is_cuda and not _is_deep_gemm_supported_cuda_arch(sm_version):
         return False
-    # DeepGEMM requires TMEM/tcgen05 (SM100+datacenter), not available on SM120
-    if sm_version == 120:
+    if _is_musa and sm_version < 31:
         return False
     if not (_is_cuda or _is_musa):
         return False

--- a/test/registered/unit/layers/deep_gemm_wrapper/test_configurer.py
+++ b/test/registered/unit/layers/deep_gemm_wrapper/test_configurer.py
@@ -1,0 +1,133 @@
+import builtins
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _EnvFlag:
+    def __init__(self, value: bool):
+        self._value = value
+
+    def get(self) -> bool:
+        return self._value
+
+
+def _load_configurer(
+    *,
+    sm_version: int = 0,
+    is_cuda: bool = False,
+    is_musa: bool = False,
+    env_enabled: bool = True,
+    deep_gemm_imports: list[str] | None = None,
+):
+    repo_root = next(
+        parent
+        for parent in Path(__file__).resolve().parents
+        if (parent / "python" / "sglang").is_dir()
+    )
+    module_path = (
+        repo_root
+        / "python"
+        / "sglang"
+        / "srt"
+        / "layers"
+        / "deep_gemm_wrapper"
+        / "configurer.py"
+    )
+
+    environ_stub = types.ModuleType("sglang.srt.environ")
+    environ_stub.envs = types.SimpleNamespace(
+        SGLANG_ENABLE_JIT_DEEPGEMM=_EnvFlag(env_enabled)
+    )
+    utils_stub = types.ModuleType("sglang.srt.utils")
+    utils_stub.get_device_sm = lambda: sm_version
+    utils_stub.is_cuda = lambda: is_cuda
+    utils_stub.is_musa = lambda: is_musa
+    utils_stub.is_sm100_supported = lambda: False
+
+    deep_gemm_stub = types.ModuleType("deep_gemm")
+    real_import = builtins.__import__
+
+    def tracked_import(name, *args, **kwargs):
+        if name == "deep_gemm" and deep_gemm_imports is not None:
+            deep_gemm_imports.append(name)
+        return real_import(name, *args, **kwargs)
+
+    spec = importlib.util.spec_from_file_location(
+        "_test_deep_gemm_configurer", module_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "sglang.srt.environ": environ_stub,
+                "sglang.srt.utils": utils_stub,
+                "deep_gemm": deep_gemm_stub,
+            },
+        ),
+        patch("builtins.__import__", side_effect=tracked_import),
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+class TestDeepGemmConfigurer(unittest.TestCase):
+    def test_cuda_architecture_allowlist(self):
+        configurer = _load_configurer()
+        self.assertTrue(
+            hasattr(configurer, "_is_deep_gemm_supported_cuda_arch"),
+            "configurer must expose a pure CUDA architecture predicate",
+        )
+        is_supported = configurer._is_deep_gemm_supported_cuda_arch
+
+        cases = {
+            80: False,
+            89: False,
+            90: True,
+            91: True,
+            100: True,
+            101: True,
+            103: True,
+            110: False,
+            120: False,
+            121: False,
+        }
+        for sm_version, expected in cases.items():
+            with self.subTest(sm_version=sm_version):
+                self.assertIs(is_supported(sm_version), expected)
+
+    def test_unsupported_cuda_arch_returns_before_importing_deep_gemm(self):
+        deep_gemm_imports = []
+
+        configurer = _load_configurer(
+            sm_version=121,
+            is_cuda=True,
+            env_enabled=True,
+            deep_gemm_imports=deep_gemm_imports,
+        )
+
+        self.assertFalse(configurer.ENABLE_JIT_DEEPGEMM)
+        self.assertEqual(deep_gemm_imports, [])
+
+    def test_musa_architecture_gate_is_unchanged(self):
+        for sm_version, expected in ((30, False), (31, True)):
+            with self.subTest(sm_version=sm_version):
+                configurer = _load_configurer(
+                    sm_version=sm_version,
+                    is_musa=True,
+                    env_enabled=True,
+                )
+                self.assertIs(configurer.ENABLE_JIT_DEEPGEMM, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- centralize the CUDA architecture support check used to enable DeepGEMM
- enable it only for NVIDIA architecture majors supported by the bundled DeepGEMM kernels (SM 9.x and 10.x)
- keep MUSA behavior unchanged and cover supported and unsupported architectures with CPU-only unit tests

## Motivation

On GB10 / SM121, deterministic batch-invariant inference reaches the DeepGEMM path even though the bundled DeepGEMM does not support this architecture. Server startup then fails during kernel compilation instead of selecting the existing persistent Triton implementation.

This change makes the capability decision before importing and configuring DeepGEMM. It also avoids a runtime catch-and-fallback path, so genuine failures on supported architectures remain visible.

## Validation

- focused unit tests: 3 passed, including 12 architecture subtests
- repository pre-commit hooks passed
- reproduced on GB10 / SM121 with deterministic batch-invariant ops; disabling the unsupported DeepGEMM subpath allows the persistent Triton path to initialize

## Scope

The static allowlist follows the architecture families accepted by the bundled DeepGEMM implementation: 90/91 and 100/101/103 are accepted; 80/89, 110, 120, and 121 are rejected.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28679212359](https://github.com/sgl-project/sglang/actions/runs/28679212359)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28679212235](https://github.com/sgl-project/sglang/actions/runs/28679212235)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->