### PR TITLE
Avoid blocking scheduler on health check send

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3466,15 +3466,14 @@ class Scheduler(
         self.metrics_reporter.update_device_timer()
 
     def maybe_send_health_check_signal(self):
-        if self.return_health_check_ipcs:
-            # Return some signal for the health check.
-            # This is used to prevent the health check signal being blocked by long context prefill.
-            # However, one minor issue is that this code path does not check the status of detokenizer manager.
-            self.ipc_channels.send_to_tokenizer.send_output(
-                HealthCheckOutput(
-                    http_worker_ipc=self.return_health_check_ipcs.popleft()
-                )
-            )
+        if not self.return_health_check_ipcs:
+            return
+        # Health checks are best-effort liveness signals; do not let a backed-up receiver block the scheduler loop.
+        http_worker_ipc = self.return_health_check_ipcs[0]
+        if self.ipc_channels.send_to_tokenizer.try_send_output(
+            HealthCheckOutput(http_worker_ipc=http_worker_ipc)
+        ):
+            self.return_health_check_ipcs.popleft()
 
     def add_external_corpus(
         self, recv_req: AddExternalCorpusReqInput

--- a/python/sglang/srt/managers/scheduler_components/output_sender.py
+++ b/python/sglang/srt/managers/scheduler_components/output_sender.py
@@ -26,3 +26,25 @@ class SenderWrapper:
             output.http_worker_ipc = recv_obj.http_worker_ipc
 
         sock_send(self.socket, output)
+
+    def try_send_output(
+        self,
+        output: Union[BaseReq, BaseBatchReq],
+        recv_obj: Optional[Union[BaseReq, BaseBatchReq]] = None,
+    ) -> bool:
+        """Best-effort send for liveness signals that must not block the scheduler."""
+        if self.socket is None:
+            return True
+
+        if (
+            isinstance(recv_obj, BaseReq)
+            and recv_obj.http_worker_ipc is not None
+            and output.http_worker_ipc is None
+        ):
+            output.http_worker_ipc = recv_obj.http_worker_ipc
+
+        try:
+            sock_send(self.socket, output, flags=zmq.NOBLOCK)
+        except zmq.Again:
+            return False
+        return True

--- a/test/registered/unit/managers/test_health_check_sender.py
+++ b/test/registered/unit/managers/test_health_check_sender.py
@@ -1,0 +1,95 @@
+"""Unit tests for best-effort HealthCheckOutput ZMQ send."""
+
+import unittest
+from collections import deque
+from unittest.mock import MagicMock
+
+import zmq
+
+from sglang.srt.managers.io_struct import HealthCheckOutput
+from sglang.srt.managers.scheduler_components.output_sender import SenderWrapper
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _maybe_send_health_check_signal(scheduler) -> None:
+    """Mirror of Scheduler.maybe_send_health_check_signal for unit testing."""
+    if not scheduler.return_health_check_ipcs:
+        return
+    http_worker_ipc = scheduler.return_health_check_ipcs[0]
+    if scheduler.ipc_channels.send_to_tokenizer.try_send_output(
+        HealthCheckOutput(http_worker_ipc=http_worker_ipc)
+    ):
+        scheduler.return_health_check_ipcs.popleft()
+
+
+class TestSenderWrapperTrySendOutput(CustomTestCase):
+    def test_try_send_output_returns_false_on_again(self):
+        socket = MagicMock()
+        socket.send_pyobj.side_effect = zmq.Again
+        wrapper = SenderWrapper(socket)
+
+        self.assertFalse(
+            wrapper.try_send_output(HealthCheckOutput(http_worker_ipc="ipc://test"))
+        )
+
+    def test_try_send_output_returns_true_on_success(self):
+        socket = MagicMock()
+        wrapper = SenderWrapper(socket)
+
+        self.assertTrue(
+            wrapper.try_send_output(HealthCheckOutput(http_worker_ipc="ipc://test"))
+        )
+        socket.send_pyobj.assert_called_once()
+        _, kwargs = socket.send_pyobj.call_args
+        self.assertEqual(kwargs.get("flags"), zmq.NOBLOCK)
+
+    def test_send_output_remains_blocking(self):
+        socket = MagicMock()
+        wrapper = SenderWrapper(socket)
+
+        wrapper.send_output(HealthCheckOutput(http_worker_ipc="ipc://test"))
+        socket.send_pyobj.assert_called_once()
+        _, kwargs = socket.send_pyobj.call_args
+        self.assertEqual(kwargs.get("flags", 0), 0)
+
+    def test_try_send_output_noop_when_socket_is_none(self):
+        wrapper = SenderWrapper(None)
+        self.assertTrue(wrapper.try_send_output(HealthCheckOutput()))
+
+    def test_try_send_output_propagates_non_again_errors(self):
+        socket = MagicMock()
+        socket.send_pyobj.side_effect = zmq.ZMQError()
+        wrapper = SenderWrapper(socket)
+
+        with self.assertRaises(zmq.ZMQError):
+            wrapper.try_send_output(HealthCheckOutput(http_worker_ipc="ipc://test"))
+
+
+class TestMaybeSendHealthCheckSignal(CustomTestCase):
+    def test_skips_tick_without_dropping_ipc_on_again(self):
+        scheduler = MagicMock()
+        scheduler.return_health_check_ipcs = deque(["ipc://worker-a"])
+        scheduler.ipc_channels.send_to_tokenizer.try_send_output.return_value = False
+
+        _maybe_send_health_check_signal(scheduler)
+
+        self.assertEqual(list(scheduler.return_health_check_ipcs), ["ipc://worker-a"])
+        scheduler.ipc_channels.send_to_tokenizer.try_send_output.assert_called_once()
+
+    def test_pops_ipc_only_after_successful_send(self):
+        scheduler = MagicMock()
+        scheduler.return_health_check_ipcs = deque(["ipc://worker-a", "ipc://worker-b"])
+        scheduler.ipc_channels.send_to_tokenizer.try_send_output.return_value = True
+
+        _maybe_send_health_check_signal(scheduler)
+
+        self.assertEqual(list(scheduler.return_health_check_ipcs), ["ipc://worker-b"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #29957.

This fixes a rare gRPC-mode decode scheduler deadlock where a scheduler rank can block indefinitely while sending `HealthCheckOutput`.

The confirmed stuck path is:

```text
event_loop_overlap_disagg_decode
  -> process_batch_result
  -> maybe_send_health_check_signal
  -> send_to_tokenizer.send_output
  -> socket.send_pyobj
  -> zmq_msg_send
```

`HealthCheckOutput` is only a liveness signal and does not carry request output or request lifecycle state. This PR makes only that health-check send best-effort with `zmq.NOBLOCK`. Normal scheduler output and control sends remain blocking.

## Modifications

- Add `SenderWrapper.try_send_output()` for best-effort nonblocking sends.
- Use it only in `maybe_send_health_check_signal()`.
- Keep the health-check IPC queued if the nonblocking send hits backpressure.
- Add CPU unit coverage for success, backpressure, no-op sender, blocking-send preservation, queue-pop behavior, and non-`Again` error propagation.

## Accuracy Tests

N/A. This change does not affect model outputs.

## Speed Tests and Profiling

N/A. This change is limited to the health-check liveness path and does not change normal decode output or request execution.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A for this internal scheduler fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). N/A because this change does not affect model outputs or inference speed.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Testing

```text
python -m pytest test/registered/unit/managers/test_health_check_sender.py -q
python -m py_compile python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/scheduler_components/output_sender.py test/registered/unit/managers/test_health_check_sender.py
python -m ruff check python/sglang/srt/managers/scheduler_components/output_sender.py test/registered/unit/managers/test_health_check_sender.py
python -m ruff format --check test/registered/unit/managers/test_health_check_sender.py
python3 scripts/ci/check_registered_tests.py
git diff --check
```















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28683528417](https://github.com/sgl-project/sglang/actions/runs/28683528417)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28683528384](https://github.com/sgl-project/sglang/actions/runs/28683528384)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->