### PR TITLE
fix(model_config): derive MLA scaling for MiniCPM3/DeepSeek-VL2/Kimi-VL and guard zero v_head_dim

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -712,7 +712,10 @@ class ModelConfig:
             setattr(self.hf_text_config, "head_dim", self.head_dim)
 
         self.v_head_dim = getattr(self.hf_text_config, "v_head_dim", None)
-        if self.v_head_dim is None:
+        # MLA-disabled checkpoints (e.g. deepseek-vl2-tiny) signal "no MLA" by
+        # zeroing the head-dim fields instead of omitting them, so fall back to
+        # head_dim on 0 as well as None to avoid a zero-width V cache.
+        if not self.v_head_dim:
             self.v_head_dim = self.head_dim
             setattr(self.hf_text_config, "v_head_dim", self.v_head_dim)
 
@@ -805,6 +808,10 @@ class ModelConfig:
             self.attention_arch = AttentionArch.MLA
             self.kv_lora_rank = self.hf_config.kv_lora_rank
             self.qk_rope_head_dim = self.hf_config.qk_rope_head_dim
+            self.qk_nope_head_dim = self.hf_config.qk_nope_head_dim
+            # MiniCPM3 uses the plain MLA softmax scale with no yarn mscale;
+            # mirror MiniCPM3Attention.scaling in models/minicpm3.py.
+            self.scaling = 1 / math.sqrt(self.qk_nope_head_dim + self.qk_rope_head_dim)
         elif "DeepseekVL2ForCausalLM" in self.hf_config.architectures and getattr(
             self.hf_text_config, "use_mla", True
         ):
@@ -813,6 +820,20 @@ class ModelConfig:
             self.kv_lora_rank = self.hf_text_config.kv_lora_rank
             self.qk_rope_head_dim = self.hf_text_config.qk_rope_head_dim
             self.qk_nope_head_dim = self.hf_text_config.qk_nope_head_dim
+            # VL2 (use_mla) runs a DeepseekV2 language model, so derive the MLA
+            # scale the same way, including yarn mscale.
+            self.scaling = 1 / math.sqrt(self.qk_nope_head_dim + self.qk_rope_head_dim)
+            rope_scaling = self.hf_text_config.rope_scaling
+            if rope_scaling:
+                rope_type = (
+                    rope_scaling.get("rope_type")
+                    or rope_scaling.get("type")
+                    or "default"
+                )
+                if rope_type != "default":
+                    self.scaling = compute_mla_mscale_scaling(
+                        rope_scaling, self.scaling
+                    )
         elif "KimiVLForConditionalGeneration" in self.hf_config.architectures:
             self.head_dim = 256
             self.attention_arch = AttentionArch.MLA
@@ -820,6 +841,20 @@ class ModelConfig:
             self.qk_rope_head_dim = self.hf_text_config.qk_rope_head_dim
             self.v_head_dim = self.hf_text_config.v_head_dim
             self.qk_nope_head_dim = self.hf_text_config.qk_nope_head_dim
+            # Kimi-VL runs a DeepseekV2 language model, so derive the MLA scale
+            # the same way, including yarn mscale.
+            self.scaling = 1 / math.sqrt(self.qk_nope_head_dim + self.qk_rope_head_dim)
+            rope_scaling = self.hf_text_config.rope_scaling
+            if rope_scaling:
+                rope_type = (
+                    rope_scaling.get("rope_type")
+                    or rope_scaling.get("type")
+                    or "default"
+                )
+                if rope_type != "default":
+                    self.scaling = compute_mla_mscale_scaling(
+                        rope_scaling, self.scaling
+                    )
         elif "KimiLinearForCausalLM" in self.hf_config.architectures:
             self.head_dim = 72
             self.attention_arch = AttentionArch.MLA

--- a/test/registered/unit/configs/test_model_config_scaling.py
+++ b/test/registered/unit/configs/test_model_config_scaling.py
@@ -1,11 +1,32 @@
 import math
 import unittest
+from types import SimpleNamespace
 
-from sglang.srt.configs.model_config import compute_mla_mscale_scaling
+from sglang.srt.configs.model_config import ModelConfig, compute_mla_mscale_scaling
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _make_mla_config(architectures, **overrides):
+    defaults = dict(
+        architectures=architectures,
+        model_type="mla",
+        hidden_size=4096,
+        num_attention_heads=32,
+        num_hidden_layers=2,
+        vocab_size=32000,
+        num_key_value_heads=32,
+        kv_lora_rank=512,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=64,
+        v_head_dim=128,
+        use_mla=True,
+        rope_scaling=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
 
 
 class TestMlaMscaleScaling(CustomTestCase):
@@ -46,6 +67,54 @@ class TestMlaMscaleScaling(CustomTestCase):
         self.assertEqual(
             compute_mla_mscale_scaling(rope_scaling, base_scaling), base_scaling
         )
+
+
+class TestModelConfigMlaScaling(CustomTestCase):
+    """MLA branches must derive model_config.scaling; FlashInferMLA reads it
+    unconditionally, so a missing value crashes those models at startup."""
+
+    def _derive(self, text_config):
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.hf_config = text_config
+        model_config.hf_text_config = text_config
+        model_config._derive_model_shapes()
+        return model_config
+
+    def test_minicpm3_sets_plain_mla_scaling(self):
+        # MiniCPM3 has no yarn mscale: plain 1/sqrt(qk_nope + qk_rope).
+        model_config = self._derive(
+            _make_mla_config(
+                ["MiniCPM3ForCausalLM"], qk_nope_head_dim=96, qk_rope_head_dim=32
+            )
+        )
+        self.assertAlmostEqual(model_config.scaling, 1 / math.sqrt(96 + 32))
+
+    def test_deepseek_vl2_mla_sets_scaling(self):
+        model_config = self._derive(
+            _make_mla_config(["DeepseekVL2ForCausalLM"], use_mla=True)
+        )
+        self.assertAlmostEqual(model_config.scaling, 1 / math.sqrt(128 + 64))
+
+    def test_kimi_vl_sets_scaling(self):
+        model_config = self._derive(
+            _make_mla_config(["KimiVLForConditionalGeneration"])
+        )
+        self.assertAlmostEqual(model_config.scaling, 1 / math.sqrt(128 + 64))
+
+    def test_kimi_vl_applies_yarn_mscale(self):
+        # VL2/Kimi-VL run a DeepseekV2 language model, so yarn mscale applies
+        # and pushes the scale above the plain base value.
+        rope_scaling = {
+            "rope_type": "deepseek_yarn",
+            "factor": 128,
+            "mscale_all_dim": 1,
+        }
+        model_config = self._derive(
+            _make_mla_config(
+                ["KimiVLForConditionalGeneration"], rope_scaling=rope_scaling
+            )
+        )
+        self.assertGreater(model_config.scaling, 1 / math.sqrt(128 + 64))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/configs/test_model_config_shapes.py
+++ b/test/registered/unit/configs/test_model_config_shapes.py
@@ -66,6 +66,23 @@ class TestModelConfigShapes(CustomTestCase):
         self.assertEqual(model_config.swa_head_dim, 64)
         self.assertEqual(model_config.swa_v_head_dim, 48)
 
+    def test_zero_v_head_dim_falls_back_to_head_dim(self):
+        # deepseek-vl2-tiny (MLA disabled) zeroes v_head_dim instead of omitting
+        # it; it must fall back to head_dim rather than size a zero-width V cache.
+        text_config = _make_text_config(
+            architectures=["DeepseekVL2ForCausalLM"],
+            model_type="deepseek_vl_v2",
+            head_dim=None,
+            v_head_dim=0,
+            use_mla=False,
+        )
+
+        model_config = self._derive_shapes(text_config)
+
+        self.assertEqual(model_config.head_dim, 128)
+        self.assertEqual(model_config.v_head_dim, 128)
+        self.assertEqual(text_config.v_head_dim, 128)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #29891 and #29889 — two `ModelConfig._derive_model_shapes` bugs.

**#29891** — The `MiniCPM3ForCausalLM`, `DeepseekVL2ForCausalLM` (`use_mla`), and `KimiVLForConditionalGeneration` branches set `attention_arch = AttentionArch.MLA` but never set `self.scaling`. `FlashInferMLAAttnBackend` reads `model_config.scaling` unconditionally, so these models crash at startup:

```
File ".../sglang/srt/layers/attention/flashinfer_mla_backend.py", line 766, in __init__
    self.scaling = model_runner.model_config.scaling
AttributeError: 'ModelConfig' object has no attribute 'scaling'
```

**#29889** — `v_head_dim` fell back to `head_dim` only when it was `None`. MLA-disabled checkpoints (e.g. `deepseek-vl2-tiny`, which is `DeepseekV2ForCausalLM` with `use_mla: false`) *zero* the head-dim fields instead of omitting them, so `v_head_dim` stayed `0`, sizing a zero-width MHA V cache and crashing at warmup:

```
RuntimeError: shape mismatch: value tensor of shape [432, 10, 128] cannot be
broadcast to indexing result of shape [432, 10, 0]
```

## Modifications

- **MiniCPM3**: derive `self.scaling = 1 / sqrt(qk_nope + qk_rope)` with **no** yarn mscale, matching `MiniCPM3Attention.scaling` in `models/minicpm3.py`.
- **DeepSeek-VL2 (`use_mla`)** and **Kimi-VL**: both delegate their language model to `DeepseekV2ForCausalLM`, so derive the scale the same way as the existing DeepseekV2 MLA branch, including yarn mscale.
- **`v_head_dim`**: fall back to `head_dim` when the value is falsy (`0` as well as `None`).
- Added CPU unit tests under `test/registered/unit/configs/` covering all three MLA scaling branches (plain + yarn-mscale) and the zero-`v_head_dim` fallback.

## Accuracy / Test

- The new unit tests pass, the pre-existing config tests still pass, and reverting only the `model_config.py` change makes the new tests fail with the exact reported symptoms (`AttributeError` on `scaling`; `v_head_dim` `0 != 128`) — so they genuinely gate the regressions.
- **Caveat:** I validated the config-derivation logic (which is where both crashes originate), but due to limited GPU resources on my side I was **not** able to boot Kimi-VL / MiniCPM3 / deepseek-vl2-tiny end-to-end with the FlashInfer backend. If a reviewer or maintainer with access to these models could confirm they now start up and generate correctly, that would be much appreciated.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28684016433](https://github.com/sgl-project/sglang/actions/runs/28684016433)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28684016356](https://github.com/sgl-project/sglang/actions/runs/28684016356)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->