### PR TITLE
[refactor] Declarative config resolution: context-owned ServerArgs, flags tier, and the model-override pipeline (stack overview)

### DIFF
--- a/.gc-stack-placeholder
+++ b/.gc-stack-placeholder
@@ -1,0 +1,3 @@
+Placeholder to keep cheng/gc-stack (the aggregate stack head) distinct from
+the last per-step branch (gc-15). No functional effect; remove when the stack
+lands.

--- a/python/sglang/multimodal_gen/test/unit/test_disagg_trace.py
+++ b/python/sglang/multimodal_gen/test/unit/test_disagg_trace.py
@@ -33,6 +33,7 @@ from sglang.multimodal_gen.runtime.pipelines_core import Req
 from sglang.srt import server_args as srt_server_args_module
 from sglang.srt.observability import trace as srt_trace
 from sglang.srt.observability.trace import TraceNullContext, TraceReqContext
+from sglang.srt.runtime_context import reset_context
 from sglang.srt.server_args import set_global_server_args_for_scheduler
 
 try:
@@ -62,12 +63,18 @@ def _enable_minimal_otel() -> None:
 
 @contextmanager
 def _srt_trace_server_args():
-    prev_server_args = srt_server_args_module._global_server_args
+    try:
+        prev_server_args = srt_server_args_module.get_global_server_args()
+    except ValueError:  # nothing published yet
+        prev_server_args = None
     set_global_server_args_for_scheduler(SimpleNamespace(trace_modules="request"))
     try:
         yield
     finally:
-        srt_server_args_module._global_server_args = prev_server_args
+        if prev_server_args is None:
+            reset_context()
+        else:
+            set_global_server_args_for_scheduler(prev_server_args)
 
 
 def _traceparent_from(ctx) -> str | None:

--- a/python/sglang/srt/arg_groups/arg_utils.py
+++ b/python/sglang/srt/arg_groups/arg_utils.py
@@ -75,17 +75,17 @@ class Arg:
     # When True, this field is skipped by add_cli_args_from_dataclass.
     # Use for fields that have no CLI surface (e.g. injected via Python only).
     no_cli: bool = False
-    # When True, this field may be resolved by model overrides: it is part of
-    # the whitelist accepted by the apply_model_overrides gate, and its
-    # resolved value lives on the flags tier (the server_args field itself
-    # stays the pristine user input).
-    model_overridable: bool = False
+    # When True, this field may be written by config resolution (model
+    # overrides and post-process passes): it is part of the whitelist accepted
+    # by the apply_model_overrides gate, and its resolved value lives on the
+    # flags tier (the server_args field itself stays the pristine user input).
+    resolvable: bool = False
 
 
 @functools.lru_cache(maxsize=None)
-def model_overridable_fields(cls) -> frozenset:
+def resolvable_fields(cls) -> frozenset:
     """Names of ``cls`` dataclass fields whose ``Arg`` metadata declares
-    ``model_overridable=True`` — the whitelist for model-override resolution.
+    ``resolvable=True`` — the whitelist for config resolution.
 
     Non-dataclass types (e.g. mock config objects in tests) have no Arg
     metadata and yield an empty whitelist."""
@@ -95,7 +95,7 @@ def model_overridable_fields(cls) -> frozenset:
     names = set()
     for field in dataclasses.fields(cls):
         _, arg = _unwrap_annotated(hints.get(field.name, field.type))
-        if arg is not None and arg.model_overridable:
+        if arg is not None and arg.resolvable:
             names.add(field.name)
     return frozenset(names)
 

--- a/python/sglang/srt/arg_groups/arg_utils.py
+++ b/python/sglang/srt/arg_groups/arg_utils.py
@@ -85,7 +85,12 @@ class Arg:
 @functools.lru_cache(maxsize=None)
 def model_overridable_fields(cls) -> frozenset:
     """Names of ``cls`` dataclass fields whose ``Arg`` metadata declares
-    ``model_overridable=True`` — the whitelist for model-override resolution."""
+    ``model_overridable=True`` — the whitelist for model-override resolution.
+
+    Non-dataclass types (e.g. mock config objects in tests) have no Arg
+    metadata and yield an empty whitelist."""
+    if not dataclasses.is_dataclass(cls):
+        return frozenset()
     hints = get_type_hints(cls, include_extras=True)
     names = set()
     for field in dataclasses.fields(cls):

--- a/python/sglang/srt/arg_groups/arg_utils.py
+++ b/python/sglang/srt/arg_groups/arg_utils.py
@@ -40,6 +40,7 @@ annotation is equivalent to ``Arg(help=that_string)``.
 from __future__ import annotations
 
 import dataclasses
+import functools
 import types
 from typing import (
     Annotated,
@@ -74,6 +75,24 @@ class Arg:
     # When True, this field is skipped by add_cli_args_from_dataclass.
     # Use for fields that have no CLI surface (e.g. injected via Python only).
     no_cli: bool = False
+    # When True, this field may be resolved by model overrides: it is part of
+    # the whitelist accepted by the apply_model_overrides gate, and its
+    # resolved value lives on the flags tier (the server_args field itself
+    # stays the pristine user input).
+    model_overridable: bool = False
+
+
+@functools.lru_cache(maxsize=None)
+def model_overridable_fields(cls) -> frozenset:
+    """Names of ``cls`` dataclass fields whose ``Arg`` metadata declares
+    ``model_overridable=True`` — the whitelist for model-override resolution."""
+    hints = get_type_hints(cls, include_extras=True)
+    names = set()
+    for field in dataclasses.fields(cls):
+        _, arg = _unwrap_annotated(hints.get(field.name, field.type))
+        if arg is not None and arg.model_overridable:
+            names.add(field.name)
+    return frozenset(names)
 
 
 # ---------------------------------------------------------------------------

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -48,6 +48,11 @@ MODEL_OVERRIDES: Dict[str, Dict[str, Any]] = {
 # Derived per-architecture override providers, in registration order.
 _MODEL_OVERRIDE_FNS: Dict[str, List[Callable[..., dict]]] = {}
 
+# Predicate-keyed providers, in registration order — for legacy branches
+# matched by substring/predicate on the architecture string rather than an
+# exact name (e.g. '"Step3p5ForCausalLM" in model_arch').
+_PREDICATE_OVERRIDE_FNS: List[Tuple[Callable[[str], bool], Callable[..., dict]]] = []
+
 
 def register_model_override(architecture: str):
     """Register a derived-override provider for ``architecture``.
@@ -66,28 +71,52 @@ def register_model_override(architecture: str):
     return decorator
 
 
+def register_model_override_predicate(predicate: Callable[[str], bool]):
+    """Register a derived-override provider keyed by an architecture
+    predicate. Same callable contract as ``register_model_override``."""
+
+    def decorator(fn: Callable[..., dict]) -> Callable[..., dict]:
+        _PREDICATE_OVERRIDE_FNS.append((predicate, fn))
+        return fn
+
+    return decorator
+
+
+def _invoke_provider(
+    fn: Callable[..., dict], server_args: Any, hf_config: Any
+) -> Dict[str, Any]:
+    declared = fn(server_args, hf_config)
+    if not isinstance(declared, dict):
+        raise TypeError(
+            f"model override provider {fn.__qualname__} must return a dict, "
+            f"got {type(declared).__name__}"
+        )
+    return declared
+
+
 def collect_model_override_declarations(
     architecture: str, server_args: Any, hf_config: Any
 ) -> List[Tuple[str, Dict[str, Any]]]:
     """Collect ``(source, declaration)`` pairs for one architecture.
 
     Application order (last writer wins downstream in the gate): the constant
-    ``MODEL_OVERRIDES`` entry first, then registered callables in registration
-    order. Empty declarations are dropped.
+    ``MODEL_OVERRIDES`` entry first, then exact-keyed callables in
+    registration order, then matching predicate-keyed callables in
+    registration order. Empty declarations are dropped.
     """
     declarations: List[Tuple[str, Dict[str, Any]]] = []
     const = MODEL_OVERRIDES.get(architecture)
     if const:
         declarations.append((f"MODEL_OVERRIDES[{architecture!r}]", dict(const)))
     for fn in _MODEL_OVERRIDE_FNS.get(architecture, ()):
-        declared = fn(server_args, hf_config)
-        if not isinstance(declared, dict):
-            raise TypeError(
-                f"model override provider {fn.__qualname__} must return a dict, "
-                f"got {type(declared).__name__}"
-            )
+        declared = _invoke_provider(fn, server_args, hf_config)
         if declared:
             declarations.append((fn.__qualname__, dict(declared)))
+    for predicate, fn in _PREDICATE_OVERRIDE_FNS:
+        if predicate(architecture):
+            declared = _invoke_provider(fn, server_args, hf_config)
+            if declared:
+                declarations.append((fn.__qualname__, dict(declared)))
     return declarations
 
 
@@ -124,6 +153,29 @@ def _minimax_m2_overrides(server_args: Any, hf_config: Any) -> dict:
         "Enable TF32 matmul for MiniMaxM2ForCausalLM model to improve gate gemm performance."
     )
     return {"enable_tf32_matmul": True}
+
+
+@register_model_override_predicate(
+    lambda arch: "Step3p5ForCausalLM" in arch
+    or "Step3p7ForConditionalGeneration" in arch
+)
+def _step3p_overrides(server_args: Any, hf_config: Any) -> dict:
+    overrides: Dict[str, Any] = {}
+    if server_args.speculative_algorithm == "EAGLE":
+        logger.info(
+            "Enable multi-layer EAGLE speculative decoding for Step3p5ForCausalLM model."
+        )
+        overrides["enable_multi_layer_eagle"] = True
+    if server_args.enable_hierarchical_cache:
+        logger.warning(
+            "Reset swa_full_tokens_ratio to 1.0 for Step3p5ForCausalLM model with hierarchical cache"
+        )
+        overrides["swa_full_tokens_ratio"] = 1.0
+        logger.warning(
+            "Disable hybrid SWA memory for Step3p5ForCausalLM model with hierarchical cache"
+        )
+        overrides["disable_hybrid_swa_memory"] = True
+    return overrides
 
 
 @dataclasses.dataclass(frozen=True)

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -29,13 +29,21 @@ Two declaration forms, keyed on ``hf_config.architectures[0]``:
 from __future__ import annotations
 
 import dataclasses
+import logging
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from sglang.srt.arg_groups.arg_utils import model_overridable_fields
 from sglang.srt.runtime_context import resolve_flag_leaf
 
+logger = logging.getLogger(__name__)
+
 # Constant per-architecture overrides (populated by the migration sweeps).
-MODEL_OVERRIDES: Dict[str, Dict[str, Any]] = {}
+MODEL_OVERRIDES: Dict[str, Dict[str, Any]] = {
+    # These models run in bfloat16 regardless of the requested dtype
+    # (faithful port of the legacy unconditional arch branch).
+    "MistralLarge3ForCausalLM": {"dtype": "bfloat16"},
+    "PixtralForConditionalGeneration": {"dtype": "bfloat16"},
+}
 
 # Derived per-architecture override providers, in registration order.
 _MODEL_OVERRIDE_FNS: Dict[str, List[Callable[..., dict]]] = {}
@@ -81,6 +89,41 @@ def collect_model_override_declarations(
         if declared:
             declarations.append((fn.__qualname__, dict(declared)))
     return declarations
+
+
+# ---------------------------------------------------------------------------
+# Derived per-family declarations (faithful ports of legacy arch branches).
+# Callables read the PRISTINE server_args, never write; logging is kept
+# verbatim from the legacy branch for operator-visible fidelity.
+# ---------------------------------------------------------------------------
+
+
+def _register_for(*architectures: str):
+    """Register one provider for several architectures (family lists)."""
+
+    def decorator(fn: Callable[..., dict]) -> Callable[..., dict]:
+        for architecture in architectures:
+            register_model_override(architecture)(fn)
+        return fn
+
+    return decorator
+
+
+# Keep in sync with MIMO_V2_MODEL_ARCHS (server_args.py / configs/hf_config.py).
+@_register_for("MiMoV2ForCausalLM", "MiMoV2FlashForCausalLM")
+def _mimo_v2_overrides(server_args: Any, hf_config: Any) -> dict:
+    if server_args.speculative_algorithm == "EAGLE":
+        logger.info("Enable multi-layer EAGLE speculative decoding for MiMoV2 model.")
+        return {"enable_multi_layer_eagle": True}
+    return {}
+
+
+@_register_for("MiniMaxM2ForCausalLM")
+def _minimax_m2_overrides(server_args: Any, hf_config: Any) -> dict:
+    logger.info(
+        "Enable TF32 matmul for MiniMaxM2ForCausalLM model to improve gate gemm performance."
+    )
+    return {"enable_tf32_matmul": True}
 
 
 @dataclasses.dataclass(frozen=True)

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -32,7 +32,7 @@ import dataclasses
 import logging
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
-from sglang.srt.arg_groups.arg_utils import model_overridable_fields
+from sglang.srt.arg_groups.arg_utils import resolvable_fields
 from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.runtime_context import resolve_flag_leaf
 from sglang.srt.utils.common import (
@@ -1308,7 +1308,7 @@ def apply_model_overrides(
     Returns the provenance log, one record per declared write.
     """
     if whitelist is None:
-        whitelist = model_overridable_fields(type(server_args))
+        whitelist = resolvable_fields(type(server_args))
     whitelist = frozenset(whitelist)
 
     ordered = list(declarations) + list(terminal)
@@ -1367,9 +1367,9 @@ def apply_declarations_to_server_args(
     mutate ``server_args`` and only be rejected at publish time.
     """
     # Non-dataclass fixtures carry no Arg metadata (mirrors the
-    # model_overridable_fields escape); only real ServerArgs is validated.
+    # resolvable_fields escape); only real ServerArgs is validated.
     if dataclasses.is_dataclass(type(server_args)):
-        whitelist = model_overridable_fields(type(server_args))
+        whitelist = resolvable_fields(type(server_args))
         for source, decl in list(declarations) + list(terminal):
             unknown = set(decl) - whitelist
             if unknown:

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -34,6 +34,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 
 from sglang.srt.arg_groups.arg_utils import model_overridable_fields
 from sglang.srt.runtime_context import resolve_flag_leaf
+from sglang.srt.utils.common import is_xpu
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,66 @@ def _minimax_m2_overrides(server_args: Any, hf_config: Any) -> dict:
         "Enable TF32 matmul for MiniMaxM2ForCausalLM model to improve gate gemm performance."
     )
     return {"enable_tf32_matmul": True}
+
+
+@_register_for(
+    "Gemma2ForCausalLM",
+    "Gemma3ForCausalLM",
+    "Gemma3ForConditionalGeneration",
+    "Gemma3nForCausalLM",
+    "Gemma3nForConditionalGeneration",
+)
+def _gemma2_gemma3_overrides(server_args: Any, hf_config: Any) -> dict:
+    # FIXME: https://github.com/sgl-project/sglang/pull/7367 is not compatible with gemma2 model.
+    # It failed at this test: https://github.com/sgl-project/sglang/actions/runs/16255155597/job/45890331952#step:4:736
+    logger.warning(
+        f"Disable hybrid SWA memory for {hf_config.architectures[0]} as it is not yet supported."
+    )
+    return {"disable_hybrid_swa_memory": True}
+
+
+@_register_for("Exaone4ForCausalLM", "ExaoneMoEForCausalLM")
+def _exaone_overrides(server_args: Any, hf_config: Any) -> dict:
+    if hf_config.sliding_window_pattern is not None:
+        logger.warning(
+            f"Disabling hybrid SWA memory for {hf_config.architectures[0]} as it is not yet supported."
+        )
+        return {"disable_hybrid_swa_memory": True}
+    return {}
+
+
+@_register_for("GptOssForCausalLM")
+def _gpt_oss_overrides(server_args: Any, hf_config: Any) -> dict:
+    if is_xpu():
+        # Check for bf16 dtype on Intel XPU. Reads the pristine dtype request,
+        # which equals the legacy mid-branch read: dtype had no earlier writer
+        # for this arch.
+        if server_args.dtype == "auto":
+            logger.warning(
+                "GptOssForCausalLM on Intel XPU currently supports bfloat16 dtype only"
+            )
+        elif server_args.dtype not in ["bfloat16"]:
+            raise NotImplementedError(
+                f"GptOssForCausalLM on Intel XPU only supports bfloat16 dtype, "
+                f"but got '{server_args.dtype}'. Please use --dtype bfloat16 or remove --dtype to use auto."
+            )
+    quantization_config = getattr(hf_config, "quantization_config", None)
+    if (
+        quantization_config is not None
+        and quantization_config.get("quant_method") == "mxfp4"
+    ):
+        # use bf16 for mxfp4 triton kernels
+        return {"dtype": "bfloat16"}
+    return {}
+
+
+@_register_for("Olmo2ForCausalLM")
+def _olmo2_overrides(server_args: Any, hf_config: Any) -> dict:
+    # FIXME: https://github.com/sgl-project/sglang/pull/7367 is not compatible with Olmo3 model.
+    logger.warning(
+        f"Disabling hybrid SWA memory for {hf_config.architectures[0]} as it is not yet supported."
+    )
+    return {"disable_hybrid_swa_memory": True}
 
 
 @register_model_override_predicate(

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -38,6 +38,8 @@ from sglang.srt.runtime_context import resolve_flag_leaf
 from sglang.srt.utils.common import (
     cpu_has_amx_support,
     get_device_sm,
+    get_nvidia_driver_version,
+    get_quantization_config,
     is_blackwell_supported,
     is_cpu,
     is_cuda,
@@ -48,6 +50,7 @@ from sglang.srt.utils.common import (
     is_sm90_supported,
     is_sm100_supported,
     is_sm120_supported,
+    is_triton_kernels_available,
     is_xpu,
     xpu_has_xmx_support,
 )
@@ -295,12 +298,70 @@ def _gpt_oss_overrides(server_args: Any, hf_config: Any) -> dict:
                 f"but got '{server_args.dtype}'. Please use --dtype bfloat16 or remove --dtype to use auto."
             )
     quantization_config = getattr(hf_config, "quantization_config", None)
-    if (
+    is_mxfp4_quant_format = (
         quantization_config is not None
         and quantization_config.get("quant_method") == "mxfp4"
-    ):
+    )
+    if is_mxfp4_quant_format:
         # use bf16 for mxfp4 triton kernels
         overrides["dtype"] = "bfloat16"
+    if server_args.moe_runner_backend == "auto":
+        from sglang.srt.environ import envs
+
+        if is_sm100_supported() and is_mxfp4_quant_format:
+            overrides["moe_runner_backend"] = "flashinfer_mxfp4"
+            logger.warning(
+                "Detected SM100 and MXFP4 quantization format for GPT-OSS model, enabling FlashInfer MXFP4 MOE kernel."
+            )
+        elif is_sm120_supported() and is_mxfp4_quant_format:
+            # trtllm-gen only supports SM100
+            overrides["moe_runner_backend"] = "marlin"
+            logger.warning(
+                "Detected SM120 and MXFP4 quantization format for GPT-OSS model, enabling Marlin MOE kernel."
+            )
+        elif (is_hip() and envs.SGLANG_USE_AITER.get()) and is_mxfp4_quant_format:
+            overrides["moe_runner_backend"] = "auto"
+            logger.warning(
+                "Detected ROCm and MXFP4 quantization format for GPT-OSS model, enabling aiter MXFP4 MOE kernel."
+            )
+            ## The AITER MXFP4 fused-MoE path for GPT-OSS expects the
+            ## SEPARATED gate/up tile layout (matches the
+            ## `gptoss_fp4_tuned_fmoe.csv` flydsl entries and the
+            ## Mxfp4MoEMethod weight shuffle). Other AITER MXFP4
+            ## callers default to INTERLEAVE; opt this path out
+            ## unless the user explicitly overrode it.
+            # envs.SGLANG_USE_AITER_MOE_GU_ITLV.set(False)
+        elif is_hip() and envs.SGLANG_USE_AITER.get():
+            # For GPT-OSS bf16 on ROCm with aiter, use triton backend
+            # because aiter CK kernel doesn't support all GEMM dimensions
+            overrides["moe_runner_backend"] = "triton"
+            logger.warning(
+                "Detected ROCm with SGLANG_USE_AITER for GPT-OSS bf16 model, using triton MOE kernel."
+            )
+        elif is_musa() and envs.SGLANG_DEEPEP_BF16_DISPATCH.get():
+            overrides["moe_runner_backend"] = "deep_gemm"
+            logger.warning(
+                "Detected MUSA with SGLANG_DEEPEP_BF16_DISPATCH for bf16 model, using deep_gemm kernel."
+            )
+        elif (
+            server_args.ep_size == 1
+            and is_triton_kernels_available()
+            and server_args.quantization is None
+            and not (is_cpu() and cpu_has_amx_support())
+        ):
+            # The triton_kernels package segfaults on Blackwell (B200)
+            # with NVIDIA driver >= 595. Fall back to triton backend.
+            if is_blackwell_supported() and get_nvidia_driver_version() >= (595,):
+                overrides["moe_runner_backend"] = "triton"
+                logger.warning(
+                    "Detected GPT-OSS model on Blackwell with driver >= 595, "
+                    "using triton MOE kernel to avoid triton_kernels SIGSEGV."
+                )
+            else:
+                overrides["moe_runner_backend"] = "triton_kernel"
+                logger.warning(
+                    "Detected GPT-OSS model, enabling triton_kernels MOE kernel."
+                )
     return overrides
 
 
@@ -309,6 +370,7 @@ def _gpt_oss_overrides(server_args: Any, hf_config: Any) -> dict:
 def _llama4_overrides(server_args: Any, hf_config: Any) -> dict:
     if server_args.device == "cpu":
         return {}
+    overrides: Dict[str, Any] = {}
     # Auto-select attention backend for Llama4 if not specified
     if server_args.attention_backend is None:
         if is_sm100_supported():
@@ -324,8 +386,14 @@ def _llama4_overrides(server_args: Any, hf_config: Any) -> dict:
         logger.warning(
             f"Use {backend} as attention backend on {platform} for Llama4 model"
         )
-        return {"attention_backend": backend}
-    return {}
+        overrides["attention_backend"] = backend
+    if is_sm100_supported() and server_args.moe_runner_backend == "auto":
+        if server_args.quantization in {"fp8", "modelopt_fp8"}:
+            overrides["moe_runner_backend"] = "flashinfer_trtllm"
+            logger.info(
+                "Use flashinfer_trtllm as MoE runner backend on SM100 for Llama4"
+            )
+    return overrides
 
 
 @_register_for(
@@ -334,18 +402,27 @@ def _llama4_overrides(server_args: Any, hf_config: Any) -> dict:
     "Gemma4UnifiedForConditionalGeneration",
 )
 def _gemma4_overrides(server_args: Any, hf_config: Any) -> dict:
+    overrides: Dict[str, Any] = {}
     default_attention_backend = "trtllm_mha" if is_sm100_supported() else "triton"
     if server_args.is_attention_backend_not_set():
         logger.info(
             f"Use {default_attention_backend} as default attention backend for Gemma4"
         )
-        return {"attention_backend": default_attention_backend}
+        overrides["attention_backend"] = default_attention_backend
     # If only one split backend is set, keep the other side on a
     # Gemma4-compatible fallback instead of letting generic backend selection
     # choose an unsupported backend later.
-    if server_args.attention_backend is None:
-        return {"attention_backend": default_attention_backend}
-    return {}
+    elif server_args.attention_backend is None:
+        overrides["attention_backend"] = default_attention_backend
+    if is_sm100_supported() and server_args.moe_runner_backend == "auto":
+        if server_args.get_model_config().quantization == "modelopt_fp4":
+            overrides["quantization"] = "modelopt_fp4"
+            overrides["moe_runner_backend"] = "flashinfer_trtllm"
+            logger.info(
+                "Use flashinfer_trtllm as MoE runner backend on "
+                "SM100 for Gemma-4 (modelopt_fp4)"
+            )
+    return overrides
 
 
 @_register_for("MiniCPMV4_6ForConditionalGeneration")
@@ -428,12 +505,71 @@ def _qwen3vl_overrides(server_args: Any, hf_config: Any) -> dict:
     return {}
 
 
+@_register_for(
+    "Qwen3MoeForCausalLM",
+    "Qwen3VLMoeForConditionalGeneration",
+    "Qwen3NextForCausalLM",
+    "Qwen3_5MoeForConditionalGeneration",
+    "InternS2PreviewForConditionalGeneration",
+    "Qwen3_5ForConditionalGeneration",
+)
+def _qwen3_moe_family_overrides(server_args: Any, hf_config: Any) -> dict:
+    overrides: Dict[str, Any] = {}
+    if is_sm100_supported():
+        quant_method = get_quantization_config(hf_config)
+        quantization = server_args.quantization
+        if (
+            quantization is None
+            and not server_args._quantization_explicitly_unset
+            and quant_method is not None
+        ):
+            overrides["quantization"] = quant_method
+            quantization = quant_method
+        if (
+            (quantization in ("fp8", "modelopt_fp4") or quantization is None)
+            and server_args.moe_a2a_backend == "none"
+            and server_args.moe_runner_backend == "auto"
+        ):
+            overrides["moe_runner_backend"] = "flashinfer_trtllm"
+            logger.info(
+                "Use flashinfer_trtllm as MoE runner backend on sm100 for "
+                f"{hf_config.architectures[0]}"
+            )
+    return overrides
+
+
 @_register_for("Glm4MoeForCausalLM")
 def _glm4_moe_overrides(server_args: Any, hf_config: Any) -> dict:
+    overrides: Dict[str, Any] = {}
+    if is_sm100_supported():
+        quantization_config = getattr(hf_config, "quantization_config", None)
+        quant_method = (
+            quantization_config.get("quant_method")
+            if quantization_config is not None
+            else None
+        )
+        quantization = server_args.quantization
+        if (
+            quantization is None
+            and not server_args._quantization_explicitly_unset
+            and quant_method is not None
+        ):
+            overrides["quantization"] = quant_method
+            quantization = quant_method
+        if (
+            quantization in {"modelopt_fp4", None}
+            and server_args.moe_a2a_backend == "none"
+            and server_args.moe_runner_backend == "auto"
+        ):
+            overrides["moe_runner_backend"] = "flashinfer_trtllm"
+            logger.info(
+                "Use flashinfer_trtllm as MoE runner backend on sm100 for Glm4MoeForCausalLM"
+            )
     logger.info(
         "Enable TF32 matmul for Glm4MoeForCausalLM model to improve gate gemm performance."
     )
-    return {"enable_tf32_matmul": True}
+    overrides["enable_tf32_matmul"] = True
+    return overrides
 
 
 @_register_for("Olmo2ForCausalLM")
@@ -764,6 +900,86 @@ def _page_size_default(view: Any) -> dict:
     if not is_musa():
         return {"page_size": 1}
     return {"page_size": 64}
+
+
+@register_post_process
+def _moe_runner_backend_quant_constraints(view: Any) -> dict:
+    """The quantization-driven moe_runner_backend resolutions at the head of
+    _handle_moe_kernel_config. The backend-compatibility asserts and the
+    disable_shared_experts_fusion writes (post-publish writers exist for that
+    field — R2 territory) stay in the handler."""
+    moe_runner_backend = view.moe_runner_backend
+    if view.quantization == "nvfp4_online":
+        if not is_sm100_supported():
+            raise ValueError(
+                "--quantization nvfp4_online is supported only on "
+                "NVIDIA Blackwell SM100/SM103 GPUs."
+            )
+        if moe_runner_backend == "auto":
+            moe_runner_backend = "flashinfer_trtllm"
+        elif moe_runner_backend not in [
+            "flashinfer_trtllm",
+            "flashinfer_trtllm_routed",
+        ]:
+            raise ValueError(
+                "--quantization nvfp4_online supports only "
+                "--moe-runner-backend flashinfer_trtllm or "
+                "flashinfer_trtllm_routed."
+            )
+    if view.quantization == "mxfp8":
+        if moe_runner_backend == "auto":
+            moe_runner_backend = "flashinfer_trtllm"
+        elif moe_runner_backend not in [
+            "cutlass",
+            "flashinfer_trtllm",
+            "flashinfer_trtllm_routed",
+        ]:
+            logger.warning(
+                "mxfp8 quantization supports only cutlass, flashinfer_trtllm, "
+                "or flashinfer_trtllm_routed backends. "
+                f"Overriding {moe_runner_backend!r}."
+            )
+            moe_runner_backend = "flashinfer_trtllm"
+    if (
+        moe_runner_backend == "auto"
+        and view.quantization == "modelopt_fp4"
+        and is_sm120_supported()
+    ):
+        moe_runner_backend = "flashinfer_cutlass"
+        logger.info(
+            "Use flashinfer_cutlass as MoE runner backend on SM120 for "
+            "modelopt_fp4 (trtllm-gen MoE kernels are SM100-only)"
+        )
+    if moe_runner_backend != view.moe_runner_backend:
+        return {"moe_runner_backend": moe_runner_backend}
+    return {}
+
+
+@register_post_process
+def _cutlass_moe_env_override(view: Any) -> dict:
+    from sglang.srt.environ import envs
+
+    if envs.SGLANG_CUTLASS_MOE.get():
+        logger.warning(
+            "SGLANG_CUTLASS_MOE is deprecated, use --moe-runner-backend=cutlass and/or --speculative-moe-runner-backend=cutlass instead"
+        )
+        assert view.quantization in [
+            "fp8",
+            "mxfp8",
+        ], "cutlass MoE is only supported with fp8/mxfp8 quantization"
+        return {"moe_runner_backend": "cutlass"}
+    return {}
+
+
+@register_post_process
+def _gguf_quantization(view: Any) -> dict:
+    from sglang.srt.utils.hf_transformers_utils import check_gguf_file
+
+    if (view.load_format == "auto" or view.load_format == "gguf") and check_gguf_file(
+        view.model_path
+    ):
+        return {"quantization": "gguf"}
+    return {}
 
 
 @register_post_process

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -34,7 +34,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 
 from sglang.srt.arg_groups.arg_utils import model_overridable_fields
 from sglang.srt.runtime_context import resolve_flag_leaf
-from sglang.srt.utils.common import is_xpu
+from sglang.srt.utils.common import is_flashinfer_available, is_xpu
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +93,72 @@ def _invoke_provider(
             f"got {type(declared).__name__}"
         )
     return declared
+
+
+class ResolvedView:
+    """Read-only view of the resolving configuration handed to post-process
+    passes.
+
+    During the dual-apply transition the view forwards every read to the live
+    ``server_args`` — the pristine input plus the declarations replayed so far
+    plus any residual imperative writes — which is exactly the state the
+    legacy handler at the same slot observed. In the end state (dual-apply
+    retired) the same type overlays the accumulated declarations on the
+    pristine object. Writes are rejected: passes return declarations.
+    """
+
+    __slots__ = ("_server_args", "_overlay")
+
+    def __init__(self, server_args: Any, overlay: Optional[Dict[str, Any]] = None):
+        object.__setattr__(self, "_server_args", server_args)
+        object.__setattr__(self, "_overlay", overlay or {})
+
+    def __getattr__(self, name: str) -> Any:
+        overlay = object.__getattribute__(self, "_overlay")
+        if name in overlay:
+            return overlay[name]
+        return getattr(object.__getattribute__(self, "_server_args"), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError(
+            "ResolvedView is read-only; post-process passes return declarations"
+        )
+
+
+# Ordered post-process passes (the normalization stage). List order is the
+# end-state execution order and mirrors today's handler call sequence in
+# __post_init__; during the transition each pass is invoked from its legacy
+# slot via run_post_process_pass, so ordering is preserved byte-for-byte.
+POST_PROCESS_PASSES: List[Callable[..., dict]] = []
+
+
+def register_post_process(fn: Callable[..., dict]) -> Callable[..., dict]:
+    """Register a post-process pass: ``fn(view) -> {field: resolved_value}``.
+
+    The pass reads a :class:`ResolvedView` (post-model-override state) and
+    must not mutate anything; validations may live in a pass (read + raise).
+    """
+    POST_PROCESS_PASSES.append(fn)
+    return fn
+
+
+def run_post_process_pass(server_args: Any, fn: Callable[..., dict]) -> None:
+    """Transition-period invocation of one pass at its legacy handler slot.
+
+    Evaluates the pass on the live state (through a read-only view), appends
+    its declaration to the R0 stash, and dual-applies it in place —
+    byte-identical to the imperative handler write this replaces.
+    """
+    declared = fn(ResolvedView(server_args))
+    if not isinstance(declared, dict):
+        raise TypeError(
+            f"post-process pass {fn.__qualname__} must return a dict, "
+            f"got {type(declared).__name__}"
+        )
+    if declared:
+        entry = (fn.__qualname__, dict(declared))
+        server_args._resolved_overrides.append(entry)
+        apply_declarations_to_server_args(server_args, [entry])
 
 
 def collect_model_override_declarations(
@@ -237,6 +303,34 @@ def _step3p_overrides(server_args: Any, hf_config: Any) -> dict:
         )
         overrides["disable_hybrid_swa_memory"] = True
     return overrides
+
+
+# ---------------------------------------------------------------------------
+# Post-process passes (normalization stage), in end-state execution order.
+# Faithful ports of the legacy __post_init__ handlers; each is invoked from
+# its legacy slot via run_post_process_pass during the transition.
+# ---------------------------------------------------------------------------
+
+
+@register_post_process
+def _sampling_backend_default(view: Any) -> dict:
+    if view.sampling_backend is None:
+        return {
+            "sampling_backend": (
+                "flashinfer" if is_flashinfer_available() else "pytorch"
+            )
+        }
+    return {}
+
+
+@register_post_process
+def _deterministic_sampling_backend(view: Any) -> dict:
+    if view.enable_deterministic_inference and view.sampling_backend != "ascend":
+        logger.warning(
+            "Sampling backend is set to pytorch for deterministic inference."
+        )
+        return {"sampling_backend": "pytorch"}
+    return {}
 
 
 @dataclasses.dataclass(frozen=True)

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -224,6 +224,129 @@ def _register_for(*architectures: str):
     return decorator
 
 
+@_register_for(
+    "DeepseekV3ForCausalLM",
+    "DeepseekV32ForCausalLM",
+    "KimiK25ForConditionalGeneration",
+    "MistralLarge3ForCausalLM",
+    "PixtralForConditionalGeneration",
+    "GlmMoeDsaForCausalLM",
+)
+def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
+    """Order-safe declarations of the DeepSeek/DSA branch. The CP parallel
+    writes (enable_dp_attention/ep_size/moe_a2a_backend have post-monolith
+    writers), the kv-cache/split-backend defaults, the quant/moe block (read
+    before it by _set_default_dsa_kv_cache_dtype) and the env writes stay in
+    the branch."""
+    from sglang.srt.configs.model_config import is_deepseek_dsa
+
+    overrides: Dict[str, Any] = {}
+    if is_deepseek_dsa(hf_config):  # DeepSeek 3.2/GLM 5
+        # Set attention backend for DeepSeek
+        if server_args.is_attention_backend_not_set():
+            overrides["attention_backend"] = "dsa"
+            logger.info("Use dsa attention backend for DeepSeek with DSA.")
+        if not is_npu() and not is_xpu():  # CUDA or ROCm GPU
+            if server_args.enable_prefill_cp:
+                logger.warning(
+                    "Context parallel feature is still under experiment. It has only been verified on Hopper platform."
+                )
+                overrides["enable_dp_attention"] = True
+                overrides["moe_dense_tp_size"] = 1
+                if server_args.cp_strategy == "zigzag":
+                    overrides["moe_a2a_backend"] = "deepep"
+                    overrides["ep_size"] = server_args.tp_size
+                    logger.warning(
+                        "zigzag DSA CP requires moe_dense_tp_size=1, "
+                        "moe_a2a_backend=deepep, ep_size=tp_size, batch_size=1."
+                    )
+                else:
+                    assert (
+                        server_args.dp_size == 1
+                    ), "interleave DSA CP does not support DP attention."
+                assert (
+                    server_args.tp_size <= 8
+                ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
+                # Note(kpham-sgl): Keep attn_tp_size == 1 under DSA CP.
+                # DSACPLayerCommunicator does not all-reduce attention-TP
+                # partial o_proj outputs before replicated dense FFNs.
+                attn_cp_size = server_args.tp_size // server_args.dp_size
+                overrides["attn_cp_size"] = attn_cp_size
+                logger.warning(
+                    "Enabled DSA context parallel: "
+                    f"strategy={server_args.cp_strategy}, dp_size={server_args.dp_size}, "
+                    f"moe_dense_tp_size={overrides['moe_dense_tp_size']}, "
+                    f"ep_size={overrides.get('ep_size', server_args.ep_size)}, tp_size={server_args.tp_size}, "
+                    f"attn_cp_size={attn_cp_size}, "
+                    f"kv_cache_dtype={server_args.kv_cache_dtype}, "
+                    f"moe_a2a_backend={overrides.get('moe_a2a_backend', server_args.moe_a2a_backend)}, "
+                    f"cuda_graph_config[prefill].backend=disabled"
+                )
+
+            # Deferred import to avoid a circular import at module-load
+            # time (dsa.utils imports get_global_server_args).
+            from sglang.srt.layers.attention.dsa.utils import (
+                aiter_can_use_preshuffle_paged_mqa,
+            )
+
+            if is_hip() and not aiter_can_use_preshuffle_paged_mqa():
+                # Legacy ROCm DSA path: aiter's gluon paged-MQA kernel is
+                # unavailable (Triton<3.5 and AITER_ENABLE_AOT_GLUON_PA_MQA_LOGITS
+                # not set, or SGLANG_DSA_HIP_DISABLE_PRESHUFFLE=1 / SGLANG_USE_AITER=0).
+                overrides["page_size"] = 1
+                logger.warning(
+                    "Setting page size to 1 for DeepSeek DSA on ROCm "
+                    "(aiter preshuffle paged-MQA path unavailable: "
+                    "needs Triton>=3.5.0 or AITER_ENABLE_AOT_GLUON_PA_MQA_LOGITS=1)."
+                )
+            else:
+                overrides["page_size"] = 64
+                logger.warning("Setting page size to 64 for DeepSeek DSA.")
+    else:
+        # DeepSeek V3/R1/V3.1
+        if is_sm100_supported():
+            if (
+                server_args.attention_backend is None
+                and server_args.prefill_attention_backend is None
+                and server_args.decode_attention_backend is None
+            ):
+                overrides["attention_backend"] = "trtllm_mla"
+                logger.info(
+                    "Use trtllm_mla as attention backend on sm100 for DeepseekV3ForCausalLM"
+                )
+        # MLA prefill CP auto-config. Mirrors the NSA CP block above
+        # (minus the in-seq/round-robin mode split, which MLA CP does not support)
+        if server_args.enable_prefill_cp and server_args.use_mla_backend():
+            logger.warning(
+                "MLA prefill context parallel is still experimental. "
+                "Verified on Hopper with the fa3 backend."
+            )
+            overrides["enable_dp_attention"] = True
+            # TODO(kpham-sgl) Supports moe_dense_tp_size != 1.
+            overrides["moe_dense_tp_size"] = 1
+            overrides["moe_a2a_backend"] = "deepep"
+            overrides["ep_size"] = server_args.tp_size
+            logger.warning(
+                "For MLA CP, we have the following restrictions: moe_dense_tp_size == 1, moe_a2a_backend == deepep, ep_size == tp_size, batch_size == 1"
+            )
+            # FIXME(kpham-sgl): Keep attn_tp_size == 1 under MLA CP.
+            # DSACPLayerCommunicator does not all-reduce attention-TP
+            # partial o_proj outputs before replicated dense FFNs.
+            attn_cp_size = server_args.tp_size // server_args.dp_size
+            overrides["attn_cp_size"] = attn_cp_size
+            logger.warning(
+                f"Enable Context Parallel opt for MLA, "
+                f"Setting dp_size == {server_args.dp_size} and "
+                f"attn_cp_size == {attn_cp_size}, "
+                f"moe_dense_tp_size == {overrides['moe_dense_tp_size']}, "
+                f"ep_size == {overrides['ep_size']}, "
+                f"tp_size == {server_args.tp_size}, "
+                f"moe_a2a_backend {overrides['moe_a2a_backend']}, "
+                f"cuda_graph_config[prefill].backend=disabled"
+            )
+    return overrides
+
+
 # Keep in sync with MIMO_V2_MODEL_ARCHS (server_args.py / configs/hf_config.py).
 @_register_for("MiMoV2ForCausalLM", "MiMoV2FlashForCausalLM")
 def _mimo_v2_overrides(server_args: Any, hf_config: Any) -> dict:
@@ -627,6 +750,91 @@ def _step3p_overrides(server_args: Any, hf_config: Any) -> dict:
 # ---------------------------------------------------------------------------
 
 
+# Keep in sync with the DeepSeek family list on _deepseek_family_overrides.
+_DEEPSEEK_FAMILY_ARCHS = frozenset(
+    {
+        "DeepseekV3ForCausalLM",
+        "DeepseekV32ForCausalLM",
+        "KimiK25ForConditionalGeneration",
+        "MistralLarge3ForCausalLM",
+        "PixtralForConditionalGeneration",
+        "GlmMoeDsaForCausalLM",
+    }
+)
+
+
+@register_post_process
+def _deepseek_moe_quant_resolution(view: Any) -> dict:
+    """Slot pass invoked from inside the DeepSeek arch branch ("Set moe
+    backend for DeepSeek"), NOT a dispatch-time declaration: the DSA
+    kv-cache-dtype default earlier in the branch must read the PRISTINE
+    quantization, so this resolution has to stay at its legacy slot."""
+    hf_config = view.get_model_config().hf_config
+    model_arch = hf_config.architectures[0]
+    if model_arch not in _DEEPSEEK_FAMILY_ARCHS:
+        return {}
+    overrides: Dict[str, Any] = {}
+    if is_sm100_supported():
+        quant_method = get_quantization_config(hf_config)
+        quant_cfg = getattr(hf_config, "quantization_config", None) or {}
+        config_groups = quant_cfg.get("config_groups", {})
+        group0 = config_groups.get("group_0", {})
+        weights_cfg = group0.get("weights", {})
+        # this also apply to kimi k2.5
+        # since it follow the compressed tensor int4 recipe
+        # but not kimi k2 instruct or 0905 instruct.
+        is_kimi_k2_k25_thinking_int4 = (
+            quant_method == "compressed-tensors"
+            and weights_cfg.get("num_bits") == 4
+            and weights_cfg.get("group_size") == 32
+            and weights_cfg.get("strategy") == "group"
+            and weights_cfg.get("type") == "int"
+        )
+        quantization = view.quantization
+        if quantization is None and not view._quantization_explicitly_unset:
+            # DeepSeek V3/R1 uses native FP8 MoE experts without
+            # declaring it in quantization_config.  However, other
+            # models that share the same architecture class (e.g.
+            # Moonlight-16B-A3B) are purely BF16.  Check the actual
+            # safetensors header instead of assuming FP8 by arch name.
+            if quant_method is None and model_arch in ["DeepseekV3ForCausalLM"]:
+                from sglang.srt.utils.common import has_fp8_weights_in_checkpoint
+
+                if has_fp8_weights_in_checkpoint(view.model_path):
+                    overrides["quantization"] = quantization = "fp8"
+                    logger.info(
+                        "Detected FP8 expert weights in checkpoint, "
+                        "default to fp8 for DeepSeek on sm100"
+                    )
+                else:
+                    logger.info(
+                        "No FP8 expert weights found in checkpoint, "
+                        "keeping bf16 for DeepSeek-arch model on sm100"
+                    )
+            else:
+                overrides["quantization"] = quantization = quant_method
+        if (
+            view.moe_a2a_backend == "none"
+            and view.moe_runner_backend == "auto"
+            and (
+                quantization
+                in ["fp8", "modelopt_fp8", "modelopt_fp4", "modelopt_mixed"]
+                or is_kimi_k2_k25_thinking_int4
+                or quantization is None
+            )
+        ):
+            overrides["moe_runner_backend"] = "flashinfer_trtllm"
+            if is_kimi_k2_k25_thinking_int4:
+                logger.info(
+                    "Use flashinfer_trtllm as MoE runner backend on Blackwell for Kimi K2 / K2.5 thinking int4"
+                )
+            else:
+                logger.info(
+                    "Use flashinfer_trtllm as MoE runner backend on sm100 for DeepseekV3ForCausalLM"
+                )
+    return overrides
+
+
 @register_post_process
 def _sampling_backend_default(view: Any) -> dict:
     if view.sampling_backend is None:
@@ -903,6 +1111,13 @@ def _page_size_default(view: Any) -> dict:
 
 
 @register_post_process
+def _data_parallelism_defaults(view: Any) -> dict:
+    if view.dp_size == 1:
+        return {"enable_dp_attention": False, "enable_dp_lm_head": False}
+    return {}
+
+
+@register_post_process
 def _moe_runner_backend_quant_constraints(view: Any) -> dict:
     """The quantization-driven moe_runner_backend resolutions at the head of
     _handle_moe_kernel_config. The backend-compatibility asserts and the
@@ -968,6 +1183,41 @@ def _cutlass_moe_env_override(view: Any) -> dict:
             "mxfp8",
         ], "cutlass MoE is only supported with fp8/mxfp8 quantization"
         return {"moe_runner_backend": "cutlass"}
+    return {}
+
+
+# Every A2A backend that forces expert parallelism to span the TP group.
+_A2A_EP_SPANNING_BACKENDS = frozenset(
+    {"megamoe", "deepep", "mooncake", "nixl", "ascend_fuseep", "flashinfer", "mori"}
+)
+
+
+@register_post_process
+def _a2a_backend_overrides(view: Any) -> dict:
+    from sglang.srt.environ import envs
+
+    moe_a2a_backend = view.moe_a2a_backend
+    if view.enable_deepep_waterfill and moe_a2a_backend != "deepep":
+        logger.warning(
+            "moe_a2a_backend is overridden to 'deepep' because DeepEP "
+            "Waterfill requires the DeepEP backend."
+        )
+        moe_a2a_backend = "deepep"
+    if envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get() and moe_a2a_backend != "megamoe":
+        moe_a2a_backend = "megamoe"
+        logger.info(
+            "SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE is set, "
+            "auto-configuring --moe-a2a-backend megamoe."
+        )
+    if moe_a2a_backend != view.moe_a2a_backend:
+        return {"moe_a2a_backend": moe_a2a_backend}
+    return {}
+
+
+@register_post_process
+def _a2a_ep_size(view: Any) -> dict:
+    if view.moe_a2a_backend in _A2A_EP_SPANNING_BACKENDS:
+        return {"ep_size": view.tp_size}
     return {}
 
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -33,8 +33,23 @@ import logging
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from sglang.srt.arg_groups.arg_utils import model_overridable_fields
+from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.runtime_context import resolve_flag_leaf
-from sglang.srt.utils.common import is_flashinfer_available, is_xpu
+from sglang.srt.utils.common import (
+    cpu_has_amx_support,
+    get_device_sm,
+    is_blackwell_supported,
+    is_cpu,
+    is_cuda,
+    is_flashinfer_available,
+    is_hip,
+    is_npu,
+    is_sm90_supported,
+    is_sm100_supported,
+    is_sm120_supported,
+    is_xpu,
+    xpu_has_xmx_support,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -250,6 +265,21 @@ def _exaone_overrides(server_args: Any, hf_config: Any) -> dict:
 
 @_register_for("GptOssForCausalLM")
 def _gpt_oss_overrides(server_args: Any, hf_config: Any) -> dict:
+    overrides: Dict[str, Any] = {}
+    # Set attention backend for GPT-OSS
+    if server_args.is_attention_backend_not_set():
+        if is_sm100_supported():
+            overrides["attention_backend"] = "trtllm_mha"
+        elif is_sm90_supported():
+            overrides["attention_backend"] = "fa3"
+        elif is_cpu() and cpu_has_amx_support():
+            overrides["attention_backend"] = "intel_amx"
+        elif is_xpu():
+            overrides["attention_backend"] = "intel_xpu"
+        elif is_hip():
+            overrides["attention_backend"] = "aiter"
+        else:
+            overrides["attention_backend"] = "triton"
     if is_xpu():
         # Check for bf16 dtype on Intel XPU. Reads the pristine dtype request,
         # which equals the legacy mid-branch read: dtype had no earlier writer
@@ -269,17 +299,111 @@ def _gpt_oss_overrides(server_args: Any, hf_config: Any) -> dict:
         and quantization_config.get("quant_method") == "mxfp4"
     ):
         # use bf16 for mxfp4 triton kernels
-        return {"dtype": "bfloat16"}
+        overrides["dtype"] = "bfloat16"
+    return overrides
+
+
+# Keep in sync with LLAMA4_MODEL_ARCHS (server_args.py).
+@_register_for("Llama4ForConditionalGeneration", "Llama4ForCausalLM")
+def _llama4_overrides(server_args: Any, hf_config: Any) -> dict:
+    if server_args.device == "cpu":
+        return {}
+    # Auto-select attention backend for Llama4 if not specified
+    if server_args.attention_backend is None:
+        if is_sm100_supported():
+            backend, platform = "trtllm_mha", "sm100"
+        elif is_sm90_supported():
+            backend, platform = "fa3", "sm90"
+        elif is_hip():
+            backend, platform = "aiter", "hip"
+        elif server_args.device == "xpu":
+            backend, platform = "intel_xpu", "xpu"
+        else:
+            backend, platform = "triton", "other platforms"
+        logger.warning(
+            f"Use {backend} as attention backend on {platform} for Llama4 model"
+        )
+        return {"attention_backend": backend}
     return {}
+
+
+@_register_for(
+    "Gemma4ForConditionalGeneration",
+    "Gemma4ForCausalLM",
+    "Gemma4UnifiedForConditionalGeneration",
+)
+def _gemma4_overrides(server_args: Any, hf_config: Any) -> dict:
+    default_attention_backend = "trtllm_mha" if is_sm100_supported() else "triton"
+    if server_args.is_attention_backend_not_set():
+        logger.info(
+            f"Use {default_attention_backend} as default attention backend for Gemma4"
+        )
+        return {"attention_backend": default_attention_backend}
+    # If only one split backend is set, keep the other side on a
+    # Gemma4-compatible fallback instead of letting generic backend selection
+    # choose an unsupported backend later.
+    if server_args.attention_backend is None:
+        return {"attention_backend": default_attention_backend}
+    return {}
+
+
+@_register_for("MiniCPMV4_6ForConditionalGeneration")
+def _minicpm_v4_6_overrides(server_args: Any, hf_config: Any) -> dict:
+    if is_sm100_supported() and server_args.attention_backend is None:
+        return {"attention_backend": "triton"}
+    return {}
+
+
+@_register_for(
+    "FalconH1ForCausalLM", "JetNemotronForCausalLM", "JetVLMForConditionalGeneration"
+)
+def _falcon_h1_jet_overrides(server_args: Any, hf_config: Any) -> dict:
+    if is_sm100_supported() and server_args.attention_backend is None:
+        return {"attention_backend": "triton"}
+    return {}
+
+
+@_register_for("GraniteMoeHybridForCausalLM")
+def _granite_moe_hybrid_overrides(server_args: Any, hf_config: Any) -> dict:
+    has_mamba = any(
+        layer_type == "mamba" for layer_type in getattr(hf_config, "layer_types", [])
+    )
+    if has_mamba and is_sm100_supported() and server_args.attention_backend is None:
+        return {"attention_backend": "flashinfer"}
+    return {}
+
+
+@_register_for("Lfm2ForCausalLM")
+def _lfm2_overrides(server_args: Any, hf_config: Any) -> dict:
+    if is_sm100_supported() and server_args.attention_backend is None:
+        return {"attention_backend": "flashinfer"}
+    return {}
+
+
+@_register_for("Glm4MoeForCausalLM")
+def _glm4_moe_overrides(server_args: Any, hf_config: Any) -> dict:
+    logger.info(
+        "Enable TF32 matmul for Glm4MoeForCausalLM model to improve gate gemm performance."
+    )
+    return {"enable_tf32_matmul": True}
 
 
 @_register_for("Olmo2ForCausalLM")
 def _olmo2_overrides(server_args: Any, hf_config: Any) -> dict:
+    overrides: Dict[str, Any] = {}
     # FIXME: https://github.com/sgl-project/sglang/pull/7367 is not compatible with Olmo3 model.
     logger.warning(
         f"Disabling hybrid SWA memory for {hf_config.architectures[0]} as it is not yet supported."
     )
-    return {"disable_hybrid_swa_memory": True}
+    overrides["disable_hybrid_swa_memory"] = True
+    if server_args.attention_backend is None:
+        if is_cuda() and is_sm100_supported():
+            overrides["attention_backend"] = "trtllm_mha"
+        elif is_cuda() and get_device_sm() >= 80:
+            overrides["attention_backend"] = "fa3"
+        else:
+            overrides["attention_backend"] = "triton"
+    return overrides
 
 
 @register_model_override_predicate(
@@ -288,6 +412,13 @@ def _olmo2_overrides(server_args: Any, hf_config: Any) -> dict:
 )
 def _step3p_overrides(server_args: Any, hf_config: Any) -> dict:
     overrides: Dict[str, Any] = {}
+    if server_args.is_attention_backend_not_set():
+        if is_blackwell_supported():
+            logger.info("Auto-select fa4 attention backend for Step3p7 on Blackwell.")
+            overrides["attention_backend"] = "fa4"
+        elif is_sm90_supported():
+            logger.info("Auto-select fa3 attention backend for Step3p7 on Hopper.")
+            overrides["attention_backend"] = "fa3"
     if server_args.speculative_algorithm == "EAGLE":
         logger.info(
             "Enable multi-layer EAGLE speculative decoding for Step3p5ForCausalLM model."
@@ -330,6 +461,155 @@ def _deterministic_sampling_backend(view: Any) -> dict:
             "Sampling backend is set to pytorch for deterministic inference."
         )
         return {"sampling_backend": "pytorch"}
+    return {}
+
+
+def _deterministic_is_deepseek_model(view: Any) -> bool:
+    """Faithful copy of the deterministic handler's arch probe (pure read;
+    the handler keeps its own copy for the later deepseek validation)."""
+    from sglang.srt.connector import ConnectorType
+    from sglang.srt.utils.common import parse_connector_type
+
+    if parse_connector_type(view.model_path) == ConnectorType.INSTANCE:
+        return False
+    try:
+        hf_config = view.get_model_config().hf_config
+        return hf_config.architectures[0] in [
+            "DeepseekV2ForCausalLM",
+            "DeepseekV3ForCausalLM",
+            "DeepseekV32ForCausalLM",
+            "MistralLarge3ForCausalLM",
+            "PixtralForConditionalGeneration",
+            "GlmMoeDsaForCausalLM",
+        ]
+    except Exception:
+        return False
+
+
+@register_post_process
+def _deterministic_attention_backend(view: Any) -> dict:
+    if not view.enable_deterministic_inference:
+        return {}
+    from sglang.srt.server_args import DETERMINISTIC_ATTENTION_BACKEND_CHOICES
+
+    if view.attention_backend is None:
+        # User didn't specify attention backend, fallback based on GPU architecture
+        if is_sm100_supported() or is_sm120_supported():
+            # Blackwell and newer architectures
+            if _deterministic_is_deepseek_model(view):
+                # fallback to triton for DeepSeek models because flashinfer
+                # doesn't support deterministic inference for DeepSeek models yet
+                backend = "triton"
+            else:
+                # fallback to flashinfer on Blackwell for non-DeepSeek models
+                backend = "flashinfer"
+        else:
+            # Hopper (SM90) and older architectures
+            backend = "fa3"
+        logger.warning(
+            f"Attention backend not specified. Falling back to '{backend}' for deterministic inference. "
+            f"You can explicitly set --attention-backend to one of {DETERMINISTIC_ATTENTION_BACKEND_CHOICES}."
+        )
+        return {"attention_backend": backend}
+    elif view.attention_backend not in DETERMINISTIC_ATTENTION_BACKEND_CHOICES:
+        # User explicitly specified an incompatible attention backend
+        raise ValueError(
+            f"Currently only {DETERMINISTIC_ATTENTION_BACKEND_CHOICES} attention backends are supported for deterministic inference, "
+            f"but you explicitly specified '{view.attention_backend}'."
+        )
+    return {}
+
+
+@register_post_process
+def _attention_backend_default(view: Any) -> dict:
+    if view.prefill_attention_backend is not None and (
+        view.prefill_attention_backend == view.decode_attention_backend
+    ):  # override the default attention backend
+        return {"attention_backend": view.prefill_attention_backend}
+    if view.attention_backend is None:
+        backend = view._get_default_attn_backend(
+            view.use_mla_backend(), view.get_model_config()
+        )
+        logger.info(
+            f"Attention backend not specified. Use {backend} backend by default."
+        )
+        return {"attention_backend": backend}
+    return {}
+
+
+@register_post_process
+def _attention_backend_fa3_fp8_fallback(view: Any) -> dict:
+    if view.attention_backend == "fa3" and view.kv_cache_dtype == "fp8_e5m2":
+        logger.warning(
+            "FlashAttention3 only supports fp8_e4m3 if using FP8; "
+            "Setting attention backend to triton."
+        )
+        return {"attention_backend": "triton"}
+    return {}
+
+
+@register_post_process
+def _attention_backend_platform_fallbacks(view: Any) -> dict:
+    if (
+        view.attention_backend == "intel_amx"
+        and view.device == "cpu"
+        and not cpu_has_amx_support()
+    ):
+        logger.warning(
+            "The current platform does not support Intel AMX, will fallback to torch_native backend."
+        )
+        return {"attention_backend": "torch_native"}
+    if (
+        view.attention_backend == "intel_xpu"
+        and view.device == "xpu"
+        and not xpu_has_xmx_support()
+    ):
+        logger.warning(
+            "The current platform does not support Intel XMX, will fallback to triton backend."
+        )
+        return {"attention_backend": "triton"}
+    return {}
+
+
+@register_post_process
+def _attention_backend_dual_chunk(view: Any) -> dict:
+    if (
+        getattr(view.get_model_config().hf_config, "dual_chunk_attention_config", None)
+        is not None
+    ):
+        if view.attention_backend is None:
+            logger.info("Dual chunk attention is turned on by default.")
+            return {"attention_backend": "dual_chunk_flash_attn"}
+        elif view.attention_backend != "dual_chunk_flash_attn":
+            raise ValueError(
+                "Dual chunk attention is enabled, but attention backend is set to "
+                f"{view.attention_backend}. Please set it to 'dual_chunk_flash_attn'."
+            )
+    return {}
+
+
+@register_post_process
+def _dllm_attention_backend(view: Any) -> dict:
+    if view.dllm_algorithm is None:
+        return {}
+    if is_hip():
+        if view.attention_backend not in ["triton", "aiter"]:
+            logger.warning(
+                "Attention backend is set to triton for diffusion LLM inference on AMD GPUs"
+            )
+            return {"attention_backend": "triton"}
+    elif is_npu():
+        if view.attention_backend != "ascend":
+            logger.warning(
+                "Attention backend is overridden to 'ascend' when running on NPU for diffusion LLM inference."
+            )
+            return {"attention_backend": "ascend"}
+    elif view.cuda_graph_config.decode.backend != Backend.DISABLED:
+        if view.attention_backend != "flashinfer":
+            logger.warning(
+                "Attention backend is set to flashinfer because of enabling cuda graph in diffusion LLM inference"
+            )
+            return {"attention_backend": "flashinfer"}
     return {}
 
 
@@ -442,6 +722,27 @@ def apply_declarations_to_server_args(
     for _source, decl in list(declarations) + list(terminal):
         for field, value in decl.items():
             setattr(server_args, field, value)
+
+
+def refresh_declared_fields(server_args: Any, fields: Iterable[str]) -> None:
+    """Transition helper for legacy code that overwrites a resolved field
+    AFTER the R0 collection in ``__post_init__`` (e.g.
+    ``ModelRunner.model_specific_adjustment`` forcing ``attention_backend``
+    for HRM-Text). Redeclares the live value so publish parity holds and the
+    flags tier materializes the adjusted end state.
+    """
+    _missing = object()
+    declarations = server_args._resolved_overrides
+    for field in fields:
+        effective = _missing
+        for _source, decl in declarations:
+            if field in decl:
+                effective = decl[field]
+        if effective is _missing:
+            continue
+        live = getattr(server_args, field)
+        if effective != live:
+            declarations.append((f"runtime_adjustment[{field}]", {field: live}))
 
 
 def assert_flag_parity(

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -43,6 +43,7 @@ from sglang.srt.utils.common import (
     is_cuda,
     is_flashinfer_available,
     is_hip,
+    is_musa,
     is_npu,
     is_sm90_supported,
     is_sm100_supported,
@@ -380,6 +381,53 @@ def _lfm2_overrides(server_args: Any, hf_config: Any) -> dict:
     return {}
 
 
+@_register_for(
+    "Qwen3NextForCausalLM",
+    "Qwen3_5MoeForConditionalGeneration",
+    "InternS2PreviewForConditionalGeneration",
+    "Qwen3_5ForConditionalGeneration",
+)
+def _qwen3_5_hybrid_overrides(server_args: Any, hf_config: Any) -> dict:
+    if not is_sm100_supported() or server_args.attention_backend is not None:
+        return {}
+    sm100_default_attn_backend = "triton"
+    # trtllm_mha requires speculative_eagle_topk == 1 and page_size > 1.
+    # _get_default_attn_backend handles the eagle_topk check.
+    # There is only one case where page_size=1 is required,
+    # which is when radix cache is enabled and both extra_buffer
+    # and spec decoding are disabled.
+    default_attn_backend = server_args._get_default_attn_backend(
+        use_mla_backend=server_args.use_mla_backend(),
+        model_config=server_args.get_model_config(),
+    )
+    if default_attn_backend == "trtllm_mha" and not (
+        not server_args.enable_mamba_extra_buffer()
+        and not server_args.disable_radix_cache
+        and server_args.speculative_algorithm is None
+    ):
+        sm100_default_attn_backend = "trtllm_mha"
+    return {
+        "attention_backend": sm100_default_attn_backend,
+        "page_size": 64 if sm100_default_attn_backend == "trtllm_mha" else 1,
+    }
+
+
+@_register_for("Qwen3VLForConditionalGeneration")
+def _qwen3vl_overrides(server_args: Any, hf_config: Any) -> dict:
+    from sglang.srt.environ import envs
+
+    if (
+        is_hip()
+        and envs.SGLANG_USE_AITER_UNIFIED_ATTN.get()
+        and server_args.page_size is None
+    ):
+        logger.info(
+            "Setting page_size=16 for aiter unified attention on Qwen3VLForConditionalGeneration."
+        )
+        return {"page_size": 16}
+    return {}
+
+
 @_register_for("Glm4MoeForCausalLM")
 def _glm4_moe_overrides(server_args: Any, hf_config: Any) -> dict:
     logger.info(
@@ -538,6 +586,72 @@ def _attention_backend_default(view: Any) -> dict:
 
 
 @register_post_process
+def _mla_backend_page_constraints(view: Any) -> dict:
+    """Page-size constraints of the MLA/TRTLLM backend family (the raises and
+    the cutedsl prefill fallback stay in the handler; only the page snaps are
+    declared). The snaps chain on a local value exactly as the legacy blocks
+    chained on self.page_size."""
+    page_size = view.page_size
+    if (
+        view.attention_backend == "flashmla"
+        or view.decode_attention_backend == "flashmla"
+    ):
+        logger.warning(
+            "FlashMLA only supports a page_size of 64, change page_size to 64."
+        )
+        page_size = 64
+    if (
+        view.attention_backend == "cutlass_mla"
+        or view.decode_attention_backend == "cutlass_mla"
+    ):
+        logger.warning(
+            "Cutlass MLA only supports a page_size of 128, change page_size to 128."
+        )
+        page_size = 128
+    if (
+        view.attention_backend == "trtllm_mla"
+        or view.decode_attention_backend == "trtllm_mla"
+    ):
+        if page_size not in [32, 64]:
+            logger.warning(
+                f"TensorRT-LLM MLA only supports page_size of 32 or 64, changing page_size from {page_size} to 64."
+            )
+            page_size = 64
+    if (
+        view.attention_backend == "tokenspeed_mla"
+        or view.decode_attention_backend == "tokenspeed_mla"
+    ):
+        if page_size not in [32, 64]:
+            logger.warning(
+                f"tokenspeed_mla only supports page_size of 32 or 64, changing page_size from {page_size} to 64."
+            )
+            page_size = 64
+    if (
+        view.attention_backend == "cutedsl_mla"
+        or view.decode_attention_backend == "cutedsl_mla"
+        or view.prefill_attention_backend == "cutedsl_mla"
+    ):
+        if page_size not in [32, 64]:
+            logger.warning(
+                f"CuteDSL MLA only supports page_size of 32 or 64, changing page_size from {page_size} to 64."
+            )
+            page_size = 64
+    if (
+        view.attention_backend == "trtllm_mha"
+        or view.decode_attention_backend == "trtllm_mha"
+        or view.prefill_attention_backend == "trtllm_mha"
+    ):
+        if page_size not in [16, 32, 64]:
+            logger.warning(
+                f"TensorRT-LLM MHA only supports page_size of 16, 32 or 64, changing page_size from {page_size} to 64."
+            )
+            page_size = 64
+    if page_size != view.page_size:
+        return {"page_size": page_size}
+    return {}
+
+
+@register_post_process
 def _attention_backend_fa3_fp8_fallback(view: Any) -> dict:
     if view.attention_backend == "fa3" and view.kv_cache_dtype == "fp8_e5m2":
         logger.warning(
@@ -545,6 +659,28 @@ def _attention_backend_fa3_fp8_fallback(view: Any) -> dict:
             "Setting attention backend to triton."
         )
         return {"attention_backend": "triton"}
+    return {}
+
+
+@register_post_process
+def _fa4_page_constraint(view: Any) -> dict:
+    if (
+        (
+            view.attention_backend == "fa4"
+            or view.decode_attention_backend == "fa4"
+            or view.prefill_attention_backend == "fa4"
+        )
+        and not view.use_mla_backend()
+        and is_sm100_supported()
+        # EAGLE topk>1 spec runs the two-pass page-tree cascade, which the FA4
+        # CUTLASS kernel aborts on at page_size>1. That path only works at
+        # page_size==1, so skip the 128 auto-force for it and keep the default.
+        and (view.speculative_eagle_topk or 0) <= 1
+    ):
+        logger.warning(
+            f"FA4 backend only supports page size 128 for non-MLA model architectures, changing page_size from {view.page_size} to 128."
+        )
+        return {"page_size": 128}
     return {}
 
 
@@ -572,6 +708,24 @@ def _attention_backend_platform_fallbacks(view: Any) -> dict:
 
 
 @register_post_process
+def _intel_xpu_page_constraint(view: Any) -> dict:
+    _, decode_backend = view.get_attention_backends()
+    if decode_backend == "intel_xpu":
+        if view.use_mla_backend():
+            supported_page_sizes = [16, 32, 64, 128]
+            msg = "Intel XPU attention backend for MLA Decode"
+        else:
+            supported_page_sizes = [64, 128]
+            msg = "Intel XPU attention backend"
+        if view.page_size not in supported_page_sizes:
+            logger.warning(
+                f"{msg} only supports page_sizes of {supported_page_sizes}, changing page_size from {view.page_size} to 128."
+            )
+            return {"page_size": 128}
+    return {}
+
+
+@register_post_process
 def _attention_backend_dual_chunk(view: Any) -> dict:
     if (
         getattr(view.get_model_config().hf_config, "dual_chunk_attention_config", None)
@@ -586,6 +740,30 @@ def _attention_backend_dual_chunk(view: Any) -> dict:
                 f"{view.attention_backend}. Please set it to 'dual_chunk_flash_attn'."
             )
     return {}
+
+
+@register_post_process
+def _page_size_default(view: Any) -> dict:
+    if view.page_size is not None:
+        return {}
+    from sglang.srt.environ import envs
+
+    # SHUFFLE 5D vectorized KV layout (aiter backend + pa_decode_gluon)
+    # is tuned for and prefers page_size=64 — making it the default
+    # when the layout flag is set avoids users having to pass
+    # --page-size 64 explicitly. The env var is only consumed by the
+    # ROCm AITER backend, so the auto-bump is gated on HIP; on other
+    # platforms the SHUFFLE 5D pool has no consumer kernels and the
+    # env var is silently ignored (see MHATokenToKVPool).
+    if is_hip() and envs.SGLANG_AITER_KV_CACHE_LAYOUT.get().lower() == "vectorized_5d":
+        logger.info(
+            "Setting page_size=64 as default for "
+            "SGLANG_AITER_KV_CACHE_LAYOUT=vectorized_5d."
+        )
+        return {"page_size": 64}
+    if not is_musa():
+        return {"page_size": 1}
+    return {"page_size": 64}
 
 
 @register_post_process
@@ -610,6 +788,21 @@ def _dllm_attention_backend(view: Any) -> dict:
                 "Attention backend is set to flashinfer because of enabling cuda graph in diffusion LLM inference"
             )
             return {"attention_backend": "flashinfer"}
+    return {}
+
+
+@register_post_process
+def _dllm_page_size(view: Any) -> dict:
+    if view.dllm_algorithm is None or view.disable_radix_cache:
+        return {}
+    from sglang.srt.dllm.config import DllmConfig
+
+    config = DllmConfig.from_server_args(view)
+    if view.page_size % config.block_size != 0:
+        logger.warning(
+            f"Setting page size to {config.block_size} for diffusion LLM inference"
+        )
+        return {"page_size": config.block_size}
     return {}
 
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1,0 +1,200 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Declarative model-override registry.
+
+Model-identity adjustments to the server configuration are DECLARED here and
+resolved into the flags tier through the ``apply_model_overrides`` gate —
+model code never mutates ``ServerArgs``, which stays the pristine user input.
+
+Two declaration forms, keyed on ``hf_config.architectures[0]``:
+
+- ``MODEL_OVERRIDES``: pure-constant cases — ``arch -> {field: value}``.
+- ``@register_model_override(arch)``: derived cases — a callable
+  ``fn(server_args, hf_config) -> dict`` that faithfully carries today's
+  conditional logic. ``server_args`` is pristine and must be treated
+  read-only: the callable returns declarations, it never writes.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from sglang.srt.arg_groups.arg_utils import model_overridable_fields
+from sglang.srt.runtime_context import resolve_flag_leaf
+
+# Constant per-architecture overrides (populated by the migration sweeps).
+MODEL_OVERRIDES: Dict[str, Dict[str, Any]] = {}
+
+# Derived per-architecture override providers, in registration order.
+_MODEL_OVERRIDE_FNS: Dict[str, List[Callable[..., dict]]] = {}
+
+
+def register_model_override(architecture: str):
+    """Register a derived-override provider for ``architecture``.
+
+    The decorated callable receives ``(server_args, hf_config)``, must not
+    mutate either, and returns a ``{field: resolved_value}`` dict (possibly
+    empty when nothing applies). Providers needing derived model data beyond
+    the HF config go through ``server_args.get_model_config()`` (cached,
+    read-only) — never anything mutating.
+    """
+
+    def decorator(fn: Callable[..., dict]) -> Callable[..., dict]:
+        _MODEL_OVERRIDE_FNS.setdefault(architecture, []).append(fn)
+        return fn
+
+    return decorator
+
+
+def collect_model_override_declarations(
+    architecture: str, server_args: Any, hf_config: Any
+) -> List[Tuple[str, Dict[str, Any]]]:
+    """Collect ``(source, declaration)`` pairs for one architecture.
+
+    Application order (last writer wins downstream in the gate): the constant
+    ``MODEL_OVERRIDES`` entry first, then registered callables in registration
+    order. Empty declarations are dropped.
+    """
+    declarations: List[Tuple[str, Dict[str, Any]]] = []
+    const = MODEL_OVERRIDES.get(architecture)
+    if const:
+        declarations.append((f"MODEL_OVERRIDES[{architecture!r}]", dict(const)))
+    for fn in _MODEL_OVERRIDE_FNS.get(architecture, ()):
+        declared = fn(server_args, hf_config)
+        if not isinstance(declared, dict):
+            raise TypeError(
+                f"model override provider {fn.__qualname__} must return a dict, "
+                f"got {type(declared).__name__}"
+            )
+        if declared:
+            declarations.append((fn.__qualname__, dict(declared)))
+    return declarations
+
+
+@dataclasses.dataclass(frozen=True)
+class OverrideRecord:
+    """Provenance of one resolved write: ``base`` is the value before this
+    declaration applied (the pristine value for the first writer)."""
+
+    source: str
+    field: str
+    base: Any
+    resolved: Any
+
+
+def apply_model_overrides(
+    flags: Any,
+    server_args: Any,
+    declarations: Sequence[Tuple[str, Dict[str, Any]]],
+    *,
+    terminal: Sequence[Tuple[str, Dict[str, Any]]] = (),
+    whitelist: Optional[Iterable[str]] = None,
+    leaf_map: Optional[Dict[str, str]] = None,
+) -> List[OverrideRecord]:
+    """Resolve model-override declarations into the flags tier.
+
+    - **Transactional**: every declaration (``terminal`` included) is
+      validated against the whitelist and the flag-leaf layout BEFORE any
+      write; on error nothing is applied.
+    - **Ordering**: ``declarations`` apply in order (last writer wins), then
+      ``terminal`` (the enforce-disable pass) applies after everything.
+    - **Materialization**: every whitelisted field becomes a flag leaf —
+      declared fields carry the resolved value, undeclared ones the pristine
+      ``server_args`` value — so readers only ever read flags, never a
+      "flag or fallback to config" combination.
+    - ``server_args`` is read-only here: resolution output lives on flags.
+
+    Returns the provenance log, one record per declared write.
+    """
+    if whitelist is None:
+        whitelist = model_overridable_fields(type(server_args))
+    whitelist = frozenset(whitelist)
+
+    ordered = list(declarations) + list(terminal)
+
+    problems = [
+        f"{source}: {sorted(set(decl) - whitelist)} not model-overridable"
+        for source, decl in ordered
+        if set(decl) - whitelist
+    ]
+    if problems:
+        raise ValueError(
+            "model override validation failed (nothing was applied): "
+            + "; ".join(problems)
+        )
+    for field in sorted(whitelist):
+        owner, leaf = resolve_flag_leaf(flags, field, leaf_map=leaf_map)
+        if leaf not in type(owner).__dataclass_fields__:
+            raise ValueError(
+                f"flag leaf for '{field}' is not declared on "
+                f"{type(owner).__name__} (declare the dataclass field and map "
+                "it in FLAG_LEAF_MAP); nothing was applied"
+            )
+        if getattr(owner, "_frozen", False):
+            raise RuntimeError(
+                f"cannot resolve '{field}': {type(owner).__name__} is frozen; "
+                "nothing was applied"
+            )
+
+    resolved = {field: getattr(server_args, field) for field in whitelist}
+    records: List[OverrideRecord] = []
+    for source, decl in ordered:
+        for field, value in decl.items():
+            records.append(OverrideRecord(source, field, resolved[field], value))
+            resolved[field] = value
+
+    for field, value in resolved.items():
+        owner, leaf = resolve_flag_leaf(flags, field, leaf_map=leaf_map)
+        setattr(owner, leaf, value)
+    return records
+
+
+def apply_declarations_to_server_args(
+    server_args: Any,
+    declarations: Sequence[Tuple[str, Dict[str, Any]]],
+    *,
+    terminal: Sequence[Tuple[str, Dict[str, Any]]] = (),
+) -> None:
+    """Transition-period dual-apply: replay declarations onto ``server_args``
+    in gate order, byte-identical to the legacy imperative writes.
+
+    Retired per field once that field's readers have all flipped to the flags
+    tier (at which point the server_args field returns to pristine).
+    """
+    for _source, decl in list(declarations) + list(terminal):
+        for field, value in decl.items():
+            setattr(server_args, field, value)
+
+
+def assert_flag_parity(
+    flags: Any,
+    server_args: Any,
+    fields: Iterable[str],
+    *,
+    leaf_map: Optional[Dict[str, str]] = None,
+) -> None:
+    """Dual-apply drift guard: each migrated field's flag leaf must equal the
+    (dual-applied) ``server_args`` value."""
+    mismatches = []
+    for field in fields:
+        owner, leaf = resolve_flag_leaf(flags, field, leaf_map=leaf_map)
+        flag_value = getattr(owner, leaf)
+        args_value = getattr(server_args, field)
+        if flag_value != args_value:
+            mismatches.append(
+                f"{field}: flags={flag_value!r} server_args={args_value!r}"
+            )
+    if mismatches:
+        raise AssertionError("flag/server_args parity broken: " + "; ".join(mismatches))

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -172,7 +172,23 @@ def apply_declarations_to_server_args(
 
     Retired per field once that field's readers have all flipped to the flags
     tier (at which point the server_args field returns to pristine).
+
+    Validates against the same whitelist as the publish gate BEFORE any write:
+    a registry typo or a not-yet-resolvable field must fail fast here, not
+    mutate ``server_args`` and only be rejected at publish time.
     """
+    # Non-dataclass fixtures carry no Arg metadata (mirrors the
+    # model_overridable_fields escape); only real ServerArgs is validated.
+    if dataclasses.is_dataclass(type(server_args)):
+        whitelist = model_overridable_fields(type(server_args))
+        for source, decl in list(declarations) + list(terminal):
+            unknown = set(decl) - whitelist
+            if unknown:
+                raise ValueError(
+                    f"{source}: {sorted(unknown)} not model-overridable; the "
+                    "transition dual-apply refuses fields the publish gate "
+                    "would reject."
+                )
     for _source, decl in list(declarations) + list(terminal):
         for field, value in decl.items():
             setattr(server_args, field, value)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1184,6 +1184,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if not server_args.disable_chunked_prefix_cache:
             log_info_on_rank0(logger, "Chunked prefix cache is turned on.")
 
+        # The imperative adjustments above may overwrite fields the R0 passes
+        # already declared (HRM-Text forces attention_backend); redeclare the
+        # adjusted values so publish parity holds.
+        from sglang.srt.arg_groups.overrides import refresh_declared_fields
+
+        refresh_declared_fields(server_args, ("attention_backend",))
+
     def check_quantized_moe_compatibility(self):
         if (
             quantization_config := getattr(

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -312,6 +312,8 @@ class Flags(_StaticFlags):
     dtype: str = "auto"
     enable_tf32_matmul: bool = False
     enable_multi_layer_eagle: bool = False
+    swa_full_tokens_ratio: float = 0.8
+    disable_hybrid_swa_memory: bool = False
 
     def freeze(self) -> None:
         for field in dataclasses.fields(self):

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -27,10 +27,19 @@ tier). The context owns the storage: publishing goes through
 ``set_global_server_args_for_scheduler`` / ``get_global_server_args`` in
 ``server_args.py`` are thin shims over this slot), and the object is returned
 by reference — the same live instance everywhere, never a copy.
+
+``get_flags()`` returns the resolved-flags tier: what the system *resolved*
+the configuration to (``server_args`` stays the pristine user input). Flags
+live in typed dataclass groups (``flags.attn`` / ``flags.moe`` / flat generic
+leaves on ``flags`` itself); reads and writes are plain attribute access.
+Static groups are writable during resolution and locked by ``freeze()``;
+``flags.capture`` stays writable (capture-time state). Each group offers a
+transactional, test-only ``override(**kw)`` that also works on frozen groups.
 """
 
 from __future__ import annotations
 
+import dataclasses
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
@@ -215,15 +224,125 @@ class ParallelContext:
         return self._v("attn_cp_group", _ps().get_attn_cp_group)
 
 
-class RuntimeContext:
-    """Container for the structured runtime accessors; exposes ``parallel`` and
-    ``server_args``."""
+class _FlagGroupBase:
+    """Shared flag-group behavior: typo-safe writes + transactional ``override()``.
 
-    __slots__ = ("parallel", "_server_args")
+    Groups are plain dataclasses; ``__dataclass_fields__`` is the single source
+    of truth for which leaves exist, so a mistyped name fails loudly instead of
+    creating a stray attribute.
+    """
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name not in type(self).__dataclass_fields__:
+            raise AttributeError(
+                f"{type(self).__name__} has no flag '{name}' (leaves are "
+                "declared as dataclass fields; check for typos)"
+            )
+        if getattr(self, "_frozen", False):
+            raise RuntimeError(
+                f"{type(self).__name__} is frozen; cannot write '{name}'. "
+                "Test-scoped changes go through override()."
+            )
+        object.__setattr__(self, name, value)
+
+    @contextmanager
+    def override(self, **kwargs):
+        """Temporarily force flag values, restoring on exit. Transactional
+        (keys validated before any write) and usable on frozen groups — this
+        is the test-only injection primitive."""
+        fields = type(self).__dataclass_fields__
+        unknown = set(kwargs) - set(fields)
+        if unknown:
+            raise ValueError(
+                f"unknown flag(s) for {type(self).__name__}: {sorted(unknown)}"
+            )
+        saved = {name: getattr(self, name) for name in kwargs}
+        for name, value in kwargs.items():
+            object.__setattr__(self, name, value)
+        try:
+            yield self
+        finally:
+            for name, value in saved.items():
+                object.__setattr__(self, name, value)
+
+
+class _StaticFlags(_FlagGroupBase):
+    """Static flag-group: writable during resolution, locked by ``freeze()``."""
+
+    def freeze(self) -> None:
+        object.__setattr__(self, "_frozen", True)
+
+    @property
+    def frozen(self) -> bool:
+        return getattr(self, "_frozen", False)
+
+
+@dataclasses.dataclass
+class AttnFlags(_StaticFlags):
+    """Attention-family resolved flags (leaves arrive with the V3 sweeps)."""
+
+
+@dataclasses.dataclass
+class MoeFlags(_StaticFlags):
+    """MoE-family resolved flags (leaves arrive with the V3 sweeps)."""
+
+
+@dataclasses.dataclass
+class CaptureFlags(_FlagGroupBase):
+    """Capture-time flags; never frozen (written during cuda-graph capture)."""
+
+
+@dataclasses.dataclass
+class Flags(_StaticFlags):
+    """Root of the resolved-flags tier.
+
+    Family groups hang off it (``flags.attn`` / ``flags.moe`` / ``flags.capture``);
+    single generic flags live flat on this container, declared as fields here.
+    ``freeze()`` locks the container and every static sub-group; ``capture``
+    stays writable.
+    """
+
+    attn: AttnFlags = dataclasses.field(default_factory=AttnFlags)
+    moe: MoeFlags = dataclasses.field(default_factory=MoeFlags)
+    capture: CaptureFlags = dataclasses.field(default_factory=CaptureFlags)
+
+    def freeze(self) -> None:
+        for field in dataclasses.fields(self):
+            value = getattr(self, field.name)
+            if isinstance(value, _StaticFlags):
+                value.freeze()
+        super().freeze()
+
+
+# Resolved-config field name → dotted flag-leaf path (e.g. a V3 sweep adds
+# "use_mla_backend": "attn.use_mla_backend"). Fields not listed default to a
+# flat leaf of the same name on the Flags container. Populated per field
+# family as readers migrate; empty in the skeleton.
+FLAG_LEAF_MAP: dict[str, str] = {}
+
+
+def resolve_flag_leaf(
+    flags: Flags, field: str, *, leaf_map: dict[str, str] | None = None
+) -> tuple[Any, str]:
+    """Return ``(owning group, leaf attribute name)`` for a resolved-config field."""
+    path = (FLAG_LEAF_MAP if leaf_map is None else leaf_map).get(field, field)
+    owner: Any = flags
+    *groups, leaf = path.split(".")
+    for part in groups:
+        owner = getattr(owner, part)
+    return owner, leaf
+
+
+class RuntimeContext:
+    """Container for the structured runtime accessors; exposes ``parallel``,
+    ``server_args``, and ``flags``."""
+
+    __slots__ = ("parallel", "_server_args", "flags")
 
     def __init__(self, parallel: ParallelContext):
         self.parallel = parallel
         self._server_args: ServerArgs | None = None
+        self.flags = Flags()
 
     @property
     def server_args(self) -> ServerArgs:
@@ -260,9 +379,15 @@ def get_server_args() -> ServerArgs:
     return _CONTEXT.server_args
 
 
+def get_flags() -> Flags:
+    return _CONTEXT.flags
+
+
 def reset_context() -> None:
-    """Clear the context-owned store (unit-test teardown).
+    """Clear the context-owned store (unit-test teardown): drop the published
+    ``server_args`` and install a fresh, unfrozen ``Flags``.
 
     Wrapper subsystems (``parallel``) hold no state and are unaffected.
     """
     _CONTEXT._server_args = None
+    _CONTEXT.flags = Flags()

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -281,6 +281,10 @@ class _StaticFlags(_FlagGroupBase):
 class AttnFlags(_StaticFlags):
     """Attention-family resolved flags (leaves arrive with the V3 sweeps)."""
 
+    # Resolved attention backend; the pristine user request stays on
+    # server_args.attention_backend.
+    backend: str | None = None
+
 
 @dataclasses.dataclass
 class MoeFlags(_StaticFlags):
@@ -327,8 +331,10 @@ class Flags(_StaticFlags):
 # Resolved-config field name → dotted flag-leaf path (e.g. a V3 sweep adds
 # "use_mla_backend": "attn.use_mla_backend"). Fields not listed default to a
 # flat leaf of the same name on the Flags container. Populated per field
-# family as readers migrate; empty in the skeleton.
-FLAG_LEAF_MAP: dict[str, str] = {}
+# family as readers migrate.
+FLAG_LEAF_MAP: dict[str, str] = {
+    "attention_backend": "attn.backend",
+}
 
 
 def resolve_flag_leaf(

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -306,6 +306,13 @@ class Flags(_StaticFlags):
     moe: MoeFlags = dataclasses.field(default_factory=MoeFlags)
     capture: CaptureFlags = dataclasses.field(default_factory=CaptureFlags)
 
+    # -- resolved config leaves (flat; materialized at publish) --------------
+    # Pristine user requests stay on the matching server_args fields; these
+    # leaves carry the model-resolved values.
+    dtype: str = "auto"
+    enable_tf32_matmul: bool = False
+    enable_multi_layer_eagle: bool = False
+
     def freeze(self) -> None:
         for field in dataclasses.fields(self):
             value = getattr(self, field.name)

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -21,10 +21,12 @@ wrapper, not a cache. It gives call-sites one import and one naming scheme in
 place of a dozen free functions, plus a test-only ``override()`` hook to force a
 topology without monkeypatching the underlying getters.
 
-``get_server_args()`` returns the process-wide ``ServerArgs`` (the config tier).
-It is a read-through to ``server_args.get_global_server_args()`` — same object,
-same pre-publish error — so new code can adopt the context accessor while the
-legacy getter remains canonical.
+``get_server_args()`` returns the process-wide ``ServerArgs`` (the config
+tier). The context owns the storage: publishing goes through
+``RuntimeContext.set_server_args`` (the legacy
+``set_global_server_args_for_scheduler`` / ``get_global_server_args`` in
+``server_args.py`` are thin shims over this slot), and the object is returned
+by reference — the same live instance everywhere, never a copy.
 """
 
 from __future__ import annotations
@@ -48,12 +50,6 @@ def _dp():
     from sglang.srt.layers import dp_attention
 
     return dp_attention
-
-
-def _sa():
-    from sglang.srt import server_args
-
-    return server_args
 
 
 _PARALLEL_FIELDS = frozenset(
@@ -223,15 +219,29 @@ class RuntimeContext:
     """Container for the structured runtime accessors; exposes ``parallel`` and
     ``server_args``."""
 
-    __slots__ = ("parallel",)
+    __slots__ = ("parallel", "_server_args")
 
     def __init__(self, parallel: ParallelContext):
         self.parallel = parallel
+        self._server_args: ServerArgs | None = None
 
     @property
     def server_args(self) -> ServerArgs:
-        """The process-wide ``ServerArgs``, read through the global getter."""
-        return _sa().get_global_server_args()
+        """The process-wide ``ServerArgs`` (context-owned slot)."""
+        server_args = self._server_args
+        if server_args is None:
+            # Verbatim legacy message: tests and user scripts may match on it.
+            raise ValueError("Global server args is not set yet!")
+        return server_args
+
+    def set_server_args(self, server_args: ServerArgs) -> None:
+        """Publish the process-wide ``ServerArgs`` into the context-owned slot.
+
+        Overwrite-allowed: a re-publish replaces the slot (test kits re-publish
+        per test; production ordering discipline lives at the call-sites, e.g.
+        the draft-worker guard in ``ModelRunner.__init__``).
+        """
+        self._server_args = server_args
 
 
 _PARALLEL = ParallelContext()
@@ -248,3 +258,11 @@ def get_parallel() -> ParallelContext:
 
 def get_server_args() -> ServerArgs:
     return _CONTEXT.server_args
+
+
+def reset_context() -> None:
+    """Clear the context-owned store (unit-test teardown).
+
+    Wrapper subsystems (``parallel``) hold no state and are unaffected.
+    """
+    _CONTEXT._server_args = None

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -325,6 +325,14 @@ class Flags(_StaticFlags):
     sampling_backend: str | None = None
     page_size: int | None = None
     quantization: str | None = None
+    # Parallel-request fields: flat transitional home, to be re-homed by the
+    # Parallel Parameters Clarification module.
+    enable_dp_attention: bool = False
+    enable_dp_lm_head: bool = False
+    moe_a2a_backend: str = "none"
+    ep_size: int = 1
+    moe_dense_tp_size: int | None = None
+    attn_cp_size: int = 1
 
     def freeze(self) -> None:
         for field in dataclasses.fields(self):

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""A single structured accessor for process-static parallel-topology state.
+"""A single structured accessor for process-static runtime state.
 
 ``get_parallel()`` returns a ``ParallelContext`` whose attributes — tp / pp /
 moe / attn size and rank, plus the process-group handles — each delegate live to
@@ -20,12 +20,20 @@ Returned values are exactly what those getters return; this is a read-through
 wrapper, not a cache. It gives call-sites one import and one naming scheme in
 place of a dozen free functions, plus a test-only ``override()`` hook to force a
 topology without monkeypatching the underlying getters.
+
+``get_server_args()`` returns the process-wide ``ServerArgs`` (the config tier).
+It is a read-through to ``server_args.get_global_server_args()`` — same object,
+same pre-publish error — so new code can adopt the context accessor while the
+legacy getter remains canonical.
 """
 
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
 
 
 # Imported lazily so this module has no import-time dependencies: any module can
@@ -40,6 +48,12 @@ def _dp():
     from sglang.srt.layers import dp_attention
 
     return dp_attention
+
+
+def _sa():
+    from sglang.srt import server_args
+
+    return server_args
 
 
 _PARALLEL_FIELDS = frozenset(
@@ -206,12 +220,18 @@ class ParallelContext:
 
 
 class RuntimeContext:
-    """Container for the structured runtime accessors; currently exposes ``parallel``."""
+    """Container for the structured runtime accessors; exposes ``parallel`` and
+    ``server_args``."""
 
     __slots__ = ("parallel",)
 
     def __init__(self, parallel: ParallelContext):
         self.parallel = parallel
+
+    @property
+    def server_args(self) -> ServerArgs:
+        """The process-wide ``ServerArgs``, read through the global getter."""
+        return _sa().get_global_server_args()
 
 
 _PARALLEL = ParallelContext()
@@ -224,3 +244,7 @@ def get_context() -> RuntimeContext:
 
 def get_parallel() -> ParallelContext:
     return _PARALLEL
+
+
+def get_server_args() -> ServerArgs:
+    return _CONTEXT.server_args

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -290,6 +290,10 @@ class AttnFlags(_StaticFlags):
 class MoeFlags(_StaticFlags):
     """MoE-family resolved flags (leaves arrive with the V3 sweeps)."""
 
+    # Resolved MoE runner backend; the pristine user request stays on
+    # server_args.moe_runner_backend.
+    runner_backend: str = "auto"
+
 
 @dataclasses.dataclass
 class CaptureFlags(_FlagGroupBase):
@@ -320,6 +324,7 @@ class Flags(_StaticFlags):
     disable_hybrid_swa_memory: bool = False
     sampling_backend: str | None = None
     page_size: int | None = None
+    quantization: str | None = None
 
     def freeze(self) -> None:
         for field in dataclasses.fields(self):
@@ -335,6 +340,7 @@ class Flags(_StaticFlags):
 # family as readers migrate.
 FLAG_LEAF_MAP: dict[str, str] = {
     "attention_backend": "attn.backend",
+    "moe_runner_backend": "moe.runner_backend",
 }
 
 

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -314,6 +314,7 @@ class Flags(_StaticFlags):
     enable_multi_layer_eagle: bool = False
     swa_full_tokens_ratio: float = 0.8
     disable_hybrid_swa_memory: bool = False
+    sampling_backend: str | None = None
 
     def freeze(self) -> None:
         for field in dataclasses.fields(self):

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -319,6 +319,7 @@ class Flags(_StaticFlags):
     swa_full_tokens_ratio: float = 0.8
     disable_hybrid_swa_memory: bool = False
     sampling_backend: str | None = None
+    page_size: int | None = None
 
     def freeze(self) -> None:
         for field in dataclasses.fields(self):

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -359,8 +359,39 @@ class RuntimeContext:
         Overwrite-allowed: a re-publish replaces the slot (test kits re-publish
         per test; production ordering discipline lives at the call-sites, e.g.
         the draft-worker guard in ``ModelRunner.__init__``).
+
+        Publishing also resolves the stashed R0 model-override declarations
+        into the flags tier (skipped for objects without the stash — dummy /
+        "none" fixture ServerArgs and test-kit mocks never compute it).
+        Resolution runs first: if it fails, the previous publish stays intact.
         """
+        self._resolve_flags(server_args)
         self._server_args = server_args
+
+    def _resolve_flags(self, server_args: ServerArgs) -> None:
+        declarations = getattr(server_args, "_resolved_overrides", None)
+        if declarations is None:
+            return
+        from sglang.srt.arg_groups.overrides import (
+            apply_model_overrides,
+            assert_flag_parity,
+        )
+
+        # Resolve into a fresh container and only install it once everything
+        # passed: a failed resolution (gate validation or the parity assert)
+        # must not leave the process-global flags half-written for callers
+        # that catch the error or republish (same install-fresh semantics as
+        # reset_context()).
+        flags = Flags()
+        apply_model_overrides(flags, server_args, declarations)
+        # Transition-period drift guard: dual-apply keeps the declared fields
+        # on server_args byte-identical to the resolved flag leaves.
+        assert_flag_parity(
+            flags,
+            server_args,
+            {field for _source, decl in declarations for field in decl},
+        )
+        self.flags = flags
 
 
 _PARALLEL = ParallelContext()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -63,12 +63,10 @@ from sglang.srt.speculative.decoupled_spec_io import DecoupledSpecIpcConfig
 from sglang.srt.utils.common import (
     LORA_TARGET_ALL_MODULES,
     SUPPORTED_LORA_TARGET_MODULES,
-    cpu_has_amx_support,
     get_device,
     get_device_memory_capacity,
     get_device_sm,
     get_int_env_var,
-    get_nvidia_driver_version,
     get_quantization_config,
     has_fp8_weights_in_checkpoint,
     human_readable_int,
@@ -87,7 +85,6 @@ from sglang.srt.utils.common import (
     is_sm90_supported,
     is_sm100_supported,
     is_sm120_supported,
-    is_triton_kernels_available,
     is_xpu,
     json_list_type,
     nullable_str,
@@ -576,7 +573,11 @@ class ServerArgs:
     ] = "auto"
     quantization: A[
         Optional[str],
-        Arg(help="The quantization method.", choices=QUANTIZATION_CHOICES),
+        Arg(
+            help="The quantization method.",
+            choices=QUANTIZATION_CHOICES,
+            model_overridable=True,
+        ),
     ] = None
     quantization_param_path: A[
         Optional[str],
@@ -1721,6 +1722,7 @@ class ServerArgs:
         Arg(
             help="Choose the runner backend for MoE.",
             choices=MOE_RUNNER_BACKEND_CHOICES,
+            model_overridable=True,
         ),
     ] = "auto"
     flashinfer_mxfp4_moe_precision: A[
@@ -4099,65 +4101,8 @@ class ServerArgs:
             # The mxfp4 dtype override moved to the R0 registry
             # (arg_groups/overrides.py: _gpt_oss_overrides).
 
-            if self.moe_runner_backend == "auto":
-                if is_sm100_supported() and is_mxfp4_quant_format:
-                    self.moe_runner_backend = "flashinfer_mxfp4"
-                    logger.warning(
-                        "Detected SM100 and MXFP4 quantization format for GPT-OSS model, enabling FlashInfer MXFP4 MOE kernel."
-                    )
-                elif is_sm120_supported() and is_mxfp4_quant_format:
-                    # trtllm-gen only supports SM100
-                    self.moe_runner_backend = "marlin"
-                    logger.warning(
-                        "Detected SM120 and MXFP4 quantization format for GPT-OSS model, enabling Marlin MOE kernel."
-                    )
-                elif (
-                    is_hip() and envs.SGLANG_USE_AITER.get()
-                ) and is_mxfp4_quant_format:
-                    self.moe_runner_backend = "auto"
-                    logger.warning(
-                        "Detected ROCm and MXFP4 quantization format for GPT-OSS model, enabling aiter MXFP4 MOE kernel."
-                    )
-                    ## The AITER MXFP4 fused-MoE path for GPT-OSS expects the
-                    ## SEPARATED gate/up tile layout (matches the
-                    ## `gptoss_fp4_tuned_fmoe.csv` flydsl entries and the
-                    ## Mxfp4MoEMethod weight shuffle). Other AITER MXFP4
-                    ## callers default to INTERLEAVE; opt this path out
-                    ## unless the user explicitly overrode it.
-                    # envs.SGLANG_USE_AITER_MOE_GU_ITLV.set(False)
-                elif is_hip() and envs.SGLANG_USE_AITER.get():
-                    # For GPT-OSS bf16 on ROCm with aiter, use triton backend
-                    # because aiter CK kernel doesn't support all GEMM dimensions
-                    self.moe_runner_backend = "triton"
-                    logger.warning(
-                        "Detected ROCm with SGLANG_USE_AITER for GPT-OSS bf16 model, using triton MOE kernel."
-                    )
-                elif is_musa() and envs.SGLANG_DEEPEP_BF16_DISPATCH.get():
-                    self.moe_runner_backend = "deep_gemm"
-                    logger.warning(
-                        "Detected MUSA with SGLANG_DEEPEP_BF16_DISPATCH for bf16 model, using deep_gemm kernel."
-                    )
-                elif (
-                    self.ep_size == 1
-                    and is_triton_kernels_available()
-                    and self.quantization is None
-                    and not (is_cpu() and cpu_has_amx_support())
-                ):
-                    # The triton_kernels package segfaults on Blackwell (B200)
-                    # with NVIDIA driver >= 595. Fall back to triton backend.
-                    if is_blackwell_supported() and get_nvidia_driver_version() >= (
-                        595,
-                    ):
-                        self.moe_runner_backend = "triton"
-                        logger.warning(
-                            "Detected GPT-OSS model on Blackwell with driver >= 595, "
-                            "using triton MOE kernel to avoid triton_kernels SIGSEGV."
-                        )
-                    else:
-                        self.moe_runner_backend = "triton_kernel"
-                        logger.warning(
-                            "Detected GPT-OSS model, enabling triton_kernels MOE kernel."
-                        )
+            # The moe_runner_backend selection moved to the R0 registry
+            # (arg_groups/overrides.py: _gpt_oss_overrides).
 
             if self.moe_runner_backend == "triton_kernel":
                 assert (
@@ -4224,12 +4169,8 @@ class ServerArgs:
                 "trtllm_mha",
                 "intel_xpu",
             }, f"fa3, aiter, triton, ascend, trtllm_mha or intel_xpu is required for Llama4 model but got {self.attention_backend}"
-            if is_sm100_supported() and self.moe_runner_backend == "auto":
-                if self.quantization in {"fp8", "modelopt_fp8"}:
-                    self.moe_runner_backend = "flashinfer_trtllm"
-                    logger.info(
-                        "Use flashinfer_trtllm as MoE runner backend on SM100 for Llama4"
-                    )
+            # The moe_runner_backend selection moved to the R0 registry
+            # (arg_groups/overrides.py: _llama4_overrides).
         # Gemma2/Gemma3 (disable_hybrid_swa_memory) moved to the R0 registry
         # (arg_groups/overrides.py: _gemma2_gemma3_overrides).
         elif model_arch in (
@@ -4249,14 +4190,8 @@ class ServerArgs:
                 f"got prefill={prefill_backend}, decode={decode_backend}"
             )
 
-            if is_sm100_supported() and self.moe_runner_backend == "auto":
-                if self.get_model_config().quantization == "modelopt_fp4":
-                    self.quantization = "modelopt_fp4"
-                    self.moe_runner_backend = "flashinfer_trtllm"
-                    logger.info(
-                        "Use flashinfer_trtllm as MoE runner backend on "
-                        "SM100 for Gemma-4 (modelopt_fp4)"
-                    )
+            # The quantization/moe_runner_backend resolution moved to the R0
+            # registry (arg_groups/overrides.py: _gemma4_overrides).
         elif model_arch == "MossVLForConditionalGeneration":
             if self.is_attention_backend_not_set():
                 self.prefill_attention_backend = "flashinfer"
@@ -4309,27 +4244,8 @@ class ServerArgs:
             "InternS2PreviewForConditionalGeneration",
             "Qwen3_5ForConditionalGeneration",
         ]:
-            if is_sm100_supported():
-                quant_method = get_quantization_config(hf_config)
-                if (
-                    self.quantization is None
-                    and not self._quantization_explicitly_unset
-                    and quant_method is not None
-                ):
-                    self.quantization = quant_method
-                if (
-                    (
-                        self.quantization in ("fp8", "modelopt_fp4")
-                        or self.quantization is None
-                    )
-                    and self.moe_a2a_backend == "none"
-                    and self.moe_runner_backend == "auto"
-                ):
-                    self.moe_runner_backend = "flashinfer_trtllm"
-                    logger.info(
-                        "Use flashinfer_trtllm as MoE runner backend on sm100 for "
-                        f"{model_arch}"
-                    )
+            # The quantization/moe_runner_backend resolution moved to the R0
+            # registry (arg_groups/overrides.py: _qwen3_moe_family_overrides).
 
             if model_arch in [
                 "Qwen3NextForCausalLM",
@@ -4349,30 +4265,10 @@ class ServerArgs:
             self._handle_mamba_radix_cache(model_arch=model_arch)
 
         elif model_arch in ["Glm4MoeForCausalLM"]:
-            if is_sm100_supported():
-                quantization_config = getattr(hf_config, "quantization_config", None)
-                quant_method = (
-                    quantization_config.get("quant_method")
-                    if quantization_config is not None
-                    else None
-                )
-                if (
-                    self.quantization is None
-                    and not self._quantization_explicitly_unset
-                    and quant_method is not None
-                ):
-                    self.quantization = quant_method
-                if (
-                    self.quantization in {"modelopt_fp4", None}
-                    and self.moe_a2a_backend == "none"
-                    and self.moe_runner_backend == "auto"
-                ):
-                    self.moe_runner_backend = "flashinfer_trtllm"
-                    logger.info(
-                        "Use flashinfer_trtllm as MoE runner backend on sm100 for Glm4MoeForCausalLM"
-                    )
-            # enable_tf32_matmul moved to the R0 registry
-            # (arg_groups/overrides.py: _glm4_moe_overrides).
+            # The quantization/moe_runner_backend/enable_tf32_matmul resolution
+            # moved to the R0 registry (arg_groups/overrides.py:
+            # _glm4_moe_overrides).
+            pass
 
         elif model_arch in [
             "FalconH1ForCausalLM",
@@ -5187,48 +5083,16 @@ class ServerArgs:
             ), "Please enable dp attention when setting enable_dp_lm_head. "
 
     def _handle_moe_kernel_config(self):
-        if self.quantization == "nvfp4_online":
-            if not is_sm100_supported():
-                raise ValueError(
-                    "--quantization nvfp4_online is supported only on "
-                    "NVIDIA Blackwell SM100/SM103 GPUs."
-                )
-            if self.moe_runner_backend == "auto":
-                self.moe_runner_backend = "flashinfer_trtllm"
-            elif self.moe_runner_backend not in [
-                "flashinfer_trtllm",
-                "flashinfer_trtllm_routed",
-            ]:
-                raise ValueError(
-                    "--quantization nvfp4_online supports only "
-                    "--moe-runner-backend flashinfer_trtllm or "
-                    "flashinfer_trtllm_routed."
-                )
-        if self.quantization == "mxfp8":
-            if self.moe_runner_backend == "auto":
-                self.moe_runner_backend = "flashinfer_trtllm"
-            elif self.moe_runner_backend not in [
-                "cutlass",
-                "flashinfer_trtllm",
-                "flashinfer_trtllm_routed",
-            ]:
-                logger.warning(
-                    "mxfp8 quantization supports only cutlass, flashinfer_trtllm, "
-                    "or flashinfer_trtllm_routed backends. "
-                    f"Overriding {self.moe_runner_backend!r}."
-                )
-                self.moe_runner_backend = "flashinfer_trtllm"
+        # The quantization-driven runner resolutions moved to the pipeline
+        # (arg_groups/overrides.py: _moe_runner_backend_quant_constraints);
+        # the compatibility asserts and fusion writes stay below.
+        from sglang.srt.arg_groups.overrides import (
+            _cutlass_moe_env_override,
+            _moe_runner_backend_quant_constraints,
+            run_post_process_pass,
+        )
 
-        if (
-            self.moe_runner_backend == "auto"
-            and self.quantization == "modelopt_fp4"
-            and is_sm120_supported()
-        ):
-            self.moe_runner_backend = "flashinfer_cutlass"
-            logger.info(
-                "Use flashinfer_cutlass as MoE runner backend on SM120 for "
-                "modelopt_fp4 (trtllm-gen MoE kernels are SM100-only)"
-            )
+        run_post_process_pass(self, _moe_runner_backend_quant_constraints)
 
         if self.moe_runner_backend == "flashinfer_cutlass":
             assert self.quantization in [
@@ -5293,15 +5157,11 @@ class ServerArgs:
                 "FlashInfer TRTLLM routed MoE is enabled. --disable-shared-experts-fusion is automatically set."
             )
 
-        if envs.SGLANG_CUTLASS_MOE.get():
-            logger.warning(
-                "SGLANG_CUTLASS_MOE is deprecated, use --moe-runner-backend=cutlass and/or --speculative-moe-runner-backend=cutlass instead"
-            )
-            assert self.quantization in [
-                "fp8",
-                "mxfp8",
-            ], "cutlass MoE is only supported with fp8/mxfp8 quantization"
-            self.moe_runner_backend = "cutlass"
+        # The deprecated SGLANG_CUTLASS_MOE override moved to the pipeline
+        # (arg_groups/overrides.py: _cutlass_moe_env_override). It sits after
+        # the fusion blocks above on purpose: they must observe the
+        # pre-override runner value, exactly as they did imperatively.
+        run_post_process_pass(self, _cutlass_moe_env_override)
         if self.moe_runner_backend == "cutlass" and self.quantization in [
             "fp8",
             "mxfp8",
@@ -5751,10 +5611,19 @@ class ServerArgs:
         )
 
     def _handle_load_format(self):
+        # The quantization side of the gguf coupling moved to the pipeline
+        # (arg_groups/overrides.py: _gguf_quantization); load_format itself is
+        # genuine config (runtime user updates write it) and stays imperative.
+        from sglang.srt.arg_groups.overrides import (
+            _gguf_quantization,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _gguf_quantization)
         if (
             self.load_format == "auto" or self.load_format == "gguf"
         ) and check_gguf_file(self.model_path):
-            self.quantization = self.load_format = "gguf"
+            self.load_format = "gguf"
 
         if self.load_format == "auto" and self._is_mistral_native_format():
             self.load_format = "mistral"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7595,10 +7595,14 @@ class ServerArgs:
 
 
 # NOTE: The process-wide ServerArgs is owned by the runtime context
-# (sglang.srt.runtime_context). The two functions below are thin shims kept for
-# the existing call-sites; they publish/read the same live object by reference.
+# (sglang.srt.runtime_context). The two functions below are LEGACY shims kept
+# for the existing call-sites; they publish/read the same live object by
+# reference. Do not add new call-sites — the counts are ratcheted
+# (decrease-only) by test/registered/unit/test_legacy_global_ratchet.py.
 # Imports are in-function so the two modules stay cycle-free at import time.
 def set_global_server_args_for_scheduler(server_args: ServerArgs):
+    """Legacy publish shim — prefer ``get_context().set_server_args()`` from
+    ``sglang.srt.runtime_context`` in new code."""
     from sglang.srt.runtime_context import get_context
 
     get_context().set_server_args(server_args)
@@ -7608,6 +7612,8 @@ set_global_server_args_for_tokenizer = set_global_server_args_for_scheduler
 
 
 def get_global_server_args() -> ServerArgs:
+    """Legacy accessor shim — prefer ``get_server_args()`` from
+    ``sglang.srt.runtime_context`` in new code."""
     from sglang.srt.runtime_context import get_context
 
     return get_context().server_args

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -68,7 +68,6 @@ from sglang.srt.utils.common import (
     get_device_sm,
     get_int_env_var,
     get_quantization_config,
-    has_fp8_weights_in_checkpoint,
     human_readable_int,
     is_blackwell_supported,
     is_cpu,
@@ -932,6 +931,7 @@ class ServerArgs:
         Arg(
             help="The attention context parallelism size.",
             aliases=["--attention-context-parallel-size"],
+            model_overridable=True,
         ),
     ] = 1
     moe_dp_size: A[
@@ -966,7 +966,10 @@ class ServerArgs:
     # DP attention
     enable_dp_attention: A[
         bool,
-        "Enabling data parallelism for attention and tensor parallelism for FFN. The dp size should be equal to the tp size. Currently DeepSeek-V2 and Qwen 2/3 MoE models are supported.",
+        Arg(
+            help="Enabling data parallelism for attention and tensor parallelism for FFN. The dp size should be equal to the tp size. Currently DeepSeek-V2 and Qwen 2/3 MoE models are supported.",
+            model_overridable=True,
+        ),
     ] = False
     enable_dp_attention_local_control_broadcast: A[
         bool,
@@ -974,7 +977,10 @@ class ServerArgs:
     ] = False
     enable_dp_lm_head: A[
         bool,
-        "Enable vocabulary parallel across the attention TP group to avoid all-gather across DP groups, optimizing performance under DP attention.",
+        Arg(
+            help="Enable vocabulary parallel across the attention TP group to avoid all-gather across DP groups, optimizing performance under DP attention.",
+            model_overridable=True,
+        ),
     ] = False
     enable_attn_tp_input_scattered: A[
         bool,
@@ -1699,6 +1705,7 @@ class ServerArgs:
         Arg(
             help="The expert parallelism size.",
             aliases=["--expert-parallel-size", "--ep"],
+            model_overridable=True,
         ),
     ] = 1
     moe_a2a_backend: A[
@@ -1715,6 +1722,7 @@ class ServerArgs:
         Arg(
             help="Choose the backend for MoE A2A.",
             choices=MOE_A2A_BACKEND_CHOICES,
+            model_overridable=True,
         ),
     ] = "none"
     moe_runner_backend: A[
@@ -1778,7 +1786,10 @@ class ServerArgs:
     ] = None
     moe_dense_tp_size: A[
         Optional[int],
-        "TP size for MoE dense MLP layers. This flag is useful when, with large TP size, there are errors caused by weights in MLP layers having dimension smaller than the min dimension GEMM supports.",
+        Arg(
+            help="TP size for MoE dense MLP layers. This flag is useful when, with large TP size, there are errors caused by weights in MLP layers having dimension smaller than the min dimension GEMM supports.",
+            model_overridable=True,
+        ),
     ] = None
     elastic_ep_backend: A[
         Literal[None, "mooncake", "nixl"],
@@ -3793,9 +3804,8 @@ class ServerArgs:
                     logger.warning(
                         f"Set dense attention kv len threshold to model index_topk={envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()} for DeepSeek with DSA."
                     )
-                if self.is_attention_backend_not_set():
-                    self.attention_backend = "dsa"
-                    logger.info("Use dsa attention backend for DeepSeek with DSA.")
+                # The "dsa" attention fill moved to the R0 registry
+                # (arg_groups/overrides.py: _deepseek_family_overrides).
 
                 index_topk_freq = getattr(hf_config, "index_topk_freq", 1) or 1
                 index_topk_pattern = getattr(hf_config, "index_topk_pattern", None)
@@ -3813,40 +3823,10 @@ class ServerArgs:
 
                 if not is_npu() and not is_xpu():  # CUDA or ROCm GPU
                     if self.enable_prefill_cp:
-                        logger.warning(
-                            "Context parallel feature is still under experiment. It has only been verified on Hopper platform."
-                        )
-                        self.enable_dp_attention = True
-                        self.moe_dense_tp_size = 1
-                        if self.cp_strategy == "zigzag":
-                            self.moe_a2a_backend = "deepep"
-                            self.ep_size = self.tp_size
-                            logger.warning(
-                                "zigzag DSA CP requires moe_dense_tp_size=1, "
-                                "moe_a2a_backend=deepep, ep_size=tp_size, batch_size=1."
-                            )
-                        else:
-                            assert (
-                                self.dp_size == 1
-                            ), "interleave DSA CP does not support DP attention."
-                        assert (
-                            self.tp_size <= 8
-                        ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
-                        # Note(kpham-sgl): Keep attn_tp_size == 1 under DSA CP.
-                        # DSACPLayerCommunicator does not all-reduce attention-TP
-                        # partial o_proj outputs before replicated dense FFNs.
-                        self.attn_cp_size = self.tp_size // self.dp_size
+                        # The DSA CP field declarations moved to the R0
+                        # registry (arg_groups/overrides.py:
+                        # _deepseek_family_overrides).
                         self.cuda_graph_config.prefill.backend = Backend.DISABLED
-                        logger.warning(
-                            "Enabled DSA context parallel: "
-                            f"strategy={self.cp_strategy}, dp_size={self.dp_size}, "
-                            f"moe_dense_tp_size={self.moe_dense_tp_size}, "
-                            f"ep_size={self.ep_size}, tp_size={self.tp_size}, "
-                            f"attn_cp_size={self.attn_cp_size}, "
-                            f"kv_cache_dtype={self.kv_cache_dtype}, "
-                            f"moe_a2a_backend={self.moe_a2a_backend}, "
-                            f"cuda_graph_config[prefill].backend=disabled"
-                        )
                     else:
                         # Pure TP and partial DP Attention mode is active for DSA, logging a warning
                         if self.dp_size < self.tp_size:
@@ -3855,25 +3835,8 @@ class ServerArgs:
                                 f"attn_tp_size={self.tp_size}, attention weights will be sharded across {self.tp_size} ranks."
                             )
 
-                    # Deferred import to avoid a circular import at module-load
-                    # time (dsa.utils imports get_global_server_args).
-                    from sglang.srt.layers.attention.dsa.utils import (
-                        aiter_can_use_preshuffle_paged_mqa,
-                    )
-
-                    if is_hip() and not aiter_can_use_preshuffle_paged_mqa():
-                        # Legacy ROCm DSA path: aiter's gluon paged-MQA kernel is
-                        # unavailable (Triton<3.5 and AITER_ENABLE_AOT_GLUON_PA_MQA_LOGITS
-                        # not set, or SGLANG_DSA_HIP_DISABLE_PRESHUFFLE=1 / SGLANG_USE_AITER=0).
-                        self.page_size = 1
-                        logger.warning(
-                            "Setting page size to 1 for DeepSeek DSA on ROCm "
-                            "(aiter preshuffle paged-MQA path unavailable: "
-                            "needs Triton>=3.5.0 or AITER_ENABLE_AOT_GLUON_PA_MQA_LOGITS=1)."
-                        )
-                    else:
-                        self.page_size = 64
-                        logger.warning("Setting page size to 64 for DeepSeek DSA.")
+                    # The DSA page-size selection moved to the R0 registry
+                    # (arg_groups/overrides.py: _deepseek_family_overrides).
 
                     import torch
 
@@ -3891,108 +3854,28 @@ class ServerArgs:
                 if self.cuda_graph_config.prefill.backend != Backend.DISABLED:
                     logger.info("Piecewise CUDA graph is enabled, use MLA for prefill.")
 
-                if is_sm100_supported():
-                    if (
-                        self.attention_backend is None
-                        and self.prefill_attention_backend is None
-                        and self.decode_attention_backend is None
-                    ):
-                        self.attention_backend = "trtllm_mla"
-                        logger.info(
-                            "Use trtllm_mla as attention backend on sm100 for DeepseekV3ForCausalLM"
-                        )
+                # The sm100 trtllm_mla fill moved to the R0 registry
+                # (arg_groups/overrides.py: _deepseek_family_overrides).
 
-                # MLA prefill CP auto-config. Mirrors the NSA CP block above
-                # (minus the in-seq/round-robin mode split, which MLA CP does not support)
+                # MLA prefill CP auto-config: the field declarations moved to
+                # the R0 registry (arg_groups/overrides.py:
+                # _deepseek_family_overrides).
                 if self.enable_prefill_cp and self.use_mla_backend():
-                    logger.warning(
-                        "MLA prefill context parallel is still experimental. "
-                        "Verified on Hopper with the fa3 backend."
-                    )
-                    self.enable_dp_attention = True
-                    # TODO(kpham-sgl) Supports moe_dense_tp_size != 1.
-                    self.moe_dense_tp_size = 1
-                    self.moe_a2a_backend = "deepep"
-                    self.ep_size = self.tp_size
-                    logger.warning(
-                        "For MLA CP, we have the following restrictions: moe_dense_tp_size == 1, moe_a2a_backend == deepep, ep_size == tp_size, batch_size == 1"
-                    )
-                    # FIXME(kpham-sgl): Keep attn_tp_size == 1 under MLA CP.
-                    # DSACPLayerCommunicator does not all-reduce attention-TP
-                    # partial o_proj outputs before replicated dense FFNs.
-                    self.attn_cp_size = self.tp_size // self.dp_size
                     self.cuda_graph_config.prefill.backend = Backend.DISABLED
-                    logger.warning(
-                        f"Enable Context Parallel opt for MLA, "
-                        f"Setting dp_size == {self.dp_size} and "
-                        f"attn_cp_size == {self.attn_cp_size}, "
-                        f"moe_dense_tp_size == {self.moe_dense_tp_size}, "
-                        f"ep_size == {self.ep_size}, "
-                        f"tp_size == {self.tp_size}, "
-                        f"moe_a2a_backend {self.moe_a2a_backend}, "
-                        f"cuda_graph_config[prefill].backend=disabled"
-                    )
 
-            # Set moe backend for DeepSeek
-            if is_sm100_supported():
-                quant_method = get_quantization_config(hf_config)
-                quant_cfg = getattr(hf_config, "quantization_config", None) or {}
-                config_groups = quant_cfg.get("config_groups", {})
-                group0 = config_groups.get("group_0", {})
-                weights_cfg = group0.get("weights", {})
-                # this also apply to kimi k2.5
-                # since it follow the compressed tensor int4 recipe
-                # but not kimi k2 instruct or 0905 instruct.
-                is_kimi_k2_k25_thinking_int4 = (
-                    quant_method == "compressed-tensors"
-                    and weights_cfg.get("num_bits") == 4
-                    and weights_cfg.get("group_size") == 32
-                    and weights_cfg.get("strategy") == "group"
-                    and weights_cfg.get("type") == "int"
-                )
-                if (
-                    self.quantization is None
-                    and not self._quantization_explicitly_unset
-                ):
-                    # DeepSeek V3/R1 uses native FP8 MoE experts without
-                    # declaring it in quantization_config.  However, other
-                    # models that share the same architecture class (e.g.
-                    # Moonlight-16B-A3B) are purely BF16.  Check the actual
-                    # safetensors header instead of assuming FP8 by arch name.
-                    if quant_method is None and model_arch in ["DeepseekV3ForCausalLM"]:
-                        if has_fp8_weights_in_checkpoint(self.model_path):
-                            self.quantization = "fp8"
-                            logger.info(
-                                "Detected FP8 expert weights in checkpoint, "
-                                "default to fp8 for DeepSeek on sm100"
-                            )
-                        else:
-                            logger.info(
-                                "No FP8 expert weights found in checkpoint, "
-                                "keeping bf16 for DeepSeek-arch model on sm100"
-                            )
-                    else:
-                        self.quantization = quant_method
-                if (
-                    self.moe_a2a_backend == "none"
-                    and self.moe_runner_backend == "auto"
-                    and (
-                        self.quantization
-                        in ["fp8", "modelopt_fp8", "modelopt_fp4", "modelopt_mixed"]
-                        or is_kimi_k2_k25_thinking_int4
-                        or self.quantization is None
-                    )
-                ):
-                    self.moe_runner_backend = "flashinfer_trtllm"
-                    if is_kimi_k2_k25_thinking_int4:
-                        logger.info(
-                            "Use flashinfer_trtllm as MoE runner backend on Blackwell for Kimi K2 / K2.5 thinking int4"
-                        )
-                    else:
-                        logger.info(
-                            "Use flashinfer_trtllm as MoE runner backend on sm100 for DeepseekV3ForCausalLM"
-                        )
-            elif is_hip():
+            # Set moe backend for DeepSeek: the sm100 quant/moe resolution
+            # moved to the resolution pipeline (arg_groups/overrides.py:
+            # _deepseek_moe_quant_resolution -- a slot pass, because the DSA
+            # kv-cache-dtype default above must read the pristine
+            # quantization). The HIP arm (fusion log + spec_moe writes, the
+            # latter awaiting the speculative-hook migration) stays below.
+            from sglang.srt.arg_groups.overrides import (
+                _deepseek_moe_quant_resolution,
+                run_post_process_pass,
+            )
+
+            run_post_process_pass(self, _deepseek_moe_quant_resolution)
+            if is_hip():
                 if not self.enable_dp_attention and self.nnodes == 1:
                     # TODO (Hubert): Put this back later
                     # self.enable_aiter_allreduce_fusion = True
@@ -5065,9 +4948,14 @@ class ServerArgs:
         init_cp_strategy(self)
 
     def _handle_data_parallelism(self):
-        if self.dp_size == 1:
-            self.enable_dp_attention = False
-            self.enable_dp_lm_head = False
+        # The dp_size==1 resets moved to the resolution pipeline
+        # (arg_groups/overrides.py: _data_parallelism_defaults).
+        from sglang.srt.arg_groups.overrides import (
+            _data_parallelism_defaults,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _data_parallelism_defaults)
 
         if self.enable_dp_attention:
             self.schedule_conservativeness = self.schedule_conservativeness * 0.3
@@ -5241,25 +5129,20 @@ class ServerArgs:
             )
 
     def _handle_a2a_moe(self):
-        if self.enable_deepep_waterfill and self.moe_a2a_backend != "deepep":
-            logger.warning(
-                "moe_a2a_backend is overridden to 'deepep' because DeepEP "
-                "Waterfill requires the DeepEP backend."
-            )
-            self.moe_a2a_backend = "deepep"
+        # The backend overrides and the ep_size=tp_size adjustments moved to
+        # the resolution pipeline (arg_groups/overrides.py:
+        # _a2a_backend_overrides / _a2a_ep_size); the per-backend logs,
+        # asserts, fusion/deepep_mode/env/cuda-graph writes stay below.
+        from sglang.srt.arg_groups.overrides import (
+            _a2a_backend_overrides,
+            _a2a_ep_size,
+            run_post_process_pass,
+        )
 
-        if (
-            envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get()
-            and self.moe_a2a_backend != "megamoe"
-        ):
-            self.moe_a2a_backend = "megamoe"
-            logger.info(
-                "SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE is set, "
-                "auto-configuring --moe-a2a-backend megamoe."
-            )
+        run_post_process_pass(self, _a2a_backend_overrides)
+        run_post_process_pass(self, _a2a_ep_size)
 
         if self.moe_a2a_backend == "megamoe":
-            self.ep_size = self.tp_size
             if not envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.is_set():
                 envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.set(True)
             logger.info(
@@ -5272,7 +5155,6 @@ class ServerArgs:
                 logger.warning("Cuda graph is disabled because deepep_mode=`normal`")
                 self.cuda_graph_config.decode.backend = Backend.DISABLED
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
-            self.ep_size = self.tp_size
             logger.warning(
                 f"DeepEP MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )
@@ -5288,19 +5170,16 @@ class ServerArgs:
                 )
 
         if self.moe_a2a_backend == "mooncake":
-            self.ep_size = self.tp_size
             logger.warning(
                 f"Mooncake MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )
 
         if self.moe_a2a_backend == "nixl":
-            self.ep_size = self.tp_size
             logger.warning(
                 f"Nixl MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )
 
         if self.moe_a2a_backend == "ascend_fuseep":
-            self.ep_size = self.tp_size
             logger.warning(
                 f"Ascend fused EP MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )
@@ -5317,7 +5196,6 @@ class ServerArgs:
             assert (
                 self.enable_dp_attention and self.dp_size == self.tp_size
             ), "Flashinfer MoE A2A is only supported with dp_size == tp_size and --enable-dp-attention"
-            self.ep_size = self.tp_size
             logger.warning(
                 f"Flashinfer MoE A2A is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )
@@ -5342,7 +5220,6 @@ class ServerArgs:
             ], "Flashinfer MoE A2A is only supported with flashinfer_cutlass, flashinfer_cutedsl or flashinfer_trtllm_routed moe runner backend"
 
         if self.moe_a2a_backend == "mori":
-            self.ep_size = self.tp_size
             if self.deepep_mode == "auto":
                 self.deepep_mode = "normal"
                 logger.warning("auto set deepep_mode=`normal` for MORI EP")

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -93,7 +93,6 @@ from sglang.srt.utils.common import (
     nullable_str,
     parse_connector_type,
     torch_release,
-    xpu_has_xmx_support,
 )
 from sglang.srt.utils.hf_transformers_utils import check_gguf_file
 from sglang.srt.utils.network import NetworkAddress, get_free_port, wait_port_available
@@ -1409,6 +1408,7 @@ class ServerArgs:
         Arg(
             help="Choose the kernels for attention layers.",
             choices=ATTENTION_BACKEND_CHOICES,
+            model_overridable=True,
         ),
     ] = None
     decode_attention_backend: A[
@@ -4059,23 +4059,8 @@ class ServerArgs:
                 envs.SGLANG_EAGER_INPUT_NO_COPY.set(True)
 
         elif model_arch in ["GptOssForCausalLM"]:
-            # Set attention backend for GPT-OSS
-            if self.is_attention_backend_not_set():
-                if is_sm100_supported():
-                    self.attention_backend = "trtllm_mha"
-                elif is_sm90_supported():
-                    self.attention_backend = "fa3"
-                elif is_cpu() and cpu_has_amx_support():
-                    self.attention_backend = "intel_amx"
-                elif is_xpu():
-                    self.attention_backend = "intel_xpu"
-                elif is_hip():
-                    self.attention_backend = "aiter"
-                else:
-                    self.attention_backend = "triton"
-
-            # XPU dtype validation moved to the R0 registry
-            # (arg_groups/overrides.py: _gpt_oss_overrides).
+            # Attention backend selection + XPU dtype validation moved to the
+            # R0 registry (arg_groups/overrides.py: _gpt_oss_overrides).
 
             supported_backends = [
                 "triton",
@@ -4221,35 +4206,13 @@ class ServerArgs:
             "Step3p5ForCausalLM" in model_arch
             or "Step3p7ForConditionalGeneration" in model_arch
         ):
-            if self.is_attention_backend_not_set():
-                if is_blackwell_supported():
-                    self.attention_backend = "fa4"
-                    logger.info(
-                        "Auto-select fa4 attention backend for Step3p7 on Blackwell."
-                    )
-                elif is_sm90_supported():
-                    self.attention_backend = "fa3"
-                    logger.info(
-                        "Auto-select fa3 attention backend for Step3p7 on Hopper."
-                    )
-            # EAGLE multi-layer + hierarchical-cache SWA writes moved to the
-            # R0 registry (arg_groups/overrides.py: _step3p_overrides).
+            # Attention backend selection + EAGLE multi-layer +
+            # hierarchical-cache SWA writes moved to the R0 registry
+            # (arg_groups/overrides.py: _step3p_overrides).
+            pass
         elif model_arch in LLAMA4_MODEL_ARCHS and self.device != "cpu":
-            # Auto-select attention backend for Llama4 if not specified
-            if self.attention_backend is None:
-                if is_sm100_supported():
-                    self.attention_backend, platform = "trtllm_mha", "sm100"
-                elif is_sm90_supported():
-                    self.attention_backend, platform = "fa3", "sm90"
-                elif is_hip():
-                    self.attention_backend, platform = "aiter", "hip"
-                elif self.device == "xpu":
-                    self.attention_backend, platform = "intel_xpu", "xpu"
-                else:
-                    self.attention_backend, platform = "triton", "other platforms"
-                logger.warning(
-                    f"Use {self.attention_backend} as attention backend on {platform} for Llama4 model"
-                )
+            # Attention backend auto-select moved to the R0 registry
+            # (arg_groups/overrides.py: _llama4_overrides).
             assert self.attention_backend in {
                 "fa3",
                 "aiter",
@@ -4271,21 +4234,8 @@ class ServerArgs:
             "Gemma4ForCausalLM",
             "Gemma4UnifiedForConditionalGeneration",
         ):
-            default_attention_backend = (
-                "trtllm_mha" if is_sm100_supported() else "triton"
-            )
-            if self.is_attention_backend_not_set():
-                self.attention_backend = default_attention_backend
-                logger.info(
-                    f"Use {self.attention_backend} as default attention backend for Gemma4"
-                )
-            else:
-                # If only one split backend is set, keep the other side on a
-                # Gemma4-compatible fallback instead of letting generic backend
-                # selection choose an unsupported backend later.
-                if self.attention_backend is None:
-                    self.attention_backend = default_attention_backend
-
+            # Default attention backend selection moved to the R0 registry
+            # (arg_groups/overrides.py: _gemma4_overrides).
             prefill_backend, decode_backend = self.get_attention_backends()
             accepted_backends = ("trtllm_mha", "triton", "ascend", "intel_xpu")
             assert (
@@ -4325,15 +4275,8 @@ class ServerArgs:
                     self.attention_backend in accepted_backends
                 ), f"One of the attention backends in {accepted_backends} is required for {model_arch}, but got {self.attention_backend}"
         elif model_arch in ["Olmo2ForCausalLM"]:
-            # disable_hybrid_swa_memory moved to the R0 registry
-            # (arg_groups/overrides.py: _olmo2_overrides).
-            if self.attention_backend is None:
-                if is_cuda() and is_sm100_supported():
-                    self.attention_backend = "trtllm_mha"
-                elif is_cuda() and get_device_sm() >= 80:
-                    self.attention_backend = "fa3"
-                else:
-                    self.attention_backend = "triton"
+            # disable_hybrid_swa_memory + attention backend selection moved to
+            # the R0 registry (arg_groups/overrides.py: _olmo2_overrides).
 
             # Flashinfer appears to degrade performance when sliding window attention
             # is used for the Olmo2 architecture. Olmo2 does not use sliding window attention
@@ -4420,8 +4363,8 @@ class ServerArgs:
         elif model_arch == "MiniCPMV4_6ForConditionalGeneration":
             # 4.6 wraps a Qwen3.5 hybrid GDN backbone, so it needs the same
             # mamba radix cache handling as Qwen3_5ForConditionalGeneration.
-            if is_sm100_supported() and self.attention_backend is None:
-                self.attention_backend = "triton"
+            # (attention backend selection moved to the R0 registry:
+            # arg_groups/overrides.py _minicpm_v4_6_overrides)
             self._handle_mamba_radix_cache(model_arch=model_arch)
 
         elif model_arch in ["Glm4MoeForCausalLM"]:
@@ -4447,18 +4390,16 @@ class ServerArgs:
                     logger.info(
                         "Use flashinfer_trtllm as MoE runner backend on sm100 for Glm4MoeForCausalLM"
                     )
-            self.enable_tf32_matmul = True
-            logger.info(
-                "Enable TF32 matmul for Glm4MoeForCausalLM model to improve gate gemm performance."
-            )
+            # enable_tf32_matmul moved to the R0 registry
+            # (arg_groups/overrides.py: _glm4_moe_overrides).
 
         elif model_arch in [
             "FalconH1ForCausalLM",
             "JetNemotronForCausalLM",
             "JetVLMForConditionalGeneration",
         ]:
-            if is_sm100_supported() and self.attention_backend is None:
-                self.attention_backend = "triton"
+            # Attention backend selection moved to the R0 registry
+            # (arg_groups/overrides.py: _falcon_h1_jet_overrides).
             self._handle_mamba_radix_cache(model_arch=model_arch)
 
         elif model_arch == "GraniteMoeHybridForCausalLM":
@@ -4468,13 +4409,13 @@ class ServerArgs:
                 for layer_type in getattr(hf_config, "layer_types", [])
             )
             if has_mamba:
-                if is_sm100_supported() and self.attention_backend is None:
-                    self.attention_backend = "flashinfer"
+                # Attention backend selection moved to the R0 registry
+                # (arg_groups/overrides.py: _granite_moe_hybrid_overrides).
                 self._handle_mamba_radix_cache(model_arch=model_arch)
 
         elif model_arch in ["Lfm2ForCausalLM"]:
-            if is_sm100_supported() and self.attention_backend is None:
-                self.attention_backend = "flashinfer"
+            # Attention backend selection moved to the R0 registry
+            # (arg_groups/overrides.py: _lfm2_overrides).
             self._handle_mamba_radix_cache(model_arch=model_arch)
             assert self.attention_backend != "triton", (
                 f"{model_arch} does not support triton attention backend, "
@@ -4690,22 +4631,20 @@ class ServerArgs:
 
     def _handle_attention_backend_compatibility(self):
         model_config = self.get_model_config()
-        use_mla_backend = self.use_mla_backend()
 
-        if self.prefill_attention_backend is not None and (
-            self.prefill_attention_backend == self.decode_attention_backend
-        ):  # override the default attention backend
-            self.attention_backend = self.prefill_attention_backend
+        # The attention_backend write clusters of this handler moved to the
+        # resolution pipeline (arg_groups/overrides.py), each invoked below at
+        # its legacy slot; the interleaved non-attention adjustments stay.
+        from sglang.srt.arg_groups.overrides import (
+            _attention_backend_default,
+            _attention_backend_dual_chunk,
+            _attention_backend_fa3_fp8_fallback,
+            _attention_backend_platform_fallbacks,
+            run_post_process_pass,
+        )
 
-        # Pick the default attention backend if not specified
-        if self.attention_backend is None:
-            self.attention_backend = self._get_default_attn_backend(
-                use_mla_backend, model_config
-            )
-
-            logger.info(
-                f"Attention backend not specified. Use {self.attention_backend} backend by default."
-            )
+        # Split-backend override + default fill.
+        run_post_process_pass(self, _attention_backend_default)
 
         # Torch native and flex attention backends
         if self.attention_backend == "torch_native":
@@ -4858,12 +4797,7 @@ class ServerArgs:
                 )
                 self.page_size = 64
 
-        if self.attention_backend == "fa3" and self.kv_cache_dtype == "fp8_e5m2":
-            logger.warning(
-                "FlashAttention3 only supports fp8_e4m3 if using FP8; "
-                "Setting attention backend to triton."
-            )
-            self.attention_backend = "triton"
+        run_post_process_pass(self, _attention_backend_fa3_fp8_fallback)
 
         if (
             (
@@ -4889,25 +4823,7 @@ class ServerArgs:
                 self.mem_fraction_static *= 0.85
 
         # Other platforms backends
-        if (
-            self.attention_backend == "intel_amx"
-            and self.device == "cpu"
-            and not cpu_has_amx_support()
-        ):
-            logger.warning(
-                "The current platform does not support Intel AMX, will fallback to torch_native backend."
-            )
-            self.attention_backend = "torch_native"
-
-        if (
-            self.attention_backend == "intel_xpu"
-            and self.device == "xpu"
-            and not xpu_has_xmx_support()
-        ):
-            logger.warning(
-                "The current platform does not support Intel XMX, will fallback to triton backend."
-            )
-            self.attention_backend = "triton"
+        run_post_process_pass(self, _attention_backend_platform_fallbacks)
 
         prefill_backend, decode_backend = self.get_attention_backends()
         if self.use_mla_backend() and prefill_backend == "intel_xpu":
@@ -4930,18 +4846,7 @@ class ServerArgs:
                 self.page_size = 128
 
         # Dual chunk flash attention backend
-        if (
-            getattr(model_config.hf_config, "dual_chunk_attention_config", None)
-            is not None
-        ):
-            if self.attention_backend is None:
-                self.attention_backend = "dual_chunk_flash_attn"
-                logger.info("Dual chunk attention is turned on by default.")
-            elif self.attention_backend != "dual_chunk_flash_attn":
-                raise ValueError(
-                    "Dual chunk attention is enabled, but attention backend is set to "
-                    f"{self.attention_backend}. Please set it to 'dual_chunk_flash_attn'."
-                )
+        run_post_process_pass(self, _attention_backend_dual_chunk)
         if self.attention_backend == "dual_chunk_flash_attn":
             logger.warning(
                 "Mixed chunk and radix cache are disabled when using dual-chunk flash attention backend"
@@ -6312,10 +6217,11 @@ class ServerArgs:
                 )
                 self.flashinfer_allreduce_fusion_backend = None
 
-            # The forced-pytorch sampling write moved to the resolution
-            # pipeline (arg_groups/overrides.py:
-            # _deterministic_sampling_backend), invoked at its legacy slot.
+            # The forced-pytorch sampling write and the attention backend
+            # fill/validation moved to the resolution pipeline
+            # (arg_groups/overrides.py), invoked at their legacy slots.
             from sglang.srt.arg_groups.overrides import (
+                _deterministic_attention_backend,
                 _deterministic_sampling_backend,
                 run_post_process_pass,
             )
@@ -6338,29 +6244,7 @@ class ServerArgs:
                     pass
 
             # Check attention backend
-            if self.attention_backend is None:
-                # User didn't specify attention backend, fallback based on GPU architecture
-                if is_sm100_supported() or is_sm120_supported():
-                    # Blackwell and newer architectures
-                    if is_deepseek_model:
-                        # fallback to triton for DeepSeek models because flashinfer doesn't support deterministic inference for DeepSeek models yet
-                        self.attention_backend = "triton"
-                    else:
-                        # fallback to flashinfer on Blackwell for non-DeepSeek models
-                        self.attention_backend = "flashinfer"
-                else:
-                    # Hopper (SM90) and older architectures
-                    self.attention_backend = "fa3"
-                logger.warning(
-                    f"Attention backend not specified. Falling back to '{self.attention_backend}' for deterministic inference. "
-                    f"You can explicitly set --attention-backend to one of {DETERMINISTIC_ATTENTION_BACKEND_CHOICES}."
-                )
-            elif self.attention_backend not in DETERMINISTIC_ATTENTION_BACKEND_CHOICES:
-                # User explicitly specified an incompatible attention backend
-                raise ValueError(
-                    f"Currently only {DETERMINISTIC_ATTENTION_BACKEND_CHOICES} attention backends are supported for deterministic inference, "
-                    f"but you explicitly specified '{self.attention_backend}'."
-                )
+            run_post_process_pass(self, _deterministic_attention_backend)
 
             if is_deepseek_model:
                 if self.attention_backend not in ["fa3", "triton"]:
@@ -6471,7 +6355,9 @@ class ServerArgs:
     def _handle_dllm_inference(self):
         if self.dllm_algorithm is None:
             return
-        # On AMD/HIP, disable cuda graph for DLLM and use triton backend
+        # On AMD/HIP, disable cuda graph for DLLM (the attention_backend
+        # resolution moved to the pipeline: arg_groups/overrides.py
+        # _dllm_attention_backend, invoked below at its legacy slot).
         if is_hip():
             if (
                 self.cuda_graph_config.decode.backend != Backend.DISABLED
@@ -6482,23 +6368,14 @@ class ServerArgs:
                 )
                 self.cuda_graph_config.decode.backend = Backend.DISABLED
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
-            if self.attention_backend not in ["triton", "aiter"]:
-                logger.warning(
-                    "Attention backend is set to triton for diffusion LLM inference on AMD GPUs"
-                )
-                self.attention_backend = "triton"
-        elif is_npu():
-            if self.attention_backend != "ascend":
-                logger.warning(
-                    "Attention backend is overridden to 'ascend' when running on NPU for diffusion LLM inference."
-                )
-                self.attention_backend = "ascend"
-        elif self.cuda_graph_config.decode.backend != Backend.DISABLED:
-            if self.attention_backend != "flashinfer":
-                logger.warning(
-                    "Attention backend is set to flashinfer because of enabling cuda graph in diffusion LLM inference"
-                )
-                self.attention_backend = "flashinfer"
+
+        from sglang.srt.arg_groups.overrides import (
+            _dllm_attention_backend,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _dllm_attention_backend)
+
         if not self.disable_overlap_schedule:
             logger.warning(
                 "Overlap schedule is disabled because of using diffusion LLM inference"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4073,17 +4073,8 @@ class ServerArgs:
                 else:
                     self.attention_backend = "triton"
 
-            if is_xpu():
-                # Check for bf16 dtype on Intel XPU
-                if self.dtype == "auto":
-                    logger.warning(
-                        "GptOssForCausalLM on Intel XPU currently supports bfloat16 dtype only"
-                    )
-                elif self.dtype not in ["bfloat16"]:
-                    raise NotImplementedError(
-                        f"GptOssForCausalLM on Intel XPU only supports bfloat16 dtype, "
-                        f"but got '{self.dtype}'. Please use --dtype bfloat16 or remove --dtype to use auto."
-                    )
+            # XPU dtype validation moved to the R0 registry
+            # (arg_groups/overrides.py: _gpt_oss_overrides).
 
             supported_backends = [
                 "triton",
@@ -4116,9 +4107,8 @@ class ServerArgs:
                 quantization_config is not None
                 and quantization_config.get("quant_method") == "mxfp4"
             )
-            if is_mxfp4_quant_format:
-                # use bf16 for mxfp4 triton kernels
-                self.dtype = "bfloat16"
+            # The mxfp4 dtype override moved to the R0 registry
+            # (arg_groups/overrides.py: _gpt_oss_overrides).
 
             if self.moe_runner_backend == "auto":
                 if is_sm100_supported() and is_mxfp4_quant_format:
@@ -4273,19 +4263,8 @@ class ServerArgs:
                     logger.info(
                         "Use flashinfer_trtllm as MoE runner backend on SM100 for Llama4"
                     )
-        elif model_arch in [
-            "Gemma2ForCausalLM",
-            "Gemma3ForCausalLM",
-            "Gemma3ForConditionalGeneration",
-            "Gemma3nForCausalLM",
-            "Gemma3nForConditionalGeneration",
-        ]:
-            # FIXME: https://github.com/sgl-project/sglang/pull/7367 is not compatible with gemma2 model.
-            # It failed at this test: https://github.com/sgl-project/sglang/actions/runs/16255155597/job/45890331952#step:4:736
-            logger.warning(
-                f"Disable hybrid SWA memory for {model_arch} as it is not yet supported."
-            )
-            self.disable_hybrid_swa_memory = True
+        # Gemma2/Gemma3 (disable_hybrid_swa_memory) moved to the R0 registry
+        # (arg_groups/overrides.py: _gemma2_gemma3_overrides).
         elif model_arch in (
             "Gemma4ForConditionalGeneration",
             "Gemma4ForCausalLM",
@@ -4337,22 +4316,16 @@ class ServerArgs:
             )
         elif model_arch in ["Exaone4ForCausalLM", "ExaoneMoEForCausalLM"]:
             if hf_config.sliding_window_pattern is not None:
-                logger.warning(
-                    f"Disabling hybrid SWA memory for {model_arch} as it is not yet supported."
-                )
-                self.disable_hybrid_swa_memory = True
+                # disable_hybrid_swa_memory moved to the R0 registry
+                # (arg_groups/overrides.py: _exaone_overrides).
                 # https://docs.sglang.ai/advanced_features/attention_backend.html
                 accepted_backends = ["fa3", "triton", "trtllm_mha"]
                 assert (
                     self.attention_backend in accepted_backends
                 ), f"One of the attention backends in {accepted_backends} is required for {model_arch}, but got {self.attention_backend}"
         elif model_arch in ["Olmo2ForCausalLM"]:
-            # FIXME: https://github.com/sgl-project/sglang/pull/7367 is not compatible with Olmo3 model.
-            logger.warning(
-                f"Disabling hybrid SWA memory for {model_arch} as it is not yet supported."
-            )
-            self.disable_hybrid_swa_memory = True
-
+            # disable_hybrid_swa_memory moved to the R0 registry
+            # (arg_groups/overrides.py: _olmo2_overrides).
             if self.attention_backend is None:
                 if is_cuda() and is_sm100_supported():
                     self.attention_backend = "trtllm_mha"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2569,6 +2569,12 @@ class ServerArgs:
         Orchestrates the handling of various server arguments, ensuring proper configuration and validation.
         """
 
+        # R0 stash for override/post-process declarations. Set before any
+        # short-circuit (none/dummy model paths) so run_post_process_pass and
+        # direct handler invocations can rely on it even when
+        # _handle_model_specific_adjustments never runs.
+        self._resolved_overrides = []
+
         self._maybe_download_model_for_runai()
 
         # Normalize load balancing defaults early (before dummy-model short-circuit).
@@ -3709,6 +3715,7 @@ class ServerArgs:
 
         self.uses_mamba_radix_cache = False
         if parse_connector_type(self.model_path) == ConnectorType.INSTANCE:
+            self._resolved_overrides = []
             return
 
         hf_config = self.get_model_config().hf_config
@@ -3717,6 +3724,22 @@ class ServerArgs:
         _hybrid_spec = get_linear_attn_spec_by_arch(model_arch)
         if _hybrid_spec is not None and _hybrid_spec.uses_mamba_radix_cache:
             self._handle_mamba_radix_cache(model_arch=model_arch)
+
+        # R0: collect the declarative model overrides (registry) on the
+        # pristine config and stash them for publish-time flags resolution.
+        # Transition dual-apply: the same declarations are applied to
+        # server_args right here, byte-identical to the imperative arch
+        # branches this dispatch gradually replaces (dual-apply is retired
+        # per field once that field's readers migrate to the flags tier).
+        from sglang.srt.arg_groups.overrides import (
+            apply_declarations_to_server_args,
+            collect_model_override_declarations,
+        )
+
+        self._resolved_overrides = collect_model_override_declarations(
+            model_arch, self, hf_config
+        )
+        apply_declarations_to_server_args(self, self._resolved_overrides)
 
         if model_arch in [
             "MistralLarge3ForCausalLM",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -754,14 +754,20 @@ class ServerArgs:
     page_size: A[Optional[int], "The number of tokens in a page."] = None
     swa_full_tokens_ratio: A[
         float,
-        (
-            "The ratio of SWA layer KV tokens / full layer KV tokens, regardless "
-            "of the number of swa:full layers. It should be between 0 and 1. "
-            "E.g. 0.5 means if each swa layer has 50 tokens, then each full "
-            "layer has 100 tokens."
+        Arg(
+            help=(
+                "The ratio of SWA layer KV tokens / full layer KV tokens, regardless "
+                "of the number of swa:full layers. It should be between 0 and 1. "
+                "E.g. 0.5 means if each swa layer has 50 tokens, then each full "
+                "layer has 100 tokens."
+            ),
+            model_overridable=True,
         ),
     ] = 0.8
-    disable_hybrid_swa_memory: A[bool, "Disable the hybrid SWA memory pool."] = False
+    disable_hybrid_swa_memory: A[
+        bool,
+        Arg(help="Disable the hybrid SWA memory pool.", model_overridable=True),
+    ] = False
     radix_eviction_policy: A[
         str,
         Arg(
@@ -4235,20 +4241,8 @@ class ServerArgs:
                     logger.info(
                         "Auto-select fa3 attention backend for Step3p7 on Hopper."
                     )
-            if self.speculative_algorithm == "EAGLE":
-                self.enable_multi_layer_eagle = True
-                logger.info(
-                    "Enable multi-layer EAGLE speculative decoding for Step3p5ForCausalLM model."
-                )
-            if self.enable_hierarchical_cache:
-                self.swa_full_tokens_ratio = 1.0
-                logger.warning(
-                    "Reset swa_full_tokens_ratio to 1.0 for Step3p5ForCausalLM model with hierarchical cache"
-                )
-                self.disable_hybrid_swa_memory = True
-                logger.warning(
-                    "Disable hybrid SWA memory for Step3p5ForCausalLM model with hierarchical cache"
-                )
+            # EAGLE multi-layer + hierarchical-cache SWA writes moved to the
+            # R0 registry (arg_groups/overrides.py: _step3p_overrides).
         elif model_arch in LLAMA4_MODEL_ARCHS and self.device != "cpu":
             # Auto-select attention backend for Llama4 if not specified
             if self.attention_backend is None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -572,6 +572,7 @@ class ServerArgs:
                 '* "float32" for FP32 precision.'
             ),
             choices=["auto", "half", "float16", "bfloat16", "float", "float32"],
+            model_overridable=True,
         ),
     ] = "auto"
     quantization: A[
@@ -653,7 +654,10 @@ class ServerArgs:
     ] = None  # For flash_rl load format
     enable_tf32_matmul: A[
         bool,
-        "Enable float32 matmuls to use TensorFloat32 precision for better performance (via torch.set_float32_matmul_precision). CUDA only.",
+        Arg(
+            help="Enable float32 matmuls to use TensorFloat32 precision for better performance (via torch.set_float32_matmul_precision). CUDA only.",
+            model_overridable=True,
+        ),
     ] = False
 
     # -------------------------------------------------------------------------
@@ -1595,7 +1599,10 @@ class ServerArgs:
     ] = False
     enable_multi_layer_eagle: A[
         bool,
-        "Enable multi-layer Eagle speculative decoding.",
+        Arg(
+            help="Enable multi-layer Eagle speculative decoding.",
+            model_overridable=True,
+        ),
     ] = False
     speculative_adaptive: A[
         bool,
@@ -3742,12 +3749,6 @@ class ServerArgs:
         apply_declarations_to_server_args(self, self._resolved_overrides)
 
         if model_arch in [
-            "MistralLarge3ForCausalLM",
-            "PixtralForConditionalGeneration",
-        ]:
-            self.dtype = "bfloat16"
-
-        if model_arch in [
             "DeepseekV4ForCausalLM",
         ]:
             from sglang.srt.arg_groups.deepseek_v4_hook import (
@@ -4205,11 +4206,8 @@ class ServerArgs:
                         f"attention TP size is {expected_attn_tp_size}."
                     )
 
-            if self.speculative_algorithm == "EAGLE":
-                self.enable_multi_layer_eagle = True
-                logger.info(
-                    "Enable multi-layer EAGLE speculative decoding for MiMoV2 model."
-                )
+            # enable_multi_layer_eagle for EAGLE moved to the R0 registry
+            # (arg_groups/overrides.py: _mimo_v2_overrides).
 
             if self.enable_hierarchical_cache:
                 if not envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.get():
@@ -4518,11 +4516,8 @@ class ServerArgs:
         elif model_arch in ["ZayaForCausalLM"]:
             self._handle_mamba_radix_cache(model_arch=model_arch)
 
-        elif model_arch in ["MiniMaxM2ForCausalLM"]:
-            self.enable_tf32_matmul = True
-            logger.info(
-                "Enable TF32 matmul for MiniMaxM2ForCausalLM model to improve gate gemm performance."
-            )
+        # MiniMaxM2ForCausalLM (enable_tf32_matmul) moved to the R0 registry
+        # (arg_groups/overrides.py: _minimax_m2_overrides).
 
         if (
             model_arch in ["Qwen3VLForConditionalGeneration"]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1430,6 +1430,7 @@ class ServerArgs:
         Arg(
             help="Choose the kernels for sampling layers.",
             choices=SAMPLING_BACKEND_CHOICES,
+            model_overridable=True,
         ),
     ] = None
     grammar_backend: A[
@@ -4611,10 +4612,14 @@ class ServerArgs:
             self._validate_mamba_no_buffer(model_arch)
 
     def _handle_sampling_backend(self):
-        if self.sampling_backend is None:
-            self.sampling_backend = (
-                "flashinfer" if is_flashinfer_available() else "pytorch"
-            )
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _sampling_backend_default), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _sampling_backend_default,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _sampling_backend_default)
 
     def _get_default_attn_backend(self, use_mla_backend: bool, model_config):
         """
@@ -6307,12 +6312,15 @@ class ServerArgs:
                 )
                 self.flashinfer_allreduce_fusion_backend = None
 
-            # Check sampling backend
-            if self.sampling_backend != "ascend":
-                self.sampling_backend = "pytorch"
-                logger.warning(
-                    "Sampling backend is set to pytorch for deterministic inference."
-                )
+            # The forced-pytorch sampling write moved to the resolution
+            # pipeline (arg_groups/overrides.py:
+            # _deterministic_sampling_backend), invoked at its legacy slot.
+            from sglang.srt.arg_groups.overrides import (
+                _deterministic_sampling_backend,
+                run_post_process_pass,
+            )
+
+            run_post_process_pass(self, _deterministic_sampling_backend)
             is_deepseek_model = False
             if parse_connector_type(self.model_path) != ConnectorType.INSTANCE:
                 try:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -750,7 +750,10 @@ class ServerArgs:
         float,
         "How conservative the schedule policy is. A larger value means more conservative scheduling. Use a larger value if you see requests being retracted frequently.",
     ] = 1.0
-    page_size: A[Optional[int], "The number of tokens in a page."] = None
+    page_size: A[
+        Optional[int],
+        Arg(help="The number of tokens in a page.", model_overridable=True),
+    ] = None
     swa_full_tokens_ratio: A[
         float,
         Arg(
@@ -4334,30 +4337,8 @@ class ServerArgs:
                 "InternS2PreviewForConditionalGeneration",
                 "Qwen3_5ForConditionalGeneration",
             ]:
-                sm100_default_attn_backend = "triton"
-                if is_sm100_supported():
-                    # trtllm_mha requires speculative_eagle_topk == 1 and page_size > 1.
-                    # _get_default_attn_backend handles the eagle_topk check.
-                    # There is only one case where page_size=1 is required,
-                    # which is when radix cache is enabled and both extra_buffer
-                    # and spec decoding are disabled.
-                    default_attn_backend = self._get_default_attn_backend(
-                        use_mla_backend=self.use_mla_backend(),
-                        model_config=self.get_model_config(),
-                    )
-                    if default_attn_backend == "trtllm_mha" and not (
-                        not self.enable_mamba_extra_buffer()
-                        and not self.disable_radix_cache
-                        and self.speculative_algorithm is None
-                    ):
-                        sm100_default_attn_backend = "trtllm_mha"
-
-                    if self.attention_backend is None:
-                        self.attention_backend = sm100_default_attn_backend
-                        self.page_size = (
-                            64 if sm100_default_attn_backend == "trtllm_mha" else 1
-                        )
-
+                # Attention backend + page size defaults moved to the R0
+                # registry (arg_groups/overrides.py: _qwen3_5_hybrid_overrides).
                 self._handle_mamba_radix_cache(model_arch=model_arch)
 
         elif model_arch == "MiniCPMV4_6ForConditionalGeneration":
@@ -4428,16 +4409,8 @@ class ServerArgs:
         # MiniMaxM2ForCausalLM (enable_tf32_matmul) moved to the R0 registry
         # (arg_groups/overrides.py: _minimax_m2_overrides).
 
-        if (
-            model_arch in ["Qwen3VLForConditionalGeneration"]
-            and is_hip()
-            and envs.SGLANG_USE_AITER_UNIFIED_ATTN.get()
-            and self.page_size is None
-        ):
-            self.page_size = 16
-            logger.info(
-                "Setting page_size=16 for aiter unified attention on Qwen3VLForConditionalGeneration."
-            )
+        # Qwen3VL aiter unified-attention page_size moved to the R0 registry
+        # (arg_groups/overrides.py: _qwen3vl_overrides).
 
         if envs.SGLANG_EMBEDDINGS_SPARSE_HEAD.is_set():
             self.disable_overlap_schedule = True
@@ -4640,6 +4613,9 @@ class ServerArgs:
             _attention_backend_dual_chunk,
             _attention_backend_fa3_fp8_fallback,
             _attention_backend_platform_fallbacks,
+            _fa4_page_constraint,
+            _intel_xpu_page_constraint,
+            _mla_backend_page_constraints,
             run_post_process_pass,
         )
 
@@ -4675,24 +4651,11 @@ class ServerArgs:
             logger.info("Radix cache is disabled for Whisper")
             self.disable_radix_cache = True
 
-        # Major NVIDIA platforms backends
-        if (
-            self.attention_backend == "flashmla"
-            or self.decode_attention_backend == "flashmla"
-        ):
-            logger.warning(
-                "FlashMLA only supports a page_size of 64, change page_size to 64."
-            )
-            self.page_size = 64
-
-        if (
-            self.attention_backend == "cutlass_mla"
-            or self.decode_attention_backend == "cutlass_mla"
-        ):
-            logger.warning(
-                "Cutlass MLA only supports a page_size of 128, change page_size to 128."
-            )
-            self.page_size = 128
+        # Major NVIDIA platforms backends: the page-size snaps of this family
+        # moved to the resolution pipeline (arg_groups/overrides.py:
+        # _mla_backend_page_constraints); the raises and the cutedsl prefill
+        # fallback stay below.
+        run_post_process_pass(self, _mla_backend_page_constraints)
 
         if (
             self.attention_backend == "trtllm_mla"
@@ -4702,12 +4665,6 @@ class ServerArgs:
                 raise ValueError(
                     "TRTLLM MLA backend is only supported on Blackwell GPUs (SM100/SM12x). Please use a different backend."
                 )
-
-            if self.page_size not in [32, 64]:
-                logger.warning(
-                    f"TensorRT-LLM MLA only supports page_size of 32 or 64, changing page_size from {self.page_size} to 64."
-                )
-                self.page_size = 64
 
             if self.kv_cache_dtype not in ["fp8_e4m3", "fp4_e2m1", "bf16", "auto"]:
                 raise ValueError(
@@ -4722,11 +4679,6 @@ class ServerArgs:
                 raise ValueError(
                     "tokenspeed_mla backend is only supported on Blackwell GPUs (SM100/SM12x)."
                 )
-            if self.page_size not in [32, 64]:
-                logger.warning(
-                    f"tokenspeed_mla only supports page_size of 32 or 64, changing page_size from {self.page_size} to 64."
-                )
-                self.page_size = 64
             if self.kv_cache_dtype not in ["fp8_e4m3"]:
                 raise ValueError(
                     "tokenspeed_mla backend requires kv-cache-dtype=fp8_e4m3, "
@@ -4745,11 +4697,6 @@ class ServerArgs:
                 raise ValueError(
                     "CuteDSL MLA backend is only supported on Blackwell GPUs (SM100). Please use a different backend."
                 )
-            if self.page_size not in [32, 64]:
-                logger.warning(
-                    f"CuteDSL MLA only supports page_size of 32 or 64, changing page_size from {self.page_size} to 64."
-                )
-                self.page_size = 64
             if self.kv_cache_dtype not in [
                 "fp8_e4m3",
                 "bf16",
@@ -4791,31 +4738,9 @@ class ServerArgs:
                     "TRTLLM MHA backend for decode is only supported on Hopper (SM90), Blackwell (SM100) and (SM120) GPUs. Please use a different decode backend."
                 )
 
-            if self.page_size not in [16, 32, 64]:
-                logger.warning(
-                    f"TensorRT-LLM MHA only supports page_size of 16, 32 or 64, changing page_size from {self.page_size} to 64."
-                )
-                self.page_size = 64
-
         run_post_process_pass(self, _attention_backend_fa3_fp8_fallback)
 
-        if (
-            (
-                self.attention_backend == "fa4"
-                or self.decode_attention_backend == "fa4"
-                or self.prefill_attention_backend == "fa4"
-            )
-            and not self.use_mla_backend()
-            and is_sm100_supported()
-            # EAGLE topk>1 spec runs the two-pass page-tree cascade, which the FA4
-            # CUTLASS kernel aborts on at page_size>1. That path only works at
-            # page_size==1, so skip the 128 auto-force for it and keep the default.
-            and (self.speculative_eagle_topk or 0) <= 1
-        ):
-            logger.warning(
-                f"FA4 backend only supports page size 128 for non-MLA model architectures, changing page_size from {self.page_size} to 128."
-            )
-            self.page_size = 128
+        run_post_process_pass(self, _fa4_page_constraint)
 
         # AMD platforms backends
         if self.attention_backend == "aiter":
@@ -4831,19 +4756,7 @@ class ServerArgs:
                 "intel_xpu backend is only supported on decode for MLA models, please set --decode-attention-backend to intel_xpu and do not set --attention-backend or --prefill-attention-backend to intel_xpu for prefill instead use triton."
             )
 
-        if decode_backend == "intel_xpu":
-            if self.use_mla_backend():
-                supported_page_sizes = [16, 32, 64, 128]
-                msg = "Intel XPU attention backend for MLA Decode"
-            else:
-                supported_page_sizes = [64, 128]
-                msg = "Intel XPU attention backend"
-
-            if self.page_size not in supported_page_sizes:
-                logger.warning(
-                    f"{msg} only supports page_sizes of {supported_page_sizes}, changing page_size from {self.page_size} to 128."
-                )
-                self.page_size = 128
+        run_post_process_pass(self, _intel_xpu_page_constraint)
 
         # Dual chunk flash attention backend
         run_post_process_pass(self, _attention_backend_dual_chunk)
@@ -4934,27 +4847,14 @@ class ServerArgs:
             raise RuntimeError("KV4 is not tested on non-CUDA platforms.")
 
     def _handle_page_size(self):
-        if self.page_size is None:
-            # SHUFFLE 5D vectorized KV layout (aiter backend + pa_decode_gluon)
-            # is tuned for and prefers page_size=64 — making it the default
-            # when the layout flag is set avoids users having to pass
-            # --page-size 64 explicitly. The env var is only consumed by the
-            # ROCm AITER backend, so the auto-bump is gated on HIP; on other
-            # platforms the SHUFFLE 5D pool has no consumer kernels and the
-            # env var is silently ignored (see MHATokenToKVPool).
-            if (
-                is_hip()
-                and envs.SGLANG_AITER_KV_CACHE_LAYOUT.get().lower() == "vectorized_5d"
-            ):
-                self.page_size = 64
-                logger.info(
-                    "Setting page_size=64 as default for "
-                    "SGLANG_AITER_KV_CACHE_LAYOUT=vectorized_5d."
-                )
-            elif not is_musa():
-                self.page_size = 1
-            else:
-                self.page_size = 64
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _page_size_default), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _page_size_default,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _page_size_default)
 
     def _handle_amd_specifics(self):
         if is_hip():
@@ -6383,14 +6283,11 @@ class ServerArgs:
             self.disable_overlap_schedule = True
 
         if not self.disable_radix_cache:
-            from sglang.srt.dllm.config import DllmConfig
+            # The page_size adjustment moved to the resolution pipeline
+            # (arg_groups/overrides.py: _dllm_page_size).
+            from sglang.srt.arg_groups.overrides import _dllm_page_size
 
-            config = DllmConfig.from_server_args(self)
-            if self.page_size % config.block_size != 0:
-                logger.warning(
-                    f"Setting page size to {config.block_size} for diffusion LLM inference"
-                )
-                self.page_size = config.block_size
+            run_post_process_pass(self, _dllm_page_size)
             if self.enable_hierarchical_cache:
                 logger.warning(
                     "Hierarchical cache is disabled because of using diffusion LLM inference"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7594,23 +7594,23 @@ class ServerArgs:
         }
 
 
-# NOTE: This is a global variable to hold the server args for scheduler.
-_global_server_args: Optional[ServerArgs] = None
-
-
+# NOTE: The process-wide ServerArgs is owned by the runtime context
+# (sglang.srt.runtime_context). The two functions below are thin shims kept for
+# the existing call-sites; they publish/read the same live object by reference.
+# Imports are in-function so the two modules stay cycle-free at import time.
 def set_global_server_args_for_scheduler(server_args: ServerArgs):
-    global _global_server_args
-    _global_server_args = server_args
+    from sglang.srt.runtime_context import get_context
+
+    get_context().set_server_args(server_args)
 
 
 set_global_server_args_for_tokenizer = set_global_server_args_for_scheduler
 
 
 def get_global_server_args() -> ServerArgs:
-    if _global_server_args is None:
-        raise ValueError("Global server args is not set yet!")
+    from sglang.srt.runtime_context import get_context
 
-    return _global_server_args
+    return get_context().server_args
 
 
 def prepare_server_args(argv: List[str]) -> ServerArgs:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -567,7 +567,7 @@ class ServerArgs:
                 '* "float32" for FP32 precision.'
             ),
             choices=["auto", "half", "float16", "bfloat16", "float", "float32"],
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = "auto"
     quantization: A[
@@ -575,7 +575,7 @@ class ServerArgs:
         Arg(
             help="The quantization method.",
             choices=QUANTIZATION_CHOICES,
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = None
     quantization_param_path: A[
@@ -655,7 +655,7 @@ class ServerArgs:
         bool,
         Arg(
             help="Enable float32 matmuls to use TensorFloat32 precision for better performance (via torch.set_float32_matmul_precision). CUDA only.",
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = False
 
@@ -752,7 +752,7 @@ class ServerArgs:
     ] = 1.0
     page_size: A[
         Optional[int],
-        Arg(help="The number of tokens in a page.", model_overridable=True),
+        Arg(help="The number of tokens in a page.", resolvable=True),
     ] = None
     swa_full_tokens_ratio: A[
         float,
@@ -763,12 +763,12 @@ class ServerArgs:
                 "E.g. 0.5 means if each swa layer has 50 tokens, then each full "
                 "layer has 100 tokens."
             ),
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = 0.8
     disable_hybrid_swa_memory: A[
         bool,
-        Arg(help="Disable the hybrid SWA memory pool.", model_overridable=True),
+        Arg(help="Disable the hybrid SWA memory pool.", resolvable=True),
     ] = False
     radix_eviction_policy: A[
         str,
@@ -931,7 +931,7 @@ class ServerArgs:
         Arg(
             help="The attention context parallelism size.",
             aliases=["--attention-context-parallel-size"],
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = 1
     moe_dp_size: A[
@@ -968,7 +968,7 @@ class ServerArgs:
         bool,
         Arg(
             help="Enabling data parallelism for attention and tensor parallelism for FFN. The dp size should be equal to the tp size. Currently DeepSeek-V2 and Qwen 2/3 MoE models are supported.",
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = False
     enable_dp_attention_local_control_broadcast: A[
@@ -979,7 +979,7 @@ class ServerArgs:
         bool,
         Arg(
             help="Enable vocabulary parallel across the attention TP group to avoid all-gather across DP groups, optimizing performance under DP attention.",
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = False
     enable_attn_tp_input_scattered: A[
@@ -1418,7 +1418,7 @@ class ServerArgs:
         Arg(
             help="Choose the kernels for attention layers.",
             choices=ATTENTION_BACKEND_CHOICES,
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = None
     decode_attention_backend: A[
@@ -1440,7 +1440,7 @@ class ServerArgs:
         Arg(
             help="Choose the kernels for sampling layers.",
             choices=SAMPLING_BACKEND_CHOICES,
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = None
     grammar_backend: A[
@@ -1618,7 +1618,7 @@ class ServerArgs:
         bool,
         Arg(
             help="Enable multi-layer Eagle speculative decoding.",
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = False
     speculative_adaptive: A[
@@ -1705,7 +1705,7 @@ class ServerArgs:
         Arg(
             help="The expert parallelism size.",
             aliases=["--expert-parallel-size", "--ep"],
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = 1
     moe_a2a_backend: A[
@@ -1722,7 +1722,7 @@ class ServerArgs:
         Arg(
             help="Choose the backend for MoE A2A.",
             choices=MOE_A2A_BACKEND_CHOICES,
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = "none"
     moe_runner_backend: A[
@@ -1730,7 +1730,7 @@ class ServerArgs:
         Arg(
             help="Choose the runner backend for MoE.",
             choices=MOE_RUNNER_BACKEND_CHOICES,
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = "auto"
     flashinfer_mxfp4_moe_precision: A[
@@ -1788,7 +1788,7 @@ class ServerArgs:
         Optional[int],
         Arg(
             help="TP size for MoE dense MLP layers. This flag is useful when, with large TP size, there are errors caused by weights in MLP layers having dimension smaller than the min dimension GEMM supports.",
-            model_overridable=True,
+            resolvable=True,
         ),
     ] = None
     elastic_ep_backend: A[

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -311,7 +311,7 @@ class TestFa4PageSizeAutoForce(CustomTestCase):
         args.model_config.hf_config.dual_chunk_attention_config = None
         return args
 
-    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    @patch("sglang.srt.arg_groups.overrides.is_sm100_supported", return_value=True)
     @patch("sglang.srt.server_args.ServerArgs.use_mla_backend", return_value=False)
     def test_combined_attention_backend_fa4_forces_page_size_128(
         self, _mock_mla, _mock_sm100
@@ -323,7 +323,7 @@ class TestFa4PageSizeAutoForce(CustomTestCase):
 
         self.assertEqual(args.page_size, 128)
 
-    @patch("sglang.srt.server_args.is_sm100_supported", return_value=True)
+    @patch("sglang.srt.arg_groups.overrides.is_sm100_supported", return_value=True)
     @patch("sglang.srt.server_args.ServerArgs.use_mla_backend", return_value=False)
     def test_explicit_prefill_fa4_forces_page_size_128(self, _mock_mla, _mock_sm100):
         # `--prefill-attention-backend fa4`: the previously-covered path.

--- a/test/registered/unit/test_legacy_global_ratchet.py
+++ b/test/registered/unit/test_legacy_global_ratchet.py
@@ -1,0 +1,63 @@
+"""Ratchet guard: legacy global-accessor call-sites may only decrease.
+
+The process-wide ``ServerArgs`` is owned by the runtime context; the legacy
+``get_global_server_args`` / ``set_global_server_args_for_*`` names survive as
+thin shims for the existing call-sites. New code should use the
+``sglang.srt.runtime_context`` accessors (``get_server_args()`` /
+``get_context().set_server_args()``), so the shim call-site counts below must
+never grow. When your change removes call-sites, lower the matching baseline
+to the new count.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import re
+import unittest
+from pathlib import Path
+
+import sglang.srt
+from sglang.test.test_utils import CustomTestCase
+
+_SRT_ROOT = Path(next(iter(sglang.srt.__path__)))
+
+# Baselines counted over python/sglang/srt/**/*.py, including each function's
+# own def line. Ratchet: decrease-only.
+_RATCHETS = [
+    ("get_global_server_args", r"\bget_global_server_args\s*\(", 346),
+    (
+        "set_global_server_args_for_*",
+        r"\bset_global_server_args_for_(?:scheduler|tokenizer)\s*\(",
+        5,
+    ),
+]
+
+
+class TestLegacyGlobalRatchet(CustomTestCase):
+    def test_legacy_accessor_call_sites_match_the_baselines(self):
+        # Exact pin, failing in BOTH directions: a grown count means new code
+        # bypassed the runtime_context accessors; a shrunk count means a
+        # removal forgot to lower the baseline, which would let later changes
+        # silently re-add call-sites up to the stale ceiling.
+        sources = [
+            path.read_text(encoding="utf-8", errors="replace")
+            for path in sorted(_SRT_ROOT.rglob("*.py"))
+        ]
+        for name, pattern, baseline in _RATCHETS:
+            count = sum(len(re.findall(pattern, source)) for source in sources)
+            if count > baseline:
+                self.fail(
+                    f"{name} call-sites grew: {count} > baseline {baseline}. "
+                    "New code must use the sglang.srt.runtime_context accessors "
+                    "(get_server_args() / get_context().set_server_args())."
+                )
+            if count < baseline:
+                self.fail(
+                    f"{name} call-sites shrank: {count} < baseline {baseline}. "
+                    "Lower the baseline in this file to lock in the progress."
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1,0 +1,42 @@
+"""Unit tests for the model-override machinery: whitelist metadata (V3a)."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import dataclasses
+import unittest
+from typing import Optional
+
+from sglang.srt.arg_groups.arg_utils import A, Arg, model_overridable_fields
+from sglang.test.test_utils import CustomTestCase
+
+
+@dataclasses.dataclass
+class _FakeArgs:
+    plain: A[int, "help text only"] = 0
+    resolved_by_model: A[str, Arg(help="x", model_overridable=True)] = "auto"
+    also_resolved: A[Optional[int], Arg(help="y", model_overridable=True)] = None
+    metadata_but_not_overridable: A[bool, Arg(help="z")] = False
+
+
+class TestModelOverridableWhitelist(CustomTestCase):
+    def test_arg_defaults_to_not_overridable(self):
+        self.assertFalse(Arg().model_overridable)
+
+    def test_whitelist_derivation_from_annotated_metadata(self):
+        self.assertEqual(
+            model_overridable_fields(_FakeArgs),
+            frozenset({"resolved_by_model", "also_resolved"}),
+        )
+
+    def test_server_args_whitelist_empty_at_skeleton(self):
+        # No ServerArgs field is tagged yet: the V3 sweeps whitelist fields
+        # one family at a time. This pin makes accidental tagging visible.
+        from sglang.srt.server_args import ServerArgs
+
+        self.assertEqual(model_overridable_fields(ServerArgs), frozenset())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -72,6 +72,12 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "page_size",
                     "moe_runner_backend",
                     "quantization",
+                    "enable_dp_attention",
+                    "enable_dp_lm_head",
+                    "moe_a2a_backend",
+                    "ep_size",
+                    "moe_dense_tp_size",
+                    "attn_cp_size",
                 }
             ),
         )
@@ -1101,6 +1107,200 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     "enable_tf32_matmul": True,
                 },
             )
+
+    def test_deepseek_moe_quant_slot_pass(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _deepseek_moe_quant_resolution,
+        )
+
+        def _view(arch="DeepseekV32ForCausalLM", quant_cfg=None, **kw):
+            defaults = dict(
+                quantization=None,
+                _quantization_explicitly_unset=False,
+                moe_a2a_backend="none",
+                moe_runner_backend="auto",
+                get_model_config=lambda: SimpleNamespace(
+                    hf_config=SimpleNamespace(
+                        architectures=[arch], quantization_config=quant_cfg
+                    )
+                ),
+            )
+            defaults.update(kw)
+            return ResolvedView(SimpleNamespace(**defaults))
+
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            with patch.object(
+                overrides_module, "get_quantization_config", return_value="fp8"
+            ):
+                # config-declared quant: detected + moe runner
+                self.assertEqual(
+                    _deepseek_moe_quant_resolution(_view()),
+                    {
+                        "quantization": "fp8",
+                        "moe_runner_backend": "flashinfer_trtllm",
+                    },
+                )
+            # non-deepseek arch guard (end-state list execution safety)
+            self.assertEqual(
+                _deepseek_moe_quant_resolution(_view(arch="LlamaForCausalLM")), {}
+            )
+        with patch.object(overrides_module, "is_sm100_supported", return_value=False):
+            self.assertEqual(_deepseek_moe_quant_resolution(_view()), {})
+
+    def test_data_parallelism_and_a2a_passes(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _a2a_backend_overrides,
+            _a2a_ep_size,
+            _data_parallelism_defaults,
+        )
+
+        self.assertEqual(
+            _data_parallelism_defaults(ResolvedView(SimpleNamespace(dp_size=1))),
+            {"enable_dp_attention": False, "enable_dp_lm_head": False},
+        )
+        self.assertEqual(
+            _data_parallelism_defaults(ResolvedView(SimpleNamespace(dp_size=2))), {}
+        )
+
+        with patch("sglang.srt.environ.envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE") as e:
+            e.get.return_value = False
+            self.assertEqual(
+                _a2a_backend_overrides(
+                    ResolvedView(
+                        SimpleNamespace(
+                            enable_deepep_waterfill=True, moe_a2a_backend="none"
+                        )
+                    )
+                ),
+                {"moe_a2a_backend": "deepep"},
+            )
+            e.get.return_value = True
+            # megamoe env wins over the waterfill override (chained, last write)
+            self.assertEqual(
+                _a2a_backend_overrides(
+                    ResolvedView(
+                        SimpleNamespace(
+                            enable_deepep_waterfill=True, moe_a2a_backend="none"
+                        )
+                    )
+                ),
+                {"moe_a2a_backend": "megamoe"},
+            )
+
+        self.assertEqual(
+            _a2a_ep_size(
+                ResolvedView(SimpleNamespace(moe_a2a_backend="deepep", tp_size=8))
+            ),
+            {"ep_size": 8},
+        )
+        self.assertEqual(
+            _a2a_ep_size(
+                ResolvedView(SimpleNamespace(moe_a2a_backend="none", tp_size=8))
+            ),
+            {},
+        )
+
+    def test_deepseek_family_order_safe_declarations(self):
+        from sglang.srt.arg_groups.overrides import _deepseek_family_overrides
+
+        def _args(**kw):
+            defaults = dict(
+                is_attention_backend_not_set=lambda: True,
+                attention_backend=None,
+                prefill_attention_backend=None,
+                decode_attention_backend=None,
+                enable_prefill_cp=False,
+            )
+            defaults.update(kw)
+            return SimpleNamespace(**defaults)
+
+        # DSA path on CUDA: dsa fill + page 64
+        with patch(
+            "sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True
+        ):
+            with patch.object(overrides_module, "is_npu", return_value=False):
+                with patch.object(overrides_module, "is_xpu", return_value=False):
+                    with patch.object(overrides_module, "is_hip", return_value=False):
+                        self.assertEqual(
+                            _deepseek_family_overrides(_args(), None),
+                            {"attention_backend": "dsa", "page_size": 64},
+                        )
+                    # HIP without the preshuffle path: page 1
+                    with patch.object(overrides_module, "is_hip", return_value=True):
+                        with patch(
+                            "sglang.srt.layers.attention.dsa.utils.aiter_can_use_preshuffle_paged_mqa",
+                            return_value=False,
+                        ):
+                            self.assertEqual(
+                                _deepseek_family_overrides(_args(), None),
+                                {"attention_backend": "dsa", "page_size": 1},
+                            )
+        # DSA CP (zigzag): the coupled parallel-field declaration
+        with patch(
+            "sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True
+        ):
+            with patch.object(overrides_module, "is_npu", return_value=False):
+                with patch.object(overrides_module, "is_xpu", return_value=False):
+                    with patch.object(overrides_module, "is_hip", return_value=False):
+                        result = _deepseek_family_overrides(
+                            _args(
+                                enable_prefill_cp=True,
+                                cp_strategy="zigzag",
+                                tp_size=8,
+                                dp_size=1,
+                                ep_size=1,
+                                moe_a2a_backend="none",
+                                kv_cache_dtype="auto",
+                            ),
+                            None,
+                        )
+                        self.assertEqual(
+                            result,
+                            {
+                                "attention_backend": "dsa",
+                                "page_size": 64,
+                                "enable_dp_attention": True,
+                                "moe_dense_tp_size": 1,
+                                "moe_a2a_backend": "deepep",
+                                "ep_size": 8,
+                                "attn_cp_size": 8,
+                            },
+                        )
+                        # interleave CP with dp>1 must assert
+                        with self.assertRaises(AssertionError):
+                            _deepseek_family_overrides(
+                                _args(
+                                    enable_prefill_cp=True,
+                                    cp_strategy="interleave",
+                                    tp_size=8,
+                                    dp_size=2,
+                                ),
+                                None,
+                            )
+
+        # MLA path on sm100: trtllm_mla fill (all three backends unset)
+        with patch(
+            "sglang.srt.configs.model_config.is_deepseek_dsa", return_value=False
+        ):
+            with patch.object(
+                overrides_module, "is_sm100_supported", return_value=True
+            ):
+                self.assertEqual(
+                    _deepseek_family_overrides(_args(), None),
+                    {"attention_backend": "trtllm_mla"},
+                )
+                self.assertEqual(
+                    _deepseek_family_overrides(
+                        _args(decode_attention_backend="fa3"), None
+                    ),
+                    {},
+                )
+            with patch.object(
+                overrides_module, "is_sm100_supported", return_value=False
+            ):
+                self.assertEqual(_deepseek_family_overrides(_args(), None), {})
 
     def test_qwen3_moe_family_quant_absorption(self):
         from sglang.srt.arg_groups.overrides import _qwen3_moe_family_overrides

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -60,7 +60,15 @@ class TestModelOverridableWhitelist(CustomTestCase):
 
         self.assertEqual(
             model_overridable_fields(ServerArgs),
-            frozenset({"dtype", "enable_tf32_matmul", "enable_multi_layer_eagle"}),
+            frozenset(
+                {
+                    "dtype",
+                    "enable_tf32_matmul",
+                    "enable_multi_layer_eagle",
+                    "swa_full_tokens_ratio",
+                    "disable_hybrid_swa_memory",
+                }
+            ),
         )
 
     def test_non_dataclass_yields_empty_whitelist(self):
@@ -75,6 +83,7 @@ class _IsolatedRegistry(CustomTestCase):
         self._patches = [
             patch.dict(overrides_module.MODEL_OVERRIDES, clear=True),
             patch.dict(overrides_module._MODEL_OVERRIDE_FNS, clear=True),
+            patch.object(overrides_module, "_PREDICATE_OVERRIDE_FNS", []),
         ]
         for p in self._patches:
             p.start()
@@ -130,6 +139,27 @@ class TestModelOverrideRegistry(_IsolatedRegistry):
 
         with self.assertRaises(TypeError):
             collect_model_override_declarations("FakeForCausalLM", None, None)
+
+    def test_predicate_keyed_provider(self):
+        from sglang.srt.arg_groups.overrides import register_model_override_predicate
+
+        @register_model_override("FakeStep9ForCausalLM")
+        def _exact(server_args, hf_config):
+            return {"a": 1}
+
+        @register_model_override_predicate(lambda arch: "Step9" in arch)
+        def _by_predicate(server_args, hf_config):
+            return {"b": 2}
+
+        # matching arch: exact-keyed first, then predicate-keyed
+        self.assertEqual(
+            collect_model_override_declarations("FakeStep9ForCausalLM", None, None),
+            [(_exact.__qualname__, {"a": 1}), (_by_predicate.__qualname__, {"b": 2})],
+        )
+        # non-matching arch: predicate does not fire
+        self.assertEqual(
+            collect_model_override_declarations("OtherForCausalLM", None, None), []
+        )
 
 
 @dataclasses.dataclass
@@ -292,13 +322,14 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         "v_head_dim": 16,
     }
 
-    def _construct(self, arch, model_type, **server_kwargs):
+    def _construct(self, arch, model_type, config_extra=None, **server_kwargs):
         from sglang.srt.server_args import ServerArgs
 
         # Golden resolution must be host-independent: accelerator-less CI
         # runners resolve only the base platform, where get_device() raises.
         server_kwargs.setdefault("device", "cuda")
         config = dict(self._MINI_CONFIG, architectures=[arch], model_type=model_type)
+        config.update(config_extra or {})
         config_dir = tempfile.mkdtemp(prefix="golden_override_")
         self.addCleanup(shutil.rmtree, config_dir, ignore_errors=True)
         with open(os.path.join(config_dir, "config.json"), "w") as f:
@@ -375,6 +406,56 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 None,
             ),
             [("_mimo_v2_overrides", {"enable_multi_layer_eagle": True})],
+        )
+
+    def test_step3p_hierarchical_cache_golden(self):
+        # SWA-hybrid arch: the mini config needs layer_types/sliding_window.
+        config_extra = {
+            "layer_types": ["sliding_attention", "full_attention"],
+            "sliding_window": 64,
+        }
+        sa = self._construct(
+            "Step3p5ForCausalLM",
+            "llama",
+            config_extra=config_extra,
+            enable_hierarchical_cache=True,
+        )
+        # dual-apply == legacy writes
+        self.assertEqual(sa.swa_full_tokens_ratio, 1.0)
+        self.assertTrue(sa.disable_hybrid_swa_memory)
+        flags = self._publish(sa)
+        self.assertEqual(flags.swa_full_tokens_ratio, 1.0)
+        self.assertTrue(flags.disable_hybrid_swa_memory)
+
+    def test_step3p_declarations_at_callable_level(self):
+        from sglang.srt.arg_groups.overrides import _step3p_overrides
+
+        self.assertEqual(
+            _step3p_overrides(
+                SimpleNamespace(
+                    speculative_algorithm="EAGLE", enable_hierarchical_cache=False
+                ),
+                None,
+            ),
+            {"enable_multi_layer_eagle": True},
+        )
+        self.assertEqual(
+            _step3p_overrides(
+                SimpleNamespace(
+                    speculative_algorithm=None, enable_hierarchical_cache=True
+                ),
+                None,
+            ),
+            {"swa_full_tokens_ratio": 1.0, "disable_hybrid_swa_memory": True},
+        )
+        self.assertEqual(
+            _step3p_overrides(
+                SimpleNamespace(
+                    speculative_algorithm=None, enable_hierarchical_cache=False
+                ),
+                None,
+            ),
+            {},
         )
 
 

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -427,6 +427,69 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         self.assertEqual(flags.swa_full_tokens_ratio, 1.0)
         self.assertTrue(flags.disable_hybrid_swa_memory)
 
+    def test_gemma2_disables_hybrid_swa_memory(self):
+        sa = self._construct("Gemma2ForCausalLM", "llama")
+        self.assertTrue(sa.disable_hybrid_swa_memory)  # dual-apply == legacy
+        self.assertEqual(
+            sa._resolved_overrides,
+            [("_gemma2_gemma3_overrides", {"disable_hybrid_swa_memory": True})],
+        )
+        self.assertTrue(self._publish(sa).disable_hybrid_swa_memory)
+
+    def test_olmo2_disables_hybrid_swa_memory(self):
+        sa = self._construct("Olmo2ForCausalLM", "llama")
+        self.assertTrue(sa.disable_hybrid_swa_memory)
+        self.assertTrue(self._publish(sa).disable_hybrid_swa_memory)
+
+    def test_exaone_conditional_on_sliding_window_pattern(self):
+        # With the pattern the branch also asserts an explicit backend.
+        sa = self._construct(
+            "Exaone4ForCausalLM",
+            "llama",
+            config_extra={"sliding_window_pattern": "LLLG"},
+            attention_backend="fa3",
+        )
+        self.assertTrue(sa.disable_hybrid_swa_memory)
+        self.assertTrue(self._publish(sa).disable_hybrid_swa_memory)
+
+    def test_exaone_without_pattern_declares_nothing(self):
+        from sglang.srt.arg_groups.overrides import _exaone_overrides
+
+        self.assertEqual(
+            _exaone_overrides(None, SimpleNamespace(sliding_window_pattern=None)),
+            {},
+        )
+
+    def test_gpt_oss_mxfp4_forces_bfloat16(self):
+        from sglang.srt.layers.quantization import QUANTIZATION_METHODS
+
+        if "mxfp4" not in QUANTIZATION_METHODS:
+            # Registration is platform-gated (CUDA / CPU engine / MXFP-HIP);
+            # plain CPU CI runners cannot construct an mxfp4 ModelConfig.
+            self.skipTest("mxfp4 quantization is not registered on this platform")
+        sa = self._construct(
+            "GptOssForCausalLM",
+            "llama",
+            config_extra={"quantization_config": {"quant_method": "mxfp4"}},
+        )
+        self.assertEqual(sa.dtype, "bfloat16")  # dual-apply == legacy
+        self.assertEqual(self._publish(sa).dtype, "bfloat16")
+
+    def test_gpt_oss_without_mxfp4_keeps_pristine_dtype(self):
+        sa = self._construct("GptOssForCausalLM", "llama")
+        self.assertEqual(sa.dtype, "auto")
+        self.assertEqual(self._publish(sa).dtype, "auto")
+
+    def test_gpt_oss_xpu_dtype_validation_reads_pristine(self):
+        from sglang.srt.arg_groups.overrides import _gpt_oss_overrides
+
+        with patch.object(overrides_module, "is_xpu", return_value=True):
+            with self.assertRaises(NotImplementedError):
+                _gpt_oss_overrides(
+                    SimpleNamespace(dtype="float16"),
+                    SimpleNamespace(architectures=["GptOssForCausalLM"]),
+                )
+
     def test_step3p_declarations_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import _step3p_overrides
 

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1,11 +1,15 @@
-"""Unit tests for the model-override machinery: whitelist metadata, registry
-(V3a — declarations only, nothing calls this in production yet)."""
+"""Unit tests for the model-override machinery: whitelist metadata, registry,
+gate, publish wiring, and the per-arch golden diffs for migrated families."""
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
 
 import dataclasses
+import json
+import os
+import shutil
+import tempfile
 import unittest
 from types import SimpleNamespace
 from typing import Optional
@@ -48,12 +52,16 @@ class TestModelOverridableWhitelist(CustomTestCase):
             frozenset({"resolved_by_model", "also_resolved"}),
         )
 
-    def test_server_args_whitelist_empty_at_skeleton(self):
-        # No ServerArgs field is tagged yet: the V3 sweeps whitelist fields
-        # one family at a time. This pin makes accidental tagging visible.
+    def test_server_args_whitelist_is_exactly_the_migrated_fields(self):
+        # Fields are whitelisted one family at a time by the migration
+        # sweeps. This pin makes accidental tagging visible — extend it in
+        # the same commit that tags a new field.
         from sglang.srt.server_args import ServerArgs
 
-        self.assertEqual(model_overridable_fields(ServerArgs), frozenset())
+        self.assertEqual(
+            model_overridable_fields(ServerArgs),
+            frozenset({"dtype", "enable_tf32_matmul", "enable_multi_layer_eagle"}),
+        )
 
     def test_non_dataclass_yields_empty_whitelist(self):
         self.assertEqual(model_overridable_fields(SimpleNamespace), frozenset())
@@ -258,6 +266,116 @@ class TestPublishResolvesFlags(_IsolatedPublish):
             get_context().set_server_args(sa)
         # a failed publish must leave BOTH the slot and the flags untouched
         self.assertIs(get_flags(), flags_before)
+
+
+class TestGoldenModelOverrides(_IsolatedPublish):
+    """Per-arch golden diff for migrated families: the declarative path must
+    reproduce the legacy imperative writes byte-identically on server_args
+    (dual-apply) and materialize the same values on the flags tier at
+    publish."""
+
+    _MINI_CONFIG = {
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_attention_heads": 4,
+        "num_hidden_layers": 2,
+        "num_key_value_heads": 2,
+        "vocab_size": 512,
+        "max_position_embeddings": 128,
+        "rms_norm_eps": 1e-5,
+        "torch_dtype": "bfloat16",
+        # MLA shape fields (required by the MistralLarge3/Pixtral arch
+        # family; inert extras for non-MLA control arches).
+        "kv_lora_rank": 32,
+        "qk_nope_head_dim": 16,
+        "qk_rope_head_dim": 8,
+        "v_head_dim": 16,
+    }
+
+    def _construct(self, arch, model_type, **server_kwargs):
+        from sglang.srt.server_args import ServerArgs
+
+        # Golden resolution must be host-independent: accelerator-less CI
+        # runners resolve only the base platform, where get_device() raises.
+        server_kwargs.setdefault("device", "cuda")
+        config = dict(self._MINI_CONFIG, architectures=[arch], model_type=model_type)
+        config_dir = tempfile.mkdtemp(prefix="golden_override_")
+        self.addCleanup(shutil.rmtree, config_dir, ignore_errors=True)
+        with open(os.path.join(config_dir, "config.json"), "w") as f:
+            json.dump(config, f)
+        return ServerArgs(model_path=config_dir, **server_kwargs)
+
+    def _publish(self, server_args):
+        from sglang.srt.runtime_context import get_flags
+        from sglang.srt.server_args import set_global_server_args_for_scheduler
+
+        set_global_server_args_for_scheduler(server_args)
+        return get_flags()
+
+    def test_mistral_large3_forces_bfloat16(self):
+        sa = self._construct("MistralLarge3ForCausalLM", "mistral")
+        self.assertEqual(sa.dtype, "bfloat16")  # dual-apply == legacy write
+        self.assertEqual(
+            sa._resolved_overrides,
+            [("MODEL_OVERRIDES['MistralLarge3ForCausalLM']", {"dtype": "bfloat16"})],
+        )
+        self.assertEqual(self._publish(sa).dtype, "bfloat16")
+
+    def test_pixtral_forces_bfloat16(self):
+        sa = self._construct("PixtralForConditionalGeneration", "pixtral")
+        self.assertEqual(sa.dtype, "bfloat16")
+        self.assertEqual(self._publish(sa).dtype, "bfloat16")
+
+    def test_user_requested_dtype_is_still_overridden(self):
+        # Legacy fidelity: the arch branch overwrote dtype unconditionally,
+        # so the declaration must too. The pristine request survives only on
+        # provenance (and, post-V3, as the un-overridden server_args field).
+        sa = self._construct("MistralLarge3ForCausalLM", "mistral", dtype="float16")
+        self.assertEqual(sa.dtype, "bfloat16")
+        self.assertEqual(self._publish(sa).dtype, "bfloat16")
+
+    def test_control_arch_keeps_pristine_dtype(self):
+        sa = self._construct("LlamaForCausalLM", "llama")
+        self.assertEqual(sa.dtype, "auto")
+        self.assertEqual(sa._resolved_overrides, [])
+        # publish still materializes the whitelisted leaf with the pristine
+        # value: readers only ever read flags.
+        self.assertEqual(self._publish(sa).dtype, "auto")
+
+    def test_minimax_m2_enables_tf32_matmul(self):
+        sa = self._construct("MiniMaxM2ForCausalLM", "llama")
+        self.assertTrue(sa.enable_tf32_matmul)  # dual-apply == legacy write
+        self.assertEqual(
+            sa._resolved_overrides,
+            [("_minimax_m2_overrides", {"enable_tf32_matmul": True})],
+        )
+        flags = self._publish(sa)
+        self.assertTrue(flags.enable_tf32_matmul)
+        self.assertFalse(flags.enable_multi_layer_eagle)  # pristine materialize
+
+    def test_mimo_v2_declarations(self):
+        # Callable-level golden: MiMoV2 archs are hybrid (config-shape heavy),
+        # so the declaration is pinned directly for both provider inputs.
+        from sglang.srt.arg_groups.overrides import _mimo_v2_overrides
+
+        self.assertEqual(
+            _mimo_v2_overrides(SimpleNamespace(speculative_algorithm="EAGLE"), None),
+            {"enable_multi_layer_eagle": True},
+        )
+        self.assertEqual(
+            _mimo_v2_overrides(SimpleNamespace(speculative_algorithm=None), None),
+            {},
+        )
+
+    def test_mimo_v2_family_is_registered(self):
+        self.assertEqual(
+            collect_model_override_declarations(
+                "MiMoV2FlashForCausalLM",
+                SimpleNamespace(speculative_algorithm="EAGLE"),
+                None,
+            ),
+            [("_mimo_v2_overrides", {"enable_multi_layer_eagle": True})],
+        )
 
 
 class TestDualApplyParity(CustomTestCase):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -21,7 +21,12 @@ from sglang.srt.arg_groups.overrides import (
     collect_model_override_declarations,
     register_model_override,
 )
-from sglang.srt.runtime_context import _StaticFlags
+from sglang.srt.runtime_context import (
+    _StaticFlags,
+    get_context,
+    get_server_args,
+    reset_context,
+)
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -49,6 +54,9 @@ class TestModelOverridableWhitelist(CustomTestCase):
         from sglang.srt.server_args import ServerArgs
 
         self.assertEqual(model_overridable_fields(ServerArgs), frozenset())
+
+    def test_non_dataclass_yields_empty_whitelist(self):
+        self.assertEqual(model_overridable_fields(SimpleNamespace), frozenset())
 
 
 class _IsolatedRegistry(CustomTestCase):
@@ -197,6 +205,59 @@ class TestApplyModelOverridesGate(CustomTestCase):
         )
         self.assertEqual(flags.attn.backend, "fa3")
         self.assertEqual(flags.resolved_by_model, "unset")  # flat leaf untouched
+
+
+class _IsolatedPublish(CustomTestCase):
+    """Publishing writes the process-global context; save/restore around it."""
+
+    def setUp(self):
+        super().setUp()
+        self._saved_server_args = get_context()._server_args
+
+    def tearDown(self):
+        reset_context()
+        if self._saved_server_args is not None:
+            get_context()._server_args = self._saved_server_args
+        super().tearDown()
+
+
+@dataclasses.dataclass
+class _NoOverridableArgs:
+    x: int = 1
+
+
+class TestPublishResolvesFlags(_IsolatedPublish):
+    """R0 publish wiring: stash-carrying publishes resolve into flags via the
+    gate; publishes without the stash skip resolution."""
+
+    def test_dummy_fixture_has_empty_stash_and_publishes_cleanly(self):
+        from sglang.srt.server_args import (
+            ServerArgs,
+            set_global_server_args_for_scheduler,
+        )
+
+        sa = ServerArgs(model_path="dummy")  # __post_init__ early-returns
+        # The stash is created before the dummy short-circuit and stays empty.
+        self.assertEqual(sa._resolved_overrides, [])
+        set_global_server_args_for_scheduler(sa)
+        self.assertIs(get_server_args(), sa)
+
+    def test_empty_stash_publish_runs_gate_as_noop(self):
+        sa = _NoOverridableArgs()
+        sa._resolved_overrides = []
+        get_context().set_server_args(sa)
+        self.assertIs(get_server_args(), sa)
+
+    def test_non_whitelisted_declaration_fails_at_publish(self):
+        from sglang.srt.runtime_context import get_flags
+
+        flags_before = get_flags()
+        sa = _NoOverridableArgs()
+        sa._resolved_overrides = [("rogue", {"x": 2})]
+        with self.assertRaises(ValueError):
+            get_context().set_server_args(sa)
+        # a failed publish must leave BOTH the slot and the flags untouched
+        self.assertIs(get_flags(), flags_before)
 
 
 class TestDualApplyParity(CustomTestCase):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -67,6 +67,7 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "enable_multi_layer_eagle",
                     "swa_full_tokens_ratio",
                     "disable_hybrid_swa_memory",
+                    "sampling_backend",
                 }
             ),
         )
@@ -160,6 +161,53 @@ class TestModelOverrideRegistry(_IsolatedRegistry):
         self.assertEqual(
             collect_model_override_declarations("OtherForCausalLM", None, None), []
         )
+
+
+class TestResolvedViewAndPasses(CustomTestCase):
+    """Pipeline skeleton: read-only view semantics + transition invocation."""
+
+    def test_view_forwards_reads_and_rejects_writes(self):
+        from sglang.srt.arg_groups.overrides import ResolvedView
+
+        live = SimpleNamespace(a=1, method=lambda: "m")
+        view = ResolvedView(live)
+        self.assertEqual(view.a, 1)
+        self.assertEqual(view.method(), "m")  # method forwarding
+        live.a = 2
+        self.assertEqual(view.a, 2)  # live, not a snapshot
+        with self.assertRaises(AttributeError):
+            view.a = 3
+
+    def test_view_overlay_wins(self):
+        from sglang.srt.arg_groups.overrides import ResolvedView
+
+        view = ResolvedView(SimpleNamespace(a=1, b=2), overlay={"a": 10})
+        self.assertEqual(view.a, 10)
+        self.assertEqual(view.b, 2)
+
+    def test_run_pass_appends_stash_and_dual_applies(self):
+        from sglang.srt.arg_groups.overrides import run_post_process_pass
+
+        live = SimpleNamespace(x=None, _resolved_overrides=[])
+
+        def _fill_x(view):
+            return {"x": "filled"} if view.x is None else {}
+
+        run_post_process_pass(live, _fill_x)
+        self.assertEqual(live.x, "filled")  # dual-applied in place
+        self.assertEqual(
+            live._resolved_overrides, [(_fill_x.__qualname__, {"x": "filled"})]
+        )
+        run_post_process_pass(live, _fill_x)  # now a no-op
+        self.assertEqual(len(live._resolved_overrides), 1)
+
+    def test_run_pass_rejects_non_dict(self):
+        from sglang.srt.arg_groups.overrides import run_post_process_pass
+
+        with self.assertRaises(TypeError):
+            run_post_process_pass(
+                SimpleNamespace(_resolved_overrides=[]), lambda view: None
+            )
 
 
 @dataclasses.dataclass
@@ -346,9 +394,9 @@ class TestGoldenModelOverrides(_IsolatedPublish):
     def test_mistral_large3_forces_bfloat16(self):
         sa = self._construct("MistralLarge3ForCausalLM", "mistral")
         self.assertEqual(sa.dtype, "bfloat16")  # dual-apply == legacy write
-        self.assertEqual(
+        self.assertIn(
+            ("MODEL_OVERRIDES['MistralLarge3ForCausalLM']", {"dtype": "bfloat16"}),
             sa._resolved_overrides,
-            [("MODEL_OVERRIDES['MistralLarge3ForCausalLM']", {"dtype": "bfloat16"})],
         )
         self.assertEqual(self._publish(sa).dtype, "bfloat16")
 
@@ -368,7 +416,8 @@ class TestGoldenModelOverrides(_IsolatedPublish):
     def test_control_arch_keeps_pristine_dtype(self):
         sa = self._construct("LlamaForCausalLM", "llama")
         self.assertEqual(sa.dtype, "auto")
-        self.assertEqual(sa._resolved_overrides, [])
+        declared = {f for _s, d in sa._resolved_overrides for f in d}
+        self.assertNotIn("dtype", declared)  # no arch declaration for Llama
         # publish still materializes the whitelisted leaf with the pristine
         # value: readers only ever read flags.
         self.assertEqual(self._publish(sa).dtype, "auto")
@@ -376,9 +425,9 @@ class TestGoldenModelOverrides(_IsolatedPublish):
     def test_minimax_m2_enables_tf32_matmul(self):
         sa = self._construct("MiniMaxM2ForCausalLM", "llama")
         self.assertTrue(sa.enable_tf32_matmul)  # dual-apply == legacy write
-        self.assertEqual(
+        self.assertIn(
+            ("_minimax_m2_overrides", {"enable_tf32_matmul": True}),
             sa._resolved_overrides,
-            [("_minimax_m2_overrides", {"enable_tf32_matmul": True})],
         )
         flags = self._publish(sa)
         self.assertTrue(flags.enable_tf32_matmul)
@@ -430,9 +479,9 @@ class TestGoldenModelOverrides(_IsolatedPublish):
     def test_gemma2_disables_hybrid_swa_memory(self):
         sa = self._construct("Gemma2ForCausalLM", "llama")
         self.assertTrue(sa.disable_hybrid_swa_memory)  # dual-apply == legacy
-        self.assertEqual(
+        self.assertIn(
+            ("_gemma2_gemma3_overrides", {"disable_hybrid_swa_memory": True}),
             sa._resolved_overrides,
-            [("_gemma2_gemma3_overrides", {"disable_hybrid_swa_memory": True})],
         )
         self.assertTrue(self._publish(sa).disable_hybrid_swa_memory)
 
@@ -489,6 +538,46 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     SimpleNamespace(dtype="float16"),
                     SimpleNamespace(architectures=["GptOssForCausalLM"]),
                 )
+
+    def test_sampling_backend_default_pass(self):
+        from sglang.srt.utils.common import is_flashinfer_available
+
+        sa = self._construct("LlamaForCausalLM", "llama")
+        expected = "flashinfer" if is_flashinfer_available() else "pytorch"
+        self.assertEqual(sa.sampling_backend, expected)
+        self.assertIn(
+            ("_sampling_backend_default", {"sampling_backend": expected}),
+            sa._resolved_overrides,
+        )
+        self.assertEqual(self._publish(sa).sampling_backend, expected)
+
+    def test_sampling_backend_user_choice_survives(self):
+        sa = self._construct("LlamaForCausalLM", "llama", sampling_backend="pytorch")
+        self.assertEqual(sa.sampling_backend, "pytorch")
+        # the pass declared nothing; publish materializes the pristine choice
+        self.assertEqual(self._publish(sa).sampling_backend, "pytorch")
+
+    def test_deterministic_inference_forces_pytorch_sampling(self):
+        sa = self._construct(
+            "LlamaForCausalLM", "llama", enable_deterministic_inference=True
+        )
+        # two pass writers chain: default fill, then the deterministic force —
+        # last writer wins on the flags leaf and parity holds end-to-end.
+        self.assertEqual(sa.sampling_backend, "pytorch")
+        self.assertEqual(self._publish(sa).sampling_backend, "pytorch")
+
+    def test_deterministic_ascend_is_left_alone(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _deterministic_sampling_backend,
+        )
+
+        view = ResolvedView(
+            SimpleNamespace(
+                enable_deterministic_inference=True, sampling_backend="ascend"
+            )
+        )
+        self.assertEqual(_deterministic_sampling_backend(view), {})
 
     def test_step3p_declarations_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import _step3p_overrides

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -68,6 +68,7 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "swa_full_tokens_ratio",
                     "disable_hybrid_swa_memory",
                     "sampling_backend",
+                    "attention_backend",
                 }
             ),
         )
@@ -535,7 +536,10 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         with patch.object(overrides_module, "is_xpu", return_value=True):
             with self.assertRaises(NotImplementedError):
                 _gpt_oss_overrides(
-                    SimpleNamespace(dtype="float16"),
+                    SimpleNamespace(
+                        dtype="float16",
+                        is_attention_backend_not_set=lambda: False,
+                    ),
                     SimpleNamespace(architectures=["GptOssForCausalLM"]),
                 )
 
@@ -564,7 +568,32 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         # two pass writers chain: default fill, then the deterministic force —
         # last writer wins on the flags leaf and parity holds end-to-end.
         self.assertEqual(sa.sampling_backend, "pytorch")
-        self.assertEqual(self._publish(sa).sampling_backend, "pytorch")
+        flags = self._publish(sa)
+        self.assertEqual(flags.sampling_backend, "pytorch")
+        # the deterministic attention fill declared a compatible backend and
+        # the compatibility default-fill then had nothing to do
+        self.assertIn(
+            (
+                "_deterministic_attention_backend",
+                {"attention_backend": sa.attention_backend},
+            ),
+            sa._resolved_overrides,
+        )
+        self.assertEqual(flags.attn.backend, sa.attention_backend)
+
+    def test_deterministic_incompatible_backend_raises(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _deterministic_attention_backend,
+        )
+
+        view = ResolvedView(
+            SimpleNamespace(
+                enable_deterministic_inference=True, attention_backend="flashmla"
+            )
+        )
+        with self.assertRaises(ValueError):
+            _deterministic_attention_backend(view)
 
     def test_deterministic_ascend_is_left_alone(self):
         from sglang.srt.arg_groups.overrides import (
@@ -579,36 +608,228 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         )
         self.assertEqual(_deterministic_sampling_backend(view), {})
 
+    def test_dllm_forces_flashinfer_with_cuda_graph(self):
+        # CUDA path: cuda graph enabled by default -> dllm forces flashinfer.
+        sa = self._construct(
+            "LlamaForCausalLM",
+            "llama",
+            dllm_algorithm="LowConfidence",
+            disable_radix_cache=True,
+        )
+        self.assertEqual(sa.attention_backend, "flashinfer")
+        self.assertIn(
+            ("_dllm_attention_backend", {"attention_backend": "flashinfer"}),
+            sa._resolved_overrides,
+        )
+        # first MAPPED leaf: attention_backend routes to flags.attn.backend
+        self.assertEqual(self._publish(sa).attn.backend, "flashinfer")
+
+    def test_attention_backend_leaf_materializes_end_state(self):
+        # The default-fill pass declares the platform-selected backend; the
+        # leaf must equal the final server_args value (publish parity).
+        sa = self._construct("LlamaForCausalLM", "llama")
+        declared = {f for _s, d in sa._resolved_overrides for f in d}
+        self.assertIn("attention_backend", declared)  # default fill declared
+        self.assertEqual(self._publish(sa).attn.backend, sa.attention_backend)
+
+    def test_runner_side_adjustment_can_refresh_declaration(self):
+        from sglang.srt.arg_groups.overrides import refresh_declared_fields
+
+        sa = self._construct("LlamaForCausalLM", "llama")
+        declared = {f for _s, d in sa._resolved_overrides for f in d}
+        self.assertIn("attention_backend", declared)
+        # Simulate a legacy runner-side overwrite between R0 and publish
+        # (model_specific_adjustment forces attention_backend for HRM-Text).
+        sa.attention_backend = "fa3" if sa.attention_backend != "fa3" else "triton"
+        with self.assertRaises(AssertionError):
+            self._publish(sa)  # stale declaration breaks parity
+        refresh_declared_fields(sa, ("attention_backend",))
+        self.assertEqual(self._publish(sa).attn.backend, sa.attention_backend)
+
+    def test_attention_backend_user_choice_declares_nothing_extra(self):
+        sa = self._construct("LlamaForCausalLM", "llama", attention_backend="triton")
+        self.assertEqual(sa.attention_backend, "triton")
+        self.assertEqual(self._publish(sa).attn.backend, "triton")
+
+    def test_compatibility_passes_at_callable_level(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _attention_backend_default,
+            _attention_backend_dual_chunk,
+            _attention_backend_fa3_fp8_fallback,
+            _attention_backend_platform_fallbacks,
+        )
+
+        # split-backend override wins over the default fill
+        view = ResolvedView(
+            SimpleNamespace(
+                prefill_attention_backend="fa3",
+                decode_attention_backend="fa3",
+                attention_backend=None,
+            )
+        )
+        self.assertEqual(_attention_backend_default(view), {"attention_backend": "fa3"})
+
+        # fa3 + fp8_e5m2 falls back to triton
+        view = ResolvedView(
+            SimpleNamespace(attention_backend="fa3", kv_cache_dtype="fp8_e5m2")
+        )
+        self.assertEqual(
+            _attention_backend_fa3_fp8_fallback(view),
+            {"attention_backend": "triton"},
+        )
+
+        # amx fallback fires only without hardware support
+        view = ResolvedView(
+            SimpleNamespace(attention_backend="intel_amx", device="cpu")
+        )
+        with patch.object(overrides_module, "cpu_has_amx_support", return_value=False):
+            self.assertEqual(
+                _attention_backend_platform_fallbacks(view),
+                {"attention_backend": "torch_native"},
+            )
+        with patch.object(overrides_module, "cpu_has_amx_support", return_value=True):
+            self.assertEqual(_attention_backend_platform_fallbacks(view), {})
+
+        # dual-chunk config: mismatched explicit backend raises verbatim
+        def _mc(dual):
+            return SimpleNamespace(
+                get_model_config=lambda: SimpleNamespace(
+                    hf_config=SimpleNamespace(dual_chunk_attention_config=dual)
+                ),
+                attention_backend="fa3",
+            )
+
+        with self.assertRaises(ValueError):
+            _attention_backend_dual_chunk(ResolvedView(_mc({"a": 1})))
+        self.assertEqual(_attention_backend_dual_chunk(ResolvedView(_mc(None))), {})
+
+    def test_dllm_platform_paths_at_callable_level(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _dllm_attention_backend,
+        )
+        from sglang.srt.model_executor.cuda_graph_config import Backend
+
+        def _view(**kw):
+            defaults = dict(
+                dllm_algorithm="LowConfidence",
+                attention_backend=None,
+                cuda_graph_config=SimpleNamespace(
+                    decode=SimpleNamespace(backend=Backend.DISABLED)
+                ),
+            )
+            defaults.update(kw)
+            return ResolvedView(SimpleNamespace(**defaults))
+
+        with patch.object(overrides_module, "is_hip", return_value=True):
+            self.assertEqual(
+                _dllm_attention_backend(_view()), {"attention_backend": "triton"}
+            )
+            self.assertEqual(
+                _dllm_attention_backend(_view(attention_backend="aiter")), {}
+            )
+        with patch.object(overrides_module, "is_hip", return_value=False):
+            with patch.object(overrides_module, "is_npu", return_value=True):
+                self.assertEqual(
+                    _dllm_attention_backend(_view()),
+                    {"attention_backend": "ascend"},
+                )
+            with patch.object(overrides_module, "is_npu", return_value=False):
+                # cuda graph disabled -> nothing to force
+                self.assertEqual(_dllm_attention_backend(_view()), {})
+                self.assertEqual(
+                    _dllm_attention_backend(_view(dllm_algorithm=None)), {}
+                )
+
+    def test_monolith_attention_families_at_callable_level(self):
+        from sglang.srt.arg_groups.overrides import (
+            _falcon_h1_jet_overrides,
+            _gemma4_overrides,
+            _glm4_moe_overrides,
+            _granite_moe_hybrid_overrides,
+            _lfm2_overrides,
+            _llama4_overrides,
+            _minicpm_v4_6_overrides,
+        )
+
+        def _args(**kw):
+            defaults = dict(
+                device="cuda",
+                attention_backend=None,
+                is_attention_backend_not_set=lambda: True,
+            )
+            defaults.update(kw)
+            return SimpleNamespace(**defaults)
+
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            self.assertEqual(
+                _llama4_overrides(_args(), None), {"attention_backend": "trtllm_mha"}
+            )
+            self.assertEqual(_llama4_overrides(_args(device="cpu"), None), {})
+            self.assertEqual(
+                _llama4_overrides(_args(attention_backend="fa3"), None), {}
+            )
+            self.assertEqual(
+                _gemma4_overrides(_args(), None), {"attention_backend": "trtllm_mha"}
+            )
+            self.assertEqual(
+                _minicpm_v4_6_overrides(_args(), None),
+                {"attention_backend": "triton"},
+            )
+            self.assertEqual(
+                _falcon_h1_jet_overrides(_args(), None),
+                {"attention_backend": "triton"},
+            )
+            self.assertEqual(
+                _granite_moe_hybrid_overrides(
+                    _args(), SimpleNamespace(layer_types=["mamba", "attention"])
+                ),
+                {"attention_backend": "flashinfer"},
+            )
+            self.assertEqual(
+                _granite_moe_hybrid_overrides(
+                    _args(), SimpleNamespace(layer_types=["attention"])
+                ),
+                {},
+            )
+            self.assertEqual(
+                _lfm2_overrides(_args(), None), {"attention_backend": "flashinfer"}
+            )
+        with patch.object(overrides_module, "is_sm100_supported", return_value=False):
+            self.assertEqual(_minicpm_v4_6_overrides(_args(), None), {})
+            with patch.object(overrides_module, "is_sm90_supported", return_value=True):
+                self.assertEqual(
+                    _llama4_overrides(_args(), None), {"attention_backend": "fa3"}
+                )
+            self.assertEqual(
+                _gemma4_overrides(_args(), None), {"attention_backend": "triton"}
+            )
+        # Glm4Moe: unconditional tf32 declaration (quant/moe writes stay in
+        # the branch until their field chains migrate)
+        self.assertEqual(_glm4_moe_overrides(None, None), {"enable_tf32_matmul": True})
+
     def test_step3p_declarations_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import _step3p_overrides
 
+        def _args(**kw):
+            defaults = dict(
+                speculative_algorithm=None,
+                enable_hierarchical_cache=False,
+                is_attention_backend_not_set=lambda: False,
+            )
+            defaults.update(kw)
+            return SimpleNamespace(**defaults)
+
         self.assertEqual(
-            _step3p_overrides(
-                SimpleNamespace(
-                    speculative_algorithm="EAGLE", enable_hierarchical_cache=False
-                ),
-                None,
-            ),
+            _step3p_overrides(_args(speculative_algorithm="EAGLE"), None),
             {"enable_multi_layer_eagle": True},
         )
         self.assertEqual(
-            _step3p_overrides(
-                SimpleNamespace(
-                    speculative_algorithm=None, enable_hierarchical_cache=True
-                ),
-                None,
-            ),
+            _step3p_overrides(_args(enable_hierarchical_cache=True), None),
             {"swa_full_tokens_ratio": 1.0, "disable_hybrid_swa_memory": True},
         )
-        self.assertEqual(
-            _step3p_overrides(
-                SimpleNamespace(
-                    speculative_algorithm=None, enable_hierarchical_cache=False
-                ),
-                None,
-            ),
-            {},
-        )
+        self.assertEqual(_step3p_overrides(_args(), None), {})
 
 
 class TestDualApplyParity(CustomTestCase):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -70,6 +70,8 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "sampling_backend",
                     "attention_backend",
                     "page_size",
+                    "moe_runner_backend",
+                    "quantization",
                 }
             ),
         )
@@ -841,6 +843,88 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     _qwen3vl_overrides(SimpleNamespace(page_size=64), None), {}
                 )
 
+    def test_moe_runner_quant_constraint_pass(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _moe_runner_backend_quant_constraints,
+        )
+
+        def _view(**kw):
+            defaults = dict(quantization=None, moe_runner_backend="auto")
+            defaults.update(kw)
+            return ResolvedView(SimpleNamespace(**defaults))
+
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            self.assertEqual(
+                _moe_runner_backend_quant_constraints(
+                    _view(quantization="nvfp4_online")
+                ),
+                {"moe_runner_backend": "flashinfer_trtllm"},
+            )
+            with self.assertRaises(ValueError):  # incompatible explicit backend
+                _moe_runner_backend_quant_constraints(
+                    _view(quantization="nvfp4_online", moe_runner_backend="triton")
+                )
+        self.assertEqual(
+            _moe_runner_backend_quant_constraints(_view(quantization="mxfp8")),
+            {"moe_runner_backend": "flashinfer_trtllm"},
+        )
+        with patch.object(overrides_module, "is_sm120_supported", return_value=True):
+            self.assertEqual(
+                _moe_runner_backend_quant_constraints(
+                    _view(quantization="modelopt_fp4")
+                ),
+                {"moe_runner_backend": "flashinfer_cutlass"},
+            )
+        self.assertEqual(_moe_runner_backend_quant_constraints(_view()), {})
+
+    def test_cutlass_moe_env_override_pass(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _cutlass_moe_env_override,
+        )
+
+        with patch("sglang.srt.environ.envs.SGLANG_CUTLASS_MOE") as e:
+            e.get.return_value = True
+            self.assertEqual(
+                _cutlass_moe_env_override(
+                    ResolvedView(SimpleNamespace(quantization="fp8"))
+                ),
+                {"moe_runner_backend": "cutlass"},
+            )
+            with self.assertRaises(AssertionError):
+                _cutlass_moe_env_override(
+                    ResolvedView(SimpleNamespace(quantization=None))
+                )
+            e.get.return_value = False
+            self.assertEqual(
+                _cutlass_moe_env_override(ResolvedView(SimpleNamespace())), {}
+            )
+
+    def test_gguf_quantization_pass(self):
+        from sglang.srt.arg_groups.overrides import ResolvedView, _gguf_quantization
+
+        with patch(
+            "sglang.srt.utils.hf_transformers_utils.check_gguf_file",
+            return_value=True,
+        ):
+            self.assertEqual(
+                _gguf_quantization(
+                    ResolvedView(
+                        SimpleNamespace(load_format="auto", model_path="x.gguf")
+                    )
+                ),
+                {"quantization": "gguf"},
+            )
+            self.assertEqual(
+                _gguf_quantization(
+                    ResolvedView(
+                        SimpleNamespace(load_format="safetensors", model_path="x")
+                    )
+                ),
+                {},
+            )
+
     def test_page_constraint_passes_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import (
             ResolvedView,
@@ -942,6 +1026,10 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 device="cuda",
                 attention_backend=None,
                 is_attention_backend_not_set=lambda: True,
+                # keep the (now-absorbed) quant/moe blocks inert so these
+                # assertions stay attention-only
+                moe_runner_backend="triton",
+                quantization=None,
             )
             defaults.update(kw)
             return SimpleNamespace(**defaults)
@@ -989,9 +1077,55 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             self.assertEqual(
                 _gemma4_overrides(_args(), None), {"attention_backend": "triton"}
             )
-        # Glm4Moe: unconditional tf32 declaration (quant/moe writes stay in
-        # the branch until their field chains migrate)
-        self.assertEqual(_glm4_moe_overrides(None, None), {"enable_tf32_matmul": True})
+        # Glm4Moe: unconditional tf32 declaration + (sm100) quant/moe absorption
+        with patch.object(overrides_module, "is_sm100_supported", return_value=False):
+            self.assertEqual(
+                _glm4_moe_overrides(None, None), {"enable_tf32_matmul": True}
+            )
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            self.assertEqual(
+                _glm4_moe_overrides(
+                    SimpleNamespace(
+                        quantization=None,
+                        _quantization_explicitly_unset=False,
+                        moe_a2a_backend="none",
+                        moe_runner_backend="auto",
+                    ),
+                    SimpleNamespace(
+                        quantization_config={"quant_method": "modelopt_fp4"}
+                    ),
+                ),
+                {
+                    "quantization": "modelopt_fp4",
+                    "moe_runner_backend": "flashinfer_trtllm",
+                    "enable_tf32_matmul": True,
+                },
+            )
+
+    def test_qwen3_moe_family_quant_absorption(self):
+        from sglang.srt.arg_groups.overrides import _qwen3_moe_family_overrides
+
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            with patch.object(
+                overrides_module, "get_quantization_config", return_value="fp8"
+            ):
+                self.assertEqual(
+                    _qwen3_moe_family_overrides(
+                        SimpleNamespace(
+                            quantization=None,
+                            _quantization_explicitly_unset=False,
+                            moe_a2a_backend="none",
+                            moe_runner_backend="auto",
+                        ),
+                        SimpleNamespace(architectures=["Qwen3MoeForCausalLM"]),
+                    ),
+                    {
+                        "quantization": "fp8",
+                        "moe_runner_backend": "flashinfer_trtllm",
+                    },
+                )
+        with patch.object(overrides_module, "is_sm100_supported", return_value=False):
+            self.assertEqual(_qwen3_moe_family_overrides(None, None), {})
 
     def test_step3p_declarations_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import _step3p_overrides

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1,4 +1,5 @@
-"""Unit tests for the model-override machinery: whitelist metadata (V3a)."""
+"""Unit tests for the model-override machinery: whitelist metadata, registry
+(V3a — declarations only, nothing calls this in production yet)."""
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -6,9 +7,21 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 import dataclasses
 import unittest
+from types import SimpleNamespace
 from typing import Optional
+from unittest.mock import patch
 
+from sglang.srt.arg_groups import overrides as overrides_module
 from sglang.srt.arg_groups.arg_utils import A, Arg, model_overridable_fields
+from sglang.srt.arg_groups.overrides import (
+    OverrideRecord,
+    apply_declarations_to_server_args,
+    apply_model_overrides,
+    assert_flag_parity,
+    collect_model_override_declarations,
+    register_model_override,
+)
+from sglang.srt.runtime_context import _StaticFlags
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -36,6 +49,172 @@ class TestModelOverridableWhitelist(CustomTestCase):
         from sglang.srt.server_args import ServerArgs
 
         self.assertEqual(model_overridable_fields(ServerArgs), frozenset())
+
+
+class _IsolatedRegistry(CustomTestCase):
+    """Run each test against empty registries (they are process-global)."""
+
+    def setUp(self):
+        super().setUp()
+        self._patches = [
+            patch.dict(overrides_module.MODEL_OVERRIDES, clear=True),
+            patch.dict(overrides_module._MODEL_OVERRIDE_FNS, clear=True),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        super().tearDown()
+
+
+class TestModelOverrideRegistry(_IsolatedRegistry):
+    def test_const_then_callables_in_registration_order(self):
+        overrides_module.MODEL_OVERRIDES["FakeForCausalLM"] = {"a": 1}
+
+        @register_model_override("FakeForCausalLM")
+        def _first(server_args, hf_config):
+            return {"b": server_args.base + 1}
+
+        @register_model_override("FakeForCausalLM")
+        def _second(server_args, hf_config):
+            return {"a": 3}
+
+        declarations = collect_model_override_declarations(
+            "FakeForCausalLM", SimpleNamespace(base=10), hf_config=None
+        )
+        self.assertEqual(
+            declarations,
+            [
+                ("MODEL_OVERRIDES['FakeForCausalLM']", {"a": 1}),
+                (_first.__qualname__, {"b": 11}),
+                (_second.__qualname__, {"a": 3}),
+            ],
+        )
+
+    def test_unknown_architecture_yields_nothing(self):
+        self.assertEqual(
+            collect_model_override_declarations("NoSuchArch", None, None), []
+        )
+
+    def test_empty_declarations_are_dropped(self):
+        @register_model_override("FakeForCausalLM")
+        def _nothing_applies(server_args, hf_config):
+            return {}
+
+        self.assertEqual(
+            collect_model_override_declarations("FakeForCausalLM", None, None), []
+        )
+
+    def test_non_dict_return_is_rejected(self):
+        @register_model_override("FakeForCausalLM")
+        def _bad(server_args, hf_config):
+            return None
+
+        with self.assertRaises(TypeError):
+            collect_model_override_declarations("FakeForCausalLM", None, None)
+
+
+@dataclasses.dataclass
+class _FakeAttnGroup(_StaticFlags):
+    backend: str = "unset"
+
+
+@dataclasses.dataclass
+class _FakeFlags(_StaticFlags):
+    attn: _FakeAttnGroup = dataclasses.field(default_factory=_FakeAttnGroup)
+    resolved_by_model: str = "unset"
+    also_resolved: Optional[int] = None
+
+
+class TestApplyModelOverridesGate(CustomTestCase):
+    def _fresh(self):
+        return _FakeFlags(), _FakeArgs()
+
+    def test_materializes_declared_and_pristine_leaves(self):
+        flags, args = self._fresh()
+        records = apply_model_overrides(
+            flags, args, [("src", {"resolved_by_model": "dsv4"})]
+        )
+        self.assertEqual(flags.resolved_by_model, "dsv4")  # declared
+        self.assertIsNone(flags.also_resolved)  # undeclared -> pristine value
+        self.assertEqual(args.resolved_by_model, "auto")  # server_args untouched
+        self.assertEqual(
+            records, [OverrideRecord("src", "resolved_by_model", "auto", "dsv4")]
+        )
+
+    def test_last_writer_wins_then_terminal_wins_last(self):
+        flags, args = self._fresh()
+        records = apply_model_overrides(
+            flags,
+            args,
+            [
+                ("first", {"resolved_by_model": "a"}),
+                ("second", {"resolved_by_model": "b"}),
+            ],
+            terminal=[("enforce_disable", {"resolved_by_model": "off"})],
+        )
+        self.assertEqual(flags.resolved_by_model, "off")
+        self.assertEqual([r.resolved for r in records], ["a", "b", "off"])
+        self.assertEqual(records[1].base, "a")  # provenance chains the writers
+
+    def test_non_whitelisted_field_rejected_before_any_write(self):
+        flags, args = self._fresh()
+        with self.assertRaises(ValueError):
+            apply_model_overrides(
+                flags,
+                args,
+                [("ok", {"resolved_by_model": "x"}), ("bad", {"plain": 1})],
+            )
+        self.assertEqual(flags.resolved_by_model, "unset")  # transactional
+
+    def test_missing_leaf_rejected_before_any_write(self):
+        flags, args = self._fresh()
+        with self.assertRaises(ValueError):
+            apply_model_overrides(
+                flags,
+                args,
+                [("src", {"resolved_by_model": "x"})],
+                whitelist={"resolved_by_model", "field_without_leaf"},
+            )
+        self.assertEqual(flags.resolved_by_model, "unset")
+
+    def test_frozen_flags_rejected(self):
+        flags, args = self._fresh()
+        flags.freeze()
+        with self.assertRaises(RuntimeError):
+            apply_model_overrides(flags, args, [("src", {"resolved_by_model": "x"})])
+
+    def test_leaf_map_routes_to_group_leaf(self):
+        flags, args = self._fresh()
+        apply_model_overrides(
+            flags,
+            args,
+            [("src", {"resolved_by_model": "fa3"})],
+            whitelist={"resolved_by_model"},
+            leaf_map={"resolved_by_model": "attn.backend"},
+        )
+        self.assertEqual(flags.attn.backend, "fa3")
+        self.assertEqual(flags.resolved_by_model, "unset")  # flat leaf untouched
+
+
+class TestDualApplyParity(CustomTestCase):
+    def test_dual_apply_replays_and_parity_holds(self):
+        flags, args = _FakeFlags(), _FakeArgs()
+        declarations = [("src", {"resolved_by_model": "dsv4", "also_resolved": 7})]
+        apply_model_overrides(flags, args, declarations)
+        apply_declarations_to_server_args(args, declarations)
+        self.assertEqual(args.resolved_by_model, "dsv4")
+        self.assertEqual(args.also_resolved, 7)
+        assert_flag_parity(flags, args, ["resolved_by_model", "also_resolved"])
+
+    def test_parity_detects_drift(self):
+        flags, args = _FakeFlags(), _FakeArgs()
+        apply_model_overrides(flags, args, [("src", {"resolved_by_model": "x"})])
+        # dual-apply skipped -> server_args still pristine -> drift is caught
+        with self.assertRaises(AssertionError):
+            assert_flag_parity(flags, args, ["resolved_by_model"])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -69,6 +69,7 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "disable_hybrid_swa_memory",
                     "sampling_backend",
                     "attention_backend",
+                    "page_size",
                 }
             ),
         )
@@ -741,6 +742,189 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 self.assertEqual(
                     _dllm_attention_backend(_view(dllm_algorithm=None)), {}
                 )
+
+    def test_page_size_default_pass(self):
+        from sglang.srt.arg_groups.overrides import ResolvedView, _page_size_default
+
+        # user-set page_size: nothing to declare
+        self.assertEqual(
+            _page_size_default(ResolvedView(SimpleNamespace(page_size=64))), {}
+        )
+        # default fill on non-HIP/non-MUSA platforms is 1
+        with patch.object(overrides_module, "is_hip", return_value=False):
+            with patch.object(overrides_module, "is_musa", return_value=False):
+                self.assertEqual(
+                    _page_size_default(ResolvedView(SimpleNamespace(page_size=None))),
+                    {"page_size": 1},
+                )
+            with patch.object(overrides_module, "is_musa", return_value=True):
+                self.assertEqual(
+                    _page_size_default(ResolvedView(SimpleNamespace(page_size=None))),
+                    {"page_size": 64},
+                )
+
+    def test_dllm_page_size_pass(self):
+        from sglang.srt.arg_groups.overrides import ResolvedView, _dllm_page_size
+
+        def _view(**kw):
+            defaults = dict(
+                dllm_algorithm="LowConfidence", disable_radix_cache=False, page_size=1
+            )
+            defaults.update(kw)
+            return ResolvedView(SimpleNamespace(**defaults))
+
+        with patch(
+            "sglang.srt.dllm.config.DllmConfig.from_server_args",
+            return_value=SimpleNamespace(block_size=32),
+        ):
+            self.assertEqual(_view() and _dllm_page_size(_view()), {"page_size": 32})
+            self.assertEqual(_dllm_page_size(_view(page_size=64)), {})  # aligned
+        self.assertEqual(_dllm_page_size(_view(dllm_algorithm=None)), {})
+        self.assertEqual(_dllm_page_size(_view(disable_radix_cache=True)), {})
+
+    def test_page_size_leaf_materializes_end_state(self):
+        sa = self._construct("LlamaForCausalLM", "llama")
+        declared = {f for _s, d in sa._resolved_overrides for f in d}
+        self.assertIn("page_size", declared)  # default fill declared
+        self.assertEqual(self._publish(sa).page_size, sa.page_size)
+
+    def test_qwen3_5_hybrid_coupled_declaration(self):
+        from sglang.srt.arg_groups.overrides import _qwen3_5_hybrid_overrides
+
+        def _args(default_backend, **kw):
+            defaults = dict(
+                attention_backend=None,
+                _get_default_attn_backend=lambda **_: default_backend,
+                use_mla_backend=lambda: False,
+                get_model_config=lambda: None,
+                enable_mamba_extra_buffer=lambda: False,
+                disable_radix_cache=False,
+                speculative_algorithm=None,
+            )
+            defaults.update(kw)
+            return SimpleNamespace(**defaults)
+
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            # radix on + no extra buffer + no spec -> page_size=1 path
+            self.assertEqual(
+                _qwen3_5_hybrid_overrides(_args("trtllm_mha"), None),
+                {"attention_backend": "triton", "page_size": 1},
+            )
+            # spec decoding present -> trtllm_mha + page 64 (coupled)
+            self.assertEqual(
+                _qwen3_5_hybrid_overrides(
+                    _args("trtllm_mha", speculative_algorithm="EAGLE"), None
+                ),
+                {"attention_backend": "trtllm_mha", "page_size": 64},
+            )
+            # user-set backend: nothing declared
+            self.assertEqual(
+                _qwen3_5_hybrid_overrides(
+                    _args("trtllm_mha", attention_backend="fa3"), None
+                ),
+                {},
+            )
+        with patch.object(overrides_module, "is_sm100_supported", return_value=False):
+            self.assertEqual(_qwen3_5_hybrid_overrides(_args("fa3"), None), {})
+
+    def test_qwen3vl_page_size(self):
+        from sglang.srt.arg_groups.overrides import _qwen3vl_overrides
+
+        with patch.object(overrides_module, "is_hip", return_value=True):
+            with patch("sglang.srt.environ.envs.SGLANG_USE_AITER_UNIFIED_ATTN") as e:
+                e.get.return_value = True
+                self.assertEqual(
+                    _qwen3vl_overrides(SimpleNamespace(page_size=None), None),
+                    {"page_size": 16},
+                )
+                self.assertEqual(
+                    _qwen3vl_overrides(SimpleNamespace(page_size=64), None), {}
+                )
+
+    def test_page_constraint_passes_at_callable_level(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _fa4_page_constraint,
+            _intel_xpu_page_constraint,
+            _mla_backend_page_constraints,
+        )
+
+        def _view(**kw):
+            defaults = dict(
+                attention_backend=None,
+                decode_attention_backend=None,
+                prefill_attention_backend=None,
+                page_size=1,
+            )
+            defaults.update(kw)
+            return ResolvedView(SimpleNamespace(**defaults))
+
+        # flashmla snaps to 64 (unconditional within the backend match)
+        self.assertEqual(
+            _mla_backend_page_constraints(_view(attention_backend="flashmla")),
+            {"page_size": 64},
+        )
+        # trtllm_mla with already-valid page: no declaration
+        self.assertEqual(
+            _mla_backend_page_constraints(
+                _view(attention_backend="trtllm_mla", page_size=32)
+            ),
+            {},
+        )
+        # chained: flashmla via decode -> 64, then trtllm_mha accepts 64
+        self.assertEqual(
+            _mla_backend_page_constraints(
+                _view(
+                    decode_attention_backend="flashmla",
+                    prefill_attention_backend="trtllm_mha",
+                )
+            ),
+            {"page_size": 64},
+        )
+        # no matching backend: nothing declared
+        self.assertEqual(_mla_backend_page_constraints(_view()), {})
+
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            self.assertEqual(
+                _fa4_page_constraint(
+                    _view(
+                        attention_backend="fa4",
+                        use_mla_backend=lambda: False,
+                        speculative_eagle_topk=None,
+                    )
+                ),
+                {"page_size": 128},
+            )
+            self.assertEqual(
+                _fa4_page_constraint(
+                    _view(
+                        attention_backend="fa4",
+                        use_mla_backend=lambda: False,
+                        speculative_eagle_topk=2,  # EAGLE topk>1 keeps default
+                    )
+                ),
+                {},
+            )
+
+        self.assertEqual(
+            _intel_xpu_page_constraint(
+                _view(
+                    get_attention_backends=lambda: (None, "intel_xpu"),
+                    use_mla_backend=lambda: False,
+                )
+            ),
+            {"page_size": 128},
+        )
+        self.assertEqual(
+            _intel_xpu_page_constraint(
+                _view(
+                    get_attention_backends=lambda: (None, "intel_xpu"),
+                    use_mla_backend=lambda: True,
+                    page_size=16,  # MLA decode accepts 16
+                )
+            ),
+            {},
+        )
 
     def test_monolith_attention_families_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import (

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -16,7 +16,7 @@ from typing import Optional
 from unittest.mock import patch
 
 from sglang.srt.arg_groups import overrides as overrides_module
-from sglang.srt.arg_groups.arg_utils import A, Arg, model_overridable_fields
+from sglang.srt.arg_groups.arg_utils import A, Arg, resolvable_fields
 from sglang.srt.arg_groups.overrides import (
     OverrideRecord,
     apply_declarations_to_server_args,
@@ -37,18 +37,18 @@ from sglang.test.test_utils import CustomTestCase
 @dataclasses.dataclass
 class _FakeArgs:
     plain: A[int, "help text only"] = 0
-    resolved_by_model: A[str, Arg(help="x", model_overridable=True)] = "auto"
-    also_resolved: A[Optional[int], Arg(help="y", model_overridable=True)] = None
+    resolved_by_model: A[str, Arg(help="x", resolvable=True)] = "auto"
+    also_resolved: A[Optional[int], Arg(help="y", resolvable=True)] = None
     metadata_but_not_overridable: A[bool, Arg(help="z")] = False
 
 
 class TestModelOverridableWhitelist(CustomTestCase):
     def test_arg_defaults_to_not_overridable(self):
-        self.assertFalse(Arg().model_overridable)
+        self.assertFalse(Arg().resolvable)
 
     def test_whitelist_derivation_from_annotated_metadata(self):
         self.assertEqual(
-            model_overridable_fields(_FakeArgs),
+            resolvable_fields(_FakeArgs),
             frozenset({"resolved_by_model", "also_resolved"}),
         )
 
@@ -59,7 +59,7 @@ class TestModelOverridableWhitelist(CustomTestCase):
         from sglang.srt.server_args import ServerArgs
 
         self.assertEqual(
-            model_overridable_fields(ServerArgs),
+            resolvable_fields(ServerArgs),
             frozenset(
                 {
                     "dtype",
@@ -83,7 +83,7 @@ class TestModelOverridableWhitelist(CustomTestCase):
         )
 
     def test_non_dataclass_yields_empty_whitelist(self):
-        self.assertEqual(model_overridable_fields(SimpleNamespace), frozenset())
+        self.assertEqual(resolvable_fields(SimpleNamespace), frozenset())
 
 
 class _IsolatedRegistry(CustomTestCase):

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -12,11 +12,13 @@ from sglang.srt.runtime_context import (
     RuntimeContext,
     get_context,
     get_parallel,
+    get_server_args,
 )
 from sglang.test.test_utils import CustomTestCase
 
 _PS = "sglang.srt.distributed.parallel_state"
 _DP = "sglang.srt.layers.dp_attention"
+_SA = "sglang.srt.server_args"
 
 SIZE_RANK_DELEGATIONS = [
     ("world_size", f"{_PS}.get_world_size"),
@@ -140,6 +142,43 @@ class TestParallelOverride(_IsolatedOverrides):
             with p.override(tp_sizee=1):  # typo
                 pass
         self.assertEqual(p._overrides, {})
+
+
+class TestServerArgsReadThrough(CustomTestCase):
+    """``server_args`` delegates live to the global getter (read-through, V2a)."""
+
+    def test_delegates_to_global_getter(self):
+        sentinel = object()
+        with patch(f"{_SA}.get_global_server_args", return_value=sentinel):
+            self.assertIs(get_server_args(), sentinel)
+            self.assertIs(get_context().server_args, sentinel)
+
+    def test_identity_with_global_getter(self):
+        import sglang.srt.server_args as server_args_module
+
+        # Identity (not equality) is the contract; publish accepts any object.
+        sentinel = object()
+        saved = server_args_module._global_server_args
+        try:
+            server_args_module.set_global_server_args_for_scheduler(sentinel)
+            self.assertIs(
+                get_server_args(), server_args_module.get_global_server_args()
+            )
+            self.assertIs(get_server_args(), sentinel)
+        finally:
+            server_args_module._global_server_args = saved
+
+    def test_pre_publish_error_passes_through(self):
+        import sglang.srt.server_args as server_args_module
+
+        saved = server_args_module._global_server_args
+        server_args_module._global_server_args = None
+        try:
+            with self.assertRaises(ValueError) as cm:
+                get_server_args()
+            self.assertEqual(str(cm.exception), "Global server args is not set yet!")
+        finally:
+            server_args_module._global_server_args = saved
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -7,18 +7,19 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 import unittest
 from unittest.mock import patch
 
+import sglang.srt.server_args as server_args_module
 from sglang.srt.runtime_context import (
     ParallelContext,
     RuntimeContext,
     get_context,
     get_parallel,
     get_server_args,
+    reset_context,
 )
 from sglang.test.test_utils import CustomTestCase
 
 _PS = "sglang.srt.distributed.parallel_state"
 _DP = "sglang.srt.layers.dp_attention"
-_SA = "sglang.srt.server_args"
 
 SIZE_RANK_DELEGATIONS = [
     ("world_size", f"{_PS}.get_world_size"),
@@ -144,41 +145,67 @@ class TestParallelOverride(_IsolatedOverrides):
         self.assertEqual(p._overrides, {})
 
 
-class TestServerArgsReadThrough(CustomTestCase):
-    """``server_args`` delegates live to the global getter (read-through, V2a)."""
+class _IsolatedServerArgs(CustomTestCase):
+    """Save/restore the published ServerArgs around each test (the slot is
+    process-global; another test file sharing the process may have published)."""
 
-    def test_delegates_to_global_getter(self):
-        sentinel = object()
-        with patch(f"{_SA}.get_global_server_args", return_value=sentinel):
-            self.assertIs(get_server_args(), sentinel)
-            self.assertIs(get_context().server_args, sentinel)
+    def setUp(self):
+        super().setUp()
+        self._saved_server_args = get_context()._server_args
 
-    def test_identity_with_global_getter(self):
-        import sglang.srt.server_args as server_args_module
+    def tearDown(self):
+        if self._saved_server_args is None:
+            reset_context()
+        else:
+            get_context().set_server_args(self._saved_server_args)
+        super().tearDown()
 
+
+class TestServerArgsOwnership(_IsolatedServerArgs):
+    """V2b: the context owns the slot; the legacy getters are identity shims."""
+
+    def test_legacy_setter_publishes_into_context(self):
         # Identity (not equality) is the contract; publish accepts any object.
         sentinel = object()
-        saved = server_args_module._global_server_args
-        try:
-            server_args_module.set_global_server_args_for_scheduler(sentinel)
-            self.assertIs(
-                get_server_args(), server_args_module.get_global_server_args()
-            )
-            self.assertIs(get_server_args(), sentinel)
-        finally:
-            server_args_module._global_server_args = saved
+        server_args_module.set_global_server_args_for_scheduler(sentinel)
+        self.assertIs(server_args_module.get_global_server_args(), sentinel)
+        self.assertIs(get_server_args(), sentinel)
+        self.assertIs(get_context().server_args, sentinel)
 
-    def test_pre_publish_error_passes_through(self):
-        import sglang.srt.server_args as server_args_module
+    def test_context_publish_visible_through_legacy_getter(self):
+        sentinel = object()
+        get_context().set_server_args(sentinel)
+        self.assertIs(server_args_module.get_global_server_args(), sentinel)
 
-        saved = server_args_module._global_server_args
-        server_args_module._global_server_args = None
-        try:
+    def test_tokenizer_alias_is_same_function(self):
+        self.assertIs(
+            server_args_module.set_global_server_args_for_tokenizer,
+            server_args_module.set_global_server_args_for_scheduler,
+        )
+
+    def test_pre_publish_error_verbatim(self):
+        reset_context()
+        for accessor in (get_server_args, server_args_module.get_global_server_args):
             with self.assertRaises(ValueError) as cm:
-                get_server_args()
+                accessor()
             self.assertEqual(str(cm.exception), "Global server args is not set yet!")
-        finally:
-            server_args_module._global_server_args = saved
+
+    def test_republish_overwrite_allowed(self):
+        first, second = object(), object()
+        server_args_module.set_global_server_args_for_scheduler(first)
+        server_args_module.set_global_server_args_for_scheduler(second)
+        self.assertIs(get_server_args(), second)
+
+    def test_reset_context_clears_owned_store(self):
+        server_args_module.set_global_server_args_for_scheduler(object())
+        reset_context()
+        with self.assertRaises(ValueError):
+            get_server_args()
+
+    def test_module_global_removed(self):
+        # The legacy storage must not survive: a stale _global_server_args would
+        # silently fork the config into two objects.
+        self.assertFalse(hasattr(server_args_module, "_global_server_args"))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -4,17 +4,23 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
+import dataclasses
 import unittest
 from unittest.mock import patch
 
 import sglang.srt.server_args as server_args_module
 from sglang.srt.runtime_context import (
+    Flags,
     ParallelContext,
     RuntimeContext,
+    _FlagGroupBase,
+    _StaticFlags,
     get_context,
+    get_flags,
     get_parallel,
     get_server_args,
     reset_context,
+    resolve_flag_leaf,
 )
 from sglang.test.test_utils import CustomTestCase
 
@@ -206,6 +212,93 @@ class TestServerArgsOwnership(_IsolatedServerArgs):
         # The legacy storage must not survive: a stale _global_server_args would
         # silently fork the config into two objects.
         self.assertFalse(hasattr(server_args_module, "_global_server_args"))
+
+
+@dataclasses.dataclass
+class _FakeStaticGroup(_StaticFlags):
+    alpha: int = 1
+    beta: str = "b"
+
+
+@dataclasses.dataclass
+class _FakeCaptureGroup(_FlagGroupBase):
+    gamma: int = 0
+
+
+class TestFlagsTier(_IsolatedServerArgs):
+    """V3a skeleton: typed dataclass groups, freeze guard, override primitive."""
+
+    def test_wiring_and_groups(self):
+        flags = get_flags()
+        self.assertIs(flags, get_context().flags)
+        self.assertIsInstance(flags, Flags)
+        for group in ("attn", "moe", "capture"):
+            self.assertTrue(hasattr(flags, group))
+        self.assertFalse(flags.frozen)
+
+    def test_typo_safety(self):
+        group = _FakeStaticGroup()
+        with self.assertRaises(AttributeError):
+            group.alpha_misspelled = 2  # undeclared leaf
+        with self.assertRaises(AttributeError):
+            get_flags().not_a_flag = 1
+
+    def test_static_group_writable_until_freeze(self):
+        group = _FakeStaticGroup()
+        group.alpha = 5
+        self.assertEqual(group.alpha, 5)
+        group.freeze()
+        with self.assertRaises(RuntimeError):
+            group.alpha = 6
+        self.assertEqual(group.alpha, 5)
+
+    def test_override_is_transactional_and_works_on_frozen(self):
+        group = _FakeStaticGroup()
+        group.freeze()
+        with group.override(alpha=99, beta="x"):
+            self.assertEqual(group.alpha, 99)
+            self.assertEqual(group.beta, "x")
+        self.assertEqual(group.alpha, 1)
+        self.assertEqual(group.beta, "b")
+        with self.assertRaises(ValueError):
+            with group.override(alpha=2, gamma=3):  # gamma undeclared
+                pass
+        self.assertEqual(group.alpha, 1)  # validated before any write
+
+    def test_non_static_group_has_no_freeze(self):
+        group = _FakeCaptureGroup()
+        group.gamma = 42
+        self.assertEqual(group.gamma, 42)
+        self.assertFalse(hasattr(group, "freeze"))
+
+    def test_container_freeze_cascades_except_capture(self):
+        flags = Flags()  # fresh container, not the process singleton
+        flags.freeze()
+        self.assertTrue(flags.frozen)
+        self.assertTrue(flags.attn.frozen)
+        self.assertTrue(flags.moe.frozen)
+        with self.assertRaises(RuntimeError):
+            flags.attn = flags.attn  # container leaves lock too
+        self.assertFalse(getattr(flags.capture, "_frozen", False))
+
+    def test_resolve_flag_leaf_flat_default_and_mapped(self):
+        flags = Flags()
+        owner, leaf = resolve_flag_leaf(flags, "some_field")
+        self.assertIs(owner, flags)
+        self.assertEqual(leaf, "some_field")
+        owner, leaf = resolve_flag_leaf(flags, "x", leaf_map={"x": "attn.x"})
+        self.assertIs(owner, flags.attn)
+        self.assertEqual(leaf, "x")
+
+    def test_reset_context_installs_fresh_unfrozen_flags(self):
+        try:
+            old = get_flags()
+            old.freeze()
+            reset_context()
+            self.assertIsNot(get_flags(), old)
+            self.assertFalse(get_flags().frozen)
+        finally:
+            reset_context()  # never leave the singleton frozen for other tests
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Global review PR** for the declarative config-resolution stack: this PR shows the full 15-commit diff against `main` and carries the full-stack CI (`run-ci`/`run-ci-extra`). Per-unit review and merging happen on the stacked PRs below; this PR is not merged directly.

| # | PR | Unit |
|---|----|------|
| 1 | #30063 | Read-through `server_args` accessor on `RuntimeContext` |
| 2 | #30064 | ServerArgs ownership flip (identity-preserving shims) |
| 3 | #30065 | Soft-deprecation + exact-pin call-site ratchet |
| 4 | #30066 | Resolved-flags tier + `Arg.resolvable` whitelist metadata |
| 5 | #30067 | Model-override registry + transactional resolution gate |
| 6 | #30068 | Resolution pipeline wiring (dispatch, stash, dual-apply, atomic publish) |
| 7 | #30069 | First override families (Mistral/Pixtral dtype, MiniMaxM2, MiMoV2) |
| 8 | #30070 | Predicate-keyed registration + Step3p family |
| 9 | #30071 | disable_hybrid_swa_memory sweep; dtype family closed |
| 10 | #30072 | Post-process resolution stage + sampling_backend |
| 11 | #30073 | attention_backend resolution chain |
| 12 | #30074 | page_size resolution chain |
| 13 | #30075 | moe_runner_backend / quantization resolution chains |
| 14 | #30076 | DeepSeek family + parallel-request chains |
| 15 | #30077 | Rename `Arg.model_overridable` → `Arg.resolvable` |

**Series summary**: imperative ServerArgs mutation moves to declarative config resolution. Behavior is byte-identical throughout via a transition dual-apply; every unit is a no-op until its fields are tagged. The context owns the `ServerArgs` slot behind identity-preserving shims (374 call-sites unchanged); model-identity and normalization writes become registry declarations and ordered post-process passes resolved through one transactional gate into a typed flags tier, with per-field back-to-front migration (a writer only migrates once every later writer of that field is declarative), provenance logging, and a publish-time parity assert that turns any ordering mistake into a loud failure. Covered families: `dtype`, `sampling_backend`, `attention_backend`, `page_size`, `moe_runner_backend`, `quantization`, and the parallel-request fields across ~20 arch families including DeepSeek/DSA.

**Testing**: ~140 unit tests (registry/gate/pipeline semantics, per-arch golden diffs running the full `__post_init__` against local mini configs, patched-probe tests for platform-guarded paths) plus repeated DeepSeek-V3.2 tp=2 e2e smokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28692990978](https://github.com/sgl-project/sglang/actions/runs/28692990978)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28692990878](https://github.com/sgl-project/sglang/actions/runs/28692990878)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->