### PR TITLE
[refactor] Soft-deprecate the legacy global ServerArgs accessors + ratchet (stack 3/15)

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7595,10 +7595,14 @@ class ServerArgs:
 
 
 # NOTE: The process-wide ServerArgs is owned by the runtime context
-# (sglang.srt.runtime_context). The two functions below are thin shims kept for
-# the existing call-sites; they publish/read the same live object by reference.
+# (sglang.srt.runtime_context). The two functions below are LEGACY shims kept
+# for the existing call-sites; they publish/read the same live object by
+# reference. Do not add new call-sites — the counts are ratcheted
+# (decrease-only) by test/registered/unit/test_legacy_global_ratchet.py.
 # Imports are in-function so the two modules stay cycle-free at import time.
 def set_global_server_args_for_scheduler(server_args: ServerArgs):
+    """Legacy publish shim — prefer ``get_context().set_server_args()`` from
+    ``sglang.srt.runtime_context`` in new code."""
     from sglang.srt.runtime_context import get_context
 
     get_context().set_server_args(server_args)
@@ -7608,6 +7612,8 @@ set_global_server_args_for_tokenizer = set_global_server_args_for_scheduler
 
 
 def get_global_server_args() -> ServerArgs:
+    """Legacy accessor shim — prefer ``get_server_args()`` from
+    ``sglang.srt.runtime_context`` in new code."""
     from sglang.srt.runtime_context import get_context
 
     return get_context().server_args

--- a/test/registered/unit/test_legacy_global_ratchet.py
+++ b/test/registered/unit/test_legacy_global_ratchet.py
@@ -1,0 +1,63 @@
+"""Ratchet guard: legacy global-accessor call-sites may only decrease.
+
+The process-wide ``ServerArgs`` is owned by the runtime context; the legacy
+``get_global_server_args`` / ``set_global_server_args_for_*`` names survive as
+thin shims for the existing call-sites. New code should use the
+``sglang.srt.runtime_context`` accessors (``get_server_args()`` /
+``get_context().set_server_args()``), so the shim call-site counts below must
+never grow. When your change removes call-sites, lower the matching baseline
+to the new count.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import re
+import unittest
+from pathlib import Path
+
+import sglang.srt
+from sglang.test.test_utils import CustomTestCase
+
+_SRT_ROOT = Path(next(iter(sglang.srt.__path__)))
+
+# Baselines counted over python/sglang/srt/**/*.py, including each function's
+# own def line. Ratchet: decrease-only.
+_RATCHETS = [
+    ("get_global_server_args", r"\bget_global_server_args\s*\(", 346),
+    (
+        "set_global_server_args_for_*",
+        r"\bset_global_server_args_for_(?:scheduler|tokenizer)\s*\(",
+        5,
+    ),
+]
+
+
+class TestLegacyGlobalRatchet(CustomTestCase):
+    def test_legacy_accessor_call_sites_match_the_baselines(self):
+        # Exact pin, failing in BOTH directions: a grown count means new code
+        # bypassed the runtime_context accessors; a shrunk count means a
+        # removal forgot to lower the baseline, which would let later changes
+        # silently re-add call-sites up to the stale ceiling.
+        sources = [
+            path.read_text(encoding="utf-8", errors="replace")
+            for path in sorted(_SRT_ROOT.rglob("*.py"))
+        ]
+        for name, pattern, baseline in _RATCHETS:
+            count = sum(len(re.findall(pattern, source)) for source in sources)
+            if count > baseline:
+                self.fail(
+                    f"{name} call-sites grew: {count} > baseline {baseline}. "
+                    "New code must use the sglang.srt.runtime_context accessors "
+                    "(get_server_args() / get_context().set_server_args())."
+                )
+            if count < baseline:
+                self.fail(
+                    f"{name} call-sites shrank: {count} < baseline {baseline}. "
+                    "Lower the baseline in this file to lock in the progress."
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Docstrings mark both shims legacy (prefer the runtime_context
accessors); a decrease-only guard test counts call-sites across srt/
(getter baseline 346, setter 5) and fails if a count grows. No runtime
DeprecationWarning: hot paths make it pure noise. Existing call-sites
are intentionally not swept — resolved-config readers will migrate to
the flags tier per field, so a blanket rename would churn lines twice.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Part 3/15 of the declarative config-resolution stack (based on `cheng/gc-pr-02`). Full-stack CI runs on the top PR #30062; `run-ci` is added per PR as it reaches the front of the merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28701764874](https://github.com/sgl-project/sglang/actions/runs/28701764874)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28701764920](https://github.com/sgl-project/sglang/actions/runs/28701764920)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->