### PR TITLE
[MiMo-VL] Fix missing padded_context_dim in vision patch merger (fixes test_mimo_v2 init crash)

### DIFF
--- a/python/sglang/srt/models/mimo_vl.py
+++ b/python/sglang/srt/models/mimo_vl.py
@@ -301,6 +301,7 @@ class MiMoVisionTransformer(nn.Module):
         self.merger = Qwen2_5_VisionPatchMerger(
             dim=vision_config.out_hidden_size,
             context_dim=hidden_size,
+            padded_context_dim=hidden_size,
             spatial_merge_size=spatial_merge_size,
             quant_config=quant_config,
             prefix=add_prefix("merger", prefix),


### PR DESCRIPTION
## Problem

`test/registered/models_e2e/test_mimo_v2.py` fails: the MiMo-V2.5 server dies at model init with
```
TypeError: Qwen2_5_VisionPatchMerger.__init__() missing 1 required positional argument: 'padded_context_dim'
```
→ all TP ranks raise it → `RuntimeError: Rank 0 scheduler died during initialization`.

## Root cause

PR #20072 ("[CPU] Padding for dim divisibility in TP3/6 cases", commit `aff44d748d`) added a **required** `padded_context_dim` parameter to `Qwen2_5_VisionPatchMerger.__init__` and updated its own caller in `qwen2_5_vl.py`, but missed the second caller in `mimo_vl.py`. MiMo-V2.5 is multimodal (`--mm-enable-dp-encoder`), so it instantiates the vision merger and hits the missing argument.

First failing scheduled run: 07-02_11 (`119b76567d`), the first to contain `aff44d748d`.

## Fix

Pass `padded_context_dim=hidden_size`. For the standard (unpadded) case this equals `context_dim`, which matches both the pre-#20072 merger MLP width and the `qwen2_5_vl.py` caller's `num_heads * head_dim` (that reduces to `hidden_size` on GPU when `hidden_size % num_heads == 0`). So the merger MLP shape and weight loading are preserved. Using `hidden_size` directly (rather than `num_heads * head_dim`) is safe here because MiMo-VL's `head_dim` may be `qk_channels`, which need not equal `hidden_size / num_heads`.

Needs GPU CI validation on `test_mimo_v2.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->