### PR TITLE
fix(config): read num_nextn_predict_layers from the outer hf_config as fallback

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -929,8 +929,16 @@ class ModelConfig:
                 self.hf_text_config, "decoder_layers", self.num_hidden_layers
             )
             self.num_attention_layers = encoder_layers + 2 * decoder_layers
+        # The draft-model architecture rewrites set num_nextn_predict_layers on
+        # the outer hf_config; for wrapper configs (e.g.
+        # Qwen3_5ForConditionalGeneration) hf_text_config is a different,
+        # nested object, so fall back to the outer config. Missing this made
+        # the EAGLE/MTP draft look like a full-depth model and shrank the KV
+        # pool by the draft/target layer ratio (#29857).
         self.num_nextn_predict_layers = getattr(
-            self.hf_text_config, "num_nextn_predict_layers", None
+            self.hf_text_config,
+            "num_nextn_predict_layers",
+            getattr(self.hf_config, "num_nextn_predict_layers", None),
         )
         self.vocab_size = self.hf_text_config.vocab_size
 

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1119,7 +1119,9 @@ class ModelConfig:
             )
             self.num_attention_layers = encoder_layers + 2 * decoder_layers
         self.num_nextn_predict_layers = getattr(
-            self.hf_text_config, "num_nextn_predict_layers", None
+            self.hf_text_config,
+            "num_nextn_predict_layers",
+            getattr(self.hf_config, "num_nextn_predict_layers", None),
         )
         self.vocab_size = self.hf_text_config.vocab_size
         # GLM-Image is the only model here whose output head predicts vision tokens.

--- a/test/registered/unit/configs/test_model_config_shapes.py
+++ b/test/registered/unit/configs/test_model_config_shapes.py
@@ -66,6 +66,54 @@ class TestModelConfigShapes(CustomTestCase):
         self.assertEqual(model_config.swa_head_dim, 64)
         self.assertEqual(model_config.swa_v_head_dim, 48)
 
+    def test_nextn_predict_layers_from_outer_config_for_wrapper_models(self):
+        """Draft rewrites set num_nextn_predict_layers on the outer hf_config;
+        for wrapper configs (hf_text_config is a nested, different object) the
+        value must still be visible, or EAGLE/MTP KV sizing treats the draft
+        as a full-depth model (#29857)."""
+        text_config = _make_text_config(
+            architectures=["Qwen3_5ForCausalLMMTP"], head_dim=128
+        )
+        outer_config = SimpleNamespace(
+            architectures=["Qwen3_5ForCausalLMMTP"],
+            model_type="qwen3_5",
+            num_nextn_predict_layers=1,
+        )
+
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.hf_config = outer_config
+        model_config.hf_text_config = text_config
+        model_config._derive_model_shapes()
+
+        self.assertEqual(model_config.num_nextn_predict_layers, 1)
+
+    def test_nextn_predict_layers_nested_value_wins(self):
+        """When the nested text config carries its own value, it takes
+        precedence over the outer config."""
+        text_config = _make_text_config(
+            head_dim=128,
+            num_nextn_predict_layers=2,
+        )
+        outer_config = SimpleNamespace(
+            architectures=["MixtralForCausalLM"],
+            model_type="mixtral",
+            num_nextn_predict_layers=1,
+        )
+
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.hf_config = outer_config
+        model_config.hf_text_config = text_config
+        model_config._derive_model_shapes()
+
+        self.assertEqual(model_config.num_nextn_predict_layers, 2)
+
+    def test_nextn_predict_layers_absent_everywhere_is_none(self):
+        text_config = _make_text_config(head_dim=128)
+
+        model_config = self._derive_shapes(text_config)
+
+        self.assertIsNone(model_config.num_nextn_predict_layers)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/configs/test_model_config_shapes.py
+++ b/test/registered/unit/configs/test_model_config_shapes.py
@@ -125,6 +125,54 @@ class TestModelConfigShapes(CustomTestCase):
 
         self.assertEqual(_quant_config_to_dict(quant_config), {"quant_method": "test"})
 
+    def test_nextn_predict_layers_from_outer_config_for_wrapper_models(self):
+        """Draft rewrites set num_nextn_predict_layers on the outer hf_config;
+        for wrapper configs (hf_text_config is a nested, different object) the
+        value must still be visible, or EAGLE/MTP KV sizing treats the draft
+        as a full-depth model (#29857)."""
+        text_config = _make_text_config(
+            architectures=["Qwen3_5ForCausalLMMTP"], head_dim=128
+        )
+        outer_config = SimpleNamespace(
+            architectures=["Qwen3_5ForCausalLMMTP"],
+            model_type="qwen3_5",
+            num_nextn_predict_layers=1,
+        )
+
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.hf_config = outer_config
+        model_config.hf_text_config = text_config
+        model_config._derive_model_shapes()
+
+        self.assertEqual(model_config.num_nextn_predict_layers, 1)
+
+    def test_nextn_predict_layers_nested_value_wins(self):
+        """When the nested text config carries its own value, it takes
+        precedence over the outer config."""
+        text_config = _make_text_config(
+            head_dim=128,
+            num_nextn_predict_layers=2,
+        )
+        outer_config = SimpleNamespace(
+            architectures=["MixtralForCausalLM"],
+            model_type="mixtral",
+            num_nextn_predict_layers=1,
+        )
+
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.hf_config = outer_config
+        model_config.hf_text_config = text_config
+        model_config._derive_model_shapes()
+
+        self.assertEqual(model_config.num_nextn_predict_layers, 2)
+
+    def test_nextn_predict_layers_absent_everywhere_is_none(self):
+        text_config = _make_text_config(head_dim=128)
+
+        model_config = self._derive_shapes(text_config)
+
+        self.assertIsNone(model_config.num_nextn_predict_layers)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

#29857: with EAGLE/MTP on, the KV pool profiler leaves ~50 GB VRAM idle on hybrid GDN models (Qwen3.6-27B NVFP4). Root cause: the draft-model architecture rewrites set `num_nextn_predict_layers` on the outer `hf_config`, but `_derive_model_shapes` reads it from `hf_text_config`. For wrapper configs (`Qwen3_5ForConditionalGeneration`) those are different objects, so the value resolves to `None`, draft KV sizing falls back to the full model depth, and the EAGLE cell-size scale becomes `1 + 64/16 = 5x` -- which replays the reporter's exact pool collapse (1572864 -> 322048 tokens) on v0.5.14.

Runtime effect on current main is confirmed by a second user in the issue thread: running the NVIDIA Qwen3.6-27B-NVFP4 checkpoint through the ModelOpt mixed-precision path, this fix recovers the pool from 78K to 363K tokens with VRAM honestly allocated (see #29857 discussion, and the mechanism analysis I posted there on the reporter's exact card+model).

## Modifications

- `_derive_model_shapes` falls back to the outer `hf_config` for `num_nextn_predict_layers` when the nested text config does not carry it. The nested value still wins when present.
- Regression tests for the wrapper-config attr visibility (outer-only, nested-wins, absent-everywhere) plus head-dim defaulting coverage.

## Test plan

`PYTHONPATH=python python -m pytest test/registered/unit/configs/test_model_config_shapes.py` -> 5 passed on this branch; reverting only `model_config.py` fails exactly the wrapper-config test (verified both ways). Mechanism verified on RTX PRO 6000 (SM120) with the reporter's card+model combination.

AI-assisted (Claude) under my direction; I reviewed every changed line and ran the verification above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33254855068](https://github.com/sgl-project/sglang/actions/runs/33254855068)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33254854983](https://github.com/sgl-project/sglang/actions/runs/33254854983)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33254855060](https://github.com/sgl-project/sglang/actions/runs/33254855060)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->