### PR TITLE
[codex] preserve kv canary across HiCache L2

### DIFF
--- a/Gaidong.md
+++ b/Gaidong.md
@@ -1,0 +1,195 @@
+# KV Canary 与 HiCache L2 集成修改方案（待确认）
+
+## 0. 本文状态
+
+- 本文件只记录计划修改的文件和内容。
+- 当前尚未修改任何 Python、CUDA/C++ 或测试代码。
+- 本方案以“复用原始 `--kv-canary`”为原则：只补充 canary 在 HiCache L2 中的保存与恢复，不新增另一套 L2 校验算法。
+
+## 1. 需求一的准确定义
+
+需要防护的链路是：
+
+```text
+L1 生成 KV + 原始 canary
+        ↓ evict（使用同一组 device_indices → host_indices）
+L2 保存 KV + 原始 canary
+        ↓ reload（使用同一组 host_indices → device_indices）
+L1 恢复 KV + 原始 canary
+        ↓
+复用原始 --kv-canary 校验
+```
+
+目标是发现 KV 在以下环节发生的损坏或错配：
+
+- L1→L2 evict 传输；
+- L2 host slot 保存；
+- host/device 索引映射；
+- L2→L1 reload 传输；
+- reload 后到 KV 被使用前的 L1 数据。
+
+### 1.1 当前代码是否已经实现
+
+没有完整实现。
+
+- 当前原始 `--kv-canary` 已经能在 L1 生成 canary，并按配置记录 token、position、chain hash 和 real-KV hash。
+- 当前 HiCache L1→L2 只复制真实 KV，没有把对应 canary 保存到 L2。
+- 当前 HiCache L2→L1 只恢复真实 KV，没有恢复对应 canary。
+- `get_contiguous_buf_infos/get_state_buf_infos` 中已有的 canary 拼接主要服务于 PD disaggregation，不能等同于 HiCache L2 已支持 canary。
+
+因此需要修改的是 HiCache 的 canary 保存/恢复通道；原始 canary 的生成和校验逻辑不需要重写。
+
+## 2. 需求一计划修改的生产代码
+
+### 新建：`python/sglang/srt/kv_canary/hicache/__init__.py`
+
+- 导出 HiCache canary bridge 的安装入口。
+- 不放具体传输逻辑，避免 `CanaryManager` 直接依赖不同 HiCache backend 的实现细节。
+
+### 新建：`python/sglang/srt/kv_canary/hicache/bridge.py`
+
+新增 `CanaryHiCacheBridge`，负责原始 canary 的 L2 生命周期：
+
+- 接收现有 `CanaryBufferGroup`，不创建新的 canary 格式。
+- 按 HiCache host pool 的 token slot 数量分配 pinned-host canary buffer。
+- MHA/FULL 保存现有 `k_head`、`k_tail`、`v_head`、`v_tail`。
+- SWA 分别保存 FULL group 和 SWA group 的现有 canary buffer。
+- L2 canary 与 L2 KV 共用同一套 host slot 编号；`host_indices[i]` 的 KV 和 canary必须描述同一个 token。
+- 提供：
+  - `backup(device_indices, host_indices)`：把原始 L1 canary 保存到 L2。
+  - `restore(host_indices, device_indices)`：把 L2 中的原始 canary恢复到新的 L1 slot。
+  - `destroy()`：释放或注销 pinned-host canary buffer。
+- 检查索引数量、范围和 FULL/SWA 索引空间，索引不合法时直接报错，不能静默跳过。
+- 不提供 `verify_restored()`，也不生成 L2 专用 verify plan；恢复后继续走原始 `--kv-canary`。
+
+### 新建：`python/sglang/srt/kv_canary/hicache/transfer.py`
+
+- 封装 canary sidecar 的 indexed D2H/H2D 复制。
+- 使用与真实 KV 相同的 `device_indices/host_indices` 顺序。
+- 优先复用 HiCache 已有的 indexed-transfer 能力；不使用逐 token Python 循环。
+- 支持当前使用的 `kernel` 和 `direct` IO backend。
+- 传输异步提交到当前 HiCache stream，不在内部执行全局 `synchronize()`。
+- 对传输使用的索引 tensor 执行正确的 stream 生命周期管理。
+
+### 修改：`python/sglang/srt/kv_canary/runner/canary_manager.py`
+
+修改 `CanaryManager.attach_radix_cache()`：
+
+- 保留当前 sweep 和 perturb 安装逻辑。
+- 检测到 HiCache `cache_controller` 后创建 `CanaryHiCacheBridge`。
+- 将 bridge 注册给 cache controller。
+- 保存 bridge 引用，保证 L2 canary buffer 在 server 生命周期内有效。
+- 防止重复 attach 和重复传输同一组 canary。
+
+### 修改：`python/sglang/srt/managers/cache_controller.py`
+
+为普通 `HiCacheController` 增加可选 canary sidecar hook：
+
+- 新增 `register_canary_hicache_bridge(bridge)`。
+- `start_writing()` 中：
+  1. 使用现有逻辑把真实 KV 从 L1 复制到 L2；
+  2. 使用完全相同的 `device_indices/host_indices` 调用 `bridge.backup(...)`；
+  3. KV 和 canary 都提交完成后才 `finish_event.record()`。
+- `start_loading()` 中：
+  1. 使用现有逻辑把真实 KV 从 L2 恢复到 L1；
+  2. 使用完全相同的 `host_indices/device_indices` 调用 `bridge.restore(...)`；
+  3. KV 和 canary 都提交完成后才完成 load event，随后由原始 `--kv-canary` 在正常使用路径校验。
+- bridge 未注册时保持原有行为不变。
+
+### 修改：`python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py`
+
+- 添加与普通 `HiCacheController` 相同的 bridge 注册和调用点。
+- FULL 与 SWA group 必须使用各自已经解析完成的 pool-transfer 索引，不能错误地共用 FULL 索引。
+- KV、SWA state 和对应 canary 都提交后才能完成 transfer event。
+
+## 3. 明确不修改的原始 KV Canary 代码
+
+按照“复用原始 `--kv-canary`”的要求，第一版不修改以下文件的校验语义：
+
+- `python/sglang/jit_kernel/kv_canary/verify.py`
+- `python/sglang/jit_kernel/csrc/kv_canary/canary_verify.cuh`
+- `python/sglang/srt/kv_canary/endpoint.py`
+- `python/sglang/srt/kv_canary/runner/violation_reporter.py`
+- `python/sglang/srt/kv_canary/runner/stats_logger.py`
+- `python/sglang/srt/kv_canary/state.py`
+- `python/sglang/srt/kv_canary/config.py`
+
+具体含义：
+
+- 不新增 `L2_RESTORE_*` launch tag。
+- 不新增 L2 专用 verify kernel。
+- 不改变现有 violation ring ABI 和日志格式。
+- 不改变现有 `log`/`raise` 行为。
+- 不在本次修改中实现自动重算。
+
+## 4. reload 后如何复用原始 `--kv-canary`
+
+reload 完成后，L1 的真实 KV 和原始 canary 已一起恢复到新的 device slot。后续请求正常进入原始校验路径：
+
+- real-KV hash 不一致：发现 KV 内容损坏或 KV/canary 错配；
+- position 不一致：发现 canary 被恢复到错误逻辑位置；
+- chain hash 不一致：发现前缀链或 slot 顺序错配；
+- 开启原有 verify-token assert 时，还会比较 token id。
+
+原始校验路径的覆盖范围保持不变：
+
+- per-forward 校验请求当前使用的 head/tail 边界；
+- 配置 `--kv-canary-sweep-interval=N` 后，按原有 sweep 机制检查 radix cache 中的 slot。
+
+本方案不会额外承诺“reload 完成时立即全量校验所有 slot”，因为这会引入新的 L2 专用校验流程，不符合本次“复用原始 `--kv-canary`”的要求。
+
+### 4.1 `--kv-canary-real-data` 的必要说明
+
+- `--kv-canary-real-data=partial`：保存并比较真实 KV 的部分指纹，可发现被覆盖范围内的 KV 字节损坏，开销较低。
+- `--kv-canary-real-data=all`：保存并比较完整 real-KV source 的指纹，覆盖更强、开销更高。
+- `--kv-canary-real-data=none`：只能检查 token、position、chain/index 等一致性，不能发现“索引完全正确但 KV 字节发生改变”的纯数据损坏。
+
+因此，若目标明确包含 KV 内容损坏检测，运行时必须使用 `partial` 或 `all`。本次不修改默认参数，也不改变原始配置语义。
+
+## 5. 第一版支持边界
+
+- 支持：普通 MHA HiCache L1↔L2。
+- 计划支持：hybrid/SWA HiCache 的 FULL 与 SWA group，前提是分别使用正确的 pool-transfer 索引。
+- L3 storage 不属于本次需求。为避免 L3 reload 使用缺失或陈旧的 canary，第一版在 `kv-canary + HiCache L3` 组合下 fail-fast；L3 若要提供同等保护，需要单独把 canary 纳入 L2↔L3 保存、索引和恢复链路。
+- DeepSeek V4 当前 adapter 未提供 real-KV fingerprint；在补齐其 real-KV source 前，不能宣称支持 DSV4 的 KV 内容损坏检测。
+- PD disaggregation 现有 canary buffer 拼接逻辑保持不变，并加入回归测试防止破坏。
+
+## 6. 计划新增或修改的测试
+
+### 新建：`test/registered/kv_canary/test_self_unit_hicache_bridge.py`
+
+覆盖：
+
+- L1→L2 后，L2 canary 与原始 L1 canary 按指定索引逐字节一致。
+- 清空或污染对应 L1 slot 后，L2→L1 能把原始 canary 恢复到新的 device slot。
+- 打乱但保持配对的 `device_indices/host_indices` 时仍正确映射。
+- 故意制造 KV/canary 索引错配后，原始 verify 路径能够记录 violation。
+- 未参与本次 evict/reload 的 slot 不被覆盖。
+- FULL 与 SWA 使用各自的索引空间。
+
+### 修改：`test/registered/kv_canary/test_self_unit_pool_patcher.py`
+
+- 保留现有 PD layout 测试。
+- 增加断言：HiCache bridge 不改变 PD buffer 列表顺序，也不会重复插入 canary。
+
+### 新建：`test/registered/kv_canary/test_self_e2e_hicache.py`
+
+至少包含：
+
+1. clean path：第一次请求生成 KV/canary 并 evict 到 L2，驱逐 L1 后通过相同前缀 reload；断言 L2 命中且原始 kv-canary 无 violation。
+2. L2 KV corruption：破坏 L2 KV、保留 L2 canary，reload 后断言原始 `verify_real_kv_hash` violation。
+3. index mismatch：故意让 KV 与 canary 使用不一致的恢复索引，断言原始 position、chain 或 real-KV hash violation。
+4. canary corruption：破坏 L2 canary 后 reload，断言原始校验能够报告 violation。
+
+测试运行时显式使用 `--kv-canary-real-data=partial` 或 `all`；需要扩大 radix 覆盖时使用原有 `--kv-canary-sweep-interval=1`。
+
+## 7. 推荐实施顺序
+
+1. 编写 HiCache bridge 的失败单元测试。
+2. 实现 L2 pinned-host canary buffer 和对称 D2H/H2D indexed copy。
+3. 接入普通 `HiCacheController`，验证 MHA clean/corruption path。
+4. 接入 `HybridCacheController`，验证 FULL/SWA 索引映射。
+5. 回归现有 kv-canary、HiCache 和 PD disaggregation 测试。
+6. 比较 `partial` 与 `all` 的延迟、带宽和 L2 内存开销。
+
+在你确认上述文件范围和行为前，不进行代码实现。

--- a/change.md
+++ b/change.md
@@ -1,0 +1,20 @@
+# KV Canary HiCache L2 修改摘要
+
+相较于原始代码，本次主要修改如下：
+
+- 新增 HiCache canary bridge，为原始 K/V head/tail canary 分配 L2 host buffer。
+- L1→L2 evict 时，使用与 KV 相同的 `device_indices → host_indices` 保存 canary。
+- L2→L1 reload 时，使用与 KV 相同的 `host_indices → device_indices` 恢复 canary。
+- 普通 MHA HiCache 和 hybrid/SWA HiCache 均已接入；SWA 使用自己的 `PoolTransfer` 索引。
+- canary 传输加入原有 HiCache stream/event 顺序，避免 KV 与 canary 状态不同步。
+- `CanaryManager` 在绑定 HiCache radix cache 时自动注册 bridge。
+- 未修改原始 `--kv-canary` 校验算法、日志格式和参数语义；reload 后继续复用原始校验流程。
+- `--kv-canary-real-data=partial/all` 可检测 KV 内容损坏；`none` 只能检测位置、索引和链错配。
+- 当前不支持 L3 canary 保存；同时启用 kv-canary 与 HiCache L3 时会 fail-fast。
+- 新增 L2 canary 往返、FULL/SWA 索引及 controller 接入测试。
+
+主要新增文件：
+
+- `python/sglang/srt/kv_canary/hicache/bridge.py`
+- `python/sglang/srt/kv_canary/hicache/transfer.py`
+- `test/registered/kv_canary/test_self_unit_hicache_bridge.py`

--- a/python/sglang/srt/kv_canary/hicache/__init__.py
+++ b/python/sglang/srt/kv_canary/hicache/__init__.py
@@ -1,0 +1,3 @@
+from sglang.srt.kv_canary.hicache.bridge import CanaryHiCacheBridge
+
+__all__ = ["CanaryHiCacheBridge"]

--- a/python/sglang/srt/kv_canary/hicache/bridge.py
+++ b/python/sglang/srt/kv_canary/hicache/bridge.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.kv_canary.buffer_group import CanaryBufferGroup, PoolKind
+from sglang.srt.kv_canary.hicache.transfer import copy_canary_buffers_indexed
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.cache_controller import HiCacheController
+
+
+class CanaryHiCacheBridge:
+    """L2 sidecar storage for the existing L1 canary buffers."""
+
+    def __init__(
+        self,
+        *,
+        buffer_groups: Sequence[CanaryBufferGroup],
+        host_sizes: Mapping[PoolKind, int],
+        pin_memory: bool,
+    ) -> None:
+        self._device_groups: dict[PoolKind, CanaryBufferGroup] = {}
+        self._host_buffers: dict[PoolKind, tuple[torch.Tensor, ...]] = {}
+
+        for group in buffer_groups:
+            if group.kind in self._device_groups:
+                raise ValueError(
+                    f"kv-canary: duplicate HiCache buffer group {group.kind.name}"
+                )
+            device_buffers = _group_buffers(group)
+            try:
+                host_size = int(host_sizes[group.kind])
+            except KeyError as exc:
+                raise ValueError(
+                    f"kv-canary: missing HiCache host size for {group.kind.name}"
+                ) from exc
+            if host_size <= 0:
+                raise ValueError(
+                    f"kv-canary: HiCache host size must be positive, got {host_size}"
+                )
+            slot_bytes = int(device_buffers[0].shape[1])
+            self._device_groups[group.kind] = group
+            self._host_buffers[group.kind] = tuple(
+                torch.empty(
+                    (host_size, slot_bytes),
+                    dtype=torch.uint8,
+                    device="cpu",
+                    pin_memory=pin_memory,
+                )
+                for _ in device_buffers
+            )
+
+    @classmethod
+    def from_cache_controller(
+        cls,
+        *,
+        buffer_groups: Sequence[CanaryBufferGroup],
+        cache_controller: HiCacheController,
+    ) -> CanaryHiCacheBridge:
+        if cache_controller.enable_storage:
+            raise NotImplementedError(
+                "kv-canary: HiCache L3 storage does not yet preserve canary sidecars"
+            )
+
+        host = cache_controller.mem_pool_host
+        if hasattr(host, "entry_map"):
+            full_host_pool = host.entry_map[PoolName.KV].host_pool
+            host_sizes = {PoolKind.FULL: int(full_host_pool.size)}
+            if any(group.kind is PoolKind.SWA for group in buffer_groups):
+                host_sizes[PoolKind.SWA] = int(
+                    host.entry_map[PoolName.SWA].host_pool.size
+                )
+            pin_memory = bool(full_host_pool.pin_memory)
+        else:
+            host_sizes = {PoolKind.FULL: int(host.size)}
+            pin_memory = bool(host.pin_memory)
+
+        return cls(
+            buffer_groups=buffer_groups,
+            host_sizes=host_sizes,
+            pin_memory=pin_memory,
+        )
+
+    def backup(
+        self,
+        *,
+        host_indices: torch.Tensor,
+        device_indices: torch.Tensor,
+        io_backend: str,
+        pool_transfers: Optional[Sequence[PoolTransfer]] = None,
+    ) -> None:
+        self._copy(
+            to_host=True,
+            host_indices=host_indices,
+            device_indices=device_indices,
+            io_backend=io_backend,
+            pool_transfers=pool_transfers,
+        )
+
+    def restore(
+        self,
+        *,
+        host_indices: torch.Tensor,
+        device_indices: torch.Tensor,
+        io_backend: str,
+        pool_transfers: Optional[Sequence[PoolTransfer]] = None,
+    ) -> None:
+        self._copy(
+            to_host=False,
+            host_indices=host_indices,
+            device_indices=device_indices,
+            io_backend=io_backend,
+            pool_transfers=pool_transfers,
+        )
+
+    def destroy(self) -> None:
+        self._host_buffers.clear()
+
+    def _copy(
+        self,
+        *,
+        to_host: bool,
+        host_indices: torch.Tensor,
+        device_indices: torch.Tensor,
+        io_backend: str,
+        pool_transfers: Optional[Sequence[PoolTransfer]],
+    ) -> None:
+        for kind, group in self._device_groups.items():
+            kind_host_indices, kind_device_indices = _indices_for_kind(
+                kind=kind,
+                host_indices=host_indices,
+                device_indices=device_indices,
+                pool_transfers=pool_transfers,
+            )
+            device_buffers = _group_buffers(group)
+            host_buffers = self._host_buffers[kind]
+            copy_canary_buffers_indexed(
+                src_buffers=device_buffers if to_host else host_buffers,
+                dst_buffers=host_buffers if to_host else device_buffers,
+                src_indices=kind_device_indices if to_host else kind_host_indices,
+                dst_indices=kind_host_indices if to_host else kind_device_indices,
+                io_backend=io_backend,
+            )
+
+
+def _group_buffers(group: CanaryBufferGroup) -> tuple[torch.Tensor, ...]:
+    if group.v_head is None or group.v_tail is None:
+        raise NotImplementedError(
+            "kv-canary: HiCache canary sidecars currently require K/V buffer halves"
+        )
+    return group.k_head, group.k_tail, group.v_head, group.v_tail
+
+
+def _indices_for_kind(
+    *,
+    kind: PoolKind,
+    host_indices: torch.Tensor,
+    device_indices: torch.Tensor,
+    pool_transfers: Optional[Sequence[PoolTransfer]],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if kind is PoolKind.FULL:
+        return host_indices, device_indices
+
+    for transfer in pool_transfers or ():
+        if transfer.name == PoolName.SWA:
+            if transfer.host_indices is None or transfer.device_indices is None:
+                break
+            return transfer.host_indices, transfer.device_indices
+    raise RuntimeError("kv-canary: missing SWA PoolTransfer for HiCache canary")

--- a/python/sglang/srt/kv_canary/hicache/transfer.py
+++ b/python/sglang/srt/kv_canary/hicache/transfer.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+
+
+def copy_canary_buffers_indexed(
+    *,
+    src_buffers: Sequence[torch.Tensor],
+    dst_buffers: Sequence[torch.Tensor],
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+    io_backend: str,
+) -> None:
+    """Copy K/V head+tail canary rows with the KV transfer's index mapping."""
+    if len(src_buffers) != 4 or len(dst_buffers) != 4:
+        raise ValueError("kv-canary: HiCache transfer requires four K/V canary buffers")
+    if src_indices.numel() != dst_indices.numel():
+        raise ValueError(
+            "kv-canary: HiCache source/destination index counts differ: "
+            f"{src_indices.numel()} != {dst_indices.numel()}"
+        )
+    if src_indices.numel() == 0:
+        return
+
+    slot_bytes = int(src_buffers[0].shape[1])
+    for name, buffers in (("src", src_buffers), ("dst", dst_buffers)):
+        for tensor in buffers:
+            if tensor.dtype is not torch.uint8 or tensor.ndim != 2:
+                raise ValueError(
+                    f"kv-canary: HiCache {name} buffers must be 2-D uint8 tensors"
+                )
+            if int(tensor.shape[1]) != slot_bytes or not tensor.is_contiguous():
+                raise ValueError(
+                    f"kv-canary: HiCache {name} buffers must be contiguous with "
+                    f"slot width {slot_bytes}"
+                )
+
+    if all(t.device.type == "cpu" for t in (*src_buffers, *dst_buffers)):
+        _copy_cpu(
+            src_buffers=src_buffers,
+            dst_buffers=dst_buffers,
+            src_indices=src_indices,
+            dst_indices=dst_indices,
+        )
+        return
+
+    if io_backend == "direct":
+        from sgl_kernel.kvcacheio import transfer_kv_direct
+
+        transfer_kv_direct(
+            src_layers=list(src_buffers),
+            dst_layers=list(dst_buffers),
+            src_indices=src_indices,
+            dst_indices=dst_indices,
+            page_size=1,
+        )
+        return
+
+    if io_backend != "kernel":
+        raise NotImplementedError(
+            f"kv-canary: HiCache canary transfer does not support io_backend={io_backend!r}"
+        )
+
+    from sgl_kernel.kvcacheio import transfer_kv_all_layer
+
+    accelerator = next(
+        (t.device for t in (*src_buffers, *dst_buffers) if t.device.type != "cpu"),
+        None,
+    )
+    assert accelerator is not None
+
+    src_ptrs = torch.tensor(
+        [t.data_ptr() for t in src_buffers], dtype=torch.uint64, device=accelerator
+    )
+    dst_ptrs = torch.tensor(
+        [t.data_ptr() for t in dst_buffers], dtype=torch.uint64, device=accelerator
+    )
+    src_indices_device = src_indices.to(
+        device=accelerator, dtype=torch.int64, non_blocking=True
+    )
+    dst_indices_device = dst_indices.to(
+        device=accelerator, dtype=torch.int64, non_blocking=True
+    )
+    transfer_kv_all_layer(
+        src_k_layers=src_ptrs[:2],
+        dst_k_layers=dst_ptrs[:2],
+        src_v_layers=src_ptrs[2:],
+        dst_v_layers=dst_ptrs[2:],
+        src_indices=src_indices_device,
+        dst_indices=dst_indices_device,
+        item_size=slot_bytes,
+        num_layers=2,
+    )
+    src_ptrs.record_stream(torch.cuda.current_stream(accelerator))
+    dst_ptrs.record_stream(torch.cuda.current_stream(accelerator))
+    src_indices_device.record_stream(torch.cuda.current_stream(accelerator))
+    dst_indices_device.record_stream(torch.cuda.current_stream(accelerator))
+
+
+def _copy_cpu(
+    *,
+    src_buffers: Sequence[torch.Tensor],
+    dst_buffers: Sequence[torch.Tensor],
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+) -> None:
+    src_indices_cpu = src_indices.to(device="cpu", dtype=torch.int64)
+    dst_indices_cpu = dst_indices.to(device="cpu", dtype=torch.int64)
+    for src, dst in zip(src_buffers, dst_buffers):
+        dst.index_copy_(0, dst_indices_cpu, src.index_select(0, src_indices_cpu))

--- a/python/sglang/srt/kv_canary/runner/canary_manager.py
+++ b/python/sglang/srt/kv_canary/runner/canary_manager.py
@@ -31,6 +31,7 @@ from sglang.srt.kv_canary.state import CanaryDeviceState
 from sglang.srt.kv_canary.token_oracle.oracle_manager import TokenOracleManager
 
 if TYPE_CHECKING:
+    from sglang.srt.kv_canary.hicache.bridge import CanaryHiCacheBridge
     from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
     from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
     from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
@@ -61,6 +62,7 @@ class CanaryManager:
         self._swa_allocator: Optional[SWATokenToKVPoolAllocator] = swa_allocator
         self._outer_step_counter: int = 0
         self._active_single_forward_manager_index: Optional[int] = None
+        self._hicache_bridge: Optional[CanaryHiCacheBridge] = None
 
         self._buffer_groups: tuple[CanaryBufferGroup, ...] = tuple(buffer_groups)
 
@@ -267,6 +269,20 @@ class CanaryManager:
     def attach_radix_cache(self, radix_cache: BasePrefixCache) -> None:
         self._sweep_orchestrator.attach_radix_cache(radix_cache)
         self._perturb_manager.attach_radix_cache(radix_cache)
+        cache_controller = getattr(radix_cache, "cache_controller", None)
+        if cache_controller is None:
+            return
+        if self._hicache_bridge is not None:
+            raise RuntimeError("kv-canary: HiCache bridge already attached")
+
+        from sglang.srt.kv_canary.hicache.bridge import CanaryHiCacheBridge
+
+        bridge = CanaryHiCacheBridge.from_cache_controller(
+            buffer_groups=self._buffer_groups,
+            cache_controller=cache_controller,
+        )
+        cache_controller.register_canary_hicache_bridge(bridge)
+        self._hicache_bridge = bridge
 
     def _get_outer_step_counter(self) -> int:
         return self._outer_step_counter

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -30,6 +30,7 @@ from sglang.srt.mem_cache.hicache_storage import (
 )
 
 if TYPE_CHECKING:
+    from sglang.srt.kv_canary.hicache.bridge import CanaryHiCacheBridge
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
     from sglang.srt.mem_cache.pool_host import HostKVCache
 
@@ -246,6 +247,7 @@ class HiCacheController:
         self.storage_backend = None
         self.storage_backend_type = None
         self.enable_storage_metrics = enable_storage_metrics
+        self.kv_canary_hicache_bridge: Optional[CanaryHiCacheBridge] = None
 
         # Draft KV pool support (best-effort piggyback on target L2/L3 ops).
         self.has_draft = False
@@ -304,6 +306,15 @@ class HiCacheController:
                 torch.distributed.get_world_size(group=self.attn_cp_group),
             )
         return 0, 1
+
+    def register_canary_hicache_bridge(self, bridge: CanaryHiCacheBridge) -> None:
+        if self.enable_storage:
+            raise NotImplementedError(
+                "kv-canary: HiCache L3 storage does not yet preserve canary sidecars"
+            )
+        if getattr(self, "kv_canary_hicache_bridge", None) is not None:
+            raise RuntimeError("kv-canary: HiCache canary bridge already registered")
+        self.kv_canary_hicache_bridge = bridge
 
     def _create_prefetch_sync_groups(self) -> None:
         from sglang.srt.distributed.parallel_state import create_custom_parallel_group
@@ -423,6 +434,11 @@ class HiCacheController:
         Requirement: no in-flight requests. This call is expected to run on the scheduler
         thread (control path), not concurrently with prefetch/backup.
         """
+        if getattr(self, "kv_canary_hicache_bridge", None) is not None:
+            raise NotImplementedError(
+                "kv-canary: cannot attach HiCache L3 storage while L2 canary "
+                "sidecars are active"
+            )
         if self.enable_storage:
             raise RuntimeError("Storage backend already attached.")
 
@@ -704,6 +720,12 @@ class HiCacheController:
                     device_indices,
                     self.io_backend,
                 )
+            if (bridge := getattr(self, "kv_canary_hicache_bridge", None)) is not None:
+                bridge.backup(
+                    host_indices=host_indices,
+                    device_indices=device_indices,
+                    io_backend=self.io_backend,
+                )
             finish_event.record()
             # NOTE: We must save the host indices and device indices here,
             # this is because we need to guarantee that these tensors are
@@ -769,6 +791,12 @@ class HiCacheController:
 
         with device_module.stream(self.load_stream):
             producer_event.start_event.wait(self.load_stream)
+            if (bridge := getattr(self, "kv_canary_hicache_bridge", None)) is not None:
+                bridge.restore(
+                    host_indices=host_indices,
+                    device_indices=device_indices,
+                    io_backend=self.io_backend,
+                )
             for i in range(self.layer_num):
                 self.mem_pool_host.load_to_device_per_layer(
                     self.mem_pool_device,

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -427,6 +427,13 @@ class HybridCacheController(BaseHiCacheController):
                     device_indices,
                     self.io_backend,
                 )
+            if (bridge := getattr(self, "kv_canary_hicache_bridge", None)) is not None:
+                bridge.backup(
+                    host_indices=host_indices,
+                    device_indices=device_indices,
+                    pool_transfers=resolved_pool_transfers,
+                    io_backend=self.io_backend,
+                )
             finish_event.record()
             self._record_transfer_indices_on_stream(
                 self.write_stream,
@@ -492,6 +499,13 @@ class HybridCacheController(BaseHiCacheController):
         producer_event.start_event.record()
         with device_module.stream(self.load_stream):
             producer_event.start_event.wait(self.load_stream)
+            if (bridge := getattr(self, "kv_canary_hicache_bridge", None)) is not None:
+                bridge.restore(
+                    host_indices=host_indices,
+                    device_indices=device_indices,
+                    pool_transfers=resolved_pool_transfers,
+                    io_backend=self.io_backend,
+                )
             for i in range(self.layer_num):
                 self.mem_pool_host.load_to_device_per_layer(
                     self.mem_pool_device,

--- a/test/registered/kv_canary/test_self_unit_hicache_bridge.py
+++ b/test/registered/kv_canary/test_self_unit_hicache_bridge.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import unittest
+import sys
+import types
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import torch
+
+if sys.platform == "win32" and "sglang" not in sys.modules:
+    sglang_stub = types.ModuleType("sglang")
+    sglang_stub.__path__ = [
+        str(Path(__file__).resolve().parents[3] / "python" / "sglang")
+    ]
+    sys.modules["sglang"] = sglang_stub
+
+    verify_stub = types.ModuleType("sglang.jit_kernel.kv_canary.verify")
+    verify_stub.RealKvSource = object
+    sys.modules["sglang.jit_kernel.kv_canary.verify"] = verify_stub
+
+    hicache_storage_stub = types.ModuleType("sglang.srt.mem_cache.hicache_storage")
+
+    class _PoolName(str, Enum):
+        KV = "kv"
+        SWA = "swa"
+
+    @dataclass
+    class _PoolTransfer:
+        name: _PoolName
+        host_indices: torch.Tensor | None = None
+        device_indices: torch.Tensor | None = None
+
+    hicache_storage_stub.PoolName = _PoolName
+    hicache_storage_stub.PoolTransfer = _PoolTransfer
+    sys.modules["sglang.srt.mem_cache.hicache_storage"] = hicache_storage_stub
+
+from sglang.srt.kv_canary.buffer_group import CanaryBufferGroup, PoolKind
+from sglang.srt.kv_canary.hicache.bridge import CanaryHiCacheBridge
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+
+
+def _make_group(*, kind: PoolKind, num_slots: int) -> CanaryBufferGroup:
+    buffers = []
+    for offset in range(4):
+        values = torch.arange(num_slots * 32, dtype=torch.int64).reshape(num_slots, 32)
+        buffers.append(((values + offset * 17) % 251).to(torch.uint8))
+    return CanaryBufferGroup(
+        kind=kind,
+        k_head=buffers[0],
+        k_tail=buffers[1],
+        v_head=buffers[2],
+        v_tail=buffers[3],
+        real_kv_sources_k=(),
+        real_kv_sources_v=(),
+        swa_index_lut=None,
+        kv_token_id_vs_position_offset=0,
+    )
+
+
+class TestCanaryHiCacheBridge(unittest.TestCase):
+    def test_factory_uses_controller_host_pool_size(self) -> None:
+        group = _make_group(kind=PoolKind.FULL, num_slots=8)
+
+        class FakeHostPool:
+            size = 13
+            pin_memory = False
+
+        class FakeController:
+            enable_storage = False
+            mem_pool_host = FakeHostPool()
+
+        bridge = CanaryHiCacheBridge.from_cache_controller(
+            buffer_groups=(group,), cache_controller=FakeController()
+        )
+        original = group.k_head[3].clone()
+        bridge.backup(
+            host_indices=torch.tensor([11]),
+            device_indices=torch.tensor([3]),
+            io_backend="direct",
+        )
+        group.k_head[6].zero_()
+        bridge.restore(
+            host_indices=torch.tensor([11]),
+            device_indices=torch.tensor([6]),
+            io_backend="direct",
+        )
+        torch.testing.assert_close(group.k_head[6], original)
+
+    def test_factory_rejects_l3_storage(self) -> None:
+        group = _make_group(kind=PoolKind.FULL, num_slots=8)
+
+        class FakeController:
+            enable_storage = True
+
+        with self.assertRaisesRegex(NotImplementedError, "L3 storage"):
+            CanaryHiCacheBridge.from_cache_controller(
+                buffer_groups=(group,), cache_controller=FakeController()
+            )
+
+    def test_full_group_round_trip_preserves_index_mapping(self) -> None:
+        group = _make_group(kind=PoolKind.FULL, num_slots=8)
+        bridge = CanaryHiCacheBridge(
+            buffer_groups=(group,),
+            host_sizes={PoolKind.FULL: 12},
+            pin_memory=False,
+        )
+        device_buffers = (group.k_head, group.k_tail, group.v_head, group.v_tail)
+        original_slot_1 = tuple(buffer[1].clone() for buffer in device_buffers)
+        original_slot_4 = tuple(buffer[4].clone() for buffer in device_buffers)
+
+        bridge.backup(
+            host_indices=torch.tensor([7, 2]),
+            device_indices=torch.tensor([1, 4]),
+            io_backend="direct",
+        )
+        group.k_head[[5, 6]].zero_()
+        group.k_tail[[5, 6]].zero_()
+        group.v_head[[5, 6]].zero_()
+        group.v_tail[[5, 6]].zero_()
+        bridge.restore(
+            host_indices=torch.tensor([2, 7]),
+            device_indices=torch.tensor([5, 6]),
+            io_backend="direct",
+        )
+
+        for buffer, expected_4, expected_1 in zip(
+            device_buffers, original_slot_4, original_slot_1
+        ):
+            torch.testing.assert_close(buffer[5], expected_4)
+            torch.testing.assert_close(buffer[6], expected_1)
+
+    def test_swa_group_uses_pool_transfer_indices(self) -> None:
+        full = _make_group(kind=PoolKind.FULL, num_slots=8)
+        swa = _make_group(kind=PoolKind.SWA, num_slots=6)
+        bridge = CanaryHiCacheBridge(
+            buffer_groups=(full, swa),
+            host_sizes={PoolKind.FULL: 12, PoolKind.SWA: 10},
+            pin_memory=False,
+        )
+        original_swa_slot = swa.v_tail[3].clone()
+        pool_transfers = [
+            PoolTransfer(
+                name=PoolName.SWA,
+                host_indices=torch.tensor([8]),
+                device_indices=torch.tensor([3]),
+            )
+        ]
+
+        bridge.backup(
+            host_indices=torch.tensor([4]),
+            device_indices=torch.tensor([2]),
+            pool_transfers=pool_transfers,
+            io_backend="direct",
+        )
+        swa.v_tail[5].zero_()
+        restore_transfers = [
+            PoolTransfer(
+                name=PoolName.SWA,
+                host_indices=torch.tensor([8]),
+                device_indices=torch.tensor([5]),
+            )
+        ]
+        bridge.restore(
+            host_indices=torch.tensor([4]),
+            device_indices=torch.tensor([6]),
+            pool_transfers=restore_transfers,
+            io_backend="direct",
+        )
+
+        torch.testing.assert_close(swa.v_tail[5], original_swa_slot)
+
+    def test_missing_swa_transfer_is_rejected(self) -> None:
+        full = _make_group(kind=PoolKind.FULL, num_slots=8)
+        swa = _make_group(kind=PoolKind.SWA, num_slots=6)
+        bridge = CanaryHiCacheBridge(
+            buffer_groups=(full, swa),
+            host_sizes={PoolKind.FULL: 12, PoolKind.SWA: 10},
+            pin_memory=False,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "missing SWA PoolTransfer"):
+            bridge.backup(
+                host_indices=torch.tensor([4]),
+                device_indices=torch.tensor([2]),
+                pool_transfers=None,
+                io_backend="direct",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kv_canary/test_self_unit_runner_sweep.py
+++ b/test/registered/kv_canary/test_self_unit_runner_sweep.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import unittest
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 from sglang.srt.kv_canary import endpoint as endpoint_module
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
@@ -31,6 +32,27 @@ def _run_one_cycle(manager, forward_batch) -> None:
 
 
 class TestSelfUnitManagerSweep(CanaryManagerTestCase):
+    def test_attach_radix_cache_registers_hicache_bridge(self) -> None:
+        manager = make_manager(device=self.device)
+        cache = make_radix_cache([[], [10, 11]], device=self.device)
+        cache.req_to_token_pool = make_req_to_token_pool(self.device)
+        controller = SimpleNamespace(register_canary_hicache_bridge=Mock())
+        cache.cache_controller = controller
+        bridge = object()
+
+        with patch(
+            "sglang.srt.kv_canary.hicache.bridge."
+            "CanaryHiCacheBridge.from_cache_controller",
+            return_value=bridge,
+        ) as factory:
+            manager.attach_radix_cache(cache)
+
+        factory.assert_called_once_with(
+            buffer_groups=manager._buffer_groups,
+            cache_controller=controller,
+        )
+        controller.register_canary_hicache_bridge.assert_called_once_with(bridge)
+
     def test_sweep_every_n_cadence(self) -> None:
         """Verify sweep execution follows the configured step cadence."""
         config = make_config(sweep_interval=4)

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -925,6 +925,135 @@ class TestHiCacheStagedWriteBackDispatch(unittest.TestCase):
         controller.move_indices.assert_called_once()
         self.assertEqual(captured["host_indices"].device.type, "cpu")
 
+    def test_cache_controller_copies_canary_with_kv_indices(self):
+        op = ManagerCacheOperation(
+            host_indices=_indices(0, 4),
+            device_indices=_indices(4, 8),
+            node_id=1,
+        )
+        bridge = mock.Mock()
+        controller = HiCacheController.__new__(HiCacheController)
+        controller.write_queue = [op]
+        controller.io_backend = "direct"
+        controller.mem_pool_host = SimpleNamespace(
+            layout="layer_first",
+            can_use_write_back_jit=False,
+            backup_from_device_all_layer=mock.Mock(),
+        )
+        controller.mem_pool_device = None
+        controller.has_draft = False
+        controller.write_stream = object()
+        controller.ack_write_queue = []
+        controller.move_indices = mock.Mock(
+            return_value=(op.host_indices, op.device_indices)
+        )
+        controller.kv_canary_hicache_bridge = bridge
+
+        with mock.patch.object(
+            manager_cache_controller, "device_module", _FakeDeviceModule
+        ):
+            controller.start_writing()
+
+        bridge.backup.assert_called_once_with(
+            host_indices=op.host_indices,
+            device_indices=op.device_indices,
+            io_backend="direct",
+        )
+
+    def test_cache_controller_restores_canary_before_layer_completion(self):
+        call_order = []
+        op = ManagerCacheOperation(
+            host_indices=_indices(0, 4),
+            device_indices=_indices(4, 8),
+            node_id=1,
+        )
+        producer_event = SimpleNamespace(
+            start_event=_FakeEvent(),
+            finish_event=_FakeEvent(),
+            complete=lambda layer_id: call_order.append(("complete", layer_id)),
+        )
+        bridge = mock.Mock()
+        bridge.restore.side_effect = lambda **_: call_order.append(("canary", None))
+        controller = HiCacheController.__new__(HiCacheController)
+        controller.load_queue = [op]
+        controller.io_backend = "direct"
+        controller.mem_pool_host = SimpleNamespace(
+            layout="layer_first",
+            load_to_device_per_layer=lambda *args: call_order.append(("kv", args[3])),
+        )
+        controller.mem_pool_device = None
+        controller.mem_pool_device_allocator = None
+        controller.has_draft = False
+        controller.layer_num = 2
+        controller.load_stream = object()
+        controller.ack_load_queue = []
+        controller.layer_done_counter = SimpleNamespace(
+            update_producer=lambda: 0,
+            events=[producer_event],
+        )
+        controller.move_indices = mock.Mock(
+            return_value=(op.host_indices, op.device_indices)
+        )
+        controller.kv_canary_hicache_bridge = bridge
+
+        with mock.patch.object(
+            manager_cache_controller, "device_module", _FakeDeviceModule
+        ):
+            controller.start_loading()
+
+        bridge.restore.assert_called_once_with(
+            host_indices=op.host_indices,
+            device_indices=op.device_indices,
+            io_backend="direct",
+        )
+        self.assertEqual(call_order[0], ("canary", None))
+        self.assertEqual(
+            call_order[1:], [("kv", 0), ("complete", 0), ("kv", 1), ("complete", 1)]
+        )
+
+    def test_hybrid_controller_passes_swa_transfer_to_canary(self):
+        swa_transfer = PoolTransfer(
+            name=PoolName.SWA,
+            host_indices=_indices(1, 3),
+            device_indices=_indices(5, 7),
+        )
+        op = CacheOperation(
+            host_indices=_indices(0, 2),
+            device_indices=_indices(4, 6),
+            node_id=1,
+            pool_transfers=[swa_transfer],
+        )
+        bridge = mock.Mock()
+        controller = HybridCacheController.__new__(HybridCacheController)
+        controller.write_queue = [op]
+        controller.io_backend = "direct"
+        controller.mem_pool_host = SimpleNamespace(
+            layout="layer_first",
+            can_use_write_back_jit=False,
+            backup_from_device_all_layer=mock.Mock(),
+        )
+        controller.mem_pool_device = None
+        controller.has_draft = False
+        controller.write_stream = object()
+        controller.ack_write_queue = []
+        controller._record_transfer_indices_on_stream = mock.Mock()
+        controller.move_hybrid_indices = mock.Mock(
+            return_value=(op.host_indices, op.device_indices, [swa_transfer])
+        )
+        controller.kv_canary_hicache_bridge = bridge
+
+        with mock.patch.object(
+            hybrid_cache_controller, "device_module", _FakeDeviceModule
+        ):
+            controller.start_writing()
+
+        bridge.backup.assert_called_once_with(
+            host_indices=op.host_indices,
+            device_indices=op.device_indices,
+            pool_transfers=[swa_transfer],
+            io_backend="direct",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- persist existing KV canary buffers alongside HiCache L2 KV data
- restore canaries with the same FULL/SWA index mappings before KV consumers run
- keep the existing `--kv-canary` verification and logging semantics unchanged

## Motivation

HiCache previously moved only KV data between L1 and L2. The expected canary stayed in L1, so corruption or mismatches introduced during L2 storage, indexing, transfer, or reload could not be checked against the original canary after eviction.

## Behavior

- supports MHA FULL and hybrid/SWA L2 paths
- requires `--kv-canary-real-data=partial` or `all` to detect raw KV-byte corruption
- fails fast when HiCache L3 storage is enabled because L3 canary sidecars are not implemented

## Validation

- focused KV canary bridge unit tests
- targeted Ruff checks
- Python bytecode compilation
- staged diff checks

Linux/GPU end-to-end validation is still required.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28697860371](https://github.com/sgl-project/sglang/actions/runs/28697860371)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28697860324](https://github.com/sgl-project/sglang/actions/runs/28697860324)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->