### PR TITLE
[Intel XPU] Bump nightly per-file timeout to 120m and extend XPU CI monitor

### DIFF
--- a/.github/workflows/nightly-test-intel.yml
+++ b/.github/workflows/nightly-test-intel.yml
@@ -84,7 +84,7 @@ jobs:
             source /opt/venv/bin/activate &&
             cd /sglang-checkout/test &&
             GITHUB_STEP_SUMMARY=/sglang-checkout/github_summary.md \
-            python3 run_suite.py --hw xpu --suite nightly-xpu-2-gpu --nightly --timeout-per-file 1800 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
+            python3 run_suite.py --hw xpu --suite nightly-xpu-2-gpu --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           " || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md)" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
@@ -143,7 +143,7 @@ jobs:
             source /opt/venv/bin/activate &&
             cd /sglang-checkout/test &&
             GITHUB_STEP_SUMMARY=/sglang-checkout/github_summary.md \
-            python3 run_suite.py --hw xpu --suite nightly-xpu-4-gpu --nightly --timeout-per-file 2400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
+            python3 run_suite.py --hw xpu --suite nightly-xpu-4-gpu --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           " || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md)" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}

--- a/.github/workflows/xpu-ci-job-monitor.yml
+++ b/.github/workflows/xpu-ci-job-monitor.yml
@@ -49,6 +49,15 @@ jobs:
       - name: Install dependencies
         run: pip install tabulate
 
+      - name: Select workflows for snapshot
+        id: select-workflows
+        run: |
+          if [[ -n "${{ inputs.job_filter }}" ]]; then
+            echo "workflows=pr-test-xpu.yml" >> "$GITHUB_OUTPUT"
+          else
+            echo "workflows=pr-test-xpu.yml,nightly-test-intel.yml" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Fetch Actions data snapshot
         timeout-minutes: 30
         run: |
@@ -56,7 +65,7 @@ jobs:
           # (0.34h) to bound API cost. schedule / dispatch run the full report.
           python scripts/ci/utils/xpu_job_monitor.py \
             --repo ${{ github.repository }} \
-            --workflow "pr-test-xpu.yml" \
+            --workflow "${{ steps.select-workflows.outputs.workflows }}" \
             --hours ${{ (github.event_name == 'pull_request' && '0.34') || inputs.hours || '24' }} \
             --dump-data-file actions-job-snapshot.json
 
@@ -109,6 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pr_jobs: ${{ steps.parse.outputs.pr_jobs }}
+      nightly_jobs: ${{ steps.parse.outputs.nightly_jobs }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -123,6 +133,14 @@ jobs:
             jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "pr_jobs=$pr_jobs" >> $GITHUB_OUTPUT
           echo "PR jobs: $pr_jobs"
+
+          # Parse nightly-test-intel.yml and extract job names (exclude utility jobs)
+          # Excluded: check-all-jobs
+          nightly_jobs=$(yq -r '.jobs | keys | .[]' .github/workflows/nightly-test-intel.yml | \
+            grep -v -E '^(check-all-jobs)$' | \
+            jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "nightly_jobs=$nightly_jobs" >> $GITHUB_OUTPUT
+          echo "Nightly jobs: $nightly_jobs"
 
   # PR CI reports using dynamic matrix
   pr-ci-reports:
@@ -163,6 +181,45 @@ jobs:
             --input-data-file ci-data/actions-job-snapshot.json \
             --summary
 
+  # Nightly XPU test reports using dynamic matrix
+  nightly-reports:
+    name: Nightly - ${{ matrix.job_name }}
+    needs: [parse-workflows, fetch-actions-data]
+    if: ${{ !inputs.job_filter }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        job_name: ${{ fromJson(needs.parse-workflows.outputs.nightly_jobs) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install tabulate
+
+      - name: Download Actions data snapshot
+        uses: actions/download-artifact@v4
+        with:
+          name: actions-job-snapshot
+          path: ci-data
+
+      - name: Generate Nightly Report
+        timeout-minutes: 15
+        run: |
+          python scripts/ci/utils/xpu_job_monitor.py \
+            --repo ${{ github.repository }} \
+            --job "${{ matrix.job_name }}" \
+            --workflow "nightly-test-intel.yml" \
+            --hours ${{ inputs.hours || '24' }} \
+            --input-data-file ci-data/actions-job-snapshot.json \
+            --summary
+
   # Runner fleet report - cross-workflow runner analytics in a single pass
   runner-fleet-report:
     name: Runner Fleet Report
@@ -193,7 +250,7 @@ jobs:
           python scripts/ci/utils/xpu_job_monitor.py \
             --repo ${{ github.repository }} \
             --runner-report \
-            --workflow "pr-test-xpu.yml" \
+            --workflow "pr-test-xpu.yml,nightly-test-intel.yml" \
             --hours ${{ inputs.hours || '24' }} \
             --input-data-file ci-data/actions-job-snapshot.json \
             --summary

--- a/scripts/ci/xpu/xpu_ci_start_container.sh
+++ b/scripts/ci/xpu/xpu_ci_start_container.sh
@@ -99,6 +99,7 @@ fi
 
 echo "Launching container: ${CONTAINER_NAME} from ${IMAGE}"
 docker run -dt \
+  --shm-size 8g \
   --group-add 992 \
   ${VIDEO_GID:+--group-add "${VIDEO_GID}"} \
   ${RENDER_GID:+--group-add "${RENDER_GID}"} \


### PR DESCRIPTION
## Summary

- **`nightly-test-intel.yml`**: bump `--timeout-per-file` from 1800/2400 → **7200 (120 min)** for both `nightly-xpu-2-gpu` and `nightly-xpu-4-gpu`. The 4-GPU Qwen3-32B (TP=4) test consistently exceeds 40 min end-to-end (load + 200-example GSM8K eval on 4× Intel Arc Pro B60), and the 2400s cap was firing mid-run — see [failing run](https://github.com/sgl-project/sglang/actions/runs/28674338401/job/85044414089). Standardizing both suites on 120 min gives long-tail models headroom without needing a workflow edit each time.
- **`xpu-ci-job-monitor.yml`**: extend to snapshot and report on `nightly-test-intel.yml` alongside `pr-test-xpu.yml`, mirroring the AMD monitor pattern:
  - Single `--dump-data-file` pass covers both workflows.
  - Adds a `Nightly - <job>` matrix (dynamic job list parsed from `nightly-test-intel.yml`).
  - Runner-fleet report spans both workflows.

## Test plan

- [ ] Manually trigger `XPU CI Job Monitor` via `workflow_dispatch` — verify the `Nightly - nightly-xpu-{1,2,4}-gpu` matrix jobs are generated and their reports include recent runs.
- [ ] Next scheduled `Nightly Test (Intel)` run: confirm `nightly-xpu-4-gpu`'s Qwen3-32B test completes within 120 min (previous log shows ~40 min got to 42%, so full run is ≈95 min).
- [ ] Confirm `nightly-xpu-2-gpu` still finishes well under its `timeout-minutes: 60` job-level cap.

## Notes

- Job-level `timeout-minutes` at `nightly-test-intel.yml:80` (2-GPU: 60) and `:139` (4-GPU: 120) are unchanged. The 4-GPU job-level cap now equals the per-file cap; if both files ever burn their full budget, the job-level timeout fires first. Happy to bump those in a follow-up if needed — the 2-GPU suite currently has one long file and finishes in ~20 min, and the 4-GPU suite has two files, so this is a live decision.
- Related failing run: https://github.com/sgl-project/sglang/actions/runs/28674338401/job/85044414089





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28730221018](https://github.com/sgl-project/sglang/actions/runs/28730221018)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #28730220963](https://github.com/sgl-project/sglang/actions/runs/28730220963)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->