### PR TITLE
[diffusion] Defer VAE offload cleanup after response

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -44,6 +44,10 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload im
 from sglang.multimodal_gen.runtime.managers.memory_managers.memory_occupation_controller import (
     MemoryOccupationController,
 )
+from sglang.multimodal_gen.runtime.managers.post_response_tasks import (
+    PostResponseTask,
+    PostResponseTaskRunner,
+)
 from sglang.multimodal_gen.runtime.pipelines_core import (
     ComposedPipelineBase,
     LoRAPipeline,
@@ -121,6 +125,10 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         # FIXME: should we use tcp as distribute init method?
         self.server_args = server_args
         self.pipeline: ComposedPipelineBase = None
+        self.post_response_task_runner = PostResponseTaskRunner(
+            f"sgl_diffusion_post_response_{rank}"
+        )
+        self._post_response_tasks: list[PostResponseTask] = []
 
         self.init_device_and_model()
         self.sp_group = get_sp_group()
@@ -400,7 +408,10 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                     stack.enter_context(
                         trace_slice(item.trace_ctx, DiffStage.GPU_FORWARD)
                     )
-                result = forward_fn()
+                try:
+                    result = forward_fn()
+                finally:
+                    self._collect_pipeline_post_response_tasks(run_inline=return_req)
 
             # disagg roles return raw Req so callers can keep and transfer intermediate tensors
             # before converting it to OutputBatch
@@ -468,6 +479,40 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
             if torch.cuda.is_initialized():
                 torch.cuda.empty_cache()
         return output_batch
+
+    def _collect_pipeline_post_response_tasks(self, *, run_inline: bool) -> None:
+        executor = getattr(self.pipeline, "executor", None)
+        if executor is None:
+            return
+        tasks = executor.pop_post_response_tasks()
+        if run_inline:
+            for _name, task in tasks:
+                task()
+            return
+        self._post_response_tasks.extend(tasks)
+
+    def submit_post_response_tasks(self) -> None:
+        tasks = self._post_response_tasks
+        self._post_response_tasks = []
+        for name, task in tasks:
+            self.post_response_task_runner.submit(
+                name,
+                self._wrap_post_response_task(task),
+            )
+
+    def wait_post_response_tasks(self) -> None:
+        self.post_response_task_runner.wait_pending()
+
+    def shutdown_post_response_tasks(self) -> None:
+        self.post_response_task_runner.shutdown()
+
+    def _wrap_post_response_task(self, task: Callable[[], None]) -> Callable[[], None]:
+        def run_task() -> None:
+            if current_platform.is_cuda():
+                torch.get_device_module().set_device(self.local_rank)
+            task()
+
+        return run_task
 
     def _materialize_output_transport(
         self,

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import lru_cache
 from typing import Mapping, MutableMapping, Protocol, Sequence
 
@@ -22,6 +22,9 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload_co
     is_image_encoder_component_name,
     is_text_encoder_component_name,
     is_vae_component_name,
+)
+from sglang.multimodal_gen.runtime.managers.post_response_tasks import (
+    PostResponseTask,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
@@ -57,6 +60,9 @@ class ComponentUse:
     # Some components are intentionally kept ready between warmup and the first
     # real request to avoid measuring a cold H2D in the user-visible request.
     keep_ready_after_warmup: bool = False
+    # finish this use after the response is sent; the scheduler waits before
+    # the next dispatch, so module mutation cannot race the next forward pass
+    finish_after_response: bool = False
 
 
 @dataclass(slots=True)
@@ -154,6 +160,7 @@ class ComponentResidencyManager:
             pipeline.component_residency_strategies
         )
         self._uses_seen: dict[str, ComponentUse] = {}
+        self._deferred_finish_uses: dict[str, tuple[ComponentUse, nn.Module]] = {}
 
     def refresh_pipeline(self, pipeline: ComponentResidencyPipeline) -> None:
         custom_strategies = dict(pipeline.component_residency_strategies)
@@ -164,6 +171,7 @@ class ComponentResidencyManager:
             self._active_use = None
             self._active_use_module = None
             self._uses_seen.clear()
+            self._deferred_finish_uses.clear()
             self._prefetched_use_keys.clear()
         elif custom_strategies != self._custom_strategies:
             self.strategy_for.cache_clear()
@@ -181,18 +189,22 @@ class ComponentResidencyManager:
     def begin_request(
         self,
         stages: Sequence[ComponentResidencyStage],
-        batch: ResidencyBatch,
+        batch: ResidencyBatch | list[ResidencyBatch],
         server_args: ServerArgs,
     ) -> None:
         """A hook called before processing an actual request"""
         self.refresh_server_args(server_args)
-        self.state = ResidencyState(stages=stages, batch_is_warmup=batch.is_warmup)
+        self.state = ResidencyState(
+            stages=stages,
+            batch_is_warmup=self._is_warmup_batch(batch),
+        )
         self._active_use = None
         self._active_use_module = None
         self._disable_active_nvtx()
         self._current_use_index = -1
         self._prefetched_use_keys.clear()
         self._uses_seen.clear()
+        self._deferred_finish_uses.clear()
         self._stage_uses_by_index = [
             tuple(stage.component_uses(server_args, self.stage_name(stage)))
             for stage in stages
@@ -426,12 +438,16 @@ class ComponentResidencyManager:
         ) or self._should_keep_after_use(use)
         if should_keep:
             return
+        if use.finish_after_response:
+            self._deferred_finish_uses[use.component_name] = (use, module)
+            return
         strategy = self.strategy_for(use.component_name, module)
         was_on_cuda = self._module_on_cuda(module)
         strategy.finish_use(module, use, self.state)
         self._empty_cache_after_large_release(use, strategy, module, was_on_cuda)
 
-    def finish_request(self) -> None:
+    def finish_request(self) -> list[PostResponseTask]:
+        post_response_tasks: list[PostResponseTask] = []
         # 1. Close the currently active sequential use.
         self.finish_active_use(prefetch_next=False)
         # 2. Pick components that should be ready for the next request.
@@ -447,14 +463,56 @@ class ComponentResidencyManager:
             if not preferred and self._should_keep_single_dit(component_name):
                 continue
             strategy = self.strategy_for(component_name, module)
-            if preferred and not self.state.batch_is_warmup:
+            if use.finish_after_response and not self.state.batch_is_warmup:
+                deferred = self._deferred_finish_uses.pop(component_name, None)
+                deferred_use, deferred_module = deferred or (use, module)
+                post_response_tasks.append(
+                    self._make_finish_request_task(
+                        component_name,
+                        deferred_use,
+                        deferred_module,
+                        strategy,
+                        preferred=False,
+                    )
+                )
+            elif preferred and not self.state.batch_is_warmup:
                 strategy.prepare_after_request(module, use, self.state)
             else:
-                was_on_cuda = self._module_on_cuda(module)
-                strategy.finish_request(module, use, self.state, preferred=preferred)
-                self._empty_cache_after_large_release(
-                    use, strategy, module, was_on_cuda
-                )
+                self._finish_request_component(module, use, strategy, preferred)
+        self._deferred_finish_uses.clear()
+        return post_response_tasks
+
+    def _make_finish_request_task(
+        self,
+        component_name: str,
+        use: ComponentUse,
+        module: nn.Module,
+        strategy: ComponentResidencyStrategy,
+        *,
+        preferred: bool,
+    ) -> PostResponseTask:
+        state = replace(self.state)
+
+        def finish_component() -> None:
+            self._finish_request_component(module, use, strategy, preferred, state)
+
+        return (
+            f"component_residency.finish_request.{component_name}",
+            finish_component,
+        )
+
+    def _finish_request_component(
+        self,
+        module: nn.Module,
+        use: ComponentUse,
+        strategy: ComponentResidencyStrategy,
+        preferred: bool,
+        state: ResidencyState | None = None,
+    ) -> None:
+        state = state or self.state
+        was_on_cuda = self._module_on_cuda(module)
+        strategy.finish_request(module, use, state, preferred=preferred)
+        self._empty_cache_after_large_release(use, strategy, module, was_on_cuda)
 
     def stage_name(self, stage: ComponentResidencyStage) -> str:
         return self._stage_names_by_id.get(id(stage), stage.__class__.__name__)
@@ -579,6 +637,12 @@ class ComponentResidencyManager:
 
     def _module_on_cuda(self, module: nn.Module | None) -> bool:
         return self._module_device(module) == "cuda"
+
+    @staticmethod
+    def _is_warmup_batch(batch: ResidencyBatch | list[ResidencyBatch]) -> bool:
+        if isinstance(batch, list):
+            return bool(batch) and all(item.is_warmup for item in batch)
+        return batch.is_warmup
 
     def _empty_cache_after_large_release(
         self,

--- a/python/sglang/multimodal_gen/runtime/managers/post_response_tasks.py
+++ b/python/sglang/multimodal_gen/runtime/managers/post_response_tasks.py
@@ -1,0 +1,42 @@
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from threading import Lock
+
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+PostResponseTask = tuple[str, Callable[[], None]]
+
+
+class PostResponseTaskRunner:
+    """Runs response-tail maintenance before the next forward dispatch."""
+
+    def __init__(self, name: str) -> None:
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=name)
+        self._lock = Lock()
+        self._pending: list[Future[None]] = []
+
+    def submit(self, name: str, fn: Callable[[], None]) -> None:
+        with self._lock:
+            self._pending.append(self._executor.submit(self._run, name, fn))
+
+    def wait_pending(self) -> None:
+        with self._lock:
+            pending = self._pending
+            self._pending = []
+
+        for future in pending:
+            future.result()
+
+    def shutdown(self) -> None:
+        self.wait_pending()
+        self._executor.shutdown(wait=True)
+
+    @staticmethod
+    def _run(name: str, fn: Callable[[], None]) -> None:
+        try:
+            fn()
+        except Exception:
+            logger.exception("Post-response task failed: %s", name)
+            raise

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -1018,6 +1018,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 continue
 
             try:
+                self.worker.wait_post_response_tasks()
                 handler_result = self._dispatch_items(items)
             except Exception as e:
                 logger.error(
@@ -1072,11 +1073,14 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 # Reply failed; log and keep loop alive to accept future requests
                 logger.error(f"ZMQ error sending reply: {e}")
                 continue
+            finally:
+                self.worker.submit_post_response_tasks()
 
         self._log_batch_metrics_summary()
 
         if self.receiver is not None:
             self.receiver.close()
+        self.worker.shutdown_post_response_tasks()
         self._cleanup_disagg()
         self.context.destroy(linger=0)
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, List
 import torch
 
 from sglang.multimodal_gen.runtime.distributed import get_world_rank
+from sglang.multimodal_gen.runtime.managers.post_response_tasks import PostResponseTask
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch, Req
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
@@ -50,6 +51,7 @@ class PipelineExecutor(ABC):
     def __init__(self, server_args):
         self.server_args = server_args
         self.component_residency_manager = None
+        self._post_response_tasks: list[PostResponseTask] = []
 
     def begin_component_residency_request(
         self,
@@ -72,7 +74,14 @@ class PipelineExecutor(ABC):
         )
 
     def finish_component_residency_request(self) -> None:
-        self.component_residency_manager.finish_request()
+        self._post_response_tasks.extend(
+            self.component_residency_manager.finish_request()
+        )
+
+    def pop_post_response_tasks(self) -> list[PostResponseTask]:
+        tasks = self._post_response_tasks
+        self._post_response_tasks = []
+        return tasks
 
     @contextlib.contextmanager
     def _component_residency_request(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
@@ -126,6 +126,7 @@ class DecodingStage(PipelineStage):
                 self.component_name,
                 target_dtype=vae_dtype,
                 keep_ready_after_warmup=True,
+                finish_after_response=server_args.vae_cpu_offload,
             )
         ]
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/decoding_av.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/decoding_av.py
@@ -44,9 +44,23 @@ class LTX2AVDecodingStage(DecodingStage):
             server_args, "audio_vae", precision_attr="audio_vae_precision"
         )
         return [
-            ComponentUse(stage_name, "vae", target_dtype=vae_dtype),
-            ComponentUse(stage_name, "audio_vae", target_dtype=audio_vae_dtype),
-            ComponentUse(stage_name, "vocoder"),
+            ComponentUse(
+                stage_name,
+                "vae",
+                target_dtype=vae_dtype,
+                finish_after_response=server_args.vae_cpu_offload,
+            ),
+            ComponentUse(
+                stage_name,
+                "audio_vae",
+                target_dtype=audio_vae_dtype,
+                finish_after_response=server_args.vae_cpu_offload,
+            ),
+            ComponentUse(
+                stage_name,
+                "vocoder",
+                finish_after_response=server_args.vae_cpu_offload,
+            ),
         ]
 
     @staticmethod

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -961,8 +961,17 @@ class MOVADecodingStage(PipelineStage):
         stage_name = self._component_stage_name(stage_name)
         vae_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision]
         return [
-            ComponentUse(stage_name, "video_vae", target_dtype=vae_dtype),
-            ComponentUse(stage_name, "audio_vae"),
+            ComponentUse(
+                stage_name,
+                "video_vae",
+                target_dtype=vae_dtype,
+                finish_after_response=server_args.vae_cpu_offload,
+            ),
+            ComponentUse(
+                stage_name,
+                "audio_vae",
+                finish_after_response=server_args.vae_cpu_offload,
+            ),
         ]
 
     @property

--- a/python/sglang/multimodal_gen/test/unit/test_component_residency_post_response.py
+++ b/python/sglang/multimodal_gen/test/unit/test_component_residency_post_response.py
@@ -1,0 +1,121 @@
+import unittest
+from types import SimpleNamespace
+
+import torch.nn as nn
+
+from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
+    ComponentResidencyManager,
+    ComponentUse,
+)
+from sglang.multimodal_gen.runtime.managers.memory_managers.component_resident_strategies import (
+    ComponentResidencyStrategy,
+)
+
+
+class _CountingStrategy(ComponentResidencyStrategy):
+    def __init__(self):
+        self.finish_use_count = 0
+        self.finish_request_count = 0
+
+    def finish_use(self, module, use, state):
+        self.finish_use_count += 1
+
+    def finish_request(self, module, use, state, *, preferred):
+        self.finish_request_count += 1
+        super().finish_request(module, use, state, preferred=preferred)
+
+
+class _FakeStage:
+    def __init__(self, uses):
+        self._uses = uses
+
+    def component_uses(self, _server_args, stage_name=None):
+        return self._uses
+
+
+class _FakePipeline:
+    def __init__(self, module, strategy):
+        self.modules = {"vae": module}
+        self._stage_name_mapping = {}
+        self.component_residency_strategies = {"vae": strategy}
+
+
+def _server_args():
+    return SimpleNamespace(enable_layerwise_nvtx_marker=False)
+
+
+class ComponentResidencyPostResponseTests(unittest.TestCase):
+    def _make_manager(self, use, batch=None):
+        strategy = _CountingStrategy()
+        manager = ComponentResidencyManager(
+            _FakePipeline(nn.Linear(1, 1), strategy),
+            _server_args(),
+        )
+        manager.begin_request(
+            [_FakeStage([use])],
+            batch or SimpleNamespace(is_warmup=False),
+            _server_args(),
+        )
+        return manager, strategy
+
+    def test_terminal_finish_after_response_defers_even_when_preferred(self):
+        use = ComponentUse("DecodingStage", "vae", finish_after_response=True)
+        manager, strategy = self._make_manager(use)
+
+        with manager.use_component(use):
+            pass
+
+        self.assertEqual(strategy.finish_use_count, 0)
+
+        tasks = manager.finish_request()
+
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(strategy.finish_request_count, 0)
+        self.assertEqual(strategy.finish_use_count, 0)
+
+        tasks[0][1]()
+
+        self.assertEqual(strategy.finish_request_count, 1)
+        self.assertEqual(strategy.finish_use_count, 1)
+
+    def test_warmup_keeps_ready_without_post_response_task(self):
+        use = ComponentUse(
+            "DecodingStage",
+            "vae",
+            keep_ready_after_warmup=True,
+            finish_after_response=True,
+        )
+        manager, strategy = self._make_manager(use, SimpleNamespace(is_warmup=True))
+
+        with manager.use_component(use):
+            pass
+
+        self.assertEqual(manager.finish_request(), [])
+        self.assertEqual(strategy.finish_request_count, 0)
+        self.assertEqual(strategy.finish_use_count, 0)
+
+    def test_grouped_batch_warmup_state(self):
+        use = ComponentUse("DecodingStage", "vae", finish_after_response=True)
+        manager, _strategy = self._make_manager(
+            use,
+            [
+                SimpleNamespace(is_warmup=True),
+                SimpleNamespace(is_warmup=True),
+            ],
+        )
+
+        self.assertTrue(manager.state.batch_is_warmup)
+
+        manager, _strategy = self._make_manager(
+            use,
+            [
+                SimpleNamespace(is_warmup=True),
+                SimpleNamespace(is_warmup=False),
+            ],
+        )
+
+        self.assertFalse(manager.state.batch_is_warmup)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR defers terminal VAE-style cleanup for explicit `--vae-cpu-offload` until after the response is sent.

- add a single-threaded post-response task runner
- let `ComponentResidencyManager.finish_request()` return deferred cleanup tasks
- submit those tasks after scheduler replies, and wait for them before the next forward dispatch
- mark terminal VAE / audio VAE / vocoder uses as post-response cleanup only when `vae_cpu_offload=True`
- add unit coverage for the old terminal-preferred VAE case, warmup behavior, and grouped warmup batches

This does not make saturated throughput faster. It hides D2H cleanup latency when there is an idle gap after a response.

## Why

With VAE CPU offload, request-end cleanup can include a visible D2H transfer. For the common low-QPS case, the response can be returned first and the cleanup can run in the idle gap. The scheduler still waits before the next dispatch, so the next forward pass cannot race with module mutation.

`--vae-cpu-offload` remains opt-in. This only changes the cleanup timing after the user has already selected VAE offload.

## Benchmark

H100 microbench using the real `ComponentResidencyManager` + `VanillaD2HStrategy` with fake VAE modules:

| module size | sync visible tail | deferred visible tail | deferred cleanup | next request wait, no idle | next request wait, 25ms idle |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 512 MB | 10.81 ms | 0.031 ms | 9.86 ms | 9.83 ms | 0.010 ms |
| 1024 MB | 21.28 ms | 0.034 ms | 19.61 ms | 19.62 ms | 0.010 ms |

Real server e2e, H100, `Tongyi-MAI/Z-Image-Turbo`, HTTP image generation, `--vae-cpu-offload`, 512x512, 1 step, 5 measured requests:

| code | traffic | throughput | mean latency | p50 | p95 | peak memory |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| main sync | request-rate=1, concurrency=1 | 1.15 req/s | 0.201 s | 0.201 s | 0.203 s | 14354 MB |
| this PR | request-rate=1, concurrency=1 | 1.27 req/s | 0.221 s | 0.201 s | 0.270 s | 14342 MB |
| main sync | back-to-back, concurrency=1 | 4.99 req/s | 0.200 s | 0.200 s | 0.201 s | 14354 MB |
| this PR | back-to-back, concurrency=1 | 5.04 req/s | 0.198 s | 0.198 s | 0.199 s | 14340 MB |

Z-Image's VAE is small, so the real server run mainly checks correctness and no throughput regression. The larger-module microbench isolates the latency-hiding benefit.

## Validation

- `pre-commit run --files <changed files>`
- `python3 -m pytest -q python/sglang/multimodal_gen/test/unit/test_component_residency_post_response.py python/sglang/multimodal_gen/test/unit/test_pipeline_executor.py python/sglang/multimodal_gen/test/unit/test_server_args.py::TestOffloadDefaults`
  - `65 passed, 20 warnings, 7 subtests passed`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28700404099](https://github.com/sgl-project/sglang/actions/runs/28700404099)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28700404044](https://github.com/sgl-project/sglang/actions/runs/28700404044)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->