### PR TITLE
fix: Guard cuda_runtime.h includes with USE_ROCM for HIP/ROCm compatibility

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/mega_moe_pre_dispatch.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/mega_moe_pre_dispatch.cuh
@@ -10,7 +10,11 @@
 #include <sgl_kernel/deepseek_v4/fp8_utils.cuh>
 
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_fp8.h>
+#else
+#include <hip/hip_fp8.h>
+#endif
 
 namespace {
 

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/silu_and_mul_masked_post_quant.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/silu_and_mul_masked_post_quant.cuh
@@ -11,7 +11,11 @@
 #include <sgl_kernel/deepseek_v4/fp8_utils.cuh>
 
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_fp8.h>
+#else
+#include <hip/hip_fp8.h>
+#endif
 #include <type_traits>
 
 namespace {

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/store.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/store.cuh
@@ -14,7 +14,11 @@
 
 #include <bit>
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_fp8.h>
+#else
+#include <hip/hip_fp8.h>
+#endif
 
 namespace {
 

--- a/python/sglang/jit_kernel/csrc/diffusion/ltx2_qknorm_split_rope.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/ltx2_qknorm_split_rope.cuh
@@ -15,7 +15,11 @@
 #include <sgl_kernel/utils.cuh>  // For LaunchKernel and CUDA dtype aliases
 
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
+#else
+#include <hip/hip_bf16.h>
+#endif
 
 namespace sglang_ltx2_qknorm_split_rope {
 

--- a/python/sglang/jit_kernel/csrc/diffusion/timestep_embedding.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/timestep_embedding.cuh
@@ -14,7 +14,11 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 #include <type_traits>
 
 namespace sglang_timestep_embedding {

--- a/python/sglang/jit_kernel/csrc/dsa/fused_store_index_cache.cuh
+++ b/python/sglang/jit_kernel/csrc/dsa/fused_store_index_cache.cuh
@@ -12,7 +12,11 @@
 
 #include <bit>
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_fp8.h>
+#else
+#include <hip/hip_fp8.h>
+#endif
 
 namespace {
 

--- a/python/sglang/jit_kernel/csrc/dsa/kpool_topk_transform.cuh
+++ b/python/sglang/jit_kernel/csrc/dsa/kpool_topk_transform.cuh
@@ -19,7 +19,11 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_fp16.h>
+#endif
 
 namespace {
 

--- a/python/sglang/jit_kernel/csrc/elementwise/concat_mla.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/concat_mla.cuh
@@ -5,8 +5,13 @@
 
 #include <tvm/ffi/container/tensor.h>
 
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
+#endif
 
 namespace {
 

--- a/python/sglang/jit_kernel/csrc/elementwise/fused_qknorm_rope.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/fused_qknorm_rope.cuh
@@ -27,8 +27,13 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <cmath>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
+#endif
 
 namespace {
 

--- a/python/sglang/jit_kernel/csrc/elementwise/pos_enc.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/pos_enc.cuh
@@ -8,8 +8,12 @@
 
 #include <tvm/ffi/container/tensor.h>
 
+#ifndef USE_ROCM
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_fp16.h>
+#endif
 
 namespace {
 

--- a/python/sglang/jit_kernel/csrc/elementwise/qknorm.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/qknorm.cuh
@@ -11,8 +11,13 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#endif
 #include <type_traits>
 
 namespace {

--- a/python/sglang/jit_kernel/csrc/fast-hadamard-transform/fast_hadamard_transform_common.h
+++ b/python/sglang/jit_kernel/csrc/fast-hadamard-transform/fast_hadamard_transform_common.h
@@ -6,8 +6,13 @@
 
 #pragma once
 
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#endif
 
 #define FULL_MASK 0xffffffff
 

--- a/python/sglang/jit_kernel/csrc/gemm/dsv3_fused_a_gemm.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/dsv3_fused_a_gemm.cuh
@@ -26,7 +26,11 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <algorithm>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
+#else
+#include <hip/hip_bf16.h>
+#endif
 #include <utility>
 
 namespace {

--- a/python/sglang/jit_kernel/csrc/gemm/nvfp4/nvfp4_expert_quant.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/nvfp4/nvfp4_expert_quant.cuh
@@ -6,8 +6,12 @@
 #include <sgl_kernel/utils.cuh>
 
 #include "nvfp4_quant.cuh"
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
 #include <cuda_runtime_api.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 
 using namespace host;
 

--- a/python/sglang/jit_kernel/csrc/gemm/nvfp4/nvfp4_quant.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/nvfp4/nvfp4_quant.cuh
@@ -18,8 +18,13 @@ limitations under the License.
 
 #include <cutlass/arch/config.h>
 
+#ifndef USE_ROCM
 #include <cuda.h>
 #include <cuda_fp8.h>
+#else
+#include <hip/hip_fp8.h>
+#include <hip/hip_runtime.h>
+#endif
 
 #define ELTS_PER_THREAD 8
 

--- a/python/sglang/jit_kernel/csrc/gemm/nvfp4/nvfp4_quant_kernels.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/nvfp4/nvfp4_quant_kernels.cuh
@@ -20,8 +20,12 @@ limitations under the License.
 #include <sgl_kernel/utils.cuh>
 
 #include "nvfp4_quant.cuh"
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
 #include <cuda_runtime_api.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 
 using namespace host;
 

--- a/python/sglang/jit_kernel/csrc/gemm/nvfp4/nvfp4_scaled_mm_common.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/nvfp4/nvfp4_scaled_mm_common.cuh
@@ -24,7 +24,11 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 
 using namespace host;
 

--- a/python/sglang/jit_kernel/csrc/gemm/per_token_group_quant_8bit_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/per_token_group_quant_8bit_v2.cuh
@@ -14,7 +14,11 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_fp8.h>
+#else
+#include <hip/hip_fp8.h>
+#endif
 #include <type_traits>
 
 namespace {

--- a/python/sglang/jit_kernel/csrc/moe/expert_specialization/es_sm100_mxfp8_blockscaled_group_quant.cuh
+++ b/python/sglang/jit_kernel/csrc/moe/expert_specialization/es_sm100_mxfp8_blockscaled_group_quant.cuh
@@ -9,9 +9,15 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include "cute/tensor.hpp"
+#ifndef USE_ROCM
 #include <cuda.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#endif
 
 namespace expert_specialization {
 

--- a/python/sglang/jit_kernel/csrc/moe/moe_finalize_fuse_shared.cu
+++ b/python/sglang/jit_kernel/csrc/moe/moe_finalize_fuse_shared.cu
@@ -52,7 +52,11 @@
 #include <cutlass/numeric_types.h>
 
 #include "tvm_ffi_utils.h"
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 
 namespace sglang {
 

--- a/python/sglang/jit_kernel/csrc/sparse_mla_q8kv8_prefill_sm90/entry.cuh
+++ b/python/sglang/jit_kernel/csrc/sparse_mla_q8kv8_prefill_sm90/entry.cuh
@@ -22,7 +22,11 @@ limitations under the License.
 #include "kernel.cuh"
 #include <cmath>
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 
 namespace {
 

--- a/python/sglang/jit_kernel/csrc/sparse_mla_q8kv8_prefill_sm90/kernel.cuh
+++ b/python/sglang/jit_kernel/csrc/sparse_mla_q8kv8_prefill_sm90/kernel.cuh
@@ -29,7 +29,11 @@ limitations under the License.
 
 #include "config.h"
 #include "helpers.h"
+#ifndef USE_ROCM
 #include <cuda_fp8.h>
+#else
+#include <hip/hip_fp8.h>
+#endif
 
 // using namespace cute must be at global scope BEFORE including dense_fp8 headers
 // (they use bare Tensor, make_tensor etc. from cute namespace)

--- a/python/sglang/jit_kernel/csrc/sparse_mla_q8kv8_prefill_sm90/params.h
+++ b/python/sglang/jit_kernel/csrc/sparse_mla_q8kv8_prefill_sm90/params.h
@@ -17,7 +17,11 @@ limitations under the License.
 
 #include "cutlass/bfloat16.h"
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 
 struct SparseMlaQ8Kv8PrefillParams {
   int s_q, s_kv, h_q, h_kv, d_qk, d_v, topk;

--- a/python/sglang/jit_kernel/trtllm_lora_temp/data/csrc/fused_activation_quant.cuh
+++ b/python/sglang/jit_kernel/trtllm_lora_temp/data/csrc/fused_activation_quant.cuh
@@ -19,7 +19,11 @@
 
 #include "nv_internal/tensorrt_llm/kernels/quantization_utils.cuh"
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
+#else
+#include <hip/hip_bf16.h>
+#endif
 #include <optional>
 
 namespace flashinfer {

--- a/python/sglang/jit_kernel/trtllm_lora_temp/data/csrc/fused_permute_quant.cuh
+++ b/python/sglang/jit_kernel/trtllm_lora_temp/data/csrc/fused_permute_quant.cuh
@@ -43,8 +43,13 @@
 
 #include "nv_internal/tensorrt_llm/kernels/quantization_utils.cuh"
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
+#endif
 #include <optional>
 #include <type_traits>
 

--- a/python/sglang/jit_kernel/trtllm_lora_temp/data/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/python/sglang/jit_kernel/trtllm_lora_temp/data/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -27,8 +27,13 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
+#endif
 #include <iomanip>
 #include <iostream>
 #include <nvrtc.h>

--- a/sgl-kernel/csrc/allreduce/custom_all_reduce.cuh
+++ b/sgl-kernel/csrc/allreduce/custom_all_reduce.cuh
@@ -1,10 +1,16 @@
 // Adapted from https://github.com/vllm-project/vllm/blob/v0.8.2/csrc/custom_all_reduce.cuh
 #pragma once
 
+#ifndef USE_ROCM
 #include <cuda.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#endif
 
 #include <array>
 #include <iostream>

--- a/sgl-kernel/csrc/cutlass_extensions/common.hpp
+++ b/sgl-kernel/csrc/cutlass_extensions/common.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
-#include "cuda_runtime.h"
+#ifndef USE_ROCM
+#include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 #include "cutlass/cutlass.h"
 
 /**

--- a/sgl-kernel/csrc/elementwise/concat_mla.cu
+++ b/sgl-kernel/csrc/elementwise/concat_mla.cu
@@ -1,6 +1,10 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDADataType.h>
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 
 #include "pytorch_extension_utils.h"
 #include "utils.cuh"

--- a/sgl-kernel/csrc/elementwise/deepseek_v4_topk.cu
+++ b/sgl-kernel/csrc/elementwise/deepseek_v4_topk.cu
@@ -18,8 +18,12 @@ limitations under the License.
 #include <c10/cuda/CUDAStream.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#ifndef USE_ROCM
 #include <cuda.h>
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_fp16.h>
+#endif
 
 #include <cstddef>
 #include <cstdint>

--- a/sgl-kernel/csrc/elementwise/topk.cu
+++ b/sgl-kernel/csrc/elementwise/topk.cu
@@ -11,8 +11,12 @@
 #include <c10/cuda/CUDAStream.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#ifndef USE_ROCM
 #include <cuda.h>
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_fp16.h>
+#endif
 
 #include <cstddef>
 #include <cstdint>

--- a/sgl-kernel/csrc/elementwise/utils.cuh
+++ b/sgl-kernel/csrc/elementwise/utils.cuh
@@ -2,8 +2,13 @@
 
 #pragma once
 
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
+#endif
 
 #include <cstdint>
 

--- a/sgl-kernel/csrc/expert_specialization/es_sm100_mxfp8_blockscaled_group_quant.cuh
+++ b/sgl-kernel/csrc/expert_specialization/es_sm100_mxfp8_blockscaled_group_quant.cuh
@@ -1,9 +1,15 @@
 #pragma once
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#ifndef USE_ROCM
 #include <cuda.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#endif
 #include <torch/all.h>
 
 #include <cuda/ptx>

--- a/sgl-kernel/csrc/gemm/awq_kernel.cu
+++ b/sgl-kernel/csrc/gemm/awq_kernel.cu
@@ -1,11 +1,19 @@
 // Adapted from
 // https://github.com/vllm-project/vllm/blob/eb59b5a6cba6727d3727c0372258db9002f687c1/csrc/quantization/awq/gemm_kernels.cu#L350
 #include <c10/cuda/CUDAGuard.h>
+#ifndef USE_ROCM
 #include <cuda.h>
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_fp16.h>
+#endif
 #include <torch/all.h>
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
+#else
+#include <hip/hip_bf16.h>
+#endif
 #endif
 
 template <int lut>

--- a/sgl-kernel/csrc/gemm/dsv3_fused_a_gemm.cu
+++ b/sgl-kernel/csrc/gemm/dsv3_fused_a_gemm.cu
@@ -20,8 +20,13 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
+#endif
 
 #include "utils.h"
 

--- a/sgl-kernel/csrc/gemm/dsv3_router_gemm_bf16_out.cu
+++ b/sgl-kernel/csrc/gemm/dsv3_router_gemm_bf16_out.cu
@@ -21,8 +21,13 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include "cuda_bf16.h"
-#include "cuda_runtime.h"
+#ifndef USE_ROCM
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
+#endif
 #include "utils.h"
 
 // Custom FMA implementation using PTX assembly instructions

--- a/sgl-kernel/csrc/gemm/dsv3_router_gemm_entry.cu
+++ b/sgl-kernel/csrc/gemm/dsv3_router_gemm_entry.cu
@@ -21,8 +21,13 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include "cuda_bf16.h"
-#include "cuda_runtime.h"
+#ifndef USE_ROCM
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
+#endif
 #include "utils.h"
 
 static constexpr int DEFAULT_NUM_EXPERTS = 256;

--- a/sgl-kernel/csrc/gemm/dsv3_router_gemm_float_out.cu
+++ b/sgl-kernel/csrc/gemm/dsv3_router_gemm_float_out.cu
@@ -21,8 +21,13 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include "cuda_bf16.h"
-#include "cuda_runtime.h"
+#ifndef USE_ROCM
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
+#endif
 #include "utils.h"
 
 // Custom FMA implementation using PTX assembly instructions

--- a/sgl-kernel/csrc/gemm/gptq/gptq_kernel.cu
+++ b/sgl-kernel/csrc/gemm/gptq/gptq_kernel.cu
@@ -5,8 +5,12 @@ https://github.com/qwopqwop200/GPTQ-for-LLaMa
 
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#ifndef USE_ROCM
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_fp16.h>
+#endif
 #include <torch/all.h>
 
 #include <cstdint>

--- a/sgl-kernel/csrc/gemm/gptq/matrix_view.cuh
+++ b/sgl-kernel/csrc/gemm/gptq/matrix_view.cuh
@@ -6,8 +6,12 @@ https://github.com/turboderp/exllama
 #ifndef _matrix_view_cuh
 #define _matrix_view_cuh
 
+#ifndef USE_ROCM
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_fp16.h>
+#endif
 
 #include "qdq_util.cuh"
 

--- a/sgl-kernel/csrc/gemm/marlin/marlin.cuh
+++ b/sgl-kernel/csrc/gemm/marlin/marlin.cuh
@@ -2,9 +2,13 @@
 
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#ifndef USE_ROCM
 #include <cuda.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_fp16.h>
+#endif
 #include <torch/all.h>
 
 #include <iostream>

--- a/sgl-kernel/csrc/gemm/marlin/marlin_dtypes.cuh
+++ b/sgl-kernel/csrc/gemm/marlin/marlin_dtypes.cuh
@@ -1,7 +1,12 @@
 #ifndef _data_types_cuh
 #define _data_types_cuh
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#endif
 
 #include "marlin.cuh"
 

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit.cu
@@ -1,5 +1,9 @@
 #include <ATen/cuda/CUDAContext.h>
+#ifndef USE_ROCM
 #include <cuda_fp8.h>
+#else
+#include <hip/hip_fp8.h>
+#endif
 
 #include <cmath>
 #include <flashinfer/vec_dtypes.cuh>

--- a/sgl-kernel/csrc/gemm/qserve_w4a8_per_chn_gemm.cu
+++ b/sgl-kernel/csrc/gemm/qserve_w4a8_per_chn_gemm.cu
@@ -13,7 +13,11 @@
 // Adapted from https://github.com/mit-han-lab/omniserve/blob/main/kernels/csrc/qgemm/w4a8_per_chn/gemm_cuda.cu
 
 #include <ATen/cuda/CUDAContext.h>
+#ifndef USE_ROCM
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_fp16.h>
+#endif
 #include <cuda_pipeline_primitives.h>
 #include <torch/all.h>
 

--- a/sgl-kernel/csrc/gemm/qserve_w4a8_per_group_gemm.cu
+++ b/sgl-kernel/csrc/gemm/qserve_w4a8_per_group_gemm.cu
@@ -13,7 +13,11 @@
 // Adapted from https://github.com/mit-han-lab/omniserve/blob/main/kernels/csrc/qgemm/w4a8_per_group/gemm_cuda.cu
 
 #include <ATen/cuda/CUDAContext.h>
+#ifndef USE_ROCM
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_fp16.h>
+#endif
 #include <cuda_pipeline_primitives.h>
 #include <torch/all.h>
 

--- a/sgl-kernel/csrc/grammar/apply_token_bitmask_inplace_cuda.cu
+++ b/sgl-kernel/csrc/grammar/apply_token_bitmask_inplace_cuda.cu
@@ -19,9 +19,15 @@
  */
 
 // clang-format off
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#endif
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
 

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -1,7 +1,11 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAException.h>
 #include <c10/util/irange.h>
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 
 #include <cstdint>
 #include <limits>

--- a/sgl-kernel/csrc/mamba/causal_conv1d.h
+++ b/sgl-kernel/csrc/mamba/causal_conv1d.h
@@ -5,8 +5,13 @@
 // adapted from https://github.com/Dao-AILab/causal-conv1d/blob/main/csrc/causal_conv1d.h
 #pragma once
 
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#endif
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 struct ConvParamsBase {

--- a/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cuh
+++ b/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cuh
@@ -19,8 +19,13 @@
  */
 
 #include <ATen/cuda/CUDAContext.h>
+#ifndef USE_ROCM
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_fp8.h>
+#include <hip/hip_runtime.h>
+#endif
 #include <torch/all.h>
 
 #include "cutlass/cutlass.h"

--- a/sgl-kernel/csrc/moe/fused_qknorm_rope_kernel.cu
+++ b/sgl-kernel/csrc/moe/fused_qknorm_rope_kernel.cu
@@ -19,10 +19,17 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_fp8.h>
+#include <hip/hip_runtime.h>
+#endif
 #include <torch/all.h>
 #include <torch/cuda.h>
 

--- a/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
+++ b/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
@@ -1,5 +1,9 @@
 #include <ATen/cuda/CUDAContext.h>
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 #include <torch/all.h>
 
 #include <cfloat>

--- a/sgl-kernel/csrc/moe/moe_fused_gate.cu
+++ b/sgl-kernel/csrc/moe/moe_fused_gate.cu
@@ -1,5 +1,9 @@
 #include <ATen/cuda/CUDAContext.h>
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 #include <cutlass/array.h>
 #include <cutlass/cutlass.h>
 #include <cutlass/numeric_types.h>

--- a/sgl-kernel/csrc/moe/moe_sum_reduce.cu
+++ b/sgl-kernel/csrc/moe/moe_sum_reduce.cu
@@ -1,9 +1,13 @@
 #include <ATen/OpMathType.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#ifndef USE_ROCM
 #include <cuda.h>
 #include <cudaTypedefs.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 #include <torch/all.h>
 
 #include <iostream>

--- a/sgl-kernel/csrc/quantization/gguf/gguf_kernel.cu
+++ b/sgl-kernel/csrc/quantization/gguf/gguf_kernel.cu
@@ -1,8 +1,13 @@
 // Adatped from
 // https://github.com/vllm-project/vllm/blob/755ed7b05be4743237d3339c4ff8c22bcaae04f4/csrc/quantization/gguf/gguf_kernel.cu
 #include <c10/cuda/CUDAGuard.h>
+#ifndef USE_ROCM
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#endif
 #include <torch/all.h>
 
 // dont use clang-format here, it breaks the include order

--- a/sgl-kernel/csrc/spatial/cuda_utils.h
+++ b/sgl-kernel/csrc/spatial/cuda_utils.h
@@ -1,5 +1,9 @@
+#ifndef USE_ROCM
 #include <cuda.h>
 #include <cuda_runtime.h>
+#else
+#include <hip/hip_runtime.h>
+#endif
 
 #include <iostream>
 

--- a/sgl-kernel/include/utils.h
+++ b/sgl-kernel/include/utils.h
@@ -16,12 +16,12 @@ limitations under the License.
 #pragma once
 
 #include <ATen/Tensor.h>
+#ifndef USE_ROCM
 #include <cuda_runtime.h>
-#include <torch/all.h>
-
-#ifdef USE_ROCM
+#else
 #include <hip/hip_runtime.h>
 #endif
+#include <torch/all.h>
 
 #ifdef USE_ROCM
 // Adapted from flashinfer-rocm [PR#491](https://github.com/flashinfer-ai/flashinfer/pull/491)


### PR DESCRIPTION
## Problem

56 source files in `sgl-kernel` and `python/sglang/jit_kernel` directly included CUDA-specific headers (`<cuda_runtime.h>`, `<cuda_bf16.h>`, `<cuda_fp16.h>`, `<cuda_fp8.h>`, `<cuda.h>`, `<cuda_runtime_api.h>`, `<cudaTypedefs.h>`) without ROCm guards, causing compilation failures on AMD GPUs (MI300X).

This prevented **speculative decoding (EAGLE)** from working on ROCm, as the draft model's JIT kernels could not compile without CUDA headers that don't exist in the ROCm environment.

## Fix

Wrap all CUDA-specific header includes with:

```cpp
#ifndef USE_ROCM
#include <cuda_runtime.h>
#include <cuda_bf16.h>
// ... other CUDA headers
#else
#include <hip/hip_runtime.h>
#include <hip/hip_bf16.h>
// ... corresponding HIP headers
#endif
```

Consecutive `#ifndef USE_ROCM` blocks for different headers in the same file are merged into a single block.

## Verification

Tested on **AMD MI300X** (gfx942, ROCm 6.4.4):

- **Model**: `zai-org/GLM-5.2-FP8`
- **Config**: `--speculative-algorithm EAGLE --speculative-num-steps 5 --speculative-eagle-topk 1 --speculative-num-draft-tokens 6`
- **Result**: Speculative decoding works correctly
  - Single-request TPS: **131.4 tok/s** (1K context), **60.7 tok/s** (640K context)
  - GSM8K accuracy: **94.77%**
  - Max tested context: **639,618 tokens** (no OOM)




<sub>✨ Presented to you with <a href="https://macaron.im/mindlab">Mind Lab</a> — A Lab for Experiential Intelligence.</sub>


































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28841782174](https://github.com/sgl-project/sglang/actions/runs/28841782174)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28841782103](https://github.com/sgl-project/sglang/actions/runs/28841782103)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->