### PR TITLE
Fix DFlash draft model crash with modelopt_mixed quantization

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -491,6 +491,9 @@ class ModelConfig:
             if is_draft_model
             else server_args.quantization
         )
+        # Convert "unquant" to None (same as main model path in server_args.py:2590)
+        if quantization == "unquant":
+            quantization = None
         override_config_file = (
             server_args.decrypted_draft_config_file
             if is_draft_model

--- a/python/sglang/srt/layers/quantization/base_config.py
+++ b/python/sglang/srt/layers/quantization/base_config.py
@@ -182,6 +182,13 @@ class QuantizationConfig(ABC):
         cls, hf_quant_config, user_quant
     ) -> Optional[str]:
         """Shared ModelOpt quantization method override logic."""
+        # If user explicitly specified a non-modelopt quantization (e.g. unquant, fp8),
+        # respect that choice and don't override.
+        # NOTE: user_quant=None means "user didn't specify" — let checkpoint detection proceed.
+        # user_quant="unquant" means "user explicitly chose no quantization" — don't override.
+        # Return None here means "don't override" — self.quantization keeps its original value.
+        if user_quant is not None and user_quant not in ("modelopt", "modelopt_mixed"):
+            return None
         if hf_quant_config is None:
             return None
 

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -612,6 +612,13 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
 
     @classmethod
     def override_quantization_method(cls, hf_quant_config, user_quant):
+        # If user explicitly specified a non-modelopt quantization (e.g. unquant, fp8),
+        # respect that choice and don't override.
+        # NOTE: user_quant=None means "user didn't specify" — let checkpoint detection proceed.
+        # user_quant="unquant" means "user explicitly chose no quantization" — don't override.
+        # Return None here means "don't override" — self.quantization keeps its original value.
+        if user_quant is not None and user_quant not in ("modelopt", "modelopt_mixed"):
+            return None
         if hf_quant_config is None:
             return None
         if hf_quant_config.get("quant_method", "") == "modelopt_mixed":

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 import torch
 
 from sglang.srt.distributed import get_tp_group
+from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -730,7 +731,12 @@ class DFlashWorkerV2(BaseSpecWorker):
                 end = min(num_tokens, start + fast_chunk_size)
                 hs = _cast_hs(hidden_states[start:end])
                 if num_org > 0:
-                    base_logits = torch.matmul(hs, weight[:num_org].T)
+                    if hasattr(lm_head, 'quant_method') and not isinstance(lm_head.quant_method, UnquantizedEmbeddingMethod):
+                        target_dtype = self.target_worker.model_runner.model_config.dtype
+                        full_logits = lm_head.quant_method.apply(lm_head, hidden_states[start:end].to(target_dtype), None)
+                        base_logits = full_logits[:, :num_org]
+                    else:
+                        base_logits = torch.matmul(hs, weight[:num_org].T)
                     local_max, local_arg = _ensure_local_reduce_buffers(
                         end - start, base_logits.dtype, hs.device
                     )
@@ -748,7 +754,12 @@ class DFlashWorkerV2(BaseSpecWorker):
 
             # Base vocab logits.
             if num_org > 0:
-                base_logits = torch.matmul(hs, weight[:num_org].T)
+                if hasattr(lm_head, 'quant_method') and not isinstance(lm_head.quant_method, UnquantizedEmbeddingMethod):
+                    target_dtype = self.target_worker.model_runner.model_config.dtype
+                    full_logits = lm_head.quant_method.apply(lm_head, hidden_states[start:end].to(target_dtype), None)
+                    base_logits = full_logits[:, :num_org]
+                else:
+                    base_logits = torch.matmul(hs, weight[:num_org].T)
                 local_max, local_arg = _ensure_local_reduce_buffers(
                     chunk_len, base_logits.dtype, hs.device
                 )

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -731,7 +731,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                 end = min(num_tokens, start + fast_chunk_size)
                 hs = _cast_hs(hidden_states[start:end])
                 if num_org > 0:
-                    if hasattr(lm_head, 'quant_method') and not isinstance(lm_head.quant_method, UnquantizedEmbeddingMethod):
+                    if hasattr(lm_head, 'quant_method') and lm_head.quant_method is not None and not isinstance(lm_head.quant_method, (UnquantizedEmbeddingMethod, UnquantizedLinearMethod)):
                         target_dtype = self.target_worker.model_runner.model_config.dtype
                         full_logits = lm_head.quant_method.apply(lm_head, hidden_states[start:end].to(target_dtype), None)
                         base_logits = full_logits[:, :num_org]

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import torch
 
 from sglang.srt.distributed import get_tp_group
-from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
+from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod, UnquantizedLinearMethod
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -754,7 +754,7 @@ class DFlashWorkerV2(BaseSpecWorker):
 
             # Base vocab logits.
             if num_org > 0:
-                if hasattr(lm_head, 'quant_method') and not isinstance(lm_head.quant_method, UnquantizedEmbeddingMethod):
+                if hasattr(lm_head, 'quant_method') and lm_head.quant_method is not None and not isinstance(lm_head.quant_method, (UnquantizedEmbeddingMethod, UnquantizedLinearMethod)):
                     target_dtype = self.target_worker.model_runner.model_config.dtype
                     full_logits = lm_head.quant_method.apply(lm_head, hidden_states[start:end].to(target_dtype), None)
                     base_logits = full_logits[:, :num_org]


### PR DESCRIPTION
This PR is built on top of PR [#30078](https://github.com/sgl-project/sglang/pull/30078) by @robbiemu.

## Problem

PR [#30078](https://github.com/sgl-project/sglang/pull/30078) (by @robbiemu) fixed `modelopt_mixed` model support in SGLang — thank you for that contribution. However, it introduced a side effect: the `--speculative-draft-model-quantization unquant` parameter no longer works, causing the draft model to inherit the main model's `modelopt_mixed` quantization.

After fixing the `unquant` parameter (config layer changes below), we discovered a bug in the DFlash worker: it reuses the main model's `lm_head` to save memory, but performs raw `torch.matmul` on the FP4-quantized weight without calling `quant_method.apply` to unpack it. Since the FP4 weight is packed 2:1 (2560 vs 5120), this causes a dimension mismatch crash at runtime.

## Fix

### Config layer — restore unquant parameter

- `base_config.py` + `modelopt_quant.py`: `override_quantization_method` returns `None` when user specifies non-modelopt quant (unquant, fp8)
- `model_config.py`: convert `"unquant"` to `None` in `from_server_args` (same as main model path in `server_args.py:2590`)

### DFlash layer — fix quantized lm_head matmul

- `dflash_worker_v2.py`: when `lm_head` has quantization, call `quant_method.apply` instead of raw `torch.matmul`
- Cast draft model output to `model_config.dtype` (bf16/fp16) before passing to `quant_method.apply` (draft outputs float32 which `fp4_quantize` rejects)
- Slice `full_logits[:, :num_org]` for vocab truncation

## Testing

Tested with `modelopt_mixed` main model + DFlash draft model. Model loads correctly, speculative decoding works, no dimension or dtype errors.

## Related

- PR [#30078](https://github.com/sgl-project/sglang/pull/30078) — Fix ModelOpt mixed-precision NVFP4 routing (by @robbiemu)





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28727984414](https://github.com/sgl-project/sglang/actions/runs/28727984414)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28727984386](https://github.com/sgl-project/sglang/actions/runs/28727984386)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->