### PR TITLE
[Apple Silicon] [CI] Move the MLX lane to the check-changes + pr-gate composite

### DIFF
--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -33,7 +33,7 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          # Ignored on pull_request; required on workflow_dispatch, which has no PR base to diff against.
+          # Ignored on pull_request; workflow_dispatch has no PR base without it.
           base: main
           filters: |
             main_package:
@@ -51,12 +51,10 @@ jobs:
     uses: ./.github/workflows/pr-gate.yml
     secrets: inherit
 
-  # ==================== Stage A ==================== #
   stage-a-unit-test-mlx:
     needs: [check-changes, pr-gate]
-    # !cancelled() lets workflow_dispatch reach this job even when pr-gate
-    # skips on the non-PR event; the pull_request path still requires pr-gate
-    # success, so the run-ci label gate stays intact.
+    # !cancelled() lets dispatch past a skipped pr-gate; the pull_request
+    # path still requires pr-gate success, keeping the run-ci gate intact.
     if: |
       !cancelled() && (
         (needs.pr-gate.result == 'success' &&
@@ -112,19 +110,18 @@ jobs:
       - name: Run model-free MLX unit tests
         timeout-minutes: 15
         run: |
-          # Intentionally explicit file list; do not replace with a directory glob.
+          # Explicit file list, intentional. Do not glob: skip guarded tests in
+          # this directory would fake green.
           uv run python -m pytest -v \
             test/registered/unit/hardware_backend/mlx/test_runner_init_contract.py \
             test/registered/unit/hardware_backend/mlx/test_metal_profiler.py \
             test/registered/unit/hardware_backend/mlx/test_attention_patching.py \
             "test/registered/unit/hardware_backend/mlx/test_quantization.py::TestMlxQuantizationOverride"
 
-  # ==================== Stage B ==================== #
   stage-b-e2e-test-mlx:
     needs: [check-changes, pr-gate]
-    # Inert until the self-hosted Apple Silicon runner registers and #29440
-    # merges; until then only a workflow_dispatch target_stage selects it.
-    # Activation later adds the change-detection terms used by stage a.
+    # Inert until a self hosted Apple Silicon runner registers and #29440
+    # merges. Activate by adding the change detection terms back to if.
     if: |
       !cancelled() && inputs.target_stage == 'stage-b-e2e-test-mlx'
     runs-on: [self-hosted, macOS, ARM64]
@@ -157,8 +154,7 @@ jobs:
           uv pip install -e "python[srt_mps]"
           uv pip install pytest
 
-      # Models: mlx-community Qwen1.5-MoE-A2.7B-Chat-4bit and Qwen3-30B-A3B-4bit;
-      # needs a warm HF cache or network, and roughly 24 GB of unified memory.
+      # Needs a warm HF cache or network and roughly 24 GB of unified memory.
       - name: Run MLX e2e smoke tests
         timeout-minutes: 90
         run: |

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -3,6 +3,13 @@ name: PR Test (MLX)
 on:
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      target_stage:
+        description: "Specific test stage to run (Optional)"
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: pr-test-mlx-${{ github.ref }}
@@ -14,7 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       changes_exist: ${{ steps.filter.outputs.main_package == 'true'
-        || steps.filter.outputs.sgl_kernel == 'true' }}
+        || steps.filter.outputs.sgl_kernel == 'true'
+        || inputs.target_stage != '' }}
       main_package: ${{ steps.filter.outputs.main_package }}
       sgl_kernel: ${{ steps.filter.outputs.sgl_kernel }}
     steps:
@@ -25,6 +33,8 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          # Ignored on pull_request; required on workflow_dispatch, which has no PR base to diff against.
+          base: main
           filters: |
             main_package:
               - "python/sglang/!(multimodal_gen)/**/!(*.md)"
@@ -41,9 +51,20 @@ jobs:
     uses: ./.github/workflows/pr-gate.yml
     secrets: inherit
 
-  mlx-unit-test:
+  # ==================== Stage A ==================== #
+  stage-a-unit-test-mlx:
     needs: [check-changes, pr-gate]
-    if: needs.check-changes.outputs.main_package == 'true' || needs.check-changes.outputs.sgl_kernel == 'true'
+    # !cancelled() lets workflow_dispatch reach this job even when pr-gate
+    # skips on the non-PR event; the pull_request path still requires pr-gate
+    # success, so the run-ci label gate stays intact.
+    if: |
+      !cancelled() && (
+        (needs.pr-gate.result == 'success' &&
+          (needs.check-changes.outputs.main_package == 'true' ||
+           needs.check-changes.outputs.sgl_kernel == 'true')) ||
+        (github.event_name == 'workflow_dispatch' &&
+         inputs.target_stage == 'stage-a-unit-test-mlx')
+      )
     runs-on: macos-26
     timeout-minutes: 60
     env:
@@ -91,6 +112,7 @@ jobs:
       - name: Run model-free MLX unit tests
         timeout-minutes: 15
         run: |
+          # Intentionally explicit file list; do not replace with a directory glob.
           uv run python -m pytest -v \
             test/registered/unit/hardware_backend/mlx/test_runner_init_contract.py \
             test/registered/unit/hardware_backend/mlx/test_metal_profiler.py \
@@ -98,16 +120,25 @@ jobs:
             "test/registered/unit/hardware_backend/mlx/test_quantization.py::TestMlxQuantizationOverride"
 
   pr-test-mlx-finish:
-    needs: [mlx-unit-test]
+    needs:
+      [
+        pr-gate,
+        check-changes,
+        stage-a-unit-test-mlx,
+      ]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check dependent job status
+      - name: Check all dependent job statuses
         run: |
-          result="${{ needs.mlx-unit-test.result }}"
-          echo "mlx-unit-test: $result"
-          if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
-            echo "The MLX unit-test job failed."
-            exit 1
-          fi
+          json_needs='${{ toJson(needs) }}'
+          job_names=$(echo "$json_needs" | jq -r 'keys_unsorted[]')
+          for job in $job_names; do
+            result=$(echo "$json_needs" | jq -r --arg j "$job" '.[$j].result')
+            echo "$job: $result"
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "The above jobs failed."
+              exit 1
+            fi
+          done
           echo "All jobs completed successfully"

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -100,8 +100,7 @@ jobs:
           rm -f python/pyproject.toml
           mv python/pyproject_other.toml python/pyproject.toml
           uv venv
-          uv pip install -e "python[srt_mps]"
-          uv pip install pytest
+          uv pip install -e "python[srt_mps,test]"
 
       - name: Report MLX / torch versions
         run: |
@@ -115,8 +114,7 @@ jobs:
 
   stage-b-e2e-test-mlx:
     needs: [check-changes, pr-gate]
-    # Inert until a self hosted Apple Silicon runner registers and #29440
-    # merges. Activate by adding the change detection terms back to if.
+    # Manual-only: no self hosted Apple Silicon runner is generally available; hosted runners are too small for e2e.
     if: |
       !cancelled() && inputs.target_stage == 'stage-b-e2e-test-mlx'
     runs-on: [self-hosted, macOS, ARM64]
@@ -146,8 +144,7 @@ jobs:
           rm -f python/pyproject.toml
           mv python/pyproject_other.toml python/pyproject.toml
           uv venv --python 3.11
-          uv pip install -e "python[srt_mps]"
-          uv pip install pytest
+          uv pip install -e "python[srt_mps,test]"
 
       # Needs a warm HF cache or network and roughly 24 GB of unified memory.
       - name: Run MLX e2e smoke tests

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -13,7 +13,10 @@ jobs:
   check-changes:
     runs-on: ubuntu-latest
     outputs:
+      changes_exist: ${{ steps.filter.outputs.main_package == 'true'
+        || steps.filter.outputs.sgl_kernel == 'true' }}
       main_package: ${{ steps.filter.outputs.main_package }}
+      sgl_kernel: ${{ steps.filter.outputs.sgl_kernel }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,19 +30,20 @@ jobs:
               - "python/sglang/!(multimodal_gen)/**/!(*.md)"
               - "python/pyproject_other.toml"
               - "test/**/!(*.md)"
-              - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
               - ".github/workflows/pr-test-mlx.yml"
+            sgl_kernel:
+              - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
 
   # ==================== PR Gate ==================== #
   pr-gate:
     needs: check-changes
-    if: needs.check-changes.outputs.main_package == 'true'
+    if: needs.check-changes.outputs.changes_exist == 'true'
     uses: ./.github/workflows/pr-gate.yml
     secrets: inherit
 
   mlx-unit-test:
     needs: [check-changes, pr-gate]
-    if: needs.check-changes.outputs.main_package == 'true'
+    if: needs.check-changes.outputs.main_package == 'true' || needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: macos-26
     timeout-minutes: 60
     env:

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -110,13 +110,7 @@ jobs:
       - name: Run model-free MLX unit tests
         timeout-minutes: 15
         run: |
-          # Explicit file list, intentional. Do not glob: skip guarded tests in
-          # this directory would fake green.
-          uv run python -m pytest -v \
-            test/registered/unit/hardware_backend/mlx/test_runner_init_contract.py \
-            test/registered/unit/hardware_backend/mlx/test_metal_profiler.py \
-            test/registered/unit/hardware_backend/mlx/test_attention_patching.py \
-            "test/registered/unit/hardware_backend/mlx/test_quantization.py::TestMlxQuantizationOverride"
+          uv run python test/run_suite.py --hw mlx --suite stage-a-unit-test-mlx
 
   stage-b-e2e-test-mlx:
     needs: [check-changes, pr-gate]

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -43,6 +43,7 @@ jobs:
               - ".github/workflows/pr-test-mlx.yml"
             sgl_kernel:
               - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
+              - ".github/workflows/pr-test-mlx.yml"
 
   # ==================== PR Gate ==================== #
   pr-gate:
@@ -152,10 +153,7 @@ jobs:
       - name: Run MLX e2e smoke tests
         timeout-minutes: 90
         run: |
-          uv run python -m pytest -v \
-            test/registered/mlx/models_e2e/test_qwen2_moe_mlx_correctness.py \
-            test/registered/mlx/models_e2e/test_qwen3_moe_mlx_correctness.py \
-            test/registered/unit/hardware_backend/mlx/test_mlx_reference_correctness.py
+          uv run python test/run_suite.py --hw mlx --suite stage-b-e2e-mlx
 
   pr-test-mlx-finish:
     needs:

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -5,11 +5,17 @@ on:
     branches: [ main ]
   workflow_dispatch:
     inputs:
+      # target_stage is the job id (e.g. stage-b-e2e-test-mlx), distinct from
+      # the run_suite.py suite name it dispatches (e.g. stage-b-e2e-mlx).
       target_stage:
-        description: "Specific test stage to run (Optional)"
+        description: "Select a stage to run from dropdown (leave empty for auto-detect)"
         required: false
-        type: string
-        default: ""
+        type: choice
+        default: ''
+        options:
+          - ''
+          - stage-a-unit-test-mlx
+          - stage-b-e2e-test-mlx
 
 concurrency:
   group: pr-test-mlx-${{ github.ref }}

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -3,32 +3,50 @@ name: PR Test (MLX)
 on:
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: pr-test-mlx-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
+  # ==================== Check Changes ==================== #
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      main_package: ${{ steps.filter.outputs.main_package }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect file changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            main_package:
+              - "python/sglang/!(multimodal_gen)/**/!(*.md)"
+              - "python/pyproject_other.toml"
+              - "test/**/!(*.md)"
+              - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
+              - ".github/workflows/pr-test-mlx.yml"
+
+  # ==================== PR Gate ==================== #
+  pr-gate:
+    needs: check-changes
+    if: needs.check-changes.outputs.main_package == 'true'
+    uses: ./.github/workflows/pr-gate.yml
+    secrets: inherit
+
   mlx-unit-test:
-    # Label-gated on 'apple-silicon', reusing the repo's run-ci label-gate mechanism
-    # (pr-test-rust.yml). The gate keys on the PR's current label set, so any
-    # event on a labeled PR re-runs the tests and a later unrelated label can't
-    # mask a prior result. The non-pull_request clause covers push / dispatch.
-    if: |
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'apple-silicon')
+    needs: [check-changes, pr-gate]
+    if: needs.check-changes.outputs.main_package == 'true'
     runs-on: macos-26
     timeout-minutes: 60
     env:
       SGLANG_IS_IN_CI: true
-      # use_mlx() needs this var (and mlx importable); without it the profiler
-      # takes the MPS branch and the MLX capture path goes untested.
+      # use_mlx() needs this; without it the profiler takes the MPS branch.
       SGLANG_USE_MLX: 1
-      # Forbid HF downloads so the model-free guarantee is enforced, not assumed.
+      # Forbid HF downloads to enforce the model-free guarantee.
       HF_HUB_OFFLINE: 1
     steps:
       - name: Checkout code
@@ -54,9 +72,7 @@ jobs:
         timeout-minutes: 30
         run: |
           test -f python/pyproject_other.toml || { echo "alt pyproject_other.toml missing"; exit 1; }
-          # Swap in the Apple Silicon project metadata, then install the srt_mps
-          # extra (mlx, mlx-lm, runtime_common, torch) into an isolated uv venv.
-          # The all_mps diffusion chain is not needed here.
+          # Swap in the Apple Silicon pyproject; srt_mps skips the all_mps diffusion chain.
           rm -f python/pyproject.toml
           mv python/pyproject_other.toml python/pyproject.toml
           uv venv
@@ -71,10 +87,6 @@ jobs:
       - name: Run model-free MLX unit tests
         timeout-minutes: 15
         run: |
-          # Model-free MLX unit tests via pytest, like MUSA's unit-test jobs
-          # (its model and server suites use run_suite.py). None load a model:
-          # signature contracts, mocked Metal capture, dummy ServerArgs patching,
-          # and quant-config dicts.
           uv run python -m pytest -v \
             test/registered/unit/hardware_backend/mlx/test_runner_init_contract.py \
             test/registered/unit/hardware_backend/mlx/test_metal_profiler.py \

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -119,12 +119,61 @@ jobs:
             test/registered/unit/hardware_backend/mlx/test_attention_patching.py \
             "test/registered/unit/hardware_backend/mlx/test_quantization.py::TestMlxQuantizationOverride"
 
+  # ==================== Stage B ==================== #
+  stage-b-e2e-test-mlx:
+    needs: [check-changes, pr-gate]
+    # Inert until the self-hosted Apple Silicon runner registers and #29440
+    # merges; until then only a workflow_dispatch target_stage selects it.
+    # Activation later adds the change-detection terms used by stage a.
+    if: |
+      !cancelled() && inputs.target_stage == 'stage-b-e2e-test-mlx'
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 120
+    env:
+      SGLANG_IS_IN_CI: true
+      SGLANG_USE_MLX: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'python/pyproject_other.toml'
+
+      - name: Verify Apple Silicon runner
+        run: |
+          echo "uname -m: $(uname -m)"
+          python3 -c "import platform; assert platform.machine()=='arm64', platform.machine(); print('machine:', platform.machine(), 'system:', platform.system())"
+
+      - name: Install dependencies (MLX / srt_mps extra)
+        timeout-minutes: 30
+        run: |
+          test -f python/pyproject_other.toml || { echo "alt pyproject_other.toml missing"; exit 1; }
+          rm -f python/pyproject.toml
+          mv python/pyproject_other.toml python/pyproject.toml
+          uv venv --python 3.11
+          uv pip install -e "python[srt_mps]"
+          uv pip install pytest
+
+      # Models: mlx-community Qwen1.5-MoE-A2.7B-Chat-4bit and Qwen3-30B-A3B-4bit;
+      # needs a warm HF cache or network, and roughly 24 GB of unified memory.
+      - name: Run MLX e2e smoke tests
+        timeout-minutes: 90
+        run: |
+          uv run python -m pytest -v \
+            test/registered/mlx/models_e2e/test_qwen2_moe_mlx_correctness.py \
+            test/registered/mlx/models_e2e/test_qwen3_moe_mlx_correctness.py \
+            test/registered/unit/hardware_backend/mlx/test_mlx_reference_correctness.py
+
   pr-test-mlx-finish:
     needs:
       [
         pr-gate,
         check-changes,
         stage-a-unit-test-mlx,
+        stage-b-e2e-test-mlx,
       ]
     if: always()
     runs-on: ubuntu-latest

--- a/python/sglang/test/ci/ci_register.py
+++ b/python/sglang/test/ci/ci_register.py
@@ -16,6 +16,7 @@ __all__ = [
     "register_npu_ci",
     "register_xpu_ci",
     "register_musa_ci",
+    "register_mlx_ci",
     "ut_parse_one_file",
 ]
 
@@ -35,6 +36,7 @@ class HWBackend(Enum):
     NPU = auto()
     XPU = auto()
     MUSA = auto()
+    MLX = auto()
 
 
 @dataclass
@@ -148,6 +150,19 @@ def register_musa_ci(
     return None
 
 
+def register_mlx_ci(
+    est_time: float,
+    suite: Optional[str] = None,
+    nightly: bool = False,
+    disabled: Optional[str] = None,
+    *,
+    stage: Optional[str] = None,
+    runner_config: Optional[str] = None,
+):
+    """Marker for MLX CI registration (parsed via AST; runtime no-op)."""
+    return None
+
+
 REGISTER_MAPPING = {
     "register_cpu_ci": HWBackend.CPU,
     "register_cuda_ci": HWBackend.CUDA,
@@ -156,6 +171,7 @@ REGISTER_MAPPING = {
     "register_npu_ci": HWBackend.NPU,
     "register_xpu_ci": HWBackend.XPU,
     "register_musa_ci": HWBackend.MUSA,
+    "register_mlx_ci": HWBackend.MLX,
 }
 
 

--- a/test/registered/mlx/models_e2e/test_qwen2_moe_mlx_correctness.py
+++ b/test/registered/mlx/models_e2e/test_qwen2_moe_mlx_correctness.py
@@ -5,7 +5,7 @@ import unittest
 import requests
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -15,9 +15,10 @@ from sglang.test.test_utils import (
 )
 
 # Registered on the CPU suite but skipped wherever mlx is absent; runs for real
-# only on Apple Silicon. The macOS CI lane (pr-test-mlx.yml) is model-free, so
-# this serving test is not wired into it and still runs only locally.
+# only on Apple Silicon. Also registered under stage-b-e2e-mlx, which the
+# macOS CI lane (pr-test-mlx.yml) only dispatches via a gated workflow_dispatch.
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-b-e2e-mlx")
 
 _HAS_MLX = importlib.util.find_spec("mlx") is not None
 

--- a/test/registered/mlx/models_e2e/test_qwen3_moe_mlx_correctness.py
+++ b/test/registered/mlx/models_e2e/test_qwen3_moe_mlx_correctness.py
@@ -5,7 +5,7 @@ import unittest
 import requests
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -15,9 +15,10 @@ from sglang.test.test_utils import (
 )
 
 # Registered on the CPU suite but skipped wherever mlx is absent; runs for real
-# only on Apple Silicon. The macOS CI lane (pr-test-mlx.yml) is model-free, so
-# this serving test is not wired into it and still runs only locally.
+# only on Apple Silicon. Also registered under stage-b-e2e-mlx, which the
+# macOS CI lane (pr-test-mlx.yml) only dispatches via a gated workflow_dispatch.
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-b-e2e-mlx")
 
 _HAS_MLX = importlib.util.find_spec("mlx") is not None
 

--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -7,9 +7,10 @@ import unittest
 from collections import deque
 from types import SimpleNamespace
 
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
 
 _HAS_MLX = importlib.util.find_spec("mlx") is not None
 _SKIP_REASON = "requires mlx"

--- a/test/registered/unit/hardware_backend/mlx/test_metal_profiler.py
+++ b/test/registered/unit/hardware_backend/mlx/test_metal_profiler.py
@@ -20,9 +20,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_mlx_ci(est_time=5, suite="stage-a-unit-test-mlx")
 
 _IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm64"
 _HAS_MLX = importlib.util.find_spec("mlx") is not None

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_pool_dtype.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_pool_dtype.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 import importlib.util
 import unittest
 
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+register_mlx_ci(est_time=4, suite="stage-a-unit-test-mlx")
 
 _HAS_MLX = (
     importlib.util.find_spec("mlx") is not None

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_quantization_override.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_quantization_override.py
@@ -1,0 +1,106 @@
+"""Unit tests for ``MlxQuantizationConfig.override_quantization_method``.
+
+The override is a classmethod over a dict; no mlx / Apple Silicon dependency.
+Runs on every CI platform and guards #25119 from regression.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from sglang.srt.layers.quantization.mlx import MlxQuantizationConfig
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+
+class TestMlxQuantizationOverride(unittest.TestCase):
+    """Pure-logic tests for ``MlxQuantizationConfig.override_quantization_method``.
+
+    The override is a classmethod over a dict; no mlx / Apple Silicon
+    dependency. Runs on every CI platform and guards #25119 from regression.
+    """
+
+    def test_mlx_q4_dict_config_autodetect(self):
+        """Bare {group_size, bits=4} dict maps to mlx_q4."""
+        result = MlxQuantizationConfig.override_quantization_method(
+            {"group_size": 64, "bits": 4}, None
+        )
+        self.assertEqual(result, "mlx_q4")
+
+    def test_mlx_q8_dict_config_autodetect(self):
+        """Bare {group_size, bits=8} dict maps to mlx_q8."""
+        result = MlxQuantizationConfig.override_quantization_method(
+            {"group_size": 32, "bits": 8}, None
+        )
+        self.assertEqual(result, "mlx_q8")
+
+    def test_non_mlx_dict_not_matched(self):
+        """Dicts with an explicit quant_method belong to that method, not ours."""
+        # modelopt-style: explicit quant_method takes priority.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"quant_method": "modelopt", "bits": 4, "group_size": 64}, None
+            )
+        )
+        # gptq-style: same.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"quant_method": "gptq", "bits": 4, "group_size": 128}, None
+            )
+        )
+
+    def test_non_dict_not_matched(self):
+        """Non-dict inputs and malformed dicts return None."""
+        # None / string inputs.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(None, None)
+        )
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method("mlx_q4", None)
+        )
+        # Missing keys.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method({"bits": 4}, None)
+        )
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method({"group_size": 64}, None)
+        )
+        # Non-integer values.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"bits": "4", "group_size": 64}, None
+            )
+        )
+        # Unsupported bit-width.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"bits": 2, "group_size": 64}, None
+            )
+        )
+
+    def test_user_quant_explicit_defers_to_user(self):
+        """When the user passes --quantization explicitly, defer to that choice."""
+        # User chose mlx_q8 explicitly, even though config dict shape suggests q4
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"group_size": 64, "bits": 4}, "mlx_q8"
+            )
+        )
+        # User chose mlx_q4 explicitly with matching config
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"group_size": 64, "bits": 4}, "mlx_q4"
+            )
+        )
+        # User chose something completely different
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"group_size": 64, "bits": 4}, "fp8"
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_reference_correctness.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_reference_correctness.py
@@ -40,10 +40,11 @@ import importlib.util
 import os
 import unittest
 
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-b-e2e-mlx")
 
 _HAS_MLX = (
     importlib.util.find_spec("mlx") is not None

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_runner_pool_contract.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_runner_pool_contract.py
@@ -16,9 +16,10 @@ import importlib.util
 import inspect
 import unittest
 
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
 
 _HAS_MLX = importlib.util.find_spec("mlx") is not None
 _SKIP_REASON = "requires mlx"

--- a/test/registered/unit/hardware_backend/mlx/test_quantization.py
+++ b/test/registered/unit/hardware_backend/mlx/test_quantization.py
@@ -17,7 +17,6 @@ import importlib.util
 import platform
 import unittest
 
-from sglang.srt.layers.quantization.mlx import MlxQuantizationConfig
 from sglang.test.ci.ci_register import register_cpu_ci
 
 # Registered with the CPU suite (runtime no-op marker, parsed via AST).
@@ -185,93 +184,6 @@ class TestMlxQuantization(unittest.TestCase):
         finally:
             del runner
             self._reset_mlx_memory()
-
-
-class TestMlxQuantizationOverride(unittest.TestCase):
-    """Pure-logic tests for ``MlxQuantizationConfig.override_quantization_method``.
-
-    The override is a classmethod over a dict; no mlx / Apple Silicon
-    dependency. Runs on every CI platform and guards #25119 from regression.
-    """
-
-    def test_mlx_q4_dict_config_autodetect(self):
-        """Bare {group_size, bits=4} dict maps to mlx_q4."""
-        result = MlxQuantizationConfig.override_quantization_method(
-            {"group_size": 64, "bits": 4}, None
-        )
-        self.assertEqual(result, "mlx_q4")
-
-    def test_mlx_q8_dict_config_autodetect(self):
-        """Bare {group_size, bits=8} dict maps to mlx_q8."""
-        result = MlxQuantizationConfig.override_quantization_method(
-            {"group_size": 32, "bits": 8}, None
-        )
-        self.assertEqual(result, "mlx_q8")
-
-    def test_non_mlx_dict_not_matched(self):
-        """Dicts with an explicit quant_method belong to that method, not ours."""
-        # modelopt-style: explicit quant_method takes priority.
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method(
-                {"quant_method": "modelopt", "bits": 4, "group_size": 64}, None
-            )
-        )
-        # gptq-style: same.
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method(
-                {"quant_method": "gptq", "bits": 4, "group_size": 128}, None
-            )
-        )
-
-    def test_non_dict_not_matched(self):
-        """Non-dict inputs and malformed dicts return None."""
-        # None / string inputs.
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method(None, None)
-        )
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method("mlx_q4", None)
-        )
-        # Missing keys.
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method({"bits": 4}, None)
-        )
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method({"group_size": 64}, None)
-        )
-        # Non-integer values.
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method(
-                {"bits": "4", "group_size": 64}, None
-            )
-        )
-        # Unsupported bit-width.
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method(
-                {"bits": 2, "group_size": 64}, None
-            )
-        )
-
-    def test_user_quant_explicit_defers_to_user(self):
-        """When the user passes --quantization explicitly, defer to that choice."""
-        # User chose mlx_q8 explicitly, even though config dict shape suggests q4
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method(
-                {"group_size": 64, "bits": 4}, "mlx_q8"
-            )
-        )
-        # User chose mlx_q4 explicitly with matching config
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method(
-                {"group_size": 64, "bits": 4}, "mlx_q4"
-            )
-        )
-        # User chose something completely different
-        self.assertIsNone(
-            MlxQuantizationConfig.override_quantization_method(
-                {"group_size": 64, "bits": 4}, "fp8"
-            )
-        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/hardware_backend/mlx/test_quantization.py
+++ b/test/registered/unit/hardware_backend/mlx/test_quantization.py
@@ -17,13 +17,18 @@ import importlib.util
 import platform
 import unittest
 
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 
-# Registered with the CPU suite (runtime no-op marker, parsed via AST).
-# On non-Apple-Silicon CI runners the entire TestCase class skips via the
-# @skipUnless guard below, so this registration is the harmless "yes this
-# test exists" signal the registry requires.
+# Registered on the CPU suite but skipped wherever mlx is absent; runs for real
+# only on Apple Silicon. Also registered under stage-b-e2e-mlx, not stage-a:
+# this class loads real HF models (Qwen/Qwen3-0.6B, mlx-community/Qwen3-0.6B-4bit)
+# via MlxModelRunner, and stage-a's job env sets HF_HUB_OFFLINE=1 to enforce a
+# model-free guarantee (.github/workflows/pr-test-mlx.yml) -- confirmed this
+# fails with LocalEntryNotFoundError on a runner with no pre-warmed cache. The
+# macOS CI lane (pr-test-mlx.yml) only dispatches stage-b-e2e-mlx via a gated
+# workflow_dispatch, matching the models_e2e correctness tests' convention.
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_mlx_ci(est_time=10, suite="stage-b-e2e-mlx")
 
 _IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm64"
 _HAS_MLX = (

--- a/test/registered/unit/hardware_backend/mlx/test_runner_init_contract.py
+++ b/test/registered/unit/hardware_backend/mlx/test_runner_init_contract.py
@@ -11,9 +11,10 @@ import importlib.util
 import inspect
 import unittest
 
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
 
 _HAS_MLX = importlib.util.find_spec("mlx") is not None
 _SKIP_REASON = "requires mlx"

--- a/test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py
+++ b/test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py
@@ -18,9 +18,10 @@ import platform
 import unittest
 from unittest.mock import MagicMock
 
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_mlx_ci(est_time=5, suite="stage-a-unit-test-mlx")
 
 _IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm64"
 _HAS_MLX = importlib.util.find_spec("mlx") is not None

--- a/test/registered/unit/hardware_backend/mlx/test_tp_worker_routing.py
+++ b/test/registered/unit/hardware_backend/mlx/test_tp_worker_routing.py
@@ -35,11 +35,13 @@ from types import SimpleNamespace
 import torch
 
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 
-# AST-parsed "this test exists" marker; actual execution is gated by the
-# @skipUnless guard below (mirrors test_quantization.py in this directory).
+# CPU marker is AST-parsed "this test exists"; actual CPU-side execution is
+# gated by the @skipUnless guard below. MLX marker runs for real on the MLX
+# lane's stage-a (model-free: mocks the runner, loads no model).
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_mlx_ci(est_time=10, suite="stage-a-unit-test-mlx")
 
 _IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm64"
 _HAS_MLX = importlib.util.find_spec("mlx") is not None

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -22,6 +22,7 @@ HW_MAPPING = {
     "musa": HWBackend.MUSA,
     "npu": HWBackend.NPU,
     "xpu": HWBackend.XPU,
+    "mlx": HWBackend.MLX,
 }
 
 # Per-commit test suites (run on every PR).
@@ -104,6 +105,9 @@ PER_COMMIT_SUITES = {
     HWBackend.XPU: [
         "stage-a-test-1-gpu-xpu",
         "stage-b-test-1-gpu-xpu",
+    ],
+    HWBackend.MLX: [
+        "stage-a-unit-test-mlx",
     ],
 }
 
@@ -193,6 +197,7 @@ _SUITE_CHECKED_BACKENDS = {
     HWBackend.CPU,
     HWBackend.MUSA,
     HWBackend.XPU,
+    HWBackend.MLX,
 }
 
 

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -108,6 +108,7 @@ PER_COMMIT_SUITES = {
     ],
     HWBackend.MLX: [
         "stage-a-unit-test-mlx",
+        "stage-b-e2e-mlx",
     ],
 }
 


### PR DESCRIPTION
## Motivation

#29691 landed the MLX lane (`pr-test-mlx.yml`) with standalone gating. This PR began as a migration to the shared check-changes plus pr-gate composite used by the other hardware lanes. Implementations include: a separate `sgl_kernel` filter output following `_pr-test-check-changes.yml`, and a staged layout aligned with the other backends, wired for the smoke tests from #29440. All three are in this PR, so it is a gate migration plus a staged restructure. Per @yeahdongcn's review, the scope is inclusive of moving stage A onto `run_suite.py` suite registration, matching how every other hardware lane selects its tests instead of an explicit file list.

## Modifications

Gate migration

- A dorny/paths-filter `check-changes` job plus the reusable `pr-gate` workflow replace the inline label gate. `pr-gate` live fetches labels at runtime, so adding `run-ci` and rerunning failed jobs restores the suite. The old frozen
  payload gate never could.
- The workflow level permissions block is removed; it zeroed the `pull-requests` and `actions` scopes the paths filter and the gate API reads require. The vendor lanes running this same chain declare no block.

Filter split

- `main_package` and `sgl_kernel` are separate filter outputs, following `_pr-test-check-changes.yml`; the `sgl_kernel` glob is copied verbatim from that file. `pr-gate` keys off a `changes_exist` aggregate, matching the MUSA and NPU lanes.
- Stage A gates on `main_package` or `sgl_kernel`, matching the base stages of `pr-test.yml`, so the trigger surface is unchanged from the single key filter.

Staged layout and #29440 wiring

- `mlx-unit-test` becomes `stage-a-unit-test-mlx`. Invocation, env, and runner are unchanged: model free unit tests, `HF_HUB_OFFLINE=1`, GitHub hosted `macos-26`.
- A new `stage-b-e2e-test-mlx` job is defined for the #29440 smoke tests: served correctness for qwen2_moe and qwen3_moe plus the reference equivalence test. Those tests load 8 GB to 17 GB models and are tuned for 24 GB of unified memory; GitHub hosted `macos-26` runners have 7 GB. Stage B therefore activates only through a `workflow_dispatch` `target_stage` input until a self hosted Apple Silicon runner registers. The mechanism is copied from the MUSA lane, with two corrections to make dispatch functional. Stage B currently has no scheduled execution; it fires only via the constrained dispatch input, pending the self hosted runner.
- `workflow_dispatch` with a `target_stage` input is added for per stage dispatch; the input is a constrained `type: choice` following the AMD lane (a free text field, per the MUSA original, silently no-ops on a typo).
- The finish job adopts the MUSA pattern: iterate over `needs`, fail on failure or cancellation, tolerate skipped.

Test registration

- Stage A now runs via `python3 run_suite.py --hw mlx --suite stage-a-unit-test-mlx` instead of an explicit pytest file list, matching how the XPU lane invokes `run_suite.py`. This adds `HWBackend.MLX` and `register_mlx_ci()` to the shared `ci_register.py`, plus a `stage-a-unit-test-mlx` entry in `run_suite.py`'s per-commit suites.
- `test_quantization.py` mixed a model-free class (`TestMlxQuantizationOverride`, previously cherry-picked via `pytest ::ClassName`) with a model-downloading class (`TestMlxQuantization`) in one file. `run_suite.py` only runs whole files, so `TestMlxQuantizationOverride` moves to its own file, `test_mlx_quantization_override.py`, registered for both `base-a-test-cpu` and the new MLX suite. `test_quantization.py` keeps only the model-dependent class, now registered under `stage-b-e2e-mlx` (it performs real HF loads, so it belongs with the gated model requiring suite rather than stage-a).
- Test registration is now structural: a new model-free MLX unit test file registers itself with `register_mlx_ci(...)`, the same pattern every other backend uses, instead of a line in the workflow's explicit list.
- A review pass surfaced three MLX test files whose assertions had never executed in any CI configuration (CPU registered with MLX skip guards: skipped on Linux, invisible to the MLX suite). `test_mlx_pool_dtype.py` and `test_tp_worker_routing.py` now run in stage-a (verified green under the lane's exact env locally); `test_quantization.py` reclassified to stage B as above.

Dependencies and deferrals

- #29440 has been merged, the referenced files exist on main, and the stage now awaits only the self-hosted runner.
- Shares the `register_mlx_ci` marker with #29804 (byte identical `ci_register.py` addition; merges cleanly in either order).

## Accuracy Tests

CI only change; no model or kernel behavior affected. The `FakeOverlapScheduler` stub desync from #29217 (AttributeError on `forward_ct`) is fixed on main via #30125, and stage A is expected green against the merge commit.

## Speed Tests and Profiling

N/A.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28996751813](https://github.com/sgl-project/sglang/actions/runs/28996751813)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28996751681](https://github.com/sgl-project/sglang/actions/runs/28996751681)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

