### PR TITLE
[rope] Fix OOB cos/sin loads in fused MRoPE triton kernel for interleaved + partial rotary

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/triton_kernels.py
+++ b/python/sglang/srt/layers/rotary_embedding/triton_kernels.py
@@ -47,16 +47,28 @@ def _triton_mrope_forward_fused(
     h_sin = h_cos + half_rd
     w_sin = w_cos + half_rd
     cos_offsets = tl.arange(0, pad_hd // 2)
+    # When head_size > rotary_dim (pad_hd // 2 > half_rd), offsets beyond
+    # half_rd must be masked out of every cos/sin load; otherwise the loads
+    # read past the end of cos_sin_cache (IMA for positions near max_position).
+    rd_mask = cos_offsets < half_rd
     if is_interleaved:
         if is_interleaved_glm:
-            axes = tl.load(axis_map_ptr + cos_offsets, mask=cos_offsets < (pad_hd // 2))
+            axes = tl.load(axis_map_ptr + cos_offsets, mask=rd_mask, other=-1)
             t_mask = axes == 0
             h_mask = axes == 1
             w_mask = axes == 2
         else:
-            h_mask = ((cos_offsets % 3) == 1) & (cos_offsets <= 3 * mrope_section_h)
-            w_mask = ((cos_offsets % 3) == 2) & (cos_offsets <= 3 * mrope_section_w)
-            t_mask = ~(h_mask | w_mask)
+            h_mask = (
+                ((cos_offsets % 3) == 1)
+                & (cos_offsets <= 3 * mrope_section_h)
+                & rd_mask
+            )
+            w_mask = (
+                ((cos_offsets % 3) == 2)
+                & (cos_offsets <= 3 * mrope_section_w)
+                & rd_mask
+            )
+            t_mask = ~(h_mask | w_mask) & rd_mask
     else:
         t_end = mrope_section_t
         h_end = t_end + mrope_section_h

--- a/test/registered/rotary/test_mrope_interleaved_partial.py
+++ b/test/registered/rotary/test_mrope_interleaved_partial.py
@@ -1,0 +1,133 @@
+"""Numerics + bounds regression tests for the fused MRoPE triton kernel.
+
+Regression context: with ``mrope_interleaved=True`` and ``head_size >
+rotary_dim`` (e.g. Qwen3.5: head_dim=256, partial_rotary_factor=0.25 ->
+rotary_dim=64), the interleaved masks (``t_mask``/``h_mask``/``w_mask``) were
+not bounded by ``half_rd``, so lanes in ``[half_rd, pad_hd // 2)`` issued
+cos/sin loads past the end of ``cos_sin_cache`` — an out-of-bounds read (IMA
+risk) for positions near ``max_position``. Verified with compute-sanitizer:
+
+    PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck \
+        python -m pytest test/registered/rotary/test_mrope_interleaved_partial.py
+
+The tests below pin the triton kernel against ``forward_native`` for the
+interleaved / non-interleaved / GLM layouts at max-position boundaries, so the
+added ``rd_mask`` bound cannot silently change numerics.
+
+Usage:
+    python -m pytest test/registered/rotary/test_mrope_interleaved_partial.py -v
+"""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.rotary_embedding.mrope import MRotaryEmbedding
+
+torch.manual_seed(0)
+
+# (head_size, partial_rotary_factor, mrope_section, interleaved, glm)
+_CASES = [
+    # Qwen3.5: head 256, rotary 64, interleaved
+    (256, 0.25, [11, 11, 10], True, False),
+    # Qwen3-VL-style: full rotary, interleaved
+    (128, 1.0, [24, 20, 20], True, False),
+    # Qwen2-VL-style: full rotary, sectioned (non-interleaved)
+    (128, 1.0, [16, 24, 24], False, False),
+    # GLM-V-style: interleaved via axis_map
+    (128, 1.0, [8, 12, 12], True, True),
+    # partial rotary + non-interleaved
+    (256, 0.5, [22, 21, 21], False, False),
+]
+
+_MAX_POS = 2048
+_NUM_TOKENS = 16
+_N_QH, _N_KH = 4, 2
+
+
+def _build_rope(head_size, partial, section, interleaved, glm):
+    rope_scaling = {
+        "rope_type": "default",
+        "mrope_section": section,
+        "mrope_interleaved": interleaved,
+    }
+    if glm:
+        rope_scaling["mrope_interleaved_glm"] = True
+    rope = get_rope(
+        head_size=head_size,
+        rotary_dim=head_size,
+        max_position=_MAX_POS,
+        base=10000000,
+        is_neox_style=True,
+        rope_scaling=rope_scaling,
+        dtype=torch.bfloat16,
+        partial_rotary_factor=partial,
+    )
+    assert isinstance(rope, MRotaryEmbedding), type(rope)
+    return rope
+
+
+class TestMRopeTritonVsNative(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA required")
+        cls.device = "cuda:0"
+
+    def _run_case(self, head_size, partial, section, interleaved, glm, positions):
+        rope = _build_rope(head_size, partial, section, interleaved, glm).to(
+            self.device
+        )
+        rope.cos_sin_cache = rope.cos_sin_cache.to(self.device, dtype=torch.bfloat16)
+        if rope.axis_map is not None:
+            rope.axis_map = rope.axis_map.to(self.device)
+
+        q = torch.randn(
+            _NUM_TOKENS, _N_QH * head_size, dtype=torch.bfloat16, device=self.device
+        )
+        k = torch.randn(
+            _NUM_TOKENS, _N_KH * head_size, dtype=torch.bfloat16, device=self.device
+        )
+
+        q_ref, k_ref = rope.forward_native(positions, q.clone(), k.clone())
+        q_tri, k_tri = rope.forward_triton(positions, q.clone(), k.clone())
+        torch.cuda.synchronize()
+
+        # bf16 rotate-add tolerance
+        torch.testing.assert_close(q_tri, q_ref, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(k_tri, k_ref, atol=2e-2, rtol=2e-2)
+
+    def test_random_positions(self):
+        for case in _CASES:
+            with self.subTest(case=case):
+                positions = torch.randint(
+                    0, _MAX_POS, (3, _NUM_TOKENS), device=self.device
+                )
+                self._run_case(*case, positions)
+
+    def test_boundary_positions(self):
+        """Positions at max_position - 1: the pre-fix interleaved kernel read
+        past cos_sin_cache here (caught by compute-sanitizer)."""
+        for case in _CASES:
+            with self.subTest(case=case):
+                positions = torch.full(
+                    (3, _NUM_TOKENS),
+                    _MAX_POS - 1,
+                    dtype=torch.int64,
+                    device=self.device,
+                )
+                self._run_case(*case, positions)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Running Qwen3.5 (`head_dim=256`, `partial_rotary_factor=0.25` -> `rotary_dim=64`, `mrope_interleaved=True`) under compute-sanitizer reports out-of-bounds reads in the fused MRoPE triton kernel:

```
========= Invalid __global__ read of size 2 bytes
=========     at _triton_mrope_forward_fused+0x320 in triton_kernels.py:66
```

Root cause: in `_triton_mrope_forward_fused`, the interleaved branch computes

```python
h_mask = ((cos_offsets % 3) == 1) & (cos_offsets <= 3 * mrope_section_h)
w_mask = ((cos_offsets % 3) == 2) & (cos_offsets <= 3 * mrope_section_w)
t_mask = ~(h_mask | w_mask)
```

`cos_offsets` spans `[0, pad_hd // 2)` (sized by `head_size`), but each `cos_sin_cache` row only has `half_rd` valid entries (sized by `rotary_dim`). When `head_size > rotary_dim` (partial rotary), the negation in `t_mask = ~(h_mask | w_mask)` silently includes all padding lanes in `[half_rd, pad_hd // 2)`, so the subsequent `tl.load(t_cos + cos_offsets, mask=t_mask)` reads past the end of the current row — and past the end of the whole `cos_sin_cache` tensor for positions near `max_position`.

The loaded garbage never reaches the output (q/k loads/stores are independently bounded by `rd // 2`), so numerics are unaffected. But the reads are genuinely out of bounds: reproducible deterministically with `PYTORCH_NO_CUDA_MEMORY_CACHING=1` + compute-sanitizer (1044 errors), and an IMA risk in production whenever `cos_sin_cache` ends at an allocation boundary.

The GLM interleaved branch has the same issue: the `axis_map` load mask `cos_offsets < (pad_hd // 2)` is a no-op for `tl.arange(0, pad_hd // 2)`, so with partial rotary the `axis_map` load itself goes OOB and undefined axis values can enable further OOB cos/sin loads.

Earlier interleaved-MRoPE models (e.g. Qwen3-VL, `head_dim=128`, full rotary) were unaffected because `pad_hd // 2 == half_rd` leaves no padding lanes; the non-interleaved branch already bounds its masks with `< half_rd`. Qwen3.5 is the first model combining interleaved MRoPE with partial rotary.

## Modifications

- Bound all three interleaved masks with `rd_mask = cos_offsets < half_rd`.
- GLM branch: load `axis_map` with `mask=rd_mask, other=-1` so padding lanes match no axis.
- Masked-off lanes already contribute nothing to the output, so this is purely a bounds fix; numerics are unchanged.
- Add `test/registered/rotary/test_mrope_interleaved_partial.py`: pins `forward_triton` against `forward_native` for Qwen3.5-style interleaved + partial rotary, Qwen3-VL-style interleaved, Qwen2-VL sectioned, GLM axis-map, and partial + sectioned layouts, at random and `max_position - 1` boundary positions.

## Accuracy Tests

```bash
# numerics: 2 passed, 10 subtests passed
python -m pytest test/registered/rotary/test_mrope_interleaved_partial.py -v

# bounds: 1044 errors before the fix -> 0 after
PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck \
    python -m pytest test/registered/rotary/test_mrope_interleaved_partial.py -q
```

Also verified end-to-end on Qwen3.5-397B-A17B-FP8 (8x H800, `--tp 8`, MTP speculative decoding + multimodal requests): no sanitizer errors, outputs unchanged.

## Speed Tests and Profiling

No perf impact expected: the change only tightens existing load masks (`rd_mask` is a compile-time-shaped comparison already computed for the non-interleaved branch); no extra memory traffic or kernel launches.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28873991151](https://github.com/sgl-project/sglang/actions/runs/28873991151)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28873990279](https://github.com/sgl-project/sglang/actions/runs/28873990279)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->