### PR TITLE
Fix LoRA prefix reuse with decode CUDA graph

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
+import torch.nn.functional as F
 from einops import rearrange
 
 from sglang.jit_kernel.fused_store_index_cache import (
@@ -106,6 +107,7 @@ if TYPE_CHECKING:
 
 
 DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
+_arange_cache: Dict[Tuple[int, torch.device], torch.Tensor] = {}
 GRAPH_WEIGHTS_PROJ_LORA_ERROR = (
     "DSA indexer weights_proj LoRA is incompatible with "
     "piecewise/breakable CUDA graph; remove the explicit "
@@ -144,6 +146,93 @@ def _uses_dsa_attention_backend(forward_batch: ForwardBatch) -> bool:
         backend_name = prefill_backend
 
     return backend_name in ("dsa", "nsa")
+
+
+def _fp8_paged_mqa_logits_torch(
+    q_fp8: torch.Tensor,
+    kv_cache_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    seqlens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_seq_len: int,
+) -> torch.Tensor:
+    """Graph-capturable FP8 paged-MQA logits reference for CUDA graph fallback."""
+    batch_size, _, num_heads, head_dim = q_fp8.shape
+    block_size = kv_cache_fp8.shape[1]
+    assert head_dim == 128
+    assert block_size == 64
+    assert q_fp8.shape == (batch_size, 1, num_heads, head_dim)
+    assert kv_cache_fp8.shape[1:] == (block_size, 1, head_dim + 4)
+    assert weights.shape == (batch_size, num_heads)
+    assert seqlens.shape == (batch_size,)
+
+    max_num_pages = block_tables.shape[1]
+    scale_offset = block_size * head_dim
+    total_dim = block_size * (head_dim + 4)
+
+    kv_cache_flat = kv_cache_fp8.view(-1, total_dim)
+    kv_gathered = kv_cache_flat[block_tables.clamp(min=0)]
+
+    kv_values_raw = kv_gathered[..., :scale_offset].contiguous()
+    kv_values = kv_values_raw.view(dtype=fp8_dtype).to(torch.float32)
+    kv_values = kv_values.reshape(batch_size, max_num_pages * block_size, head_dim)
+
+    kv_scales_raw = kv_gathered[..., scale_offset:].contiguous()
+    kv_scales = kv_scales_raw.view(dtype=torch.float32)
+    kv_scales = kv_scales.reshape(batch_size, max_num_pages * block_size)
+
+    q_float = q_fp8[:, 0].to(torch.float32)
+    scores = torch.bmm(kv_values, q_float.transpose(1, 2))
+    scores = F.relu(scores)
+    scores = scores * weights.unsqueeze(1)
+    scores = scores.sum(dim=2)
+    scores = scores * kv_scales
+
+    padded_seq_len = max_num_pages * block_size
+    arange_key = (padded_seq_len, scores.device)
+    if arange_key not in _arange_cache:
+        _arange_cache[arange_key] = torch.arange(padded_seq_len, device=scores.device)
+    positions = _arange_cache[arange_key].unsqueeze(0)
+    scores = scores.masked_fill(positions >= seqlens.unsqueeze(1), 0.0)
+
+    if padded_seq_len < max_seq_len:
+        return F.pad(scores, (0, max_seq_len - padded_seq_len), value=0.0)
+    return scores[:, :max_seq_len]
+
+
+def _fp8_paged_mqa_logits_for_cuda_graph(
+    q_fp8: torch.Tensor,
+    kv_cache_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    seqlens: torch.Tensor,
+    block_tables: torch.Tensor,
+    schedule_metadata: torch.Tensor,
+    max_seq_len: int,
+) -> torch.Tensor:
+    try:
+        from sglang.srt.layers.attention.dsa.tilelang_kernel import (
+            tilelang_fp8_paged_mqa_logits,
+        )
+    except ImportError:
+        return _fp8_paged_mqa_logits_torch(
+            q_fp8,
+            kv_cache_fp8,
+            weights,
+            seqlens,
+            block_tables,
+            max_seq_len,
+        )
+
+    return tilelang_fp8_paged_mqa_logits(
+        q_fp8,
+        kv_cache_fp8,
+        weights,
+        seqlens,
+        block_tables,
+        schedule_metadata,
+        max_seq_len,
+        clean_logits=False,
+    )
 
 
 if _is_cuda:
@@ -882,6 +971,16 @@ class Indexer(MultiPlatformOp):
                 max_seq_len,
                 Preshuffle=_use_aiter_preshuffle,
                 KVBlockSize=block_kv,
+            )
+        elif get_is_capture_mode():
+            logits = _fp8_paged_mqa_logits_for_cuda_graph(
+                q_fp8[:q_offset].unsqueeze(1),
+                kv_cache_fp8,
+                weights[:q_offset],
+                seqlens_32_2d.reshape(-1),
+                block_tables,
+                schedule_metadata,
+                max_seq_len,
             )
         elif use_dg_native:
             # block_tables[::next_n] de-expands dsa_backend's repeat_interleave

--- a/python/sglang/srt/managers/prefix_cache_namespace.py
+++ b/python/sglang/srt/managers/prefix_cache_namespace.py
@@ -1,0 +1,28 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from typing import Optional
+
+
+def compose_prefix_cache_extra_key(
+    extra_key: Optional[str], lora_id: Optional[str]
+) -> Optional[str]:
+    if lora_id is None:
+        return extra_key
+
+    parts = []
+    if extra_key is not None:
+        parts.append(f"extra_key:{len(extra_key)}:{extra_key}")
+    parts.append(f"lora_id:{len(lora_id)}:{lora_id}")
+    return "|".join(parts)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -73,6 +73,7 @@ from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     maybe_evict_dsv4_state,
 )
 from sglang.srt.managers.embed_types import PositionalEmbeds
+from sglang.srt.managers.prefix_cache_namespace import compose_prefix_cache_extra_key
 from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
     NewTokenRatioTracker,
 )
@@ -779,13 +780,8 @@ class Req(ReqDllmMixin):
         self.custom_logit_processor = custom_logit_processor
         self.return_hidden_states = return_hidden_states
 
-        # extra key for classifying the request (e.g. cache_salt)
-        if lora_id is not None:
-            extra_key = (
-                extra_key or ""
-            ) + lora_id  # lora_id is concatenated to the extra key
-
-        self.extra_key = extra_key
+        # extra key for classifying the request (e.g. cache_salt, lora_id)
+        self.extra_key = compose_prefix_cache_extra_key(extra_key, lora_id)
         self.lora_id = lora_id
         self.routing_key = routing_key
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -419,15 +419,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         else:
             cuda_graph_bs = forward_batch.batch_size
 
-        graph_key = cuda_graph_bs
-        if self.enable_pdmux:
-            graph_key = f"{get_current_stream_idx()}_{cuda_graph_bs}"
-
-        is_bs_supported = (
-            self.backend.can_run(forward_batch, graph_key)
-            if self.disable_padding
-            else cuda_graph_bs <= self.max_bs
-        )
+        if self.disable_padding:
+            stream_idx = get_current_stream_idx() if self.enable_pdmux else None
+            variant_label = self._resolve_lora_variant(forward_batch)
+            graph_key = self._make_graph_key(cuda_graph_bs, stream_idx, variant_label)
+            is_bs_supported = self.backend.can_run(forward_batch, graph_key)
+        else:
+            is_bs_supported = cuda_graph_bs <= self.max_bs
 
         if self.require_mlp_sync:
             is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph

--- a/test/registered/unit/managers/test_prefix_cache_namespace.py
+++ b/test/registered/unit/managers/test_prefix_cache_namespace.py
@@ -1,0 +1,29 @@
+import unittest
+
+from sglang.srt.managers.prefix_cache_namespace import compose_prefix_cache_extra_key
+
+
+class TestPrefixCacheNamespace(unittest.TestCase):
+    def test_preserves_existing_namespace_without_lora(self):
+        self.assertIsNone(compose_prefix_cache_extra_key(None, None))
+        self.assertEqual(compose_prefix_cache_extra_key("tenant", None), "tenant")
+
+    def test_adds_lora_namespace(self):
+        self.assertEqual(
+            compose_prefix_cache_extra_key(None, "adapter"),
+            "lora_id:7:adapter",
+        )
+        self.assertEqual(
+            compose_prefix_cache_extra_key("tenant", "adapter"),
+            "extra_key:6:tenant|lora_id:7:adapter",
+        )
+
+    def test_avoids_string_concatenation_collisions(self):
+        self.assertNotEqual(
+            compose_prefix_cache_extra_key("ab", "c"),
+            compose_prefix_cache_extra_key("a", "bc"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Keep DSA decode CUDA graph fully captured by using the graph-safe TileLang `fp8_paged_mqa_logits` path while CUDA graph capture is active.
- Leave the normal eager/non-captured CUDA path on DeepGEMM, so this does not switch decode to breakable CUDA graph or force the indexer eager.
- Keep LoRA prefix-cache namespaces unambiguous by length-prefixing the `(extra_key, lora_id)` components.
- Use the canonical `ShapeKey` lookup in `DecodeCudaGraphRunner.can_run_graph` when CUDA graph padding is disabled and LoRA variants participate in the graph key.

## Why

The corruption is not caused by stale Python-side DSA metadata: the decode metadata buffers are refreshed before CUDA graph replay. The failure is in the captured DSA paged-MQA logits/indexer path for GLM-style DSA models. When the DeepGEMM `fp8_paged_mqa_logits` call is captured, multi-LoRA concurrent decode with the same prefix can reuse capture-time indexer/top-k behavior even though the live page tables and sequence lengths have changed.

This patch keeps the full decode CUDA graph path and replaces only the DSA paged-MQA logits implementation used during capture with the TileLang implementation, which was already written as a graph-safe kernel surface. The rest of decode remains captured.

The prefix-cache namespace helper is a separate guard for adapter-aware reuse: raw string concatenation can collapse distinct `(extra_key, lora_id)` pairs into the same cache namespace.

## Tests

```bash
PYTHONPATH=python python3 -m pytest -q test/registered/unit/managers/test_prefix_cache_namespace.py
python3 -m py_compile \
  python/sglang/srt/layers/attention/dsa/dsa_indexer.py \
  python/sglang/srt/managers/prefix_cache_namespace.py \
  python/sglang/srt/managers/schedule_batch.py \
  python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
git diff --check upstream/main
```

`test/registered/kernels/test_dsa_indexer.py` is still blocked in this local Deployment environment by the existing `transformers.configuration_utils.PreTrainedConfig` import mismatch during collection.

Manual H20 validation:

- launched a 2-node H20 TP16 GLM-5.1-FP8 LoRA service with DSA attention, RadixCache enabled, and default full decode CUDA graph;
- verified decode CUDA graph capture completed with `backend=full` for batch sizes `[1, 2, 4, 8, 12, 16]`;
- sent warmup requests plus 16 concurrent OpenAI-compatible chat requests alternating `lora_a` and `lora_u` over the same long prefix;
- all requests returned HTTP 200 with stable text;
- server logs showed prefix-cache reuse (`#cached-token: 103680`) followed by `Decode batch ... cuda graph: True`.






<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28715923497](https://github.com/sgl-project/sglang/actions/runs/28715923497)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28715923141](https://github.com/sgl-project/sglang/actions/runs/28715923141)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
