### PR TITLE
[MLX] Fix FakeOverlapScheduler test stub broken by forward_ct accounting

### DIFF
--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -1538,6 +1538,13 @@ if _HAS_MLX:
             self.last_batch = None
             self.processed_batch = None
             self.processed_result = None
+            # _finalize_mlx_pending_job now advances forward_ct and runs the
+            # profiler batch predicate (mirroring run_batch); stub both so the
+            # overlap accounting added in #29217 has something to call.
+            self.forward_ct = 0
+            self.profiler_manager = SimpleNamespace(
+                _profile_batch_predicate=lambda batch: None
+            )
 
         def process_batch_result(self, batch, result):
             self.processed_batch = batch


### PR DESCRIPTION
## Motivation

Follow-up to #29217. Thanks @LarrySimingDeng for the catch.

#29217 made `_finalize_mlx_pending_job` advance `self.forward_ct` and call
`self.profiler_manager._profile_batch_predicate(...)` (mirroring `run_batch()`),
but the pre-existing `FakeOverlapScheduler` stub in
`test/registered/unit/hardware_backend/mlx/test_attention_patching.py`
(`TestMlxOverlapScheduler`) defines neither attribute. As a result
`test_finalize_pending_job_updates_scheduler_last_batch` — which calls
`_finalize_mlx_pending_job` on the real stub — now fails with:

```
AttributeError: 'FakeOverlapScheduler' object has no attribute 'forward_ct'
```

This was latent when #29217 merged (no macOS MLX CI lane was running the
suite yet) and only surfaced once #29691 landed and started turning
`mlx-unit-test` red for PRs that trigger the lane.

## Modifications

- `test_attention_patching.py`: in `FakeOverlapScheduler.__init__`, stub
  `forward_ct = 0` and a no-op `profiler_manager` exposing
  `_profile_batch_predicate`, using the same `SimpleNamespace` idiom already
  used throughout this file — mirroring the accounting the mixin now expects
  (same wiring the new `test_scheduler_mixin.py` stubs via `MagicMock`).

## Accuracy Tests

N/A — test-only stub fix; no production code change.

## Speed Tests and Profiling

N/A.

Verified locally (`upstream/main`): `test_attention_patching.py` goes from 1
errored to 39/39 passing; `TestMlxOverlapScheduler` is green.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28717179579](https://github.com/sgl-project/sglang/actions/runs/28717179579)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28717179516](https://github.com/sgl-project/sglang/actions/runs/28717179516)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->