### PR TITLE
[refactor] Migrate the disable_overlap_schedule writers and the mamba radix cache resolution to the pipeline (stack 1/10)

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -750,6 +750,100 @@ def _step3p_overrides(server_args: Any, hf_config: Any) -> dict:
 # ---------------------------------------------------------------------------
 
 
+# Architectures whose monolith branch routes through the mamba radix cache
+# handling (hybrid linear-attention models). Keep in sync with the branch
+# guards in _handle_model_specific_adjustments.
+_MAMBA_RADIX_CACHE_ARCHS = frozenset(
+    {
+        "KimiLinearForCausalLM",
+        "BailingMoeV2_5ForCausalLM",
+        "Qwen3NextForCausalLM",
+        "Qwen3_5MoeForConditionalGeneration",
+        "InternS2PreviewForConditionalGeneration",
+        "Qwen3_5ForConditionalGeneration",
+        "MiniCPMV4_6ForConditionalGeneration",
+        "NemotronHForCausalLM",
+        "NemotronHPuzzleForCausalLM",
+        "FalconH1ForCausalLM",
+        "JetNemotronForCausalLM",
+        "JetVLMForConditionalGeneration",
+        "Lfm2ForCausalLM",
+        "ZayaForCausalLM",
+    }
+)
+
+# Architectures that support the extra_buffer mamba radix cache strategy.
+# Single source of truth: ServerArgs._support_mamba_cache_extra_buffer
+# delegates here.
+_MAMBA_EXTRA_BUFFER_ARCHS = frozenset(
+    {
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3NextForCausalLM",
+        "InternS2PreviewForConditionalGeneration",
+        "MiniCPMV4_6ForConditionalGeneration",
+        "BailingMoeV2_5ForCausalLM",
+        "FalconH1ForCausalLM",
+        "GraniteMoeHybridForCausalLM",
+        "NemotronHForCausalLM",
+        "NemotronHPuzzleForCausalLM",
+    }
+)
+
+
+def supports_mamba_cache_extra_buffer(view: Any, model_arch: str) -> bool:
+    """Whether ``model_arch`` supports the extra_buffer strategy on the
+    configured linear-attention backend (pure read)."""
+    if model_arch in _MAMBA_EXTRA_BUFFER_ARCHS:
+        return view.linear_attn_backend == "triton"
+    return False
+
+
+@register_post_process
+def _mamba_radix_cache_resolution(view: Any) -> dict:
+    """Resolve the hybrid-mamba radix cache fields (pure).
+
+    Slot pass: invoked at each legacy ``_handle_mamba_radix_cache`` slot —
+    the hybrid-spec call at the head of the monolith and the per-arch branch
+    calls — where it reads the mid-resolution ``page_size`` /
+    ``disable_overlap_schedule`` exactly as the legacy helper did. The arch
+    guard replicates the union of the legacy call-site guards so the pass is
+    self-sufficient in the end-state pass list.
+    """
+    from sglang.srt.configs.linear_attn_model_registry import (
+        get_linear_attn_spec_by_arch,
+    )
+
+    hf_config = view.get_model_config().hf_config
+    model_arch = hf_config.architectures[0]
+
+    in_branch = model_arch in _MAMBA_RADIX_CACHE_ARCHS
+    if model_arch == "GraniteMoeHybridForCausalLM":
+        in_branch = any(
+            layer_type == "mamba"
+            for layer_type in getattr(hf_config, "layer_types", [])
+        )
+    spec = get_linear_attn_spec_by_arch(model_arch)
+    if not ((spec is not None and spec.uses_mamba_radix_cache) or in_branch):
+        return {}
+
+    if view.disable_radix_cache:
+        return {}
+
+    declared: Dict[str, Any] = {"uses_mamba_radix_cache": True}
+    if view.mamba_radix_cache_strategy == "auto":
+        wants_overlap = not view.disable_overlap_schedule
+        wants_paging = view.page_size is not None and view.page_size > 1
+        if (wants_overlap or wants_paging) and supports_mamba_cache_extra_buffer(
+            view, model_arch
+        ):
+            declared["mamba_radix_cache_strategy"] = "extra_buffer"
+        else:
+            declared["mamba_radix_cache_strategy"] = "no_buffer"
+            declared["disable_overlap_schedule"] = True
+    return declared
+
+
 # Keep in sync with the DeepSeek family list on _deepseek_family_overrides.
 _DEEPSEEK_FAMILY_ARCHS = frozenset(
     {
@@ -833,6 +927,18 @@ def _deepseek_moe_quant_resolution(view: Any) -> dict:
                     "Use flashinfer_trtllm as MoE runner backend on sm100 for DeepseekV3ForCausalLM"
                 )
     return overrides
+
+
+@register_post_process
+def _sparse_head_overlap_disable(view: Any) -> dict:
+    from sglang.srt.environ import envs
+
+    if envs.SGLANG_EMBEDDINGS_SPARSE_HEAD.is_set():
+        logger.warning(
+            "Overlap scheduler is disabled when using sparse head for embedding model."
+        )
+        return {"disable_overlap_schedule": True}
+    return {}
 
 
 @register_post_process
@@ -1222,6 +1328,14 @@ def _a2a_ep_size(view: Any) -> dict:
 
 
 @register_post_process
+def _pipeline_parallel_overlap_disable(view: Any) -> dict:
+    if view.pp_size > 1:
+        logger.warning("Pipeline parallelism is incompatible with overlap schedule.")
+        return {"disable_overlap_schedule": True}
+    return {}
+
+
+@register_post_process
 def _gguf_quantization(view: Any) -> dict:
     from sglang.srt.utils.hf_transformers_utils import check_gguf_file
 
@@ -1255,6 +1369,18 @@ def _dllm_attention_backend(view: Any) -> dict:
             )
             return {"attention_backend": "flashinfer"}
     return {}
+
+
+@register_post_process
+def _dllm_overlap_disable(view: Any) -> dict:
+    if view.dllm_algorithm is None:
+        return {}
+    if view.disable_overlap_schedule:
+        return {}
+    logger.warning(
+        "Overlap schedule is disabled because of using diffusion LLM inference"
+    )
+    return {"disable_overlap_schedule": True}
 
 
 @register_post_process

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -325,6 +325,9 @@ class Flags(_StaticFlags):
     sampling_backend: str | None = None
     page_size: int | None = None
     quantization: str | None = None
+    disable_overlap_schedule: bool = False
+    uses_mamba_radix_cache: bool = False
+    mamba_radix_cache_strategy: str = "auto"
     # Parallel-request fields: flat transitional home, to be re-homed by the
     # Parallel Parameters Clarification module.
     enable_dp_attention: bool = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -809,7 +809,10 @@ class ServerArgs:
     ] = False
     disable_overlap_schedule: A[
         bool,
-        "Disable the overlap scheduler, which overlaps the CPU scheduler with GPU model worker.",
+        Arg(
+            help="Disable the overlap scheduler, which overlaps the CPU scheduler with GPU model worker.",
+            resolvable=True,
+        ),
     ] = False
     num_continuous_decode_steps: A[
         int,
@@ -1856,8 +1859,19 @@ class ServerArgs:
         Arg(
             help="The strategy to use for mamba radix cache.",
             choices=MAMBA_RADIX_CACHE_STRATEGY_CHOICES,
+            resolvable=True,
         ),
     ] = "auto"
+    uses_mamba_radix_cache: A[
+        bool,
+        Arg(
+            help="(Derived) whether the model routes through the hybrid-mamba "
+            "radix cache handling; resolved from the model architecture, no "
+            "CLI surface.",
+            no_cli=True,
+            resolvable=True,
+        ),
+    ] = False
     mamba_track_interval: A[
         int,
         "The interval to track the mamba state during decode.",
@@ -4109,10 +4123,6 @@ class ServerArgs:
             logger.info(
                 f"Using {self.attention_backend} as attention backend for {model_arch}."
             )
-        elif model_arch in ["KimiLinearForCausalLM"]:
-            self._handle_mamba_radix_cache(model_arch=model_arch)
-        elif model_arch in ["BailingMoeV2_5ForCausalLM"]:
-            self._handle_mamba_radix_cache(model_arch=model_arch)
         elif model_arch in ["NemotronHForCausalLM", "NemotronHPuzzleForCausalLM"]:
             from sglang.srt.arg_groups.nemotron_h_hook import (
                 apply_nemotron_h_defaults,
@@ -4127,25 +4137,11 @@ class ServerArgs:
             "InternS2PreviewForConditionalGeneration",
             "Qwen3_5ForConditionalGeneration",
         ]:
-            # The quantization/moe_runner_backend resolution moved to the override
-            # registry (arg_groups/overrides.py: _qwen3_moe_family_overrides).
-
-            if model_arch in [
-                "Qwen3NextForCausalLM",
-                "Qwen3_5MoeForConditionalGeneration",
-                "InternS2PreviewForConditionalGeneration",
-                "Qwen3_5ForConditionalGeneration",
-            ]:
-                # Attention backend + page size defaults moved to the override
-                # registry (arg_groups/overrides.py: _qwen3_5_hybrid_overrides).
-                self._handle_mamba_radix_cache(model_arch=model_arch)
-
-        elif model_arch == "MiniCPMV4_6ForConditionalGeneration":
-            # 4.6 wraps a Qwen3.5 hybrid GDN backbone, so it needs the same
-            # mamba radix cache handling as Qwen3_5ForConditionalGeneration.
-            # (attention backend selection moved to the override registry:
-            # arg_groups/overrides.py _minicpm_v4_6_overrides)
-            self._handle_mamba_radix_cache(model_arch=model_arch)
+            # The quantization/moe_runner_backend resolution moved to the
+            # override registry (arg_groups/overrides.py:
+            # _qwen3_moe_family_overrides); the hybrid sub-family's attention
+            # backend + page size defaults to _qwen3_5_hybrid_overrides.
+            pass
 
         elif model_arch in ["Glm4MoeForCausalLM"]:
             # The quantization/moe_runner_backend/enable_tf32_matmul resolution
@@ -4153,37 +4149,13 @@ class ServerArgs:
             # _glm4_moe_overrides).
             pass
 
-        elif model_arch in [
-            "FalconH1ForCausalLM",
-            "JetNemotronForCausalLM",
-            "JetVLMForConditionalGeneration",
-        ]:
-            # Attention backend selection moved to the override registry
-            # (arg_groups/overrides.py: _falcon_h1_jet_overrides).
-            self._handle_mamba_radix_cache(model_arch=model_arch)
-
-        elif model_arch == "GraniteMoeHybridForCausalLM":
-            hf_config = self.get_model_config().hf_config
-            has_mamba = any(
-                layer_type == "mamba"
-                for layer_type in getattr(hf_config, "layer_types", [])
-            )
-            if has_mamba:
-                # Attention backend selection moved to the override registry
-                # (arg_groups/overrides.py: _granite_moe_hybrid_overrides).
-                self._handle_mamba_radix_cache(model_arch=model_arch)
-
         elif model_arch in ["Lfm2ForCausalLM"]:
             # Attention backend selection moved to the override registry
             # (arg_groups/overrides.py: _lfm2_overrides).
-            self._handle_mamba_radix_cache(model_arch=model_arch)
             assert self.attention_backend != "triton", (
                 f"{model_arch} does not support triton attention backend, "
                 "as the first layer might not be an attention layer"
             )
-
-        elif model_arch in ["ZayaForCausalLM"]:
-            self._handle_mamba_radix_cache(model_arch=model_arch)
 
         # MiniMaxM2ForCausalLM (enable_tf32_matmul) moved to the override registry
         # (arg_groups/overrides.py: _minimax_m2_overrides).
@@ -4191,11 +4163,21 @@ class ServerArgs:
         # Qwen3VL aiter unified-attention page_size moved to the override registry
         # (arg_groups/overrides.py: _qwen3vl_overrides).
 
-        if envs.SGLANG_EMBEDDINGS_SPARSE_HEAD.is_set():
-            self.disable_overlap_schedule = True
-            logger.warning(
-                "Overlap scheduler is disabled when using sparse head for embedding model."
-            )
+        # Hybrid-mamba radix cache handling for the per-arch branch call sites
+        # dissolved above: the resolution pass self-guards on the arch union
+        # (and the Granite layer_types probe), so one call covers them all.
+        # Hybrid-spec archs already resolved at the pre-dispatch call above;
+        # for them this re-invocation is an idempotent no-op plus validation.
+        # Kept ahead of the sparse-head pass: the legacy per-branch calls
+        # resolved before that tail write of disable_overlap_schedule.
+        self._handle_mamba_radix_cache(model_arch=model_arch)
+
+        from sglang.srt.arg_groups.overrides import (
+            _sparse_head_overlap_disable,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _sparse_head_overlap_disable)
 
         # Auto-enable FlashInfer AllReduce Fusion on SM90/SM100, for models with
         # explicit support (DeepseekV3, GptOss, Glm4Moe, MistralLarge3,
@@ -4242,21 +4224,9 @@ class ServerArgs:
             )
 
     def _support_mamba_cache_extra_buffer(self, model_arch: str):
-        if model_arch in [
-            "Qwen3_5ForConditionalGeneration",
-            "Qwen3_5MoeForConditionalGeneration",
-            "Qwen3NextForCausalLM",
-            "InternS2PreviewForConditionalGeneration",
-            "MiniCPMV4_6ForConditionalGeneration",
-            "BailingMoeV2_5ForCausalLM",
-            "FalconH1ForCausalLM",
-            "GraniteMoeHybridForCausalLM",
-            "NemotronHForCausalLM",
-            "NemotronHPuzzleForCausalLM",
-        ]:
-            return self.linear_attn_backend == "triton"
+        from sglang.srt.arg_groups.overrides import supports_mamba_cache_extra_buffer
 
-        return False
+        return supports_mamba_cache_extra_buffer(self, model_arch)
 
     def _validate_mamba_no_buffer(self, model_arch: str):
         assert self.page_size in (1, None), "no_buffer only supports page_size=1."
@@ -4284,20 +4254,17 @@ class ServerArgs:
             assert self.mamba_cache_chunk_size is not None
 
     def _handle_mamba_radix_cache(self, model_arch: str):
-        if self.disable_radix_cache:
-            return
+        # Resolution moved to the resolution pipeline (arg_groups/overrides.py:
+        # _mamba_radix_cache_resolution), invoked here at each legacy call
+        # slot; this handler keeps the validation.
+        from sglang.srt.arg_groups.overrides import (
+            _mamba_radix_cache_resolution,
+            run_post_process_pass,
+        )
 
-        self.uses_mamba_radix_cache = True
-        if self.mamba_radix_cache_strategy == "auto":
-            wants_overlap = not self.disable_overlap_schedule
-            wants_paging = self.page_size is not None and self.page_size > 1
-            if (
-                wants_overlap or wants_paging
-            ) and self._support_mamba_cache_extra_buffer(model_arch):
-                self.mamba_radix_cache_strategy = "extra_buffer"
-            else:
-                self.mamba_radix_cache_strategy = "no_buffer"
-                self.disable_overlap_schedule = True
+        run_post_process_pass(self, _mamba_radix_cache_resolution)
+        if not self.uses_mamba_radix_cache:
+            return
 
         if self.enable_mamba_extra_buffer():
             self._validate_mamba_extra_buffer(model_arch)
@@ -5292,11 +5259,14 @@ class ServerArgs:
                 self.expert_distribution_recorder_buffer_size = 1000
 
     def _handle_pipeline_parallelism(self):
-        if self.pp_size > 1:
-            self.disable_overlap_schedule = True
-            logger.warning(
-                "Pipeline parallelism is incompatible with overlap schedule."
-            )
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _pipeline_parallel_overlap_disable), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _pipeline_parallel_overlap_disable,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _pipeline_parallel_overlap_disable)
 
     def _validate_prefill_only_disable_kv_cache_args(self):
         """Validate --prefill-only-disable-kv-cache flag/precondition constraints.
@@ -6017,16 +5987,12 @@ class ServerArgs:
 
         from sglang.srt.arg_groups.overrides import (
             _dllm_attention_backend,
+            _dllm_overlap_disable,
             run_post_process_pass,
         )
 
         run_post_process_pass(self, _dllm_attention_backend)
-
-        if not self.disable_overlap_schedule:
-            logger.warning(
-                "Overlap schedule is disabled because of using diffusion LLM inference"
-            )
-            self.disable_overlap_schedule = True
+        run_post_process_pass(self, _dllm_overlap_disable)
 
         if not self.disable_radix_cache:
             # The page_size adjustment moved to the resolution pipeline

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -78,6 +78,9 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "ep_size",
                     "moe_dense_tp_size",
                     "attn_cp_size",
+                    "disable_overlap_schedule",
+                    "uses_mamba_radix_cache",
+                    "mamba_radix_cache_strategy",
                 }
             ),
         )
@@ -789,6 +792,164 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             self.assertEqual(_dllm_page_size(_view(page_size=64)), {})  # aligned
         self.assertEqual(_dllm_page_size(_view(dllm_algorithm=None)), {})
         self.assertEqual(_dllm_page_size(_view(disable_radix_cache=True)), {})
+
+    def test_overlap_disable_passes(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _dllm_overlap_disable,
+            _pipeline_parallel_overlap_disable,
+            _sparse_head_overlap_disable,
+        )
+
+        # pipeline parallelism: declares only when pp_size > 1
+        self.assertEqual(
+            _pipeline_parallel_overlap_disable(
+                ResolvedView(SimpleNamespace(pp_size=1))
+            ),
+            {},
+        )
+        self.assertEqual(
+            _pipeline_parallel_overlap_disable(
+                ResolvedView(SimpleNamespace(pp_size=2))
+            ),
+            {"disable_overlap_schedule": True},
+        )
+
+        # dllm: guarded on the algorithm and the current value
+        def _view(**kw):
+            defaults = dict(
+                dllm_algorithm="LowConfidence", disable_overlap_schedule=False
+            )
+            defaults.update(kw)
+            return ResolvedView(SimpleNamespace(**defaults))
+
+        self.assertEqual(_dllm_overlap_disable(_view(dllm_algorithm=None)), {})
+        self.assertEqual(
+            _dllm_overlap_disable(_view(disable_overlap_schedule=True)), {}
+        )
+        self.assertEqual(
+            _dllm_overlap_disable(_view()), {"disable_overlap_schedule": True}
+        )
+
+        # embeddings sparse head: keyed on the env var being set
+        from sglang.srt.environ import envs
+
+        view = ResolvedView(SimpleNamespace())
+        with patch.object(
+            envs.SGLANG_EMBEDDINGS_SPARSE_HEAD, "is_set", return_value=False
+        ):
+            self.assertEqual(_sparse_head_overlap_disable(view), {})
+        with patch.object(
+            envs.SGLANG_EMBEDDINGS_SPARSE_HEAD, "is_set", return_value=True
+        ):
+            self.assertEqual(
+                _sparse_head_overlap_disable(view), {"disable_overlap_schedule": True}
+            )
+
+    def test_mamba_radix_cache_resolution_pass(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _mamba_radix_cache_resolution,
+            supports_mamba_cache_extra_buffer,
+        )
+
+        def _view(arch, layer_types=None, **kw):
+            hf = SimpleNamespace(architectures=[arch])
+            if layer_types is not None:
+                hf.layer_types = layer_types
+            defaults = dict(
+                disable_radix_cache=False,
+                mamba_radix_cache_strategy="auto",
+                disable_overlap_schedule=False,
+                page_size=None,
+                linear_attn_backend="triton",
+            )
+            defaults.update(kw)
+            return ResolvedView(
+                SimpleNamespace(
+                    get_model_config=lambda: SimpleNamespace(hf_config=hf), **defaults
+                )
+            )
+
+        # arch guard: non-mamba arch declares nothing
+        self.assertEqual(_mamba_radix_cache_resolution(_view("LlamaForCausalLM")), {})
+        # radix cache disabled: nothing to resolve
+        self.assertEqual(
+            _mamba_radix_cache_resolution(
+                _view("Qwen3NextForCausalLM", disable_radix_cache=True)
+            ),
+            {},
+        )
+        # auto + overlap wanted + extra-buffer support -> extra_buffer
+        self.assertEqual(
+            _mamba_radix_cache_resolution(_view("Qwen3NextForCausalLM")),
+            {
+                "uses_mamba_radix_cache": True,
+                "mamba_radix_cache_strategy": "extra_buffer",
+            },
+        )
+        # auto + no extra-buffer support (Lfm2) -> no_buffer + overlap disable
+        self.assertEqual(
+            _mamba_radix_cache_resolution(_view("Lfm2ForCausalLM")),
+            {
+                "uses_mamba_radix_cache": True,
+                "mamba_radix_cache_strategy": "no_buffer",
+                "disable_overlap_schedule": True,
+            },
+        )
+        # neither overlap nor paging wanted -> no_buffer even when supported
+        declared = _mamba_radix_cache_resolution(
+            _view("Qwen3NextForCausalLM", disable_overlap_schedule=True, page_size=1)
+        )
+        self.assertEqual(declared["mamba_radix_cache_strategy"], "no_buffer")
+        self.assertIs(declared["disable_overlap_schedule"], True)
+        # paging alone wants the extra buffer
+        self.assertEqual(
+            _mamba_radix_cache_resolution(
+                _view(
+                    "Qwen3NextForCausalLM", disable_overlap_schedule=True, page_size=64
+                )
+            )["mamba_radix_cache_strategy"],
+            "extra_buffer",
+        )
+        # user-set strategy: only the routing marker is declared
+        self.assertEqual(
+            _mamba_radix_cache_resolution(
+                _view(
+                    "Qwen3NextForCausalLM",
+                    mamba_radix_cache_strategy="extra_buffer_lazy",
+                )
+            ),
+            {"uses_mamba_radix_cache": True},
+        )
+        # NemotronH routes through the pass (covered by the guard union,
+        # not the branch chain — its hook invokes the handler)
+        self.assertEqual(
+            _mamba_radix_cache_resolution(_view("NemotronHForCausalLM")),
+            {
+                "uses_mamba_radix_cache": True,
+                "mamba_radix_cache_strategy": "extra_buffer",
+            },
+        )
+        # GraniteMoeHybrid is guarded on mamba layer types
+        self.assertEqual(
+            _mamba_radix_cache_resolution(
+                _view("GraniteMoeHybridForCausalLM", layer_types=["attention"])
+            ),
+            {},
+        )
+        self.assertEqual(
+            _mamba_radix_cache_resolution(
+                _view("GraniteMoeHybridForCausalLM", layer_types=["mamba", "attention"])
+            )["mamba_radix_cache_strategy"],
+            "extra_buffer",
+        )
+        # extra-buffer support requires the triton linear-attn backend
+        self.assertFalse(
+            supports_mamba_cache_extra_buffer(
+                SimpleNamespace(linear_attn_backend="fla"), "Qwen3NextForCausalLM"
+            )
+        )
 
     def test_page_size_leaf_materializes_end_state(self):
         sa = self._construct("LlamaForCausalLM", "llama")


### PR DESCRIPTION
Unit 1 of a 10-PR stack continuing the config-resolution pipeline refactor (previous stack: #30063–#30077).

The three post-monolith writers of disable_overlap_schedule become
slot-preserving post-process passes (embeddings sparse head, pipeline
parallelism, diffusion-LLM inference), and the field joins the resolvable
whitelist with a flat flag leaf — earlier writers stay imperative and remain
visible to the passes through the live view.

On top of that, the field resolution of _handle_mamba_radix_cache becomes a
pure post-process pass (_mamba_radix_cache_resolution) invoked at the legacy
call slots; its arch guard replicates the union of the legacy call-site
guards (including the Granite layer_types probe and the hybrid-spec
registry), so the per-branch call sites collapse into one self-guarded call
after the arch chain — for non-mamba archs the pass declares nothing and the
handler returns before validation. The pre-dispatch hybrid-spec call keeps
its position, so those archs still resolve against the pristine page_size;
the post-chain re-invocation is an idempotent no-op plus validation.
uses_mamba_radix_cache becomes a real (derived, no-CLI) ServerArgs field;
both mamba fields join the resolvable whitelist; pure-mamba branches
dissolve while Lfm2 keeps its backend assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28721910483](https://github.com/sgl-project/sglang/actions/runs/28721910483)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28721910430](https://github.com/sgl-project/sglang/actions/runs/28721910430)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->