### PR TITLE
[refactor] Migrate the speculative MoE backend resolution to the pipeline (stack 3/10)

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -177,7 +177,15 @@ def run_post_process_pass(server_args: Any, fn: Callable[..., dict]) -> None:
         )
     if declared:
         entry = (fn.__qualname__, dict(declared))
-        server_args._resolved_overrides.append(entry)
+        stash = getattr(server_args, "_resolved_overrides", None)
+        if stash is None:
+            # Handlers hosting pass slots may be invoked directly on fixtures
+            # that never ran the monolith dispatch (which owns the stash);
+            # create it lazily. Real publishes always pass through the
+            # dispatch first — the dispatch ASSIGNS the stash, so pass slots
+            # must sit at or after it in __post_init__ order.
+            stash = server_args._resolved_overrides = []
+        stash.append(entry)
         apply_declarations_to_server_args(server_args, [entry])
 
 
@@ -1028,6 +1036,55 @@ def _deepseek_moe_quant_resolution(view: Any) -> dict:
 
 
 @register_post_process
+def _deepseek_spec_moe_resolution(view: Any) -> dict:
+    """Slot pass at the DeepSeek branch's HIP arm: draft (nextn) spec-MoE
+    backends for the DeepSeek fp4 checkpoint. Reads the mid-resolution
+    quantization (after _deepseek_moe_quant_resolution) and the pre-a2a
+    ep_size, exactly like the legacy in-branch writes."""
+    from sglang.srt.environ import envs
+
+    hf_config = view.get_model_config().hf_config
+    model_arch = hf_config.architectures[0]
+    if model_arch not in _DEEPSEEK_FAMILY_ARCHS:
+        return {}
+    if not is_hip():
+        return {}
+    if not (
+        view.quantization == "modelopt_fp4"
+        and view.speculative_algorithm == "EAGLE"
+        and (
+            view.speculative_moe_runner_backend is None
+            or view.speculative_moe_a2a_backend is None
+        )
+    ):
+        return {}
+    if envs.SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE.get():
+        logger.info(
+            "Use deep_gemm moe runner and deepep a2a backend for bf16 nextn layer in deepseek fp4 checkpoint."
+        )
+        # Validate usage of ep
+        if view.ep_size == 1:
+            raise ValueError(
+                "Invalid configuration: 'deep_gemm' speculative MoE runner backend with "
+                "'deepep' a2a backend requires expert parallelism (ep_size > 1). "
+                f"Current ep_size is {view.ep_size}. "
+                "Please set --ep-size > 1 (e.g., --ep-size 8) to use this configuration, "
+                "or change --speculative-moe-a2a-backend to 'none' if expert parallelism is not available."
+            )
+        return {
+            "speculative_moe_runner_backend": "deep_gemm",
+            "speculative_moe_a2a_backend": "deepep",
+        }
+    logger.info(
+        "Use triton fused moe by default for bf16 nextn layer in deepseek fp4 checkpoint."
+    )
+    return {
+        "speculative_moe_runner_backend": "triton",
+        "speculative_moe_a2a_backend": "none",
+    }
+
+
+@register_post_process
 def _deepseek_v4_sm120_moe(view: Any) -> dict:
     """Slot pass in the DeepSeek V4 validation branch: SM120 lacks
     tcgen05/TMEM, fall back to the marlin MoE runner (reads the
@@ -1445,6 +1502,16 @@ def _pipeline_parallel_overlap_disable(view: Any) -> dict:
     if view.pp_size > 1:
         logger.warning("Pipeline parallelism is incompatible with overlap schedule.")
         return {"disable_overlap_schedule": True}
+    return {}
+
+
+@register_post_process
+def _speculative_moe_runner_default(view: Any) -> dict:
+    """Default the speculative (draft) MoE runner backend to the resolved
+    target-model backend. Invoked at the head of the speculative-decoding
+    hook, after the MoE kernel chain has resolved."""
+    if view.speculative_moe_runner_backend is None:
+        return {"speculative_moe_runner_backend": view.moe_runner_backend}
     return {}
 
 

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -58,8 +58,14 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
     ):
         server_args.speculative_draft_model_revision = "main"
 
-    if server_args.speculative_moe_runner_backend is None:
-        server_args.speculative_moe_runner_backend = server_args.moe_runner_backend
+    # Moved to the resolution pipeline (arg_groups/overrides.py:
+    # _speculative_moe_runner_default), invoked here at its legacy slot.
+    from sglang.srt.arg_groups.overrides import (
+        _speculative_moe_runner_default,
+        run_post_process_pass,
+    )
+
+    run_post_process_pass(server_args, _speculative_moe_runner_default)
 
     if server_args.speculative_algorithm is not None:
         server_args.speculative_algorithm = server_args.speculative_algorithm.upper()

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -328,6 +328,8 @@ class Flags(_StaticFlags):
     disable_overlap_schedule: bool = False
     uses_mamba_radix_cache: bool = False
     mamba_radix_cache_strategy: str = "auto"
+    speculative_moe_runner_backend: str | None = None
+    speculative_moe_a2a_backend: str | None = None
     # Parallel-request fields: flat transitional home, to be re-homed by the
     # Parallel Parameters Clarification module.
     enable_dp_attention: bool = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1597,6 +1597,7 @@ class ServerArgs:
         Arg(
             help="Choose the runner backend for MoE in speculative decoding.",
             choices=MOE_RUNNER_BACKEND_CHOICES,
+            resolvable=True,
         ),
     ] = None
     speculative_moe_a2a_backend: A[
@@ -1604,6 +1605,7 @@ class ServerArgs:
         Arg(
             help="Choose the backend for MoE A2A in speculative decoding",
             choices=MOE_A2A_BACKEND_CHOICES,
+            resolvable=True,
         ),
     ] = None
     speculative_draft_model_quantization: A[
@@ -3897,35 +3899,15 @@ class ServerArgs:
                         "Enable Aiter AllReduce Fusion for DeepseekV3ForCausalLM"
                     )
 
-                if (
-                    self.quantization == "modelopt_fp4"
-                    and self.speculative_algorithm == "EAGLE"
-                    and (
-                        self.speculative_moe_runner_backend is None
-                        or self.speculative_moe_a2a_backend is None
-                    )
-                ):
-                    if envs.SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE.get():
-                        self.speculative_moe_runner_backend = "deep_gemm"
-                        self.speculative_moe_a2a_backend = "deepep"
-                        logger.info(
-                            "Use deep_gemm moe runner and deepep a2a backend for bf16 nextn layer in deepseek fp4 checkpoint."
-                        )
-                        # Validate usage of ep
-                        if self.ep_size == 1:
-                            raise ValueError(
-                                "Invalid configuration: 'deep_gemm' speculative MoE runner backend with "
-                                "'deepep' a2a backend requires expert parallelism (ep_size > 1). "
-                                f"Current ep_size is {self.ep_size}. "
-                                "Please set --ep-size > 1 (e.g., --ep-size 8) to use this configuration, "
-                                "or change --speculative-moe-a2a-backend to 'none' if expert parallelism is not available."
-                            )
-                    else:
-                        self.speculative_moe_runner_backend = "triton"
-                        self.speculative_moe_a2a_backend = "none"
-                        logger.info(
-                            "Use triton fused moe by default for bf16 nextn layer in deepseek fp4 checkpoint."
-                        )
+                # The fp4-checkpoint draft spec-MoE resolution moved to the
+                # resolution pipeline (arg_groups/overrides.py:
+                # _deepseek_spec_moe_resolution), invoked here at its legacy
+                # slot.
+                from sglang.srt.arg_groups.overrides import (
+                    _deepseek_spec_moe_resolution,
+                )
+
+                run_post_process_pass(self, _deepseek_spec_moe_resolution)
 
         elif model_arch in [
             "DeepseekV4ForCausalLM",

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -81,6 +81,8 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "disable_overlap_schedule",
                     "uses_mamba_radix_cache",
                     "mamba_radix_cache_strategy",
+                    "speculative_moe_runner_backend",
+                    "speculative_moe_a2a_backend",
                 }
             ),
         )
@@ -981,6 +983,102 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 _nemotron_h_overrides(_args(None, hf, moe_runner_backend="triton"), hf),
                 {},
             )
+
+    def test_speculative_moe_runner_default_pass(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _speculative_moe_runner_default,
+        )
+
+        self.assertEqual(
+            _speculative_moe_runner_default(
+                ResolvedView(
+                    SimpleNamespace(
+                        speculative_moe_runner_backend=None, moe_runner_backend="triton"
+                    )
+                )
+            ),
+            {"speculative_moe_runner_backend": "triton"},
+        )
+        # user-set draft backend survives
+        self.assertEqual(
+            _speculative_moe_runner_default(
+                ResolvedView(
+                    SimpleNamespace(
+                        speculative_moe_runner_backend="deep_gemm",
+                        moe_runner_backend="auto",
+                    )
+                )
+            ),
+            {},
+        )
+
+    def test_deepseek_spec_moe_resolution_pass(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _deepseek_spec_moe_resolution,
+        )
+        from sglang.srt.environ import envs
+
+        def _view(**kw):
+            hf = SimpleNamespace(architectures=["DeepseekV3ForCausalLM"])
+            defaults = dict(
+                quantization="modelopt_fp4",
+                speculative_algorithm="EAGLE",
+                speculative_moe_runner_backend=None,
+                speculative_moe_a2a_backend=None,
+                ep_size=8,
+            )
+            defaults.update(kw)
+            return ResolvedView(
+                SimpleNamespace(
+                    get_model_config=lambda: SimpleNamespace(hf_config=hf), **defaults
+                )
+            )
+
+        with patch.object(overrides_module, "is_hip", return_value=True):
+            with patch.object(
+                envs.SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE, "get", return_value=False
+            ):
+                self.assertEqual(
+                    _deepseek_spec_moe_resolution(_view()),
+                    {
+                        "speculative_moe_runner_backend": "triton",
+                        "speculative_moe_a2a_backend": "none",
+                    },
+                )
+                # guards: quantization / algorithm / both fields user-set
+                self.assertEqual(
+                    _deepseek_spec_moe_resolution(_view(quantization="fp8")), {}
+                )
+                self.assertEqual(
+                    _deepseek_spec_moe_resolution(_view(speculative_algorithm=None)),
+                    {},
+                )
+                self.assertEqual(
+                    _deepseek_spec_moe_resolution(
+                        _view(
+                            speculative_moe_runner_backend="triton",
+                            speculative_moe_a2a_backend="none",
+                        )
+                    ),
+                    {},
+                )
+            with patch.object(
+                envs.SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE, "get", return_value=True
+            ):
+                self.assertEqual(
+                    _deepseek_spec_moe_resolution(_view()),
+                    {
+                        "speculative_moe_runner_backend": "deep_gemm",
+                        "speculative_moe_a2a_backend": "deepep",
+                    },
+                )
+                with self.assertRaises(ValueError):
+                    _deepseek_spec_moe_resolution(_view(ep_size=1))
+        # the arm is HIP-only
+        with patch.object(overrides_module, "is_hip", return_value=False):
+            self.assertEqual(_deepseek_spec_moe_resolution(_view()), {})
 
     def test_mamba_radix_cache_resolution_pass(self):
         from sglang.srt.arg_groups.overrides import (


### PR DESCRIPTION
Unit 3 of a 10-PR stack continuing the config-resolution pipeline refactor (previous stack: #30063–#30077). Based on #30128.

The draft-MoE runner default fill at the head of the speculative-decoding
hook becomes a post-process pass invoked at its legacy slot, and the HIP
arm's nextn spec-MoE backend resolution in the DeepSeek branch becomes the
slot pass _deepseek_spec_moe_resolution, reading the mid-resolution
quantization exactly like the legacy in-branch writes. Both draft spec-MoE
fields join the resolvable whitelist with flat flag leaves.
run_post_process_pass now creates the declaration stash lazily so handlers
hosting pass slots can still be invoked directly on fixtures that never ran
the monolith dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28721911149](https://github.com/sgl-project/sglang/actions/runs/28721911149)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28721911076](https://github.com/sgl-project/sglang/actions/runs/28721911076)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->