### PR TITLE
[refactor] Add runtime resolution stages and declare the load-time shared-experts fusion (stack 4/10)

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -189,6 +189,19 @@ def run_post_process_pass(server_args: Any, fn: Callable[..., dict]) -> None:
         apply_declarations_to_server_args(server_args, [entry])
 
 
+def declare_load_time_override(source: str, declared: Dict[str, Any]) -> None:
+    """Transition helper for load-time resolved fields (model-file config
+    overrides, weight-resolved dtypes): dual-apply the declaration onto the
+    published ``server_args`` — byte-identical to the imperative write this
+    replaces — and record it into the flags tier through the runtime gate."""
+    from sglang.srt.runtime_context import get_context
+
+    ctx = get_context()
+    entry = (source, dict(declared))
+    apply_declarations_to_server_args(ctx.server_args, [entry])
+    ctx.record_runtime_overrides([entry])
+
+
 def collect_model_override_declarations(
     architecture: str, server_args: Any, hf_config: Any
 ) -> List[Tuple[str, Dict[str, Any]]]:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2774,7 +2774,12 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             disable_reason = "Deepseek V3/R1 W4AFP8 model uses different quant method for routed experts and shared experts."
 
         if disable_reason is not None:
-            server_args.disable_shared_experts_fusion = True
+            from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+            declare_load_time_override(
+                "DeepseekV2ForCausalLM.determine_num_fused_shared_experts",
+                {"disable_shared_experts_fusion": True},
+            )
             self.num_fused_shared_experts = 0
             log_info_on_rank0(
                 logger,

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1876,7 +1876,12 @@ class DeepseekV4ForCausalLM(nn.Module):
             disable_reason = "Config does not support fused shared expert(s)."
 
         if disable_reason is not None:
-            get_global_server_args().disable_shared_experts_fusion = True
+            from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+            declare_load_time_override(
+                "DeepseekV4ForCausalLM.determine_num_fused_shared_experts",
+                {"disable_shared_experts_fusion": True},
+            )
             log_info_on_rank0(
                 logger,
                 f"{disable_reason} Shared experts fusion optimization is disabled.",

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -1217,7 +1217,12 @@ class Glm4MoeForCausalLM(nn.Module):
             disable_reason = "GLM-4.5 W4AFP8 model uses different quant method for routed experts and shared experts."
 
         if disable_reason is not None:
-            get_global_server_args().disable_shared_experts_fusion = True
+            from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+            declare_load_time_override(
+                "Glm4MoeForCausalLM.determine_num_fused_shared_experts",
+                {"disable_shared_experts_fusion": True},
+            )
             self.num_fused_shared_experts = 0
             log_info_on_rank0(
                 logger,

--- a/python/sglang/srt/models/glm4_moe_lite.py
+++ b/python/sglang/srt/models/glm4_moe_lite.py
@@ -956,7 +956,12 @@ class Glm4MoeLiteForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             disable_reason = "GLM-4.5 or GLM-4.6 cannot use shared experts fusion optimization under expert parallelism."
 
         if disable_reason is not None:
-            get_global_server_args().disable_shared_experts_fusion = True
+            from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+            declare_load_time_override(
+                "Glm4MoeLiteForCausalLM.determine_num_fused_shared_experts",
+                {"disable_shared_experts_fusion": True},
+            )
             self.num_fused_shared_experts = 0
             log_info_on_rank0(
                 logger,

--- a/python/sglang/srt/models/glm4v_moe.py
+++ b/python/sglang/srt/models/glm4v_moe.py
@@ -100,7 +100,12 @@ class Glm4vMoeForConditionalGeneration(Glm4vForConditionalGeneration):
             disable_reason = "Shared experts fusion is not supported when Deepep MoE backend is enabled."
 
         if disable_reason is not None:
-            get_global_server_args().disable_shared_experts_fusion = True
+            from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+            declare_load_time_override(
+                "Glm4vMoeForConditionalGeneration.determine_num_fused_shared_experts",
+                {"disable_shared_experts_fusion": True},
+            )
             log_info_on_rank0(
                 logger,
                 f"{disable_reason} Shared experts fusion optimization is disabled.",

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1178,7 +1178,12 @@ class Qwen3_5ForCausalLM(nn.Module):
             and not server_args.disable_shared_experts_fusion
             and not can_fuse_shared_expert(config, quant_config)
         ):
-            server_args.disable_shared_experts_fusion = True
+            from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+            declare_load_time_override(
+                "Qwen3_5ForCausalLM._maybe_autodisable_shared_experts_fusion",
+                {"disable_shared_experts_fusion": True},
+            )
             logger.info(
                 "Qwen3.5: shared-expert fusion not supported for this checkpoint; "
                 "auto-disabling (multi-streaming #25885 still applies)."

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -330,6 +330,7 @@ class Flags(_StaticFlags):
     mamba_radix_cache_strategy: str = "auto"
     speculative_moe_runner_backend: str | None = None
     speculative_moe_a2a_backend: str | None = None
+    disable_shared_experts_fusion: bool = False
     # Parallel-request fields: flat transitional home, to be re-homed by the
     # Parallel Parameters Clarification module.
     enable_dp_attention: bool = False
@@ -373,12 +374,16 @@ class RuntimeContext:
     """Container for the structured runtime accessors; exposes ``parallel``,
     ``server_args``, and ``flags``."""
 
-    __slots__ = ("parallel", "_server_args", "flags")
+    __slots__ = ("parallel", "_server_args", "flags", "_runtime_overrides")
 
     def __init__(self, parallel: ParallelContext):
         self.parallel = parallel
         self._server_args: ServerArgs | None = None
         self.flags = Flags()
+        # Post-publish resolution declarations (runner- and load-time
+        # resolved fields), replayed after the publish-time stash on
+        # every re-resolve. Cleared on (re-)publish and reset.
+        self._runtime_overrides: list[tuple[str, dict]] = []
 
     @property
     def server_args(self) -> ServerArgs:
@@ -400,14 +405,67 @@ class RuntimeContext:
         into the flags tier (skipped for objects without the stash — dummy /
         "none" fixture ServerArgs and test-kit mocks never compute it).
         Resolution runs first: if it fails, the previous publish stays intact.
+        A publish after ``freeze_flags()`` is an ordering violation and raises.
         """
-        self._resolve_flags(server_args)
+        if self.flags.frozen:
+            raise RuntimeError(
+                "set_server_args() after freeze_flags(): the flags tier is "
+                "frozen for this process; use reset_context() in tests."
+            )
+        # A (re-)publish starts a fresh resolution lifecycle; a failed
+        # resolve keeps the previous lifecycle (including its recorded
+        # runtime overrides) intact.
+        saved_runtime_overrides = self._runtime_overrides
+        self._runtime_overrides = []
+        try:
+            self._resolve_flags(server_args)
+        except BaseException:
+            self._runtime_overrides = saved_runtime_overrides
+            raise
         self._server_args = server_args
+
+    def record_runtime_overrides(
+        self, entries: list[tuple[str, dict]]
+    ) -> list[tuple[str, dict]]:
+        """Append post-publish resolution declarations (the runner- and
+        load-time stages) and
+        atomically re-resolve the flags tier.
+
+        Target-worker only, and only before ``freeze_flags()``. During the
+        dual-apply transition the call sites keep their imperative
+        ``server_args`` writes; the recorded declarations must match them —
+        parity is re-asserted on every declared field. On failure the
+        recorded entries are rolled back and the previous flags stay
+        installed.
+        """
+        server_args = self._server_args
+        if server_args is None:
+            raise ValueError("Global server args is not set yet!")
+        if self.flags.frozen:
+            raise RuntimeError(
+                "record_runtime_overrides() after freeze_flags(): runtime "
+                "resolution stages must complete before the flags tier "
+                "freezes."
+            )
+        entries = [(source, dict(declared)) for source, declared in entries]
+        self._runtime_overrides.extend(entries)
+        try:
+            self._resolve_flags(server_args)
+        except BaseException:
+            del self._runtime_overrides[len(self._runtime_overrides) - len(entries) :]
+            raise
+        return entries
+
+    def freeze_flags(self) -> None:
+        """Lock every static flag group (the resolution end point: after the
+        load-time stages, before serving). ``flags.capture`` stays writable."""
+        self.flags.freeze()
 
     def _resolve_flags(self, server_args: ServerArgs) -> None:
         declarations = getattr(server_args, "_resolved_overrides", None)
-        if declarations is None:
+        if declarations is None and not self._runtime_overrides:
             return
+        declarations = list(declarations or ()) + self._runtime_overrides
         from sglang.srt.arg_groups.overrides import (
             apply_model_overrides,
             assert_flag_parity,
@@ -458,3 +516,4 @@ def reset_context() -> None:
     """
     _CONTEXT._server_args = None
     _CONTEXT.flags = Flags()
+    _CONTEXT._runtime_overrides = []

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1824,7 +1824,10 @@ class ServerArgs:
     ] = False
     disable_shared_experts_fusion: A[
         bool,
-        "Disable the built-in shared experts fusion optimization for DeepSeek V3/R1. Note: DeepEP Waterfill (--enable-deepep-waterfill) still routes shared expert through DeepEP as an extra MoE slot, so shared expert is not separated from the MoE path when Waterfill is enabled.",
+        Arg(
+            help="Disable the built-in shared experts fusion optimization for DeepSeek V3/R1. Note: DeepEP Waterfill (--enable-deepep-waterfill) still routes shared expert through DeepEP as an extra MoE slot, so shared expert is not separated from the MoE path when Waterfill is enabled.",
+            resolvable=True,
+        ),
     ] = False
     enforce_shared_experts_fusion: A[
         bool,

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -83,6 +83,7 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "mamba_radix_cache_strategy",
                     "speculative_moe_runner_backend",
                     "speculative_moe_a2a_backend",
+                    "disable_shared_experts_fusion",
                 }
             ),
         )

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -9,6 +9,7 @@ import unittest
 from unittest.mock import patch
 
 import sglang.srt.server_args as server_args_module
+from sglang.srt.arg_groups.arg_utils import A, Arg
 from sglang.srt.runtime_context import (
     Flags,
     ParallelContext,
@@ -299,6 +300,108 @@ class TestFlagsTier(_IsolatedServerArgs):
             self.assertFalse(get_flags().frozen)
         finally:
             reset_context()  # never leave the singleton frozen for other tests
+
+
+@dataclasses.dataclass
+class _FakeResolvedArgs:
+    """Publishable fixture with a resolvable whitelist (real flat leaves)."""
+
+    page_size: A[int | None, Arg(help="p", resolvable=True)] = None
+    sampling_backend: A[str | None, Arg(help="s", resolvable=True)] = None
+    _resolved_overrides: list = dataclasses.field(default_factory=list)
+
+
+class TestRuntimeResolutionStages(_IsolatedServerArgs):
+    """Runtime stages: post-publish declarations re-resolve the flags tier
+    atomically; freeze_flags() ends the resolution lifecycle."""
+
+    def _publish(self, **kw):
+        args = _FakeResolvedArgs(**kw)
+        get_context().set_server_args(args)
+        return args
+
+    def test_record_before_publish_raises(self):
+        reset_context()
+        with self.assertRaises(ValueError):
+            get_context().record_runtime_overrides([("stage", {"page_size": 64})])
+
+    def test_record_updates_leaves_and_accumulates_stages(self):
+        args = self._publish(page_size=1, sampling_backend="flashinfer")
+        self.assertEqual(get_flags().page_size, 1)  # publish-time materialize
+        # dual-apply transition: the call site keeps its imperative write
+        args.page_size = 64
+        get_context().record_runtime_overrides([("stage.runner", {"page_size": 64})])
+        self.assertEqual(get_flags().page_size, 64)
+        args.sampling_backend = "pytorch"
+        get_context().record_runtime_overrides(
+            [("stage.load", {"sampling_backend": "pytorch"})]
+        )
+        self.assertEqual(get_flags().sampling_backend, "pytorch")
+        self.assertEqual(get_flags().page_size, 64)  # earlier stage survives
+
+    def test_record_parity_failure_rolls_back(self):
+        self._publish(page_size=1)
+        flags_before = get_flags()
+        with self.assertRaises(AssertionError):
+            # declared value diverges from the live server_args (no dual-apply)
+            get_context().record_runtime_overrides([("bad", {"page_size": 64})])
+        self.assertIs(get_flags(), flags_before)  # previous flags intact
+        self.assertEqual(get_context()._runtime_overrides, [])  # rolled back
+
+    def test_record_whitelist_violation_rolls_back(self):
+        self._publish()
+        with self.assertRaises(ValueError):
+            get_context().record_runtime_overrides([("bad", {"nope": 1})])
+        self.assertEqual(get_context()._runtime_overrides, [])
+
+    def test_freeze_ends_the_resolution_lifecycle(self):
+        args = self._publish(page_size=1)
+        try:
+            get_context().freeze_flags()
+            self.assertTrue(get_flags().frozen)
+            with self.assertRaises(RuntimeError):
+                get_context().record_runtime_overrides([("late", {"page_size": 64})])
+            with self.assertRaises(RuntimeError):
+                get_context().set_server_args(args)
+        finally:
+            reset_context()
+
+    def test_declare_load_time_override_dual_applies_and_records(self):
+        from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+        args = self._publish(page_size=1)
+        declare_load_time_override("model.load_time", {"page_size": 64})
+        self.assertEqual(args.page_size, 64)  # dual-applied onto server_args
+        self.assertEqual(get_flags().page_size, 64)  # resolved into the leaf
+        self.assertEqual(
+            get_context()._runtime_overrides,
+            [("model.load_time", {"page_size": 64})],
+        )
+
+    def test_failed_republish_keeps_previous_lifecycle(self):
+        args = self._publish(page_size=1)
+        args.page_size = 64
+        get_context().record_runtime_overrides([("stage", {"page_size": 64})])
+        flags_before = get_flags()
+        bad = _FakeResolvedArgs(page_size=1)
+        bad._resolved_overrides = [("bad", {"nope": 1})]  # gate rejects
+        with self.assertRaises(ValueError):
+            get_context().set_server_args(bad)
+        # previous publish fully intact: slot, flags, and the recorded stages
+        self.assertIs(get_context()._server_args, args)
+        self.assertIs(get_flags(), flags_before)
+        self.assertEqual(
+            get_context()._runtime_overrides, [("stage", {"page_size": 64})]
+        )
+
+    def test_republish_clears_runtime_overrides(self):
+        args = self._publish(page_size=1)
+        args.page_size = 64
+        get_context().record_runtime_overrides([("stage", {"page_size": 64})])
+        self.assertEqual(get_flags().page_size, 64)
+        self._publish(page_size=1)  # fresh lifecycle
+        self.assertEqual(get_flags().page_size, 1)
+        self.assertEqual(get_context()._runtime_overrides, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Unit 4 of a 10-PR stack continuing the config-resolution pipeline refactor (previous stack: #30063–#30077). Based on #30129.

RuntimeContext.record_runtime_overrides() appends post-publish resolution
declarations (runner- and load-time resolved fields) and atomically
re-resolves the flags tier — same gate, whitelist, parity assert and
fresh-container adopt as the publish path, with rollback on failure. A
(re-)publish starts a fresh resolution lifecycle. freeze_flags() locks every
static flag group and ends the lifecycle: recording or re-publishing after
freeze raises.

As the first consumer, the six model-file writes of
disable_shared_experts_fusion on the published global config go through the
new declare_load_time_override helper: the declaration is dual-applied onto
server_args (byte-identical to the imperative write it replaces) and
recorded into the flags tier through the runtime gate with provenance. The
field joins the resolvable whitelist with a flat flag leaf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28721911680](https://github.com/sgl-project/sglang/actions/runs/28721911680)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28721911638](https://github.com/sgl-project/sglang/actions/runs/28721911638)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->