### PR TITLE
[refactor] Resolve the kv-cache dtype into the flags tier (stack 5/10)

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -15,11 +15,13 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
     """Residual imperative arm of the DeepSeek V4 defaults.
 
     The attention/page/window/MoE-runner declarations moved to the override
-    registry (arg_groups/overrides.py: _deepseek_v4_overrides). This keeps,
-    at the legacy slot: the ROCm env fill (env-write policy), the kv-cache
-    dtype and NPU split-backend writes (kv/split-backend resolution is R2
-    territory), the max_running_requests fill (the speculative hook is a
-    later writer of that field) and the validations.
+    registry (arg_groups/overrides.py: _deepseek_v4_overrides) and the
+    kv-cache dtype default to the resolution pipeline
+    (_deepseek_v4_kv_cache_dtype, invoked below at its legacy slot). This
+    keeps, at the legacy slot: the ROCm env fill (env-write policy), the NPU
+    split-backend writes (split fields not yet resolvable), the
+    max_running_requests fill (the speculative hook is a later writer of
+    that field) and the validations.
     """
     from sglang.srt.utils import is_hip
 
@@ -35,11 +37,15 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
         )
         envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.set(False)
 
-    if server_args.kv_cache_dtype == "auto":
-        server_args.kv_cache_dtype = "fp8_e4m3"
-        logger.warning(
-            f"Setting KV cache dtype to {server_args.kv_cache_dtype} for {model_arch}."
-        )
+    # The kv-cache dtype default moved to the resolution pipeline
+    # (arg_groups/overrides.py: _deepseek_v4_kv_cache_dtype), invoked here at
+    # its legacy slot.
+    from sglang.srt.arg_groups.overrides import (
+        _deepseek_v4_kv_cache_dtype,
+        run_post_process_pass,
+    )
+
+    run_post_process_pass(server_args, _deepseek_v4_kv_cache_dtype)
 
     if server_args.device == "npu":
         # NPU keeps the device-aware "dsv4" backend (the registry routes it to
@@ -48,12 +54,6 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
         # generic NPU models; undo that here so V4 stays consistently on dsv4.
         server_args.prefill_attention_backend = "dsv4"
         server_args.decode_attention_backend = "dsv4"
-        server_args.kv_cache_dtype = "bfloat16"
-
-    assert server_args.kv_cache_dtype in [
-        "fp8_e4m3",
-        "bfloat16",
-    ], f"{server_args.kv_cache_dtype} is not supported for {model_arch}"
 
     if server_args.max_running_requests is None:
         server_args.max_running_requests = 256

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -963,6 +963,54 @@ def _mamba_radix_cache_resolution(view: Any) -> dict:
     return declared
 
 
+@register_post_process
+def _dsa_kv_cache_dtype_default(view: Any) -> dict:
+    """Slot pass in the DSA arm, ordered before the split-backend
+    resolution: default the kv-cache dtype from the device capability
+    (Blackwell FP8, Hopper bf16) and normalize the bf16 alias. Reads the
+    PRISTINE dsa split backends (their resolution runs after this pass)."""
+    from sglang.srt.configs.model_config import is_deepseek_dsa
+
+    hf_config = view.get_model_config().hf_config
+    if hf_config.architectures[0] not in _DEEPSEEK_FAMILY_ARCHS:
+        return {}
+    if not is_deepseek_dsa(hf_config):
+        return {}
+    if is_npu() or is_xpu():
+        return {}
+
+    import torch
+
+    major, _ = torch.cuda.get_device_capability()
+
+    # If user specified a backend but didn't explicitly set kv_cache_dtype,
+    # suggest them to be explicit about kv_cache_dtype to avoid surprises
+    if (
+        view.dsa_prefill_backend is not None or view.dsa_decode_backend is not None
+    ) and view.kv_cache_dtype == "auto":
+        logger.warning(
+            "When specifying --dsa-prefill-backend or --dsa-decode-backend, "
+            "you should also explicitly set --kv-cache-dtype (e.g., 'fp8_e4m3' or 'bfloat16'). "
+            "DeepSeek V3.2 defaults to FP8 KV cache which may not be compatible with all backends."
+        )
+
+    kv_cache_dtype = view.kv_cache_dtype
+    if kv_cache_dtype == "auto":
+        kv_cache_dtype = "fp8_e4m3" if major >= 10 else "bfloat16"
+        logger.warning(
+            f"Setting KV cache dtype to {kv_cache_dtype} for DeepSeek DSA on SM{major} device."
+        )
+    if kv_cache_dtype == "bf16":
+        kv_cache_dtype = "bfloat16"
+    assert kv_cache_dtype in [
+        "bfloat16",
+        "fp8_e4m3",
+    ], "DeepSeek DSA only supports bf16/bfloat16 or fp8_e4m3 kv_cache_dtype"
+    if kv_cache_dtype != view.kv_cache_dtype:
+        return {"kv_cache_dtype": kv_cache_dtype}
+    return {}
+
+
 # Keep in sync with the DeepSeek family list on _deepseek_family_overrides.
 _DEEPSEEK_FAMILY_ARCHS = frozenset(
     {
@@ -1095,6 +1143,31 @@ def _deepseek_spec_moe_resolution(view: Any) -> dict:
         "speculative_moe_runner_backend": "triton",
         "speculative_moe_a2a_backend": "none",
     }
+
+
+@register_post_process
+def _deepseek_v4_kv_cache_dtype(view: Any) -> dict:
+    """Slot pass in the DeepSeek V4 hook: default the kv-cache dtype to FP8
+    (bfloat16 on NPU, where the pool geometry differs) and validate the
+    result. The NPU split-backend writes stay in the hook."""
+    hf_config = view.get_model_config().hf_config
+    model_arch = hf_config.architectures[0]
+    if model_arch != "DeepseekV4ForCausalLM":
+        return {}
+
+    kv_cache_dtype = view.kv_cache_dtype
+    if kv_cache_dtype == "auto":
+        kv_cache_dtype = "fp8_e4m3"
+        logger.warning(f"Setting KV cache dtype to {kv_cache_dtype} for {model_arch}.")
+    if view.device == "npu":
+        kv_cache_dtype = "bfloat16"
+    assert kv_cache_dtype in [
+        "fp8_e4m3",
+        "bfloat16",
+    ], f"{kv_cache_dtype} is not supported for {model_arch}"
+    if kv_cache_dtype != view.kv_cache_dtype:
+        return {"kv_cache_dtype": kv_cache_dtype}
+    return {}
 
 
 @register_post_process

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2427,6 +2427,23 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         result = self._get_linear_attn_registry_result()
         return result[1] if result else None
 
+    def _record_kv_cache_dtype(self, resolved: str) -> None:
+        # Load-time resolution transition: the weight-resolved kv-cache dtype
+        # is declared into the flags tier; the dual-apply inside the helper
+        # replaces the legacy in-place write. Mock runners whose server_args
+        # is not the published object keep the plain write.
+        from sglang.srt.runtime_context import get_context
+
+        if get_context()._server_args is self.server_args:
+            from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+            declare_load_time_override(
+                "ModelRunner.configure_kv_cache_dtype",
+                {"kv_cache_dtype": resolved},
+            )
+        else:
+            self.server_args.kv_cache_dtype = resolved
+
     def configure_kv_cache_dtype(self):
         if self.server_args.kv_cache_dtype == "auto":
             quant_config = getattr(self.model, "quant_config", None)
@@ -2435,16 +2452,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 isinstance(kv_cache_quant_algo, str)
                 and kv_cache_quant_algo.upper() == "FP8"
             ):
-                if _is_hip:
-                    self.kv_cache_dtype = fp8_dtype
-                    self.server_args.kv_cache_dtype = TORCH_DTYPE_TO_KV_CACHE_STR[
-                        self.kv_cache_dtype
-                    ]
-                else:
-                    self.kv_cache_dtype = torch.float8_e4m3fn
-                    self.server_args.kv_cache_dtype = TORCH_DTYPE_TO_KV_CACHE_STR[
-                        self.kv_cache_dtype
-                    ]
+                self.kv_cache_dtype = fp8_dtype if _is_hip else torch.float8_e4m3fn
+                self._record_kv_cache_dtype(
+                    TORCH_DTYPE_TO_KV_CACHE_STR[self.kv_cache_dtype]
+                )
             else:
                 self.kv_cache_dtype = self.dtype
         elif self.server_args.kv_cache_dtype == "fp8_e5m2":

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -331,6 +331,7 @@ class Flags(_StaticFlags):
     speculative_moe_runner_backend: str | None = None
     speculative_moe_a2a_backend: str | None = None
     disable_shared_experts_fusion: bool = False
+    kv_cache_dtype: str = "auto"
     # Parallel-request fields: flat transitional home, to be re-homed by the
     # Parallel Parameters Clarification module.
     enable_dp_attention: bool = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -600,6 +600,7 @@ class ServerArgs:
                 "mxfp4) is supported for CUDA 12.8+ and PyTorch 2.8.0+"
             ),
             choices=["auto", "fp8_e5m2", "fp8_e4m3", "bf16", "bfloat16", "fp4_e2m1"],
+            resolvable=True,
         ),
     ] = "auto"
     enable_fp32_lm_head: A[
@@ -3672,33 +3673,15 @@ class ServerArgs:
 
         return capture_sizes
 
-    def _set_default_dsa_kv_cache_dtype(self, major: int, quantization: str) -> str:
-        user_set_prefill = self.dsa_prefill_backend is not None
-        user_set_decode = self.dsa_decode_backend is not None
+    def _set_default_dsa_kv_cache_dtype(self, major: int, quantization: str) -> None:
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _dsa_kv_cache_dtype_default), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _dsa_kv_cache_dtype_default,
+            run_post_process_pass,
+        )
 
-        # If user specified a backend but didn't explicitly set kv_cache_dtype,
-        # suggest them to be explicit about kv_cache_dtype to avoid surprises
-        if (user_set_prefill or user_set_decode) and self.kv_cache_dtype == "auto":
-            logger.warning(
-                "When specifying --dsa-prefill-backend or --dsa-decode-backend, "
-                "you should also explicitly set --kv-cache-dtype (e.g., 'fp8_e4m3' or 'bfloat16'). "
-                "DeepSeek V3.2 defaults to FP8 KV cache which may not be compatible with all backends."
-            )
-
-        if self.kv_cache_dtype == "auto":
-            if major >= 10:
-                self.kv_cache_dtype = "fp8_e4m3"
-            else:
-                self.kv_cache_dtype = "bfloat16"
-            logger.warning(
-                f"Setting KV cache dtype to {self.kv_cache_dtype} for DeepSeek DSA on SM{major} device."
-            )
-        if self.kv_cache_dtype == "bf16":
-            self.kv_cache_dtype = "bfloat16"
-        assert self.kv_cache_dtype in [
-            "bfloat16",
-            "fp8_e4m3",
-        ], "DeepSeek DSA only supports bf16/bfloat16 or fp8_e4m3 kv_cache_dtype"
+        run_post_process_pass(self, _dsa_kv_cache_dtype_default)
 
     def _set_default_dsa_backends(self, kv_cache_dtype: str, major: int) -> str:
         from sglang.srt.arg_groups.hisparse_hook import (

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -84,6 +84,7 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "speculative_moe_runner_backend",
                     "speculative_moe_a2a_backend",
                     "disable_shared_experts_fusion",
+                    "kv_cache_dtype",
                 }
             ),
         )
@@ -1012,6 +1013,90 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 )
             ),
             {},
+        )
+
+    def test_dsa_kv_cache_dtype_default_pass(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _dsa_kv_cache_dtype_default,
+        )
+
+        def _view(**kw):
+            hf = SimpleNamespace(architectures=["DeepseekV32ForCausalLM"])
+            defaults = dict(
+                kv_cache_dtype="auto",
+                dsa_prefill_backend=None,
+                dsa_decode_backend=None,
+            )
+            defaults.update(kw)
+            return ResolvedView(
+                SimpleNamespace(
+                    get_model_config=lambda: SimpleNamespace(hf_config=hf), **defaults
+                )
+            )
+
+        with (
+            patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True),
+            patch.object(overrides_module, "is_npu", return_value=False),
+            patch.object(overrides_module, "is_xpu", return_value=False),
+        ):
+            with patch("torch.cuda.get_device_capability", return_value=(9, 0)):
+                # Hopper: auto -> bfloat16
+                self.assertEqual(
+                    _dsa_kv_cache_dtype_default(_view()),
+                    {"kv_cache_dtype": "bfloat16"},
+                )
+                # alias normalization
+                self.assertEqual(
+                    _dsa_kv_cache_dtype_default(_view(kv_cache_dtype="bf16")),
+                    {"kv_cache_dtype": "bfloat16"},
+                )
+                # explicit value survives (no declaration)
+                self.assertEqual(
+                    _dsa_kv_cache_dtype_default(_view(kv_cache_dtype="fp8_e4m3")), {}
+                )
+                # unsupported dtype rejected
+                with self.assertRaises(AssertionError):
+                    _dsa_kv_cache_dtype_default(_view(kv_cache_dtype="fp8_e5m2"))
+            with patch("torch.cuda.get_device_capability", return_value=(10, 0)):
+                # Blackwell: auto -> fp8
+                self.assertEqual(
+                    _dsa_kv_cache_dtype_default(_view()),
+                    {"kv_cache_dtype": "fp8_e4m3"},
+                )
+
+    def test_deepseek_v4_kv_cache_dtype_pass(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _deepseek_v4_kv_cache_dtype,
+        )
+
+        def _view(arch="DeepseekV4ForCausalLM", **kw):
+            hf = SimpleNamespace(architectures=[arch])
+            defaults = dict(kv_cache_dtype="auto", device="cuda")
+            defaults.update(kw)
+            return ResolvedView(
+                SimpleNamespace(
+                    get_model_config=lambda: SimpleNamespace(hf_config=hf), **defaults
+                )
+            )
+
+        self.assertEqual(
+            _deepseek_v4_kv_cache_dtype(_view()), {"kv_cache_dtype": "fp8_e4m3"}
+        )
+        # NPU pins bfloat16 regardless of the auto default
+        self.assertEqual(
+            _deepseek_v4_kv_cache_dtype(_view(device="npu")),
+            {"kv_cache_dtype": "bfloat16"},
+        )
+        # explicit supported value survives
+        self.assertEqual(
+            _deepseek_v4_kv_cache_dtype(_view(kv_cache_dtype="bfloat16")), {}
+        )
+        with self.assertRaises(AssertionError):
+            _deepseek_v4_kv_cache_dtype(_view(kv_cache_dtype="fp8_e5m2"))
+        self.assertEqual(
+            _deepseek_v4_kv_cache_dtype(_view(arch="LlamaForCausalLM")), {}
         )
 
     def test_deepseek_spec_moe_resolution_pass(self):


### PR DESCRIPTION
Unit 5 of a 10-PR stack continuing the config-resolution pipeline refactor (previous stack: #30063–#30077). Based on #30130.

kv_cache_dtype joins the resolvable whitelist with a flat flag leaf, and
every post-CLI writer becomes declarative: the weight-resolved auto+FP8
write in configure_kv_cache_dtype goes through declare_load_time_override
(mock runners whose server_args is not the published object keep the plain
write); the DSA device-capability default becomes the slot pass
_dsa_kv_cache_dtype_default; and the DeepSeek V4 hook's kv writes become
_deepseek_v4_kv_cache_dtype (the NPU bfloat16 pin folds into the
declaration). Validation asserts ride inside the passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28721912178](https://github.com/sgl-project/sglang/actions/runs/28721912178)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28721912103](https://github.com/sgl-project/sglang/actions/runs/28721912103)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->