### PR TITLE
[refactor] Resolve the DSA and split attention backends into the flags tier (stack 6/10)

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -18,8 +18,7 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
     registry (arg_groups/overrides.py: _deepseek_v4_overrides) and the
     kv-cache dtype default to the resolution pipeline
     (_deepseek_v4_kv_cache_dtype, invoked below at its legacy slot). This
-    keeps, at the legacy slot: the ROCm env fill (env-write policy), the NPU
-    split-backend writes (split fields not yet resolvable), the
+    keeps, at the legacy slot: the ROCm env fill (env-write policy), the
     max_running_requests fill (the speculative hook is a later writer of
     that field) and the validations.
     """
@@ -46,14 +45,6 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
     )
 
     run_post_process_pass(server_args, _deepseek_v4_kv_cache_dtype)
-
-    if server_args.device == "npu":
-        # NPU keeps the device-aware "dsv4" backend (the registry routes it to
-        # the Ascend V4 subclass); only the pool geometry / dtype differ.
-        # set_default_server_args() pins all three backends to "ascend" for
-        # generic NPU models; undo that here so V4 stays consistently on dsv4.
-        server_args.prefill_attention_backend = "dsv4"
-        server_args.decode_attention_backend = "dsv4"
 
     if server_args.max_running_requests is None:
         server_args.max_running_requests = 256

--- a/python/sglang/srt/arg_groups/hisparse_hook.py
+++ b/python/sglang/srt/arg_groups/hisparse_hook.py
@@ -36,30 +36,8 @@ def _hisparse_allowed_backends(kv_cache_dtype: str) -> set[str]:
     )
 
 
-def apply_hisparse_dsa_backend_defaults(
-    server_args: ServerArgs,
-    user_set_prefill: bool,
-    user_set_decode: bool,
-    kv_cache_dtype: str,
-) -> bool:
-    """Pick DSA backends for --enable-hisparse based on KV dtype.
-
-    CUDA uses dtype-specific FlashMLA backends; ROCm uses TileLang. Returns
-    True if hisparse handled backend selection.
-    """
-    if not server_args.enable_hisparse:
-        return False
-
-    backend = _hisparse_default_backend(kv_cache_dtype)
-    if not user_set_prefill:
-        server_args.dsa_prefill_backend = backend
-    if not user_set_decode:
-        server_args.dsa_decode_backend = backend
-    logger.warning(
-        f"HiSparse enabled ({kv_cache_dtype}): using DSA backends "
-        f"prefill={server_args.dsa_prefill_backend}, decode={server_args.dsa_decode_backend}."
-    )
-    return True
+# The hisparse DSA backend defaults moved to the resolution pipeline
+# (arg_groups/overrides.py: _dsa_split_backend_resolution, hisparse arm).
 
 
 def validate_hisparse_dsa_backend(

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -570,6 +570,23 @@ def _gemma4_overrides(server_args: Any, hf_config: Any) -> dict:
     return overrides
 
 
+@_register_for("MossVLForConditionalGeneration")
+def _moss_vl_overrides(server_args: Any, hf_config: Any) -> dict:
+    overrides: Dict[str, Any] = {}
+    if server_args.is_attention_backend_not_set():
+        overrides["prefill_attention_backend"] = "flashinfer"
+        logger.info("Use flashinfer as default prefill attention backend for Moss-VL")
+    prefill_backend = (
+        overrides.get("prefill_attention_backend")
+        or server_args.get_attention_backends()[0]
+    )
+    assert prefill_backend == "flashinfer", (
+        "MossVLForConditionalGeneration requires flashinfer prefill "
+        "attention backend for cross-attention custom mask support."
+    )
+    return overrides
+
+
 @_register_for("MiniCPMV4_6ForConditionalGeneration")
 def _minicpm_v4_6_overrides(server_args: Any, hf_config: Any) -> dict:
     if is_sm100_supported() and server_args.attention_backend is None:
@@ -618,7 +635,12 @@ def _deepseek_v4_overrides(server_args: Any, hf_config: Any) -> dict:
     if server_args.device == "npu":
         # NPU keeps the device-aware "dsv4" backend (the registry routes it to
         # the Ascend V4 subclass); only the pool geometry / dtype differ.
+        # set_default_server_args() pins all three backends to "ascend" for
+        # generic NPU models; override that here so V4 stays consistently on
+        # dsv4.
         page_size = 128
+        overrides["prefill_attention_backend"] = "dsv4"
+        overrides["decode_attention_backend"] = "dsv4"
     overrides["page_size"] = page_size
     logger.info(
         f"Use dsv4 attention backend for {model_arch}, setting page_size to {page_size}."
@@ -1011,6 +1033,71 @@ def _dsa_kv_cache_dtype_default(view: Any) -> dict:
     return {}
 
 
+@register_post_process
+def _dsa_split_backend_resolution(view: Any) -> dict:
+    """Slot pass in the DSA arm: default the DSA prefill/decode split
+    backends from the mid-resolution kv-cache dtype and the device
+    capability. The hisparse arm takes precedence under --enable-hisparse."""
+    from sglang.srt.configs.model_config import is_deepseek_dsa
+
+    hf_config = view.get_model_config().hf_config
+    if hf_config.architectures[0] not in _DEEPSEEK_FAMILY_ARCHS:
+        return {}
+    if not is_deepseek_dsa(hf_config):
+        return {}
+    if is_npu() or is_xpu():
+        return {}
+
+    import torch
+
+    major, _ = torch.cuda.get_device_capability()
+    kv_cache_dtype = view.kv_cache_dtype
+    user_set_prefill = view.dsa_prefill_backend is not None
+    user_set_decode = view.dsa_decode_backend is not None
+    declared: Dict[str, Any] = {}
+
+    if view.enable_hisparse:
+        from sglang.srt.arg_groups.hisparse_hook import _hisparse_default_backend
+
+        backend = _hisparse_default_backend(kv_cache_dtype)
+        if not user_set_prefill:
+            declared["dsa_prefill_backend"] = backend
+        if not user_set_decode:
+            declared["dsa_decode_backend"] = backend
+        prefill = declared.get("dsa_prefill_backend", view.dsa_prefill_backend)
+        decode = declared.get("dsa_decode_backend", view.dsa_decode_backend)
+        logger.warning(
+            f"HiSparse enabled ({kv_cache_dtype}): using DSA backends "
+            f"prefill={prefill}, decode={decode}."
+        )
+        return declared
+
+    if not user_set_prefill and not user_set_decode and is_hip():
+        declared["dsa_prefill_backend"] = "tilelang"
+        declared["dsa_decode_backend"] = "tilelang"
+    elif kv_cache_dtype == "fp8_e4m3":
+        # Blackwell FP8 defaults to trtllm; Hopper FP8 to flashmla_kv.
+        default = "trtllm" if major >= 10 else "flashmla_kv"
+        if not user_set_prefill:
+            declared["dsa_prefill_backend"] = default
+        if not user_set_decode:
+            declared["dsa_decode_backend"] = default
+    else:
+        # Set prefill/decode backends based on hardware architecture.
+        if not user_set_prefill:
+            declared["dsa_prefill_backend"] = "flashmla_sparse"
+        if not user_set_decode:
+            declared["dsa_decode_backend"] = "trtllm" if major >= 10 else "fa3"
+
+    prefill = declared.get("dsa_prefill_backend", view.dsa_prefill_backend)
+    decode = declared.get("dsa_decode_backend", view.dsa_decode_backend)
+    logger.warning(
+        f"Set DSA backends for {kv_cache_dtype} KV Cache: "
+        f"prefill={prefill}, decode={decode}."
+    )
+    return declared
+
+
 # Keep in sync with the DeepSeek family list on _deepseek_family_overrides.
 _DEEPSEEK_FAMILY_ARCHS = frozenset(
     {
@@ -1354,6 +1441,39 @@ def _mla_backend_page_constraints(view: Any) -> dict:
             page_size = 64
     if page_size != view.page_size:
         return {"page_size": page_size}
+    return {}
+
+
+@register_post_process
+def _cutedsl_prefill_backend_fill(view: Any) -> dict:
+    """Slot pass in the attention-backend compatibility handler: CuteDSL MLA
+    is decode-only, so validate the combination and default the prefill side
+    to trtllm_mla. The trtllm_mha check that follows at the legacy slot reads
+    the dual-applied value."""
+    if not (
+        view.attention_backend == "cutedsl_mla"
+        or view.decode_attention_backend == "cutedsl_mla"
+        or view.prefill_attention_backend == "cutedsl_mla"
+    ):
+        return {}
+    assert (
+        view.prefill_attention_backend != "cutedsl_mla"
+    ), "CuteDSL MLA only supports decoding for now"
+    if not is_sm100_supported():
+        raise ValueError(
+            "CuteDSL MLA backend is only supported on Blackwell GPUs (SM100). Please use a different backend."
+        )
+    if view.kv_cache_dtype not in [
+        "fp8_e4m3",
+        "bf16",
+        "bfloat16",
+        "auto",
+    ]:
+        raise ValueError(
+            "CuteDSL MLA backend only supports kv-cache-dtype of fp8_e4m3, bf16, or auto."
+        )
+    if view.prefill_attention_backend is None:
+        return {"prefill_attention_backend": "trtllm_mla"}
     return {}
 
 

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -284,6 +284,8 @@ class AttnFlags(_StaticFlags):
     # Resolved attention backend; the pristine user request stays on
     # server_args.attention_backend.
     backend: str | None = None
+    prefill_backend: str | None = None
+    decode_backend: str | None = None
 
 
 @dataclasses.dataclass
@@ -332,6 +334,8 @@ class Flags(_StaticFlags):
     speculative_moe_a2a_backend: str | None = None
     disable_shared_experts_fusion: bool = False
     kv_cache_dtype: str = "auto"
+    dsa_prefill_backend: str | None = None
+    dsa_decode_backend: str | None = None
     # Parallel-request fields: flat transitional home, to be re-homed by the
     # Parallel Parameters Clarification module.
     enable_dp_attention: bool = False
@@ -355,6 +359,8 @@ class Flags(_StaticFlags):
 # family as readers migrate.
 FLAG_LEAF_MAP: dict[str, str] = {
     "attention_backend": "attn.backend",
+    "prefill_attention_backend": "attn.prefill_backend",
+    "decode_attention_backend": "attn.decode_backend",
     "moe_runner_backend": "moe.runner_backend",
 }
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1430,6 +1430,7 @@ class ServerArgs:
         Arg(
             help="Choose the kernels for decode attention layers (have priority over --attention-backend).",
             choices=ATTENTION_BACKEND_CHOICES,
+            resolvable=True,
         ),
     ] = None
     prefill_attention_backend: A[
@@ -1437,6 +1438,7 @@ class ServerArgs:
         Arg(
             help="Choose the kernels for prefill attention layers (have priority over --attention-backend).",
             choices=ATTENTION_BACKEND_CHOICES,
+            resolvable=True,
         ),
     ] = None
     sampling_backend: A[
@@ -1496,6 +1498,7 @@ class ServerArgs:
         Arg(
             help="DSA (DeepSeek Sparse Attention) prefill backend. If not specified, auto-detects based on hardware and kv_cache_dtype.",
             choices=DSA_CHOICES,
+            resolvable=True,
         ),
     ] = None
     dsa_decode_backend: A[
@@ -1503,6 +1506,7 @@ class ServerArgs:
         Arg(
             help="DSA (DeepSeek Sparse Attention) decode backend. If not specified, auto-detects based on hardware and kv_cache_dtype.",
             choices=DSA_CHOICES,
+            resolvable=True,
         ),
     ] = None
     dsa_topk_backend: A[
@@ -3683,51 +3687,15 @@ class ServerArgs:
 
         run_post_process_pass(self, _dsa_kv_cache_dtype_default)
 
-    def _set_default_dsa_backends(self, kv_cache_dtype: str, major: int) -> str:
-        from sglang.srt.arg_groups.hisparse_hook import (
-            apply_hisparse_dsa_backend_defaults,
+    def _set_default_dsa_backends(self, kv_cache_dtype: str, major: int) -> None:
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _dsa_split_backend_resolution), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _dsa_split_backend_resolution,
+            run_post_process_pass,
         )
 
-        user_set_prefill = self.dsa_prefill_backend is not None
-        user_set_decode = self.dsa_decode_backend is not None
-
-        if apply_hisparse_dsa_backend_defaults(
-            self, user_set_prefill, user_set_decode, kv_cache_dtype
-        ):
-            return
-
-        if not user_set_prefill and not user_set_decode and is_hip():
-            self.dsa_prefill_backend = "tilelang"
-            self.dsa_decode_backend = "tilelang"
-        elif kv_cache_dtype == "fp8_e4m3":
-            if major >= 10:
-                if not user_set_prefill:
-                    self.dsa_prefill_backend = "trtllm"
-                if not user_set_decode:
-                    self.dsa_decode_backend = "trtllm"
-            else:
-                # Hopper FP8 defaults to flashmla_kv for both prefill and decode.
-                if not user_set_prefill:
-                    self.dsa_prefill_backend = "flashmla_kv"
-                if not user_set_decode:
-                    self.dsa_decode_backend = "flashmla_kv"
-        else:
-            # set prefill/decode backends based on hardware architecture.
-            if major >= 10:
-                if not user_set_prefill:
-                    self.dsa_prefill_backend = "flashmla_sparse"
-                if not user_set_decode:
-                    self.dsa_decode_backend = "trtllm"
-            else:
-                # Hopper defaults for bfloat16
-                if not user_set_prefill:
-                    self.dsa_prefill_backend = "flashmla_sparse"
-                if not user_set_decode:
-                    self.dsa_decode_backend = "fa3"
-
-        logger.warning(
-            f"Set DSA backends for {self.kv_cache_dtype} KV Cache: prefill={self.dsa_prefill_backend}, decode={self.dsa_decode_backend}."
-        )
+        run_post_process_pass(self, _dsa_split_backend_resolution)
 
     def _validate_hisparse_dsa_backend(self, attr: str, label: str):
         from sglang.srt.arg_groups.hisparse_hook import validate_hisparse_dsa_backend
@@ -4062,16 +4030,9 @@ class ServerArgs:
             # The quantization/moe_runner_backend resolution moved to the override
             # registry (arg_groups/overrides.py: _gemma4_overrides).
         elif model_arch == "MossVLForConditionalGeneration":
-            if self.is_attention_backend_not_set():
-                self.prefill_attention_backend = "flashinfer"
-                logger.info(
-                    "Use flashinfer as default prefill attention backend for Moss-VL"
-                )
-            prefill_backend, _ = self.get_attention_backends()
-            assert prefill_backend == "flashinfer", (
-                "MossVLForConditionalGeneration requires flashinfer prefill "
-                "attention backend for cross-attention custom mask support."
-            )
+            # The prefill attention backend default + validation moved to the
+            # override registry (arg_groups/overrides.py: _moss_vl_overrides).
+            pass
         elif model_arch in ["Exaone4ForCausalLM", "ExaoneMoEForCausalLM"]:
             if hf_config.sliding_window_pattern is not None:
                 # disable_hybrid_swa_memory moved to the override registry
@@ -4405,29 +4366,12 @@ class ServerArgs:
                     f"got {self.kv_cache_dtype}."
                 )
 
-        if (
-            self.attention_backend == "cutedsl_mla"
-            or self.decode_attention_backend == "cutedsl_mla"
-            or self.prefill_attention_backend == "cutedsl_mla"
-        ):
-            assert (
-                self.prefill_attention_backend != "cutedsl_mla"
-            ), "CuteDSL MLA only supports decoding for now"
-            if not is_sm100_supported():
-                raise ValueError(
-                    "CuteDSL MLA backend is only supported on Blackwell GPUs (SM100). Please use a different backend."
-                )
-            if self.kv_cache_dtype not in [
-                "fp8_e4m3",
-                "bf16",
-                "bfloat16",
-                "auto",
-            ]:
-                raise ValueError(
-                    "CuteDSL MLA backend only supports kv-cache-dtype of fp8_e4m3, bf16, or auto."
-                )
-            if self.prefill_attention_backend is None:
-                self.prefill_attention_backend = "trtllm_mla"
+        # The CuteDSL MLA validation + prefill fill moved to the resolution
+        # pipeline (arg_groups/overrides.py: _cutedsl_prefill_backend_fill),
+        # invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import _cutedsl_prefill_backend_fill
+
+        run_post_process_pass(self, _cutedsl_prefill_backend_fill)
 
         if (
             self.attention_backend == "trtllm_mha"

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -184,47 +184,75 @@ class TestLoadBalanceMethod(unittest.TestCase):
 
 
 class TestHiSparseDsaBackendPolicy(unittest.TestCase):
+    # The backend selection moved to the resolution pipeline; these policy
+    # tests drive the pass through its read-only view.
+    @staticmethod
+    def _resolve(kv_cache_dtype, **kw):
+        from types import SimpleNamespace
+
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _dsa_split_backend_resolution,
+        )
+
+        hf = SimpleNamespace(architectures=["DeepseekV32ForCausalLM"])
+        defaults = dict(
+            kv_cache_dtype=kv_cache_dtype,
+            dsa_prefill_backend=None,
+            dsa_decode_backend=None,
+            enable_hisparse=True,
+        )
+        defaults.update(kw)
+        view = ResolvedView(
+            SimpleNamespace(
+                get_model_config=lambda: SimpleNamespace(hf_config=hf), **defaults
+            )
+        )
+        with (
+            patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True),
+            patch("sglang.srt.arg_groups.overrides.is_npu", return_value=False),
+            patch("sglang.srt.arg_groups.overrides.is_xpu", return_value=False),
+            patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+        ):
+            declared = _dsa_split_backend_resolution(view)
+        return {
+            "dsa_prefill_backend": declared.get(
+                "dsa_prefill_backend", defaults["dsa_prefill_backend"]
+            ),
+            "dsa_decode_backend": declared.get(
+                "dsa_decode_backend", defaults["dsa_decode_backend"]
+            ),
+        }
+
     @patch("sglang.srt.server_args.is_hip", return_value=False)
     def test_hisparse_defaults_to_flashmla_sparse_on_cuda_bfloat16(self, _mock_is_hip):
-        server_args = ServerArgs(model_path="dummy", enable_hisparse=True)
+        resolved = self._resolve("bfloat16")
 
-        server_args._set_default_dsa_backends(kv_cache_dtype="bfloat16", major=9)
-
-        self.assertEqual(server_args.dsa_prefill_backend, "flashmla_sparse")
-        self.assertEqual(server_args.dsa_decode_backend, "flashmla_sparse")
+        self.assertEqual(resolved["dsa_prefill_backend"], "flashmla_sparse")
+        self.assertEqual(resolved["dsa_decode_backend"], "flashmla_sparse")
 
     @patch("sglang.srt.server_args.is_hip", return_value=False)
     def test_hisparse_defaults_to_flashmla_kv_on_cuda_fp8(self, _mock_is_hip):
-        server_args = ServerArgs(model_path="dummy", enable_hisparse=True)
+        resolved = self._resolve("fp8_e4m3")
 
-        server_args._set_default_dsa_backends(kv_cache_dtype="fp8_e4m3", major=9)
-
-        self.assertEqual(server_args.dsa_prefill_backend, "flashmla_kv")
-        self.assertEqual(server_args.dsa_decode_backend, "flashmla_kv")
+        self.assertEqual(resolved["dsa_prefill_backend"], "flashmla_kv")
+        self.assertEqual(resolved["dsa_decode_backend"], "flashmla_kv")
 
     @patch("sglang.srt.server_args.is_hip", return_value=True)
     def test_hisparse_defaults_to_tilelang_on_rocm(self, _mock_is_hip):
-        server_args = ServerArgs(model_path="dummy", enable_hisparse=True)
+        resolved = self._resolve("bfloat16")
 
-        server_args._set_default_dsa_backends(kv_cache_dtype="bfloat16", major=9)
-
-        self.assertEqual(server_args.dsa_prefill_backend, "tilelang")
-        self.assertEqual(server_args.dsa_decode_backend, "tilelang")
+        self.assertEqual(resolved["dsa_prefill_backend"], "tilelang")
+        self.assertEqual(resolved["dsa_decode_backend"], "tilelang")
 
     @patch("sglang.srt.server_args.is_hip", return_value=True)
     def test_hisparse_preserves_rocm_user_backend_and_defaults_missing_side(
         self, _mock_is_hip
     ):
-        server_args = ServerArgs(
-            model_path="dummy",
-            enable_hisparse=True,
-            dsa_prefill_backend="tilelang",
-        )
+        resolved = self._resolve("bfloat16", dsa_prefill_backend="tilelang")
 
-        server_args._set_default_dsa_backends(kv_cache_dtype="bfloat16", major=9)
-
-        self.assertEqual(server_args.dsa_prefill_backend, "tilelang")
-        self.assertEqual(server_args.dsa_decode_backend, "tilelang")
+        self.assertEqual(resolved["dsa_prefill_backend"], "tilelang")
+        self.assertEqual(resolved["dsa_decode_backend"], "tilelang")
 
     @patch("sglang.srt.server_args.is_hip", return_value=True)
     def test_hisparse_accepts_aiter_backend_on_rocm(self, _mock_is_hip):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -85,6 +85,10 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "speculative_moe_a2a_backend",
                     "disable_shared_experts_fusion",
                     "kv_cache_dtype",
+                    "dsa_prefill_backend",
+                    "dsa_decode_backend",
+                    "prefill_attention_backend",
+                    "decode_attention_backend",
                 }
             ),
         )
@@ -1014,6 +1018,162 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             ),
             {},
         )
+
+    def test_dsa_split_backend_resolution_pass(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _dsa_split_backend_resolution,
+        )
+
+        def _view(arch="DeepseekV32ForCausalLM", **kw):
+            hf = SimpleNamespace(architectures=[arch])
+            defaults = dict(
+                kv_cache_dtype="fp8_e4m3",
+                dsa_prefill_backend=None,
+                dsa_decode_backend=None,
+                enable_hisparse=False,
+            )
+            defaults.update(kw)
+            return ResolvedView(
+                SimpleNamespace(
+                    get_model_config=lambda: SimpleNamespace(hf_config=hf), **defaults
+                )
+            )
+
+        with (
+            patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True),
+            patch.object(overrides_module, "is_npu", return_value=False),
+            patch.object(overrides_module, "is_xpu", return_value=False),
+            patch.object(overrides_module, "is_hip", return_value=False),
+            patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+        ):
+            # Hopper FP8 -> flashmla_kv both
+            self.assertEqual(
+                _dsa_split_backend_resolution(_view()),
+                {
+                    "dsa_prefill_backend": "flashmla_kv",
+                    "dsa_decode_backend": "flashmla_kv",
+                },
+            )
+            # Hopper bf16 -> flashmla_sparse / fa3
+            self.assertEqual(
+                _dsa_split_backend_resolution(_view(kv_cache_dtype="bfloat16")),
+                {
+                    "dsa_prefill_backend": "flashmla_sparse",
+                    "dsa_decode_backend": "fa3",
+                },
+            )
+            # user-set prefill survives; only decode defaulted
+            self.assertEqual(
+                _dsa_split_backend_resolution(_view(dsa_prefill_backend="trtllm")),
+                {"dsa_decode_backend": "flashmla_kv"},
+            )
+            # hisparse arm takes precedence (CUDA fp8 -> flashmla_kv)
+            self.assertEqual(
+                _dsa_split_backend_resolution(_view(enable_hisparse=True)),
+                {
+                    "dsa_prefill_backend": "flashmla_kv",
+                    "dsa_decode_backend": "flashmla_kv",
+                },
+            )
+            # non-family arch declares nothing
+            self.assertEqual(
+                _dsa_split_backend_resolution(_view(arch="LlamaForCausalLM")), {}
+            )
+        with (
+            patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True),
+            patch.object(overrides_module, "is_npu", return_value=False),
+            patch.object(overrides_module, "is_xpu", return_value=False),
+            patch.object(overrides_module, "is_hip", return_value=True),
+            patch("torch.cuda.get_device_capability", return_value=(9, 4)),
+        ):
+            # ROCm with both unset -> tilelang
+            self.assertEqual(
+                _dsa_split_backend_resolution(_view(kv_cache_dtype="bfloat16")),
+                {
+                    "dsa_prefill_backend": "tilelang",
+                    "dsa_decode_backend": "tilelang",
+                },
+            )
+
+    def test_cutedsl_prefill_backend_fill_pass(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _cutedsl_prefill_backend_fill,
+        )
+
+        def _view(**kw):
+            defaults = dict(
+                attention_backend=None,
+                decode_attention_backend="cutedsl_mla",
+                prefill_attention_backend=None,
+                kv_cache_dtype="auto",
+            )
+            defaults.update(kw)
+            return ResolvedView(SimpleNamespace(**defaults))
+
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            # decode-only cutedsl: prefill defaults to trtllm_mla
+            self.assertEqual(
+                _cutedsl_prefill_backend_fill(_view()),
+                {"prefill_attention_backend": "trtllm_mla"},
+            )
+            # user-set prefill survives
+            self.assertEqual(
+                _cutedsl_prefill_backend_fill(_view(prefill_attention_backend="fa3")),
+                {},
+            )
+            # cutedsl on the prefill side is rejected
+            with self.assertRaises(AssertionError):
+                _cutedsl_prefill_backend_fill(
+                    _view(prefill_attention_backend="cutedsl_mla")
+                )
+            # unsupported kv dtype rejected
+            with self.assertRaises(ValueError):
+                _cutedsl_prefill_backend_fill(_view(kv_cache_dtype="fp8_e5m2"))
+            # not a cutedsl config: nothing declared
+            self.assertEqual(
+                _cutedsl_prefill_backend_fill(_view(decode_attention_backend=None)),
+                {},
+            )
+        with patch.object(overrides_module, "is_sm100_supported", return_value=False):
+            with self.assertRaises(ValueError):
+                _cutedsl_prefill_backend_fill(_view())
+
+    def test_moss_vl_overrides_at_callable_level(self):
+        from sglang.srt.arg_groups.overrides import _moss_vl_overrides
+
+        def _args(**kw):
+            defaults = dict(
+                attention_backend=None,
+                prefill_attention_backend=None,
+                decode_attention_backend=None,
+            )
+            defaults.update(kw)
+            ns = SimpleNamespace(**defaults)
+            ns.is_attention_backend_not_set = lambda: (
+                ns.attention_backend is None
+                and ns.prefill_attention_backend is None
+                and ns.decode_attention_backend is None
+            )
+            ns.get_attention_backends = lambda: (
+                ns.prefill_attention_backend or ns.attention_backend,
+                ns.decode_attention_backend or ns.attention_backend,
+            )
+            return ns
+
+        # nothing set: prefill defaults to flashinfer
+        self.assertEqual(
+            _moss_vl_overrides(_args(), None),
+            {"prefill_attention_backend": "flashinfer"},
+        )
+        # compatible user choice passes with no declaration
+        self.assertEqual(
+            _moss_vl_overrides(_args(attention_backend="flashinfer"), None), {}
+        )
+        # incompatible user choice rejected
+        with self.assertRaises(AssertionError):
+            _moss_vl_overrides(_args(attention_backend="fa3"), None)
 
     def test_dsa_kv_cache_dtype_default_pass(self):
         from sglang.srt.arg_groups.overrides import (


### PR DESCRIPTION
Unit 6 of a 10-PR stack continuing the config-resolution pipeline refactor (previous stack: #30063–#30077). Based on #30131.

_set_default_dsa_backends (including the hisparse arm from
arg_groups/hisparse_hook.py) becomes the slot pass
_dsa_split_backend_resolution, reading the mid-resolution kv-cache dtype and
the device capability exactly like the legacy in-branch fill; the hisparse
policy tests drive the pass through its read-only view.

prefill/decode_attention_backend join the resolvable whitelist with mapped
leaves (attn.prefill_backend / attn.decode_backend), and their post-CLI
writers become declarative, latest first: the CuteDSL decode-only validation
+ prefill fill becomes the slot pass _cutedsl_prefill_backend_fill; the
MossVL branch dissolves into the registry callable _moss_vl_overrides; the
DeepSeek V4 NPU split pins move from the hook into the dispatch declaration.
The NPU early-handler writes stay imperative as earlier writers.
dsa_prefill_backend / dsa_decode_backend get flat flag leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28721912673](https://github.com/sgl-project/sglang/actions/runs/28721912673)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28721912609](https://github.com/sgl-project/sglang/actions/runs/28721912609)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->