### PR TITLE
[refactor] Migrate the FlashInfer AllReduce Fusion resolution to the pipeline (stack 7/10)

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1284,6 +1284,68 @@ def _sparse_head_overlap_disable(view: Any) -> dict:
     return {}
 
 
+# Architectures with explicit FlashInfer AllReduce Fusion support. Keep in
+# sync with the model-side fusion implementations.
+_FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
+    {
+        "DeepseekV3ForCausalLM",
+        "DeepseekV32ForCausalLM",
+        "GptOssForCausalLM",
+        "GlmMoeDsaForCausalLM",
+        "Glm4MoeForCausalLM",
+        "Glm4MoeLiteForCausalLM",
+        "MistralLarge3ForCausalLM",
+        "Qwen3MoeForCausalLM",
+        "Qwen3VLMoeForConditionalGeneration",
+        "Qwen3NextForCausalLM",
+        "KimiK25ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+        "InternS2PreviewForConditionalGeneration",
+        "Qwen3_5ForConditionalGeneration",
+        "NemotronHForCausalLM",
+        "NemotronHPuzzleForCausalLM",
+    }
+)
+
+
+@register_post_process
+def _flashinfer_allreduce_fusion_auto_enable(view: Any) -> dict:
+    """Slot pass at the monolith tail: auto-enable FlashInfer AllReduce
+    Fusion on SM90/SM100 for models with explicit support. auto resolves to
+    mnnvl on Blackwell (single- and multi-node) and trtllm on SM90
+    single-node systems. Reads the mid-resolution enable_dp_attention /
+    moe_a2a_backend (after the DeepSeek CP and a2a declarations), exactly
+    like the legacy tail block."""
+    model_arch = view.get_model_config().hf_config.architectures[0]
+    if (
+        view.flashinfer_allreduce_fusion_backend is None
+        and model_arch in _FLASHINFER_ALLREDUCE_FUSION_ARCHS
+        and (is_sm90_supported() or is_sm100_supported())
+        and view.tp_size > 1
+        and not view.enable_dp_attention
+        and (view.nnodes == 1 or is_sm100_supported())
+        and view.moe_a2a_backend == "none"
+    ):
+        logger.info(
+            f"Auto-enabling FlashInfer AllReduce Fusion on SM90/SM10X for {model_arch}"
+        )
+        return {"flashinfer_allreduce_fusion_backend": "auto"}
+    return {}
+
+
+@register_post_process
+def _enforce_disable_allreduce_fusion(view: Any) -> dict:
+    """Slot pass right after the auto-enable: the user's enforce-disable
+    switch wins over every model-specific adjustment."""
+    if view.enforce_disable_flashinfer_allreduce_fusion:
+        logger.info(
+            "FlashInfer allreduce fusion is forcibly disabled "
+            "via --enforce-disable-flashinfer-allreduce-fusion."
+        )
+        return {"flashinfer_allreduce_fusion_backend": None}
+    return {}
+
+
 @register_post_process
 def _sampling_backend_default(view: Any) -> dict:
     if view.sampling_backend is None:
@@ -1325,6 +1387,19 @@ def _deterministic_is_deepseek_model(view: Any) -> bool:
         ]
     except Exception:
         return False
+
+
+@register_post_process
+def _deterministic_allreduce_fusion_disable(view: Any) -> dict:
+    if (
+        view.enable_deterministic_inference
+        and view.flashinfer_allreduce_fusion_backend is not None
+    ):
+        logger.warning(
+            "Disable --flashinfer-allreduce-fusion-backend because deterministic inference is enabled."
+        )
+        return {"flashinfer_allreduce_fusion_backend": None}
+    return {}
 
 
 @register_post_process

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -336,6 +336,7 @@ class Flags(_StaticFlags):
     kv_cache_dtype: str = "auto"
     dsa_prefill_backend: str | None = None
     dsa_decode_backend: str | None = None
+    flashinfer_allreduce_fusion_backend: str | None = None
     # Parallel-request fields: flat transitional home, to be re-homed by the
     # Parallel Parameters Clarification module.
     enable_dp_attention: bool = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2233,6 +2233,7 @@ class ServerArgs:
                 "single-node or multi-node systems via MNNVL fabric. "
                 "Fuses allreduce with Residual + RMSNorm for supported MoE models."
             ),
+            resolvable=True,
         ),
     ] = None
     enable_aiter_allreduce_fusion: A[bool, "Enable Aiter AllReduce Fusion."] = False
@@ -4114,49 +4115,18 @@ class ServerArgs:
 
         run_post_process_pass(self, _sparse_head_overlap_disable)
 
-        # Auto-enable FlashInfer AllReduce Fusion on SM90/SM100, for models with
-        # explicit support (DeepseekV3, GptOss, Glm4Moe, MistralLarge3,
-        # Qwen3/Qwen3-VL/Qwen3Next/Qwen3.5 MoE families). auto resolves to mnnvl on
-        # Blackwell (single- and multi-node) and trtllm on SM90 single-node systems.
-        if (
-            self.flashinfer_allreduce_fusion_backend is None
-            and model_arch
-            in [
-                "DeepseekV3ForCausalLM",
-                "DeepseekV32ForCausalLM",
-                "GptOssForCausalLM",
-                "GlmMoeDsaForCausalLM",
-                "Glm4MoeForCausalLM",
-                "Glm4MoeLiteForCausalLM",
-                "MistralLarge3ForCausalLM",
-                "Qwen3MoeForCausalLM",
-                "Qwen3VLMoeForConditionalGeneration",
-                "Qwen3NextForCausalLM",
-                "KimiK25ForConditionalGeneration",
-                "Qwen3_5MoeForConditionalGeneration",
-                "InternS2PreviewForConditionalGeneration",
-                "Qwen3_5ForConditionalGeneration",
-                "NemotronHForCausalLM",
-                "NemotronHPuzzleForCausalLM",
-            ]
-            and (is_sm90_supported() or is_sm100_supported())
-            and self.tp_size > 1
-            and not self.enable_dp_attention
-            and (self.nnodes == 1 or is_sm100_supported())
-            and self.moe_a2a_backend == "none"
-        ):
-            self.flashinfer_allreduce_fusion_backend = "auto"
-            logger.info(
-                f"Auto-enabling FlashInfer AllReduce Fusion on SM90/SM10X for {model_arch}"
-            )
+        # The FlashInfer AllReduce Fusion auto-enable and the enforce-disable
+        # terminal moved to the resolution pipeline (arg_groups/overrides.py:
+        # _flashinfer_allreduce_fusion_auto_enable /
+        # _enforce_disable_allreduce_fusion), invoked here at their legacy
+        # slots.
+        from sglang.srt.arg_groups.overrides import (
+            _enforce_disable_allreduce_fusion,
+            _flashinfer_allreduce_fusion_auto_enable,
+        )
 
-        # Apply enforce_disable_flashinfer_allreduce_fusion after all model-specific adjustments
-        if self.enforce_disable_flashinfer_allreduce_fusion:
-            self.flashinfer_allreduce_fusion_backend = None
-            logger.info(
-                "FlashInfer allreduce fusion is forcibly disabled "
-                "via --enforce-disable-flashinfer-allreduce-fusion."
-            )
+        run_post_process_pass(self, _flashinfer_allreduce_fusion_auto_enable)
+        run_post_process_pass(self, _enforce_disable_allreduce_fusion)
 
     def _support_mamba_cache_extra_buffer(self, model_arch: str):
         from sglang.srt.arg_groups.overrides import supports_mamba_cache_extra_buffer
@@ -5745,11 +5715,15 @@ class ServerArgs:
                 )
                 self.enable_aiter_allreduce_fusion = False
 
-            if self.flashinfer_allreduce_fusion_backend is not None:
-                logger.warning(
-                    "Disable --flashinfer-allreduce-fusion-backend because deterministic inference is enabled."
-                )
-                self.flashinfer_allreduce_fusion_backend = None
+            # Moved to the resolution pipeline (arg_groups/overrides.py:
+            # _deterministic_allreduce_fusion_disable), invoked here at its
+            # legacy slot.
+            from sglang.srt.arg_groups.overrides import (
+                _deterministic_allreduce_fusion_disable,
+                run_post_process_pass,
+            )
+
+            run_post_process_pass(self, _deterministic_allreduce_fusion_disable)
 
             # The forced-pytorch sampling write and the attention backend
             # fill/validation moved to the resolution pipeline

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -89,6 +89,7 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "dsa_decode_backend",
                     "prefill_attention_backend",
                     "decode_attention_backend",
+                    "flashinfer_allreduce_fusion_backend",
                 }
             ),
         )
@@ -1095,6 +1096,103 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     "dsa_decode_backend": "tilelang",
                 },
             )
+
+    def test_flashinfer_allreduce_fusion_passes(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _deterministic_allreduce_fusion_disable,
+            _enforce_disable_allreduce_fusion,
+            _flashinfer_allreduce_fusion_auto_enable,
+        )
+
+        def _view(arch="Qwen3MoeForCausalLM", **kw):
+            hf = SimpleNamespace(architectures=[arch])
+            defaults = dict(
+                flashinfer_allreduce_fusion_backend=None,
+                tp_size=2,
+                enable_dp_attention=False,
+                nnodes=1,
+                moe_a2a_backend="none",
+                enforce_disable_flashinfer_allreduce_fusion=False,
+                enable_deterministic_inference=False,
+            )
+            defaults.update(kw)
+            return ResolvedView(
+                SimpleNamespace(
+                    get_model_config=lambda: SimpleNamespace(hf_config=hf), **defaults
+                )
+            )
+
+        with (
+            patch.object(overrides_module, "is_sm90_supported", return_value=True),
+            patch.object(overrides_module, "is_sm100_supported", return_value=False),
+        ):
+            self.assertEqual(
+                _flashinfer_allreduce_fusion_auto_enable(_view()),
+                {"flashinfer_allreduce_fusion_backend": "auto"},
+            )
+            # guards: unsupported arch / tp==1 / dp attention / a2a backend
+            self.assertEqual(
+                _flashinfer_allreduce_fusion_auto_enable(
+                    _view(arch="LlamaForCausalLM")
+                ),
+                {},
+            )
+            self.assertEqual(
+                _flashinfer_allreduce_fusion_auto_enable(_view(tp_size=1)), {}
+            )
+            self.assertEqual(
+                _flashinfer_allreduce_fusion_auto_enable(
+                    _view(enable_dp_attention=True)
+                ),
+                {},
+            )
+            self.assertEqual(
+                _flashinfer_allreduce_fusion_auto_enable(
+                    _view(moe_a2a_backend="deepep")
+                ),
+                {},
+            )
+            # SM90 multi-node: blocked (nnodes>1 needs SM100)
+            self.assertEqual(
+                _flashinfer_allreduce_fusion_auto_enable(_view(nnodes=2)), {}
+            )
+            # user-set backend survives
+            self.assertEqual(
+                _flashinfer_allreduce_fusion_auto_enable(
+                    _view(flashinfer_allreduce_fusion_backend="trtllm")
+                ),
+                {},
+            )
+
+        # enforce-disable wins over everything
+        self.assertEqual(
+            _enforce_disable_allreduce_fusion(
+                _view(
+                    flashinfer_allreduce_fusion_backend="auto",
+                    enforce_disable_flashinfer_allreduce_fusion=True,
+                )
+            ),
+            {"flashinfer_allreduce_fusion_backend": None},
+        )
+        self.assertEqual(_enforce_disable_allreduce_fusion(_view()), {})
+
+        # deterministic inference disables an enabled fusion
+        self.assertEqual(
+            _deterministic_allreduce_fusion_disable(
+                _view(
+                    flashinfer_allreduce_fusion_backend="auto",
+                    enable_deterministic_inference=True,
+                )
+            ),
+            {"flashinfer_allreduce_fusion_backend": None},
+        )
+        self.assertEqual(
+            _deterministic_allreduce_fusion_disable(
+                _view(enable_deterministic_inference=True)
+            ),
+            {},
+        )
 
     def test_cutedsl_prefill_backend_fill_pass(self):
         from sglang.srt.arg_groups.overrides import (


### PR DESCRIPTION
Unit 7 of a 10-PR stack continuing the config-resolution pipeline refactor (previous stack: #30063–#30077). Based on #30132.

The field's full post-CLI writer chain becomes three slot passes, latest
writer first: the deterministic-inference disable in its later handler, the
enforce-disable switch, and the monolith-tail auto-enable (which reads the
mid-resolution enable_dp_attention / moe_a2a_backend, after the DeepSeek CP
and a2a declarations). flashinfer_allreduce_fusion_backend joins the
resolvable whitelist with a flat leaf. The deprecated-alias normalization in
_handle_deprecated_args stays imperative — it is CLI normalization inside
the pristine boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28721913272](https://github.com/sgl-project/sglang/actions/runs/28721913272)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28721913202](https://github.com/sgl-project/sglang/actions/runs/28721913202)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->