### PR TITLE
[refactor] Freeze the static flag groups at the end of scheduler init (stack 8/10)

### DIFF
--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -87,7 +87,7 @@ def get_cp_padding_align_size() -> int:
 
 def is_mla_prefill_cp_enabled() -> bool:
     sa = get_global_server_args()
-    return sa.enable_prefill_context_parallel and sa.use_mla_backend
+    return sa.enable_prefill_context_parallel and sa.use_mla_backend()
 
 
 def mla_use_prefill_cp(forward_batch, mla_enable_prefill_cp=None):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -553,6 +553,14 @@ class Scheduler(
 
         self.init_batch_result_processor()
 
+        # The config-resolution lifecycle of this scheduler process ends
+        # here: every load-time stage has run (target and draft model init,
+        # weight-resolved kv-cache dtype), so lock the static flag groups.
+        # flags.capture stays writable; late resolution writes now raise.
+        from sglang.srt.runtime_context import get_context
+
+        get_context().freeze_flags()
+
         self.is_initializing = False
 
     def init_zbal_on_npu(self):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -532,8 +532,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # only, so a draft init cannot clobber target-derived global state).
         if not self.is_draft_worker:
             set_global_server_args_for_scheduler(server_args)
-            # FIXME: hacky set `use_mla_backend`
-            get_global_server_args().use_mla_backend = self.use_mla_backend
 
         # Init OpenMP threads binding for CPU
         if self.device == "cpu":

--- a/test/registered/unit/test_legacy_global_ratchet.py
+++ b/test/registered/unit/test_legacy_global_ratchet.py
@@ -25,7 +25,7 @@ _SRT_ROOT = Path(next(iter(sglang.srt.__path__)))
 # Baselines counted over python/sglang/srt/**/*.py, including each function's
 # own def line. Ratchet: decrease-only.
 _RATCHETS = [
-    ("get_global_server_args", r"\bget_global_server_args\s*\(", 346),
+    ("get_global_server_args", r"\bget_global_server_args\s*\(", 341),
     (
         "set_global_server_args_for_*",
         r"\bset_global_server_args_for_(?:scheduler|tokenizer)\s*\(",


### PR DESCRIPTION
Unit 8 of a 10-PR stack continuing the config-resolution pipeline refactor (previous stack: #30063–#30077). Based on #30133.

The config-resolution lifecycle of a scheduler process now has an end point:
after every load-time stage has run (target and draft model init, the
weight-resolved kv-cache dtype), Scheduler.__init__ locks the static flag
groups via freeze_flags(). flags.capture stays writable; recording a runtime
override or re-publishing after the freeze raises. Placed at scheduler-init
end rather than alloc_memory_pool because draft (NextN) model init — a
load-time resolution stage — runs after the target runner's memory pool is
allocated.

Also removes the dead instance write of use_mla_backend on the published
ServerArgs (ModelRunner.__init__): its readers migrated to the runner's own
attribute, and the write shadowed the ServerArgs.use_mla_backend() method
with a bool on the published instance. Ratchet baseline 346 -> 341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28721913859](https://github.com/sgl-project/sglang/actions/runs/28721913859)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28721913810](https://github.com/sgl-project/sglang/actions/runs/28721913810)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->