### PR TITLE
[fix] Wrap the sp_shard test entry point in sys.exit so failures propagate

### DIFF
--- a/python/sglang/multimodal_gen/test/unit/test_sp_shard.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sp_shard.py
@@ -1,5 +1,7 @@
 """Unit tests for the unified SP shard helpers (pure logic, no distributed)."""
 
+import sys
+
 import pytest
 import torch
 
@@ -210,4 +212,4 @@ def test_gather_seq_trims(monkeypatch):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-q"])
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
test_sp_shard.py (added in #30107) runs a bare `pytest.main(...)` in its `__main__` block, which swallows the exit code. The repo hygiene check `test_no_bare_pytest_main` now fails on main and on every open PR's merge commit:

```
AssertionError: ['python/sglang/multimodal_gen/test/unit/test_sp_shard.py:213'] is not false : Found bare pytest.main(...) in __main__ blocks
```

One-line fix: wrap it in `sys.exit(...)` (sys import added). Verified `test_no_bare_pytest_main` passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28719846149](https://github.com/sgl-project/sglang/actions/runs/28719846149)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28719849266](https://github.com/sgl-project/sglang/actions/runs/28719849266)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->