### PR TITLE
[Fix] Skip cross-node probe in MultimemAllGatherer on single-node runs (fixes mooncake EP segfault)

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
+++ b/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
@@ -466,10 +466,19 @@ class MultimemAllGatherer:
             # Lazy import avoids a module-load dependency on the distributed facade.
             from sglang.srt.distributed import get_tp_group
             from sglang.srt.distributed.parallel_state import in_the_same_node_as
+            from sglang.srt.runtime_context import get_server_args
 
             tp_group = get_tp_group()
-            if tp_group.world_size > 1 and not all(
-                in_the_same_node_as(tp_group.cpu_group, source_rank=0)
+            # Only probe node topology when the deployment can actually span
+            # nodes. Check world_size first so a TP=1 gatherer short-circuits
+            # before reading server args (which may be unpublished on offline
+            # paths). On a single node every TP rank is co-located, so skip the
+            # in_the_same_node_as() all-reduce, which can segfault under some
+            # EP/mooncake setups, and keep multimem enabled.
+            if (
+                tp_group.world_size > 1
+                and get_server_args().nnodes > 1
+                and not all(in_the_same_node_as(tp_group.cpu_group, source_rank=0))
             ):
                 logger.warning(
                     "multimem all-gather disabled because the TP group spans "


### PR DESCRIPTION
## Problem

`test/registered/ep/test_mooncake_ep_small.py` crashes the server at startup with a **segmentation fault** in today's scheduled run:

```
Current thread (most recent call first):
  File ".../torch/distributed/distributed_c10d.py", line 3068 in all_reduce
  ...
  File ".../srt/distributed/parallel_state.py", line 2681 in in_the_same_node_as
  File ".../srt/distributed/device_communicators/triton_symm_mem_ag.py", line 472 in __init__
  File ".../srt/layers/logits_processor.py", line 297 in __init__
```
→ `Server process exited with code 1` → `FAILED (errors=1, skipped=6)`.

## Root cause

PR #29881 ("Avoid logits multimem all-gather on cross-node TP groups") added an `in_the_same_node_as(tp_group.cpu_group, source_rank=0)` probe to `MultimemAllGatherer.__init__`. That probe runs a gloo `all_reduce` during logits-processor construction, and it **segfaults under the mooncake EP + DP-attention config** (tp4 / dp2 / ep4, DeepEP, `nnodes=1`).

Timeline for this test: it last passed on 0702_23; broke on 0703 with the router NaN crash (#29771, fixed by #30079); and now fails on 0704 with this segfault from #29881. Both fixes are needed for it to go green — #30079 is already merged, this PR is the second half.

## Fix

On a single-node deployment every TP rank is trivially co-located, so the cross-node probe is unnecessary. Gate it on `nnodes > 1`:
- single-node runs skip the fragile `all_reduce` and keep multimem enabled (pre-#29881 behavior),
- genuine multi-node deployments still get #29881's cross-node guard.

This unblocks CI and sidesteps the deeper question of *why* that gloo `all_reduce` segfaults under mooncake/DeepEP (worth a follow-up with the #29881 author). Needs a 4-GPU mooncake-EP run to confirm green (I can't run that locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28721778107](https://github.com/sgl-project/sglang/actions/runs/28721778107)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28721778022](https://github.com/sgl-project/sglang/actions/runs/28721778022)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->