### PR TITLE
Add LTX2 post-RMS modulation CUDA fast path

### DIFF
--- a/python/sglang/jit_kernel/csrc/diffusion/ltx2_post_rms_modulate.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/ltx2_post_rms_modulate.cuh
@@ -1,0 +1,301 @@
+// CUDA fast path for LTX2 post-RMSNorm BF16 modulation.
+//
+// Implements the elementwise eager contract:
+//   out = x * (1 + scale) + shift
+//
+// This intentionally leaves RMSNorm itself on the PyTorch path so the norm
+// reduction order stays identical to main.  The kernel only fuses the BF16
+// modulation chain after the normalized tensor has already been materialized.
+
+#pragma once
+
+#include <sgl_kernel/tensor.h>  // For TensorView metadata and dtype helpers
+#include <sgl_kernel/utils.h>   // For RuntimeCheck and div_ceil
+
+#include <sgl_kernel/utils.cuh>  // For LaunchKernel and CUDA dtype aliases
+#include <sgl_kernel/vec.cuh>    // For device::AlignedVector
+
+#include <cstdint>
+#include <cuda_bf16.h>
+
+namespace sglang_ltx2_post_rms_modulate {
+
+namespace {
+
+constexpr int kBlockSize = 256;
+constexpr int kVec = 8;
+constexpr int64_t kMaxGrid = 65535;
+
+inline const char* data_ptr(const tvm::ffi::TensorView& t) {
+  return static_cast<const char*>(t.data_ptr()) + t.byte_offset();
+}
+
+inline char* mutable_data_ptr(const tvm::ffi::TensorView& t) {
+  return static_cast<char*>(t.data_ptr()) + t.byte_offset();
+}
+
+inline bool aligned16(const void* p) {
+  return (reinterpret_cast<uintptr_t>(p) & 0xF) == 0;
+}
+
+inline int64_t grid_for(int64_t total) {
+  int64_t grid = host::div_ceil(total, static_cast<int64_t>(kBlockSize));
+  if (grid < 1) {
+    grid = 1;
+  }
+  if (grid > kMaxGrid) {
+    grid = kMaxGrid;
+  }
+  return grid;
+}
+
+inline bool is_dense_contiguous(const tvm::ffi::TensorView& t) {
+  int64_t expected = 1;
+  for (int i = t.ndim() - 1; i >= 0; --i) {
+    if (t.size(i) == 1) {
+      continue;
+    }
+    if (t.stride(i) != expected) {
+      return false;
+    }
+    expected *= t.size(i);
+  }
+  return true;
+}
+
+inline void check_bf16_cuda(const tvm::ffi::TensorView& t, const char* name) {
+  host::RuntimeCheck(host::is_type<bf16_t>(t.dtype()), name, " must be BF16");
+  host::RuntimeCheck(t.device().device_type == kDLCUDA, name, " must be CUDA");
+}
+
+inline void check_same_device(
+    const tvm::ffi::TensorView& a,
+    const tvm::ffi::TensorView& b,
+    const char* a_name,
+    const char* b_name) {
+  host::RuntimeCheck(
+      a.device().device_id == b.device().device_id,
+      a_name,
+      " and ",
+      b_name,
+      " must be on the same CUDA device");
+}
+
+inline void check_param_shape(
+    const tvm::ffi::TensorView& param,
+    const tvm::ffi::TensorView& x,
+    const char* name) {
+  host::RuntimeCheck(param.ndim() == 3, name, " must be 3D");
+  host::RuntimeCheck(param.size(0) == 1 || param.size(0) == x.size(0), name, " batch dim must broadcast to x");
+  host::RuntimeCheck(param.size(1) == 1 || param.size(1) == x.size(1), name, " seq dim must broadcast to x");
+  host::RuntimeCheck(param.size(2) == x.size(2), name, " hidden dim must match x");
+  host::RuntimeCheck(param.stride(2) == 1, name, " last dim must be contiguous");
+}
+
+SGL_DEVICE bf16_t bf16_from_float(float v) {
+  return __float2bfloat16_rn(v);
+}
+
+SGL_DEVICE float bf16_to_float(bf16_t v) {
+  return __bfloat162float(v);
+}
+
+SGL_DEVICE bf16_t modulate_value(bf16_t x, bf16_t scale, bf16_t shift) {
+  const bf16_t one_plus_scale = bf16_from_float(1.0f + bf16_to_float(scale));
+  const bf16_t product = bf16_from_float(bf16_to_float(x) * bf16_to_float(one_plus_scale));
+  return bf16_from_float(bf16_to_float(product) + bf16_to_float(shift));
+}
+
+struct ParamStrides {
+  int64_t b;
+  int64_t s;
+  int64_t d;
+  int64_t batch;
+  int64_t seq;
+};
+
+SGL_DEVICE int64_t param_offset(const ParamStrides strides, int64_t batch, int64_t token, int64_t col) {
+  const int64_t param_batch = strides.batch == 1 ? 0 : batch;
+  const int64_t param_token = strides.seq == 1 ? 0 : token;
+  return param_batch * strides.b + param_token * strides.s + col * strides.d;
+}
+
+__global__ void ltx2_post_rms_modulate_vec_kernel(
+    const bf16_t* __restrict__ x,
+    const bf16_t* __restrict__ scale,
+    const bf16_t* __restrict__ shift,
+    bf16_t* __restrict__ out,
+    int64_t total_vec,
+    int64_t seq,
+    int64_t hidden,
+    ParamStrides scale_strides,
+    ParamStrides shift_strides) {
+  using Vec = device::AlignedVector<bf16_t, kVec>;
+  const int64_t row_vec = hidden / kVec;
+  const int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+
+  for (int64_t vi = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; vi < total_vec; vi += stride) {
+    const int64_t row = vi / row_vec;
+    const int64_t col_vec = vi - row * row_vec;
+    const int64_t batch = row / seq;
+    const int64_t token = row - batch * seq;
+    const int64_t col = col_vec * kVec;
+
+    Vec x_vec;
+    Vec scale_vec;
+    Vec shift_vec;
+    Vec out_vec;
+    x_vec.load(x, vi);
+    scale_vec.load(scale + param_offset(scale_strides, batch, token, col), 0);
+    shift_vec.load(shift + param_offset(shift_strides, batch, token, col), 0);
+#pragma unroll
+    for (int i = 0; i < kVec; ++i) {
+      out_vec[i] = modulate_value(x_vec[i], scale_vec[i], shift_vec[i]);
+    }
+    out_vec.store(out, vi);
+  }
+}
+
+__global__ void ltx2_post_rms_dual_modulate_vec_kernel(
+    const bf16_t* __restrict__ x,
+    const bf16_t* __restrict__ scale0,
+    const bf16_t* __restrict__ shift0,
+    const bf16_t* __restrict__ scale1,
+    const bf16_t* __restrict__ shift1,
+    bf16_t* __restrict__ out0,
+    bf16_t* __restrict__ out1,
+    int64_t total_vec,
+    int64_t seq,
+    int64_t hidden,
+    ParamStrides scale0_strides,
+    ParamStrides shift0_strides,
+    ParamStrides scale1_strides,
+    ParamStrides shift1_strides) {
+  using Vec = device::AlignedVector<bf16_t, kVec>;
+  const int64_t row_vec = hidden / kVec;
+  const int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+
+  for (int64_t vi = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; vi < total_vec; vi += stride) {
+    const int64_t row = vi / row_vec;
+    const int64_t col_vec = vi - row * row_vec;
+    const int64_t batch = row / seq;
+    const int64_t token = row - batch * seq;
+    const int64_t col = col_vec * kVec;
+
+    Vec x_vec;
+    Vec scale0_vec;
+    Vec shift0_vec;
+    Vec scale1_vec;
+    Vec shift1_vec;
+    Vec out0_vec;
+    Vec out1_vec;
+    x_vec.load(x, vi);
+    scale0_vec.load(scale0 + param_offset(scale0_strides, batch, token, col), 0);
+    shift0_vec.load(shift0 + param_offset(shift0_strides, batch, token, col), 0);
+    scale1_vec.load(scale1 + param_offset(scale1_strides, batch, token, col), 0);
+    shift1_vec.load(shift1 + param_offset(shift1_strides, batch, token, col), 0);
+#pragma unroll
+    for (int i = 0; i < kVec; ++i) {
+      out0_vec[i] = modulate_value(x_vec[i], scale0_vec[i], shift0_vec[i]);
+      out1_vec[i] = modulate_value(x_vec[i], scale1_vec[i], shift1_vec[i]);
+    }
+    out0_vec.store(out0, vi);
+    out1_vec.store(out1, vi);
+  }
+}
+
+inline ParamStrides strides_for(const tvm::ffi::TensorView& t) {
+  return ParamStrides{t.stride(0), t.stride(1), t.stride(2), t.size(0), t.size(1)};
+}
+
+inline void check_launchable(
+    const tvm::ffi::TensorView& out,
+    const tvm::ffi::TensorView& x,
+    const tvm::ffi::TensorView& scale,
+    const tvm::ffi::TensorView& shift) {
+  check_bf16_cuda(out, "out");
+  check_bf16_cuda(x, "x");
+  check_bf16_cuda(scale, "scale");
+  check_bf16_cuda(shift, "shift");
+  check_same_device(out, x, "out", "x");
+  check_same_device(out, scale, "out", "scale");
+  check_same_device(out, shift, "out", "shift");
+  host::RuntimeCheck(x.ndim() == 3, "x must be 3D");
+  host::RuntimeCheck(out.ndim() == 3, "out must be 3D");
+  for (int i = 0; i < 3; ++i) {
+    host::RuntimeCheck(out.size(i) == x.size(i), "out shape must match x");
+  }
+  host::RuntimeCheck(is_dense_contiguous(x), "x must be contiguous");
+  host::RuntimeCheck(is_dense_contiguous(out), "out must be contiguous");
+  host::RuntimeCheck(x.size(2) % kVec == 0, "hidden size must be divisible by vector width");
+  host::RuntimeCheck(aligned16(data_ptr(x)), "x must be 16-byte aligned");
+  host::RuntimeCheck(aligned16(data_ptr(out)), "out must be 16-byte aligned");
+  host::RuntimeCheck(aligned16(data_ptr(scale)), "scale must be 16-byte aligned");
+  host::RuntimeCheck(aligned16(data_ptr(shift)), "shift must be 16-byte aligned");
+  check_param_shape(scale, x, "scale");
+  check_param_shape(shift, x, "shift");
+}
+
+}  // namespace
+
+struct LTX2PostRMSModulateKernel {
+  static void run(
+      tvm::ffi::TensorView out,
+      tvm::ffi::TensorView x,
+      tvm::ffi::TensorView scale,
+      tvm::ffi::TensorView shift) {
+    check_launchable(out, x, scale, shift);
+    const int64_t total_vec = x.size(0) * x.size(1) * x.size(2) / kVec;
+    if (total_vec == 0) {
+      return;
+    }
+    host::LaunchKernel(static_cast<uint32_t>(grid_for(total_vec)), kBlockSize, out.device())(
+        ltx2_post_rms_modulate_vec_kernel,
+        reinterpret_cast<const bf16_t*>(data_ptr(x)),
+        reinterpret_cast<const bf16_t*>(data_ptr(scale)),
+        reinterpret_cast<const bf16_t*>(data_ptr(shift)),
+        reinterpret_cast<bf16_t*>(mutable_data_ptr(out)),
+        total_vec,
+        x.size(1),
+        x.size(2),
+        strides_for(scale),
+        strides_for(shift));
+  }
+};
+
+struct LTX2PostRMSDualModulateKernel {
+  static void run(
+      tvm::ffi::TensorView out0,
+      tvm::ffi::TensorView out1,
+      tvm::ffi::TensorView x,
+      tvm::ffi::TensorView scale0,
+      tvm::ffi::TensorView shift0,
+      tvm::ffi::TensorView scale1,
+      tvm::ffi::TensorView shift1) {
+    check_launchable(out0, x, scale0, shift0);
+    check_launchable(out1, x, scale1, shift1);
+    check_same_device(out0, out1, "out0", "out1");
+    const int64_t total_vec = x.size(0) * x.size(1) * x.size(2) / kVec;
+    if (total_vec == 0) {
+      return;
+    }
+    host::LaunchKernel(static_cast<uint32_t>(grid_for(total_vec)), kBlockSize, out0.device())(
+        ltx2_post_rms_dual_modulate_vec_kernel,
+        reinterpret_cast<const bf16_t*>(data_ptr(x)),
+        reinterpret_cast<const bf16_t*>(data_ptr(scale0)),
+        reinterpret_cast<const bf16_t*>(data_ptr(shift0)),
+        reinterpret_cast<const bf16_t*>(data_ptr(scale1)),
+        reinterpret_cast<const bf16_t*>(data_ptr(shift1)),
+        reinterpret_cast<bf16_t*>(mutable_data_ptr(out0)),
+        reinterpret_cast<bf16_t*>(mutable_data_ptr(out1)),
+        total_vec,
+        x.size(1),
+        x.size(2),
+        strides_for(scale0),
+        strides_for(shift0),
+        strides_for(scale1),
+        strides_for(shift1));
+  }
+};
+
+}  // namespace sglang_ltx2_post_rms_modulate

--- a/python/sglang/jit_kernel/diffusion/ltx2_post_rms_modulate.py
+++ b/python/sglang/jit_kernel/diffusion/ltx2_post_rms_modulate.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_ltx2_post_rms_modulate_module() -> Module:
+    return load_jit(
+        "diffusion_ltx2_post_rms_modulate",
+        cuda_files=["diffusion/ltx2_post_rms_modulate.cuh"],
+        cuda_wrappers=[
+            (
+                "ltx2_post_rms_modulate",
+                "sglang_ltx2_post_rms_modulate::LTX2PostRMSModulateKernel::run",
+            ),
+            (
+                "ltx2_post_rms_dual_modulate",
+                "sglang_ltx2_post_rms_modulate::LTX2PostRMSDualModulateKernel::run",
+            ),
+        ],
+    )
+
+
+def _is_sm100_or_newer(x: torch.Tensor) -> bool:
+    if not x.is_cuda:
+        return False
+    try:
+        return torch.cuda.get_device_capability(x.device)[0] >= 10
+    except RuntimeError:
+        return False
+
+
+def _supported_param(x: torch.Tensor, param: torch.Tensor) -> bool:
+    return (
+        param.is_cuda
+        and param.device == x.device
+        and param.dtype == torch.bfloat16
+        and param.ndim == 3
+        and param.shape[0] in (1, x.shape[0])
+        and param.shape[1] in (1, x.shape[1])
+        and param.shape[2] == x.shape[2]
+        and param.stride(-1) == 1
+    )
+
+
+def can_use_ltx2_post_rms_modulate_cuda(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+) -> bool:
+    return (
+        _is_sm100_or_newer(x)
+        and x.is_cuda
+        and x.dtype == torch.bfloat16
+        and x.ndim == 3
+        and x.is_contiguous()
+        and x.shape[-1] % 8 == 0
+        and _supported_param(x, scale)
+        and _supported_param(x, shift)
+    )
+
+
+def can_use_ltx2_post_rms_dual_modulate_cuda(
+    x: torch.Tensor,
+    scale0: torch.Tensor,
+    shift0: torch.Tensor,
+    scale1: torch.Tensor,
+    shift1: torch.Tensor,
+) -> bool:
+    return (
+        can_use_ltx2_post_rms_modulate_cuda(x, scale0, shift0)
+        and _supported_param(x, scale1)
+        and _supported_param(x, shift1)
+    )
+
+
+def _fake_single_impl(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+def _fake_dual_impl(
+    x: torch.Tensor,
+    scale0: torch.Tensor,
+    shift0: torch.Tensor,
+    scale1: torch.Tensor,
+    shift1: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.empty_like(x), torch.empty_like(x)
+
+
+@register_custom_op(
+    op_name="diffusion_ltx2_post_rms_modulate",
+    mutates_args=[],
+    fake_impl=_fake_single_impl,
+)
+def _ltx2_post_rms_modulate_custom_op(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+) -> torch.Tensor:
+    out = torch.empty_like(x)
+    _jit_ltx2_post_rms_modulate_module().ltx2_post_rms_modulate(out, x, scale, shift)
+    return out
+
+
+@register_custom_op(
+    op_name="diffusion_ltx2_post_rms_dual_modulate",
+    mutates_args=[],
+    fake_impl=_fake_dual_impl,
+)
+def _ltx2_post_rms_dual_modulate_custom_op(
+    x: torch.Tensor,
+    scale0: torch.Tensor,
+    shift0: torch.Tensor,
+    scale1: torch.Tensor,
+    shift1: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out0 = torch.empty_like(x)
+    out1 = torch.empty_like(x)
+    _jit_ltx2_post_rms_modulate_module().ltx2_post_rms_dual_modulate(
+        out0, out1, x, scale0, shift0, scale1, shift1
+    )
+    return out0, out1
+
+
+def ltx2_post_rms_modulate_cuda(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+) -> torch.Tensor:
+    if not can_use_ltx2_post_rms_modulate_cuda(x, scale, shift):
+        raise RuntimeError("unsupported input for LTX2 post-RMS modulation CUDA")
+    return _ltx2_post_rms_modulate_custom_op(x, scale, shift)
+
+
+def ltx2_post_rms_dual_modulate_cuda(
+    x: torch.Tensor,
+    scale0: torch.Tensor,
+    shift0: torch.Tensor,
+    scale1: torch.Tensor,
+    shift1: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not can_use_ltx2_post_rms_dual_modulate_cuda(x, scale0, shift0, scale1, shift1):
+        raise RuntimeError("unsupported input for LTX2 post-RMS dual modulation CUDA")
+    return _ltx2_post_rms_dual_modulate_custom_op(x, scale0, shift0, scale1, shift1)

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -14,6 +14,12 @@ from sglang.jit_kernel.diffusion.ltx2_qknorm_split_rope import (
     can_use_ltx2_qknorm_split_rope_cuda,
     ltx2_qknorm_split_rope_cuda,
 )
+from sglang.jit_kernel.diffusion.ltx2_post_rms_modulate import (
+    can_use_ltx2_post_rms_dual_modulate_cuda,
+    can_use_ltx2_post_rms_modulate_cuda,
+    ltx2_post_rms_dual_modulate_cuda,
+    ltx2_post_rms_modulate_cuda,
+)
 from sglang.jit_kernel.diffusion.residual_gate_add import (
     can_use_residual_gate_add_cuda,
     residual_gate_add_cuda,
@@ -58,6 +64,7 @@ ADALN_NUM_BASE_PARAMS = 6
 ADALN_NUM_CROSS_ATTN_PARAMS = 3
 _LTX2_RESIDUAL_GATE_CUDA_DISABLED = False
 _LTX2_QKNORM_SPLIT_ROPE_CUDA_DISABLED = False
+_LTX2_POST_RMS_MODULATE_CUDA_DISABLED = False
 
 
 def _ltx2_residual_gate_add(
@@ -139,6 +146,56 @@ def _ltx2_try_fused_qknorm_split_rope(
         logger.warning_once(f"Disabling LTX2 QKNorm split-RoPE CUDA fast path: {exc}")
         _LTX2_QKNORM_SPLIT_ROPE_CUDA_DISABLED = True
         return None
+
+
+def _ltx2_post_rms_modulate(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+) -> torch.Tensor:
+    global _LTX2_POST_RMS_MODULATE_CUDA_DISABLED
+
+    if (
+        not _LTX2_POST_RMS_MODULATE_CUDA_DISABLED
+        and can_use_ltx2_post_rms_modulate_cuda(x, scale, shift)
+    ):
+        try:
+            return ltx2_post_rms_modulate_cuda(x, scale, shift)
+        except Exception as exc:
+            if torch.compiler.is_compiling():
+                raise
+            logger.warning_once(
+                f"Disabling LTX2 post-RMS modulation CUDA fast path: {exc}"
+            )
+            _LTX2_POST_RMS_MODULATE_CUDA_DISABLED = True
+
+    return x * (1 + scale) + shift
+
+
+def _ltx2_post_rms_dual_modulate(
+    x: torch.Tensor,
+    scale0: torch.Tensor,
+    shift0: torch.Tensor,
+    scale1: torch.Tensor,
+    shift1: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    global _LTX2_POST_RMS_MODULATE_CUDA_DISABLED
+
+    if (
+        not _LTX2_POST_RMS_MODULATE_CUDA_DISABLED
+        and can_use_ltx2_post_rms_dual_modulate_cuda(x, scale0, shift0, scale1, shift1)
+    ):
+        try:
+            return ltx2_post_rms_dual_modulate_cuda(x, scale0, shift0, scale1, shift1)
+        except Exception as exc:
+            if torch.compiler.is_compiling():
+                raise
+            logger.warning_once(
+                f"Disabling LTX2 post-RMS modulation CUDA fast path: {exc}"
+            )
+            _LTX2_POST_RMS_MODULATE_CUDA_DISABLED = True
+
+    return x * (1 + scale0) + shift0, x * (1 + scale1) + shift1
 
 
 _LTX2_FUSED_ADA_VALUES_RUNTIME_DISABLED = False
@@ -1216,8 +1273,8 @@ class LTX2TransformerBlock(nn.Module):
             )
         else:
             vshift_msa, vscale_msa, vgate_msa = video_ada_values[0:3]
-        norm_hidden_states = (
-            self.rms_norm(hidden_states, self.norm_eps) * (1 + vscale_msa) + vshift_msa
+        norm_hidden_states = _ltx2_post_rms_modulate(
+            self.rms_norm(hidden_states, self.norm_eps), vscale_msa, vshift_msa
         )
         attn_hidden_states = self.attn1(
             norm_hidden_states,
@@ -1238,9 +1295,10 @@ class LTX2TransformerBlock(nn.Module):
             )
         else:
             ashift_msa, ascale_msa, agate_msa = audio_ada_values[0:3]
-        norm_audio_hidden_states = (
-            self.rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_msa)
-            + ashift_msa
+        norm_audio_hidden_states = _ltx2_post_rms_modulate(
+            self.rms_norm(audio_hidden_states, self.norm_eps),
+            ascale_msa,
+            ashift_msa,
         )
         attn_audio_hidden_states = self.audio_attn1(
             norm_audio_hidden_states,
@@ -1269,11 +1327,11 @@ class LTX2TransformerBlock(nn.Module):
             v_prompt_shift, v_prompt_scale = self.get_ada_values(
                 self.prompt_scale_shift_table, batch_size, temb_prompt, slice(None)
             )
-            norm_hidden_states = (
-                self.rms_norm(hidden_states, self.norm_eps) * (1 + vscale_q) + vshift_q
+            norm_hidden_states = _ltx2_post_rms_modulate(
+                self.rms_norm(hidden_states, self.norm_eps), vscale_q, vshift_q
             )
-            mod_encoder_hidden_states = (
-                encoder_hidden_states * (1 + v_prompt_scale) + v_prompt_shift
+            mod_encoder_hidden_states = _ltx2_post_rms_modulate(
+                encoder_hidden_states, v_prompt_scale, v_prompt_shift
             )
             attn_hidden_states = self.attn2(
                 norm_hidden_states,
@@ -1296,12 +1354,13 @@ class LTX2TransformerBlock(nn.Module):
                 temb_audio_prompt,
                 slice(None),
             )
-            norm_audio_hidden_states = (
-                self.rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_q)
-                + ashift_q
+            norm_audio_hidden_states = _ltx2_post_rms_modulate(
+                self.rms_norm(audio_hidden_states, self.norm_eps),
+                ascale_q,
+                ashift_q,
             )
-            mod_audio_encoder_hidden_states = (
-                audio_encoder_hidden_states * (1 + a_prompt_scale) + a_prompt_shift
+            mod_audio_encoder_hidden_states = _ltx2_post_rms_modulate(
+                audio_encoder_hidden_states, a_prompt_scale, a_prompt_shift
             )
             attn_audio_hidden_states = self.audio_attn2(
                 norm_audio_hidden_states,
@@ -1390,17 +1449,31 @@ class LTX2TransformerBlock(nn.Module):
         v2a_gate = audio_ca_gate[0].squeeze(2)
 
         # A2V
-        mod_norm_hidden_states = (
-            norm_hidden_states * (1 + video_a2v_ca_scale) + video_a2v_ca_shift
+        (
+            a2v_mod_norm_hidden_states,
+            v2a_context_hidden_states,
+        ) = _ltx2_post_rms_dual_modulate(
+            norm_hidden_states,
+            video_a2v_ca_scale,
+            video_a2v_ca_shift,
+            video_v2a_ca_scale,
+            video_v2a_ca_shift,
         )
-        mod_norm_audio_hidden_states = (
-            norm_audio_hidden_states * (1 + audio_a2v_ca_scale) + audio_a2v_ca_shift
+        (
+            a2v_context_audio_hidden_states,
+            v2a_mod_norm_audio_hidden_states,
+        ) = _ltx2_post_rms_dual_modulate(
+            norm_audio_hidden_states,
+            audio_a2v_ca_scale,
+            audio_a2v_ca_shift,
+            audio_v2a_ca_scale,
+            audio_v2a_ca_shift,
         )
 
         if not skip_a2v_cross_attn:
             a2v_attn_hidden_states = self.audio_to_video_attn(
-                mod_norm_hidden_states,
-                context=mod_norm_audio_hidden_states,
+                a2v_mod_norm_hidden_states,
+                context=a2v_context_audio_hidden_states,
                 pe=ca_video_rotary_emb,
                 k_pe=ca_audio_rotary_emb,
                 mask=a2v_cross_attention_mask,
@@ -1415,17 +1488,10 @@ class LTX2TransformerBlock(nn.Module):
             )
 
         # V2A
-        mod_norm_hidden_states = (
-            norm_hidden_states * (1 + video_v2a_ca_scale) + video_v2a_ca_shift
-        )
-        mod_norm_audio_hidden_states = (
-            norm_audio_hidden_states * (1 + audio_v2a_ca_scale) + audio_v2a_ca_shift
-        )
-
         if not skip_v2a_cross_attn:
             v2a_attn_hidden_states = self.video_to_audio_attn(
-                mod_norm_audio_hidden_states,
-                context=mod_norm_hidden_states,
+                v2a_mod_norm_audio_hidden_states,
+                context=v2a_context_hidden_states,
                 pe=ca_audio_rotary_emb,
                 k_pe=ca_video_rotary_emb,
                 mask=v2a_cross_attention_mask,
@@ -1446,8 +1512,8 @@ class LTX2TransformerBlock(nn.Module):
             )
         else:
             vshift_mlp, vscale_mlp, vgate_mlp = video_ada_values[3:6]
-        norm_hidden_states = (
-            self.rms_norm(hidden_states, self.norm_eps) * (1 + vscale_mlp) + vshift_mlp
+        norm_hidden_states = _ltx2_post_rms_modulate(
+            self.rms_norm(hidden_states, self.norm_eps), vscale_mlp, vshift_mlp
         )
         ff_output = self.ff(norm_hidden_states)
         hidden_states = _ltx2_residual_gate_add(hidden_states, ff_output, vgate_mlp)
@@ -1458,9 +1524,10 @@ class LTX2TransformerBlock(nn.Module):
             )
         else:
             ashift_mlp, ascale_mlp, agate_mlp = audio_ada_values[3:6]
-        norm_audio_hidden_states = (
-            self.rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_mlp)
-            + ashift_mlp
+        norm_audio_hidden_states = _ltx2_post_rms_modulate(
+            self.rms_norm(audio_hidden_states, self.norm_eps),
+            ascale_mlp,
+            ashift_mlp,
         )
         audio_ff_output = self.audio_ff(norm_audio_hidden_states)
         audio_hidden_states = _ltx2_residual_gate_add(

--- a/test/registered/jit/benchmark/diffusion/bench_ltx2_post_rms_modulate.py
+++ b/test/registered/jit/benchmark/diffusion/bench_ltx2_post_rms_modulate.py
@@ -1,0 +1,116 @@
+import torch
+
+from sglang.jit_kernel.benchmark import marker
+from sglang.jit_kernel.diffusion.ltx2_post_rms_modulate import (
+    can_use_ltx2_post_rms_dual_modulate_cuda,
+    can_use_ltx2_post_rms_modulate_cuda,
+    ltx2_post_rms_dual_modulate_cuda,
+    ltx2_post_rms_modulate_cuda,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=12, stage="base-b-kernel-benchmark", runner_config="4-gpu-b200"
+)
+
+
+def _require_b200() -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 10:
+        marker.skip("LTX2 post-RMS modulation benchmark requires B200/SM100")
+
+
+def _param(batch: int, seq: int, hidden: int, param_seq: int) -> torch.Tensor:
+    packed = torch.randn(
+        batch, param_seq, 3, hidden, device="cuda", dtype=torch.bfloat16
+    )
+    return packed.unbind(dim=2)[1]
+
+
+def torch_single(x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor):
+    return x * (1 + scale) + shift
+
+
+def cuda_single(x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor):
+    if not can_use_ltx2_post_rms_modulate_cuda(x, scale, shift):
+        marker.skip("unsupported single modulation shape")
+    return ltx2_post_rms_modulate_cuda(x, scale, shift)
+
+
+def torch_dual(
+    x: torch.Tensor,
+    scale0: torch.Tensor,
+    shift0: torch.Tensor,
+    scale1: torch.Tensor,
+    shift1: torch.Tensor,
+):
+    return x * (1 + scale0) + shift0, x * (1 + scale1) + shift1
+
+
+def cuda_dual(
+    x: torch.Tensor,
+    scale0: torch.Tensor,
+    shift0: torch.Tensor,
+    scale1: torch.Tensor,
+    shift1: torch.Tensor,
+):
+    if not can_use_ltx2_post_rms_dual_modulate_cuda(x, scale0, shift0, scale1, shift1):
+        marker.skip("unsupported dual modulation shape")
+    return ltx2_post_rms_dual_modulate_cuda(x, scale0, shift0, scale1, shift1)
+
+
+FN_MAP = {
+    "torch": {
+        "single": torch_single,
+        "dual": torch_dual,
+    },
+    "cuda": {
+        "single": cuda_single,
+        "dual": cuda_dual,
+    },
+}
+
+
+@marker.parametrize(
+    "mode,batch,seq,hidden,param_seq",
+    [
+        ("single", 1, 161, 4096, 1),
+        ("single", 1, 529, 4096, 529),
+        ("dual", 1, 32640, 4096, 32640),
+        ("dual", 1, 1024, 2048, 1024),
+    ],
+    [
+        ("single", 1, 161, 4096, 1),
+        ("dual", 1, 1024, 2048, 1024),
+    ],
+)
+@marker.benchmark("impl", ["torch", "cuda"])
+def benchmark(
+    mode: str,
+    batch: int,
+    seq: int,
+    hidden: int,
+    param_seq: int,
+    impl: str,
+):
+    _require_b200()
+    x = torch.randn(batch, seq, hidden, device="cuda", dtype=torch.bfloat16)
+    scale0 = _param(batch, seq, hidden, param_seq)
+    shift0 = _param(batch, seq, hidden, param_seq)
+    if mode == "single":
+        return marker.do_bench(
+            FN_MAP[impl][mode],
+            input_args=(x, scale0, shift0),
+            graph_clone_args=(0, 1, 2),
+        )
+
+    scale1 = _param(batch, seq, hidden, param_seq)
+    shift1 = _param(batch, seq, hidden, param_seq)
+    return marker.do_bench(
+        FN_MAP[impl][mode],
+        input_args=(x, scale0, shift0, scale1, shift1),
+        graph_clone_args=(0, 1, 2, 3, 4),
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/jit/diffusion/test_ltx2_post_rms_modulate.py
+++ b/test/registered/jit/diffusion/test_ltx2_post_rms_modulate.py
@@ -1,0 +1,120 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.jit_kernel.diffusion.ltx2_post_rms_modulate import (
+    can_use_ltx2_post_rms_dual_modulate_cuda,
+    can_use_ltx2_post_rms_modulate_cuda,
+    ltx2_post_rms_dual_modulate_cuda,
+    ltx2_post_rms_modulate_cuda,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=35, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+
+def _require_cuda_b200() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("LTX2 post-RMS modulation CUDA path is validated on B200")
+
+
+@pytest.fixture(autouse=True)
+def cuda_setup():
+    _require_cuda_b200()
+    torch.cuda.manual_seed(20260704)
+
+
+def _make_param(
+    batch: int, seq: int, hidden: int, param_seq: int, *, non_contiguous: bool
+) -> torch.Tensor:
+    if non_contiguous:
+        packed = torch.randn(
+            batch, param_seq, 3, hidden, device="cuda", dtype=torch.bfloat16
+        )
+        return packed.unbind(dim=2)[1]
+    return torch.randn(batch, param_seq, hidden, device="cuda", dtype=torch.bfloat16)
+
+
+def _reference(
+    x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor
+) -> torch.Tensor:
+    return x * (1 + scale) + shift
+
+
+@pytest.mark.parametrize(
+    "batch,seq,hidden,param_seq,non_contiguous",
+    [
+        (1, 161, 4096, 1, False),
+        (1, 529, 4096, 529, True),
+        (2, 7, 2048, 1, True),
+    ],
+)
+@torch.no_grad()
+def test_ltx2_post_rms_modulate_matches_torch_exactly(
+    batch: int,
+    seq: int,
+    hidden: int,
+    param_seq: int,
+    non_contiguous: bool,
+) -> None:
+    x = torch.randn(batch, seq, hidden, device="cuda", dtype=torch.bfloat16)
+    scale = _make_param(batch, seq, hidden, param_seq, non_contiguous=non_contiguous)
+    shift = _make_param(batch, seq, hidden, param_seq, non_contiguous=non_contiguous)
+
+    assert can_use_ltx2_post_rms_modulate_cuda(x, scale, shift)
+    actual = ltx2_post_rms_modulate_cuda(x, scale, shift)
+    expected = _reference(x, scale, shift)
+    torch.cuda.synchronize()
+
+    assert torch.equal(actual, expected)
+
+
+@torch.no_grad()
+def test_ltx2_post_rms_dual_modulate_matches_torch_exactly() -> None:
+    batch, seq, hidden = 1, 32640, 4096
+    x = torch.randn(batch, seq, hidden, device="cuda", dtype=torch.bfloat16)
+    scale0 = _make_param(batch, seq, hidden, seq, non_contiguous=True)
+    shift0 = _make_param(batch, seq, hidden, seq, non_contiguous=True)
+    scale1 = _make_param(batch, seq, hidden, seq, non_contiguous=True)
+    shift1 = _make_param(batch, seq, hidden, seq, non_contiguous=True)
+
+    assert can_use_ltx2_post_rms_dual_modulate_cuda(x, scale0, shift0, scale1, shift1)
+    actual0, actual1 = ltx2_post_rms_dual_modulate_cuda(
+        x, scale0, shift0, scale1, shift1
+    )
+    expected0 = _reference(x, scale0, shift0)
+    expected1 = _reference(x, scale1, shift1)
+    torch.cuda.synchronize()
+
+    assert torch.equal(actual0, expected0)
+    assert torch.equal(actual1, expected1)
+
+
+@torch.no_grad()
+def test_ltx2_post_rms_modulate_rejects_unsupported_inputs() -> None:
+    x = torch.randn(1, 4, 4096, device="cuda", dtype=torch.bfloat16)
+    scale = torch.randn(1, 1, 4096, device="cuda", dtype=torch.bfloat16)
+    shift = torch.randn(1, 1, 4096, device="cuda", dtype=torch.bfloat16)
+
+    assert can_use_ltx2_post_rms_modulate_cuda(x, scale, shift)
+    assert not can_use_ltx2_post_rms_modulate_cuda(x.float(), scale, shift)
+    assert not can_use_ltx2_post_rms_modulate_cuda(x, scale.transpose(-1, -2), shift)
+
+
+def test_ltx2_post_rms_modulate_custom_op_torch_compile_fullgraph() -> None:
+    x = torch.randn(1, 5, 2048, device="cuda", dtype=torch.bfloat16)
+    scale = torch.randn(1, 1, 2048, device="cuda", dtype=torch.bfloat16)
+    shift = torch.randn(1, 1, 2048, device="cuda", dtype=torch.bfloat16)
+
+    compiled = torch.compile(ltx2_post_rms_modulate_cuda, fullgraph=True)
+    actual = compiled(x, scale, shift)
+    expected = _reference(x, scale, shift)
+    torch.cuda.synchronize()
+    assert torch.equal(actual, expected)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

Add a native CUDA JIT fast path for the LTX-2.3 BF16 post-normalization modulation pattern.

The hot pattern is equivalent to:

```python
out = x * (1 + scale) + shift
```

for BF16 contiguous `[B, S, D]` tensors and LTX-2.3 AdaLN / cross-attention modulation parameters with broadcastable `[B|1, S|1, D]` shapes. This intentionally does **not** fuse RMSNorm itself, so the RMS reduction order stays identical to the original PyTorch path. The CUDA path only replaces the elementwise BF16 modulation chain after the normalized tensor has already been materialized.

## Modifications

- Add `diffusion_ltx2_post_rms_modulate` lightweight JIT CUDA custom ops.
- Add single-output and dual-output kernels:
  - `ltx2_post_rms_modulate`: one `out = x * (1 + scale) + shift` output.
  - `ltx2_post_rms_dual_modulate`: two independent modulation outputs from the same `x`, used by LTX-2.3 A2V/V2A cross-attention preparation.
- Register the ops eagerly with fake impls so direct `torch.compile(fullgraph=True)` sees opaque custom ops instead of tracing JIT/module loading.
- Gate the fast path to SM100+ only. H100/Hopper keeps the original PyTorch expression.
- Support BF16 CUDA tensors, contiguous `[B, S, D]` input/output, hidden size divisible by 8, and production non-contiguous parameter tensors with contiguous last dimension.
- Wire `LTX2TransformerBlock` to try this CUDA path and fall back to the existing PyTorch implementation on unsupported inputs or one-time runtime failure.
- Add a B200 correctness test covering bitwise equality, unsupported input rejection, and `torch.compile(fullgraph=True)` custom-op coverage.
- Add a standalone benchmark over LTX-2.3 production-like shapes plus CI-small shapes.

## Accuracy Tests

```bash
python3 -m py_compile \
  python/sglang/jit_kernel/diffusion/ltx2_post_rms_modulate.py \
  python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py \
  test/registered/jit/diffusion/test_ltx2_post_rms_modulate.py \
  test/registered/jit/benchmark/diffusion/bench_ltx2_post_rms_modulate.py
python3 -m ruff format --check ...
python3 -m ruff check ...
git diff --check
```

Result: local syntax/format/lint/diff checks passed.

B200 unit test, rebased on `origin/main=854b46be99`:

```bash
CUDA_VISIBLE_DEVICES=1 \
PYTHONPATH=/home/sglang-omni/bbuf/tmp/sglang_ltx2_postmod_rebased/python:/home/sglang-omni/bbuf/tmp/sglang_ltx2_postmod_rebased \
FLASHINFER_DISABLE_VERSION_CHECK=1 \
SGLANG_IS_IN_CI=1 \
python3 -m pytest -q test/registered/jit/diffusion/test_ltx2_post_rms_modulate.py -s
```

Result: `6 passed`.

H100 CI / GT check attempt:

- `ltx_2_3_two_stage_ti2v_2gpus` with forced `torch_sdpa` completed the video/GT consistency check:
  - Min similarity: `0.8982`
  - Min SSIM: `0.5527`
  - Min PSNR: `15.7539`
  - Max mean_abs_diff: `25.4767`
  - Result: consistency `PASSED`
- The same H100 run failed the CI performance gate because forcing `torch_sdpa` made `LTX2UpsampleStage=171.3690ms`, above the `122.3100ms` limit.
- The exact H100 FA path for `ltx_2.3_two_stage_t2v_2gpus` and `ltx_2.3_one_stage_ti2v` failed before metrics with:

```text
TypeError: flash_attn_varlen_func() got an unexpected keyword argument 'only_qv'
```

The H100 container has `sgl_kernel.flash_attn_varlen_func` and kernels-community `sgl-flash-attn3` v1 signatures without `only_qv`, while current SGLang passes `only_qv`. This is unrelated to this PR's CUDA kernel: on H100 `(cc=9.0)`, `can_use_ltx2_post_rms_modulate_cuda(...) == False`, so the PR falls back to the original PyTorch expression. The optimization is enabled only on SM100+.

## Speed Tests and Profiling

B200 kernel benchmark, rebased on `origin/main=854b46be99`:

```bash
CUDA_VISIBLE_DEVICES=1 \
PYTHONPATH=/home/sglang-omni/bbuf/tmp/sglang_ltx2_postmod_rebased/python:/home/sglang-omni/bbuf/tmp/sglang_ltx2_postmod_rebased \
FLASHINFER_DISABLE_VERSION_CHECK=1 \
python3 test/registered/jit/benchmark/diffusion/bench_ltx2_post_rms_modulate.py
```

| Workload | Torch us | CUDA us | Speedup |
| --- | ---: | ---: | ---: |
| single, B=1, S=161, D=4096, param_seq=1 | 8.5197 | 2.8058 | 3.04x |
| single, B=1, S=529, D=4096, param_seq=529 | 8.9642 | 4.4824 | 2.00x |
| dual, B=1, S=32640, D=4096, param_seq=32640 | 1461.9545 | 282.2650 | 5.18x |
| dual, B=1, S=1024, D=2048, param_seq=1024 | 17.3537 | 7.1835 | 2.42x |

B200 LTX-2.3 small end-to-end A/B, same prompt/seed/shape (`640x384`, 33 frames, 8 denoise steps, `seed=42`, `torch_sdpa` backend):

| Implementation | Total request | Denoise stage | Refinement stage |
| --- | ---: | ---: | ---: |
| main | 7.46s | 5.4545s | 1.3929s |
| PR | 7.37s | 5.4092s | 1.3477s |
| Delta | -1.24% | -0.83% | -3.25% |

Rebased integrated smoke A/B, including first-use overhead and LoRA switching, also completed with no total regression:

| Implementation | Pixel generation time | Denoise stage | Refinement stage |
| --- | ---: | ---: | ---: |
| main | 40.98s | 1.6620s | 0.8961s |
| PR | 40.29s | 2.9897s | 0.8513s |

The first PR request includes JIT first-use overhead, so the warmed small E2E run and the kernel benchmark are the primary speed evidence. The rebased smoke run is included as an integrated accuracy check against the exact current base.

## B200 Fused-vs-Unfused Accuracy

The fused CUDA path was validated on B200 against the original unfused PyTorch implementation for the exact modulation contract it replaces:

```python
ref = x * (1 + scale) + shift
```

The CUDA implementation explicitly rounds the intermediate BF16 operations to match the eager PyTorch BF16 chain, and the unit tests use `torch.equal` rather than tolerance-based comparison.

| B200 check | Shape coverage | Comparison | Result |
| --- | --- | --- | --- |
| SGLang unit test | supported single/dual rows, broadcast parameter rows, non-contiguous parameter rows, unsupported-input rejection, `torch.compile(fullgraph=True)` custom-op coverage | fused CUDA vs unfused PyTorch | `6 passed` |
| Kernel benchmark | LTX-2.3 production-like single and dual modulation rows | CUDA latency vs PyTorch expression latency | 2.00x to 5.18x speedup |
| Warm small E2E | `640x384`, 33 frames, 8 denoise steps, `seed=42` | main total request vs PR total request | `7.46s -> 7.37s` |
| Rebased video A/B | `640x384`, 33 frames, 8 denoise steps, `seed=42` | main mp4 vs PR mp4 | byte-identical mp4 and frame-identical decode |

Accuracy conclusion: on B200, the optimization produces the same modulation tensors as the original non-fused PyTorch path for all covered inputs; precision is unchanged.

### Result Image Comparison

B200 LTX-2.3 A/B output sample (`seed=42`, `640x384`, 33 frames, 8 denoise steps). The original main path and the PR path produced byte-identical MP4 files:

```text
c2396d1729f8916a0aedf6f973e5a53dc831df70ae4926e5546d61552de4e389  main_small.mp4
c2396d1729f8916a0aedf6f973e5a53dc831df70ae4926e5546d61552de4e389  current_small.mp4
```

Decoded-frame comparison:

```python
{"frames": 33, "pixel_equal": True, "max_abs": 0, "sum_abs": 0}
```

Video-level conclusion: `SSIM=1.0`, `PSNR=inf`, and visual output is identical for this sample.

## Checklist

- [x] Default LTX2 path tries CUDA first and falls back to the existing PyTorch implementation on unsupported inputs or one-time runtime failure.
- [x] No environment variable is required to enable the CUDA kernel.
- [x] Direct custom op registration is eager and has a fake impl for `torch.compile` compatibility.
- [x] Fast path is gated to SM100+; H100/Hopper keeps the original PyTorch expression.
- [x] B200 bitwise unit test included.
- [x] Standalone benchmark script included for LTX-2.3 production-like shapes.
- [x] B200 kernel benchmark and LTX-2.3 A/B evidence included.
- [x] B200 end-to-end LTX-2.3 speed evidence included.
- [x] H100 LTX-2.3 CI/GT path was attempted and documented.

## Review and Merge Process

This is a focused LTX-2.3 kernel integration PR. The expected useful effect is faster post-RMS/AdaLN BF16 modulation; whole-model speedup is measurable but bounded because attention, MLP, LoRA switching, decode, and IO still dominate full video generation runtime.
