### PR TITLE
[chore] Remove the stack-review placeholder file

### DIFF
--- a/STACK_REVIEW_PLACEHOLDER.md
+++ b/STACK_REVIEW_PLACEHOLDER.md
@@ -1,5 +1,0 @@
-# Full-stack review placeholder
-
-This file exists only to distinguish the full-stack review PR from the last
-stack member. This PR is for review and full CI only — merging happens
-through the individual stack PRs. Do not merge this PR.


### PR DESCRIPTION
STACK_REVIEW_PLACEHOLDER.md existed only to distinguish the full-stack review PR (#30137) from its last stack member; the review PR ended up being the merge vehicle, so the placeholder landed on main with it. This removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28732822421](https://github.com/sgl-project/sglang/actions/runs/28732822421)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28732823068](https://github.com/sgl-project/sglang/actions/runs/28732823068)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->