### PR TITLE
[Gemma4] Support per-request max_soft_tokens (image resolution) via images_config and mm_processor_kwargs

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -741,6 +741,8 @@ class ChatCompletionRequest(BaseModel):
     use_audio_in_video: bool = False
 
     images_config: Optional[Dict] = None
+    # vLLM-compatible per-request multimodal processor kwargs, e.g. {"max_soft_tokens": 1120}
+    mm_processor_kwargs: Optional[Dict] = None
 
     # Custom logit processor for advanced sampling control
     custom_logit_processor: Optional[Union[List[Optional[str]], str]] = None

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -629,6 +629,7 @@ class OpenAIServingChat(OpenAIServingBase):
             custom_labels=custom_labels,
             custom_logit_processor=request.custom_logit_processor,
             images_config=getattr(request, "images_config", None),
+            mm_processor_kwargs=getattr(request, "mm_processor_kwargs", None),
             image_max_dynamic_patch=img_max_dynamic_patch,
             video_max_dynamic_patch=vid_max_dynamic_patch,
             max_dynamic_patch=getattr(request, "max_dynamic_patch", None),

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -300,6 +300,8 @@ class GenerateReqInput:
 
     # For Unlimited-OCR
     images_config: Optional[dict] = None
+    # vLLM-compatible per-request multimodal processor kwargs (e.g. Gemma4 max_soft_tokens)
+    mm_processor_kwargs: Optional[dict] = None
 
     # Pre-computed delimiter indices for multi-item scoring.
     # Batch-level: List[List[int]] (one per request). After __getitem__: List[int].

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -712,6 +712,8 @@ class GenerateReqInput:
             image_data=self.image_data[i],
             video_data=self.video_data[i],
             audio_data=self.audio_data[i],
+            images_config=self.images_config,
+            mm_processor_kwargs=self.mm_processor_kwargs,
             sampling_params=self.sampling_params[i],
             return_logprob=self.return_logprob[i],
             logprob_start_len=self.logprob_start_len[i],

--- a/python/sglang/srt/multimodal/processors/gemma4.py
+++ b/python/sglang/srt/multimodal/processors/gemma4.py
@@ -143,10 +143,16 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
             getattr(request_obj, "mm_processor_kwargs", None),
         ):
             if isinstance(src, dict) and src.get("max_soft_tokens") is not None:
-                mst = src["max_soft_tokens"]
+                try:
+                    mst = int(src["max_soft_tokens"])
+                except (TypeError, ValueError):
+                    raise ValueError(
+                        f"max_soft_tokens must be an integer, got "
+                        f"{src['max_soft_tokens']!r}"
+                    )
                 if mst not in Gemma4SGLangProcessor._SUPPORTED_SOFT_TOKENS:
                     raise ValueError(
-                        f"max_soft_tokens={mst!r} is not supported; expected one of "
+                        f"max_soft_tokens={mst} is not supported; expected one of "
                         f"{Gemma4SGLangProcessor._SUPPORTED_SOFT_TOKENS}"
                     )
                 return {"max_soft_tokens": mst}
@@ -154,22 +160,18 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
 
     @staticmethod
     def _mix_config_into_hash(mm_items, processor_kwargs) -> None:
-        """Mix per-request processor kwargs into mm-item hashes so different budgets do
-        not collide in the radix / embedding cache. Mirrors UnlimitedOCRProcessor."""
+        """Mix per-request processor kwargs into the already-computed mm-item hashes so
+        different budgets do not collide in the radix / embedding cache. Reuses each
+        item's existing ``hash`` (populated by ``process_and_combine_mm_data``) instead
+        of re-hashing the full feature tensor."""
         import hashlib
-
-        from sglang.srt.managers.mm_utils import hash_feature
 
         config_bytes = str(sorted(processor_kwargs.items())).encode()
         for item in mm_items:
-            if item.feature is not None:
-                base_hash = hash_feature(item.feature)
-            elif item.precomputed_embeddings is not None:
-                base_hash = hash_feature(item.precomputed_embeddings)
-            else:
+            if item.hash is None:
                 continue
             combined = hashlib.sha256(
-                base_hash.to_bytes(8, byteorder="big") + config_bytes
+                item.hash.to_bytes(8, byteorder="big") + config_bytes
             ).digest()[:8]
             item.hash = int.from_bytes(combined, byteorder="big", signed=False)
 

--- a/python/sglang/srt/multimodal/processors/gemma4.py
+++ b/python/sglang/srt/multimodal/processors/gemma4.py
@@ -127,6 +127,52 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
             input_text, images=images, videos=videos, audios=audios, **kwargs
         )
 
+    _SUPPORTED_SOFT_TOKENS = (70, 140, 280, 560, 1120)
+
+    @staticmethod
+    def _resolve_image_processor_kwargs(request_obj) -> dict:
+        """Per-request Gemma4 image budget (``max_soft_tokens``), which controls the
+        effective image resolution. Accepts the SGLang-native ``images_config`` and the
+        vLLM-compatible ``mm_processor_kwargs`` (``images_config`` wins if both are set).
+        Returns ``{}`` when unset, leaving the model/processor default in place.
+        """
+        if request_obj is None:
+            return {}
+        for src in (
+            getattr(request_obj, "images_config", None),
+            getattr(request_obj, "mm_processor_kwargs", None),
+        ):
+            if isinstance(src, dict) and src.get("max_soft_tokens") is not None:
+                mst = src["max_soft_tokens"]
+                if mst not in Gemma4SGLangProcessor._SUPPORTED_SOFT_TOKENS:
+                    raise ValueError(
+                        f"max_soft_tokens={mst!r} is not supported; expected one of "
+                        f"{Gemma4SGLangProcessor._SUPPORTED_SOFT_TOKENS}"
+                    )
+                return {"max_soft_tokens": mst}
+        return {}
+
+    @staticmethod
+    def _mix_config_into_hash(mm_items, processor_kwargs) -> None:
+        """Mix per-request processor kwargs into mm-item hashes so different budgets do
+        not collide in the radix / embedding cache. Mirrors UnlimitedOCRProcessor."""
+        import hashlib
+
+        from sglang.srt.managers.mm_utils import hash_feature
+
+        config_bytes = str(sorted(processor_kwargs.items())).encode()
+        for item in mm_items:
+            if item.feature is not None:
+                base_hash = hash_feature(item.feature)
+            elif item.precomputed_embeddings is not None:
+                base_hash = hash_feature(item.precomputed_embeddings)
+            else:
+                continue
+            combined = hashlib.sha256(
+                base_hash.to_bytes(8, byteorder="big") + config_bytes
+            ).digest()[:8]
+            item.hash = int.from_bytes(combined, byteorder="big", signed=False)
+
     async def process_mm_data_async(
         self,
         image_data: Optional[List[Union[str, bytes, Dict]]] = None,
@@ -137,6 +183,9 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
         **kwargs,
     ):
         """Process multimodal data including images, video, and audio."""
+        # Per-request image resolution budget (Gemma4 max_soft_tokens), if provided.
+        image_processor_kwargs = self._resolve_image_processor_kwargs(request_obj)
+
         base_output = await self.load_mm_data(
             prompt=input_text,
             image_data=image_data,
@@ -146,8 +195,10 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
         )
 
         mm_items, input_ids, _ = self.process_and_combine_mm_data(
-            base_output, self.mm_tokens
+            base_output, self.mm_tokens, **image_processor_kwargs
         )
+        if image_processor_kwargs:
+            self._mix_config_into_hash(mm_items, image_processor_kwargs)
 
         return MultimodalProcessorOutput(
             input_ids=input_ids.tolist(),


### PR DESCRIPTION
## Motivation

Gemma 4 encodes each image to a fixed soft-token budget (`max_soft_tokens` ∈ {70, 140, 280, 560, 1120}) that controls the effective image resolution. The default is 280; Google recommends **1120 for dense OCR / document layout**. vLLM already exposes this per request (`mm_processor_kwargs`); SGLang currently pins Gemma 4 images to the default with no per-request override, so dense-document OCR loses fidelity — in our tests a dense page miscounts a figure at 280 but is correct at 1120.

SGLang's Gemma 4 vision tower already derives its output length from the actual patch grid, and the HF `Gemma4ImageProcessor` already accepts `max_soft_tokens` as a per-call kwarg — so the only missing piece is forwarding a per-request budget to the processor.

## Change (additive, backward-compatible)

Per-request `max_soft_tokens` for Gemma 4, accepted from two sources (`images_config` takes precedence):

- **`images_config`** — SGLang-native, already plumbed end-to-end: `{"max_soft_tokens": 1120}`
- **`mm_processor_kwargs`** — vLLM-compatible: `{"max_soft_tokens": 1120}`

`Gemma4SGLangProcessor` resolves the budget, validates it against the supported set, forwards it to the HF image processor via `process_and_combine_mm_data(**kwargs)`, and mixes it into the mm-item hashes (mirroring `UnlimitedOCRProcessor`) so different budgets don't collide in the radix / embedding cache. With no field set, behavior is unchanged.

Files: `protocol.py`, `io_struct.py`, `serving_chat.py` (add `mm_processor_kwargs`; `images_config` already present) and `multimodal/processors/gemma4.py` (processor logic).

## Testing

Runtime-verified on current `main` (built from source, `Gemma-4-26B-A4B-NVFP4`, aarch64/cu130, tp1, `--attention-backend triton`): a per-request `mm_processor_kwargs={"max_soft_tokens": 1120}` yields **1118** image tokens (vs the ~280 default), matching vLLM's ~1092. Also verified earlier on 0.5.14: a dense page went 268 → 1099 image tokens at 1120 and corrected an OCR miscount. Backward-compatible (no field set → unchanged); concurrent mixed budgets isolate correctly (the mm-hash mix prevents cache collisions).

## Note

Higher budgets increase vision-prefill cost roughly ∝ patches², so concurrency should be sized accordingly — this PR adds the resolution knob only, not concurrency handling. A related sm121 vision-prefill concurrency limitation observed at 1120 is tracked in #30162.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28803837157](https://github.com/sgl-project/sglang/actions/runs/28803837157)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28803837000](https://github.com/sgl-project/sglang/actions/runs/28803837000)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->