### PR TITLE
Fix MiMo-V2 on Blackwell: FA3 fallback and auto-select attention backend

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -383,10 +383,10 @@ def _mimo_v2_overrides(server_args: Any, hf_config: Any) -> dict:
             overrides["attention_backend"] = "fa4"
         elif is_sm90_supported():
             logger.info(
-                "Auto-select flashinfer attention backend for MiMoV2 on Hopper "
+                "Auto-select fa3 attention backend for MiMoV2 on Hopper "
                 "(trtllm_mha lacks headDimQk=192 kernel)."
             )
-            overrides["attention_backend"] = "flashinfer"
+            overrides["attention_backend"] = "fa3"
     if server_args.speculative_algorithm == "EAGLE":
         logger.info("Enable multi-layer EAGLE speculative decoding for MiMoV2 model.")
         overrides["enable_multi_layer_eagle"] = True

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -372,10 +372,25 @@ def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
 # Keep in sync with MIMO_V2_MODEL_ARCHS (server_args.py / configs/hf_config.py).
 @_register_for("MiMoV2ForCausalLM", "MiMoV2FlashForCausalLM")
 def _mimo_v2_overrides(server_args: Any, hf_config: Any) -> dict:
+    overrides: Dict[str, Any] = {}
+    # MiMo-V2 uses head_dim=192 (QK) which trtllm_mha does not support.
+    if server_args.is_attention_backend_not_set():
+        if is_blackwell_supported():
+            logger.info(
+                "Auto-select fa4 attention backend for MiMoV2 on Blackwell "
+                "(trtllm_mha lacks headDimQk=192 kernel)."
+            )
+            overrides["attention_backend"] = "fa4"
+        elif is_sm90_supported():
+            logger.info(
+                "Auto-select flashinfer attention backend for MiMoV2 on Hopper "
+                "(trtllm_mha lacks headDimQk=192 kernel)."
+            )
+            overrides["attention_backend"] = "flashinfer"
     if server_args.speculative_algorithm == "EAGLE":
         logger.info("Enable multi-layer EAGLE speculative decoding for MiMoV2 model.")
-        return {"enable_multi_layer_eagle": True}
-    return {}
+        overrides["enable_multi_layer_eagle"] = True
+    return overrides
 
 
 @_register_for("MiniMaxM2ForCausalLM")

--- a/python/sglang/srt/models/mimo_audio.py
+++ b/python/sglang/srt/models/mimo_audio.py
@@ -25,11 +25,17 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_cuda
 
 if is_cuda():
-    from sgl_kernel.flash_attn import flash_attn_varlen_func
-else:
+    from sglang.srt.layers.attention.triton_ops.prefill_attention import (
+        context_attention_fwd as _triton_context_attention_fwd,
+    )
 
-    def flash_attn_varlen_func(*args, **kwargs):
-        raise RuntimeError("MiMoAudioTokenizer requires CUDA to run.")
+    try:
+        from sgl_kernel.flash_attn import flash_attn_varlen_func
+    except ImportError:
+        flash_attn_varlen_func = None
+else:
+    flash_attn_varlen_func = None
+    _triton_context_attention_fwd = None
 
 
 logger = logging.getLogger(__name__)
@@ -520,17 +526,31 @@ class AudioEncoderAttention(nn.Module):
                 query_states, key_states, cos, sin
             )
 
-        attn_output = flash_attn_varlen_func(
-            query_states,
-            key_states,
-            value_states,
-            cu_seqlens,
-            cu_seqlens,
-            max_seqlen,
-            max_seqlen,
-            causal=self.causal,
-            window_size=self.window_size,
-        )
+        if flash_attn_varlen_func is not None:
+            attn_output = flash_attn_varlen_func(
+                query_states,
+                key_states,
+                value_states,
+                cu_seqlens,
+                cu_seqlens,
+                max_seqlen,
+                max_seqlen,
+                causal=self.causal,
+                window_size=self.window_size,
+            )
+        else:
+            attn_output = torch.empty_like(query_states)
+            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+            _triton_context_attention_fwd(
+                query_states,
+                key_states,
+                value_states,
+                attn_output,
+                cu_seqlens[:-1],
+                seq_lens,
+                max_seqlen,
+                is_causal=self.causal,
+            )
 
         attn_output = attn_output.reshape(bsz, self.embed_dim)
         attn_output = self.out_proj(attn_output)

--- a/python/sglang/srt/models/mimo_audio.py
+++ b/python/sglang/srt/models/mimo_audio.py
@@ -24,18 +24,7 @@ from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_cuda
 
-if is_cuda():
-    from sglang.srt.layers.attention.triton_ops.prefill_attention import (
-        context_attention_fwd as _triton_context_attention_fwd,
-    )
-
-    try:
-        from sgl_kernel.flash_attn import flash_attn_varlen_func
-    except ImportError:
-        flash_attn_varlen_func = None
-else:
-    flash_attn_varlen_func = None
-    _triton_context_attention_fwd = None
+from sglang.srt.layers.attention.vision import VisionAttention
 
 
 logger = logging.getLogger(__name__)
@@ -483,6 +472,22 @@ def get_position_ids(lengths):
 LAYER_NORM = {"LayerNorm": nn.LayerNorm}
 
 
+def _audio_rope_applier(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """RoPE applier for audio encoder attention, compatible with VisionAttention."""
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    x1_q, x2_q = q[..., : q.shape[-1] // 2], q[..., q.shape[-1] // 2 :]
+    x1_k, x2_k = k[..., : k.shape[-1] // 2], k[..., k.shape[-1] // 2 :]
+    q_embed = q * cos + torch.cat((-x2_q, x1_q), dim=-1) * sin
+    k_embed = k * cos + torch.cat((-x2_k, x1_k), dim=-1) * sin
+    return q_embed, k_embed
+
+
 class AudioEncoderAttention(nn.Module):
     def __init__(
         self,
@@ -498,10 +503,18 @@ class AudioEncoderAttention(nn.Module):
         self.window_size = window_size
         self.causal = causal
 
-        self.k_proj = nn.Linear(embed_dim, embed_dim, bias=False)
-        self.v_proj = nn.Linear(embed_dim, embed_dim, bias=True)
-        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=True)
-        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=True)
+        self.attn = VisionAttention(
+            embed_dim=embed_dim,
+            num_heads=num_heads,
+            projection_size=embed_dim,
+            use_qkv_parallel=True,
+            qkv_bias=True,
+            proj_bias=True,
+            flatten_batch=True,
+            window_size=window_size,
+            customized_position_embedding_applier=_audio_rope_applier,
+            prefix="attn",
+        )
 
     def forward(
         self,
@@ -510,65 +523,12 @@ class AudioEncoderAttention(nn.Module):
         max_seqlen: int,
         rope_position_embeddings=None,
     ):
-        bsz, _ = hidden_states.size()
-
-        query_states = self.q_proj(hidden_states).view(
-            bsz, self.num_heads, self.head_dim
+        return self.attn(
+            hidden_states,
+            cu_seqlens=cu_seqlens,
+            position_embeddings=rope_position_embeddings,
+            max_seqlen=max_seqlen,
         )
-        key_states = self.k_proj(hidden_states).view(bsz, self.num_heads, self.head_dim)
-        value_states = self.v_proj(hidden_states).view(
-            bsz, self.num_heads, self.head_dim
-        )
-
-        if rope_position_embeddings is not None:
-            cos, sin = rope_position_embeddings
-            query_states, key_states = self.apply_rotary_pos_emb(
-                query_states, key_states, cos, sin
-            )
-
-        if flash_attn_varlen_func is not None:
-            attn_output = flash_attn_varlen_func(
-                query_states,
-                key_states,
-                value_states,
-                cu_seqlens,
-                cu_seqlens,
-                max_seqlen,
-                max_seqlen,
-                causal=self.causal,
-                window_size=self.window_size,
-            )
-        else:
-            attn_output = torch.empty_like(query_states)
-            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-            _triton_context_attention_fwd(
-                query_states,
-                key_states,
-                value_states,
-                attn_output,
-                cu_seqlens[:-1],
-                seq_lens,
-                max_seqlen,
-                is_causal=self.causal,
-            )
-
-        attn_output = attn_output.reshape(bsz, self.embed_dim)
-        attn_output = self.out_proj(attn_output)
-        return attn_output
-
-    @staticmethod
-    def _rotate_half(x):
-        x1 = x[..., : x.shape[-1] // 2]
-        x2 = x[..., x.shape[-1] // 2 :]
-        return torch.cat((-x2, x1), dim=-1)
-
-    @classmethod
-    def apply_rotary_pos_emb(cls, q, k, cos, sin, unsqueeze_dim=1):
-        cos = cos.unsqueeze(unsqueeze_dim)
-        sin = sin.unsqueeze(unsqueeze_dim)
-        q_embed = (q * cos) + (cls._rotate_half(q) * sin)
-        k_embed = (k * cos) + (cls._rotate_half(k) * sin)
-        return q_embed, k_embed
 
 
 class AudioEncoderTransformerLayer(nn.Module):

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -1291,6 +1291,27 @@ class MiMoV2ForCausalLM(nn.Module, AudioEncoderMixin):
                 if name.startswith("audio_encoder."):
                     name = name[len("audio_encoder.") :]
                 name = self.remap_audio_weight_name(name)
+                # AudioEncoderAttention now uses VisionAttention internally:
+                #   self_attn.{q,k,v}_proj -> self_attn.attn.qkv_proj (stacked)
+                #   self_attn.out_proj     -> self_attn.attn.proj
+                name = name.replace("self_attn.out_proj", "self_attn.attn.proj")
+                audio_stacked = False
+                for param_name, weight_name, shard_id in [
+                    ("self_attn.attn.qkv_proj", "self_attn.q_proj", "q"),
+                    ("self_attn.attn.qkv_proj", "self_attn.k_proj", "k"),
+                    ("self_attn.attn.qkv_proj", "self_attn.v_proj", "v"),
+                ]:
+                    if weight_name in name:
+                        name = name.replace(weight_name, param_name)
+                        if name not in params_dict:
+                            break
+                        param = params_dict[name]
+                        weight_loader = param.weight_loader
+                        weight_loader(param, loaded_weight, shard_id)
+                        audio_stacked = True
+                        break
+                if audio_stacked:
+                    continue
                 if name not in params_dict:
                     logger.warning(
                         f"Audio param {name} not found in params_dict, skipping"

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -1291,27 +1291,30 @@ class MiMoV2ForCausalLM(nn.Module, AudioEncoderMixin):
                 if name.startswith("audio_encoder."):
                     name = name[len("audio_encoder.") :]
                 name = self.remap_audio_weight_name(name)
-                # AudioEncoderAttention now uses VisionAttention internally:
-                #   self_attn.{q,k,v}_proj -> self_attn.attn.qkv_proj (stacked)
-                #   self_attn.out_proj     -> self_attn.attn.proj
-                name = name.replace("self_attn.out_proj", "self_attn.attn.proj")
-                audio_stacked = False
-                for param_name, weight_name, shard_id in [
-                    ("self_attn.attn.qkv_proj", "self_attn.q_proj", "q"),
-                    ("self_attn.attn.qkv_proj", "self_attn.k_proj", "k"),
-                    ("self_attn.attn.qkv_proj", "self_attn.v_proj", "v"),
-                ]:
-                    if weight_name in name:
-                        name = name.replace(weight_name, param_name)
-                        if name not in params_dict:
+                # AudioEncoderAttention (in AudioEncoderTransformerLayer) now
+                # uses VisionAttention internally. Remap weight names, but
+                # skip input_local_transformer which uses Qwen2 attention.
+                if "input_local_transformer" not in name:
+                    name = name.replace(
+                        "self_attn.out_proj", "self_attn.attn.proj"
+                    )
+                    audio_stacked = False
+                    for param_name, weight_name, shard_id in [
+                        ("self_attn.attn.qkv_proj", "self_attn.q_proj", "q"),
+                        ("self_attn.attn.qkv_proj", "self_attn.k_proj", "k"),
+                        ("self_attn.attn.qkv_proj", "self_attn.v_proj", "v"),
+                    ]:
+                        if weight_name in name:
+                            name = name.replace(weight_name, param_name)
+                            if name not in params_dict:
+                                break
+                            param = params_dict[name]
+                            weight_loader = param.weight_loader
+                            weight_loader(param, loaded_weight, shard_id)
+                            audio_stacked = True
                             break
-                        param = params_dict[name]
-                        weight_loader = param.weight_loader
-                        weight_loader(param, loaded_weight, shard_id)
-                        audio_stacked = True
-                        break
-                if audio_stacked:
-                    continue
+                    if audio_stacked:
+                        continue
                 if name not in params_dict:
                     logger.warning(
                         f"Audio param {name} not found in params_dict, skipping"

--- a/python/sglang/srt/models/mimo_vl.py
+++ b/python/sglang/srt/models/mimo_vl.py
@@ -279,7 +279,7 @@ class MiMoVisionTransformer(nn.Module):
                     num_heads=num_heads,
                     hidden_act=vision_config.hidden_act,
                     norm_layer=norm_layer,
-                    attn_implementation="flash_attention_3",
+                    attn_implementation=None,
                     quant_config=quant_config,
                     prefix=add_prefix(f"blocks.{i}", prefix),
                     use_sink=(


### PR DESCRIPTION
## Summary
- **mimo_audio.py**: Fall back to triton `context_attention_fwd` when `sgl_kernel.flash_attn` is unavailable (e.g. sm103/Blackwell where FA3 is not supported)
- **overrides.py**: Auto-select `fa4` (Blackwell) or `flashinfer` (Hopper) attention backend for MiMoV2 since `trtllm_mha` lacks the `headDimQk=192` kernel

MiMo-V2 uses a non-standard `head_dim=192` for QK, which `trtllm_mha` does not have a precompiled kernel for. Without this fix, launching MiMo-V2.5-Pro on GB300 fails at model import (FA3 not available on sm103) and at attention kernel dispatch (missing trtllm_mha kernel for headDimQk=192).

Tested with MiMo-V2.5-Pro on 2-node TP8 GB300 (cross-node MNNVL).







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28745588001](https://github.com/sgl-project/sglang/actions/runs/28745588001)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28745587913](https://github.com/sgl-project/sglang/actions/runs/28745587913)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->