### PR TITLE
[diffusion] Fuse ERNIE AdaLN residual path

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/ernie_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ernie_image.py
@@ -19,6 +19,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 
+from sglang.jit_kernel.diffusion.residual_gate_add import (
+    can_use_residual_gate_add_cuda,
+    residual_gate_add_cuda,
+)
 from sglang.multimodal_gen.configs.models.dits.ernie_image import (
     ErnieImageDitConfig,
 )
@@ -149,15 +153,11 @@ def _ernie_residual_gate_add(
 ) -> torch.Tensor:
     global _ERNIE_RESIDUAL_GATE_ADD_DISABLED
 
-    if not _ERNIE_RESIDUAL_GATE_ADD_DISABLED:
+    if not _ERNIE_RESIDUAL_GATE_ADD_DISABLED and can_use_residual_gate_add_cuda(
+        residual, update, gate
+    ):
         try:
-            from sglang.jit_kernel.diffusion.residual_gate_add import (
-                can_use_residual_gate_add_cuda,
-                residual_gate_add_cuda,
-            )
-
-            if can_use_residual_gate_add_cuda(residual, update, gate):
-                return residual_gate_add_cuda(residual, update, gate)
+            return residual_gate_add_cuda(residual, update, gate)
         except Exception as exc:
             if torch.compiler.is_compiling():
                 raise

--- a/python/sglang/multimodal_gen/runtime/models/dits/ernie_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ernie_image.py
@@ -37,6 +37,134 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload im
     LayerwiseOffloadableModuleMixin,
 )
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+_ERNIE_FUSED_ADALN_DISABLED = False
+_ERNIE_RESIDUAL_GATE_ADD_DISABLED = False
+
+
+def _ernie_can_use_fused_adaln(
+    x: torch.Tensor,
+    norm: RMSNorm,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+) -> bool:
+    return (
+        x.is_cuda
+        and x.dim() == 3
+        and x.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and norm.weight is not None
+        and norm.weight.is_cuda
+        and norm.weight.dtype == x.dtype
+        and shift.is_cuda
+        and scale.is_cuda
+        and shift.dtype == x.dtype
+        and scale.dtype == x.dtype
+        and x.shape[-1] % 256 == 0
+        and x.shape[-1] <= 8192
+    )
+
+
+def _ernie_norm_scale_shift(
+    x: torch.Tensor,
+    norm: RMSNorm,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+) -> torch.Tensor:
+    global _ERNIE_FUSED_ADALN_DISABLED
+
+    if not _ERNIE_FUSED_ADALN_DISABLED and _ernie_can_use_fused_adaln(
+        x, norm, shift, scale
+    ):
+        try:
+            from sglang.jit_kernel.diffusion.cutedsl.scale_residual_norm_scale_shift import (
+                fused_norm_scale_shift,
+            )
+
+            return fused_norm_scale_shift(
+                x.contiguous(),
+                norm.weight.contiguous(),
+                None,
+                scale.contiguous(),
+                shift.contiguous(),
+                "rms",
+                norm.variance_epsilon,
+            )
+        except Exception as exc:
+            if torch.compiler.is_compiling():
+                raise
+            logger.warning_once(f"Disabling ERNIE fused AdaLN fast path: {exc}")
+            _ERNIE_FUSED_ADALN_DISABLED = True
+
+    return norm(x) * (1 + scale) + shift
+
+
+def _ernie_scale_residual_norm_scale_shift(
+    residual: torch.Tensor,
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    norm: RMSNorm,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    global _ERNIE_FUSED_ADALN_DISABLED
+
+    if not _ERNIE_FUSED_ADALN_DISABLED and _ernie_can_use_fused_adaln(
+        x, norm, shift, scale
+    ):
+        try:
+            from sglang.jit_kernel.diffusion.cutedsl.scale_residual_norm_scale_shift import (
+                fused_scale_residual_norm_scale_shift,
+            )
+
+            return fused_scale_residual_norm_scale_shift(
+                residual.contiguous(),
+                x.contiguous(),
+                gate.contiguous(),
+                norm.weight.contiguous(),
+                None,
+                scale.contiguous(),
+                shift.contiguous(),
+                "rms",
+                norm.variance_epsilon,
+            )
+        except Exception as exc:
+            if torch.compiler.is_compiling():
+                raise
+            logger.warning_once(
+                f"Disabling ERNIE fused residual AdaLN fast path: {exc}"
+            )
+            _ERNIE_FUSED_ADALN_DISABLED = True
+
+    residual = residual + gate * x
+    return norm(residual) * (1 + scale) + shift, residual
+
+
+def _ernie_residual_gate_add(
+    residual: torch.Tensor,
+    update: torch.Tensor,
+    gate: torch.Tensor,
+) -> torch.Tensor:
+    global _ERNIE_RESIDUAL_GATE_ADD_DISABLED
+
+    if not _ERNIE_RESIDUAL_GATE_ADD_DISABLED:
+        try:
+            from sglang.jit_kernel.diffusion.residual_gate_add import (
+                can_use_residual_gate_add_cuda,
+                residual_gate_add_cuda,
+            )
+
+            if can_use_residual_gate_add_cuda(residual, update, gate):
+                return residual_gate_add_cuda(residual, update, gate)
+        except Exception as exc:
+            if torch.compiler.is_compiling():
+                raise
+            logger.warning_once(f"Disabling ERNIE residual-gate CUDA fast path: {exc}")
+            _ERNIE_RESIDUAL_GATE_ADD_DISABLED = True
+
+    return residual + update * gate
 
 
 def _rope(pos: torch.Tensor, dim: int, theta: int) -> torch.Tensor:
@@ -246,12 +374,18 @@ class ErnieImageSharedAdaLNBlock(nn.Module):
         gate_mlp: torch.Tensor,
     ) -> torch.Tensor:
         residual = x
-        x = self.adaLN_sa_ln(x) * (1 + scale_msa) + shift_msa
-        x = residual + gate_msa * self.self_attention(x, rotary_pos_emb)
+        x = _ernie_norm_scale_shift(x, self.adaLN_sa_ln, shift_msa, scale_msa)
+        attention_output = self.self_attention(x, rotary_pos_emb)
 
-        residual = x
-        x = self.adaLN_mlp_ln(x) * (1 + scale_mlp) + shift_mlp
-        x = residual + gate_mlp * self.mlp(x)
+        x, residual = _ernie_scale_residual_norm_scale_shift(
+            residual,
+            attention_output,
+            gate_msa,
+            self.adaLN_mlp_ln,
+            shift_mlp,
+            scale_mlp,
+        )
+        x = _ernie_residual_gate_add(residual, self.mlp(x), gate_mlp)
 
         return x
 

--- a/test/registered/jit/diffusion/test_ernie_fused_adaln.py
+++ b/test/registered/jit/diffusion/test_ernie_fused_adaln.py
@@ -1,0 +1,74 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm
+from sglang.multimodal_gen.runtime.models.dits.ernie_image import (
+    _ernie_norm_scale_shift,
+    _ernie_residual_gate_add,
+    _ernie_scale_residual_norm_scale_shift,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=18, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
+
+
+@pytest.fixture(autouse=True)
+def cuda_setup():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    torch.cuda.manual_seed(0)
+
+
+def _tol(dtype: torch.dtype) -> tuple[float, float]:
+    return (1e-5, 1e-5) if dtype == torch.float32 else (5e-2, 5e-2)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_ernie_norm_scale_shift_helper(dtype: torch.dtype) -> None:
+    x = torch.randn((1, 17, 256), device="cuda", dtype=dtype)
+    norm = RMSNorm(256, eps=1e-6).to(device="cuda", dtype=dtype)
+    shift = torch.randn((1, 1, 256), device="cuda", dtype=dtype)
+    scale = torch.randn((1, 1, 256), device="cuda", dtype=dtype)
+
+    actual = _ernie_norm_scale_shift(x, norm, shift, scale)
+    expected = norm(x) * (1 + scale) + shift
+
+    atol, rtol = _tol(dtype)
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_ernie_residual_adaln_helpers(dtype: torch.dtype) -> None:
+    residual = torch.randn((1, 17, 256), device="cuda", dtype=dtype)
+    update = torch.randn_like(residual)
+    norm = RMSNorm(256, eps=1e-6).to(device="cuda", dtype=dtype)
+    gate = torch.randn((1, 1, 256), device="cuda", dtype=dtype)
+    shift = torch.randn((1, 1, 256), device="cuda", dtype=dtype)
+    scale = torch.randn((1, 1, 256), device="cuda", dtype=dtype)
+
+    actual, residual_out = _ernie_scale_residual_norm_scale_shift(
+        residual, update, gate, norm, shift, scale
+    )
+    expected_residual = residual + gate * update
+    expected = norm(expected_residual) * (1 + scale) + shift
+
+    atol, rtol = _tol(dtype)
+    torch.testing.assert_close(residual_out, expected_residual, atol=atol, rtol=rtol)
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+    final = _ernie_residual_gate_add(residual_out, update, gate)
+    torch.testing.assert_close(
+        final,
+        residual_out + update * gate,
+        atol=0 if dtype != torch.float32 else atol,
+        rtol=0 if dtype != torch.float32 else rtol,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

Use existing diffusion fused kernels in the ERNIE-Image Turbo shared AdaLN block to reduce repeated RMSNorm, scale/shift, residual, and gate-add overhead in the denoising transformer path.

The optimized block keeps the checkpoint parameter names unchanged while replacing this hot eager pattern with guarded fused calls:

```python
hidden_states = norm(hidden_states) * scale + shift
hidden_states = residual + gate * branch_out
```

## Modifications

- Add private ERNIE fast-path helpers around existing `fused_norm_scale_shift`, `fused_scale_residual_norm_scale_shift`, and `residual_gate_add_cuda`.
- Fuse the first RMSNorm + scale/shift before attention.
- Fuse attention residual + gate add + MLP-input RMSNorm + scale/shift.
- Reuse the residual-gate CUDA op for the final MLP residual update.
- Keep `adaLN_sa_ln` and `adaLN_mlp_ln` checkpoint parameter names unchanged.
- Guard CUDA/dtype/layout/runtime support and fall back to the original PyTorch expressions on unsupported inputs or one-time runtime failure.

## Accuracy Tests

```bash
python3 -m py_compile   python/sglang/multimodal_gen/runtime/models/dits/ernie_image.py   test/registered/jit/diffusion/test_ernie_fused_adaln.py
python3 -m ruff format --check ...
python3 -m ruff check ...
git diff --check
```

Result: local syntax/format/lint/diff checks passed.

H200 unit test:

```bash
CUDA_VISIBLE_DEVICES=6 PYTHONPATH=python FLASHINFER_DISABLE_VERSION_CHECK=1 pytest -q test/registered/jit/diffusion/test_ernie_fused_adaln.py -q
```

Result: `6 passed`.

## Speed Tests and Profiling

H200 native-backend A/B on `ernie-image-turbo` with the benchmark preset. Native backend gate passed: no `Falling back to diffusers backend`, `Using diffusers backend`, or `Loaded diffusers pipeline` in the benchmark log.

E2E command, run once at the PR parent baseline and once at this PR head. Only the checkout and `--perf-dump-path` label changed between the two runs.

```bash
cd /tmp/sglang_local_validate
CUDA_VISIBLE_DEVICES=7 PYTHONPATH=python sglang generate \
  --backend=sglang \
  --model-path=baidu/ERNIE-Image-Turbo \
  --prompt="A futuristic cyberpunk city at night, neon lights reflecting on wet streets" \
  --seed=42 \
  --width=1024 \
  --height=1024 \
  --save-output \
  --warmup \
  --enable-torch-compile \
  --perf-dump-path /tmp/sglang_local_validate/outputs/pr_candidate/ernie-image-turbo_fused_adaln.json
```

Compare the baseline/head perf dumps with:

```bash
PYTHONPATH=python python python/sglang/multimodal_gen/benchmarks/compare_perf.py \
  /tmp/sglang_local_validate/outputs/pr_baseline/ernie-image-turbo_baseline.json \
  /tmp/sglang_local_validate/outputs/pr_candidate/ernie-image-turbo_fused_adaln.json
```

| Implementation | E2E ms | DenoisingStage ms | Delta E2E | Delta Denoise |
| --- | ---: | ---: | ---: | ---: |
| Baseline | 22154.41 | 14652.40 | - | - |
| Fused AdaLN | 20071.36 | 13334.39 | -9.4% | -9.0% |

Perf dump: `/tmp/sglang_local_validate/outputs/pr_candidate/ernie-image-turbo_fused_adaln.json` on the H200 validation box.

## H200 Fused-vs-Unfused Accuracy

The generated-image A/B compares the PR parent baseline against this PR head:

| Side | Commit |
| --- | --- |
| Baseline unfused | `3ea875fef48f6f01fa3bddd9e2197ad190cef29d` |
| Fused AdaLN | `8d2b755a167be19a7a45971243c47e8f5c1e9946` |

To isolate the denoising transformer change, the ERNIE prompt enhancement output was fixed once and then reused for both runs with `use_pe=false`. This avoids PromptEnhancementStage nondeterminism; a baseline-vs-baseline repeat with the same fixed prompt is bitwise identical.

| Check | Prompt / Seed / Shape | Comparison | Result |
| --- | --- | --- | --- |
| Native backend gate | fixed ERNIE enhanced prompt, `seed=42`, `1024x1024` | logs for baseline and fused generation | no diffusers fallback signals |
| Baseline repeat determinism | same fixed prompt, same seed | baseline vs baseline repeat | `SSIM=1.000000`, `PSNR=inf`, `max_abs=0` |
| Fused-vs-unfused output | same fixed prompt, same seed | fused image vs unfused image | `SSIM=0.720635`, `PSNR=18.06 dB`, `max_abs=255` |

Quality conclusion: the fused full-image sample is not pixel-identical to the unfused path, but the visual layout/content is preserved in the side-by-side sample below. The difference is from the fused residual/norm path changing floating-point accumulation in the denoising trajectory, not from prompt rewriting.

### Result Image Comparison

H200 ERNIE-Image Turbo A/B output sample (`seed=42`, `1024x1024`). The figure compares the original unfused path against the fused AdaLN residual path and includes an amplified absolute-difference view.

![ernie_fixed_compare.png](https://github.com/user-attachments/assets/c095311e-2ef6-41fb-a709-2b483e39a55c)

Image-level comparison: `SSIM=0.720635`, `PSNR=18.06 dB`, `max_abs=255`. Baseline repeat check: `SSIM=1.000000`, `PSNR=inf`, `max_abs=0`.

## Checklist

- [x] Default ERNIE path tries the fused CUDA/Triton helpers first and falls back to the existing PyTorch implementation when unsupported.
- [x] No checkpoint parameter names changed.
- [x] H200 unit test included for fused helper behavior.
- [x] H200 native-backend benchmark evidence included.
- [x] H200 same-prompt generated-image comparison and SSIM/PSNR included.










<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28763999706](https://github.com/sgl-project/sglang/actions/runs/28763999706)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28763999617](https://github.com/sgl-project/sglang/actions/runs/28763999617)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


