### PR TITLE
[Feature] Support return_hidden_states="last"

### DIFF
--- a/examples/runtime/hidden_states/hidden_states_engine.py
+++ b/examples/runtime/hidden_states/hidden_states_engine.py
@@ -1,10 +1,9 @@
 """
 Usage:
-python hidden_states.py
+python hidden_states_engine.py
 
-Note that each time you change the `return_hidden_states` parameter,
-the cuda graph will be recaptured, which might lead to a performance hit.
-So avoid getting hidden states and completions alternately.
+CUDA graphs use the configured maximum hidden-state mode. Requests may select
+that mode or a weaker one without triggering mode-dependent recapture.
 """
 
 import torch
@@ -22,7 +21,7 @@ def main():
     # Create an LLM.
     llm = sgl.Engine(
         model_path="Alibaba-NLP/gte-Qwen2-1.5B-instruct",
-        enable_return_hidden_states=True,
+        return_hidden_states_mode="last",
     )
 
     sampling_params = {
@@ -32,16 +31,15 @@ def main():
     }
 
     outputs = llm.generate(
-        prompts, sampling_params=sampling_params, return_hidden_states=True
+        prompts, sampling_params=sampling_params, return_hidden_states="last"
     )
 
     llm.shutdown()
 
     for prompt, output in zip(prompts, outputs):
-        for i in range(len(output["meta_info"]["hidden_states"])):
-            output["meta_info"]["hidden_states"][i] = torch.tensor(
-                output["meta_info"]["hidden_states"][i], dtype=torch.bfloat16
-            )
+        hidden_state = torch.tensor(
+            output["meta_info"]["hidden_states"], dtype=torch.bfloat16
+        )
         print("===============================")
         print(
             f"Prompt: {prompt}\n"
@@ -49,14 +47,8 @@ def main():
             f"Prompt_Tokens: {output['meta_info']['prompt_tokens']}\t"
             f"Completion_tokens: {output['meta_info']['completion_tokens']}"
         )
-        print("Hidden states: ")
-        hidden_states = torch.cat(
-            [
-                i.unsqueeze(0) if len(i.shape) == 1 else i
-                for i in output["meta_info"]["hidden_states"]
-            ]
-        )
-        print(hidden_states)
+        print("Last hidden state: ")
+        print(hidden_state)
         print()
 
 

--- a/examples/runtime/hidden_states/hidden_states_server.py
+++ b/examples/runtime/hidden_states/hidden_states_server.py
@@ -3,9 +3,8 @@ Usage:
 
 python hidden_states_server.py
 
-Note that each time you change the `return_hidden_states` parameter,
-the cuda graph will be recaptured, which might lead to a performance hit.
-So avoid getting hidden states and completions alternately.
+CUDA graphs use the configured maximum hidden-state mode. Requests may select
+that mode or a weaker one without triggering mode-dependent recapture.
 """
 
 import requests
@@ -23,7 +22,9 @@ else:
 def main():
     # Launch the server
     server_process, port = launch_server_cmd(
-        "python -m sglang.launch_server --model-path Alibaba-NLP/gte-Qwen2-1.5B-instruct --enable-return-hidden-states --host 0.0.0.0"
+        "python -m sglang.launch_server --model-path "
+        "Alibaba-NLP/gte-Qwen2-1.5B-instruct "
+        "--return-hidden-states-mode last --host 0.0.0.0"
     )
     wait_for_server(f"http://localhost:{port}", process=server_process)
 
@@ -43,7 +44,7 @@ def main():
     json_data = {
         "text": prompts,
         "sampling_params": sampling_params,
-        "return_hidden_states": True,
+        "return_hidden_states": "last",
     }
 
     response = requests.post(
@@ -55,10 +56,9 @@ def main():
 
     outputs = response.json()
     for prompt, output in zip(prompts, outputs):
-        for i in range(len(output["meta_info"]["hidden_states"])):
-            output["meta_info"]["hidden_states"][i] = torch.tensor(
-                output["meta_info"]["hidden_states"][i], dtype=torch.bfloat16
-            )
+        hidden_state = torch.tensor(
+            output["meta_info"]["hidden_states"], dtype=torch.bfloat16
+        )
         print("===============================")
         print(
             f"Prompt: {prompt}\n"
@@ -66,14 +66,8 @@ def main():
             f"Prompt_Tokens: {output['meta_info']['prompt_tokens']}\t"
             f"Completion_tokens: {output['meta_info']['completion_tokens']}"
         )
-        print("Hidden states: ")
-        hidden_states = torch.cat(
-            [
-                i.unsqueeze(0) if len(i.shape) == 1 else i
-                for i in output["meta_info"]["hidden_states"]
-            ]
-        )
-        print(hidden_states)
+        print("Last hidden state: ")
+        print(hidden_state)
         print()
 
 

--- a/python/sglang/srt/entrypoints/EngineBase.py
+++ b/python/sglang/srt/entrypoints/EngineBase.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Dict, Iterator, List, Literal, Optional, Tuple, Union
 
 import torch
 
@@ -23,7 +23,9 @@ class EngineBase(ABC):
         token_ids_logprob: Optional[Union[List[List[int]], List[int]]] = None,
         lora_path: Optional[Union[List[Optional[str]], Optional[str]]] = None,
         custom_logit_processor: Optional[Union[List[str], str]] = None,
-        return_hidden_states: Optional[bool] = None,
+        return_hidden_states: Optional[
+            Union[bool, Literal["last"], List[Union[bool, Literal["last"]]]]
+        ] = None,
         stream: Optional[bool] = None,
         bootstrap_host: Optional[Union[List[str], str]] = None,
         bootstrap_port: Optional[Union[List[int], int]] = None,

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -76,6 +76,7 @@ from sglang.srt.managers.io_struct import (
     ProfileReqType,
     ReleaseMemoryOccupationReqInput,
     ResumeMemoryOccupationReqInput,
+    ReturnHiddenStatesMode,
     RpcReqInput,
     RpcReqOutput,
     UnloadLoRAAdapterReqInput,
@@ -363,7 +364,9 @@ class Engine(EngineScoreMixin, EngineBase):
         lora_path: Optional[List[Optional[str]]] = None,
         custom_logit_processor: Optional[Union[List[str], str]] = None,
         require_reasoning: bool = False,
-        return_hidden_states: bool = False,
+        return_hidden_states: Union[
+            ReturnHiddenStatesMode, List[ReturnHiddenStatesMode]
+        ] = False,
         return_routed_experts: bool = False,
         routed_experts_start_len: int = 0,
         stream: bool = False,
@@ -467,7 +470,9 @@ class Engine(EngineScoreMixin, EngineBase):
         lora_path: Optional[List[Optional[str]]] = None,
         custom_logit_processor: Optional[Union[List[str], str]] = None,
         require_reasoning: bool = False,
-        return_hidden_states: bool = False,
+        return_hidden_states: Union[
+            ReturnHiddenStatesMode, List[ReturnHiddenStatesMode]
+        ] = False,
         return_routed_experts: bool = False,
         routed_experts_start_len: int = 0,
         stream: bool = False,

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -24,6 +24,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Literal,
     NamedTuple,
     Optional,
     Protocol,
@@ -338,7 +339,7 @@ class CompletionRequest(BaseModel):
     temperature: float = 1.0
     top_p: float = 1.0
     user: Optional[str] = None
-    return_hidden_states: bool = False
+    return_hidden_states: Union[bool, Literal["last"]] = False
     return_routed_experts: bool = False
     routed_experts_start_len: int = 0
     return_cached_tokens_details: bool = False
@@ -754,7 +755,7 @@ class ChatCompletionRequest(BaseModel):
         default="auto", examples=["none"]
     )  # noqa
     parallel_tool_calls: bool = True
-    return_hidden_states: bool = False
+    return_hidden_states: Union[bool, Literal["last"]] = False
     return_routed_experts: bool = False
     routed_experts_start_len: int = 0
     return_cached_tokens_details: bool = False

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -53,6 +53,7 @@ from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
 from sglang.srt.entrypoints.openai.utils import (
     cached_tokens_details_from_dict,
     process_cached_tokens_details_from_ret,
+    process_hidden_states_for_response,
     process_hidden_states_from_ret,
     process_routed_experts_from_ret,
     should_include_usage,
@@ -1380,10 +1381,8 @@ class OpenAIServingChat(OpenAIServingBase):
             if request.return_hidden_states and hidden_states:
                 for index, choice_hidden_states in hidden_states.items():
                     if choice_hidden_states:
-                        last_token_hidden_states = (
-                            choice_hidden_states[-1]
-                            if len(choice_hidden_states) > 1
-                            else []
+                        response_hidden_states = process_hidden_states_for_response(
+                            choice_hidden_states, request.return_hidden_states
                         )
                         hidden_states_chunk = ChatCompletionStreamResponse(
                             id=content["meta_info"]["id"],
@@ -1392,7 +1391,7 @@ class OpenAIServingChat(OpenAIServingBase):
                                 ChatCompletionResponseStreamChoice(
                                     index=index,
                                     delta=DeltaMessage(
-                                        hidden_states=last_token_hidden_states
+                                        hidden_states=response_hidden_states
                                     ),
                                     finish_reason=None,  # Hidden states don't need finish_reason
                                 )

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -22,6 +22,7 @@ from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
 from sglang.srt.entrypoints.openai.utils import (
     cached_tokens_details_from_dict,
     process_cached_tokens_details_from_ret,
+    process_hidden_states_for_response,
     process_hidden_states_from_ret,
     process_routed_experts_from_ret,
     should_include_usage,
@@ -392,10 +393,8 @@ class OpenAIServingCompletion(OpenAIServingBase):
             if request.return_hidden_states and hidden_states:
                 for index, choice_hidden_states in hidden_states.items():
                     if choice_hidden_states:
-                        last_token_hidden_states = (
-                            choice_hidden_states[-1]
-                            if len(choice_hidden_states) > 1
-                            else []
+                        response_hidden_states = process_hidden_states_for_response(
+                            choice_hidden_states, request.return_hidden_states
                         )
                         hidden_states_chunk = CompletionStreamResponse(
                             id=content["meta_info"]["id"],
@@ -405,7 +404,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
                                 CompletionResponseStreamChoice(
                                     index=index,
                                     text="",
-                                    hidden_states=last_token_hidden_states,
+                                    hidden_states=response_hidden_states,
                                     finish_reason=None,
                                 )
                             ],

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import torch
 
@@ -71,9 +71,21 @@ def process_hidden_states_from_ret(
         return None
 
     hidden_states = ret_item["meta_info"].get("hidden_states", None)
-    if hidden_states is not None:
-        hidden_states = hidden_states[-1] if len(hidden_states) > 1 else []
-    return hidden_states
+    return process_hidden_states_for_response(
+        hidden_states, request.return_hidden_states
+    )
+
+
+def process_hidden_states_for_response(
+    hidden_states: Optional[List],
+    return_hidden_states: Union[bool, Literal["last"]],
+) -> Optional[List]:
+    """Format scheduler hidden states for OpenAI API responses."""
+    if not return_hidden_states or hidden_states is None:
+        return None
+    if return_hidden_states == "last":
+        return hidden_states
+    return hidden_states[-1] if len(hidden_states) > 1 else []
 
 
 def should_include_usage(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -53,7 +53,7 @@ from pydantic import PlainValidator
 from sglang.srt.environ import envs
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.embed_types import PositionalEmbeds
-from sglang.srt.managers.schedule_batch import Modality
+from sglang.srt.managers.schedule_batch import Modality, ReturnHiddenStatesMode
 from sglang.srt.multimodal.mm_utils import has_valid_data
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.utils import ImageData, VideoData
@@ -219,7 +219,9 @@ class GenerateReqInput:
     # Whether to log metrics for this request (e.g. health_generate calls do not log metrics)
     log_metrics: bool = True
     # Whether to return hidden states
-    return_hidden_states: Union[List[bool], bool] = False
+    return_hidden_states: Union[
+        List[ReturnHiddenStatesMode], ReturnHiddenStatesMode
+    ] = False
     # Whether to return captured routed experts
     return_routed_experts: bool = False
     # Absolute start position for returned routings; response covers
@@ -838,7 +840,7 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     return_flat_raw_top_logprobs: bool = False
 
     # Whether to return hidden states
-    return_hidden_states: bool = False
+    return_hidden_states: ReturnHiddenStatesMode = False
 
     # Whether to return captured routed experts
     return_routed_experts: bool = False

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -53,7 +53,11 @@ from pydantic import PlainValidator
 from sglang.srt.environ import envs
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.embed_types import PositionalEmbeds
-from sglang.srt.managers.schedule_batch import Modality, ReturnHiddenStatesMode
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    ReturnHiddenStatesMode,
+    get_return_hidden_states_mode,
+)
 from sglang.srt.multimodal.mm_utils import has_valid_data
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.utils import ImageData, VideoData
@@ -483,6 +487,7 @@ class GenerateReqInput:
         self._normalize_audio_data(num)
         self._normalize_sampling_params(num)
         self._normalize_logprob_params(num)
+        self._normalize_return_hidden_states(num)
         self._normalize_custom_logit_processor(num)
         self._normalize_extra_key(num)
         self._normalize_bootstrap_params(num)
@@ -645,6 +650,22 @@ class GenerateReqInput:
             raise ValueError(
                 "Cannot use list token_ids_logprob with parallel_sample_num > 1"
             )
+
+    def _normalize_return_hidden_states(self, num):
+        """Normalize and validate per-request hidden-state return modes."""
+        if isinstance(self.return_hidden_states, list):
+            if len(self.return_hidden_states) != self.batch_size:
+                raise ValueError(
+                    "The length of return_hidden_states should be equal to the batch size."
+                )
+            for mode in self.return_hidden_states:
+                get_return_hidden_states_mode(mode)
+            self.return_hidden_states = (
+                self.return_hidden_states * self.parallel_sample_num
+            )
+        else:
+            get_return_hidden_states_mode(self.return_hidden_states)
+            self.return_hidden_states = [self.return_hidden_states] * num
 
     def _normalize_custom_logit_processor(self, num):
         """Normalize custom logit processor for batch processing."""

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -52,6 +52,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Literal,
     NamedTuple,
     Optional,
     Set,
@@ -96,7 +97,11 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
 from sglang.srt.observability.metrics_collector import (
     DPCooperationInfo,
     SchedulerMetricsCollector,
@@ -132,6 +137,41 @@ INIT_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 MM_PAD_SHIFT_VALUE = 1_000_000
 
 logger = logging.getLogger(__name__)
+
+
+ReturnHiddenStatesMode = Union[bool, Literal["last"]]
+
+
+def get_return_hidden_states_mode(
+    return_hidden_states: ReturnHiddenStatesMode,
+) -> CaptureHiddenMode:
+    if return_hidden_states is True:
+        return CaptureHiddenMode.FULL
+    if return_hidden_states == "last":
+        return CaptureHiddenMode.LAST
+    if return_hidden_states is False:
+        return CaptureHiddenMode.NULL
+    raise ValueError(
+        "return_hidden_states must be a boolean or the string literal 'last'."
+    )
+
+
+def get_batch_return_hidden_states_mode(reqs: List[Req]) -> CaptureHiddenMode:
+    mode = CaptureHiddenMode.NULL
+    for req in reqs:
+        mode = max(mode, req.return_hidden_states_mode)
+    return mode
+
+
+def need_return_hidden_states(
+    return_hidden_states: Union[List[ReturnHiddenStatesMode], ReturnHiddenStatesMode],
+) -> bool:
+    if isinstance(return_hidden_states, list):
+        return any(
+            get_return_hidden_states_mode(mode).need_capture()
+            for mode in return_hidden_states
+        )
+    return get_return_hidden_states_mode(return_hidden_states).need_capture()
 
 
 @lru_cache(maxsize=1)
@@ -741,7 +781,7 @@ class Req(ReqDllmMixin):
         session: Optional[Session] = None,
         custom_logit_processor: Optional[str] = None,
         require_reasoning: bool = False,
-        return_hidden_states: bool = False,
+        return_hidden_states: ReturnHiddenStatesMode = False,
         return_routed_experts: bool = False,
         routed_experts_start_len: int = 0,
         return_indexer_topk: bool = False,
@@ -826,6 +866,9 @@ class Req(ReqDllmMixin):
         self.sampling_params = sampling_params
         self.custom_logit_processor = custom_logit_processor
         self.return_hidden_states = return_hidden_states
+        self.return_hidden_states_mode = get_return_hidden_states_mode(
+            return_hidden_states
+        )
 
         # extra key for classifying the request (e.g. cache_salt)
         if lora_id is not None:
@@ -1989,6 +2032,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     # Whether to return hidden states
     return_hidden_states: bool = False
+    return_hidden_states_mode: CaptureHiddenMode = CaptureHiddenMode.NULL
 
     # Has grammar
     has_grammar: bool = False
@@ -2047,6 +2091,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     ):
         return_logprob = any(req.return_logprob for req in reqs)
 
+        return_hidden_states_mode = get_batch_return_hidden_states_mode(reqs)
+
         batch = cls(
             reqs=reqs,
             req_to_token_pool=req_to_token_pool,
@@ -2058,7 +2104,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             has_grammar=any(req.grammar for req in reqs),
             device=req_to_token_pool.device,
             spec_algorithm=spec_algorithm,
-            return_hidden_states=any(req.return_hidden_states for req in reqs),
+            return_hidden_states=return_hidden_states_mode.need_capture(),
+            return_hidden_states_mode=return_hidden_states_mode,
             is_prefill_only=all(req.is_prefill_only for req in reqs),
             chunked_req=chunked_req,
             chunked_req_next_prompt_token=_compute_chunked_req_next_prompt_token(
@@ -2970,6 +3017,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # Filter out all requests. Stale tensors are left as-is: is_empty()
             # keys off reqs, so callers drop the batch before a forward reads them.
             self.reqs = []
+            self.return_hidden_states = False
+            self.return_hidden_states_mode = CaptureHiddenMode.NULL
             return
 
         if len(keep_indices) == len(self.reqs):
@@ -3019,6 +3068,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             self.token_ids_logprobs = None
 
         self.has_grammar = any(req.grammar for req in self.reqs)
+        self.return_hidden_states_mode = get_batch_return_hidden_states_mode(self.reqs)
+        self.return_hidden_states = self.return_hidden_states_mode.need_capture()
 
         self.sampling_info.filter_batch(keep_indices, keep_indices_device)
         if self.spec_info:
@@ -3080,9 +3131,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
         self.return_logprob = self.return_logprob or other.return_logprob
         self.has_grammar = self.has_grammar or other.has_grammar
-        self.return_hidden_states = (
-            self.return_hidden_states or other.return_hidden_states
+        self.return_hidden_states_mode = max(
+            self.return_hidden_states_mode, other.return_hidden_states_mode
         )
+        self.return_hidden_states = self.return_hidden_states_mode.need_capture()
         self.is_prefill_only = self.is_prefill_only and other.is_prefill_only
 
         if self.spec_info:
@@ -3105,6 +3157,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             out_cache_loc=self.out_cache_loc,
             return_logprob=self.return_logprob,
             has_grammar=self.has_grammar,
+            return_hidden_states=self.return_hidden_states,
+            return_hidden_states_mode=self.return_hidden_states_mode,
             decoding_reqs=self.decoding_reqs,
             spec_algorithm=self.spec_algorithm,
             spec_info=self.spec_info,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -156,6 +156,17 @@ def get_return_hidden_states_mode(
     )
 
 
+def get_request_return_hidden_states_mode(
+    return_hidden_states: Union[List[ReturnHiddenStatesMode], ReturnHiddenStatesMode],
+) -> CaptureHiddenMode:
+    if isinstance(return_hidden_states, list):
+        return max(
+            (get_return_hidden_states_mode(mode) for mode in return_hidden_states),
+            default=CaptureHiddenMode.NULL,
+        )
+    return get_return_hidden_states_mode(return_hidden_states)
+
+
 def get_batch_return_hidden_states_mode(reqs: List[Req]) -> CaptureHiddenMode:
     mode = CaptureHiddenMode.NULL
     for req in reqs:
@@ -166,12 +177,7 @@ def get_batch_return_hidden_states_mode(reqs: List[Req]) -> CaptureHiddenMode:
 def need_return_hidden_states(
     return_hidden_states: Union[List[ReturnHiddenStatesMode], ReturnHiddenStatesMode],
 ) -> bool:
-    if isinstance(return_hidden_states, list):
-        return any(
-            get_return_hidden_states_mode(mode).need_capture()
-            for mode in return_hidden_states
-        )
-    return get_return_hidden_states_mode(return_hidden_states).need_capture()
+    return get_request_return_hidden_states_mode(return_hidden_states).need_capture()
 
 
 @lru_cache(maxsize=1)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3593,16 +3593,19 @@ class Scheduler(
             # These 2 values are needed for processing the output, but the values can be
             # modified by overlap schedule. So we have to copy them here so that
             # we can use the correct values in output processing.
-            if batch.return_logprob:
+            if batch.return_logprob or batch.return_hidden_states:
                 batch_result.extend_input_len_per_req = [
                     req.extend_range.length if req.extend_range is not None else 0
                     for req in batch.reqs
                 ]
+            else:
+                batch_result.extend_input_len_per_req = None
+
+            if batch.return_logprob:
                 batch_result.extend_logprob_start_len_per_req = (
                     batch.extend_logprob_start_lens
                 )
             else:
-                batch_result.extend_input_len_per_req = None
                 batch_result.extend_logprob_start_len_per_req = None
 
             ret = batch_result

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -235,6 +235,24 @@ class SchedulerBatchResultProcessor:
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
                 if (
+                    batch.return_hidden_states
+                    and logits_output.hidden_states is not None
+                ):
+                    assert extend_input_len_per_req is not None
+                    hidden_state_offset = self._append_prefill_hidden_states(
+                        req=req,
+                        logits_output=logits_output,
+                        hidden_state_offset=hidden_state_offset,
+                        capture_hidden_mode=prefill_hidden_capture_mode,
+                        extend_input_len=extend_input_len_per_req[i],
+                        store=(
+                            not req.finished()
+                            and not req.is_retracted
+                            and req.inflight_middle_chunks <= 0
+                        ),
+                    )
+
+                if (
                     req.finished() and req.inflight_middle_chunks <= 0
                 ) or req.is_retracted:
                     # Decode req in a mixed batch, or a retracted req. Keep an
@@ -276,19 +294,6 @@ class SchedulerBatchResultProcessor:
 
                     if req.return_sampling_mask:
                         self.add_sampling_mask_return_values(i, req, logits_output)
-
-                    if (
-                        batch.return_hidden_states
-                        and logits_output.hidden_states is not None
-                    ):
-                        assert extend_input_len_per_req is not None
-                        hidden_state_offset = self._append_prefill_hidden_states(
-                            req=req,
-                            logits_output=logits_output,
-                            hidden_state_offset=hidden_state_offset,
-                            capture_hidden_mode=prefill_hidden_capture_mode,
-                            extend_input_len=extend_input_len_per_req[i],
-                        )
 
                     if req.grammar is not None:
                         self._apply_prefill_grammar(
@@ -496,27 +501,59 @@ class SchedulerBatchResultProcessor:
         hidden_state_offset: int,
         capture_hidden_mode: CaptureHiddenMode,
         extend_input_len: int,
+        store: bool = True,
     ) -> int:
         if capture_hidden_mode.is_full():
-            req_hidden_states = logits_output.hidden_states[
-                hidden_state_offset : (
-                    hidden_state_offset := hidden_state_offset + extend_input_len
-                )
-            ]
+            start = hidden_state_offset
+            hidden_state_offset += extend_input_len
+            if not store or not req.return_hidden_states:
+                return hidden_state_offset
+
+            req_hidden_states = logits_output.hidden_states[start:hidden_state_offset]
             if req.return_hidden_states is True:
                 req.hidden_states.append(req_hidden_states.cpu().clone().tolist())
             elif req.return_hidden_states == "last":
                 req.hidden_states.append(req_hidden_states[-1].cpu().tolist())
         elif capture_hidden_mode.is_last():
-            req_hidden_states = logits_output.hidden_states[hidden_state_offset]
+            index = hidden_state_offset
             hidden_state_offset += 1
-            if req.return_hidden_states:
-                req.hidden_states.append(req_hidden_states.cpu().tolist())
+            if store and req.return_hidden_states:
+                req.hidden_states.append(
+                    logits_output.hidden_states[index].cpu().tolist()
+                )
         else:
             raise ValueError(
                 f"Unexpected hidden states capture mode: {capture_hidden_mode}"
             )
         return hidden_state_offset
+
+    @staticmethod
+    def _append_decode_hidden_states(
+        *,
+        req: Req,
+        hidden_states: torch.Tensor,
+        start: int,
+        accept_len: int,
+    ) -> None:
+        if accept_len <= 0:
+            return
+
+        if req.return_hidden_states == "last":
+            valid_accept_len = accept_len
+            if req.finished_len is not None:
+                step_start = len(req.output_ids) - accept_len
+                valid_accept_len = max(
+                    0,
+                    min(accept_len, req.finished_len - step_start),
+                )
+            if valid_accept_len > 0:
+                req.hidden_states[:] = [
+                    hidden_states[start + valid_accept_len - 1].cpu().tolist()
+                ]
+        else:
+            req.hidden_states.extend(
+                hidden_states[start : start + accept_len].cpu().tolist()
+            )
 
     @staticmethod
     def _get_prefill_hidden_capture_mode(
@@ -849,10 +886,11 @@ class SchedulerBatchResultProcessor:
                 stride = result.speculative_num_draft_tokens or 1
                 accept_len = len(next_token_id)
                 start = i * stride
-                req.hidden_states.extend(
-                    logits_output.hidden_states[start : start + accept_len]
-                    .cpu()
-                    .tolist()
+                self._append_decode_hidden_states(
+                    req=req,
+                    hidden_states=logits_output.hidden_states,
+                    start=start,
+                    accept_len=accept_len,
                 )
 
             if req.grammar is not None:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -27,6 +27,10 @@ from sglang.srt.mem_cache.common import (
     maybe_cache_unfinished_req,
     release_kv_cache,
 )
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    get_required_capture_hidden_mode,
+)
 from sglang.srt.runtime_context import (
     get_disagg,
     get_exec,
@@ -220,6 +224,7 @@ class SchedulerBatchResultProcessor:
             self._validate_pp_skip_output_comm(batch, result)
 
             hidden_state_offset = 0
+            prefill_hidden_capture_mode = self._get_prefill_hidden_capture_mode(batch)
 
             # Check finish conditions
             logprob_pt = 0
@@ -269,13 +274,14 @@ class SchedulerBatchResultProcessor:
                         self.add_sampling_mask_return_values(i, req, logits_output)
 
                     if (
-                        req.return_hidden_states
+                        batch.return_hidden_states
                         and logits_output.hidden_states is not None
                     ):
                         hidden_state_offset = self._append_prefill_hidden_states(
                             req=req,
                             logits_output=logits_output,
                             hidden_state_offset=hidden_state_offset,
+                            capture_hidden_mode=prefill_hidden_capture_mode,
                         )
 
                     if req.grammar is not None:
@@ -482,19 +488,36 @@ class SchedulerBatchResultProcessor:
         req: Req,
         logits_output: LogitsProcessorOutput,
         hidden_state_offset: int,
+        capture_hidden_mode: CaptureHiddenMode,
     ) -> int:
-        req.hidden_states.append(
-            logits_output.hidden_states[
+        if capture_hidden_mode.is_full():
+            req_hidden_states = logits_output.hidden_states[
                 hidden_state_offset : (
                     hidden_state_offset := hidden_state_offset
                     + len(req.origin_input_ids)
                 )
             ]
-            .cpu()
-            .clone()
-            .tolist()
-        )
+            if req.return_hidden_states is True:
+                req.hidden_states.append(req_hidden_states.cpu().clone().tolist())
+            elif req.return_hidden_states == "last":
+                req.hidden_states.append(req_hidden_states[-1].cpu().tolist())
+        elif capture_hidden_mode.is_last():
+            req_hidden_states = logits_output.hidden_states[hidden_state_offset]
+            hidden_state_offset += 1
+            if req.return_hidden_states:
+                req.hidden_states.append(req_hidden_states.cpu().tolist())
+        else:
+            raise ValueError(
+                f"Unexpected hidden states capture mode: {capture_hidden_mode}"
+            )
         return hidden_state_offset
+
+    @staticmethod
+    def _get_prefill_hidden_capture_mode(batch: ScheduleBatch) -> CaptureHiddenMode:
+        return get_required_capture_hidden_mode(
+            batch.return_hidden_states_mode,
+            batch.spec_info,
+        )
 
     def _apply_prefill_grammar(
         self, *, req: Req, next_token_id: int, already_advanced: bool = False

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -30,6 +30,7 @@ from sglang.srt.mem_cache.common import (
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     get_required_capture_hidden_mode,
+    get_server_return_hidden_states_mode,
 )
 from sglang.srt.runtime_context import (
     get_disagg,
@@ -224,7 +225,10 @@ class SchedulerBatchResultProcessor:
             self._validate_pp_skip_output_comm(batch, result)
 
             hidden_state_offset = 0
-            prefill_hidden_capture_mode = self._get_prefill_hidden_capture_mode(batch)
+            prefill_hidden_capture_mode = self._get_prefill_hidden_capture_mode(
+                batch,
+                self.server_args,
+            )
 
             # Check finish conditions
             logprob_pt = 0
@@ -277,11 +281,13 @@ class SchedulerBatchResultProcessor:
                         batch.return_hidden_states
                         and logits_output.hidden_states is not None
                     ):
+                        assert extend_input_len_per_req is not None
                         hidden_state_offset = self._append_prefill_hidden_states(
                             req=req,
                             logits_output=logits_output,
                             hidden_state_offset=hidden_state_offset,
                             capture_hidden_mode=prefill_hidden_capture_mode,
+                            extend_input_len=extend_input_len_per_req[i],
                         )
 
                     if req.grammar is not None:
@@ -489,12 +495,12 @@ class SchedulerBatchResultProcessor:
         logits_output: LogitsProcessorOutput,
         hidden_state_offset: int,
         capture_hidden_mode: CaptureHiddenMode,
+        extend_input_len: int,
     ) -> int:
         if capture_hidden_mode.is_full():
             req_hidden_states = logits_output.hidden_states[
                 hidden_state_offset : (
-                    hidden_state_offset := hidden_state_offset
-                    + len(req.origin_input_ids)
+                    hidden_state_offset := hidden_state_offset + extend_input_len
                 )
             ]
             if req.return_hidden_states is True:
@@ -513,9 +519,15 @@ class SchedulerBatchResultProcessor:
         return hidden_state_offset
 
     @staticmethod
-    def _get_prefill_hidden_capture_mode(batch: ScheduleBatch) -> CaptureHiddenMode:
+    def _get_prefill_hidden_capture_mode(
+        batch: ScheduleBatch,
+        server_args: ServerArgs,
+    ) -> CaptureHiddenMode:
         return get_required_capture_hidden_mode(
-            batch.return_hidden_states_mode,
+            max(
+                batch.return_hidden_states_mode,
+                get_server_return_hidden_states_mode(server_args),
+            ),
             batch.spec_info,
         )
 

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -564,13 +564,18 @@ class _GenerationStreamAccumulator:
 
         if self.return_hidden_states:
             if req.return_hidden_states:
-                # Mirror output_ids_through_stop: spec verify steps can overshoot finished_len.
-                hs = req.hidden_states
-                if req.finished_len is not None:
-                    hs = hs[: req.finished_len]
                 if req.return_hidden_states == "last":
-                    self.output_hidden_states.append(hs[-1] if hs else None)
+                    # Collection keeps this list bounded to the final valid
+                    # accepted token, including speculative verify overshoot.
+                    self.output_hidden_states.append(
+                        req.hidden_states[-1] if req.hidden_states else None
+                    )
                 else:
+                    # Mirror output_ids_through_stop: spec verify steps can
+                    # overshoot finished_len.
+                    hs = req.hidden_states
+                    if req.finished_len is not None:
+                        hs = hs[: req.finished_len]
                     self.output_hidden_states.append(hs)
             else:
                 self.output_hidden_states.append(None)

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -568,7 +568,10 @@ class _GenerationStreamAccumulator:
                 hs = req.hidden_states
                 if req.finished_len is not None:
                     hs = hs[: req.finished_len]
-                self.output_hidden_states.append(hs)
+                if req.return_hidden_states == "last":
+                    self.output_hidden_states.append(hs[-1] if hs else None)
+                else:
+                    self.output_hidden_states.append(hs)
             else:
                 self.output_hidden_states.append(None)
         if self.return_routed_experts:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -93,7 +93,7 @@ from sglang.srt.managers.mm_utils import TensorTransportMode, wrap_shm_features
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
 from sglang.srt.managers.schedule_batch import (
     MultimodalDataItem,
-    need_return_hidden_states,
+    get_request_return_hidden_states_mode,
 )
 from sglang.srt.managers.scheduler_input_blocker import input_blocker_guard_region
 from sglang.srt.managers.tokenizer_control_mixin import TokenizerControlMixin
@@ -101,6 +101,9 @@ from sglang.srt.managers.tokenizer_manager_score_mixin import TokenizerManagerSc
 from sglang.srt.managers.utils import (
     compute_num_reserved_tokens,
     is_health_check_generate_req,
+)
+from sglang.srt.model_executor.forward_batch_info import (
+    get_server_return_hidden_states_mode,
 )
 from sglang.srt.observability.cpu_monitor import start_cpu_monitor_thread
 from sglang.srt.observability.metrics_collector import (
@@ -1140,13 +1143,23 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Validate generation-specific fields
         if isinstance(obj, GenerateReqInput):
             self._validate_token_ids_logprob(obj)
-            if (
-                need_return_hidden_states(obj.return_hidden_states)
-                and not self.server_args.enable_return_hidden_states
-            ):
+            requested_hidden_mode = get_request_return_hidden_states_mode(
+                obj.return_hidden_states
+            )
+            server_hidden_mode = get_server_return_hidden_states_mode(self.server_args)
+            if requested_hidden_mode > server_hidden_mode:
+                if server_hidden_mode.need_capture():
+                    raise ValueError(
+                        "The requested return_hidden_states mode exceeds the "
+                        f"server maximum `{self.server_args.return_hidden_states_mode}`. "
+                        "Please launch with `--return-hidden-states-mode full` "
+                        "to allow return_hidden_states=True."
+                    )
                 raise ValueError(
-                    "The server is not configured to return the hidden states. "
-                    "Please set `--enable-return-hidden-states` to enable this feature."
+                    "The server is not configured to return hidden states. "
+                    "Please set `--return-hidden-states-mode last`, "
+                    "`--return-hidden-states-mode full`, or the legacy "
+                    "`--enable-return-hidden-states` flag."
                 )
             if (
                 obj.custom_logit_processor

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -91,7 +91,10 @@ from sglang.srt.managers.io_struct import (
 from sglang.srt.managers.load_snapshot import create_load_snapshot_reader
 from sglang.srt.managers.mm_utils import TensorTransportMode, wrap_shm_features
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
-from sglang.srt.managers.schedule_batch import MultimodalDataItem
+from sglang.srt.managers.schedule_batch import (
+    MultimodalDataItem,
+    need_return_hidden_states,
+)
 from sglang.srt.managers.scheduler_input_blocker import input_blocker_guard_region
 from sglang.srt.managers.tokenizer_control_mixin import TokenizerControlMixin
 from sglang.srt.managers.tokenizer_manager_score_mixin import TokenizerManagerScoreMixin
@@ -1138,7 +1141,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if isinstance(obj, GenerateReqInput):
             self._validate_token_ids_logprob(obj)
             if (
-                obj.return_hidden_states
+                need_return_hidden_states(obj.return_hidden_states)
                 and not self.server_args.enable_return_hidden_states
             ):
                 raise ValueError(

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -34,6 +34,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     PPProxyTensors,
     enable_num_token_non_padded,
+    get_required_capture_hidden_mode,
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner_utils.capture_mode import model_capture_mode
@@ -703,21 +704,7 @@ class CPUGraphRunner:
             else forward_batch.batch_size <= self.max_bs
         )
 
-        requested_capture_hidden_mode = max(
-            forward_batch.capture_hidden_mode,
-            (
-                forward_batch.spec_info.capture_hidden_mode
-                if getattr(forward_batch.spec_info, "capture_hidden_mode", None)
-                is not None
-                else CaptureHiddenMode.NULL
-            ),
-        )
-        capture_hidden_mode_matches = (
-            requested_capture_hidden_mode == CaptureHiddenMode.NULL
-            or requested_capture_hidden_mode == self.capture_hidden_mode
-        )
-
-        return is_bs_supported and capture_hidden_mode_matches
+        return is_bs_supported
 
     def capture(self) -> None:
         capture_range = (
@@ -793,10 +780,10 @@ class CPUGraphRunner:
             encoder_lens = None
 
         spec_info = self.get_spec_info(num_tokens)
-        if self.capture_hidden_mode != CaptureHiddenMode.FULL:
-            self.capture_hidden_mode = (
-                spec_info.capture_hidden_mode if spec_info else CaptureHiddenMode.NULL
-            )
+        self.capture_hidden_mode = get_required_capture_hidden_mode(
+            self.capture_hidden_mode,
+            spec_info,
+        )
 
         forward_batch = ForwardBatch(
             forward_mode=self.capture_forward_mode,
@@ -870,33 +857,12 @@ class CPUGraphRunner:
                         self.captured_forward_batches_cross[bs] = forward_batch
                     return forward, out
 
-    def recapture_if_needed(self, forward_batch: ForwardBatch):
-
-        # If the required capture_hidden_mode changes, we need to recapture the graph
-
-        # These are the different factors that can influence the capture_hidden_mode
-        capture_hidden_mode_required_by_forward_batch = (
-            forward_batch.capture_hidden_mode
-        )
-        capture_hidden_mode_required_by_spec_info = getattr(
-            forward_batch.spec_info, "capture_hidden_mode", CaptureHiddenMode.NULL
-        )
-        capture_hidden_mode_required_for_returning_hidden_states = (
-            CaptureHiddenMode.FULL
-            if self.enable_return_hidden_states
-            else CaptureHiddenMode.NULL
+    def recapture_if_needed(self, forward_batch: ForwardBatch) -> None:
+        required_capture_hidden_mode = get_required_capture_hidden_mode(
+            forward_batch.capture_hidden_mode,
+            forward_batch.spec_info,
         )
 
-        # Determine the highest capture_hidden_mode required
-        # (If we have FULL, we can emulate LAST or NULL)
-        # (If we have LAST, we can emulate NULL)
-        required_capture_hidden_mode = max(
-            capture_hidden_mode_required_by_forward_batch,
-            capture_hidden_mode_required_by_spec_info,
-            capture_hidden_mode_required_for_returning_hidden_states,
-        )
-
-        # If the current hidden mode is no longer aligned with the required hidden mode, we need to set it to what is required and re-capture
         if self.capture_hidden_mode != required_capture_hidden_mode:
             self.capture_hidden_mode = required_capture_hidden_mode
             self.capture()

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -35,6 +35,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     PPProxyTensors,
     enable_num_token_non_padded,
     get_required_capture_hidden_mode,
+    get_server_return_hidden_states_mode,
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner_utils.capture_mode import model_capture_mode
@@ -563,9 +564,12 @@ class CPUGraphRunner:
         # Parse args
         self.model_runner = model_runner
         self.device = model_runner.device
-        self.enable_return_hidden_states = (
-            model_runner.server_args.enable_return_hidden_states
+        self.return_hidden_states_mode = (
+            CaptureHiddenMode.NULL
+            if model_runner.is_draft_worker
+            else get_server_return_hidden_states_mode(model_runner.server_args)
         )
+        self.enable_return_hidden_states = self.return_hidden_states_mode.need_capture()
         # bs -> compiled fn (text-only / skip_cross_attention=True)
         self.graphs = {}
         # bs -> compiled fn (cross-attention / skip_cross_attention=False, enc-dec only)
@@ -590,13 +594,9 @@ class CPUGraphRunner:
         self.pp_size = model_runner.server_args.pp_size
 
         self.capture_forward_mode = ForwardMode.DECODE
-        self.capture_hidden_mode = CaptureHiddenMode.NULL
+        self.capture_hidden_mode = self.return_hidden_states_mode
         # Static capture width: CPU graphs are decode-only.
         self.captured_req_width = 1
-
-        # If returning hidden states is enabled, set initial capture hidden mode to full to avoid double-capture on startup
-        if self.enable_return_hidden_states:
-            self.capture_hidden_mode = CaptureHiddenMode.FULL
 
         assert (
             not self.model_runner.server_args.enable_lora
@@ -857,22 +857,24 @@ class CPUGraphRunner:
                         self.captured_forward_batches_cross[bs] = forward_batch
                     return forward, out
 
-    def recapture_if_needed(self, forward_batch: ForwardBatch) -> None:
+    def _validate_capture_hidden_mode(self, forward_batch: ForwardBatch) -> None:
         required_capture_hidden_mode = get_required_capture_hidden_mode(
             forward_batch.capture_hidden_mode,
             forward_batch.spec_info,
         )
 
-        if self.capture_hidden_mode != required_capture_hidden_mode:
-            self.capture_hidden_mode = required_capture_hidden_mode
-            self.capture()
+        if self.capture_hidden_mode < required_capture_hidden_mode:
+            raise RuntimeError(
+                "The runtime hidden-state mode exceeds the fixed CPU graph "
+                f"capture mode ({self.capture_hidden_mode.name})."
+            )
 
     def prepare_replay(
         self,
         forward_batch: ForwardBatch,
         skip: bool = False,
     ):
-        self.recapture_if_needed(forward_batch)
+        self._validate_capture_hidden_mode(forward_batch)
 
         graphs = self.graphs_cross if not skip else self.graphs
         cfbs = (

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -858,12 +858,7 @@ class CPUGraphRunner:
                     return forward, out
 
     def _validate_capture_hidden_mode(self, forward_batch: ForwardBatch) -> None:
-        required_capture_hidden_mode = get_required_capture_hidden_mode(
-            forward_batch.capture_hidden_mode,
-            forward_batch.spec_info,
-        )
-
-        if self.capture_hidden_mode < required_capture_hidden_mode:
+        if self.capture_hidden_mode < forward_batch.capture_hidden_mode:
             raise RuntimeError(
                 "The runtime hidden-state mode exceeds the fixed CPU graph "
                 f"capture mode ({self.capture_hidden_mode.name})."

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -231,6 +231,16 @@ def register_attn_tp_sequence_sharded_predicate(
     _attn_tp_sequence_sharded_predicate = predicate
 
 
+def get_required_capture_hidden_mode(
+    capture_hidden_mode: CaptureHiddenMode,
+    spec_info: Optional[SpecInput],
+) -> CaptureHiddenMode:
+    spec_capture_hidden_mode = (
+        getattr(spec_info, "capture_hidden_mode", None) or CaptureHiddenMode.NULL
+    )
+    return max(capture_hidden_mode, spec_capture_hidden_mode)
+
+
 def _attn_tp_local_shard_bounds(num_tokens_per_dp: int) -> Tuple[int, int]:
     """(tokens_per_rank, rank_offset) of this attn-TP rank's slice of the sequence.
 
@@ -696,13 +706,15 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # SB.return_hidden_states / spec_info.capture_hidden_mode.
         if capture_hidden_mode is None:
             if batch.return_hidden_states:
-                capture_hidden_mode = CaptureHiddenMode.FULL
-            elif batch.spec_info is not None:
-                capture_hidden_mode = getattr(
-                    batch.spec_info, "capture_hidden_mode", CaptureHiddenMode.NULL
+                capture_hidden_mode = get_required_capture_hidden_mode(
+                    batch.return_hidden_states_mode,
+                    batch.spec_info,
                 )
             else:
-                capture_hidden_mode = CaptureHiddenMode.NULL
+                capture_hidden_mode = get_required_capture_hidden_mode(
+                    CaptureHiddenMode.NULL,
+                    batch.spec_info,
+                )
 
         # extend-mode-only fields are None on decode/idle
         if batch.forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -32,7 +32,7 @@ import warnings
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from functools import total_ordering
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import torch
 
@@ -229,6 +229,15 @@ def register_attn_tp_sequence_sharded_predicate(
     """Register the predicate for whether a forward is sharded across attn-TP."""
     global _attn_tp_sequence_sharded_predicate
     _attn_tp_sequence_sharded_predicate = predicate
+
+
+def get_server_return_hidden_states_mode(server_args: Any) -> CaptureHiddenMode:
+    mode = getattr(server_args, "return_hidden_states_mode", None)
+    if mode == "last":
+        return CaptureHiddenMode.LAST
+    if mode == "full" or getattr(server_args, "enable_return_hidden_states", False):
+        return CaptureHiddenMode.FULL
+    return CaptureHiddenMode.NULL
 
 
 def get_required_capture_hidden_mode(
@@ -702,19 +711,21 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # init_new must not mutate the input ScheduleBatch; per-forward
         # overrides go through explicit keyword arguments.
 
-        # capture_hidden_mode=None means no override: derive from
-        # SB.return_hidden_states / spec_info.capture_hidden_mode.
+        # capture_hidden_mode=None means no override: capture the server's
+        # configured maximum so lower-mode requests can share one graph.
         if capture_hidden_mode is None:
-            if batch.return_hidden_states:
-                capture_hidden_mode = get_required_capture_hidden_mode(
+            request_capture_hidden_mode = (
+                CaptureHiddenMode.NULL
+                if model_runner.is_draft_worker
+                else max(
                     batch.return_hidden_states_mode,
-                    batch.spec_info,
+                    get_server_return_hidden_states_mode(model_runner.server_args),
                 )
-            else:
-                capture_hidden_mode = get_required_capture_hidden_mode(
-                    CaptureHiddenMode.NULL,
-                    batch.spec_info,
-                )
+            )
+            capture_hidden_mode = get_required_capture_hidden_mode(
+                request_capture_hidden_mode,
+                batch.spec_info,
+            )
 
         # extend-mode-only fields are None on decode/idle
         if batch.forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -19,6 +19,10 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    get_server_return_hidden_states_mode,
+)
 from sglang.srt.model_executor.graph_shared_output import GraphSharedOutput
 from sglang.srt.model_executor.hook_manager import register_forward_hooks
 from sglang.srt.model_executor.model_runner_components.layer_setup import (
@@ -162,16 +166,17 @@ def capture_prefill_graph(
     if model_runner.is_draft_worker and not force_for_draft_worker:
         return None
 
-    # Skip prefill CG for EAGLE target on tc_piecewise: that backend
-    # captures CaptureHiddenMode.NULL while runtime requests FULL, so
-    # the captured graph is dead, and capturing it perturbs FP4 /
-    # TRTLLM-MoE state and corrupts decode replay (see #28386). BCG
-    # captures FULL for EAGLE target in PrefillCudaGraphRunner.__init__
-    # (restored from #25795), so it does NOT need this skip.
+    # Skip prefill CG for EAGLE target on tc_piecewise when the fixed server
+    # capture ceiling is below FULL. EAGLE target prefill requests FULL, so a
+    # NULL or LAST graph is dead; capturing it can perturb FP4/TRTLLM-MoE
+    # state and corrupt decode replay (see #28386 and #28870). BCG captures
+    # FULL for EAGLE target in PrefillCudaGraphRunner.__init__, so it does not
+    # need this skip.
     if (
         model_runner.spec_algorithm.is_eagle()
         and not model_runner.is_draft_worker
-        and not model_runner.server_args.enable_return_hidden_states
+        and get_server_return_hidden_states_mode(model_runner.server_args)
+        < CaptureHiddenMode.FULL
         and not check_cuda_graph_backend(Phase.PREFILL, Backend.BREAKABLE)
     ):
         logger.info(

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -38,6 +38,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     NgramEmbeddingInfo,
     PPProxyTensors,
+    get_server_return_hidden_states_mode,
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner.flashinfer_autotune import (
@@ -200,9 +201,12 @@ class BaseRunner(ABC):
         self.dp_size = model_runner.server_args.dp_size
         self.pp_size = model_runner.server_args.pp_size
         self.enable_pdmux = model_runner.server_args.enable_pdmux
-        self.enable_return_hidden_states = (
-            model_runner.server_args.enable_return_hidden_states
+        self.return_hidden_states_mode = (
+            CaptureHiddenMode.NULL
+            if model_runner.is_draft_worker
+            else get_server_return_hidden_states_mode(model_runner.server_args)
         )
+        self.enable_return_hidden_states = self.return_hidden_states_mode.need_capture()
         self.attn_tp_size = get_parallel().attn_tp_size
         self.attn_tp_rank = get_parallel().attn_tp_rank
         self.tbo_plugin = TboCudaGraphRunnerPlugin()
@@ -367,7 +371,11 @@ class BaseRunner(ABC):
             capture_forward_mode = ForwardMode.DECODE
         else:
             capture_forward_mode = ForwardMode.EXTEND
-        capture_hidden_mode = CaptureHiddenMode.NULL
+        capture_hidden_mode = (
+            CaptureHiddenMode.NULL
+            if mr.is_draft_worker
+            else get_server_return_hidden_states_mode(mr.server_args)
+        )
         num_tokens_per_req = 1
         if mr.spec_algorithm.is_speculative():
             if mr.is_draft_worker:
@@ -376,9 +384,6 @@ class BaseRunner(ABC):
                 ), "This should not happen"
             capture_forward_mode = ForwardMode.TARGET_VERIFY
             num_tokens_per_req = mr.decode_num_tokens_per_req()
-
-        if mr.server_args.enable_return_hidden_states:
-            capture_hidden_mode = CaptureHiddenMode.FULL
 
         num_tokens = batch_size * num_tokens_per_req
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -259,7 +259,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         # --- capture mode + tokens-per-bs ------------------------------
         self.capture_forward_mode = ForwardMode.DECODE
-        self.capture_hidden_mode = CaptureHiddenMode.NULL
+        self.capture_hidden_mode = self.return_hidden_states_mode
         # Static capture width.
         self.captured_req_width = model_runner.decode_num_tokens_per_req(
             num_draft_tokens=self.speculative_num_draft_tokens
@@ -304,10 +304,6 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 "tier); disable SGLANG_RAGGED_VERIFY_MODE or the conflicting "
                 "feature."
             )
-
-        # If returning hidden states is enabled, set initial capture hidden mode to full to avoid double-capture on startup
-        if self.enable_return_hidden_states:
-            self.capture_hidden_mode = CaptureHiddenMode.FULL
 
         # Attention backend
         self.max_bs = max(self.capture_bs)
@@ -607,8 +603,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             ),
         )
         capture_hidden_mode_matches = (
-            requested_capture_hidden_mode == CaptureHiddenMode.NULL
-            or requested_capture_hidden_mode == self.capture_hidden_mode
+            requested_capture_hidden_mode <= self.capture_hidden_mode
         )
 
         return (
@@ -1010,16 +1005,17 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     post_warmup_hook=post_warmup_hook,
                 )
 
-    def recapture_if_needed(self, forward_batch: ForwardBatch) -> None:
+    def _validate_capture_hidden_mode(self, forward_batch: ForwardBatch) -> None:
         required_capture_hidden_mode = get_required_capture_hidden_mode(
             forward_batch.capture_hidden_mode,
             forward_batch.spec_info,
         )
 
-        if self.capture_hidden_mode != required_capture_hidden_mode:
-            self.capture_hidden_mode = required_capture_hidden_mode
-            self.backend.cleanup()
-            self.capture()
+        if self.capture_hidden_mode < required_capture_hidden_mode:
+            raise RuntimeError(
+                "The runtime hidden-state mode exceeds the fixed CUDA graph "
+                f"capture mode ({self.capture_hidden_mode.name})."
+            )
 
     def load_batch(
         self,
@@ -1069,7 +1065,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             return
 
         buffers = self.buffers
-        self.recapture_if_needed(forward_batch)
+        self._validate_capture_hidden_mode(forward_batch)
 
         raw_bs = forward_batch.batch_size
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -593,17 +593,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             else True
         )
 
-        requested_capture_hidden_mode = max(
-            forward_batch.capture_hidden_mode,
-            (
-                forward_batch.spec_info.capture_hidden_mode
-                if getattr(forward_batch.spec_info, "capture_hidden_mode", None)
-                is not None
-                else CaptureHiddenMode.NULL
-            ),
-        )
         capture_hidden_mode_matches = (
-            requested_capture_hidden_mode <= self.capture_hidden_mode
+            forward_batch.capture_hidden_mode <= self.capture_hidden_mode
         )
 
         return (
@@ -1006,12 +997,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 )
 
     def _validate_capture_hidden_mode(self, forward_batch: ForwardBatch) -> None:
-        required_capture_hidden_mode = get_required_capture_hidden_mode(
-            forward_batch.capture_hidden_mode,
-            forward_batch.spec_info,
-        )
-
-        if self.capture_hidden_mode < required_capture_hidden_mode:
+        if self.capture_hidden_mode < forward_batch.capture_hidden_mode:
             raise RuntimeError(
                 "The runtime hidden-state mode exceeds the fixed CUDA graph "
                 f"capture mode ({self.capture_hidden_mode.name})."

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -62,6 +62,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     PPProxyTensors,
     compute_local_num_token_non_padded,
     enable_num_token_non_padded,
+    get_required_capture_hidden_mode,
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
@@ -557,19 +558,6 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             else True
         )
 
-        requested_capture_hidden_mode = max(
-            forward_batch.capture_hidden_mode,
-            (
-                forward_batch.spec_info.capture_hidden_mode
-                if getattr(forward_batch.spec_info, "capture_hidden_mode", None)
-                is not None
-                else CaptureHiddenMode.NULL
-            ),
-        )
-        capture_hidden_mode_matches = (
-            requested_capture_hidden_mode == CaptureHiddenMode.NULL
-            or requested_capture_hidden_mode == self.capture_hidden_mode
-        )
         is_tbo_supported = (
             forward_batch.can_run_tbo if self.enable_two_batch_overlap else True
         )
@@ -587,7 +575,6 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             is_bs_supported
             and is_encoder_lens_supported
             and is_tbo_supported
-            and capture_hidden_mode_matches
             and is_ngram_supported
         )
 
@@ -751,10 +738,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             global_dp_buffer_len = None
 
         spec_info = self.get_spec_info(num_tokens)
-        if self.capture_hidden_mode != CaptureHiddenMode.FULL:
-            self.capture_hidden_mode = (
-                spec_info.capture_hidden_mode if spec_info else CaptureHiddenMode.NULL
-            )
+        self.capture_hidden_mode = get_required_capture_hidden_mode(
+            self.capture_hidden_mode,
+            spec_info,
+        )
 
         if self.model_runner.server_args.enable_lora:
             # It is safe to capture CUDA graph using empty LoRA id, as the LoRA kernels will always be launched whenever
@@ -1023,34 +1010,12 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     post_warmup_hook=post_warmup_hook,
                 )
 
-    def recapture_if_needed(self, forward_batch: ForwardBatch):
-
-        # If the required capture_hidden_mode changes, we need to recapture the graph
-
-        # These are the different factors that can influence the capture_hidden_mode
-        capture_hidden_mode_required_by_forward_batch = (
-            forward_batch.capture_hidden_mode
-        )
-        capture_hidden_mode_required_by_spec_info = (
-            getattr(forward_batch.spec_info, "capture_hidden_mode", None)
-            or CaptureHiddenMode.NULL
-        )
-        capture_hidden_mode_required_for_returning_hidden_states = (
-            CaptureHiddenMode.FULL
-            if self.enable_return_hidden_states
-            else CaptureHiddenMode.NULL
+    def recapture_if_needed(self, forward_batch: ForwardBatch) -> None:
+        required_capture_hidden_mode = get_required_capture_hidden_mode(
+            forward_batch.capture_hidden_mode,
+            forward_batch.spec_info,
         )
 
-        # Determine the highest capture_hidden_mode required
-        # (If we have FULL, we can emulate LAST or NULL)
-        # (If we have LAST, we can emulate NULL)
-        required_capture_hidden_mode = max(
-            capture_hidden_mode_required_by_forward_batch,
-            capture_hidden_mode_required_by_spec_info,
-            capture_hidden_mode_required_for_returning_hidden_states,
-        )
-
-        # If the current hidden mode is no longer aligned with the required hidden mode, we need to set it to what is required and re-capture
         if self.capture_hidden_mode != required_capture_hidden_mode:
             self.capture_hidden_mode = required_capture_hidden_mode
             self.backend.cleanup()

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -73,6 +73,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     PPProxyTensors,
     compute_local_num_token_non_padded,
     enable_num_token_non_padded,
+    get_required_capture_hidden_mode,
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
@@ -1652,9 +1653,20 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             "PPProxyTensors is not supported in PrefillCudaGraphRunner yet."
         )
 
+    def recapture_if_needed(self, forward_batch: ForwardBatch) -> None:
+        required_capture_hidden_mode = get_required_capture_hidden_mode(
+            forward_batch.capture_hidden_mode,
+            forward_batch.spec_info,
+        )
+        if self.capture_hidden_mode != required_capture_hidden_mode:
+            self.capture_hidden_mode = required_capture_hidden_mode
+            self.backend.cleanup()
+            self.capture()
+
     def execute(
         self, forward_batch: ForwardBatch, **kwargs
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
+        self.recapture_if_needed(forward_batch)
         with self.backend.replay_session():
             static_forward_batch = self.load_batch(forward_batch, **kwargs)
             static_num_tokens = len(static_forward_batch.input_ids)

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -278,16 +278,12 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             self.prefill_backend_name == Backend.BREAKABLE
             and model_runner.spec_algorithm.is_eagle()
         )
-        needs_full_hidden_states = (
-            model_runner.server_args.enable_return_hidden_states
-            or model_runner.spec_algorithm.is_dflash_family()
-        )
         if is_breakable_eagle and model_runner.is_draft_worker:
             self.capture_hidden_mode = CaptureHiddenMode.LAST
-        elif is_breakable_eagle or needs_full_hidden_states:
+        elif is_breakable_eagle or model_runner.spec_algorithm.is_dflash_family():
             self.capture_hidden_mode = CaptureHiddenMode.FULL
         else:
-            self.capture_hidden_mode = CaptureHiddenMode.NULL
+            self.capture_hidden_mode = self.return_hidden_states_mode
 
         self.mamba_track_enabled = self._is_mamba_track_enabled()
 
@@ -1653,20 +1649,21 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             "PPProxyTensors is not supported in PrefillCudaGraphRunner yet."
         )
 
-    def recapture_if_needed(self, forward_batch: ForwardBatch) -> None:
+    def _validate_capture_hidden_mode(self, forward_batch: ForwardBatch) -> None:
         required_capture_hidden_mode = get_required_capture_hidden_mode(
             forward_batch.capture_hidden_mode,
             forward_batch.spec_info,
         )
-        if self.capture_hidden_mode != required_capture_hidden_mode:
-            self.capture_hidden_mode = required_capture_hidden_mode
-            self.backend.cleanup()
-            self.capture()
+        if self.capture_hidden_mode < required_capture_hidden_mode:
+            raise RuntimeError(
+                "The runtime hidden-state mode exceeds the fixed CUDA graph "
+                f"capture mode ({self.capture_hidden_mode.name})."
+            )
 
     def execute(
         self, forward_batch: ForwardBatch, **kwargs
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
-        self.recapture_if_needed(forward_batch)
+        self._validate_capture_hidden_mode(forward_batch)
         with self.backend.replay_session():
             static_forward_batch = self.load_batch(forward_batch, **kwargs)
             static_num_tokens = len(static_forward_batch.input_ids)

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -73,7 +73,6 @@ from sglang.srt.model_executor.forward_batch_info import (
     PPProxyTensors,
     compute_local_num_token_non_padded,
     enable_num_token_non_padded,
-    get_required_capture_hidden_mode,
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
@@ -1053,7 +1052,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             return False
         if (
             capture_hidden_mode is not None
-            and capture_hidden_mode != self.capture_hidden_mode
+            and self.capture_hidden_mode < capture_hidden_mode
         ):
             return False
         if return_logprob and not self._uses_eager_prefill_tail():
@@ -1650,11 +1649,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         )
 
     def _validate_capture_hidden_mode(self, forward_batch: ForwardBatch) -> None:
-        required_capture_hidden_mode = get_required_capture_hidden_mode(
-            forward_batch.capture_hidden_mode,
-            forward_batch.spec_info,
-        )
-        if self.capture_hidden_mode < required_capture_hidden_mode:
+        if self.capture_hidden_mode < forward_batch.capture_hidden_mode:
             raise RuntimeError(
                 "The runtime hidden-state mode exceeds the fixed CUDA graph "
                 f"capture mode ({self.capture_hidden_mode.name})."

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3305,8 +3305,21 @@ class ServerArgs:
         NS("exec.features"),
     ] = False
     enable_return_hidden_states: A[
-        bool, "Enable returning hidden states with responses.", NS("exec.features")
+        bool,
+        "Enable returning full hidden states with responses. Equivalent to "
+        "`--return-hidden-states-mode full`.",
+        NS("exec.features"),
     ] = False
+    return_hidden_states_mode: A[
+        Optional[str],
+        Arg(
+            help="Set the maximum hidden-state return mode supported by the "
+            "server. `last` allows requests with return_hidden_states=False or "
+            "`last`; `full` also allows return_hidden_states=True.",
+            choices=["last", "full"],
+        ),
+        NS("exec.features"),
+    ] = None
     enable_return_routed_experts: A[
         bool,
         "Enable returning routed experts of each layer with responses.",
@@ -3408,6 +3421,7 @@ class ServerArgs:
         # _handle_model_specific_adjustments never runs.
         self._resolved_overrides = []
 
+        self._handle_return_hidden_states_mode()
         if self.model_path.lower() in ["none", "dummy"]:
             return
 
@@ -3583,6 +3597,13 @@ class ServerArgs:
         from sglang.srt.arg_groups.overrides import materialize_declarations
 
         materialize_declarations(self)
+
+    def _handle_return_hidden_states_mode(self):
+        if self.return_hidden_states_mode is None:
+            if self.enable_return_hidden_states:
+                self.return_hidden_states_mode = "full"
+        else:
+            self.enable_return_hidden_states = True
 
     def _handle_model_capability_adjustments(self):
         if parse_connector_type(self.model_path) == ConnectorType.INSTANCE:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3599,6 +3599,10 @@ class ServerArgs:
         materialize_declarations(self)
 
     def _handle_return_hidden_states_mode(self):
+        if self.return_hidden_states_mode not in (None, "last", "full"):
+            raise ValueError(
+                "return_hidden_states_mode must be one of: None, 'last', or 'full'."
+            )
         if self.return_hidden_states_mode is None:
             if self.enable_return_hidden_states:
                 self.return_hidden_states_mode = "full"

--- a/test/registered/core/test_hidden_states.py
+++ b/test/registered/core/test_hidden_states.py
@@ -53,8 +53,12 @@ class TestHiddenState(CustomTestCase):
             return_hidden_states=True,
         )
 
+        expected_num_hidden_states = self.sampling_params["max_new_tokens"]
         for output in outputs:
-            self.assertEqual(len(output["meta_info"]["hidden_states"]), 8)
+            self.assertEqual(
+                len(output["meta_info"]["hidden_states"]),
+                expected_num_hidden_states,
+            )
             for i in range(len(output["meta_info"]["hidden_states"])):
                 assert isinstance(output["meta_info"]["hidden_states"][i], list)
                 output["meta_info"]["hidden_states"][i] = torch.tensor(
@@ -102,6 +106,63 @@ class TestHiddenState(CustomTestCase):
                     rtol=0,
                 )
             )
+
+    def test_return_last_hidden_state(self):
+        outputs = self.engine.generate(
+            input_ids=self.input_ids,
+            sampling_params=self.sampling_params,
+            return_hidden_states="last",
+        )
+
+        model = AutoModelForCausalLM.from_pretrained(
+            self.model_path, torch_dtype=torch.bfloat16, device_map=get_device()
+        )
+
+        for input_id, output in zip(self.input_ids, outputs):
+            sg_hidden_state = torch.tensor(
+                output["meta_info"]["hidden_states"], dtype=torch.bfloat16
+            ).to(get_device())
+            self.assertEqual(sg_hidden_state.dim(), 1)
+
+            with torch.inference_mode():
+                hf_out = model(
+                    torch.tensor(
+                        [input_id + output["output_ids"][:-1]], device=model.device
+                    ),
+                    output_hidden_states=True,
+                )
+            hf_last_hidden_state = hf_out["hidden_states"][-1][0, -1]
+
+            atol = 0.8
+            self.assertTrue(
+                torch.allclose(
+                    hf_last_hidden_state,
+                    sg_hidden_state,
+                    atol=atol,
+                    rtol=0,
+                )
+            )
+
+    def test_mixed_return_hidden_states_modes(self):
+        outputs = self.engine.generate(
+            input_ids=self.input_ids + [self.input_ids[0]],
+            sampling_params=self.sampling_params,
+            return_hidden_states=[False, True, "last"],
+        )
+
+        self.assertNotIn("hidden_states", outputs[0]["meta_info"])
+
+        full_hidden_states = outputs[1]["meta_info"]["hidden_states"]
+        last_hidden_state = outputs[2]["meta_info"]["hidden_states"]
+
+        self.assertIsInstance(full_hidden_states, list)
+        self.assertEqual(
+            len(full_hidden_states), self.sampling_params["max_new_tokens"]
+        )
+        self.assertEqual(torch.tensor(full_hidden_states[0]).dim(), 2)
+
+        last_hidden_state = torch.tensor(last_hidden_state)
+        self.assertEqual(last_hidden_state.dim(), 1)
 
     def test_repeatedly_changes_hidden_states(self):
         outputs_completion_first_round = self.engine.generate(

--- a/test/registered/core/test_hidden_states.py
+++ b/test/registered/core/test_hidden_states.py
@@ -32,7 +32,7 @@ class TestHiddenState(CustomTestCase):
             model_path=cls.model_path,
             random_seed=42,
             skip_tokenizer_init=True,
-            enable_return_hidden_states=True,
+            return_hidden_states_mode="full",
             mem_fraction_static=0.7,
         )
 
@@ -163,6 +163,34 @@ class TestHiddenState(CustomTestCase):
 
         last_hidden_state = torch.tensor(last_hidden_state)
         self.assertEqual(last_hidden_state.dim(), 1)
+
+    def test_mixed_return_hidden_states_modes_with_warm_cache(self):
+        # Prime the radix cache so each repeated prompt only extends its
+        # uncached suffix during the mixed-mode prefill.
+        self.engine.generate(
+            input_ids=self.input_ids,
+            sampling_params={"temperature": 0, "max_new_tokens": 1},
+            return_hidden_states=False,
+        )
+
+        outputs = self.engine.generate(
+            input_ids=self.input_ids + [self.input_ids[1]],
+            sampling_params={"temperature": 0, "max_new_tokens": 1},
+            return_hidden_states=[True, True, "last"],
+        )
+
+        self.assertEqual(
+            torch.tensor(outputs[0]["meta_info"]["hidden_states"][0]).dim(),
+            2,
+        )
+        self.assertEqual(
+            torch.tensor(outputs[2]["meta_info"]["hidden_states"]).dim(),
+            1,
+        )
+        torch.testing.assert_close(
+            torch.tensor(outputs[1]["meta_info"]["hidden_states"][0])[-1],
+            torch.tensor(outputs[2]["meta_info"]["hidden_states"]),
+        )
 
     def test_repeatedly_changes_hidden_states(self):
         outputs_completion_first_round = self.engine.generate(

--- a/test/registered/openai_server/features/test_openai_server_hidden_states.py
+++ b/test/registered/openai_server/features/test_openai_server_hidden_states.py
@@ -100,7 +100,7 @@ class BaseTestOpenAIServerWithHiddenStates(ABC):
         )
 
         for choice in response.choices:
-            assert hasattr(choice, "hidden_states") == return_hidden_states
+            assert hasattr(choice, "hidden_states") == bool(return_hidden_states)
             if return_hidden_states:
                 assert choice.hidden_states is not None, "hidden_states was None"
 
@@ -139,7 +139,7 @@ class BaseTestOpenAIServerWithHiddenStates(ABC):
             usage = response.usage
             for choice in response.choices:
                 if hasattr(choice, "hidden_states"):
-                    assert return_hidden_states
+                    assert bool(return_hidden_states)
                     assert choice.hidden_states is not None
                     hidden_states_list.append(choice.hidden_states)
 
@@ -169,7 +169,7 @@ class BaseTestOpenAIServerWithHiddenStates(ABC):
         )
 
         for choice in response.choices:
-            assert hasattr(choice, "hidden_states") == return_hidden_states
+            assert hasattr(choice, "hidden_states") == bool(return_hidden_states)
             if return_hidden_states:
                 assert choice.hidden_states is not None, "hidden_states was None"
 
@@ -196,7 +196,7 @@ class BaseTestOpenAIServerWithHiddenStates(ABC):
         for response in generator:
             for choice in response.choices:
                 if hasattr(choice.delta, "hidden_states"):
-                    assert return_hidden_states
+                    assert bool(return_hidden_states)
                     assert choice.delta.hidden_states is not None
                     hidden_states_list.append(choice.delta.hidden_states)
 
@@ -227,7 +227,7 @@ class TestOpenAIServerWithHiddenStatesEnabled(
         )
         cls.base_url += "/v1"
         cls.tokenizer = get_tokenizer(DEFAULT_SMALL_MODEL_NAME_FOR_TEST)
-        cls.return_hidden_states = [False, True]
+        cls.return_hidden_states = [False, True, "last"]
         cls.use_list_input = [True, False]
         cls.parallel_sample_nums = [1, 2]
 
@@ -253,7 +253,7 @@ class TestOpenAIServerWithHiddenStatesEnabledAndCUDAGraphDisabled(
         )
         cls.base_url += "/v1"
         cls.tokenizer = get_tokenizer(DEFAULT_SMALL_MODEL_NAME_FOR_TEST)
-        cls.return_hidden_states = [False, True]
+        cls.return_hidden_states = [False, True, "last"]
         cls.use_list_input = [True, False]
         cls.parallel_sample_nums = [1]
 

--- a/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
+++ b/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
@@ -1,0 +1,225 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _make_processor(server_mode: str = "full") -> SchedulerBatchResultProcessor:
+    metrics_reporter = Mock()
+    metrics_reporter.num_generated_tokens = 0
+    metrics_reporter.forward_ct_decode = 0
+    return SchedulerBatchResultProcessor(
+        is_generation=True,
+        disaggregation_mode=None,
+        enable_overlap=False,
+        enable_overlap_mlx=False,
+        server_args=SimpleNamespace(
+            enable_metrics=False,
+            enable_hisparse=False,
+            enable_return_hidden_states=True,
+            return_hidden_states_mode=server_mode,
+        ),
+        model_config=SimpleNamespace(think_end_id=None),
+        token_to_kv_pool_allocator=Mock(),
+        tree_cache=None,
+        hisparse_coordinator=None,
+        req_to_token_pool=None,
+        decode_offload_manager=None,
+        metrics_collector=None,
+        metrics_reporter=metrics_reporter,
+        draft_worker=None,
+        model_worker=Mock(),
+        logprob_result_processor=None,
+        output_streamer=Mock(),
+        abort_request=lambda *args, **kwargs: None,
+    )
+
+
+class _PrefillReq:
+    def __init__(self, *, rid: str, inflight_middle_chunks: int, return_hidden_states):
+        self.rid = rid
+        self.inflight_middle_chunks = inflight_middle_chunks
+        self.return_hidden_states = return_hidden_states
+        self.hidden_states = []
+        self.is_retracted = False
+        self.output_ids = []
+        self.time_stats = Mock()
+        self.return_logprob = False
+        self.return_sampling_mask = False
+        self.grammar = None
+        self.require_reasoning = False
+        self.customized_info = None
+
+    def finished(self):
+        return False
+
+    def update_finish_state(self):
+        return None
+
+
+class _DecodeReq:
+    def __init__(self):
+        self.return_hidden_states = "last"
+        self.hidden_states = []
+        self.output_ids = []
+        self.finished_len = None
+        self.is_retracted = False
+        self.return_logprob = False
+        self.return_sampling_mask = False
+        self.grammar = None
+        self.time_stats = Mock()
+
+    def finished(self):
+        return self.finished_len is not None
+
+    def update_finish_state(self, new_accept_len):
+        if len(self.output_ids) >= 6:
+            self.finished_len = 5
+
+
+class TestPrefillHiddenStateOffsets(CustomTestCase):
+    def test_active_middle_chunk_advances_before_new_last_request(self):
+        cases = (
+            (
+                "full",
+                CaptureHiddenMode.FULL,
+                torch.tensor([[10.0], [11.0], [20.0], [21.0], [22.0]]),
+            ),
+            (
+                "last",
+                CaptureHiddenMode.LAST,
+                torch.tensor([[11.0], [22.0]]),
+            ),
+        )
+
+        for server_mode, capture_mode, hidden_states in cases:
+            with self.subTest(server_mode=server_mode):
+                middle = _PrefillReq(
+                    rid="middle",
+                    inflight_middle_chunks=1,
+                    return_hidden_states=False,
+                )
+                last = _PrefillReq(
+                    rid="last",
+                    inflight_middle_chunks=0,
+                    return_hidden_states="last",
+                )
+                batch = SimpleNamespace(
+                    reqs=[middle, last],
+                    decoding_reqs=[],
+                    return_logprob=False,
+                    return_hidden_states=True,
+                    return_hidden_states_mode=capture_mode,
+                    spec_info=None,
+                    prefill_stats=None,
+                    dp_cooperation_info=None,
+                )
+                result = SimpleNamespace(
+                    copy_done=None,
+                    routed_experts_output=None,
+                    indexer_topk_output=None,
+                    logits_output=SimpleNamespace(
+                        hidden_states=hidden_states,
+                        customized_info=None,
+                    ),
+                    next_token_ids=torch.tensor([0, 1]),
+                    extend_input_len_per_req=[2, 3],
+                    extend_logprob_start_len_per_req=None,
+                    grammar_advanced=False,
+                    can_run_cuda_graph=False,
+                    skipped_output_comm=False,
+                )
+                processor = _make_processor(server_mode)
+
+                with (
+                    patch(
+                        "sglang.srt.managers.scheduler_components."
+                        "batch_result_processor.maybe_cache_unfinished_req"
+                    ),
+                    patch(
+                        "sglang.srt.managers.scheduler_components."
+                        "batch_result_processor.get_memory",
+                        return_value=SimpleNamespace(enable_hisparse=False),
+                    ),
+                ):
+                    processor.process_batch_result_prefill(batch, result)
+
+                self.assertEqual(middle.hidden_states, [])
+                self.assertEqual(last.hidden_states, [[22.0]])
+
+
+class TestDecodeHiddenStateRetention(CustomTestCase):
+    def test_last_mode_multi_step_storage_stays_bounded(self):
+        processor = _make_processor()
+        req = _DecodeReq()
+        batch = SimpleNamespace(
+            reqs=[req],
+            return_logprob=False,
+            spec_algorithm=SimpleNamespace(is_none=lambda: False),
+            batch_size=lambda: 1,
+        )
+        first_step = torch.arange(8, dtype=torch.float32).view(4, 2)
+        second_step = torch.arange(16, dtype=torch.float32).view(8, 2)[4:]
+
+        def result(hidden_states):
+            return SimpleNamespace(
+                copy_done=None,
+                routed_experts_output=None,
+                indexer_topk_output=None,
+                logits_output=SimpleNamespace(hidden_states=hidden_states),
+                next_token_ids=None,
+                can_run_cuda_graph=False,
+                num_correct_drafts=0,
+                num_block_accept_tokens=0,
+                num_cap_tokens=0,
+                speculative_num_draft_tokens=4,
+            )
+
+        with (
+            patch.object(
+                SchedulerBatchResultProcessor,
+                "_normalize_decode_outputs",
+                side_effect=[
+                    ([[1, 2, 3]], None),
+                    ([[4, 5, 6]], None),
+                ],
+            ),
+            patch.object(
+                SchedulerBatchResultProcessor,
+                "_maybe_update_reasoning_tokens",
+            ),
+            patch.object(
+                SchedulerBatchResultProcessor,
+                "_handle_finish_state_updated_req",
+            ),
+            patch(
+                "sglang.srt.managers.scheduler_components."
+                "batch_result_processor.get_observability",
+                return_value=SimpleNamespace(enable_metrics=False),
+            ),
+        ):
+            processor.process_batch_result_decode(batch, result(first_step))
+
+            self.assertEqual(req.hidden_states, [first_step[2].tolist()])
+            self.assertEqual(len(req.hidden_states), 1)
+
+            # Only the first two accepted tokens are valid because the request
+            # stops inside this speculative verify step.
+            processor.process_batch_result_decode(batch, result(second_step))
+
+        self.assertEqual(req.hidden_states, [second_step[1].tolist()])
+        self.assertEqual(len(req.hidden_states), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_hidden_state_server_mode.py
+++ b/test/registered/unit/managers/test_hidden_state_server_mode.py
@@ -1,0 +1,72 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestHiddenStateServerMode(CustomTestCase):
+    @staticmethod
+    def _make_tokenizer_manager(mode):
+        manager = TokenizerManager.__new__(TokenizerManager)
+        manager.context_len = 128
+        manager.num_reserved_tokens = 0
+        manager.allow_auto_truncate = False
+        manager.validate_total_tokens = False
+        manager.is_generation = True
+        manager.server_args = SimpleNamespace(
+            enable_return_hidden_states=mode is not None,
+            return_hidden_states_mode=mode,
+            enable_custom_logit_processor=False,
+        )
+        manager._validate_token_ids_logprob = Mock()
+        return manager
+
+    @staticmethod
+    def _make_request(return_hidden_states):
+        return GenerateReqInput(
+            input_ids=[1, 2, 3],
+            sampling_params={},
+            return_hidden_states=return_hidden_states,
+        )
+
+    def test_last_server_accepts_false_and_last(self):
+        manager = self._make_tokenizer_manager("last")
+
+        for mode in (False, "last"):
+            with self.subTest(mode=mode):
+                manager._validate_one_request(
+                    self._make_request(mode),
+                    [1, 2, 3],
+                )
+
+    def test_last_server_rejects_full(self):
+        manager = self._make_tokenizer_manager("last")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "server maximum `last`",
+        ):
+            manager._validate_one_request(
+                self._make_request(True),
+                [1, 2, 3],
+            )
+
+    def test_full_server_accepts_all_request_modes(self):
+        manager = self._make_tokenizer_manager("full")
+
+        for mode in (False, "last", True):
+            with self.subTest(mode=mode):
+                manager._validate_one_request(
+                    self._make_request(mode),
+                    [1, 2, 3],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -164,6 +164,48 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         # Check text expansion
         self.assertEqual(req.text, expected_text)
 
+    def test_return_hidden_states_expands_with_parallel_sampling(self):
+        req = GenerateReqInput(
+            text=["Prompt 1", "Prompt 2"],
+            sampling_params={"n": 2},
+            return_hidden_states=[False, "last"],
+        )
+
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(
+            req.return_hidden_states,
+            [False, "last", False, "last"],
+        )
+        self.assertEqual(
+            [req[i].return_hidden_states for i in range(4)],
+            [False, "last", False, "last"],
+        )
+
+    def test_return_hidden_states_batch_length_is_validated(self):
+        req = GenerateReqInput(
+            text=["Prompt 1", "Prompt 2"],
+            return_hidden_states=["last"],
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "return_hidden_states should be equal to the batch size",
+        ):
+            req.normalize_batch_and_arguments()
+
+    def test_return_hidden_states_batch_modes_are_validated(self):
+        req = GenerateReqInput(
+            text=["Prompt 1", "Prompt 2"],
+            return_hidden_states=[False, "invalid"],
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "return_hidden_states must be a boolean or the string literal 'last'",
+        ):
+            req.normalize_batch_and_arguments()
+
     def test_mixed_none_and_images_with_parallel_samples(self):
         """Test that when some batch items have images and others None, parallel expansion works correctly."""
         req = copy.deepcopy(self.base_req)
@@ -480,14 +522,14 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             logprob_start_len=[10, 5],
             top_logprobs_num=[5, 3],
             token_ids_logprob=[[7, 8, 9], [4, 5, 6]],
-            return_hidden_states=[False, False, True],
+            return_hidden_states=[False, True],
         )
         req.normalize_batch_and_arguments()
         self.assertEqual(req.return_logprob, [True, False])
         self.assertEqual(req.logprob_start_len, [10, 5])
         self.assertEqual(req.top_logprobs_num, [5, 3])
         self.assertEqual(req.token_ids_logprob, [[7, 8, 9], [4, 5, 6]])
-        self.assertEqual(req.return_hidden_states, [False, False, True])
+        self.assertEqual(req.return_hidden_states, [False, True])
 
     def test_custom_logit_processor_normalization(self):
         """Test normalization of custom_logit_processor."""

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -559,7 +559,7 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             modalities=["image", "image"],
             lora_path=["path1", "path2"],
             custom_logit_processor=["processor1", "processor2"],
-            return_hidden_states=True,
+            return_hidden_states=[True, "last"],
         )
         req.normalize_batch_and_arguments()
 
@@ -580,6 +580,7 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(item0.lora_path, "path1")
         self.assertEqual(item0.custom_logit_processor, "processor1")
         self.assertEqual(item0.return_hidden_states, True)
+        self.assertEqual(req[1].return_hidden_states, "last")
 
     def test_getitem_preserves_return_prompt_token_ids(self):
         """Batch subrequests must keep the prompt-token-id return flag."""

--- a/test/registered/unit/managers/test_schedule_batch_req_pool_indices.py
+++ b/test/registered/unit/managers/test_schedule_batch_req_pool_indices.py
@@ -11,6 +11,7 @@ maybe_stub_sgl_kernel()
 
 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator  # noqa: E402
 from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode  # noqa: E402
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -23,6 +24,7 @@ def _make_req(req_pool_idx, origin_input_ids, output_ids):
         return_logprob=False,
         grammar=None,
         return_hidden_states=False,
+        return_hidden_states_mode=CaptureHiddenMode.NULL,
         is_prefill_only=False,
     )
 

--- a/test/registered/unit/model_executor/runner/test_hidden_state_graph_recapture.py
+++ b/test/registered/unit/model_executor/runner/test_hidden_state_graph_recapture.py
@@ -1,0 +1,106 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from sglang.srt.model_executor.cpu_graph_runner import CPUGraphRunner
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    get_server_return_hidden_states_mode,
+)
+from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+    DecodeCudaGraphRunner,
+)
+from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+    PrefillCudaGraphRunner,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestHiddenStateGraphRecapture(CustomTestCase):
+    def test_server_mode_sets_graph_capture_ceiling(self):
+        disabled = SimpleNamespace(
+            enable_return_hidden_states=False,
+            return_hidden_states_mode=None,
+        )
+        last = SimpleNamespace(
+            enable_return_hidden_states=True,
+            return_hidden_states_mode="last",
+        )
+        full = SimpleNamespace(
+            enable_return_hidden_states=True,
+            return_hidden_states_mode="full",
+        )
+
+        self.assertEqual(
+            get_server_return_hidden_states_mode(disabled),
+            CaptureHiddenMode.NULL,
+        )
+        self.assertEqual(
+            get_server_return_hidden_states_mode(last),
+            CaptureHiddenMode.LAST,
+        )
+        self.assertEqual(
+            get_server_return_hidden_states_mode(full),
+            CaptureHiddenMode.FULL,
+        )
+
+    @staticmethod
+    def _make_runner(runner_cls, capture_hidden_mode):
+        runner = runner_cls.__new__(runner_cls)
+        runner.capture_hidden_mode = capture_hidden_mode
+        runner.backend = Mock()
+        runner.capture = Mock()
+        return runner
+
+    @staticmethod
+    def _make_forward_batch(capture_hidden_mode):
+        return SimpleNamespace(
+            capture_hidden_mode=capture_hidden_mode,
+            spec_info=None,
+        )
+
+    def test_stronger_graph_is_reused_for_weaker_modes(self):
+        runner = self._make_runner(DecodeCudaGraphRunner, CaptureHiddenMode.FULL)
+
+        for required_mode in (
+            CaptureHiddenMode.FULL,
+            CaptureHiddenMode.NULL,
+            CaptureHiddenMode.LAST,
+            CaptureHiddenMode.FULL,
+            CaptureHiddenMode.NULL,
+        ):
+            with self.subTest(required_mode=required_mode):
+                runner._validate_capture_hidden_mode(
+                    self._make_forward_batch(required_mode)
+                )
+
+        self.assertEqual(runner.capture_hidden_mode, CaptureHiddenMode.FULL)
+        runner.backend.cleanup.assert_not_called()
+        runner.capture.assert_not_called()
+
+    def test_graph_does_not_recapture_above_fixed_server_mode(self):
+        for runner_cls in (
+            DecodeCudaGraphRunner,
+            PrefillCudaGraphRunner,
+            CPUGraphRunner,
+        ):
+            runner = self._make_runner(runner_cls, CaptureHiddenMode.NULL)
+
+            with self.subTest(runner_cls=runner_cls), self.assertRaisesRegex(
+                RuntimeError,
+                "exceeds the fixed (CUDA|CPU) graph capture mode",
+            ):
+                runner._validate_capture_hidden_mode(
+                    self._make_forward_batch(CaptureHiddenMode.LAST)
+                )
+
+            self.assertEqual(runner.capture_hidden_mode, CaptureHiddenMode.NULL)
+            runner.backend.cleanup.assert_not_called()
+            runner.capture.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/runner/test_hidden_state_graph_recapture.py
+++ b/test/registered/unit/model_executor/runner/test_hidden_state_graph_recapture.py
@@ -3,8 +3,10 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 from sglang.srt.model_executor.cpu_graph_runner import CPUGraphRunner
+from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
+    ForwardMode,
     get_server_return_hidden_states_mode,
 )
 from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
@@ -62,6 +64,33 @@ class TestHiddenStateGraphRecapture(CustomTestCase):
             spec_info=None,
         )
 
+    @staticmethod
+    def _make_prefill_runner_for_can_run(capture_hidden_mode):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner._is_full_backend = False
+        runner.prefill_backend_name = Backend.BREAKABLE
+        runner.has_mha_companion_layers = False
+        runner.enable_lora = False
+        runner._capture_chunked_prefix = False
+        runner.capture_hidden_mode = capture_hidden_mode
+        runner.capture_num_tokens = [4]
+        runner.max_num_tokens = 4
+        return runner
+
+    @staticmethod
+    def _make_prefill_forward_batch(capture_hidden_mode, spec_capture_hidden_mode):
+        return SimpleNamespace(
+            batch_size=1,
+            input_embeds=None,
+            replace_embeds=None,
+            forward_mode=ForwardMode.EXTEND,
+            capture_hidden_mode=capture_hidden_mode,
+            spec_info=SimpleNamespace(capture_hidden_mode=spec_capture_hidden_mode),
+            global_num_tokens_cpu=None,
+            return_logprob=False,
+            input_ids=list(range(4)),
+        )
+
     def test_stronger_graph_is_reused_for_weaker_modes(self):
         runner = self._make_runner(DecodeCudaGraphRunner, CaptureHiddenMode.FULL)
 
@@ -100,6 +129,41 @@ class TestHiddenStateGraphRecapture(CustomTestCase):
             self.assertEqual(runner.capture_hidden_mode, CaptureHiddenMode.NULL)
             runner.backend.cleanup.assert_not_called()
             runner.capture.assert_not_called()
+
+    def test_spec_worker_override_is_the_effective_runtime_mode(self):
+        runner = self._make_prefill_runner_for_can_run(CaptureHiddenMode.LAST)
+        forward_batch = self._make_prefill_forward_batch(
+            CaptureHiddenMode.LAST,
+            CaptureHiddenMode.FULL,
+        )
+
+        self.assertTrue(runner.can_run_graph(forward_batch))
+        for runner_cls in (
+            DecodeCudaGraphRunner,
+            PrefillCudaGraphRunner,
+            CPUGraphRunner,
+        ):
+            graph_runner = self._make_runner(runner_cls, CaptureHiddenMode.LAST)
+            with self.subTest(runner_cls=runner_cls):
+                graph_runner._validate_capture_hidden_mode(forward_batch)
+
+    def test_prefill_graph_falls_back_for_stronger_effective_mode(self):
+        runner = self._make_prefill_runner_for_can_run(CaptureHiddenMode.LAST)
+        forward_batch = self._make_prefill_forward_batch(
+            CaptureHiddenMode.FULL,
+            CaptureHiddenMode.LAST,
+        )
+
+        self.assertFalse(runner.can_run_graph(forward_batch))
+
+    def test_prefill_graph_accepts_weaker_spec_mode(self):
+        runner = self._make_prefill_runner_for_can_run(CaptureHiddenMode.FULL)
+        forward_batch = self._make_prefill_forward_batch(
+            CaptureHiddenMode.NULL,
+            CaptureHiddenMode.LAST,
+        )
+
+        self.assertTrue(runner.can_run_graph(forward_batch))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_executor/runner/test_hidden_state_graph_recapture.py
+++ b/test/registered/unit/model_executor/runner/test_hidden_state_graph_recapture.py
@@ -88,6 +88,7 @@ class TestHiddenStateGraphRecapture(CustomTestCase):
             spec_info=SimpleNamespace(capture_hidden_mode=spec_capture_hidden_mode),
             global_num_tokens_cpu=None,
             return_logprob=False,
+            extend_prefix_lens_cpu=None,
             input_ids=list(range(4)),
         )
 

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -6,9 +6,13 @@ from unittest.mock import patch
 
 import torch
 
+import sglang.srt.model_executor.model_runner_components.cuda_graph_setup as graph_setup
 import sglang.srt.model_executor.runner.prefill_cuda_graph_runner as runner_module
 from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.model_executor.model_runner_components.cuda_graph_setup import (
+    capture_prefill_graph,
+)
 from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
     PrefillCudaGraphRunner,
 )
@@ -57,6 +61,29 @@ class _FakeKVIndexKernel:
 
 
 class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
+    def test_eagle_target_tc_piecewise_skips_last_mode_capture(self):
+        eager_runner = object()
+        model_runner = SimpleNamespace(
+            is_draft_worker=False,
+            spec_algorithm=SimpleNamespace(is_eagle=lambda: True),
+            server_args=SimpleNamespace(
+                enable_return_hidden_states=True,
+                return_hidden_states_mode="last",
+            ),
+        )
+
+        with patch.object(
+            graph_setup,
+            "check_cuda_graph_backend",
+            return_value=False,
+        ):
+            runner = capture_prefill_graph(
+                model_runner=model_runner,
+                eager_runner=eager_runner,
+            )
+
+        self.assertIs(runner, eager_runner)
+
     def test_prefix_chunk_capacity_is_aggregate_and_can_be_overridden(self):
         model_runner = SimpleNamespace(
             server_args=SimpleNamespace(

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -8,6 +8,7 @@ import torch
 
 import sglang.srt.model_executor.runner.prefill_cuda_graph_runner as runner_module
 from sglang.srt.model_executor.cuda_graph_config import Backend
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
     PrefillCudaGraphRunner,
 )
@@ -212,7 +213,7 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
         runner._capture_req_slots = 4
         runner.enable_lora = False
-        runner.capture_hidden_mode = None
+        runner.capture_hidden_mode = CaptureHiddenMode.NULL
         runner.max_num_tokens = 32
         runner.capture_num_tokens = [4]
         runner.backend = SimpleNamespace()
@@ -227,7 +228,7 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
             input_embeds=None,
             replace_embeds=None,
             forward_mode=SimpleNamespace(is_target_verify=lambda: False),
-            capture_hidden_mode=None,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
             global_num_tokens_cpu=None,
             return_logprob=False,
             extend_prefix_lens_cpu=[8],

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -72,6 +72,15 @@ class TestPrepareServerArgs(CustomTestCase):
         self.assertTrue(parsed_last.enable_return_hidden_states)
         self.assertEqual(parsed_last.return_hidden_states_mode, "last")
 
+        with self.assertRaisesRegex(
+            ValueError,
+            "return_hidden_states_mode must be one of",
+        ):
+            ServerArgs(
+                model_path="dummy",
+                return_hidden_states_mode="lst",
+            )
+
     def test_config_nested_dict_args_are_json(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write("mm-process-config:\n  image:\n    resize: 128\n")

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -42,6 +42,36 @@ _mock_device.start()
 
 
 class TestPrepareServerArgs(CustomTestCase):
+    def test_return_hidden_states_mode_configuration(self):
+        disabled = ServerArgs(model_path="dummy")
+        self.assertFalse(disabled.enable_return_hidden_states)
+        self.assertIsNone(disabled.return_hidden_states_mode)
+
+        last = ServerArgs(
+            model_path="dummy",
+            return_hidden_states_mode="last",
+        )
+        self.assertTrue(last.enable_return_hidden_states)
+        self.assertEqual(last.return_hidden_states_mode, "last")
+
+        legacy_full = ServerArgs(
+            model_path="dummy",
+            enable_return_hidden_states=True,
+        )
+        self.assertTrue(legacy_full.enable_return_hidden_states)
+        self.assertEqual(legacy_full.return_hidden_states_mode, "full")
+
+        parsed_last = prepare_server_args(
+            [
+                "--model-path",
+                "dummy",
+                "--return-hidden-states-mode",
+                "last",
+            ]
+        )
+        self.assertTrue(parsed_last.enable_return_hidden_states)
+        self.assertEqual(parsed_last.return_hidden_states_mode, "last")
+
     def test_config_nested_dict_args_are_json(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write("mm-process-config:\n  image:\n    resize: 128\n")


### PR DESCRIPTION
## Motivation

SGLang is increasingly used not only for text generation, but also as a serving layer for extracting model representations that downstream systems consume. Examples include second-stage classifiers, safety/risk heads, rerankers, calibration models, clustering, retrieval, and monitoring pipelines. In these workflows, the generated token is often not the only useful output; the model's hidden representation after processing the full prompt can be used as a compact semantic feature.

SGLang already supports returning hidden states, but the public request option is currently boolean:

- `False`: do not return hidden states.
- `True`: return full hidden states.

This is sufficient when callers either do not need hidden states or need the full sequence. However, many representation-extraction workloads only need the final-token hidden state. For decoder-only and chat-style models, the final token representation is a natural compact summary because it is produced after the model has attended to the full prompt and any multimodal context.

Returning the full hidden-state sequence for these workloads is unnecessarily expensive:

- It increases response payload size.
- It increases downstream serialization, network, and storage cost.
- It requires each client to slice out the final vector manually.
- It makes mixed workloads harder when some requests need full hidden states and others only need a compact representation.

One common example is a production classifier or router that already emits probabilities for its main task, while downstream teams want to train separate lightweight heads for narrower objectives. Those heads may target recall, precision, calibration, or policy-specific labels without retraining the main model. In that setting, the final hidden state acts as a reusable semantic feature extracted by the served LLM/VLM.

This is not model-specific behavior. It is a general serving capability: allow callers to request a compact hidden-state representation directly from SGLang.

This PR adds an opt-in `"last"` mode while preserving the existing boolean behavior.

### Server and request-mode compatibility

The server startup option defines the maximum hidden-state mode that requests are allowed to use.

| Server startup configuration | Request omitted or `False` | Request `"last"` | Request `True` |
| --- | --- | --- | --- |
| No hidden-state option | No hidden states returned | Rejected | Rejected |
| `--return-hidden-states-mode last` | No hidden states returned | Return the final hidden-state vector | Rejected |
| `--return-hidden-states-mode full` | No hidden states returned | Return the final hidden-state vector | Return full hidden states |
| `--enable-return-hidden-states` | No hidden states returned | Return the final hidden-state vector | Return full hidden states |

`--enable-return-hidden-states` is preserved for backward compatibility and is equivalent to `--return-hidden-states-mode full`.

The configured server maximum also determines the fixed graph capture mode. Requests using weaker modes reuse the captured graph and only control what is included in the response; they do not trigger graph recapture. Requests exceeding the configured maximum are rejected explicitly.

## Modifications

This PR extends `return_hidden_states` to accept:

- `False`: unchanged, do not return hidden states.
- `True`: unchanged, return full hidden states.
- `"last"`: return only the last hidden state for the request.

Main changes:

- Add request-mode parsing for `return_hidden_states: bool | Literal["last"]`.
- Map request values to `CaptureHiddenMode.NULL`, `CaptureHiddenMode.FULL`, and `CaptureHiddenMode.LAST`.
- Preserve existing scheduler boolean behavior while carrying the precise capture mode separately.
- Support mixed batches where different requests use `False`, `True`, and `"last"`.
- Update prefill hidden-state slicing so offsets follow the actual batch capture mode.
- Update Engine and OpenAI response processing so `"last"` returns one vector while `True` still returns the full hidden-state sequence.
- Update CUDA/CPU graph runner recapture logic to recapture based on the required hidden-state capture mode.
- Add and update tests for the new `"last"` mode and mixed hidden-state modes.

## Accuracy Tests

This PR does not change model weights, logits computation, or sampling semantics. The hidden-state mode controls only whether hidden states are captured and how much of them is returned.

Targeted checks run locally:

```bash
git diff --check upstream/main..HEAD
```

Result: passed.

```bash
python -m py_compile \
  python/sglang/srt/entrypoints/EngineBase.py \
  python/sglang/srt/entrypoints/engine.py \
  python/sglang/srt/entrypoints/openai/protocol.py \
  python/sglang/srt/entrypoints/openai/serving_chat.py \
  python/sglang/srt/entrypoints/openai/serving_completions.py \
  python/sglang/srt/entrypoints/openai/utils.py \
  python/sglang/srt/managers/io_struct.py \
  python/sglang/srt/managers/schedule_batch.py \
  python/sglang/srt/managers/scheduler_components/batch_result_processor.py \
  python/sglang/srt/managers/scheduler_components/output_streamer.py \
  python/sglang/srt/managers/tokenizer_manager.py \
  python/sglang/srt/model_executor/cpu_graph_runner.py \
  python/sglang/srt/model_executor/forward_batch_info.py \
  python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py \
  python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py \
  test/registered/core/test_hidden_states.py \
  test/registered/openai_server/features/test_openai_server_hidden_states.py \
  test/registered/unit/managers/test_io_struct.py
```

Result: passed.

```bash
env PYTHONPATH=python \
  FLASHINFER_WORKSPACE_BASE=/tmp \
  SGLANG_CACHE_DIR=/tmp/sglang-cache \
  python test/registered/unit/managers/test_io_struct.py
```

Result:

```text
Ran 26 tests in 0.003s
OK
```

GPU smoke test:

- GPU: NVIDIA H20
- PyTorch: `2.11.0+cu130`
- Model family: Qwen3-VL multimodal model
- Request data: warmup request with 5 sampled image frames, OCR text, ASR text, highlight text, and comment text
- Prompt length: 1971 characters
- Generation config: `max_new_tokens=1`, `temperature=0`, `skip_special_tokens=False`
- Server config: `enable_return_hidden_states=True`, `context_length=4096`, `max_total_tokens=4096`, `chunked_prefill_size=2048`

Observed outputs:

| `return_hidden_states` | text | output ids | hidden states |
| --- | --- | --- | --- |
| `False` | `A` | `[32]` | absent |
| `True` | `A` | `[32]` | present, shape `[1, 1, 1024]` |
| `"last"` | `A` | `[32]` | present, shape `[1024]` |

Assertions:

```text
ASSERT false_no_hidden True
ASSERT true_full_dim_ge_2 True [1, 1, 1024]
ASSERT last_dim_eq_1 True [1024]
```

I also reran a bool-only compatibility smoke test:

```text
return_hidden_states=False -> has_hidden_states: false
return_hidden_states=True  -> has_hidden_states: true, shape [1, 1, 1024]
ASSERT false_no_hidden True
ASSERT true_full_hidden True [1, 1, 1024]
```

## Speed Tests and Profiling

This PR does not change model forward computation, logits, or sampling. It only changes the hidden-state capture mode and the response payload for requests that opt in to hidden-state returns.

The change is opt-in and preserves the existing fast path for callers that do not request hidden states:

- `False` remains the no-hidden-states path.
- `True` preserves the existing full-hidden-states behavior.
- `"last"` captures only the last hidden state needed by the request and returns a single vector instead of the full hidden-state sequence.

The GPU smoke test above covered the decode CUDA graph recapture path with hidden states enabled.

Performance validation focused on the affected hidden-state paths. The expected impact is limited to requests using hidden-state return modes, and `"last"` reduces the returned hidden-state payload from a sequence to a single vector compared with the existing full-hidden-states mode.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30696315570](https://github.com/sgl-project/sglang/actions/runs/30696315570)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30696315499](https://github.com/sgl-project/sglang/actions/runs/30696315499)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->