### PR TITLE
Only log DCP status when DCP is enabled

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2129,11 +2129,6 @@ def initialize_model_parallel(
             logger.info(
                 f"DCP enabled, dcp_size={decode_context_parallel_size}, tp_size={tensor_model_parallel_size}"
             )
-    else:
-        if get_tensor_model_parallel_rank() == 0:
-            logger.info(
-                f"DCP disabled, dcp_size={decode_context_parallel_size}, tp_size={tensor_model_parallel_size}"
-            )
 
     attn_dp_size = attention_data_parallel_size
     attn_cp_size = attention_context_model_parallel_size


### PR DESCRIPTION
## Motivation

The line

```
[2026-07-05 12:47:29] DCP disabled, dcp_size=1, tp_size=1
```

was logged on every startup that runs **without** decode context parallelism — i.e. the common case (`dcp_size=1`). It is pure noise for the vast majority of runs.

## Change

Drop the `else` branch that logs the disabled state in `initialize_model_parallel` (`python/sglang/srt/distributed/parallel_state.py`). The `DCP enabled, dcp_size=..., tp_size=...` log is kept, so we still get a one-line confirmation exactly when decode context parallelism is actually active (`decode_context_parallel_size > 1`).

No behavior change beyond logging.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28757849322](https://github.com/sgl-project/sglang/actions/runs/28757849322)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28757849277](https://github.com/sgl-project/sglang/actions/runs/28757849277)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->