### PR TITLE
[fix] Correct OpenAI streaming and mixed-batch logprob handling

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1446,10 +1446,7 @@ class OpenAIServingChat(OpenAIServingBase):
             token_bytes = list(token.encode("utf-8"))
             top_logprobs = []
             if logprobs.top_logprobs:
-                top_logprobs_idx = token_idx
-                for top_token, top_logprob in logprobs.top_logprobs[
-                    top_logprobs_idx
-                ].items():
+                for top_token, top_logprob in logprobs.top_logprobs[token_idx].items():
                     top_token_bytes = list(top_token.encode("utf-8"))
                     top_logprobs.append(
                         TopLogprob(

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1436,7 +1436,7 @@ class OpenAIServingChat(OpenAIServingBase):
 
         Args:
             logprobs: LogProbs data from model
-            use_token_index: True for non-streaming (use token_idx), False for streaming (use index 0)
+            use_token_index: deprecated; top logprobs are already aligned to tokens.
         """
         token_logprobs = []
 
@@ -1446,9 +1446,7 @@ class OpenAIServingChat(OpenAIServingBase):
             token_bytes = list(token.encode("utf-8"))
             top_logprobs = []
             if logprobs.top_logprobs:
-                # - Non-streaming (use_token_index=True): uses token_idx for full data
-                # - Streaming (use_token_index=False): uses index 0 for pre-sliced data
-                top_logprobs_idx = token_idx if use_token_index else 0
+                top_logprobs_idx = token_idx
                 for top_token, top_logprob in logprobs.top_logprobs[
                     top_logprobs_idx
                 ].items():

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -314,8 +314,12 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     n_prev_tokens[index] = total_output_logprobs
 
                 # Generate delta
-                delta = text[offset:]
-                stream_offsets[index] = len(content["text"])
+                if self.tokenizer_manager.server_args.incremental_streaming_output:
+                    delta = text
+                    stream_offsets[index] = len(content["text"])
+                else:
+                    delta = text[offset:]
+                    stream_offsets[index] = len(content["text"])
                 finish_reason = content["meta_info"].get("finish_reason", None)
                 finish_reason_type = finish_reason["type"] if finish_reason else None
 

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -316,10 +316,9 @@ class OpenAIServingCompletion(OpenAIServingBase):
                 # Generate delta
                 if self.tokenizer_manager.server_args.incremental_streaming_output:
                     delta = text
-                    stream_offsets[index] = len(content["text"])
                 else:
                     delta = text[offset:]
-                    stream_offsets[index] = len(content["text"])
+                stream_offsets[index] = len(content["text"])
                 finish_reason = content["meta_info"].get("finish_reason", None)
                 finish_reason_type = finish_reason["type"] if finish_reason else None
 

--- a/python/sglang/srt/layers/utils/logprob.py
+++ b/python/sglang/srt/layers/utils/logprob.py
@@ -114,6 +114,11 @@ def get_token_ids_logprobs_raw(
                 vals.append([])
                 idxs.append([])
                 continue
+            if token_ids is None:
+                vals.append([])
+                idxs.append([])
+                pt += pruned_len
+                continue
             token_ids_tensor = torch.tensor(token_ids, dtype=torch.long).to(
                 logprobs.device, non_blocking=True
             )

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -21,6 +21,7 @@ from fastapi import Request
 
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
+    LogProbs,
     MessageProcessingResult,
 )
 from sglang.srt.entrypoints.openai.serving_chat import (
@@ -1943,6 +1944,26 @@ class ServingChatTestCase(unittest.TestCase):
             joined,
             "I am a large language model.",
             f"Streaming deltas produced broken text: {deltas!r}",
+        )
+
+    def test_streaming_logprobs_uses_per_token_top_logprobs(self):
+        logprobs = LogProbs(
+            tokens=["A", "B", "C"],
+            token_logprobs=[-0.1, -0.2, -0.3],
+            top_logprobs=[
+                {"A_alt": -1.1},
+                {"B_alt": -2.2},
+                {"C_alt": -3.3},
+            ],
+        )
+
+        token_logprobs = self.chat._process_logprobs_tokens(
+            logprobs, use_token_index=False
+        )
+
+        self.assertEqual(
+            [entry.top_logprobs[0].token for entry in token_logprobs],
+            ["A_alt", "B_alt", "C_alt"],
         )
 
     # ------------- X-Data-Parallel-Rank header tests -------------

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -50,7 +50,10 @@ class ServingCompletionTestCase(unittest.TestCase):
         tm.tokenizer.bos_token_id = 1
 
         tm.model_config = Mock(is_multimodal=False)
-        tm.server_args = Mock(enable_cache_report=False)
+        tm.server_args = Mock(
+            enable_cache_report=False,
+            incremental_streaming_output=False,
+        )
 
         tm.generate_request = AsyncMock()
         tm.create_abort_task = Mock()
@@ -272,6 +275,63 @@ class ServingCompletionTestCase(unittest.TestCase):
         # Check that there is an error chunk and a DONE chunk, and possibly a role chunk
         self.assertGreaterEqual(len(chunks), 2)
         self.assertIn("error", chunks[0])
+
+    def test_incremental_streaming_output_delta(self):
+        self.sc.tokenizer_manager.server_args.incremental_streaming_output = True
+
+        incremental_chunks = [
+            ("Hello", None),
+            (" World", None),
+            (" Foo", {"type": "stop", "matched": None}),
+        ]
+
+        async def _mock_generate_incremental(*args, **kwargs):
+            for text, finish_reason in incremental_chunks:
+                yield {
+                    "text": text,
+                    "meta_info": {
+                        "id": "cmpl-incr-test",
+                        "prompt_tokens": 10,
+                        "completion_tokens": 5,
+                        "cached_tokens": 0,
+                        "finish_reason": finish_reason,
+                        "output_token_logprobs": None,
+                        "output_top_logprobs": None,
+                    },
+                    "index": 0,
+                }
+
+        self.sc.tokenizer_manager.generate_request = _mock_generate_incremental
+
+        req = CompletionRequest(
+            model="x",
+            prompt="Hello world",
+            max_tokens=100,
+            stream=True,
+        )
+        adapted_request, _ = self.sc._convert_to_internal_request(req)
+
+        async def run_stream():
+            chunks = []
+            async for chunk in self.sc._generate_completion_stream(
+                adapted_request, req, self.fastapi_request
+            ):
+                chunks.append(chunk)
+            return chunks
+
+        chunks = get_or_create_event_loop().run_until_complete(run_stream())
+
+        deltas = []
+        for chunk in chunks:
+            if not chunk.startswith("data: ") or chunk.strip() == "data: [DONE]":
+                continue
+            data = json.loads(chunk[len("data: ") :])
+            if data.get("choices"):
+                text = data["choices"][0].get("text")
+                if text:
+                    deltas.append(text)
+
+        self.assertEqual("".join(deltas), "Hello World Foo")
 
     def test_non_streaming_cached_tokens_details_emits_sglext(self):
         """Test that non-streaming completion responses emit cached token details in sglext."""

--- a/test/registered/unit/layers/test_logprob_utils.py
+++ b/test/registered/unit/layers/test_logprob_utils.py
@@ -1,0 +1,48 @@
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.utils.logprob import (
+    LogprobStage,
+    get_token_ids_logprobs_raw,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class LogprobUtilsTestCase(unittest.TestCase):
+    def test_prefill_token_ids_logprobs_none_advances_position(self):
+        logprobs = torch.tensor(
+            [
+                [0.0, 0.1, 0.2, 0.3],
+                [1.0, 1.1, 1.2, 1.3],
+                [2.0, 2.1, 2.2, 2.3],
+                [3.0, 3.1, 3.2, 3.3],
+            ]
+        )
+
+        vals, idxs = get_token_ids_logprobs_raw(
+            logprobs,
+            [[0, 2], None, [1]],
+            stage=LogprobStage.PREFILL,
+            extend_logprob_pruned_lens_cpu=[1, 2, 1],
+        )
+
+        self.assertEqual(len(vals[0]), 1)
+        self.assertAlmostEqual(vals[0][0][0], 0.0)
+        self.assertAlmostEqual(vals[0][0][1], 0.2, places=6)
+        self.assertEqual(idxs[0], [[0, 2]])
+        self.assertEqual(vals[1], [])
+        self.assertEqual(idxs[1], [])
+        self.assertEqual(len(vals[2]), 1)
+        self.assertAlmostEqual(vals[2][0][0], 3.1, places=6)
+        self.assertEqual(idxs[2], [[1]])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

Fixes #30188.

This PR fixes three OpenAI-compatible logprob / streaming response correctness issues.

1. Chat streaming `top_logprobs` used the first token's top-logprobs for every token in a multi-token streaming chunk.
2. Completion streaming corrupted text when `incremental_streaming_output=True`.
3. Prefill token-id logprob extraction crashed on mixed batches where token-id logprobs were enabled for at least one request but another request had `token_ids_logprob=None`.

## Root Cause

For chat streaming logprobs, `_process_logprobs_tokens(..., use_token_index=False)` always selected `top_logprobs[0]`. That is only correct for a single-token chunk. When a chunk contains multiple output tokens, each token's top-logprobs are already aligned by token position.

For completion streaming, `_generate_completion_stream` always computed:

```python
delta = text[offset:]
```

When `incremental_streaming_output=True`, `content["text"]` is already the delta, not cumulative text. Slicing it by a previous chunk offset drops characters.

For prefill token-id logprobs, the PREFILL branch of `get_token_ids_logprobs_raw` called:

```python
torch.tensor(token_ids, dtype=torch.long)
```

without handling `token_ids is None`. The DECODE path already handled `None`, and mixed batches can contain both `None` and non-`None` token-id logprob entries.

## Examples

Chat streaming `top_logprobs`:

```python
tokens = ["A", "B", "C"]
top_logprobs = [{"A_alt": -0.1}, {"B_alt": -0.2}, {"C_alt": -0.3}]
```

Before this PR, streaming used index `0` for every token:

```text
A -> A_alt
B -> A_alt
C -> A_alt
```

After this PR, each token uses its aligned entry:

```text
A -> A_alt
B -> B_alt
C -> C_alt
```

Completion incremental streaming:

```python
chunks = ["Hello", " World", " Foo"]
```

Before this PR, completions sliced already-incremental chunks by the previous offset:

```text
"Hello" + " World"[5:] + " Foo"[6:] = "Hellod"
```

After this PR:

```text
"Hello World Foo"
```

Prefill token-id logprobs:

Mixed prefill batches can contain:

```python
token_ids_logprobs = [[0, 2], None, [1]]
```

Before this PR, the PREFILL path called `torch.tensor(None)`. After this PR, `None` entries return empty logprob results while still advancing the row pointer for the next request.

## Modifications

- Use each token's own index when attaching chat streaming `top_logprobs`.
- Mirror chat streaming behavior in completions: use `content["text"]` directly when `incremental_streaming_output=True`.
- In PREFILL token-id logprob extraction, return empty results for `token_ids is None` and still advance the logprob row pointer by the request's pruned length.
- Add focused regression tests for all three cases.
- Address review cleanup comments by removing redundant local/duplicated assignments.

## Accuracy Tests

Not applicable. This PR does not change model forward, sampling, kernels, logits, or token selection. It only fixes response/logprob bookkeeping for already-computed outputs.

## Speed Tests and Profiling

Not applicable. The changes are small control-flow fixes in response formatting and logprob extraction paths.

## Verification

- `PYTHONPATH=python:. /tmp/sglang-test-venv/bin/python test/registered/unit/entrypoints/openai/test_serving_chat.py ServingChatTestCase.test_streaming_logprobs_uses_per_token_top_logprobs -v`
- `PYTHONPATH=python:. /tmp/sglang-test-venv/bin/python test/registered/unit/entrypoints/openai/test_serving_completions.py ServingCompletionTestCase.test_incremental_streaming_output_delta -v`
- `PYTHONPATH=python:. /tmp/sglang-test-venv/bin/python test/registered/unit/layers/test_logprob_utils.py LogprobUtilsTestCase.test_prefill_token_ids_logprobs_none_advances_position -v`
- `/tmp/sglang-test-venv/bin/python -m py_compile python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_completions.py python/sglang/srt/layers/utils/logprob.py test/registered/unit/entrypoints/openai/test_serving_chat.py test/registered/unit/entrypoints/openai/test_serving_completions.py test/registered/unit/layers/test_logprob_utils.py`
- `ruff check --select F401,F821,F841 python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_completions.py python/sglang/srt/layers/utils/logprob.py test/registered/unit/entrypoints/openai/test_serving_chat.py test/registered/unit/entrypoints/openai/test_serving_completions.py test/registered/unit/layers/test_logprob_utils.py`
- `/tmp/sglang-test-venv/bin/pre-commit run --all-files`
- `git diff --check`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28760524237](https://github.com/sgl-project/sglang/actions/runs/28760524237)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28760524182](https://github.com/sgl-project/sglang/actions/runs/28760524182)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->