### PR TITLE
Fix waiting-timeout cleanup for disaggregated requests

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1873,6 +1873,8 @@ class SchedulerDisaggregationDecodeMixin:
         self: Scheduler,
     ) -> Optional[ScheduleBatch]:
         """Process prebuilt batch and schedule the next decode batch."""
+        self._abort_on_waiting_timeout()
+
         # Process pending prebuilt batch: output processing + filter + merge
         new_prebuilt_batch = self.get_new_prebuilt_batch()
         if new_prebuilt_batch:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -450,6 +450,7 @@ class SchedulerDisaggregationPrefillMixin:
         self: Scheduler,
     ) -> Optional[ScheduleBatch]:
         self.process_pending_chunked_abort()
+        self._abort_on_waiting_timeout()
 
         # HACK (byronhsu): reset the batch_is_full flag because we never enter update_running_batch which resets it
         # Otherwise, it hangs under high concurrency

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1839,12 +1839,20 @@ class Scheduler(
             get_waiting_queue=lambda: self.waiting_queue,
             get_stats=lambda: self.metrics_reporter.stats,
             get_chunked_req=lambda: self.chunked_req,
-            get_disagg_prefill_bootstrap_queue=lambda: self.disagg_prefill_bootstrap_queue,
-            get_disagg_prefill_inflight_queue=lambda: self.disagg_prefill_inflight_queue,
+            get_disagg_prefill_bootstrap_queue=lambda: (
+                self.disagg_prefill_bootstrap_queue
+            ),
+            get_disagg_prefill_inflight_queue=lambda: (
+                self.disagg_prefill_inflight_queue
+            ),
             get_disagg_decode_prealloc_queue=lambda: self.disagg_decode_prealloc_queue,
             get_disagg_decode_transfer_queue=lambda: self.disagg_decode_transfer_queue,
-            get_spec_total_num_accept_tokens=lambda: self.metrics_reporter.spec_total_num_accept_tokens,
-            get_spec_total_num_forward_ct=lambda: self.metrics_reporter.spec_total_num_forward_ct,
+            get_spec_total_num_accept_tokens=lambda: (
+                self.metrics_reporter.spec_total_num_accept_tokens
+            ),
+            get_spec_total_num_forward_ct=lambda: (
+                self.metrics_reporter.spec_total_num_forward_ct
+            ),
         )
 
     def init_output_streamer(self) -> None:
@@ -2402,16 +2410,14 @@ class Scheduler(
         for req in self.waiting_queue:
             entry_time = req.time_stats.wait_queue_entry_time
             if 0 < entry_time < deadline:
-                if self.enable_hicache_storage:
-                    # Release prefetch events associated with the request
-                    self.tree_cache.release_aborted_request(req.rid)
+                req.finished_reason = FINISH_ABORT(
+                    "Request waiting timeout reached.",
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                )
+                self._release_waiting_queue_abort_resources(req)
                 self.ipc_channels.send_to_tokenizer.send_output(
                     AbortReq(
-                        finished_reason={
-                            "type": "abort",
-                            "status_code": HTTPStatus.SERVICE_UNAVAILABLE,
-                            "message": "Request waiting timeout reached.",
-                        },
+                        finished_reason=req.finished_reason.to_json(),
                         rid=req.rid,
                     ),
                     req,
@@ -2422,6 +2428,37 @@ class Scheduler(
             self.waiting_queue = [
                 req for req in self.waiting_queue if req not in deleted_reqs
             ]
+
+    def _release_waiting_queue_abort_resources(self, req: Req):
+        if not isinstance(getattr(req, "finished_reason", None), FINISH_ABORT):
+            req.finished_reason = FINISH_ABORT()
+
+        if self.enable_hicache_storage:
+            # Release prefetch events associated with the request
+            self.tree_cache.release_aborted_request(req.rid)
+        elif self.enable_hierarchical_cache:
+            self.tree_cache.terminate_prefetch(req.rid)
+
+        # For disaggregation decode mode, the request in the waiting queue has
+        # KV cache allocated.
+        if self.disaggregation_mode == DisaggregationMode.DECODE:
+            release_kv_cache(req, self.tree_cache)
+
+        # For disaggregation prefill mode, free the metadata buffer index.
+        if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            disagg_kv_sender = getattr(req, "disagg_kv_sender", None)
+            if disagg_kv_sender is not None and hasattr(disagg_kv_sender, "abort"):
+                disagg_kv_sender.abort()
+            maybe_release_metadata_buffer(
+                req, self.req_to_metadata_buffer_idx_allocator
+            )
+
+        # For mamba radix cache
+        if (
+            req.mamba_pool_idx is not None
+            and self.disaggregation_mode != DisaggregationMode.DECODE
+        ):
+            release_kv_cache(req, self.tree_cache, is_insert=False)
 
     def handle_embedding_request(
         self,
@@ -3879,33 +3916,8 @@ class Scheduler(
             # This only works for requests that have not started anything.
             # We still need to send something back to TokenizerManager to clean up the state.
             req = self.waiting_queue.pop(i)
-            if self.enable_hicache_storage:
-                # to release prefetch events associated with the request
-                self.tree_cache.release_aborted_request(req.rid)
+            self._release_waiting_queue_abort_resources(req)
             self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
-            # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
-            if self.disaggregation_mode == DisaggregationMode.DECODE:
-                release_kv_cache(req, self.tree_cache)
-            # For disaggregation prefill mode, free the metadata buffer index
-            if self.disaggregation_mode == DisaggregationMode.PREFILL:
-                bootstrap_pending = req.pending_bootstrap
-                maybe_release_metadata_buffer(
-                    req, self.req_to_metadata_buffer_idx_allocator
-                )
-                if (
-                    bootstrap_pending
-                    and hasattr(req, "disagg_kv_sender")
-                    and req.disagg_kv_sender is not None
-                ):
-                    if hasattr(req.disagg_kv_sender, "abort"):
-                        req.disagg_kv_sender.abort()
-
-            # For mamba radix cache
-            if (
-                req.mamba_pool_idx is not None
-                and self.disaggregation_mode != DisaggregationMode.DECODE
-            ):
-                release_kv_cache(req, self.tree_cache, is_insert=False)
             logger.debug(f"Abort queued request. {req.rid=}")
 
         # Delete the requests in the grammar queue

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -1,4 +1,5 @@
 import unittest
+from http import HTTPStatus
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -9,6 +10,7 @@ from sglang.srt.disaggregation.decode import (
     HiCacheRestoreResult,
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.managers.scheduler import Scheduler
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -26,6 +28,13 @@ class FakeReceiver:
 
     def failure_exception(self):
         return None
+
+
+class FakeWaitingReq:
+    def __init__(self, rid: str, wait_queue_entry_time: float):
+        self.rid = rid
+        self.time_stats = SimpleNamespace(wait_queue_entry_time=wait_queue_entry_time)
+        self.mamba_pool_idx = None
 
 
 class TestDecodeQueueCleanup(CustomTestCase):
@@ -145,6 +154,135 @@ class TestDecodeQueueCleanup(CustomTestCase):
         scheduler.enable_hierarchical_cache = False
 
         self.assertFalse(scheduler.is_fully_idle())
+
+    @patch("sglang.srt.managers.scheduler.release_kv_cache")
+    @patch("sglang.srt.managers.scheduler.time.perf_counter")
+    def test_waiting_timeout_releases_disagg_decode_kv_cache(
+        self, mock_perf_counter, mock_release_kv_cache
+    ):
+        timed_out_req = FakeWaitingReq("timed-out", wait_queue_entry_time=98.0)
+        fresh_req = FakeWaitingReq("fresh", wait_queue_entry_time=99.5)
+
+        def assert_marked_aborted_before_release(req, _tree_cache):
+            self.assertIs(req, timed_out_req)
+            self.assertIsInstance(req.finished_reason, FINISH_ABORT)
+            self.assertEqual(
+                req.finished_reason.message, "Request waiting timeout reached."
+            )
+            self.assertEqual(
+                req.finished_reason.status_code, HTTPStatus.SERVICE_UNAVAILABLE
+            )
+
+        mock_release_kv_cache.side_effect = assert_marked_aborted_before_release
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.waiting_queue = [timed_out_req, fresh_req]
+        scheduler.enable_hicache_storage = False
+        scheduler.enable_hierarchical_cache = False
+        scheduler.disaggregation_mode = DisaggregationMode.DECODE
+        scheduler.tree_cache = MagicMock()
+        scheduler.ipc_channels = SimpleNamespace(
+            send_to_tokenizer=SimpleNamespace(send_output=MagicMock())
+        )
+        mock_perf_counter.return_value = 100.0
+
+        with envs.SGLANG_REQ_WAITING_TIMEOUT.override(1.0):
+            scheduler._abort_on_waiting_timeout()
+
+        self.assertEqual(scheduler.waiting_queue, [fresh_req])
+        mock_release_kv_cache.assert_called_once_with(
+            timed_out_req, scheduler.tree_cache
+        )
+        scheduler.ipc_channels.send_to_tokenizer.send_output.assert_called_once()
+        abort_req = scheduler.ipc_channels.send_to_tokenizer.send_output.call_args[0][0]
+        self.assertEqual(abort_req.rid, "timed-out")
+        self.assertEqual(abort_req.finished_reason["type"], "abort")
+
+    @patch("sglang.srt.managers.scheduler.time.perf_counter")
+    def test_waiting_timeout_terminates_hierarchical_prefetch(self, mock_perf_counter):
+        timed_out_req = FakeWaitingReq("timed-out", wait_queue_entry_time=98.0)
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.waiting_queue = [timed_out_req]
+        scheduler.enable_hicache_storage = False
+        scheduler.enable_hierarchical_cache = True
+        scheduler.disaggregation_mode = DisaggregationMode.NULL
+        scheduler.tree_cache = MagicMock()
+        scheduler.ipc_channels = SimpleNamespace(
+            send_to_tokenizer=SimpleNamespace(send_output=MagicMock())
+        )
+        mock_perf_counter.return_value = 100.0
+
+        with envs.SGLANG_REQ_WAITING_TIMEOUT.override(1.0):
+            scheduler._abort_on_waiting_timeout()
+
+        self.assertEqual(scheduler.waiting_queue, [])
+        scheduler.tree_cache.terminate_prefetch.assert_called_once_with("timed-out")
+
+    @patch("sglang.srt.managers.scheduler.maybe_release_metadata_buffer")
+    @patch("sglang.srt.managers.scheduler.time.perf_counter")
+    def test_waiting_timeout_aborts_finalized_prefill_sender_before_metadata_release(
+        self, mock_perf_counter, mock_release_metadata_buffer
+    ):
+        timed_out_req = FakeWaitingReq("timed-out", wait_queue_entry_time=98.0)
+        timed_out_req.pending_bootstrap = False
+        timed_out_req.disagg_kv_sender = MagicMock()
+
+        def assert_sender_aborted_before_release(*_args, **_kwargs):
+            timed_out_req.disagg_kv_sender.abort.assert_called_once_with()
+
+        mock_release_metadata_buffer.side_effect = assert_sender_aborted_before_release
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.waiting_queue = [timed_out_req]
+        scheduler.enable_hicache_storage = False
+        scheduler.enable_hierarchical_cache = False
+        scheduler.disaggregation_mode = DisaggregationMode.PREFILL
+        scheduler.tree_cache = MagicMock()
+        scheduler.req_to_metadata_buffer_idx_allocator = MagicMock()
+        scheduler.ipc_channels = SimpleNamespace(
+            send_to_tokenizer=SimpleNamespace(send_output=MagicMock())
+        )
+        mock_perf_counter.return_value = 100.0
+
+        with envs.SGLANG_REQ_WAITING_TIMEOUT.override(1.0):
+            scheduler._abort_on_waiting_timeout()
+
+        self.assertEqual(scheduler.waiting_queue, [])
+        timed_out_req.disagg_kv_sender.abort.assert_called_once_with()
+        mock_release_metadata_buffer.assert_called_once_with(
+            timed_out_req, scheduler.req_to_metadata_buffer_idx_allocator
+        )
+
+    def test_disagg_decode_scheduler_runs_waiting_timeout_cleanup(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler._abort_on_waiting_timeout = MagicMock()
+        scheduler.get_new_prebuilt_batch = MagicMock(return_value=None)
+        scheduler.running_batch = MagicMock()
+        scheduler.running_batch.is_empty.return_value = True
+        scheduler.dp_attn_adapter = MagicMock()
+        scheduler.dp_attn_adapter.maybe_prepare_mlp_sync_batch.return_value = None
+
+        batch = scheduler.get_next_disagg_decode_batch_to_run()
+
+        self.assertIsNone(batch)
+        scheduler._abort_on_waiting_timeout.assert_called_once_with()
+
+    def test_disagg_prefill_scheduler_runs_waiting_timeout_cleanup(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.process_pending_chunked_abort = MagicMock()
+        scheduler._abort_on_waiting_timeout = MagicMock()
+        scheduler.running_batch = SimpleNamespace(batch_is_full=True)
+        scheduler.process_prefill_chunk = MagicMock()
+        scheduler.resolve_waiting_queue_bootstrap = MagicMock()
+        scheduler.get_new_batch_prefill = MagicMock(return_value=None)
+        scheduler.dp_attn_adapter = MagicMock()
+        scheduler.dp_attn_adapter.maybe_prepare_mlp_sync_batch.return_value = None
+
+        batch = scheduler.get_next_disagg_prefill_batch_to_run()
+
+        self.assertIsNone(batch)
+        scheduler._abort_on_waiting_timeout.assert_called_once_with()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`SGLANG_REQ_WAITING_TIMEOUT` could remove timed-out waiting requests without cleaning up resources owned by disaggregated requests.

In disaggregated decode, waiting requests may already own KV cache. In disaggregated prefill, waiting requests may own metadata buffer state and finalized KV senders. The timeout cleanup was also only reached from the normal scheduler path, while disaggregated decode and prefill use separate scheduling loops.

## Modifications

- Run waiting-timeout cleanup from both disaggregated scheduler loops:
  - `get_next_disagg_decode_batch_to_run`
  - `get_next_disagg_prefill_batch_to_run`
- Reuse waiting-queue abort cleanup for timeout-driven aborts.
- Release disaggregated decode KV cache for timed-out waiting requests.
- Abort finalized disaggregated prefill senders before releasing metadata buffers.
- Mark timed-out requests as `FINISH_ABORT` before releasing KV cache, so session-backed cache cleanup treats them as aborted instead of successful completions.
- Add focused unit tests for cleanup behavior and reachability from the disaggregated scheduler loops.

## Direct Proof

### Timeout cleanup was unreachable in disaggregated scheduler loops

Before this change, `_abort_on_waiting_timeout()` only ran from the normal scheduler path. Disaggregated decode and prefill use separate scheduling loops:

- `get_next_disagg_decode_batch_to_run()`
- `get_next_disagg_prefill_batch_to_run()`

So requests sitting in those waiting queues could exceed `SGLANG_REQ_WAITING_TIMEOUT` without running timeout cleanup.

This PR calls `_abort_on_waiting_timeout()` directly from both disaggregated loops. The tests `test_disagg_decode_scheduler_runs_waiting_timeout_cleanup` and `test_disagg_prefill_scheduler_runs_waiting_timeout_cleanup` prove those loops now invoke the cleanup path.

### Timed-out cache-owning requests must be marked aborted before KV release

`release_kv_cache()` eventually calls `tree_cache.cache_finished_req(...)`. For streaming sessions, `StreamingSession.try_cache_finished_req()` distinguishes abort cleanup from successful completion by checking:

```python
isinstance(req.finished_reason, FINISH_ABORT)
```

So if a timed-out waiting request owns KV/session state and releases KV before setting `FINISH_ABORT`, the session path can treat the request like a successful finish.

This PR sets `req.finished_reason = FINISH_ABORT(...)` before `_release_waiting_queue_abort_resources(req)` can call `release_kv_cache(...)`. The test `test_waiting_timeout_releases_disagg_decode_kv_cache` asserts this ordering directly inside the mocked `release_kv_cache` call.

## Accuracy Tests

Not applicable. This does not change model forward computation or expected model outputs.

## Speed Tests and Profiling

Not applicable. This only runs when waiting-queue timeout cleanup is enabled and a request exceeds `SGLANG_REQ_WAITING_TIMEOUT`.

## Verification

- `PYTHONPATH=python:. /tmp/sglang-test-venv/bin/python test/registered/unit/disaggregation/test_decode_queue_cleanup.py -v`
- `/tmp/sglang-test-venv/bin/python -m py_compile python/sglang/srt/disaggregation/decode.py python/sglang/srt/disaggregation/prefill.py python/sglang/srt/managers/scheduler.py test/registered/unit/disaggregation/test_decode_queue_cleanup.py`
- `/tmp/sglang-test-venv/bin/pre-commit run --all-files`
- `git diff --check`
- `autoreview clean: no accepted/actionable findings reported`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28760357883](https://github.com/sgl-project/sglang/actions/runs/28760357883)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28760357825](https://github.com/sgl-project/sglang/actions/runs/28760357825)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->