### PR TITLE
[CP] DCP Phase 2: decode-context-parallel strategy + wire backends

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -26,10 +26,10 @@ from sglang.srt.layers.attention.utils import assert_buffer_fits
 from sglang.srt.layers.dcp import (
     DecodeContextParallelMetadata,
     dcp_enabled,
+    dcp_plan_decode_metadata,
+    dcp_update_local_decode_kv_lens,
     get_attention_dcp_world_size,
-    update_local_kv_lens_for_dcp,
 )
-from sglang.srt.layers.dcp.planner import plan_dcp_decode_metadata
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
@@ -471,7 +471,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         if forward_mode.is_decode_or_idle():
             assert seq_lens_cpu is not None
             kv_len_arr_cpu = seq_lens_cpu[:bs].to(torch.int32)
-            update_local_kv_lens_for_dcp(kv_len_arr_cpu)
+            dcp_update_local_decode_kv_lens(kv_len_arr_cpu)
             self.cuda_graph_kv_indptr_cpu[1 : bs + 1] = torch.cumsum(
                 kv_len_arr_cpu, dim=0
             )
@@ -735,13 +735,13 @@ class FlashInferMLAIndicesUpdaterDecode:
             )
 
             if dcp_enabled():
-                plan_dcp_decode_metadata(
-                    kv_lens,
-                    kv_indptr,
-                    kv_indices,
-                    init_metadata_replay,
-                    fast_decode_kwargs,
-                    bs,
+                dcp_plan_decode_metadata(
+                    kv_lens=kv_lens,
+                    kv_indptr=kv_indptr,
+                    kv_indices=kv_indices,
+                    init_metadata_replay=init_metadata_replay,
+                    fast_decode_kwargs=fast_decode_kwargs,
+                    bs=bs,
                 )
         else:
             kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -20,6 +20,7 @@ from sglang.srt.layers.attention.triton_ops.metadata import get_num_kv_splits_tr
 from sglang.srt.layers.dcp import (
     cp_lse_ag_out_rs_mha,
     create_triton_kv_indices_for_dcp_triton,
+    dcp_merge_attention,
     get_dcp_lens,
 )
 from sglang.srt.layers.radix_attention import AttentionType
@@ -1748,7 +1749,7 @@ class TritonAttnBackend(AttentionBackend):
                 ],
                 dim=-1,
             )
-            o = cp_lse_ag_out_rs_mha(o_for_decode, local_lse, group)
+            o = dcp_merge_attention(o_for_decode, local_lse, group, backend="mha")
             return o.reshape(-1, layer.tp_q_head_num * layer.v_head_dim).to(q.dtype)
 
         self.decode_attention_fwd(

--- a/python/sglang/srt/layers/dcp/__init__.py
+++ b/python/sglang/srt/layers/dcp/__init__.py
@@ -25,6 +25,12 @@ Package-internal helpers (the @triton.jit kernels, ``CPTritonContext``,
 ``_all_gather_dcp_kv_cache``) stay private to their submodules — import them from
 ``sglang.srt.layers.dcp.{kernels,comm}`` if ever needed internally."""
 
+from sglang.srt.layers.dcp.base import (
+    DecodeContextParallelStrategyKind,
+    get_dcp_strategy,
+    init_dcp_strategy,
+    is_dcp_enabled,
+)
 from sglang.srt.layers.dcp.comm import (
     all_gather_kv_cache_for_dcp,
     all_gather_kv_cache_for_mha_chunk_extend,
@@ -44,17 +50,27 @@ from sglang.srt.layers.dcp.layout import (
     update_local_kv_lens_for_dcp,
 )
 from sglang.srt.layers.dcp.metadata import DecodeContextParallelMetadata
+from sglang.srt.layers.dcp.utils import (
+    dcp_build_decode_metadata,
+    dcp_gather_decode_query,
+    dcp_merge_attention,
+    dcp_plan_decode_metadata,
+    dcp_shard_decode_kv_indices,
+    dcp_update_local_decode_kv_lens,
+)
 
-# NOTE: planner.py is intentionally NOT imported here. It depends on server_args
-# (get_global_server_args), whereas this package-init executes at module-load time
-# for every eager importer of the DCP primitives — triton_backend,
-# mem_cache.memory_pool, mem_cache.triton_ops.mla_buffer, mem_cache.kv_cache_builder,
-# the FlashInfer-MLA / FlashMLA backends, and the deepseek forward methods. Keeping
-# the init server_args-free avoids a load-time import edge into server_args. Import
-# planner functions from sglang.srt.layers.dcp.planner directly.
+# NOTE: strategy.py and planner.py are intentionally NOT imported here. planner
+# depends on server_args (get_global_server_args), and strategy imports planner;
+# this package-init executes at module-load time for every eager importer of the DCP
+# primitives — triton_backend, mem_cache.memory_pool, mem_cache.triton_ops.mla_buffer,
+# mem_cache.kv_cache_builder, the FlashInfer-MLA / FlashMLA backends, and the deepseek
+# forward methods. Keeping the init server_args-free avoids a load-time import edge.
+# The concrete strategy is reached via get_dcp_strategy() (which lazily imports it);
+# import planner functions from sglang.srt.layers.dcp.planner directly if needed.
 
 __all__ = [
     "DecodeContextParallelMetadata",
+    "DecodeContextParallelStrategyKind",
     "all_gather_kv_cache_for_dcp",
     "all_gather_kv_cache_for_mha_chunk_extend",
     "all_gather_kv_cache_for_mha_extend",
@@ -63,10 +79,19 @@ __all__ = [
     "cp_lse_ag_out_rs_mha",
     "cp_lse_ag_out_rs_mla",
     "create_triton_kv_indices_for_dcp_triton",
+    "dcp_build_decode_metadata",
     "dcp_enabled",
+    "dcp_gather_decode_query",
+    "dcp_merge_attention",
+    "dcp_plan_decode_metadata",
+    "dcp_shard_decode_kv_indices",
+    "dcp_update_local_decode_kv_lens",
     "filter_dcp_local_kv_indices",
     "get_attention_dcp_rank",
     "get_attention_dcp_world_size",
     "get_dcp_lens",
+    "get_dcp_strategy",
+    "init_dcp_strategy",
+    "is_dcp_enabled",
     "update_local_kv_lens_for_dcp",
 ]

--- a/python/sglang/srt/layers/dcp/base.py
+++ b/python/sglang/srt/layers/dcp/base.py
@@ -1,0 +1,107 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Kind enum + process-wide singleton for the decode context parallel (DCP) strategy.
+
+Deliberately mirrors the prefill CP-v2 "head" in ``layers/cp/base.py`` (kind enum +
+``init_/get_/is_`` singletons with lazy worker recovery) so a developer who knows CP
+navigates DCP the same way. But decode-CP is a SEPARATE parallelism on the ``_DCP``
+group (owner rule ``pos % dcp_size == dcp_rank``); it does NOT inherit the prefill
+``ContextParallelStrategy`` ABC. The concrete strategy lives in
+``layers/dcp/strategy.py``; the runtime facade (None-safe op wrappers) in
+``layers/dcp/utils.py``.
+
+Keep this module ``server_args``-free at import time: ``strategy`` (which transitively
+imports ``planner`` -> ``server_args``) is imported lazily inside ``init_dcp_strategy``.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.dcp.strategy import DecodeContextParallelStrategy
+    from sglang.srt.server_args import ServerArgs
+
+
+class DecodeContextParallelStrategyKind(IntEnum):
+    """Decode context parallel strategy identifiers.
+
+    Distinct from ``ContextParallelStrategyKind`` (prefill): a DCP strategy reports
+    ``DECODE`` here, so ``strategy.kind`` is never confused with the prefill layout.
+    """
+
+    NONE = 0
+    DECODE = 1
+
+
+# _UNSET distinguishes "not yet resolved" from "resolved to disabled" (dcp_size<=1
+# -> None), so get_dcp_strategy() memoizes the disabled state instead of re-running
+# the server-args lookup on every call. This matters because the DCP facade
+# (layers/dcp/utils.py) is invoked from ungated hot-path sites (per attention layer /
+# per decode step), where the DCP-off case must stay as cheap as the free functions
+# it replaced.
+_UNSET = object()
+_DCP_STRATEGY = _UNSET
+
+
+def init_dcp_strategy(server_args: ServerArgs) -> None:
+    """Bind the decode-context-parallel strategy for this process.
+
+    Independent of the prefill CP strategy: DCP is configured by ``dcp_size`` (not
+    ``attn_cp_size``/``cp_strategy``) and runs on the ``_DCP`` group. Platform-agnostic
+    (``dcp_size > 1`` on both CUDA-MLA and AMD-HIP-MHA).
+    """
+    global _DCP_STRATEGY
+
+    if getattr(server_args, "dcp_size", 1) > 1:
+        from sglang.srt.layers.dcp.strategy import DecodeContextParallelStrategy
+
+        _DCP_STRATEGY = DecodeContextParallelStrategy(dcp_size=server_args.dcp_size)
+    else:
+        _DCP_STRATEGY = None
+
+
+def get_dcp_strategy() -> Optional[DecodeContextParallelStrategy]:
+    """Return the decode-CP strategy, lazily initializing from global server args.
+
+    Mirrors ``get_cp_strategy``'s lazy pattern so pickled worker processes (which
+    bypass ``ServerArgs.__post_init__``) recover the singleton. Once resolved (to a
+    strategy or, when disabled, None) the result is memoized. Returns None when DCP
+    is not configured (``dcp_size <= 1``).
+    """
+    global _DCP_STRATEGY
+
+    if _DCP_STRATEGY is _UNSET:
+        from sglang.srt.server_args import get_global_server_args
+
+        try:
+            server_args = get_global_server_args()
+        except ValueError:
+            return None  # global args not set yet; retry on the next call
+        if server_args is None:
+            return None
+        init_dcp_strategy(server_args)  # resolves _DCP_STRATEGY to a strategy or None
+    return None if _DCP_STRATEGY is _UNSET else _DCP_STRATEGY
+
+
+def is_dcp_enabled() -> bool:
+    """True if decode context parallel is configured (``dcp_size > 1``).
+
+    This is the *configuration* gate (strategy existence). It is broader than
+    ``layers.dcp.comm.dcp_enabled()`` — the latter additionally requires CUDA and is
+    the MLA-path runtime gate. Use ``dcp_enabled()`` where the CUDA gate is intended.
+    """
+    return get_dcp_strategy() is not None

--- a/python/sglang/srt/layers/dcp/strategy.py
+++ b/python/sglang/srt/layers/dcp/strategy.py
@@ -1,0 +1,108 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""``DecodeContextParallelStrategy`` — the decode context parallel strategy.
+
+STANDALONE: it does NOT inherit the prefill ``ContextParallelStrategy``. Decode-CP is
+an orthogonal parallelism on the ``_DCP`` group (owner rule ``pos % dcp_size == rank``)
+applied during decode. The class is structurally aligned with the CP-v2 strategies for
+familiarity — the package mirrors CP's ``base``/``strategy``/``utils``/``__init__``
+layout and ``init_/get_/is_`` singleton naming (see ``layers/dcp/base.py`` and
+``layers/dcp/utils.py``) — but shares no code with them (no prefill ``shard_*`` /
+``run_attention`` / ``materialize_full_kv``, no prefill-axis ``cp_rank``).
+
+Its methods are a behavior-preserving *seam* over the ``layers/dcp`` primitives
+(comm/layout/planner) — no new logic. Imported lazily (only by ``init_dcp_strategy``),
+so pulling ``planner`` (-> ``server_args``) adds no load-time edge to the DCP package
+init.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sglang.srt.layers.dcp.base import DecodeContextParallelStrategyKind
+from sglang.srt.layers.dcp.comm import (
+    all_gather_q_for_mla_decode,
+    cp_lse_ag_out_rs_mha,
+    cp_lse_ag_out_rs_mla,
+)
+from sglang.srt.layers.dcp.layout import (
+    filter_dcp_local_kv_indices,
+    get_dcp_lens,
+    update_local_kv_lens_for_dcp,
+)
+from sglang.srt.layers.dcp.planner import (
+    plan_dcp_decode_metadata,
+    prepare_decode_context_parallel_metadata,
+)
+
+
+class DecodeContextParallelStrategy:
+    """Decode context parallel on the ``_DCP`` group (owner rule pos % N == rank)."""
+
+    name = "decode_context_parallel"
+    kind = DecodeContextParallelStrategyKind.DECODE
+
+    def __init__(self, dcp_size: int):
+        self.dcp_size = dcp_size
+
+    def can_apply(self, num_tokens: int, forward_batch) -> bool:
+        if self.dcp_size <= 1:
+            return False
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        return forward_mode is None or forward_mode.is_decode()
+
+    # -- KV layout -------------------------------------------------------------
+    def local_decode_kv_lens(
+        self, lens: Any, dcp_size: int, dcp_rank: int, start: Any = None
+    ) -> Any:
+        return get_dcp_lens(lens, dcp_size, dcp_rank, start)
+
+    def update_local_decode_kv_lens(self, kv_len_arr: Any) -> None:
+        update_local_kv_lens_for_dcp(kv_len_arr)
+
+    def shard_decode_kv_indices(self, kv_indices: Any) -> Any:
+        return filter_dcp_local_kv_indices(kv_indices=kv_indices)
+
+    # -- metadata --------------------------------------------------------------
+    def build_decode_metadata(self, **kwargs: Any) -> Any:
+        return prepare_decode_context_parallel_metadata(**kwargs)
+
+    def plan_decode_metadata(self, **kwargs: Any) -> Any:
+        return plan_dcp_decode_metadata(**kwargs)
+
+    # -- attention -------------------------------------------------------------
+    def gather_decode_query(self, q_nope_out: Any, q_pe: Any) -> Any:
+        return all_gather_q_for_mla_decode(q_nope_out, q_pe)
+
+    def merge_decode_attention(
+        self,
+        cp_attn_out: Any,
+        cp_attn_lse: Any,
+        cp_group: Any,
+        *,
+        backend: str,
+        return_lse: bool = False,
+        ctx: Optional[Any] = None,
+    ) -> Any:
+        if backend == "mha":
+            return cp_lse_ag_out_rs_mha(
+                cp_attn_out, cp_attn_lse, cp_group, return_lse=return_lse
+            )
+        if backend == "mla":
+            return cp_lse_ag_out_rs_mla(cp_attn_out, cp_attn_lse, cp_group, ctx=ctx)
+        raise ValueError(
+            f"unknown decode-CP attention backend {backend!r}; expected 'mha' or 'mla'"
+        )

--- a/python/sglang/srt/layers/dcp/utils.py
+++ b/python/sglang/srt/layers/dcp/utils.py
@@ -1,0 +1,93 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Runtime facade for the decode context parallel (DCP) strategy.
+
+Mirrors ``layers/cp/utils.py``: backends call these thin, None-safe wrappers instead
+of reaching ``get_dcp_strategy()`` directly, so the strategy-existence guard lives in
+one place. When DCP is not configured each wrapper is a no-op / identity that matches
+the call site's original inline guard, so callers keep their surrounding mode/platform
+gates (``dcp_enabled()``, ``dcp_size > 1``) and route only the operation here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sglang.srt.layers.dcp.base import get_dcp_strategy
+
+
+def dcp_shard_decode_kv_indices(kv_indices: Any) -> Any:
+    """Keep only this rank's owned KV indices; identity when DCP is off."""
+    strategy = get_dcp_strategy()
+    if strategy is None:
+        return kv_indices
+    return strategy.shard_decode_kv_indices(kv_indices)
+
+
+def dcp_update_local_decode_kv_lens(kv_len_arr: Any) -> None:
+    """In-place per-rank KV length; no-op when DCP is off."""
+    strategy = get_dcp_strategy()
+    if strategy is not None:
+        strategy.update_local_decode_kv_lens(kv_len_arr)
+
+
+def dcp_build_decode_metadata(**kwargs: Any) -> Any:
+    """Build per-forward DCP decode metadata; None when DCP is off."""
+    strategy = get_dcp_strategy()
+    if strategy is None:
+        return None
+    return strategy.build_decode_metadata(**kwargs)
+
+
+def dcp_plan_decode_metadata(**kwargs: Any) -> Any:
+    """Plan/replay per-rank decode kv-len + index buffers; no-op when DCP is off."""
+    strategy = get_dcp_strategy()
+    if strategy is None:
+        return None
+    return strategy.plan_decode_metadata(**kwargs)
+
+
+def dcp_gather_decode_query(q_nope_out: Any, q_pe: Any) -> Any:
+    """All-gather sharded decode query heads (MLA); identity when DCP is off."""
+    strategy = get_dcp_strategy()
+    if strategy is None:
+        return q_nope_out, q_pe
+    return strategy.gather_decode_query(q_nope_out, q_pe)
+
+
+def dcp_merge_attention(
+    cp_attn_out: Any,
+    cp_attn_lse: Any,
+    cp_group: Any,
+    *,
+    backend: str,
+    return_lse: bool = False,
+    ctx: Optional[Any] = None,
+) -> Any:
+    """Merge per-rank partial attention via LSE rescale; identity when DCP is off.
+
+    ``backend`` in {"mha", "mla"}.
+    """
+    strategy = get_dcp_strategy()
+    if strategy is None:
+        return (cp_attn_out, cp_attn_lse) if return_lse else cp_attn_out
+    return strategy.merge_decode_attention(
+        cp_attn_out,
+        cp_attn_lse,
+        cp_group,
+        backend=backend,
+        return_lse=return_lse,
+        ctx=ctx,
+    )

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -13,7 +13,7 @@ from sglang.srt.layers.dcp import (
     all_gather_kv_cache_for_mha_chunk_extend,
     all_gather_kv_cache_for_mha_extend,
     dcp_enabled,
-    filter_dcp_local_kv_indices,
+    dcp_shard_decode_kv_indices,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import (
@@ -511,7 +511,7 @@ class DeepseekMHAForwardMixin:
         forward_batch: ForwardBatch,
     ):
         if _is_cuda or _use_aiter_gfx95:
-            kv_indices = filter_dcp_local_kv_indices(kv_indices=kv_indices)
+            kv_indices = dcp_shard_decode_kv_indices(kv_indices)
             kv_a, k_pe = get_token_to_kv_pool().get_mla_kv_buffer(
                 self.attn_mha, kv_indices, dst_dtype
             )

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -17,9 +17,9 @@ from sglang.srt.layers.attention.dsa.utils import (
 from sglang.srt.layers.communicator import get_attn_tp_context
 from sglang.srt.layers.dcp import (
     all_gather_kv_cache_for_mla_extend,
-    all_gather_q_for_mla_decode,
-    cp_lse_ag_out_rs_mla,
     dcp_enabled,
+    dcp_gather_decode_query,
+    dcp_merge_attention,
     get_attention_dcp_world_size,
 )
 from sglang.srt.layers.quantization.fp8_kernel import (
@@ -566,10 +566,7 @@ class DeepseekMLAForwardMixin:
         if dcp_enabled():
             if forward_batch.forward_mode.is_decode():
                 # if forward_batch.forward_mode is decode, gather q
-                q_nope_out, q_pe = all_gather_q_for_mla_decode(
-                    q_nope_out=q_nope_out,
-                    q_pe=q_pe,
-                )
+                q_nope_out, q_pe = dcp_gather_decode_query(q_nope_out, q_pe)
             elif forward_batch.forward_mode.is_extend():
                 # for extend, gather kv
                 all_gather_kv_cache_for_mla_extend(
@@ -797,7 +794,9 @@ class DeepseekMLAForwardMixin:
                 self.num_local_heads * get_attention_dcp_world_size(),
                 self.kv_lora_rank,
             )
-            attn_output = cp_lse_ag_out_rs_mla(attn_output, lse, get_dcp_group())
+            attn_output = dcp_merge_attention(
+                attn_output, lse, get_dcp_group(), backend="mla"
+            )
             attn_output = attn_output.transpose(0, 1)
         attn_output = attn_output.view(-1, self.num_local_heads, self.kv_lora_rank)
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -71,9 +71,10 @@ from sglang.srt.layers.communicator import (
     get_attn_tp_context,
 )
 from sglang.srt.layers.communicator_dsa_cp import DSACPLayerCommunicator
-from sglang.srt.layers.dcp import dcp_enabled, get_attention_dcp_world_size
-from sglang.srt.layers.dcp.planner import (
-    prepare_decode_context_parallel_metadata,
+from sglang.srt.layers.dcp import (
+    dcp_build_decode_metadata,
+    dcp_enabled,
+    get_attention_dcp_world_size,
 )
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
@@ -2914,7 +2915,7 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         kv_cache_device,
         create_chunked_prefix_cache_kv_indices_fn,
     ):
-        return prepare_decode_context_parallel_metadata(
+        return dcp_build_decode_metadata(
             seq_lens=seq_lens,
             extend_prefix_lens=extend_prefix_lens,
             extend_prefix_lens_cpu=extend_prefix_lens_cpu,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4817,8 +4817,10 @@ class ServerArgs:
             ), "attn_cp_size != moe_dp_size is only supported when moe_dp_size == 1"
 
         from sglang.srt.layers.cp.base import init_cp_strategy
+        from sglang.srt.layers.dcp import init_dcp_strategy
 
         init_cp_strategy(self)
+        init_dcp_strategy(self)
 
     def _handle_data_parallelism(self):
         # The dp_size==1 resets moved to the resolution pipeline

--- a/test/registered/dcp/test_dcp_strategy_unit.py
+++ b/test/registered/dcp/test_dcp_strategy_unit.py
@@ -1,0 +1,98 @@
+"""CPU unit test for the decode-context-parallel (DCP) strategy.
+
+Pins the standalone ``DecodeContextParallelStrategy`` (``layers/dcp/strategy.py``):
+
+* it reports the DCP-specific kind ``DecodeContextParallelStrategyKind.DECODE`` (NOT
+  the prefill ``INTERLEAVE``) and is configured by ``dcp_size``;
+* its delegating methods are behavior-preserving wrappers over the ``layers/dcp``
+  primitives (``local_decode_kv_lens`` == ``get_dcp_lens``; ``merge_decode_attention``
+  dispatches mha/mla and short-circuits on a world_size==1 group);
+* ``can_apply`` fires on decode only.
+
+Usage:
+    python -m pytest test_dcp_strategy_unit.py -v
+    python test_dcp_strategy_unit.py
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.dcp.base import DecodeContextParallelStrategyKind
+from sglang.srt.layers.dcp.layout import get_dcp_lens
+from sglang.srt.layers.dcp.strategy import DecodeContextParallelStrategy
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+DCP_SIZES = [1, 2, 3, 4, 8]
+LENS = list(range(0, 41))
+
+
+def _fake_batch(is_decode: bool):
+    mode = SimpleNamespace(
+        is_decode=lambda: is_decode,
+        is_extend=lambda: not is_decode,
+    )
+    return SimpleNamespace(forward_mode=mode)
+
+
+class _FakeGroup:
+    """A single-rank group: the merge/gather ops short-circuit on world_size==1."""
+
+    world_size = 1
+    rank_in_group = 0
+
+
+class TestDecodeStrategy(unittest.TestCase):
+    def test_identity(self):
+        strategy = DecodeContextParallelStrategy(dcp_size=4)
+        self.assertEqual(strategy.kind, DecodeContextParallelStrategyKind.DECODE)
+        self.assertEqual(strategy.name, "decode_context_parallel")
+        self.assertEqual(strategy.dcp_size, 4)
+
+    def test_local_decode_kv_lens_matches_free_function(self):
+        strategy = DecodeContextParallelStrategy(dcp_size=2)
+        for n in DCP_SIZES:
+            for rank in range(n):
+                lens = torch.tensor(LENS, dtype=torch.int32)
+                got = strategy.local_decode_kv_lens(lens, n, rank)
+                ref = get_dcp_lens(lens, n, rank)
+                self.assertTrue(
+                    torch.equal(got, ref),
+                    f"delegation mismatch at n={n}, rank={rank}",
+                )
+
+    def test_can_apply_fires_on_decode_only(self):
+        strategy = DecodeContextParallelStrategy(dcp_size=2)
+        self.assertTrue(strategy.can_apply(1, _fake_batch(is_decode=True)))
+        self.assertFalse(strategy.can_apply(1, _fake_batch(is_decode=False)))
+        # dcp_size <= 1 disables DCP regardless of mode.
+        self.assertFalse(
+            DecodeContextParallelStrategy(dcp_size=1).can_apply(
+                1, _fake_batch(is_decode=True)
+            )
+        )
+
+    def test_merge_decode_attention_dispatch(self):
+        strategy = DecodeContextParallelStrategy(dcp_size=2)
+        out = torch.randn(3, 2, 4)
+        lse = torch.randn(3, 2)
+        group = _FakeGroup()
+        # world_size==1 short-circuit: both backends return the input unchanged.
+        mha = strategy.merge_decode_attention(out, lse, group, backend="mha")
+        self.assertTrue(torch.equal(mha, out))
+        mla = strategy.merge_decode_attention(out, lse, group, backend="mla")
+        self.assertTrue(torch.equal(mla, out))
+        # return_lse path (mha) yields the (out, lse) tuple on the single-rank group.
+        mha_o, mha_lse = strategy.merge_decode_attention(
+            out, lse, group, backend="mha", return_lse=True
+        )
+        self.assertTrue(torch.equal(mha_o, out) and torch.equal(mha_lse, lse))
+        with self.assertRaises(ValueError):
+            strategy.merge_decode_attention(out, lse, group, backend="bogus")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Draft — decode-context-parallel (DCP) strategy layer. Behavior-preserving (no numeric change).**

## What this changes (high level)

Today, decode context parallel (DCP) is a **bag of free functions** that each attention backend imports and calls directly — per-rank KV-length math, KV-index sharding, the query all-gather, the cross-rank LSE merge, and metadata planning are each wired independently in `triton_backend`, `flashinfer_mla_backend`, the DeepSeek `forward_mla`/`forward_mha` methods, and `deepseek_v2`.

This PR turns DCP into a **first-class strategy object with a runtime facade**, structurally mirroring the existing prefill context-parallel (CP) strategy framework so a developer who knows CP navigates DCP the same way. A single `DecodeContextParallelStrategy` owns the decode-CP operations, and backends call a small `layers/dcp/utils.py` facade (just like prefill backends call `cp_split_before_forward` etc.).

```text
BEFORE  (each backend imports DCP free functions)     AFTER  (backends call the dcp facade)
----------------------------------------------------  ------------------------------------------------
filter_dcp_local_kv_indices(...)                      dcp_shard_decode_kv_indices(...)
update_local_kv_lens_for_dcp(...)                     dcp_update_local_decode_kv_lens(...)
all_gather_q_for_mla_decode(...)                      dcp_gather_decode_query(...)
cp_lse_ag_out_rs_mha(...) / cp_lse_ag_out_rs_mla(...) dcp_merge_attention(..., backend="mha"/"mla")
prepare_decode_context_parallel_metadata(...)         dcp_build_decode_metadata(...)
plan_dcp_decode_metadata(...)                         dcp_plan_decode_metadata(...)
   -> scattered across 5 files                            -> one DecodeContextParallelStrategy + facade
```

Note: `get_dcp_lens(...)` is intentionally left as a direct free-function call (`triton_backend.py:333`) and is **not** part of the facade migration.

**No behavior change:** the strategy/facade methods are thin delegations to the same underlying `layers/dcp` primitives — only the call path changes (free function → facade → strategy).

## Aligned with CP, but a standalone package (not inherited)

Decode-CP and prefill-CP are **orthogonal axes** (separate `_DCP` vs `attn_cp` process groups; decode vs prefill phase). So `layers/dcp/` is made a **self-contained mirror** of `layers/cp/` — same file roles and `init_/get_/is_` conventions — but it shares **no code** with it and **does not modify `layers/cp/`**:

| `layers/cp/` (prefill) | `layers/dcp/` (decode) |
|---|---|
| `base.py` — `ContextParallelStrategyKind` + `init_/get_/is_cp` singletons + ABC | `base.py` — `DecodeContextParallelStrategyKind{NONE,DECODE}` + `init_dcp_strategy`/`get_dcp_strategy`/`is_dcp_enabled` singletons (no ABC) |
| `zigzag.py` / `interleave.py` — concrete strategies | `strategy.py` — `DecodeContextParallelStrategy` (standalone; owns `dcp_size`; `kind=DECODE`) |
| `utils.py` — runtime facade | `utils.py` — None-safe `dcp_*` op wrappers |
| `__init__.py` — surface | `__init__.py` — surface (strategy/planner kept out of eager init → server_args-free) |
| — | `metadata.py`/`kernels.py`/`comm.py`/`layout.py`/`planner.py` — DCP mechanism internals |

The decode strategy **does not inherit** `ContextParallelStrategy` (it would only inherit prefill methods that don't apply and a prefill-axis `cp_rank`); `strategy.kind` is a real `DECODE` value; and `DecodeContextParallelMetadata` stays a standalone dataclass on its own `ForwardBatch` field.

## Details

- **`layers/dcp/base.py`** — the `DecodeContextParallelStrategyKind{NONE,DECODE}` enum + the three process-wide singletons that survive: `init_dcp_strategy` (setup) / `get_dcp_strategy` (lazy worker recovery) / `is_dcp_enabled` (config gate, `dcp_size>1`). Mirrors `layers/cp/base.py`'s `init_/get_/is_` pattern and stays server_args-free at import (concrete strategy imported lazily). `get_dcp_strategy()` **negative-caches the disabled result** via an `_UNSET` sentinel, so once DCP is resolved off, the DCP-off hot path never re-runs the server-args lookup.
- **`layers/dcp/strategy.py`** — standalone `DecodeContextParallelStrategy`; every method is a thin delegation over `layers/dcp` comm/layout/planner. Of its methods, the ops actually reached via the facade on the decode path are `update_local_decode_kv_lens`, `shard_decode_kv_indices`, `build_decode_metadata`, `plan_decode_metadata`, `gather_decode_query`, and `merge_decode_attention`. `can_apply` and `local_decode_kv_lens` are currently **not referenced by any backend** (carried for CP-symmetry / future use — `get_dcp_lens` is still called directly at `triton_backend.py:333` rather than through `local_decode_kv_lens`).
- **`layers/dcp/utils.py`** — the None-safe `dcp_*` facade wrappers (identity / no-op when DCP is off): `dcp_shard_decode_kv_indices` / `dcp_update_local_decode_kv_lens` / `dcp_build_decode_metadata` / `dcp_plan_decode_metadata` / `dcp_gather_decode_query` / `dcp_merge_attention`.
- **Backends** — the FlashInfer-MLA and Triton/MHA decode paths call the `dcp_*` facade (each stays inside its existing platform/mode gate).
- Two gates kept distinct: `is_dcp_enabled()` (config: `dcp_size>1`) vs `layers/dcp/comm.py:dcp_enabled()` (CUDA runtime gate for the MLA path).

## Validation

Behavior-preserving, verified on B200 (DeepSeek-V2-Lite-Chat, tp2, FlashInfer-MLA, CUDA) as an installed build of the branch:
- **Decouple/init checks**: importing `layers/dcp` does not pull `strategy`/`planner` (server_args-free); `layers/cp` exposes no decode symbols.
- **Unit sweep — all green** — `test/registered/dcp/test_dcp_strategy_unit.py` (CPU CI, suite `base-a-test-cpu`: identity/config, `local_decode_kv_lens` vs the `get_dcp_lens` oracle, `can_apply` decode-only gating, `merge_decode_attention` dispatch incl. bad-backend `ValueError`), plus `test_dcp_layout_unit`, `test_cp_strategy_unit` (prefill CP intact), `test_reduce_scatter_along_dim`, `test_create_kvindices`, `test_set_mla_kv_buffer`, and the `mla_flashinfer`/`mla_flashmla`/`mla_triton` backends.
- **GSM8K parity**: strategy-routed `dcp=1` ≈ **0.655** and `dcp=2` ≈ **0.675** — both ≈ **0.66** baseline, no regression.

## Checklist

- [ ] CI green.
- [ ] Maintainer review of the `layers/dcp/` layout + facade.