### PR TITLE
[AMD] [GLM5] Route DSA indexer q/k RoPE through apply_rope_inplace on gfx950

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -58,6 +58,15 @@ _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
+# Opt-in: fuse the indexer query's hadamard (rotate_activation) + fp8 act_quant
+# into one Triton kernel (gfx950). Enable with SGLANG_DSA_FUSE_HADAMARD_QUANT=1.
+_DSA_FUSE_HADAMARD_QUANT = get_bool_env_var("SGLANG_DSA_FUSE_HADAMARD_QUANT")
+# Opt-in: route the indexer q/k RoPE through the portable sglang fused-rope JIT
+# kernel (jit_kernel/rope.py -> rope.cuh, hipified for gfx950) instead of aiter's
+# slower cached-rope (kn_entry_2c_sbhd_cached, ~4.2x slower vs the B200 fused_rope
+# in the GLM-5.2 decode profile). gfx950; handles neox + interleaved via is_neox.
+# Enable with SGLANG_DSA_FUSED_ROPE=1.
+_DSA_FUSED_ROPE = get_bool_env_var("SGLANG_DSA_FUSED_ROPE")
 # Whether the aiter preshuffle paged-MQA path (page_size=64 + Preshuffle=True +
 # KVBlockSize=64) can be used. Falls back to the legacy page_size=1 / KVBlockSize=1
 # path when the gluon kernel is unavailable (Triton<3.5 and no AOT bundle).
@@ -428,6 +437,22 @@ class Indexer(MultiPlatformOp):
             device=get_global_server_args().device,
         )
         self.block_size = block_size
+        # Fuse the query hadamard + fp8 quant when opted in, on gfx950, and the
+        # shape is a single quant group (head_dim == block_size, power of 2).
+        self.fuse_hadamard_quant = (
+            _DSA_FUSE_HADAMARD_QUANT
+            and _is_hip
+            and _is_gfx95_supported
+            and self.head_dim == self.block_size
+            and (self.head_dim & (self.head_dim - 1)) == 0
+        )
+        # Opt-in fused-rope path (gfx950): replace aiter's cached-rope with the
+        # portable sglang fused-rope JIT kernel (matches the CUDA/B200 path, which
+        # also uses apply_rope_inplace). Handles both neox and interleaved (GLM-5.2
+        # uses interleaved, is_neox_style=False) via the is_neox arg. cos_sin_cache
+        # is lazily built as fp32 (what the kernel expects).
+        self.fused_rope = _DSA_FUSED_ROPE and _is_hip and _is_gfx95_supported
+        self._fused_rope_cos_sin = None
         self.scale_fmt = scale_fmt
         self.softmax_scale = self.head_dim**-0.5
 
@@ -483,6 +508,31 @@ class Indexer(MultiPlatformOp):
         weights = weights * self.n_heads**-0.5
         weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
         return weights
+
+    def _quant_query(self, query, act_quant, weights=None):
+        """Quantize the indexer query to fp8. When fusion is enabled the query
+        is passed in WITHOUT the hadamard (skipped in _get_q_k_bf16) and the
+        fused kernel does hadamard + quant in one pass; otherwise it has already
+        been hadamard'd and we just act_quant it.
+
+        If `weights` (the head-gate, ready before quant on the decode path) is
+        passed AND fusion is on, the kernel also folds
+        `_apply_q_scale_and_softmax_scale` and returns
+        `(q_fp8, q_scale, weights_scaled)`; the caller then skips that elementwise.
+        Otherwise returns `(q_fp8, q_scale)`."""
+        if self.fuse_hadamard_quant:
+            from sglang.srt.layers.attention.dsa.triton_hadamard_quant import (
+                fused_hadamard_act_quant,
+            )
+
+            return fused_hadamard_act_quant(
+                query,
+                self.block_size,
+                self.scale_fmt,
+                weights=weights,
+                softmax_scale=self.softmax_scale,
+            )
+        return act_quant(query, self.block_size, self.scale_fmt)
 
     @torch.compile(dynamic=True)
     def _apply_q_scale_and_softmax_scale(
@@ -566,7 +616,22 @@ class Indexer(MultiPlatformOp):
                 key, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
             )
 
-        q_rope, k_rope = self.rotary_emb(positions, q_rope, k_rope)
+        if self.fused_rope:
+            from sglang.jit_kernel.rope import apply_rope_inplace
+
+            # q_rope [l,h,rope] and k_rope [l,rope] are views into query/key, so
+            # the in-place rotation updates them directly (k as [l,1,rope]). The
+            # guarded write-back below self-aliases and no-ops.
+            apply_rope_inplace(
+                q_rope,
+                k_rope.unsqueeze(1),
+                self._fused_rope_cos_sin_cache(),
+                positions,
+                is_neox=self.rotary_emb.is_neox_style,
+                rope_dim=self.rope_head_dim,
+            )
+        else:
+            q_rope, k_rope = self.rotary_emb(positions, q_rope, k_rope)
 
         self._update_rope_guarded(query[..., : self.rope_head_dim], q_rope)
         self._update_rope_guarded(key[..., : self.rope_head_dim], k_rope)
@@ -574,7 +639,8 @@ class Indexer(MultiPlatformOp):
         if enable_dual_stream:
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
-            query = self._maybe_rotate(query)
+            if not self.fuse_hadamard_quant:
+                query = self._maybe_rotate(query)
 
             with torch.cuda.stream(self.alt_stream):
                 key = self._maybe_rotate(key)
@@ -587,7 +653,8 @@ class Indexer(MultiPlatformOp):
             key = self._maybe_rotate(key)
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
-            query = self._maybe_rotate(query)
+            if not self.fuse_hadamard_quant:
+                query = self._maybe_rotate(query)
 
             with torch.cuda.stream(self.alt_stream):
                 key = cp_all_gather_rerange_output(
@@ -599,7 +666,8 @@ class Indexer(MultiPlatformOp):
             current_stream.wait_stream(self.alt_stream)
             return query, key, weights_raw
         else:
-            query = self._maybe_rotate(query)
+            if not self.fuse_hadamard_quant:
+                query = self._maybe_rotate(query)
             key = self._maybe_rotate(key)
 
         # allgather+rerrange
@@ -625,7 +693,22 @@ class Indexer(MultiPlatformOp):
             key, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
         )
 
-        _, k_rope = self.rotary_emb(positions, k_rope, k_rope)
+        if self.fused_rope:
+            from sglang.jit_kernel.rope import apply_rope_inplace
+
+            # Key-only rope: apply_rope_inplace mutates both q and k, so pass a
+            # throwaway clone as q and the real k_rope view ([l,1,rope]) as k.
+            k3 = k_rope.unsqueeze(1)
+            apply_rope_inplace(
+                k3.clone(),
+                k3,
+                self._fused_rope_cos_sin_cache(),
+                positions,
+                is_neox=self.rotary_emb.is_neox_style,
+                rope_dim=self.rope_head_dim,
+            )
+        else:
+            _, k_rope = self.rotary_emb(positions, k_rope, k_rope)
         self._update_rope_guarded(key[..., : self.rope_head_dim], k_rope)
         key = rotate_activation(key)
 
@@ -762,6 +845,21 @@ class Indexer(MultiPlatformOp):
 
         current_stream.wait_stream(self.alt_stream)
         return q_fp8, weights
+
+    def _fused_rope_cos_sin_cache(self) -> torch.Tensor:
+        # aiter's rope stores cos/sin separately as [max_pos, 1, 1, rope/2];
+        # apply_rope_inplace wants a single [max_pos, rope] fp32 cache with the
+        # first half cos and the second half sin. Built once, lazily.
+        if self._fused_rope_cos_sin is None:
+            mp = self.rotary_emb.cos_cache.shape[0]
+            self._fused_rope_cos_sin = torch.cat(
+                [
+                    self.rotary_emb.cos_cache.reshape(mp, -1).float(),
+                    self.rotary_emb.sin_cache.reshape(mp, -1).float(),
+                ],
+                dim=-1,
+            ).contiguous()
+        return self._fused_rope_cos_sin
 
     @staticmethod
     def _update_rope_guarded(dst: torch.Tensor, src: torch.Tensor) -> None:
@@ -1720,7 +1818,15 @@ class Indexer(MultiPlatformOp):
             query, key, weights_raw = self._get_q_k_bf16(
                 q_lora, x, positions, enable_dual_stream, forward_batch=forward_batch
             )
-            q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+            if self.fuse_hadamard_quant:
+                # fold _apply_q_scale_and_softmax_scale (weights * q_scale *
+                # softmax_scale) into the fused quant kernel: weights is ready here
+                # and the kernel already emits q_scale, so no separate launch.
+                q_fp8, q_scale, weights = self._quant_query(
+                    query, act_quant, weights=weights
+                )
+            else:
+                q_fp8, q_scale = self._quant_query(query, act_quant)
             with torch.cuda.stream(self.alt_stream):
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
@@ -1731,7 +1837,7 @@ class Indexer(MultiPlatformOp):
             current_stream.wait_stream(self.alt_stream)
             if self.use_dsa_indexer_fusion:
                 weights = self._scale_head_gates(weights_raw, q_scale)
-            else:
+            elif not self.fuse_hadamard_quant:
                 weights = self._apply_q_scale_and_softmax_scale(weights, q_scale)
         else:
             query, key, weights_raw = self._get_q_k_bf16(
@@ -1742,7 +1848,7 @@ class Indexer(MultiPlatformOp):
                 current_stream = torch.cuda.current_stream()
                 self.alt_stream.wait_stream(current_stream)
 
-                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+                q_fp8, q_scale = self._quant_query(query, act_quant)
                 with torch.cuda.stream(self.alt_stream):
                     self._store_index_k_cache(
                         forward_batch=forward_batch,
@@ -1752,7 +1858,7 @@ class Indexer(MultiPlatformOp):
                     )
                 current_stream.wait_stream(self.alt_stream)
             elif not in_piecewise_or_breakable_cuda_graph:
-                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+                q_fp8, q_scale = self._quant_query(query, act_quant)
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
                     layer_id=layer_id,
@@ -1764,7 +1870,7 @@ class Indexer(MultiPlatformOp):
                 # still need q_fp8 for paged topk and q_scale for
                 # logits_head_gate_graph. K-cache storage is handled by the
                 # full graph split path when prefill requires it.
-                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+                q_fp8, q_scale = self._quant_query(query, act_quant)
 
             # aiter (ROCm gfx95): the 3-tuple (fp8, scale, bf16) from
             # fused_rms_fp8_group_quant is passed directly to _get_logits_head_gate,


### PR DESCRIPTION
## Motivation

On gfx950 the DSA indexer applies RoPE to its q/k through aiter's cached-position
kernel (`kn_entry_2c_sbhd_cached_indirect_inplace`). This adds an opt-in path
that instead routes the indexer q/k rope through the portable
`apply_rope_inplace` kernel already used on the CUDA path, which is faster for
the indexer's small q/k shapes.

## Modifications

Add `SGLANG_DSA_FUSED_ROPE=1` (gfx950 only, default off): route the indexer q/k
rope through `jit_kernel/rope.py`'s `apply_rope_inplace`, for both
`_get_q_k_bf16` and `_get_k_bf16`. Supports the GLM-5.2 interleaved
(`is_neox=False`) layout.

## Accuracy Tests

GLM-5.2-MXFP4, MI355X TP4, GSM8K (1319 questions):

| config | GSM8K |
|---|---|
| baseline | 0.925 |
| fused-rope on | 0.936 |

## Speed Benchmarks

GLM-5.2-MXFP4, MI355X TP4, graphs-on, random 8192/1024, `sglang.bench_serving`, median.

Baseline:

| concurrency | TTFT (ms) | TPOT (ms) | E2EL (ms) |
|---|---|---|---|
| 2  | 661   | 14.00 | 15332 |
| 4  | 1412  | 14.58 | 16600 |
| 8  | 2024  | 16.41 | 20231 |
| 16 | 3543  | 19.48 | 26342 |
| 32 | 6627  | 22.99 | 36047 |
| 64 | 13058 | 29.02 | 55110 |

Fused-rope on:

| concurrency | TTFT (ms) | TPOT (ms) | Δ TPOT | E2EL (ms) | Δ E2EL |
|---|---|---|---|---|---|
| 2  | 652   | 13.90 | −0.71% | 15157 | −1.14% |
| 4  | 1231  | 14.48 | −0.69% | 16502 | −0.59% |
| 8  | 2005  | 16.24 | −1.04% | 19880 | −1.73% |
| 16 | 3589  | 19.32 | −0.82% | 26164 | −0.68% |
| 32 | 6633  | 22.80 | −0.83% | 36048 | −0.00% |
| 64 | 12850 | 28.81 | −0.72% | 54391 | −1.30% |

## Checklist

- [x] Format the code with pre-commit.
- [x] Accuracy results provided (GSM8K above).
- [x] e2e benchmark results provided (above).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28764575913](https://github.com/sgl-project/sglang/actions/runs/28764575913)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28764575795](https://github.com/sgl-project/sglang/actions/runs/28764575795)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->