### PR TITLE
Fix Gemma4 video frame metadata

### DIFF
--- a/python/sglang/srt/multimodal/processors/gemma4.py
+++ b/python/sglang/srt/multimodal/processors/gemma4.py
@@ -13,7 +13,7 @@
 # ==============================================================================
 
 import re
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -78,14 +78,17 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
         first_stride = _SSCP_CONV_STRIDE_SIZES[0][0]
         return hop * first_stride
 
-    def _video_decoder_to_tensor(self, vdw: VideoDecoderWrapper) -> torch.Tensor:
-        """Convert a VideoDecoderWrapper to a (sampled_frames, C, H, W) uint8 tensor.
+    def _video_decoder_to_tensor(
+        self, vdw: VideoDecoderWrapper
+    ) -> Tuple[torch.Tensor, Dict]:
+        """Convert a VideoDecoderWrapper to a tensor and matching metadata.
 
         SGLang's load_video returns VideoDecoderWrapper which the HF
         Gemma4VideoProcessor does not recognise (expects torch.Tensor or
         np.ndarray).  We replicate HF's uniform frame sampling here to
         avoid materialising the entire video in memory, then delegate the
         rest (resize, patchify, position IDs) to the HF video processor.
+        Gemma4 also needs the sampled frame indices to derive timestamps.
         """
         total = len(vdw)
         num_frames = getattr(
@@ -98,7 +101,16 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
         else:
             indices = torch.arange(0, total, total / num_frames).int().tolist()
         frames_np = vdw.get_frames_at(indices)  # (N, H, W, C)
-        return torch.from_numpy(frames_np).permute(0, 3, 1, 2).contiguous()
+        video = torch.from_numpy(frames_np).permute(0, 3, 1, 2).contiguous()
+        fps = vdw.avg_fps
+        metadata = {
+            "fps": fps,
+            "duration": total / fps if fps and fps > 0 else None,
+            "total_num_frames": total,
+            "frames_indices": indices,
+            "video_backend": "torchcodec",
+        }
+        return video, metadata
 
     def process_mm_data(
         self, input_text, images=None, videos=None, audios=None, **kwargs
@@ -114,15 +126,17 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
                 padded.append(a)
             audios = padded
         if videos:
-            videos = [
-                (
-                    self._video_decoder_to_tensor(v)
-                    if isinstance(v, VideoDecoderWrapper)
-                    else v
-                )
-                for v in videos
-            ]
+            processed_videos = []
+            video_metadata = []
+            for video in videos:
+                if isinstance(video, VideoDecoderWrapper):
+                    video, metadata = self._video_decoder_to_tensor(video)
+                    video_metadata.append(metadata)
+                processed_videos.append(video)
+            videos = processed_videos
             kwargs.setdefault("do_sample_frames", False)
+            if video_metadata and len(video_metadata) == len(videos):
+                kwargs.setdefault("video_metadata", video_metadata)
         return super().process_mm_data(
             input_text, images=images, videos=videos, audios=audios, **kwargs
         )

--- a/test/registered/unit/managers/test_mm_process_config.py
+++ b/test/registered/unit/managers/test_mm_process_config.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+
 from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
@@ -284,6 +286,30 @@ class TestOverrideProcessorsConfigInjection(unittest.TestCase):
         audio_kw = call_kwargs.kwargs.get("audio_kwargs", {})
         # User config can override truncation if they explicitly set it
         self.assertTrue(audio_kw.get("truncation"))
+
+    def test_gemma4_video_decoder_injects_frame_metadata(self):
+        from sglang.srt.multimodal.processors.gemma4 import Gemma4SGLangProcessor
+        from sglang.srt.utils.video_decoder import VideoDecoderWrapper
+
+        proc, mock_proc = self._make_override_processor(Gemma4SGLangProcessor, {})
+        proc._processor.video_processor.num_frames = 3
+
+        video = MagicMock(spec=VideoDecoderWrapper)
+        video.__len__.return_value = 10
+        video.avg_fps = 5.0
+        video.get_frames_at.return_value = np.zeros((3, 4, 5, 3), dtype=np.uint8)
+
+        proc.process_mm_data("test", videos=[video])
+
+        call_kwargs = mock_proc.__call__.call_args.kwargs
+        video_metadata = call_kwargs.get("video_metadata")
+        self.assertEqual(call_kwargs.get("do_sample_frames"), False)
+        self.assertEqual(video_metadata[0]["frames_indices"], [0, 3, 6])
+        self.assertEqual(video_metadata[0]["fps"], 5.0)
+        self.assertEqual(video_metadata[0]["duration"], 2.0)
+        self.assertEqual(video_metadata[0]["total_num_frames"], 10)
+        self.assertEqual(video_metadata[0]["video_backend"], "torchcodec")
+        self.assertEqual(call_kwargs["videos"][0].shape, (3, 3, 4, 5))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- return sampled frame metadata from Gemma4 VideoDecoderWrapper conversion
- pass video_metadata with frames_indices when using pre-sampled Gemma4 video tensors
- add a unit test covering the Gemma4 metadata injection path

Fixes #29171

## Test
- git diff --check
- PYTHONPATH=python python3 -m py_compile python/sglang/srt/multimodal/processors/gemma4.py test/registered/unit/managers/test_mm_process_config.py

Note: full pytest was not run locally because the system Python environment is missing runtime dependencies such as orjson/torch.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28764254606](https://github.com/sgl-project/sglang/actions/runs/28764254606)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28764254513](https://github.com/sgl-project/sglang/actions/runs/28764254513)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->