### PR TITLE
Add fused sampler for small top-k

### DIFF
--- a/python/sglang/jit_kernel/csrc/sampling/fused_sampler.cuh
+++ b/python/sglang/jit_kernel/csrc/sampling/fused_sampler.cuh
@@ -1,0 +1,418 @@
+#pragma once
+
+#include <sgl_kernel/tensor.h>   // For TensorMatcher, SymbolicSize, SymbolicDevice
+#include <sgl_kernel/utils.h>    // For RuntimeCheck, div_ceil
+
+#include <sgl_kernel/utils.cuh>  // For LaunchKernel, scalar dtype aliases
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cfloat>
+#include <climits>
+#include <cstdint>
+#include <type_traits>
+
+namespace {
+
+constexpr uint32_t kThreadsPerBlock = 256;
+constexpr uint32_t kTileSize = 1024;
+
+template <typename T>
+SGL_DEVICE float load_logit_as_float(const T* ptr, int64_t offset) {
+  if constexpr (std::is_same_v<T, fp32_t>) {
+    return ptr[offset];
+  } else if constexpr (std::is_same_v<T, fp16_t>) {
+    return __half2float(ptr[offset]);
+  } else {
+    return __bfloat162float(ptr[offset]);
+  }
+}
+
+SGL_DEVICE bool pair_greater(float lhs_score, int32_t lhs_idx, float rhs_score, int32_t rhs_idx) {
+  if (lhs_idx < 0) return false;
+  if (rhs_idx < 0) return true;
+  return lhs_score > rhs_score || (lhs_score == rhs_score && lhs_idx < rhs_idx);
+}
+
+SGL_DEVICE bool pair_less_than_prev(float score, int32_t idx, float prev_score, int32_t prev_idx) {
+  if (idx < 0) return false;
+  if (prev_idx < 0) return true;
+  return score < prev_score || (score == prev_score && idx > prev_idx);
+}
+
+template <typename DType>
+__global__ void greedy_sample_kernel(
+    int64_t* __restrict__ out,
+    const DType* __restrict__ logits,
+    uint32_t batch_size,
+    uint32_t vocab_size) {
+  const uint32_t row = blockIdx.x;
+  if (row >= batch_size) return;
+
+  const DType* row_logits = logits + static_cast<int64_t>(row) * vocab_size;
+  float local_best = -FLT_MAX;
+  int32_t local_idx = -1;
+
+  for (uint32_t col = threadIdx.x; col < vocab_size; col += blockDim.x) {
+    const float score = load_logit_as_float(row_logits, col);
+    if (pair_greater(score, static_cast<int32_t>(col), local_best, local_idx)) {
+      local_best = score;
+      local_idx = static_cast<int32_t>(col);
+    }
+  }
+
+  __shared__ float reduce_scores[kThreadsPerBlock];
+  __shared__ int32_t reduce_indices[kThreadsPerBlock];
+  reduce_scores[threadIdx.x] = local_best;
+  reduce_indices[threadIdx.x] = local_idx;
+  __syncthreads();
+
+  for (uint32_t stride = kThreadsPerBlock / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride &&
+        pair_greater(reduce_scores[threadIdx.x + stride], reduce_indices[threadIdx.x + stride],
+                     reduce_scores[threadIdx.x], reduce_indices[threadIdx.x])) {
+      reduce_scores[threadIdx.x] = reduce_scores[threadIdx.x + stride];
+      reduce_indices[threadIdx.x] = reduce_indices[threadIdx.x + stride];
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    out[row] = static_cast<int64_t>(reduce_indices[0]);
+  }
+}
+
+template <typename DType, uint32_t kTopK, bool kNeedsTopP>
+__global__ void tile_topk_iterative_kernel(
+    float* __restrict__ tile_scores,
+    int32_t* __restrict__ tile_indices,
+    float* __restrict__ tile_exp_sums,
+    const DType* __restrict__ logits,
+    const float* __restrict__ temperatures,
+    uint32_t batch_size,
+    uint32_t vocab_size,
+    uint32_t num_tiles) {
+  const uint32_t tile_id = blockIdx.x;
+  const uint32_t row = blockIdx.y;
+  if (row >= batch_size || tile_id >= num_tiles) return;
+
+  const uint32_t tile_start = tile_id * kTileSize;
+  const DType* row_logits = logits + static_cast<int64_t>(row) * vocab_size;
+
+  __shared__ float values[kTileSize];
+  __shared__ float reduce_scores[kThreadsPerBlock];
+  __shared__ int32_t reduce_indices[kThreadsPerBlock];
+  __shared__ float selected_score;
+  __shared__ int32_t selected_idx;
+
+  for (uint32_t offset = threadIdx.x; offset < kTileSize; offset += blockDim.x) {
+    const uint32_t col = tile_start + offset;
+    values[offset] = col < vocab_size ? load_logit_as_float(row_logits, col) : -FLT_MAX;
+  }
+  __syncthreads();
+
+  float prev_score = FLT_MAX;
+  int32_t prev_idx = -1;
+  const int64_t out_base =
+      (static_cast<int64_t>(row) * num_tiles + tile_id) * static_cast<int64_t>(kTopK);
+
+#pragma unroll
+  for (uint32_t rank = 0; rank < kTopK; ++rank) {
+    float local_best = -FLT_MAX;
+    int32_t local_idx = -1;
+
+    for (uint32_t offset = threadIdx.x; offset < kTileSize; offset += blockDim.x) {
+      const uint32_t col = tile_start + offset;
+      if (col >= vocab_size) continue;
+      const float score = values[offset];
+      const int32_t idx = static_cast<int32_t>(col);
+      if (pair_less_than_prev(score, idx, prev_score, prev_idx) &&
+          pair_greater(score, idx, local_best, local_idx)) {
+        local_best = score;
+        local_idx = idx;
+      }
+    }
+
+    reduce_scores[threadIdx.x] = local_best;
+    reduce_indices[threadIdx.x] = local_idx;
+    __syncthreads();
+
+    for (uint32_t stride = kThreadsPerBlock / 2; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride &&
+          pair_greater(reduce_scores[threadIdx.x + stride], reduce_indices[threadIdx.x + stride],
+                       reduce_scores[threadIdx.x], reduce_indices[threadIdx.x])) {
+        reduce_scores[threadIdx.x] = reduce_scores[threadIdx.x + stride];
+        reduce_indices[threadIdx.x] = reduce_indices[threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+
+    if (threadIdx.x == 0) {
+      selected_score = reduce_scores[0];
+      selected_idx = reduce_indices[0];
+      tile_scores[out_base + rank] = selected_score;
+      tile_indices[out_base + rank] = selected_idx;
+    }
+    __syncthreads();
+
+    prev_score = selected_score;
+    prev_idx = selected_idx;
+  }
+
+  if constexpr (kNeedsTopP) {
+    const float tile_max_score = tile_scores[out_base];
+    const float inv_temperature = 1.0f / fmaxf(temperatures[row], 1.0e-6f);
+    const float tile_max_scaled = tile_max_score * inv_temperature;
+    float local_sum = 0.0f;
+
+    for (uint32_t offset = threadIdx.x; offset < kTileSize; offset += blockDim.x) {
+      const uint32_t col = tile_start + offset;
+      if (col < vocab_size) {
+        local_sum += expf(values[offset] * inv_temperature - tile_max_scaled);
+      }
+    }
+
+    reduce_scores[threadIdx.x] = local_sum;
+    __syncthreads();
+
+    for (uint32_t stride = kThreadsPerBlock / 2; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride) {
+        reduce_scores[threadIdx.x] += reduce_scores[threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+
+    if (threadIdx.x == 0) {
+      tile_exp_sums[static_cast<int64_t>(row) * num_tiles + tile_id] = reduce_scores[0];
+    }
+  }
+}
+
+template <uint32_t kTopK, bool kNeedsTopP>
+__global__ void merge_topk_sample_kernel(
+    int64_t* __restrict__ out,
+    const float* __restrict__ tile_scores,
+    const int32_t* __restrict__ tile_indices,
+    const float* __restrict__ tile_exp_sums,
+    const float* __restrict__ temperatures,
+    const float* __restrict__ top_ps,
+    const float* __restrict__ uniforms,
+    uint32_t batch_size,
+    uint32_t num_tiles) {
+  const uint32_t row = blockIdx.x;
+  if (row >= batch_size) return;
+
+  __shared__ float reduce_scores[kThreadsPerBlock];
+  __shared__ int32_t reduce_indices[kThreadsPerBlock];
+  __shared__ float selected_scores[kTopK];
+  __shared__ int32_t selected_indices[kTopK];
+  __shared__ float selected_score;
+  __shared__ int32_t selected_idx;
+  __shared__ float full_total_exp;
+
+  const uint32_t candidate_count = num_tiles * kTopK;
+  const int64_t row_base = static_cast<int64_t>(row) * candidate_count;
+  float prev_score = FLT_MAX;
+  int32_t prev_idx = -1;
+
+#pragma unroll
+  for (uint32_t rank = 0; rank < kTopK; ++rank) {
+    float local_best = -FLT_MAX;
+    int32_t local_idx = -1;
+
+    for (uint32_t i = threadIdx.x; i < candidate_count; i += blockDim.x) {
+      const int64_t offset = row_base + i;
+      const int32_t idx = tile_indices[offset];
+      if (idx < 0) continue;
+      const float score = tile_scores[offset];
+      if (pair_less_than_prev(score, idx, prev_score, prev_idx) &&
+          pair_greater(score, idx, local_best, local_idx)) {
+        local_best = score;
+        local_idx = idx;
+      }
+    }
+
+    reduce_scores[threadIdx.x] = local_best;
+    reduce_indices[threadIdx.x] = local_idx;
+    __syncthreads();
+
+    for (uint32_t stride = kThreadsPerBlock / 2; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride &&
+          pair_greater(reduce_scores[threadIdx.x + stride], reduce_indices[threadIdx.x + stride],
+                       reduce_scores[threadIdx.x], reduce_indices[threadIdx.x])) {
+        reduce_scores[threadIdx.x] = reduce_scores[threadIdx.x + stride];
+        reduce_indices[threadIdx.x] = reduce_indices[threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+
+    if (threadIdx.x == 0) {
+      selected_score = reduce_scores[0];
+      selected_idx = reduce_indices[0];
+      selected_scores[rank] = selected_score;
+      selected_indices[rank] = selected_idx;
+    }
+    __syncthreads();
+
+    prev_score = selected_score;
+    prev_idx = selected_idx;
+  }
+
+  const float inv_temperature = 1.0f / fmaxf(temperatures[row], 1.0e-6f);
+  const float max_scaled = selected_scores[0] * inv_temperature;
+  const float top_p = fminf(fmaxf(top_ps[row], 0.0f), 1.0f);
+
+  if constexpr (kNeedsTopP) {
+    float local_total = 0.0f;
+    for (uint32_t tile = threadIdx.x; tile < num_tiles; tile += blockDim.x) {
+      const int64_t offset = row_base + static_cast<int64_t>(tile) * kTopK;
+      if (tile_indices[offset] >= 0) {
+        local_total +=
+            expf(tile_scores[offset] * inv_temperature - max_scaled) *
+            tile_exp_sums[static_cast<int64_t>(row) * num_tiles + tile];
+      }
+    }
+
+    reduce_scores[threadIdx.x] = local_total;
+    __syncthreads();
+
+    for (uint32_t stride = kThreadsPerBlock / 2; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride) {
+        reduce_scores[threadIdx.x] += reduce_scores[threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+
+    if (threadIdx.x == 0) {
+      full_total_exp = reduce_scores[0];
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    float weights[kTopK];
+    uint32_t valid_count = 0;
+
+#pragma unroll
+    for (uint32_t i = 0; i < kTopK; ++i) {
+      if (selected_indices[i] >= 0) {
+        const float w = expf(selected_scores[i] * inv_temperature - max_scaled);
+        weights[i] = w;
+        valid_count = i + 1;
+      } else {
+        weights[i] = 0.0f;
+      }
+    }
+
+    float accepted_sum = 0.0f;
+    uint32_t accepted_count = 0;
+    const float cutoff = kNeedsTopP ? top_p * full_total_exp : FLT_MAX;
+#pragma unroll
+    for (uint32_t i = 0; i < kTopK; ++i) {
+      if (i >= valid_count) break;
+      if (accepted_sum > cutoff) break;
+      accepted_sum += weights[i];
+      accepted_count = i + 1;
+    }
+    if (accepted_count == 0 && valid_count > 0) {
+      accepted_count = 1;
+      accepted_sum = weights[0];
+    }
+
+    const float target = fminf(fmaxf(uniforms[row], 0.0f), 0.99999994f) * accepted_sum;
+    float cumsum = 0.0f;
+    int32_t sampled = selected_indices[0];
+#pragma unroll
+    for (uint32_t i = 0; i < kTopK; ++i) {
+      if (i >= accepted_count) break;
+      cumsum += weights[i];
+      sampled = selected_indices[i];
+      if (cumsum >= target) break;
+    }
+    out[row] = static_cast<int64_t>(sampled);
+  }
+}
+
+template <typename DType, uint32_t kTopK, bool kNeedsTopP>
+struct FusedTopKSampleKernel {
+  static_assert(
+      std::is_same_v<DType, fp32_t> || std::is_same_v<DType, fp16_t> || std::is_same_v<DType, bf16_t>,
+      "fused sampler supports fp32/fp16/bf16 logits");
+  static_assert(kTopK >= 1 && kTopK <= 8, "top_k must be in [1, 8]");
+
+  static void run(
+      const tvm::ffi::TensorView out,
+      const tvm::ffi::TensorView logits,
+      const tvm::ffi::TensorView temperatures,
+      const tvm::ffi::TensorView top_ps,
+      const tvm::ffi::TensorView uniforms,
+      const tvm::ffi::TensorView scratch_scores,
+      const tvm::ffi::TensorView scratch_indices,
+      const tvm::ffi::TensorView scratch_sums) {
+    using namespace host;
+
+    auto B = SymbolicSize{"batch_size"};
+    auto V = SymbolicSize{"vocab_size"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+
+    TensorMatcher({B, V}).with_dtype<DType>().with_device(device).verify(logits);
+    TensorMatcher({B}).with_dtype<fp32_t>().with_device(device).verify(temperatures).verify(top_ps).verify(uniforms);
+    TensorMatcher({B}).with_dtype<int64_t>().with_device(device).verify(out);
+
+    const uint32_t batch_size = static_cast<uint32_t>(B.unwrap());
+    const uint32_t vocab_size = static_cast<uint32_t>(V.unwrap());
+    const auto dl_device = device.unwrap();
+    RuntimeCheck(batch_size > 0, "fused_topk_sample: batch_size must be > 0");
+    RuntimeCheck(vocab_size > 0, "fused_topk_sample: vocab_size must be > 0");
+    RuntimeCheck(kTopK <= vocab_size, "fused_topk_sample: top_k exceeds vocab_size");
+
+    if constexpr (kTopK == 1) {
+      LaunchKernel(batch_size, kThreadsPerBlock, dl_device)(
+          greedy_sample_kernel<DType>,
+          static_cast<int64_t*>(out.data_ptr()),
+          static_cast<const DType*>(logits.data_ptr()),
+          batch_size,
+          vocab_size);
+      return;
+    }
+
+    const uint32_t num_tiles = static_cast<uint32_t>(div_ceil(vocab_size, kTileSize));
+    auto T = SymbolicSize{"num_tiles"};
+    auto K = SymbolicSize{"top_k"};
+    T.set_value(num_tiles);
+    K.set_value(kTopK);
+    TensorMatcher({B, T, K}).with_dtype<fp32_t>().with_device(device).verify(scratch_scores);
+    TensorMatcher({B, T, K}).with_dtype<int32_t>().with_device(device).verify(scratch_indices);
+    float* scratch_sums_ptr = nullptr;
+    if constexpr (kNeedsTopP) {
+      TensorMatcher({B, T}).with_dtype<fp32_t>().with_device(device).verify(scratch_sums);
+      scratch_sums_ptr = static_cast<float*>(scratch_sums.data_ptr());
+    }
+
+    LaunchKernel(dim3(num_tiles, batch_size), kThreadsPerBlock, dl_device)(
+        tile_topk_iterative_kernel<DType, kTopK, kNeedsTopP>,
+        static_cast<float*>(scratch_scores.data_ptr()),
+        static_cast<int32_t*>(scratch_indices.data_ptr()),
+        scratch_sums_ptr,
+        static_cast<const DType*>(logits.data_ptr()),
+        static_cast<const float*>(temperatures.data_ptr()),
+        batch_size,
+        vocab_size,
+        num_tiles);
+    LaunchKernel(batch_size, kThreadsPerBlock, dl_device)(
+        merge_topk_sample_kernel<kTopK, kNeedsTopP>,
+        static_cast<int64_t*>(out.data_ptr()),
+        static_cast<const float*>(scratch_scores.data_ptr()),
+        static_cast<const int32_t*>(scratch_indices.data_ptr()),
+        static_cast<const float*>(scratch_sums_ptr),
+        static_cast<const float*>(temperatures.data_ptr()),
+        static_cast<const float*>(top_ps.data_ptr()),
+        static_cast<const float*>(uniforms.data_ptr()),
+        batch_size,
+        num_tiles);
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/fused_sampler.py
+++ b/python/sglang/jit_kernel/fused_sampler.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+_TILE_SIZE = 1024
+_MAX_TOP_K = 8
+_SUPPORTED_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+
+
+@cache_once
+def _jit_fused_sampler_module(
+    dtype: torch.dtype, top_k: int, needs_top_p: bool
+) -> Module:
+    args = make_cpp_args(dtype, top_k, needs_top_p)
+    return load_jit(
+        "fused_sampler",
+        *args,
+        cuda_files=["sampling/fused_sampler.cuh"],
+        cuda_wrappers=[("fused_topk_sample", f"FusedTopKSampleKernel<{args}>::run")],
+        extra_cuda_cflags=["-O3", "--use_fast_math"],
+    )
+
+
+def _as_batch_float_tensor(
+    value: float | torch.Tensor,
+    *,
+    batch_size: int,
+    device: torch.device,
+    name: str,
+) -> torch.Tensor:
+    if isinstance(value, torch.Tensor):
+        if value.numel() != batch_size:
+            raise RuntimeError(
+                f"{name} must have {batch_size} values, got shape {tuple(value.shape)}"
+            )
+        return (
+            value.reshape(batch_size)
+            .to(device=device, dtype=torch.float32)
+            .contiguous()
+        )
+    return torch.full((batch_size,), float(value), device=device, dtype=torch.float32)
+
+
+def fused_topk_sample(
+    logits: torch.Tensor,
+    temperatures: float | torch.Tensor,
+    top_ps: float | torch.Tensor,
+    top_k: int,
+    uniforms: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+    scratch_scores: torch.Tensor | None = None,
+    scratch_indices: torch.Tensor | None = None,
+    scratch_sums: torch.Tensor | None = None,
+    needs_top_p: bool | None = None,
+) -> torch.Tensor:
+    """Sample token ids from logits with fused top-k/top-p softmax.
+
+    This lightweight JIT kernel is intended for homogeneous small-top-k batches.
+    It expects logits after any penalties or vocab masks have already been applied.
+    """
+    if logits.dim() != 2:
+        raise RuntimeError(
+            f"logits must be 2D [batch, vocab], got {tuple(logits.shape)}"
+        )
+    if not logits.is_cuda:
+        raise RuntimeError("logits must be a CUDA tensor")
+    if logits.dtype not in _SUPPORTED_DTYPES:
+        raise RuntimeError(
+            f"Unsupported logits dtype {logits.dtype}; supported: {_SUPPORTED_DTYPES}"
+        )
+    if not logits.is_contiguous():
+        logits = logits.contiguous()
+    if top_k < 1 or top_k > _MAX_TOP_K:
+        raise RuntimeError(f"top_k must be in [1, {_MAX_TOP_K}], got {top_k}")
+
+    batch_size, vocab_size = logits.shape
+    if top_k > vocab_size:
+        raise RuntimeError(f"top_k ({top_k}) must not exceed vocab_size ({vocab_size})")
+
+    device = logits.device
+    temperatures_t = _as_batch_float_tensor(
+        temperatures, batch_size=batch_size, device=device, name="temperatures"
+    )
+    top_ps_t = _as_batch_float_tensor(
+        top_ps, batch_size=batch_size, device=device, name="top_ps"
+    )
+    if needs_top_p is None:
+        if isinstance(top_ps, torch.Tensor):
+            # Standalone callers may rely on inference. The runtime hot path passes
+            # this flag from SamplingBatchInfo to avoid synchronizing here.
+            needs_top_p = bool(torch.any(top_ps_t != 1.0).item())
+        else:
+            needs_top_p = float(top_ps) != 1.0
+    if uniforms is None:
+        uniforms_t = torch.rand((batch_size,), device=device, dtype=torch.float32)
+    else:
+        uniforms_t = _as_batch_float_tensor(
+            uniforms, batch_size=batch_size, device=device, name="uniforms"
+        )
+
+    if out is None:
+        out = torch.empty((batch_size,), device=device, dtype=torch.int64)
+    elif out.shape != (batch_size,) or out.dtype != torch.int64 or out.device != device:
+        raise RuntimeError(
+            "out must have shape (batch_size,), dtype torch.int64, and match logits.device"
+        )
+
+    if top_k == 1:
+        if scratch_scores is None:
+            scratch_scores = torch.empty((0,), device=device, dtype=torch.float32)
+        if scratch_indices is None:
+            scratch_indices = torch.empty((0,), device=device, dtype=torch.int32)
+        if scratch_sums is None:
+            scratch_sums = torch.empty((0,), device=device, dtype=torch.float32)
+    else:
+        num_tiles = (vocab_size + _TILE_SIZE - 1) // _TILE_SIZE
+        expected_shape = (batch_size, num_tiles, top_k)
+        expected_sums_shape = (batch_size, num_tiles)
+        if scratch_scores is None:
+            scratch_scores = torch.empty(
+                expected_shape, device=device, dtype=torch.float32
+            )
+        if scratch_indices is None:
+            scratch_indices = torch.empty(
+                expected_shape, device=device, dtype=torch.int32
+            )
+        if scratch_sums is None:
+            scratch_sums = (
+                torch.empty(expected_sums_shape, device=device, dtype=torch.float32)
+                if needs_top_p
+                else torch.empty((0,), device=device, dtype=torch.float32)
+            )
+        if (
+            scratch_scores.shape != expected_shape
+            or scratch_scores.dtype != torch.float32
+            or scratch_scores.device != device
+        ):
+            raise RuntimeError(
+                "scratch_scores must have shape "
+                f"{expected_shape}, dtype torch.float32, and match logits.device"
+            )
+        if (
+            scratch_indices.shape != expected_shape
+            or scratch_indices.dtype != torch.int32
+            or scratch_indices.device != device
+        ):
+            raise RuntimeError(
+                "scratch_indices must have shape "
+                f"{expected_shape}, dtype torch.int32, and match logits.device"
+            )
+        expected_scratch_sums_shape = expected_sums_shape if needs_top_p else (0,)
+        if (
+            scratch_sums.shape != expected_scratch_sums_shape
+            or scratch_sums.dtype != torch.float32
+            or scratch_sums.device != device
+        ):
+            raise RuntimeError(
+                "scratch_sums must have shape "
+                f"{expected_scratch_sums_shape}, dtype torch.float32, and match logits.device"
+            )
+
+    module = _jit_fused_sampler_module(logits.dtype, int(top_k), bool(needs_top_p))
+    module.fused_topk_sample(
+        out,
+        logits,
+        temperatures_t,
+        top_ps_t,
+        uniforms_t,
+        scratch_scores,
+        scratch_indices,
+        scratch_sums,
+    )
+    return out

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -31,6 +31,7 @@ if is_cuda():
         min_p_sampling_from_probs,
         top_k_top_p_sampling_from_probs,
     )
+    from sglang.jit_kernel.fused_sampler import fused_topk_sample
     from sgl_kernel import (
         top_k_renorm_prob,
         top_p_renorm_prob,
@@ -90,6 +91,37 @@ class Sampler(nn.Module):
             apply_custom_logit_processor(logits, sampling_info)
         sanitize_nan_logits(logits, "sampler: next_token_logits")
         return logits
+
+    def _try_fused_topk_sample_from_logits(
+        self,
+        logits: torch.Tensor,
+        sampling_info: SamplingBatchInfo,
+        return_logprob: bool,
+    ) -> Optional[torch.Tensor]:
+        """Sample directly from logits for homogeneous small-top-k batches."""
+        top_k = sampling_info.fused_top_k
+        if top_k is None:
+            return None
+        if (
+            return_logprob
+            or self.use_ascend_backend
+            or self.use_log_softmax_logprob
+            or sampling_info.need_min_p_sampling
+            or sampling_info.sampling_seed is not None
+            or get_flags().sampling_backend != "flashinfer"
+            or not is_cuda()
+            or not logits.is_cuda
+            or logits.dtype not in (torch.float32, torch.float16, torch.bfloat16)
+        ):
+            return None
+
+        return fused_topk_sample(
+            logits,
+            sampling_info.temperatures,
+            sampling_info.top_ps,
+            top_k,
+            needs_top_p=sampling_info.need_top_p_sampling,
+        )
 
     def forward(
         self,
@@ -177,23 +209,27 @@ class Sampler(nn.Module):
                 if return_logprob and not SGLANG_RETURN_ORIGINAL_LOGPROB:
                     logprobs = logprobs_via_logsoftmax_kernel
             else:
-                # Standard path: do softmax and sample from probs.
-                logits.div_(sampling_info.temperatures)
-
-                # In-place op to save memory
-                logits[:] = torch.softmax(logits, dim=-1)
-                probs = logits
-
-                batch_next_token_ids = self._sample_from_probs(
-                    probs, sampling_info, positions, simple_sampling_case
+                batch_next_token_ids = self._try_fused_topk_sample_from_logits(
+                    logits, sampling_info, return_logprob
                 )
-                if return_logprob and not SGLANG_RETURN_ORIGINAL_LOGPROB:
-                    logprobs = (
-                        logprobs_via_logsoftmax_kernel
-                        if logprobs_via_logsoftmax_kernel is not None
-                        else torch.log(probs)
+                if batch_next_token_ids is None:
+                    # Standard path: do softmax and sample from probs.
+                    logits.div_(sampling_info.temperatures)
+
+                    # In-place op to save memory
+                    logits[:] = torch.softmax(logits, dim=-1)
+                    probs = logits
+
+                    batch_next_token_ids = self._sample_from_probs(
+                        probs, sampling_info, positions, simple_sampling_case
                     )
-                del probs
+                    if return_logprob and not SGLANG_RETURN_ORIGINAL_LOGPROB:
+                        logprobs = (
+                            logprobs_via_logsoftmax_kernel
+                            if logprobs_via_logsoftmax_kernel is not None
+                            else torch.log(probs)
+                        )
+                    del probs
 
         # Attach logprobs to logits_output (in-place modification)
         if return_logprob:

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import torch
 
@@ -18,6 +18,21 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+FUSED_SAMPLER_MAX_TOP_K = 8
+
+
+def get_fused_sampler_top_k(top_ks: Sequence[int]) -> Optional[int]:
+    """Return the homogeneous small sampler top-k supported by fused sampler."""
+    if not top_ks:
+        return None
+
+    top_k = int(top_ks[0])
+    if top_k <= 1 or top_k > FUSED_SAMPLER_MAX_TOP_K:
+        return None
+    if any(int(value) != top_k for value in top_ks):
+        return None
+    return top_k
 
 
 @dataclasses.dataclass
@@ -73,6 +88,9 @@ class SamplingBatchInfo:
     # Handle logit bias
     logit_bias: Optional[torch.Tensor] = None
 
+    # Homogeneous sampler top-k for the fused small-top-k sampler fast path.
+    fused_top_k: Optional[int] = None
+
     @classmethod
     def from_schedule_batch(cls, batch: ScheduleBatch, vocab_size: int):
         global_server_args = get_global_server_args()
@@ -81,6 +99,8 @@ class SamplingBatchInfo:
         reqs = batch.reqs
         device = batch.device
         _pin = is_pin_memory_available(device)
+        top_p_values = [r.sampling_params.top_p for r in reqs]
+        top_k_values = [r.sampling_params.top_k for r in reqs]
         temperatures = (
             torch.tensor(
                 [r.sampling_params.temperature for r in reqs],
@@ -91,12 +111,12 @@ class SamplingBatchInfo:
             .view(-1, 1)
         )
         top_ps = torch.tensor(
-            [r.sampling_params.top_p for r in reqs],
+            top_p_values,
             dtype=torch.float,
             pin_memory=_pin,
         ).to(device, non_blocking=True)
         top_ks = torch.tensor(
-            [r.sampling_params.top_k for r in reqs],
+            top_k_values,
             dtype=torch.int32,
             pin_memory=_pin,
         ).to(device, non_blocking=True)
@@ -198,6 +218,7 @@ class SamplingBatchInfo:
             custom_logit_processor=merged_custom_logit_processor,
             device=device,
             logit_bias=logit_bias,
+            fused_top_k=get_fused_sampler_top_k(top_k_values),
         )
         ret.adjusted_from_schedule_batch(batch, vocab_size)
         return ret
@@ -412,6 +433,8 @@ class SamplingBatchInfo:
         self.need_top_p_sampling |= other.need_top_p_sampling
         self.need_top_k_sampling |= other.need_top_k_sampling
         self.need_min_p_sampling |= other.need_min_p_sampling
+        if self.fused_top_k != other.fused_top_k:
+            self.fused_top_k = None
 
         self.adjusted_merge_batch(other)
 

--- a/test/registered/jit/benchmark/bench_fused_sampler.py
+++ b/test/registered/jit/benchmark/bench_fused_sampler.py
@@ -1,0 +1,135 @@
+import torch
+
+from sglang.jit_kernel.benchmark import marker
+from sglang.jit_kernel.fused_sampler import fused_topk_sample
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=12, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+
+
+def _flashinfer_topk_topp_sample(
+    logits: torch.Tensor,
+    temperatures: torch.Tensor,
+    top_ps: torch.Tensor,
+    top_ks: torch.Tensor,
+    top_k: int,
+) -> torch.Tensor:
+    if top_k == 1:
+        return torch.argmax(logits, dim=-1)
+
+    try:
+        from flashinfer.sampling import top_k_top_p_sampling_from_probs
+    except ImportError:
+        marker.skip("flashinfer.sampling is unavailable")
+
+    probs = torch.softmax(logits / temperatures.view(-1, 1), dim=-1)
+    return top_k_top_p_sampling_from_probs(
+        probs.contiguous(),
+        top_ks,
+        top_ps,
+        filter_apply_order="joint",
+    )
+
+
+def _jit_fused_sample(
+    logits: torch.Tensor,
+    temperatures: torch.Tensor,
+    top_ps: torch.Tensor,
+    uniforms: torch.Tensor,
+    out: torch.Tensor,
+    scratch_scores: torch.Tensor,
+    scratch_indices: torch.Tensor,
+    scratch_sums: torch.Tensor,
+    top_k: int,
+    needs_top_p: bool,
+) -> torch.Tensor:
+    return fused_topk_sample(
+        logits,
+        temperatures,
+        top_ps,
+        top_k,
+        uniforms,
+        out=out,
+        scratch_scores=scratch_scores,
+        scratch_indices=scratch_indices,
+        scratch_sums=scratch_sums,
+        needs_top_p=needs_top_p,
+    )
+
+
+FN_MAP = {
+    "baseline": _flashinfer_topk_topp_sample,
+    "jit": _jit_fused_sample,
+}
+
+
+@marker.parametrize("top_p", [1.0, 0.95], [1.0])
+@marker.parametrize("top_k", [2, 4, 8], [4])
+@marker.parametrize("vocab_size", [128256, 151552], [128256])
+@marker.parametrize("batch_size", [1, 16, 64, 256, 1024], [16])
+@marker.benchmark("impl", ["baseline", "jit"])
+def benchmark(
+    batch_size: int,
+    vocab_size: int,
+    top_k: int,
+    top_p: float,
+    impl: str,
+):
+    logits = torch.randn((batch_size, vocab_size), device="cuda", dtype=torch.float32)
+    temperatures = torch.ones((batch_size,), device="cuda", dtype=torch.float32)
+    top_ps = torch.full((batch_size,), top_p, device="cuda", dtype=torch.float32)
+    uniforms = torch.rand((batch_size,), device="cuda", dtype=torch.float32)
+    top_ks = torch.full((batch_size,), top_k, device="cuda", dtype=torch.int32)
+    needs_top_p = top_p != 1.0
+
+    out = torch.empty((batch_size,), device="cuda", dtype=torch.int64)
+    if top_k == 1:
+        scratch_scores = torch.empty((0,), device="cuda", dtype=torch.float32)
+        scratch_indices = torch.empty((0,), device="cuda", dtype=torch.int32)
+        scratch_sums = torch.empty((0,), device="cuda", dtype=torch.float32)
+    else:
+        num_tiles = (vocab_size + 1023) // 1024
+        scratch_scores = torch.empty(
+            (batch_size, num_tiles, top_k), device="cuda", dtype=torch.float32
+        )
+        scratch_indices = torch.empty(
+            (batch_size, num_tiles, top_k), device="cuda", dtype=torch.int32
+        )
+        scratch_sums = (
+            torch.empty((batch_size, num_tiles), device="cuda", dtype=torch.float32)
+            if needs_top_p
+            else torch.empty((0,), device="cuda", dtype=torch.float32)
+        )
+
+    if impl == "baseline":
+        return marker.do_bench(
+            FN_MAP[impl],
+            input_args=(logits, temperatures, top_ps, top_ks, top_k),
+            graph_clone_args=(0,),
+            disable_log_bandwidth=True,
+        )
+
+    return marker.do_bench(
+        FN_MAP[impl],
+        input_args=(
+            logits,
+            temperatures,
+            top_ps,
+            uniforms,
+            out,
+            scratch_scores,
+            scratch_indices,
+            scratch_sums,
+            top_k,
+            needs_top_p,
+        ),
+        graph_clone_args=(0,),
+        memory_output=(out,),
+        disable_log_bandwidth=True,
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/jit/test_fused_sampler.py
+++ b/test/registered/jit/test_fused_sampler.py
@@ -1,0 +1,96 @@
+import pytest
+import torch
+
+from sglang.jit_kernel.fused_sampler import fused_topk_sample
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+def _reference_topk_sample(
+    logits: torch.Tensor,
+    temperatures: torch.Tensor,
+    top_ps: torch.Tensor,
+    top_k: int,
+    uniforms: torch.Tensor,
+) -> torch.Tensor:
+    if top_k == 1:
+        return torch.argmax(logits, dim=-1)
+
+    probs = torch.softmax(logits.float() / temperatures.view(-1, 1), dim=-1)
+    top_probs, top_idx = torch.topk(probs, k=top_k, dim=-1)
+    out = torch.empty((logits.shape[0],), dtype=torch.int64, device=logits.device)
+
+    for row in range(logits.shape[0]):
+        cutoff = float(top_ps[row].clamp(0.0, 1.0).item())
+        cumulative = 0.0
+        accepted = 0
+        for i in range(top_k):
+            if cumulative > cutoff:
+                break
+            cumulative += float(top_probs[row, i].item())
+            accepted = i + 1
+
+        accepted_sum = float(top_probs[row, :accepted].sum().item())
+        target = float(uniforms[row].clamp(0.0, 0.99999994).item()) * accepted_sum
+        cumulative = 0.0
+        sampled = int(top_idx[row, 0].item())
+        for i in range(accepted):
+            cumulative += float(top_probs[row, i].item())
+            sampled = int(top_idx[row, i].item())
+            if cumulative >= target:
+                break
+        out[row] = sampled
+
+    return out
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("batch_size", [1, 7])
+@pytest.mark.parametrize("vocab_size", [257, 4099])
+@pytest.mark.parametrize("top_k", [1, 4, 8])
+@pytest.mark.parametrize("top_p", [1.0, 0.95])
+def test_fused_topk_sample_matches_reference(batch_size, vocab_size, top_k, top_p):
+    torch.manual_seed(0)
+    logits = torch.randn(batch_size, vocab_size, device="cuda", dtype=torch.float32)
+    logits += torch.arange(vocab_size, device="cuda", dtype=torch.float32) * 1.0e-7
+    temperatures = torch.linspace(0.7, 1.3, batch_size, device="cuda")
+    top_ps = torch.full((batch_size,), top_p, device="cuda", dtype=torch.float32)
+    uniforms = torch.linspace(0.05, 0.95, batch_size, device="cuda")
+
+    actual = fused_topk_sample(logits, temperatures, top_ps, top_k, uniforms)
+    expected = _reference_topk_sample(logits, temperatures, top_ps, top_k, uniforms)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_topk_sample_out_parameter_and_scalar_params():
+    logits = torch.tensor(
+        [[0.0, 1.0, 2.0, 3.0], [4.0, 1.0, 3.0, 2.0]],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    uniforms = torch.tensor([0.01, 0.99], device="cuda", dtype=torch.float32)
+    out = torch.empty((2,), device="cuda", dtype=torch.int64)
+
+    result = fused_topk_sample(logits, 1.0, 1.0, 2, uniforms, out=out)
+    expected = _reference_topk_sample(
+        logits,
+        torch.ones((2,), device="cuda"),
+        torch.ones((2,), device="cuda"),
+        2,
+        uniforms,
+    )
+
+    assert result is out
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_topk_sample_rejects_bad_topk():
+    logits = torch.randn(2, 16, device="cuda", dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="top_k"):
+        fused_topk_sample(logits, 1.0, 1.0, 0)
+    with pytest.raises(RuntimeError, match="top_k"):
+        fused_topk_sample(logits, 1.0, 1.0, 9)

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -12,6 +12,8 @@ import torch
 
 from sglang.srt.sampling.sampling_batch_info import (
     SamplingBatchInfo,
+    get_fused_sampler_top_k,
+    is_fused_sampler_batch_shape_supported,
     merge_bias_tensor,
 )
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
@@ -42,7 +44,6 @@ def _make_info(batch_size=2, **overrides):
 
 
 class TestMergeBiasTensor(CustomTestCase):
-
     def test_both_none_returns_none(self):
         """Test that merging two None tensors returns None."""
         result = merge_bias_tensor(None, None, 2, 3, DEVICE, 0.0)
@@ -87,15 +88,49 @@ class TestMergeBiasTensor(CustomTestCase):
 
 # SamplingBatchInfo.__len__
 class TestSamplingBatchInfoLen(CustomTestCase):
-
     def test_len_matches_batch_size(self):
         """Test that __len__ returns batch size (number of temperature rows)."""
         info = _make_info(batch_size=5)
         self.assertEqual(len(info), 5)
 
 
-class TestMergeCustomLogitProcessor(CustomTestCase):
+class TestFusedSamplerTopK(CustomTestCase):
+    def test_requires_homogeneous_small_non_greedy_top_k(self):
+        """Test the fused sampler gate for sampler top-k values."""
+        self.assertEqual(get_fused_sampler_top_k([2, 2]), 2)
+        self.assertEqual(get_fused_sampler_top_k([8, 8, 8]), 8)
+        self.assertIsNone(get_fused_sampler_top_k([]))
+        self.assertIsNone(get_fused_sampler_top_k([1, 1]))
+        self.assertIsNone(get_fused_sampler_top_k([9, 9]))
+        self.assertIsNone(get_fused_sampler_top_k([2, 3]))
+        self.assertIsNone(get_fused_sampler_top_k([TOP_K_ALL, TOP_K_ALL]))
 
+    def test_batch_shape_supports_k8_only_for_small_batches(self):
+        """Test the fused sampler batch guard for larger top-k values."""
+        self.assertTrue(is_fused_sampler_batch_shape_supported(4, 1024))
+        self.assertTrue(is_fused_sampler_batch_shape_supported(8, 16))
+        self.assertFalse(is_fused_sampler_batch_shape_supported(8, 17))
+
+    def test_merge_preserves_matching_fused_top_k(self):
+        """Test that merging same small top-k batches keeps the fast path enabled."""
+        lhs = _make_info(batch_size=2, fused_top_k=4)
+        rhs = _make_info(batch_size=3, fused_top_k=4)
+
+        lhs.merge_batch(rhs)
+
+        self.assertEqual(lhs.fused_top_k, 4)
+
+    def test_merge_clears_mismatched_fused_top_k(self):
+        """Test that merging different top-k batches disables the fast path."""
+        lhs = _make_info(batch_size=2, fused_top_k=4)
+        rhs = _make_info(batch_size=3, fused_top_k=8)
+
+        lhs.merge_batch(rhs)
+
+        self.assertIsNone(lhs.fused_top_k)
+
+
+class TestMergeCustomLogitProcessor(CustomTestCase):
     def test_both_none_returns_none(self):
         """Test that merging two None processor dicts returns None."""
         result = SamplingBatchInfo.merge_custom_logit_processor(
@@ -142,7 +177,6 @@ class TestMergeCustomLogitProcessor(CustomTestCase):
 
 # apply_logits_bias
 class TestApplyLogitsBias(CustomTestCase):
-
     def test_applies_additive_penalties(self):
         """Test that pre-accumulated additive penalties are added to logits."""
         info = _make_info(batch_size=1)
@@ -193,7 +227,6 @@ class TestApplyLogitsBias(CustomTestCase):
 
 # update_penalties
 class TestUpdatePenalties(CustomTestCase):
-
     def test_required_creates_penalties_tensor(self):
         """Test that update_penalties allocates a zero tensor and calls orchestrator methods."""
         orch = MagicMock(is_required=True)
@@ -217,7 +250,6 @@ class TestUpdatePenalties(CustomTestCase):
 
 # update_regex_vocab_mask
 class TestUpdateRegexVocabMask(CustomTestCase):
-
     def test_no_grammars_clears_mask(self):
         """Test that None grammars clears both vocab_mask and apply_mask_func."""
         info = _make_info(batch_size=1)
@@ -273,7 +305,6 @@ class TestUpdateRegexVocabMask(CustomTestCase):
 
 # filter_batch
 class TestFilterBatch(CustomTestCase):
-
     def test_filter_keeps_correct_indices(self):
         """Test that filter retains rows at indices 0 and 2, dropping index 1."""
         info = _make_info(batch_size=3)
@@ -328,7 +359,6 @@ class TestFilterBatch(CustomTestCase):
 
 # merge_batch
 class TestMergeBatch(CustomTestCase):
-
     def test_merge_concatenates_tensors(self):
         """Test that merge concatenates temperature tensors from both batches."""
         info1 = _make_info(batch_size=2)
@@ -407,7 +437,6 @@ class TestMergeBatch(CustomTestCase):
 
 # copy_for_forward
 class TestCopyForForward(CustomTestCase):
-
     def test_returns_copy_without_orchestrator(self):
         """Test that copy_for_forward returns a copy with orchestrator set to None."""
         orch = MagicMock(is_required=False)
@@ -420,7 +449,6 @@ class TestCopyForForward(CustomTestCase):
 
 # from_schedule_batch
 class TestFromScheduleBatch(CustomTestCase):
-
     def _make_req(
         self,
         temp=1.0,


### PR DESCRIPTION
## Summary

- add a lightweight JIT CUDA fused sampler for homogeneous small sampler top-k batches
- route the standard CUDA/FlashInfer sampling path directly from logits when the batch is eligible
- support both `top_p == 1.0` and exact joint top-k/top-p sampling for `top_p < 1.0`; the `top_p < 1.0` specialization reuses per-tile denominator partials instead of rescanning the full vocab in the merge kernel
- gate the runtime path to homogeneous sampler `2 <= top_k <= 8`, no min-p, no deterministic seed/logprob/RL/Ascend path, CUDA tensors, and FlashInfer sampling backend
- add correctness tests and a microbenchmark for the new JIT sampler

## Validation

- Local, PR head `87c13e4ad0`: `python3 -m py_compile python/sglang/srt/layers/sampler.py python/sglang/srt/sampling/sampling_batch_info.py python/sglang/jit_kernel/fused_sampler.py`
- Local, PR head `87c13e4ad0`: `git diff --check`
- Local, PR head `87c13e4ad0`: `python3 -m ruff check python/sglang/srt/layers/sampler.py python/sglang/srt/sampling/sampling_batch_info.py python/sglang/jit_kernel/fused_sampler.py`
- GB300 rx-devbox: JIT smoke for `top_p=0.95`, `top_k=8`, `bs=48` passed against a PyTorch reference
- H200 earlier validation before rebase: sampling batch unit tests passed, 43 tests; fused sampler JIT tests passed, 26 tests

## Microbench Notes

Baseline = temperature softmax + FlashInfer `top_k_top_p_sampling_from_probs(filter_apply_order="joint")`; fused = JIT fused top-k/top-p path with preallocated output/scratch. Units are median microseconds.

### H200, vocab=151552, top_p=0.95

| batch | top_k | baseline | fused | speedup |
|---:|---:|---:|---:|---:|
| 16 | 4 | 435.09 | 42.41 | 10.26x |
| 16 | 8 | 409.93 | 78.51 | 5.22x |
| 256 | 4 | 1120.66 | 460.34 | 2.43x |
| 256 | 8 | 1084.37 | 871.89 | 1.24x |
| 1024 | 4 | 3773.61 | 1792.07 | 2.11x |
| 1024 | 8 | 3612.34 | 3419.97 | 1.06x |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28768817458](https://github.com/sgl-project/sglang/actions/runs/28768817458)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28768817432](https://github.com/sgl-project/sglang/actions/runs/28768817432)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
