### PR TITLE
fix: release HiCache prefetch for oversized PD requests

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -295,6 +295,8 @@ class PrefillBootstrapQueue:
         if len(req.origin_input_ids) > self.max_total_num_tokens:
             message = f"Request {req.rid} exceeds the maximum number of tokens: {len(req.origin_input_ids)} > {self.max_total_num_tokens}"
             logger.error(message)
+            if self.scheduler.enable_hicache_storage:
+                self.scheduler.tree_cache.release_aborted_request(req.rid)
             req.time_stats.trace_ctx.abort(abort_info={"reason": message})
             prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)
             self.scheduler.output_streamer.stream_output([req], req.return_logprob)

--- a/test/registered/unit/disaggregation/test_prefill_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_prefill_queue_cleanup.py
@@ -1,0 +1,60 @@
+import unittest
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.prefill import PrefillBootstrapQueue
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestPrefillBootstrapQueueCleanup(CustomTestCase):
+    @patch("sglang.srt.disaggregation.prefill.prepare_abort")
+    def test_oversized_request_releases_hicache_prefetch(self, mock_prepare_abort):
+        req = SimpleNamespace(
+            rid="oversized",
+            origin_input_ids=[1, 2, 3],
+            return_logprob=False,
+            time_stats=SimpleNamespace(trace_ctx=MagicMock()),
+        )
+        scheduler = SimpleNamespace(
+            enable_hicache_storage=True,
+            tree_cache=MagicMock(),
+            output_streamer=MagicMock(),
+        )
+        queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+        queue.scheduler = scheduler
+        queue.max_total_num_tokens = 2
+
+        self.assertTrue(queue._check_if_req_exceed_kv_capacity(req))
+
+        message = "Request oversized exceeds the maximum number of tokens: 3 > 2"
+        scheduler.tree_cache.release_aborted_request.assert_called_once_with(req.rid)
+        req.time_stats.trace_ctx.abort.assert_called_once_with(
+            abort_info={"reason": message}
+        )
+        mock_prepare_abort.assert_called_once_with(
+            req, message, status_code=HTTPStatus.BAD_REQUEST
+        )
+        scheduler.output_streamer.stream_output.assert_called_once_with(
+            [req], req.return_logprob
+        )
+
+    def test_request_at_capacity_keeps_hicache_prefetch(self):
+        req = SimpleNamespace(rid="at-capacity", origin_input_ids=[1, 2])
+        scheduler = SimpleNamespace(
+            enable_hicache_storage=True,
+            tree_cache=MagicMock(),
+        )
+        queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+        queue.scheduler = scheduler
+        queue.max_total_num_tokens = 2
+
+        self.assertFalse(queue._check_if_req_exceed_kv_capacity(req))
+        scheduler.tree_cache.release_aborted_request.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
Follow-up to #30053.

Oversized PD-prefill requests are rejected after HiCache prefetch starts. 

1. It's leaving the prefetch reservation active. 
2. it's preventing subsequent L3 prefetches.

## Modifications

- Release HiCache prefetch state when the capacity check rejects a request before bootstrap enqueue.
- Add CPU regression coverage for oversized and at-capacity requests.

## Accuracy Tests

N/A. This only changes cleanup for rejected requests and does not affect model outputs.

## Speed Tests and Profiling

N/A. Accepted-request scheduling and model execution are unchanged.

## Testing

Verified using `lmsysorg/sglang:dev`:

- `PYTHONPATH=python python3 -m pytest test/registered/unit/disaggregation/test_prefill_queue_cleanup.py -q` (2 passed)
- `python3 scripts/ci/check_registered_tests.py` (passed)
- `pre-commit run --all-files` (passed)

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Documentation is not required for this internal cleanup.
- [x] Accuracy and speed benchmarks are not applicable; see the sections above.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Request review from the PD disaggregation Merge Oncalls.
2. Get the required CODEOWNER approvals.
3. Ask an authorized user to trigger CI.
4. After green CI and approvals, ask a Merge Oncall or maintainer to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28766080471](https://github.com/sgl-project/sglang/actions/runs/28766080471)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28766080346](https://github.com/sgl-project/sglang/actions/runs/28766080346)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->